### PR TITLE
A link is attached, an interface is in-use, and they are not one word

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -18,6 +18,16 @@ change ni l'un ni l'autre a sa place dans `git log`.
 ## [Non publié]
 
 ### Corrigé
+- **Une interface réseau attachée rapportait un état de lien que le provider
+  Terraform refuse.** `LinkNic.State` publiait `in-use`, qui est l'état de
+  l'*interface* ; l'état du *lien* est `attached`, et le provider interroge
+  `ReadNics` jusqu'à le lire. Il abandonnait sur `unexpected state 'in-use',
+  wanted target 'attached, detached, failed'`, laissant un apply à moitié fait
+  et un destroy incapable d'aboutir. Le même fichier rendait `attached` pour la
+  NIC primaire d'une Vm quarante lignes plus haut — un champ, deux orthographes
+  — et le test unitaire qui affirmait `in-use` verrouillait la mauvaise, sous un
+  nom prétendant correspondre à un enregistrement, alors que `feint shapes`
+  enregistre des arbres de champs et jamais des valeurs.
 
 - **Un enregistrement pouvait s'arrêter tôt sans rien dire.** Certaines API
   remettent une adresse au client dans un corps de réponse — Exoscale publie un

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ what this project is judged on: **a response shape a client can observe**, and
 ## [Unreleased]
 
 ### Fixed
+- **An attached network interface reported a link state the Terraform provider
+  refuses.** `LinkNic.State` published `in-use`, which is the state of the
+  *interface*; the state of the *link* is `attached`, and the provider polls
+  `ReadNics` until it reads that. It gave up with `unexpected state 'in-use',
+  wanted target 'attached, detached, failed'`, leaving an apply half done and a
+  destroy unable to finish. The same file rendered `attached` for the primary
+  NIC inside a Vm four dozen lines away — one field, two spellings — and the
+  unit test asserting `in-use` was holding the wrong one in place under a name
+  claiming it matched a recording, when `feint shapes` records field trees and
+  never values.
 
 - **A recording could stop early and say nothing.** Some APIs hand the client an
   address in a response body — Exoscale publishes an `api-endpoint` per zone —

--- a/internal/providers/outscale/nics.go
+++ b/internal/providers/outscale/nics.go
@@ -29,8 +29,12 @@ import (
 // Shapes measured against a real account (read sweep and lifecycle sweep,
 // 2026-08-08): PrivateDnsName is "ip-<a-b-c-d>.<region>.compute.internal", on the
 // NIC and on each PrivateIps entry; a fresh CreateNic carries neither LinkNic
-// nor LinkPublicIp; an attached interface's LinkNic carries DeviceNumber from 1,
-// State "in-use", VmAccountId the account's own.
+// nor LinkPublicIp; an attached interface carries State "in-use" and a LinkNic
+// with DeviceNumber from 1, State "attached" and VmAccountId the account's own.
+//
+// The two states are not the same word and this comment said they were, which
+// is how the wrong one survived: the interface is "in-use", the link is
+// "attached".
 
 const kindNic = "nic"
 
@@ -214,12 +218,28 @@ func (p *Pack) storedNicView(nic *resource.Resource) map[string]any {
 	}
 	// The link appears only when attached, in the measured shape: DeviceNumber
 	// from 1 (0 is the derived primary), VmAccountId the account's own.
+	//
+	// `attached`, not `in-use`. Those are two different fields: `in-use` is the
+	// state of the *interface*, set above from Attrs, and `attached` is the
+	// state of the *link*. This spot published the interface's word for the
+	// link's field, while the primary NIC rendered inside a Vm published
+	// `attached` four dozen lines up — the same field, two spellings, in one
+	// file.
+	//
+	// Nothing could see it. No contract does: their OpenAPI types LinkNic.State
+	// as a bare string, and the value only appears in their examples. No unit
+	// test did either, because the pack's own tests read back what the pack
+	// wrote. It took the Terraform provider, which polls ReadNics until the
+	// link reports `attached` and gave up with "unexpected state 'in-use',
+	// wanted target 'attached, detached, failed'" — leaving the apply half done
+	// and the destroy unable to finish.
+	// TestAnAttachedNicReportsTheLinkStateTheProviderWaitsFor fails without this.
 	if vmID := stringOf(nic.Attrs["LinkVmId"]); vmID != "" {
 		out["LinkNic"] = map[string]any{
 			"DeleteOnVmDeletion": false,
 			"DeviceNumber":       numOf(nic.Attrs["DeviceNumber"]),
 			"LinkNicId":          stringOf(nic.Attrs["LinkNicId"]),
-			"State":              "in-use",
+			"State":              "attached",
 			"VmAccountId":        accountID,
 			"VmId":               vmID,
 		}

--- a/internal/providers/outscale/nics_lifecycle_test.go
+++ b/internal/providers/outscale/nics_lifecycle_test.go
@@ -60,8 +60,21 @@ func TestANicLifecycleMatchesTheRecordedShapes(t *testing.T) {
 	if dn, _ := linkNic["DeviceNumber"].(float64); dn != 1 {
 		t.Fatalf("DeviceNumber = %v, want 1", linkNic["DeviceNumber"])
 	}
-	if linkNic["State"] != "in-use" {
-		t.Fatalf("the attach state is not in-use: %v", linkNic)
+	// "attached", not "in-use". This assertion asked for "in-use" and so held a
+	// defect in place until a real client walked the path: the Terraform
+	// provider polls ReadNics until the link reports attached and gave up with
+	// "unexpected state 'in-use', wanted target 'attached, detached, failed'".
+	//
+	// The value did not come from a recording despite this test's name —
+	// `feint shapes` records field trees, never values, so nothing here was ever
+	// measured. Outscale's own API document shows `State: attached` in its
+	// LinkNic examples, and the interface's own State, checked separately below,
+	// is the field that reads "in-use".
+	if linkNic["State"] != "attached" {
+		t.Fatalf("the link state is not attached: %v", linkNic)
+	}
+	if attached["State"] != "in-use" {
+		t.Fatalf("the interface state is not in-use: %v", attached["State"])
 	}
 
 	// It can be found by the machine it is attached to.
@@ -115,4 +128,57 @@ func TestDeletingAVmDetachesItsSecondaryNics(t *testing.T) {
 		t.Fatalf("the detached interface is not available again: %v", nic)
 	}
 	call(t, ts, doc, "DeleteNic", `{"NicId":"`+nicID+`"}`)
+}
+
+// TestAnAttachedNicReportsTheLinkStateTheProviderWaitsFor holds the two states
+// apart. The interface is "in-use"; its link is "attached". The pack published
+// the interface's word in the link's field, and the Terraform provider — which
+// polls ReadNics until the link reports attached — gave up with "unexpected
+// state 'in-use', wanted target 'attached, detached, failed'", leaving an apply
+// half done and a destroy unable to finish.
+//
+// Nothing else could have caught it: their OpenAPI types LinkNic.State as a
+// bare string, so no contract applies, and a unit test that reads back what the
+// pack wrote agrees with whatever the pack chose. The same file rendered
+// "attached" for the primary NIC inside a Vm, so the two spellings sat four
+// dozen lines apart.
+func TestAnAttachedNicReportsTheLinkStateTheProviderWaitsFor(t *testing.T) {
+	ts := newServer(t)
+	_, subnetID := netAndSubnet(t, ts, "10.81.0.0/16", "10.81.1.0/24")
+
+	_, out := post(t, ts, "CreateVms",
+		`{"ImageId":"ami-12345678","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+	vms, _ := out["Vms"].([]any)
+	vm, _ := vms[0].(map[string]any)
+	vmID, _ := vm["VmId"].(string)
+
+	_, out = post(t, ts, "CreateNic", `{"SubnetId":"`+subnetID+`"}`)
+	nic, _ := out["Nic"].(map[string]any)
+	nicID, _ := nic["NicId"].(string)
+
+	if status, out := post(t, ts, "LinkNic",
+		`{"NicId":"`+nicID+`","VmId":"`+vmID+`","DeviceNumber":1}`); status != 200 {
+		t.Fatalf("LinkNic answered %d: %v", status, out["Errors"])
+	}
+
+	_, out = post(t, ts, "ReadNics", `{"Filters":{"NicIds":["`+nicID+`"]}}`)
+	nics, _ := out["Nics"].([]any)
+	if len(nics) != 1 {
+		t.Fatalf("ReadNics answered %d interfaces", len(nics))
+	}
+	read, _ := nics[0].(map[string]any)
+
+	// The interface's own state.
+	if got := read["State"]; got != "in-use" {
+		t.Errorf("the interface reports State %q, want \"in-use\"", got)
+	}
+	// The link's state, which is the one the provider polls.
+	link, _ := read["LinkNic"].(map[string]any)
+	if link == nil {
+		t.Fatalf("an attached interface carries no LinkNic: %v", read)
+	}
+	if got := link["State"]; got != "attached" {
+		t.Errorf("LinkNic reports State %q; the provider waits for \"attached\" "+
+			"and gives up on anything else", got)
+	}
 }

--- a/tools/conformance/outscale/oapi-cli.sh
+++ b/tools/conformance/outscale/oapi-cli.sh
@@ -216,6 +216,26 @@ fi
 nat="$(osc CreateNatService --SubnetId "$sub_id" --PublicIpId "$eip_id")" \
   || fail "CreateNatService rejected: $nat"
 nat_id="$(printf '%s' "$nat" | jq -r '.NatService.NatServiceId // empty')"
+
+# A default route, then retargeted onto the NAT service. UpdateRoute is the last
+# operation OSC-3 named that no client walked: Terraform replaces a route rather
+# than updating it, so only a direct call reaches it, and a route whose target
+# moves is what a client does when a subnet stops being public.
+main_rtb="$(printf '%s' "$rtbs" | jq -r '.RouteTables[0].RouteTableId')"
+osc CreateRoute --RouteTableId "$main_rtb" --DestinationIpRange 0.0.0.0/0 \
+    --GatewayId "$gw_id" >/dev/null || fail "CreateRoute rejected"
+moved="$(osc UpdateRoute --RouteTableId "$main_rtb" --DestinationIpRange 0.0.0.0/0 \
+           --NatServiceId "$nat_id")" || fail "UpdateRoute rejected: $moved"
+printf '%s' "$moved" | jq -e --arg n "$nat_id" \
+  'any(.RouteTable.Routes[]; .DestinationIpRange == "0.0.0.0/0" and .NatServiceId == $n)' >/dev/null \
+  || fail "the route still points at the gateway after UpdateRoute: $moved"
+# The old target must go with it: a route naming two next hops is one no
+# forwarding table could act on, and it reads as success.
+printf '%s' "$moved" | jq -e \
+  'any(.RouteTable.Routes[]; .DestinationIpRange == "0.0.0.0/0" and (has("GatewayId") | not))' >/dev/null \
+  || fail "the route kept its gateway alongside the NAT service: $moved"
+osc DeleteRoute --RouteTableId "$main_rtb" --DestinationIpRange 0.0.0.0/0 >/dev/null \
+  || fail "DeleteRoute rejected"
 if osc DeletePublicIp --PublicIpId "$eip_id" >/dev/null 2>&1; then
   fail "an address held by a NAT service was released"
 fi
@@ -265,8 +285,58 @@ printf '%s' "$restored" | jq -e --arg s "$snap_id" '.Volume.SnapshotId == $s and
 restored_id="$(printf '%s' "$restored" | jq -r '.Volume.VolumeId')"
 osc DeleteSnapshot --SnapshotId "$snap_id" >/dev/null || fail "DeleteSnapshot rejected"
 osc DeleteVolume --VolumeId "$restored_id" >/dev/null || fail "DeleteVolume rejected"
-osc DeleteVolume --VolumeId "$vol_id" >/dev/null || fail "DeleteVolume rejected"
 ok "record, restore, and the key only when it means something"
+
+# The three updates OSC-3 and OSC-4 promised and no client drove. They were
+# served, unit-tested, and unproven: the batches list them among their
+# deliverables, and "a unit test alone closes nothing" is condition 3 of what
+# makes a batch done. Terraform walks none of them — it replaces rather than
+# updates for these — so they belong to this suite.
+echo "- the updates a batch promised and nothing had exercised"
+
+# A volume grows and refuses to shrink: a filesystem does not survive its disk
+# getting smaller, which is why the refusal matters more than the growth.
+grown="$(osc UpdateVolume --VolumeId "$vol_id" --Size 9)" || fail "UpdateVolume rejected: $grown"
+printf '%s' "$grown" | jq -e '.Volume.Size == 9' >/dev/null \
+  || fail "the volume did not grow: $grown"
+if osc UpdateVolume --VolumeId "$vol_id" --Size 3 >/dev/null 2>&1; then
+  fail "the volume shrank, which loses a filesystem"
+fi
+
+# An image's description, which is the field of UpdateImage this emulator can
+# mean something by. `PermissionsToLaunch` is refused on purpose and the refusal
+# is checked below: it grants to another account, and there is only one here.
+#
+# Cut from a snapshot, because the pack refuses an image with no provenance —
+# "an image needs a VmId or BlockDeviceMappings naming a snapshot" — and that
+# refusal is the right one: an image of nothing boots nothing.
+img_snap="$(osc CreateSnapshot --VolumeId "$vol_id")" || fail "CreateSnapshot rejected: $img_snap"
+img_snap_id="$(printf '%s' "$img_snap" | jq -r '.Snapshot.SnapshotId')"
+img="$(osc CreateImage --ImageName feint-conformance-update \
+         --BlockDeviceMappings.0.Bsu.SnapshotId "$img_snap_id" \
+         --BlockDeviceMappings.0.DeviceName /dev/sda1)" || fail "CreateImage rejected: $img"
+img_id="$(printf '%s' "$img" | jq -r '.Image.ImageId')"
+updated="$(osc UpdateImage --ImageId "$img_id" --Description "renamed by conformance")" \
+  || fail "UpdateImage rejected: $updated"
+printf '%s' "$updated" | jq -e --arg i "$img_id" \
+  '.Image.ImageId == $i and .Image.Description == "renamed by conformance"' >/dev/null \
+  || fail "UpdateImage did not apply the description it was given: $updated"
+# And it reads back, because an update that answers the new value while storing
+# the old one is the failure a single response cannot distinguish.
+reread="$(osc ReadImages --Filters.ImageIds.0 "$img_id")" || fail "ReadImages rejected: $reread"
+printf '%s' "$reread" | jq -e '.Images[0].Description == "renamed by conformance"' >/dev/null \
+  || fail "the description did not survive the write: $reread"
+
+# The half that is refused, and must stay refused.
+if osc UpdateImage --ImageId "$img_id" \
+     --PermissionsToLaunch.Additions.0.AccountId 123456789012 >/dev/null 2>&1; then
+  fail "PermissionsToLaunch was accepted, granting to an account that cannot exist here"
+fi
+osc DeleteImage --ImageId "$img_id" >/dev/null || fail "DeleteImage rejected"
+osc DeleteSnapshot --SnapshotId "$img_snap_id" >/dev/null || fail "DeleteSnapshot rejected"
+
+osc DeleteVolume --VolumeId "$vol_id" >/dev/null || fail "DeleteVolume rejected"
+ok "a volume grows and refuses to shrink, an image's permissions round-trip"
 
 echo "- a keypair, because a machine nobody can log into proves nothing"
 keys="$(osc ReadKeypairs)" || fail "ReadKeypairs rejected: $keys"

--- a/tools/conformance/outscale/terraform/net_vm.tf
+++ b/tools/conformance/outscale/terraform/net_vm.tf
@@ -102,8 +102,47 @@ resource "outscale_public_ip_link" "net_vm" {
   public_ip = outscale_public_ip.net_vm.public_ip
 }
 
+# Beyond the upstream example, and for a stated reason: OSC-3 promises "Nic and
+# its links" and "NatService", the pack serves all of them, and no client drove
+# a single one — six routes whose behaviour was held by unit tests alone. The
+# batch's own closing condition says a unit test closes nothing.
+#
+# A NIC is also the one resource here that carries an address of its own, so a
+# client attaching one is the only thing that exercises the second-interface
+# path of the addressing plane.
+resource "outscale_nic" "net_vm" {
+  subnet_id          = outscale_subnet.conformance.subnet_id
+  security_group_ids = [outscale_security_group.net_vm.security_group_id]
+}
+
+resource "outscale_nic_link" "net_vm" {
+  device_number = "1"
+  vm_id         = outscale_vm.conformance.vm_id
+  nic_id        = outscale_nic.net_vm.nic_id
+}
+
+# Its own address, not the machine's: a NAT service and a linked public IP
+# cannot share one, and the pack refuses it — which is the behaviour a second
+# address proves rather than assumes.
+resource "outscale_public_ip" "nat" {}
+
+resource "outscale_nat_service" "net_vm" {
+  subnet_id    = outscale_subnet.conformance.subnet_id
+  public_ip_id = outscale_public_ip.nat.public_ip_id
+
+  depends_on = [outscale_route_table_link.net_vm]
+}
+
 output "internet_service_id" {
   value = outscale_internet_service.net_vm.internet_service_id
+}
+
+output "nic_id" {
+  value = outscale_nic.net_vm.nic_id
+}
+
+output "nat_service_id" {
+  value = outscale_nat_service.net_vm.nat_service_id
 }
 
 output "route_table_id" {


### PR DESCRIPTION
Closes #10 (OSC-3). Closes #13 (OSC-4).

Both batches shipped in 0.6.0 and were left open. Checking whether they could honestly be closed is what found this.

## Why they could not just be closed

Their operations were all served — **30 of 30** for OSC-3, **12 of 13** for OSC-4 with `UpdateSnapshot` declined for a stated reason (cross-account permissions, one implicit account here). But the third condition of *when a batch is done* says a unit test closes nothing, and **eight routes the two batches name among their own deliverables had never been driven by a client**: `CreateNic`, `LinkNic`, `UnlinkNic`, `DeleteNic`, `ReadNatServices`, `UpdateRoute`, `UpdateVolume`, `UpdateImage`.

Driving them found a defect no unit test could have.

## The defect

`LinkNic.State` published `in-use`. That is the state of the **interface**; the state of the **link** is `attached`, and the Terraform provider polls `ReadNics` until it reads it:

```
Error: error waiting for nic to attach to Instance: eni-15c00b65,
unexpected state 'in-use', wanted target 'attached, detached, failed'
```

The apply stopped there and the destroy could not finish, so the run left resources behind on the emulator.

Four dozen lines up, **the same file** renders the primary NIC inside a Vm with `State: "attached"`. One field, two spellings, in one file.

Nothing was in a position to notice:

- their OpenAPI types `LinkNic.State` as a bare string, so no contract applies — the value appears only in their examples, where it reads `attached`;
- `TestANicLifecycleMatchesTheRecordedShapes` asserted `in-use`, so the emulator's own choice became the thing its suite defended — **under a name claiming the shape was recorded**, when `feint shapes` records field trees and never values.

That assertion now checks both states, because they are two fields and the bug was reading them as one. The header comment said they were the same word too, and says the opposite now.

## What the batches promised is now driven

- The Terraform fixture gains `outscale_nic`, `outscale_nic_link`, `outscale_nat_service`, and the second public IP the NAT needs — a NAT service and a linked address cannot share one and the pack refuses it, so the second address **proves** the refusal rather than assuming it.
- The oapi-cli suite gains the updates Terraform never walks, because it replaces rather than updates: a volume that grows and refuses to shrink; an image description that survives a re-read, with `PermissionsToLaunch` still refused; and a default route retargeted from the gateway onto the NAT service — which also checks the old next hop goes, since a route naming two would read as success and forward nowhere.

## Numbers

Conformance **132 → 140 of 175** routes proven by a real client. Outscale routes no client drives **13 → 4**, and none of the four belongs to either batch: `DeleteTags`, `ReadAdminPassword` (a Windows call), `ReadNetAccessPointServices`, `ReadPublicIpRanges`.

## Falsified

With the link republishing the interface's state, both the new test and the corrected one fail, and the mutation compiles.

## Checks

```
mise run check        ✅
mise run conformance  ✅ 140 of 175
mise run drift:check  ✅ 0
feint docs --check    ✅ 0
shellcheck            ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)