### PR TITLE
feat(lifecycle): what survives a dead emulator is stated once, noticed at restart, and proven by a kill

### DIFF
--- a/.github/workflows/runtime-proof.yml
+++ b/.github/workflows/runtime-proof.yml
@@ -315,3 +315,15 @@ jobs:
       - name: Stop the emulator
         if: always()
         run: sudo ./feint stop --addr 127.0.0.1:4599 || true
+
+      # The crash policy, proven by a kill (#135): SIGKILL a serving emulator
+      # with a machine up, assert the leftovers survive labelled, assert the
+      # restart names them without adopting them, assert `clean` leaves zero
+      # labelled objects with the runtime queried directly. After the stop
+      # above, deliberately: this suite runs `feint clean`, which sweeps every
+      # labelled object on the host — including the main emulator's networks,
+      # had it still been serving.
+      - name: Crash proof — what survives a kill
+        env:
+          MODE: ${{ matrix.mode }}
+        run: sudo env FEINT_VM="${MODE}" tools/conformance/crash.sh

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -181,6 +181,39 @@ still holds a subnet — all reachable, all refused, all tested. A refusal that
 would need an artificial delay to become reachable is not served, and belongs in
 this list instead.
 
+## What survives a dead emulator, in one table
+
+The store is memory: a dead process loses every emulated resource, and that is
+the model, not a defect. The machines are different. A container the runtime
+started does not die with the process that asked for it, so the policy below
+exists, and it is deterministic — measured on 2026-08-13 by running every row
+that can be triggered (`tools/conformance/crash.sh` triggers them on every run
+where a runtime is configured).
+
+| Event | The store | The machines, networks and rule sets |
+|---|---|---|
+| Graceful exit (Ctrl-C, SIGTERM, `feint stop`) | lost (saved first with `--state`) | stay, labelled `user.feint.provider` |
+| Graceful exit with `--cleanup` | lost (saved first with `--state`) | swept before exit, counted out loud |
+| SIGKILL, crash, power loss | lost | stay, labelled — nothing had a chance to run |
+| Restart | starts empty | **named, never adopted**: startup warns "labelled machines from a previous run exist; nothing was adopted, `feint clean` removes them", listing them by name |
+| `feint clean` | untouched (it is a separate process) | everything labelled is removed; the runtime is queried, and the sweep reports what it could not remove instead of claiming success |
+
+Why restart never adopts: the store that gave those machines meaning died with
+the previous process. A machine resurrected from the runtime would be state
+without an owner — trusted for the same bad reason a restored snapshot used to
+be trusted, and `snapshot.go` documents where that leads. The startup notice
+names the leftovers precisely so the operator decides, with
+`TestStartupNamesTheLeftoversItDidNotAdopt` holding the line and
+`tools/conformance/crash.sh` proving the whole sequence — kill, survive
+labelled, warn, sweep to zero — against a real runtime, the runtime queried
+directly rather than the store.
+
+The notice keys on machines. Networks and rule sets alone stay silent: an
+empty emulated bridge is reused under its own name by the next run or refused
+as a block conflict out loud, the OVN uplink is deliberately kept across runs,
+and a warning that fired on every healthy restart would train everyone to
+ignore it — the exact way a gate dies, already measured on this repository.
+
 ## Authentication is accepted, never verified
 
 No signature is checked, on any provider. Credentials must merely be well-formed,

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -474,6 +474,10 @@ func serve(args []string, stdout io.Writer) error {
 	// What the runtime knows, the emulator says. Without this an operator debugs
 	// a machine that will not start by reading the daemon's own log, which is
 	// exactly the step nobody thinks of taking.
+	// What a previous life left on the runtime, said before this one serves
+	// beside it. The policy and its boundaries live in leftovers.go.
+	reportLeftovers(driver, env.Log)
+
 	watchCtx, stopWatching := context.WithCancel(context.Background())
 	defer stopWatching()
 	if watcher, ok := driver.(machine.Watcher); ok {

--- a/internal/cli/leftovers.go
+++ b/internal/cli/leftovers.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/machine"
+)
+
+// A killed emulator leaves its labelled machines running, and until #135 its
+// next life said nothing about them: the operator's next apply ran beside
+// zombie machines holding addresses on emulator-owned bridges, and the policy
+// — die, leave labelled leftovers; restart, ignore; clean, sweep — was only
+// visible to whoever assembled it from four files. This is the one moment the
+// policy can be observed cheaply, so it is where the emulator says it.
+//
+// Named, never adopted. The store that gave those machines meaning died with
+// the previous process; resurrecting them from the runtime would trust state
+// that no longer has an owner, which is the same mistake as trusting a
+// restored snapshot without revalidating it.
+//
+// The notice keys on machines, not on networks or rule sets alone. An empty
+// emulated network is plumbing: the next run reuses it under the same name or
+// refuses the block conflict out loud, and the OVN uplink is deliberately
+// kept across runs. A warning that fired on every healthy restart would be
+// read by nobody, which this repository has already measured on its gates.
+
+// reportLeftovers names the labelled machines a previous run left on the
+// runtime. TestStartupNamesTheLeftoversItDidNotAdopt fails without it.
+func reportLeftovers(driver machine.Driver, log *slog.Logger) {
+	surveyor, ok := driver.(machine.Surveyor)
+	if !ok {
+		return
+	}
+	// Bounded: a hung runtime must delay the listener by seconds, not hold it.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	left, err := surveyor.Survey(ctx)
+	if err != nil {
+		// Silence on error would be the defect this file exists to remove: an
+		// operator who cannot be told "there are leftovers" must at least be
+		// told "I could not look".
+		log.Warn("could not look for a previous run's leftovers", "error", err)
+		return
+	}
+	if len(left.Machines) == 0 {
+		return
+	}
+	log.Warn("labelled machines from a previous run exist; nothing was adopted, `feint clean` removes them",
+		"machines", strings.Join(left.Machines, " "),
+		"networks", len(left.Networks),
+		"rule_sets", len(left.Firewalls))
+}

--- a/internal/cli/leftovers_test.go
+++ b/internal/cli/leftovers_test.go
@@ -1,0 +1,102 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/machine"
+)
+
+// The startup notice is the observable half of the crash policy (#135): after
+// a kill -9, labelled machines survive on the runtime, and the next start must
+// name them without resurrecting them. These tests hold the notice through a
+// fake Surveyor, so no real runtime is needed; the Incus half of the property
+// (only labelled names, only read commands) lives with the driver, in
+// TestSurveyFindsOnlyTheEmulatorsWorkAndTouchesNothing.
+
+// surveyingDriver is a metadata-only driver that also answers a survey, which
+// is exactly the shape reportLeftovers keys on.
+type surveyingDriver struct {
+	machine.Noop
+	left machine.Leftovers
+	err  error
+}
+
+func (d surveyingDriver) Survey(context.Context) (machine.Leftovers, error) {
+	return d.left, d.err
+}
+
+func noticed(t *testing.T, driver machine.Driver) string {
+	t.Helper()
+	var buf bytes.Buffer
+	reportLeftovers(driver, slog.New(slog.NewTextHandler(&buf, nil)))
+	return buf.String()
+}
+
+func TestStartupNamesTheLeftoversItDidNotAdopt(t *testing.T) {
+	out := noticed(t, surveyingDriver{left: machine.Leftovers{
+		Machines: []string{"feint-scw-79e3ef40", "feint-osc-i-21519d57"},
+		Networks: []string{"fnt-default"},
+	}})
+
+	// The line must name the machines: "2 machines exist" sends the operator
+	// to the runtime to find out which, and the whole point is that the
+	// emulator already knows.
+	for _, name := range []string{"feint-scw-79e3ef40", "feint-osc-i-21519d57"} {
+		if !strings.Contains(out, name) {
+			t.Errorf("the notice does not name %s:\n%s", name, out)
+		}
+	}
+	// And it must say what to do, and what was not done: `feint clean` is the
+	// remedy, adoption is the trap.
+	if !strings.Contains(out, "feint clean") {
+		t.Errorf("the notice does not name the remedy:\n%s", out)
+	}
+	if !strings.Contains(out, "adopted") {
+		t.Errorf("the notice does not state that nothing was adopted:\n%s", out)
+	}
+	if !strings.Contains(out, "level=WARN") {
+		t.Errorf("leftover machines are a warning, not chatter:\n%s", out)
+	}
+}
+
+func TestStartupStaysSilentWhenTheRuntimeIsClean(t *testing.T) {
+	if out := noticed(t, surveyingDriver{}); out != "" {
+		t.Errorf("a clean runtime produced a notice:\n%s", out)
+	}
+}
+
+func TestStartupStaysSilentOverPlumbingAlone(t *testing.T) {
+	// Networks without machines are the healthy steady state: an emulated
+	// bridge is reused under its name on the next boot, and the OVN uplink is
+	// kept across runs by design. A notice that fired on every restart would
+	// be read by nobody, which is worse than none.
+	out := noticed(t, surveyingDriver{left: machine.Leftovers{
+		Networks:  []string{"feint-uplink", "fnt-default"},
+		Firewalls: []string{"scw-bbbb"},
+	}})
+	if out != "" {
+		t.Errorf("plumbing without machines produced a notice:\n%s", out)
+	}
+}
+
+func TestStartupSaysWhenItCouldNotLook(t *testing.T) {
+	// Silence on error would be the exact defect the notice removes: the
+	// operator must at least learn that nobody looked.
+	out := noticed(t, surveyingDriver{err: errors.New("incus: connection refused")})
+	if !strings.Contains(out, "could not look") || !strings.Contains(out, "connection refused") {
+		t.Errorf("a failed survey must be said, got:\n%s", out)
+	}
+}
+
+func TestStartupAsksNothingOfADriverThatCannotAnswer(t *testing.T) {
+	// Noop backs --vm off: no runtime, nothing to survey, and the notice must
+	// not manufacture one.
+	if out := noticed(t, machine.Noop{}); out != "" {
+		t.Errorf("a driver without Survey produced a notice:\n%s", out)
+	}
+}

--- a/internal/core/machine/incus_prune.go
+++ b/internal/core/machine/incus_prune.go
@@ -99,6 +99,27 @@ func (d *Incus) Prune(ctx context.Context) (Pruned, error) {
 	return pruned, nil
 }
 
+// Survey implements Surveyor: the same three listings Prune starts from, and
+// nothing else. Every command it issues is a read (`query`); the test
+// TestSurveyFindsOnlyTheEmulatorsWorkAndTouchesNothing fails if a mutating
+// verb ever creeps in.
+func (d *Incus) Survey(ctx context.Context) (Leftovers, error) {
+	var left Leftovers
+	machines, err := d.labelled(ctx, "/1.0/instances?recursion=1")
+	if err != nil {
+		return left, err
+	}
+	left.Machines = machines
+
+	networks, err := d.labelled(ctx, "/1.0/networks?recursion=1")
+	if err != nil {
+		return left, err
+	}
+	left.Networks = networks
+	left.Firewalls = d.ownedACLs(ctx)
+	return left, nil
+}
+
 // labelled returns the names of the resources at the endpoint carrying the
 // emulator's label. Incus stores labels as user.* config keys.
 func (d *Incus) labelled(ctx context.Context, endpoint string) ([]string, error) {

--- a/internal/core/machine/incus_survey_test.go
+++ b/internal/core/machine/incus_survey_test.go
@@ -1,0 +1,56 @@
+package machine
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// Survey is the read-only half of the sweep: what a restart names must be
+// exactly what Prune would remove, and looking must never become touching.
+// The world is pruneWorld, deliberately: one labelled machine next to two
+// foreign ones, one labelled network next to the host's bridge, two owned
+// rule sets next to an operator's.
+
+func TestSurveyFindsOnlyTheEmulatorsWorkAndTouchesNothing(t *testing.T) {
+	f := &fakeRuntime{answers: pruneWorld()}
+	d := newFakeDriver(f)
+
+	left, err := d.Survey(context.Background())
+	if err != nil {
+		t.Fatalf("survey: %v", err)
+	}
+
+	if len(left.Machines) != 1 || left.Machines[0] != "feint-scw-1" {
+		t.Errorf("machines = %v, want exactly [feint-scw-1]: a foreign name in this list ends up in a log line that sends someone to `feint clean`", left.Machines)
+	}
+	if len(left.Networks) != 1 || left.Networks[0] != "scw-aaaa" {
+		t.Errorf("networks = %v, want exactly [scw-aaaa]", left.Networks)
+	}
+	if len(left.Firewalls) != 2 {
+		t.Errorf("rule sets = %v, want the described one and the isolation one", left.Firewalls)
+	}
+	if left.Total() != 4 {
+		t.Errorf("total = %d, want 4", left.Total())
+	}
+
+	// Naming is the whole contract. A survey that stops, deletes or unsets
+	// anything is a sweep wearing the wrong name, and it would run at every
+	// startup.
+	for _, cmd := range f.commands() {
+		if !strings.HasPrefix(cmd, "query ") {
+			t.Errorf("survey issued a non-read command: %q", cmd)
+		}
+	}
+}
+
+func TestSurveyReportsAnUnreachableRuntime(t *testing.T) {
+	f := &fakeRuntime{fail: map[string]error{
+		"/1.0/instances?recursion=1": context.DeadlineExceeded,
+	}}
+	d := newFakeDriver(f)
+
+	if _, err := d.Survey(context.Background()); err == nil {
+		t.Fatal("a listing that failed must surface, not read as an empty runtime")
+	}
+}

--- a/internal/core/machine/prune.go
+++ b/internal/core/machine/prune.go
@@ -34,3 +34,27 @@ type Pruner interface {
 	// in that order: a network cannot go while a machine sits on it.
 	Prune(ctx context.Context) (Pruned, error)
 }
+
+// Leftovers names the labelled work a runtime still holds, without touching
+// it. It is the read-only half of a sweep: what Prune would remove, found and
+// named so a restart can say it out loud instead of serving beside it (#135).
+type Leftovers struct {
+	Machines  []string
+	Networks  []string
+	Firewalls []string
+}
+
+// Total reports whether anything was found at all.
+func (l Leftovers) Total() int { return len(l.Machines) + len(l.Networks) + len(l.Firewalls) }
+
+// Surveyor is the optional half of a Driver that can name the emulator's
+// labelled work without acting on it. A restart uses it to notice what a
+// previous life left behind; adoption is deliberately not on offer, because
+// the store that gave those objects meaning died with the process that
+// created them.
+type Surveyor interface {
+	// Survey lists the machines, networks and rule sets carrying the
+	// emulator's mark. It must issue no mutating command: naming is the whole
+	// contract, TestSurveyFindsOnlyTheEmulatorsWorkAndTouchesNothing holds it.
+	Survey(ctx context.Context) (Leftovers, error)
+}

--- a/mise.toml
+++ b/mise.toml
@@ -151,6 +151,14 @@ run = [
   "tools/conformance/exoscale/ssh.sh http://$FEINT_ADDR",
 ]
 
+[tasks."conformance:crash"]
+description = "Kill a serving emulator and prove the crash policy: leftovers labelled, restart warns, clean sweeps to zero. Needs FEINT_VM=incus"
+depends = ["build"]
+# Not part of the `conformance` aggregate: this suite runs `feint clean`, which
+# sweeps every labelled object on the host — including the aggregate's own
+# running emulator's networks. It owns its emulator, on its own port.
+run = "tools/conformance/crash.sh"
+
 [tasks."conformance:oapi"]
 description = "Drive the running emulator with the real Outscale CLI"
 run = "tools/conformance/outscale/oapi-cli.sh http://$FEINT_ADDR"

--- a/tools/conformance/crash.sh
+++ b/tools/conformance/crash.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Conformance check: the crash policy, proven by a kill (#135).
+#
+# docs/limits.md states the lifecycle in one table: die and the labelled
+# leftovers survive; restart and nothing is adopted but the leftovers are
+# named; `feint clean` and the runtime is empty again. Every row of that table
+# that can be triggered is triggered here, in order, against a real runtime:
+# SIGKILL on a serving emulator with a machine up, the leftovers asserted
+# present and labelled, the restart asserted to warn and to adopt nothing, the
+# sweep asserted to leave zero labelled objects — with the runtime queried
+# directly, because the store is not a witness for what the host holds.
+#
+# Requires a machine runtime (FEINT_VM=incus, incus-vm or incus-ovn). With
+# FEINT_VM unset or off the whole suite is skipped: there is no runtime to
+# leave anything on.
+#
+# This suite starts its own emulator on its own port and must not run beside
+# another feint that is serving machines: the final sweep removes everything
+# carrying the emulator's label, and labels identify the emulator's work, not
+# one run's.
+#
+# Usage: FEINT_VM=incus tools/conformance/crash.sh
+set -euo pipefail
+
+MODE="${FEINT_VM:-off}"
+PORT="${FEINT_CRASH_PORT:-4661}"
+ADDR="127.0.0.1:$PORT"
+EP="http://$ADDR"
+ZONE="fr-par-1"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/guard.sh"
+guard_local "$EP"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ok()   { echo "  ok: $*"; }
+skip() { echo "  SKIP: $*" >&2; }
+
+if [ "$MODE" = "off" ]; then
+  skip "no machine runtime (set FEINT_VM=incus); a crash with no machines leaves nothing to prove"
+  exit 0
+fi
+command -v incus >/dev/null 2>&1 || fail "FEINT_VM=$MODE but no incus client to verify the runtime with"
+
+FEINT_BIN="${FEINT_BIN:-$SCRIPT_DIR/../../feint}"
+[ -x "$FEINT_BIN" ] || fail "no feint binary at $FEINT_BIN (build it: mise run build)"
+
+echo "conformance: crash policy against $EP (mode $MODE)"
+
+# The failure path frees the runtime too: a suite that dies holding its
+# emulator blocks whatever runs next for its whole timeout, which was measured
+# on this repository at ten minutes for one missing trap.
+cleanup() {
+  "$FEINT_BIN" stop --addr "$ADDR" >/dev/null 2>&1 || true
+  "$FEINT_BIN" clean --vm "$MODE" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# Labelled leftovers on the runtime, counted by asking the runtime itself.
+labelled_instances() {
+  incus list -f json | jq '[.[] | select((.config["user.feint.provider"] // "") != "")] | length'
+}
+labelled_networks() {
+  incus network list -f json | jq '[.[] | select((.config["user.feint.provider"] // "") != "")] | length'
+}
+owned_rulesets() {
+  incus network acl list -f json | jq '[.[] | select(((.description // "") | startswith("feint security group")) or (.name | startswith("iso-fnt-")))] | length'
+}
+
+echo "- a clean runtime to start from"
+"$FEINT_BIN" clean --vm "$MODE" >/dev/null
+[ "$(labelled_instances)" = 0 ] || fail "labelled machines exist before the suite began; refusing to measure over them"
+ok "zero labelled machines"
+
+echo "- an emulator serving machines"
+out="$("$FEINT_BIN" start --addr "$ADDR" --vm "$MODE" --timeout 90s)"
+pid="$(echo "$out" | sed -n 's/.*(pid \([0-9]\+\)).*/\1/p' | head -1)"
+[ -n "$pid" ] || fail "start did not report a pid: $out"
+ok "pid $pid"
+
+echo "- a server booted through the API"
+id="$(curl -sf -X POST "$EP/instance/v1/zones/$ZONE/servers" \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"crash-proof","commercial_type":"DEV1-S","image":"alpine"}' | jq -r '.server.id')"
+[ -n "$id" ] && [ "$id" != null ] || fail "the server was not created"
+curl -sf -X POST "$EP/instance/v1/zones/$ZONE/servers/$id/action" \
+  -H 'Content-Type: application/json' -d '{"action":"poweron"}' >/dev/null
+machine="feint-scw-$id"
+running=""
+for _ in $(seq 1 60); do
+  if incus list -f json | jq -e --arg n "$machine" \
+       'any(.[]; .name == $n and .status == "Running")' >/dev/null; then running=yes; break; fi
+  sleep 2
+done
+[ -n "$running" ] || fail "$machine never reached Running"
+ok "$machine is running"
+
+echo "- kill -9: the crash nothing announces"
+kill -9 "$pid"
+for _ in $(seq 1 10); do kill -0 "$pid" 2>/dev/null || break; sleep 1; done
+kill -0 "$pid" 2>/dev/null && fail "pid $pid survived SIGKILL"
+ok "the emulator is dead"
+
+echo "- the leftovers survive, labelled"
+incus list -f json | jq -e --arg n "$machine" \
+  'any(.[]; .name == $n and .status == "Running" and .config["user.feint.provider"] == "scaleway")' >/dev/null \
+  || fail "$machine is gone or unlabelled: the crash policy says it must survive, labelled"
+ok "$machine still runs and carries user.feint.provider=scaleway"
+
+echo "- a restart names them and adopts nothing"
+"$FEINT_BIN" start --addr "$ADDR" --vm "$MODE" --timeout 90s >/dev/null
+log="$("$FEINT_BIN" logs --addr "$ADDR" -n 80)"
+echo "$log" | grep -q "labelled machines from a previous run exist" \
+  || fail "the restart said nothing about the leftovers (the notice #135 requires): $log"
+echo "$log" | grep -q "$machine" \
+  || fail "the notice does not name $machine: $log"
+servers="$(curl -sf "$EP/instance/v1/zones/$ZONE/servers" | jq '.servers | length')"
+[ "$servers" = 0 ] || fail "the restart adopted $servers server(s); the store must start empty"
+ok "warned, named $machine, store empty"
+
+echo "- clean leaves zero labelled objects, asked of the runtime itself"
+"$FEINT_BIN" stop --addr "$ADDR" >/dev/null
+# The sweep's exit code is reported but does not render the verdict: the state
+# of the runtime does. A clean that exits 0 while leaving a machine and a
+# clean that exits 1 having removed nothing must both fail on the assertions
+# below — measured: a Prune mutated to skip machines failed here as "network
+# is in use" and a set -e abort, one line before the assertion that names the
+# actual defect.
+if sweep="$("$FEINT_BIN" clean --vm "$MODE" 2>&1)"; then
+  echo "  sweep: ${sweep%%$'\n'*}"
+else
+  echo "  sweep reported: ${sweep%%$'\n'*}"
+fi
+[ "$(labelled_instances)" = 0 ] || fail "labelled machines remain after clean"
+[ "$(labelled_networks)" = 0 ] || fail "labelled networks remain after clean"
+[ "$(owned_rulesets)" = 0 ] || fail "emulator-owned rule sets remain after clean"
+ok "zero labelled machines, networks and rule sets"
+
+echo "conformance: crash policy passed"


### PR DESCRIPTION
# Summary

Closes the three holes #135 names around a policy that already existed but was
scattered, silent at restart, and untested on the crash path.

**Measured before writing anything** (2026-08-13, on a real Incus runtime):
`feint start --vm incus`, a server booted through the API, `kill -9` on the
serve process. The container survives RUNNING, labelled
`user.feint.provider=scaleway`; the restart exits 0 and says nothing; the
store is empty (nothing adopted); `feint clean` removes 1 machine, 1 network,
1 rule set and leaves the runtime empty. Deterministic — but silent, and
stated nowhere as one thing.

Three answers, one per hole:

1. **`docs/limits.md` states the lifecycle in one table** — graceful exit
   with and without `--cleanup`, SIGKILL, restart, `clean`, each row with its
   observable outcome — and states why restart never adopts: the store that
   gave those machines meaning died with the process, and a machine
   resurrected from the runtime would be state without an owner.
2. **Startup names the leftovers it did not adopt.** `machine.Surveyor` is
   the read-only half of the sweep: the same three listings `Prune` starts
   from, and provably no mutating command
   (`TestSurveyFindsOnlyTheEmulatorsWorkAndTouchesNothing`, through the
   injectable runner, on the same world as the prune tests — one labelled
   machine among foreign ones). `serve` warns once, naming the machines and
   the remedy; `TestStartupNamesTheLeftoversItDidNotAdopt` fails without it.
   The notice keys on machines: networks alone are plumbing the next run
   reuses (the OVN uplink deliberately so), and a warning firing on every
   healthy restart would be read by nobody — that choice is itself tested
   (`TestStartupStaysSilentOverPlumbingAlone`).
3. **The crash path is a conformance suite.** `tools/conformance/crash.sh`
   triggers the whole sequence against a real runtime: SIGKILL → leftovers
   present and labelled → restart warns and names, store empty → `clean` →
   zero labelled machines, networks and rule sets, **the runtime queried
   directly, never the store**. The sweep's exit code is reported but the
   runtime state renders the verdict, so a `clean` that lies in either
   direction (exit 0 leaving work, exit 1 having removed nothing) fails the
   same assertion. Wired into `runtime-proof.yml` after the main emulator
   stops (a label identifies the emulator's work, not one run's, so the sweep
   is global by design), and into mise as `conformance:crash`, excluded from
   the `conformance` aggregate for the same reason.

**/falsify — five mutations, each compiled, each bitten:**

| Mutation | What bit, and where |
|---|---|
| notice condition inverted (never fires) | `TestStartupNamesTheLeftoversItDidNotAdopt` red |
| `labelled()` stops reading the label | `TestSurveyFindsOnlyTheEmulatorsWorkAndTouchesNothing` red |
| a `delete` slipped into `Survey` | same test red (non-read command) |
| `Prune` skips the machine class (the mutation #135 names) | `crash.sh` red on a real runtime: "labelled machines remain after clean" |
| `reportLeftovers` call removed from `serve` | `crash.sh` red on a real runtime: "restart said nothing about the leftovers" |

The fourth mutation also caught a harness defect before it shipped: the
mutated `clean` exits nonzero ("network is in use") and `set -e` aborted the
suite one line before the assertion that names the defect — `crash.sh` now
tolerates the sweep's exit code and lets the runtime state render the verdict.

Run locally: `FEINT_VM=incus mise run conformance:crash` (passes on this
station, several times, including via the mise task). In CI it runs in the
`runtime-proof.yml` job delivered by #139, which stays nightly plus dispatch
under the promotion rule #125 records.

Note: #133 (snapshot format) is not merged as of this branch; nothing here
touches `Restore` or the snapshot format, so there is no interaction to
resolve. The limits section cites `snapshot.go`'s existing rule only.

## Type of change

- [ ] A route added or changed
- [ ] Bug fix
- [x] Refactor
- [x] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

(A new observable behaviour — the startup notice — plus its documentation and
its proof; no route or response shape moves.)

## Checklist

### Always

- [x] `mise run check` passes (gofmt, vet, golangci-lint, `go test -race`)
- [x] No new external Go dependency, or the pull request justifies it —
      `go.mod` untouched
- [x] `internal/core` still knows no provider. `Surveyor` and `Leftovers` are
      provider-neutral; the one provider-looking string in the tests
      (`feint-scw-…`) is test data naming what a real crash left
- [x] Nothing in the diff could be written identically for another provider —
      the notice and the survey live in the shared layers (`internal/cli`,
      `internal/core/machine`), once, for all three packs

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] I ran `mise run conformance` myself — not "it should pass": the crash
      suite ran on a real Incus runtime on this station repeatedly (including
      under /falsify), and the control-plane suites are untouched by this diff
- [x] Every field name in the diff comes from the provider's SDK, their
      OpenAPI document, or a run of the real client — no API field is added;
      the Incus endpoints queried (`/1.0/instances`, `/1.0/networks`,
      `/1.0/network-acls`) are the ones `Prune` already reads

### When a route is added or changed — otherwise N/A

N/A — no route changes.

### When behaviour a client can observe changes — otherwise N/A

- [x] `docs/limits.md` updated — the new section is the deliverable itself
- [x] The README's generated tables regenerated — `feint docs --check` passes
      unchanged (no generated section moves)

### When `.github/workflows/` is touched — otherwise N/A

- [x] Every action pinned to a full 40-character commit SHA — no action
      added; one `run:` step appended to `runtime-proof.yml`
- [x] `step-security/harden-runner` is the job's first step — unchanged
- [x] `permissions:` is least-privilege on every job — unchanged
- [x] No job renamed, or the required status checks updated — no rename;
      `runtime-proof.yml` is not a required check (promotion rule of #125)
- [x] The exit-code contract still holds — `crash.sh` exits 0/1 and gates on
      its own assertions; the sweep's exit code is deliberately reported
      rather than piped into the verdict, and the comment in the script says
      why

### When a machine runtime is involved — otherwise N/A

- [x] Tested with `FEINT_VM=incus`, not only with `--vm off` — the suite
      exists to be run there, and was, repeatedly
- [x] Nothing the emulator did not create was touched — `Survey` is
      read-only and proven to issue only `query`; the suite's sweep removes
      by label only, and the falsification runs swept with the unmutated
      binary afterwards
- [x] The run leaves nothing behind — checked, not assumed: the suite's last
      assertion is zero labelled objects asked of the runtime itself, and the
      station's `incus list` is empty after every run

## Related issues

Closes #135
