### PR TITLE
refactor(cli): derive provider lists from the mounted packs

### DIFF
--- a/docs/fourth-pack.md
+++ b/docs/fourth-pack.md
@@ -79,9 +79,17 @@ comment ("could this line be written identically for another provider?").
 
 ### Category 2: shared code the fourth pack must edit
 
-Thirteen files, roughly 45 additive lines, none of which changes the behaviour
+Eleven files, roughly 43 additive lines, none of which changes the behaviour
 of the three existing packs. Each entry says what would make it data, or why it
 should stay code.
+
+Two entries this audit originally counted — hardcoded provider lists in
+`internal/cli/shapes_check.go` and `internal/cli/docs.go` — were fixed on
+2026-08-11: both now derive the list from the mounted packs, so a fourth pack
+is covered by the shapes gate and printed by the banner by construction.
+`TestShapesCheckCoversEveryMountedPack` holds the first; the second is held by
+`feint docs --check` itself, which regenerates the banner from whatever
+`packsFor` mounts.
 
 | File | Edit | Remedy |
 |---|---|---|
@@ -89,8 +97,6 @@ should stay code.
 | `internal/upstream/upstream.go` | +3: `Provider` const, one `case` in `New` | Keep for now. The three dialect conditionals (`if c.Provider == Outscale`) are doctrine-compliant while exactly one provider deviates; the day a second POST-action provider arrives they become fields of a dialect struct, not before. |
 | `internal/upstream/credentials.go` | +2 dispatch, then a reader (category 3 content) | Keep. Reading a CLI's config file is provider knowledge; the one-file-per-provider seam already exists (`sign_*.go` pattern). |
 | `internal/upstream/reads.go` | +10 to 15 lines of curated data | Keep. The file says why it is curated, and the entries are data already. |
-| `internal/cli/shapes_check.go:46` | +1 to a hardcoded `[]string` | **Fix.** Derive from `srv.Packs()` as `env.go` does. Today a fourth pack is *invisible* to the shapes gate rather than reported as "no catalogue": the honest degradation already written at line 66 is unreachable for a pack the list omits. |
-| `internal/cli/docs.go:514` | +1 to the same hardcoded list | **Fix, same remedy.** `feint docs --check` goes red after mounting a pack until this line is found; deriving from packs deletes the treasure hunt. |
 | `internal/cli/status.go:289` (`productsOfProvider`) | +1 data row | Acceptable. Display-only and it degrades honestly (its comment says so). Could become a `Pack` method the day a second consumer appears. |
 | `internal/cli/doctor.go` (clients table) | +1 row | Data row, keep. |
 | `internal/cli/docs_clients.go` | +1 to 2 rows | Data row, keep. |
@@ -125,7 +131,7 @@ Measured against the Exoscale history (the honest baseline: bootstrap at
 **Largely industrial.** A fourth pack serving ten operations and proving them
 costs, measured rather than guessed:
 
-- **~45 additive lines across 13 shared files**, none of which can regress the
+- **~43 additive lines across 11 shared files**, none of which can regress the
   three existing packs (every edit is a new case, row, or task);
 - **~1 500 lines in its own directory** (pack, tests, conformance script);
 - **~100 to 350 lines of adapters** (signer, credentials, possibly a contract
@@ -164,12 +170,11 @@ What is **not** industrial today is three things, none structural:
    `shapes/*.json` is regenerated, which is exactly where a human decision must
    not live. Estimated ~100 lines including the test. This unblocks wiring the
    gate into every pull request, which is the point of having built it.
-3. **Derive provider lists from mounted packs** in `shapes_check.go:46` and
-   `docs.go:514`. Two real hardcoded callers, and the correct pattern already
-   exists in `env.go`: this is applying an existing seam, not building an
-   abstraction. It makes both gates cover a fourth pack by construction, and
-   turns "invisible to the gate" into the honest "no catalogue; nothing to
-   check".
+3. **Derive provider lists from mounted packs** in `shapes_check.go` and
+   `docs.go`. Done, 2026-08-11: both gates read `srv.Packs()`, the pattern
+   `env.go` already used. "Invisible to the gate" became the honest "no
+   catalogue; nothing to check", and `TestShapesCheckCoversEveryMountedPack`
+   fails if the list is ever written by hand again.
 4. **Deduplicate the Outscale call identity** between `upstream` and
    `shapes_check` (one exported function, two existing callers).
 5. **Watch, do not build:** the day a second provider deviates from the

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -16,6 +16,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime/debug"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -595,7 +596,14 @@ func coverage(args []string, stdout, stderr io.Writer) int {
 	}
 	// One scanner per provider, because their SDKs share no shape: Scaleway
 	// generates a package per product and version from its own IDL, Outscale
-	// generates one client per service from OpenAPI.
+	// generates one client per service from OpenAPI. A map rather than a switch,
+	// so the refusal below lists what is registered instead of repeating it: the
+	// old message named two providers in its own words, which is the kind of
+	// sentence that stays true until the third scanner lands and then lies.
+	scanners := map[string]func(string) ([]drift.Operation, error){
+		scaleway.Name: drift.ScanScalewaySDK,
+		outscale.Name: drift.ScanOutscaleSDK,
+	}
 	var (
 		upstream []drift.Operation
 		err      error
@@ -609,14 +617,19 @@ func coverage(args []string, stdout, stderr io.Writer) int {
 		if doc, err = contract.Load(*contractPath); err == nil {
 			upstream, err = drift.ScanContract(doc)
 		}
-	case *provider == scaleway.Name:
-		upstream, err = drift.ScanScalewaySDK(*sdk)
-	case *provider == outscale.Name:
-		upstream, err = drift.ScanOutscaleSDK(*sdk)
 	default:
-		fmt.Fprintf(stderr, "feint: no SDK scanner for provider %q yet; %q and %q are supported\n",
-			*provider, scaleway.Name, outscale.Name)
-		return exitError
+		scan, known := scanners[*provider]
+		if !known {
+			names := make([]string, 0, len(scanners))
+			for name := range scanners {
+				names = append(names, name)
+			}
+			sort.Strings(names)
+			fmt.Fprintf(stderr, "feint: no SDK scanner for provider %q yet; supported: %s\n",
+				*provider, strings.Join(names, ", "))
+			return exitError
+		}
+		upstream, err = scan(*sdk)
 	}
 	if err != nil {
 		fmt.Fprintf(stderr, "feint: %v\n", err)

--- a/internal/cli/docs.go
+++ b/internal/cli/docs.go
@@ -14,9 +14,6 @@ import (
 	"strings"
 
 	"github.com/stephrobert/feint/internal/drift"
-	"github.com/stephrobert/feint/internal/providers/exoscale"
-	"github.com/stephrobert/feint/internal/providers/outscale"
-	"github.com/stephrobert/feint/internal/providers/scaleway"
 )
 
 // The coverage tables in the README are generated, and this is why.
@@ -97,7 +94,7 @@ func docs(args []string, stdout, stderr io.Writer) int {
 		return exitOK
 	}
 
-	routes, err := routesByProvider()
+	order, routes, err := routesByProvider()
 	if err != nil {
 		fmt.Fprintf(stderr, "feint: %v\n", err)
 		return exitError
@@ -129,7 +126,7 @@ func docs(args []string, stdout, stderr io.Writer) int {
 	// legitimate target, and failing it over a marker it never claimed to have
 	// would make --coverage on another document useless.
 	if strings.Contains(updated, bannerStartMarker) {
-		updated, err = spliceSection(updated, bannerStartMarker, bannerEndMarker, renderBanner(routes))
+		updated, err = spliceSection(updated, bannerStartMarker, bannerEndMarker, renderBanner(order, routes))
 		if err != nil {
 			fmt.Fprintf(stderr, "feint: %v\n", err)
 			return exitError
@@ -352,20 +349,24 @@ func staleCoverage(reports []drift.CoverageFile, routes map[string]map[string]in
 // mounted against a surface nobody scans — six of them, on the day this was
 // written. A table reporting 55 routes next to 49 served operations and saying
 // nothing about the gap invites the reader to assume a rounding error.
-func routesByProvider() (map[string]map[string]int, error) {
+// The order returned beside the counts is the mount order, because the banner
+// must print providers in the order the server does and a map has none.
+func routesByProvider() ([]string, map[string]map[string]int, error) {
 	srv, _, err := newServer(nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
+	var order []string
 	counts := make(map[string]map[string]int)
 	for _, p := range srv.Packs() {
 		byProduct := make(map[string]int)
 		for _, r := range p.Routes() {
 			byProduct[productOf(r.Operation)]++
 		}
+		order = append(order, p.Name())
 		counts[p.Name()] = byProduct
 	}
-	return counts, nil
+	return order, counts, nil
 }
 
 // productOf takes the product an operation belongs to, which every provider
@@ -498,7 +499,11 @@ func renderCoverage(reports []drift.CoverageFile, routes map[string]map[string]i
 //
 // The provider order is the one the server mounts packs in, not an alphabetical
 // one, because the point is to match what a reader will see in their terminal.
-func renderBanner(routes map[string]map[string]int) string {
+// It arrives from routesByProvider rather than being written here: a hardcoded
+// list held this banner at three providers, so mounting a fourth pack turned
+// `feint docs --check` red until somebody found this line — the treasure hunt
+// docs/fourth-pack.md recorded.
+func renderBanner(order []string, routes map[string]map[string]int) string {
 	var b strings.Builder
 	// The line the binary actually prints, format string and all. It carried
 	// neither the version nor the real default address, which meant a reader
@@ -511,7 +516,7 @@ func renderBanner(routes map[string]map[string]int) string {
 	// would flip on who ran it. "dev" is what anybody building from a checkout
 	// sees, which is who reads a README; a released binary prints its tag there.
 	fmt.Fprintf(&b, "```bash\nfeint serve\n#  feint dev listening on %s\n", DefaultAddr)
-	for _, provider := range []string{scaleway.Name, outscale.Name, exoscale.Name} {
+	for _, provider := range order {
 		fmt.Fprintf(&b, "#    %-9s %2d routes\n", provider, routeTotal(routes[provider]))
 	}
 	b.WriteString("#    machines  none\n```\n")

--- a/internal/cli/shapes_check.go
+++ b/internal/cli/shapes_check.go
@@ -42,14 +42,21 @@ import (
 // files needs a real account and is a human's job (`feint shapes --record`);
 // checking against them is not.
 func checkShapes(dir string, providers []string, stdout, stderr io.Writer) int {
-	if len(providers) == 0 {
-		providers = []string{"scaleway", "outscale", "exoscale"}
-	}
-
-	srv, err := emulator.NewServer(emulator.DefaultEnv(), packsFor(emulator.DefaultEnv())...)
+	env := emulator.DefaultEnv()
+	srv, err := emulator.NewServer(env, packsFor(env)...)
 	if err != nil {
 		fmt.Fprintf(stderr, "feint: build the emulator: %v\n", err)
 		return exitError
+	}
+	// Derived from the mounted packs rather than written here. A hardcoded list
+	// made a fourth pack invisible to this gate instead of reported: the honest
+	// degradation below — "no catalogue; nothing to check" — was unreachable for
+	// a pack the list omitted, and nothing failed to say so.
+	// TestShapesCheckCoversEveryMountedPack fails without this.
+	if len(providers) == 0 {
+		for _, p := range srv.Packs() {
+			providers = append(providers, p.Name())
+		}
 	}
 	ts := httptest.NewServer(srv.Handler())
 	defer ts.Close()

--- a/internal/cli/shapes_check_test.go
+++ b/internal/cli/shapes_check_test.go
@@ -1,8 +1,10 @@
 package cli
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/stephrobert/feint/internal/core/emulator"
 	"github.com/stephrobert/feint/internal/transcript"
 )
 
@@ -78,3 +80,39 @@ func TestADictionarysKeysAreNotMissingFields(t *testing.T) {
 		t.Errorf("a field missing from a published key was not reported: %v", gaps)
 	}
 }
+
+// The gate must cover whatever the server mounts, not a list written beside it.
+//
+// The provider names used to be hardcoded in checkShapes, which made a fourth
+// pack invisible to the gate rather than reported: the honest "no catalogue;
+// nothing to check" degradation existed in the code and was unreachable for a
+// pack the list omitted. packsFor is the same seam
+// TestCoverageRefusesAPackWithUnusableRefusals uses, and for the same reason —
+// proving the call site rather than a helper.
+func TestShapesCheckCoversEveryMountedPack(t *testing.T) {
+	original := packsFor
+	t.Cleanup(func() { packsFor = original })
+	packsFor = func(env *emulator.Env) []emulator.Pack {
+		return append(original(env), stubPack{name: "fourthcloud"})
+	}
+
+	var out, errOut strings.Builder
+	if rc := checkShapes(t.TempDir(), nil, &out, &errOut); rc != exitOK {
+		t.Fatalf("checkShapes exited %d with no catalogue recorded, want %d\n%s",
+			rc, exitOK, errOut.String())
+	}
+	for _, name := range []string{"scaleway", "outscale", "exoscale", "fourthcloud"} {
+		if !strings.Contains(out.String(), name+": no catalogue") {
+			t.Errorf("the gate never accounted for the mounted pack %q:\n%s", name, out.String())
+		}
+	}
+}
+
+// stubPack is a mounted pack the shapes gate has no catalogue for. It serves
+// nothing: what is being proven is that the gate accounts for it anyway.
+type stubPack struct{ name string }
+
+func (p stubPack) Name() string                    { return p.name }
+func (p stubPack) Routes() []emulator.Route        { return nil }
+func (p stubPack) Declined() []emulator.Decline    { return nil }
+func (p stubPack) Env(string) emulator.Environment { return emulator.Environment{} }

--- a/internal/core/emulator/emulator.go
+++ b/internal/core/emulator/emulator.go
@@ -89,7 +89,9 @@ type Route struct {
 
 // Pack is one provider implementation.
 type Pack interface {
-	// Name is the provider key: "scaleway", "outscale", "exoscale".
+	// Name is the provider key: one lowercase word, unique among the mounted
+	// packs (e.g. "scaleway"). The core never holds a list of them — anything
+	// keyed by provider derives its names from the packs the server mounts.
 	Name() string
 	// Routes lists everything the pack serves.
 	Routes() []Route


### PR DESCRIPTION
# Summary

Three places outside the packs held a provider list in their own words — the pattern CLAUDE.md names as a past defect, and the one `docs/fourth-pack.md` counted as part of what a fourth pack costs:

- **`checkShapes`** defaulted to a hardcoded `[]string{"scaleway", "outscale", "exoscale"}`, which made a fourth pack *invisible* to the shapes gate rather than reported: the honest "no catalogue; nothing to check" degradation existed in the code and was unreachable for a pack the list omitted. The list now comes from `srv.Packs()`. `TestShapesCheckCoversEveryMountedPack` mounts a fourth pack through the `packsFor` seam and fails without the derivation — falsified in a copy outside the repository: the hardcoded list restored, the mutant compiles, and the test fails on the pack it never accounted for.
- **`renderBanner`** iterated its own three-name list, so mounting a fourth pack turned `feint docs --check` red until somebody found the line. The order now travels from `routesByProvider`, which reads the packs in mount order; the three provider imports leave `docs.go` entirely.
- **`coverage()`'s scanner switch** ended in a message naming two providers in its own words — true until a third SDK scanner lands, then a lie. The scanners are now a registration map and the refusal lists its keys.

Also: the `Pack.Name` comment in the neutral core no longer enumerates the three providers; it states the rule instead. And `docs/fourth-pack.md` is a measurement, so it is updated to what is now true: its category-2 table loses the two "Fix." rows, ~45 lines across 13 files becomes ~43 across 11, and recommendation 3 is recorded as done with its guard test named.

The generated README is byte-identical — the derived order is the mount order it already used — so `feint docs --check` returns 0 without regeneration.

## Type of change

- [ ] A route added or changed
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes — `go test ./...` green in a clean worktree of this branch; golangci-lint 0 issues on the touched packages; every pre-commit hook passed on the commit
- [x] No new external Go dependency, or the pull request justifies it
- [x] `internal/core` still knows no provider — this PR *reduces* what it names: the one comment enumerating the three providers is gone
- [x] Nothing in the diff could be written identically for another provider — that test is the content of the PR: the lines that could be were moved to derivation from the mounted packs; what stays (`packsFor`, the scanner map) is the explicit registration point `docs/fourth-pack.md` argues should stay code

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] I ran `mise run conformance` myself — the full sequence (scw CLI, Scaleway Terraform, oapi-cli, Outscale Terraform, exo CLI, the probe with `--contracts`) in a clean worktree of this branch, on an alternate port; every suite passed, probe: 0 failed
- [x] Every field name in the diff comes from a source I can name — there is no provider field name in the diff; the only provider names are pack registrations (`scaleway.Name`, `outscale.Name`) at the mount/scanner registration points

### When a route is added or changed — otherwise N/A

N/A — no route touched; `mise run conformance` was run anyway (above) because `internal/cli` is close to what serves them.

### When behaviour a client can observe changes — otherwise N/A

- [x] `docs/limits.md` updated if the change moves a documented limit — no limit moved; `docs/fourth-pack.md` updated because it is a measurement of exactly what this PR changed
- [x] The README's generated tables regenerated — `feint docs --check` returns 0 with no regeneration needed: the output is byte-identical by construction

### When `.github/workflows/` is touched — otherwise N/A

N/A

### When a machine runtime is involved — otherwise N/A

N/A

## Related issues

N/A — recommendation 3 of `docs/fourth-pack.md`, which this PR marks done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
