### PR TITLE
CreateTags answered that a resource the emulator had just created does not exist

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -17,6 +17,34 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ## [Non publié]
 
+### Corrigé
+
+- **`CreateTags` affirmait qu'une ressource que l'émulateur venait de créer
+  n'existait pas.** Signalé par Vincent Dislaire sur un
+  `outscale_internet_service` portant un bloc `tags` : l'apply échouait sur
+  `the resource igw-… does not exist`, à propos d'une ressource que
+  `ReadInternetServices` servait. La table de préfixes de `tags.go` avait quatre
+  entrées, écrites quand le pack servait quatre familles, et 0.6.0 en a ajouté
+  dix sans y toucher. Trois préfixes étaient signalés ; lire quels schémas
+  déclarent `Tags` en a trouvé **dix** — volumes, snapshots, images, groupes de
+  sécurité, tables de routage, IP publiques, NIC, options DHCP, services NAT et
+  services internet.
+- **Deux des quatre valeurs `ResourceType` que publiait `ReadTags` étaient
+  inventées** : `net` là où le SDK d'Outscale dit `vpc`, `vm` là où il dit
+  `instance`. Un client qui filtrait sur `instance` ne trouvait rien. Aucun
+  contrat ne pouvait le voir — leur OpenAPI déclare `ResourceType` comme une
+  simple chaîne — et un test unitaire affirmait `net` depuis trois versions, ce
+  qui est la façon dont l'erreur d'un émulateur devient ce que sa propre suite
+  protège.
+
+  Les valeurs viennent désormais de `TagResourceType` dans `osc-sdk-go`, et un
+  test épingle chaque ligne de la table à cette énumération.
+- **La table qui a causé tout cela ne peut plus prendre du retard en silence.**
+  Chaque préfixe d'identifiant que le pack émet est lu depuis le source et doit
+  être trié : étiquetable avec son type upstream, ou refusé avec une raison — la
+  discipline que `Declined()` applique aux opérations. Ajouter les dix lignes
+  manquantes corrige aujourd'hui ; la onzième ressource aurait recommencé.
+
 ### Modifié
 
 - **Exoscale est *starter*, plus *preview*.** Le label avait été pris

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,32 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ## [Unreleased]
 
+### Fixed
+
+- **`CreateTags` answered that a resource the emulator had just created did not
+  exist.** Reported by Vincent Dislaire against an `outscale_internet_service`
+  with a `tags` block: the apply failed on `the resource igw-… does not exist`,
+  about a resource `ReadInternetServices` was serving. The prefix table in
+  `tags.go` held four entries, written when the pack served four kinds, and
+  0.6.0 added ten resources without touching it. Three prefixes were reported;
+  reading which schemas declare `Tags` found **ten** — volumes, snapshots,
+  images, security groups, route tables, public IPs, NICs, DHCP options, NAT
+  services and internet services.
+- **Two of the four `ResourceType` values `ReadTags` published were invented**:
+  `net` where Outscale's own SDK says `vpc`, `vm` where it says `instance`. A
+  client filtering on `instance` matched nothing. No contract could see it —
+  their OpenAPI declares `ResourceType` as a bare string — and a unit test had
+  been asserting `net` for three releases, which is how an emulator's mistake
+  becomes the thing its own suite protects.
+
+  The values now come from `TagResourceType` in `osc-sdk-go`, and a test pins
+  every row of the table to that enum.
+- **The table that caused it can no longer fall behind in silence.** Every
+  identifier prefix the pack mints is read from the source and has to be
+  triaged: taggable with its upstream type, or refused with a reason, the same
+  discipline `Declined()` applies to operations. Adding the ten missing rows
+  fixes today; the eleventh resource would have done it again.
+
 ### Changed
 
 - **Exoscale is *starter*, not *preview*.** The label was taken deliberately,

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -674,6 +674,36 @@ The consequence, stated rather than hidden: a client asking for `ch-gva-2` gets
 difference. The alternative — one endpoint pretending to be eight zones — is a
 silent, wrong one.
 
+## ReadTags does not list an internet service, because upstream names no type for one
+
+Outscale's `Tag` carries a `ResourceType`, and their OpenAPI declares it as a
+bare string. The values come from the SDK instead, where they are a deliberate
+patch: `TagResourceType` in `osc-sdk-go/pkg/osc/client.gen.go`, twenty of them,
+listed in the `enum` block of `patch.yaml`.
+
+An internet service is not among the twenty — and their `InternetService` schema
+declares `Tags`, which the Terraform provider sets. Both are true at once, and
+they cannot both be honoured in the flat view.
+
+So the emulator splits the two questions rather than picking one:
+
+- **`CreateTags` and `DeleteTags` accept it.** This is what
+  [#99](https://github.com/stephrobert/feint/issues/99) was: the pack answered
+  `the resource igw-… does not exist` about a resource it was serving, and an
+  `outscale_internet_service` with a `tags` block failed its apply.
+- **`ReadTags` leaves it out.** Every row of that view carries a
+  `ResourceType`, and there is no value upstream declares for this one.
+  Inventing `internet-gateway` because AWS spells it that way is the invented
+  format rule 4 forbids, and it would be indistinguishable from a measured
+  value to anyone reading the answer.
+
+The tag is not lost: `ReadInternetServices` returns it on the resource, which is
+where the provider reads it back. `TestReadTagsOmitsAKindUpstreamDoesNotName`
+pins both halves.
+
+This is one row of `taggable` in `internal/providers/outscale/tags.go`, the only
+one with an empty type. If Outscale adds a value, that field is where it goes.
+
 ## Outscale's gateways and NAT move records, not packets
 
 `InternetService`, `LinkInternetService`, `NatService`, `LinkPublicIp` and the

--- a/internal/providers/outscale/audit_test.go
+++ b/internal/providers/outscale/audit_test.go
@@ -1135,7 +1135,13 @@ func TestTagsAreStoredOnTheResourceTheyName(t *testing.T) {
 		t.Fatalf("ReadTags answered %d tag(s), want 2: %v", len(tags), out)
 	}
 	first, _ := tags[0].(map[string]any)
-	if first["ResourceId"] != netID || first["ResourceType"] != "net" {
+	// "vpc", not "net": this assertion asked for "net" for three releases and
+	// so held the invented value in place, the way a test that asserts the
+	// emulator rather than the cloud always does. The name comes from the SDK's
+	// TagResourceType enum (osc-sdk-go/pkg/osc/client.gen.go).
+	// TestEveryTaggableResourceTypeIsOneTheSDKDeclares now checks the whole
+	// table rather than this one row.
+	if first["ResourceId"] != netID || first["ResourceType"] != "vpc" {
 		t.Errorf("a tag does not name what it is on: %v", first)
 	}
 

--- a/internal/providers/outscale/tags.go
+++ b/internal/providers/outscale/tags.go
@@ -17,21 +17,66 @@ import (
 // mistake this repository has already paid for with volume ownership.
 //
 // ResourceType is derived from the identifier's prefix, which is where Outscale
-// puts it: vpc-, subnet-, i-, key- are the pack's own shapes, declared once in
-// ids.go. Deriving beats storing it: a stored type can disagree with the id it
+// puts it. Deriving beats storing it: a stored type can disagree with the id it
 // sits beside, and nothing would notice.
+//
+// The values are the `TagResourceType` enum of the official SDK
+// (`osc-sdk-go/pkg/osc/client.gen.go`, and its source in `patch.yaml`), not
+// names of our own. Two of the four this table first carried were invented —
+// `net` where Outscale says `vpc`, `vm` where it says `instance` — so a client
+// filtering ReadTags on `instance` matched nothing. Their OpenAPI declares
+// ResourceType as a bare string, which is why no contract check could see it.
+//
+// The table itself is the defect #99 reported: it held four prefixes, written
+// when the pack served four kinds, and 0.6.0 added ten more without touching
+// it. CreateTags therefore answered "the resource igw-… does not exist" about a
+// resource the emulator had just created and was serving.
+// TestEveryIdentifierPrefixIsTriagedForTagging fails when a prefix is added and
+// this table is not, which is the only thing that stops it happening an
+// eleventh time.
 
 // taggable maps an identifier prefix to the kind that holds it, and to the
 // ResourceType the API publishes.
+//
+// An empty resourceType means the resource carries Tags upstream while the SDK
+// enum declares no value naming it: tags are stored and returned on the
+// resource, and ReadTags leaves it out rather than invent a name. See
+// notTaggable below for what carries no tags at all.
 var taggable = []struct {
 	prefix       string
 	kind         string
 	resourceType string
 }{
-	{"vpc-", kindNet, "net"},
+	{"vpc-", kindNet, "vpc"},
 	{"subnet-", kindSubnet, "subnet"},
-	{"i-", kindVM, "vm"},
+	{"i-", kindVM, "instance"},
 	{"key-", kindKeypair, "keypair"},
+	{"vol-", kindVolume, "volume"},
+	{"snap-", kindSnapshot, "snapshot"},
+	{"ami-", kindImage, "image"},
+	{"sg-", kindSecurityGroup, "security-group"},
+	{"rtb-", kindRouteTable, "route-table"},
+	{"eipalloc-", kindPublicIP, "public-ip"},
+	{"eni-", kindNic, "network-interface"},
+	{"dopt-", kindDhcpOptions, "dhcpoptions"},
+	{"nat-", kindNatService, "natgateway"},
+
+	// An internet service carries Tags in their own schema — the Terraform
+	// provider sets them, which is how #99 was found — but the SDK's enum lists
+	// twenty values and none of them names one. So it is taggable, and ReadTags
+	// cannot say what type it is without inventing a name. docs/limits.md
+	// records the gap.
+	{"igw-", kindInternetService, ""},
+}
+
+// notTaggable is the other half of the same triage, and it exists for the same
+// reason Declined() does: "carries no tags" and "nobody has looked" must not be
+// indistinguishable. Every identifier prefix the pack mints is in one table or
+// the other, and a test proves it.
+var notTaggable = map[string]string{
+	"eipassoc-": "the link between a public IP and its target, not a resource: their schema declares no Tags",
+	"rtbassoc-": "the link between a route table and a subnet, not a resource: their schema declares no Tags",
+	"sgr-":      "a rule inside a security group: SecurityGroupRule declares no Tags, the group it belongs to does",
 }
 
 // resourceOf finds what an identifier names, whatever kind it is.
@@ -145,6 +190,13 @@ func (p *Pack) readTags(w http.ResponseWriter, r *http.Request) {
 
 	out := make([]map[string]any, 0)
 	for _, t := range taggable {
+		// A kind the SDK enum does not name is tagged and readable on the
+		// resource itself, and left out of this flat view: every row here
+		// carries a ResourceType, and there is no honest value to put in it.
+		// TestReadTagsOmitsAKindUpstreamDoesNotName fails without this.
+		if t.resourceType == "" {
+			continue
+		}
 		for _, res := range p.env.Store.List(t.kind, resource.Tenant{Provider: Name}) {
 			for key, value := range tagsOf(res) {
 				if !matchesStrings(req.Filters, "ResourceIds", res.ID) ||

--- a/internal/providers/outscale/tags_internal_test.go
+++ b/internal/providers/outscale/tags_internal_test.go
@@ -1,0 +1,145 @@
+package outscale
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// The defect #99 reported was not a wrong line, it was a table nobody had to
+// keep in step. `taggable` held four prefixes, written when the pack served
+// four kinds; 0.6.0 added ten resources and none of them reached it, so
+// CreateTags answered "the resource igw-… does not exist" about a resource the
+// emulator had just created.
+//
+// Adding the ten missing rows fixes today and nothing else: the eleventh
+// resource would do it again. So the source of truth becomes the identifiers
+// the pack actually mints, read from the source, and every one of them has to
+// be triaged — taggable, or refused with a reason, the same discipline
+// Declined() applies to operations.
+func mintedPrefixes(t *testing.T) map[string]string {
+	t.Helper()
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading the pack: %v", err)
+	}
+
+	found := map[string]string{}
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(token.NewFileSet(), name, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", name, err)
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			fn, ok := call.Fun.(*ast.Ident)
+			if !ok || fn.Name != "newID" || len(call.Args) == 0 {
+				return true
+			}
+			lit, ok := call.Args[0].(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				return true
+			}
+			prefix, err := strconv.Unquote(lit.Value)
+			if err != nil || prefix == "" {
+				return true
+			}
+			found[prefix+"-"] = name
+			return true
+		})
+	}
+
+	// A scan that finds nothing passes every table check and measures nothing.
+	// The pack minted sixteen prefixes when this was written; the floor is set
+	// well below that so it catches a broken scan without failing on a
+	// legitimate removal.
+	if len(found) < 10 {
+		t.Fatalf("only %d identifier prefixes found across %d entries: the scan is "+
+			"broken, not the table", len(found), len(entries))
+	}
+	return found
+}
+
+// TestEveryIdentifierPrefixIsTriagedForTagging is what #99 was missing. It
+// fails when a resource is added with a new identifier prefix and neither
+// table mentions it, which is exactly how ten prefixes went unnoticed.
+func TestEveryIdentifierPrefixIsTriagedForTagging(t *testing.T) {
+	canTag := map[string]bool{}
+	for _, entry := range taggable {
+		canTag[entry.prefix] = true
+	}
+
+	for prefix, file := range mintedPrefixes(t) {
+		if canTag[prefix] || notTaggable[prefix] != "" {
+			continue
+		}
+		t.Errorf("%s mints %q and no table says whether it can be tagged.\n"+
+			"Add it to taggable with its TagResourceType from the SDK enum "+
+			"(osc-sdk-go/pkg/osc/client.gen.go), or to notTaggable with the reason "+
+			"its schema declares no Tags. Leaving it out is what made CreateTags "+
+			"answer that a resource the emulator serves does not exist (#99).",
+			file, prefix)
+	}
+}
+
+// A prefix in both tables, or refused with a reason that is not one, would be a
+// triage that says nothing — the placeholder-reason failure the Declined() gate
+// already refuses at start-up.
+func TestTheTwoTaggingTablesDoNotOverlapOrHedge(t *testing.T) {
+	seen := map[string]bool{}
+	for _, entry := range taggable {
+		if seen[entry.prefix] {
+			t.Errorf("%q appears twice in taggable", entry.prefix)
+		}
+		seen[entry.prefix] = true
+	}
+	for prefix, reason := range notTaggable {
+		if seen[prefix] {
+			t.Errorf("%q is in both tables: it cannot be taggable and not", prefix)
+		}
+		if len(strings.Fields(reason)) < 5 {
+			t.Errorf("%q is refused with %q, which is not a reason", prefix, reason)
+		}
+	}
+}
+
+// TestEveryTaggableResourceTypeIsOneTheSDKDeclares pins the values to the enum
+// rather than to what reads well. Two of the four this table first carried were
+// invented — "net" for "vpc" and "vm" for "instance" — and no contract could
+// see it, because their OpenAPI declares ResourceType as a bare string.
+func TestEveryTaggableResourceTypeIsOneTheSDKDeclares(t *testing.T) {
+	// TagResourceType, osc-sdk-go/pkg/osc/client.gen.go, whose source is the
+	// enum block of patch.yaml. Twenty values, and none naming an internet
+	// service — which is why one row of taggable carries no type at all.
+	declared := map[string]bool{
+		"customer-gateway": true, "dhcpoptions": true, "flexible-gpu": true,
+		"image": true, "instance": true, "keypair": true, "natgateway": true,
+		"network-interface": true, "public-ip": true, "route-table": true,
+		"security-group": true, "snapshot": true, "subnet": true, "task": true,
+		"virtual-private-gateway": true, "volume": true, "vpc": true,
+		"vpc-endpoint": true, "vpc-peering-connection": true, "vpn-connection": true,
+	}
+
+	for _, entry := range taggable {
+		if entry.resourceType == "" {
+			continue // declared upstream with Tags and no name for its type
+		}
+		if !declared[entry.resourceType] {
+			t.Errorf("%s publishes ResourceType %q, which the SDK's TagResourceType "+
+				"enum does not declare: read the enum, do not invent a name",
+				entry.prefix, entry.resourceType)
+		}
+	}
+}

--- a/internal/providers/outscale/tags_test.go
+++ b/internal/providers/outscale/tags_test.go
@@ -1,0 +1,123 @@
+package outscale_test
+
+import "testing"
+
+// TestTagsReachEveryResourceTheEmulatorServes drives the defect #99 reported:
+// CreateTags answered "the resource igw-… does not exist" about a resource the
+// emulator had just created and was serving, because the prefix table had
+// never grown past the four kinds the pack had when it was written.
+//
+// The table checks in tags_internal_test.go prove the tables are complete; this
+// proves they are true, because a row naming a kind the store never holds would
+// satisfy those checks and still fail a client.
+func TestTagsReachEveryResourceTheEmulatorServes(t *testing.T) {
+	ts := newServer(t)
+
+	id := func(action, body, envelope, field string) string {
+		t.Helper()
+		_, out := post(t, ts, action, body)
+		obj, _ := out[envelope].(map[string]any)
+		got, _ := obj[field].(string)
+		if got == "" {
+			t.Fatalf("%s returned no %s: %v", action, field, out)
+		}
+		return got
+	}
+
+	net := id("CreateNet", `{"IpRange":"10.71.0.0/16"}`, "Net", "NetId")
+	subnet := id("CreateSubnet", `{"NetId":"`+net+`","IpRange":"10.71.1.0/24"}`, "Subnet", "SubnetId")
+	vol := id("CreateVolume", `{"SubregionName":"eu-west-2a","Size":10}`, "Volume", "VolumeId")
+
+	for _, resourceID := range []string{
+		net,
+		subnet,
+		vol,
+		id("CreateInternetService", `{}`, "InternetService", "InternetServiceId"),
+		id("CreateRouteTable", `{"NetId":"`+net+`"}`, "RouteTable", "RouteTableId"),
+		id("CreateSecurityGroup",
+			`{"NetId":"`+net+`","SecurityGroupName":"tagged","Description":"tagged"}`,
+			"SecurityGroup", "SecurityGroupId"),
+		id("CreatePublicIp", `{}`, "PublicIp", "PublicIpId"),
+		id("CreateNic", `{"SubnetId":"`+subnet+`"}`, "Nic", "NicId"),
+		id("CreateSnapshot", `{"VolumeId":"`+vol+`"}`, "Snapshot", "SnapshotId"),
+	} {
+		status, out := post(t, ts, "CreateTags",
+			`{"ResourceIds":["`+resourceID+`"],"Tags":[{"Key":"Name","Value":"x"}]}`)
+		if status != 200 {
+			t.Errorf("CreateTags on %s answered %d: %v", resourceID, status, out["Errors"])
+		}
+	}
+}
+
+// TestReadTagsPublishesTheTypesTheSDKDeclares is the wire half of the second
+// defect: the pack published ResourceType "net" and "vm", where Outscale's own
+// enum says "vpc" and "instance". A client filtering ReadTags on `instance`
+// matched nothing, and no contract could see it — their OpenAPI declares
+// ResourceType as a bare string.
+func TestReadTagsPublishesTheTypesTheSDKDeclares(t *testing.T) {
+	ts := newServer(t)
+
+	_, out := post(t, ts, "CreateNet", `{"IpRange":"10.72.0.0/16"}`)
+	net, _ := out["Net"].(map[string]any)
+	netID, _ := net["NetId"].(string)
+	post(t, ts, "CreateTags", `{"ResourceIds":["`+netID+`"],"Tags":[{"Key":"Name","Value":"n"}]}`)
+
+	_, out = post(t, ts, "ReadTags", `{}`)
+	tags, _ := out["Tags"].([]any)
+	if len(tags) != 1 {
+		t.Fatalf("expected one tag, got %d", len(tags))
+	}
+	first, _ := tags[0].(map[string]any)
+	if first["ResourceType"] != "vpc" {
+		t.Fatalf("ReadTags published ResourceType %q for a Net: the SDK's "+
+			"TagResourceType enum says \"vpc\"", first["ResourceType"])
+	}
+
+	// And the filter a client sends must match that same value.
+	_, out = post(t, ts, "ReadTags", `{"Filters":{"ResourceTypes":["vpc"]}}`)
+	if tags, _ := out["Tags"].([]any); len(tags) != 1 {
+		t.Fatalf("filtering on the type the API publishes matched %d tags", len(tags))
+	}
+}
+
+// TestReadTagsOmitsAKindUpstreamDoesNotName holds the one honest gap in place.
+// An internet service carries Tags in Outscale's own schema — the Terraform
+// provider sets them, which is how #99 was found — and the SDK enum names no
+// type for it. So the tag is readable on the resource and absent from the flat
+// view. Serving a row with an invented ResourceType is what this asserts
+// against.
+func TestReadTagsOmitsAKindUpstreamDoesNotName(t *testing.T) {
+	ts := newServer(t)
+
+	_, out := post(t, ts, "CreateInternetService", `{}`)
+	svc, _ := out["InternetService"].(map[string]any)
+	igw, _ := svc["InternetServiceId"].(string)
+
+	if status, out := post(t, ts, "CreateTags",
+		`{"ResourceIds":["`+igw+`"],"Tags":[{"Key":"Name","Value":"gateway"}]}`); status != 200 {
+		t.Fatalf("tagging an internet service answered %d: %v", status, out["Errors"])
+	}
+
+	// Readable where the client puts it: on the resource.
+	_, out = post(t, ts, "ReadInternetServices", `{}`)
+	services, _ := out["InternetServices"].([]any)
+	if len(services) != 1 {
+		t.Fatalf("expected one internet service, got %d", len(services))
+	}
+	first, _ := services[0].(map[string]any)
+	if entries, _ := first["Tags"].([]any); len(entries) != 1 {
+		t.Fatalf("the tag is not on the internet service: %v", first["Tags"])
+	}
+
+	// And absent from the flat view, rather than carrying a name nobody
+	// upstream declares.
+	_, out = post(t, ts, "ReadTags", `{}`)
+	tags, _ := out["Tags"].([]any)
+	for _, entry := range tags {
+		tag, _ := entry.(map[string]any)
+		if tag["ResourceId"] == igw {
+			t.Fatalf("ReadTags published %q for an internet service, a ResourceType "+
+				"the SDK enum does not declare", tag["ResourceType"])
+		}
+	}
+}

--- a/tools/conformance/outscale/terraform.sh
+++ b/tools/conformance/outscale/terraform.sh
@@ -157,6 +157,34 @@ printf '%s' "$addresses" | jq -e --arg v "$vm_id" \
   || fail "the public IP is not linked to the Vm: $addresses"
 ok "route, link, rule, group and address all served as built"
 
+# The tags the provider set on the internet service and the route table, which
+# it applies through CreateTags with the identifier it has just been handed. The
+# apply above already fails without this working — that is issue #99, where the
+# emulator answered "the resource igw-… does not exist" about a resource it was
+# serving — so this reads them back to prove the tag was stored rather than
+# merely accepted.
+echo "- the tags the provider set on families beyond the first four"
+igw_id="$("$TF" output -raw internet_service_id)"
+services="$(curl -sf -X POST "$ENDPOINT/api/v1/ReadInternetServices" -H 'Content-Type: application/json' \
+             -d "{\"Filters\":{\"InternetServiceIds\":[\"$igw_id\"]}}")" \
+  || fail "ReadInternetServices rejected"
+printf '%s' "$services" | jq -e \
+  'any(.InternetServices[0].Tags[]; .Key == "Name" and .Value == "conformance-igw")' >/dev/null \
+  || fail "the tag the provider set on the internet service is not served: $services"
+
+printf '%s' "$routes" | jq -e \
+  'any(.RouteTables[0].Tags[]; .Key == "Name" and .Value == "conformance-rtb")' >/dev/null \
+  || fail "the tag the provider set on the route table is not served: $routes"
+
+# And the flat view names them with the types Outscale's own SDK declares, not
+# with names of our own: "vpc" rather than "net", "instance" rather than "vm".
+tags="$(curl -sf -X POST "$ENDPOINT/api/v1/ReadTags" -H 'Content-Type: application/json' \
+         -d '{"Filters":{"ResourceTypes":["route-table"]}}')" || fail "ReadTags rejected"
+printf '%s' "$tags" | jq -e --arg r "$rtb_id" \
+  'any(.Tags[]; .ResourceId == $r and .ResourceType == "route-table")' >/dev/null \
+  || fail "ReadTags does not name the route table with the SDK's own type: $tags"
+ok "tags set, stored, and named with the types the SDK declares"
+
 echo "- the volume the provider created is served"
 volume_id="$("$TF" output -raw volume_id)"
 [ -n "$volume_id" ] || fail "no volume id in the outputs"

--- a/tools/conformance/outscale/terraform/net_vm.tf
+++ b/tools/conformance/outscale/terraform/net_vm.tf
@@ -28,15 +28,34 @@
 # behaviour the emulator does not have, and the explicit
 # `outscale_public_ip_link` below is what the pack actually serves.
 
-resource "outscale_internet_service" "net_vm" {}
+# The tags block is the whole of issue #99, and it is here rather than in a unit
+# test because only the provider walks this path: it creates the resource, then
+# calls CreateTags with the identifier it just received. The emulator answered
+# "the resource igw-… does not exist" about a resource it was serving, because
+# the prefix table in tags.go had never grown past the four kinds the pack had
+# when it was written. An apply of this file fails without the fix.
+resource "outscale_internet_service" "net_vm" {
+  tags {
+    key   = "Name"
+    value = "conformance-igw"
+  }
+}
 
 resource "outscale_internet_service_link" "net_vm" {
   internet_service_id = outscale_internet_service.net_vm.internet_service_id
   net_id              = outscale_net.conformance.net_id
 }
 
+# Tagged for the same reason, and on purpose on a second family: rtb- and sg-
+# were reported failing beside igw-, and the defect was a missing row per
+# prefix rather than one wrong line.
 resource "outscale_route_table" "net_vm" {
   net_id = outscale_net.conformance.net_id
+
+  tags {
+    key   = "Name"
+    value = "conformance-rtb"
+  }
 }
 
 resource "outscale_route_table_link" "net_vm" {


### PR DESCRIPTION
Closes #99. Reported by Vincent Dislaire.

An `outscale_internet_service` with a `tags` block failed its apply on `the resource igw-… does not exist`, about a resource `ReadInternetServices` was serving in the same session, and failed identically on a retry.

## The cause is the shape of the table, not a wrong line in it

`taggable` in `tags.go` mapped four identifier prefixes to four kinds, written when the pack served exactly those four. 0.6.0 added ten resource families and none of them reached it.

Three prefixes were reported. Reading which schemas declare `Tags` found **ten**: volumes, snapshots, images, security groups, route tables, public IPs, NICs, DHCP options, NAT services and internet services.

## Two of the four rows that were there were also wrong

`ReadTags` published `ResourceType: "net"` and `"vm"`, where Outscale's own SDK declares `vpc` and `instance` — `TagResourceType` in `osc-sdk-go/pkg/osc/client.gen.go`, from the `enum` block of `patch.yaml`. A client filtering `ReadTags` on `instance` matched nothing.

Nothing was in a position to catch it: their OpenAPI declares `ResourceType` as a bare string, so no contract check applies, and `TestTagsAreStoredOnTheResourceTheyName` had been asserting `"net"` for three releases. That is how an emulator's own mistake becomes the thing its suite defends. The assertion is corrected and now cites where the name comes from.

## Adding ten rows would fix today and nothing else

The eleventh resource would do it again, which is the whole lesson. So the prefixes the pack mints are read from its own source, and each must be triaged — taggable with its upstream type, or refused with a reason, the discipline `Declined()` already applies to operations.

`TestEveryIdentifierPrefixIsTriagedForTagging` fails on a new prefix that reaches neither table, and names both files in the message.

## One case has no honest answer, and is recorded rather than guessed

An internet service carries `Tags` upstream and the SDK enum has no value naming one. So `CreateTags` accepts it and `ReadTags` leaves it out: every row of that view carries a `ResourceType`, and inventing `internet-gateway` because AWS spells it that way is the invented format rule 4 forbids. The tag stays readable where the provider reads it, on the resource. `docs/limits.md` carries the reasoning.

## Proven by the real client

A unit test cannot see this path — only the provider creates a resource and then calls `CreateTags` with the identifier it was just handed. The Terraform fixture now tags the internet service and the route table; the suite reads both back and checks the flat view names the route table `route-table`. **The apply fails without the fix.**

Conformance goes from 131 to **132 of 175** routes proven by a real client: `ReadTags` had never been driven by one.

## Falsified

Three mutations, each compiling, package green before and after:

| mutation | tests that must die |
|---|---|
| the four-row table restored | triage, create-and-tag, internet-service — all failed |
| `vpc`/`instance` reverted to `net`/`vm` | enum, ReadTags type, corrected audit test — all failed |
| the skip in `readTags` removed | internet-service — failed |

## Checks

```
mise run check        ✅
mise run conformance  ✅ 132 of 175
mise run drift:check  ✅ 0
feint docs --check    ✅ 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)