### PR TITLE
The page check says why the browser did not start, and gives it longer

### DIFF
--- a/tools/ui/check-page.py
+++ b/tools/ui/check-page.py
@@ -51,6 +51,7 @@ import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass, field
+from typing import IO
 
 # The browsers this looks for, in order. A GitHub runner ships google-chrome; a
 # Debian or Ubuntu workstation ships chromium or chromium-browser. Naming them
@@ -255,8 +256,42 @@ def find_browser() -> str | None:
 
 
 def start_browser(binary: str, profile: str) -> tuple[subprocess.Popen, str]:
-    """Start the browser and return it with the URL of its page target."""
+    """Start the browser and return it with the URL of its page target.
+
+    Tried twice, on a fresh port each time. The port is chosen by binding zero
+    and closing, so between that close and the browser's own bind the number is
+    anybody's — on a busy runner it is a race this cannot win, only retry.
+    """
+    failures = []
+    for attempt in range(2):
+        try:
+            # A subdirectory rather than a sibling: main() removes `profile`
+            # and only that, so a sibling would survive every run as a leak.
+            # A fresh one per attempt, because a first launch that died holding
+            # the profile lock makes the second fail for the wrong reason.
+            return start_browser_once(binary, os.path.join(profile, str(attempt)))
+        except Failure as why:
+            failures.append(f"attempt {attempt + 1}: {why}")
+    raise Failure("the browser never opened a page target.\n" + "\n".join(failures))
+
+
+def start_browser_once(binary: str, profile: str) -> tuple[subprocess.Popen, str]:
+    """One start: spawn the browser and wait for its debugging port."""
     port = free_port()
+    # The browser's own account of why it failed. It used to go to DEVNULL,
+    # which is how four consecutive CI failures produced one sentence between
+    # them — "the browser never opened a page target" — and no way to tell a
+    # taken port from a slow cold start from a missing shared library. A
+    # harness that cannot say why it failed gets re-run instead of read.
+    #
+    # Closed on the way out of this function, which the browser does not mind:
+    # the descriptor it writes to is its own, duplicated at spawn.
+    with tempfile.TemporaryFile() as diagnosis:
+        return spawn_and_wait(binary, profile, port, diagnosis)
+
+
+def spawn_and_wait(binary: str, profile: str, port: int, diagnosis: IO[bytes]):
+    """Spawn the browser, and wait for a page target or a reason there is none."""
     process = subprocess.Popen(  # noqa: S603 - a fixed binary, list arguments, no shell
         [
             binary,
@@ -280,12 +315,31 @@ def start_browser(binary: str, profile: str) -> tuple[subprocess.Popen, str]:
             "about:blank",
         ],
         stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        stderr=diagnosis,
     )
-    deadline = time.monotonic() + 20
+
+    def why() -> str:
+        """What the browser said, for a message that can be acted on."""
+        try:
+            diagnosis.seek(0)
+            said = diagnosis.read().decode("utf-8", "replace").strip()
+        except OSError:
+            return "and said nothing readable"
+        if not said:
+            return "and said nothing"
+        return "and said: " + " / ".join(said.splitlines()[-4:])
+
+    # 60 seconds rather than 20. The old budget covered a cold start on an idle
+    # machine and nothing else: this job runs after a Go build and an emulator
+    # start, on a shared runner, and headless Chrome's first launch is the part
+    # that gets slow when the runner is busy.
+    deadline = time.monotonic() + 60
     while time.monotonic() < deadline:
         if process.poll() is not None:
-            raise Failure(f"{binary} exited before it opened its debugging port")
+            raise Failure(
+                f"{binary} exited with {process.returncode} before it opened "
+                f"its debugging port on {port}, {why()}"
+            )
         try:
             # The scheme and host are literals here: the browser this script
             # just started, on the loopback interface.
@@ -297,7 +351,12 @@ def start_browser(binary: str, profile: str) -> tuple[subprocess.Popen, str]:
                     return process, target["webSocketDebuggerUrl"]
         except (urllib.error.URLError, OSError, json.JSONDecodeError):
             time.sleep(0.2)
-    raise Failure("the browser never opened a page target")
+
+    process.kill()
+    process.wait(timeout=10)
+    raise Failure(
+        f"{binary} was still running after 60s without a page target on port {port}, {why()}"
+    )
 
 
 def free_port() -> int:


### PR DESCRIPTION
Four consecutive failures of the `page` job produced one sentence between them — `Failure: the browser never opened a page target` — and nothing else. Twice on a pull request, twice on `main`, each time re-run rather than read, because there was nothing in the log to read.

## The reason there was nothing to read

The browser was spawned with `stderr=subprocess.DEVNULL`. A taken debugging port, a slow cold start and a missing shared library all arrived as the same sentence, and they need different fixes.

stderr is captured now, and the last four lines come back with the exit code and the port. Driven rather than asserted, by substituting a binary for the browser:

```
/bin/false exited with 1 before it opened its debugging port on 42533,
and said nothing

noisy.sh exited with 127 before it opened its debugging port on 47201,
and said: error while loading shared libraries: libnss3.so
```

## Two likely causes, addressed while the message is being fixed

- **The deadline was 20 seconds**, covering a cold start on an idle machine and nothing else. This job runs after a Go build and an emulator start, on a shared runner. It is 60 now.
- **`free_port()` binds zero, closes, and hands the number to the browser.** Between that close and the browser's bind the port belongs to whoever takes it — a race this cannot win, only retry. Two attempts, a fresh port each, both reported when both fail.

Each attempt gets its own profile *under* the directory `main()` already removes, not beside it: a sibling would survive every run as a leak, and a reused profile makes the second attempt fail on the first one's lock rather than on its own merits.

## What this does not claim

Whether it fixes the CI failure is not yet knowable: the condition is a busy runner, which does not reproduce here. What is true is that the next occurrence names its cause instead of costing another blind re-run.

There is no committed test. The repository has no Python test path, and adding pytest plus a runner plus CI wiring for one script is infrastructure this does not earn — saying so is more honest than a comment implying a test exists.

## Checks

```
tools/ui/screenshots.sh --check   ✅ 17 assertions held, 0 failed
ruff check                        ✅
mise run check                    ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)