### PR TITLE
fix(addressing): the published address answers on every provider, in both runtime modes

### DIFF
--- a/docs/limits.md
+++ b/docs/limits.md
@@ -263,6 +263,19 @@ Bounds, stated rather than implied:
   emulated machines). It is a documentation address on purpose; nothing routes
   it beyond the host, and that is the point — a test that half-works against
   the real internet is worse than an address that visibly goes nowhere.
+- A **subnet-internal** address — Outscale's `PrivateIp`, Exoscale's
+  `public-ip`, both of which this emulator fills with the machine's own
+  address — answers the host in bridge mode and not in OVN mode, and the
+  runtime declares which (`capabilities.private_from_host`). The cause is
+  isolation's own machinery: the OVN router that separates two VPCs by
+  construction also SNATs the host's connections on the way back, so the
+  handshake never completes — measured, sshd up and answering its neighbours
+  while the host read the port as closed. The routed public plane crosses
+  that boundary in both modes, which is why every pack's ssh chain logs in
+  through it: a Scaleway flexible IP, an Outscale `LinkPublicIp`, an Exoscale
+  elastic IP — each is genuinely routed to the machine, and each pack draws
+  from its own RFC 5737 block (TEST-NET-3, -2 and -1 respectively) so two
+  emulated clouds on one host can never route the same /32 to two machines.
 - On a **virtual machine** (`--vm incus-vm`), the host half of the route is in
   place from the first boot, and the guest half — the address on the guest's
   own interface — lands on the first read after the agent answers, the same
@@ -785,16 +798,23 @@ one with an empty type. If Outscale adds a value, that field is where it goes.
 
 ## Outscale's gateways and NAT move records, not packets
 
-`InternetService`, `LinkInternetService`, `NatService`, `LinkPublicIp` and the
-routes that name them are served, and none of them makes a packet flow.
+`InternetService`, `LinkInternetService`, `NatService` and the routes that
+name them are served, and none of them makes a packet flow.
 
-This one is structural rather than unbuilt, and the difference matters because
+`LinkPublicIp` is no longer on that list: a linked address is routed to the
+Vm's machine, answers from the host that runs the emulator, and
+`ssh outscale@<PublicIp>` opens a shell — the outscale ssh conformance suite
+drives exactly that. The limit was real while the machines sat on the
+operator's default bridge, which the driver rightly refuses to route through;
+they boot on emulator-owned networks now.
+
+The rest is structural rather than unbuilt, and the difference matters because
 everything around it was buildable and got built. The emulator has no data
-plane: it creates bridges and containers on one host through Incus, and a NAT
-service is a managed appliance in a facility this machine is not in. A public
-address allocated here comes from `203.0.113.0/24` — TEST-NET-3, reserved by
-RFC 5737 and routed nowhere on purpose, so an address that goes nowhere is
-visibly fictional rather than quietly broken.
+plane beyond that host: a NAT service is a managed appliance in a facility
+this machine is not in. A public address allocated here comes from
+`198.51.100.0/24` — TEST-NET-2, reserved by RFC 5737 and routed nowhere on
+purpose, so beyond this host an address goes visibly nowhere rather than
+quietly somewhere.
 
 What *is* real is the resource algebra, and it is what a plan actually depends
 on: an address a NAT service holds refuses to be released, a gateway refuses to

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -210,6 +210,73 @@ misreading its own probe, not the firewall: a dropped connection is killed by
 `timeout` with an empty output, which the assertion then matched as a successful
 answer. The verdict of every probe in `network.sh` is now an exit code.
 
+## A public address is the provider's value, made to answer on the host
+
+Two defensible answers existed for which address a client reads on a server
+(#116): the runtime address the machine got from its bridge, or the fictional
+one the pack allocated from `203.0.113.0/24` (TEST-NET-3, RFC 5737). This
+emulator publishes **the fictional one, and routes it for real**: the address
+`public_ips[0].address` reports is the address the machine carries on its
+interface, reachable from the host that runs the emulator, filtered by the
+server's security group. `ssh root@203.0.113.2` opens a shell.
+
+The rejected option — publishing the runtime address — is rejected for three
+measured reasons. It desynchronises the two views of one attachment, since
+`GET /ips/{id}` must keep answering the address it allocated, and the real API
+never lets `server.public_ips[].address` differ from the flexible IP it names.
+It changes with the `--vm` mode and the operator's host, so the same test would
+read different "public" addresses on two machines, which is the half-truth this
+project exists to avoid. And it was never needed: the network conformance suite
+had already proven the fictional address can genuinely answer through the
+group; what #116 measured was two ordering holes, not a wrong address plane.
+
+The two holes, and where they are held:
+
+- **An address attached before the boot was never routed.** `attachAddress`
+  ran while the server had no machine and silently did nothing, and nothing
+  replayed it at poweron. Now the promised addresses ride the launch as device
+  route keys — set while the instance is cold, because editing them on a live
+  OVN NIC re-plugs the device and the guest loses its DHCP lease with nothing
+  left to renew it — and poweron replays the guest half.
+  `TestPowerOnRoutesAnAddressAttachedBeforeBoot` and
+  `TestPublicAddressesAreRoutedBeforeTheFirstBoot` hold it.
+- **A machine with no private NIC had no lawful interface for the route.** It
+  used to boot on the operator's default profile bridge, which the driver
+  rightly refuses to route through (`mustOwn`), and covering that NIC with a
+  firewall meant *overriding* a profile device — a re-plug after boot that cost
+  the guest its DHCP lease: `incus list` showed RUNNING with no IPv4 at all.
+  Machines with no attachment now boot on the emulator's own labelled network
+  (`fnt-default`, `10.209.84.0/24`, deliberately obscure like the OVN uplink's
+  block), created on first use and removed by the sweep.
+  `TestAMachineWithNoAttachmentBootsOnTheEmulatorsOwnNetwork` holds it.
+
+`dynamic_ip_required` follows the same mechanism (#117): poweron allocates an
+ephemeral address from the same block — suppressed when a flexible IP is
+already attached, which is upstream's own precedence — publishes it as a
+`dynamic: true` entry of `public_ips`, and releases it on stop, standby,
+terminate and delete alike. It never appears in `/ips`, because upstream never
+lists it there. `TestADynamicAddressFollowsThePowerCycle` holds the cycle.
+
+Bounds, stated rather than implied:
+
+- The address answers **from the host that runs the emulator** (and from the
+  emulated machines). It is a documentation address on purpose; nothing routes
+  it beyond the host, and that is the point — a test that half-works against
+  the real internet is worse than an address that visibly goes nowhere.
+- On a **virtual machine** (`--vm incus-vm`), the host half of the route is in
+  place from the first boot, and the guest half — the address on the guest's
+  own interface — lands on the first read after the agent answers, the same
+  read that publishes a VM's address.
+- An address attached to a **running** server in OVN mode still bounces the
+  NIC for an instant (the route keys are not live-updatable there; the driver
+  restores what it can, and a DHCP-owned lease is the runtime's to re-issue).
+  Attach before boot when the order is yours to choose; it always is in
+  Terraform, where the IP and the server share a plan.
+- A stored address — a flexible IP's, a dynamic one — is revalidated before it
+  reaches the driver: one outside the emulated block is refused and logged,
+  never routed, because a restored snapshot carries these values verbatim.
+  `TestAPoisonedStoredAddressIsNeverRouted` holds the refusal.
+
 ## Subnet isolation depends on the runtime mode
 
 Upstream, two private networks of two different VPCs do not reach each other.

--- a/internal/core/machine/binding.go
+++ b/internal/core/machine/binding.go
@@ -122,6 +122,12 @@ type Boot struct {
 	// default bridge alone while the API publishes an address on a network it
 	// never joined.
 	Attachments []Attachment
+	// PublicAddresses are the emulated public addresses the pack has already
+	// promised for this machine — a flexible IP attached before the boot, an
+	// ephemeral address the flag asked for. Carried here so the driver can
+	// install the routes before the first boot instead of editing a live NIC:
+	// the edit is what cost a guest its DHCP lease (see Spec.PublicAddresses).
+	PublicAddresses []string
 	// Labels are added to the ones the binding sets itself.
 	Labels map[string]string
 }
@@ -178,13 +184,14 @@ func (b Binding) Start(ctx context.Context, boot Boot) Started {
 	}
 
 	m, err := b.Driver.Start(ctx, Spec{
-		Name:           name,
-		Image:          boot.Image,
-		Labels:         labels,
-		User:           user,
-		AuthorizedKeys: boot.AuthorizedKeys,
-		CloudInit:      userData,
-		Attachments:    boot.Attachments,
+		Name:            name,
+		Image:           boot.Image,
+		Labels:          labels,
+		User:            user,
+		AuthorizedKeys:  boot.AuthorizedKeys,
+		CloudInit:       userData,
+		Attachments:     boot.Attachments,
+		PublicAddresses: boot.PublicAddresses,
 	})
 	if err != nil {
 		// Deliberately not fatal, and never swallowed: this log is the only way

--- a/internal/core/machine/capabilities.go
+++ b/internal/core/machine/capabilities.go
@@ -37,6 +37,20 @@ type Capabilities struct {
 	// OwnKernel: the machine boots its own kernel, so a test touching sysctl,
 	// kernel modules or the boot path measures something.
 	OwnKernel bool `json:"own_kernel"`
+	// PrivateFromHost: an address inside an emulated subnet answers from the
+	// host that runs the emulator, not only from the other machines.
+	//
+	// This is the second claim that separates the modes, and it is isolation's
+	// mirror image. A managed bridge is an interface of the host, so the host
+	// reaches every machine on it directly. An OVN network sits behind its own
+	// router with SNAT towards the uplink: a connection from the host to an
+	// internal address goes in unmapped and the reply comes back source-NATed
+	// to the router's uplink address, so the handshake never completes —
+	// measured, sshd up and answering its neighbours while the host read the
+	// port as closed. Only an externally routed public address (l2proxy)
+	// answers the host there, which is why the Scaleway ssh chain holds in
+	// both modes and a chain reading a subnet-internal address holds in one.
+	PrivateFromHost bool `json:"private_from_host"`
 }
 
 // Capable is implemented by a driver that declares what it delivers. It is an
@@ -93,12 +107,16 @@ func (Noop) Capabilities() Capabilities { return Capabilities{} }
 // Isolation follows OVN and nothing else. Addresses and the firewall hold in
 // every mode: both were measured on bridges, and the OVN mode carries them with
 // three documented behavioural differences rather than losing them.
+// PrivateFromHost is isolation's trade, not an accident: the same router that
+// separates two VPC's subnets by construction NATs the host away from their
+// insides, so the two claims cannot both be true of one Incus mode.
 func (d *Incus) Capabilities() Capabilities {
 	return Capabilities{
-		Machines:  true,
-		Addresses: true,
-		Firewall:  true,
-		Isolation: d.OVN,
-		OwnKernel: d.VM,
+		Machines:        true,
+		Addresses:       true,
+		Firewall:        true,
+		Isolation:       d.OVN,
+		OwnKernel:       d.VM,
+		PrivateFromHost: !d.OVN,
 	}
 }

--- a/internal/core/machine/incus.go
+++ b/internal/core/machine/incus.go
@@ -74,6 +74,10 @@ type Incus struct {
 	// without the lock pick the same name, and the loser's attachment silently
 	// becomes the winner's.
 	attachMu sync.Mutex
+	// defaultNetMu serialises the creation of the default machine network: two
+	// concurrent first boots would otherwise both see it absent and the loser's
+	// `network create` would fail the launch it was only preparing.
+	defaultNetMu sync.Mutex
 	// uplinkMu serialises edits of the uplink's ipv4.routes, one value shared
 	// by every routed public address.
 	uplinkMu sync.Mutex
@@ -150,7 +154,58 @@ func (d *Incus) imageRef(image string) string {
 	return fmt.Sprintf("%s:%s/%s/cloud", remote, name, version)
 }
 
+// DefaultMachineNetwork is the network a machine with no attachments boots on.
+//
+// It exists because "no attachment" used to mean the operator's default profile
+// bridge, and that broke the addressing plane twice over. A route the driver
+// writes is refused outside its own networks (mustOwn), so a public address on
+// such a machine had nowhere lawful to live. And the firewall had to *override*
+// the profile's NIC to cover it, which re-plugs the device after boot and costs
+// the guest its DHCP lease with nothing left to renew it — measured on Incus
+// 7.2: `incus list` showed RUNNING and no IPv4 at all (#116).
+//
+// The name satisfies ownedNetwork and fits MaxNetworkNameLen; the label makes
+// mustOwn accept it and the sweep remove it.
+const DefaultMachineNetwork = NetworkPrefix + "-default"
+
+// DefaultMachineCIDR is the block that network carries. Deliberately obscure,
+// next to the OVN uplink's block and for the same reason: a collision with a
+// block already routed on the operator's host makes the create fail, and
+// failing is better than capturing someone's traffic.
+const DefaultMachineCIDR = "10.209.84.0/24"
+
+// ensureDefaultNetwork creates the default machine network once, in whichever
+// mode the driver runs: a managed bridge, or an OVN network behind the uplink.
+// NAT is on because the machines on it expect outbound access — the rendered
+// cloud-init installs an ssh daemon at first boot.
+func (d *Incus) ensureDefaultNetwork(ctx context.Context) error {
+	d.defaultNetMu.Lock()
+	defer d.defaultNetMu.Unlock()
+	return d.EnsureNetwork(ctx, NetworkSpec{
+		Name:   DefaultMachineNetwork,
+		CIDR:   DefaultMachineCIDR,
+		NAT:    true,
+		Labels: map[string]string{LabelKey: "feint"},
+	})
+}
+
+// publicRouteKey is the device key that routes a public address to a NIC:
+// nic_bridged applies ipv4.routes host-side, an OVN NIC carries the same
+// intent as ipv4.routes.external (l2proxy answers ARP on the uplink).
+func (d *Incus) publicRouteKey() string {
+	if d.OVN {
+		return "ipv4.routes.external"
+	}
+	return "ipv4.routes"
+}
+
 // Start implements Driver.
+//
+// The instance is initialised cold, its devices configured, then started —
+// rather than launched in one step — because every device key must be in place
+// before the first boot. Editing a route key on a live OVN NIC re-plugs the
+// device and the guest loses its DHCP lease with nothing left to renew it; a
+// cold `config device set` costs nothing on either NIC kind.
 func (d *Incus) Start(ctx context.Context, spec Spec) (Machine, error) {
 	if !safeName.MatchString(spec.Name) {
 		return Machine{}, fmt.Errorf("invalid machine name %q", spec.Name)
@@ -166,24 +221,29 @@ func (d *Incus) Start(ctx context.Context, spec Spec) (Machine, error) {
 		return d.inspectOrFail(ctx, spec.Name)
 	}
 
-	args := []string{"launch", d.imageRef(spec.Image), spec.Name}
+	// Every machine sits on a network of the emulator's. With no attachment it
+	// gets the default machine network, never the operator's default profile:
+	// see DefaultMachineNetwork for the two measured reasons.
+	attachments := spec.Attachments
+	if len(attachments) == 0 {
+		if err := d.ensureDefaultNetwork(ctx); err != nil {
+			return Machine{}, err
+		}
+		attachments = []Attachment{{Network: DefaultMachineNetwork}}
+	}
+	primary := attachments[0]
+	if !safeName.MatchString(primary.Network) {
+		return Machine{}, fmt.Errorf("invalid network name %q", primary.Network)
+	}
+
+	args := []string{"init", d.imageRef(spec.Image), spec.Name}
 	if d.VM {
 		args = append(args, "--vm")
 	}
-	// The primary interface is set at launch: --network creates eth0 on the
-	// managed bridge, --device pins its address. Incus takes the address as a
-	// device key, not as a launch flag, and the two have to be given together
-	// or the NIC comes up on DHCP and the published address becomes a lie.
-	if len(spec.Attachments) > 0 {
-		primary := spec.Attachments[0]
-		if !safeName.MatchString(primary.Network) {
-			return Machine{}, fmt.Errorf("invalid network name %q", primary.Network)
-		}
-		args = append(args, "--network", primary.Network)
-		if primary.Address != "" {
-			args = append(args, "--device", "eth0,ipv4.address="+primary.Address)
-		}
-	}
+	// --network creates eth0 on the named network, as the instance's own
+	// device, which is what lets the firewall `set` its keys later instead of
+	// overriding a profile device — the override is a re-plug too.
+	args = append(args, "--network", primary.Network)
 	// Labels become user.* config keys, the Incus equivalent of container labels.
 	for k, v := range spec.Labels {
 		args = append(args, "--config", "user."+k+"="+v)
@@ -197,9 +257,33 @@ func (d *Incus) Start(ctx context.Context, spec Spec) (Machine, error) {
 	for _, e := range spec.Env {
 		args = append(args, "--config", "environment."+e)
 	}
-
 	if _, err := d.run(ctx, args...); err != nil {
-		return Machine{}, fmt.Errorf("launch instance %s from %s: %w", spec.Name, d.imageRef(spec.Image), err)
+		return Machine{}, fmt.Errorf("create instance %s from %s: %w", spec.Name, d.imageRef(spec.Image), err)
+	}
+
+	// Device keys, while the instance is cold. The address pin and the public
+	// routes must both precede the first boot, or the NIC comes up on DHCP and
+	// the published address becomes a lie.
+	if primary.Address != "" {
+		if _, err := d.run(ctx, "config", "device", "set", spec.Name, "eth0",
+			"ipv4.address="+primary.Address); err != nil {
+			return Machine{}, fmt.Errorf("pin %s on %s: %w", primary.Address, spec.Name, err)
+		}
+	}
+	if len(spec.PublicAddresses) > 0 {
+		routes := make([]string, 0, len(spec.PublicAddresses))
+		for _, address := range spec.PublicAddresses {
+			routes = append(routes, address+"/32")
+		}
+		if _, err := d.run(ctx, "config", "device", "set", spec.Name, "eth0",
+			d.publicRouteKey()+"="+strings.Join(routes, ",")); err != nil {
+			return Machine{}, fmt.Errorf("route %s to %s: %w",
+				strings.Join(spec.PublicAddresses, ", "), spec.Name, err)
+		}
+	}
+
+	if _, err := d.run(ctx, "start", spec.Name); err != nil {
+		return Machine{}, fmt.Errorf("start instance %s: %w", spec.Name, err)
 	}
 	if err := d.attachExtra(ctx, spec); err != nil {
 		return Machine{}, err

--- a/internal/core/machine/incus.go
+++ b/internal/core/machine/incus.go
@@ -178,9 +178,39 @@ const DefaultMachineCIDR = "10.209.84.0/24"
 // mode the driver runs: a managed bridge, or an OVN network behind the uplink.
 // NAT is on because the machines on it expect outbound access — the rendered
 // cloud-init installs an ssh daemon at first boot.
+//
+// A mode switch leaves the network behind as the wrong type — a bridge after
+// `--vm incus`, when `--vm incus-ovn` now needs an OVN network — and
+// EnsureNetwork rightly refuses to reuse it, which would fail every boot
+// until somebody swept. So a wrong-typed default network is replaced here,
+// under three conditions and all three: it carries the emulator's own label,
+// it is empty, and it is this constant's name. An operator's network, or one
+// with a machine still on it, is never touched.
+// TestTheDefaultNetworkFollowsTheMode fails without the replacement, and
+// without either refusal.
 func (d *Incus) ensureDefaultNetwork(ctx context.Context) error {
 	d.defaultNetMu.Lock()
 	defer d.defaultNetMu.Unlock()
+
+	wantType := "bridge"
+	if d.OVN {
+		wantType = "ovn"
+	}
+	if out, err := d.run(ctx, "query", "/1.0/networks/"+DefaultMachineNetwork); err == nil {
+		var existing struct {
+			Type   string            `json:"type"`
+			Config map[string]string `json:"config"`
+			UsedBy []string          `json:"used_by"`
+		}
+		if json.Unmarshal(out, &existing) == nil &&
+			existing.Type != wantType &&
+			existing.Config["user."+LabelKey] != "" &&
+			len(existing.UsedBy) == 0 {
+			if err := d.RemoveNetwork(ctx, DefaultMachineNetwork); err != nil {
+				return err
+			}
+		}
+	}
 	return d.EnsureNetwork(ctx, NetworkSpec{
 		Name:   DefaultMachineNetwork,
 		CIDR:   DefaultMachineCIDR,
@@ -264,31 +294,59 @@ func (d *Incus) Start(ctx context.Context, spec Spec) (Machine, error) {
 	// Device keys, while the instance is cold. The address pin and the public
 	// routes must both precede the first boot, or the NIC comes up on DHCP and
 	// the published address becomes a lie.
+	//
+	// A failure past this point removes the instance before reporting: an
+	// init'ed instance left behind answers the next poweron on the
+	// already-exists path and boots without the keys this path was setting —
+	// measured in OVN mode, where the half-made machine came up with no route
+	// key, no DHCP lease and no ssh daemon, while the API said running.
 	if primary.Address != "" {
 		if _, err := d.run(ctx, "config", "device", "set", spec.Name, "eth0",
 			"ipv4.address="+primary.Address); err != nil {
-			return Machine{}, fmt.Errorf("pin %s on %s: %w", primary.Address, spec.Name, err)
+			return Machine{}, d.abandonStart(ctx, spec.Name,
+				fmt.Errorf("pin %s on %s: %w", primary.Address, spec.Name, err))
 		}
 	}
 	if len(spec.PublicAddresses) > 0 {
 		routes := make([]string, 0, len(spec.PublicAddresses))
 		for _, address := range spec.PublicAddresses {
+			// The uplink must carry the /32 before the device may name it:
+			// Incus validates ipv4.routes.external against the uplink's routes
+			// and refuses the key outright otherwise — measured, "Uplink
+			// network doesn't contain ... in its routes". Bridge mode has no
+			// uplink and skips this inside setUplinkRoute's OVN guard.
+			if d.OVN {
+				if err := d.setUplinkRoute(ctx, address, true); err != nil {
+					return Machine{}, d.abandonStart(ctx, spec.Name, err)
+				}
+			}
 			routes = append(routes, address+"/32")
 		}
 		if _, err := d.run(ctx, "config", "device", "set", spec.Name, "eth0",
 			d.publicRouteKey()+"="+strings.Join(routes, ",")); err != nil {
-			return Machine{}, fmt.Errorf("route %s to %s: %w",
-				strings.Join(spec.PublicAddresses, ", "), spec.Name, err)
+			return Machine{}, d.abandonStart(ctx, spec.Name, fmt.Errorf("route %s to %s: %w",
+				strings.Join(spec.PublicAddresses, ", "), spec.Name, err))
 		}
 	}
 
 	if _, err := d.run(ctx, "start", spec.Name); err != nil {
-		return Machine{}, fmt.Errorf("start instance %s: %w", spec.Name, err)
+		return Machine{}, d.abandonStart(ctx, spec.Name,
+			fmt.Errorf("start instance %s: %w", spec.Name, err))
 	}
 	if err := d.attachExtra(ctx, spec); err != nil {
 		return Machine{}, err
 	}
 	return d.inspectOrFail(ctx, spec.Name)
+}
+
+// abandonStart removes an instance a failed Start leaves behind, and returns
+// the failure that caused it. Best-effort: the original error is the one the
+// caller must hear, and a delete that fails leaves exactly the state it found.
+//
+// TestAFailedStartLeavesNoHalfMadeInstance fails without this.
+func (d *Incus) abandonStart(ctx context.Context, name string, cause error) error {
+	_, _ = d.run(ctx, "delete", "--force", name)
+	return cause
 }
 
 // attachExtra adds the interfaces beyond the first, which launch cannot carry:
@@ -423,9 +481,9 @@ func (d *Incus) configureGuestAddress(ctx context.Context, name, device, cidr st
 		return err
 	}
 	if _, err := d.run(ctx, "exec", name, "--", "ip", "address", "add", cidr, "dev", iface); err != nil &&
-		// "file exists" is the address already being there, which is the
-		// outcome this call wants.
-		!strings.Contains(strings.ToLower(err.Error()), "file exists") {
+		// Already-there is the outcome this call wants, in whichever wording
+		// the guest's `ip` uses (addressAlreadyThere: busybox differs).
+		!addressAlreadyThere(err) {
 		return fmt.Errorf("give %s to %s inside the guest: %w", cidr, name, err)
 	}
 	if _, err := d.run(ctx, "exec", name, "--", "ip", "link", "set", iface, "up"); err != nil {

--- a/internal/core/machine/incus_address.go
+++ b/internal/core/machine/incus_address.go
@@ -48,15 +48,34 @@ func (d *Incus) RouteAddress(ctx context.Context, spec AddressSpec) error {
 		return err
 	}
 	// The machine answers on it. A /32 on purpose: the address is a route to
-	// this machine, not a subnet it belongs to. "file exists" is the address
-	// already being there, which is what the contract promises on a second call.
+	// this machine, not a subnet it belongs to.
 	if _, err := d.run(ctx, "exec", spec.Machine, "--",
 		"ip", "address", "add", spec.Address+"/32", "dev", device); err != nil {
-		if !strings.Contains(strings.ToLower(err.Error()), "file exists") {
+		if !addressAlreadyThere(err) {
 			return fmt.Errorf("give %s to %s: %w", spec.Address, spec.Machine, err)
 		}
 	}
 	return nil
+}
+
+// addressAlreadyThere reads "the address is already on the interface" out of an
+// `ip address add` failure, which the contract promises on a second call.
+//
+// Two wordings, because two implementations of `ip` are in play and only one of
+// them was known. iproute2, on Debian, Ubuntu and the RHEL family, says
+// "RTNETLINK answers: File exists". Busybox, which is the `ip` an Alpine image
+// ships, says "Error: ipv4: Address already assigned." — measured on
+// images:alpine/3.21/cloud rather than recalled.
+//
+// Matching only the first turned a re-route of an Alpine machine into a hard
+// failure, on the idempotent path the contract says must succeed. A third
+// runtime would need its own line here, and the failure would at least name the
+// address rather than hide.
+// TestARepeatedRouteIsNotAFailure fails without this.
+func addressAlreadyThere(err error) bool {
+	said := strings.ToLower(err.Error())
+	return strings.Contains(said, "file exists") ||
+		strings.Contains(said, "address already assigned")
 }
 
 // mustOwn refuses to touch a network the emulator did not create. The label is

--- a/internal/core/machine/incus_address_test.go
+++ b/internal/core/machine/incus_address_test.go
@@ -1,6 +1,9 @@
 package machine
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 // The route lookup is over an exact comma-separated entry: a substring match
 // would see 203.0.113.2/32 inside 203.0.113.22/32 and undo the wrong address.
@@ -18,6 +21,44 @@ func TestRouteListContains(t *testing.T) {
 	for _, tt := range tests {
 		if got := routeListContains(tt.routes, tt.route); got != tt.want {
 			t.Errorf("routeListContains(%q, %q) = %v, want %v", tt.routes, tt.route, got, tt.want)
+		}
+	}
+}
+
+// TestARepeatedRouteIsNotAFailure holds the idempotent half of RouteAddress.
+//
+// Giving an address that is already on the interface must succeed: the contract
+// says a second call is a no-op, and the poweron path replays the routing of an
+// address attached before the machine existed.
+//
+// Two wordings, because two implementations of `ip` are in play and the code
+// knew one. iproute2 says "File exists"; busybox, which is what an Alpine image
+// ships, says "Address already assigned" — measured on images:alpine/3.21/cloud,
+// not recalled. Matching only the first turned a re-route of an Alpine machine
+// into a hard failure on the path that must not fail.
+func TestARepeatedRouteIsNotAFailure(t *testing.T) {
+	tolerated := map[string]string{
+		"iproute2": "RTNETLINK answers: File exists",
+		"busybox":  "Error: ipv4: Address already assigned.",
+		// Case is not the contract: the comparison lowercases, and a runtime
+		// that shouts would otherwise reopen the same hole.
+		"shouting": "ERROR: IPV4: ADDRESS ALREADY ASSIGNED.",
+	}
+	for who, said := range tolerated {
+		if !addressAlreadyThere(errors.New(said)) {
+			t.Errorf("%s: %q should read as already there", who, said)
+		}
+	}
+
+	// And a real failure must stay one. A permission error or a missing device
+	// silently swallowed is a machine the API says is addressed and is not.
+	for who, said := range map[string]string{
+		"missing device": "Cannot find device \"eth9\"",
+		"not permitted":  "RTNETLINK answers: Operation not permitted",
+		"no such file":   "exec: \"ip\": executable file not found in $PATH",
+	} {
+		if addressAlreadyThere(errors.New(said)) {
+			t.Errorf("%s: %q was swallowed as already there", who, said)
 		}
 	}
 }

--- a/internal/core/machine/incus_ovn.go
+++ b/internal/core/machine/incus_ovn.go
@@ -331,11 +331,12 @@ func (d *Incus) routeAddressOVN(ctx context.Context, spec AddressSpec) error {
 	}
 
 	// The machine answers on it, a /32 because the address is a route to this
-	// machine, not a subnet it belongs to. "file exists" is the second call's
-	// success.
+	// machine, not a subnet it belongs to. Already-there is the second call's
+	// success, in whichever wording the guest's `ip` uses (addressAlreadyThere:
+	// busybox does not say "file exists", and Alpine ships busybox).
 	if _, err := d.run(ctx, "exec", spec.Machine, "--",
 		"ip", "address", "add", route, "dev", device); err != nil &&
-		!strings.Contains(strings.ToLower(err.Error()), "file exists") {
+		!addressAlreadyThere(err) {
 		return fmt.Errorf("give %s to %s: %w", spec.Address, spec.Machine, err)
 	}
 	return nil
@@ -370,17 +371,32 @@ func (d *Incus) unrouteAddressOVN(ctx context.Context, machine, address string) 
 }
 
 // repairGuestInterface restores what a device re-plug cost the guest: the
-// fixed address the control plane published, and the link state. Measured on
+// address the interface carried, the link state, and the routes. Measured on
 // 7.2: any change to a non-live-updatable key removes and re-adds the NIC,
 // and the new interface comes up bare, with no DHCP client watching it.
+//
+// Two kinds of address, one repair. A pinned one is read off the device key.
+// A DHCP-owned one used to be declared unrepairable here, which turned a hot
+// route edit into a machine with no address at all — measured: RUNNING, guest
+// bare, sshd unreachable. The runtime itself records what the interface
+// carried (volatile.<device>.last_state.ip_addresses), the re-plug keeps the
+// NIC's hwaddr, and OVN's IPAM ties the address to that MAC — so restoring
+// the recorded address statically restores the port's own reservation, and
+// the lease's default route comes back with it.
+// TestAHotRouteEditRepairsADHCPInterface fails without the second kind.
 func (d *Incus) repairGuestInterface(ctx context.Context, machine, network, device string) error {
 	devices, err := d.instanceDevices(ctx, machine)
 	if err != nil {
 		return fmt.Errorf("inspect %s after re-plug: %w", machine, err)
 	}
 	address := devices.own[device]["ipv4.address"]
+	leased := false
 	if address == "" {
-		// Nothing was pinned, so nothing to put back; DHCP owns this one.
+		address = d.lastKnownAddress(ctx, machine, device)
+		leased = true
+	}
+	if address == "" {
+		// The interface never carried an address; there is nothing to put back.
 		return nil
 	}
 	gateway, err := d.networkGateway(ctx, network)
@@ -391,8 +407,34 @@ func (d *Incus) repairGuestInterface(ctx context.Context, machine, network, devi
 		fmt.Sprintf("%s/%d", address, gateway.Bits())); err != nil {
 		return err
 	}
+	if leased {
+		// The default route died with the lease, and nothing renews either.
+		// Restored only for the leased case: a pinned private NIC never had
+		// one, and inventing it would route a machine the control plane
+		// declared isolated.
+		if _, err := d.run(ctx, "exec", machine, "--",
+			"ip", "route", "add", "default", "via", gateway.Addr().String(), "dev", device); err != nil &&
+			!strings.Contains(strings.ToLower(err.Error()), "file exists") {
+			return fmt.Errorf("restore the default route of %s: %w", machine, err)
+		}
+	}
 	// The routes towards the peered subnets died with the interface too.
 	return d.installGuestPrivateRoutes(ctx, machine, network, device)
+}
+
+// lastKnownAddress is the IPv4 the runtime last saw on an interface, from the
+// volatile key Incus maintains per device. Empty when it never carried one.
+func (d *Incus) lastKnownAddress(ctx context.Context, machine, device string) string {
+	out, err := d.run(ctx, "config", "get", machine, "volatile."+device+".last_state.ip_addresses")
+	if err != nil {
+		return ""
+	}
+	for _, field := range strings.Split(strings.TrimSpace(string(out)), ",") {
+		if addr, err := netip.ParseAddr(strings.TrimSpace(field)); err == nil && addr.Is4() {
+			return addr.String()
+		}
+	}
+	return ""
 }
 
 // networkGateway reads a network's gateway address, with its mask, from the

--- a/internal/core/machine/incus_repair_test.go
+++ b/internal/core/machine/incus_repair_test.go
@@ -1,0 +1,56 @@
+package machine
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// A hot route edit on an OVN NIC re-plugs the device, and the guest comes back
+// bare: no address, link down, no DHCP client left to renew anything. The
+// repair used to stop at pinned addresses and declare a leased one
+// unrepairable, which turned `scw instance ip attach` on a running server into
+// a machine with no address at all — measured: RUNNING, guest empty, sshd
+// unreachable, while the API said addressed.
+//
+// The runtime records what the interface carried
+// (volatile.<dev>.last_state.ip_addresses), the re-plug keeps the NIC's
+// hwaddr, and OVN's IPAM ties the address to that MAC: restoring the recorded
+// address statically restores the port's own reservation. Measured by hand on
+// Incus 7.2 before being coded: address back, default route back, outbound
+// alive, and the public /32 answering from the host.
+func TestAHotRouteEditRepairsADHCPInterface(t *testing.T) {
+	f := &fakeRuntime{answers: map[string]string{
+		"query /1.0/instances/srv": `{
+			"devices": {"eth0": {"type": "nic", "network": "fnt-default"}},
+			"expanded_devices": {"eth0": {"type": "nic", "network": "fnt-default"}}
+		}`,
+		"network get fnt-default user.":                        "feint",
+		"network get fnt-default ipv4.address":                 "10.209.84.1/24",
+		"network get " + DefaultUplinkName:                     "",
+		"config get srv volatile.eth0.last_state.ip_addresses": "10.209.84.2",
+	}}
+	d := newFakeDriver(f)
+	d.OVN = true
+
+	if err := d.RouteAddress(context.Background(), AddressSpec{
+		Machine: "srv", Address: "203.0.113.9",
+	}); err != nil {
+		t.Fatalf("route: %v", err)
+	}
+
+	wanted := []string{
+		// The re-plug happened: the route key was edited on the device.
+		"config device set srv eth0 ipv4.routes.external=203.0.113.9/32",
+		// The leased address the interface carried comes back, statically.
+		"exec srv -- ip address add 10.209.84.2/24 dev eth0",
+		// And the lease's default route with it: without one the guest can
+		// answer nothing beyond its own subnet, cloud-init included.
+		"exec srv -- ip route add default via 10.209.84.1 dev eth0",
+	}
+	for _, want := range wanted {
+		if len(f.matching(want)) == 0 {
+			t.Errorf("missing %q in:\n%s", want, strings.Join(f.commands(), "\n"))
+		}
+	}
+}

--- a/internal/core/machine/incus_start_test.go
+++ b/internal/core/machine/incus_start_test.go
@@ -1,0 +1,121 @@
+package machine
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// Start owns two facts the conformance suite cannot see until they hurt, both
+// argument-level and both measured on Incus 7.2 before being coded (#116):
+//
+//   - a machine with no attachment must boot on a network the emulator owns,
+//     because a route is refused outside them (mustOwn) and covering a profile
+//     NIC with a firewall means overriding it, which re-plugs the device after
+//     boot and costs the guest its DHCP lease with nothing left to renew it;
+//   - a public address must be a device key before the first boot, because
+//     editing a route key on a live OVN NIC is the same re-plug.
+
+// startScript answers the calls Start makes on the path that creates a new
+// instance: the instance does not exist until "start" ran, and the default
+// network does not exist at all.
+func startScript(f *fakeRuntime) {
+	started := false
+	f.hook = func(_ int, args []string) ([]byte, error, bool) {
+		switch args[0] {
+		case "list":
+			if started {
+				return []byte(`[{"name":"srv","status":"Running","state":{"network":{}}}]`), nil, true
+			}
+			return []byte(`[]`), nil, true
+		case "query":
+			if strings.Contains(args[len(args)-1], "/1.0/networks/") {
+				return nil, errors.New("Network not found"), true
+			}
+		case "start":
+			started = true
+		}
+		return nil, nil, false
+	}
+}
+
+func TestAMachineWithNoAttachmentBootsOnTheEmulatorsOwnNetwork(t *testing.T) {
+	f := &fakeRuntime{}
+	startScript(f)
+	d := newFakeDriver(f)
+
+	if _, err := d.Start(context.Background(), Spec{Name: "srv", Image: "alpine:3.21"}); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	creates := f.matching("network create " + DefaultMachineNetwork)
+	if len(creates) != 1 {
+		t.Fatalf("expected the default machine network to be created once, got:\n%s",
+			strings.Join(f.commands(), "\n"))
+	}
+	// Labelled, or mustOwn refuses to route public addresses through it and the
+	// sweep cannot remove it; NATed, or the guest cannot install its ssh daemon.
+	for _, want := range []string{"user." + LabelKey + "=", "ipv4.nat=true"} {
+		if !strings.Contains(creates[0], want) {
+			t.Errorf("the default network is missing %q: %s", want, creates[0])
+		}
+	}
+
+	inits := f.matching("init ")
+	if len(inits) != 1 || !strings.Contains(inits[0], "--network "+DefaultMachineNetwork) {
+		t.Fatalf("the machine did not boot on %s:\n%s",
+			DefaultMachineNetwork, strings.Join(f.commands(), "\n"))
+	}
+}
+
+// The route keys must be set while the instance is cold — after init, before
+// start. Setting them on a running instance is exactly the live edit whose
+// re-plug this order exists to avoid.
+func TestPublicAddressesAreRoutedBeforeTheFirstBoot(t *testing.T) {
+	modes := []struct {
+		name string
+		key  string
+		ovn  bool
+	}{
+		{"bridge", "ipv4.routes", false},
+		{"ovn", "ipv4.routes.external", true},
+	}
+	for _, mode := range modes {
+		t.Run(mode.name, func(t *testing.T) {
+			f := &fakeRuntime{}
+			startScript(f)
+			d := newFakeDriver(f)
+			d.OVN = mode.ovn
+
+			_, err := d.Start(context.Background(), Spec{
+				Name:            "srv",
+				Image:           "alpine:3.21",
+				Attachments:     []Attachment{{Network: "fnt-abc", Address: "10.181.0.2"}},
+				PublicAddresses: []string{"203.0.113.2", "203.0.113.9"},
+			})
+			if err != nil {
+				t.Fatalf("start: %v", err)
+			}
+
+			routeIdx, startIdx := -1, -1
+			want := "config device set srv eth0 " + mode.key + "=203.0.113.2/32,203.0.113.9/32"
+			for i, cmd := range f.commands() {
+				switch cmd {
+				case want:
+					routeIdx = i
+				case "start srv":
+					startIdx = i
+				}
+			}
+			if routeIdx == -1 {
+				t.Fatalf("the public routes never became a device key (%s):\n%s",
+					want, strings.Join(f.commands(), "\n"))
+			}
+			if startIdx == -1 || routeIdx > startIdx {
+				t.Fatalf("the routes were set after the boot (route at %d, start at %d): the live edit re-plugs an OVN NIC",
+					routeIdx, startIdx)
+			}
+		})
+	}
+}

--- a/internal/core/machine/incus_start_test.go
+++ b/internal/core/machine/incus_start_test.go
@@ -98,14 +98,17 @@ func TestPublicAddressesAreRoutedBeforeTheFirstBoot(t *testing.T) {
 				t.Fatalf("start: %v", err)
 			}
 
-			routeIdx, startIdx := -1, -1
+			routeIdx, startIdx, uplinkIdx := -1, -1, -1
 			want := "config device set srv eth0 " + mode.key + "=203.0.113.2/32,203.0.113.9/32"
 			for i, cmd := range f.commands() {
-				switch cmd {
-				case want:
+				switch {
+				case cmd == want:
 					routeIdx = i
-				case "start srv":
+				case cmd == "start srv":
 					startIdx = i
+				case strings.HasPrefix(cmd, "network set "+DefaultUplinkName+" ipv4.routes=") &&
+					strings.Contains(cmd, "203.0.113.2/32") && uplinkIdx == -1:
+					uplinkIdx = i
 				}
 			}
 			if routeIdx == -1 {
@@ -116,6 +119,87 @@ func TestPublicAddressesAreRoutedBeforeTheFirstBoot(t *testing.T) {
 				t.Fatalf("the routes were set after the boot (route at %d, start at %d): the live edit re-plugs an OVN NIC",
 					routeIdx, startIdx)
 			}
+			if mode.ovn {
+				// Incus validates the device key against the uplink's routes
+				// and refuses it otherwise — measured: "Uplink network doesn't
+				// contain ... in its routes". So the /32 must reach the uplink
+				// first, or the whole boot fails.
+				if uplinkIdx == -1 || uplinkIdx > routeIdx {
+					t.Fatalf("the uplink does not carry the /32 before the device names it (uplink at %d, device at %d):\n%s",
+						uplinkIdx, routeIdx, strings.Join(f.commands(), "\n"))
+				}
+			} else if uplinkIdx != -1 {
+				t.Fatalf("bridge mode touched the OVN uplink:\n%s", strings.Join(f.commands(), "\n"))
+			}
 		})
+	}
+}
+
+// A mode switch leaves the default network behind as the wrong type, and
+// EnsureNetwork rightly refuses to reuse it — so every boot of the new mode
+// failed until somebody swept by hand. The replacement is bounded twice over:
+// only the emulator's own labelled network goes, and only when it is empty.
+func TestTheDefaultNetworkFollowsTheMode(t *testing.T) {
+	leftover := func(labelled bool, usedBy string) string {
+		label := ""
+		if labelled {
+			label = `"user.` + LabelKey + `": "feint"`
+		}
+		return `{"type": "bridge", "config": {` + label + `}, "used_by": [` + usedBy + `]}`
+	}
+
+	cases := []struct {
+		name     string
+		existing string
+		replaced bool
+	}{
+		{"an empty labelled bridge is replaced in ovn mode", leftover(true, ""), true},
+		{"a network with a machine on it stays", leftover(true, `"/1.0/instances/x"`), false},
+		{"an unlabelled network is never touched", leftover(false, ""), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &fakeRuntime{answers: map[string]string{
+				"query /1.0/networks/" + DefaultMachineNetwork: tc.existing,
+			}}
+			d := newFakeDriver(f)
+			d.OVN = true
+
+			// The error path is not under test: EnsureNetwork will refuse the
+			// wrong-typed leftover in the cases where it stays, and that
+			// refusal is its own test's business.
+			_ = d.ensureDefaultNetwork(context.Background())
+
+			deleted := len(f.matching("network delete "+DefaultMachineNetwork)) > 0
+			if deleted != tc.replaced {
+				t.Errorf("deleted=%v, want %v:\n%s", deleted, tc.replaced,
+					strings.Join(f.commands(), "\n"))
+			}
+		})
+	}
+}
+
+// A Start that fails after init must not leave the instance behind: the next
+// poweron would find it, take the already-exists path, and boot a machine
+// missing the very keys the failed call was setting — measured in OVN mode,
+// where the half-made machine came up with no route key, no DHCP lease and no
+// ssh daemon, while the API said running.
+func TestAFailedStartLeavesNoHalfMadeInstance(t *testing.T) {
+	f := &fakeRuntime{fail: map[string]error{
+		"ipv4.address=10.181.0.2": errors.New("Device validation failed"),
+	}}
+	startScript(f)
+	d := newFakeDriver(f)
+
+	_, err := d.Start(context.Background(), Spec{
+		Name:        "srv",
+		Image:       "alpine:3.21",
+		Attachments: []Attachment{{Network: "fnt-abc", Address: "10.181.0.2"}},
+	})
+	if err == nil {
+		t.Fatal("a refused device key did not fail the start")
+	}
+	if len(f.matching("delete --force srv")) != 1 {
+		t.Fatalf("the half-made instance was left behind:\n%s", strings.Join(f.commands(), "\n"))
 	}
 }

--- a/internal/core/machine/machine.go
+++ b/internal/core/machine/machine.go
@@ -78,9 +78,21 @@ type Spec struct {
 	// verbatim; the others fall back to User and AuthorizedKeys.
 	CloudInit string
 	// Attachments place the machine on emulated networks. The first one is the
-	// primary interface. Empty leaves the machine on the runtime default,
-	// which is the metadata-only behaviour.
+	// primary interface. Empty puts the machine on the driver's own default
+	// network, never on the operator's: a machine on a network the emulator did
+	// not create cannot lawfully carry a routed public address, because every
+	// route the driver writes is refused outside its own networks (mustOwn).
 	Attachments []Attachment
+	// PublicAddresses are the emulated public addresses this machine must
+	// answer on from its first boot, each routed to its primary interface.
+	//
+	// They ride the launch rather than a later edit because editing route keys
+	// on a live OVN NIC re-plugs the device, and the re-plug costs the guest its
+	// DHCP lease with nothing left to renew it — measured on Incus 7.2: the
+	// machine then holds no address at all, which is worse than an address
+	// nothing routes. An address attached after boot still goes through
+	// Router.RouteAddress, and pays the bounce documented in docs/limits.md.
+	PublicAddresses []string
 }
 
 // Machine is a running (or stopped) backing machine.

--- a/internal/providers/exoscale/elasticip_routing_test.go
+++ b/internal/providers/exoscale/elasticip_routing_test.go
@@ -1,0 +1,187 @@
+package exoscale_test
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/machine"
+	"github.com/stephrobert/feint/internal/providers/exoscale"
+)
+
+// The elastic-IP plane, asserted through the runtime's arguments: an attached
+// address and a routed one look identical in JSON, and their difference is the
+// whole reason the attach stopped being a membership edit alone.
+
+// routedRuntime is a recordingRuntime that also carries addresses.
+type routedRuntime struct {
+	recordingRuntime
+
+	mu       sync.Mutex
+	routed   []machine.AddressSpec
+	withdrew []string
+}
+
+func (r *routedRuntime) Inspect(_ context.Context, n string) (machine.Machine, bool, error) {
+	// Running, with an address: the packs replay routes on machines that
+	// exist, and the base recording runtime reports every machine absent.
+	return machine.Machine{Name: n, IP: "10.209.84.9", Running: true}, true, nil
+}
+
+func (r *routedRuntime) RouteAddress(_ context.Context, spec machine.AddressSpec) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.routed = append(r.routed, spec)
+	return nil
+}
+
+func (r *routedRuntime) UnrouteAddress(_ context.Context, _, address string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.withdrew = append(r.withdrew, address)
+	return nil
+}
+
+func (r *routedRuntime) routedAddresses() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, 0, len(r.routed))
+	for _, spec := range r.routed {
+		out = append(out, spec.Address)
+	}
+	return out
+}
+
+func (r *routedRuntime) bootedAddresses() []string {
+	r.recordingRuntime.mu.Lock()
+	defer r.recordingRuntime.mu.Unlock()
+	out := []string{}
+	for _, spec := range r.specs {
+		out = append(out, spec.PublicAddresses...)
+	}
+	return out
+}
+
+func routedServe(t *testing.T) (http.Handler, *routedRuntime, *emulator.Env) {
+	t.Helper()
+	env := emulator.DefaultEnv()
+	rt := &routedRuntime{}
+	env.Machines = rt
+	srv, err := emulator.NewServer(env, exoscale.New(env))
+	if err != nil {
+		t.Fatalf("build the server: %v", err)
+	}
+	return srv.Handler(), rt, env
+}
+
+func has(list []string, want string) bool {
+	for _, have := range list {
+		if have == want {
+			return true
+		}
+	}
+	return false
+}
+
+// anAttachedInstance builds one running instance carrying one elastic IP, and
+// returns both identifiers with the address.
+func anAttachedInstance(t *testing.T, h http.Handler) (instanceID, eipID, address string) {
+	t.Helper()
+	call(t, h, "POST", "/v2/instance", `{
+		"name":"carrier",
+		"instance-type":{"id":"21624abb-764e-4def-81d7-9fc54b5957fb"},
+		"template":{"id":"11111111-1111-4111-8111-111111111111"},
+		"disk-size":10
+	}`)
+	_, out := call(t, h, "GET", "/v2/instance", "")
+	instances, _ := out["instances"].([]any)
+	if len(instances) == 0 {
+		t.Fatal("no instance after create")
+	}
+	inst, _ := instances[0].(map[string]any)
+	instanceID, _ = inst["id"].(string)
+
+	_, out = call(t, h, "POST", "/v2/elastic-ip", `{}`)
+	ref, _ := out["reference"].(map[string]any)
+	eipID, _ = ref["id"].(string)
+	_, out = call(t, h, "GET", "/v2/elastic-ip/"+eipID, "")
+	address, _ = out["ip"].(string)
+	if address == "" {
+		t.Fatal("the elastic IP has no address")
+	}
+
+	if rec, body := call(t, h, "PUT", "/v2/elastic-ip/"+eipID+":attach",
+		`{"instance":{"id":"`+instanceID+`"}}`); rec.Code != http.StatusOK {
+		t.Fatalf("attach: %d %v", rec.Code, body)
+	}
+	return instanceID, eipID, address
+}
+
+// An attached address reaches the machine: the attach routes it at once, and
+// the next boot carries it as a launch key rather than a live edit.
+func TestAttachElasticIPRoutesTheAddress(t *testing.T) {
+	h, rt, _ := routedServe(t)
+	instanceID, eipID, address := anAttachedInstance(t, h)
+
+	if !has(rt.routedAddresses(), address) {
+		t.Errorf("%s was attached and never routed: %v", address, rt.routedAddresses())
+	}
+
+	call(t, h, "PUT", "/v2/instance/"+instanceID+":stop", "{}")
+	call(t, h, "PUT", "/v2/instance/"+instanceID+":start", "{}")
+	if !has(rt.bootedAddresses(), address) {
+		t.Errorf("the boot does not carry %s: a live route edit re-plugs an OVN NIC", address)
+	}
+
+	// The detach takes the route back.
+	call(t, h, "PUT", "/v2/elastic-ip/"+eipID+":detach", `{"instance":{"id":"`+instanceID+`"}}`)
+	rt.mu.Lock()
+	withdrawn := append([]string(nil), rt.withdrew...)
+	rt.mu.Unlock()
+	if !has(withdrawn, address) {
+		t.Errorf("the address was not withdrawn on detach: %v", withdrawn)
+	}
+}
+
+// A stored address is untrusted input: PUT /_feint/state restores it verbatim,
+// and routing an arbitrary value would send the host's traffic for that
+// address into a container. emulatedElasticIP is the authorisation half.
+func TestAPoisonedElasticIPIsNeverRouted(t *testing.T) {
+	h, rt, env := routedServe(t)
+
+	const poison = "10.76.154.1" // a host bridge gateway, well-formed and not ours
+
+	call(t, h, "POST", "/v2/instance", `{
+		"name":"victim",
+		"instance-type":{"id":"21624abb-764e-4def-81d7-9fc54b5957fb"},
+		"template":{"id":"11111111-1111-4111-8111-111111111111"},
+		"disk-size":10
+	}`)
+	_, out := call(t, h, "GET", "/v2/instance", "")
+	instances, _ := out["instances"].([]any)
+	inst, _ := instances[0].(map[string]any)
+	instanceID, _ := inst["id"].(string)
+
+	_, out = call(t, h, "POST", "/v2/elastic-ip", `{}`)
+	ref, _ := out["reference"].(map[string]any)
+	eipID, _ := ref["id"].(string)
+	stored, found := env.Store.Get(exoscale.Name, "elastic-ip", eipID)
+	if !found {
+		t.Fatal("the elastic IP is not in the store")
+	}
+	stored.Attrs["ip"] = poison
+	env.Store.Commit(stored, env.Now())
+
+	call(t, h, "PUT", "/v2/elastic-ip/"+eipID+":attach", `{"instance":{"id":"`+instanceID+`"}}`)
+	call(t, h, "PUT", "/v2/instance/"+instanceID+":stop", "{}")
+	call(t, h, "PUT", "/v2/instance/"+instanceID+":start", "{}")
+
+	if has(rt.routedAddresses(), poison) {
+		t.Errorf("the poisoned address reached the driver: %v", rt.routedAddresses())
+	}
+	if has(rt.bootedAddresses(), poison) {
+		t.Errorf("the poisoned address rode a boot: %v", rt.bootedAddresses())
+	}
+}

--- a/internal/providers/exoscale/elasticips.go
+++ b/internal/providers/exoscale/elasticips.go
@@ -1,11 +1,14 @@
 package exoscale
 
 import (
+	"context"
 	"fmt"
 	"net/http"
+	"net/netip"
 	"sort"
 
 	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/machine"
 	"github.com/stephrobert/feint/internal/core/resource"
 )
 
@@ -14,9 +17,97 @@ import (
 // naming the instance, and the operation they mint refers to the elastic IP,
 // not the instance — that is what the recording shows the provider waiting on.
 //
-// The addresses come from 203.0.113.0/24 (TEST-NET-3): fixed, documented as
-// never routable, and disjoint from the machine runtime's own ranges, so an
-// elastic IP can never collide with an address a real machine answers on.
+// The addresses come from 192.0.2.0/24 (TEST-NET-1): fixed, documented as
+// never routable on the internet, and disjoint from the machine runtime's own
+// ranges. One RFC 5737 block per pack, because an attached address is routed
+// on the host now and one host serves three emulated clouds: Scaleway keeps
+// TEST-NET-3, Outscale has TEST-NET-2, and each pack's guard refuses the
+// other two.
+//
+// Attaching routes the address to the instance's machine, the way the real
+// cloud puts an elastic IP on an instance; detaching and deleting take the
+// route back. It moved only the record for as long as the machines sat on the
+// operator's default bridge, which the driver rightly refuses to route
+// through; they live on emulator-owned networks now.
+
+// elasticIPBlock is the block as a prefix, for the guard below.
+const elasticIPBlock = "192.0.2.0/24"
+
+// emulatedElasticIP reports whether an address is one this pack can have
+// handed out: inside elasticIPBlock. A stored address is restored verbatim by
+// PUT /_feint/state and `feint snapshot load`, and routing an arbitrary value
+// would send the host's traffic for that address into a container.
+// TestAPoisonedElasticIPIsNeverRouted fails without it.
+func emulatedElasticIP(address string) bool {
+	prefix, err := netip.ParsePrefix(elasticIPBlock)
+	if err != nil {
+		return false
+	}
+	addr, err := netip.ParseAddr(address)
+	if err != nil {
+		return false
+	}
+	return prefix.Contains(addr)
+}
+
+// routeElasticIP makes an attached address reach the instance's machine.
+// Degrades quietly, like every runtime call in this pack.
+// TestAttachElasticIPRoutesTheAddress fails without it.
+func (p *Pack) routeElasticIP(ctx context.Context, address string, inst *resource.Resource) {
+	router, ok := p.env.Machines.(machine.Router)
+	if !ok {
+		return
+	}
+	name := inst.Runtime[p.binding().RuntimeKey]
+	if name == "" || address == "" {
+		return
+	}
+	if !emulatedElasticIP(address) {
+		p.logger().Warn("refusing to route an address outside the emulated elastic block",
+			"address", address, "instance", inst.ID)
+		return
+	}
+	if err := router.RouteAddress(ctx, machine.AddressSpec{Machine: name, Address: address}); err != nil {
+		p.logger().Error("could not route the elastic IP to the machine",
+			"address", address, "instance", inst.ID, "error", err)
+	}
+}
+
+// unrouteElasticIP takes the route back. The machine may already be gone; the
+// driver treats that as nothing left to undo, and on OVN it still withdraws
+// the uplink route, which outlives the machine.
+func (p *Pack) unrouteElasticIP(ctx context.Context, address string, inst *resource.Resource) {
+	router, ok := p.env.Machines.(machine.Router)
+	if !ok || !emulatedElasticIP(address) {
+		return
+	}
+	name := ""
+	if inst != nil {
+		name = inst.Runtime[p.binding().RuntimeKey]
+	}
+	if err := router.UnrouteAddress(ctx, name, address); err != nil {
+		p.logger().Error("could not stop routing the elastic IP",
+			"address", address, "error", err)
+	}
+}
+
+// elasticBootAddresses is what an instance's machine must answer on from its
+// first boot: every elastic IP attached to it. On the launch rather than
+// routed afterwards, because editing a live OVN NIC re-plugs it.
+func (p *Pack) elasticBootAddresses(res *resource.Resource) []string {
+	ids := stringList(res.Attrs[attrElasticIPIDs])
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		eip, found := p.env.Store.Get(Name, kindElasticIP, id)
+		if !found {
+			continue
+		}
+		if address, _ := eip.Attrs["ip"].(string); emulatedElasticIP(address) {
+			out = append(out, address)
+		}
+	}
+	return out
+}
 
 const (
 	kindElasticIP = "elastic-ip"
@@ -78,7 +169,7 @@ func (p *Pack) freeElasticAddress() (string, bool) {
 		}
 	}
 	for host := 1; host <= 254; host++ {
-		ip := fmt.Sprintf("203.0.113.%d", host)
+		ip := fmt.Sprintf("192.0.2.%d", host)
 		if !used[ip] {
 			return ip, true
 		}
@@ -142,12 +233,18 @@ func (p *Pack) deleteElasticIP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// The address is withdrawn from every instance that publishes it before the
-	// IP goes: a view naming a deleted IP would be published by nothing.
+	// IP goes: a view naming a deleted IP would be published by nothing, and a
+	// route that outlived its record would shadow the next allocation.
+	address := ""
+	if eip, found := p.env.Store.Get(Name, kindElasticIP, id); found {
+		address, _ = eip.Attrs["ip"].(string)
+	}
 	for _, inst := range p.env.Store.List(kindInstance, resource.Tenant{Provider: Name}) {
 		ids := stringList(inst.Attrs[attrElasticIPIDs])
 		if !contains(ids, id) {
 			continue
 		}
+		p.unrouteElasticIP(r.Context(), address, inst)
 		_ = p.env.Store.Update(Name, kindInstance, inst.ID, func(stored *resource.Resource) error {
 			stored.Attrs[attrElasticIPIDs] = without(stringList(stored.Attrs[attrElasticIPIDs]), id)
 			return nil
@@ -158,11 +255,35 @@ func (p *Pack) deleteElasticIP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (p *Pack) attachInstanceToElasticIP(w http.ResponseWriter, r *http.Request) {
-	p.changeInstanceMembership(w, r, kindElasticIP, nounElasticIP, attrElasticIPIDs, true)
+	instanceID, ok := p.changeInstanceMembership(w, r, kindElasticIP, nounElasticIP, attrElasticIPIDs, true)
+	if !ok {
+		return
+	}
+	p.moveElasticRoute(r, instanceID, true)
 }
 
 func (p *Pack) detachInstanceFromElasticIP(w http.ResponseWriter, r *http.Request) {
-	p.changeInstanceMembership(w, r, kindElasticIP, nounElasticIP, attrElasticIPIDs, false)
+	instanceID, ok := p.changeInstanceMembership(w, r, kindElasticIP, nounElasticIP, attrElasticIPIDs, false)
+	if !ok {
+		return
+	}
+	p.moveElasticRoute(r, instanceID, false)
+}
+
+// moveElasticRoute routes or unroutes the elastic IP the request names, on the
+// instance the membership change just touched.
+func (p *Pack) moveElasticRoute(r *http.Request, instanceID string, attach bool) {
+	inst, foundInstance := p.env.Store.Get(Name, kindInstance, instanceID)
+	eip, foundIP := p.env.Store.Get(Name, kindElasticIP, r.PathValue("id"))
+	if !foundInstance || !foundIP {
+		return
+	}
+	address, _ := eip.Attrs["ip"].(string)
+	if attach {
+		p.routeElasticIP(r.Context(), address, inst)
+		return
+	}
+	p.unrouteElasticIP(r.Context(), address, inst)
 }
 
 func elasticIPView(res *resource.Resource) map[string]any {

--- a/internal/providers/exoscale/machines.go
+++ b/internal/providers/exoscale/machines.go
@@ -2,6 +2,7 @@ package exoscale
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/stephrobert/feint/internal/core/cloudinit"
 	"github.com/stephrobert/feint/internal/core/machine"
@@ -34,6 +35,15 @@ func (p *Pack) binding() machine.Binding {
 		FailedState: "error",
 		Log:         p.env.Log,
 	}
+}
+
+// logger returns the environment logger, or the default one when a caller
+// built an Env by hand without setting it.
+func (p *Pack) logger() *slog.Logger {
+	if p.env.Log != nil {
+		return p.env.Log
+	}
+	return slog.Default()
 }
 
 // catalogueDate is when the emulated catalogue claims to have been built. A
@@ -135,8 +145,16 @@ func (p *Pack) start(ctx context.Context, res *resource.Resource) {
 		// Decoded here, stored encoded: Exoscale documents user-data as base64,
 		// so that is what a read gives back and what cloud-init must not see.
 		CloudInit: cloudinit.Decode(userData),
-		Labels:    map[string]string{"feint.instance": res.ID},
+		// The elastic IPs already attached, on the launch: a route edited onto
+		// a live OVN NIC re-plugs it and costs the guest its lease.
+		PublicAddresses: p.elasticBootAddresses(res),
+		Labels:          map[string]string{"feint.instance": res.ID},
 	})
+	// The boot installed the host half of every route; this hands the guest
+	// its addresses, and repairs a machine that already existed. Idempotent.
+	for _, address := range p.elasticBootAddresses(res) {
+		p.routeElasticIP(ctx, address, res)
+	}
 }
 
 // authorizedKeys is the material of the key an instance names, or nothing.
@@ -166,8 +184,12 @@ func (p *Pack) authorizedKeys(res *resource.Resource) []string {
 }
 
 // destroy removes the backing machine, so a leftover cannot outlive the instance
-// that justified it.
+// that justified it. The elastic routes go first, because on OVN the uplink
+// route outlives the machine.
 func (p *Pack) destroy(ctx context.Context, res *resource.Resource) {
+	for _, address := range p.elasticBootAddresses(res) {
+		p.unrouteElasticIP(ctx, address, res)
+	}
 	p.binding().Destroy(ctx, res)
 }
 

--- a/internal/providers/exoscale/securitygroups.go
+++ b/internal/providers/exoscale/securitygroups.go
@@ -250,21 +250,23 @@ func (p *Pack) detachInstanceFromSecurityGroup(w http.ResponseWriter, r *http.Re
 
 // changeInstanceMembership adds or removes one group-like resource on one
 // instance. Shared by security groups and elastic IPs, whose attach routes are
-// the same measured shape with different nouns.
-func (p *Pack) changeInstanceMembership(w http.ResponseWriter, r *http.Request, kind, noun, attr string, add bool) {
+// the same measured shape with different nouns. It reports the instance it
+// touched, so a caller with a side effect to apply — routing an elastic IP —
+// knows the membership really changed first.
+func (p *Pack) changeInstanceMembership(w http.ResponseWriter, r *http.Request, kind, noun, attr string, add bool) (instanceID string, ok bool) {
 	var req instanceTarget
 	if err := emulator.DecodeJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
-		return
+		return "", false
 	}
 	if req.Instance.ID == "" {
 		writeError(w, http.StatusBadRequest, "instance is required")
-		return
+		return "", false
 	}
 	id := r.PathValue("id")
-	if _, ok := p.env.Store.Get(Name, kind, id); !ok {
+	if _, found := p.env.Store.Get(Name, kind, id); !found {
 		writeError(w, http.StatusNotFound, "resource not found")
-		return
+		return "", false
 	}
 	err := p.env.Store.Update(Name, kindInstance, req.Instance.ID, func(stored *resource.Resource) error {
 		ids := stringList(stored.Attrs[attr])
@@ -283,9 +285,10 @@ func (p *Pack) changeInstanceMembership(w http.ResponseWriter, r *http.Request, 
 	})
 	if err != nil {
 		writeError(w, http.StatusNotFound, "resource not found")
-		return
+		return "", false
 	}
 	p.writeOperation(w, p.operationReferring(noun, id))
+	return req.Instance.ID, true
 }
 
 // securityGroupView is the measured shape: rules and external-sources are

--- a/internal/providers/outscale/machines.go
+++ b/internal/providers/outscale/machines.go
@@ -88,9 +88,17 @@ func (p *Pack) powerOn(ctx context.Context, res *resource.Resource) {
 		// Base64-encoded, so that is what a read must give back, and what
 		// cloud-init must never receive.
 		CloudInit: cloudinit.Decode(userData),
-		Labels:    map[string]string{"feint.vm": res.ID},
+		// The public address linked to this Vm, on the launch: a route edited
+		// onto a live OVN NIC re-plugs it and costs the guest its lease.
+		PublicAddresses: p.publicBootAddresses(res.ID),
+		Labels:          map[string]string{"feint.vm": res.ID},
 	})
 	p.rememberAddress(res)
+	// The boot installed the host half of the route; this hands the guest its
+	// address, and repairs a machine that already existed. Idempotent.
+	for _, address := range p.publicBootAddresses(res.ID) {
+		p.routeLinkedIP(ctx, address, res)
+	}
 }
 
 // rememberAddress keeps the private address on the resource, not only on the

--- a/internal/providers/outscale/netresources_test.go
+++ b/internal/providers/outscale/netresources_test.go
@@ -17,8 +17,8 @@ func TestAPublicIpIsAllocatedListedAndReleased(t *testing.T) {
 	ip, _ := created["PublicIp"].(map[string]any)
 	// Deterministic first address, from the documented-fictional TEST-NET-3
 	// block ReadPublicIpRanges publishes.
-	if ip["PublicIp"] != "203.0.113.1" {
-		t.Fatalf("first allocation = %v, want 203.0.113.1", ip["PublicIp"])
+	if ip["PublicIp"] != "198.51.100.1" {
+		t.Fatalf("first allocation = %v, want 198.51.100.1", ip["PublicIp"])
 	}
 	// Measured: an unlinked address is exactly {PublicIpId, PublicIp, Tags} —
 	// no Vm, Nic or NatService keys, not even empty ones.
@@ -30,18 +30,18 @@ func TestAPublicIpIsAllocatedListedAndReleased(t *testing.T) {
 
 	second := call(t, ts, doc, "CreatePublicIp", `{}`)
 	ip2, _ := second["PublicIp"].(map[string]any)
-	if ip2["PublicIp"] != "203.0.113.2" {
-		t.Fatalf("second allocation = %v, want 203.0.113.2", ip2["PublicIp"])
+	if ip2["PublicIp"] != "198.51.100.2" {
+		t.Fatalf("second allocation = %v, want 198.51.100.2", ip2["PublicIp"])
 	}
 
 	// The catalogue and the allocator answer from the same block.
 	ranges := call(t, ts, doc, "ReadPublicIpRanges", `{}`)
-	if list, _ := ranges["PublicIps"].([]any); len(list) != 1 || list[0] != "203.0.113.0/24" {
+	if list, _ := ranges["PublicIps"].([]any); len(list) != 1 || list[0] != "198.51.100.0/24" {
 		t.Fatalf("ReadPublicIpRanges does not publish the allocator's block: %v", ranges["PublicIps"])
 	}
 
 	// Deleting by address value, which the API accepts alongside the id.
-	call(t, ts, doc, "DeletePublicIp", `{"PublicIp":"203.0.113.1"}`)
+	call(t, ts, doc, "DeletePublicIp", `{"PublicIp":"198.51.100.1"}`)
 	left := call(t, ts, doc, "ReadPublicIps", `{}`)
 	if list, _ := left["PublicIps"].([]any); len(list) != 1 {
 		t.Fatalf("one address should remain: %v", left["PublicIps"])

--- a/internal/providers/outscale/publicip_routing_test.go
+++ b/internal/providers/outscale/publicip_routing_test.go
@@ -1,0 +1,229 @@
+package outscale_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/machine"
+	"github.com/stephrobert/feint/internal/providers/outscale"
+)
+
+// The public-IP plane, asserted through the runtime's arguments: a linked
+// address and a routed one look identical in JSON, and their difference is the
+// whole reason LinkPublicIp stopped being control-plane-only.
+
+// routedRuntime runs machines instantly and records what was booted, routed
+// and withdrawn.
+type routedRuntime struct {
+	mu       sync.Mutex
+	machines map[string]bool
+	specs    []machine.Spec
+	routed   []machine.AddressSpec
+	withdrew []string
+}
+
+func newRoutedRuntime() *routedRuntime {
+	return &routedRuntime{machines: map[string]bool{}}
+}
+
+func (r *routedRuntime) Name() string                   { return "routed-fake" }
+func (r *routedRuntime) Available(context.Context) bool { return true }
+
+func (r *routedRuntime) Start(_ context.Context, spec machine.Spec) (machine.Machine, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.specs = append(r.specs, spec)
+	r.machines[spec.Name] = true
+	return machine.Machine{Name: spec.Name, IP: "10.209.84.9", Running: true}, nil
+}
+
+func (r *routedRuntime) Stop(_ context.Context, n string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.machines[n] = false
+	return nil
+}
+
+func (r *routedRuntime) Remove(_ context.Context, n string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.machines, n)
+	return nil
+}
+
+func (r *routedRuntime) Inspect(_ context.Context, n string) (machine.Machine, bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	running, found := r.machines[n]
+	if !found {
+		return machine.Machine{}, false, nil
+	}
+	return machine.Machine{Name: n, IP: "10.209.84.9", Running: running}, true, nil
+}
+
+func (r *routedRuntime) EnsureNetwork(context.Context, machine.NetworkSpec) error { return nil }
+func (r *routedRuntime) Attach(context.Context, string, machine.Attachment) error { return nil }
+func (r *routedRuntime) RemoveNetwork(context.Context, string) error              { return nil }
+
+func (r *routedRuntime) RouteAddress(_ context.Context, spec machine.AddressSpec) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.routed = append(r.routed, spec)
+	return nil
+}
+
+func (r *routedRuntime) UnrouteAddress(_ context.Context, _, address string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.withdrew = append(r.withdrew, address)
+	return nil
+}
+
+func (r *routedRuntime) routedAddresses() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, 0, len(r.routed))
+	for _, spec := range r.routed {
+		out = append(out, spec.Address)
+	}
+	return out
+}
+
+func (r *routedRuntime) bootedAddresses() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := []string{}
+	for _, spec := range r.specs {
+		out = append(out, spec.PublicAddresses...)
+	}
+	return out
+}
+
+func (r *routedRuntime) withdrawn() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.withdrew...)
+}
+
+func newRoutedServer(t *testing.T) (*httptest.Server, *routedRuntime, *emulator.Env) {
+	t.Helper()
+	env := emulator.DefaultEnv()
+	rt := newRoutedRuntime()
+	env.Machines = rt
+	srv, err := emulator.NewServer(env, outscale.New(env))
+	if err != nil {
+		t.Fatalf("build emulator: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return ts, rt, env
+}
+
+func has(list []string, want string) bool {
+	for _, have := range list {
+		if have == want {
+			return true
+		}
+	}
+	return false
+}
+
+// aLinkedVm builds one running Vm carrying one linked public IP, and returns
+// both identifiers with the address.
+func aLinkedVm(t *testing.T, ts *httptest.Server) (vmID, ipID, address string) {
+	t.Helper()
+	_, out := post(t, ts, "CreatePublicIp", `{}`)
+	ip, _ := out["PublicIp"].(map[string]any)
+	ipID, _ = ip["PublicIpId"].(string)
+	address, _ = ip["PublicIp"].(string)
+	if address == "" {
+		t.Fatal("no address allocated")
+	}
+	_, out = post(t, ts, "CreateVms", `{"ImageId":"ami-00000001","VmType":"tinav6.c1r1p2"}`)
+	vms, _ := out["Vms"].([]any)
+	vm, _ := vms[0].(map[string]any)
+	vmID, _ = vm["VmId"].(string)
+	if status, body := post(t, ts, "LinkPublicIp",
+		`{"PublicIpId":"`+ipID+`","VmId":"`+vmID+`"}`); status != http.StatusOK {
+		t.Fatalf("link: %d %v", status, body)
+	}
+	return vmID, ipID, address
+}
+
+// A linked address reaches the machine: the link routes it at once, and the
+// next boot carries it as a launch key rather than a live edit.
+func TestLinkPublicIpRoutesTheAddress(t *testing.T) {
+	ts, rt, _ := newRoutedServer(t)
+	vmID, _, address := aLinkedVm(t, ts)
+
+	if !has(rt.routedAddresses(), address) {
+		t.Errorf("%s was linked and never routed: %v", address, rt.routedAddresses())
+	}
+
+	post(t, ts, "StopVms", `{"VmIds":["`+vmID+`"]}`)
+	post(t, ts, "StartVms", `{"VmIds":["`+vmID+`"]}`)
+	if !has(rt.bootedAddresses(), address) {
+		t.Errorf("the boot does not carry %s: a live route edit re-plugs an OVN NIC", address)
+	}
+}
+
+// Terminating the Vm releases its address, upstream's own behaviour: the
+// address stays allocated, stops naming the machine, and stops being routed —
+// on OVN the uplink route would otherwise outlive the machine.
+func TestTerminateReleasesTheLinkedPublicIp(t *testing.T) {
+	ts, rt, _ := newRoutedServer(t)
+	vmID, ipID, address := aLinkedVm(t, ts)
+
+	if status, body := post(t, ts, "DeleteVms", `{"VmIds":["`+vmID+`"]}`); status != http.StatusOK {
+		t.Fatalf("delete: %d %v", status, body)
+	}
+	if !has(rt.withdrawn(), address) {
+		t.Errorf("the address was not withdrawn on terminate: %v", rt.withdrawn())
+	}
+	_, out := post(t, ts, "ReadPublicIps", `{}`)
+	ips, _ := out["PublicIps"].([]any)
+	for _, entry := range ips {
+		ip, _ := entry.(map[string]any)
+		if ip["PublicIpId"] == ipID && ip["VmId"] != nil {
+			t.Errorf("the address still names the terminated Vm: %v", ip)
+		}
+	}
+}
+
+// A stored address is untrusted input: PUT /_feint/state restores it verbatim,
+// and routing an arbitrary value would send the host's traffic for that
+// address into a container. emulatedPublicIP is the authorisation half.
+func TestAPoisonedPublicIpIsNeverRouted(t *testing.T) {
+	ts, rt, env := newRoutedServer(t)
+
+	const poison = "10.76.154.1" // a host bridge gateway, well-formed and not ours
+
+	_, out := post(t, ts, "CreatePublicIp", `{}`)
+	ip, _ := out["PublicIp"].(map[string]any)
+	ipID, _ := ip["PublicIpId"].(string)
+	stored, found := env.Store.Get(outscale.Name, "publicip", ipID)
+	if !found {
+		t.Fatal("the public IP is not in the store")
+	}
+	stored.Attrs["PublicIp"] = poison
+	env.Store.Commit(stored, env.Now())
+
+	_, out = post(t, ts, "CreateVms", `{"ImageId":"ami-00000001","VmType":"tinav6.c1r1p2"}`)
+	vms, _ := out["Vms"].([]any)
+	vm, _ := vms[0].(map[string]any)
+	vmID, _ := vm["VmId"].(string)
+	post(t, ts, "LinkPublicIp", `{"PublicIpId":"`+ipID+`","VmId":"`+vmID+`"}`)
+	post(t, ts, "StopVms", `{"VmIds":["`+vmID+`"]}`)
+	post(t, ts, "StartVms", `{"VmIds":["`+vmID+`"]}`)
+
+	if has(rt.routedAddresses(), poison) {
+		t.Errorf("the poisoned address reached the driver: %v", rt.routedAddresses())
+	}
+	if has(rt.bootedAddresses(), poison) {
+		t.Errorf("the poisoned address rode a boot: %v", rt.bootedAddresses())
+	}
+}

--- a/internal/providers/outscale/publicips.go
+++ b/internal/providers/outscale/publicips.go
@@ -1,29 +1,42 @@
 package outscale
 
 import (
+	"context"
 	"fmt"
 	"net/http"
+	"net/netip"
 	"strings"
 
 	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/machine"
 	"github.com/stephrobert/feint/internal/core/resource"
 )
 
 // Public IPs: allocate, list, release.
 //
-// The addresses come from 203.0.113.0/24 — TEST-NET-3, reserved by RFC 5737 for
-// documentation and never routed. An emulator that handed out addresses from a
-// real public block would let a test half-work against the real internet, which
-// is worse than an address that visibly goes nowhere. ReadPublicIpRanges
-// publishes the same block, so the catalogue and the allocator cannot disagree.
+// The addresses come from 198.51.100.0/24 — TEST-NET-2, reserved by RFC 5737
+// for documentation and never routed. An emulator that handed out addresses
+// from a real public block would let a test half-work against the real
+// internet, which is worse than an address that visibly goes nowhere.
+// ReadPublicIpRanges publishes the same block, so the catalogue and the
+// allocator cannot disagree.
 //
-// LinkPublicIp and UnlinkPublicIp are served in the CONTROL PLANE ONLY: the
-// record moves, no packet does. They were declined at first on the argument that
-// publishing an address is the runtime's job — defensible, and wrong on the
-// evidence: the provider's own examples/net_vm fixture holds an
-// `outscale_public_ip_link`, so the refusal failed the apply partway through and
-// left the twelve other resources unproven. A stated limit beats an apply that
-// cannot finish; docs/limits.md carries it.
+// TEST-NET-2 and not TEST-NET-3, which every pack used to draw from: a linked
+// address is routed on the host now, and one host serves three emulated
+// clouds, so two packs handing out the same "public" /32 would route it to
+// two machines and let ARP order pick the winner. RFC 5737 reserves exactly
+// three blocks; each pack owns one (Scaleway keeps TEST-NET-3, Exoscale takes
+// TEST-NET-1), and the guard of each refuses the other two.
+//
+// LinkPublicIp and UnlinkPublicIp move the record AND the packet: a linked
+// address is routed to the Vm's machine the way a Scaleway flexible IP is, so
+// `ssh outscale@<PublicIp>` opens a shell — that is the address a real
+// Outscale user logs into, and for a long time this pack only moved the
+// record. The limit was real while machines sat on the operator's default
+// profile bridge, which the driver rightly refuses to route through; the
+// machines live on emulator-owned networks now, and the limit went with it.
+// (They were declined even earlier, which failed the provider's own
+// examples/net_vm fixture partway through its apply.)
 //
 // Shape measured (X-2 sweep, 2026-08-08): an unlinked address carries exactly
 // PublicIp, PublicIpId and Tags — no Vm/Nic/NatService keys, not even empty.
@@ -34,7 +47,96 @@ const kindPublicIP = "publicip"
 
 // publicIPBase is the fictional block addresses are allocated from,
 // sequentially from .1: deterministic, so a test can pin the first address.
-const publicIPBase = "203.0.113."
+const publicIPBase = "198.51.100."
+
+// publicIPBlock is the same block as a prefix, for the guard below.
+const publicIPBlock = "198.51.100.0/24"
+
+// emulatedPublicIP reports whether an address is one this pack can have handed
+// out: inside publicIPBlock. It is the authorisation half on the way to the
+// driver — a stored address is restored verbatim by PUT /_feint/state and
+// `feint snapshot load`, and routing an arbitrary value would send the host's
+// traffic for that address into a container.
+// TestAPoisonedPublicIpIsNeverRouted fails without it.
+func emulatedPublicIP(address string) bool {
+	prefix, err := netip.ParsePrefix(publicIPBlock)
+	if err != nil {
+		return false
+	}
+	addr, err := netip.ParseAddr(address)
+	if err != nil {
+		return false
+	}
+	return prefix.Contains(addr)
+}
+
+// routeLinkedIP makes a linked public address reach the Vm's machine, the way
+// the real cloud routes an EIP to its instance. LinkPublicIp used to move the
+// record and no packet — a stated limit while nothing on the host could carry
+// the address; the machines sit on emulator-owned networks now, so the limit
+// stopped being one. Degrades quietly, like every runtime call in this pack.
+// TestLinkPublicIpRoutesTheAddress fails without it.
+func (p *Pack) routeLinkedIP(ctx context.Context, address string, vm *resource.Resource) {
+	router, ok := p.env.Machines.(machine.Router)
+	if !ok {
+		return
+	}
+	name := vm.Runtime[p.binding().RuntimeKey]
+	if name == "" || address == "" {
+		return
+	}
+	if !emulatedPublicIP(address) {
+		p.logger().Warn("refusing to route an address outside the emulated public block",
+			"address", address, "vm", vm.ID)
+		return
+	}
+	if err := router.RouteAddress(ctx, machine.AddressSpec{Machine: name, Address: address}); err != nil {
+		p.logger().Error("could not route the public IP to the machine",
+			"address", address, "vm", vm.ID, "error", err)
+	}
+}
+
+// unrouteLinkedIP takes the route back. The machine may already be gone; the
+// driver treats that as nothing left to undo, and on OVN it still withdraws
+// the uplink route, which outlives the machine.
+func (p *Pack) unrouteLinkedIP(ctx context.Context, address string, vm *resource.Resource) {
+	router, ok := p.env.Machines.(machine.Router)
+	if !ok || !emulatedPublicIP(address) {
+		return
+	}
+	machineName := ""
+	if vm != nil {
+		machineName = vm.Runtime[p.binding().RuntimeKey]
+	}
+	if err := router.UnrouteAddress(ctx, machineName, address); err != nil {
+		p.logger().Error("could not stop routing the public IP",
+			"address", address, "error", err)
+	}
+}
+
+// publicBootAddresses is what a Vm's machine must answer on from its first
+// boot: the public address linked to it, when one is. On the launch rather
+// than routed afterwards, because editing a live OVN NIC re-plugs it.
+func (p *Pack) publicBootAddresses(vmID string) []string {
+	if address := p.publicIPOf(vmID); emulatedPublicIP(address) {
+		return []string{address}
+	}
+	return nil
+}
+
+// releaseVmPublicIPs unlinks and unroutes every public address a Vm holds,
+// which is what terminating the Vm does upstream: the address stays allocated,
+// and stops naming a machine that no longer exists.
+// TestTerminateReleasesTheLinkedPublicIp fails without it.
+func (p *Pack) releaseVmPublicIPs(ctx context.Context, vm *resource.Resource) {
+	for _, address := range p.env.Store.List(kindPublicIP, resource.Tenant{Provider: Name}) {
+		if stringOf(address.Attrs["VmId"]) != vm.ID {
+			continue
+		}
+		p.unrouteLinkedIP(ctx, stringOf(address.Attrs["PublicIp"]), vm)
+		p.releasePublicIP(address)
+	}
+}
 
 func (p *Pack) createPublicIP(w http.ResponseWriter, r *http.Request) {
 	var req struct {
@@ -156,6 +258,13 @@ func (p *Pack) deletePublicIP(w http.ResponseWriter, r *http.Request) {
 		p.conflict(w, "the public IP "+res.ID+" is held by "+natID)
 		return
 	}
+	// A linked address is unrouted before its record vanishes, or the machine
+	// keeps answering on an address the API no longer describes.
+	if vmID := stringOf(res.Attrs["VmId"]); vmID != "" {
+		if vm, found := p.env.Store.Get(Name, kindVM, vmID); found {
+			p.unrouteLinkedIP(r.Context(), stringOf(res.Attrs["PublicIp"]), vm)
+		}
+	}
 	p.env.Store.Delete(Name, kindPublicIP, res.ID)
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{"ResponseContext": p.context()})
 }
@@ -187,15 +296,15 @@ func publicIPView(res *resource.Resource) map[string]any {
 	return out
 }
 
-// linkPublicIP attaches an address to a machine, in the control plane only.
+// linkPublicIP attaches an address to a machine, and routes it there: with a
+// runtime on, the linked address answers from the host, filtered like any
+// other traffic to the machine. The address still comes from the
+// documented-fictional block, so it answers this host and nothing beyond it.
 //
-// What this does NOT do is route a packet, and saying so is the point: the
-// address comes from a documented-fictional block, nothing on the host carries
-// it, and no NAT rule is written. docs/limits.md records it. The reason it is
-// served rather than declined is measured: the provider's own examples/net_vm
-// fixture holds an `outscale_public_ip_link`, so declining it fails the apply on
-// the eleventh resource of thirteen — and an apply that cannot complete proves
-// nothing about the twelve that worked.
+// The reason it is served rather than declined is measured: the provider's own
+// examples/net_vm fixture holds an `outscale_public_ip_link`, so declining it
+// fails the apply on the eleventh resource of thirteen — and an apply that
+// cannot complete proves nothing about the twelve that worked.
 //
 // The fields it fills come from the read sweep: an address linked to a machine
 // answers with VmId, NicId, NicAccountId and PrivateIp beside its own.
@@ -254,6 +363,14 @@ func (p *Pack) linkPublicIP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Moving the address means taking it back first: the route lives on the
+	// previous machine, and two machines claiming one /32 answer by ARP order.
+	if holder := stringOf(address.Attrs["VmId"]); holder != "" && holder != req.VMID {
+		if previous, found := p.env.Store.Get(Name, kindVM, holder); found {
+			p.unrouteLinkedIP(r.Context(), stringOf(address.Attrs["PublicIp"]), previous)
+		}
+	}
+
 	linkID := newID("eipassoc", p.env.NewID())
 	address.Attrs["VmId"] = req.VMID
 	address.Attrs["NicId"] = nicID
@@ -264,6 +381,13 @@ func (p *Pack) linkPublicIP(w http.ResponseWriter, r *http.Request) {
 	if !p.env.Store.Commit(address, p.env.Now()) {
 		p.notFound(w, "public IP", address.ID)
 		return
+	}
+	// The record moved; now the packet does too. A link to a bare NicId names
+	// no machine, so only the VmId form routes.
+	if req.VMID != "" {
+		if vm, found := p.env.Store.Get(Name, kindVM, req.VMID); found {
+			p.routeLinkedIP(r.Context(), stringOf(address.Attrs["PublicIp"]), vm)
+		}
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
 		"LinkPublicIpId":  linkID,
@@ -288,6 +412,11 @@ func (p *Pack) unlinkPublicIP(w http.ResponseWriter, r *http.Request) {
 		}
 		if linked != req.LinkPublicIPID && stringOf(address.Attrs["PublicIp"]) != req.PublicIP {
 			continue
+		}
+		// The route goes with the record: an address that stays routed after
+		// its unlink shadows the next machine it is linked to.
+		if vm, found := p.env.Store.Get(Name, kindVM, stringOf(address.Attrs["VmId"])); found {
+			p.unrouteLinkedIP(r.Context(), stringOf(address.Attrs["PublicIp"]), vm)
 		}
 		p.releasePublicIP(address)
 		emulator.WriteJSON(w, http.StatusOK, map[string]any{"ResponseContext": p.context()})

--- a/internal/providers/outscale/vms.go
+++ b/internal/providers/outscale/vms.go
@@ -670,6 +670,11 @@ func (p *Pack) deleteVms(w http.ResponseWriter, r *http.Request) {
 			defer unlock()
 
 			previous := res.State
+			// Terminating releases the machine's public address, which is
+			// upstream's own behaviour: the address stays allocated and stops
+			// naming a machine that no longer exists. It must precede the
+			// destroy, because on OVN the uplink route outlives the machine.
+			p.releaseVmPublicIPs(r.Context(), res)
 			p.removeMachine(r.Context(), res)
 			// Terminated, not removed. The machine is destroyed, and the record
 			// stays readable: the Terraform provider answers DeleteVms by

--- a/internal/providers/scaleway/address_routing_test.go
+++ b/internal/providers/scaleway/address_routing_test.go
@@ -1,0 +1,270 @@
+package scaleway_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/machine"
+	"github.com/stephrobert/feint/internal/core/store"
+	"github.com/stephrobert/feint/internal/providers/scaleway"
+)
+
+// The addressing plane, asserted through the runtime's arguments, because the
+// API cannot witness for itself here: a published address and a routed one look
+// identical in JSON, and #116 was exactly their difference — an address
+// attached at create was published, pinned nowhere, and answered nothing.
+
+// addressRuntime is a fakeRuntime that also records what was booted, routed and
+// withdrawn, which is the whole story of a public address.
+type addressRuntime struct {
+	*fakeRuntime
+
+	mu       sync.Mutex
+	specs    []machine.Spec
+	routed   []machine.AddressSpec
+	withdrew []string
+}
+
+func newAddressRuntime() *addressRuntime {
+	rt := &addressRuntime{fakeRuntime: newFakeRuntime()}
+	close(rt.release) // nothing here needs to block
+	return rt
+}
+
+func (r *addressRuntime) Start(ctx context.Context, spec machine.Spec) (machine.Machine, error) {
+	r.mu.Lock()
+	r.specs = append(r.specs, spec)
+	r.mu.Unlock()
+	return r.fakeRuntime.Start(ctx, spec)
+}
+
+func (r *addressRuntime) RouteAddress(_ context.Context, spec machine.AddressSpec) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.routed = append(r.routed, spec)
+	return nil
+}
+
+func (r *addressRuntime) UnrouteAddress(_ context.Context, _, address string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.withdrew = append(r.withdrew, address)
+	return nil
+}
+
+func (r *addressRuntime) routedAddresses() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, 0, len(r.routed))
+	for _, spec := range r.routed {
+		out = append(out, spec.Address)
+	}
+	return out
+}
+
+func (r *addressRuntime) bootedAddresses() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := []string{}
+	for _, spec := range r.specs {
+		out = append(out, spec.PublicAddresses...)
+	}
+	return out
+}
+
+func (r *addressRuntime) withdrawn() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.withdrew...)
+}
+
+// newAddressTestServer is newRuntimeTestServer with the env kept in reach, so a
+// test can poison the store the way a restored snapshot would.
+func newAddressTestServer(t testing.TB, drv machine.Driver) (*httptest.Server, *emulator.Env) {
+	t.Helper()
+
+	var seq atomic.Int64
+	env := &emulator.Env{
+		Store:    store.New(),
+		Machines: drv,
+		Now:      func() time.Time { return time.Unix(1700000000, 0).UTC() },
+		NewID: func() string {
+			return fmt.Sprintf("00000000-0000-4000-8000-%012d", seq.Add(1))
+		},
+	}
+	srv, err := emulator.NewServer(env, scaleway.New(env))
+	if err != nil {
+		t.Fatalf("build emulator: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return ts, env
+}
+
+func contains(list []string, want string) bool {
+	for _, have := range list {
+		if have == want {
+			return true
+		}
+	}
+	return false
+}
+
+// An address attached at create must be routed once the machine exists.
+//
+// This is #116: attachAddress ran while the server had no machine, silently did
+// nothing, and nothing replayed it at poweron — so the API published an address
+// no packet could reach. Both halves are asserted: the boot carries the address
+// (so the route precedes the first boot instead of re-plugging a live NIC), and
+// the replay hands the guest its address.
+func TestPowerOnRoutesAnAddressAttachedBeforeBoot(t *testing.T) {
+	rt := newAddressRuntime()
+	ts, _ := newAddressTestServer(t, rt)
+
+	_, out := do(t, ts, "POST", zone+"/ips", `{}`)
+	ip, _ := out["ip"].(map[string]any)
+	ipID, _ := ip["id"].(string)
+	address, _ := ip["address"].(string)
+	if address == "" {
+		t.Fatal("no address allocated")
+	}
+
+	_, out = do(t, ts, "POST", zone+"/servers",
+		`{"name":"carrier","commercial_type":"DEV1-S","image":"ubuntu_jammy","public_ip":"`+ipID+`"}`)
+	srv, _ := out["server"].(map[string]any)
+	id, _ := srv["id"].(string)
+
+	if status, body := do(t, ts, "POST", zone+"/servers/"+id+"/action",
+		`{"action":"poweron"}`); status != http.StatusAccepted {
+		t.Fatalf("poweron: %d %v", status, body)
+	}
+
+	if !contains(rt.bootedAddresses(), address) {
+		t.Errorf("the boot does not carry %s: the route would be a live edit, which re-plugs an OVN NIC", address)
+	}
+	if !contains(rt.routedAddresses(), address) {
+		t.Errorf("%s was published and never routed: routed %v", address, rt.routedAddresses())
+	}
+}
+
+// dynamic_ip_required allocates at poweron, publishes as a dynamic ServerIP,
+// never shows in /ips, and releases on stop — which is #117: the flag was
+// decoded, echoed back, and read by nobody.
+func TestADynamicAddressFollowsThePowerCycle(t *testing.T) {
+	rt := newAddressRuntime()
+	ts, _ := newAddressTestServer(t, rt)
+
+	_, out := do(t, ts, "POST", zone+"/servers",
+		`{"name":"ephemeral","commercial_type":"DEV1-S","image":"ubuntu_jammy","dynamic_ip_required":true}`)
+	srv, _ := out["server"].(map[string]any)
+	id, _ := srv["id"].(string)
+
+	do(t, ts, "POST", zone+"/servers/"+id+"/action", `{"action":"poweron"}`)
+
+	_, out = do(t, ts, "GET", zone+"/servers/"+id, "")
+	srv, _ = out["server"].(map[string]any)
+	ips, _ := srv["public_ips"].([]any)
+	if len(ips) != 1 {
+		t.Fatalf("a powered-on dynamic server publishes %d addresses, want 1: %v", len(ips), srv["public_ips"])
+	}
+	entry, _ := ips[0].(map[string]any)
+	address, _ := entry["address"].(string)
+	if dynamic, _ := entry["dynamic"].(bool); !dynamic {
+		t.Errorf("the address is not marked dynamic: %v", entry)
+	}
+	if !strings.HasPrefix(address, "203.0.113.") {
+		t.Errorf("dynamic address %q is outside the emulated public block", address)
+	}
+	if entry["id"] == "" || entry["id"] == nil {
+		t.Errorf("the dynamic address carries no id: %v", entry)
+	}
+	// The singular field the CLI renders follows the list.
+	if first, _ := srv["public_ip"].(map[string]any); first == nil || first["address"] != address {
+		t.Errorf("public_ip does not carry the dynamic address: %v", srv["public_ip"])
+	}
+	if !contains(rt.routedAddresses(), address) {
+		t.Errorf("the dynamic address was published and never routed")
+	}
+
+	// Not a flexible IP: upstream never lists it in /ips.
+	_, out = do(t, ts, "GET", zone+"/ips", "")
+	if listed, _ := out["ips"].([]any); len(listed) != 0 {
+		t.Errorf("the dynamic address leaked into /ips: %v", listed)
+	}
+
+	// The allocator sees it: the next flexible IP must not collide.
+	_, out = do(t, ts, "POST", zone+"/ips", `{}`)
+	flexible, _ := out["ip"].(map[string]any)
+	if flexible["address"] == address {
+		t.Errorf("a flexible IP received the dynamic address %s: the allocator cannot see dynamic ones", address)
+	}
+
+	// Released on stop, withdrawn from the machine, gone from the view.
+	do(t, ts, "POST", zone+"/servers/"+id+"/action", `{"action":"poweroff"}`)
+	if !contains(rt.withdrawn(), address) {
+		t.Errorf("the dynamic address was not withdrawn on poweroff: %v", rt.withdrawn())
+	}
+	_, out = do(t, ts, "GET", zone+"/servers/"+id, "")
+	srv, _ = out["server"].(map[string]any)
+	if ips, _ := srv["public_ips"].([]any); len(ips) != 0 {
+		t.Errorf("a stopped dynamic server still publishes %v", ips)
+	}
+	if srv["public_ip"] != nil {
+		t.Errorf("public_ip survives the stop: %v", srv["public_ip"])
+	}
+}
+
+// A stored address is untrusted input: PUT /_feint/state and `feint snapshot
+// load` restore it verbatim, and routing it verbatim would send the host's
+// traffic for an arbitrary address — an operator's LAN peer, a real service —
+// into a container. Well-formed is not authorised; emulatedAddress is the
+// authorisation half, and this holds it on both stored paths.
+func TestAPoisonedStoredAddressIsNeverRouted(t *testing.T) {
+	rt := newAddressRuntime()
+	ts, env := newAddressTestServer(t, rt)
+
+	const poison = "10.76.154.1" // a host bridge gateway, well-formed and not ours
+
+	_, out := do(t, ts, "POST", zone+"/servers",
+		`{"name":"victim","commercial_type":"DEV1-S","image":"ubuntu_jammy"}`)
+	srv, _ := out["server"].(map[string]any)
+	id, _ := srv["id"].(string)
+	do(t, ts, "POST", zone+"/servers/"+id+"/action", `{"action":"poweron"}`)
+
+	// A flexible IP whose stored address a snapshot rewrote.
+	_, out = do(t, ts, "POST", zone+"/ips", `{}`)
+	ip, _ := out["ip"].(map[string]any)
+	ipID, _ := ip["id"].(string)
+	stored, found := env.Store.Get(scaleway.Name, "instance/ip", ipID)
+	if !found {
+		t.Fatal("the flexible IP is not in the store")
+	}
+	stored.Attrs["address"] = poison
+	env.Store.Commit(stored, time.Unix(1700000001, 0))
+
+	do(t, ts, "PATCH", zone+"/ips/"+ipID, `{"server":"`+id+`"}`)
+
+	// A dynamic address a snapshot rewrote, replayed by the next poweron.
+	server, found := env.Store.Get(scaleway.Name, "instance/server", id)
+	if !found {
+		t.Fatal("the server is not in the store")
+	}
+	server.Runtime["dynamic-ip"] = poison
+	env.Store.Commit(server, time.Unix(1700000002, 0))
+	do(t, ts, "POST", zone+"/servers/"+id+"/action", `{"action":"reboot"}`)
+
+	if contains(rt.routedAddresses(), poison) {
+		t.Errorf("the poisoned address %s reached the driver: routed %v", poison, rt.routedAddresses())
+	}
+	if contains(rt.bootedAddresses(), poison) {
+		t.Errorf("the poisoned address %s rode a boot: %v", poison, rt.bootedAddresses())
+	}
+}

--- a/internal/providers/scaleway/ips.go
+++ b/internal/providers/scaleway/ips.go
@@ -138,7 +138,74 @@ func (p *Pack) allocateFlexibleAddress() (netip.Addr, error) {
 			}
 		}
 	}
+	// Dynamic addresses draw from the same block, and live on the server rather
+	// than as IP resources — upstream, a dynamic address is not a flexible IP
+	// and never appears in /ips. Skipping them here would hand a flexible IP an
+	// address a running server already answers on.
+	for _, srv := range p.env.Store.List(kindServer, resource.Tenant{Provider: Name}) {
+		if taken := srv.Runtime[runtimeDynamicIPKey]; taken != "" {
+			if addr, err := netip.ParseAddr(taken); err == nil {
+				_ = alloc.Reserve(addr)
+			}
+		}
+	}
 	return alloc.Allocate()
+}
+
+// emulatedAddress reports whether an address is one this pack can have handed
+// out: inside flexibleBlock.
+//
+// It is the gate every address must pass on its way to the driver, and it
+// exists because the values it filters come from the store: a flexible IP's
+// address and a server's dynamic address are restored verbatim by
+// PUT /_feint/state and `feint snapshot load`. Routing an arbitrary address to
+// a machine would make the host send its traffic for that address — an
+// operator's LAN peer, a real service — into a container. Well-formed is not
+// authorised; this is the authorisation half.
+//
+// TestAPoisonedStoredAddressIsNeverRouted fails without it.
+func emulatedAddress(address string) bool {
+	prefix, err := netip.ParsePrefix(flexibleBlock)
+	if err != nil {
+		return false
+	}
+	addr, err := netip.ParseAddr(address)
+	if err != nil {
+		return false
+	}
+	return prefix.Contains(addr)
+}
+
+// attachedIPsOf lists the flexible IPs attached to a server. One walk for the
+// view, the release path, the boot and the replay — four callers, one loop,
+// because the copies had already started to disagree once (an audit found the
+// create path and updateIP setting different halves of the same link).
+func (p *Pack) attachedIPsOf(serverID, zone string) []*resource.Resource {
+	out := make([]*resource.Resource, 0, 1)
+	for _, ip := range p.env.Store.List(kindIP, resource.Tenant{Provider: Name, Zone: zone}) {
+		attached, _ := ip.Attrs["server"].(map[string]any)
+		if attached != nil && attached["id"] == serverID {
+			out = append(out, ip)
+		}
+	}
+	return out
+}
+
+// publicAddressesOf is every public address the server has been promised: its
+// attached flexible IPs, and the dynamic address when it holds one. This is
+// what rides the launch, so the machine answers on them from its first boot.
+func (p *Pack) publicAddressesOf(server *resource.Resource) []string {
+	ips := p.attachedIPsOf(server.ID, server.Tenant.Zone)
+	out := make([]string, 0, len(ips)+1)
+	for _, ip := range ips {
+		if address, _ := ip.Attrs["address"].(string); emulatedAddress(address) {
+			out = append(out, address)
+		}
+	}
+	if address := server.Runtime[runtimeDynamicIPKey]; emulatedAddress(address) {
+		out = append(out, address)
+	}
+	return out
 }
 
 func (p *Pack) listIPs(w http.ResponseWriter, r *http.Request) {
@@ -260,13 +327,28 @@ func (p *Pack) updateIP(w http.ResponseWriter, r *http.Request) {
 // Degrades quietly, like every other runtime call in this pack: the control
 // plane keeps describing the attachment, and the log says why nothing answers.
 func (p *Pack) attachAddress(ctx context.Context, ip, server *resource.Resource) {
+	address, _ := ip.Attrs["address"].(string)
+	p.routeAddress(ctx, address, server)
+}
+
+// routeAddress routes one public address — flexible or dynamic — to the
+// server's machine. Idempotent by the Router contract, which is what lets the
+// poweron replay call it on addresses the launch already installed.
+func (p *Pack) routeAddress(ctx context.Context, address string, server *resource.Resource) {
 	router, ok := p.env.Machines.(machine.Router)
 	if !ok {
 		return
 	}
 	name := server.Runtime[runtimeMachineKey]
-	address, _ := ip.Attrs["address"].(string)
 	if name == "" || address == "" {
+		return
+	}
+	// A stored address is untrusted input: a restored snapshot carries it
+	// verbatim, and routing an arbitrary value would send the host's traffic
+	// for that address into a container. See emulatedAddress.
+	if !emulatedAddress(address) {
+		p.logger().Warn("refusing to route an address outside the emulated public block",
+			"address", address, "server", server.ID)
 		return
 	}
 	// On the network the server lives on, when it has one: a public address on
@@ -277,8 +359,28 @@ func (p *Pack) attachAddress(ctx context.Context, ip, server *resource.Resource)
 		Address: address,
 		Network: p.privateNetworkNameOf(server),
 	}); err != nil {
-		p.logger().Error("could not route the flexible IP to the machine",
-			"ip", ip.ID, "address", address, "server", server.ID, "error", err)
+		p.logger().Error("could not route the public address to the machine",
+			"address", address, "server", server.ID, "error", err)
+	}
+}
+
+// routeServerAddresses (re)routes every public address a server holds.
+//
+// Called after the machine exists: at poweron, and on the read that discovers
+// a late address. The boot itself installs the host half (the route keys ride
+// the launch); this replay is what hands the guest its addresses, and what
+// repairs a machine that already existed with different attachments.
+//
+// It is the missing half of #116: an address attached at create was recorded
+// and never routed, because attachAddress ran while the server had no machine
+// and nothing replayed it once one existed.
+// TestPowerOnRoutesAnAddressAttachedBeforeBoot fails without it.
+func (p *Pack) routeServerAddresses(ctx context.Context, res *resource.Resource) {
+	for _, ip := range p.attachedIPsOf(res.ID, res.Tenant.Zone) {
+		p.attachAddress(ctx, ip, res)
+	}
+	if address := res.Runtime[runtimeDynamicIPKey]; address != "" {
+		p.routeAddress(ctx, address, res)
 	}
 }
 
@@ -355,14 +457,87 @@ func ipView(res *resource.Resource) map[string]any {
 //
 // TestDeletingAServerReleasesItsAddresses fails without this.
 func (p *Pack) releaseAddressesOf(ctx context.Context, serverID, zone string) {
-	for _, ip := range p.env.Store.List(kindIP, resource.Tenant{Provider: Name, Zone: zone}) {
-		attached, _ := ip.Attrs["server"].(map[string]any)
-		if attached == nil || attached["id"] != serverID {
-			continue
-		}
+	for _, ip := range p.attachedIPsOf(serverID, zone) {
 		p.detachAddress(ctx, ip)
 		ip.Attrs["server"] = nil
 		ip.State = "detached"
 		p.env.Store.Commit(ip, p.env.Now())
+	}
+}
+
+// ---- Dynamic addresses ------------------------------------------------------
+//
+// `dynamic_ip_required` upstream gives the server an ephemeral public address
+// at poweron and takes it back when the server stops; the address is not a
+// flexible IP and never appears in /ips. The pack used to decode the flag,
+// echo it back, and allocate nothing — which no report could see, because the
+// field *was* read (#117).
+
+// runtimeDynamicIPKey is where a server's dynamic address is kept, and
+// runtimeDynamicIPIDKey the identifier public_ips publishes for it. Runtime,
+// not Attrs: the address is surfaced through the ServerIP view only, the way
+// the machine name and the runtime address already are.
+const (
+	runtimeDynamicIPKey   = "dynamic-ip"
+	runtimeDynamicIPIDKey = "dynamic-ip-id"
+)
+
+// ensureDynamicAddress allocates the ephemeral address a poweron owes a server
+// whose dynamic_ip_required is set, when no flexible IP already covers it —
+// upstream's own precedence: a reserved address suppresses the dynamic one.
+//
+// The allocation is committed to the store at once, not left for the caller's
+// final write-back: the allocator is rebuilt from the store, and a machine
+// takes seconds to boot, so an uncommitted reservation is an address a
+// concurrent POST /ips hands out a second time.
+func (p *Pack) ensureDynamicAddress(res *resource.Resource) {
+	if want, _ := res.Attrs["dynamic_ip_required"].(bool); !want {
+		return
+	}
+	if res.Runtime[runtimeDynamicIPKey] != "" {
+		return
+	}
+	if len(p.attachedIPsOf(res.ID, res.Tenant.Zone)) > 0 {
+		return
+	}
+
+	p.addresses.Lock()
+	defer p.addresses.Unlock()
+	address, err := p.allocateFlexibleAddress()
+	if err != nil {
+		p.logger().Error("could not allocate a dynamic address",
+			"server", res.ID, "error", err)
+		return
+	}
+	if res.Runtime == nil {
+		res.Runtime = map[string]string{}
+	}
+	res.Runtime[runtimeDynamicIPKey] = address.String()
+	res.Runtime[runtimeDynamicIPIDKey] = p.env.NewID()
+	p.env.Store.Commit(res, p.env.Now())
+}
+
+// releaseDynamicAddress takes the ephemeral address back: on poweroff, standby,
+// terminate and delete alike. Upstream releases it on stop — it is the whole
+// difference between dynamic and flexible — and holding it here would publish
+// an address a stopped machine no longer answers on.
+//
+// The store write stays with the caller, which either commits the resource or
+// deletes it; what must not wait is the unroute, because on OVN the uplink
+// route outlives the machine.
+func (p *Pack) releaseDynamicAddress(ctx context.Context, res *resource.Resource) {
+	address := res.Runtime[runtimeDynamicIPKey]
+	if address == "" {
+		return
+	}
+	delete(res.Runtime, runtimeDynamicIPKey)
+	delete(res.Runtime, runtimeDynamicIPIDKey)
+	router, ok := p.env.Machines.(machine.Router)
+	if !ok || !emulatedAddress(address) {
+		return
+	}
+	if err := router.UnrouteAddress(ctx, res.Runtime[runtimeMachineKey], address); err != nil {
+		p.logger().Error("could not stop routing the dynamic address",
+			"address", address, "server", res.ID, "error", err)
 	}
 }

--- a/internal/providers/scaleway/machines.go
+++ b/internal/providers/scaleway/machines.go
@@ -102,6 +102,11 @@ func (p *Pack) startMachine(ctx context.Context, res *resource.Resource) {
 		// bridge alone while the API published an address on a private network
 		// it had never joined.
 		Attachments: p.attachmentsOf(res),
+		// So do the public addresses it was promised — flexible IPs attached
+		// before the boot, and the dynamic one when the flag asked for it. On
+		// the launch, not routed afterwards: editing a live OVN NIC re-plugs it
+		// and the guest loses its DHCP lease (#116).
+		PublicAddresses: p.publicAddressesOf(res),
 		Labels: map[string]string{
 			"feint.server": res.ID,
 			"feint.zone":   res.Tenant.Zone,

--- a/internal/providers/scaleway/servers.go
+++ b/internal/providers/scaleway/servers.go
@@ -386,11 +386,17 @@ func (p *Pack) getServer(w http.ResponseWriter, r *http.Request) {
 	}
 	// A virtual machine gets its address after it boots, so a read is where it
 	// becomes visible.
-	if p.refreshMachine(r.Context(), res) && !p.env.Store.Commit(res, p.env.Now()) {
-		// Deleted while its address was being discovered. Answering the copy we
-		// hold would hand the client a server the next read denies.
-		writeNotFound(w, "server", id)
-		return
+	if p.refreshMachine(r.Context(), res) {
+		if !p.env.Store.Commit(res, p.env.Now()) {
+			// Deleted while its address was being discovered. Answering the copy
+			// we hold would hand the client a server the next read denies.
+			writeNotFound(w, "server", id)
+			return
+		}
+		// The machine just proved reachable, so the guest half of its public
+		// addresses can finally land — a virtual machine's agent answers long
+		// after poweron returned. Idempotent for a machine already served.
+		p.routeServerAddresses(r.Context(), res)
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{"server": p.view(res)})
 }
@@ -478,6 +484,9 @@ func (p *Pack) deleteServer(w http.ResponseWriter, r *http.Request) {
 		writeTransientState(w, "server", id, res.State)
 		return
 	}
+	// A stopped server should hold no dynamic address; a restored snapshot may
+	// claim otherwise, and the OVN uplink route would outlive the machine.
+	p.releaseDynamicAddress(r.Context(), res)
 	p.removeMachine(r.Context(), res)
 	p.env.Store.Delete(Name, kindServer, id)
 	p.releaseServerResources(r.Context(), id, zone)
@@ -553,6 +562,10 @@ func (p *Pack) serverAction(w http.ResponseWriter, r *http.Request) {
 		// that is not up. reboot is deliberately not covered: acting on a
 		// running machine is its whole purpose.
 		if req.Action == "reboot" || res.State != "running" {
+			// The ephemeral address dynamic_ip_required asks for, allocated
+			// before the boot so it rides the launch like an attached flexible
+			// IP does.
+			p.ensureDynamicAddress(res)
 			// The state is the binding's to set, not this switch's. With no
 			// runtime the server reaches running, which is the documented
 			// degraded mode; with a runtime that failed to start the machine it
@@ -564,6 +577,11 @@ func (p *Pack) serverAction(w http.ResponseWriter, r *http.Request) {
 			// edited still gets the current rules, because every group mutation
 			// replays onto the machines carrying it.
 			p.applyServerFirewall(r.Context(), res)
+			// The launch installed the host half of every public route; this
+			// hands the guest its addresses, and repairs a machine that already
+			// existed. Without it, an address attached at create was published
+			// and never routed (#116).
+			p.routeServerAddresses(r.Context(), res)
 		}
 		res.Attrs["allowed_actions"] = allowedActions(res.State)
 	case "poweroff", "stop_in_place":
@@ -582,9 +600,13 @@ func (p *Pack) serverAction(w http.ResponseWriter, r *http.Request) {
 		}
 		res.Attrs["allowed_actions"] = allowedActions(res.State)
 		// Stopping withdraws the address: one the API publishes and nothing
-		// answers on is the defect this project exists to avoid.
+		// answers on is the defect this project exists to avoid. The dynamic
+		// address goes entirely — upstream releases it on stop, and that is
+		// the whole difference between dynamic and flexible.
+		p.releaseDynamicAddress(r.Context(), res)
 		p.stopMachine(r.Context(), res)
 	case "terminate":
+		p.releaseDynamicAddress(r.Context(), res)
 		p.removeMachine(r.Context(), res)
 		p.env.Store.Delete(Name, kindServer, id)
 		// One function for both doors, because writing the release twice is how
@@ -678,35 +700,51 @@ func (p *Pack) view(res *resource.Resource) map[string]any {
 	out["state"] = res.State
 	out["creation_date"] = res.Created.Format(time.RFC3339)
 	out["modification_date"] = res.Updated.Format(time.RFC3339)
-	out["public_ips"] = p.publicIPsOf(res)
+	publicIPs := p.publicIPsOf(res)
+	out["public_ips"] = publicIPs
+	// Server.public_ip is the SDK's own field for the first address, and the
+	// one `scw instance server list` renders. Null when the server has none,
+	// which is what the real API answers.
+	out["public_ip"] = nil
+	if len(publicIPs) > 0 {
+		out["public_ip"] = publicIPs[0]
+	}
 	return out
 }
 
-// publicIPsOf lists the flexible IPs attached to a server, in the ServerIP shape
-// the SDK declares on Server.PublicIPs — which is not the shape of an IP: it
-// carries the address and its provisioning, not the project or the tags.
+// publicIPsOf lists a server's public addresses in the ServerIP shape the SDK
+// declares on Server.PublicIPs — which is not the shape of an IP: it carries
+// the address and its provisioning, not the project or the tags.
+//
+// Two kinds of entry: the attached flexible IPs, and the ephemeral address
+// dynamic_ip_required allocated, marked dynamic the way upstream marks it. The
+// dynamic one lives on the server itself because upstream never lists it in
+// /ips, so a store record would leak it there.
 func (p *Pack) publicIPsOf(server *resource.Resource) []any {
 	out := make([]any, 0, 1)
-	for _, ip := range p.env.Store.List(kindIP, resource.Tenant{Provider: Name, Zone: server.Tenant.Zone}) {
-		attached, _ := ip.Attrs["server"].(map[string]any)
-		if attached == nil || attached["id"] != server.ID {
-			continue
-		}
+	for _, ip := range p.attachedIPsOf(server.ID, server.Tenant.Zone) {
 		address, _ := ip.Attrs["address"].(string)
-		out = append(out, map[string]any{
-			"id":      ip.ID,
-			"address": address,
-			"gateway": nil,
-			"netmask": "32",
-			"family":  "inet",
-			// A flexible IP is not the dynamic one a server gets by default, and
-			// routed_ip_enabled is this emulator's default, so the machine
-			// carries the address itself rather than being NATed to it.
-			"dynamic":           false,
-			"provisioning_mode": "dhcp",
-		})
+		out = append(out, serverIPView(ip.ID, address, false))
+	}
+	if address := server.Runtime[runtimeDynamicIPKey]; address != "" {
+		out = append(out, serverIPView(server.Runtime[runtimeDynamicIPIDKey], address, true))
 	}
 	return out
+}
+
+// serverIPView is one ServerIP entry. routed_ip_enabled is this emulator's
+// default, so the machine carries the address itself rather than being NATed
+// to it, flexible and dynamic alike.
+func serverIPView(id, address string, dynamic bool) map[string]any {
+	return map[string]any{
+		"id":                id,
+		"address":           address,
+		"gateway":           nil,
+		"netmask":           "32",
+		"family":            "inet",
+		"dynamic":           dynamic,
+		"provisioning_mode": "dhcp",
+	}
 }
 
 // setServerVolumes makes the server's attached volumes be exactly what the

--- a/mise.toml
+++ b/mise.toml
@@ -129,8 +129,16 @@ run = [
 ]
 
 [tasks."conformance:ssh"]
-description = "Register a key, boot a server, log into it. Needs FEINT_VM=incus or incus-vm"
-run = "tools/conformance/scaleway/ssh.sh http://$FEINT_ADDR"
+description = "Register a key, boot a server, log into it — on every provider. Needs FEINT_VM=incus or incus-vm"
+# Three providers, three logins, one chain each: the login is a per-pack fact
+# (root, outscale, the template's default-user), and a good image with the
+# wrong login is a machine nobody enters. One suite proved it, two asserted it;
+# now each pack is driven by its own official client to a real shell.
+run = [
+  "tools/conformance/scaleway/ssh.sh http://$FEINT_ADDR",
+  "tools/conformance/outscale/ssh.sh http://$FEINT_ADDR",
+  "tools/conformance/exoscale/ssh.sh http://$FEINT_ADDR",
+]
 
 [tasks."conformance:oapi"]
 description = "Drive the running emulator with the real Outscale CLI"

--- a/tools/conformance/exoscale/ssh.sh
+++ b/tools/conformance/exoscale/ssh.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Conformance check: register an SSH key through the Exoscale API, boot an instance, log into it.
+#
+# Exoscale is the pack that motivated Boot.User existing at all: the login is not a property of
+# the cloud but of the template, declared in its own default-user field. So this suite does not
+# hardcode a login — it reads the field where the provider publishes it, and proves that the
+# machine really provisions that account. A good image with the wrong login is a machine nobody
+# enters, and only a real ssh(1) can catch it.
+#
+# The address logged into is an elastic IP, attached through the API: attaching routes it to the
+# machine, and it is the one plane that answers the host in both runtime modes — an OVN router
+# SNATs the host away from subnet-internal addresses, so a suite reading the instance's own
+# public-ip would prove the login in bridge mode and read a closed port over a live sshd in OVN,
+# measured. The instance's public-ip field is still asserted as published.
+#
+# Requires a machine runtime (`feint serve --vm incus`); with --vm off an instance has no address
+# at all here, so the suite skips itself entirely rather than asserting on nothing.
+#
+# Usage: tools/conformance/exoscale/ssh.sh [endpoint]
+set -euo pipefail
+
+ENDPOINT="${1:-http://127.0.0.1:4599}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Never let a client reach anything but the local emulator. Without this, a
+# missing endpoint does not fail: every official client falls back to the
+# operator's stored credentials, and a test creates billable resources on a real
+# account. That is not hypothetical — it happened, to this repository.
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/../guard.sh"
+guard_local "$ENDPOINT"
+
+command -v exo >/dev/null 2>&1 || { echo "FAIL: exo is not installed" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "FAIL: jq is not installed" >&2; exit 1; }
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ok()   { echo "  ok: $*"; }
+skip() { echo "  SKIP: $*" >&2; }
+
+echo "conformance: exoscale ssh round-trip against $ENDPOINT"
+
+MACHINES="$(curl -sf "$ENDPOINT/_feint/health" | jq -r '.machines')"
+if [ "$MACHINES" = "none" ]; then
+  skip "no machine runtime (start with FEINT_VM=incus); an instance publishes no address without one"
+  exit 0
+fi
+
+set -a
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/fake-credentials.env"
+set +a
+export EXOSCALE_API_ENDPOINT=${ENDPOINT}/v2
+
+WORK="$(mktemp -d)"
+KEY_NAME="feint-sshconf-exo"
+INSTANCE_NAME="feint-sshconf-exo"
+instance_id=""
+eip=""
+
+# The trap is set before anything is created, not at the end of the file: an
+# interrupted run never reaches a cleanup written as a final step, and the
+# machines it leaves carry no label a sweep could recognise as somebody's probe.
+cleanup() {
+  # Every line tolerates absence: after a clean run everything is already
+  # gone, and under `set -e` a failing delete inside this trap turns a passed
+  # suite into exit 1 — measured, the task runner then never ran the next
+  # suite while this one printed "passed".
+  [ -n "$instance_id" ] && exo -Q compute instance delete "$instance_id" --force >/dev/null 2>&1 || true
+  [ -n "$eip" ] && exo -Q compute elastic-ip delete "$eip" --force >/dev/null 2>&1 || true
+  exo -Q compute ssh-key delete "$KEY_NAME" --force >/dev/null 2>&1 || true
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+echo "- generate a throwaway key pair"
+ssh-keygen -q -t ed25519 -N '' -C feint-sshconf -f "$WORK/id" </dev/null
+ok "$(cut -d' ' -f1,3 <"$WORK/id.pub")"
+
+echo "- register it through the SSH key API"
+exo compute ssh-key register "$KEY_NAME" "$WORK/id.pub" >/dev/null || fail "ssh-key register rejected"
+exo -O json compute ssh-key list | jq -e --arg n "$KEY_NAME" 'any(.[]; .name == $n)' >/dev/null \
+  || fail "the key is missing from the list"
+ok "key $KEY_NAME"
+
+echo "- read the template, and the login it declares"
+templates="$(exo -O json compute instance-template list)" || fail "template list rejected"
+template_name="$(printf '%s' "$templates" | jq -r '.[0].name // empty')"
+template_id="$(printf '%s' "$templates" | jq -r '.[0].id // empty')"
+[ -n "$template_id" ] || fail "no template on offer: $templates"
+# The login lives in the template's own default-user field — Exoscale declares
+# it per template, not per cloud, and hardcoding one here would assert this
+# suite's guess instead of the provider's answer.
+user="$(curl -sf "$ENDPOINT/v2/template/$template_id" | jq -r '."default-user" // empty')"
+[ -n "$user" ] || fail "the template $template_name declares no default-user"
+type_name="$(exo -O json compute instance-type list | jq -r '"\(.[0].family).\(.[0].name)"')"
+case "$type_name" in *null*|.) fail "no instance type on offer" ;; esac
+ok "$template_name, login $user"
+
+echo "- boot an instance carrying the key"
+exo compute instance create "$INSTANCE_NAME" \
+  --zone "$EXOSCALE_ZONE" --template "$template_name" --instance-type "$type_name" \
+  --ssh-key "$KEY_NAME" >/dev/null || fail "instance create rejected"
+instance_id="$(exo -O json compute instance list \
+               | jq -r --arg n "$INSTANCE_NAME" '.[] | select(.name == $n) | .id')"
+[ -n "$instance_id" ] || fail "the instance is not in the list after create"
+ok "instance $instance_id"
+
+echo "- wait for the address the API publishes (public-ip)"
+ip=""
+for _ in $(seq 1 60); do
+  ip="$(exo -O json compute instance show "$instance_id" \
+        | jq -r '.ip_address // .public_ip // empty')"
+  # The CLI renders an absent address as the literal string "<nil>" — measured,
+  # and read once by this suite as an address to ssh into. An instrument that
+  # accepts its tool's own placeholder measures the placeholder.
+  case "$ip" in ""|null|"<nil>") ip="" ;; esac
+  [ -n "$ip" ] && break
+  sleep 2
+done
+[ -n "$ip" ] || fail "the instance never published an address although the $MACHINES runtime is on"
+ok "address $ip"
+
+echo "- attach an elastic IP, the address a client logs into"
+exo -O json compute elastic-ip create --description feint-sshconf >/dev/null \
+  || fail "elastic-ip create rejected"
+eip="$(exo -O json compute elastic-ip list | jq -r '.[0].ip_address // .[0].ip // empty')"
+case "$eip" in ""|null|"<nil>") fail "no address on the created elastic IP" ;; esac
+exo compute instance elastic-ip attach "$instance_id" "$eip" >/dev/null \
+  || fail "elastic-ip attach rejected"
+ok "elastic IP $eip attached"
+
+echo "- log in on the elastic IP, as the template's default user ($user)"
+# -F /dev/null ignores the operator's ~/.ssh/config: a ProxyJump matching a
+# broad Host pattern also matches the machine runtime's private range, ssh then
+# dials a bastion that cannot route there, and the connection dies on "timed
+# out during banner exchange" while sshd is up and holding the right key.
+logged_in=false
+for _ in $(seq 1 45); do
+  if ssh -F /dev/null -i "$WORK/id" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+       -o ConnectTimeout=3 -o BatchMode=yes "$user@$eip" 'echo alive' 2>/dev/null | grep -q alive; then
+    logged_in=true
+    break
+  fi
+  sleep 2
+done
+[ "$logged_in" = true ] \
+  || fail "no ssh daemon answered for $user@$eip although the $MACHINES runtime is on: the published address is a promise nobody keeps"
+remote="$(ssh -F /dev/null -i "$WORK/id" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+            -o BatchMode=yes "$user@$eip" 'id -un; grep -c feint-sshconf ~/.ssh/authorized_keys')"
+[ "$(printf '%s' "$remote" | head -1)" = "$user" ] \
+  || fail "logged in as '$(printf '%s' "$remote" | head -1)', not as the template's declared $user"
+ok "logged in: $(echo "$remote" | tr '\n' ' ')"
+
+echo "- clean up"
+exo -Q compute instance delete "$instance_id" --force >/dev/null || fail "instance delete rejected"
+instance_id=""
+exo -Q compute elastic-ip delete "$eip" --force >/dev/null || fail "elastic-ip delete rejected"
+eip=""
+exo -Q compute ssh-key delete "$KEY_NAME" --force >/dev/null || fail "ssh-key delete rejected"
+ok "instance and key removed"
+
+echo "conformance: exoscale ssh round-trip passed"

--- a/tools/conformance/outscale/oapi-cli.sh
+++ b/tools/conformance/outscale/oapi-cli.sh
@@ -88,6 +88,7 @@ EOF
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 ok() { echo "  ok: $*"; }
+skip() { echo "  SKIP: $*" >&2; }
 osc() { oapi-cli --config "$WORK/config.json" "$@"; }
 
 echo "conformance: oapi-cli against $ENDPOINT"
@@ -402,7 +403,8 @@ ok "vm $vm_id, running"
 # With a machine runtime configured, "running" has to mean something. Without
 # one the emulator tracks state only, which is the default and stays untested
 # here so CI needs no runtime.
-MACHINES="$(curl -sf "$ENDPOINT/_feint/health" | jq -r '.machines')"
+health="$(curl -sf "$ENDPOINT/_feint/health")"
+MACHINES="$(printf '%s' "$health" | jq -r '.machines')"
 if [ "$MACHINES" != "none" ]; then
   echo "- the address the API publishes is the one the machine answers on"
   ip=""
@@ -412,9 +414,18 @@ if [ "$MACHINES" != "none" ]; then
     sleep 0.5
   done
   [ -n "$ip" ] || fail "the machine is running and the API publishes no PrivateIp"
-  ping -c 2 -W 2 "$ip" >/dev/null 2>&1 \
-    || fail "the API publishes $ip and nothing answers there"
-  ok "$ip, and it answers"
+  # This probe runs from the host, and whether a subnet-internal address
+  # answers the host is a property of the mode, declared rather than deduced
+  # from its name: an OVN router SNATs the host away from the inside of its
+  # networks (docs/limits.md), and the ssh suite proves reachability there
+  # through the routed public plane instead.
+  if [ "$(printf '%s' "$health" | jq -r '.capabilities.private_from_host')" = "true" ]; then
+    ping -c 2 -W 2 "$ip" >/dev/null 2>&1 \
+      || fail "the API publishes $ip and nothing answers there"
+    ok "$ip, and it answers"
+  else
+    skip "$MACHINES declares private_from_host=false; reachability is proven on the public plane (ssh suite)"
+  fi
 fi
 
 echo "- read it back"

--- a/tools/conformance/outscale/ssh.sh
+++ b/tools/conformance/outscale/ssh.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Conformance check: register a keypair through the Outscale API, boot a Vm, log into it.
+#
+# The Scaleway sibling proved the chain for one provider and left the other two asserted rather
+# than driven: the login is a per-pack fact (root there, `outscale` here, Outscale's own
+# documentation says so on their OMIs), and a good image with the wrong login is a machine nobody
+# enters — nothing but a real ssh(1) can catch it.
+#
+# The address read is PublicIp — the address a real Outscale user logs into. LinkPublicIp routes
+# the address to the machine here (it moved only the record for a long time), and it is the one
+# plane that answers the host in both runtime modes: an OVN router SNATs the host away from
+# subnet-internal addresses, so a suite reading PrivateIp would prove the login in bridge mode
+# and read a closed port over a live sshd in OVN — measured.
+#
+# Requires a machine runtime (`feint serve --vm incus`); with --vm off a Vm has no address at all
+# here, so the suite skips itself entirely rather than asserting on nothing.
+#
+# Usage: tools/conformance/outscale/ssh.sh [endpoint]
+set -euo pipefail
+
+ENDPOINT="${1:-http://127.0.0.1:4599}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Never let a client reach anything but the local emulator. Without this, a
+# missing endpoint does not fail: every official client falls back to the
+# operator's stored credentials, and a test creates billable resources on a real
+# account. That is not hypothetical — it happened, to this repository.
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/../guard.sh"
+guard_local "$ENDPOINT"
+
+command -v oapi-cli >/dev/null 2>&1 || { echo "FAIL: oapi-cli is not installed" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "FAIL: jq is not installed" >&2; exit 1; }
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ok()   { echo "  ok: $*"; }
+skip() { echo "  SKIP: $*" >&2; }
+
+echo "conformance: outscale ssh round-trip against $ENDPOINT"
+
+MACHINES="$(curl -sf "$ENDPOINT/_feint/health" | jq -r '.machines')"
+if [ "$MACHINES" = "none" ]; then
+  skip "no machine runtime (start with FEINT_VM=incus); a Vm publishes no address without one"
+  exit 0
+fi
+
+set -a
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/fake-credentials.env"
+# The endpoint comes from the argument, not from the credentials file: oapi-cli
+# lets the environment override --config, so a pinned value there silently wins
+# over the port this run was asked to measure.
+# shellcheck disable=SC2034 # read by oapi-cli from the environment, not here
+OSC_ENDPOINT_API="$ENDPOINT"
+set +a
+guard_no_real_profile OSC_ENDPOINT_API oapi-cli
+
+WORK="$(mktemp -d)"
+KEY_NAME="feint-sshconf-osc"
+vm_id=""
+ip_id=""
+
+# The trap is set before anything is created, not at the end of the file: an
+# interrupted run never reaches a cleanup written as a final step, and the
+# machines it leaves carry no label a sweep could recognise as somebody's probe.
+cleanup() {
+  # Every line tolerates absence: after a clean run everything is already
+  # gone, and under `set -e` a failing delete inside this trap turns a passed
+  # suite into exit 1 — measured, the task runner then never ran the next
+  # suite while this one printed "passed".
+  [ -n "$vm_id" ] && osc DeleteVms '--VmIds[]' "$vm_id" >/dev/null 2>&1 || true
+  [ -n "$ip_id" ] && osc DeletePublicIp --PublicIpId "$ip_id" >/dev/null 2>&1 || true
+  osc DeleteKeypair --KeypairName "$KEY_NAME" >/dev/null 2>&1 || true
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+cat > "$WORK/config.json" <<EOF
+{
+  "default": {
+    "access_key": "$OSC_ACCESS_KEY",
+    "secret_key": "$OSC_SECRET_KEY",
+    "region": "$OSC_REGION",
+    "protocol": "http",
+    "endpoints": { "api": "$ENDPOINT" }
+  }
+}
+EOF
+osc() { oapi-cli --config "$WORK/config.json" "$@"; }
+
+echo "- generate a throwaway key pair"
+ssh-keygen -q -t ed25519 -N '' -C feint-sshconf -f "$WORK/id" </dev/null
+ok "$(cut -d' ' -f1,3 <"$WORK/id.pub")"
+
+echo "- register it through CreateKeypair"
+created="$(osc CreateKeypair --KeypairName "$KEY_NAME" --PublicKey "$(cat "$WORK/id.pub")")" \
+  || fail "CreateKeypair rejected: $created"
+fingerprint="$(printf '%s' "$created" | jq -r '.Keypair.KeypairFingerprint // empty')"
+[ -n "$fingerprint" ] || fail "the keypair came back without a fingerprint: $created"
+osc ReadKeypairs | jq -e --arg n "$KEY_NAME" 'any(.Keypairs[]; .KeypairName == $n)' >/dev/null \
+  || fail "the keypair is missing from ReadKeypairs"
+ok "keypair $KEY_NAME ($fingerprint)"
+
+echo "- allocate a public IP"
+created_ip="$(osc CreatePublicIp)" || fail "CreatePublicIp rejected: $created_ip"
+ip_id="$(printf '%s' "$created_ip" | jq -r '.PublicIp.PublicIpId // empty')"
+public="$(printf '%s' "$created_ip" | jq -r '.PublicIp.PublicIp // empty')"
+[ -n "$ip_id" ] && [ -n "$public" ] || fail "no address in the create response: $created_ip"
+ok "$public ($ip_id)"
+
+echo "- boot a Vm carrying the keypair"
+vm="$(osc CreateVms --ImageId ami-00000001 --VmType tinav6.c1r1p2 --KeypairName "$KEY_NAME")" \
+  || fail "CreateVms rejected: $vm"
+vm_id="$(printf '%s' "$vm" | jq -r '.Vms[0].VmId // empty')"
+[ -n "$vm_id" ] || fail "no VmId in the create response: $vm"
+ok "vm $vm_id"
+
+echo "- link the public IP, and read it back where a client reads it"
+osc LinkPublicIp --PublicIpId "$ip_id" --VmId "$vm_id" >/dev/null || fail "LinkPublicIp rejected"
+published="$(osc ReadVms | jq -r --arg id "$vm_id" \
+             '.Vms[] | select(.VmId == $id) | .PublicIp // empty')"
+[ "$published" = "$public" ] \
+  || fail "the Vm publishes '$published', the linked address is $public"
+ok "the Vm publishes $public"
+
+echo "- log in on the public address, as the provider's default user (outscale)"
+# -F /dev/null ignores the operator's ~/.ssh/config: a ProxyJump matching a
+# broad Host pattern also matches the machine runtime's private range, ssh then
+# dials a bastion that cannot route there, and the connection dies on "timed
+# out during banner exchange" while sshd is up and holding the right key.
+logged_in=false
+for _ in $(seq 1 45); do
+  if ssh -F /dev/null -i "$WORK/id" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+       -o ConnectTimeout=3 -o BatchMode=yes "outscale@$public" 'echo alive' 2>/dev/null | grep -q alive; then
+    logged_in=true
+    break
+  fi
+  sleep 2
+done
+[ "$logged_in" = true ] \
+  || fail "no ssh daemon answered for outscale@$public although the $MACHINES runtime is on: the published address is a promise nobody keeps"
+remote="$(ssh -F /dev/null -i "$WORK/id" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+            -o BatchMode=yes "outscale@$public" 'id -un; grep -c feint-sshconf ~/.ssh/authorized_keys')"
+[ "$(printf '%s' "$remote" | head -1)" = "outscale" ] \
+  || fail "logged in as '$(printf '%s' "$remote" | head -1)', not as the login Outscale provisions"
+ok "logged in: $(echo "$remote" | tr '\n' ' ')"
+
+echo "- clean up"
+osc DeleteVms '--VmIds[]' "$vm_id" >/dev/null || fail "DeleteVms rejected"
+vm_id=""
+osc DeletePublicIp --PublicIpId "$ip_id" >/dev/null || fail "DeletePublicIp rejected"
+ip_id=""
+osc DeleteKeypair --KeypairName "$KEY_NAME" >/dev/null || fail "DeleteKeypair rejected"
+ok "vm, public IP and keypair removed"
+
+echo "conformance: outscale ssh round-trip passed"

--- a/tools/conformance/scaleway/ssh.sh
+++ b/tools/conformance/scaleway/ssh.sh
@@ -37,6 +37,13 @@ ok() { echo "  ok: $*"; }
 
 echo "conformance: ssh round-trip against $ENDPOINT"
 
+# Asked up front, because it decides the verdict at the end. With no runtime the
+# control plane still publishes the flexible address — the documented degraded
+# mode — so the login step can only be skipped. With a runtime, a login that
+# fails is a failure: this suite used to skip there too, which made it unable to
+# say the one thing it exists to say (#116 shipped under a green run).
+MACHINES="$(curl -sf "$ENDPOINT/_feint/health" | jq -r '.machines')"
+
 echo "- generate a throwaway key pair"
 ssh-keygen -q -t ed25519 -N '' -C feint-conformance -f "$WORK/id" </dev/null
 ok "$(cut -d' ' -f1,3 <"$WORK/id.pub")"
@@ -95,8 +102,10 @@ if [ "$logged_in" = true ]; then
   remote="$(ssh -F /dev/null -i "$WORK/id" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
               -o BatchMode=yes "root@$ip" 'hostname; id -un; grep -c feint-conformance ~/.ssh/authorized_keys')"
   ok "logged in: $(echo "$remote" | tr '\n' ' ')"
-else
+elif [ "$MACHINES" = "none" ]; then
   echo "  SKIP: no ssh daemon answered on $ip (expected with --vm off; use --vm incus)" >&2
+else
+  fail "no ssh daemon answered on $ip although the $MACHINES runtime is on: the published address is a promise nobody keeps"
 fi
 
 echo "- clean up"


### PR DESCRIPTION
# Summary

The chain "a client creates a server, the API publishes an address, a human logs in" is the product, and it was broken in the addressing plane (#116, #117). This branch closes it — for **every** provider, in **both** runtime modes, and proves it with the official clients.

**The decision #116 asked for**: a client keeps reading the provider-shaped address, and the emulator makes that address genuinely answer on the host. The rejected option — publishing the runtime/DHCP address — is named with its reasons in `docs/limits.md`: it desynchronises `server.public_ips[].address` from `GET /ips/{id}` (the real API never lets them differ), and it changes with the `--vm` mode and the host, which is the half-truth this project exists to avoid.

**The causes, measured on this station before coding:**

- an address attached before boot was recorded and never routed: `attachAddress` no-ops with no machine, and poweron never replayed it;
- a server with no private NIC booted on the operator's default profile bridge, where `mustOwn` rightly refuses every route, and the firewall had to *override* the profile NIC — a post-boot re-plug that cost the guest its DHCP lease ("RUNNING, no IPv4 at all" in the issue);
- `dynamic_ip_required` was decoded, echoed, and read by nobody (#117);
- in OVN, a cold `ipv4.routes.external` is refused until the uplink carries the /32, a failed `Start` left a half-made instance that the next poweron booted without its keys, and a hot route edit re-plugs the NIC and cost a leased address everything (the repair restores the address the runtime itself recorded, plus the default route — OVN's IPAM ties it to the MAC, which survives the re-plug);
- an OVN router SNATs the host away from subnet-internal addresses — sshd up and answering its neighbours while the host read the port closed. That part is structural: it is now a declared capability (`private_from_host`), and every ssh chain logs in through the routed public plane, which crosses that boundary in both modes.

**What changed:**

- machines with no attachment boot on the emulator's own labelled `fnt-default` network, never the operator's bridge; promised public addresses ride the launch as cold device keys (a live edit re-plugs an OVN NIC); poweron replays the guest half;
- `dynamic_ip_required` allocates an ephemeral address at poweron, publishes it as a `dynamic: true` ServerIP (plus the singular `public_ip`), and releases it on stop — closing #117 with the same mechanism as #116;
- Outscale's `LinkPublicIp` and Exoscale's elastic-ip attach now **route the address for real** — `ssh outscale@&lt;PublicIp&gt;` opens a shell — and each pack owns one RFC 5737 block (TEST-NET-3/-2/-1) so two packs can never route the same /32 on one host;
- new conformance suites `tools/conformance/{outscale,exoscale}/ssh.sh`: key registered through the provider's API, machine booted by the official CLI, login on the address that provider publishes, as the login that provider declares (`outscale`; the template's `default-user`, read from the API). `conformance:ssh` runs all three, and a failed login **fails** when a runtime is on;
- stored addresses are revalidated against each pack's block before they reach the driver: a snapshot restores them verbatim, and routing an arbitrary value would send the host's traffic into a container.

**Proof, on this station:** `conformance:ssh` 3/3 real logins under `FEINT_VM=incus` **and** `FEINT_VM=incus-ovn`; full `mise run conformance` in both modes, 143/175, both network suites, hard cross-VPC isolation held in OVN; falsified with 22 compiling mutations in a copy outside the tree, each biting its cited test, 0 unproven; `check`, `drift:check`, `docs --check` all 0; runtime swept and verified empty (`incus list`, `incus network list`, `incus network acl list`).

## Type of change

- [x] Bug fix
- [x] A route added or changed (behaviour of existing routes: LinkPublicIp, elastic-ip attach, server actions)
- [x] Documentation

## Checklist

### Always

- [x] `mise run check` passes (gofmt, vet, golangci-lint, `go test -race`)
- [x] No new external Go dependency
- [x] `internal/core` still knows no provider — the default network, the launch-time routes and the repair are driver plumbing with no provider name; what varies (blocks, guards, keys) lives in the packs
- [x] Nothing in the diff could be written identically for another provider — the route/unroute/boot sequence lives in the shared driver and binding; each pack keeps only its block, its guard and its API shapes

### When a model wrote a substantive part of this

- [x] `Assisted-by: Claude Code (claude-fable-5)` trailer on every commit
- [x] I ran `mise run conformance` myself — twice, once per runtime mode, plus `conformance:ssh` in both
- [x] Every field name comes from the provider's SDK or a run of the real client (ServerIP shape mirrors the existing measured entries; `PublicIp`/`elastic-ip` fields were already measured by the X-2 sweep and the 2026-08-10 recording; the `exo` CLI's `&lt;nil&gt;` placeholder was measured, not recalled)

### When a route is added or changed

- [x] Operations unchanged; no new route, so the coverage report is untouched — `mise run drift:check` exits 0
- [x] `mise run conformance` passes, both modes, with `--contracts contracts`
- [x] Responses validated against the providers' own API descriptions
- [x] `/_feint/conformance` unread-field report: no new unread field (dynamic_ip_required is now read to the end)
- [x] `drift:update` N/A — the upstream surface did not move; baseline untouched

### When behaviour a client can observe changes

- [x] `docs/limits.md` updated: the decision and its rejected option, the per-pack RFC 5737 blocks, `private_from_host`, and `LinkPublicIp` moved off the records-only list
- [x] Generated tables unchanged (`feint docs --check` exits 0)

### When `.github/workflows/` is touched

N/A

### When a machine runtime is involved

- [x] Tested with `FEINT_VM=incus` and `FEINT_VM=incus-ovn`, end to end
- [x] Nothing the emulator did not create was touched — every new destructive or reconfiguring path answers ownership (label, prefix, or block guard), and the mode-switch replacement of `fnt-default` requires label + emptiness + the constant's name
- [x] The runs leave nothing behind — checked with `incus list`, `incus network list` and `incus network acl list`, not assumed

## Related issues

Closes #116. Closes #117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)