### PR TITLE
The proxy says when a recording stopped because the client was sent elsewhere

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -15,6 +15,36 @@ parce que c'est là-dessus que ce projet est jugé : **une forme de réponse qu'
 client peut observer**, et **une limite qui a bougé**. Une refactorisation qui ne
 change ni l'un ni l'autre a sa place dans `git log`.
 
+## [Non publié]
+
+### Corrigé
+
+- **Un enregistrement pouvait s'arrêter tôt sans rien dire.** Certaines API
+  remettent une adresse au client dans un corps de réponse — Exoscale publie un
+  `api-endpoint` par zone — et un client qui la suit quitte le proxy pour tout
+  ce qui vient après. Mesuré sur un vrai compte : une session valant environ
+  quatre-vingt-dix échanges en a enregistré **huit**, et la transcription avait
+  l'air complète. `feint proxy` compte désormais les réponses qui nomment un
+  hôte autre que celui auquel le client s'adresse, nomme ces hôtes à la fin du
+  run, et dit franchement que ce qui est parti là-bas est absent du fichier.
+
+  Détecté par la forme plutôt que par le nom du champ — une URL absolue dont
+  l'hôte n'est pas celui du client — parce que nommer `api-endpoint` mettrait le
+  vocabulaire d'un provider dans un outil qui n'en porte aucun, et la prochaine
+  API à faire cela serait de nouveau silencieuse. Deux propriétés portent leur
+  propre test : une réponse qui nomme le proxy lui-même n'est **pas** un renvoi,
+  parce que la liste de zones de l'émulateur pointe sur elle-même et qu'une
+  alarme qui sonne sur le cas normal finit ignorée ; et un corps gzippé est
+  décompressé avant le scan, parce que `scw` et `exo` envoient tous deux
+  `Accept-Encoding` et qu'un scan sur des octets compressés ne trouve rien d'une
+  façon qui se lit « il n'y a rien ».
+
+  Il ne réécrit pas l'adresse, délibérément : un enregistreur qui modifie ce
+  qu'il enregistre n'en est pas un. `docs/proxy.md` énonce désormais ce qu'un
+  enregistrement peut promettre pour les trois providers plutôt que pour le seul
+  Outscale — l'un refuse bruyamment, l'un tronquait en silence, l'un enregistre
+  entièrement (#92).
+
 ## [0.7.1]
 
 ### Corrigé

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,34 @@ Two kinds of change deserve their own line whatever their size, because they are
 what this project is judged on: **a response shape a client can observe**, and
 **a limit that moved**. A refactor that changes neither belongs in `git log`.
 
+## [Unreleased]
+
+### Fixed
+
+- **A recording could stop early and say nothing.** Some APIs hand the client an
+  address in a response body — Exoscale publishes an `api-endpoint` per zone —
+  and a client that follows it walks away from the proxy for everything after.
+  Measured on a real account: a session worth about ninety exchanges recorded
+  **eight**, and the transcript looked complete. `feint proxy` now counts
+  responses that named a host other than the one the client is addressing, names
+  those hosts when the run ends, and says plainly that whatever went there is
+  absent from the file.
+
+  Detected by shape rather than by field name — an absolute URL whose host is
+  not the client's — because naming `api-endpoint` would put one provider's
+  vocabulary into a tool that carries none, and the next API to do this would be
+  silent all over again. Two properties carry their own tests: an answer naming
+  the proxy itself is **not** a handoff, because the emulator's own zone list
+  points back at itself and an alarm that fires on the normal case gets ignored;
+  and a gzipped body is decompressed before the scan, because `scw` and `exo`
+  both send `Accept-Encoding` and a scan over compressed bytes finds nothing in
+  a way that reads like nothing being there.
+
+  It does not rewrite the address, deliberately: a recorder that edits what it
+  records is not one. `docs/proxy.md` now states what a recording can promise
+  for all three providers rather than for Outscale alone — one refuses loudly,
+  one used to truncate quietly, one records whole (#92).
+
 ## [0.7.1]
 
 ### Fixed

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -98,6 +98,71 @@ finds, because the unit test was written against the same reading of the SDK the
 handler was. This is the project's "jamais de format inventé" rule, made
 checkable.
 
+## What a recording can promise
+
+A transcript covers **what the client kept sending to the proxy**, and that is
+narrower than "the session". Two of the three providers served here can take a
+client out of the recording, for unrelated reasons, and the two fail
+differently — which matters more than either mechanism, because one is loud and
+the other was not.
+
+| provider | mechanism | how it fails |
+|---|---|---|
+| Scaleway | none | records whole |
+| Outscale | the signature covers `Host` | **refuses**: the cloud answers 401, nothing is distorted |
+| Exoscale | the server returns an address in the body | **truncates**: recording stops, and used to say nothing |
+
+Scaleway is the one that works, and that is why the trap went unnoticed for so
+long: the provider this tool was built against signs nothing and never
+republishes its own address, so it is the only one immune to both.
+
+### The recorder says when it has handed the client away
+
+The Exoscale case is the dangerous one, because a transcript that stops early
+looks exactly like a session that ended early. Measured: a full Exoscale
+session, seven resources created and swept on a real account, recorded **8
+exchanges**; the same session with the endpoints rewritten recorded about
+**ninety**. Nothing in the file said the other eighty-two existed.
+
+So the proxy now counts responses that named a host other than the one the
+client is addressing, and says so when the run ends:
+
+```text
+3 response(s) handed the client an address that is not this proxy: api-ch-dk-2.exoscale.com
+  anything the client sent there is absent from this transcript. See docs/proxy.md.
+```
+
+It is detected by shape, not by field name: an absolute URL in a response body
+whose host is not the client's. Naming `api-endpoint` would put one provider's
+vocabulary in a tool that carries none, and the fourth API to do this would be
+silent all over again.
+
+Two properties matter as much as the detection, and each has its own test:
+
+- **An answer naming the proxy itself is not a handoff.** The emulator's own
+  `/v2/zone` publishes an endpoint pointing back at itself — `catalog.go` says
+  that is the whole reason the route exists — so counting it would raise the
+  alarm on every correct recording, and an alarm that fires on the normal case
+  gets ignored.
+- **A gzipped body is decompressed before the scan.** `scw` and `exo` both send
+  `Accept-Encoding`, so on a real session nearly every body arrives compressed;
+  a scan over the raw bytes would find nothing in any of them and report
+  nothing found, which reads exactly like nothing being there.
+
+### What this deliberately does not do
+
+**It does not rewrite the address.** A recorder that edits the answer it is
+recording is not a recorder, and the scratchpad rewriter used to capture the
+Exoscale shapes was honest about shapes and lying about one field. If following
+the endpoint is ever wanted, it belongs behind an explicit flag that records the
+answer **as received** and marks that it rewrote what the client saw — which is
+the open half of #92, deliberately not decided by this change.
+
+**The other route is already there and needs no proxy.** `internal/upstream`
+signs the real host and talks to it directly, so it has neither problem: it is
+how `feint shapes --record` captures a real cloud's field tree. When a recording
+would be truncated, that is the tool to reach for.
+
 ### What it cannot record: a signed client pointed at a real cloud
 
 A reverse proxy cannot relay a SigV4-signed request to a real cloud when the

--- a/internal/cli/proxy.go
+++ b/internal/cli/proxy.go
@@ -11,6 +11,8 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"sort"
+	"strings"
 	"syscall"
 	"time"
 
@@ -142,6 +144,18 @@ func proxyCommand(args []string, _ io.Writer, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "%d of them walked a route no pack claims: grep '\"operation\":\"\"' or filter on .mounted == false\n",
 			unnamed)
 	}
+	if handed, hosts := p.HandedElsewhere(); handed > 0 {
+		// The other half of the product, and the one that would otherwise be
+		// invisible: an answer that gave the client a different address. If the
+		// client followed it, everything after this point left no trace here,
+		// and a transcript that stops early is indistinguishable from a session
+		// that ended early. Measured on Exoscale: a session worth about ninety
+		// exchanges recorded eight, and nothing said so.
+		fmt.Fprintf(stderr,
+			"%d response(s) handed the client an address that is not this proxy: %s\n"+
+				"  anything the client sent there is absent from this transcript. See docs/proxy.md.\n",
+			handed, strings.Join(sortedHosts(hosts), ", "))
+	}
 	if dropped > 0 {
 		fmt.Fprintf(stderr, "%d exchange(s) were dropped because the transcript could not keep up; "+
 			"the gaps in \"seq\" are where. Raise --queue.\n", dropped)
@@ -220,4 +234,20 @@ func transcriptFile(path string) (io.Writer, func() error, error) {
 		return nil, nil, fmt.Errorf("open the transcript %s: %w", path, err)
 	}
 	return f, f.Close, nil
+}
+
+// sortedHosts names the hosts a run was handed, most seen first, then
+// alphabetically so two identical runs print identically.
+func sortedHosts(hosts map[string]int64) []string {
+	out := make([]string, 0, len(hosts))
+	for host := range hosts {
+		out = append(out, host)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if hosts[out[i]] != hosts[out[j]] {
+			return hosts[out[i]] > hosts[out[j]]
+		}
+		return out[i] < out[j]
+	})
+	return out
 }

--- a/internal/proxy/handoff.go
+++ b/internal/proxy/handoff.go
@@ -1,0 +1,136 @@
+package proxy
+
+import (
+	"net/url"
+	"strings"
+	"sync"
+)
+
+// A recorder that stops recording without saying so is worse than one that
+// refuses, and this file is about the second of the two ways that happens here.
+//
+// The first is loud: a client that signs the host it was configured with gets a
+// 401 from the real cloud, nothing is distorted, and docs/proxy.md has always
+// said so. The second is silent. Some APIs hand the client an address in a
+// response body — Exoscale publishes an `api-endpoint` per zone in `GET
+// /v2/zone` — and a client that follows it walks away from the proxy for
+// everything after. A full session that produced about ninety exchanges through
+// a rewriter recorded **eight** through the proxy alone, and the transcript said
+// nothing about the other eighty-two. It looked complete.
+//
+// So the proxy notices when it has just handed the client somewhere else. Not by
+// knowing which field any provider uses — that would put three provider names in
+// a tool that has none, and a fourth API would be silent again — but by the
+// shape of the thing: an absolute URL in a response body naming a host that is
+// not the one the client is talking to.
+//
+// This is a finding rather than a diagnostic, in the same sense `unnamed` is: it
+// is the recorder saying what its own transcript does not cover.
+
+// handoff counts responses that named a host other than this proxy, and keeps
+// the hosts so the report can name them.
+type handoff struct {
+	mu    sync.Mutex
+	count int64
+	hosts map[string]int64
+}
+
+// note records one response body that pointed elsewhere.
+//
+// `self` is the authority the client addressed — r.Host — rather than the
+// listen address: behind a name, an alias or a container port mapping those
+// differ, and what matters is whether the client is being sent away from what it
+// is currently talking to.
+func (h *handoff) note(self string, body []byte) {
+	elsewhere := hostsElsewhere(self, body)
+	if len(elsewhere) == 0 {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.count++
+	if h.hosts == nil {
+		h.hosts = map[string]int64{}
+	}
+	for _, host := range elsewhere {
+		h.hosts[host]++
+	}
+}
+
+// seen answers how many responses pointed elsewhere, and at which hosts.
+func (h *handoff) seen() (int64, map[string]int64) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make(map[string]int64, len(h.hosts))
+	for host, n := range h.hosts {
+		out[host] = n
+	}
+	return h.count, out
+}
+
+// schemes are the two an in-band endpoint can carry. A body naming `ws://` or a
+// bare hostname is not a redirect a client follows for its next API call, and
+// widening this would turn every documentation link in an error message into a
+// finding.
+var schemes = []string{"https://", "http://"}
+
+// hostsElsewhere finds absolute URLs in a body whose host is not `self`.
+//
+// A scan rather than a JSON walk, deliberately: the body may be XML, may be a
+// form, may be truncated at the recording cap mid-document, and a walk that
+// needs to parse would go blind on all three. What is being looked for is a
+// string with a scheme in it, which survives all of them.
+func hostsElsewhere(self string, body []byte) []string {
+	if self == "" || len(body) == 0 {
+		return nil
+	}
+	text := string(body)
+
+	seen := map[string]bool{}
+	var out []string
+	for _, scheme := range schemes {
+		for from := 0; ; {
+			at := strings.Index(text[from:], scheme)
+			if at < 0 {
+				break
+			}
+			at += from
+			from = at + len(scheme)
+
+			raw := text[at:]
+			if end := strings.IndexAny(raw, "\"'`\\ \t\r\n,)]}<>"); end >= 0 {
+				raw = raw[:end]
+			}
+			parsed, err := url.Parse(raw)
+			if err != nil || parsed.Host == "" {
+				continue
+			}
+			if sameAuthority(parsed.Host, self) || seen[parsed.Host] {
+				continue
+			}
+			seen[parsed.Host] = true
+			out = append(out, parsed.Host)
+		}
+	}
+	return out
+}
+
+// sameAuthority compares hosts without being fooled by a default port.
+//
+// A client addressing `127.0.0.1:4701` and a body naming `http://127.0.0.1:4701`
+// are the same place; so are `example.test` and `example.test:80` over http.
+// Getting this wrong would report a handoff on every response of a proxy that
+// correctly points at itself, which is the false positive that would make the
+// whole signal ignored.
+func sameAuthority(a, b string) bool {
+	return strings.EqualFold(trimDefaultPort(a), trimDefaultPort(b))
+}
+
+func trimDefaultPort(host string) string {
+	for _, port := range []string{":80", ":443"} {
+		if strings.HasSuffix(host, port) {
+			return strings.TrimSuffix(host, port)
+		}
+	}
+	return host
+}

--- a/internal/proxy/handoff_test.go
+++ b/internal/proxy/handoff_test.go
@@ -1,0 +1,167 @@
+package proxy_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/proxy"
+)
+
+// recorder builds a proxy in front of an upstream and hands back both the
+// address a client uses and the proxy itself, which the shared helper does not
+// expose — these tests assert on a counter rather than on the file.
+func recorder(t *testing.T, upstream string) (client string, p *proxy.Proxy) {
+	t.Helper()
+
+	target, err := url.Parse(upstream)
+	if err != nil {
+		t.Fatalf("parse the upstream URL: %v", err)
+	}
+	file, err := os.OpenFile(filepath.Join(t.TempDir(), "run.jsonl"),
+		os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatalf("open the transcript: %v", err)
+	}
+	writer := proxy.NewWriter(file, 0)
+
+	p, err = proxy.New(proxy.Options{Upstream: target, Writer: writer})
+	if err != nil {
+		t.Fatalf("build the proxy: %v", err)
+	}
+	front := httptest.NewServer(p)
+	t.Cleanup(func() {
+		front.Close()
+		_ = writer.Close()
+		_ = file.Close()
+	})
+	return front.URL, p
+}
+
+func get(t *testing.T, addr string) {
+	t.Helper()
+	res, err := http.Get(addr + "/v2/zone") //nolint:noctx // test client
+	if err != nil {
+		t.Fatalf("GET through the proxy: %v", err)
+	}
+	_ = res.Body.Close()
+}
+
+// TestAnAnswerThatSendsTheClientElsewhereIsCounted is the defect #92 named.
+//
+// Exoscale publishes an `api-endpoint` per zone in `GET /v2/zone`, and `exo`
+// follows it for everything after. Against a real cloud that address is the
+// real cloud, so the proxy sees the first exchange and none of the rest: a
+// session worth about ninety exchanges recorded eight, and the transcript said
+// nothing about the other eighty-two. It looked complete, which is the one
+// thing a recorder must never look when it is not.
+//
+// The proxy does not know the field name, and must not: three provider names in
+// a tool that has none would leave a fourth API silent again. It knows the
+// shape — an absolute URL naming a host that is not the one the client is
+// talking to.
+func TestAnAnswerThatSendsTheClientElsewhereIsCounted(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"zones":[{"name":"ch-dk-2","api-endpoint":"https://api-ch-dk-2.exoscale.com/v2"}]}`)
+	}))
+	defer upstream.Close()
+
+	client, p := recorder(t, upstream.URL)
+	get(t, client)
+
+	handed, hosts := p.HandedElsewhere()
+	if handed != 1 {
+		t.Fatalf("HandedElsewhere counted %d, want 1", handed)
+	}
+	if hosts["api-ch-dk-2.exoscale.com"] != 1 {
+		t.Errorf("the host the client was sent to is not named: %v", hosts)
+	}
+}
+
+// TestAnAnswerNamingThisProxyIsNotAHandoff is the half that keeps the signal
+// worth reading. An emulator serving this same route publishes an api-endpoint
+// pointing at itself — internal/providers/exoscale/catalog.go does exactly that,
+// and says it is the whole reason the route exists. Counting that as a handoff
+// would raise the alarm on every correct recording, and an alarm that fires on
+// the normal case gets ignored, which costs more than the silence it replaced.
+func TestAnAnswerNamingThisProxyIsNotAHandoff(t *testing.T) {
+	var upstream *httptest.Server
+	proxied := make(chan string, 1)
+
+	upstream = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The emulator answers with the address the client used, which through a
+		// proxy is the proxy's own. r.Host here is the upstream's, so the test
+		// feeds back what the client asked for.
+		self := <-proxied
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"zones":[{"name":"ch-dk-2","api-endpoint":"http://%s/v2"}]}`, self)
+	}))
+	defer upstream.Close()
+
+	client, p := recorder(t, upstream.URL)
+	proxied <- strings.TrimPrefix(client, "http://")
+	get(t, client)
+
+	if handed, hosts := p.HandedElsewhere(); handed != 0 {
+		t.Fatalf("an answer naming this proxy was reported as a handoff: %d %v", handed, hosts)
+	}
+}
+
+// TestAGzippedHandoffIsStillSeen holds the blind spot shut. `scw` and `exo`
+// both send Accept-Encoding, so on a real session almost every body arrives
+// compressed: a scan over the raw bytes would find no URL in any of them and
+// report nothing found, which reads exactly like nothing being there.
+func TestAGzippedHandoffIsStillSeen(t *testing.T) {
+	var packed bytes.Buffer
+	zw := gzip.NewWriter(&packed)
+	if _, err := zw.Write([]byte(
+		`{"zones":[{"api-endpoint":"https://api-de-fra-1.exoscale.com/v2"}]}`)); err != nil {
+		t.Fatalf("gzip: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close the gzip writer: %v", err)
+	}
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Encoding", "gzip")
+		_, _ = w.Write(packed.Bytes())
+	}))
+	defer upstream.Close()
+
+	client, p := recorder(t, upstream.URL)
+	get(t, client)
+
+	handed, hosts := p.HandedElsewhere()
+	if handed != 1 {
+		t.Fatalf("a gzipped handoff was not seen: %d %v", handed, hosts)
+	}
+	if hosts["api-de-fra-1.exoscale.com"] != 1 {
+		t.Errorf("the host is not named: %v", hosts)
+	}
+}
+
+// TestAnAnswerWithNoAddressInItIsNotAHandoff: the ordinary case, which is most
+// of them. A body that carries no absolute URL cannot send anybody anywhere.
+func TestAnAnswerWithNoAddressInItIsNotAHandoff(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"server":{"id":"a-b-c","state":"running","private_ip":"10.0.0.4"}}`)
+	}))
+	defer upstream.Close()
+
+	client, p := recorder(t, upstream.URL)
+	get(t, client)
+
+	if handed, hosts := p.HandedElsewhere(); handed != 0 {
+		t.Fatalf("an ordinary answer was reported as a handoff: %d %v", handed, hosts)
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -81,6 +81,10 @@ type Proxy struct {
 	// exactly the list #74 ranks and the gap tools/conformance/README.md
 	// describes finding three times by hand.
 	unnamed atomic.Int64
+	// handed counts responses that gave the client an address other than this
+	// proxy. See handoff.go: it is the difference between a recording that
+	// stops and a recording that stops and says so.
+	handed handoff
 }
 
 // New validates the options and builds the proxy.
@@ -175,6 +179,11 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	p.rp.ServeHTTP(tap, r)
 	elapsed := time.Since(started)
 
+	// Read from the recorded copy, not from the wire: the client already has the
+	// bytes and nothing here alters them. r.Host is the authority the client
+	// addressed, which is what "elsewhere" is measured against.
+	p.handed.note(r.Host, tap.body.plain(w.Header()))
+
 	p.writer.Record(capture(seen{
 		at:        p.now(),
 		elapsed:   elapsed,
@@ -198,6 +207,16 @@ func (p *Proxy) Unnamed() int64 {
 	}
 	return p.unnamed.Load()
 }
+
+// HandedElsewhere is how many responses gave the client an address that is not
+// this proxy, and which hosts they named.
+//
+// It is not an error and not always a problem — an API may name a bucket
+// endpoint in a body nobody follows. It matters because the client *may* follow
+// it, and if it does, everything after leaves no trace here. A transcript that
+// stops early looks exactly like a session that ended early, and only this
+// number tells them apart.
+func (p *Proxy) HandedElsewhere() (int64, map[string]int64) { return p.handed.seen() }
 
 // responseTap copies what is written to the client, and passes it through.
 //

--- a/internal/proxy/record.go
+++ b/internal/proxy/record.go
@@ -149,6 +149,33 @@ func (b *body) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
+// plain copies out what was captured, decompressed if it was gzipped, for a
+// reader that wants the text rather than the decoded value.
+//
+// The gzip step is not optional here: `scw` and `exo` both send
+// Accept-Encoding, so without it every response of a real session is a blob and
+// a scan over it finds nothing — a detector that is quietly blind on the common
+// case, which is the failure mode this package exists to avoid.
+//
+// A copy rather than the buffer's own slice: the caller reads outside the lock
+// and the buffer can still be written to.
+func (b *body) plain(header http.Header) []byte {
+	b.mu.Lock()
+	data := append([]byte(nil), b.buf.Bytes()...)
+	b.mu.Unlock()
+
+	if strings.EqualFold(header.Get("Content-Encoding"), "gzip") {
+		if unpacked, err := gunzip(data); err == nil {
+			return unpacked
+		}
+		// A body that will not decompress is one nothing can be read out of.
+		// Answering the compressed bytes would scan gibberish and report
+		// nothing found, which reads like "nothing there".
+		return nil
+	}
+	return data
+}
+
 // decoded turns what was captured into the value the transcript carries.
 func (b *body) decoded(header http.Header) any {
 	b.mu.Lock()


### PR DESCRIPTION
Addresses [#92](https://github.com/stephrobert/feint/issues/92), and answers the question it actually asks — *what a recorder can promise* — rather than patching per provider.

## The finding under the finding

Two of three providers can take a client out of a recording, and **they fail differently**:

| provider | mechanism | how it fails |
|---|---|---|
| Scaleway | none | records whole |
| Outscale | the signature covers `Host` | **refuses**: 401, nothing distorted, documented since the proxy shipped |
| Exoscale | the server returns an address in the body | **truncates**: recording stops, and said nothing |

The second is the dangerous one: a transcript that stops early looks exactly like a session that ended early. Measured on a real account — seven resources created and swept, about ninety exchanges through a rewriter, **eight** through the proxy alone, and nothing in the file saying the other eighty-two existed.

## What changes

The recorder now says what its own transcript does not cover, the same job `unnamed` already does for routes no pack claims:

```
3 response(s) handed the client an address that is not this proxy: api-ch-dk-2.exoscale.com
  anything the client sent there is absent from this transcript. See docs/proxy.md.
```

**Detected by shape, not by field name** — an absolute URL whose host is not the client's. Naming `api-endpoint` would put one provider's vocabulary into a tool that deliberately carries none, and the fourth API to do this would be silent all over again.

## Two properties that matter as much as the detection

Each has its own test, because each is a way this could have been written and been useless.

- **An answer naming the proxy itself is not a handoff.** The emulator's own `/v2/zone` publishes an endpoint pointing back at itself — `catalog.go` says that is the whole reason the route exists — so counting it would fire on every correct recording, and an alarm that fires on the normal case is one people learn to ignore.
- **A gzipped body is decompressed before the scan.** `scw` and `exo` both send `Accept-Encoding`, so on a real session nearly every body arrives compressed. A scan over raw bytes would find nothing in any of them and report nothing found — which reads exactly like nothing being there. It would have shipped blind without that line.

## What it deliberately does not do

**It does not rewrite the address.** A recorder that edits the answer it records is not a recorder: the scratchpad rewriter used to capture the Exoscale shapes was honest about shapes and lying about one field. If following the endpoint is ever wanted, it belongs behind an explicit flag that records the answer *as received* and marks that it rewrote what the client saw — the open half of #92, left open on purpose.

The other route already exists and needs no proxy: `internal/upstream` signs the real host and talks to it directly, which is how `feint shapes --record` captures a real cloud.

## Documentation

`docs/proxy.md` gains **What a recording can promise**, with all three providers in one table instead of the Outscale case alone. It read as *one provider is awkward* when the truth is *two of three, for unrelated reasons* — the point Vincent Dislaire made on #74.

## Falsified

Three mutations, each compiling, package green before and after:

| mutation | verdict |
|---|---|
| the scan made to find nothing | both positive tests fail |
| two authorities never equal | the not-a-handoff test fails |
| the gzip branch removed | the gzipped test fails; the uncompressed one correctly still passes |

That last row is the isolation working, not a miss.

## Checks

```
mise run check      ✅
feint docs --check  ✅ 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)