### PR TITLE
ci(deps): bump seven pinned actions, each past the cooldown

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,12 +26,12 @@ jobs:
         with:
           egress-policy: audit
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.26'
           # No go.sum to key a cache on: the zero-dependency rule keeps this module
@@ -41,7 +41,7 @@ jobs:
           cache: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: go
           queries: security-extended
@@ -50,4 +50,4 @@ jobs:
         run: go build ./...
 
       - name: Analyze
-        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -35,12 +35,12 @@ jobs:
         with:
           egress-policy: audit
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.26'
           # No go.sum to key a cache on: the zero-dependency rule keeps this module

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           egress-policy: audit
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/drift.yml
+++ b/.github/workflows/drift.yml
@@ -39,12 +39,12 @@ jobs:
         with:
           egress-policy: audit
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.26'
           # No go.sum to key a cache on: the zero-dependency rule keeps this module
@@ -55,14 +55,14 @@ jobs:
 
       # The SDKs are read as source, never imported: no module dependency, no build of upstream code.
       - name: Checkout the Scaleway SDK
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: scaleway/scaleway-sdk-go
           path: .upstream/scaleway-sdk-go
           persist-credentials: false
 
       - name: Checkout the Outscale SDK
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: outscale/osc-sdk-go
           path: .upstream/osc-sdk-go
@@ -196,7 +196,7 @@ jobs:
         with:
           egress-policy: audit
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Kept, and stated rather than left to the default. This is the one job
           # in the repository that pushes a branch, so it needs the credentials
@@ -266,7 +266,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,12 +24,12 @@ jobs:
         with:
           egress-policy: audit
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.26'
           # No go.sum to key a cache on: the zero-dependency rule keeps this module
@@ -146,12 +146,12 @@ jobs:
         with:
           egress-policy: audit
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.26'
           cache: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,12 +30,12 @@ jobs:
         with:
           egress-policy: audit
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.26'
           cache: false   # a release build must not consume a cache a PR could poison
@@ -72,7 +72,7 @@ jobs:
         with:
           egress-policy: audit
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -122,7 +122,7 @@ jobs:
       - name: Attest build provenance
         id: attest
         if: ${{ !github.event.repository.private }}
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: dist/feint-*
 
@@ -171,7 +171,7 @@ jobs:
           fi
 
       - name: Create release with assets
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           egress-policy: audit
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -56,7 +56,7 @@ jobs:
         with:
           egress-policy: audit
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           egress-policy: audit
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -59,6 +59,6 @@ jobs:
           repo_token: ${{ secrets.ADMIN_READ_TOKEN }}
 
       - name: Upload to code scanning
-        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           sarif_file: results.sarif

--- a/.github/workflows/secrets.yml
+++ b/.github/workflows/secrets.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           egress-policy: audit
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false


### PR DESCRIPTION
# Summary

The seven action bumps Dependabot proposed in #20, applied directly. Its branch
conflicted with the workflow rewrites that had just landed in #19 — the bumps
touch the same `uses:` lines those fixes rewrote — and the bumps are mechanical
where the conflicts are not.

Every target version was **dated against the fourteen-day cooldown this
repository declares**, rather than trusted because Dependabot offered it:

| Action | From → to | Published | Age |
|---|---|---|---|
| `actions/checkout` | 6.0.2 → 7.0.0 | 2026-06-18 | 42 d |
| `actions/setup-go` | 6.4.0 → 7.0.0 | 2026-07-16 | **14 d** |
| `github/codeql-action` (init, analyze, upload-sarif) | 4.35.5 → 4.37.1 | 2026-07-16 | **14 d** |
| `actions/attest-build-provenance` | 4.1.0 → 4.1.1 | 2026-06-26 | 34 d |
| `softprops/action-gh-release` | 3.0.0 → 3.0.2 | 2026-07-13 | 17 d |

Two clear the threshold to the day. Every SHA was read from the GitHub API for
the tag it claims rather than copied from the pull request body: a pin is only
worth whatever verified it.

Closes #20 once merged — Dependabot will see these versions in `main`.

## Type of change

- [ ] A route added or changed
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Chore / tooling
- [x] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes
- [x] No new external Go dependency — no Go file is in this diff
- [x] `internal/core` still knows no provider — no Go file is in this diff
- [x] Nothing in the diff could be written identically for another provider

### When a model wrote a substantive part of this

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] `mise run conformance` run locally, green
- [x] Every value in the diff comes from a source I can name: `gh api
      repos/<action>/commits/<tag>` for each SHA, and `gh release view` for each
      publication date

### When a route is added or changed

N/A — no route is touched.

### When behaviour a client can observe changes

N/A — this changes which versions of third-party actions CI runs, nothing a
client of the emulator can observe.

### When `.github/workflows/` is touched

- [x] Every action pinned to a full 40-character commit SHA with its `# vX.Y.Z`
      comment, and the comment matches the SHA — that is what was verified
- [x] `step-security/harden-runner` is still each job's first step
- [x] `permissions:` unchanged, still least-privilege
- [x] **No job renamed**, so the required status checks in
      `.github/rulesets/main.json` still match
- [x] Exit-code contract untouched
- [x] `actionlint`, `zizmor`, `poutine` and `plumber` all pass locally after the
      bump — the four scanners whose business is exactly this

### When a machine runtime is involved

N/A.

## Related issues

Supersedes #20.
