### PR TITLE
perf(proxy): measure what the handoff scan costs instead of guessing

### DIFF
--- a/internal/proxy/handoff.go
+++ b/internal/proxy/handoff.go
@@ -80,6 +80,16 @@ var schemes = []string{"https://", "http://"}
 // form, may be truncated at the recording cap mid-document, and a walk that
 // needs to parse would go blind on all three. What is being looked for is a
 // string with a scheme in it, which survives all of them.
+//
+// What running it on every response costs, measured rather than guessed
+// (BenchmarkHostsElsewhere, i7-12650H, 2026-08-11): a clean body scans at
+// ~7 GB/s — 0.5 µs for the few kilobytes one API answer weighs, 161 µs at the
+// 1 MiB DefaultMaxBody cap that bounds the input. A body whose every element
+// names another host pays url.Parse per hit and drops to ~700 MB/s, 1.4 ms at
+// the cap. All of it runs after the response has been streamed to the client
+// (see ServeHTTP), so nothing here sits on the wait path of the answer being
+// scanned; a change that puts the scan on that path, or one that slows the
+// clean case, is what the benchmark exists to catch.
 func hostsElsewhere(self string, body []byte) []string {
 	if self == "" || len(body) == 0 {
 		return nil

--- a/internal/proxy/handoff_bench_test.go
+++ b/internal/proxy/handoff_bench_test.go
@@ -1,0 +1,68 @@
+package proxy
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+// These benchmarks answer one question: what does scanning every response body
+// for absolute URLs cost on the request path? The claim "negligible on a
+// terraform apply" was a guess when handoff.go landed, and this repository does
+// not ship guesses. The measured numbers live in the comment on
+// [hostsElsewhere]; re-run with
+//
+//	go test ./internal/proxy/ -bench BenchmarkHostsElsewhere -benchmem
+//
+// and update that comment if the implementation changes.
+//
+// Three sizes, because the input is bounded: a few kilobytes is what one API
+// answer weighs (the shape below is a Scaleway server object), 64 KiB is a large
+// list page, and 1 MiB is the hard cap — DefaultMaxBody truncates anything
+// bigger before the scan ever sees it. Each size runs twice: the common case
+// where no body names another host, and the finding case where every element
+// carries an endpoint elsewhere, which costs more because each hit is parsed by
+// url.Parse.
+
+// benchBody builds a JSON list of about `size` bytes out of realistic server
+// objects. With elsewhere set, each object carries the in-band endpoint that
+// made this scan exist (Exoscale's api-endpoint in GET /v2/zone).
+func benchBody(size int, elsewhere bool) []byte {
+	endpoint := ""
+	if elsewhere {
+		endpoint = `"api-endpoint":"https://api-ch-gva-2.exoscale.com",`
+	}
+	var b bytes.Buffer
+	b.WriteString(`{"servers":[`)
+	for i := 0; b.Len() < size; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		fmt.Fprintf(&b,
+			`{"id":"11111111-1111-1111-1111-%012d","name":"conformance-%d",`+
+				`"state":"running","commercial_type":"DEV1-S",%s`+
+				`"public_ips":[{"address":"51.15.0.%d"}],"tags":["a","b"],"zone":"fr-par-1"}`,
+			i, i, endpoint, i%254+1)
+	}
+	b.WriteString(`]}`)
+	return b.Bytes()
+}
+
+func BenchmarkHostsElsewhere(b *testing.B) {
+	for _, size := range []int{4 << 10, 64 << 10, 1 << 20} {
+		for _, elsewhere := range []bool{false, true} {
+			label := "clean"
+			if elsewhere {
+				label = "handoffs"
+			}
+			body := benchBody(size, elsewhere)
+			b.Run(fmt.Sprintf("%dKiB/%s", size>>10, label), func(b *testing.B) {
+				b.SetBytes(int64(len(body)))
+				b.ReportAllocs()
+				for range b.N {
+					hostsElsewhere("127.0.0.1:4701", body)
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
# Summary

`internal/proxy/handoff.go` scans every response body for absolute URLs, and the claim that this is negligible on a `terraform apply` was a guess when it landed. This project does not ship guesses, so `BenchmarkHostsElsewhere` now measures the scan on the three sizes that bound its input: the few kilobytes one API answer weighs, a 64 KiB list page, and the 1 MiB `DefaultMaxBody` cap the recorder truncates at before the scan ever sees a byte.

Measured (i7-12650H, 2026-08-11):

| body | clean | every element names another host |
|---|---|---|
| 4 KiB | 0.5 µs (~8 GB/s) | 6.4 µs |
| 64 KiB | 7.6 µs | 95 µs |
| 1 MiB (the cap) | 161 µs | 1.4 ms |

The finding case pays `url.Parse` per hit, hence the drop to ~700 MB/s. The scan also runs **after** the response has been streamed to the client (`note` is called once `rp.ServeHTTP` returns), so none of it sits on the wait path of the answer being scanned — it can only delay the next request on the same keep-alive connection, by the microseconds above. Verdict: negligible, now on record instead of assumed. The numbers live in the comment on `hostsElsewhere`, next to the command that refreshes them, so a change that slows the clean case or moves the scan onto the request path has a benchmark to answer to.

## Type of change

- [ ] A route added or changed
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes — `go test ./...` green in a clean worktree of this branch; every pre-commit hook passed on the commit
- [x] No new external Go dependency, or the pull request justifies it
- [x] `internal/core` still knows no provider
- [x] Nothing in the diff could be written identically for another provider — the benchmark body imitates a Scaleway server list because a realistic shape was needed, but it exercises provider-neutral code and lives in `internal/proxy`, which has no provider

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
- [ ] I ran `mise run conformance` myself — not run for this diff: a benchmark and a comment, no route, no response byte, nothing a client can observe
- [x] Every field name in the diff comes from a source I can name — the benchmark body's field names come from the Scaleway instance API's server object, same as the existing `bench_test.go` answer they imitate

### When a route is added or changed — otherwise N/A

N/A

### When behaviour a client can observe changes — otherwise N/A

N/A

### When `.github/workflows/` is touched — otherwise N/A

N/A

### When a machine runtime is involved — otherwise N/A

N/A

## Related issues

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
