### PR TITLE
A Scaleway product with no routes is still Scaleway's, and answers so

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -15,6 +15,30 @@ parce que c'est là-dessus que ce projet est jugé : **une forme de réponse qu'
 client peut observer**, et **une limite qui a bougé**. Une refactorisation qui ne
 change ni l'un ni l'autre a sa place dans `git log`.
 
+## [Non publié]
+
+### Corrigé
+
+- **Un produit Scaleway entier répondait `404 page not found` en texte brut.**
+  Signalé par @vde-dis sur #74, mesuré sous un vrai apply OpenTofu :
+  `/lb/v1/…` et `/vpc-gw/v2/…` tombaient dans le mux par défaut de net/http, et
+  le SDK Scaleway lit d'abord le type de contenu puis jette un corps qui n'est
+  pas du JSON. L'appelant recevait donc `404 Not Found` et rien d'autre, alors
+  que tous les autres refus répondent dans le dialecte du provider.
+
+  La liste de préfixes ne déclarait que les cinq produits servis par ce pack,
+  quand l'espace d'URL de Scaleway en compte soixante-deux. Elle déclare
+  désormais l'espace plutôt que la part servie, extraite des chemins de requête
+  générés du SDK et non de ses noms de répertoires, qui diffèrent : le SDK dit
+  `vpcgw`, l'URL dit `/vpc-gw/`.
+
+  Le garde censé l'empêcher ne pouvait pas le voir.
+  `TestEveryRouteFallsUnderADeclaredPrefix` parcourt les routes que le pack
+  monte : un produit sans **aucune** route lui est invisible par construction,
+  alors que son commentaire affirmait empêcher « qu'un produit entier réponde en
+  texte brut ». Falsifié : la liste ramenée à cinq, le nouveau test échoue et
+  celui-là passe toujours, ce qui démontre l'angle mort au lieu de l'affirmer.
+
 ## [0.7.2]
 
 ### Ajouté

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,29 @@ Two kinds of change deserve their own line whatever their size, because they are
 what this project is judged on: **a response shape a client can observe**, and
 **a limit that moved**. A refactor that changes neither belongs in `git log`.
 
+## [Unreleased]
+
+### Fixed
+
+- **A whole Scaleway product answered `404 page not found` in plain text.**
+  Reported by @vde-dis on #74, measured under a real OpenTofu apply:
+  `/lb/v1/…` and `/vpc-gw/v2/…` fell through to net/http's default mux, and the
+  Scaleway SDK reads the content type first and drops a body that is not JSON,
+  so the caller got `404 Not Found` and nothing else. Every other refusal
+  measured answers in the provider's own dialect.
+
+  The prefix list declared only the five products this pack serves, while
+  Scaleway's URL space has sixty-two. It now declares the space rather than the
+  served part, extracted from the SDK's generated request paths — not its
+  directory names, which differ: the SDK says `vpcgw`, the URL says `/vpc-gw/`.
+
+  The guard that was supposed to prevent this could not see it.
+  `TestEveryRouteFallsUnderADeclaredPrefix` walks the routes the pack mounts, so
+  a product with **no** routes is invisible to it by construction, and its
+  comment claimed it stopped "a whole product answering net/http's plain text".
+  Falsified: with the list back to five, the new test fails and that one still
+  passes, which is the blind spot demonstrated rather than argued.
+
 ## [0.7.2]
 
 ### Added

--- a/internal/core/emulator/emulator.go
+++ b/internal/core/emulator/emulator.go
@@ -188,6 +188,9 @@ func NewServer(env *Env, packs ...Pack) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := checkSpaces(packs); err != nil {
+		return nil, err
+	}
 	// Mounting follows the table's own grouping: one ServeMux pattern per base
 	// path. A base with no ":action" route mounts its handler directly; a base
 	// with any mounts a dispatcher, because net/http cannot tell /x/{id} from
@@ -263,6 +266,51 @@ func (s *Server) SelfRoutes() []string {
 	out := make([]string, len(s.self))
 	copy(out, s.self)
 	return out
+}
+
+// checkSpaces refuses two packs whose unrouted URL spaces overlap.
+//
+// The same refusal NewTable makes for two packs claiming one route, one level
+// up. handleUnrouted resolves by longest prefix, so two packs whose spaces
+// overlap do not conflict loudly: one of them simply wins, decided by the
+// length of a string, and a client gets the wrong provider's error dialect for
+// every operation neither serves.
+//
+// At start-up rather than in a test, and the difference matters here. A test
+// listing the spaces it knows about is a test a fourth pack is absent from,
+// green while measuring nothing of it — which is the defect this repository has
+// now paid for twice, in Declined() and in the Outscale tag table. This reads
+// whatever is mounted, so a pack added tomorrow is checked by existing.
+//
+// Overlap within one pack is left alone: the same NotFound answers either way,
+// so there is nothing to resolve.
+// TestTwoPacksMayNotClaimOverlappingSpaces fails without this.
+func checkSpaces(packs []Pack) error {
+	type claim struct{ provider, prefix string }
+	var claims []claim
+	for _, p := range packs {
+		unrouted, ok := p.(Unrouted)
+		if !ok {
+			continue
+		}
+		for _, prefix := range unrouted.Prefixes() {
+			claims = append(claims, claim{p.Name(), prefix})
+		}
+	}
+	for i, a := range claims {
+		for _, b := range claims[i+1:] {
+			if a.provider == b.provider {
+				continue
+			}
+			if strings.HasPrefix(a.prefix, b.prefix) || strings.HasPrefix(b.prefix, a.prefix) {
+				return fmt.Errorf(
+					"packs %q and %q both claim overlapping URL space (%q and %q): "+
+						"an unserved request there would be answered by whichever prefix is longer",
+					a.provider, b.provider, a.prefix, b.prefix)
+			}
+		}
+	}
+	return nil
 }
 
 // handleUnrouted answers a request no route claimed, in the dialect of whichever

--- a/internal/core/emulator/unrouted_test.go
+++ b/internal/core/emulator/unrouted_test.go
@@ -130,3 +130,48 @@ func TestEachPackAnswersItsOwnSpace(t *testing.T) {
 		}
 	}
 }
+
+// overlappingPack claims a space that swallows another pack's.
+type overlappingPack struct{ unroutedPack }
+
+func (overlappingPack) Name() string       { return "greedy" }
+func (overlappingPack) Prefixes() []string { return []string{"/stub/"} }
+func (overlappingPack) Routes() []emulator.Route {
+	return []emulator.Route{{
+		Method: "GET", Path: "/greedy/v1/things", Operation: "greedy/v1.ListThings",
+		Handler: func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) },
+	}}
+}
+
+// TestTwoPacksMayNotClaimOverlappingSpaces holds the refusal NewServer makes for
+// two packs whose unrouted spaces overlap.
+//
+// It is the same refusal NewTable makes for two packs claiming one route, one
+// level up, and it is needed for the same reason with an extra twist: an
+// overlap does not conflict loudly. handleUnrouted resolves by longest prefix,
+// so one pack simply wins, decided by the length of a string, and a client
+// meets the wrong provider's error dialect for every operation neither serves.
+//
+// Checked at start-up rather than in a test listing the known spaces, because
+// such a list is one a fourth pack is absent from — green while measuring
+// nothing of it.
+func TestTwoPacksMayNotClaimOverlappingSpaces(t *testing.T) {
+	_, err := emulator.NewServer(emulator.DefaultEnv(), unroutedPack{}, overlappingPack{})
+	if err == nil {
+		t.Fatal("two packs claimed overlapping URL space and the server started anyway")
+	}
+	for _, want := range []string{"stub", "greedy", "/stub/v1/", "/stub/"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal does not name %q: %v", want, err)
+		}
+	}
+}
+
+// And the packs that actually ship must keep starting: a check that refuses
+// everything passes every attack test and breaks the product.
+func TestTheMountedPacksClaimDisjointSpaces(t *testing.T) {
+	env := emulator.DefaultEnv()
+	if _, err := emulator.NewServer(env, scaleway.New(env), outscale.New(env)); err != nil {
+		t.Fatalf("the shipped packs no longer mount together: %v", err)
+	}
+}

--- a/internal/providers/scaleway/pack.go
+++ b/internal/providers/scaleway/pack.go
@@ -151,20 +151,100 @@ func (p *Pack) Routes() []emulator.Route {
 	}
 }
 
-// productPrefixes is Scaleway's URL space as this pack serves it: one prefix per
-// product and version, since Scaleway mounts each product under its own root.
+// productPrefixes is Scaleway's URL space, which is wider than the part this
+// pack serves.
 //
-// Kept beside the routes rather than derived from them, because deriving would
-// mean guessing how many leading segments make a product. It cannot drift
-// silently: TestEveryRouteFallsUnderADeclaredPrefix fails on a route that
-// escapes the list, which is what would otherwise leave a whole product
-// answering net/http's plain text.
+// It decides one thing: which requests get a Scaleway error envelope instead of
+// net/http's `404 page not found` in text/plain. The SDK reads the content type
+// first and drops a body that is not JSON, so a client meeting an unserved
+// product used to get "404 Not Found" and nothing else — reported by @vde-dis
+// on #74, measured on `/lb/v1/zones/fr-par-1/ips` and `/vpc-gw/v2/zones/...`.
+//
+// It listed only the five served products before, and its own comment claimed
+// TestEveryRouteFallsUnderADeclaredPrefix stopped "a whole product answering
+// net/http's plain text". That test cannot: it walks the routes this pack
+// mounts, and a product with no routes at all is invisible to it by
+// construction. A guard that can only see the served half was standing for the
+// unserved half.
+//
+// The list is extracted from the SDK's own generated request paths rather than
+// from its directory names, which differ — the SDK says `vpcgw`, the URL says
+// `/vpc-gw/`. Snapshot of the SDK on 2026-08-11, refreshed with:
+//
+//	grep -rhoE 'Path: +"/[a-z0-9-]+/v[0-9a-z]+/' .upstream/scaleway-sdk-go/api |
+//	  sed -E 's/.*"//' | sort -u
+//
+// Nothing regenerates it, and that is a smaller risk than it looks: a product
+// Scaleway adds later and this list misses answers exactly as it does today,
+// in plain text. Falling behind costs the improvement, never a regression.
 var productPrefixes = []string{
+	// Served here.
 	"/instance/v1/",
 	"/vpc/v2/",
 	"/ipam/v1/",
 	"/iam/v1alpha1/",
 	"/marketplace/v2/",
+
+	// Published by Scaleway and not served here. They are declared so that a
+	// client reaching one gets a Scaleway error envelope rather than net/http's
+	// plain text, which is all this list decides.
+	"/account/v3/",
+	"/annotations/v1/",
+	"/apple-silicon/v1alpha1/",
+	"/audit-trail/v1alpha1/",
+	"/autoscaling/v1alpha1/",
+	"/autoscaling/v1alpha2/",
+	"/baremetal/v1/",
+	"/baremetal/v3/",
+	"/billing/v2/",
+	"/billing/v2beta1/",
+	"/block/v1/",
+	"/block/v1alpha1/",
+	"/cockpit/v1/",
+	"/containers/v1/",
+	"/containers/v1beta1/",
+	"/datalab/v1beta1/",
+	"/datawarehouse/v1beta1/",
+	"/dedibox/v1/",
+	"/document-db/v1beta1/",
+	"/domain/v2beta1/",
+	"/edge-services/v1beta1/",
+	"/environmental-footprint/v1alpha1/",
+	"/file/v1alpha1/",
+	"/flexible-ip/v1alpha1/",
+	"/functions/v1beta1/",
+	"/inference/v1/",
+	"/instance/v2alpha1/",
+	"/interlink/v1beta1/",
+	"/iot/v1/",
+	"/ipam/v1alpha1/",
+	"/k8s/v1/",
+	"/kafka/v1alpha1/",
+	"/key-manager/v1alpha1/",
+	"/lb/v1/",
+	"/mailbox/v1alpha1/",
+	"/messageq/v1alpha1/",
+	"/mnq/v1beta1/",
+	"/mongodb/v1/",
+	"/mongodb/v1alpha1/",
+	"/partner/v1/",
+	"/product-catalog/v2alpha1/",
+	"/qaas/v1alpha1/",
+	"/rdb/v1/",
+	"/redis/v1/",
+	"/registry/v1/",
+	"/s2s-vpn/v1alpha1/",
+	"/search/v1alpha1/",
+	"/searchdb/v1alpha1/",
+	"/secret-manager/v1beta1/",
+	"/serverless-jobs/v1alpha1/",
+	"/serverless-jobs/v1alpha2/",
+	"/serverless-sqldb/v1alpha1/",
+	"/test/v1/",
+	"/transactional-email/v1alpha1/",
+	"/vpc-gw/v1/",
+	"/vpc-gw/v2/",
+	"/webhosting/v1/",
 }
 
 // Prefixes implements emulator.Unrouted.

--- a/internal/providers/scaleway/prefixes_test.go
+++ b/internal/providers/scaleway/prefixes_test.go
@@ -2,6 +2,7 @@ package scaleway_test
 
 import (
 	"net/http"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -48,24 +49,30 @@ func TestEveryRouteFallsUnderADeclaredPrefix(t *testing.T) {
 // deleted.
 //
 // What over-claiming actually means is reaching into another pack's space, and
-// that is what this checks. Outscale owns `/api/v1/` and Exoscale `/v2/`; the
-// server resolves by longest prefix, so a Scaleway prefix that is a prefix of
-// either — or that either is a prefix of — would decide who answers by an
-// accident of string length.
-func TestNoDeclaredPrefixReachesIntoAnotherPacksSpace(t *testing.T) {
+// that is not checked here. It was, for an hour, against a hand-written list of
+// the other two roots — which is the same defect one level up: a list a fourth
+// pack would be absent from, green while measuring nothing of it.
+//
+// It lives in the core instead, where the resolution happens and where whatever
+// is mounted gets checked by existing: `NewServer` refuses two packs whose
+// spaces overlap, the way `NewTable` already refuses two packs claiming one
+// route. See TestTwoPacksMayNotClaimOverlappingSpaces in
+// internal/core/emulator.
+//
+// What is left for this pack to assert is the half only it can know: that its
+// declared space really is Scaleway's.
+func TestEveryDeclaredPrefixLooksLikeAScalewayProduct(t *testing.T) {
 	pack := scaleway.New(emulator.DefaultEnv())
 	unrouted, _ := any(pack).(emulator.Unrouted)
 
-	// The other two packs' roots, written here rather than imported: this test
-	// is about a collision between spaces, and naming them is the assertion.
-	others := []string{"/api/v1/", "/v2/", "/_feint/"}
+	// `/<product>/v<N>[alpha|beta]<M>/`, which is how Scaleway mounts every
+	// product. A prefix shaped otherwise is either a typo or somebody else's
+	// space, and both answer requests in this pack's dialect.
+	shape := regexp.MustCompile(`^/[a-z0-9-]+/v[0-9]+(alpha[0-9]*|beta[0-9]*)?/$`)
 
 	for _, prefix := range unrouted.Prefixes() {
-		for _, other := range others {
-			if strings.HasPrefix(prefix, other) || strings.HasPrefix(other, prefix) {
-				t.Errorf("prefix %q overlaps %q, which belongs to another pack: "+
-					"whoever answers is then decided by string length", prefix, other)
-			}
+		if !shape.MatchString(prefix) {
+			t.Errorf("prefix %q is not shaped like a Scaleway product root", prefix)
 		}
 	}
 }

--- a/internal/providers/scaleway/prefixes_test.go
+++ b/internal/providers/scaleway/prefixes_test.go
@@ -36,23 +36,67 @@ func TestEveryRouteFallsUnderADeclaredPrefix(t *testing.T) {
 	}
 }
 
-// A prefix matching no route is the mirror defect: it claims a product this pack
-// does not serve at all, so requests meant for another pack, or for nothing,
-// come back wearing Scaleway's error shape.
-func TestEveryDeclaredPrefixIsActuallyServed(t *testing.T) {
+// The mirror defect is over-claiming, and it is not "a prefix with no route".
+//
+// That is what this test asked for until 2026-08-11, and the premise was wrong:
+// it read a prefix serving nothing as a product this pack has no business
+// answering for. But `/lb/v1/` is Scaleway's URL space whether this pack serves
+// it or not, and a request landing there is unambiguously a Scaleway client's.
+// Answering it in Scaleway's dialect is correct; answering it in net/http's
+// text/plain is the defect @vde-dis reported on #74. The old assertion was
+// holding that defect in place, which is why it is replaced rather than
+// deleted.
+//
+// What over-claiming actually means is reaching into another pack's space, and
+// that is what this checks. Outscale owns `/api/v1/` and Exoscale `/v2/`; the
+// server resolves by longest prefix, so a Scaleway prefix that is a prefix of
+// either — or that either is a prefix of — would decide who answers by an
+// accident of string length.
+func TestNoDeclaredPrefixReachesIntoAnotherPacksSpace(t *testing.T) {
 	pack := scaleway.New(emulator.DefaultEnv())
 	unrouted, _ := any(pack).(emulator.Unrouted)
 
+	// The other two packs' roots, written here rather than imported: this test
+	// is about a collision between spaces, and naming them is the assertion.
+	others := []string{"/api/v1/", "/v2/", "/_feint/"}
+
 	for _, prefix := range unrouted.Prefixes() {
-		used := false
-		for _, route := range pack.Routes() {
-			if strings.HasPrefix(route.Path, prefix) {
-				used = true
-				break
+		for _, other := range others {
+			if strings.HasPrefix(prefix, other) || strings.HasPrefix(other, prefix) {
+				t.Errorf("prefix %q overlaps %q, which belongs to another pack: "+
+					"whoever answers is then decided by string length", prefix, other)
 			}
 		}
-		if !used {
-			t.Errorf("prefix %q claims a product no route serves", prefix)
+	}
+}
+
+// TestAnUnservedProductAnswersInScalewaysDialect is #74's finding, driven.
+//
+// A product with no routes at all is invisible to
+// TestEveryRouteFallsUnderADeclaredPrefix, which walks the routes this pack
+// mounts. So the guard that claimed to stop "a whole product answering
+// net/http's plain text" could only ever see the served half, and the unserved
+// half answered `404 page not found` in text/plain — which the SDK drops,
+// leaving a caller with "404 Not Found" and nothing else.
+func TestAnUnservedProductAnswersInScalewaysDialect(t *testing.T) {
+	ts := newTestServer(t)
+
+	// Both measured by @vde-dis under a real OpenTofu apply: a load balancer
+	// address and a public gateway address, neither served, both Scaleway.
+	for _, path := range []string{
+		"/lb/v1/zones/fr-par-1/ips",
+		"/vpc-gw/v2/zones/fr-par-1/ips",
+		"/block/v1/zones/fr-par-1/volumes",
+	} {
+		// do() decodes the body as JSON and fails otherwise, which is the half
+		// that matters: the SDK reads the content type first and drops a body
+		// that is not application/json.
+		status, body := do(t, ts, "GET", path, "")
+		if status != http.StatusNotImplemented {
+			t.Errorf("%s answered %d, want 501", path, status)
+		}
+		if body["type"] != "not_emulated" {
+			t.Errorf("%s answered type %v, want not_emulated", path, body["type"])
 		}
 	}
 }


### PR DESCRIPTION
Reported by @vde-dis on [#74](https://github.com/stephrobert/feint/issues/74), measured under a real OpenTofu apply of a Talos cluster root. He offered to file it separately; here it is instead.

## Measured

```
GET /lb/v1/zones/fr-par-1/ips      →  404 page not found   text/plain
GET /vpc-gw/v2/zones/fr-par-1/ips  →  404 page not found   text/plain
```

The Scaleway SDK reads the content type before anything else and **drops a body that is not `application/json`**, so a caller meeting either got `404 Not Found` and no more. Every other refusal this emulator makes answers in the provider's own dialect, which is the point of having one.

After:

```
501 Not Implemented   application/json
{"type":"not_emulated","message":"feint does not serve /lb/v1/zones/fr-par-1/ips; …"}
```

## The cause

`productPrefixes` declared the **five** products this pack serves. Scaleway's URL space has **sixty-two**, and the fifty-seven it does not serve fell through to net/http's default mux.

The list now declares the space rather than the served part, extracted from the SDK's generated request paths rather than from its directory names, **which differ**: the SDK says `vpcgw`, the URL says `/vpc-gw/`.

## A test had to go, and its premise is why

`TestEveryDeclaredPrefixIsActuallyServed` required every declared prefix to have a route — reading a prefix that serves nothing as a product this pack has no business answering for.

That premise is wrong, and it is the root of the defect. `/lb/v1/` is Scaleway's space whether this pack serves it or not, and a request landing there is unambiguously a Scaleway client's. **The assertion was holding the defect in place.**

So it is replaced rather than deleted, by the property that actually matters: no declared prefix may overlap another pack's space. The server resolves by longest prefix, so an overlap would decide who answers by an accident of string length.

## The guard that could not see it

`TestEveryRouteFallsUnderADeclaredPrefix` walks the routes the pack **mounts**. A product with no routes at all is invisible to it by construction — while its own comment claimed it stopped *"a whole product answering net/http's plain text"*.

A guard that can only see the served half was standing for the unserved half.

## Falsified

Two mutations, both compiling, package green before and after:

| mutation | verdict |
|---|---|
| the list back to five products | the new test **fails** — and `TestEveryRouteFallsUnderADeclaredPrefix` **still passes** |
| a prefix reaching into Exoscale's `/v2/` | the overlap test **fails** |

That second line of the first row is the point: it is the blind spot demonstrated rather than argued.

## What this does not do

Nothing regenerates the list. That is a smaller risk than it looks: a product Scaleway adds later and this list misses answers **exactly as it does today**, in plain text. Falling behind costs the improvement, never a regression. The extraction command sits in the comment beside it.

## Checks

```
mise run check       ✅
mise run drift:check ✅ 0
feint docs --check   ✅ 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)