### PR TITLE
A green check must have run against the commit it merges onto

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -42,7 +42,7 @@
     {
       "type": "required_status_checks",
       "parameters": {
-        "strict_required_status_checks_policy": false,
+        "strict_required_status_checks_policy": true,
         "do_not_enforce_on_create": false,
         "required_status_checks": [
           {


### PR DESCRIPTION
Today #107 was merged on a green that predated #105 by one commit. GitHub allowed it, **correctly**: `strict_required_status_checks_policy` was `false`, the fifteen required checks were green, and nothing required them to have been computed against the current tip.

## Why that is a gap, not a near miss

A CI run proves *this branch against that base*. Git merges without textual conflict two changes that contradict each other semantically. The combination is what lands on `main`, and it is the one thing nobody had run.

It was harmless this time — `proxy_test.go` on one side, `internal/cli` and `internal/core` on the other, and `mise run check` was green on `main` a minute later.

**But a minute later is a report, not a gate.** It observes instead of preventing, and `main` was unverified for that minute. That distinction is most of what this repository is about.

## What changes

One line:

```diff
-        "strict_required_status_checks_policy": false,
+        "strict_required_status_checks_policy": true,
```

A pull request can no longer merge unless its branch already contains the tip it merges onto. The discipline moves out of somebody remembering it and into the ruleset — which is what `tools/governance/ruleset.sh` exists for.

## The cost, stated rather than discovered

Every merge invalidates every other open pull request, so they rebase and re-run in series. With five open at once, as today, that is five sequential conformance suites.

The lighter answer at that scale is a **merge queue**, which does the same thing in parallel. Not taken here: it needs a `merge_group` trigger on all fifteen workflows, and rewiring the CI is its own decision rather than a side effect of this one.

## Ordering

The gate asks for containment: everything the file declares must be in force. So `tools/governance/ruleset.sh apply` runs **before** this merges, otherwise the check on this very pull request reads the change as drift and blocks it.

Between the apply and this landing, `main`'s committed file says `false` while the repository enforces `true`. That window is short and it is not silent — which is the property that matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)