### PR TITLE
docs(contributing): say what a fork's contributor cannot see

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,24 @@
+<!--
+Two things that surprise first-time contributors here, both worth thirty seconds
+before you push:
+
+1. **From a fork, no CI runs until a maintainer approves it.** GitHub holds every
+   workflow in `action_required` — its protection against a fork editing a
+   workflow to reach this repository's secrets — so `gh pr checks` answers "no
+   checks reported" and you get no feedback at all, not even a red one. That is
+   normal. It is not your pull request being ignored, and it means the first
+   review is human. A pull request has already been merged here that broke a
+   conformance suite with nothing on the page to say so.
+
+2. **Commit subjects must be Conventional Commits**, because the version is
+   derived from them: `fix(exoscale): read both key forms`. A check enforces it,
+   and it will fail after you push rather than before.
+
+`pre-commit install` catches the second one locally, along with everything else
+CI runs. It is the first step of CONTRIBUTING.md and it is not a courtesy: git
+hooks are not versioned, so a fresh clone has none of them.
+-->
+
 # Summary
 
 <!-- What does this change, and why? -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,27 @@ It installs two hook types, and the second one is easy to miss: `pre-commit` and
 `commit-msg`. The configuration declares both through
 `default_install_hook_types`, so the single command is enough.
 
+### If you are contributing from a fork
+
+Nothing will run on your pull request until a maintainer approves it. GitHub
+holds every workflow in `action_required` for contributions from forks, which is
+the right default — it is what stops a fork from editing a workflow to read this
+repository's secrets — but it means `gh pr checks` answers "no checks reported"
+and you see no feedback at all, not even a failing one.
+
+So the local gates are not a nicety for you, they are the only ones you have
+until someone looks:
+
+```bash
+mise run check         # what CI runs on every pull request
+mise run conformance   # the real clients, for anything touching a route or a suite
+```
+
+A pull request has already been merged here that broke the Exoscale conformance
+suite, with nothing on the page to say so. Running the suite yourself is what
+would have shown it, and it is why the AI-assisted checklist asks whether you
+ran it rather than whether you expect it to pass.
+
 The upstream SDKs the drift scan reads are cloned on demand:
 
 ```bash


### PR DESCRIPTION
# Summary

Two frictions the first outside contribution exposed (#51), neither of them the
contributor's fault.

**No CI ran on their pull request** until a maintainer approved it: GitHub holds
every workflow from a fork in `action_required`, so `gh pr checks` answered "no
checks reported". They had no feedback at all, not even a failing one — and the
pull request had broken the Exoscale conformance suite, with nothing on the page
to say so.

**The Conventional Commits check then failed on both their subjects**, after the
work was done, from a regular expression in a CI log.

The pull request template now says both in a comment at the top, where it is read
while writing the description, and CONTRIBUTING.md gains a short section for
contributors from a fork.

## What this deliberately is not

A workflow. Something on `pull_request_target` could comment automatically, and
that trigger runs with this repository's secrets: building it to be friendlier to
newcomers is how the protection it explains gets undone. Prose costs nothing and
cannot be exploited.

## Type of change

- [x] Documentation

## Checklist

### Always

- [x] `mise run check` passes
- [x] No new external Go dependency
- [x] `internal/core` still knows no provider
- [x] Nothing in the diff could be written identically for another provider

### When a model wrote a substantive part of this

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] N/A — no route, no field, no client behaviour involved

### When a route is added or changed

N/A.

### When behaviour a client can observe changes

N/A.

### When `.github/workflows/` is touched

N/A — the template is not a workflow, which is the point above.

### When a machine runtime is involved

N/A.

## Related issues

Closes #53, closes #54.