### PR TITLE
test(ui): the page harness proves its own failure diagnosis

### DIFF
--- a/tools/ui/check-page.py
+++ b/tools/ui/check-page.py
@@ -653,12 +653,73 @@ def capture(page: Page, out: str) -> list[str]:
     return written
 
 
+def self_check() -> int:
+    """Prove the harness can say why a browser failed, with no browser at all.
+
+    This holds the fix for four consecutive CI failures that produced one
+    sentence between them — "the browser never opened a page target" — by
+    driving start_browser() against a stub that dies the way a runner's browser
+    dies: noisily on stderr, silently to the harness. Two behaviours are
+    asserted, because both rotted once: the stderr is quoted in the failure,
+    and a failed launch is attempted a second time on a fresh port.
+
+    Why here and not a pytest suite: this repository's Python is tooling, like
+    `scw` or `terraform`, and its harnesses prove themselves the way
+    tools/conformance/ does — by running against the real seam. A test
+    framework for one script would be more machinery than subject; this
+    function is the recorded conclusion of that trade-off, and
+    tools/ui/screenshots.sh runs it before every real check so it cannot rot
+    unnoticed. What it deliberately does not hold: the 60-second launch
+    deadline, which only means something on a loaded runner and would cost a
+    minute per run to prove.
+    """
+    workdir = tempfile.mkdtemp(prefix="feint-ui-selfcheck-")
+    problems: list[str] = []
+    try:
+        stub = os.path.join(workdir, "stub-browser")
+        with open(stub, "w") as handle:
+            handle.write(
+                "#!/bin/sh\n"
+                "echo 'error while loading shared libraries: libstub.so.9' >&2\n"
+                "exit 127\n"
+            )
+        # Owner-only: the stub is spawned by this process and nobody else.
+        os.chmod(stub, 0o700)
+        try:
+            start_browser(stub, os.path.join(workdir, "profile"))
+            problems.append("a browser that exits 127 was reported as started")
+        except Failure as why:
+            said = str(why)
+            if "libstub.so.9" not in said:
+                problems.append(f"the browser's stderr is not quoted in the failure: {said!r}")
+            if "attempt 2" not in said:
+                problems.append(f"a failed launch is not retried on a fresh port: {said!r}")
+            if "exited with 127" not in said:
+                problems.append(f"the exit code is not named: {said!r}")
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+    for problem in problems:
+        print(f"SELF-CHECK FAIL: {problem}", file=sys.stderr)
+    if not problems:
+        print("  self-check: the harness can name a browser failure, twice, with its stderr")
+    return 1 if problems else 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--endpoint", default="http://127.0.0.1:4599")
     parser.add_argument("--out", default="docs/assets/ui")
     parser.add_argument("--check", action="store_true", help="assert only, write no image")
+    parser.add_argument(
+        "--self-check",
+        action="store_true",
+        help="prove the harness's own failure diagnosis works, then exit",
+    )
     args = parser.parse_args()
+
+    if args.self_check:
+        return self_check()
 
     binary = find_browser()
     if binary is None:

--- a/tools/ui/screenshots.sh
+++ b/tools/ui/screenshots.sh
@@ -22,6 +22,14 @@ cd "$ROOT"
 CHECK=""
 [ "${1:-}" = "--check" ] && CHECK="--check"
 
+# The harness proves itself before it proves the page. Its failure diagnosis
+# (the browser's stderr quoted, a retry on a fresh port) was fixed once without
+# anything holding it, which is this repository's named defect: a comment where
+# a control should be. Needs no browser and no emulator, so it runs first and
+# costs nothing when everything else is about to.
+echo "page: checking the harness itself"
+python3 tools/ui/check-page.py --self-check
+
 ADDR="${FEINT_UI_ADDR:-127.0.0.1:4622}"
 ENDPOINT="http://$ADDR"
 OUT="docs/assets/ui"


### PR DESCRIPTION
# Summary

`tools/ui/check-page.py` recently gained a repaired failure diagnosis — the browser's stderr captured and quoted, a second attempt on a fresh port, a 60 s launch deadline — and nothing held any of it. A fix for four consecutive one-sentence CI failures, itself unproven: the repository's named defect, a comment where a control should be.

The earlier refusal to build a pytest suite for one script was re-examined and **stands**: this repository's Python is tooling, like `scw` and `terraform`, and its harnesses prove themselves the way `tools/conformance/` does — against the real seam, not through a framework that would be more machinery than subject. That conclusion is now *recorded* in the `self_check` docstring instead of implicit.

So the script gains `--self-check`: it drives `start_browser()` against a stub that dies the way a runner's browser dies — noisily on stderr, silently to the harness — and asserts the stderr is quoted in the failure, the launch is retried on a fresh port, and the exit code is named. `tools/ui/screenshots.sh` runs it before every real check; it needs no browser and no emulator, so the CI `page` job holds it from now on at zero marginal cost.

Falsified in a copy outside the repository, one mutant per held behaviour, both compiling (well, parsing — it is Python) and both failing:

- `stderr=subprocess.DEVNULL` (the pre-fix code): self-check fails on the missing quote;
- `range(1)` (a single attempt): self-check fails on the missing retry.

What the self-check deliberately does **not** hold, stated in its docstring: the 60-second deadline, which only means something on a loaded runner and would cost a minute per run to prove. Whether the repaired diagnosis fixes the original CI flake stays unknown until CI meets a slow runner again — what is no longer unknown is that the diagnosis itself cannot silently rot.

Full run on this station: `tools/ui/screenshots.sh --check` green, self-check plus 17 page assertions.

## Type of change

- [ ] A route added or changed
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes — no Go file touched; `go test ./...` green in a clean worktree of this branch; ruff, bandit and shellcheck passed on the two changed files via pre-commit
- [x] No new external Go dependency, or the pull request justifies it — no new Python dependency either: the self-check is standard library, like the script it proves
- [x] `internal/core` still knows no provider
- [x] Nothing in the diff could be written identically for another provider — no provider appears in it

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
- [ ] I ran `mise run conformance` myself — not run for this diff: it touches the page harness only; the page suite itself (`tools/ui/screenshots.sh --check`) was run for real and passed
- [x] Every field name in the diff comes from a source I can name — no provider field name in the diff

### When a route is added or changed — otherwise N/A

N/A

### When behaviour a client can observe changes — otherwise N/A

N/A — the page and its endpoints are untouched; only the harness that checks them grew a proof of itself

### When `.github/workflows/` is touched — otherwise N/A

N/A — `conformance.yml` still calls `tools/ui/screenshots.sh --check`; the self-check rides inside that call, no job added or renamed

### When a machine runtime is involved — otherwise N/A

N/A

## Related issues

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
