### PR TITLE
The readiness probe waits instead of dying, and quotes what the page threw

### DIFF
--- a/tools/ui/check-page.py
+++ b/tools/ui/check-page.py
@@ -205,17 +205,36 @@ class Page:
             awaitPromise=True,
         )
         if result.get("exceptionDetails"):
-            thrown = result["exceptionDetails"].get("text")
-            raise Failure(f"the page threw evaluating {expression!r}: {thrown}")
+            raise Failure(f"the page threw evaluating {expression!r}: {thrownIn(result)}")
         return result.get("result", {}).get("value")
 
     def wait_for(self, expression: str, what: str, timeout: float = READY_TIMEOUT) -> None:
+        """Poll until the expression is true, treating a throw as "not yet".
+
+        A readiness probe reaches into the DOM — `querySelector('#served')
+        .textContent` — and that throws a TypeError while the node is still
+        absent, which is the very state being waited for. Letting the first
+        throw out of here turned "the page has not rendered yet" into a fatal
+        error, and it only ever showed on a loaded runner: locally the first
+        poll already finds the page built, so the throw never happens.
+
+        The exception is kept rather than swallowed. A probe that never comes
+        true because the page is genuinely broken must say what broke, and the
+        difference between that and a slow render is exactly what the last
+        throw carries.
+        """
         deadline = time.monotonic() + timeout
+        last = ""
         while time.monotonic() < deadline:
-            if self.evaluate(expression) is True:
-                return
+            try:
+                if self.evaluate(expression) is True:
+                    return
+            except Failure as why:
+                last = str(why)
             time.sleep(0.1)
-        raise Failure(f"timed out after {timeout:.0f}s waiting for {what}")
+
+        detail = f"; the last attempt {last}" if last else ""
+        raise Failure(f"timed out after {timeout:.0f}s waiting for {what}{detail}")
 
     def screenshot(self, path: str, selector: str | None = None) -> None:
         # captureBeyondViewport, because every region worth photographing but the
@@ -245,6 +264,24 @@ class Page:
         data = self.call("Page.captureScreenshot", **params)["data"]
         with open(path, "wb") as handle:
             handle.write(base64.b64decode(data))
+
+
+def thrownIn(result: dict) -> str:  # noqa: N802 - reads as prose at the call site
+    """What the page actually threw, rather than the word "Uncaught".
+
+    `exceptionDetails["text"]` is a label — literally "Uncaught" for anything a
+    page throws — and that is what a CI failure carried the first time this
+    fired: an expression, a colon, and no reason. The message lives one level
+    down, in `exception.description`, which holds the class, the text and a
+    stack.
+
+    First line only: a stack trace inside a one-line failure buries the
+    sentence that matters.
+    """
+    details = result.get("exceptionDetails") or {}
+    described = (details.get("exception") or {}).get("description")
+    text = described or details.get("text") or "nothing readable"
+    return text.strip().splitlines()[0]
 
 
 def find_browser() -> str | None:


### PR DESCRIPTION
The first `page` failure since the diagnostics landed (#101), and it was a **different** one — which is the diagnostics working:

```
Failure: the page threw evaluating "document.querySelector('#served').textContent.trim() !== '—' && …": Uncaught
```

Two defects, and the second hid the first.

## A readiness probe that dies on the first throw cannot wait

The expression reaches into the DOM, and `querySelector('#served').textContent` throws a `TypeError` while that node is still absent — which is **precisely the state `wait_for` exists to wait out**. Letting the throw escape turned *the page has not rendered yet* into a fatal error.

It never showed locally: on an idle station the first poll already finds the page built. On a loaded runner it does not.

`wait_for` now treats a throw as *not yet* and keeps polling. It **keeps** the last one rather than swallowing it — a probe that never comes true because the page is genuinely broken must still say what broke, and that exception is the whole difference between a broken page and a slow one.

The tolerance is in `wait_for` alone. `evaluate` still raises, because everywhere else a throw is a real failure.

## And the message named nothing

`exceptionDetails["text"]` is a label, and for anything a page throws it is the literal string `"Uncaught"`. The message lives one level down, in `exception.description`.

So the CI log carried an expression, a colon, and no reason — **the same dead end the browser's discarded stderr produced last week**, one layer up. That is the argument for fixing the message every time rather than only the cause.

## Driven, not asserted

Against a substitute `Page` with no browser:

| case | result |
|---|---|
| throws three times, then answers | 4 attempts, no exception — `wait_for` waited |
| never answers | `timed out after 20s waiting for the page; the last attempt the page threw evaluating 'ready': TypeError: Cannot read properties of null (reading 'textContent')` |
| the extractor | class and message, stack trimmed, bare label kept when there is nothing better |

## Checks

```
tools/ui/screenshots.sh --check   ✅ 17 assertions held, 0 failed
ruff check / ruff format          ✅
```

Whether this is what has been failing CI is now **answerable rather than guessed**: if it recurs, the timeout line names the throw.

Note for merge order: this touches `check-page.py`, as does #108 (`--self-check`). Different functions, but whichever lands second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)