### PR TITLE
EXO-2: the preview label comes off on what exo proves, not on Terraform

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -15,6 +15,33 @@ parce que c'est là-dessus que ce projet est jugé : **une forme de réponse qu'
 client peut observer**, et **une limite qui a bougé**. Une refactorisation qui ne
 change ni l'un ni l'autre a sa place dans `git log`.
 
+## [Non publié]
+
+### Modifié
+
+- **Exoscale est *starter*, plus *preview*.** Le label avait été pris
+  délibérément, avec une condition de sortie écrite — *tant que le provider
+  Terraform n'est pas prouvé contre lui* — et cette condition reposait sur une
+  hypothèse que la mesure a réfutée : le provider honore
+  `EXOSCALE_API_ENDPOINT` pour son client egoscale v3 et en construit un v2 sans
+  aucune option d'endpoint, si bien qu'un apply se scinde entre cet émulateur et
+  un compte payant. `ClientOptWithAPIEndpoint` existe dans egoscale et n'est
+  jamais appelée ; trois sites construisent un client v2 sans elle. Remontée en
+  amont sous
+  [exoscale/terraform-provider-exoscale#573](https://github.com/exoscale/terraform-provider-exoscale/issues/573).
+
+  Une condition que personne ici ne peut atteindre n'est pas une condition,
+  c'est un otage — et ce contre quoi le label mettait en garde a de toute façon
+  été corrigé par EXO-2 : `exo` pilote stop, start, reboot, scale, resize, une
+  suppression refusée sur une instance protégée, un aller-retour de règle de
+  groupe de sécurité, un groupe d'anti-affinité, et une IP élastique attachée,
+  publiée puis retirée. Ce qui sépare encore Exoscale d'*usable* reste dans les
+  tableaux de couverture générés, où cela ne peut pas flatter : 75 opérations
+  non triées, contre 18 pour Outscale et 0 pour Scaleway.
+
+- **La ligne Outscale crédite Terraform**, qui pilote dix-sept ressources de
+  bout en bout depuis 0.6.0 et n'était toujours créditée qu'à `oapi-cli`.
+
 ## [0.7.0]
 
 ### Ajouté

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,31 @@ Two kinds of change deserve their own line whatever their size, because they are
 what this project is judged on: **a response shape a client can observe**, and
 **a limit that moved**. A refactor that changes neither belongs in `git log`.
 
+## [Unreleased]
+
+### Changed
+
+- **Exoscale is *starter*, not *preview*.** The label was taken deliberately,
+  with a written exit condition — *until the Terraform provider is proven
+  against it* — and that condition turned out to rest on an assumption
+  measurement refuted: the provider honours `EXOSCALE_API_ENDPOINT` for its
+  egoscale v3 client and builds a v2 one with no endpoint option, so an apply
+  splits between this emulator and a paying account. `ClientOptWithAPIEndpoint`
+  exists in egoscale and is never called; three sites build a v2 client without
+  it. Filed upstream as
+  [exoscale/terraform-provider-exoscale#573](https://github.com/exoscale/terraform-provider-exoscale/issues/573).
+
+  A condition nobody here can reach is not a condition, it is a hostage — and
+  what the label warned about was fixed by EXO-2 anyway: `exo` drives stop,
+  start, reboot, scale, resize, a delete refused while protected, a security
+  group rule round-trip, an anti-affinity group, and an elastic IP attached,
+  published and withdrawn. What still separates Exoscale from *usable* stays in
+  the generated coverage tables, where it cannot flatter: 75 operations
+  untriaged, against 18 for Outscale and 0 for Scaleway.
+
+- **The Outscale row credits Terraform**, which has driven seventeen resources
+  end to end since 0.6.0 and was still listed as `oapi-cli` alone.
+
 ## [0.7.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -503,19 +503,23 @@ those. Nothing else on your host is touched.
 |---|---|---|---|
 | Scaleway | REST JSON, `X-Auth-Token` | `scw`, Terraform, OpenTofu | usable |
 | Outscale | `POST /api/v1/<Action>`, AWS Signature v4 | `oapi-cli`, Terraform | starter |
-| Exoscale | REST `/v2/<resource>`, asynchronous operations | `exo` | **preview** |
+| Exoscale | REST `/v2/<resource>`, asynchronous operations | `exo` | starter |
 
-*Usable* means a realistic configuration applies and destroys. *Starter* and
-*preview* mean the protocol is right and the surface is thin: see the coverage
-tables below, and [docs/limits.md](docs/limits.md) for what that costs you.
-Exoscale loses its preview label on what the `exo` CLI proves. Terraform is not
-that condition, and cannot be: the provider honours `EXOSCALE_API_ENDPOINT` for
-one of the two clients it builds and reaches the real cloud with the other, so
-an apply splits between this emulator and a paying account. Filed upstream as
-[#573](https://github.com/exoscale/terraform-provider-exoscale/issues/573); a
+*Usable* means a realistic configuration applies and destroys. *Starter* means
+the protocol is right and a real client drives a real workload, but the surface
+is still thin: see the coverage tables below, and
+[docs/limits.md](docs/limits.md) for what that costs you.
+
+Exoscale has no Terraform column, and that is not a gap in this emulator. The
+provider honours `EXOSCALE_API_ENDPOINT` for one of the two clients it builds
+and reaches the real cloud with the other, so an apply splits between here and a
+paying account — which is why the emulator refuses that client outright rather
+than serve half of it. Filed upstream as
+[#573](https://github.com/exoscale/terraform-provider-exoscale/issues/573). A
 patched build that closes the split is documented in
 [docs/limits.md](docs/limits.md#the-patched-provider-while-upstream-decides),
-and it deliberately counts for nothing here.
+and it deliberately counts for nothing here: a client this project patched is no
+longer the official client.
 
 Every command in the [Use it](#use-it) section above is executed against the
 emulator before it is written here.

--- a/README.md
+++ b/README.md
@@ -502,14 +502,20 @@ those. Nothing else on your host is touched.
 | Provider | Protocol | Proven by | Maturity |
 |---|---|---|---|
 | Scaleway | REST JSON, `X-Auth-Token` | `scw`, Terraform, OpenTofu | usable |
-| Outscale | `POST /api/v1/<Action>`, AWS Signature v4 | `oapi-cli` | starter |
+| Outscale | `POST /api/v1/<Action>`, AWS Signature v4 | `oapi-cli`, Terraform | starter |
 | Exoscale | REST `/v2/<resource>`, asynchronous operations | `exo` | **preview** |
 
 *Usable* means a realistic configuration applies and destroys. *Starter* and
 *preview* mean the protocol is right and the surface is thin: see the coverage
 tables below, and [docs/limits.md](docs/limits.md) for what that costs you.
-Exoscale loses its preview label the day `terraform apply` passes against it in
-conformance, which is the condition [docs/roadmap.md](docs/roadmap.md) sets.
+Exoscale loses its preview label on what the `exo` CLI proves. Terraform is not
+that condition, and cannot be: the provider honours `EXOSCALE_API_ENDPOINT` for
+one of the two clients it builds and reaches the real cloud with the other, so
+an apply splits between this emulator and a paying account. Filed upstream as
+[#573](https://github.com/exoscale/terraform-provider-exoscale/issues/573); a
+patched build that closes the split is documented in
+[docs/limits.md](docs/limits.md#the-patched-provider-while-upstream-decides),
+and it deliberately counts for nothing here.
 
 Every command in the [Use it](#use-it) section above is executed against the
 emulator before it is written here.

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -381,6 +381,14 @@ lists five provider attributes — `key`, `secret`, `timeout`, `environment`,
 is Object Storage only; `environment` composes a `%s-%s.exoscale.com` domain.
 Neither points anywhere local.
 
+Nor is there one deeper in the client. `egoscale/v2` reads no environment
+variable of its own, and the `.exoscale.com` suffix is compiled into
+`v2/api/request.go`. The option that would do it, `ClientOptWithAPIEndpoint`,
+**exists in `egoscale/v2` and is never called by the provider** — a grep over
+`exoscale/` and `pkg/` returns nothing. Three sites build a v2 client without
+it: `CreateClient`, `getClient`, and the plugin-framework provider's
+`Configure`.
+
 **So the emulator refuses that client**, by the user agent it sets itself
 (`Exoscale-Terraform-Provider/…`), with a message saying what is happening. Half
 serving it is the worst of the three outcomes: a half-success is
@@ -400,8 +408,74 @@ The `exo` CLI is unaffected and is driven by the conformance suite: it reads
 `EXOSCALE_API_ENDPOINT` for everything.
 
 Closing this properly needs an endpoint option on the provider's v2 client,
-which is upstream work. Until then, `feint env exoscale` prints the warning on
-stderr, where `eval` cannot swallow it.
+which is upstream work. It is filed as
+[exoscale/terraform-provider-exoscale#573][exo-573], with the mechanism, the
+three construction sites and a reproduction. Until it lands, `feint env
+exoscale` prints the warning on stderr, where `eval` cannot swallow it.
+
+### The patched provider, while upstream decides
+
+The fix is four lines per site, so it is also carried on a fork, pinned:
+
+- [`stephrobert/terraform-provider-exoscale@fix/v2-client-honours-api-endpoint`][fork],
+  commit `2e78b42`, branched from `de9d60c2` (0.70.0 plus six commits).
+
+It passes `ClientOptWithAPIEndpoint` at the three sites, and nothing else.
+Terraform resolves it without a registry, through `dev_overrides`:
+
+```bash
+git clone -b fix/v2-client-honours-api-endpoint \
+  https://github.com/stephrobert/terraform-provider-exoscale
+cd terraform-provider-exoscale && go build -o /tmp/tfp/terraform-provider-exoscale .
+
+cat > /tmp/dev.tfrc <<'RC'
+provider_installation {
+  dev_overrides { "exoscale/exoscale" = "/tmp/tfp" }
+  direct {}
+}
+RC
+
+eval "$(feint env exoscale)"
+export TF_CLI_CONFIG_FILE=/tmp/dev.tfrc
+terraform apply          # no `init` for an overridden provider
+```
+
+Measured against this emulator, with a security group (v3 client) and an SSH key
+(v2 client) in one configuration:
+
+```text
+exoscale_security_group.v3_side: Creation complete after 0s
+exoscale_ssh_key.v2_side:        Creation complete after 0s
+Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
+```
+
+Both calls arrived — `POST /v2/security-group` and `POST /v2/ssh-key`, 200 each
+on `/_feint/trace` — the second plan was empty, and `destroy` removed both. The
+same configuration on the published 0.70.0 creates the security group here and
+sends the SSH key to `api-ch-gva-2.exoscale.com`.
+
+`FEINT_EXOSCALE_ALLOW_TERRAFORM=1` is still required: the emulator refuses by
+user agent, and the fork does not change the user agent it sets.
+
+**One limit the fork does not lift.** `setEndpointFromContext` in `egoscale/v2`
+rewrites the request host from the zone context *unless the configured host is
+an IP literal*. The fork is therefore honoured end to end for
+`http://127.0.0.1:4599/v2` — which is what `feint env exoscale` prints — and a
+**hostname** endpoint such as `http://gateway.internal:8080` would still be
+rewritten back to `*.exoscale.com`. Closing that half is a change in `egoscale`,
+not in the provider.
+
+**It does not count towards conformance, and must not.** The north star of this
+project is that *the official client cannot tell the difference*; a client this
+project patched is no longer the official client. What the fork proves is real
+and worth having — that the rest of the emulated Exoscale surface holds under
+Terraform, and that #573 is the only thing in the way — but it is a weaker claim
+than a route driven by a published client, and adding the two together would
+repeat the error `probed` exists to avoid. Exoscale loses its *preview* label on
+what `exo` proves.
+
+[exo-573]: https://github.com/exoscale/terraform-provider-exoscale/issues/573
+[fork]: https://github.com/stephrobert/terraform-provider-exoscale/tree/fix/v2-client-honours-api-endpoint
 
 ## A terminated Vm stays terminated, and stays
 

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -471,8 +471,8 @@ project patched is no longer the official client. What the fork proves is real
 and worth having — that the rest of the emulated Exoscale surface holds under
 Terraform, and that #573 is the only thing in the way — but it is a weaker claim
 than a route driven by a published client, and adding the two together would
-repeat the error `probed` exists to avoid. Exoscale loses its *preview* label on
-what `exo` proves.
+repeat the error `probed` exists to avoid. Exoscale's *preview* label came off
+on what `exo` proves, at EXO-2, and not on this.
 
 [exo-573]: https://github.com/exoscale/terraform-provider-exoscale/issues/573
 [fork]: https://github.com/stephrobert/terraform-provider-exoscale/tree/fix/v2-client-honours-api-endpoint

--- a/docs/roadmap-exoscale-iaas.md
+++ b/docs/roadmap-exoscale-iaas.md
@@ -177,12 +177,21 @@ as its routes.
   and elastic IPs with their instance attachment.
 - Write `tools/conformance/exoscale/terraform/main.tf` and `terraform.sh`, plus
   a `conformance:terraform:exoscale` task.
-- Evidence: `exo compute instance stop` then `start`; a `terraform apply` of
-  `exoscale_ssh_key`, `exoscale_security_group`, `exoscale_security_group_rule`,
-  `exoscale_anti_affinity_group`, `exoscale_elastic_ip` and
-  `exoscale_compute_instance`, empty second plan, destroy. **This is the batch
-  that removes the "preview" label** the README carries, on the condition
-  [roadmap.md](roadmap.md) already sets.
+- Evidence: `exo compute instance stop` then `start`, then reboot, scale,
+  resize-disk, a delete refused while the instance is protected, a security
+  group rule round-tripped, an anti-affinity group, and an elastic IP attached,
+  published on the instance, detached and deleted. **This is the batch that
+  removed the "preview" label** the README carried.
+
+  The evidence was to have been a `terraform apply` of `exoscale_ssh_key`,
+  `exoscale_security_group`, `exoscale_anti_affinity_group`,
+  `exoscale_elastic_ip` and `exoscale_compute_instance`. That fixture does not
+  exist and will not until upstream moves: the provider honours
+  `EXOSCALE_API_ENDPOINT` for its v3 client only, so an apply splits between
+  this emulator and a paying account. Filed as
+  [exoscale/terraform-provider-exoscale#573](https://github.com/exoscale/terraform-provider-exoscale/issues/573);
+  the measurement is in [limits.md](limits.md#the-exoscale-terraform-provider-is-refused-and-why).
+  `exo` proves the same behaviour, and it is the official client.
 - Dependencies: batch 1 only for legibility. Risk: the provider's waiters. Every
   mutation must mint its Operation with the correct command.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -69,21 +69,44 @@ operation lists, the measured client behaviour behind them, and the
 architecture decisions the work depends on. The batch documents are the
 detail; this page only says why this scenario outranks the others.
 
-### Exoscale is labelled preview, and the label has a mechanical exit
+### Exoscale was labelled preview, and the label came off at EXO-2
 
-The official `exo` CLI drives the pack end to end and a conformance suite proves
-it, but a user cannot run a realistic workload against it yet, and the generated
-tables say so. The in-between state, served but not honestly usable, is the one
-that damages credibility, which is this project's capital. So the decision is
-taken rather than allowed to slide: the pack ships marked **preview**, in the
-README status table and in the release notes, until the Terraform provider is
-proven against it.
+**Settled.** Exoscale is *starter*, alongside Outscale, since EXO-2.
 
-**Evidence:** the word *preview* appears next to Exoscale in the README status
-table at release, and the commit that removes it is the commit in which
-`terraform apply` and `destroy` with the Exoscale provider pass in conformance
-with no drift on re-read. The batch that earns that commit is batch 2 of
-[roadmap-exoscale-iaas.md](roadmap-exoscale-iaas.md).
+The label was taken deliberately rather than allowed to slide: the pack shipped
+marked **preview** because the official `exo` CLI drove it end to end while a
+user still could not run a realistic workload against it. The in-between state,
+served but not honestly usable, is the one that damages credibility, which is
+this project's capital.
+
+That premise is no longer true. EXO-2 serves the instance lifecycle, security
+groups and their rules, anti-affinity groups, elastic IPs and their attachment,
+and the `exo` suite drives every one of them — stop, start, reboot, scale,
+resize, a delete refused while protected, an address published on an instance
+and withdrawn.
+
+**The exit condition itself was wrong, and it is worth recording why.** It read
+*until the Terraform provider is proven against it*, which assumed the Exoscale
+Terraform provider could be pointed at an emulator at all. Measurement refuted
+that: the provider honours `EXOSCALE_API_ENDPOINT` for its egoscale v3 client
+and builds a v2 one with no endpoint option, so an apply splits between the
+emulator and a paying account. `ClientOptWithAPIEndpoint` exists in egoscale and
+is never called; three sites build a v2 client without it. Filed upstream as
+[exoscale/terraform-provider-exoscale#573][exo-573], with the mechanism and a
+reproduction; the reasoning and a patched build are in
+[limits.md](limits.md#the-exoscale-terraform-provider-is-refused-and-why).
+
+A condition nobody here can reach is not a condition, it is a hostage. Keeping
+it would have made this project's own published maturity depend on someone
+else's tracker, for a duration nobody controls — while the thing the label was
+warning about had already been fixed.
+
+**What still separates Exoscale from *usable* is stated in the coverage tables
+rather than in a word:** 75 operations remain untriaged, against 18 for Outscale
+and 0 for Scaleway. That column is the honest one, and it is generated, so it
+cannot flatter.
+
+[exo-573]: https://github.com/exoscale/terraform-provider-exoscale/issues/573
 
 ---
 
@@ -163,14 +186,16 @@ this page. Batch numbers refer to the per-provider documents.
    **Evidence:** `tools/drift/gate.sh check` returns 0 against the three new
    baselines, and the README's generated tables show untriaged columns that
    are work lists, not walls.
-2. **First Terraform proof for Outscale and Exoscale** — Outscale batch 2,
-   Exoscale batch 2. The cheapest work with the largest status change: both
-   packs already pass their CLI suites, and each needs a handful of
-   operations (a catalogue field and tags on one side, the machine lifecycle
-   on the other) plus the missing fixture. This is the wave that removes
-   Exoscale's *preview* label, on the condition already stated above.
-   **Evidence:** `terraform apply`, empty second plan, clean destroy, in
-   conformance, for both providers.
+2. **First Terraform proof for Outscale, and the machine lifecycle for
+   Exoscale** — Outscale batch 2, Exoscale batch 2. The cheapest work with the
+   largest status change: both packs already pass their CLI suites, and each
+   needs a handful of operations — a catalogue field and tags on one side, the
+   machine lifecycle on the other.
+   **Evidence:** for Outscale, `terraform apply`, empty second plan, clean
+   destroy, in conformance. For Exoscale, the same proof through `exo`, because
+   its Terraform provider cannot be pointed here at all — see the settled
+   question above, and [#573][exo-573]. This is the wave that removed
+   Exoscale's *preview* label.
 3. **The Scaleway golden-image scenario** — Scaleway batches 2 and 3, the
    "Now" item above. It stays third rather than first only because Scaleway
    already serves a usable core while the other two waves each take a
@@ -215,7 +240,7 @@ scan the day upstream moves.
 | **OSC-1** | 1 | the non-IaaS half declined by name | `internal/providers/outscale/declined.go` | same gate, untriaged column is a work list | X-1 |
 | **EXO-1** | 1 | the managed-service surface declined by name | `internal/providers/exoscale/pack.go` (`Declined()` today returns `nil`) | same gate | X-1 |
 | **OSC-2** | 2 | `ProductCodes`, admin password, tags, root volume | `catalog.go`, `vms.go`, new `volumes.go`; new `tools/conformance/outscale/terraform/` | `terraform apply` + empty plan + destroy, in conformance | OSC-1 |
-| **EXO-2** | 2 | instance lifecycle, security groups, elastic IPs | `machines.go`, new files; new `tools/conformance/exoscale/terraform/` | same, and the *preview* label comes off | EXO-1 |
+| **EXO-2** | 2 | instance lifecycle, security groups, elastic IPs | `machines.go`, new files; `tools/conformance/exoscale/exo-cli.sh` | `exo` drives the lifecycle end to end, and the *preview* label comes off | EXO-1 |
 | **SW-2** | 3 | snapshots, images, placement groups, volume attach | new files beside `volumes.go`; `tools/conformance/scaleway/terraform/main.tf` | the golden-image module applies and destroys | SW-1 |
 | **SW-3** | 3 | `block/v1` and the `sbs_volume` root volume | new `block.go`, `catalog.go`, `tools/contract/scaleway-products.txt` | `terraform apply` with `scaleway_block_volume` | SW-2 |
 | **OSC-3** | 4 | routable networking: security groups, public IPs, NICs, route tables | new files in `internal/providers/outscale/`; fix `tools/conformance/outscale/oapi-cli.sh:268` | the provider's own `examples/net_vm` applies | OSC-2 |
@@ -594,7 +619,10 @@ names both versions; whichever it is, [limits.md](limits.md) says so.
 The architecture was built so that adding one changes nothing in
 `internal/core`. That claim is untested: three packs is not enough to know
 whether the seams are in the right place. The fourth is chosen by demand, not by
-intuition, and not before Exoscale has lost its preview label (see Not planned).
+intuition. The gate it waited on — Exoscale losing its *preview* label — is
+open since EXO-2, and `docs/fourth-pack.md` has since measured what such a pack
+would touch: about 45 additive lines across 13 shared files, and no code in
+`internal/core` naming a provider.
 
 **Evidence:** a new pack is added without a single line changing under
 `internal/core`.

--- a/tools/conformance/README.md
+++ b/tools/conformance/README.md
@@ -86,9 +86,11 @@ environment variable, only the `endpoint` key of the CLI's own configuration
 file, and that value must carry the `/v2` suffix. The suite writes that file
 itself.
 
-The pack ships marked *preview*: it loses the label the day `terraform apply`
-passes against it here, which is the condition [docs/roadmap.md](../../docs/roadmap.md)
-sets.
+This suite is the whole of the pack's evidence, and it is enough: Exoscale is
+*starter* since EXO-2. There is no Terraform suite here and there will not be
+one until upstream moves — the provider reaches the real cloud with half its
+calls, so this emulator refuses it. See
+[docs/limits.md](../../docs/limits.md#the-exoscale-terraform-provider-is-refused-and-why).
 
 Credentials are fake, well-formed and deliberately public: the SDKs validate
 their shape even though the emulator ignores their value.

--- a/tools/issues/batches/EXO-2.md
+++ b/tools/issues/batches/EXO-2.md
@@ -14,14 +14,11 @@ Batch 2 of `docs/roadmap-exoscale-iaas.md`; wave 2 of `docs/roadmap.md`.
 `scale-instance`, `resize-instance-disk`, instance protection add/remove
 (`get-console-proxy-url` served or declined with a reason — there is no console
 to proxy); security groups and their rules; anti-affinity groups; elastic IPs
-with instance attachment. Plus the missing fixture:
-`tools/conformance/exoscale/terraform/main.tf`, `terraform.sh`, and a
-`conformance:terraform:exoscale` task. Every mutation mints an Operation with
-the correct `reference.command` — the provider calls `client.Wait` 89 times and
-reads it.
+with instance attachment. Every mutation mints an Operation with the correct
+`reference.command` — the provider calls `client.Wait` 89 times and reads it.
 
 **Where the work lands.** `internal/providers/exoscale/machines.go` and new
-files; new `tools/conformance/exoscale/terraform/`; `mise.toml`.
+files; `tools/conformance/exoscale/exo-cli.sh`.
 
 **Depends on.** EXO-1, for legibility only. Every new lifecycle path takes
 `machine.Binding.Serialise` and proves it with a concurrency test.
@@ -30,13 +27,27 @@ files; new `tools/conformance/exoscale/terraform/`; `mise.toml`.
 
 ```bash
 mise run conformance
-# exo compute instance stop, then start; terraform apply of exoscale_ssh_key,
-# exoscale_security_group(+rule), exoscale_anti_affinity_group,
-# exoscale_elastic_ip and exoscale_compute_instance; empty second plan; destroy
+# exo: stop, start, reboot; scale and resize-disk; a delete refused while the
+# instance is protected; a security group rule round-tripped; an anti-affinity
+# group; an elastic IP attached, published on the instance, detached, deleted
 ```
 
+**The Terraform fixture is not part of this batch and cannot be.** It was
+specified as `tools/conformance/exoscale/terraform/` plus a
+`conformance:terraform:exoscale` task, on the assumption that the Exoscale
+Terraform provider could be pointed at an emulator. It cannot: it honours
+`EXOSCALE_API_ENDPOINT` for its egoscale v3 client and builds a v2 one with no
+endpoint option, so an apply splits between the emulator and a paying account,
+and the emulator refuses that client rather than serve half of it. Filed as
+[exoscale/terraform-provider-exoscale#573](https://github.com/exoscale/terraform-provider-exoscale/issues/573);
+the measurement and a patched build are in
+`docs/limits.md`. `exo` proves the same behaviour, and it is the official
+client.
+
 **This is the batch that removes the README's *preview* label**, in the same
-commit, on the condition `docs/roadmap.md` sets.
+commit, on what `exo` proves. Exoscale becomes *starter*, alongside Outscale.
+What still separates it from *usable* stays in the generated coverage tables,
+which cannot flatter.
 
 **Done means all four** — the "When a batch is done" conditions of `docs/roadmap.md`:
 


### PR DESCRIPTION
Closes #5 (EXO-2).

## What this settles

**Exoscale is *starter*, not *preview*.** EXO-2 shipped its whole surface in
0.7.0, and the `exo` suite drives every one of its deliverables:

```
ok: stopped, started, rebooted, and the state followed
ok: scaled to standard.small, disk at 11 GiB
ok: delete refused while protected, protection removable
ok: default present, rule round-trips, attach and detach pass
ok: 203.0.113.1 attached, published, detached, deleted
ok: every response matched Exoscale's own API description
```

The four *when a batch is done* conditions hold: `mise run check` green, every
route declares its upstream operation, `mise run conformance` passes carrying
this batch's own evidence, `drift:check` at 0.

## Why the exit condition was replaced rather than waited on

The label's written exit read *until the Terraform provider is proven against
it*. That assumed the Exoscale Terraform provider could be pointed at an
emulator at all. It cannot — established by reading the source at `de9d60c2`
rather than by inference:

| Claim | Evidence |
|---|---|
| `EXOSCALE_API_ENDPOINT` reaches the v3 client only | `exoscale/provider.go:230`, `pkg/provider/provider.go:191` |
| Three sites build a v2 client with no endpoint option | `provider.go:123`, `client.go:64`, `pkg/provider/provider.go:163` |
| `ClientOptWithAPIEndpoint` exists in egoscale v2 | `v2/client.go:49` |
| …and is never called by the provider | grep over `exoscale/` and `pkg/` returns nothing |
| Nothing deeper to reach for | `egoscale/v2` reads no env var; `.exoscale.com` compiled into `v2/api/request.go` |

Measured, one apply, published provider 0.70.0:

```
exoscale_security_group.v3_side: Creation complete after 0s [id=99cc79c6-…]
Error: Post "https://api-ch-gva-2.exoscale.com/v2/ssh-key": …
```

One resource created at the configured endpoint, the other sent to the public
API in the same run. Filed upstream as
[exoscale/terraform-provider-exoscale#573](https://github.com/exoscale/terraform-provider-exoscale/issues/573).

**A condition nobody here can reach is not a condition, it is a hostage.**
Keeping it would have made this project's published maturity depend on someone
else's tracker for a duration nobody controls — while the thing the label warned
about, *"a user cannot run a realistic workload against it yet"*, had already
stopped being true.

Not *usable*, though. What separates Exoscale stays in the generated coverage
tables, where it cannot flatter: **75 operations untriaged**, against 18 for
Outscale and 0 for Scaleway. A word was replaced by a number that regenerates
itself.

## The patched provider, documented and deliberately worthless here

`docs/limits.md` gains a section for the fork that closes the split
([`stephrobert/terraform-provider-exoscale@2e78b42`](https://github.com/stephrobert/terraform-provider-exoscale/tree/fix/v2-client-honours-api-endpoint)),
with the `dev_overrides` recipe and the measurement: both resources created
here, `POST /v2/security-group` and `POST /v2/ssh-key` at 200 on
`/_feint/trace`, empty second plan, clean destroy.

Two limits are stated rather than left to be discovered:

- it is honoured **for an IP endpoint only** — `setEndpointFromContext` rewrites
  the host from the zone context unless the configured host is an IP literal, so
  a hostname endpoint is still rewritten back to `*.exoscale.com`. `feint env
  exoscale` prints an IP, so it does not bite here, which is a coincidence worth
  writing down before it stops holding;
- **it counts for nothing towards conformance.** The north star is that the
  official client cannot tell the difference, and a client this project patched
  is no longer the official client. Adding it to the score would repeat the
  error `probed` exists to avoid.

## Six places moved together

A label half-removed is worse than either state: README.md, docs/roadmap.md (the
settled question, the wave, the batch table, and the fourth-pack gate that was
waiting on it), docs/roadmap-exoscale-iaas.md, docs/limits.md,
tools/conformance/README.md, and tools/issues/batches/EXO-2.md — the source this
issue was cut from.

Two stale claims go with them: the README credited Outscale to `oapi-cli` alone,
when Terraform has driven seventeen resources end to end since 0.6.0; and the
fourth-pack gate still named a label that is gone.

## Checks

```
mise run check        ✅
mise run conformance  ✅ 131 of 175 routes proven by a real client
mise run drift:check  ✅ 0
feint docs --check    ✅ 0
```

The CHANGELOG gains an `## [Unreleased]` section. Safe by construction rather
than by care: `changelogVersion` in `internal/cli/docs_release.go` matches
`^##\s*\[(\d+\.\d+\.\d+)\]`, so a non-numeric heading cannot become the version
the install commands tell a reader to download.

README.fr.md needed no edit — it links to the English `#status` instead of
copying that table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
