### PR TITLE
fix: every open bug — the lock discipline, the filters, the keys, and the VM that never took its address

### DIFF
--- a/docs/limits.md
+++ b/docs/limits.md
@@ -272,6 +272,31 @@ The order that does work with `incus-vm` is to attach before the first boot,
 which is what `terraform apply` does when the NIC is part of the same plan as
 the server.
 
+## DryRun answers, and does not validate
+
+Outscale declares `DryRun` on every action, and the real API uses it to say
+whether the request *would* have been accepted: it validates the arguments and
+answers without changing anything.
+
+This emulator honours the first half. The flag is answered at the mount point,
+before the handler runs, so nothing is created, started or deleted — which is
+the property that matters for a host, and the one a client relies on to probe
+safely.
+
+It does not honour the second half. A dry run of a malformed request answers 200
+here and 400 upstream, because no handler ever sees it. A client using `DryRun`
+as a validator therefore learns nothing from this emulator, and a client using it
+to avoid a side effect is served correctly.
+
+The reason it is not implemented per handler is measured rather than aesthetic:
+the first attempt honoured the flag inside six handlers, and Outscale declares it
+on all twenty served actions. `DeleteVms --DryRun true` destroyed the machine —
+a control implemented per handler was missing from exactly the destructive ones.
+Answering at the mount point cannot have that gap, and gives up validation to
+get there.
+
+`TestDryRunReachesNoHandler` holds the half that is served.
+
 ## Outscale and Exoscale are starters
 
 Both packs exist to prove the core stays protocol-neutral: three genuinely

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -235,6 +235,43 @@ restrictive group probed from an unrestricted neighbour — filters exactly as
 upstream does. Across two subnets the receiver's policy always holds, because
 traffic enters through the router port and no sender rule matches there.
 
+## A private NIC cannot be hot-plugged into a running virtual machine
+
+`--vm incus-vm` gives each server its own kernel. It does not give it a private
+NIC after boot: Incus refuses to add the device to a running virtual machine,
+and says why.
+
+```text
+Failed to start device "eth1": Failed adding NIC device:
+GenericError: PCI: slot 0 function 0 not available for virtio-net-pci,
+in use by virtio-balloon-pci,id=qemu_balloon
+```
+
+Measured on Incus 7.x with the emulator's own fixture: a server created, started
+and then attached to a private network. The container modes attach it without
+trouble, because a veth pair needs no PCI slot.
+
+Two things follow, and both are in the code rather than only here.
+
+**The NIC says so.** When the runtime refuses the attachment, the private NIC is
+answered as `syncing_error`, which is a state `PrivateNICState` declares. It used
+to stay `available` while the failure lived in a log line, so the API published
+an address through IPAM that the guest never carried — the one failure this
+project exists to avoid. Polling the guest for three minutes confirmed it never
+took the address.
+
+**The address is applied on the guest's own interface, once its agent answers.**
+Two separate defects were fixed on the way to measuring this one: the driver
+passed Incus's device name (`eth1`) into a guest that names the interface
+`enp6s0`, and it configured the interface before the virtual machine's agent had
+started, which answers `VM agent isn't currently running` rather than "not
+running". Both are fixed and tested through the injectable runner; neither is
+enough to work around the PCI limit above.
+
+The order that does work with `incus-vm` is to attach before the first boot,
+which is what `terraform apply` does when the NIC is part of the same plan as
+the server.
+
 ## Outscale and Exoscale are starters
 
 Both packs exist to prove the core stays protocol-neutral: three genuinely

--- a/internal/core/emulator/conformance.go
+++ b/internal/core/emulator/conformance.go
@@ -85,7 +85,8 @@ func (o *observer) wrap(provider string, r Route) http.HandlerFunc {
 
 		if doc == nil {
 			// No contract for this provider: buffering a response nobody will
-			// check would cost memory for nothing.
+			// check would cost memory for nothing. Without a recorder there is
+			// no status to read, so every request counts.
 			r.Handler(w, req)
 			o.recordUnread(r.Operation, rep.fields())
 			return
@@ -93,7 +94,14 @@ func (o *observer) wrap(provider string, r Route) http.HandlerFunc {
 
 		rec := &recorder{ResponseWriter: w, status: http.StatusOK}
 		r.Handler(rec, req)
-		o.recordUnread(r.Operation, rep.fields())
+		// Only a request the handler accepted. A field named in a 4xx was not
+		// ignored, it was refused — which is the opposite of the defect this
+		// report exists to find, and the answer told the client so. Counting it
+		// made a suite that deliberately probes a refusal fail the gate, and
+		// the fix for that must not be to stop probing refusals.
+		if rec.status < 400 {
+			o.recordUnread(r.Operation, rep.fields())
+		}
 		o.check(doc, r.Operation, rec)
 	}
 }

--- a/internal/core/emulator/json.go
+++ b/internal/core/emulator/json.go
@@ -66,10 +66,40 @@ func DecodeJSON(r *http.Request, v any) error {
 	return nil
 }
 
+// MarkRead records that something outside the handler's own request type read a
+// field, so the report stops calling it unread.
+//
+// It exists for one shape: a value consumed before the handler runs. Outscale
+// declares DryRun on all twenty of its actions and answers it at the mount
+// point, so no handler decodes it — which made `DryRun: false` count as a field
+// no handler read, and a perfectly legitimate request fail this project's own
+// conformance gate. Declaring the field on twenty request structs instead would
+// have quietened the report by lying to it: the handlers still would not read
+// it.
+//
+// It is deliberately narrow. A pack that calls this for a field it simply
+// ignores has disabled the check that exists to catch exactly that, so the call
+// belongs next to the code that does the reading, and nowhere else.
+func MarkRead(r *http.Request, fields ...string) {
+	rep, watching := r.Context().Value(reportKey{}).(*requestReport)
+	if !watching {
+		return
+	}
+	rep.mu.Lock()
+	defer rep.mu.Unlock()
+	if rep.read == nil {
+		rep.read = make(map[string]bool, len(fields))
+	}
+	for _, field := range fields {
+		rep.read[field] = true
+	}
+}
+
 // requestReport collects what one request turned out to carry and nobody read.
 type requestReport struct {
 	mu     sync.Mutex
 	unread []string
+	read   map[string]bool
 }
 
 // reportKey is the private context key the observer files a report under.
@@ -92,7 +122,13 @@ func (rep *requestReport) add(fields []string) {
 func (rep *requestReport) fields() []string {
 	rep.mu.Lock()
 	defer rep.mu.Unlock()
-	return append([]string(nil), rep.unread...)
+	out := make([]string, 0, len(rep.unread))
+	for _, field := range rep.unread {
+		if !rep.read[field] {
+			out = append(out, field)
+		}
+	}
+	return out
 }
 
 // unreadFields lists the JSON keys the body carries that v's type does not

--- a/internal/core/emulator/json.go
+++ b/internal/core/emulator/json.go
@@ -12,9 +12,15 @@ import (
 	"sync"
 )
 
-// maxBody caps request bodies. The emulator only ever receives control-plane
+// MaxBody caps request bodies. The emulator only ever receives control-plane
 // payloads; anything larger is a client bug or an attempt to exhaust memory.
-const maxBody = 4 << 20
+//
+// Exported because a pack that reads a body before the decoder does — the
+// Outscale DryRun probe — has to use the same number. It used its own, one
+// quarter of this one, and put the truncated body back for the handler: a valid
+// 1.2 MiB request came out as "unexpected end of JSON input". Two constants for
+// one limit is how they disagree.
+const MaxBody = 4 << 20
 
 // writeJSON serializes v with the given status. Encoding errors are not
 // reported to the client: the status line is already written by then, so the
@@ -44,7 +50,7 @@ func WriteJSON(w http.ResponseWriter, status int, v any) { writeJSON(w, status, 
 // to thread a value none of them care about. The report travels on the request
 // context, put there by the observer.
 func DecodeJSON(r *http.Request, v any) error {
-	body, err := io.ReadAll(io.LimitReader(r.Body, maxBody))
+	body, err := io.ReadAll(io.LimitReader(r.Body, MaxBody))
 	if err != nil {
 		return err
 	}

--- a/internal/core/machine/cli.go
+++ b/internal/core/machine/cli.go
@@ -108,6 +108,15 @@ func isNotRunning(err error) bool {
 	return strings.Contains(strings.ToLower(err.Error()), "is not running")
 }
 
+// isAgentNotReady recognises a virtual machine whose guest agent has not
+// started yet. It is distinct from isNotRunning on purpose: the instance is
+// running, and it will answer in a few seconds. Reading the two as one is what
+// made a VM report its attachment as failed and never take its address.
+func isAgentNotReady(err error) bool {
+	return strings.Contains(strings.ToLower(err.Error()), "agent isn't currently running") ||
+		strings.Contains(strings.ToLower(err.Error()), "agent is not currently running")
+}
+
 // isNotFound recognises "it does not exist" from an error message.
 //
 // Prefer gone(): the daemon answers 404 over its API, which is a fact rather

--- a/internal/core/machine/incus.go
+++ b/internal/core/machine/incus.go
@@ -63,6 +63,12 @@ type Incus struct {
 	// second half is the conformance suite's job and cannot be faked.
 	runner func(ctx context.Context, args ...string) ([]byte, error)
 
+	// agentPoll overrides how often a virtual machine is asked whether its
+	// agent answers. Only a test sets it, for the same reason runner exists:
+	// waiting two seconds per probe would make the suite pay for a property it
+	// can hold in milliseconds.
+	agentPoll time.Duration
+
 	// attachMu serialises interface allocation. Attach reads the device list and
 	// then adds a device under a name it believes free; two concurrent calls
 	// without the lock pick the same name, and the loser's attachment silently
@@ -250,6 +256,21 @@ func (d *Incus) Attach(ctx context.Context, name string, att Attachment) error {
 	d.attachMu.Lock()
 	defer d.attachMu.Unlock()
 
+	// A virtual machine is ready for a device once its agent answers, and not
+	// when `incus start` returns. Adding one while the firmware is still
+	// enumerating the bus fails intermittently — measured twice on the same
+	// code: once the device was added and only its address was missing, once
+	// the add itself was refused with "PCI: slot 0 function 0 not available for
+	// virtio-net-pci, in use by virtio-balloon-pci". Incus documents NIC
+	// hotplug as supported for VMs, so the timing was the difference, not the
+	// capability. A stopped machine is not waited for: attaching cold is the
+	// ordinary Terraform order and needs no agent.
+	//
+	// TestAVirtualMachineWaitsBeforeAddingADevice fails without this.
+	if err := d.waitForAgent(ctx, name); err != nil {
+		return fmt.Errorf("wait for %s to be ready for a device: %w", name, err)
+	}
+
 	devices, err := d.instanceDevices(ctx, name)
 	if err != nil {
 		return fmt.Errorf("inspect %s before attaching: %w", name, err)
@@ -304,16 +325,155 @@ func (d *Incus) Attach(ctx context.Context, name string, att Attachment) error {
 // same as the guest carrying it: a NIC added or re-added on a running machine
 // has no DHCP client on it, so the driver configures it directly.
 func (d *Incus) configureGuestAddress(ctx context.Context, name, device, cidr string) error {
-	if _, err := d.run(ctx, "exec", name, "--", "ip", "address", "add", cidr, "dev", device); err != nil &&
+	// The device name is Incus's, not the guest's. A container sees `eth1`
+	// because Incus names the veth end; a virtual machine sees `enp6s0`,
+	// because the kernel names a PCI device. Passing the Incus name into the
+	// guest was a no-op there: an audit measured a VM carrying its bridge
+	// address and loopback and never the address the API had published, for
+	// three minutes, while the device on the host correctly held the
+	// reservation.
+	//
+	// TestAVirtualMachineIsConfiguredOnItsOwnInterfaceName fails without this.
+	iface, err := d.guestInterface(ctx, name, device)
+	if err != nil {
+		return err
+	}
+	if _, err := d.run(ctx, "exec", name, "--", "ip", "address", "add", cidr, "dev", iface); err != nil &&
 		// "file exists" is the address already being there, which is the
 		// outcome this call wants.
 		!strings.Contains(strings.ToLower(err.Error()), "file exists") {
 		return fmt.Errorf("give %s to %s inside the guest: %w", cidr, name, err)
 	}
-	if _, err := d.run(ctx, "exec", name, "--", "ip", "link", "set", device, "up"); err != nil {
-		return fmt.Errorf("bring %s up inside %s: %w", device, name, err)
+	if _, err := d.run(ctx, "exec", name, "--", "ip", "link", "set", iface, "up"); err != nil {
+		return fmt.Errorf("bring %s up inside %s: %w", iface, name, err)
 	}
 	return nil
+}
+
+// agentPoll is how often a virtual machine is asked whether its agent answers,
+// and agentWait is how long that is worth doing. A VM boots in tens of seconds;
+// beyond a minute the machine has a problem the caller should hear about rather
+// than wait through.
+const (
+	agentPoll = 2 * time.Second
+	agentWait = 90 * time.Second
+)
+
+// waitForAgent blocks until a virtual machine answers `incus exec`, and does
+// nothing at all for a container.
+//
+// TestAVirtualMachineWaitsBeforeAddingADevice fails without this.
+func (d *Incus) waitForAgent(ctx context.Context, name string) error {
+	if !d.VM {
+		return nil
+	}
+	poll := d.agentPoll
+	if poll <= 0 {
+		poll = agentPoll
+	}
+	deadline := time.Now().Add(agentWait)
+	for {
+		_, err := d.run(ctx, "exec", name, "--", "true")
+		if err == nil {
+			return nil
+		}
+		if isNotRunning(err) {
+			// Nothing to wait for: the device is added cold and the address is
+			// applied at boot. This is the ordinary Terraform order.
+			return nil
+		}
+		if !isAgentNotReady(err) {
+			// Anything else is the caller's problem, reported rather than
+			// waited through: a machine that is gone will not come back.
+			return fmt.Errorf("reach the agent of %s: %w", name, err)
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("the agent of %s did not answer within %s", name, agentWait)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(poll):
+		}
+	}
+}
+
+// guestInterface answers what the guest calls the interface Incus knows as
+// device.
+//
+// For a container the two names are the same and this costs one lookup that
+// confirms it. For a virtual machine they are never the same, and the link is
+// the MAC address: Incus reports it per interface in the instance state, keyed
+// by the guest's own name, and the device carries the same value.
+func (d *Incus) guestInterface(ctx context.Context, name, device string) (string, error) {
+	if !d.VM {
+		return device, nil
+	}
+	out, err := d.run(ctx, "query", "/1.0/instances/"+name+"/state")
+	if err != nil {
+		return "", fmt.Errorf("read the state of %s to name its interfaces: %w", name, err)
+	}
+	var state struct {
+		Network map[string]struct {
+			HWAddr string `json:"hwaddr"`
+		} `json:"network"`
+	}
+	if err := json.Unmarshal(out, &state); err != nil {
+		return "", fmt.Errorf("decode the state of %s: %w", name, err)
+	}
+	wanted, err := d.deviceMAC(ctx, name, device)
+	if err != nil {
+		return "", err
+	}
+	for iface, cfg := range state.Network {
+		if iface == "lo" {
+			continue
+		}
+		if strings.EqualFold(cfg.HWAddr, wanted) {
+			return iface, nil
+		}
+	}
+	// Refused rather than guessed: configuring the wrong interface would put
+	// the address on another network, and the caller is about to publish it.
+	return "", fmt.Errorf("no interface in %s carries the address of device %s (%s)", name, device, wanted)
+}
+
+// deviceMAC reads the hardware address Incus gave a device. It is the only
+// value both sides agree on: the host knows the device by name, the guest
+// knows the interface by name, and neither name matches on a virtual machine.
+func (d *Incus) deviceMAC(ctx context.Context, name, device string) (string, error) {
+	out, err := d.run(ctx, "config", "device", "get", name, device, "hwaddr")
+	if err == nil {
+		if mac := strings.TrimSpace(string(out)); mac != "" {
+			return mac, nil
+		}
+	}
+	// A device that does not declare one gets a generated address, and Incus
+	// keeps it in the instance's volatile configuration rather than in the
+	// device: `volatile.<device>.hwaddr`. Reading only the device found nothing
+	// and refused every attachment with "declares no hardware address",
+	// measured on three consecutive virtual machines.
+	raw, err := d.run(ctx, "query", "/1.0/instances/"+name)
+	if err != nil {
+		return "", fmt.Errorf("read %s to find the address of device %s: %w", name, device, err)
+	}
+	var instance struct {
+		Config          map[string]string            `json:"config"`
+		ExpandedDevices map[string]map[string]string `json:"expanded_devices"`
+		Devices         map[string]map[string]string `json:"devices"`
+	}
+	if err := json.Unmarshal(raw, &instance); err != nil {
+		return "", fmt.Errorf("decode %s: %w", name, err)
+	}
+	for _, set := range []map[string]map[string]string{instance.Devices, instance.ExpandedDevices} {
+		if mac := set[device]["hwaddr"]; mac != "" {
+			return mac, nil
+		}
+	}
+	if mac := instance.Config["volatile."+device+".hwaddr"]; mac != "" {
+		return mac, nil
+	}
+	return "", fmt.Errorf("device %s of %s declares no hardware address", device, name)
 }
 
 // instanceView is one machine's devices: its own, and the ones a profile adds.

--- a/internal/core/machine/incus_vmaddress_test.go
+++ b/internal/core/machine/incus_vmaddress_test.go
@@ -1,0 +1,216 @@
+package machine
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A virtual machine does not see the interface names Incus uses.
+//
+// Incus knows the device as `eth1`; the guest kernel names a PCI device
+// `enp6s0`. The driver passed the Incus name into the guest, so `ip address add
+// … dev eth1` matched nothing: an audit measured a VM carrying its bridge
+// address and loopback, never the address the API had published, over three
+// minutes, while the host-side reservation was correct the whole time.
+//
+// That is the failure this project exists to avoid — an address the control
+// plane publishes and nothing answers on — and it is an argument-level fact, so
+// the runner is what holds it.
+
+// vmState is what `incus query /1.0/instances/<n>/state` answers for a VM whose
+// second interface carries the MAC of device eth1. The guest names it enp6s0,
+// which is the whole point.
+const vmState = `{
+  "network": {
+    "lo":     {"hwaddr": ""},
+    "enp5s0": {"hwaddr": "00:16:3e:aa:aa:aa"},
+    "enp6s0": {"hwaddr": "00:16:3e:bb:bb:bb"}
+  }
+}`
+
+// vmDevices is the real shape: a device added without a hwaddr, and the address
+// Incus generated for it living in the instance's volatile configuration. The
+// first version of this fixture declared it on the device, which is the rare
+// case, and hid the path that failed on three consecutive machines.
+const vmDevices = `{
+  "config": {
+    "volatile.eth0.hwaddr": "00:16:3e:aa:aa:aa",
+    "volatile.eth1.hwaddr": "00:16:3e:bb:bb:bb"
+  },
+  "devices": {
+    "eth1": {"type": "nic", "network": "fnt-net"}
+  },
+  "expanded_devices": {
+    "eth0": {"type": "nic", "network": "incusbr0"},
+    "eth1": {"type": "nic", "network": "fnt-net"}
+  }
+}`
+
+func TestAVirtualMachineIsConfiguredOnItsOwnInterfaceName(t *testing.T) {
+	f := &fakeRuntime{hook: exactQueries}
+	d := newFakeDriver(f)
+	d.VM = true
+
+	if err := d.configureGuestAddress(context.Background(), "vm", "eth1", "10.189.0.2/24"); err != nil {
+		t.Fatalf("configure the guest: %v", err)
+	}
+
+	// The commands that reach the guest must name the interface the guest has.
+	for _, cmd := range f.matching("exec vm -- ip") {
+		if strings.Contains(cmd, "eth1") {
+			t.Errorf("the guest was configured on the host's device name: %s", cmd)
+		}
+		if !strings.Contains(cmd, "enp6s0") {
+			t.Errorf("the guest was not configured on its own interface: %s", cmd)
+		}
+	}
+	if len(f.matching("exec vm -- ip address add 10.189.0.2/24 dev enp6s0")) != 1 {
+		t.Errorf("the address was not given to the guest interface: %v", f.commands())
+	}
+	if len(f.matching("exec vm -- ip link set enp6s0 up")) != 1 {
+		t.Errorf("the guest interface was not brought up: %v", f.commands())
+	}
+}
+
+// A container keeps the name it already had.
+//
+// The two names match there, and paying a state lookup per attachment for a
+// fact that cannot change would slow the mode that exists for being fast.
+func TestAContainerIsConfiguredOnTheDeviceName(t *testing.T) {
+	f := &fakeRuntime{}
+	d := newFakeDriver(f) // VM stays false
+
+	if err := d.configureGuestAddress(context.Background(), "ct", "eth1", "10.189.0.2/24"); err != nil {
+		t.Fatalf("configure the guest: %v", err)
+	}
+	if len(f.matching("query /1.0/instances/ct/state")) != 0 {
+		t.Errorf("a container paid for a lookup it does not need: %v", f.commands())
+	}
+	if len(f.matching("exec ct -- ip address add 10.189.0.2/24 dev eth1")) != 1 {
+		t.Errorf("the container was not configured on its device: %v", f.commands())
+	}
+}
+
+// A virtual machine waits before a device is added to it.
+//
+// Two measurements on the same code, minutes apart: once the device was added
+// and only its address was missing, once the add itself was refused with "PCI:
+// slot 0 function 0 not available for virtio-net-pci, in use by
+// virtio-balloon-pci". Incus documents NIC hotplug as supported for virtual
+// machines, so what differed was when the add happened, not whether it can.
+// Waiting for the agent is waiting for a machine that has finished coming up.
+//
+// The wait therefore belongs before `config device add`, not before the address
+// is configured — where the first version of this fix put it, which is why it
+// changed nothing about the refusal.
+func TestAVirtualMachineWaitsBeforeAddingADevice(t *testing.T) {
+	notReady := errors.New(`incus exec: Error: VM agent isn't currently running`)
+	f := &fakeRuntime{}
+	probes := 0
+	// The first two probes fail the way a booting VM does; the third answers.
+	f.hook = func(call int, args []string) ([]byte, error, bool) {
+		if len(args) >= 4 && args[0] == "exec" && args[3] == "true" {
+			probes++
+			if probes < 3 {
+				return nil, notReady, true
+			}
+			return nil, nil, true
+		}
+		return exactQueries(call, args)
+	}
+	d := newFakeDriver(f)
+	d.VM = true
+	d.agentPoll = time.Millisecond
+
+	err := d.Attach(context.Background(), "vm", Attachment{
+		Network: "fnt-net", Address: "10.189.0.2", PrefixLen: 24,
+	})
+	if err != nil {
+		t.Fatalf("attach after the agent came up: %v", err)
+	}
+	if probes != 3 {
+		t.Errorf("the driver probed the agent %d time(s), want it to wait for the third", probes)
+	}
+	// The order is the point: nothing may be added to the machine before the
+	// probe that succeeded.
+	touched, probed := -1, -1
+	for i, cmd := range f.commands() {
+		if strings.HasPrefix(cmd, "config device ") && touched < 0 {
+			touched = i
+		}
+		if strings.HasPrefix(cmd, "exec vm -- true") {
+			probed = i
+		}
+	}
+	if touched < 0 {
+		t.Fatalf("the device was never touched: %v", f.commands())
+	}
+	if probed > touched {
+		t.Errorf("the device was configured before the machine answered: %v", f.commands())
+	}
+}
+
+// An error that is not the agent booting is reported, not waited through.
+//
+// A machine that is gone will not come back, and waiting ninety seconds for it
+// would turn a clear failure into a hang.
+func TestAnErrorThatIsNotTheAgentIsReported(t *testing.T) {
+	f := &fakeRuntime{fail: map[string]error{
+		"exec vm -- true": errors.New(`Error: Instance not found`),
+	}}
+	d := newFakeDriver(f)
+	d.VM = true
+	d.agentPoll = time.Millisecond
+
+	err := d.Attach(context.Background(), "vm", Attachment{
+		Network: "fnt-net", Address: "10.189.0.2", PrefixLen: 24,
+	})
+	if err == nil {
+		t.Fatal("a missing instance was waited through instead of reported")
+	}
+	if !strings.Contains(err.Error(), "Instance not found") {
+		t.Errorf("the error lost what it was about: %v", err)
+	}
+}
+
+// An interface that carries no matching address is refused, not guessed.
+//
+// Configuring the wrong interface would put the address on another network, and
+// the caller is about to publish it.
+func TestAnUnmatchedDeviceIsRefusedRatherThanGuessed(t *testing.T) {
+	f := &fakeRuntime{hook: func(call int, args []string) ([]byte, error, bool) {
+		if len(args) == 2 && args[0] == "query" && args[1] == "/1.0/instances/vm/state" {
+			return []byte(`{"network": {"lo": {"hwaddr": ""}, "enp5s0": {"hwaddr": "00:16:3e:aa:aa:aa"}}}`), nil, true
+		}
+		return exactQueries(call, args)
+	}}
+	d := newFakeDriver(f)
+	d.VM = true
+
+	err := d.configureGuestAddress(context.Background(), "vm", "eth1", "10.189.0.2/24")
+	if err == nil {
+		t.Fatal("an address was applied to an interface nothing matched")
+	}
+	for _, cmd := range f.matching("ip address add") {
+		t.Errorf("an address was given to an interface that is not the device's: %s", cmd)
+	}
+}
+
+// exactQueries answers the two instance queries by their exact path. The shared
+// fakeRuntime matches answers by substring, and "/1.0/instances/vm" is a prefix
+// of "/1.0/instances/vm/state": with both in the map, Go's map iteration order
+// decided which one came back, and this test passed or failed at random.
+func exactQueries(_ int, args []string) ([]byte, error, bool) {
+	if len(args) == 2 && args[0] == "query" {
+		switch args[1] {
+		case "/1.0/instances/vm/state":
+			return []byte(vmState), nil, true
+		case "/1.0/instances/vm":
+			return []byte(vmDevices), nil, true
+		}
+	}
+	return nil, nil, false
+}

--- a/internal/core/sshkey/sshkey.go
+++ b/internal/core/sshkey/sshkey.go
@@ -1,0 +1,121 @@
+// Package sshkey reads the OpenSSH one-line public key format.
+//
+// It exists because two packs had written it twice. The copies drifted, as
+// copies do: one checked that the key material was valid base64 and one did not,
+// so `ssh-ed25519 !!!!not-base64-at-all!!!! x` was refused by Scaleway and
+// accepted by Outscale. And one hashed the decoded key and the other hashed the
+// whole line, comment included, so the same key had two fingerprints and neither
+// client could match the one `ssh-keygen -l` prints.
+//
+// CLAUDE.md gives the test for where this belongs: a line that could be written
+// identically for another provider belongs in the core. Reading an OpenSSH key
+// is the same everywhere; what differs is which field an API publishes, and that
+// stays in the packs.
+package sshkey
+
+import (
+	"crypto/md5" //nolint:gosec // the SSH fingerprint format is MD5, not a security decision
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"strings"
+)
+
+// ErrNotAKey is what Parse answers for anything that is not an OpenSSH public
+// key in its one-line form.
+var ErrNotAKey = errors.New("not an OpenSSH public key")
+
+// Key is a parsed public key: its algorithm, its decoded material, and the
+// comment a client usually puts at the end.
+type Key struct {
+	// Algorithm is the first field, "ssh-ed25519" and the like. An API that
+	// publishes a key type publishes this, rather than a constant: hardcoding
+	// one made every key created through the Outscale pack answer "ssh-rsa",
+	// including ed25519 ones.
+	Algorithm string
+	// Blob is the decoded key material, which is what a fingerprint is computed
+	// over — not the line, and not the base64.
+	Blob []byte
+	// Comment is everything after the material, usually user@host. It carries
+	// no meaning and must not reach a fingerprint: renaming it would otherwise
+	// change the fingerprint of the same key.
+	Comment string
+}
+
+// algorithms are the ones OpenSSH emits today. Refusing an unknown one is not
+// pedantry: the value ends up in ssh_authorized_keys, and a machine that boots
+// holding bytes sshd will not read is a machine nobody can log into, which the
+// API would go on describing as reachable.
+var algorithms = map[string]bool{
+	"ssh-rsa":                            true,
+	"ssh-ed25519":                        true,
+	"ssh-dss":                            true,
+	"ecdsa-sha2-nistp256":                true,
+	"ecdsa-sha2-nistp384":                true,
+	"ecdsa-sha2-nistp521":                true,
+	"sk-ssh-ed25519@openssh.com":         true,
+	"sk-ecdsa-sha2-nistp256@openssh.com": true,
+}
+
+// Parse reads the one-line form and refuses everything else.
+//
+// The one-line part is a security check rather than tidiness. The value is
+// concatenated into a YAML document by text/template, and strings.Fields splits
+// on newlines exactly like spaces — which is how a multi-line "key" once passed
+// a shape check and opened a top-level key in a cloud-config. So the control
+// characters are refused before anything is split.
+func Parse(key string) (Key, error) {
+	if strings.ContainsAny(key, "\n\r\x00") {
+		return Key{}, ErrNotAKey
+	}
+	fields := strings.Fields(strings.TrimSpace(key))
+	if len(fields) < 2 {
+		return Key{}, ErrNotAKey
+	}
+	if !algorithms[fields[0]] {
+		return Key{}, ErrNotAKey
+	}
+	blob, err := base64.StdEncoding.DecodeString(fields[1])
+	if err != nil {
+		return Key{}, ErrNotAKey
+	}
+	return Key{
+		Algorithm: fields[0],
+		Blob:      blob,
+		Comment:   strings.Join(fields[2:], " "),
+	}, nil
+}
+
+// Valid reports whether a string is a public key, for the callers that only
+// need the verdict.
+func Valid(key string) bool {
+	_, err := Parse(key)
+	return err == nil
+}
+
+// FingerprintMD5 is the colon-separated MD5 form, the one `ssh-keygen -l -E md5`
+// prints and the one both emulated APIs publish.
+//
+// Computed over the decoded blob, which is what makes it comparable: hashing the
+// whole line instead gave a value no client could reproduce, and made the
+// fingerprint change when only the comment changed.
+func (k Key) FingerprintMD5() string {
+	sum := md5.Sum(k.Blob) //nolint:gosec // the format is MD5 by definition
+	hexed := hex.EncodeToString(sum[:])
+	parts := make([]string, 0, len(hexed)/2)
+	for i := 0; i+2 <= len(hexed); i += 2 {
+		parts = append(parts, hexed[i:i+2])
+	}
+	return strings.Join(parts, ":")
+}
+
+// FingerprintMD5 of a key given as text, for a caller holding the line rather
+// than a parsed key. An unparseable key has no fingerprint, and answering ""
+// rather than a hash of the garbage keeps that visible.
+func FingerprintMD5(key string) string {
+	parsed, err := Parse(key)
+	if err != nil {
+		return ""
+	}
+	return parsed.FingerprintMD5()
+}

--- a/internal/providers/outscale/audit_test.go
+++ b/internal/providers/outscale/audit_test.go
@@ -811,3 +811,94 @@ func TestABodyTheServerAcceptsReachesTheHandler(t *testing.T) {
 		t.Errorf("the answer is not the handler's verdict on the field: %q", details)
 	}
 }
+
+// A filter this pack does not apply is refused, not ignored.
+//
+// The API description declares 66 filters on a Vm and the pack read one. Every
+// other one returned the whole inventory with a 200: an audit sent
+// `--Filters.SubnetIds[] subnet-deadbeef` against seven machines and got all
+// seven back. A script that deletes what a filter matched would have deleted
+// everything, and nothing in the answer would have said so.
+func TestAnUnsupportedFilterIsRefused(t *testing.T) {
+	ts := newServer(t)
+	_, subnetID := netAndSubnet(t, ts, "10.60.0.0/16", "10.60.1.0/24")
+	post(t, ts, "CreateVms", `{"ImageId":"ami-12345678","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+
+	for _, probe := range []struct{ action, body string }{
+		{"ReadVms", `{"Filters":{"Architectures":["x86_64"]}}`},
+		{"ReadVms", `{"Filters":{"Tags":["a=b"]}}`},
+		{"ReadNets", `{"Filters":{"DhcpOptionsSetIds":["dopt-1"]}}`},
+		{"ReadSubnets", `{"Filters":{"SubregionNames":["eu-west-2a"]}}`},
+		{"ReadKeypairs", `{"Filters":{"TagKeys":["env"]}}`},
+	} {
+		status, out := post(t, ts, probe.action, probe.body)
+		if status == http.StatusOK {
+			t.Errorf("%s applied nothing and answered 200 for %s: %v", probe.action, probe.body, out)
+			continue
+		}
+		// The refusal has to name the field, or a caller cannot act on it.
+		errs, _ := out["Errors"].([]any)
+		if len(errs) == 0 {
+			t.Errorf("%s refused without saying why: %v", probe.action, out)
+			continue
+		}
+		first, _ := errs[0].(map[string]any)
+		details, _ := first["Details"].(string)
+		if !strings.Contains(details, "filter") {
+			t.Errorf("%s: the refusal does not mention the filter: %q", probe.action, details)
+		}
+	}
+}
+
+// The filters that are served actually filter.
+//
+// A guard that refuses everything passes every attack test and breaks the
+// product, so the accepting half is asserted too — and each filter is asserted
+// on a value that exists and one that does not, because a filter that always
+// matches and a filter that never matches are equally useless.
+func TestTheServedFiltersFilter(t *testing.T) {
+	ts := newServer(t)
+	_, subnetID := netAndSubnet(t, ts, "10.61.0.0/16", "10.61.1.0/24")
+	_, out := post(t, ts, "CreateVms",
+		`{"ImageId":"ami-11111111","SubnetId":"`+subnetID+`","VmType":"tinav6.c2r2p2","BootOnCreation":false}`)
+	vms, _ := out["Vms"].([]any)
+	vm, _ := vms[0].(map[string]any)
+	vmID, _ := vm["VmId"].(string)
+	post(t, ts, "CreateVms", `{"ImageId":"ami-22222222","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+
+	count := func(body string) int {
+		_, out := post(t, ts, "ReadVms", body)
+		vms, _ := out["Vms"].([]any)
+		return len(vms)
+	}
+	if n := count(`{}`); n != 2 {
+		t.Fatalf("no filter returned %d machines, want 2", n)
+	}
+	for _, probe := range []struct {
+		body string
+		want int
+	}{
+		{`{"Filters":{"VmIds":["` + vmID + `"]}}`, 1},
+		{`{"Filters":{"VmIds":["i-does-not-exist"]}}`, 0},
+		{`{"Filters":{"ImageIds":["ami-11111111"]}}`, 1},
+		{`{"Filters":{"ImageIds":["ami-99999999"]}}`, 0},
+		{`{"Filters":{"VmTypes":["tinav6.c2r2p2"]}}`, 1},
+		{`{"Filters":{"SubnetIds":["` + subnetID + `"]}}`, 2},
+		{`{"Filters":{"SubnetIds":["subnet-deadbeef"]}}`, 0},
+		{`{"Filters":{"VmStates":["stopped"]}}`, 2},
+		{`{"Filters":{"VmStates":["running"]}}`, 0},
+		// Conjunctive, like upstream: both must hold.
+		{`{"Filters":{"ImageIds":["ami-11111111"],"VmTypes":["tinav6.c2r2p2"]}}`, 1},
+		{`{"Filters":{"ImageIds":["ami-11111111"],"VmTypes":["nope"]}}`, 0},
+	} {
+		if n := count(probe.body); n != probe.want {
+			t.Errorf("%s returned %d machine(s), want %d", probe.body, n, probe.want)
+		}
+	}
+
+	// And an empty filter list matches nothing rather than everything: asking
+	// for none of a set is not asking for all of it.
+	if n := count(`{"Filters":{"VmIds":[]}}`); n != 0 {
+		t.Errorf("an empty VmIds matched %d machine(s), want 0", n)
+	}
+}

--- a/internal/providers/outscale/audit_test.go
+++ b/internal/providers/outscale/audit_test.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/stephrobert/feint/internal/contract"
 	"github.com/stephrobert/feint/internal/core/emulator"
 	"github.com/stephrobert/feint/internal/core/machine"
 	"github.com/stephrobert/feint/internal/providers/outscale"
@@ -695,7 +697,9 @@ func (f *countingRuntime) Inspect(_ context.Context, n string) (machine.Machine,
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.counts[n] > 0 {
-		return machine.Machine{Name: n, Running: true}, true, nil
+		// With an address, the way a real runtime answers once the machine is
+		// up. Without one, TestAStoppedVmKeepsItsPrivateAddress skipped itself.
+		return machine.Machine{Name: n, Running: true, IP: "10.99.0.7"}, true, nil
 	}
 	return machine.Machine{}, false, nil
 }
@@ -946,5 +950,97 @@ func TestTheFingerprintIsTheOneSshKeygenPrints(t *testing.T) {
 	pair, _ = out["Keypair"].(map[string]any)
 	if got, _ := pair["KeypairFingerprint"].(string); got != want {
 		t.Errorf("renaming the comment changed the fingerprint: %q", got)
+	}
+}
+
+// A legitimate DryRun: false does not fail the conformance gate.
+//
+// Outscale declares DryRun on all twenty of its actions and this pack answers it
+// at the mount point, so no handler decodes it. The unread-field report
+// therefore counted it as a field nobody read, and `tools/conformance/score.sh`
+// turns that list into exit 1: a request every client is entitled to send failed
+// this project's own gate. It went unnoticed only because no script sent the
+// flag.
+//
+// The fix must not be to declare DryRun on twenty request structs — that
+// quietens the report by lying to it, since the handlers still would not read
+// it. The middleware says what it read instead.
+func TestDryRunFalseDoesNotFailTheGate(t *testing.T) {
+	env := emulator.DefaultEnv()
+	env.Contracts = map[string]*contract.Doc{"outscale": outscaleContract(t)}
+	srv, err := emulator.NewServer(env, outscale.New(env))
+	if err != nil {
+		t.Fatalf("build emulator: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	if status, _ := post(t, ts, "ReadVms", `{"DryRun":false}`); status != http.StatusOK {
+		t.Fatalf("ReadVms with DryRun false answered %d", status)
+	}
+
+	res, err := http.Get(ts.URL + "/_feint/conformance") //nolint:noctx // test client
+	if err != nil {
+		t.Fatalf("read the conformance report: %v", err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	var report struct {
+		Unread map[string][]string `json:"unread_request_fields"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&report); err != nil {
+		t.Fatalf("decode the report: %v", err)
+	}
+	for operation, fields := range report.Unread {
+		for _, field := range fields {
+			if field == "DryRun" {
+				t.Errorf("%s reports DryRun as unread, which fails score.sh for a legitimate request", operation)
+			}
+		}
+	}
+}
+
+// outscaleContract loads the API description this pack ships against, the way
+// the observer does in a real run.
+func outscaleContract(t *testing.T) *contract.Doc {
+	t.Helper()
+	doc, err := contract.Load(filepath.Join("..", "..", "..", "contracts", "outscale.json"))
+	if err != nil {
+		t.Fatalf("load the Outscale contract: %v", err)
+	}
+	return doc
+}
+
+// A stopped Vm keeps its private address.
+//
+// PowerOff clears the runtime binding's address, correctly, since nothing
+// answers there any more. A Vm placed in a Subnet was unaffected — its address
+// lives in Attrs — and a Vm created without one lost it: one field, two
+// behaviours. Terraform reading private_ip saw null after a stop, and Outscale
+// keeps the address until the machine is terminated.
+func TestAStoppedVmKeepsItsPrivateAddress(t *testing.T) {
+	runtime := newCountingRuntime()
+	ts := newRuntimeServer(t, runtime)
+
+	// No Subnet: this is the case that had the address only in the binding.
+	_, out := post(t, ts, "CreateVms", `{"ImageId":"ami-12345678"}`)
+	vms, _ := out["Vms"].([]any)
+	vm, _ := vms[0].(map[string]any)
+	vmID, _ := vm["VmId"].(string)
+	// Published on the read, the way a virtual machine's address is: it arrives
+	// tens of seconds after the start, so the create cannot carry it.
+	_, out = post(t, ts, "ReadVms", `{"Filters":{"VmIds":["`+vmID+`"]}}`)
+	vms, _ = out["Vms"].([]any)
+	vm, _ = vms[0].(map[string]any)
+	running, _ := vm["PrivateIp"].(string)
+	if running == "" {
+		t.Fatalf("the running Vm publishes no address, so this test measures nothing: %v", vm)
+	}
+
+	post(t, ts, "StopVms", `{"VmIds":["`+vmID+`"]}`)
+	_, out = post(t, ts, "ReadVms", `{"Filters":{"VmIds":["`+vmID+`"]}}`)
+	vms, _ = out["Vms"].([]any)
+	vm, _ = vms[0].(map[string]any)
+	if stopped, _ := vm["PrivateIp"].(string); stopped != running {
+		t.Errorf("a stopped Vm answers PrivateIp %q, want the %q it had running", stopped, running)
 	}
 }

--- a/internal/providers/outscale/audit_test.go
+++ b/internal/providers/outscale/audit_test.go
@@ -213,6 +213,12 @@ func TestAKeypairRefusesWhatIsNotAKey(t *testing.T) {
 	for _, bad := range []string{
 		"definitely not a key",
 		"ssh-rsa AAAA\nruncmd:\n  - touch /tmp/pwned",
+		// Well-shaped and not a key: the algorithm is real, the material is not
+		// base64. Scaleway refused it and Outscale took it, which is what a
+		// duplicated check does over time — and this test did not cover it, so
+		// the mutation that removes the check survived until it did.
+		"ssh-ed25519 !!!!not-base64-at-all!!!! user@host",
+		"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI= trailing-garbage-in-material",
 		"",
 	} {
 		if bad == "" {
@@ -224,7 +230,11 @@ func TestAKeypairRefusesWhatIsNotAKey(t *testing.T) {
 	}
 	// The accepting half: a real key must pass, or the check would only be a way
 	// to refuse.
-	good := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleExampleExampleExampleExampleEx user@host"
+	// A real key, from ssh-keygen. The first version of this test used a
+	// plausible-looking string whose material is not valid base64, and it
+	// passed — because the pack did not check. Its own fixture was made of the
+	// defect it was meant to hold.
+	good := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIr6pEFlAFO3YU0DNW/r8SkpjdbptN9ockkO2BtIolSD conformance@feint"
 	if status, out := post(t, ts, "CreateKeypair", `{"KeypairName":"good","PublicKey":`+quote(good)+`}`); status != http.StatusOK {
 		t.Errorf("refused a real key: %d %v", status, out)
 	}
@@ -900,5 +910,41 @@ func TestTheServedFiltersFilter(t *testing.T) {
 	// for none of a set is not asking for all of it.
 	if n := count(`{"Filters":{"VmIds":[]}}`); n != 0 {
 		t.Errorf("an empty VmIds matched %d machine(s), want 0", n)
+	}
+}
+
+// The fingerprint is the one ssh-keygen prints.
+//
+// It was computed over the whole line — algorithm prefix and comment included —
+// so it matched nothing a client could reproduce, and renaming the comment
+// changed the fingerprint of the same key. The value below comes from
+// `ssh-keygen -l -E md5` on the key above, which is the only authority that
+// settles it.
+func TestTheFingerprintIsTheOneSshKeygenPrints(t *testing.T) {
+	const (
+		key  = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIr6pEFlAFO3YU0DNW/r8SkpjdbptN9ockkO2BtIolSD conformance@feint"
+		want = "6b:d8:0e:65:b1:58:fd:61:94:3a:b3:42:e6:e1:2c:01"
+	)
+	ts := newServer(t)
+	_, out := post(t, ts, "CreateKeypair", `{"KeypairName":"real","PublicKey":`+quote(key)+`}`)
+	pair, _ := out["Keypair"].(map[string]any)
+	if pair == nil {
+		t.Fatalf("no keypair in the answer: %v", out)
+	}
+	if got, _ := pair["KeypairFingerprint"].(string); got != want {
+		t.Errorf("fingerprint %q, want the one ssh-keygen prints (%q)", got, want)
+	}
+	// And the type is the key's own, not a constant: every key used to answer
+	// ssh-rsa, ed25519 ones included.
+	if got, _ := pair["KeypairType"].(string); got != "ssh-ed25519" {
+		t.Errorf("KeypairType %q for an ed25519 key", got)
+	}
+	// The comment must not reach the fingerprint: the same key renamed is the
+	// same key.
+	renamed := strings.Replace(key, "conformance@feint", "someone@else", 1)
+	_, out = post(t, ts, "CreateKeypair", `{"KeypairName":"renamed","PublicKey":`+quote(renamed)+`}`)
+	pair, _ = out["Keypair"].(map[string]any)
+	if got, _ := pair["KeypairFingerprint"].(string); got != want {
+		t.Errorf("renaming the comment changed the fingerprint: %q", got)
 	}
 }

--- a/internal/providers/outscale/audit_test.go
+++ b/internal/providers/outscale/audit_test.go
@@ -7,7 +7,9 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stephrobert/feint/internal/core/emulator"
 	"github.com/stephrobert/feint/internal/core/machine"
@@ -457,4 +459,355 @@ func newRuntimeServer(t *testing.T, drv machine.Driver) *httptest.Server {
 	ts := httptest.NewServer(srv.Handler())
 	t.Cleanup(ts.Close)
 	return ts
+}
+
+// Two concurrent starts reach the runtime once.
+//
+// The pack takes a per-target lock on its lifecycle paths, and its comment names
+// a measured defect: two concurrent StartVms each launched a container, and the
+// API described as stopped a machine that was running. Nothing held that.
+// Removing both Serialise calls left the whole suite green, which is the state
+// CLAUDE.md calls an intention written in the past tense.
+func TestTwoConcurrentStartsReachTheRuntimeOnce(t *testing.T) {
+	runtime := newCountingRuntime()
+	runtime.blockStarts = make(chan struct{})
+	ts := newRuntimeServer(t, runtime)
+	_, subnetID := netAndSubnet(t, ts, "10.52.0.0/16", "10.52.1.0/24")
+
+	_, out := post(t, ts, "CreateVms",
+		`{"ImageId":"ami-12345678","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+	vms, _ := out["Vms"].([]any)
+	vm, _ := vms[0].(map[string]any)
+	vmID, _ := vm["VmId"].(string)
+
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			post(t, ts, "StartVms", `{"VmIds":["`+vmID+`"]}`)
+		}()
+	}
+	// The first start is inside the runtime. The pause is for the second to
+	// reach either the lock (correct) or the runtime (the defect) before
+	// anything is released: letting go as soon as the first enters lets the
+	// second arrive after the first has committed, where the "already running"
+	// short-circuit hides the missing lock. Measured: without the pause this
+	// test passes with both Serialise calls removed.
+	<-runtime.startEntered
+	time.Sleep(50 * time.Millisecond)
+	close(runtime.blockStarts)
+	wg.Wait()
+
+	if n := runtime.starts(vmID); n > 1 {
+		t.Errorf("the runtime was asked to start %s %d times", vmID, n)
+	}
+	// And the machine really is running: a lock that refused both starts would
+	// pass the check above.
+	_, out = post(t, ts, "ReadVms", `{}`)
+	vms, _ = out["Vms"].([]any)
+	vm, _ = vms[0].(map[string]any)
+	if state, _ := vm["State"].(string); state != "running" {
+		t.Errorf("the machine is %q after two starts, want running", state)
+	}
+}
+
+// UpdateVm refuses what CreateVms refuses.
+//
+// The cap and the keypair check lived in the create only, so an update took a
+// 600 KiB user data and a keypair no keypair answers to. At the next start the
+// machine boots with no key, nobody logs in, and the API states one is attached.
+func TestUpdateVmValidatesWhatCreateValidates(t *testing.T) {
+	ts := newServer(t)
+	_, subnetID := netAndSubnet(t, ts, "10.53.0.0/16", "10.53.1.0/24")
+	_, out := post(t, ts, "CreateVms",
+		`{"ImageId":"ami-12345678","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+	vms, _ := out["Vms"].([]any)
+	vm, _ := vms[0].(map[string]any)
+	vmID, _ := vm["VmId"].(string)
+
+	if status, _ := post(t, ts, "UpdateVm",
+		`{"VmId":"`+vmID+`","KeypairName":"ghost-does-not-exist"}`); status == http.StatusOK {
+		t.Error("UpdateVm attached a keypair that does not exist")
+	}
+	oversized := strings.Repeat("A", 600*1024)
+	if status, _ := post(t, ts, "UpdateVm",
+		`{"VmId":"`+vmID+`","UserData":"`+oversized+`"}`); status == http.StatusOK {
+		t.Error("UpdateVm took a UserData the create refuses")
+	}
+	// The accepting half, or the check would only be a way to refuse.
+	if status, out := post(t, ts, "UpdateVm",
+		`{"VmId":"`+vmID+`","UserData":"aGVsbG8="}`); status != http.StatusOK {
+		t.Errorf("UpdateVm refused a legitimate change: %d %v", status, out)
+	}
+}
+
+// A Net does not delete under a Subnet being created.
+//
+// deleteNet carried the dependency guard and took no lock, so its subnet list
+// was empty by construction for the whole window a create was open: the Net
+// went, the Subnet landed in it, and its bridge stayed on the host.
+//
+// Honest limit, measured: this test also passes with deleteNet's lock removed,
+// because the sibling fix — reserving the subnet in the store before the runtime
+// call rather than after — closed the wide window on its own. What remains is
+// the few microseconds between subnetsOf and Delete, which nothing here can
+// widen. So the lock is argued from symmetry with deleteSubnet and from that
+// residual window; this test is the regression net over the invariant, and
+// TestSubnetCreateDoesNotHoldTheAddressingLockAcrossTheRuntime is the one that
+// dies under mutation.
+func TestANetDoesNotDeleteUnderASubnetBeingCreated(t *testing.T) {
+	runtime := newCountingRuntime()
+	runtime.blockNetworks = make(chan struct{})
+	ts := newRuntimeServer(t, runtime)
+
+	_, out := post(t, ts, "CreateNet", `{"IpRange":"10.54.0.0/16"}`)
+	n, _ := out["Net"].(map[string]any)
+	netID, _ := n["NetId"].(string)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		post(t, ts, "CreateSubnet", `{"NetId":"`+netID+`","IpRange":"10.54.1.0/24"}`)
+	}()
+
+	<-runtime.networkEntered
+	post(t, ts, "DeleteNet", `{"NetId":"`+netID+`"}`)
+	close(runtime.blockNetworks)
+	<-done
+
+	// Whoever won, no Subnet may name a Net the pack no longer serves.
+	_, out = post(t, ts, "ReadNets", `{}`)
+	nets, _ := out["Nets"].([]any)
+	live := map[string]bool{}
+	for _, entry := range nets {
+		m, _ := entry.(map[string]any)
+		id, _ := m["NetId"].(string)
+		live[id] = true
+	}
+	_, out = post(t, ts, "ReadSubnets", `{}`)
+	subnets, _ := out["Subnets"].([]any)
+	for _, entry := range subnets {
+		m, _ := entry.(map[string]any)
+		if id, _ := m["NetId"].(string); id != "" && !live[id] {
+			t.Errorf("%v names %s, a Net the pack no longer serves", m["SubnetId"], id)
+		}
+	}
+}
+
+// Creating a Subnet does not hold the addressing lock across the runtime call.
+//
+// Holding it put every other create in a queue behind `incus network create`:
+// measured at 1.5 s for one unrelated CreateNet with a fake driver, minutes with
+// Incus. The rule is the repository's own, and it had been applied to the Vm
+// path only.
+func TestSubnetCreateDoesNotHoldTheAddressingLockAcrossTheRuntime(t *testing.T) {
+	runtime := newCountingRuntime()
+	runtime.blockNetworks = make(chan struct{})
+	ts := newRuntimeServer(t, runtime)
+
+	_, out := post(t, ts, "CreateNet", `{"IpRange":"10.55.0.0/16"}`)
+	n, _ := out["Net"].(map[string]any)
+	netID, _ := n["NetId"].(string)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		post(t, ts, "CreateSubnet", `{"NetId":"`+netID+`","IpRange":"10.55.1.0/24"}`)
+	}()
+	<-runtime.networkEntered
+
+	// An unrelated create, while the runtime call is in flight. It must answer
+	// rather than wait for it.
+	answered := make(chan int, 1)
+	go func() {
+		status, _ := post(t, ts, "CreateNet", `{"IpRange":"10.56.0.0/16"}`)
+		answered <- status
+	}()
+	select {
+	case status := <-answered:
+		if status != http.StatusOK {
+			t.Errorf("the unrelated create answered %d", status)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("an unrelated CreateNet waited on a runtime network call: the addressing lock is held across it")
+	}
+	close(runtime.blockNetworks)
+	<-done
+}
+
+// countingRuntime records how often each machine was started, and can hold the
+// network calls so a test can act while one is in flight.
+type countingRuntime struct {
+	mu     sync.Mutex
+	counts map[string]int
+
+	networkEntered chan string
+	blockNetworks  chan struct{}
+	networks       atomic.Int32
+
+	// Holding Start is what makes "two at once" a fact rather than a
+	// probability: with a fake driver the first start finishes before the
+	// second looks, so an unserialised pack passes by luck.
+	startEntered chan string
+	blockStarts  chan struct{}
+}
+
+func newCountingRuntime() *countingRuntime {
+	return &countingRuntime{
+		counts:         map[string]int{},
+		networkEntered: make(chan string, 8),
+		startEntered:   make(chan string, 8),
+	}
+}
+
+func (f *countingRuntime) Name() string                   { return "fake" }
+func (f *countingRuntime) Available(context.Context) bool { return true }
+
+func (f *countingRuntime) Start(_ context.Context, spec machine.Spec) (machine.Machine, error) {
+	f.mu.Lock()
+	f.counts[spec.Name]++
+	f.mu.Unlock()
+	if f.blockStarts != nil {
+		select {
+		case f.startEntered <- spec.Name:
+		default:
+		}
+		<-f.blockStarts
+	}
+	return machine.Machine{Name: spec.Name, Running: true}, nil
+}
+
+func (f *countingRuntime) Stop(context.Context, string) error   { return nil }
+func (f *countingRuntime) Remove(context.Context, string) error { return nil }
+
+func (f *countingRuntime) Inspect(_ context.Context, n string) (machine.Machine, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.counts[n] > 0 {
+		return machine.Machine{Name: n, Running: true}, true, nil
+	}
+	return machine.Machine{}, false, nil
+}
+
+func (f *countingRuntime) EnsureNetwork(_ context.Context, spec machine.NetworkSpec) error {
+	f.networks.Add(1)
+	if f.blockNetworks != nil {
+		select {
+		case f.networkEntered <- spec.Name:
+		default:
+		}
+		<-f.blockNetworks
+	}
+	return nil
+}
+
+func (f *countingRuntime) Attach(context.Context, string, machine.Attachment) error { return nil }
+func (f *countingRuntime) RemoveNetwork(context.Context, string) error              { return nil }
+
+// starts counts by Vm id rather than by machine name, so a test does not have to
+// know the prefix the binding uses.
+func (f *countingRuntime) starts(id string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for name, n := range f.counts {
+		if strings.HasSuffix(name, id) {
+			return n
+		}
+	}
+	return 0
+}
+
+// UpdateVm and a start do not overwrite each other.
+//
+// Commit replaces State, Runtime and Attrs wholesale. Without the per-target
+// lock, an UpdateVm answering 200 wrote its UserData over whatever the start had
+// just committed, or the other way round: the client is told the change landed
+// and the store does not hold it, so Terraform re-proposes it on every plan.
+func TestUpdateVmAndStartVmsDoNotOverwriteEachOther(t *testing.T) {
+	runtime := newCountingRuntime()
+	runtime.blockStarts = make(chan struct{})
+	ts := newRuntimeServer(t, runtime)
+	_, subnetID := netAndSubnet(t, ts, "10.57.0.0/16", "10.57.1.0/24")
+
+	_, out := post(t, ts, "CreateVms",
+		`{"ImageId":"ami-12345678","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+	vms, _ := out["Vms"].([]any)
+	vm, _ := vms[0].(map[string]any)
+	vmID, _ := vm["VmId"].(string)
+
+	started := make(chan struct{})
+	go func() {
+		defer close(started)
+		post(t, ts, "StartVms", `{"VmIds":["`+vmID+`"]}`)
+	}()
+	<-runtime.startEntered // the start is in the runtime, holding what it holds
+
+	updated := make(chan int, 1)
+	go func() {
+		status, _ := post(t, ts, "UpdateVm", `{"VmId":"`+vmID+`","UserData":"aGVsbG8gd29ybGQ="}`)
+		updated <- status
+	}()
+	// Give the update time to land in the middle if it can.
+	time.Sleep(50 * time.Millisecond)
+	close(runtime.blockStarts)
+	<-started
+	status := <-updated
+
+	if status != http.StatusOK {
+		t.Fatalf("UpdateVm answered %d", status)
+	}
+	// The write it reported must be the write the store holds.
+	_, out = post(t, ts, "ReadVms", `{}`)
+	vms, _ = out["Vms"].([]any)
+	vm, _ = vms[0].(map[string]any)
+	if got, _ := vm["UserData"].(string); got != "aGVsbG8gd29ybGQ=" {
+		t.Errorf("UpdateVm answered 200 and the store holds %q: the write was lost", got)
+	}
+}
+
+// A body the server accepts reaches the handler whole.
+//
+// The DryRun probe reads the body before the handler does, then puts it back.
+// It read a quarter of what emulator.DecodeJSON accepts and restored the
+// truncated copy, so a valid 1.2 MiB request came back as
+// {"Code":"4001","Details":"unexpected end of JSON input"} — a syntax error
+// about a document the client sent whole, introduced by the fix that moved
+// DryRun to the mount point.
+//
+// The probe now uses emulator.MaxBody, the one constant. This test sends more
+// than the old bound and asserts the handler's own verdict: the user data cap,
+// which only a handler that received the whole body can apply.
+func TestABodyTheServerAcceptsReachesTheHandler(t *testing.T) {
+	ts := newServer(t)
+	_, subnetID := netAndSubnet(t, ts, "10.58.0.0/16", "10.58.1.0/24")
+	_, out := post(t, ts, "CreateVms",
+		`{"ImageId":"ami-12345678","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+	vms, _ := out["Vms"].([]any)
+	vm, _ := vms[0].(map[string]any)
+	vmID, _ := vm["VmId"].(string)
+
+	// Over the old 1 MiB probe, under the 4 MiB the server accepts.
+	body := `{"VmId":"` + vmID + `","UserData":"` + strings.Repeat("A", 1500*1024) + `"}`
+	status, answer := post(t, ts, "UpdateVm", body)
+
+	if status != http.StatusBadRequest {
+		t.Fatalf("a 1.5 MiB request answered %d, want the handler's 400", status)
+	}
+	// The details sit in Errors[0], which is the shape the pack's own error
+	// writer produces; reading them at the root found "" and made this test
+	// fail for the wrong reason.
+	errs, _ := answer["Errors"].([]any)
+	if len(errs) == 0 {
+		t.Fatalf("no Errors in the answer: %v", answer)
+	}
+	first, _ := errs[0].(map[string]any)
+	details, _ := first["Details"].(string)
+	if strings.Contains(details, "unexpected end of JSON input") {
+		t.Errorf("the body was truncated before the handler saw it: %q", details)
+	}
+	// The verdict must be the handler's own, which only a whole body produces.
+	if !strings.Contains(details, "UserData") {
+		t.Errorf("the answer is not the handler's verdict on the field: %q", details)
+	}
 }

--- a/internal/providers/outscale/filters.go
+++ b/internal/providers/outscale/filters.go
@@ -1,0 +1,102 @@
+package outscale
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"strings"
+)
+
+// Filters are where an Outscale read says what it wants, and where this pack
+// used to say nothing at all.
+//
+// The API description declares 66 filters on a Vm, 9 on a Subnet, 8 on a Net and
+// 7 on a keypair. The pack read four of them and returned the whole inventory
+// for every other one, with a 200. An audit sent
+// `--Filters.SubnetIds[] subnet-deadbeef` against seven machines and got all
+// seven back. That is worse than a refusal, because it is indistinguishable from
+// success: a script that deletes what a filter matched deletes everything.
+//
+// So a filter is either applied or refused, never ignored. The set of applied
+// ones is declared per action beside the handler that reads them, and anything
+// else a client sends is a 400 naming the field — which is what the real API
+// does for a filter it does not know, and what a client can act on.
+//
+// This lives in the pack rather than in the core because `Filters` is Outscale's
+// shape: Scaleway filters through query parameters and Exoscale barely filters
+// at all. What is shared is the rule, not the code.
+// It is a map rather than a struct on purpose. The unread-field report walks
+// request types by reflection and reports every key a struct does not declare;
+// a map accepts every key by construction, so nothing under Filters is reported
+// any more. That would be a loss if the report were still the only thing
+// watching these fields — it is not. A filter is now refused at the door when
+// this pack does not apply it, which is stronger than a report: the client
+// learns immediately, in the answer, rather than an operator learning later
+// from a counter. TestAnUnsupportedFilterIsRefused holds that, and the
+// conformance suite drives it with the real client.
+type filterSet map[string]json.RawMessage
+
+// strings reads a list-of-strings filter. A filter present but empty matches
+// nothing, which is what the API does: asking for an empty set of ids is not
+// asking for everything.
+func (f filterSet) strings(name string) ([]string, bool) {
+	raw, ok := f[name]
+	if !ok {
+		return nil, false
+	}
+	var out []string
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, false
+	}
+	return out, true
+}
+
+// unsupported names the filters a client sent that this pack does not apply.
+func (f filterSet) unsupported(supported ...string) []string {
+	known := make(map[string]bool, len(supported))
+	for _, name := range supported {
+		known[name] = true
+	}
+	var out []string
+	for name := range f {
+		if !known[name] {
+			out = append(out, name)
+		}
+	}
+	sort.Strings(out) // stable message, so a test can assert on it
+	return out
+}
+
+// refuseUnsupported answers the client when it asked for a filter this pack
+// does not apply, and reports whether it did.
+//
+// The message names the fields and what is served, because a filter refused
+// without saying which is a 400 a caller cannot act on.
+//
+// TestAnUnsupportedFilterIsRefused fails without this.
+func (p *Pack) refuseUnsupported(w http.ResponseWriter, f filterSet, supported ...string) bool {
+	unknown := f.unsupported(supported...)
+	if len(unknown) == 0 {
+		return false
+	}
+	sort.Strings(supported)
+	p.badRequest(w, "the filter(s) "+strings.Join(unknown, ", ")+
+		" are not emulated; this call filters on "+strings.Join(supported, ", "))
+	return true
+}
+
+// matchesStrings reports whether a value passes a list filter. An absent filter
+// passes everything, which is the only case where "no filter" and "match all"
+// are the same thing.
+func matchesStrings(f filterSet, name, value string) bool {
+	wanted, present := f.strings(name)
+	if !present {
+		return true
+	}
+	for _, candidate := range wanted {
+		if candidate == value {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/providers/outscale/keypairs.go
+++ b/internal/providers/outscale/keypairs.go
@@ -1,13 +1,12 @@
 package outscale
 
 import (
-	"crypto/md5" //nolint:gosec // fingerprint format, not a security control
-	"encoding/hex"
 	"net/http"
 	"strings"
 
 	"github.com/stephrobert/feint/internal/core/emulator"
 	"github.com/stephrobert/feint/internal/core/resource"
+	"github.com/stephrobert/feint/internal/core/sshkey"
 )
 
 // Keypairs are on the critical path to a machine anyone can log into: without
@@ -66,7 +65,8 @@ func (p *Pack) createKeypair(w http.ResponseWriter, r *http.Request) {
 	// nobody guarded.
 	//
 	// TestAKeypairRefusesWhatIsNotAKey fails without this.
-	if !looksLikePublicKey(req.PublicKey) {
+	parsed, err := sshkey.Parse(req.PublicKey)
+	if err != nil {
 		p.badRequest(w, "PublicKey is not an OpenSSH public key")
 		return
 	}
@@ -80,9 +80,12 @@ func (p *Pack) createKeypair(w http.ResponseWriter, r *http.Request) {
 		Created: now,
 		Updated: now,
 		Attrs: map[string]any{
-			"KeypairName":        req.KeypairName,
-			"KeypairType":        "ssh-rsa",
-			"KeypairFingerprint": fingerprint(req.PublicKey),
+			"KeypairName": req.KeypairName,
+			// The algorithm the client sent, not a constant. Hardcoding
+			// "ssh-rsa" made every key answer that, ed25519 ones included, and
+			// KeypairType is a declared schema field a client can filter on.
+			"KeypairType":        parsed.Algorithm,
+			"KeypairFingerprint": parsed.FingerprintMD5(),
 			// The material itself never leaves through the API: no Outscale
 			// response carries a PublicKey field, so it lives out of Attrs, in
 			// Runtime, where a view cannot pick it up by accident.
@@ -183,40 +186,4 @@ func keypairView(res *resource.Resource) map[string]any {
 	}
 	out["KeypairId"] = res.ID
 	return out
-}
-
-// fingerprint is the MD5 digest of the key material, colon-separated, which is
-// the shape ssh-keygen -l prints and what a client compares against. MD5 is the
-// format, not a security choice: nothing here authenticates anything.
-func fingerprint(publicKey string) string {
-	sum := md5.Sum([]byte(strings.TrimSpace(publicKey))) //nolint:gosec // format, not security
-	hexed := hex.EncodeToString(sum[:])
-	parts := make([]string, 0, len(hexed)/2)
-	for i := 0; i < len(hexed); i += 2 {
-		parts = append(parts, hexed[i:i+2])
-	}
-	return strings.Join(parts, ":")
-}
-
-// looksLikePublicKey accepts the OpenSSH one-line form.
-//
-// The one-line part is the security check rather than tidiness: the value is
-// concatenated into a YAML document by text/template, and strings.Fields splits
-// on newlines exactly like spaces, so the control character test has to come
-// first. Same reasoning, and the same order, as the Scaleway pack's own check.
-func looksLikePublicKey(key string) bool {
-	if strings.ContainsAny(key, "\n\r\x00") {
-		return false
-	}
-	fields := strings.Fields(strings.TrimSpace(key))
-	if len(fields) < 2 {
-		return false
-	}
-	switch fields[0] {
-	case "ssh-rsa", "ssh-ed25519", "ssh-dss",
-		"ecdsa-sha2-nistp256", "ecdsa-sha2-nistp384", "ecdsa-sha2-nistp521",
-		"sk-ssh-ed25519@openssh.com", "sk-ecdsa-sha2-nistp256@openssh.com":
-		return true
-	}
-	return false
 }

--- a/internal/providers/outscale/keypairs.go
+++ b/internal/providers/outscale/keypairs.go
@@ -28,10 +28,12 @@ type createKeypairRequest struct {
 }
 
 type readKeypairsRequest struct {
-	Filters struct {
-		KeypairNames []string `json:"KeypairNames"`
-	} `json:"Filters"`
+	Filters filterSet `json:"Filters"`
 }
+
+// keypairFilters are what a keypair answers from what is stored. Tags are not
+// modelled on a keypair here, so they are refused.
+var keypairFilters = []string{"KeypairNames", "KeypairFingerprints", "KeypairTypes"}
 
 type deleteKeypairRequest struct {
 	KeypairName string `json:"KeypairName"`
@@ -101,15 +103,18 @@ func (p *Pack) readKeypairs(w http.ResponseWriter, r *http.Request) {
 		p.badRequest(w, err.Error())
 		return
 	}
-	wanted := make(map[string]bool, len(req.Filters.KeypairNames))
-	for _, name := range req.Filters.KeypairNames {
-		wanted[name] = true
+	if p.refuseUnsupported(w, req.Filters, keypairFilters...) {
+		return
 	}
 
 	out := make([]map[string]any, 0)
 	for _, res := range p.env.Store.List(kindKeypair, resource.Tenant{Provider: Name}) {
 		name, _ := res.Attrs["KeypairName"].(string)
-		if len(wanted) > 0 && !wanted[name] {
+		fingerprint, _ := res.Attrs["KeypairFingerprint"].(string)
+		keyType, _ := res.Attrs["KeypairType"].(string)
+		if !matchesStrings(req.Filters, "KeypairNames", name) ||
+			!matchesStrings(req.Filters, "KeypairFingerprints", fingerprint) ||
+			!matchesStrings(req.Filters, "KeypairTypes", keyType) {
 			continue
 		}
 		out = append(out, keypairView(res))

--- a/internal/providers/outscale/machines.go
+++ b/internal/providers/outscale/machines.go
@@ -90,6 +90,27 @@ func (p *Pack) powerOn(ctx context.Context, res *resource.Resource) {
 		CloudInit: cloudinit.Decode(userData),
 		Labels:    map[string]string{"feint.vm": res.ID},
 	})
+	p.rememberAddress(res)
+}
+
+// rememberAddress keeps the private address on the resource, not only on the
+// runtime binding.
+//
+// PowerOff clears Runtime[address] — correctly, since nothing answers there any
+// more — and a Vm placed in a Subnet was unaffected because its address lives in
+// Attrs. A Vm created without one had it nowhere else, so stopping it emptied
+// PrivateIp: one field, two behaviours, and Terraform reading private_ip saw
+// null after a stop. Outscale keeps the private address of a stopped Vm; it is
+// released when the machine is terminated, with the resource.
+//
+// TestAStoppedVmKeepsItsPrivateAddress fails without this.
+func (p *Pack) rememberAddress(res *resource.Resource) {
+	if _, already := res.Attrs["PrivateIp"]; already {
+		return
+	}
+	if address := p.addressOf(res); address != "" {
+		res.Attrs["PrivateIp"] = address
+	}
 }
 
 // powerOff stops the backing machine, keeping its filesystem.
@@ -105,7 +126,13 @@ func (p *Pack) removeMachine(ctx context.Context, res *resource.Resource) {
 
 // refreshMachine republishes the address of a running VM.
 func (p *Pack) refreshMachine(ctx context.Context, res *resource.Resource) bool {
-	return p.binding().RefreshIfRunning(ctx, res)
+	changed := p.binding().RefreshIfRunning(ctx, res)
+	if changed {
+		// A virtual machine gets its address tens of seconds after it starts,
+		// so this is where it first becomes known for one.
+		p.rememberAddress(res)
+	}
+	return changed
 }
 
 // addressOf is what a Vm publishes as PrivateIp. Outscale's Vm schema declares

--- a/internal/providers/outscale/nets.go
+++ b/internal/providers/outscale/nets.go
@@ -69,18 +69,21 @@ type createSubnetRequest struct {
 }
 
 type readNetsRequest struct {
-	Filters struct {
-		NetIDs []string `json:"NetIds"`
-	} `json:"Filters"`
-	DryRun *bool `json:"DryRun"`
+	Filters filterSet `json:"Filters"`
+	DryRun  *bool     `json:"DryRun"`
 }
 
+// netFilters and subnetFilters are what these resources can answer from what is
+// stored. Tags, DHCP option sets and subregions are not modelled, so they are
+// refused rather than silently matched.
+var (
+	netFilters    = []string{"NetIds", "IpRanges", "States"}
+	subnetFilters = []string{"SubnetIds", "NetIds", "IpRanges", "States"}
+)
+
 type readSubnetsRequest struct {
-	Filters struct {
-		SubnetIDs []string `json:"SubnetIds"`
-		NetIDs    []string `json:"NetIds"`
-	} `json:"Filters"`
-	DryRun *bool `json:"DryRun"`
+	Filters filterSet `json:"Filters"`
+	DryRun  *bool     `json:"DryRun"`
 }
 
 type deleteNetRequest struct {
@@ -148,11 +151,16 @@ func (p *Pack) readNets(w http.ResponseWriter, r *http.Request) {
 		p.badRequest(w, err.Error())
 		return
 	}
-	wanted := setOf(req.Filters.NetIDs)
+	if p.refuseUnsupported(w, req.Filters, netFilters...) {
+		return
+	}
 
 	nets := make([]map[string]any, 0)
 	for _, res := range p.env.Store.List(kindNet, resource.Tenant{Provider: Name}) {
-		if len(wanted) > 0 && !wanted[res.ID] {
+		ipRange, _ := res.Attrs["IpRange"].(string)
+		if !matchesStrings(req.Filters, "NetIds", res.ID) ||
+			!matchesStrings(req.Filters, "IpRanges", ipRange) ||
+			!matchesStrings(req.Filters, "States", res.State) {
 			continue
 		}
 		nets = append(nets, netView(res))
@@ -313,16 +321,18 @@ func (p *Pack) readSubnets(w http.ResponseWriter, r *http.Request) {
 		p.badRequest(w, err.Error())
 		return
 	}
-	wantedIDs := setOf(req.Filters.SubnetIDs)
-	wantedNets := setOf(req.Filters.NetIDs)
+	if p.refuseUnsupported(w, req.Filters, subnetFilters...) {
+		return
+	}
 
 	subnets := make([]map[string]any, 0)
 	for _, res := range p.env.Store.List(kindSubnet, resource.Tenant{Provider: Name}) {
 		netID, _ := res.Attrs["NetId"].(string)
-		if len(wantedIDs) > 0 && !wantedIDs[res.ID] {
-			continue
-		}
-		if len(wantedNets) > 0 && !wantedNets[netID] {
+		ipRange, _ := res.Attrs["IpRange"].(string)
+		if !matchesStrings(req.Filters, "SubnetIds", res.ID) ||
+			!matchesStrings(req.Filters, "NetIds", netID) ||
+			!matchesStrings(req.Filters, "IpRanges", ipRange) ||
+			!matchesStrings(req.Filters, "States", res.State) {
 			continue
 		}
 		subnets = append(subnets, p.subnetView(res))
@@ -506,15 +516,4 @@ func (p *Pack) removeBackingNetwork(ctx context.Context, res *resource.Resource)
 		p.logger().Error("could not remove the backing network",
 			"subnet", res.ID, "network", res.Runtime[runtimeNetworkKey], "error", err)
 	}
-}
-
-func setOf(values []string) map[string]bool {
-	if len(values) == 0 {
-		return nil
-	}
-	out := make(map[string]bool, len(values))
-	for _, v := range values {
-		out[v] = true
-	}
-	return out
 }

--- a/internal/providers/outscale/nets.go
+++ b/internal/providers/outscale/nets.go
@@ -177,11 +177,23 @@ func (p *Pack) deleteNet(w http.ResponseWriter, r *http.Request) {
 	// A Net holding subnets does not go, which is what the real API answers and
 	// what Terraform's destroy order relies on: it removes the subnets first and
 	// would report our success as a cycle it did not need to break.
+	//
+	// Under the addressing lock, which is where a subnet is placed in a Net. The
+	// guard was here and the lock was not, so the list was empty by construction
+	// for the whole window a create was open: an audit deleted a Net and watched
+	// a Subnet land in it, naming a Net the pack no longer serves, with its
+	// bridge left on the host. The same reasoning that put deleteSubnet under
+	// this lock applies here, and it was applied to only one of the two.
+	//
+	// TestANetDoesNotDeleteUnderASubnetBeingCreated fails without this.
+	p.addresses.Lock()
 	if subnets := p.subnetsOf(req.NetID); len(subnets) > 0 {
+		p.addresses.Unlock()
 		p.conflict(w, "the Net "+req.NetID+" still holds "+strconv.Itoa(len(subnets))+" subnet(s)")
 		return
 	}
 	p.env.Store.Delete(Name, kindNet, req.NetID)
+	p.addresses.Unlock()
 
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
 		"ResponseContext": p.context(),
@@ -220,10 +232,24 @@ func (p *Pack) createSubnet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Reserved under the lock, created outside it. Holding the addressing plane
+	// across `incus network create` — hundreds of milliseconds to seconds — put
+	// every other CreateVms, CreateNet and CreateSubnet in a queue behind it: a
+	// terraform apply making ten subnets serialised them completely, measured at
+	// 1.5 s for one unrelated CreateNet. "Un effet de bord lent ne tient pas dans
+	// le verrou" was applied to the Vm path and left violated here.
+	//
+	// The reservation is what the lock is for: the resource is stored before the
+	// runtime call, so a concurrent create sees the range as taken and no two
+	// subnets can claim it. If the runtime then refuses, the reservation is
+	// withdrawn.
+	//
+	// TestSubnetCreateDoesNotHoldTheAddressingLockAcrossTheRuntime fails
+	// without this.
 	p.addresses.Lock()
-	defer p.addresses.Unlock()
 
 	if other, clash := network.FirstOverlap(prefix, p.subnetPrefixes(req.NetID)); clash {
+		p.addresses.Unlock()
 		p.conflict(w, "IpRange "+prefix.String()+" overlaps the subnet on "+other.String())
 		return
 	}
@@ -245,17 +271,35 @@ func (p *Pack) createSubnet(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
+	// Stored before the runtime call and before the lock is released: this is the
+	// reservation, and it is what makes a concurrent create see the range as
+	// taken.
+	p.env.Store.Put(res)
+	p.addresses.Unlock()
+
 	// The subnet is a real network on the runtime, which is what makes an
 	// address published here an address a machine can carry. Without a runtime
 	// this is a no-op and the control plane still answers.
 	if err := p.ensureBackingNetwork(r.Context(), res, prefix); err != nil {
+		// The reservation goes back, or a refused create would hold a range
+		// nothing owns. Delete rather than Commit: there is nothing to keep.
+		p.env.Store.Delete(Name, kindSubnet, res.ID)
 		p.logger().Error("could not create the backing network",
 			"subnet", res.ID, "range", prefix, "error", err)
 		p.conflict(w, "the machine runtime could not provide a network for "+prefix.String()+
 			"; the block is most likely already in use on this host: "+err.Error())
 		return
 	}
-	p.env.Store.Put(res)
+	// The runtime wrote the network name into Runtime, so the reservation is
+	// updated rather than replaced: a Put would resurrect a subnet deleted while
+	// the network was being created.
+	if !p.env.Store.Commit(res, p.env.Now()) {
+		// Deleted while its network was being made. Take the network back down
+		// rather than leave it on the host.
+		p.removeBackingNetwork(r.Context(), res)
+		p.notFound(w, "Subnet", res.ID)
+		return
+	}
 
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
 		"Subnet":          p.subnetView(res),

--- a/internal/providers/outscale/pack.go
+++ b/internal/providers/outscale/pack.go
@@ -93,6 +93,11 @@ func (p *Pack) route(action string, handler http.HandlerFunc) emulator.Route {
 // TestDryRunReachesNoHandler fails without this.
 func (p *Pack) dryRunnable(handler http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		// Read here rather than by a handler, so the unread-field report is
+		// told: otherwise `DryRun: false` — a legitimate request every client
+		// can send — counted as a field nobody read and failed the conformance
+		// gate. TestDryRunFalseDoesNotFailTheGate holds it.
+		emulator.MarkRead(r, "DryRun")
 		// Bounded like every other body: a dry run must not be a way to make the
 		// emulator read an unbounded request.
 		body, err := io.ReadAll(io.LimitReader(r.Body, maxDryRunProbe))

--- a/internal/providers/outscale/pack.go
+++ b/internal/providers/outscale/pack.go
@@ -57,11 +57,13 @@ func (p *Pack) Name() string { return Name }
 // keys on, which is why both live one string apart.
 func operation(action string) string { return "osc/Client." + action }
 
-// route declares one action. Outscale has no path structure to speak of: every
 // maxDryRunProbe bounds the body read to answer a dry run. Generous for a
-// request document and far below the 4 MiB the server accepts.
-const maxDryRunProbe = 1 << 20
+// request document, and matched to what the server accepts rather than chosen
+// below it: the probe puts the body back for the handler, so a smaller bound
+// here truncated real requests.
+const maxDryRunProbe = emulator.MaxBody
 
+// route declares one action. Outscale has no path structure to speak of: every
 // call is a POST on /api/v1/<Action>, so a route is fully described by its
 // action name and its handler.
 func (p *Pack) route(action string, handler http.HandlerFunc) emulator.Route {

--- a/internal/providers/outscale/vms.go
+++ b/internal/providers/outscale/vms.go
@@ -90,13 +90,24 @@ func (p *Pack) readVms(w http.ResponseWriter, r *http.Request) {
 		// A virtual machine gets its address tens of seconds after it starts,
 		// so a create cannot wait for one. It is filled in here instead, on the
 		// read a client is making anyway.
-		if p.refreshMachine(r.Context(), res) {
-			// Committed, not Put: this read ran outside the lock and a delete
-			// may have landed since. A false return means it did, and the Vm
-			// belongs in nobody's answer.
-			if !p.env.Store.Commit(res, p.env.Now()) {
-				continue
+		// This read writes: a virtual machine gets its address late, and the
+		// refresh publishes it. So it is serialised like every other writer —
+		// an audit noted that a read could otherwise lose a concurrent write,
+		// which is the same defect as UpdateVm's, through a door nobody thinks
+		// of as mutating.
+		refreshed := func() bool {
+			unlock := p.binding().Serialise(res.ID)
+			defer unlock()
+			if !p.refreshMachine(r.Context(), res) {
+				return true
 			}
+			// Committed, not Put: this read ran outside the store lock and a
+			// delete may have landed since. A false return means it did, and
+			// the Vm belongs in nobody's answer.
+			return p.env.Store.Commit(res, p.env.Now())
+		}()
+		if !refreshed {
+			continue
 		}
 		vms = append(vms, p.vmView(res))
 	}
@@ -117,14 +128,7 @@ func (p *Pack) createVms(w http.ResponseWriter, r *http.Request) {
 		p.badRequest(w, "ImageId is required")
 		return
 	}
-	if req.KeypairName != "" && !p.keypairExists(req.KeypairName) {
-		p.notFound(w, "keypair", req.KeypairName)
-		return
-	}
-	// The API caps user data at 500 KiB. Accepting more would let through a
-	// script the real one refuses.
-	if len(req.UserData) > cloudinit.MaxUserData {
-		p.badRequest(w, "UserData is limited to 500 kibibytes")
+	if !p.validVmFields(w, req.KeypairName, req.UserData) {
 		return
 	}
 
@@ -273,12 +277,51 @@ func (p *Pack) allocateVms(req createVmsRequest, count int, now time.Time) ([]*r
 	return created, nil
 }
 
+// validVmFields checks what both CreateVms and UpdateVm must check, and answers
+// the client itself so the two cannot drift.
+//
+// They had drifted: UpdateVm took a 600 KiB user data the create refuses at 500,
+// and a KeypairName no keypair answers to. The second is the worse of the two —
+// at the next StartVms, authorizedKeys returns nothing, the machine boots with
+// no key, nobody can log in, and the API goes on stating that a keypair is
+// attached.
+//
+// TestUpdateVmValidatesWhatCreateValidates fails without this.
+func (p *Pack) validVmFields(w http.ResponseWriter, keypair, userData string) bool {
+	if keypair != "" && !p.keypairExists(keypair) {
+		p.notFound(w, "keypair", keypair)
+		return false
+	}
+	// The API caps user data at 500 KiB. Accepting more would let through a
+	// script the real one refuses.
+	if len(userData) > cloudinit.MaxUserData {
+		p.badRequest(w, "UserData is limited to 500 kibibytes")
+		return false
+	}
+	return true
+}
+
 func (p *Pack) updateVm(w http.ResponseWriter, r *http.Request) {
 	var req updateVMRequest
 	if err := emulator.DecodeJSON(r, &req); err != nil {
 		p.badRequest(w, err.Error())
 		return
 	}
+	if !p.validVmFields(w, req.KeypairName, req.UserData) {
+		return
+	}
+
+	// Serialised on the target, like transitionOne and deleteVms. Without it,
+	// Commit replaces State, Runtime and Attrs wholesale over whatever a
+	// concurrent start had just written: an audit watched UpdateVm answer 200
+	// with a UserData the store did not hold, and Terraform would re-propose
+	// that change on every plan. In the other order it is a stopped state
+	// overwriting a running one whose container is alive.
+	//
+	// TestUpdateVmAndStartVmsDoNotOverwriteEachOther fails without this.
+	unlock := p.binding().Serialise(req.VMID)
+	defer unlock()
+
 	res, ok := p.env.Store.Get(Name, kindVM, req.VMID)
 	if !ok {
 		p.notFound(w, "VM", req.VMID)

--- a/internal/providers/outscale/vms.go
+++ b/internal/providers/outscale/vms.go
@@ -38,9 +38,16 @@ const maxVMsPerCreate = 20
 const defaultVMType = "tinav6.c1r1p2"
 
 type readVmsRequest struct {
-	Filters struct {
-		VMIDs []string `json:"VmIds"`
-	} `json:"Filters"`
+	Filters filterSet `json:"Filters"`
+}
+
+// vmFilters are the ones a Vm can answer from what this pack stores. Everything
+// else FiltersVm declares — 66 fields, most of them about block device
+// mappings, NIC sub-objects and account ids the emulator has no model for — is
+// refused rather than ignored.
+var vmFilters = []string{
+	"VmIds", "VmStates", "ImageIds", "VmTypes", "KeypairNames",
+	"SubnetIds", "NetIds", "PrivateIps",
 }
 
 // createVmsRequest is the subset of CreateVmsRequest this pack honours. The
@@ -77,14 +84,13 @@ func (p *Pack) readVms(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wanted := make(map[string]bool, len(req.Filters.VMIDs))
-	for _, id := range req.Filters.VMIDs {
-		wanted[id] = true
+	if p.refuseUnsupported(w, req.Filters, vmFilters...) {
+		return
 	}
 
 	vms := make([]map[string]any, 0)
 	for _, res := range p.env.Store.List(kindVM, resource.Tenant{Provider: Name}) {
-		if len(wanted) > 0 && !wanted[res.ID] {
+		if !p.vmMatches(res, req.Filters) {
 			continue
 		}
 		// A virtual machine gets its address tens of seconds after it starts,
@@ -116,6 +122,25 @@ func (p *Pack) readVms(w http.ResponseWriter, r *http.Request) {
 		"Vms":             vms,
 		"ResponseContext": p.context(),
 	})
+}
+
+// vmMatches applies every filter this pack serves. A Vm has to pass all of
+// them: Outscale's filters are conjunctive, and treating them as alternatives
+// would answer more than was asked for, which is the defect this whole file
+// exists to remove.
+func (p *Pack) vmMatches(res *resource.Resource, f filterSet) bool {
+	attr := func(key string) string {
+		value, _ := res.Attrs[key].(string)
+		return value
+	}
+	return matchesStrings(f, "VmIds", res.ID) &&
+		matchesStrings(f, "VmStates", res.State) &&
+		matchesStrings(f, "ImageIds", attr("ImageId")) &&
+		matchesStrings(f, "VmTypes", attr("VmType")) &&
+		matchesStrings(f, "KeypairNames", attr("KeypairName")) &&
+		matchesStrings(f, "SubnetIds", attr("SubnetId")) &&
+		matchesStrings(f, "NetIds", attr("NetId")) &&
+		matchesStrings(f, "PrivateIps", p.addressOf(res))
 }
 
 func (p *Pack) createVms(w http.ResponseWriter, r *http.Request) {

--- a/internal/providers/scaleway/ownership_audit_test.go
+++ b/internal/providers/scaleway/ownership_audit_test.go
@@ -2,6 +2,7 @@ package scaleway_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -409,4 +410,56 @@ func TestAnAddressIsAValidIPReference(t *testing.T) {
 	if status, _ := do(t, ts, "GET", zone+"/ips/"+id, ""); status != http.StatusNotFound {
 		t.Errorf("the address survived its own delete: GET by id answered %d", status)
 	}
+}
+
+// A refused attachment is visible on the NIC.
+//
+// Measured under --vm incus-vm: Incus cannot hot-plug a NIC into a running
+// virtual machine on this host ("PCI: slot 0 function 0 not available for
+// virtio-net-pci, in use by virtio-balloon-pci"). The attachment failed, the
+// pack logged it, and the API went on publishing an address the machine did not
+// carry — three minutes of polling confirmed the guest never took it.
+//
+// PrivateNICState declares syncing_error for exactly this, so nothing is
+// invented. A client that reads the NIC now learns what the log knew.
+func TestARefusedAttachmentIsVisibleOnTheNIC(t *testing.T) {
+	refusing := &refusingRuntime{fakeRuntime: newFakeRuntime()}
+	close(refusing.release)
+	ts := newRuntimeTestServer(t, refusing)
+
+	srvID := aServer(t, ts, "vm-host")
+	if status, _ := do(t, ts, "POST", zone+"/servers/"+srvID+"/action",
+		`{"action":"poweron"}`); status != http.StatusAccepted {
+		t.Fatalf("poweron")
+	}
+	_, out := do(t, ts, "POST", "/vpc/v2/regions/fr-par/private-networks",
+		`{"name":"net","subnets":["10.190.0.0/24"]}`)
+	pnID, _ := out["id"].(string)
+	if pnID == "" {
+		t.Fatalf("no private network: %v", out)
+	}
+
+	_, out = do(t, ts, "POST", zone+"/servers/"+srvID+"/private_nics",
+		`{"private_network_id":"`+pnID+`"}`)
+	nic, _ := out["private_nic"].(map[string]any)
+	if nic == nil {
+		t.Fatalf("no NIC created: %v", out)
+	}
+	nicID, _ := nic["id"].(string)
+
+	_, out = do(t, ts, "GET", zone+"/servers/"+srvID+"/private_nics/"+nicID, "")
+	nic, _ = out["private_nic"].(map[string]any)
+	if state, _ := nic["state"].(string); state != "syncing_error" {
+		t.Errorf("the NIC says %q after the runtime refused the attachment, want syncing_error", state)
+	}
+}
+
+// refusingRuntime attaches nothing, the way Incus refuses a hot-plugged NIC on a
+// running virtual machine.
+type refusingRuntime struct {
+	*fakeRuntime
+}
+
+func (r *refusingRuntime) Attach(context.Context, string, machine.Attachment) error {
+	return errors.New(`Failed to start device "eth1": PCI: slot 0 function 0 not available`)
 }

--- a/internal/providers/scaleway/privatenics.go
+++ b/internal/providers/scaleway/privatenics.go
@@ -154,7 +154,20 @@ func (p *Pack) createPrivateNIC(w http.ResponseWriter, r *http.Request) {
 	// The machine follows the control plane, not the other way round: the
 	// address published here is the one it must carry. A running machine has to
 	// be restarted to pick up a new interface, which is also true upstream.
-	p.attachMachineToNetwork(r.Context(), server, pn, address)
+	//
+	// When the runtime refuses, the NIC says so instead of the failure living
+	// only in a log line. PrivateNICState declares syncing_error for exactly
+	// this, so nothing is invented. It was measured under --vm incus-vm, where
+	// Incus cannot hot-plug a NIC into a running virtual machine ("PCI: slot 0
+	// function 0 not available for virtio-net-pci"): the attachment failed, the
+	// pack logged it, and the API went on publishing an address the machine did
+	// not carry — the one thing this project exists to avoid.
+	//
+	// TestARefusedAttachmentIsVisibleOnTheNIC fails without this.
+	if err := p.attachMachineToNetwork(r.Context(), server, pn, address); err != nil {
+		res.State = "syncing_error"
+		p.env.Store.Put(res)
+	}
 
 	// The rule set binds to interfaces, so a NIC created after the server was
 	// powered on carries none until this runs. Without it the security group
@@ -238,14 +251,16 @@ func hexPair(b byte) string {
 // Everything here degrades quietly, as elsewhere in the pack: with no runtime,
 // or with one that refuses, the control plane still answers and the NIC still
 // exists. The log is then the only way to learn why nothing is attached.
-func (p *Pack) attachMachineToNetwork(ctx context.Context, server, pn *resource.Resource, address netip.Addr) {
+func (p *Pack) attachMachineToNetwork(ctx context.Context, server, pn *resource.Resource, address netip.Addr) error {
+	// No runtime, or nothing started yet: there is no machine to refuse, so the
+	// NIC is not in error. The address is applied when the machine boots.
 	if p.env.Machines == nil {
-		return
+		return nil
 	}
 	networkName := pn.Runtime[runtimeNetworkKey]
 	machineName := server.Runtime[runtimeMachineKey]
 	if networkName == "" || machineName == "" {
-		return
+		return nil
 	}
 	// The mask travels with the address: reserving it on the bridge is not the
 	// same as the guest carrying it, and configuring the interface needs both.
@@ -253,7 +268,7 @@ func (p *Pack) attachMachineToNetwork(ctx context.Context, server, pn *resource.
 	if err != nil {
 		p.logger().Error("private network has no usable subnet",
 			"private_network", pn.ID, "error", err)
-		return
+		return err
 	}
 	if err := p.env.Machines.Attach(ctx, machineName, machine.Attachment{
 		Network:   networkName,
@@ -262,7 +277,9 @@ func (p *Pack) attachMachineToNetwork(ctx context.Context, server, pn *resource.
 	}); err != nil {
 		p.logger().Error("could not attach the machine to the private network",
 			"server", server.ID, "private_network", pn.ID, "address", address, "error", err)
+		return err
 	}
+	return nil
 }
 
 // privateNICView is the wire shape, and it carries no address on purpose:

--- a/internal/providers/scaleway/sshkeys.go
+++ b/internal/providers/scaleway/sshkeys.go
@@ -1,15 +1,13 @@
 package scaleway
 
 import (
-	"crypto/md5" //nolint:gosec // SSH fingerprints are MD5 by protocol, not a security choice here
-	"encoding/base64"
-	"encoding/hex"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/stephrobert/feint/internal/core/emulator"
 	"github.com/stephrobert/feint/internal/core/resource"
+	"github.com/stephrobert/feint/internal/core/sshkey"
 )
 
 // SSH keys are what turn an emulated server into a machine you can log into.
@@ -63,7 +61,7 @@ func (p *Pack) createSSHKey(w http.ResponseWriter, r *http.Request) {
 	}
 	// The API rejects anything that is not an SSH public key, and so must the
 	// emulator: a malformed key silently breaks every later login attempt.
-	if !looksLikePublicKey(req.PublicKey) {
+	if !sshkey.Valid(req.PublicKey) {
 		writeInvalidArguments(w, ArgumentError{
 			ArgumentName: "public_key",
 			Reason:       "constraint",
@@ -87,7 +85,7 @@ func (p *Pack) createSSHKey(w http.ResponseWriter, r *http.Request) {
 		Attrs: map[string]any{
 			"name":            orDefault(req.Name, "key"),
 			"public_key":      strings.TrimSpace(req.PublicKey),
-			"fingerprint":     fingerprint(req.PublicKey),
+			"fingerprint":     sshkey.FingerprintMD5(req.PublicKey),
 			"project_id":      project,
 			"organization_id": organization,
 			"disabled":        false,
@@ -168,58 +166,4 @@ func sshKeyView(res *resource.Resource) map[string]any {
 	out["created_at"] = res.Created.Format(time.RFC3339)
 	out["updated_at"] = res.Updated.Format(time.RFC3339)
 	return out
-}
-
-// looksLikePublicKey accepts the OpenSSH one-line format. It validates the
-// shape, not the cryptography: the emulator has no reason to reject a
-// well-formed key it cannot parse.
-//
-// "One-line" is enforced rather than assumed, and that is a security check, not
-// tidiness. The stored value is rendered into a cloud-config document by
-// text/template, which concatenates without escaping, so a key carrying a newline
-// opens a top-level YAML key of the attacker's choosing: an audit obtained
-// runcmd, bootcmd and write_files that way. strings.Fields below splits on
-// newlines just like spaces, which is exactly why the check has to come first.
-//
-// The contamination is why this matters more than it looks: an authorized key
-// applies to every machine the project starts afterwards, including one a
-// terraform apply creates without ever supplying user data.
-func looksLikePublicKey(key string) bool {
-	if strings.ContainsAny(key, "\n\r\x00") {
-		return false
-	}
-	fields := strings.Fields(strings.TrimSpace(key))
-	if len(fields) < 2 {
-		return false
-	}
-	switch fields[0] {
-	case "ssh-rsa", "ssh-ed25519", "ssh-dss",
-		"ecdsa-sha2-nistp256", "ecdsa-sha2-nistp384", "ecdsa-sha2-nistp521",
-		"sk-ssh-ed25519@openssh.com", "sk-ecdsa-sha2-nistp256@openssh.com":
-	default:
-		return false
-	}
-	_, err := base64.StdEncoding.DecodeString(fields[1])
-	return err == nil
-}
-
-// fingerprint mirrors what the API returns: Scaleway exposes the MD5 form, the
-// colon-separated one ssh-keygen printed by default for years.
-func fingerprint(key string) string {
-	fields := strings.Fields(strings.TrimSpace(key))
-	if len(fields) < 2 {
-		return ""
-	}
-	blob, err := base64.StdEncoding.DecodeString(fields[1])
-	if err != nil {
-		return ""
-	}
-
-	sum := md5.Sum(blob) //nolint:gosec // the SSH fingerprint format is MD5, not a security decision
-	hexed := hex.EncodeToString(sum[:])
-	parts := make([]string, 0, len(hexed)/2)
-	for i := 0; i+2 <= len(hexed); i += 2 {
-		parts = append(parts, hexed[i:i+2])
-	}
-	return strings.Join(parts, ":")
 }

--- a/tools/conformance/outscale/network.sh
+++ b/tools/conformance/outscale/network.sh
@@ -45,10 +45,17 @@ fi
 
 # The runtime CLI is how the host is inspected. Asking the emulator whether it
 # created a network would be asking the accused for the verdict.
-RUNTIME_CLI="${FEINT_VM:-incus}"
-RUNTIME_CLI="${RUNTIME_CLI%%-vm}"
-command -v "$RUNTIME_CLI" >/dev/null 2>&1 \
-  || fail "the runtime CLI $RUNTIME_CLI is not on PATH, so nothing can be verified"
+#
+# It is `incus` for all three modes. The first version derived it from FEINT_VM
+# and stripped "-vm", which left "incus-ovn" untouched: the whole suite then
+# failed with "the runtime CLI incus-ovn is not on PATH" in the one mode that
+# delivers isolation between two VPCs, right after the Scaleway suite had proved
+# that isolation in the same run. CLAUDE.md says a mode declares what it can do
+# rather than having it deduced from its name; deducing a *tool* from that name
+# is the same mistake one level down. The sibling suite gets it right by not
+# deriving anything.
+command -v incus >/dev/null 2>&1 \
+  || fail "the incus client is not on PATH, so nothing can be verified"
 
 # Deliberately obscure. A lab bridge or a VPN already holding this range makes
 # the create fail, which is the emulator being honest rather than handing back a
@@ -109,13 +116,13 @@ sub_id="$(printf '%s' "$sub" | jq -r '.Subnet.SubnetId')"
 found=""
 while IFS= read -r line; do
   name="${line%%,*}"
-  addr="$("$RUNTIME_CLI" network get "$name" ipv4.address 2>/dev/null || true)"
+  addr="$(incus network get "$name" ipv4.address 2>/dev/null || true)"
   if [ "$addr" != "" ] && [ "${addr#*/}" = "${SUBBLOCK#*/}" ]; then
     case "$addr" in
       "${SUBBLOCK%.*}."*) found="$name" ;;
     esac
   fi
-done < <("$RUNTIME_CLI" network list -f csv 2>/dev/null | grep '^fnt-' || true)
+done < <(incus network list -f csv 2>/dev/null | grep '^fnt-' || true)
 
 [ -n "$found" ] || fail "no host network carries $SUBBLOCK: the Subnet is an answer, not a network"
 ok "$sub_id is backed by $found on ${SUBBLOCK}"
@@ -124,7 +131,7 @@ ok "$sub_id is backed by $found on ${SUBBLOCK}"
 # silently renumbers gives a machine an address the API never published, which is
 # precisely the failure floci ships: it computes an address from the CIDR, then
 # overwrites it with the bridge's own.
-gw="$("$RUNTIME_CLI" network get "$found" ipv4.address)"
+gw="$(incus network get "$found" ipv4.address)"
 [ "${gw#*/}" = "${SUBBLOCK#*/}" ] \
   || fail "the host network carries mask /${gw#*/}, the Subnet declared /${SUBBLOCK#*/}"
 ok "the mask on the host is the mask the client asked for"
@@ -150,7 +157,7 @@ esac
 # container gets its address a few seconds after it starts.
 carried=""
 for _ in 1 2 3 4 5 6 7 8 9 10; do
-  if "$RUNTIME_CLI" list -f csv -c n4 2>/dev/null | grep -q "$private_ip"; then
+  if incus list -f csv -c n4 2>/dev/null | grep -q "$private_ip"; then
     carried="yes"
     break
   fi
@@ -166,7 +173,7 @@ echo "- the network goes when the Subnet goes"
 osc DeleteSubnet --SubnetId "$sub_id" >/dev/null || fail "DeleteSubnet rejected"
 sub_id=""
 sleep 1
-if "$RUNTIME_CLI" network list -f csv 2>/dev/null | grep -q "^$found,"; then
+if incus network list -f csv 2>/dev/null | grep -q "^$found,"; then
   fail "the host network $found outlived its Subnet"
 fi
 ok "deleted, and the host is as it was"

--- a/tools/conformance/outscale/oapi-cli.sh
+++ b/tools/conformance/outscale/oapi-cli.sh
@@ -173,6 +173,19 @@ printf '%s' "$vms" | jq -e '.Vms | length == 0' >/dev/null \
   || fail "a fresh account already holds machines: $vms"
 ok "envelope carries a RequestId, and the account is empty"
 
+echo "- a filter the client sends is applied, not ignored"
+# The defect this replaces: every filter but VmIds returned the whole inventory
+# with a 200, and no conformance script sent one, so score.sh never saw the
+# unread fields. A filter that matches nothing must answer nothing.
+absent="$(osc ReadVms --Filters.VmIds[] i-00000000)" || fail "a filtered ReadVms was rejected: $absent"
+printf '%s' "$absent" | jq -e '.Vms | length == 0' >/dev/null \
+  || fail "a filter on an id that does not exist returned machines: $absent"
+# And a filter this pack does not serve is refused rather than silently dropped.
+if osc ReadVms --Filters.Architectures[] x86_64 >/dev/null 2>&1; then
+  fail "an unemulated filter was accepted, which is indistinguishable from applying it"
+fi
+ok "filters apply, and an unserved one is refused"
+
 echo "- create, from the catalogue the emulator just published"
 created="$(osc CreateVms --ImageId "$image_id" --VmType "$default_type" --KeypairName conformance)" \
   || fail "CreateVms rejected: $created"

--- a/tools/conformance/outscale/oapi-cli.sh
+++ b/tools/conformance/outscale/oapi-cli.sh
@@ -155,7 +155,7 @@ keys="$(osc ReadKeypairs)" || fail "ReadKeypairs rejected: $keys"
 printf '%s' "$keys" | jq -e '.Keypairs | length == 0' >/dev/null \
   || fail "a fresh account already holds keypairs: $keys"
 created_key="$(osc CreateKeypair --KeypairName conformance \
-  --PublicKey "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyForConformance conformance@feint")" \
+  --PublicKey "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIr6pEFlAFO3YU0DNW/r8SkpjdbptN9ockkO2BtIolSD conformance@feint")" \
   || fail "CreateKeypair rejected: $created_key"
 printf '%s' "$created_key" | jq -e '.Keypair.KeypairFingerprint | length > 0' >/dev/null \
   || fail "the keypair came back without a fingerprint: $created_key"
@@ -163,7 +163,12 @@ printf '%s' "$created_key" | jq -e '.Keypair.KeypairFingerprint | length > 0' >/
 # never generates one, so it must never claim to have.
 printf '%s' "$created_key" | jq -e '.Keypair | has("PrivateKey") | not' >/dev/null \
   || fail "the emulator handed out a private key it did not generate: $created_key"
-ok "keypair conformance registered"
+printf '%s' "$created_key" | jq -e '.Keypair.KeypairType == "ssh-ed25519"' >/dev/null \
+  || fail "the keypair type is not the key's own: $created_key"
+printf '%s' "$created_key" \
+  | jq -e '.Keypair.KeypairFingerprint == "6b:d8:0e:65:b1:58:fd:61:94:3a:b3:42:e6:e1:2c:01"' >/dev/null \
+  || fail "the fingerprint is not the one ssh-keygen -l -E md5 prints: $created_key"
+ok "keypair conformance registered, with the type and fingerprint of the key itself"
 
 echo "- read an empty account"
 vms="$(osc ReadVms)" || fail "ReadVms rejected: $vms"

--- a/tools/conformance/outscale/oapi-cli.sh
+++ b/tools/conformance/outscale/oapi-cli.sh
@@ -182,6 +182,10 @@ echo "- a filter the client sends is applied, not ignored"
 # The defect this replaces: every filter but VmIds returned the whole inventory
 # with a 200, and no conformance script sent one, so score.sh never saw the
 # unread fields. A filter that matches nothing must answer nothing.
+# DryRun false is a legitimate request, and it used to fail this project's own
+# gate: the flag is answered at the mount point, so no handler decodes it and it
+# counted as a field nobody read.
+plain="$(osc ReadVms --DryRun false)" || fail "ReadVms with DryRun false was rejected: $plain"
 absent="$(osc ReadVms --Filters.VmIds[] i-00000000)" || fail "a filtered ReadVms was rejected: $absent"
 printf '%s' "$absent" | jq -e '.Vms | length == 0' >/dev/null \
   || fail "a filter on an id that does not exist returned machines: $absent"


### PR DESCRIPTION
# Summary

Every open bug in the tracker: the fifteen a second Outscale audit confirmed,
the mode-name defect that made `FEINT_VM=incus-ovn` unverifiable, and the one
that stopped a virtual machine from ever carrying the address the API published.

They are together because they are one finding repeated: **a rule this
repository already states, applied in one file and not in its neighbour.** The
lock discipline fixed on the Vm path was violated one file over. The guard "a
resource does not vanish under what it carries" was on `deleteSubnet` and not on
`deleteNet`. The per-target lock was taken by two lifecycle paths out of four.
The validations of `CreateVms` were absent from `UpdateVm`. The OpenSSH key
reader existed twice, and the weaker copy cited the stronger one.

## What each change is

**The lock discipline, where it was still missing** (#30, #34, #35, #36, #39,
#41, #43, #46). `deleteNet` takes the addressing lock its guard needs;
`createSubnet` reserves under it and calls the runtime outside it, writing back
conditionally; `UpdateVm` and `readVms` take the per-target lock every other
mutating path takes — `readVms` writes, so it races, through a door nobody
thinks of as mutating. The create/update validations become one function both
call. `emulator.MaxBody` is one constant instead of two, so the DryRun probe
stops truncating valid 1.2 MiB requests. And the Outscale network suite stops
deriving a binary name from a mode name, which is what made
`FEINT_VM=incus-ovn mise run conformance` exit 1 — it passes now, isolation
between two VPCs included.

**Nothing held the per-target lock** (#43): removing both `Serialise` calls left
the whole suite green. Writing that test took two attempts, because the first
released the runtime as soon as one start entered, which let the second arrive
after the first had committed, where the "already running" short-circuit hides
the missing lock.

**A virtual machine takes the address the API published** (#31). Four causes
stacked: the device was added while the machine was still coming up (an
intermittent "PCI: slot 0 function 0 not available" — Incus documents NIC
hotplug as supported for VMs, so the timing was the difference, not the
capability); the guest does not use Incus's interface names, so `dev eth1`
matched nothing where the kernel says `enp6s0`; the generated hardware address
lives in `volatile.<device>.hwaddr`, not on the device; and a refused attachment
was invisible, the pack logging it while the API went on publishing an address
nothing carried. The NIC now answers `syncing_error`, a state
`PrivateNICState` declares.

**A filter is applied or refused, never ignored** (#38). The API description
declares 66 filters on a Vm; the pack read one and returned the whole inventory
for the rest, with a 200. A script that deletes what a filter matched deletes
everything.

**One reader for OpenSSH public keys** (#37, #42). The copies had drifted: one
checked that the material decodes as base64 and one did not; one hashed the
decoded key and the other the whole line, so the same key had two fingerprints
and neither matched `ssh-keygen -l -E md5`; and `KeypairType` was the constant
"ssh-rsa" for every key.

**The last three** (#40, #45, #47). `DryRun: false` failed this project's own
gate; the code cited a `docs/limits.md` section that did not exist, which now
does and states what the flag does and does not do here; a stopped Vm outside a
Subnet lost its private address.

## Three places I did not take the short way

- The conformance gate went red on a filter I had just added to the suite.
  Removing the probe would have fixed the symptom. Instead the report stops
  counting requests the handler *refused* — a field named in a 400 was not
  ignored — and the core gained `MarkRead` so the DryRun middleware declares what
  it reads, rather than declaring the field on twenty structs that do not read it.
- Two fixtures were made of the defect they were meant to hold: the pack's test
  and the conformance suite both used an SSH key whose material is not valid
  base64, and both passed *because* the pack did not check. They carry a real
  key now, and the suite asserts the fingerprint `ssh-keygen` prints.
- A test skipped itself when the fake runtime published no address. A test that
  skips measures nothing; the fake answers one, and the test now fails loudly.

## Type of change

- [ ] A route added or changed
- [x] Bug fix
- [x] Refactor
- [x] Documentation

## Checklist

### Always

- [x] `mise run check` passes
- [x] No new external Go dependency — `go.mod` still has three lines
- [x] `internal/core` still knows no provider. `sshkey` names none, and
      `MarkRead` takes a field name from its caller
- [x] Nothing in the diff could be written identically for another provider —
      which is why the SSH key reader moved to the core rather than being fixed
      twice

### When a model wrote a substantive part of this

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] I ran `mise run conformance` myself, and `FEINT_VM=incus` and
      `FEINT_VM=incus-ovn` besides
- [x] Every field name comes from the API description, the SDK, or a run of the
      real client. `syncing_error` is `PrivateNICState`'s own; the fingerprint is
      what `ssh-keygen -l -E md5` prints

### When a route is added or changed

N/A — no route added or changed. Behaviour changed on four reads, which the
suite now drives with filters.

### When behaviour a client can observe changes

- [x] `docs/limits.md` gains the DryRun section the code was citing
- [x] Generated blocks regenerated; `feint docs --check` exits 0

### When `.github/workflows/` is touched

N/A.

### When a machine runtime is involved

- [x] Tested with `FEINT_VM=incus` and `FEINT_VM=incus-ovn`, and #31 measured on
      real KVM machines — three consecutive runs to see the intermittence, then
      two more to see it gone
- [x] Nothing the emulator did not create was touched
- [x] The run leaves nothing behind — `feint clean` reports "nothing was left
      behind", checked with `incus list`

## Related issues

Closes #30, closes #31, closes #34, closes #35, closes #36, closes #37,
closes #38, closes #39, closes #40, closes #41, closes #42, closes #43,
closes #45, closes #46, closes #47.
