### PR TITLE
docs(limits): the fork recipe says it is a snapshot, and checks out its pin

### DIFF
--- a/docs/limits.md
+++ b/docs/limits.md
@@ -420,13 +420,25 @@ The fix is four lines per site, so it is also carried on a fork, pinned:
 - [`stephrobert/terraform-provider-exoscale@fix/v2-client-honours-api-endpoint`][fork],
   commit `2e78b42`, branched from `de9d60c2` (0.70.0 plus six commits).
 
+**This recipe is a snapshot, and nothing re-checks it.** It was last verified on
+2026-08-11: the branch tip was still `2e78b42` and the build below succeeded.
+No gate clones a third-party repository — deliberately, that would put someone
+else's availability in this project's CI — so past that date the honest claim
+is "it worked then", not "it works". The recipe checks out the measured commit
+rather than the branch tip for the same reason: a tip can move under a reader,
+a commit cannot. If the build breaks or the fork disappears, check
+[exoscale/terraform-provider-exoscale#573][exo-573] first — upstream landing an
+endpoint option is the outcome that makes this whole section obsolete, and the
+released provider is then the thing to use.
+
 It passes `ClientOptWithAPIEndpoint` at the three sites, and nothing else.
 Terraform resolves it without a registry, through `dev_overrides`:
 
 ```bash
 git clone -b fix/v2-client-honours-api-endpoint \
   https://github.com/stephrobert/terraform-provider-exoscale
-cd terraform-provider-exoscale && go build -o /tmp/tfp/terraform-provider-exoscale .
+cd terraform-provider-exoscale && git checkout 2e78b42
+go build -o /tmp/tfp/terraform-provider-exoscale .
 
 cat > /tmp/dev.tfrc <<'RC'
 provider_installation {


### PR DESCRIPTION
# Summary

The "patched provider, while upstream decides" recipe in `docs/limits.md` promised something nobody tests: a clone of a third-party branch, a build, `dev_overrides` — with no gate anywhere to notice the branch moving or the build breaking. Documentation promising what nothing checks is the repository's named defect, so the section now tells the truth about itself.

Proportion was weighed rather than assumed, and the conclusion is recorded in the section: **no CI check is built**, deliberately, because a gate that clones a third-party repository on every run puts someone else's availability in this project's gates. Instead:

- the section states plainly that the recipe is a snapshot and nothing re-checks it, and dates what was actually measured: on 2026-08-11 the branch tip was still `2e78b42` and the build succeeded on this station (verified for this PR, not assumed);
- the recipe now checks out the measured commit after the clone — a branch tip can move under a reader, the pinned commit cannot;
- it names upstream [exoscale/terraform-provider-exoscale#573] as the exit: the day an endpoint option lands in the released provider, this whole section is obsolete and says which thing to use instead.

Past the recorded date the honest claim is "it worked then", which is the claim that stays true on its own.

## Type of change

- [ ] A route added or changed
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes — no Go file touched; `go test ./...` green in a clean worktree of this branch; `feint docs --check` returns 0 (the edit is outside the generated markers)
- [x] No new external Go dependency, or the pull request justifies it
- [x] `internal/core` still knows no provider
- [x] Nothing in the diff could be written identically for another provider — it is the Exoscale limits section, which is where provider knowledge belongs

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
- [ ] I ran `mise run conformance` myself — not run for this diff: documentation only, no route, no response byte; what *was* run is the thing the document claims — the fork was cloned and built at the pinned commit on the date now written in the section
- [x] Every field name in the diff comes from a source I can name — no field name in the diff; the commit ids come from the fork's own history, re-read for this PR

### When a route is added or changed — otherwise N/A

N/A

### When behaviour a client can observe changes — otherwise N/A

- [x] `docs/limits.md` updated if the change moves a documented limit — no limit moved; the limit's documentation moved to being honest about its own freshness
- [x] The README's generated tables regenerated — nothing generated changed; `feint docs --check` returns 0

### When `.github/workflows/` is touched — otherwise N/A

N/A

### When a machine runtime is involved — otherwise N/A

N/A

## Related issues

Tracks upstream exoscale/terraform-provider-exoscale#573.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
