### PR TITLE
test(proxy): the transcript test raced the writer's own counter

### DIFF
--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -635,19 +635,32 @@ func TestTheTranscriptIsOnDiskBeforeTheRunEnds(t *testing.T) {
 
 	// The write is asynchronous by design, so this waits for it rather than
 	// assuming it has happened; what it must never need is a Close.
+	//
+	// Two facts are waited for, not one: the line on disk, and the writer
+	// counting it. They never become true atomically — run() writes, then locks
+	// and increments — so a poll landing between the syscall and the count sees
+	// the line with written still 0. Asserted instantaneously, that window
+	// failed this test about one run in five on a loaded station ("the file
+	// holds a line the writer does not count: 0"); a 20 ms pause inserted at
+	// that exact point, standing in for a scheduler preemption, reproduced it
+	// on every run. Waiting for both keeps what the test pins — nothing here
+	// ever calls Close before returning — without asserting an ordering the
+	// writer does not promise.
 	deadline := time.Now().Add(5 * time.Second)
 	for {
 		raw, err := os.ReadFile(path)
 		if err != nil {
 			t.Fatalf("read the transcript: %v", err)
 		}
-		if bytes.HasSuffix(raw, []byte("\n")) && len(raw) > 0 {
-			if written, _ := writer.Stats(); written != 1 {
-				t.Errorf("the file holds a line the writer does not count: %d", written)
-			}
+		onDisk := bytes.HasSuffix(raw, []byte("\n"))
+		written, _ := writer.Stats()
+		if onDisk && written == 1 {
 			return
 		}
 		if time.Now().After(deadline) {
+			if onDisk {
+				t.Fatalf("the file holds a line the writer never counted: %d", written)
+			}
 			t.Fatal("nothing reached the transcript while the proxy was still running")
 		}
 		time.Sleep(5 * time.Millisecond)


### PR DESCRIPTION
# Summary

`TestTheTranscriptIsOnDiskBeforeTheRunEnds` failed about one run in five on a loaded station during an earlier session, with "the file holds a line the writer does not count: 0" — and the observation lived only in a conversation, which is the defect this repository is most hostile to. This PR records it, diagnoses it, and fixes it.

The mechanism, reproduced deterministically in a copy outside the tree: `run()` writes the line (a syscall), *then* locks and increments `written`. A 20 ms pause between the two — exactly what a scheduler preemption does on a busy machine — fails the test on every run with the observed message. The test polled the file and asserted `Stats()` counted the line the instant its newline appeared: an ordering the writer never promises, and must not (incrementing before the write would make `written` a lie).

The test now waits for both facts inside its poll loop, still without ever calling `Close`, which is the property it pins. Falsified against three mutants of `writer.go` in a copy outside the repository, each still compiling:

- the legal 20 ms delay now **passes** (the flake is gone);
- a writer buffering until the end still **fails** on the deadline;
- a write that is never counted still **fails**, naming the counter.

Statistical reproduction was attempted and is recorded here for honesty: 400 runs under 20 busy loops on 16 cores, 1000 runs at `GOMAXPROCS=1`, 500 under `-race` at `GOMAXPROCS=2` — zero failures on an otherwise idle station. The mutation proof is what ties the fix to the field observation.

## Type of change

- [ ] A route added or changed
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes (gofmt, vet, golangci-lint, `go test -race`) — `go test ./...` green in a clean worktree of this branch; every pre-commit hook (golangci-lint included) passed on the commit
- [x] No new external Go dependency, or the pull request justifies it
- [x] `internal/core` still knows no provider
- [x] Nothing in the diff could be written identically for another provider — the diff is one provider-neutral test in `internal/proxy`

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
- [ ] I ran `mise run conformance` myself — not run for this diff: it changes one test's polling loop in `internal/proxy`, no route, no response byte, nothing a client can observe
- [x] Every field name in the diff comes from a source I can name — there is no provider field name in the diff

### When a route is added or changed — otherwise N/A

N/A

### When behaviour a client can observe changes — otherwise N/A

N/A

### When `.github/workflows/` is touched — otherwise N/A

N/A

### When a machine runtime is involved — otherwise N/A

N/A

## Related issues

N/A — this PR *is* the record of the observation that was never filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
