### PR TITLE
feat(shapes): a declined field has a reason, and the gate runs on every PR

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -86,6 +86,18 @@ jobs:
       - name: go test (race)
         run: go test -race ./...
 
+      # The emulator must answer the shapes a real cloud was observed to return
+      # (shapes/*.json) — the drift the SDK scan cannot see, because it measures
+      # what a provider offers, never what it returns. Offline, no credential,
+      # so it runs on every pull request, forks included. Exit 2 means a field
+      # the record proves and no pack declines: serve it, or decline it with a
+      # reason in the pack's DeclinedFields(). Exit 1 means the declines
+      # themselves are unusable (no reason, or stale).
+      - name: The emulator answers the recorded shapes
+        run: |
+          go build -o feint ./cmd/feint
+          ./feint shapes --check
+
       # Fuzz the one input feint does not control: the JSON body a client posts. A panic in a
       # handler takes down every provider sharing the process, so a crasher must surface in CI
       # rather than in someone's terminal. Crashers land in testdata/fuzz/ and become permanent

--- a/docs/fourth-pack.md
+++ b/docs/fourth-pack.md
@@ -153,23 +153,26 @@ What is **not** industrial today is three things, none structural:
 1. **Make proxy redaction hold for dialects nobody has read** (security,
    above). Allowlist request headers; prove it with a recorded exchange whose
    credential carrier matches no pattern.
-2. **Give the shapes gate a way to record a decision.** Today `feint shapes
-   --check` exits 2 on six fields that are decisions, not omissions:
+2. **Give the shapes gate a way to record a decision.** Done, 2026-08-13
+   (#91): `emulator.FieldDecline` is the transposition of `Declined()` to
+   fields — declared in the pack via the optional `FieldDecliner` interface,
+   `{operation key, field path, reason}`, subtracted by `feint shapes --check`,
+   and counted in its output so a growing declined list stays visible.
+   Pack-side code rather than a sidecar JSON, for the same reason `Declined()`
+   is code: a decision needs a review path and a reason next to it, and
+   `shapes/*.json` is regenerated, which is exactly where a human decision must
+   not live. The six fields that kept the gate red are now declared: Scaleway's
    `per_volume_constraint.l_ssd` (a constraint for local volumes the emulator
    never attaches, and `docs/limits.md` already documents why `min_size` stays
    0), and Exoscale's `zones[].id` and `security-groups[].visibility` (live on
    the wire, absent from the published OpenAPI this emulator enforces as
-   closed; the 98f8df6 commit message records the decision in prose, which is
-   the one place a gate cannot read). A permanently red gate is a gate that
-   never gets wired into CI, or gets disarmed, and this one is not wired yet.
-   The transposition of `Declined()` to fields is the right shape: declared in
-   the pack, `{operation key, field path, reason}`, subtracted by the check,
-   **and counted in its output** so a growing declined list stays visible.
-   Pack-side code rather than a sidecar JSON, for the same reason `Declined()`
-   is code: a decision needs a review path and a reason next to it, and
-   `shapes/*.json` is regenerated, which is exactly where a human decision must
-   not live. Estimated ~100 lines including the test. This unblocks wiring the
-   gate into every pull request, which is the point of having built it.
+   closed; the 98f8df6 commit message recorded the decision in prose, which is
+   the one place a gate cannot read). A reason faces the same guard as an
+   operation's (`TestEveryDeclinedFieldSaysWhy`), and a decline that excuses
+   nothing fails the gate as stale (`TestAStaleFieldDeclineFailsTheGate`), so
+   the list cannot rot. The gate is wired into every pull request — a go.yml
+   step and `TestTheRepositorysShapesAreServedOrDeclined` inside `go test` —
+   which was the point of building it.
 3. **Derive provider lists from mounted packs** in `shapes_check.go` and
    `docs.go`. Done, 2026-08-11: both gates read `srv.Packs()`, the pattern
    `env.go` already used. "Invisible to the gate" became the honest "no

--- a/internal/cli/declined_test.go
+++ b/internal/cli/declined_test.go
@@ -42,6 +42,32 @@ func TestEveryDeclinedOperationSaysWhy(t *testing.T) {
 	t.Logf("%d refusals, each with a reason", total)
 }
 
+// Every field-level refusal in every pack states its reason, exactly as the
+// operation-level test above asserts one level up, and for the same reason: the
+// FieldDecliner interface alone would accept Reason: "" and move the problem
+// instead of solving it. It lives here rather than in each pack because a check
+// copied into three packs is a check the fourth pack will not have.
+func TestEveryDeclinedFieldSaysWhy(t *testing.T) {
+	env := &emulator.Env{Store: store.New()}
+	packs := []emulator.Pack{scaleway.New(env), outscale.New(env), exoscale.New(env)}
+
+	total := 0
+	for _, p := range packs {
+		fields := emulator.FieldDeclinesOf(p)
+		total += len(fields)
+		for _, f := range emulator.UnexplainedFieldDeclines(fields) {
+			t.Errorf("%s declines the field %s with no usable reason", p.Name(), f)
+		}
+		for _, f := range emulator.DuplicateFieldDeclines(fields) {
+			t.Errorf("%s declines the field %s more than once", p.Name(), f)
+		}
+	}
+	if total == 0 {
+		t.Fatal("no pack declines a field: this test would pass on an empty repository")
+	}
+	t.Logf("%d field refusal(s), each with a reason", total)
+}
+
 // One operation declined twice is not a style problem. `feint coverage` builds a
 // map and keeps the last reason; docs/routes.md walks the slice and prints the
 // operation twice with both reasons, so the two documents disagree and the count

--- a/internal/cli/shapes_check.go
+++ b/internal/cli/shapes_check.go
@@ -41,11 +41,42 @@ import (
 // belongs on every pull request and in the release preflight. Refreshing those
 // files needs a real account and is a human's job (`feint shapes --record`);
 // checking against them is not.
+//
+// A gap a pack has declined at field level (emulator.FieldDecliner) is excused
+// rather than counted: it is printed with its reason, because what the gate
+// subtracts must stay visible, and it does not redden the build. What does:
+//   - an undeclared gap — exit 2, the drift code, because either the emulator
+//     or the cloud moved;
+//   - a decline whose reason carries no decision — exit 1, the same guard
+//     Declined() faces;
+//   - a decline that excuses nothing — exit 1, because a decline that outlives
+//     its gap reads as a decision about a field the emulator now serves, or
+//     never omitted, and keeping it would let the list rot into fiction.
 func checkShapes(dir string, providers []string, stdout, stderr io.Writer) int {
 	env := emulator.DefaultEnv()
 	srv, err := emulator.NewServer(env, packsFor(env)...)
 	if err != nil {
 		fmt.Fprintf(stderr, "feint: build the emulator: %v\n", err)
+		return exitError
+	}
+	// The same gate the operation-level refusals face in coverage(): a decline
+	// with an unusable reason, or written twice, is refused before anything is
+	// compared. TestAnUnusableFieldDeclineReasonFailsTheGate fails without it.
+	declines := map[string][]emulator.FieldDecline{}
+	unusable := 0
+	for _, p := range srv.Packs() {
+		fd := emulator.FieldDeclinesOf(p)
+		for _, f := range emulator.UnexplainedFieldDeclines(fd) {
+			fmt.Fprintf(stderr, "feint: %s declines the field %s with no usable reason\n", p.Name(), f)
+			unusable++
+		}
+		for _, f := range emulator.DuplicateFieldDeclines(fd) {
+			fmt.Fprintf(stderr, "feint: %s declines the field %s more than once\n", p.Name(), f)
+			unusable++
+		}
+		declines[p.Name()] = fd
+	}
+	if unusable > 0 {
 		return exitError
 	}
 	// Derived from the mounted packs rather than written here. A hardcoded list
@@ -61,7 +92,7 @@ func checkShapes(dir string, providers []string, stdout, stderr io.Writer) int {
 	ts := httptest.NewServer(srv.Handler())
 	defer ts.Close()
 
-	total, missing := 0, 0
+	total, missing, excused, stale := 0, 0, 0, 0
 	for _, name := range providers {
 		p := upstream.Provider(name)
 		cat, err := readCatalogue(filepath.Join(dir, name+".json"), name)
@@ -70,13 +101,26 @@ func checkShapes(dir string, providers []string, stdout, stderr io.Writer) int {
 			return exitError
 		}
 		if cat == nil {
+			// No catalogue means nothing observed, so nothing to compare — and
+			// nothing to hold this provider's declines against either: their
+			// staleness is only measurable where a comparison ran.
 			fmt.Fprintf(stdout, "%s: no catalogue in %s; nothing to check\n", name, dir)
 			continue
 		}
 
-		checked, gaps := checkProvider(p, cat, ts, stdout)
+		checked, gaps, excusedHere, unused := checkProvider(p, cat, declines[name], ts, stdout)
 		total += checked
 		missing += gaps
+		excused += excusedHere
+		// A decline that excused no gap is stale: the field is served now, or
+		// was never observed missing. Failing on it is what keeps the declined
+		// list a set of live decisions instead of an archive — the analogue of
+		// the orphan-route check on Route.Operation.
+		// TestAStaleFieldDeclineFailsTheGate fails without this.
+		for _, d := range unused {
+			fmt.Fprintf(stderr, "feint: %s declines %s %s, and the emulator does not omit it: the decline is stale, remove it\n", name, d.Operation, d.Path)
+			stale++
+		}
 	}
 
 	// Coverage is printed whatever the verdict. A gate that says "ok" without
@@ -84,6 +128,14 @@ func checkShapes(dir string, providers []string, stdout, stderr io.Writer) int {
 	// "nothing was checked" — the same reason `feint status` prints how many
 	// routes no client has driven.
 	fmt.Fprintf(stdout, "\n%d operation(s) compared, %d field(s) the real cloud returns and this emulator does not\n", total, missing)
+	if excused > 0 {
+		// Counted out loud so a growing declined list stays visible instead of
+		// silently hollowing the gate.
+		fmt.Fprintf(stdout, "%d field(s) knowingly not served, each printed above with its reason\n", excused)
+	}
+	if stale > 0 {
+		return exitError
+	}
 	if missing > 0 {
 		fmt.Fprintln(stderr, "feint: run `feint shapes --record --provider <name>` on a station with an account if the cloud is what changed")
 		return exitDrift
@@ -92,7 +144,12 @@ func checkShapes(dir string, providers []string, stdout, stderr io.Writer) int {
 }
 
 // checkProvider drives one provider's read list against the emulator.
-func checkProvider(p upstream.Provider, cat *shape.Catalogue, ts *httptest.Server, stdout io.Writer) (checked, missing int) {
+//
+// Besides the counts, it returns the declines that excused nothing, for the
+// caller to refuse: whether a decline is stale is only known once every
+// operation of its provider has been compared.
+func checkProvider(p upstream.Provider, cat *shape.Catalogue, declines []emulator.FieldDecline, ts *httptest.Server, stdout io.Writer) (checked, missing, excused int, unused []emulator.FieldDecline) {
+	used := make([]bool, len(declines))
 	for _, call := range upstream.Reads[p] {
 		key, method, path := callIdentity(p, call)
 		want, known := cat.Operations[key]
@@ -107,20 +164,45 @@ func checkProvider(p upstream.Provider, cat *shape.Catalogue, ts *httptest.Serve
 		if !ok {
 			continue
 		}
-
-		gaps := absentFrom(want.Fields, got)
-		if len(gaps) == 0 {
-			checked++
-			continue
-		}
 		checked++
-		missing += len(gaps)
-		fmt.Fprintf(stdout, "\n%s %s\n", p, key)
-		for _, g := range gaps {
-			fmt.Fprintf(stdout, "  missing  %s: %s\n", g.Path, g.Type)
+
+		var lines []string
+		for _, g := range absentFrom(want.Fields, got) {
+			if i := matchingDecline(declines, key, g.Path); i >= 0 {
+				used[i] = true
+				excused++
+				lines = append(lines, fmt.Sprintf("  declined %s: %s", g.Path, declines[i].Reason))
+				continue
+			}
+			missing++
+			lines = append(lines, fmt.Sprintf("  missing  %s: %s", g.Path, g.Type))
+		}
+		if len(lines) > 0 {
+			fmt.Fprintf(stdout, "\n%s %s\n", p, key)
+			for _, l := range lines {
+				fmt.Fprintln(stdout, l)
+			}
 		}
 	}
-	return checked, missing
+	for i, ok := range used {
+		if !ok {
+			unused = append(unused, declines[i])
+		}
+	}
+	return checked, missing, excused, unused
+}
+
+// matchingDecline is the first decline covering this field, or -1. First match
+// wins; two declines that could both cover one field are caught upstream — an
+// exact duplicate by DuplicateFieldDeclines, an overlapping pair because the
+// shadowed one excuses nothing and fails the gate as stale.
+func matchingDecline(declines []emulator.FieldDecline, operation, path string) int {
+	for i, d := range declines {
+		if d.Matches(operation, path) {
+			return i
+		}
+	}
+	return -1
 }
 
 // absentFrom returns the observed fields the emulator did not produce.

--- a/internal/cli/shapes_check_test.go
+++ b/internal/cli/shapes_check_test.go
@@ -1,10 +1,13 @@
 package cli
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/providers/scaleway"
+	"github.com/stephrobert/feint/internal/shape"
 	"github.com/stephrobert/feint/internal/transcript"
 )
 
@@ -116,3 +119,157 @@ func (p stubPack) Name() string                    { return p.name }
 func (p stubPack) Routes() []emulator.Route        { return nil }
 func (p stubPack) Declined() []emulator.Decline    { return nil }
 func (p stubPack) Env(string) emulator.Environment { return emulator.Environment{} }
+
+// fieldDecliningPack grafts an injected field-decline list onto a real pack, so
+// these tests do not depend on what the pack actually declines today: the
+// mechanism is what is under test, the repository's own declines are covered by
+// TestEveryDeclinedFieldSaysWhy and by the gate run in CI.
+type fieldDecliningPack struct {
+	emulator.Pack
+	fields []emulator.FieldDecline
+}
+
+func (p fieldDecliningPack) DeclinedFields() []emulator.FieldDecline { return p.fields }
+
+// aReason passes the shared reason guard; what these tests exercise is the
+// matching, not the guard, which has its own tests in internal/core/emulator.
+const aReason = "a bound for volumes this emulator never attaches, stated here only to exercise the gate"
+
+// declineScaleway mounts the real Scaleway pack alone, wearing the injected
+// declines, and restores packsFor on cleanup.
+func declineScaleway(t *testing.T, fields ...emulator.FieldDecline) {
+	t.Helper()
+	original := packsFor
+	t.Cleanup(func() { packsFor = original })
+	packsFor = func(env *emulator.Env) []emulator.Pack {
+		return []emulator.Pack{fieldDecliningPack{Pack: scaleway.New(env), fields: fields}}
+	}
+}
+
+// productsServersOp is the one real operation these tests compare: the Scaleway
+// catalogue, whose per_volume_constraint the emulator serves empty on purpose.
+const productsServersOp = "GET /instance/v1/zones/fr-par-1/products/servers"
+
+// writeShapeFile commits a hand-built catalogue for the gate to read.
+func writeShapeFile(t *testing.T, dir string, fields ...transcript.Field) {
+	t.Helper()
+	cat := shape.New("scaleway")
+	cat.Operations[productsServersOp] = &shape.Operation{
+		Method:   "GET",
+		Path:     "/instance/v1/zones/fr-par-1/products/servers",
+		Fields:   fields,
+		Statuses: []int{200},
+	}
+	if err := writeCatalogue(filepath.Join(dir, "scaleway.json"), cat); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A gap the pack declines is excused, printed with its reason, and does not
+// redden the gate; a gap it does not decline still does. This is the pair the
+// mechanism exists for — without the decline the first half exits 2 (proven by
+// the second half, same catalogue plus one undeclared field), and without the
+// matching in matchingDecline the first half fails.
+func TestADeclinedFieldIsExcusedAndAnUndeclaredOneIsNot(t *testing.T) {
+	declineScaleway(t, emulator.FieldDecline{
+		Operation: productsServersOp,
+		Path:      "servers.*.per_volume_constraint.l_ssd",
+		Reason:    aReason,
+	})
+	observed := []transcript.Field{
+		{Path: "servers", Type: "object"},
+		{Path: "servers.DEV1-S", Type: "object"},
+		{Path: "servers.DEV1-S.per_volume_constraint", Type: "object"},
+		{Path: "servers.DEV1-S.per_volume_constraint.l_ssd", Type: "object"},
+		{Path: "servers.DEV1-S.per_volume_constraint.l_ssd.min_size", Type: "number"},
+	}
+
+	dir := t.TempDir()
+	writeShapeFile(t, dir, observed...)
+	var out, errOut strings.Builder
+	if rc := checkShapes(dir, nil, &out, &errOut); rc != exitOK {
+		t.Fatalf("a declined gap exited %d, want %d\n%s%s", rc, exitOK, out.String(), errOut.String())
+	}
+	if !strings.Contains(out.String(), "declined servers.DEV1-S.per_volume_constraint.l_ssd: "+aReason) {
+		t.Errorf("the excused field and its reason were not printed:\n%s", out.String())
+	}
+
+	// The refusing half: one more observed field, not declined, and the gate
+	// answers the drift code again. Without it the decline mechanism could
+	// excuse everything and this suite would stay green.
+	dir2 := t.TempDir()
+	writeShapeFile(t, dir2, append(observed,
+		transcript.Field{Path: "servers.DEV1-S.invented_by_this_test", Type: "string"})...)
+	out.Reset()
+	errOut.Reset()
+	if rc := checkShapes(dir2, nil, &out, &errOut); rc != exitDrift {
+		t.Fatalf("an undeclared gap exited %d, want %d\n%s", rc, exitDrift, out.String())
+	}
+	if !strings.Contains(out.String(), "missing  servers.DEV1-S.invented_by_this_test") {
+		t.Errorf("the undeclared gap was not named:\n%s", out.String())
+	}
+}
+
+// A decline that excuses nothing is stale, and stale is a failure: the field is
+// served now, or was never observed missing, and either way the entry describes
+// a decision that no longer exists. Letting it rest would let the declined list
+// rot into fiction — the exact analogue of an orphan Route.Operation.
+func TestAStaleFieldDeclineFailsTheGate(t *testing.T) {
+	declineScaleway(t, emulator.FieldDecline{
+		Operation: productsServersOp,
+		Path:      "servers.*.per_volume_constraint.l_ssd",
+		Reason:    aReason,
+	})
+	// The catalogue observes only fields the emulator serves: no gap, so the
+	// decline has nothing to excuse.
+	dir := t.TempDir()
+	writeShapeFile(t, dir,
+		transcript.Field{Path: "servers", Type: "object"},
+		transcript.Field{Path: "servers.DEV1-S", Type: "object"},
+		transcript.Field{Path: "servers.DEV1-S.ncpus", Type: "number"},
+	)
+
+	var out, errOut strings.Builder
+	if rc := checkShapes(dir, nil, &out, &errOut); rc != exitError {
+		t.Fatalf("a stale decline exited %d, want %d\n%s%s", rc, exitError, out.String(), errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "stale") ||
+		!strings.Contains(errOut.String(), "servers.*.per_volume_constraint.l_ssd") {
+		t.Errorf("the stale decline was not named:\n%s", errOut.String())
+	}
+}
+
+// A field decline with a reason that carries no decision is refused before
+// anything is compared, under the same guard Declined() faces. Without this
+// call site the guard would exist and gate nothing — the defect
+// TestCoverageRefusesAPackWithUnusableRefusals exists for, one level down.
+func TestAnUnusableFieldDeclineReasonFailsTheGate(t *testing.T) {
+	declineScaleway(t, emulator.FieldDecline{
+		Operation: productsServersOp,
+		Path:      "servers.*.per_volume_constraint.l_ssd",
+		Reason:    "TODO",
+	})
+	var out, errOut strings.Builder
+	if rc := checkShapes(t.TempDir(), nil, &out, &errOut); rc != exitError {
+		t.Fatalf("an unusable reason exited %d, want %d\n%s", rc, exitError, errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "no usable reason") {
+		t.Errorf("the unusable reason was not named:\n%s", errOut.String())
+	}
+}
+
+// The repository's own state passes its own gate: every field the recorded
+// shapes prove the clouds return is either served or declined with a reason.
+// This is what puts `feint shapes --check` inside `mise run check` — go test
+// runs it with no network and no credential — and it proves the instrument ran
+// by refusing a zero comparison count, because a gate that compared nothing
+// reports success indistinguishably from one that worked.
+func TestTheRepositorysShapesAreServedOrDeclined(t *testing.T) {
+	var out, errOut strings.Builder
+	if rc := checkShapes(filepath.Join("..", "..", "shapes"), nil, &out, &errOut); rc != exitOK {
+		t.Fatalf("the committed shapes exited %d, want %d\n%s%s", rc, exitOK, out.String(), errOut.String())
+	}
+	if strings.Contains(out.String(), "\n0 operation(s) compared") {
+		t.Fatalf("the gate compared nothing, which proves nothing:\n%s", out.String())
+	}
+}

--- a/internal/core/emulator/declined.go
+++ b/internal/core/emulator/declined.go
@@ -109,34 +109,45 @@ const minReasonWords = 5
 func UnexplainedDeclines(declined []Decline) []string {
 	var out []string
 	for _, d := range declined {
-		reason := strings.ToLower(strings.TrimSpace(strings.Trim(d.Reason, ".:;— -")))
-		words := strings.Fields(reason)
-		// Token level, not whole string: "TODO TODO TODO TODO TODO" passed the
-		// exact-match list and the word count at once, which an audit found in
-		// one try. A reason built out of placeholder tokens is a placeholder
-		// however many times it repeats.
-		stems := 0
-		for _, w := range words {
-			if placeholderStems[strings.Trim(w, ".,;:!?")] {
-				stems++
-			}
-		}
-		switch {
-		// A waiting word in a short reason is a note to self; the same word in a
-		// developed sentence can be honest prose ("nobody has decided what a
-		// later version should answer"). So the length is what separates them,
-		// and the ratio catches the shorter repetitions. Neither closes the case
-		// entirely: an audit passed six stems drowned in seven other words, and
-		// no string check ever will. What actually reviews these sentences is a
-		// reader, which is why they are printed into docs/routes.md.
-		case reason == "", placeholders[reason],
-			len(words) < minReasonWords,
-			stems > 0 && len(words) < shortReasonWords,
-			stems*2 >= len(words):
+		if carriesNoDecision(d.Reason) {
 			out = append(out, d.Operation)
 		}
 	}
 	return out
+}
+
+// carriesNoDecision is the shared judgement on one reason string, so a decline
+// of a field faces exactly the same guard as a decline of an operation. Two
+// copies of this switch would be two guards one audit hardens and the other
+// keeps accepting "TODO".
+func carriesNoDecision(raw string) bool {
+	reason := strings.ToLower(strings.TrimSpace(strings.Trim(raw, ".:;— -")))
+	words := strings.Fields(reason)
+	// Token level, not whole string: "TODO TODO TODO TODO TODO" passed the
+	// exact-match list and the word count at once, which an audit found in
+	// one try. A reason built out of placeholder tokens is a placeholder
+	// however many times it repeats.
+	stems := 0
+	for _, w := range words {
+		if placeholderStems[strings.Trim(w, ".,;:!?")] {
+			stems++
+		}
+	}
+	switch {
+	// A waiting word in a short reason is a note to self; the same word in a
+	// developed sentence can be honest prose ("nobody has decided what a
+	// later version should answer"). So the length is what separates them,
+	// and the ratio catches the shorter repetitions. Neither closes the case
+	// entirely: an audit passed six stems drowned in seven other words, and
+	// no string check ever will. What actually reviews these sentences is a
+	// reader, which is why they are printed into docs/routes.md.
+	case reason == "", placeholders[reason],
+		len(words) < minReasonWords,
+		stems > 0 && len(words) < shortReasonWords,
+		stems*2 >= len(words):
+		return true
+	}
+	return false
 }
 
 // DuplicateDeclines reports operations declined more than once.

--- a/internal/core/emulator/declined_fields.go
+++ b/internal/core/emulator/declined_fields.go
@@ -1,0 +1,117 @@
+package emulator
+
+import (
+	"sort"
+	"strings"
+)
+
+// Declined() answers for whole operations. One level down, the shapes gate
+// (`feint shapes --check`) compares what this emulator answers with what a real
+// cloud was observed to answer, field by field — and some of those fields are
+// decisions, not omissions: a constraint for volumes the emulator never
+// attaches, a field live on the wire but absent from the API description the
+// contract gate enforces as closed. Without a way to say so, the gate stays red
+// on purpose-made gaps, and a gate that is red on purpose is a gate nobody
+// wires into CI. The same doctrine applies at both levels: "not served" and
+// "not triaged" are different answers, and the difference is data, not a
+// comment.
+
+// FieldDecline is one field of an observed response a pack knowingly does not
+// serve, and why.
+type FieldDecline struct {
+	// Operation is spelled exactly as the shapes catalogue keys it — the
+	// upstream operation name when the recording carried one, "METHOD path"
+	// otherwise. The gate joins on this string; a spelling of its own would
+	// make the decline silently match nothing, which is why a decline that
+	// matches nothing fails the gate instead of resting unused.
+	Operation string
+	// Path is the field's dotted path in the recorded shape, e.g.
+	// "things[].limits.local". A "*" segment matches exactly one segment, for
+	// dictionaries whose keys are data: "things.*.limits.local" declines the
+	// field under every key without writing the keys down, because the keys
+	// belong to the cloud's inventory, not to the decision.
+	Path string
+	// Reason is one line, in the present tense, saying what makes this field a
+	// decision rather than an omission. It faces the same guard as an
+	// operation's reason: no placeholder, no half-clause.
+	Reason string
+}
+
+// FieldDecliner is implemented by a pack that declines fields of otherwise
+// served operations. Optional, in the manner of machine.Capable: a pack with
+// nothing to declare implements nothing, and FieldDeclinesOf answers nil for
+// it, so absence of the method reads as "no field is declined" rather than as
+// an error.
+type FieldDecliner interface {
+	DeclinedFields() []FieldDecline
+}
+
+// FieldDeclinesOf returns what a pack declines at field level, or nil for a
+// pack that declares nothing.
+func FieldDeclinesOf(p Pack) []FieldDecline {
+	if fd, ok := p.(FieldDecliner); ok {
+		return fd.DeclinedFields()
+	}
+	return nil
+}
+
+// Matches reports whether this decline covers the field at path within
+// operation.
+//
+// Paths compare segment by segment, and "*" stands for exactly one segment —
+// never zero, never several, or a decline written for "things.*.limits.local"
+// would also excuse "things.limits.local" and every deeper field a future
+// recording learns, widening a narrow decision silently.
+//
+// TestAWildcardSegmentMatchesExactlyOneSegment fails without this.
+func (d FieldDecline) Matches(operation, path string) bool {
+	if d.Operation != operation {
+		return false
+	}
+	want := strings.Split(d.Path, ".")
+	got := strings.Split(path, ".")
+	if len(want) != len(got) {
+		return false
+	}
+	for i := range want {
+		if want[i] != "*" && want[i] != got[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// UnexplainedFieldDeclines reports field declines whose reason carries no
+// decision, under the same guard as UnexplainedDeclines: an empty reason, a
+// known placeholder, a clause too short to hold an argument. The identifiers
+// come back as "operation path" so the caller can name the offender.
+//
+// TestFieldDeclineReasonsFaceTheSameGuardAsOperations fails without this.
+func UnexplainedFieldDeclines(declined []FieldDecline) []string {
+	var out []string
+	for _, d := range declined {
+		if carriesNoDecision(d.Reason) {
+			out = append(out, d.Operation+" "+d.Path)
+		}
+	}
+	return out
+}
+
+// DuplicateFieldDeclines reports fields declined more than once, for the same
+// reason DuplicateDeclines exists one level up: two entries for one field mean
+// two reasons for one decision, and whichever consumer walks the slice prints
+// a count that disagrees with the set.
+func DuplicateFieldDeclines(declined []FieldDecline) []string {
+	seen := map[string]int{}
+	for _, d := range declined {
+		seen[d.Operation+" "+d.Path]++
+	}
+	var out []string
+	for key, n := range seen {
+		if n > 1 {
+			out = append(out, key)
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/core/emulator/declined_fields_test.go
+++ b/internal/core/emulator/declined_fields_test.go
@@ -1,0 +1,84 @@
+package emulator
+
+import "testing"
+
+// A "*" segment stands for exactly one segment. The widening this refuses is
+// the silent kind: a wildcard that also matched zero segments, or several,
+// would let a decline written for one dictionary level excuse fields it was
+// never a decision about, and the gate would go quiet on a real omission.
+func TestAWildcardSegmentMatchesExactlyOneSegment(t *testing.T) {
+	d := FieldDecline{Operation: "GET /v1/things", Path: "things.*.limits.local"}
+
+	for _, tc := range []struct {
+		operation, path string
+		want            bool
+	}{
+		// The case the wildcard exists for: a dictionary key that is data.
+		{"GET /v1/things", "things.alpha.limits.local", true},
+		{"GET /v1/things", "things.beta.limits.local", true},
+		// One segment, not zero.
+		{"GET /v1/things", "things.limits.local", false},
+		// One segment, not two.
+		{"GET /v1/things", "things.alpha.beta.limits.local", false},
+		// Not a prefix match: a deeper field is a different decision.
+		{"GET /v1/things", "things.alpha.limits.local.min", false},
+		// The operation is part of the identity.
+		{"GET /v1/others", "things.alpha.limits.local", false},
+	} {
+		if got := d.Matches(tc.operation, tc.path); got != tc.want {
+			t.Errorf("Matches(%q, %q) = %v, want %v", tc.operation, tc.path, got, tc.want)
+		}
+	}
+
+	// And a literal path, no wildcard: the common case must still work.
+	exact := FieldDecline{Operation: "GET /v1/things", Path: "things[].visibility"}
+	if !exact.Matches("GET /v1/things", "things[].visibility") {
+		t.Error("an exact path did not match itself")
+	}
+	if exact.Matches("GET /v1/things", "things[].id") {
+		t.Error("an exact path matched a different field")
+	}
+}
+
+// A field's reason faces the same guard as an operation's: the check is one
+// shared function, so an audit that hardens one level hardens the other. This
+// asserts the sharing holds in both directions — the refusing half and the
+// accepting half.
+func TestFieldDeclineReasonsFaceTheSameGuardAsOperations(t *testing.T) {
+	for _, bad := range []string{"", "   ", "TODO", "-", "x", "n/a", "out of scope", "see above"} {
+		got := UnexplainedFieldDeclines([]FieldDecline{{Operation: "GET /v1/things", Path: "things[].id", Reason: bad}})
+		if len(got) != 1 || got[0] != "GET /v1/things things[].id" {
+			t.Errorf("the guard accepted %q as a field reason: %v", bad, got)
+		}
+	}
+	ok := "the emulator attaches no local volume, so a bound here would enter arithmetic nothing enforces"
+	if got := UnexplainedFieldDeclines([]FieldDecline{{Operation: "GET /v1/things", Path: "things[].id", Reason: ok}}); len(got) != 0 {
+		t.Errorf("the guard refused a real reason: %v", got)
+	}
+}
+
+// Two declines for one field are two reasons for one decision.
+func TestDuplicateFieldDeclinesAreNamed(t *testing.T) {
+	long := "a reason long enough to pass the shared guard on its own"
+	dup := DuplicateFieldDeclines([]FieldDecline{
+		{Operation: "GET /v1/things", Path: "things[].id", Reason: long},
+		{Operation: "GET /v1/things", Path: "things[].id", Reason: long},
+		{Operation: "GET /v1/things", Path: "things[].name", Reason: long},
+	})
+	if len(dup) != 1 || dup[0] != "GET /v1/things things[].id" {
+		t.Errorf("duplicates = %v, want the one duplicated field", dup)
+	}
+}
+
+// mutePack is a pack that does not implement FieldDecliner.
+type mutePack struct{ Pack }
+
+func (mutePack) Name() string { return "mute" }
+
+// A pack that declares nothing declines nothing — absence of the method is
+// data, not an error, exactly as machine.CapabilitiesOf reads a mute driver.
+func TestAMutePackDeclinesNoFields(t *testing.T) {
+	if got := FieldDeclinesOf(mutePack{}); got != nil {
+		t.Errorf("a mute pack declined fields: %v", got)
+	}
+}

--- a/internal/providers/exoscale/declined_fields.go
+++ b/internal/providers/exoscale/declined_fields.go
@@ -1,0 +1,29 @@
+package exoscale
+
+import "github.com/stephrobert/feint/internal/core/emulator"
+
+// DeclinedFields implements emulator.FieldDecliner: fields the recorded shapes
+// prove the live API returns and this pack knowingly does not serve.
+//
+// Both entries are the same decision, recorded in prose by 98f8df6 and until
+// now readable nowhere a gate could see: the live wire is ahead of Exoscale's
+// published OpenAPI description, and this emulator enforces that description as
+// closed — internal/contract fails a response carrying a field the schema does
+// not declare. Serving these would trade a shape finding for a contract
+// finding; the description is the API the SDKs are generated from, so the
+// description wins until Exoscale publishes the field.
+func (p *Pack) DeclinedFields() []emulator.FieldDecline {
+	const liveAheadOfSpec = "live on the wire but absent from the published OpenAPI description, which the contract gate enforces as closed"
+	return []emulator.FieldDecline{
+		{
+			Operation: "GET /v2/security-group",
+			Path:      "security-groups[].visibility",
+			Reason:    liveAheadOfSpec,
+		},
+		{
+			Operation: "GET /v2/zone",
+			Path:      "zones[].id",
+			Reason:    liveAheadOfSpec,
+		},
+	}
+}

--- a/internal/providers/scaleway/declined_fields.go
+++ b/internal/providers/scaleway/declined_fields.go
@@ -1,0 +1,27 @@
+package scaleway
+
+import "github.com/stephrobert/feint/internal/core/emulator"
+
+// DeclinedFields implements emulator.FieldDecliner: the fields the recorded
+// shapes prove this cloud returns and this pack knowingly does not serve. The
+// decision level below Declined() — an operation served, one field of it
+// refused — consumed by `feint shapes --check`, which excuses these with their
+// reason instead of failing, and fails the other way when one stops excusing a
+// real gap, so an entry here cannot outlive the omission it argues for.
+func (p *Pack) DeclinedFields() []emulator.FieldDecline {
+	return []emulator.FieldDecline{
+		// catalog.go serialises per_volume_constraint as an empty object on
+		// purpose, and documents why beside the field: the real cloud states
+		// l_ssd bounds on the DEV1 and GP1 types because they carry local SSD,
+		// while the emulated types attach no local volume — the same measured
+		// trap that keeps volumes_constraint.min_size at 0, where a bound the
+		// CLI sums against made `scw instance server create` refuse. The "*"
+		// stands for the commercial type names, which are the catalogue's
+		// inventory rather than part of this decision.
+		{
+			Operation: "GET /instance/v1/zones/fr-par-1/products/servers",
+			Path:      "servers.*.per_volume_constraint.l_ssd",
+			Reason:    "a bound for local volumes this catalogue never attaches, which would enter the client's size arithmetic with nothing behind it",
+		},
+	}
+}

--- a/mise.toml
+++ b/mise.toml
@@ -52,8 +52,19 @@ golangci-lint run ./...
 
 [tasks.check]
 description = "Everything CI runs on a pull request"
-depends = ["lint", "test"]
+depends = ["lint", "test", "shapes:check"]
 run = "echo 'local check passed'"
+
+[tasks."shapes:check"]
+description = "Fail if the emulator omits a field the recorded shapes prove the real cloud returns"
+depends = ["build"]
+# Offline, no credential: shapes/*.json is the committed record of what the real
+# clouds were observed to answer. Exit 2 means the emulator and the record
+# disagree on a field no pack has declined — either serve it, or decline it with
+# a reason in the pack's DeclinedFields(). go test covers the same gate
+# (TestTheRepositorysShapesAreServedOrDeclined); this task is the legible form,
+# with the field list and the exit-code contract (0 ok, 1 error, 2 drift).
+run = "./feint shapes --check"
 
 # ---- Upstream tracking (the anti-drift loop) --------------------------------------------------
 [tasks."upstream:sync"]


### PR DESCRIPTION
# Summary

The drift chain measures what a provider *offers*; `feint shapes --check` measures what it *returns*, and nothing ran it: six fields the recorded shapes prove the real clouds return kept the gate red **by decision, not by omission**, and a permanently red gate is a gate nobody wires into CI. This change gives the gate a way to record a decision, then wires it into every pull request.

**The mechanism** is `Declined()` transposed one level down. A pack declares `emulator.FieldDecline{Operation, Path, Reason}` through the optional `FieldDecliner` interface (`DeclinedFields()`), with `"*"` in a path standing for exactly one dictionary-key segment — the keys of `/products/servers` are the cloud's inventory, not part of the decision. Pack-side code rather than a sidecar JSON, for the reason `docs/fourth-pack.md` already stated: a decision needs a review path and a reason next to it, and `shapes/*.json` is regenerated.

**Three refusals keep the list honest**, each falsified:

- a reason faces the *same shared guard* as an operation's reason (no placeholder, no half-clause): `carriesNoDecision` is one function, so an audit hardening one level hardens the other;
- the gate exits 1 on an unusable reason, at the call site, not only in a test;
- a decline that excuses nothing is **stale** and exits 1 — the field is served now, or was never observed missing — so an entry cannot outlive the omission it argues for (the analogue of the orphan `Route.Operation` check).

A declined gap is printed with its reason and **counted out loud** (`6 field(s) knowingly not served`), so a growing declined list hollows nothing silently. An undeclared gap still exits 2.

**The triage of the six red fields — all declined, none served:**

| field | verdict | reason |
| --- | --- | --- |
| `servers.*.per_volume_constraint.l_ssd` (Scaleway, ×4 types) | declined | a bound for local volumes the emulated catalogue never attaches; serving one would enter the client's size arithmetic with nothing behind it — the same measured trap that keeps `volumes_constraint.min_size` at 0, and `catalog.go` already argues it beside the field |
| `security-groups[].visibility` (Exoscale) | declined | live on the wire, absent from the published OpenAPI this emulator's contract gate enforces as closed; serving it would trade a shape finding for a contract finding. Decision recorded in prose by 98f8df6, now readable by a gate |
| `zones[].id` (Exoscale) | declined | same decision as above |

**The wiring is double, deliberately:** `TestTheRepositorysShapesAreServedOrDeclined` runs the gate inside `go test` — so `mise run check` covers it, offline, no credential, forks included — and refuses a zero comparison count, so a gate that compared nothing cannot read as green. The `go.yml` step and the `shapes:check` mise task are the legible form, with the exit-code contract stated (0 ok, 1 error, 2 drift).

**Falsification** (copy outside the repository, `go vet` required on every mutation before its test ran): eight mutations — permissive segment matching, widened wildcard depth, an accepting reason guard, each of the two dropped call sites, nothing-excused matching, a forgotten decline in each pack — every one compiled, every one killed by its test, and the restored copy came back green.

**Deliberately not built** (judged against #91's remaining scope): comparing two recordings over time and a standalone report — `git diff` on `shapes/*.json` is already the drift report the issue describes, and recording stays a human's job (`feint shapes --record`); replaying transcripts is #73; ranking the untriaged column is #74. No new flag, no new file format: a gate sufficed.

## Type of change

- [ ] A route added or changed
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes (gofmt, vet, golangci-lint, `go test -race`)
- [x] No new external Go dependency, or the pull request justifies it. The
      standard library covers routing, JSON and Go parsing; `go.mod` has three
      lines and a pre-commit hook keeps it that way
- [x] `internal/core` still knows no provider. If a change seemed to require it,
      the pack changed instead — `FieldDecline` lives in the core with
      placeholder vocabulary (`things.*.limits.local`); the six real declines
      live in the two packs they belong to
- [x] Nothing in the diff could be written identically for another provider. If
      it could, it belongs in the core — the matching, the reason guard and the
      staleness rule are core; each pack writes only its own fields and reasons

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] I ran `mise run conformance` myself — not "it should pass": **N/A with a
      stated reason** — no route, handler or response byte changes in this diff
      (`git diff` touches no handler), so the suite measures nothing this change
      moved; `mise run check`, `feint docs --check` and `mise run drift:check`
      all ran green locally
- [x] Every field name in the diff comes from the provider's SDK, their OpenAPI
      document, or a run of the real client, and I can say which: the three
      declined paths come from `shapes/scaleway.json` and `shapes/exoscale.json`,
      recorded against the real clouds; the Exoscale rationale from commit
      98f8df6 and the OpenAPI description `internal/contract` enforces

### When a route is added or changed — otherwise N/A

N/A — no route added or changed; the emulator's HTTP surface and every response
byte are identical before and after.

### When behaviour a client can observe changes — otherwise N/A

N/A — clients observe nothing new; only `feint shapes --check` (a development
gate) changes verdicts. `docs/fourth-pack.md` recommendation 2 is marked done.

### When `.github/workflows/` is touched — otherwise N/A

- [x] Every action pinned to a full 40-character commit SHA with a `# vX.Y.Z`
      comment — the new step uses no action, only `run:`
- [x] `step-security/harden-runner` is the job's first step — unchanged
- [x] `permissions:` is least-privilege on every job — unchanged
- [x] No job renamed, or the required status checks updated — no job renamed,
      one step added inside the existing `quality` job
- [x] The exit-code contract still holds: `0` ok, `1` error, `2` drift — the
      step runs `./feint shapes --check` bare, no `tee`, so exit 2 fails the job

### When a machine runtime is involved — otherwise N/A

N/A — no machine runtime involved; the gate runs against an in-process
`httptest` server.

## Related issues

Closes #91.
