### PR TITLE
fix(cli): clean collects the state directories nobody was collecting

### DIFF
--- a/internal/cli/clean.go
+++ b/internal/cli/clean.go
@@ -24,12 +24,42 @@ func clean(args []string, stdout io.Writer) error {
 		return err
 	}
 
+	// The state directories go first, and deliberately before the runtime is
+	// even resolved: they are swept on every station, including the ones with no
+	// machine runtime installed at all. Put after the driver, this would never
+	// run for anybody using --vm off, which is the default and the majority.
+	//
+	// TestCleanReapsWithoutAMachineRuntime fails without this ordering.
+	reaped, err := reapStaleInstances()
+	if reaped > 0 {
+		fmt.Fprintf(stdout, "removed %d stale instance record(s)\n", reaped)
+	}
+	if err != nil {
+		return err
+	}
+
 	driver, err := machineDriver(*vm, stdout)
 	if err != nil {
 		return err
 	}
 	pruner, ok := driver.(machine.Pruner)
 	if !ok {
+		// --vm off has no runtime, so there is nothing to sweep and that is not a
+		// failure. It became worth distinguishing when this command started
+		// collecting instance records as well: an operator with no machine
+		// runtime — the default, and the majority — did the work, saw it
+		// reported, and still got exit 1. A success that exits like a failure is
+		// the ambiguity this project refuses everywhere else.
+		//
+		// TestCleanSucceedsWithNoRuntimeToSweep fails without this.
+		if _, noRuntime := driver.(machine.Noop); noRuntime {
+			// The same sentence as the swept case, because it is just as true
+			// with no runtime and network.sh asserts on it. An early return that
+			// stayed silent would make the line depend on the mode, and a caller
+			// checking it would read "no runtime" as "dirty runtime".
+			fmt.Fprintln(stdout, "nothing was left behind on the runtime")
+			return nil
+		}
 		return fmt.Errorf("the %s runtime cannot be swept", driver.Name())
 	}
 
@@ -41,8 +71,13 @@ func clean(args []string, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
+	// This line is about the runtime and nothing else, and it stays that way.
+	// tools/conformance/scaleway/network.sh asserts on it to decide whether the
+	// runtime is clean; making it depend on the instance records too would have
+	// it report a dirty runtime because a directory was collected, which is a
+	// different question with a different answer.
 	if pruned.Total() == 0 {
-		fmt.Fprintln(stdout, "nothing was left behind")
+		fmt.Fprintln(stdout, "nothing was left behind on the runtime")
 	}
 	return nil
 }

--- a/internal/cli/instance.go
+++ b/internal/cli/instance.go
@@ -22,6 +22,17 @@ import (
 // `feint stop` is somebody else's process killed by this tool, which is the
 // single worst thing a developer tool can do to a workstation.
 
+// snapshotsDirName is the one place this name is written.
+//
+// It has to be shared rather than repeated, because two directories answer to
+// it under different roots: snapshots follow persistentHome and instance state
+// follows stateHome, and those two resolve to the same path whenever
+// XDG_RUNTIME_DIR is unset or XDG_STATE_HOME points at it. When they coincide,
+// reapStaleInstances walks over the snapshot directory, and a name spelled twice
+// is a name that will one day be spelled once — which here means deleting work
+// an operator saved on purpose.
+const snapshotsDirName = "snapshots"
+
 // Instance is what one detached emulator recorded about itself.
 type Instance struct {
 	PID     int      `json:"pid"`
@@ -131,12 +142,95 @@ func (i *Instance) save() error {
 
 // remove deletes the instance file. A missing file is success: the caller wants
 // it gone, and it is.
+//
+// The directory and its log survive on purpose. `feint logs --addr` reads that
+// file, and the moment an operator wants it most is right after the emulator
+// stopped — a crash is read after the fact or not at all. Reaping is therefore
+// not stop's job; it is reapStaleInstances, called by `feint clean`, where the
+// operator has asked for a sweep rather than an exit.
 func (i *Instance) remove() error {
 	err := os.Remove(filepath.Join(i.Dir, "instance.json"))
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
 	}
 	return err
+}
+
+// reapStaleInstances removes the state directories of emulators that are gone,
+// and returns how many went.
+//
+// Measured on a development station after one day: fourteen directories for two
+// live emulators. `stop` clears the record and leaves the directory holding the
+// log, which is right on its own (see remove) and wrong in aggregate — nothing
+// ever collected them, so `/run/user/1000/feint/` stopped being readable as an
+// answer to "what is running". Twelve of the fourteen described nothing at all.
+//
+// Stale means one of three things, and the third is the one that matters: no
+// instance file at all (a stopped emulator's leftovers), a recorded pid that
+// nothing holds any more, or a pid that now belongs to a stranger. That last
+// case is exactly what alive() calls Foreign, and reusing it here rather than
+// re-deriving it is the point: the rule for "is this still ours" is written
+// once, and a reaper that got it wrong would delete the directory of a running
+// emulator.
+//
+// A live instance is never touched, whatever its age. An emulator someone left
+// running overnight is not litter.
+//
+// TestCleanReapsOnlyDeadInstances fails without this.
+func reapStaleInstances() (int, error) {
+	home, err := stateHome()
+	if err != nil {
+		return 0, err
+	}
+	entries, err := os.ReadDir(home)
+	if errors.Is(err, os.ErrNotExist) {
+		// Nothing was ever started. That is not a failure.
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+
+	reaped := 0
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		dir := filepath.Join(home, entry.Name())
+
+		// Snapshots are not instance state and outlive every emulator by design;
+		// removing them would destroy work an operator named in order to come
+		// back to it.
+		if entry.Name() == snapshotsDirName {
+			continue
+		}
+
+		raw, readErr := os.ReadFile(filepath.Join(dir, "instance.json")) //nolint:gosec // a path this package builds
+		switch {
+		case errors.Is(readErr, os.ErrNotExist):
+			// No record: a stopped emulator's leftovers.
+		case readErr != nil:
+			// Unreadable rather than absent. Left alone and reported by the
+			// caller's error, because deleting what cannot be read is how a
+			// sweep destroys something it never identified.
+			return reaped, fmt.Errorf("%s: %w", dir, readErr)
+		default:
+			var inst Instance
+			if err := json.Unmarshal(raw, &inst); err != nil {
+				return reaped, fmt.Errorf("%s: the instance file is not readable: %w", dir, err)
+			}
+			inst.Dir = dir
+			if inst.alive() == Alive {
+				continue
+			}
+		}
+
+		if err := os.RemoveAll(dir); err != nil {
+			return reaped, err
+		}
+		reaped++
+	}
+	return reaped, nil
 }
 
 // Liveness is what a recorded instance turned out to be.

--- a/internal/cli/reap_test.go
+++ b/internal/cli/reap_test.go
@@ -1,0 +1,225 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Stale instance directories are collected; live ones are not.
+//
+// Measured on a development station after one day: fourteen directories under
+// XDG_RUNTIME_DIR for two live emulators. `stop` clears the record and leaves
+// the directory holding the log — right on its own, since a crash is read after
+// the fact — but nothing ever collected them, so the directory stopped being
+// readable as an answer to "what is running".
+//
+// The accepting half is the half that matters here. A reaper that removed
+// everything would pass any test that only checks that litter goes, and would
+// delete the state of an emulator someone left running overnight. So the live
+// case is asserted twice: its directory survives, and so does its log.
+func TestCleanReapsOnlyDeadInstances(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", home)
+	t.Setenv("XDG_STATE_HOME", "")
+
+	// A live instance has to satisfy alive() on both of its paths, because they
+	// are chosen by the operating system rather than by the test: on Linux it
+	// compares /proc/<pid>/comm with the recorded binary's base name, and where
+	// /proc does not exist — macOS, which is in this project's CI matrix — it
+	// falls back to probing the recorded address for this emulator's own health.
+	//
+	// The first version satisfied only the first, so the stand-in was reaped on
+	// macOS and the failure read as a broken reaper. It was a broken fixture:
+	// alive() was right both times. So the stand-in now answers health for real,
+	// and this test drives whichever path the platform takes.
+	ts := httptest.NewServer(healthOnly(t))
+	t.Cleanup(ts.Close)
+	live := writeInstance(t, ts.Listener.Addr().String(), os.Getpid())
+	// A pid nothing holds. 4194303 is above the default pid_max on Linux, so it
+	// cannot be allocated to anything while this test runs.
+	dead := writeInstance(t, "127.0.0.1:4600", 4194303)
+	// A directory with a log and no record: what `stop` leaves behind.
+	stopped := filepath.Join(home, "feint", "127.0.0.1_4601")
+	mkdirWithLog(t, stopped)
+	// Snapshots share this root whenever the two XDG homes coincide, and they
+	// are work an operator named on purpose.
+	snapshots := filepath.Join(home, "feint", snapshotsDirName)
+	mkdirWithLog(t, snapshots)
+
+	reaped, err := reapStaleInstances()
+	if err != nil {
+		t.Fatalf("reap: %v", err)
+	}
+	if reaped != 2 {
+		t.Errorf("reaped %d directories, want 2 (the dead record and the stopped leftovers)", reaped)
+	}
+
+	for _, gone := range []string{dead, stopped} {
+		if _, err := os.Stat(gone); !os.IsNotExist(err) {
+			t.Errorf("%s survived the sweep", gone)
+		}
+	}
+	for _, kept := range []string{live, snapshots} {
+		if _, err := os.Stat(kept); err != nil {
+			t.Errorf("%s was removed: %v", kept, err)
+		}
+		if _, err := os.Stat(filepath.Join(kept, "feint.log")); err != nil {
+			t.Errorf("%s lost its log: %v", kept, err)
+		}
+	}
+}
+
+// `feint clean` sweeps the state directories even where no machine runtime can
+// be resolved.
+//
+// --vm off is the default and the majority of runs. With the reap placed after
+// the driver is resolved, every one of those users would get an error and no
+// sweep at all — the directories would accumulate on exactly the stations that
+// never start a machine.
+func TestCleanReapsWithoutAMachineRuntime(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", home)
+	t.Setenv("XDG_STATE_HOME", "")
+	mkdirWithLog(t, filepath.Join(home, "feint", "127.0.0.1_4602"))
+
+	var out bytes.Buffer
+	// A runtime name nothing can resolve, which is the point: clean must have
+	// swept before it fails.
+	err := clean([]string{"--vm", "no-such-runtime"}, &out)
+	if err == nil {
+		t.Fatal("an unknown runtime was accepted, so this test no longer drives the failing path")
+	}
+	if !strings.Contains(out.String(), "stale instance record") {
+		t.Errorf("clean failed on the runtime without sweeping first; it printed: %q", out.String())
+	}
+	if _, err := os.Stat(filepath.Join(home, "feint", "127.0.0.1_4602")); !os.IsNotExist(err) {
+		t.Error("the stale directory survived a clean that could not resolve a runtime")
+	}
+}
+
+// `feint clean --vm off` succeeds. There is no runtime to sweep, which is not a
+// failure — and since this command now collects instance records too, the
+// operator did work, saw it reported, and used to get exit 1 anyway.
+//
+// --vm off is the default of `serve` and the majority of runs, so this is the
+// common path rather than an edge.
+func TestCleanSucceedsWithNoRuntimeToSweep(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", home)
+	t.Setenv("XDG_STATE_HOME", "")
+	stale := filepath.Join(home, "feint", "127.0.0.1_4603")
+	mkdirWithLog(t, stale)
+
+	var out bytes.Buffer
+	if err := clean([]string{"--vm", "off"}, &out); err != nil {
+		t.Fatalf("clean --vm off reported a failure: %v", err)
+	}
+	if !strings.Contains(out.String(), "stale instance record") {
+		t.Errorf("the sweep was not reported: %q", out.String())
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Error("the stale directory survived")
+	}
+
+	// And a runtime that genuinely cannot be swept still fails, or this would be
+	// a guard that turned every error into success.
+	if err := clean([]string{"--vm", "no-such-runtime"}, &bytes.Buffer{}); err == nil {
+		t.Error("an unknown runtime was accepted")
+	}
+}
+
+// The sentence tools/conformance/scaleway/network.sh greps for is produced
+// whatever the mode.
+//
+// That suite decides the runtime is clean by matching this string, and it skips
+// itself when no machine runtime is configured — which is CI, and which is this
+// station. So nothing was checking the contract at all: the string could have
+// changed under it and the suite would have gone on reporting SKIP. A grep in a
+// shell script that only runs on a developer's machine is not a control.
+//
+// The literal is written out here rather than shared with clean.go on purpose.
+// A constant referenced by both would move in lockstep and prove nothing; this
+// has to fail when the message changes, because the reader that matters is a
+// script this test cannot import.
+func TestCleanAlwaysReportsTheRuntimeVerdict(t *testing.T) {
+	const asserted = "nothing was left behind" // tools/conformance/scaleway/network.sh:105
+
+	home := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", home)
+	t.Setenv("XDG_STATE_HOME", "")
+
+	var out bytes.Buffer
+	if err := clean([]string{"--vm", "off"}, &out); err != nil {
+		t.Fatalf("clean --vm off: %v", err)
+	}
+	if !strings.Contains(out.String(), asserted) {
+		t.Errorf("network.sh greps for %q and clean printed %q", asserted, out.String())
+	}
+
+	// And it still says it after collecting records, because the two verdicts
+	// answer different questions: one is about the host's runtime, the other
+	// about this tool's own bookkeeping.
+	mkdirWithLog(t, filepath.Join(home, "feint", "127.0.0.1_4604"))
+	out.Reset()
+	if err := clean([]string{"--vm", "off"}, &out); err != nil {
+		t.Fatalf("clean --vm off after a reap: %v", err)
+	}
+	if !strings.Contains(out.String(), asserted) {
+		t.Errorf("collecting a record silenced the runtime verdict: %q", out.String())
+	}
+}
+
+func writeInstance(t *testing.T, addr string, pid int) string {
+	t.Helper()
+	dir, err := instanceDir(addr)
+	if err != nil {
+		t.Fatalf("instance dir: %v", err)
+	}
+	mkdirWithLog(t, dir)
+	raw, err := json.Marshal(Instance{PID: pid, Addr: addr, Binary: os.Args[0]})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "instance.json"), raw, 0o600); err != nil {
+		t.Fatalf("write instance: %v", err)
+	}
+	return dir
+}
+
+// healthOnly serves what healthy() demands and nothing more: status and
+// providers, both checked, because a bare 200 could come from anything.
+//
+// A real emulator would do, and is not used on purpose — building one drags the
+// packs into a test about directory collection, and a fixture that needs the
+// whole product to prove a filesystem sweep is a fixture that will be deleted
+// the first time it gets in the way.
+func healthOnly(t *testing.T) http.Handler {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /_feint/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"status":    "ok",
+			"providers": []string{"scaleway"},
+		}); err != nil {
+			t.Errorf("encode health: %v", err)
+		}
+	})
+	return mux
+}
+
+func mkdirWithLog(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "feint.log"), []byte("listening\n"), 0o600); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+}

--- a/internal/cli/snapshot.go
+++ b/internal/cli/snapshot.go
@@ -96,7 +96,7 @@ func snapshotDir() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	dir := filepath.Join(home, "snapshots")
+	dir := filepath.Join(home, snapshotsDirName)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return "", fmt.Errorf("create %s: %w", dir, err)
 	}


### PR DESCRIPTION
Measured on a development station after one day: **fourteen state directories under `XDG_RUNTIME_DIR` for two live emulators.** Twelve described nothing at all.

`stop` clears the record and leaves the directory holding the log. That is right on its own — a crash is read after the fact or not at all, and `feint logs` reads that file — but nothing ever collected them, so the state directory stopped being readable as an answer to "what is running".

Reaping therefore belongs to `clean`, where the operator asked for a sweep rather than an exit. Stale means one of three things: no instance file, a pid nothing holds, or a pid that now belongs to a stranger. The third is decided by `alive()`, reused rather than re-derived — a reaper that got that wrong would delete the directory of a running emulator.

## Three consequences the tests hold

- **The sweep runs before the machine runtime is resolved.** Placed after, it would never run for anyone using `--vm off`, which is the default and the majority. `TestCleanReapsWithoutAMachineRuntime` drives a runtime that cannot resolve and asserts the directories went anyway.
- **`clean --vm off` now succeeds.** It reaped, it said so, and it exited 1. A success that exits like a failure is the ambiguity this project refuses everywhere else. The unknown-runtime error is asserted in the same test, so this is not a guard that turned every failure into success.
- **`snapshotsDirName` is written once.** Snapshots follow `persistentHome` and instance state follows `stateHome`, and those resolve to the same path whenever `XDG_RUNTIME_DIR` is unset — at which point the reaper walks over saved work.

## The defect this found in the project's own controls

`tools/conformance/scaleway/network.sh:105` decides the runtime is clean by grepping for `nothing was left behind`. Running the conformance suite to check I had not broken that string produced:

```
conformance: outscale network against http://127.0.0.1:4599
  SKIP: no machine runtime (start with FEINT_VM=incus); nothing to measure
```

**The control skipped itself** — and it skips itself in CI too, since CI has no machine runtime. So nothing was checking that contract at all: the string could have drifted under it indefinitely while the suite went on reporting SKIP. A grep in a shell script that only runs on a developer's machine is not a control.

`TestCleanAlwaysReportsTheRuntimeVerdict` now holds it, in every mode. The literal is written out in the test rather than shared with `clean.go` as a constant: a shared constant would move on both sides at once and prove nothing, and the reader that matters is a script this test cannot import.

That test also caught a defect I had just introduced — an early return for `--vm off` that silenced the line the script greps for.

## Falsification

| mutation | verdict |
| --- | --- |
| the reap gutted | **meurt** (2s) |
| the reap moved after the driver | **meurt** (1s) |
| the snapshot guard disarmed | **meurt** (2s) |

`mise run check` green. `mise run conformance` green, 74 of 104 routes proven.

On the station that prompted this: fifteen directories to two, keeping the live emulator and the snapshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
