### PR TITLE
fix: four defects three audits found, and the preflight that let 0.3.0 through

### DIFF
--- a/docs/routes.md
+++ b/docs/routes.md
@@ -203,7 +203,7 @@ missed one — and the reason is what separates a decision from a list.
 - `instance/v1/API.CreateSnapshot` — a snapshot copies the bytes of a volume, and an emulated volume is a size and a name with nothing written behind it, so the object produced would restore nothing
 - `instance/v1/API.DeleteImage` — the pack answers image lookups from the fixed catalogue the CLI resolves against, so creating or editing one would edit a table nothing can add to
 - `instance/v1/API.DeletePlacementGroup` — placement constrains which physical hosts run a machine, and every emulated machine runs on the single host that started feint, so any policy would be reported satisfied whatever it asked
-- `instance/v1/API.DeleteSnapshot` — a snapshot copies the bytes of a volume, and an emulated volume is a size and a name with nothing written behind it, so the object produced would restore nothing
+- `instance/v1/API.DeleteSnapshot` — creating a snapshot is declined, so no snapshot can exist in this emulator for these calls to read, edit or delete
 - `instance/v1/API.DetachServerFileSystem` — it mounts Scaleway's File Storage product, and there is no filesystem service behind this emulator for a machine to mount
 - `instance/v1/API.DetachVolume` — the SDK's hand-written helpers, deprecated upstream in favour of AttachServerVolume and DetachServerVolume, which this pack serves and which the CLI calls
 - `instance/v1/API.ExportSnapshot` — it writes into Object Storage, which is not emulated because the Terraform provider builds the S3 endpoint in code: supporting it needs DNS interception and a certificate, measured in docs/limits.md
@@ -212,12 +212,12 @@ missed one — and the reason is what separates a decision from a list.
 - `instance/v1/API.GetPlacementGroupServers` — placement constrains which physical hosts run a machine, and every emulated machine runs on the single host that started feint, so any policy would be reported satisfied whatever it asked
 - `instance/v1/API.GetServerCompatibleTypes` — capacity and quotas are the provider's fleet, and a local emulator that answered would be inventing headroom a client could plan against
 - `instance/v1/API.GetServerTypesAvailability` — capacity and quotas are the provider's fleet, and a local emulator that answered would be inventing headroom a client could plan against
-- `instance/v1/API.GetSnapshot` — a snapshot copies the bytes of a volume, and an emulated volume is a size and a name with nothing written behind it, so the object produced would restore nothing
+- `instance/v1/API.GetSnapshot` — creating a snapshot is declined, so no snapshot can exist in this emulator for these calls to read, edit or delete
 - `instance/v1/API.ListDefaultSecurityGroupRules` — the seeded rule set is a value the SDK does not carry, so an invented list would state which ports a real client believes are open, and docs/limits.md records that these rules do filter packets
 - `instance/v1/API.ListImages` — the catalogue exists so the CLI can resolve one image by id before a create, and listing it would publish six fixed entries as if they were an inventory a client could grow
 - `instance/v1/API.ListPlacementGroups` — placement constrains which physical hosts run a machine, and every emulated machine runs on the single host that started feint, so any policy would be reported satisfied whatever it asked
 - `instance/v1/API.ListServerActions` — the server already publishes allowed_actions, derived from its state, so a second listing would be a second place to keep in step with the first
-- `instance/v1/API.ListSnapshots` — a snapshot copies the bytes of a volume, and an emulated volume is a size and a name with nothing written behind it, so the object produced would restore nothing
+- `instance/v1/API.ListSnapshots` — creating a snapshot is declined, so no snapshot can exist in this emulator for these calls to read, edit or delete
 - `instance/v1/API.ListVolumesTypes` — the emulator serves one volume type, b_ssd, because that is what its catalogue attaches, so a type list would describe capabilities nothing here can create
 - `instance/v1/API.PlanBlockMigration` — there is no legacy storage behind this emulator to migrate from, so a plan would describe a move between two things that are the same store
 - `instance/v1/API.ReleaseIPToIpam` — addresses come from the subnet plan a server or a private NIC is placed in rather than from a client reservation, so booking or moving one would hand out an address no runtime configures
@@ -227,7 +227,7 @@ missed one — and the reason is what separates a decision from a list.
 - `instance/v1/API.UpdatePlacementGroup` — placement constrains which physical hosts run a machine, and every emulated machine runs on the single host that started feint, so any policy would be reported satisfied whatever it asked
 - `instance/v1/API.UpdatePlacementGroupServers` — placement constrains which physical hosts run a machine, and every emulated machine runs on the single host that started feint, so any policy would be reported satisfied whatever it asked
 - `instance/v1/API.UpdatePrivateNIC` — its request carries tags and nothing else, and the pack stores no tag on a private NIC, so it would answer success over a field nothing reads back
-- `instance/v1/API.UpdateSnapshot` — a snapshot copies the bytes of a volume, and an emulated volume is a size and a name with nothing written behind it, so the object produced would restore nothing
+- `instance/v1/API.UpdateSnapshot` — creating a snapshot is declined, so no snapshot can exist in this emulator for these calls to read, edit or delete
 - `instance/v1/MetadataAPI.DeleteUserData` — the metadata service answers on the link-local address 169.254.42.42, from inside the machine, to a caller that carries no credentials
 - `instance/v1/MetadataAPI.GetMetadata` — the metadata service answers on the link-local address 169.254.42.42, from inside the machine, to a caller that carries no credentials
 - `instance/v1/MetadataAPI.GetUserData` — the metadata service answers on the link-local address 169.254.42.42, from inside the machine, to a caller that carries no credentials

--- a/internal/core/emulator/citations_test.go
+++ b/internal/core/emulator/citations_test.go
@@ -25,14 +25,23 @@ import (
 func TestEveryCitedTestExists(t *testing.T) {
 	root := repositoryRoot(t)
 
-	// A citation is a Test-prefixed identifier inside a comment. The length
-	// bound keeps `TestMain` and the httptest types out; the word boundary
-	// keeps `newTestServer` out.
-	cited := regexp.MustCompile(`\bTest[A-Z][A-Za-z0-9]{7,}\b`)
+	// A citation is a Test-prefixed identifier inside a comment. The word
+	// boundary keeps `newTestServer` out; the length bound keeps `TestMain`
+	// out, and is deliberately short — five characters after the prefix — so a
+	// briefly named test is still checked. An audit found the first version
+	// required twelve, which made short citations invisible.
+	cited := regexp.MustCompile(`\bTest[A-Z][A-Za-z0-9]{4,}\b`)
 	declared := regexp.MustCompile(`(?m)^func (Test[A-Za-z0-9]+)\(`)
 
-	tests := map[string]bool{}
-	citations := map[string][]string{} // test name -> files citing it
+	// Indexed by directory, not flat across the module: an audit renamed a
+	// cited test in one package, dropped a stub of the same name in another,
+	// and this test passed — a homonym elsewhere satisfied a citation that
+	// pointed at nothing local. A citation is checked against the package that
+	// carries it, then against the module, because a comment in the core may
+	// legitimately name a test that proves the point in a pack.
+	homes := map[string][]string{} // test name -> the directories declaring it
+	byDir := map[string]map[string]bool{}
+	citations := map[string][]citation{} // "dir\x00name" -> where it is cited
 
 	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
 		if err != nil {
@@ -52,19 +61,37 @@ func TestEveryCitedTestExists(t *testing.T) {
 		if readErr != nil {
 			return readErr
 		}
+		dir := filepath.Dir(path)
 		for _, match := range declared.FindAllStringSubmatch(string(body), -1) {
-			tests[match[1]] = true
+			homes[match[1]] = append(homes[match[1]], dir)
+			if byDir[dir] == nil {
+				byDir[dir] = map[string]bool{}
+			}
+			byDir[dir][match[1]] = true
+		}
+		// Comment lines are joined before matching: a citation split across two
+		// of them escaped the line-by-line scan, and the comment style in this
+		// repository makes that likely.
+		rel, _ := filepath.Rel(root, path)
+		var block strings.Builder
+		harvest := func() {
+			text := block.String()
+			for _, name := range cited.FindAllString(text, -1) {
+				key := dir + "\x00" + name
+				citations[key] = append(citations[key], citation{file: rel, text: text})
+			}
+			block.Reset()
 		}
 		for _, line := range strings.Split(string(body), "\n") {
 			comment := strings.Index(line, "//")
 			if comment < 0 {
+				harvest()
 				continue
 			}
-			for _, name := range cited.FindAllString(line[comment:], -1) {
-				rel, _ := filepath.Rel(root, path)
-				citations[name] = append(citations[name], rel)
-			}
+			block.WriteString(strings.TrimPrefix(line[comment+2:], " "))
+			block.WriteString(" ")
 		}
+		harvest()
 		return nil
 	})
 	if err != nil {
@@ -74,12 +101,47 @@ func TestEveryCitedTestExists(t *testing.T) {
 		t.Fatal("no citation found anywhere, which means this test measures nothing")
 	}
 
-	for name, files := range citations {
-		if !tests[name] {
+	for key, where := range citations {
+		dir, name, _ := strings.Cut(key, "\x00")
+		files := make([]string, 0, len(where))
+		for _, c := range where {
+			files = append(files, c.file)
+		}
+		switch {
+		case byDir[dir][name]:
+			// The ordinary case: the test lives beside the comment citing it.
+		case len(homes[name]) == 0:
 			t.Errorf("%s is cited in %s and does not exist: a comment that cannot fail is not a control",
 				name, strings.Join(files, ", "))
+		default:
+			// It lives elsewhere, which is legitimate — the core cites a test a
+			// pack runs — but only when the comment says where. Otherwise a
+			// homonym in any package satisfies a citation pointing at nothing:
+			// an audit renamed a cited test, dropped a stub of the same name in
+			// another package, and this test went green.
+			for _, c := range where {
+				if !namesItsHome(c.text, homes[name]) {
+					t.Errorf("%s is cited in %s, lives in %s, and the comment does not say so: "+
+						"name the package, or a homonym anywhere satisfies this citation",
+						name, c.file, strings.Join(homes[name], ", "))
+				}
+			}
 		}
 	}
+}
+
+type citation struct{ file, text string }
+
+// namesItsHome reports whether a comment citing a test from another package
+// says which one. The package name alone is enough — "emulator's TestX", "TestX
+// in internal/cli" — because that is what a reader needs to find it.
+func namesItsHome(comment string, homes []string) bool {
+	for _, home := range homes {
+		if strings.Contains(comment, filepath.Base(home)) || strings.Contains(comment, home) {
+			return true
+		}
+	}
+	return false
 }
 
 // repositoryRoot walks up from the test's own directory to the module root,

--- a/internal/providers/outscale/audit_test.go
+++ b/internal/providers/outscale/audit_test.go
@@ -1,12 +1,17 @@
 package outscale_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/machine"
+	"github.com/stephrobert/feint/internal/providers/outscale"
 )
 
 // The defects a whole-pack audit found on paths the conformance suite does not
@@ -322,4 +327,134 @@ func TestASubnetDoesNotDeleteUnderARace(t *testing.T) {
 			}
 		}
 	}
+}
+
+// A create whose resource disappears leaves no machine behind.
+//
+// createVms started the machine outside the per-target lock every other
+// lifecycle path takes, and when the commit failed it merely skipped the answer:
+// the container went on running while the control plane described nothing. An
+// audit obtained it with `PUT /_feint/state` carrying an empty list — a designed
+// path, since internal/cli/snapshot.go documents the format as meant to be
+// loaded into another instance.
+//
+// A machine the control plane does not describe is a machine nobody thinks to
+// stop, which is the worst outcome this layer can produce.
+func TestACreateWhoseResourceVanishesLeavesNoMachineBehind(t *testing.T) {
+	runtime := newBlockingRuntime()
+	ts := newRuntimeServer(t, runtime)
+	_, subnetID := netAndSubnet(t, ts, "10.51.0.0/16", "10.51.1.0/24")
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		post(t, ts, "CreateVms", `{"ImageId":"ami-12345678","SubnetId":"`+subnetID+`"}`)
+	}()
+
+	// The machine is starting; empty the store under it.
+	<-runtime.entered
+	req, err := http.NewRequest(http.MethodPut, ts.URL+"/_feint/state", strings.NewReader("[]"))
+	if err != nil {
+		t.Fatalf("build the restore: %v", err)
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("restore an empty state: %v", err)
+	}
+	_ = res.Body.Close()
+	// Checked, because a refused restore would leave this test measuring
+	// nothing while looking green.
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("the restore answered %d; the store was not emptied", res.StatusCode)
+	}
+	close(runtime.release)
+	<-done
+
+	if left := runtime.running(); len(left) != 0 {
+		t.Errorf("the API describes no machine and %v is still running on the host", left)
+	}
+}
+
+// blockingRuntime holds Start until the test lets it go, so "while it was
+// starting" is a fact rather than a probability.
+type blockingRuntime struct {
+	mu       sync.Mutex
+	machines map[string]bool
+	entered  chan string
+	release  chan struct{}
+}
+
+func newBlockingRuntime() *blockingRuntime {
+	return &blockingRuntime{
+		machines: map[string]bool{},
+		entered:  make(chan string, 8),
+		release:  make(chan struct{}),
+	}
+}
+
+func (f *blockingRuntime) Name() string                   { return "fake" }
+func (f *blockingRuntime) Available(context.Context) bool { return true }
+
+func (f *blockingRuntime) Start(_ context.Context, spec machine.Spec) (machine.Machine, error) {
+	select {
+	case f.entered <- spec.Name:
+	default:
+	}
+	<-f.release
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.machines[spec.Name] = true
+	return machine.Machine{Name: spec.Name, Running: true}, nil
+}
+
+func (f *blockingRuntime) Stop(_ context.Context, n string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.machines[n] = false
+	return nil
+}
+
+func (f *blockingRuntime) Remove(_ context.Context, n string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.machines, n)
+	return nil
+}
+
+func (f *blockingRuntime) Inspect(_ context.Context, n string) (machine.Machine, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if running, found := f.machines[n]; found {
+		return machine.Machine{Name: n, Running: running}, true, nil
+	}
+	return machine.Machine{}, false, nil
+}
+
+func (f *blockingRuntime) EnsureNetwork(context.Context, machine.NetworkSpec) error { return nil }
+func (f *blockingRuntime) Attach(context.Context, string, machine.Attachment) error { return nil }
+func (f *blockingRuntime) RemoveNetwork(context.Context, string) error              { return nil }
+
+func (f *blockingRuntime) running() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []string
+	for name, up := range f.machines {
+		if up {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+func newRuntimeServer(t *testing.T, drv machine.Driver) *httptest.Server {
+	t.Helper()
+	env := emulator.DefaultEnv()
+	env.Machines = drv
+	srv, err := emulator.NewServer(env, outscale.New(env))
+	if err != nil {
+		t.Fatalf("build emulator: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return ts
 }

--- a/internal/providers/outscale/vms.go
+++ b/internal/providers/outscale/vms.go
@@ -189,12 +189,24 @@ func (p *Pack) createVms(w http.ResponseWriter, r *http.Request) {
 		// intended. The store clones on Put, so the machine name and the running
 		// state have to be written back explicitly.
 		if boot {
+			// Serialised on the target, like every other lifecycle path here:
+			// deleteVms and transitionOne both take it, and the create did not,
+			// so a delete arriving mid-boot raced the start it was meant to
+			// cancel.
+			unlock := p.binding().Serialise(res.ID)
 			p.powerOn(r.Context(), res)
 			if !p.env.Store.Commit(res, p.env.Now()) {
-				// Deleted while it was starting. Not an error: the client asked
-				// for a machine it then removed.
+				// Gone while it was starting — a delete, or a snapshot restored
+				// over it, which `PUT /_feint/state` does and snapshot.go
+				// documents as a designed path. The machine has to go with it:
+				// the previous version just skipped the answer, leaving a
+				// container running that the control plane no longer describes,
+				// and a machine nobody describes is a machine nobody stops.
+				p.removeMachine(r.Context(), res)
+				unlock()
 				continue
 			}
+			unlock()
 		}
 		vms = append(vms, p.vmView(res))
 	}

--- a/internal/providers/scaleway/ownership_audit_test.go
+++ b/internal/providers/scaleway/ownership_audit_test.go
@@ -123,6 +123,13 @@ func TestAttachingDoesNotStealAnotherServersVolume(t *testing.T) {
 				t.Fatalf("the owner has no root volume: %v", srv)
 			}
 
+			// The thief's own root, which a failed steal must not cost it.
+			_, out = do(t, ts, "GET", zone+"/servers/"+thief, "")
+			srv, _ = out["server"].(map[string]any)
+			volumes, _ = srv["volumes"].(map[string]any)
+			own, _ := volumes["0"].(map[string]any)
+			ownRoot, _ := own["id"].(string)
+
 			door.take(t, ts, thief, rootID)
 
 			// Whatever the status, the volume must not have moved: a create that
@@ -133,6 +140,25 @@ func TestAttachingDoesNotStealAnotherServersVolume(t *testing.T) {
 			server, _ := vol["server"].(map[string]any)
 			if server == nil || server["id"] != owner {
 				t.Errorf("%s moved the root volume: it now names %v", door.what, vol["server"])
+			}
+
+			// The two consequences the first version of this test did not
+			// assert, which is how the PATCH door went on stealing through
+			// three audits: the thief must not list the volume, and must not
+			// have lost its own root doing so.
+			_, out = do(t, ts, "GET", zone+"/servers/"+thief, "")
+			srv, _ = out["server"].(map[string]any)
+			volumes, _ = srv["volumes"].(map[string]any)
+			for key, entry := range volumes {
+				listed, _ := entry.(map[string]any)
+				if id, _ := listed["id"].(string); id == rootID {
+					t.Errorf("%s: the thief lists the owner's volume under %q — both servers hold it", door.what, key)
+				}
+			}
+			_, out = do(t, ts, "GET", zone+"/volumes/"+ownRoot, "")
+			vol, _ = out["volume"].(map[string]any)
+			if holder, _ := vol["server"].(map[string]any); holder == nil || holder["id"] != thief {
+				t.Errorf("%s: the thief's own root was detached by the attempt: %v", door.what, vol["server"])
 			}
 		})
 	}

--- a/internal/providers/scaleway/pack.go
+++ b/internal/providers/scaleway/pack.go
@@ -189,10 +189,18 @@ func (p *Pack) Declined() []emulator.Decline {
 		// have in order to answer, which is what makes a refusal revisitable —
 		// "not triaged yet" and "out of scope" are different answers.
 
-		// A snapshot and an image are bytes. An emulated volume is a size and a
-		// name in a store, with nothing written behind it.
+		// A snapshot is bytes. An emulated volume is a size and a name in a
+		// store, with nothing written behind it.
 		emulator.Because("a snapshot copies the bytes of a volume, and an emulated volume is a size and a name with nothing written behind it, so the object produced would restore nothing",
-			"instance/v1/API.CreateSnapshot",
+			"instance/v1/API.CreateSnapshot"),
+
+		// The four reads are separated for the reason ListImages already
+		// established below: the sentence above is about producing an object,
+		// which is true of the create and false of everything that only reads
+		// one. An audit found the family reason applied to members it does not
+		// describe — the defect this repository keeps meeting, and the reason
+		// Declined() carries prose at all.
+		emulator.Because("creating a snapshot is declined, so no snapshot can exist in this emulator for these calls to read, edit or delete",
 			"instance/v1/API.DeleteSnapshot",
 			"instance/v1/API.GetSnapshot",
 			"instance/v1/API.ListSnapshots",

--- a/internal/providers/scaleway/servers.go
+++ b/internal/providers/scaleway/servers.go
@@ -713,8 +713,19 @@ func (p *Pack) setServerVolumes(server *resource.Resource, wanted map[string]vol
 			if !found || vol.Tenant.Zone != server.Tenant.Zone {
 				return fmt.Errorf("volume %s does not exist in %s", tmpl.ID, server.Tenant.Zone)
 			}
-			// A volume this call just created: it can belong to nobody else.
-			_ = p.attachVolume(vol, server, name)
+			// An existing volume, which another live server may hold. The
+			// verdict was thrown away here — under a comment copied from the
+			// case below, where the volume really is new — so `scw instance
+			// server update <thief> volumes.0.id=<their-root>` took it, both
+			// servers listed it, and the patched server's own root was
+			// detached with no error. A fourth audit found it: the shared
+			// question was asked and its answer dropped, which is worse than
+			// not asking, because the guard reads as present.
+			//
+			// TestAttachingDoesNotStealAnotherServersVolume fails without this.
+			if err := p.attachVolume(vol, server, name); err != nil {
+				return err
+			}
 			p.env.Store.Put(vol)
 			keep[vol.ID] = true
 			view[key] = volumeView(vol)

--- a/tools/conformance/outscale/fake-credentials.env
+++ b/tools/conformance/outscale/fake-credentials.env
@@ -12,4 +12,14 @@ OSC_ACCESS_KEY=AAAAAAAAAAAAAAAAAAAA
 OSC_SECRET_KEY=BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
 OSC_REGION=eu-west-2
 OSC_PROTOCOL=http
-OSC_ENDPOINT_API=http://127.0.0.1:4599
+# OSC_ENDPOINT_API is deliberately NOT set here.
+#
+# oapi-cli lets the environment win over --config, so pinning it to 4599 in this
+# file made the [endpoint] argument of every Outscale script inert: a run against
+# another port measured whatever answered on 4599 — another server, or nothing.
+# An audit reproduced it, and the failure looked like a broken emulator (three
+# retries, then a timeout) rather than like a misdirected client.
+#
+# Each script exports it from the endpoint it was given, and calls
+# guard_no_real_profile so an unset value refuses to run rather than letting the
+# client find the operator's real profile.

--- a/tools/conformance/outscale/network.sh
+++ b/tools/conformance/outscale/network.sh
@@ -59,7 +59,17 @@ SUBBLOCK="${FEINT_TEST_SUBNET_BLOCK:-10.182.9.0/24}"
 set -a
 # shellcheck source=/dev/null
 . "$SCRIPT_DIR/fake-credentials.env"
+# The endpoint comes from the argument, not from the credentials file: oapi-cli
+# lets the environment override --config, so a pinned value there silently wins
+# over the port this run was asked to measure.
+# shellcheck disable=SC2034 # read by oapi-cli from the environment, not here
+OSC_ENDPOINT_API="$ENDPOINT"
 set +a
+
+# And it must be set, because an unset one sends oapi-cli looking for the
+# operator's stored profile. guard_local checked where we intend to go; this
+# checks the client cannot go anywhere else.
+guard_no_real_profile OSC_ENDPOINT_API oapi-cli
 
 WORK="$(mktemp -d)"
 cat > "$WORK/config.json" <<EOF

--- a/tools/conformance/outscale/oapi-cli.sh
+++ b/tools/conformance/outscale/oapi-cli.sh
@@ -31,7 +31,17 @@ command -v jq >/dev/null 2>&1 || { echo "FAIL: jq is not installed" >&2; exit 1;
 set -a
 # shellcheck source=/dev/null
 . "$SCRIPT_DIR/fake-credentials.env"
+# The endpoint comes from the argument, not from the credentials file: oapi-cli
+# lets the environment override --config, so a pinned value there silently wins
+# over the port this run was asked to measure.
+# shellcheck disable=SC2034 # read by oapi-cli from the environment, not here
+OSC_ENDPOINT_API="$ENDPOINT"
 set +a
+
+# And it must be set, because an unset one sends oapi-cli looking for the
+# operator's stored profile. guard_local checked where we intend to go; this
+# checks the client cannot go anywhere else.
+guard_no_real_profile OSC_ENDPOINT_API oapi-cli
 
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT

--- a/tools/release/preflight.sh
+++ b/tools/release/preflight.sh
@@ -97,12 +97,31 @@ esac
 # checkable against the commits since the last one, and a mismatch is worth a
 # sentence before it is worth a release.
 #
-# It reports rather than refuses when commitizen is absent: a maintainer without
-# the Python tooling must still be able to cut a release, and every other check
-# here already had that property.
+# It reports rather than refuses when commitizen cannot be reached at all: a
+# maintainer without the Python tooling must still be able to cut a release, and
+# every other check here already had that property.
+#
+# But "cannot be reached" is not the same as "is not on the PATH", and treating
+# them as one skipped this check on the station that cuts the releases — where
+# the commitizen pre-commit hook runs on every single commit, through pre-commit's
+# own isolated environment. So v0.3.0 was published with the number derived by
+# hand rather than from the commits. uv is already a declared tool of this
+# project (mise.toml), so uvx runs commitizen without installing anything, at the
+# version .pre-commit-config.yaml pins — the same one the hook uses, because two
+# versions of the same tool disagreeing about an increment is a defect nobody
+# would think to look for.
+cz_version="$(sed -n '/commitizen-tools\/commitizen/,/rev:/s/.*rev: *v\{0,1\}\([0-9.]*\).*/\1/p' \
+  .pre-commit-config.yaml | head -1)"
+cz_cmd=""
 if command -v cz >/dev/null 2>&1; then
+  cz_cmd="cz"
+elif command -v uvx >/dev/null 2>&1 && [ -n "$cz_version" ]; then
+  cz_cmd="uvx --from commitizen==$cz_version cz"
+fi
+
+if [ -n "$cz_cmd" ]; then
   # --yes so it never prompts, --dry-run so it writes nothing at all.
-  implied="$(cz bump --dry-run --yes 2>/dev/null | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | tail -1)"
+  implied="$($cz_cmd bump --dry-run --yes 2>/dev/null | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | tail -1)"
   if [ -z "$implied" ]; then
     # No bump to compute: no conventional commit since the last tag, which is
     # the ordinary case for the first release.
@@ -111,10 +130,10 @@ if command -v cz >/dev/null 2>&1; then
     ok "$VERSION is what the commits since the last tag imply"
   else
     ko "the commits imply v${implied#v}, not $VERSION" \
-       "read: cz bump --dry-run. Tag what the commits say, or say why in the CHANGELOG"
+       "read: $cz_cmd bump --dry-run. Tag what the commits say, or say why in the CHANGELOG"
   fi
 else
-  ok "${DIM}skipped: commitizen is not installed, so the implied version was not derived${OFF}"
+  ok "${DIM}skipped: neither cz nor uvx is available, so the implied version was not derived${OFF}"
 fi
 
 # --- what a reader of the release will look for -----------------------------


### PR DESCRIPTION
# Summary

Four defects that three adversarial whole-pack audits found, plus the release
preflight that let v0.3.0 be tagged on a number nobody had derived. Every one of
them sits on a path a previous *fix* opened, which is why they are together: the
lesson is not four unrelated bugs, it is that a control asked and ignored, a
guard indexed too loosely, and a check that skips itself all read as protection.

**The Outscale suite measured whatever answered on 4599** (#33). `oapi-cli` lets
the environment win over `--config`, and `fake-credentials.env` pinned
`OSC_ENDPOINT_API`. So the `[endpoint]` argument every Outscale script
documents, validates through `guard_local` and writes into `config.json` was
inert. Reproduced both ways: with a live emulator on 4599 and the suite pointed
at a dead 4723, the old code answers with 4599's inventory; the new one fails at
once. `guard_no_real_profile` — which existed, is called by `scw-cli.sh`, and no
Outscale script called — is now called.

**A create whose resource vanished left a machine running** (#44).
`createVms` started the machine outside the per-target lock every other
lifecycle path takes, and when the commit failed it skipped the answer without
destroying anything. Obtained with `PUT /_feint/state` carrying an empty list,
which `internal/cli/snapshot.go` documents as a designed path. A machine the
control plane does not describe is a machine nobody thinks to stop.

**The update door asked the ownership question and threw the answer away.**
`scw instance server update <thief> volumes.0.id=<owner's root>` answered 200:
both servers then listed that volume, and the thief's own root was detached with
no error. The guard was in the shared layer and one of three callers discarded
its verdict, under a comment copied from the branch below where the volume
really is new. The test claimed to cover "all three doors" and passed through
three audits because it asserted only that the victim keeps its disk; it now
asserts the two consequences that were missing.

**A homonym satisfied a stale citation** (#29). `TestEveryCitedTestExists`
indexed every test name in one flat set, so renaming a cited test and dropping a
stub of that name in another package left it green. It now indexes by package,
joins comment lines before matching — a citation split over two lines escaped it
— and accepts a cross-package citation only when the comment says which package,
which the two legitimate ones in this repository already do.

**A decline reason true of the family and false of four members** (#32). The
snapshot reason speaks of "the object produced", which is the create; the four
reads produce nothing. Separated the way `ListImages` already was.

**The preflight could not find the commitizen this repository runs on every
commit.** It reported "commitizen is not installed" — false: the pre-commit hook
runs it from pre-commit's isolated environment, which is not on the `PATH`. So
v0.3.0 was tagged on a number derived by hand. `uv` is already a declared tool
here, so `uvx` runs commitizen pinned to the version `.pre-commit-config.yaml`
gives the hook. Verified after the fact on a clone with the tag removed:
`0.2.0 → 0.3.0, increment MINOR`. The published number was right; it is now
measured.

## Type of change

- [ ] A route added or changed
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Chore / tooling

## Checklist

### Always

- [x] `mise run check` passes (gofmt, vet, golangci-lint, `go test -race`)
- [x] No new external Go dependency — `go.mod` still has three lines
- [x] `internal/core` still knows no provider. The citation guard walks the
      repository as text and names no provider; the ownership question lives in
      the Scaleway pack because volume ownership is that pack's model
- [x] Nothing in the diff could be written identically for another provider —
      with one deliberate exception noted below

### When a model wrote a substantive part of this

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] I ran `mise run conformance` myself — green, 68 of 91 routes proven by a
      real client
- [x] Every field name comes from the SDK, the API description, or a run of the
      real client

### When a route is added or changed

N/A — no route added or changed.

### When behaviour a client can observe changes

- [x] `docs/routes.md` regenerated (the snapshot reasons moved)
- [x] `feint docs --check` exits 0

### When `.github/workflows/` is touched

N/A.

### When a machine runtime is involved

- [x] Tested with `FEINT_VM=incus` and `FEINT_VM=incus-ovn`: a server created by
      `scw` becomes a container carrying the address the API published, and
      `terminate` removes it
- [x] `feint clean` sweeps exactly what the emulator labelled — it collected one
      orphan from an earlier session and `incus list` came back empty
- [x] The run leaves nothing behind — checked with `incus list`, not assumed

## What is not in here, deliberately

Fourteen Outscale defects the second audit confirmed (#34–#43, #45–#47), plus
#30 and #31, stay open. They are written up with their reproduction, their
`file:line` and what would prove the fix. Outscale is at 6/10 and Scaleway at
6.5/10; neither has been re-marked since these fixes.

The one place a control is duplicated across packs — `looksLikePublicKey` and
the fingerprint helper, in Scaleway and Outscale, where the Outscale copy is the
weaker one — is #37 and is left for the batch that factors it into a shared
layer. Fixing the copy in place would violate the rule that made the audit find
it.

## Related issues

Closes #29, closes #32, closes #33, closes #44.
