### PR TITLE
fix(store): a snapshot is understood or refused, never restored in silence

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -17,6 +17,38 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ## [Non publié]
 
+### Modifié
+
+- **Un snapshot est compris ou refusé, et dit de quelle version il est** (#133).
+  `feint snapshot save`, `GET /_feint/state` et `--state` écrivent désormais
+  `{"format": "feint-snapshot", "version": 1, "resources": [...]}` au lieu d'un
+  tableau nu, et `Restore` refuse tout ce dont il ne peut pas rendre compte :
+  une version qu'il ne lit pas, un format qui n'est pas le nôtre, un champ
+  inconnu sur une ressource.
+
+  **C'est un changement cassant des formats d'état et de snapshot.** Un fichier
+  écrit par une 0.7.x est refusé, avec le message qui dit comment le convertir,
+  et un `PUT /_feint/state` portant un tableau nu l'est aussi. Reprendre un
+  snapshot depuis l'instance qui détient l'état est la voie de sortie.
+
+  Pourquoi cela valait de casser : l'ancien format perdait des données en
+  silence. Un snapshot portant un champ que ce binaire ne déclare pas se
+  restaurait *avec succès*, `encoding/json` jetait le champ, et la sauvegarde
+  suivante réécrivait le fichier sans lui. Le store était cohérent, faux, et
+  vert — mesuré avant le changement, pas redouté. `snapshot.go` documente ce
+  format comme fait pour survivre à son instance et être chargé dans une autre,
+  ce qui est précisément le moment où cela mord.
+
+  `Attrs` reste ouvert, parce que ses clés sont des données qu'un pack a
+  choisies et non un schéma : un attribut nouveau n'est pas un changement de
+  format, et le refuser rendrait cassant tout ajout dans un pack.
+
+  Deux documents se contredisaient sur la nature de cette promesse —
+  `store.go` qualifiait le format de détail d'implémentation sans engagement de
+  compatibilité, `RELEASING.md` le classait parmi les surfaces dont le
+  changement est cassant. Ils disent maintenant la même chose, et c'est le plus
+  strict qui l'emporte.
+
 ### Ajouté
 
 - **Scaleway sert le Block Storage, et le volume racine d'un serveur devient

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,35 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ## [Unreleased]
 
+### Changed
+
+- **A snapshot is understood or refused, and says which version it is** (#133).
+  `feint snapshot save`, `GET /_feint/state` and `--state` now write
+  `{"format": "feint-snapshot", "version": 1, "resources": [...]}` instead of a
+  bare array, and `Restore` refuses anything it cannot account for: a version it
+  does not read, a format that is not ours, an unknown field on a resource.
+
+  **This is a breaking change to the snapshot and state formats.** A file written
+  by 0.7.x is refused with a message saying how to convert it, and a `PUT
+  /_feint/state` carrying a bare array is refused too. Taking a fresh snapshot
+  from the instance that holds the state is the way through.
+
+  The reason it is worth breaking: the old format lost data in silence. A
+  snapshot carrying a field this build does not declare restored *successfully*,
+  `encoding/json` dropped the field, and the next save wrote the file back
+  without it. The store was coherent, wrong, and green — measured before the
+  change, not feared. `snapshot.go` documents the format as made to outlive its
+  instance and be loaded into another one, which is exactly when this bites.
+
+  `Attrs` stays open, because its keys are data a pack chose rather than schema:
+  a new attribute is not a format change, and refusing one would make every pack
+  addition breaking.
+
+  Two documents disagreed about whether any of this was a promise —
+  `store.go` called the format an implementation detail with no compatibility
+  promise, `RELEASING.md` listed it among the surfaces whose change is breaking.
+  They now say the same thing, and the stricter one won.
+
 ### Added
 
 - **Scaleway serves Block Storage, and a server's root volume can finally be

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -125,6 +125,15 @@ wanted. What breaks is on this project's own side — the CLI's verbs and flags,
 the exit codes, the shape of `/_feint/*`, the state and snapshot formats, and
 any emulated behaviour a test could have relied on.
 
+The snapshot format is the one of those that says its own version. Since #133 a
+snapshot is `{"format": "feint-snapshot", "version": N, "resources": [...]}`, and
+`Restore` refuses anything it cannot account for: another version, another
+format, an unknown field. Bumping `snapshotVersion` in
+`internal/core/store/store.go` is therefore a breaking change under this
+section — and a file written by an older feint fails loudly at the boundary
+rather than restoring three quarters of itself in silence, which is what it did
+before.
+
 The one exception worth calling out: **a response shape corrected to match the
 provider's document is a fix, not a break**, even when a downstream test was
 asserting the wrong one. That is the point of the project, and a test that

--- a/internal/cli/snapshot.go
+++ b/internal/cli/snapshot.go
@@ -375,13 +375,17 @@ func putState(addr string, body []byte) (int, error) {
 
 // countResources counts the entries of a snapshot without giving them a type.
 //
-// The store's format is documented as an implementation detail with no
-// compatibility promise, so this decodes into raw messages: counting must not be
-// a second place that knows what a resource looks like.
+// Raw messages, deliberately: counting must not become a second place that knows
+// what a resource looks like. But it does have to know the envelope, and that is
+// the whole point of #133 — this function read a bare array, so the day the
+// header appeared it would have answered -1 for every snapshot ever written,
+// silently, because its own error path is a sentinel rather than a failure.
 func countResources(body []byte) int {
-	var list []json.RawMessage
-	if err := json.Unmarshal(body, &list); err != nil {
+	var file struct {
+		Resources []json.RawMessage `json:"resources"`
+	}
+	if err := json.Unmarshal(body, &file); err != nil {
 		return -1
 	}
-	return len(list)
+	return len(file.Resources)
 }

--- a/internal/cli/snapshot_test.go
+++ b/internal/cli/snapshot_test.go
@@ -62,7 +62,7 @@ func TestSnapshotNeedsANameBeforeItsFlags(t *testing.T) {
 // the endpoint returned, that load sends it back unchanged, and that list counts
 // the entries of the file rather than trusting whoever wrote it.
 func TestSnapshotRoundTrip(t *testing.T) {
-	state := `[{"id":"a","kind":"ip"},{"id":"b","kind":"server"}]`
+	state := `{"format":"feint-snapshot","version":1,"resources":[{"id":"a","kind":"ip"},{"id":"b","kind":"server"}]}`
 	var received string
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -131,7 +131,7 @@ func TestSnapshotRoundTrip(t *testing.T) {
 // fails afterwards.
 func TestSnapshotSaveRefusesToOverwriteWithoutForce(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(`[{"id":"a"}]`))
+		_, _ = w.Write([]byte(`{"format":"feint-snapshot","version":1,"resources":[{"id":"a"}]}`))
 	}))
 	defer srv.Close()
 	addr := strings.TrimPrefix(srv.URL, "http://")

--- a/internal/core/emulator/state_test.go
+++ b/internal/core/emulator/state_test.go
@@ -52,7 +52,11 @@ func TestStateRoundTripsThroughTheRealHandlers(t *testing.T) {
 	}
 
 	// Emptied, then restored from the bytes the emulator itself produced.
-	if err := env.Store.Restore(strings.NewReader("[]")); err != nil {
+	//
+	// The envelope is not decoration here: a bare `[]` is refused since #133,
+	// because a file with no format header cannot be shown to be complete.
+	empty := `{"format":"feint-snapshot","version":1,"resources":[]}`
+	if err := env.Store.Restore(strings.NewReader(empty)); err != nil {
 		t.Fatalf("empty the store: %v", err)
 	}
 	if env.Store.Len() != 0 {

--- a/internal/core/store/snapshot_format_test.go
+++ b/internal/core/store/snapshot_format_test.go
@@ -1,0 +1,203 @@
+package store_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/resource"
+	"github.com/stephrobert/feint/internal/core/store"
+)
+
+// The rule #133 exists for: a snapshot is understood or refused.
+//
+// The scenario the external review described — "the snapshot carries a field
+// this version no longer knows, the field is ignored, the restore succeeds" —
+// was not a risk, it was the behaviour. Measured before any of this was written:
+// a resource carrying `encryption_key_ref` restored without complaint, and the
+// following Snapshot wrote it back without the field. The store was coherent,
+// wrong, and green.
+//
+// These tests are that scenario inverted into a control.
+
+// envelope wraps resources the way Snapshot writes them.
+func envelope(resources string) string {
+	return `{"format":"feint-snapshot","version":1,"resources":[` + resources + `]}`
+}
+
+// oneServer is a resource in the shape Snapshot produces — Go field names, since
+// resource.Resource declares no JSON tags.
+const oneServer = `{
+  "ID": "11111111-1111-4111-8111-111111111111",
+  "Kind": "instance/server",
+  "Tenant": {"Provider": "scaleway", "Project": "p", "Zone": "fr-par-1"},
+  "State": "running",
+  "Created": "2026-01-01T00:00:00Z",
+  "Updated": "2026-01-01T00:00:00Z",
+  "Attrs": {"name": "prod"},
+  "Runtime": {"machine": "feint-scw-1"}
+}`
+
+// What a client stores must come back byte for byte, which is the half a guard
+// that refuses everything would also pass.
+func TestASnapshotOfThisVersionRoundTrips(t *testing.T) {
+	s := store.New()
+	if err := s.Restore(strings.NewReader(envelope(oneServer))); err != nil {
+		t.Fatalf("restore a snapshot of this version: %v", err)
+	}
+	if got := s.Len(); got != 1 {
+		t.Fatalf("the store holds %d resources, want 1", got)
+	}
+
+	var written bytes.Buffer
+	if err := s.Snapshot(&written); err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	// The header is what makes the next restore decidable.
+	for _, want := range []string{`"format": "feint-snapshot"`, `"version": 1`, `"resources"`} {
+		if !bytes.Contains(written.Bytes(), []byte(want)) {
+			t.Errorf("the snapshot does not carry %s:\n%s", want, written.String())
+		}
+	}
+
+	// And it reloads into another store, which is what the format is for.
+	again := store.New()
+	if err := again.Restore(bytes.NewReader(written.Bytes())); err != nil {
+		t.Fatalf("reload what we just wrote: %v", err)
+	}
+	if got := again.Len(); got != 1 {
+		t.Fatalf("the reloaded store holds %d resources, want 1", got)
+	}
+	res, found := again.Get("scaleway", "instance/server", "11111111-1111-4111-8111-111111111111")
+	if !found {
+		t.Fatal("the resource did not survive the round trip")
+	}
+	if res.Runtime["machine"] != "feint-scw-1" || res.Attrs["name"] != "prod" {
+		t.Errorf("the resource came back changed: %+v", res)
+	}
+}
+
+// A snapshot written by a newer feint is refused, naming both versions.
+//
+// An operator whose restore fails needs to know which of the two binaries to
+// change, which a bare "cannot restore" never tells them.
+func TestASnapshotFromTheFutureIsRefused(t *testing.T) {
+	s := store.New()
+	future := `{"format":"feint-snapshot","version":99,"resources":[` + oneServer + `]}`
+
+	err := s.Restore(strings.NewReader(future))
+	if err == nil {
+		t.Fatal("a snapshot from version 99 restored into a build that reads version 1")
+	}
+	for _, want := range []string{"99", "1"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal does not name version %s: %v", want, err)
+		}
+	}
+	if s.Len() != 0 {
+		t.Errorf("the refused snapshot was loaded anyway: %d resources", s.Len())
+	}
+
+	// A format that is not ours is refused too, and says what this build reads.
+	err = s.Restore(strings.NewReader(`{"format":"terraform-state","version":1,"resources":[]}`))
+	if err == nil || !strings.Contains(err.Error(), "feint-snapshot") {
+		t.Errorf("a foreign format was not refused by name: %v", err)
+	}
+}
+
+// An unknown field on a resource is refused, and the field is named.
+//
+// This is the review's scenario exactly. Attrs stays open on purpose — its keys
+// are data a pack chose, not schema — so the test asserts both halves: the
+// unknown envelope-level field is refused, and an unknown Attrs key is kept.
+func TestAnUnknownResourceFieldIsRefused(t *testing.T) {
+	s := store.New()
+	fromTheFuture := envelope(`{
+	  "ID": "11111111-1111-4111-8111-111111111111",
+	  "Kind": "instance/server",
+	  "Tenant": {"Provider": "scaleway", "Zone": "fr-par-1"},
+	  "State": "running",
+	  "Attrs": {"name": "prod"},
+	  "EncryptionKeyRef": "a-field-this-build-never-heard-of"
+	}`)
+
+	err := s.Restore(strings.NewReader(fromTheFuture))
+	if err == nil {
+		t.Fatal("a resource carrying an unknown field restored silently, which is the defect #133 names")
+	}
+	if !strings.Contains(err.Error(), "EncryptionKeyRef") {
+		t.Errorf("the refusal does not name the field, so nobody can act on it: %v", err)
+	}
+	if s.Len() != 0 {
+		t.Errorf("the refused snapshot was loaded anyway: %d resources", s.Len())
+	}
+
+	// The accepting half: a pack invents Attrs keys freely, and refusing those
+	// would make every new field a breaking change to the snapshot format.
+	withNewAttr := envelope(`{
+	  "ID": "22222222-2222-4222-8222-222222222222",
+	  "Kind": "instance/server",
+	  "Tenant": {"Provider": "scaleway", "Zone": "fr-par-1"},
+	  "State": "running",
+	  "Attrs": {"name": "prod", "a_key_no_test_knows": {"nested": true}}
+	}`)
+	if err := s.Restore(strings.NewReader(withNewAttr)); err != nil {
+		t.Fatalf("an unknown Attrs key was refused, and Attrs is data rather than schema: %v", err)
+	}
+	res, _ := s.Get("scaleway", "instance/server", "22222222-2222-4222-8222-222222222222")
+	if res == nil || res.Attrs["a_key_no_test_knows"] == nil {
+		t.Error("the unknown Attrs key was dropped, which is the silent loss one level down")
+	}
+}
+
+// A snapshot written before the envelope is refused, with the remedy in the
+// message rather than a decoder complaint.
+//
+// Accepting it as "version 0" was the other option, and it loses the property
+// this change is for: such a file has already been through a decoder that drops
+// unknown fields, so nobody can say whether it is complete. Refusing it is a
+// decision; accepting it silently would be the same silence one version later.
+func TestALegacyBareArrayIsRefusedWithARemedy(t *testing.T) {
+	s := store.New()
+
+	err := s.Restore(strings.NewReader("[" + oneServer + "]"))
+	if err == nil {
+		t.Fatal("a pre-#133 bare array restored, and its completeness cannot be established")
+	}
+	// The message has to be actionable: an operator holding this file needs to
+	// know what to do, not that their JSON is invalid.
+	for _, want := range []string{"format", "feint-snapshot", "resources"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal does not tell the operator how to convert the file (missing %q): %v", want, err)
+		}
+	}
+
+	// An empty array too, which is how tests and scripts used to clear a store.
+	if err := s.Restore(strings.NewReader("[]")); err == nil {
+		t.Error("a bare empty array was accepted, and the header is what makes a file readable")
+	}
+
+	// And genuinely corrupt input stays a decode error rather than being
+	// explained as a legacy file, which would send an operator converting
+	// something that is not a snapshot at all.
+	err = s.Restore(strings.NewReader("{not json"))
+	if err == nil || strings.Contains(err.Error(), "no format header") {
+		t.Errorf("corrupt input was explained as a legacy snapshot: %v", err)
+	}
+}
+
+// A resource with no provider still lands somewhere findable rather than
+// vanishing into a key nothing queries.
+func TestARestoredResourceKeepsItsIdentity(t *testing.T) {
+	s := store.New()
+	if err := s.Restore(strings.NewReader(envelope(oneServer))); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	all := s.List("instance/server", resource.Tenant{Provider: "scaleway"})
+	if len(all) != 1 {
+		t.Fatalf("listing the restored kind found %d, want 1", len(all))
+	}
+	if all[0].Tenant.Zone != "fr-par-1" {
+		t.Errorf("the tenant did not survive: %+v", all[0].Tenant)
+	}
+}

--- a/internal/core/store/store.go
+++ b/internal/core/store/store.go
@@ -190,8 +190,14 @@ func (s *Store) Len() int {
 	return len(s.items)
 }
 
-// Snapshot writes the whole store as JSON. The format is an implementation
-// detail of the emulator and carries no compatibility promise.
+// Snapshot writes the whole store as JSON, under a format header.
+//
+// The format is a published surface, not an implementation detail. This comment
+// said the opposite until #133, while RELEASING.md listed "the state and
+// snapshot formats" among the surfaces whose change is breaking — two sentences
+// that could not both be the policy, and the file itself was written as if the
+// looser one were true. It is the stricter one: the format is named, versioned,
+// and a change to it is a breaking change under SemVer.
 //
 // The encoding happens into memory under the lock, and the write to w happens
 // without it. Encoding straight into w held the read lock for as long as the
@@ -218,7 +224,11 @@ func (s *Store) Snapshot(w io.Writer) error {
 	}
 	enc := json.NewEncoder(&buf)
 	enc.SetIndent("", "  ")
-	err := enc.Encode(list)
+	err := enc.Encode(snapshotFile{
+		Format:    snapshotFormat,
+		Version:   snapshotVersion,
+		Resources: list,
+	})
 	s.mu.RUnlock()
 
 	if err != nil {
@@ -230,16 +240,86 @@ func (s *Store) Snapshot(w io.Writer) error {
 	return nil
 }
 
+// The snapshot envelope, and the rule it exists to enforce: a snapshot is
+// understood or refused, never restored partially in silence.
+//
+// Until #133 the file was a bare JSON array decoded with a plain Decode, so
+// `encoding/json` dropped every field this build does not declare — measured,
+// not feared: a resource carrying `encryption_key_ref` restored successfully,
+// and the following Snapshot wrote it back without the field. The store was
+// coherent, wrong, and green, which is the exact failure this project exists to
+// refuse, committed on its own state file.
+//
+// snapshot.go documents the format as made to outlive its instance and be loaded
+// into another one, and RELEASING.md lists it among the surfaces whose change is
+// breaking. Both are only true if the file says which version it is.
+const (
+	snapshotFormat  = "feint-snapshot"
+	snapshotVersion = 1
+)
+
+// snapshotFile is the envelope. Kept closed on the way in — an unknown key here
+// means the file was written by something this build does not understand, and
+// guessing which half is safe to keep is the silent partial restore all over
+// again.
+type snapshotFile struct {
+	Format    string               `json:"format"`
+	Version   int                  `json:"version"`
+	Resources []*resource.Resource `json:"resources"`
+}
+
 // Restore replaces the store content with a snapshot produced by Snapshot.
+//
+// Understood or refused. Four answers, each deliberate:
+//
+//   - this version, every field known: restored;
+//   - a version from the future, or a format that is not ours: refused, naming
+//     both what was read and what this build writes, because an operator whose
+//     restore fails needs to know which of the two binaries to change;
+//   - a bare `[...]`, which is every snapshot written before #133: refused, and
+//     the message says how to convert it. Accepting it silently as "version 0"
+//     was the other option and it loses the property this change is for — such a
+//     file has already passed through a decoder that drops unknown fields, so
+//     nobody can say whether it is complete.
+//   - an unknown field on a resource: refused, naming the field. Attrs stays
+//     open, because its keys are data a pack chose, not schema.
+//
+// TestASnapshotFromTheFutureIsRefused, TestAnUnknownResourceFieldIsRefused and
+// TestALegacyBareArrayIsRefusedWithARemedy fail without this.
 func (s *Store) Restore(r io.Reader) error {
-	var list []*resource.Resource
-	if err := json.NewDecoder(r).Decode(&list); err != nil {
+	dec := json.NewDecoder(r)
+	dec.DisallowUnknownFields()
+
+	var file snapshotFile
+	if err := dec.Decode(&file); err != nil {
+		// A bare array is the pre-#133 format, and it is worth telling apart
+		// from a corrupt file: the operator has a real snapshot in their hand
+		// and needs to know what to do with it, not that their JSON is broken.
+		if looksLikeBareArray(err) {
+			return fmt.Errorf("restore store: this snapshot has no format header, "+
+				"so it was written by feint before the %s envelope existed (#133). "+
+				"Its completeness cannot be established — the decoder that wrote it "+
+				"dropped fields it did not know. Take a fresh snapshot from the "+
+				"instance that holds the state, or wrap the array as "+
+				`{"format":%q,"version":%d,"resources":[...]}`,
+				snapshotFormat, snapshotFormat, snapshotVersion)
+		}
 		return fmt.Errorf("restore store: %w", err)
 	}
+	if file.Format != snapshotFormat {
+		return fmt.Errorf("restore store: format is %q, and this build reads %q",
+			file.Format, snapshotFormat)
+	}
+	if file.Version != snapshotVersion {
+		return fmt.Errorf("restore store: snapshot version %d, and this build reads version %d: "+
+			"restore it with the feint that wrote it, or take a fresh snapshot",
+			file.Version, snapshotVersion)
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.items = make(map[string]*resource.Resource, len(list))
-	for _, res := range list {
+	s.items = make(map[string]*resource.Resource, len(file.Resources))
+	for _, res := range file.Resources {
 		// A snapshot is operator-supplied, and a null element in the array
 		// decodes to a nil pointer that panics on the next field read. Skipped
 		// rather than refused: one bad entry must not make a session
@@ -250,4 +330,15 @@ func (s *Store) Restore(r io.Reader) error {
 		s.items[key(res.Tenant.Provider, res.Kind, res.ID)] = res
 	}
 	return nil
+}
+
+// looksLikeBareArray tells the old format from a corrupt file.
+//
+// By the decoder's own complaint rather than by peeking at the first byte: the
+// reader may not be seekable — `PUT /_feint/state` hands a request body straight
+// through — and buffering the whole file to look at one character would undo the
+// bound snapshot.go puts on it.
+func looksLikeBareArray(err error) bool {
+	var typeErr *json.UnmarshalTypeError
+	return errors.As(err, &typeErr) && typeErr.Value == "array"
 }

--- a/internal/providers/outscale/audit_test.go
+++ b/internal/providers/outscale/audit_test.go
@@ -373,18 +373,31 @@ func TestACreateWhoseResourceVanishesLeavesNoMachineBehind(t *testing.T) {
 
 	// The machine is starting; empty the store under it.
 	<-runtime.entered
-	req, err := http.NewRequest(http.MethodPut, ts.URL+"/_feint/state", strings.NewReader("[]"))
+	// The snapshot envelope, not a bare array: a file with no format header is
+	// refused since #133, and this fixture was one.
+	empty := `{"format":"feint-snapshot","version":1,"resources":[]}`
+	req, err := http.NewRequest(http.MethodPut, ts.URL+"/_feint/state", strings.NewReader(empty))
 	if err != nil {
+		close(runtime.release)
 		t.Fatalf("build the restore: %v", err)
 	}
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
+		close(runtime.release)
 		t.Fatalf("restore an empty state: %v", err)
 	}
 	_ = res.Body.Close()
 	// Checked, because a refused restore would leave this test measuring
 	// nothing while looking green.
+	//
+	// Every failure path above releases the runtime first, and that is not
+	// tidiness: t.Fatalf unwinds this goroutine, the create is still blocked
+	// inside Start, and httptest's Close waits for requests in flight. So a
+	// refused restore used to hang the whole package until the test binary's
+	// timeout — ten minutes of silence instead of one red line, met exactly
+	// once, when #133 made this very restore start failing.
 	if res.StatusCode != http.StatusOK {
+		close(runtime.release)
 		t.Fatalf("the restore answered %d; the store was not emptied", res.StatusCode)
 	}
 	close(runtime.release)


### PR DESCRIPTION
Closes #133. From the second pass of the external review, and the strongest single point of both passes.

> **BREAKING CHANGE:** the snapshot and state formats gain a required envelope. A file written by 0.7.x, and a `PUT /_feint/state` carrying a bare array, are refused with a message naming the remedy.

## The defect was the behaviour, not a risk

Measured before writing anything. A snapshot carrying a field this build does not declare restored **successfully**, `encoding/json` dropped it, and the following `Snapshot` wrote the file back without it:

```
ACCEPTÉ — le restore a réussi
  1 ressource(s) restaurée(s)
  le champ inconnu a-t-il survécu au tour ? false
```

The store was coherent, wrong, and green — on the one file `snapshot.go` documents as made to outlive its instance and be loaded into another one.

## What it answers now

```json
{"format": "feint-snapshot", "version": 1, "resources": [...]}
```

| Input | Answer |
|---|---|
| This version, every field known | Restored |
| A version or format it does not read | Refused, **naming both** — an operator needs to know which of the two binaries to change |
| An unknown field on a resource | Refused, **naming the field** |
| A pre-#133 bare array | Refused, with the conversion in the message rather than a decoder complaint |
| Corrupt input | Refused as a decode error, not explained as a legacy file |

Accepting the bare array as "version 0" was the other option, and it loses the property this change is for: such a file has already passed through a decoder that drops unknown fields, so nobody can say whether it is complete.

`Attrs` stays **open**. Its keys are data a pack chose, not schema — refusing an unknown one would make every pack addition a breaking format change. `TestAnUnknownResourceFieldIsRefused` asserts both halves.

## Two things that fell out, both of the same family as the defect

- **`countResources` in the CLI** unmarshalled a bare array and returns `-1` as a *sentinel* rather than an error. The day the header appeared it would have called every snapshot "not a snapshot" — silently, in the one place that decides whether to write the file.
- **An Outscale audit test** emptied the store with `[]` while a create was blocked inside the runtime, and its own failure path never released it. `httptest`'s `Close` waits for requests in flight, so a refused restore hung the package until the binary timed out: **ten minutes of silence instead of one red line**. Every failure path there releases the runtime first now. The full suite runs in 2.2s.

## The policy contradiction is settled

`store.go` called the format an implementation detail with no compatibility promise; `RELEASING.md` listed it among the surfaces whose change is breaking. Both now say the stricter one, and `RELEASING.md` states that bumping `snapshotVersion` is a breaking change.

## Proof

- Five tests, each named in the code that needs it: round trip, future version, foreign format, unknown resource field (and the open `Attrs` half), legacy array with its remedy, corrupt input kept distinct.
- **Five guards falsified** in a copy outside the repository: each mutation compiles, each kills its named test. One mutation was rejected as too weak and rewritten — it removed a phrase from the message rather than the property under test.
- `mise run check`, `feint docs --check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)