### PR TITLE
An unknown image fails the boot instead of booting a substitute

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -39,6 +39,23 @@ change ni l'un ni l'autre a sa place dans `git log`.
   texte brut ». Falsifié : la liste ramenée à cinq, le nouveau test échoue et
   celui-là passe toujours, ce qui démontre l'angle mort au lieu de l'affirmer.
 
+- **Un identifiant d'image inconnu ne démarre plus un substitut** (#83). Avec
+  un runtime configuré, les trois packs remplaçaient en silence une image
+  qu'aucun catalogue ne connaît : demander Alpine, obtenir Ubuntu, pendant que
+  l'API continuait d'afficher l'identifiant envoyé par le client ; la
+  résolution Scaleway comparait les labels par sous-chaîne, si bien que
+  `centos`, `rocky` et `ubuntu_focal` devenaient tous Ubuntu 22.04. La création
+  réussit toujours, comme `docs/limits.md` le promet aux identifiants de
+  production codés en dur, mais le démarrage refuse désormais : la machine
+  atteint l'état d'échec propre au provider et le journal nomme l'identifiant.
+  L'image et le login se résolvent maintenant ensemble (root chez Scaleway,
+  `outscale` chez Outscale, le `default-user` du template chez Exoscale) et la
+  marketplace Scaleway répond un UUID fixe par label, de sorte qu'un label
+  résolu par Terraform nomme toujours la distribution choisie. Une image
+  enregistrée par le client via `CreateImage` (Outscale) refuse de la même
+  façon, l'émulateur n'ayant derrière elle qu'un enregistrement et aucun
+  contenu de disque, et le journal dit lequel des deux cas s'applique.
+
 ## [0.7.2]
 
 ### Ajouté

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,22 @@ what this project is judged on: **a response shape a client can observe**, and
   Falsified: with the list back to five, the new test fails and that one still
   passes, which is the blind spot demonstrated rather than argued.
 
+- **An unknown image identifier no longer boots a substitute** (#83). With a
+  runtime configured, all three packs silently replaced an image no catalogue
+  held — ask for Alpine, boot Ubuntu — while the API kept reporting the
+  identifier the client sent; Scaleway's resolution matched labels by
+  substring, so `centos`, `rocky` and `ubuntu_focal` all became Ubuntu 22.04.
+  The create still succeeds, as `docs/limits.md` promises for hardcoded
+  production identifiers, but the boot now refuses: the machine reaches the
+  provider's own failed state and the log names the identifier. Image and
+  login now resolve together — root on Scaleway, `outscale` on Outscale, the
+  template's `default-user` on Exoscale — and the Scaleway marketplace answers
+  one fixed UUID per label, so a label resolved through it by Terraform still
+  names the distribution it chose. An image the client registered through
+  Outscale's `CreateImage` refuses the same way — the emulator serves its
+  record and holds no disk contents — and the log says which of the two cases
+  it is.
+
 ## [0.7.2]
 
 ### Added

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -60,6 +60,56 @@ turns out to be the wrong one, the place to change it is `resolveImage` in
 `internal/providers/scaleway/images.go`, and the change must come with a way to
 keep hardcoded production ids working.
 
+**What an unknown identifier can no longer do is boot a substitute.** Measured
+in #83, on all three packs: with a runtime configured (`--vm incus`, `incus-vm`,
+`incus-ovn`), an image identifier no catalogue held was silently replaced at
+boot — ask for Alpine, boot Ubuntu — while the API kept reporting the identifier
+the client sent. Scaleway's resolution matched labels by substring, so `centos`,
+`rocky` and `ubuntu_focal` all became Ubuntu 22.04 without a word.
+
+Since then the create still succeeds and the boot refuses: the machine reaches
+the provider's own failed state (`stopped` on Scaleway and Outscale, which
+declare no error state for a machine; `error` on Exoscale) and the emulator's
+log names the identifier. The state published is the one the effect produced,
+not the one the intention aimed at. With `--vm off`, the default, nothing boots
+and nothing changes — the control plane keeps accepting, exactly as this
+section promises.
+
+Two alternatives lost, and why:
+
+- **Refusing at the create**, as the real clouds do, would turn the emulated
+  catalogue into a whitelist and break the paragraph above: a configuration
+  hardcoding a production image UUID must keep applying, because that is the
+  first thing a team points at the emulator.
+- **Substituting out loud** — a warning in the log, a mark on the resource —
+  keeps a machine whose `/etc/os-release` contradicts the API for as long as it
+  runs. A cloud-init that installs an Alpine package, or a playbook that
+  branches on the OS family, still gets the wrong operating system with every
+  signal saying success. A boot that fails with a stated reason is the only
+  answer that cannot be misread.
+
+An identifier resolves to nothing in **two** ways, and they end in the same
+refusal without being the same case. An identifier nobody ever created is a
+typo the control plane accepted, as above. An image the client **registered** —
+Outscale serves `CreateImage`, and Scaleway snapshots and images are planned to
+follow it (#7) — is the more embarrassing one: `ReadImages` lists it, yet this
+emulator keeps records, not disk contents, so there are no bytes to boot.
+Booting the source's base image instead would silently drop whatever the client
+baked into the image — and the golden-image workflow is precisely the one where
+that difference is the point — so it is refused like the first case, and the
+log says which of the two it was. If the emulator ever captures disk contents
+(the runtime could: `incus publish` exists), that refusal is the line to
+replace.
+
+Two details follow from the same decision. The Scaleway marketplace answers one
+fixed UUID **per label**, so Terraform — which resolves a label into a UUID and
+sends the UUID back — still names the distribution it chose; a single shared
+UUID is how `image = "debian_bookworm"` used to boot an Ubuntu. And image and
+login resolve **together**: whatever a pack resolves an identifier to carries
+the login that image provisions — root on Scaleway, `outscale` on Outscale, the
+template's own `default-user` on Exoscale — because the right distribution with
+the wrong login is still a machine nobody can enter.
+
 ## A Scaleway server's root volume type cannot be written
 
 `scaleway_instance_server` has no usable `root_volume { volume_type }` here

--- a/internal/core/cloudinit/cloudinit.go
+++ b/internal/core/cloudinit/cloudinit.go
@@ -107,6 +107,14 @@ func templateFor(distribution string) string {
 	switch {
 	case strings.Contains(d, "ubuntu"):
 		return "ubuntu.yaml.tmpl"
+	// Alpine before the default, because falling through to Debian asked it for
+	// four things it cannot do: bash it does not ship, a sudo group it calls
+	// wheel, an openssh-server package apk names openssh, and systemctl where
+	// it runs OpenRC. The machine booted, the API said running, and nothing
+	// answered on port 22.
+	// TestAlpineGetsItsOwnConventions fails without this.
+	case strings.Contains(d, "alpine"):
+		return "alpine.yaml.tmpl"
 	case strings.Contains(d, "alma"), strings.Contains(d, "rocky"),
 		strings.Contains(d, "fedora"), strings.Contains(d, "centos"), strings.Contains(d, "rhel"):
 		return "almalinux.yaml.tmpl"

--- a/internal/core/cloudinit/cloudinit_test.go
+++ b/internal/core/cloudinit/cloudinit_test.go
@@ -123,3 +123,93 @@ func TestRenderSkipsThePackageInstallWhenNotNeeded(t *testing.T) {
 		t.Fatalf("cloud images already carry sshd, no package should be installed:\n%s", out)
 	}
 }
+
+// directives drops the comment lines of a cloud-config, keeping what the
+// machine acts on.
+//
+// Needed because the first version of the Alpine test asserted against the
+// whole document and failed on its own template's prose: the comment explaining
+// that apk names the package openssh rather than openssh-server contains the
+// string openssh-server. A test that reads comments measures the text, not the
+// behaviour.
+func directives(config string) string {
+	var kept []string
+	for _, line := range strings.Split(config, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return strings.Join(kept, "\n")
+}
+
+// TestAlpineGetsItsOwnConventions holds the four things Alpine does differently.
+//
+// It fell through to the Debian template, which asked it for bash it does not
+// ship, a sudo group it calls wheel, an openssh-server package apk names
+// openssh, and systemctl where it runs OpenRC. The container booted and the API
+// reported it running; nothing answered on port 22, and an operator reading
+// either signal had no reason to doubt it.
+//
+// Four assertions rather than one, because any single one of them silently
+// undoes the login: a missing package means no daemon, an unstarted service
+// means no listener, a wrong group means no sudo, and a shell that does not
+// exist closes the session after the key was accepted — which reads like a
+// refused key.
+func TestAlpineGetsItsOwnConventions(t *testing.T) {
+	out, err := cloudinit.Render(cloudinit.Spec{
+		Distribution:   "alpine",
+		User:           "cloud",
+		AuthorizedKeys: []string{"ssh-ed25519 AAAA demo"},
+		InstallSSHD:    true,
+	})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	acted := directives(out)
+
+	for _, want := range []string{
+		"groups: [wheel]", // not sudo: that group does not exist on Alpine
+		"shell: /bin/sh",  // busybox ash; /bin/bash is not installed
+		"\n  - openssh\n", // the apk package, exactly, not openssh-server
+		"rc-update add sshd default",
+		"rc-service sshd start",
+		"\n  - sudo\n", // the NOPASSWD rule above is read by nobody without it
+	} {
+		if !strings.Contains(acted, want) {
+			t.Errorf("the Alpine cloud-config is missing %q:\n%s", want, acted)
+		}
+	}
+
+	// And none of the conventions that belong to the other families. Checked
+	// against the directives alone, because the template's own comments name
+	// these on purpose, to say why Alpine cannot use them.
+	for _, unwanted := range []string{"openssh-server", "systemctl", "/bin/bash", "[sudo]"} {
+		if strings.Contains(acted, unwanted) {
+			t.Errorf("the Alpine cloud-config still carries %q, which it cannot honour:\n%s",
+				unwanted, acted)
+		}
+	}
+}
+
+// Root needs neither sudo nor a shell line, and asking apk for a sudo package
+// it will not use is a slower boot for nothing.
+func TestAlpineAsRootInstallsOnlyWhatItNeeds(t *testing.T) {
+	out, err := cloudinit.Render(cloudinit.Spec{
+		Distribution:   "alpine",
+		User:           "root",
+		AuthorizedKeys: []string{"ssh-ed25519 AAAA demo"},
+		InstallSSHD:    true,
+	})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	acted := directives(out)
+
+	if !strings.Contains(acted, "\n  - openssh\n") {
+		t.Errorf("root still needs the daemon:\n%s", acted)
+	}
+	if strings.Contains(acted, "\n  - sudo\n") {
+		t.Errorf("root does not need sudo:\n%s", acted)
+	}
+}

--- a/internal/core/cloudinit/templates/alpine.yaml.tmpl
+++ b/internal/core/cloudinit/templates/alpine.yaml.tmpl
@@ -1,0 +1,58 @@
+#cloud-config
+# Cloud-init Alpine pour les machines émulées par feint.
+#
+# Alpine tombait jusqu'ici dans le gabarit Debian par défaut, et lui demandait
+# quatre choses qu'il ne sait pas faire : un shell bash qu'il n'a pas, un groupe
+# sudo qui s'appelle wheel chez lui, un paquet openssh-server dont le nom apk
+# est openssh, et un systemctl là où il utilise OpenRC. La machine démarrait,
+# l'API la disait running, et rien n'écoutait sur le port 22.
+
+hostname: {{ .Hostname }}
+fqdn: {{ .Hostname }}.local
+manage_etc_hosts: true
+preserve_hostname: false
+
+users:
+  - name: {{ .User }}
+{{- if ne .User "root" }}
+    # wheel, pas sudo : c'est le groupe d'administration d'Alpine, et sudo n'y
+    # est pas installé par défaut. Le paquet est ajouté plus bas, sans quoi la
+    # règle NOPASSWD ne serait lue par personne.
+    groups: [wheel]
+    sudo: "ALL=(ALL) NOPASSWD:ALL"
+    # /bin/sh, qui est busybox ash : l'image de base n'embarque pas bash, et un
+    # shell inexistant fait échouer la connexion après une authentification
+    # pourtant réussie, ce qui se lit comme un refus de clé.
+    shell: /bin/sh
+{{- end }}
+    # Même raison que sur Debian : sshd 9+ refuse un compte « locked », et
+    # cloud-init verrouille par défaut.
+    lock_passwd: false
+    passwd: "*"
+    ssh_authorized_keys:
+{{- range .AuthorizedKeys }}
+      - {{ . }}
+{{- end }}
+
+disable_root: {{ if eq .User "root" }}false{{ else }}true{{ end }}
+ssh_pwauth: false
+{{ if .InstallSSHD }}
+packages:
+  - openssh
+{{- if ne .User "root" }}
+  - sudo
+{{- end }}
+
+runcmd:
+  # ssh-keygen -A d'abord, et ce n'est pas une précaution : le paquet openssh
+  # d'Alpine n'installe aucune clé d'hôte, et sshd démarré sans clé répond
+  # « Starting sshd ... [ ok ] » puis n'écoute sur rien. Mesuré : 0 clé après
+  # l'installation, 6 après cette ligne, et le port 22 ouvert seulement ensuite.
+  # Debian et Ubuntu n'en ont pas besoin, leur paquet les génère à la
+  # post-installation.
+  #
+  # Puis OpenRC, pas systemd : `rc-update add` inscrit le service au boot et
+  # `rc-service start` le démarre maintenant, ce que `systemctl enable --now`
+  # fait en une fois ailleurs.
+  - [sh, -c, "ssh-keygen -A && rc-update add sshd default && rc-service sshd start"]
+{{- end }}

--- a/internal/core/machine/binding.go
+++ b/internal/core/machine/binding.go
@@ -89,14 +89,45 @@ func (b Binding) Name(id string) string {
 	return b.Prefix + strings.ReplaceAll(id, "/", "-")
 }
 
+// Image is what a pack's catalogue resolves an image identifier to: the image
+// the runtime boots and the login that image provisions. One value on purpose,
+// never two lookups — an identifier resolved to the right distribution with
+// the wrong login still hands the user a machine nobody can enter, which is
+// the same half-success in a different place.
+//
+// The zero value means the identifier resolved to nothing, and Start refuses
+// to boot it rather than substituting: see the guard there.
+type Image struct {
+	// Ref is runtime-agnostic ("ubuntu:24.04"): the driver translates it,
+	// which is what lets a pack name an operating system without knowing what
+	// runs it.
+	Ref string
+	// User is the login the image provisions. Empty keeps the binding's
+	// provider-wide login, for the clouds where the login belongs to the cloud
+	// rather than to the image.
+	User string
+}
+
 // Boot is what a pack asks for when it powers a server on.
 type Boot struct {
 	// ID is the emulated resource, used for the machine name and the labels.
 	ID string
 	// Image is runtime-agnostic ("ubuntu:24.04"): the driver translates it,
 	// which is what lets a pack name an operating system without knowing what
-	// runs it.
+	// runs it. Empty means the identifier the client sent resolved to nothing,
+	// and a real runtime refuses to boot it rather than substituting.
 	Image string
+	// Requested is the identifier the client sent, verbatim, so the refusal
+	// log can name it. Image is what that identifier resolved to; this is what
+	// to say when it resolved to nothing.
+	Requested string
+	// Reason, when Image is empty, is the pack's diagnosis of why the
+	// identifier resolved to nothing. The two known cases end in the same
+	// refusal and must not read the same in the log: an identifier nobody ever
+	// created is a typo the control plane accepted, while an image the
+	// emulator itself registered and serves is a record with no disk contents
+	// behind it. Empty falls back to the generic wording.
+	Reason string
 	// Hostname the guest takes. Empty falls back to the resource id.
 	Hostname string
 	// User overrides the binding's login for this boot, empty to keep it.
@@ -147,6 +178,25 @@ type Started struct {
 func (b Binding) Start(ctx context.Context, boot Boot) Started {
 	name := b.Name(boot.ID)
 	if b.Driver == nil {
+		return Started{}
+	}
+	// An identifier no catalogue holds resolves to no image at all, and a real
+	// runtime must not paper over it: ask for Alpine, boot Ubuntu, and every
+	// signal says success — the exact defect this project exists to avoid
+	// (#83). The refusal lives here, in the shared layer, so no pack can
+	// substitute silently and a fourth one could not either. Noop is exempt on
+	// purpose: it boots nothing, so there is nothing to substitute, and the
+	// control plane must stay usable without a runtime — hardcoded production
+	// identifiers included, as docs/limits.md promises.
+	//
+	// TestAnUnknownImageFailsTheBootInsteadOfSubstituting fails without this.
+	if _, metadataOnly := b.Driver.(Noop); boot.Image == "" && !metadataOnly {
+		reason := boot.Reason
+		if reason == "" {
+			reason = "the identifier is in no catalogue"
+		}
+		b.logger().Error("refusing to boot: the image identifier resolves to nothing this emulator can run",
+			"provider", b.Provider, "resource", boot.ID, "image", boot.Requested, "reason", reason)
 		return Started{}
 	}
 	user := b.User

--- a/internal/core/machine/binding_boot_test.go
+++ b/internal/core/machine/binding_boot_test.go
@@ -1,0 +1,126 @@
+package machine
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/resource"
+)
+
+// The property under test (#83): an image identifier that resolves to nothing
+// must never boot a substitute. Ask for Alpine, boot Ubuntu, and every signal
+// says success — the API reports the identifier the client sent while the
+// machine runs something else. Either nothing starts and the resource says so
+// through FailedState, or what starts is exactly what the resolution named.
+//
+// The guard lives in Binding.Start, the shared layer, so a pack cannot
+// substitute silently and a fourth pack could not either. Every case here
+// fails if the guard is removed; /falsify checks that claim.
+
+// recordingDriver is a Driver that records every Spec it was asked to start,
+// so a test can assert on what would have booted rather than on a state name.
+type recordingDriver struct {
+	specs []Spec
+}
+
+func (d *recordingDriver) Name() string                   { return "recording" }
+func (d *recordingDriver) Available(context.Context) bool { return true }
+func (d *recordingDriver) Start(_ context.Context, spec Spec) (Machine, error) {
+	d.specs = append(d.specs, spec)
+	return Machine{Name: spec.Name, IP: "10.42.0.9", Running: true}, nil
+}
+func (d *recordingDriver) Stop(context.Context, string) error   { return nil }
+func (d *recordingDriver) Remove(context.Context, string) error { return nil }
+func (d *recordingDriver) Inspect(_ context.Context, name string) (Machine, bool, error) {
+	return Machine{Name: name}, false, nil
+}
+func (d *recordingDriver) EnsureNetwork(context.Context, NetworkSpec) error { return nil }
+func (d *recordingDriver) Attach(context.Context, string, Attachment) error { return nil }
+func (d *recordingDriver) RemoveNetwork(context.Context, string) error      { return nil }
+
+func bootBinding(driver Driver) Binding {
+	return Binding{
+		Driver:       driver,
+		Provider:     "acme",
+		Prefix:       "feint-acme-",
+		User:         "root",
+		RuntimeKey:   "machine",
+		AddressKey:   "address",
+		RunningState: "running",
+		FailedState:  "failed",
+		Log:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+}
+
+func TestAnUnknownImageFailsTheBootInsteadOfSubstituting(t *testing.T) {
+	driver := &recordingDriver{}
+	b := bootBinding(driver)
+	res := &resource.Resource{ID: "srv-1", State: "stopped"}
+
+	if b.PowerOn(context.Background(), res, Boot{Requested: "totalement-inconnue"}) {
+		t.Fatal("a boot with no resolved image reported success")
+	}
+	if res.State != "failed" {
+		t.Fatalf("state %q, want the failed state: running on a substitute is the defect under test", res.State)
+	}
+	if len(driver.specs) != 0 {
+		t.Fatalf("the runtime was asked to boot %q for an identifier that resolves to nothing", driver.specs[0].Image)
+	}
+}
+
+func TestAnUnknownImageStaysMetadataOnlyWithoutARuntime(t *testing.T) {
+	// Noop boots nothing, so there is nothing to substitute: the control plane
+	// must keep accepting — docs/limits.md promises hardcoded production
+	// identifiers keep working, and CI runs the conformance suites this way.
+	for name, driver := range map[string]Driver{"noop": Noop{}, "nil": nil} {
+		b := bootBinding(driver)
+		res := &resource.Resource{ID: "srv-1", State: "stopped"}
+		if !b.PowerOn(context.Background(), res, Boot{Requested: "totalement-inconnue"}) {
+			t.Fatalf("%s: the metadata-only mode refused a boot it cannot lie about", name)
+		}
+		if res.State != "running" {
+			t.Fatalf("%s: state %q, want running: with no runtime the control plane is the whole emulation", name, res.State)
+		}
+	}
+}
+
+func TestAResolvedImageBootsWithTheLoginItCarries(t *testing.T) {
+	driver := &recordingDriver{}
+	b := bootBinding(driver)
+	res := &resource.Resource{ID: "srv-1", State: "stopped"}
+
+	// Image and login travel together: a resolution that got the distribution
+	// right and the login wrong hands the user a machine nobody can enter.
+	ok := b.PowerOn(context.Background(), res, Boot{
+		Image:          "alpine:3.21",
+		User:           "alpine",
+		Requested:      "alpine",
+		AuthorizedKeys: []string{"ssh-ed25519 AAAA test"},
+	})
+	if !ok || res.State != "running" {
+		t.Fatalf("ok=%v state=%q, want a running machine", ok, res.State)
+	}
+	if len(driver.specs) != 1 {
+		t.Fatalf("%d boots, want 1", len(driver.specs))
+	}
+	if got := driver.specs[0]; got.Image != "alpine:3.21" || got.User != "alpine" {
+		t.Fatalf("booted image=%q user=%q, want the pair the resolution named", got.Image, got.User)
+	}
+}
+
+func TestAnImageWithoutItsOwnLoginKeepsTheProviderWideOne(t *testing.T) {
+	driver := &recordingDriver{}
+	b := bootBinding(driver)
+	res := &resource.Resource{ID: "srv-1", State: "stopped"}
+
+	b.PowerOn(context.Background(), res, Boot{
+		Image:          "ubuntu:22.04",
+		Requested:      "ubuntu_jammy",
+		AuthorizedKeys: []string{"ssh-ed25519 AAAA test"},
+	})
+	if len(driver.specs) != 1 || driver.specs[0].User != "root" {
+		t.Fatalf("specs=%v, want one boot as the binding's own login", driver.specs)
+	}
+}

--- a/internal/providers/exoscale/machines.go
+++ b/internal/providers/exoscale/machines.go
@@ -93,24 +93,31 @@ var runtimeTemplates = map[string]string{
 	"22222222-2222-4222-8222-222222222222": "debian:12",
 }
 
-const defaultTemplateID = "11111111-1111-4111-8111-111111111111"
-
-// templateFor returns what to boot and the login that template declares. An
-// unknown identifier falls back rather than failing: the catalogue is small and
-// fixed, and refusing to boot over a template name would block a workflow the
-// control plane already accepted.
-func templateFor(id string) (image, user string) {
-	image, known := runtimeTemplates[id]
+// templateFor resolves a template onto what to boot and the login that
+// template declares — one resolution, because Exoscale's login is a property
+// of the template rather than of the cloud, and the right distribution with
+// the wrong login is still a machine nobody can enter.
+//
+// An unknown identifier resolves to nothing rather than falling back: the
+// control plane has accepted it — docs/limits.md declares identifiers
+// unchecked, deliberately — and the shared binding refuses the boot out loud
+// instead of starting the default template under the client's template id
+// (#83).
+//
+// TestExoscaleTemplateResolutionIsExact fails against the fallback version.
+func templateFor(id string) (machine.Image, bool) {
+	ref, known := runtimeTemplates[id]
 	if !known {
-		id, image = defaultTemplateID, runtimeTemplates[defaultTemplateID]
+		return machine.Image{}, false
 	}
+	img := machine.Image{Ref: ref}
 	for _, t := range templates {
 		if t["id"] == id {
-			user, _ = t["default-user"].(string)
+			img.User, _ = t["default-user"].(string)
 			break
 		}
 	}
-	return image, user
+	return img, true
 }
 
 // start powers an instance on. The state is set whether or not a machine
@@ -121,14 +128,15 @@ func (p *Pack) start(ctx context.Context, res *resource.Resource) {
 	if t, ok := res.Attrs["template"].(map[string]any); ok {
 		templateID, _ = t["id"].(string)
 	}
-	image, user := templateFor(templateID)
+	img, _ := templateFor(templateID)
 	name, _ := res.Attrs["name"].(string)
 	userData, _ := res.Attrs["user-data"].(string)
 
 	p.binding().PowerOn(ctx, res, machine.Boot{
-		Image:    image,
-		Hostname: name,
-		User:     user,
+		Image:     img.Ref,
+		Requested: templateID,
+		Hostname:  name,
+		User:      img.User,
 		// The key the client registered, so the machine it is attached to can
 		// actually be opened. Nothing was passed here: the instance booted with
 		// empty cloud-init — no user provisioned, no sshd on a minimal image —

--- a/internal/providers/exoscale/machines_internal_test.go
+++ b/internal/providers/exoscale/machines_internal_test.go
@@ -1,0 +1,125 @@
+package exoscale
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/machine"
+	"github.com/stephrobert/feint/internal/core/resource"
+	"github.com/stephrobert/feint/internal/core/store"
+)
+
+// recordingDriver records every Spec it was asked to start, so a test can
+// assert on the image and the login rather than on a state name (#83).
+type recordingDriver struct {
+	specs []machine.Spec
+}
+
+func (d *recordingDriver) Name() string                   { return "recording" }
+func (d *recordingDriver) Available(context.Context) bool { return true }
+func (d *recordingDriver) Start(_ context.Context, spec machine.Spec) (machine.Machine, error) {
+	d.specs = append(d.specs, spec)
+	return machine.Machine{Name: spec.Name, IP: "10.42.0.9", Running: true}, nil
+}
+func (d *recordingDriver) Stop(context.Context, string) error   { return nil }
+func (d *recordingDriver) Remove(context.Context, string) error { return nil }
+func (d *recordingDriver) Inspect(_ context.Context, name string) (machine.Machine, bool, error) {
+	return machine.Machine{Name: name}, false, nil
+}
+func (d *recordingDriver) EnsureNetwork(context.Context, machine.NetworkSpec) error { return nil }
+func (d *recordingDriver) Attach(context.Context, string, machine.Attachment) error { return nil }
+func (d *recordingDriver) RemoveNetwork(context.Context, string) error              { return nil }
+
+func runtimePack(driver machine.Driver) *Pack {
+	return New(&emulator.Env{
+		Store:    store.New(),
+		Machines: driver,
+		Now:      func() time.Time { return time.Unix(1700000000, 0).UTC() },
+		NewID:    func() string { return "00000000-0000-4000-8000-000000000001" },
+		Log:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+}
+
+// One case per row of the template table: the boot and the login the template
+// declares resolve together — the login is a property of the template on
+// Exoscale, which is the reason Boot.User exists at all — and an identifier
+// outside the table resolves to nothing.
+func TestExoscaleTemplateResolutionIsExact(t *testing.T) {
+	rows := map[string]machine.Image{
+		"11111111-1111-4111-8111-111111111111": {Ref: "ubuntu:24.04", User: "ubuntu"},
+		"22222222-2222-4222-8222-222222222222": {Ref: "debian:12", User: "debian"},
+	}
+	if len(rows) != len(runtimeTemplates) {
+		t.Fatalf("the table serves %d templates and this test knows %d: add the row here, one per template", len(runtimeTemplates), len(rows))
+	}
+	for id, want := range rows {
+		got, known := templateFor(id)
+		if !known {
+			t.Errorf("%s: a served template stopped resolving", id)
+			continue
+		}
+		if got != want {
+			t.Errorf("%s: resolved to %+v, want %+v — the template's own default-user must travel with it", id, got, want)
+		}
+	}
+	for _, id := range []string{"99999999-9999-4999-8999-999999999999", "totalement-inconnue", ""} {
+		if img, known := templateFor(id); known {
+			t.Errorf("%q: resolved to %+v, want no resolution at all", id, img)
+		}
+	}
+}
+
+// The wiring of #83 for this pack: an unknown template under a runtime
+// reaches error — the state Exoscale's own instance-state enum declares —
+// and the runtime is never asked for anything.
+func TestAnUnknownTemplateDoesNotBootASubstitute(t *testing.T) {
+	driver := &recordingDriver{}
+	p := runtimePack(driver)
+	res := &resource.Resource{
+		ID:    "00000000-0000-4000-8000-0000000000aa",
+		State: "stopped",
+		Attrs: map[string]any{
+			"name":     "demo",
+			"template": map[string]any{"id": "99999999-9999-4999-8999-999999999999"},
+		},
+	}
+
+	p.start(context.Background(), res)
+
+	if res.State != "error" {
+		t.Fatalf("state %q, want error: running on a substitute is the defect under test", res.State)
+	}
+	if len(driver.specs) != 0 {
+		t.Fatalf("the runtime was asked to boot %q for a template nobody serves", driver.specs[0].Image)
+	}
+}
+
+// The accepting half: a served template still boots, as its own default-user.
+func TestAServedTemplateBootsAsItsDefaultUser(t *testing.T) {
+	driver := &recordingDriver{}
+	p := runtimePack(driver)
+	res := &resource.Resource{
+		ID:    "00000000-0000-4000-8000-0000000000ab",
+		State: "stopped",
+		Attrs: map[string]any{
+			"name":     "demo",
+			"template": map[string]any{"id": "22222222-2222-4222-8222-222222222222"},
+		},
+	}
+
+	p.start(context.Background(), res)
+
+	if res.State != "running" {
+		t.Fatalf("state %q, want running: a guard that refuses everything breaks the product", res.State)
+	}
+	if len(driver.specs) != 1 {
+		t.Fatalf("%d boots, want 1", len(driver.specs))
+	}
+	if got := driver.specs[0]; got.Image != "debian:12" || got.User != "debian" {
+		t.Fatalf("booted image=%q user=%q, want debian:12 as debian", got.Image, got.User)
+	}
+}

--- a/internal/providers/outscale/audit_test.go
+++ b/internal/providers/outscale/audit_test.go
@@ -72,7 +72,7 @@ func TestConcurrentCreatesDoNotShareAnAddress(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			_, out := post(t, ts, "CreateVms",
-				`{"ImageId":"ami-12345678","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+				`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 			vms, _ := out["Vms"].([]any)
 			if len(vms) == 0 {
 				return
@@ -109,7 +109,7 @@ func TestASubnetDoesNotDeleteUnderAVm(t *testing.T) {
 	ts := newServer(t)
 	_, subnetID := netAndSubnet(t, ts, "10.43.0.0/16", "10.43.1.0/24")
 
-	post(t, ts, "CreateVms", `{"ImageId":"ami-12345678","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+	post(t, ts, "CreateVms", `{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 
 	status, out := post(t, ts, "DeleteSubnet", `{"SubnetId":"`+subnetID+`"}`)
 	if status == http.StatusOK {
@@ -134,7 +134,7 @@ func TestAFailedCreateLeavesNothingBehind(t *testing.T) {
 	_, subnetID := netAndSubnet(t, ts, "10.44.0.0/16", "10.44.1.0/28")
 
 	status, _ := post(t, ts, "CreateVms",
-		`{"ImageId":"ami-12345678","SubnetId":"`+subnetID+`","MaxVmsCount":14,"BootOnCreation":false}`)
+		`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","MaxVmsCount":14,"BootOnCreation":false}`)
 	if status == http.StatusOK {
 		t.Skip("the subnet was large enough; nothing to unwind")
 	}
@@ -191,7 +191,7 @@ func TestAvailableIpsCountFollowsTheMachines(t *testing.T) {
 	empty, _ := first["AvailableIpsCount"].(float64)
 
 	for range 3 {
-		post(t, ts, "CreateVms", `{"ImageId":"ami-12345678","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+		post(t, ts, "CreateVms", `{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 	}
 
 	_, out = post(t, ts, "ReadSubnets", `{}`)
@@ -257,7 +257,7 @@ func TestDryRunReachesNoHandler(t *testing.T) {
 	ts := newServer(t)
 	_, subnetID := netAndSubnet(t, ts, "10.47.0.0/16", "10.47.1.0/24")
 
-	_, out := post(t, ts, "CreateVms", `{"ImageId":"ami-12345678","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+	_, out := post(t, ts, "CreateVms", `{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 	vms, _ := out["Vms"].([]any)
 	vm, _ := vms[0].(map[string]any)
 	vmID, _ := vm["VmId"].(string)
@@ -272,7 +272,7 @@ func TestDryRunReachesNoHandler(t *testing.T) {
 	}
 
 	// And the creating one.
-	if status, _ := post(t, ts, "CreateVms", `{"ImageId":"ami-12345678","SubnetId":"`+subnetID+`","DryRun":true}`); status != http.StatusOK {
+	if status, _ := post(t, ts, "CreateVms", `{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","DryRun":true}`); status != http.StatusOK {
 		t.Fatalf("dry run create: status %d", status)
 	}
 	_, out = post(t, ts, "ReadVms", `{}`)
@@ -313,7 +313,7 @@ func TestASubnetDoesNotDeleteUnderARace(t *testing.T) {
 			// placement and its Put. Still not wide enough to catch the missing
 			// lock, which is why the comment above says so.
 			post(t, ts, "CreateVms",
-				`{"ImageId":"ami-12345678","SubnetId":"`+subnetID+`","MaxVmsCount":8,"BootOnCreation":false}`)
+				`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","MaxVmsCount":8,"BootOnCreation":false}`)
 		}()
 		go func() {
 			defer wg.Done()
@@ -354,6 +354,12 @@ func TestASubnetDoesNotDeleteUnderARace(t *testing.T) {
 //
 // A machine the control plane does not describe is a machine nobody thinks to
 // stop, which is the worst outcome this layer can produce.
+//
+// The fixture names a catalogue OMI on purpose. It used to say ami-12345678 as
+// a placeholder, and the fallback booted the default image for it; since #83 an
+// unknown identifier never reaches the runtime at all, so this test — whose
+// subject is the vanished resource, not the resolution — must ask for an image
+// that boots.
 func TestACreateWhoseResourceVanishesLeavesNoMachineBehind(t *testing.T) {
 	runtime := newBlockingRuntime()
 	ts := newRuntimeServer(t, runtime)
@@ -362,7 +368,7 @@ func TestACreateWhoseResourceVanishesLeavesNoMachineBehind(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		post(t, ts, "CreateVms", `{"ImageId":"ami-12345678","SubnetId":"`+subnetID+`"}`)
+		post(t, ts, "CreateVms", `{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`"}`)
 	}()
 
 	// The machine is starting; empty the store under it.
@@ -487,7 +493,7 @@ func TestTwoConcurrentStartsReachTheRuntimeOnce(t *testing.T) {
 	_, subnetID := netAndSubnet(t, ts, "10.52.0.0/16", "10.52.1.0/24")
 
 	_, out := post(t, ts, "CreateVms",
-		`{"ImageId":"ami-12345678","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+		`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 	vms, _ := out["Vms"].([]any)
 	vm, _ := vms[0].(map[string]any)
 	vmID, _ := vm["VmId"].(string)
@@ -533,7 +539,7 @@ func TestUpdateVmValidatesWhatCreateValidates(t *testing.T) {
 	ts := newServer(t)
 	_, subnetID := netAndSubnet(t, ts, "10.53.0.0/16", "10.53.1.0/24")
 	_, out := post(t, ts, "CreateVms",
-		`{"ImageId":"ami-12345678","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+		`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 	vms, _ := out["Vms"].([]any)
 	vm, _ := vms[0].(map[string]any)
 	vmID, _ := vm["VmId"].(string)
@@ -745,7 +751,7 @@ func TestUpdateVmAndStartVmsDoNotOverwriteEachOther(t *testing.T) {
 	_, subnetID := netAndSubnet(t, ts, "10.57.0.0/16", "10.57.1.0/24")
 
 	_, out := post(t, ts, "CreateVms",
-		`{"ImageId":"ami-12345678","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+		`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 	vms, _ := out["Vms"].([]any)
 	vm, _ := vms[0].(map[string]any)
 	vmID, _ := vm["VmId"].(string)
@@ -796,7 +802,7 @@ func TestABodyTheServerAcceptsReachesTheHandler(t *testing.T) {
 	ts := newServer(t)
 	_, subnetID := netAndSubnet(t, ts, "10.58.0.0/16", "10.58.1.0/24")
 	_, out := post(t, ts, "CreateVms",
-		`{"ImageId":"ami-12345678","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+		`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 	vms, _ := out["Vms"].([]any)
 	vm, _ := vms[0].(map[string]any)
 	vmID, _ := vm["VmId"].(string)
@@ -836,7 +842,7 @@ func TestABodyTheServerAcceptsReachesTheHandler(t *testing.T) {
 func TestAnUnsupportedFilterIsRefused(t *testing.T) {
 	ts := newServer(t)
 	_, subnetID := netAndSubnet(t, ts, "10.60.0.0/16", "10.60.1.0/24")
-	post(t, ts, "CreateVms", `{"ImageId":"ami-12345678","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+	post(t, ts, "CreateVms", `{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 
 	for _, probe := range []struct{ action, body string }{
 		{"ReadVms", `{"Filters":{"Architectures":["x86_64"]}}`},
@@ -1022,7 +1028,7 @@ func TestAStoppedVmKeepsItsPrivateAddress(t *testing.T) {
 	ts := newRuntimeServer(t, runtime)
 
 	// No Subnet: this is the case that had the address only in the binding.
-	_, out := post(t, ts, "CreateVms", `{"ImageId":"ami-12345678"}`)
+	_, out := post(t, ts, "CreateVms", `{"ImageId":"ami-00000001"}`)
 	vms, _ := out["Vms"].([]any)
 	vm, _ := vms[0].(map[string]any)
 	vmID, _ := vm["VmId"].(string)
@@ -1062,7 +1068,7 @@ func TestReadAdminPasswordAnswersEmpty(t *testing.T) {
 	ts := newServer(t)
 	_, subnetID := netAndSubnet(t, ts, "10.62.0.0/16", "10.62.1.0/24")
 	_, out := post(t, ts, "CreateVms",
-		`{"ImageId":"ami-12345678","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+		`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 	vms, _ := out["Vms"].([]any)
 	vm, _ := vms[0].(map[string]any)
 	vmID, _ := vm["VmId"].(string)
@@ -1162,13 +1168,13 @@ func TestDeletionProtectionRefusesTheDelete(t *testing.T) {
 	_, subnetID := netAndSubnet(t, ts, "10.64.0.0/16", "10.64.1.0/24")
 
 	_, out := post(t, ts, "CreateVms",
-		`{"ImageId":"ami-12345678","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+		`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 	vms, _ := out["Vms"].([]any)
 	plain, _ := vms[0].(map[string]any)
 	plainID, _ := plain["VmId"].(string)
 
 	_, out = post(t, ts, "CreateVms",
-		`{"ImageId":"ami-12345678","SubnetId":"`+subnetID+`","BootOnCreation":false,"DeletionProtection":true}`)
+		`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false,"DeletionProtection":true}`)
 	vms, _ = out["Vms"].([]any)
 	guarded, _ := vms[0].(map[string]any)
 	guardedID, _ := guarded["VmId"].(string)
@@ -1202,7 +1208,7 @@ func TestResultsPerPageIsHonoured(t *testing.T) {
 	_, subnetID := netAndSubnet(t, ts, "10.65.0.0/16", "10.65.1.0/24")
 	for range 3 {
 		post(t, ts, "CreateVms",
-			`{"ImageId":"ami-12345678","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+			`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 	}
 
 	count := func(body string) int {
@@ -1232,7 +1238,7 @@ func TestATerminatedVmStaysReadable(t *testing.T) {
 	ts := newServer(t)
 	_, subnetID := netAndSubnet(t, ts, "10.66.0.0/16", "10.66.1.0/24")
 	_, out := post(t, ts, "CreateVms",
-		`{"ImageId":"ami-12345678","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+		`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 	vms, _ := out["Vms"].([]any)
 	vm, _ := vms[0].(map[string]any)
 	vmID, _ := vm["VmId"].(string)
@@ -1326,7 +1332,7 @@ func TestAVolumeIsCreatedReadAndLinked(t *testing.T) {
 	}
 
 	_, out = post(t, ts, "CreateVms",
-		`{"ImageId":"ami-12345678","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+		`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 	vms, _ := out["Vms"].([]any)
 	vm, _ := vms[0].(map[string]any)
 	vmID, _ := vm["VmId"].(string)
@@ -1393,7 +1399,7 @@ func TestAVolumeDoesNotShrink(t *testing.T) {
 func TestReadVmsStateAnswersRunningByDefault(t *testing.T) {
 	ts := newServer(t)
 	_, subnetID := netAndSubnet(t, ts, "10.68.0.0/16", "10.68.1.0/24")
-	_, out := post(t, ts, "CreateVms", `{"ImageId":"ami-12345678","SubnetId":"`+subnetID+`"}`)
+	_, out := post(t, ts, "CreateVms", `{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`"}`)
 	vms, _ := out["Vms"].([]any)
 	vm, _ := vms[0].(map[string]any)
 	vmID, _ := vm["VmId"].(string)

--- a/internal/providers/outscale/catalog.go
+++ b/internal/providers/outscale/catalog.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/machine"
 	"github.com/stephrobert/feint/internal/core/resource"
 )
 
@@ -138,23 +139,23 @@ var images = func() []map[string]any {
 	return out
 }()
 
-// runtimeImages maps an emulated OMI onto what the machine driver boots. Kept
+// runtimeImages maps an emulated OMI onto what the machine driver boots and
+// the login Outscale provisions on it — one value, because the right
+// distribution with the wrong login is still a machine nobody can enter. Kept
 // apart from the catalogue on purpose: it is not API surface, and holding it in
 // the same map is how it ended up in a response.
-var runtimeImages = map[string]string{
-	"ami-00000001": "ubuntu:24.04",
-	"ami-00000002": "debian:12",
-	"ami-00000003": "alpine:3.21",
+//
+// An identifier outside this map resolves to nothing, and the shared binding
+// refuses the boot rather than substituting an OS the client never named (#83).
+var runtimeImages = map[string]machine.Image{
+	"ami-00000001": {Ref: "ubuntu:24.04", User: DefaultUser},
+	"ami-00000002": {Ref: "debian:12", User: DefaultUser},
+	"ami-00000003": {Ref: "alpine:3.21", User: DefaultUser},
 }
 
 // accountID is the one account this emulator has. Outscale account IDs are
 // twelve digits, like AWS's.
 const accountID = "000000000001"
-
-// defaultImageID is what the machine driver falls back to. It is not a default
-// the API applies: CreateVms requires an ImageId, and the emulator refuses
-// without one exactly as Outscale does.
-const defaultImageID = "ami-00000001"
 
 func (p *Pack) readVmTypes(w http.ResponseWriter, _ *http.Request) {
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{

--- a/internal/providers/outscale/machines.go
+++ b/internal/providers/outscale/machines.go
@@ -51,15 +51,37 @@ func (p *Pack) logger() *slog.Logger {
 	return slog.Default()
 }
 
-// imageFor maps an emulated OMI onto the base image the runtime boots. An
-// unknown identifier falls back rather than failing: the catalogue is small and
-// fixed, and refusing to boot over an image name would block a workflow the
-// control plane already accepted.
-func imageFor(imageID string) string {
-	if image, known := runtimeImages[imageID]; known {
-		return image
+// imageFor resolves an emulated OMI onto what the machine driver boots, login
+// included — one resolution, because the right distribution with the wrong
+// login is still a machine nobody can enter.
+//
+// An unknown identifier resolves to nothing rather than falling back: the
+// control plane has accepted it — docs/limits.md declares identifiers
+// unchecked, deliberately — and the shared binding refuses the boot out loud
+// instead of starting an OS the client never named (#83).
+//
+// TestOutscaleImageResolutionIsExact fails against the fallback version.
+func imageFor(imageID string) (machine.Image, bool) {
+	image, known := runtimeImages[imageID]
+	return image, known
+}
+
+// bootRefusalReason distinguishes, for the refusal log, the two ways an OMI
+// resolves to nothing. An identifier nobody ever created is a typo the control
+// plane accepted. An image the client registered through CreateImage is the
+// more embarrassing case: ReadImages serves it, yet this emulator keeps
+// records, not disk contents, so there are no bytes to boot — and booting the
+// source's base image instead would silently drop whatever the client baked
+// into it, which is the golden-image scenario, the exact place the difference
+// matters. Both end in the same refusal; the log must not describe them the
+// same way.
+//
+// TestARegisteredImageRefusesToBootAndSaysWhy fails without the distinction.
+func (p *Pack) bootRefusalReason(imageID string) string {
+	if _, registered := p.env.Store.Get(Name, kindImage, imageID); registered {
+		return "registered by CreateImage, but this emulator keeps records, not disk contents (docs/limits.md)"
 	}
-	return runtimeImages[defaultImageID]
+	return "the identifier is in no catalogue"
 }
 
 // powerOn starts the backing machine and moves the resource to running.
@@ -74,9 +96,17 @@ func (p *Pack) powerOn(ctx context.Context, res *resource.Resource) {
 	imageID, _ := res.Attrs["ImageId"].(string)
 	keypair, _ := res.Attrs["KeypairName"].(string)
 	userData, _ := res.Attrs["UserData"].(string)
+	img, known := imageFor(imageID)
+	reason := ""
+	if !known {
+		reason = p.bootRefusalReason(imageID)
+	}
 
 	p.binding().PowerOn(ctx, res, machine.Boot{
-		Image:          imageFor(imageID),
+		Image:          img.Ref,
+		User:           img.User,
+		Requested:      imageID,
+		Reason:         reason,
 		Hostname:       res.ID,
 		AuthorizedKeys: p.authorizedKeys(keypair),
 		// The Subnet the client asked for, carried onto the machine. Without

--- a/internal/providers/outscale/machines_internal_test.go
+++ b/internal/providers/outscale/machines_internal_test.go
@@ -1,0 +1,158 @@
+package outscale
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/machine"
+	"github.com/stephrobert/feint/internal/core/resource"
+	"github.com/stephrobert/feint/internal/core/store"
+)
+
+// recordingDriver records every Spec it was asked to start, so a test can
+// assert on the image and the login rather than on a state name (#83).
+type recordingDriver struct {
+	specs []machine.Spec
+}
+
+func (d *recordingDriver) Name() string                   { return "recording" }
+func (d *recordingDriver) Available(context.Context) bool { return true }
+func (d *recordingDriver) Start(_ context.Context, spec machine.Spec) (machine.Machine, error) {
+	d.specs = append(d.specs, spec)
+	return machine.Machine{Name: spec.Name, IP: "10.42.0.9", Running: true}, nil
+}
+func (d *recordingDriver) Stop(context.Context, string) error   { return nil }
+func (d *recordingDriver) Remove(context.Context, string) error { return nil }
+func (d *recordingDriver) Inspect(_ context.Context, name string) (machine.Machine, bool, error) {
+	return machine.Machine{Name: name}, false, nil
+}
+func (d *recordingDriver) EnsureNetwork(context.Context, machine.NetworkSpec) error { return nil }
+func (d *recordingDriver) Attach(context.Context, string, machine.Attachment) error { return nil }
+func (d *recordingDriver) RemoveNetwork(context.Context, string) error              { return nil }
+
+func runtimePack(driver machine.Driver) *Pack {
+	return New(&emulator.Env{
+		Store:    store.New(),
+		Machines: driver,
+		Now:      func() time.Time { return time.Unix(1700000000, 0).UTC() },
+		NewID:    func() string { return "00000000-0000-4000-8000-000000000001" },
+		Log:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+}
+
+// One case per row of the OMI table: image and login resolve together, and an
+// identifier outside the table resolves to nothing at all.
+func TestOutscaleImageResolutionIsExact(t *testing.T) {
+	rows := map[string]machine.Image{
+		"ami-00000001": {Ref: "ubuntu:24.04", User: "outscale"},
+		"ami-00000002": {Ref: "debian:12", User: "outscale"},
+		"ami-00000003": {Ref: "alpine:3.21", User: "outscale"},
+	}
+	if len(rows) != len(runtimeImages) {
+		t.Fatalf("the table serves %d OMIs and this test knows %d: add the row here, one per OMI", len(runtimeImages), len(rows))
+	}
+	for id, want := range rows {
+		got, known := imageFor(id)
+		if !known {
+			t.Errorf("%s: a served OMI stopped resolving", id)
+			continue
+		}
+		if got != want {
+			t.Errorf("%s: resolved to %+v, want %+v — image and login travel together", id, got, want)
+		}
+	}
+	for _, id := range []string{"ami-deadbeef", "ami-99999999", ""} {
+		if img, known := imageFor(id); known {
+			t.Errorf("%q: resolved to %+v, want no resolution at all", id, img)
+		}
+	}
+}
+
+// The wiring of #83 for this pack: an unknown OMI under a runtime reaches
+// stopped — the true state Outscale declares for a Vm that did not start —
+// and the runtime is never asked for anything.
+func TestAnUnknownOmiDoesNotBootASubstitute(t *testing.T) {
+	driver := &recordingDriver{}
+	p := runtimePack(driver)
+	res := &resource.Resource{
+		ID:    "i-00000001",
+		State: stateStopped,
+		Attrs: map[string]any{"ImageId": "ami-deadbeef"},
+	}
+
+	p.powerOn(context.Background(), res)
+
+	if res.State != stateStopped {
+		t.Fatalf("state %q, want stopped: running on a substitute is the defect under test", res.State)
+	}
+	if len(driver.specs) != 0 {
+		t.Fatalf("the runtime was asked to boot %q for an OMI nobody serves", driver.specs[0].Image)
+	}
+}
+
+// The other way an OMI resolves to nothing (#83, scope note): an image the
+// client registered through CreateImage. ReadImages serves it, yet no disk
+// contents exist behind the record, so it refuses to boot exactly like an
+// identifier nobody created — and the log must say which case it is, because
+// "the emulator serves this image" and "this image never existed" are not the
+// same embarrassment.
+func TestARegisteredImageRefusesToBootAndSaysWhy(t *testing.T) {
+	driver := &recordingDriver{}
+	var log bytes.Buffer
+	p := runtimePack(driver)
+	p.env.Log = slog.New(slog.NewTextHandler(&log, nil))
+	p.env.Store.Put(&resource.Resource{
+		ID:     "ami-0000cafe",
+		Kind:   kindImage,
+		Tenant: resource.Tenant{Provider: Name},
+		State:  "available",
+		Attrs:  map[string]any{"ImageName": "golden"},
+	})
+	res := &resource.Resource{
+		ID:    "i-00000001",
+		State: stateStopped,
+		Attrs: map[string]any{"ImageId": "ami-0000cafe"},
+	}
+
+	p.powerOn(context.Background(), res)
+
+	if res.State != stateStopped {
+		t.Fatalf("state %q, want stopped: booting the source's base image would drop what the image was made to carry", res.State)
+	}
+	if len(driver.specs) != 0 {
+		t.Fatalf("the runtime was asked to boot %q for a record-only image", driver.specs[0].Image)
+	}
+	if !strings.Contains(log.String(), "CreateImage") {
+		t.Fatalf("the refusal log does not say the image was registered: %s", log.String())
+	}
+}
+
+// The accepting half: a served OMI still boots, with the login Outscale
+// provisions on its images.
+func TestAServedOmiBootsWithItsLogin(t *testing.T) {
+	driver := &recordingDriver{}
+	p := runtimePack(driver)
+	res := &resource.Resource{
+		ID:    "i-00000001",
+		State: stateStopped,
+		Attrs: map[string]any{"ImageId": "ami-00000002"},
+	}
+
+	p.powerOn(context.Background(), res)
+
+	if res.State != stateRunning {
+		t.Fatalf("state %q, want running: a guard that refuses everything breaks the product", res.State)
+	}
+	if len(driver.specs) != 1 {
+		t.Fatalf("%d boots, want 1", len(driver.specs))
+	}
+	if got := driver.specs[0]; got.Image != "debian:12" || got.User != DefaultUser {
+		t.Fatalf("booted image=%q user=%q, want debian:12 as %s", got.Image, got.User, DefaultUser)
+	}
+}

--- a/internal/providers/outscale/nics_lifecycle_test.go
+++ b/internal/providers/outscale/nics_lifecycle_test.go
@@ -147,7 +147,7 @@ func TestAnAttachedNicReportsTheLinkStateTheProviderWaitsFor(t *testing.T) {
 	_, subnetID := netAndSubnet(t, ts, "10.81.0.0/16", "10.81.1.0/24")
 
 	_, out := post(t, ts, "CreateVms",
-		`{"ImageId":"ami-12345678","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+		`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 	vms, _ := out["Vms"].([]any)
 	vm, _ := vms[0].(map[string]any)
 	vmID, _ := vm["VmId"].(string)

--- a/internal/providers/scaleway/boot_test.go
+++ b/internal/providers/scaleway/boot_test.go
@@ -1,0 +1,98 @@
+package scaleway_test
+
+import (
+	"net/http"
+	"testing"
+)
+
+// The measurement of #83, replayed against the pack the way the issue took it:
+// a create naming an image no catalogue holds answers 201 — docs/limits.md
+// declares identifiers unchecked, deliberately — and under a runtime the
+// poweron must not start a stand-in. The server reaches this provider's own
+// failed state, stopped, and the runtime is never asked for anything.
+func TestAnUnknownImageDoesNotBootASubstitute(t *testing.T) {
+	rt := newFakeRuntime()
+	close(rt.release) // nothing here needs to hold a start open
+	ts := newRuntimeTestServer(t, rt)
+	const zone = "/instance/v1/zones/fr-par-1"
+
+	status, out := do(t, ts, "POST", zone+"/servers",
+		`{"name":"demo","commercial_type":"DEV1-S","image":"totalement-inconnue"}`)
+	if status != http.StatusCreated {
+		t.Fatalf("create: status %d, the control plane must keep accepting", status)
+	}
+	server, _ := out["server"].(map[string]any)
+	id, _ := server["id"].(string)
+
+	do(t, ts, "POST", zone+"/servers/"+id+"/action", `{"action":"poweron"}`)
+
+	_, out = do(t, ts, "GET", zone+"/servers/"+id, "")
+	server, _ = out["server"].(map[string]any)
+	if state, _ := server["state"].(string); state != "stopped" {
+		t.Fatalf("state %q, want stopped: running on a substitute is the defect under test", state)
+	}
+	if n := rt.starts.Load(); n != 0 {
+		t.Fatalf("the runtime was asked %d time(s) to boot an image nobody can name", n)
+	}
+}
+
+// The marketplace answers one image per label. A single shared UUID is how
+// `image = "debian_bookworm"` used to boot an Ubuntu under Terraform, which
+// resolves a label through this route and sends the UUID back; an unknown
+// label answers a UUID that no boot resolves, instead of the default image's.
+func TestTheMarketplaceAnswersOneImagePerLabel(t *testing.T) {
+	rt := newFakeRuntime()
+	close(rt.release)
+	ts := newRuntimeTestServer(t, rt)
+
+	idOf := func(label string) string {
+		_, out := do(t, ts, "GET", "/marketplace/v2/local-images?image_label="+label, "")
+		images, _ := out["local_images"].([]any)
+		if len(images) != 1 {
+			t.Fatalf("%s: %d local images, want 1", label, len(images))
+		}
+		image, _ := images[0].(map[string]any)
+		id, _ := image["id"].(string)
+		return id
+	}
+
+	jammy, bookworm := idOf("ubuntu_jammy"), idOf("debian_bookworm")
+	if jammy == bookworm {
+		t.Fatalf("two labels share the UUID %s: the second one boots the first one's image", jammy)
+	}
+	if unknown := idOf("rocky"); unknown == jammy || unknown == bookworm {
+		t.Fatalf("an unknown label answered a served image's UUID %s", unknown)
+	}
+}
+
+// The accepting half, end to end: the label whose accidental survival named
+// the issue. Asking for alpine must boot an Alpine, as root, because on
+// Scaleway the login belongs to the cloud and travels with the resolution.
+func TestAKnownImageBootsWhatItNamesWithItsLogin(t *testing.T) {
+	rt := newFakeRuntime()
+	close(rt.release)
+	ts := newRuntimeTestServer(t, rt)
+	const zone = "/instance/v1/zones/fr-par-1"
+
+	status, out := do(t, ts, "POST", zone+"/servers",
+		`{"name":"demo","commercial_type":"DEV1-S","image":"alpine"}`)
+	if status != http.StatusCreated {
+		t.Fatalf("create: status %d", status)
+	}
+	server, _ := out["server"].(map[string]any)
+	id, _ := server["id"].(string)
+
+	do(t, ts, "POST", zone+"/servers/"+id+"/action", `{"action":"poweron"}`)
+
+	_, out = do(t, ts, "GET", zone+"/servers/"+id, "")
+	server, _ = out["server"].(map[string]any)
+	if state, _ := server["state"].(string); state != "running" {
+		t.Fatalf("state %q, want running: a guard that refuses everything breaks the product", state)
+	}
+	if len(rt.specs) != 1 {
+		t.Fatalf("%d boots, want 1", len(rt.specs))
+	}
+	if got := rt.specs[0]; got.Image != "alpine:3.21" || got.User != "root" {
+		t.Fatalf("booted image=%q user=%q, want alpine:3.21 as root", got.Image, got.User)
+	}
+}

--- a/internal/providers/scaleway/catalog.go
+++ b/internal/providers/scaleway/catalog.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/machine"
 )
 
 // A local emulator has no inventory of its own, but it cannot decline the
@@ -125,6 +126,49 @@ var catalogue = map[string]*serverType{
 // defaultImageLabel is the image the CLI asks for when none is given.
 const defaultImageLabel = "ubuntu_jammy"
 
+// marketplaceImages is the emulated marketplace: which label answers which
+// stable UUID, and what the machine driver boots for it — login included,
+// because an image resolved without its login is a machine nobody can enter.
+// Scaleway provisions root on every image (`scw instance server ssh` documents
+// username=root), so every row carries the same login; that is this cloud's own
+// shape, where Exoscale's login varies per template.
+//
+// The table is fiction, like the rest of this catalogue (docs/limits.md), and
+// exact on purpose: image labels used to be matched by substring with a
+// fallback, which turned ubuntu_focal, centos, rocky — every label the table
+// does not list — into a silent Ubuntu 22.04 (#83). An identifier outside this
+// table now resolves to nothing and the shared binding refuses the boot.
+//
+// One UUID per label, so a client that resolves a label through the
+// marketplace and sends the UUID back still names the distribution it chose;
+// a single shared UUID is how `image = "debian_bookworm"` used to boot an
+// Ubuntu under Terraform. The UUIDs are fixed because Terraform keeps them in
+// state, and ubuntu_jammy keeps the UUID this emulator has always answered.
+var marketplaceImages = map[string]struct {
+	ID   string
+	Boot machine.Image
+}{
+	"ubuntu_noble":    {"55555555-5555-4555-8555-555555555555", machine.Image{Ref: "ubuntu:24.04", User: DefaultUser}},
+	"ubuntu_jammy":    {"22222222-2222-4222-8222-222222222222", machine.Image{Ref: "ubuntu:22.04", User: DefaultUser}},
+	"debian_bookworm": {"66666666-6666-4666-8666-666666666666", machine.Image{Ref: "debian:12", User: DefaultUser}},
+	"debian_trixie":   {"77777777-7777-4777-8777-777777777777", machine.Image{Ref: "debian:13", User: DefaultUser}},
+	// Not a label the real marketplace lists today; kept because this emulator
+	// has always booted an Alpine for it — previously by accident of substring
+	// matching, now by decision — and the question that raised #83 was
+	// precisely "does it boot the OS I asked for", asked about Alpine.
+	"alpine": {"88888888-8888-4888-8888-888888888888", machine.Image{Ref: "alpine:3.21", User: DefaultUser}},
+}
+
+// labelByID is the reverse of marketplaceImages, for the UUID a client sends
+// after resolving a label through the marketplace.
+var labelByID = func() map[string]string {
+	out := make(map[string]string, len(marketplaceImages))
+	for label, entry := range marketplaceImages {
+		out[entry.ID] = label
+	}
+	return out
+}()
+
 func (p *Pack) listServerTypes(w http.ResponseWriter, r *http.Request) {
 	if _, ok := zoneOf(w, r); !ok {
 		return
@@ -136,9 +180,10 @@ func (p *Pack) listServerTypes(w http.ResponseWriter, r *http.Request) {
 }
 
 // listLocalImages answers the marketplace lookup the CLI performs to resolve an
-// image label into an ID. Any label is accepted and mapped onto one stable
-// image, because refusing an unknown label would only block a workflow the
-// emulator has no opinion about.
+// image label into an ID. Any label is accepted and answers 200, because
+// refusing an unknown one would block a workflow the emulator has no opinion
+// about (docs/limits.md) — but an unknown label maps onto unknownImageID, which
+// no boot resolves, rather than onto an image the client never named (#83).
 func (p *Pack) listLocalImages(w http.ResponseWriter, r *http.Request) {
 	label := r.URL.Query().Get("image_label")
 	if label == "" {
@@ -154,9 +199,12 @@ func (p *Pack) listLocalImages(w http.ResponseWriter, r *http.Request) {
 		compatible = append(compatible, name)
 	}
 
-	// A fixed UUID: Terraform stores the image ID in state, and a value that
-	// changed between two runs would show up as a permanent diff.
-	const imageID = "22222222-2222-4222-8222-222222222222"
+	// Fixed UUIDs, one per label: Terraform stores the image ID in state, and a
+	// value that changed between two runs would show up as a permanent diff.
+	imageID := unknownImageID
+	if entry, known := marketplaceImages[label]; known {
+		imageID = entry.ID
+	}
 
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
 		"local_images": []map[string]any{{

--- a/internal/providers/scaleway/concurrency_test.go
+++ b/internal/providers/scaleway/concurrency_test.go
@@ -25,6 +25,9 @@ import (
 type fakeRuntime struct {
 	mu       sync.Mutex
 	machines map[string]bool
+	// specs keeps what each start was asked to boot, so a test can assert on
+	// the image and the login rather than on a state name (#83).
+	specs []machine.Spec
 
 	starts atomic.Int32
 	// entered is signalled on the way into Start, before it blocks, so a test
@@ -70,6 +73,7 @@ func (f *fakeRuntime) Start(_ context.Context, spec machine.Spec) (machine.Machi
 
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.specs = append(f.specs, spec)
 	if _, taken := f.machines[spec.Name]; taken {
 		return machine.Machine{}, errors.New(`Failed creating instance record: Add instance info to the database: This "instances" entry already exists`)
 	}

--- a/internal/providers/scaleway/images.go
+++ b/internal/providers/scaleway/images.go
@@ -6,24 +6,32 @@ import (
 	"github.com/stephrobert/feint/internal/core/emulator"
 )
 
-// imageID is the single image the emulator knows about, matching the one the
-// marketplace lookup returns. Fixed on purpose: Terraform keeps the image ID in
-// state, and a value that changed between runs would show as a permanent diff.
-const imageID = "22222222-2222-4222-8222-222222222222"
+// unknownImageID is the UUID answered for an image label no catalogue holds.
+// The lookup still succeeds — docs/limits.md declares identifiers unchecked,
+// deliberately — but this UUID maps back onto no bootable image, so a runtime
+// refuses to boot it instead of substituting a distribution the client never
+// named (#83). Fixed, like every catalogue UUID, because Terraform keeps it in
+// state.
+const unknownImageID = "99999999-9999-4999-8999-999999999999"
 
-// getImage answers the lookup the CLI performs after resolving a label. Any ID
-// is served as the same image: the emulator has no image catalogue and refusing
-// unknown IDs would only break scripts that hardcode a real one.
+// getImage answers the lookup the CLI performs after resolving a label. An
+// unknown ID is still served — refusing would break scripts that hardcode a
+// real one (docs/limits.md) — under the default label, which is display
+// fiction like the rest of the catalogue; a known ID answers its own label.
 func (p *Pack) getImage(w http.ResponseWriter, r *http.Request) {
 	zone, ok := zoneOf(w, r)
 	if !ok {
 		return
 	}
 	id := r.PathValue("id")
-	if id == "" {
-		id = imageID
+	label := defaultImageLabel
+	switch l, known := labelByID[id]; {
+	case id == "":
+		id = marketplaceImages[defaultImageLabel].ID
+	case known:
+		label = l
 	}
-	emulator.WriteJSON(w, http.StatusOK, map[string]any{"image": p.imageView(zone, id, defaultImageLabel)})
+	emulator.WriteJSON(w, http.StatusOK, map[string]any{"image": p.imageView(zone, id, label)})
 }
 
 // imageView is the shape the SDK decodes into instance.Image, shared by the
@@ -66,22 +74,35 @@ func (p *Pack) imageView(zone, id, label string) map[string]any {
 	}
 }
 
-// resolveImage maps what a create request put in `image` onto the pair the
-// emulator needs: the ID to publish, and the label the machine driver turns into
-// a base image.
+// resolveImage maps what a create request put in `image` onto what the
+// emulator needs: the ID to publish, the name to display, and the catalogue
+// label the machine driver turns into a base image.
 //
 // Clients send either form. The Terraform provider resolves the label through
 // the marketplace first and sends a UUID; the CLI can send the label itself.
 // Telling them apart is what lets `image = "debian_bookworm"` boot a Debian
 // rather than the default.
-func resolveImage(requested string) (id, label string) {
+//
+// label is empty when the identifier is in no catalogue. The create still
+// succeeds — deliberate, and documented in docs/limits.md — but a boot refuses
+// an empty label rather than substituting a distribution the client never
+// named (#83). display keeps the response behaviour of before: the requested
+// label verbatim, or the default label for a foreign UUID, because an image
+// name in a response is catalogue fiction either way.
+func resolveImage(requested string) (id, display, label string) {
 	switch {
 	case requested == "":
-		return imageID, defaultImageLabel
+		return marketplaceImages[defaultImageLabel].ID, defaultImageLabel, defaultImageLabel
 	case looksLikeUUID(requested):
-		return requested, defaultImageLabel
+		if l, known := labelByID[requested]; known {
+			return requested, l, l
+		}
+		return requested, defaultImageLabel, ""
 	default:
-		return imageID, requested
+		if entry, known := marketplaceImages[requested]; known {
+			return entry.ID, requested, requested
+		}
+		return unknownImageID, requested, ""
 	}
 }
 

--- a/internal/providers/scaleway/machines.go
+++ b/internal/providers/scaleway/machines.go
@@ -3,7 +3,6 @@ package scaleway
 import (
 	"context"
 	"log/slog"
-	"strings"
 
 	"github.com/stephrobert/feint/internal/core/machine"
 	"github.com/stephrobert/feint/internal/core/resource"
@@ -34,9 +33,6 @@ const runtimeMachineKey = "machine"
 // ssh` documents username=root).
 const DefaultUser = "root"
 
-// defaultImage stands in for the default Scaleway image.
-const defaultImage = "ubuntu:22.04"
-
 // binding is this pack's half of the shared machine lifecycle.
 func (p *Pack) binding() machine.Binding {
 	return machine.Binding{
@@ -57,28 +53,46 @@ func (p *Pack) binding() machine.Binding {
 	}
 }
 
-// imageFor maps a Scaleway image label onto the base image that stands in for
-// it, the same way local AWS emulators map an AMI onto a runtime image. The
-// value is runtime-agnostic ("ubuntu:22.04"): the driver translates it, which is
-// what lets a pack name an operating system without knowing what runs it.
+// imageFor resolves a Scaleway image label onto what stands in for it — image
+// and login in one value, because the right distribution with the wrong login
+// is still a machine nobody can enter.
 //
-// An unknown label falls back to the default rather than failing: the emulator
-// has no image catalogue and refusing would only block a workflow.
-func imageFor(label string) string {
-	switch {
-	case strings.Contains(label, "noble"), strings.Contains(label, "24_04"), strings.Contains(label, "2404"):
-		return "ubuntu:24.04"
-	case strings.Contains(label, "jammy"), strings.Contains(label, "22_04"), strings.Contains(label, "2204"):
-		return "ubuntu:22.04"
-	case strings.Contains(label, "bookworm"), strings.Contains(label, "debian12"):
-		return "debian:12"
-	case strings.Contains(label, "trixie"), strings.Contains(label, "debian13"):
-		return "debian:13"
-	case strings.Contains(label, "alpine"):
-		return "alpine:3.21"
-	default:
-		return defaultImage
+// Exact lookup, deliberately. This used to match by substring with a fallback,
+// which booted a silent Ubuntu 22.04 for ubuntu_focal, centos, rocky — every
+// label the table does not list — while the API kept reporting the label the
+// client sent (#83). An unknown label now resolves to nothing, and the shared
+// binding refuses the boot instead of substituting.
+//
+// TestScalewayImageResolutionIsExact fails against the substring version.
+func imageFor(label string) (machine.Image, bool) {
+	entry, known := marketplaceImages[label]
+	if !known {
+		return machine.Image{}, false
 	}
+	return entry.Boot, true
+}
+
+// requestedImageOf names, for the refusal log, what the client asked to boot:
+// the catalogue label when there is one, otherwise what the create stored. A
+// foreign UUID is named as itself; behind unknownImageID the stored name is
+// the client's own label when the create carried one, and the display default
+// — which the client never said — is never reported as if it had.
+func requestedImageOf(res *resource.Resource, label string) string {
+	if label != "" {
+		return label
+	}
+	image, _ := res.Attrs["image"].(map[string]any)
+	if image == nil {
+		return ""
+	}
+	id, _ := image["id"].(string)
+	if id != "" && id != unknownImageID {
+		return id
+	}
+	if name, _ := image["name"].(string); name != "" && name != defaultImageLabel {
+		return name
+	}
+	return id
 }
 
 // startMachine powers the server on. It returns the address to publish, empty
@@ -86,13 +100,16 @@ func imageFor(label string) string {
 func (p *Pack) startMachine(ctx context.Context, res *resource.Resource) {
 	label, _ := res.Attrs["image_label"].(string)
 	hostname, _ := res.Attrs["hostname"].(string)
+	img, _ := imageFor(label)
 
 	// A client that stored its own cloud-init gets it verbatim, the way Scaleway
 	// hands the "cloud-init" user data key to cloud-init at boot. The
 	// consequence is stated in docs/limits.md: with a custom cloud-init, the
 	// project's SSH keys are only installed if the script installs them.
 	p.binding().PowerOn(ctx, res, machine.Boot{
-		Image:          imageFor(label),
+		Image:          img.Ref,
+		User:           img.User,
+		Requested:      requestedImageOf(res, label),
 		Hostname:       hostname,
 		AuthorizedKeys: p.authorizedKeys(res.Tenant.Project),
 		CloudInit:      userDataOf(res, CloudInitKey),

--- a/internal/providers/scaleway/machines_internal_test.go
+++ b/internal/providers/scaleway/machines_internal_test.go
@@ -1,0 +1,75 @@
+package scaleway
+
+import (
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/machine"
+)
+
+// One case per row of the marketplace table, spelled out rather than iterated
+// from the table itself: a guard that refused everything would pass a loop
+// over an emptied table and break the product (#83).
+func TestScalewayImageResolutionIsExact(t *testing.T) {
+	rows := map[string]machine.Image{
+		"ubuntu_noble":    {Ref: "ubuntu:24.04", User: "root"},
+		"ubuntu_jammy":    {Ref: "ubuntu:22.04", User: "root"},
+		"debian_bookworm": {Ref: "debian:12", User: "root"},
+		"debian_trixie":   {Ref: "debian:13", User: "root"},
+		"alpine":          {Ref: "alpine:3.21", User: "root"},
+	}
+	if len(rows) != len(marketplaceImages) {
+		t.Fatalf("the table serves %d labels and this test knows %d: add the row here, one per label", len(marketplaceImages), len(rows))
+	}
+	for label, want := range rows {
+		got, known := imageFor(label)
+		if !known {
+			t.Errorf("%s: a served label stopped resolving", label)
+			continue
+		}
+		if got != want {
+			t.Errorf("%s: resolved to %+v, want %+v — image and login travel together", label, got, want)
+		}
+	}
+
+	// The substring victims: every one of these used to become Ubuntu 22.04
+	// silently, including the labels that merely contain a served word.
+	for _, label := range []string{"ubuntu_focal", "centos", "rocky", "fedora", "alpine_edge", "my_ubuntu_jammy_copy", ""} {
+		if img, known := imageFor(label); known {
+			t.Errorf("%q: resolved to %+v, want no resolution at all", label, img)
+		}
+	}
+}
+
+// The identifiers a client can send round-trip through the marketplace: a
+// label resolves to its own UUID, and that UUID resolves back to the same
+// boot. A single shared UUID is how `image = "debian_bookworm"` used to boot
+// an Ubuntu under Terraform, which resolves labels through the marketplace
+// and sends the UUID back.
+func TestResolveImageRoundTripsTheMarketplace(t *testing.T) {
+	for label, entry := range marketplaceImages {
+		id, display, boot := resolveImage(label)
+		if id != entry.ID || display != label || boot != label {
+			t.Errorf("%s: resolved to (%s, %s, %s), want (%s, %s, %s)", label, id, display, boot, entry.ID, label, label)
+		}
+		id, display, boot = resolveImage(entry.ID)
+		if id != entry.ID || display != label || boot != label {
+			t.Errorf("%s: the marketplace UUID resolved to (%s, %s, %s), want its own label back", entry.ID, id, display, boot)
+		}
+	}
+	if id, display, boot := resolveImage(""); id != marketplaceImages[defaultImageLabel].ID || display != defaultImageLabel || boot != defaultImageLabel {
+		t.Errorf("no image requested: resolved to (%s, %s, %s), want the default", id, display, boot)
+	}
+}
+
+// An identifier no catalogue holds is still accepted — docs/limits.md declares
+// identifiers unchecked, deliberately — but resolves to no bootable label, so
+// a runtime refuses the boot instead of substituting.
+func TestResolveImageLeavesAnUnknownIdentifierUnresolved(t *testing.T) {
+	if id, display, boot := resolveImage("rocky"); id != unknownImageID || display != "rocky" || boot != "" {
+		t.Errorf("unknown label: resolved to (%s, %s, %q), want (%s, rocky, empty)", id, display, boot, unknownImageID)
+	}
+	const foreign = "de305d54-75b4-431b-adb2-eb6b9e546014"
+	if id, display, boot := resolveImage(foreign); id != foreign || display != defaultImageLabel || boot != "" {
+		t.Errorf("foreign UUID: resolved to (%s, %s, %q), want the UUID kept, the default display, no boot", id, display, boot)
+	}
+}

--- a/internal/providers/scaleway/servers.go
+++ b/internal/providers/scaleway/servers.go
@@ -282,7 +282,7 @@ func (p *Pack) createServer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resolvedImageID, imageLabel := resolveImage(req.Image)
+	resolvedImageID, imageDisplay, imageLabel := resolveImage(req.Image)
 
 	res := &resource.Resource{
 		ID:      p.env.NewID(),
@@ -301,7 +301,7 @@ func (p *Pack) createServer(w http.ResponseWriter, r *http.Request) {
 		"organization":    organization,
 		"hostname":        req.Name,
 		"tags":            orEmpty(req.Tags),
-		"image":           p.imageView(zone, resolvedImageID, imageLabel),
+		"image":           p.imageView(zone, resolvedImageID, imageDisplay),
 		"volumes":         p.attachTemplateVolumes(req.Volumes, rootVol, res, zone, req.Name),
 		// Deprecated upstream, and "always null when routed_ip_enabled is True",
 		// which is this emulator's default. The address of a server on a private
@@ -317,9 +317,11 @@ func (p *Pack) createServer(w http.ResponseWriter, r *http.Request) {
 		"security_group":      securityGroup,
 		"allowed_actions":     []any{"poweron", "backup"},
 		"maintenances":        []any{},
-		// Kept so the machine driver knows which OCI image stands in for the
-		// requested cloud image. Harmless in the response: the real API exposes
-		// the image too, just as an object.
+		// Kept so the machine driver knows which catalogue image stands in for
+		// the requested cloud image. Empty when the identifier resolved to
+		// nothing, which a boot refuses rather than substituting (#83).
+		// Harmless in the response: the real API exposes the image too, just
+		// as an object.
 		"image_label": imageLabel,
 	}
 	// Every flexible IP the caller named is resolved before anything is stored.


### PR DESCRIPTION
Closes #83.

Ask for Alpine, boot Ubuntu, and nothing said so. An image identifier no catalogue held was silently substituted at boot by all three packs — Scaleway by label **substring** matching, so `centos`, `rocky` and `ubuntu_focal` all became Ubuntu 22.04 — while the API kept reporting the identifier the client sent.

Raised by a reader of the 0.4.0 announcement, whose question was the sharpest available: *does it correctly simulate the boot of an instance depending on the OS version?*

## The decision

Two sound decisions collided. `docs/limits.md` deliberately declares identifiers unchecked, so a hardcoded production image UUID keeps working; the north star says the machine must not run something the client never named.

The way out is this repository's own line: **the state published is the one the effect produced, not the one the intention aimed at.** So the control plane keeps accepting, and the boot refuses — the machine reaches the provider's own failed state and the log names the identifier.

Rejected, and both named in `docs/limits.md`: refusing at the create, which turns the fiction catalogue into a whitelist and breaks the documented production-UUID promise; and substituting out loud, which leaves a machine whose `/etc/os-release` contradicts the API for as long as it runs — a warning does not fix what a playbook branches on.

The guard lives in the shared `machine.Binding.Start`, so no pack can substitute silently and a fourth one could not either. `Noop` is exempt: with `--vm off` nothing boots, so nothing changes.

## Image and login are one resolution

New `machine.Image{Ref, User}`: every resolver returns the pair — `root` on Scaleway, `outscale` on Outscale, the template's own `default-user` on Exoscale. A good image with the wrong login is a machine nobody enters, which is the same half-success in a different place.

## Alpine could not have logged in either way

Found while trying to prove the above. Alpine fell through to the Debian template and was asked for four things it cannot do: bash it does not ship, a sudo group it calls `wheel`, an `openssh-server` package apk names `openssh`, and `systemctl` where it runs OpenRC.

A fifth was found by measuring rather than reading, and it is the one a careful review would have missed: **Alpine's openssh package installs no host key**, and sshd started without one answers `Starting sshd ... [ ok ]` and then listens on nothing. Measured on `images:alpine/3.21/cloud`: 0 keys after the install, 6 after `ssh-keygen -A`, port 22 open only then. Debian and Ubuntu never needed it, so the omission was invisible in the templates this one was copied from.

The tests assert the **directives**, not the document: the first version failed on this template's own prose, since the comment explaining that apk names the package `openssh` rather than `openssh-server` contains the string `openssh-server`. A test that reads comments measures the text and not the behaviour.

## Proven on real machines, combined with #119

Both branches touch the boot path, so neither one's green said anything about the pair. Run together, on this station, with `--vm incus`:

```
scaleway   ok: address 203.0.113.2     ok: logged in: root
outscale   ok: publishes 198.51.100.1  ok: logged in: outscale
exoscale   ok: elastic IP 192.0.2.1    ok: logged in: debian

image "totalement-inconnue"  →  201 accepted, then stopped, and no machine booted
```

That last line is the whole issue: the control plane accepts as documented, the boot refuses, and nothing runs an OS nobody asked for.

## Checks

```
mise run check        ✅
mise run drift:check  ✅ 0
feint docs --check    ✅ 0
conformance:ssh       ✅ 3/3 with real logins, rebased on #119
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)