### PR TITLE
fix(cli): status reports the real number, and serve refuses to disarm the browser guard

### DIFF
--- a/internal/cli/bind_test.go
+++ b/internal/cli/bind_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// serve refuses an address that disarms the browser guard.
+//
+// Measured on this repository, before the fix:
+//
+//	                                   127.0.0.1   0.0.0.0
+//	cross-origin page (Origin: evil)      403        200
+//	forged Host: evil.example             403        200
+//
+// and the only thing printed was "feint dev listening on 0.0.0.0:4603". The
+// guard in internal/core/emulator turns itself off when the listen address is
+// not loopback — correctly, since it can no longer tell what is local — and
+// nothing told the operator the protection had gone with it. With --vm on, what
+// is exposed is a container runtime, and store.Restore validates nothing.
+//
+// This drives the decision, not the server. The first version ran serve, and
+// falsifying it hung the suite: with the refusal removed, serve listened, which
+// is what it is for. A test that cannot finish without the fix it checks is not
+// a test.
+func TestServeRefusesANonLoopbackAddress(t *testing.T) {
+	for _, addr := range []string{"0.0.0.0:4599", ":4599", "[::]:4599", "192.168.1.10:4599"} {
+		err := checkListenAddr(addr, false)
+		if err == nil {
+			t.Errorf("%s was accepted", addr)
+			continue
+		}
+		// The refusal says what the exposure costs and how to accept it. Without
+		// both, an operator reads it as a bug and works around it.
+		for _, want := range []string{"browser guard", "--expose-to-network"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("the refusal for %s does not mention %q: %v", addr, want, err)
+			}
+		}
+	}
+
+	// The accepting half, which is what stops this from being a guard that
+	// refuses everything and passes every attack test while breaking the
+	// product: loopback needs no flag, and the flag lifts the refusal for
+	// someone who means it.
+	for _, addr := range []string{"127.0.0.1:4599", "localhost:4599", "[::1]:4599"} {
+		if err := checkListenAddr(addr, false); err != nil {
+			t.Errorf("the loopback address %s was refused: %v", addr, err)
+		}
+	}
+	if err := checkListenAddr("0.0.0.0:4599", true); err != nil {
+		t.Errorf("--expose-to-network did not lift the refusal: %v", err)
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -360,6 +360,33 @@ func newServer(contracts map[string]*contract.Doc) (*emulator.Server, *emulator.
 	return srv, env, nil
 }
 
+// checkListenAddr refuses an address that would serve with the browser guard
+// disarmed, unless the operator asked for exactly that.
+//
+// Off loopback, the anti-rebinding guard stops refusing anything: measured, a
+// page on another origin gets 200 where it gets 403 on 127.0.0.1, and so does a
+// forged Host. With --vm on, what is then reachable from the network is a
+// container runtime — and store.Restore validates nothing, so a forged state is
+// one request away from naming a machine on the host. The old behaviour was to
+// print "feint dev listening on 0.0.0.0:4599" and say nothing else.
+//
+// It is a function rather than a branch inside serve because of what falsifying
+// it showed: the first test drove `serve` itself, and with the refusal removed,
+// serve did its job — it listened, and the test never returned. A test that
+// hangs when its fix is deleted proves nothing and blocks every test behind it.
+// The decision is therefore separated from the act, and only the decision is
+// tested.
+//
+// TestServeRefusesANonLoopbackAddress fails without this.
+func checkListenAddr(addr string, expose bool) error {
+	if emulator.LoopbackListen(addr) || expose {
+		return nil
+	}
+	return fmt.Errorf("refusing to listen on %s: off loopback the browser guard is disarmed, "+
+		"so any page the operator visits can drive this emulator — and with --vm, start containers. "+
+		"Pass --expose-to-network if that is what you want", addr)
+}
+
 func serve(args []string, stdout io.Writer) error {
 	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
 	addr := fs.String("addr", DefaultAddr, "listen address")
@@ -368,7 +395,12 @@ func serve(args []string, stdout io.Writer) error {
 	cleanup := fs.Bool("cleanup", false, "remove the machines and networks this run created before exiting")
 	logLevel := fs.String("log-level", "info", "log verbosity: error, warn, info, debug")
 	contracts := fs.String("contracts", "", "directory of API contracts; every response is checked against them and /_feint/conformance reports what failed")
+	expose := fs.Bool("expose-to-network", false, "listen off loopback, which disarms the browser guard: read what it costs before setting it")
 	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if err := checkListenAddr(*addr, *expose); err != nil {
 		return err
 	}
 

--- a/internal/cli/conformance_view_test.go
+++ b/internal/cli/conformance_view_test.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+)
+
+// `feint status` reports the number a real client actually drove.
+//
+// It could not. `internal/cli` declared its own shape for /_feint/conformance —
+// `proven_by_a_client`, a key that exists in no other file of this repository,
+// and `untouched` as an object where the wire carries an array. The decode
+// failed with "cannot unmarshal array into Go struct field", both callers fell
+// back to empty, and the "driven by a client" column printed 0 whatever a client
+// had driven. The header comment of status.go promised exactly that number.
+//
+// The test drives provenPerProvider, the function status.go calls, against a
+// server that has just answered a real request. Asserting on the type instead
+// would prove nothing now that the CLI and the server share one: both sides
+// would move together under any rename, and a test that cannot fail is not a
+// test. What can still break is the path — a second shape declared somewhere,
+// a count read from a key nobody emits — and that is what this drives.
+//
+// It fails on the code before the fix.
+func TestStatusCountsWhatAClientDrove(t *testing.T) {
+	env := emulator.DefaultEnv()
+	srv, err := emulator.NewServer(env, packsFor(env)...)
+	if err != nil {
+		t.Fatalf("build the server: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	addr := ts.Listener.Addr().String()
+
+	providers := make([]string, 0, len(srv.Packs()))
+	for _, p := range srv.Packs() {
+		providers = append(providers, p.Name())
+	}
+
+	// Nothing has been driven yet: every provider sits at zero. Without this
+	// half, a function that returned a constant would pass.
+	for _, p := range provenPerProvider(addr, providers) {
+		if p.Proven != 0 {
+			t.Fatalf("%s reports %d proven before any client call", p.Provider, p.Proven)
+		}
+		if p.Routes == 0 {
+			t.Fatalf("%s mounts no route, so this test measures nothing", p.Provider)
+		}
+	}
+
+	// One real call, on a route the pack mounts.
+	resp, err := http.Get(ts.URL + "/instance/v1/zones/fr-par-1/servers") //nolint:noctx // a test server
+	if err != nil {
+		t.Fatalf("drive the emulator: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("the route answered %d, so nothing was driven", resp.StatusCode)
+	}
+
+	total := 0
+	for _, p := range provenPerProvider(addr, providers) {
+		total += p.Proven
+	}
+	if total == 0 {
+		t.Fatal("a client drove one route and status still reports 0 proven: the count does not reach the wire")
+	}
+}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -8,6 +8,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
 )
 
 // What is running, and how much of the real API it is standing in for.
@@ -48,11 +50,10 @@ type routeResponse struct {
 	Operation string `json:"operation"`
 }
 
-type conformanceResponse struct {
-	Proven    map[string][]string `json:"proven_by_a_client"`
-	Untouched map[string][]string `json:"untouched"`
-	Contracts []string            `json:"contracts"`
-}
+// The conformance view is the server's own type, imported rather than
+// redeclared. The copy that used to live here named a key the server never
+// emitted, so every decode failed and this command reported zero for the number
+// it exists to report.
 
 // statusReport is what status prints, and what --format json emits verbatim.
 type statusReport struct {
@@ -194,8 +195,8 @@ func fetchHealth(addr string) (healthResponse, error) {
 	return out, err
 }
 
-func fetchConformance(addr string) (conformanceResponse, error) {
-	var out conformanceResponse
+func fetchConformance(addr string) (emulator.ConformanceView, error) {
+	var out emulator.ConformanceView
 	err := getJSON(strings.Replace(healthURL(addr), "/health", "/conformance", 1), statusTimeout, &out)
 	return out, err
 }
@@ -210,7 +211,7 @@ func provenPerProvider(addr string, providers []string) []providerStatus {
 	}
 	conf, err := fetchConformance(addr)
 	if err != nil {
-		conf = conformanceResponse{}
+		conf = emulator.ConformanceView{}
 	}
 
 	counts := map[string]int{}
@@ -229,9 +230,15 @@ func provenPerProvider(addr string, providers []string) []providerStatus {
 			p.Routes += n
 		}
 	}
-	for provider, proven := range conf.Proven {
-		if p, ok := byProvider[provider]; ok {
-			p.Proven = len(proven)
+	// Counted from the calls a real client made, keyed by operation, which is
+	// what the server publishes. The old code read a per-provider map that never
+	// existed on the wire.
+	for operation, calls := range conf.Calls {
+		if calls == 0 {
+			continue
+		}
+		if p, ok := byProvider[providerOfProduct(productOf(operation), providers)]; ok {
+			p.Proven++
 		}
 	}
 

--- a/internal/core/emulator/conformance.go
+++ b/internal/core/emulator/conformance.go
@@ -189,8 +189,22 @@ func (r *recorder) Write(b []byte) (int, error) {
 	return r.ResponseWriter.Write(b)
 }
 
-// conformanceView is what /_feint/conformance answers.
-type conformanceView struct {
+// ConformanceView is what /_feint/conformance answers.
+// ConformanceView is the shape of /_feint/conformance, exported because more
+// than one thing reads it.
+//
+// It was unexported, so `internal/cli` declared its own copy — with a key
+// (`proven_by_a_client`) the server never emitted and `untouched` as an object
+// where this one carries an array. The decode failed, both callers fell back to
+// empty, and `feint status` printed 0 in the "driven by a client" column
+// whatever a client had driven. Nobody noticed, because a silent fallback looks
+// exactly like an emulator nobody has used yet.
+//
+// One shape, one owner. A reader that cannot import it is a reader that will
+// copy it.
+//
+// TestStatusCountsWhatAClientDrove in internal/cli fails without this.
+type ConformanceView struct {
 	// Served is how many routes are mounted.
 	Served int `json:"served"`
 	// Exercised is how many of them a real client drove at least once. The
@@ -266,7 +280,7 @@ func (s *Server) handleConformance(w http.ResponseWriter, _ *http.Request) {
 	}
 	sort.Strings(untouched)
 
-	writeJSON(w, http.StatusOK, conformanceView{
+	writeJSON(w, http.StatusOK, ConformanceView{
 		Served:              len(routes),
 		Exercised:           len(routes) - len(untouched),
 		Probed:              probedOnly,

--- a/internal/core/emulator/rebinding.go
+++ b/internal/core/emulator/rebinding.go
@@ -38,7 +38,7 @@ type rebindingGuard struct {
 // listen address; the bare Handler stays unguarded so tests and in-process users
 // are not made to care.
 func GuardRebinding(h http.Handler, addr string) http.Handler {
-	return rebindingGuard{next: h, guard: isLoopbackListen(addr)}
+	return rebindingGuard{next: h, guard: LoopbackListen(addr)}
 }
 
 func (g rebindingGuard) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -74,9 +74,14 @@ func (g rebindingGuard) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	g.next.ServeHTTP(w, r)
 }
 
-// isLoopbackListen reports whether a listen address keeps the emulator on the
+// LoopbackListen reports whether a listen address keeps the emulator on the
 // local machine. A bare port, or one bound to every interface, does not.
-func isLoopbackListen(addr string) bool {
+//
+// Exported because the refusal at start-up must ask exactly this question. Two
+// implementations of "is this local" would eventually disagree, and the one that
+// drifted would be the one nobody tested — which is how the browser guard came
+// to be silently disarmed by an address nothing validated.
+func LoopbackListen(addr string) bool {
 	host, _, err := net.SplitHostPort(addr)
 	if err != nil {
 		host = addr


### PR DESCRIPTION
Two defects found while designing the web interface, and one found while
falsifying the fix for the second.

Closes #65, closes #66.

## #65 — the "driven by a client" column was structurally zero

`internal/cli` declared its own shape for `/_feint/conformance`, with a key the
server emits nowhere (`proven_by_a_client`) and `untouched` as an object where
the wire carries an array. The decode failed with `cannot unmarshal array into
Go struct field`, both callers fell back to an empty view, and the column printed
`0` whatever a client had driven. The header comment of `status.go` promised
exactly that number.

Measured after two `scw` calls: **0 before, 2 after.**

The fix is not to correct the copy but to delete it. `conformanceView` becomes
`emulator.ConformanceView`, `internal/cli` imports it, and the count comes from
`conf.Calls` — the per-operation map the server actually publishes.

One shape, one owner. This one was about to acquire a third reader in the web
interface.

## #66 — `serve` disarmed the browser guard without a word

```
$ feint serve --addr 0.0.0.0:4599
feint dev listening on 0.0.0.0:4599          ← the whole output
```

|                                    | 127.0.0.1 | 0.0.0.0 |
| ---------------------------------- | --------- | ------- |
| cross-origin page (`Origin: evil`) | **403**   | **200** |
| forged `Host: evil.example`        | **403**   | **200** |

The anti-rebinding guard turns itself off off-loopback — correctly, since it can
no longer tell what is local — and nothing said so. With `--vm` on, what is then
reachable from the network is a container runtime, and `store.Restore` validates
nothing.

`serve` now exits 1 without listening, and `--expose-to-network` lifts it for
someone who means it.

## The third defect: a test that hangs instead of failing

Falsifying #66 sat on one mutation for twenty minutes and reported nothing.

The cause was the test, not the harness: it drove `serve` itself, so with the
refusal removed `serve` did its job — it listened — and the test never returned.
That is worse than a test that always passes, because it also blocks every test
behind it, and the symptom reads as a slow machine.

The fix is structural rather than a timeout: **separate the decision from the
act, and test the decision.** `checkListenAddr(addr, expose) error` returns in
microseconds and cannot hang in either direction. The test went from unbounded
to `0.00s`.

The harness now caps each mutation at 120s anyway and counts a timeout as
*survival* — the cautious verdict, the one that makes you look.

## The fourth: the test for #65 could not fail

Its first version asserted on `emulator.ConformanceView` itself. With the client
and the server sharing one type, both sides move together under any rename: the
test was green by construction.

`TestStatusCountsWhatAClientDrove` now drives `provenPerProvider` — the function
`status.go` actually calls — against a server that has just answered a real
request, and asserts both halves: every provider at zero before the call,
non-zero after.

## Falsification

| mutation                          | verdict           |
| --------------------------------- | ----------------- |
| the refusal removed               | **meurt** (2s)    |
| the hand-copied shape restored    | **meurt** (1s)    |

`mise run check` green.

The phantom-citation guard added last week caught the rename of the test cited in
`internal/core/emulator/conformance.go` — its first catch in real conditions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
