### PR TITLE
docs(exoscale): redirect exo through EXOSCALE_API_ENDPOINT

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,20 +313,21 @@ the emulator.
 
 ### Exoscale — the `exo` CLI
 
-`exo` can be redirected through environment variable `EXOSCALE_API_ENDPOINT` or
-the `endpoint` key of its own configuration file, and that value **must carry
-the `/v2` suffix**: the CLI concatenates it with the route it wants rather than
-adding a version segment.
+`exo` is redirected through the `EXOSCALE_API_ENDPOINT` environment variable, or
+the `endpoint` key of its own configuration file, and that value **must carry the
+`/v2` suffix**: the CLI concatenates it with the route it wants rather than
+adding a version segment. Measured on `exo` 1.95.1, in both directions: pointed
+at the emulator it drives it, pointed at a dead port it fails naming that port.
 
 ```bash
 export EXOSCALE_API_ENDPOINT=http://127.0.0.1:4599/v2
 export EXOSCALE_API_KEY=EXOxxxxxxxxxxxxxxxxxxxx
 export EXOSCALE_API_SECRET=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
-exo -C /tmp/exoscale.toml compute instance-template list
-exo -C /tmp/exoscale.toml compute instance create demo \
+exo compute instance-template list
+exo compute instance create demo \
   --zone ch-dk-2 --template "Linux Ubuntu 24.04 LTS 64-bit" --instance-type standard.tiny
-exo -C /tmp/exoscale.toml compute instance list
+exo compute instance list
 ```
 
 ### Ask the emulator what it is doing

--- a/README.md
+++ b/README.md
@@ -313,23 +313,15 @@ the emulator.
 
 ### Exoscale — the `exo` CLI
 
-`exo` has no endpoint flag and no endpoint environment variable. It is redirected
-only through the `endpoint` key of its own configuration file, and that value
-**must carry the `/v2` suffix**: the CLI concatenates it with the route it wants
-rather than adding a version segment. Both facts were found by putting a logging
-proxy between the CLI and the emulator; neither is documented anywhere.
+`exo` can be redirected through environment variable `EXOSCALE_API_ENDPOINT` or
+the `endpoint` key of its own configuration file, and that value **must carry
+the `/v2` suffix**: the CLI concatenates it with the route it wants rather than
+adding a version segment.
 
 ```bash
-cat > /tmp/exoscale.toml <<'EOF'
-defaultaccount = "feint"
-
-[[accounts]]
-name = "feint"
-account = "feint"
-key = "EXOxxxxxxxxxxxxxxxxxxxx"
-secret = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-endpoint = "http://127.0.0.1:4599/v2"
-EOF
+export EXOSCALE_API_ENDPOINT=http://127.0.0.1:4599/v2
+export EXOSCALE_API_KEY=EXOxxxxxxxxxxxxxxxxxxxx
+export EXOSCALE_API_SECRET=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
 exo -C /tmp/exoscale.toml compute instance-template list
 exo -C /tmp/exoscale.toml compute instance create demo \

--- a/tools/conformance/exoscale/exo-cli.sh
+++ b/tools/conformance/exoscale/exo-cli.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
 # Conformance check: drive the emulator with the real Exoscale CLI.
 #
-# `exo` has endpoint environment variable EXOSCALE_API_ENDPOINT, and that value
-# must carry the /v2 suffix: the CLI concatenates it with the route it wants
-# rather than adding a version segment of its own. Both facts were measured by
-# putting a logging proxy between the CLI and the emulator, because neither is
-# documented.
+# `exo` is redirected through EXOSCALE_API_ENDPOINT, and that value must carry
+# the /v2 suffix: the CLI concatenates it with the route it wants rather than
+# adding a version segment of its own. Both facts were measured, the suffix by
+# putting a logging proxy between the CLI and the emulator, the variable by
+# pointing it at a dead port and reading the error name that port.
+#
+# It replaces a generated configuration file, which this suite wrote for as long
+# as the variable was believed not to exist. `exo -C` refuses a file that is not
+# there, so nothing here may pass -C any more.
 #
 # The order the CLI works in was measured the same way, and it is why this suite
 # exists at all. `exo compute instance create` issues, before it posts anything:
@@ -42,7 +46,7 @@ export EXOSCALE_API_ENDPOINT=${ENDPOINT}/v2
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 ok() { echo "  ok: $*"; }
-exoc() { exo -C "$WORK/exoscale.toml" "$@"; }
+exoc() { exo "$@"; }
 
 echo "conformance: exo CLI against $ENDPOINT"
 

--- a/tools/conformance/exoscale/exo-cli.sh
+++ b/tools/conformance/exoscale/exo-cli.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 # Conformance check: drive the emulator with the real Exoscale CLI.
 #
-# `exo` has no --endpoint flag and no endpoint environment variable. It is
-# redirected through the `endpoint` key of its own configuration file, and that
-# value must carry the /v2 suffix: the CLI concatenates it with the route it
-# wants rather than adding a version segment of its own. Both facts were measured
-# by putting a logging proxy between the CLI and the emulator, because neither is
+# `exo` has endpoint environment variable EXOSCALE_API_ENDPOINT, and that value
+# must carry the /v2 suffix: the CLI concatenates it with the route it wants
+# rather than adding a version segment of its own. Both facts were measured by
+# putting a logging proxy between the CLI and the emulator, because neither is
 # documented.
 #
 # The order the CLI works in was measured the same way, and it is why this suite
@@ -39,16 +38,7 @@ set +a
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
-cat > "$WORK/exoscale.toml" <<EOF
-defaultaccount = "feint"
-
-[[accounts]]
-name = "feint"
-account = "feint"
-key = "$EXOSCALE_API_KEY"
-secret = "$EXOSCALE_API_SECRET"
-endpoint = "$ENDPOINT/v2"
-EOF
+export EXOSCALE_API_ENDPOINT=${ENDPOINT}/v2
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 ok() { echo "  ok: $*"; }


### PR DESCRIPTION
# Summary

This PR updates the exoscale example from README.md to use environment variable `EXOSCALE_API_ENDPOINT` instead of config parameter to redirect exo cli. This variable is defined in exo CLI [here](https://github.com/exoscale/cli/blob/master/cmd/config_resolution.go#L36).

I've also updated exo-cli conformance test which is using the same pattern.

## Type of change

- [ ] A route added or changed
- [ ] Bug fix
- [x] Refactor
- [x] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

Only the **Always** block applies to every pull request. The other blocks are
conditional: if a block does not apply, write `N/A` rather than leaving it blank
— a blank box reads as "forgotten", an explicit `N/A` reads as "considered".

### Always

- [x] `mise run check` passes (gofmt, vet, golangci-lint, `go test -race`)
- [x] No new external Go dependency, or the pull request justifies it. The
      standard library covers routing, JSON and Go parsing; `go.mod` has three
      lines and a pre-commit hook keeps it that way
- [x] `internal/core` still knows no provider. If a change seemed to require it,
      the pack changed instead
- [x] Nothing in the diff could be written identically for another provider. If
      it could, it belongs in the core — that is the rule that stopped the same
      lifecycle bug being fixed once and surviving twice

### When a model wrote a substantive part of this — otherwise N/A

See the AI-assisted contributions section of
[CONTRIBUTING.md](../CONTRIBUTING.md). The bar is the same as for everyone; what
is added here is disclosure and one extra question.

- [ ] An `Assisted-by:` trailer names the tool and the model version
- [ ] I ran `mise run conformance` myself — not "it should pass"
- [ ] Every field name in the diff comes from the provider's SDK, their OpenAPI
      document, or a run of the real client, and I can say which. "The model
      produced it" is not a source

### When a route is added or changed — otherwise N/A

- [ ] The route declares its upstream operation at the SDK's exact name
      (`Route.Operation`), or the coverage report lies
- [ ] `mise run conformance` passes — at minimum the suite of the provider
      touched. **A unit test alone does not prove a response shape.** The claim
      this project makes is that the official client cannot tell the difference,
      and only the official client can check it
- [ ] The response was validated against the provider's own API description
      (`--contracts contracts`), not against what looked right
- [ ] What the client sends is read, or refused. Check
      `/_feint/conformance | jq .unread_request_fields` — a field declared on a
      request struct and never read is invisible to that report, and is how a
      client got a 200 for a Vm that went nowhere
- [ ] `mise run drift:update` run, and `coverage/` committed with the change

### When behaviour a client can observe changes — otherwise N/A

- [ ] `docs/limits.md` updated if the change moves a documented limit
- [ ] The README's generated tables regenerated (`mise run docs:coverage`) — CI
      fails otherwise, so it is cheaper to do it here

### When `.github/workflows/` is touched — otherwise N/A

- [ ] Every action pinned to a full 40-character commit SHA with a `# vX.Y.Z`
      comment — never `@v4`, never `@main`
- [ ] `step-security/harden-runner` is the job's first step
- [ ] `permissions:` is least-privilege on every job
- [ ] No job renamed, or the required status checks updated — they match job
      names exactly, and a renamed job silently stops being required
- [ ] The exit-code contract still holds: `0` ok, `1` error, `2` drift. A job
      that pipes a gate through `tee` reads `tee`'s zero and can never fail —
      this happened

### When a machine runtime is involved — otherwise N/A

- [ ] Tested with `FEINT_VM=incus` (or `incus-vm`), not only with `--vm off`
- [ ] Nothing the emulator did not create was touched. Everything it creates is
      labelled, and `feint clean` sweeps exactly those
- [ ] The run leaves nothing behind — checked, not assumed

## Related issues

<!-- e.g. Closes #123 -->
