### PR TITLE
test(core): a barrage, one invariant sweep, and the defect it found in Exoscale

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -19,6 +19,27 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Modifié
 
+- **Un barrage de trafic concurrent, et un balayage d'invariants sur le store**
+  (#134). Chaque pack pilote désormais ses propres routes servies depuis dix
+  travailleurs simultanés — le parallélisme par défaut de Terraform — puis le
+  store est balayé par un contrôle neutre vis-à-vis des providers dans
+  `internal/core/store/storetest` : aucun identifiant émis deux fois, aucune
+  adresse détenue par deux ressources d'un même genre, aucun objet runtime
+  revendiqué par deux ressources. Un restore de snapshot en pleine circulation a
+  son propre test.
+
+  **Il a trouvé un vrai défaut dès sa première exécution contre Exoscale** :
+  l'allocation d'IP élastique était un lire-modifier-écrire sans verrou, si bien
+  que trois adresses sur seize créations sont allées à deux ressources chacune.
+  Le pack Scaleway avait corrigé cette forme pour ses propres pools depuis
+  longtemps et celui-ci ne l'a jamais reçue — écrit deux fois, corrigé une fois,
+  vivant dans l'autre copie.
+
+  Le balayage vit dans le noyau et ne connaît aucun provider : un quatrième pack
+  en hérite en appelant une fonction. Il reconnaît les adresses à leur forme et
+  non au nom de l'attribut, parce qu'un balayage indexé sur l'orthographe de
+  chaque pack est un balayage auquel un pack nouveau échappe.
+
 - **Un snapshot est compris ou refusé, et dit de quelle version il est** (#133).
   `feint snapshot save`, `GET /_feint/state` et `--state` écrivent désormais
   `{"format": "feint-snapshot", "version": 1, "resources": [...]}` au lieu d'un

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Changed
 
+- **A barrage of concurrent traffic, and one invariant sweep over the store**
+  (#134). Each pack now drives its own served routes from ten workers at once —
+  Terraform's default parallelism — and the store is then swept by a
+  provider-neutral check in `internal/core/store/storetest`: no identifier issued
+  twice, no address held by two resources of one kind, no runtime object claimed
+  by two resources. A snapshot restore racing live traffic has its own test.
+
+  **It found a real defect on its first run against Exoscale**: elastic IP
+  allocation was a read-modify-write with no lock, so three addresses out of
+  sixteen creates went to two resources each. The Scaleway pack fixed that shape
+  for its own pools long ago and this one never received it — written twice,
+  fixed once, alive in the other copy.
+
+  The sweep lives in the core and knows no provider, so a fourth pack inherits it
+  by calling one function; it finds addresses by shape rather than by attribute
+  name, because a sweep keyed on each pack's spelling is a sweep a new pack
+  escapes.
+
 - **A snapshot is understood or refused, and says which version it is** (#133).
   `feint snapshot save`, `GET /_feint/state` and `--state` now write
   `{"format": "feint-snapshot", "version": 1, "resources": [...]}` instead of a

--- a/internal/core/store/storetest/sweep.go
+++ b/internal/core/store/storetest/sweep.go
@@ -1,0 +1,199 @@
+// Package storetest holds the invariant sweep the packs run after a barrage.
+//
+// It exists because of a defect shape no per-path test can see: two different
+// routes, each correctly locked on its own target, jointly violating a
+// cross-resource invariant. Every concurrency test in this repository stages one
+// race, on one path, in one pack — `TestConcurrentPowerOnStartsTheMachineOnce`
+// in internal/providers/scaleway, `TestConcurrentCreatesDoNotShareAnAddress` in
+// internal/providers/outscale, and the seven others. They hold the
+// defects that were once real, and none of them would notice an address handed
+// out by the flexible-IP pool that the subnet allocator also handed out.
+//
+// So the sweep is not a second implementation of those tests. It is the question
+// they cannot ask: after a barrage of concurrent traffic, is the store still
+// internally coherent?
+//
+// It lives in the core and knows no provider, which is what makes it usable by
+// the three packs and by a fourth that does not exist yet. It reads nothing but
+// `resource.Resource`: identifiers, the addresses it finds by shape, and the
+// runtime object names the emulator itself wrote. A sweep that had to be taught
+// each pack's attribute names would be a sweep a new pack silently escapes.
+package storetest
+
+import (
+	"fmt"
+	"net/netip"
+	"sort"
+	"strings"
+
+	"github.com/stephrobert/feint/internal/core/resource"
+)
+
+// Sweep reports every invariant the store broke, one line each, sorted so two
+// runs of the same failure read the same.
+//
+// Empty means coherent. The caller decides what to do about it — this returns
+// findings rather than calling t.Error, so a barrage can sweep repeatedly and
+// report only the first breach, and so the sweep itself is testable.
+func Sweep(resources []*resource.Resource) []string {
+	var found []string
+	found = append(found, duplicateIdentifiers(resources)...)
+	found = append(found, sharedAddresses(resources)...)
+	found = append(found, sharedRuntimeObjects(resources)...)
+	sort.Strings(found)
+	return found
+}
+
+// duplicateIdentifiers: an identifier is issued once.
+//
+// Two resources sharing one is not a cosmetic clash. The store keys on
+// provider|kind|id, so the second Put silently replaces the first: a client
+// holding the older identifier reads somebody else's resource, and a delete
+// removes both at once.
+func duplicateIdentifiers(resources []*resource.Resource) []string {
+	seen := map[string]*resource.Resource{}
+	var found []string
+	for _, res := range resources {
+		if res == nil || res.ID == "" {
+			continue
+		}
+		if first, clash := seen[res.ID]; clash {
+			found = append(found, fmt.Sprintf(
+				"identifier %s was issued twice: %s/%s and %s/%s",
+				res.ID, first.Tenant.Provider, first.Kind, res.Tenant.Provider, res.Kind))
+			continue
+		}
+		seen[res.ID] = res
+	}
+	return found
+}
+
+// sharedAddresses: one address belongs to one resource of a kind.
+//
+// Scoped to the kind on purpose, and that is the difference between an invariant
+// and a false alarm: an address resource and the server it is attached to both
+// carry the same string, legitimately, and a naive "this address appears twice"
+// would fail every healthy store. Two *servers* carrying it, or two *flexible
+// IPs*, is the double allocation this is for.
+//
+// Addresses are found by shape rather than by attribute name, because the names
+// are each pack's own — `address`, `PublicIp`, `ipv4_address` — and a sweep
+// keyed on them is a sweep the fourth pack escapes. Anything that parses as an
+// IP is an address; a prefix like 10.0.0.0/24 is not, and is skipped, since a
+// subnet legitimately appears on the network and on everything placed in it.
+func sharedAddresses(resources []*resource.Resource) []string {
+	// kind -> address -> the first resource holding it
+	byKind := map[string]map[string]string{}
+	var found []string
+
+	for _, res := range resources {
+		if res == nil {
+			continue
+		}
+		held := byKind[res.Kind]
+		if held == nil {
+			held = map[string]string{}
+			byKind[res.Kind] = held
+		}
+		for _, addr := range addressesIn(res.Attrs) {
+			if first, clash := held[addr]; clash && first != res.ID {
+				found = append(found, fmt.Sprintf(
+					"address %s is held by two %s resources: %s and %s",
+					addr, res.Kind, first, res.ID))
+				continue
+			}
+			held[addr] = res.ID
+		}
+	}
+	return found
+}
+
+// sharedRuntimeObjects: one runtime object belongs to one resource.
+//
+// Runtime holds the names the emulator itself wrote for the machine, the network
+// or the interface behind a resource. Two resources naming one object means a
+// delete of either destroys the other's machine, and the API describes something
+// that is not there — the orphan shape, seen from the store side, which is the
+// half that holds even with --vm off.
+func sharedRuntimeObjects(resources []*resource.Resource) []string {
+	// key -> value -> first resource
+	byKey := map[string]map[string]string{}
+	var found []string
+
+	for _, res := range resources {
+		if res == nil {
+			continue
+		}
+		for k, v := range res.Runtime {
+			if v == "" {
+				continue
+			}
+			held := byKey[k]
+			if held == nil {
+				held = map[string]string{}
+				byKey[k] = held
+			}
+			// A runtime value that names another resource — a server id on a
+			// volume, say — is a reference, not an object this resource owns,
+			// and several volumes legitimately name one server. Only values the
+			// emulator minted for itself are exclusive, and those are the ones
+			// that do not look like an identifier it also stored.
+			if isStoredIdentifier(resources, v) {
+				continue
+			}
+			if first, clash := held[v]; clash && first != res.ID {
+				found = append(found, fmt.Sprintf(
+					"runtime object %s=%q is claimed by two resources: %s and %s",
+					k, v, first, res.ID))
+				continue
+			}
+			held[v] = res.ID
+		}
+	}
+	return found
+}
+
+func isStoredIdentifier(resources []*resource.Resource, value string) bool {
+	for _, res := range resources {
+		if res != nil && res.ID == value {
+			return true
+		}
+	}
+	return false
+}
+
+// addressesIn walks an attribute tree and returns everything that parses as an
+// IP address. Recursive because packs nest: a server carries its addresses under
+// public_ips[], a NIC under its own object.
+func addressesIn(attrs map[string]any) []string {
+	var out []string
+	var walk func(any)
+	walk = func(v any) {
+		switch t := v.(type) {
+		case string:
+			if addr, err := netip.ParseAddr(strings.TrimSpace(t)); err == nil && !addr.IsUnspecified() {
+				out = append(out, addr.String())
+			}
+		case map[string]any:
+			for _, nested := range t {
+				walk(nested)
+			}
+		case []any:
+			for _, nested := range t {
+				walk(nested)
+			}
+		case []string:
+			for _, nested := range t {
+				walk(nested)
+			}
+		case []map[string]any:
+			for _, nested := range t {
+				walk(nested)
+			}
+		}
+	}
+	for _, v := range attrs {
+		walk(v)
+	}
+	return out
+}

--- a/internal/core/store/storetest/sweep_test.go
+++ b/internal/core/store/storetest/sweep_test.go
@@ -1,0 +1,117 @@
+package storetest_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/resource"
+	"github.com/stephrobert/feint/internal/core/store/storetest"
+)
+
+// A sweep that finds nothing passes every barrage ever written, which is the
+// instrument measuring its own silence. So it is tested against stores that are
+// broken on purpose, and against one that is merely busy.
+
+func res(id, kind string, attrs map[string]any) *resource.Resource {
+	return &resource.Resource{
+		ID:     id,
+		Kind:   kind,
+		Tenant: resource.Tenant{Provider: "scaleway", Zone: "fr-par-1"},
+		Attrs:  attrs,
+	}
+}
+
+// The accepting half, and the one that matters most: a healthy store produces no
+// finding, including the shapes that look like breaches and are not.
+func TestAHealthyStoreSweepsClean(t *testing.T) {
+	server := res("s1", "instance/server", map[string]any{
+		"name": "web",
+		// The same address the flexible IP below carries. Legitimate: one is the
+		// address resource, the other is the server it is attached to, and a
+		// sweep that flagged this would fail every healthy store.
+		"public_ips": []any{map[string]any{"address": "203.0.113.7"}},
+		// A subnet, which several resources share by design.
+		"subnet": "10.182.0.0/24",
+	})
+	address := res("ip1", "instance/ip", map[string]any{"address": "203.0.113.7"})
+	network := res("pn1", "vpc/private-network", map[string]any{"subnet": "10.182.0.0/24"})
+
+	// Two volumes naming one server in Runtime: a reference, not an object each
+	// of them owns.
+	volA := res("v1", "instance/volume", map[string]any{"name": "a"})
+	volA.Runtime = map[string]string{"server": "s1"}
+	volB := res("v2", "instance/volume", map[string]any{"name": "b"})
+	volB.Runtime = map[string]string{"server": "s1"}
+
+	server.Runtime = map[string]string{"machine": "feint-scw-s1"}
+
+	if found := storetest.Sweep([]*resource.Resource{server, address, network, volA, volB}); len(found) != 0 {
+		t.Errorf("a healthy store produced findings, so the sweep would cry wolf on every run:\n%s",
+			strings.Join(found, "\n"))
+	}
+}
+
+func TestTheSweepSeesAnIdentifierIssuedTwice(t *testing.T) {
+	found := storetest.Sweep([]*resource.Resource{
+		res("same", "instance/server", map[string]any{"name": "a"}),
+		res("same", "instance/ip", map[string]any{"address": "203.0.113.1"}),
+	})
+	if len(found) == 0 {
+		t.Fatal("two resources sharing an identifier swept clean, and the store keys on it")
+	}
+	if !strings.Contains(found[0], "same") {
+		t.Errorf("the finding does not name the identifier: %q", found[0])
+	}
+}
+
+func TestTheSweepSeesOneAddressAllocatedTwice(t *testing.T) {
+	found := storetest.Sweep([]*resource.Resource{
+		res("ip1", "instance/ip", map[string]any{"address": "203.0.113.9"}),
+		res("ip2", "instance/ip", map[string]any{"address": "203.0.113.9"}),
+	})
+	if len(found) == 0 {
+		t.Fatal("one address held by two resources of one kind swept clean")
+	}
+	if !strings.Contains(found[0], "203.0.113.9") {
+		t.Errorf("the finding does not name the address: %q", found[0])
+	}
+
+	// Nested the way a pack really carries it, since the walk is what makes the
+	// sweep independent of attribute names.
+	nested := storetest.Sweep([]*resource.Resource{
+		res("s1", "instance/server", map[string]any{
+			"public_ips": []any{map[string]any{"address": "198.51.100.4"}}}),
+		res("s2", "instance/server", map[string]any{
+			"public_ips": []any{map[string]any{"address": "198.51.100.4"}}}),
+	})
+	if len(nested) == 0 {
+		t.Error("a duplicated address nested inside a list swept clean")
+	}
+}
+
+func TestTheSweepSeesTwoResourcesClaimingOneMachine(t *testing.T) {
+	a := res("s1", "instance/server", map[string]any{"name": "a"})
+	a.Runtime = map[string]string{"machine": "feint-scw-orphan"}
+	b := res("s2", "instance/server", map[string]any{"name": "b"})
+	b.Runtime = map[string]string{"machine": "feint-scw-orphan"}
+
+	found := storetest.Sweep([]*resource.Resource{a, b})
+	if len(found) == 0 {
+		t.Fatal("two resources naming one runtime machine swept clean: deleting either destroys the other's")
+	}
+	if !strings.Contains(found[0], "feint-scw-orphan") {
+		t.Errorf("the finding does not name the object: %q", found[0])
+	}
+}
+
+// A nil element is what a hand-edited snapshot produces, and the sweep runs on
+// restored stores. Crashing there would make the instrument the outage.
+func TestTheSweepSurvivesANilResource(t *testing.T) {
+	found := storetest.Sweep([]*resource.Resource{
+		nil,
+		res("s1", "instance/server", map[string]any{"name": "a"}),
+	})
+	if len(found) != 0 {
+		t.Errorf("a nil element produced findings: %v", found)
+	}
+}

--- a/internal/providers/exoscale/barrage_test.go
+++ b/internal/providers/exoscale/barrage_test.go
@@ -1,0 +1,116 @@
+package exoscale_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/store"
+	"github.com/stephrobert/feint/internal/core/store/storetest"
+	"github.com/stephrobert/feint/internal/providers/exoscale"
+)
+
+// The barrage, and the invariant sweep that follows it.
+//
+// Same reasoning as the two beside it, and the same sweep: it lives in the core,
+// keyed on nothing but resource.Resource, so no pack defines its own idea of
+// coherent. What is Exoscale's own is the traffic — a REST path per resource,
+// operations that answer asynchronously, and elastic IPs allocated from a pool
+// this pack keeps.
+
+const exoscaleBarrageWorkers = 8
+
+func newExoscaleBarrageServer(t *testing.T) (http.Handler, *store.Store) {
+	t.Helper()
+	env := emulator.DefaultEnv()
+	srv, err := emulator.NewServer(env, exoscale.New(env))
+	if err != nil {
+		t.Fatalf("build the server: %v", err)
+	}
+	return srv.Handler(), env.Store
+}
+
+// callRaw is call() without the testing.T: a goroutine may not call t.Fatalf,
+// and a helper that does turns a failure into undefined behaviour.
+func callRaw(h http.Handler, method, path, body string) (int, map[string]any) {
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	decoded := map[string]any{}
+	if rec.Body.Len() > 0 {
+		_ = json.Unmarshal(rec.Body.Bytes(), &decoded)
+	}
+	return rec.Code, decoded
+}
+
+func TestAnExoscaleBarrageLeavesTheStoreCoherent(t *testing.T) {
+	h, st := newExoscaleBarrageServer(t)
+
+	var wg sync.WaitGroup
+	problems := make(chan string, exoscaleBarrageWorkers*8)
+
+	for w := range exoscaleBarrageWorkers {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			tag := fmt.Sprintf("w%d", worker)
+
+			// An elastic IP per worker: the shared pool, which is where a
+			// missing lock hands one address to two resources.
+			if status, _ := callRaw(h, "POST", "/v2/elastic-ip", `{"description":"barrage-`+tag+`"}`); status != http.StatusOK {
+				problems <- fmt.Sprintf("%s: elastic-ip answered %d", tag, status)
+			}
+
+			status, _ := callRaw(h, "POST", "/v2/security-group",
+				`{"name":"barrage-`+tag+`","description":"barrage"}`)
+			if status != http.StatusOK {
+				problems <- fmt.Sprintf("%s: security-group answered %d", tag, status)
+			}
+
+			for i := range 2 {
+				status, created := callRaw(h, "POST", "/v2/instance", fmt.Sprintf(`{
+					"name": "barrage-%s-%d",
+					"instance-type": {"id": "21624abb-764e-4def-81d7-9fc54b5957fb"},
+					"template": {"id": "11111111-1111-4111-8111-111111111111"},
+					"disk-size": 10,
+					"public-ip-assignment": "inet4"
+				}`, tag, i))
+				if status != http.StatusOK {
+					problems <- fmt.Sprintf("%s-%d: instance create answered %d", tag, i, status)
+					continue
+				}
+				// Exoscale answers an operation carrying the resource it acted
+				// on, which is the shape the CLI follows to find the id.
+				ref, _ := created["reference"].(map[string]any)
+				id, _ := ref["id"].(string)
+				if id == "" {
+					problems <- fmt.Sprintf("%s-%d: the operation names no resource", tag, i)
+					continue
+				}
+				callRaw(h, "DELETE", "/v2/instance/"+id, "")
+			}
+		}(w)
+	}
+	wg.Wait()
+	close(problems)
+
+	var refused []string
+	for p := range problems {
+		refused = append(refused, p)
+	}
+	if len(refused) > 0 {
+		t.Errorf("%d request(s) the barrage did not expect to fail:\n%s",
+			len(refused), strings.Join(refused, "\n"))
+	}
+
+	if found := storetest.Sweep(st.All()); len(found) != 0 {
+		t.Errorf("the store is incoherent after the barrage:\n%s", strings.Join(found, "\n"))
+	}
+}

--- a/internal/providers/exoscale/elasticips.go
+++ b/internal/providers/exoscale/elasticips.go
@@ -133,6 +133,12 @@ func (p *Pack) createElasticIP(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "this emulator allocates inet4 elastic IPs only")
 		return
 	}
+	// Held across the read and the write, which is the whole point: the address
+	// is chosen from what the store holds and only becomes taken when the
+	// resource lands in it.
+	p.addresses.Lock()
+	defer p.addresses.Unlock()
+
 	ip, ok := p.freeElasticAddress()
 	if !ok {
 		writeError(w, http.StatusBadRequest, "no elastic IP left in the emulated pool")

--- a/internal/providers/exoscale/pack.go
+++ b/internal/providers/exoscale/pack.go
@@ -18,6 +18,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/stephrobert/feint/internal/core/cloudinit"
@@ -50,6 +51,19 @@ const (
 // Pack implements emulator.Pack for Exoscale.
 type Pack struct {
 	env *emulator.Env
+	// addresses serializes elastic IP allocation, which is read-modify-write
+	// over the store: freeElasticAddress rebuilds the used set from what exists,
+	// answers the lowest free address, and the caller then stores it. Two
+	// requests interleaving there receive the same address.
+	//
+	// Not a precaution. The barrage of #134 found it on its first run — three
+	// addresses handed to two elastic IPs each, out of sixteen creates — and it
+	// is the same defect the Scaleway pack fixed for its own pools long ago and
+	// this one never received. CLAUDE.md names that shape: written twice, fixed
+	// once, alive in the other copy.
+	//
+	// TestAnExoscaleBarrageLeavesTheStoreCoherent fails without this.
+	addresses sync.Mutex
 }
 
 // New returns an Exoscale pack backed by env.

--- a/internal/providers/outscale/barrage_test.go
+++ b/internal/providers/outscale/barrage_test.go
@@ -1,0 +1,131 @@
+package outscale_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/store"
+	"github.com/stephrobert/feint/internal/core/store/storetest"
+	"github.com/stephrobert/feint/internal/providers/outscale"
+)
+
+// The barrage, and the invariant sweep that follows it.
+//
+// Same reasoning as the Scaleway one, and the sweep is literally the same code:
+// it lives in the core, keyed on nothing but resource.Resource, so a pack does
+// not get to define its own idea of coherent — and a fourth pack inherits it by
+// calling one function.
+//
+// What each pack still owns is the traffic. Outscale's is a POST per action, its
+// resources are Nets and Subnets and Vms, and its addresses come from a pool
+// this pack allocates itself.
+
+const outscaleBarrageWorkers = 8
+
+func newOutscaleBarrageServer(t *testing.T) (*httptest.Server, *store.Store) {
+	t.Helper()
+	env := emulator.DefaultEnv()
+	srv, err := emulator.NewServer(env, outscale.New(env))
+	if err != nil {
+		t.Fatalf("build emulator: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return ts, env.Store
+}
+
+// postRaw is post() without the testing.T: a goroutine may not call t.Fatalf,
+// and a helper that does turns a failure into undefined behaviour.
+func postRaw(ts *httptest.Server, action, body string) (int, map[string]any) {
+	resp, err := ts.Client().Post(ts.URL+"/api/v1/"+action, "application/json", strings.NewReader(body))
+	if err != nil {
+		return -1, nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var decoded map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&decoded)
+	return resp.StatusCode, decoded
+}
+
+func TestAnOutscaleBarrageLeavesTheStoreCoherent(t *testing.T) {
+	ts, st := newOutscaleBarrageServer(t)
+
+	var wg sync.WaitGroup
+	problems := make(chan string, outscaleBarrageWorkers*8)
+
+	for w := range outscaleBarrageWorkers {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			tag := fmt.Sprintf("w%d", worker)
+
+			status, net := postRaw(ts, "CreateNet", fmt.Sprintf(`{"IpRange":"10.%d.0.0/16"}`, 100+worker))
+			if status != http.StatusOK {
+				problems <- fmt.Sprintf("%s: CreateNet answered %d", tag, status)
+				return
+			}
+			netID := nestedID(net, "Net", "NetId")
+
+			status, subnet := postRaw(ts, "CreateSubnet",
+				fmt.Sprintf(`{"NetId":%q,"IpRange":"10.%d.1.0/24"}`, netID, 100+worker))
+			if status != http.StatusOK {
+				problems <- fmt.Sprintf("%s: CreateSubnet answered %d", tag, status)
+				return
+			}
+			subnetID := nestedID(subnet, "Subnet", "SubnetId")
+
+			// Two addresses and two machines per worker: enough interleaving for
+			// a shared pool to hand one out twice if nothing serialises it.
+			for i := range 2 {
+				status, ip := postRaw(ts, "CreatePublicIp", `{}`)
+				if status != http.StatusOK {
+					problems <- fmt.Sprintf("%s: CreatePublicIp answered %d", tag, status)
+					continue
+				}
+				_ = ip
+
+				status, vm := postRaw(ts, "CreateVms",
+					fmt.Sprintf(`{"ImageId":"ami-00000001","SubnetId":%q}`, subnetID))
+				if status != http.StatusOK {
+					problems <- fmt.Sprintf("%s-%d: CreateVms answered %d", tag, i, status)
+					continue
+				}
+				vms, _ := vm["Vms"].([]any)
+				if len(vms) == 0 {
+					problems <- fmt.Sprintf("%s-%d: CreateVms answered no machine", tag, i)
+					continue
+				}
+				first, _ := vms[0].(map[string]any)
+				vmID, _ := first["VmId"].(string)
+				postRaw(ts, "DeleteVms", fmt.Sprintf(`{"VmIds":[%q]}`, vmID))
+			}
+		}(w)
+	}
+	wg.Wait()
+	close(problems)
+
+	var refused []string
+	for p := range problems {
+		refused = append(refused, p)
+	}
+	if len(refused) > 0 {
+		t.Errorf("%d request(s) the barrage did not expect to fail:\n%s",
+			len(refused), strings.Join(refused, "\n"))
+	}
+
+	if found := storetest.Sweep(st.All()); len(found) != 0 {
+		t.Errorf("the store is incoherent after the barrage:\n%s", strings.Join(found, "\n"))
+	}
+}
+
+func nestedID(body map[string]any, object, field string) string {
+	nested, _ := body[object].(map[string]any)
+	id, _ := nested[field].(string)
+	return id
+}

--- a/internal/providers/scaleway/barrage_test.go
+++ b/internal/providers/scaleway/barrage_test.go
@@ -1,0 +1,414 @@
+package scaleway_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/machine"
+	"github.com/stephrobert/feint/internal/core/store"
+	"github.com/stephrobert/feint/internal/core/store/storetest"
+	"github.com/stephrobert/feint/internal/providers/scaleway"
+)
+
+// newBarrageServer is newRuntimeTestServer with a handle on the store, so the
+// sweep can read what the barrage left behind.
+//
+// The identifier generator is atomic for the reason newRuntimeTestServer already
+// gives beside its own: the sequential one races the moment a test issues
+// concurrent calls, and a barrage that hands out one identifier twice would make
+// the sweep report the harness rather than the pack. Measured, not assumed —
+// this repository's most expensive recurring defect is the instrument, not the
+// subject.
+func newBarrageServer(t *testing.T, drv machine.Driver) (*httptest.Server, *store.Store) {
+	t.Helper()
+
+	var seq atomic.Int64
+	seq.Store(1_000_000)
+	st := store.New()
+	env := &emulator.Env{
+		Store:    st,
+		Machines: drv,
+		Now:      func() time.Time { return time.Unix(1700000000, 0).UTC() },
+		NewID: func() string {
+			return fmt.Sprintf("00000000-0000-4000-8000-%012d", seq.Add(1))
+		},
+	}
+	srv, err := emulator.NewServer(env, scaleway.New(env))
+	if err != nil {
+		t.Fatalf("build emulator: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return ts, st
+}
+
+// barrageRuntime is a driver that takes a moment and refuses a name it has
+// already given out, the way Incus refuses an instance whose name exists.
+//
+// Both properties are load-bearing, and falsification proved it. The store-side
+// barrage alone could not see machine.Binding.Serialise disappear: with no
+// runtime there is nothing slow between the read and the write, so two poweron
+// requests write the same value and nothing is lost. Give the start a moment and
+// a duplicate-name refusal, and the missing lock becomes a server the API
+// reports as failed with a machine still running — the orphan CLAUDE.md records.
+//
+// It never blocks: a barrage that waits to be released measures the release.
+type barrageRuntime struct {
+	mu       sync.Mutex
+	machines map[string]bool
+	starts   atomic.Int32
+}
+
+func newBarrageRuntime() *barrageRuntime {
+	return &barrageRuntime{machines: map[string]bool{}}
+}
+
+func (b *barrageRuntime) Name() string                   { return "barrage" }
+func (b *barrageRuntime) Available(context.Context) bool { return true }
+
+func (b *barrageRuntime) Start(_ context.Context, spec machine.Spec) (machine.Machine, error) {
+	b.starts.Add(1)
+	// The window the lock exists to close. Short enough that the suite stays
+	// fast, long enough that a scheduler running ten workers interleaves.
+	time.Sleep(time.Millisecond)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.machines[spec.Name] {
+		return machine.Machine{}, errors.New(`Failed creating instance record: Add instance info to the database: This "instances" entry already exists`)
+	}
+	b.machines[spec.Name] = true
+	return machine.Machine{Name: spec.Name, IP: "10.42.0.7", Running: true}, nil
+}
+
+func (b *barrageRuntime) Stop(_ context.Context, n string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.machines[n] = false
+	return nil
+}
+
+func (b *barrageRuntime) Remove(_ context.Context, n string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	delete(b.machines, n)
+	return nil
+}
+
+func (b *barrageRuntime) Inspect(_ context.Context, n string) (machine.Machine, bool, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	running, known := b.machines[n]
+	if !known {
+		return machine.Machine{}, false, nil
+	}
+	return machine.Machine{Name: n, IP: "10.42.0.7", Running: running}, true, nil
+}
+
+func (b *barrageRuntime) EnsureNetwork(context.Context, machine.NetworkSpec) error { return nil }
+func (b *barrageRuntime) Attach(context.Context, string, machine.Attachment) error { return nil }
+func (b *barrageRuntime) RemoveNetwork(context.Context, string) error              { return nil }
+
+// leftRunning reports the machines the runtime still holds, which after a
+// barrage that deleted everything must be none.
+func (b *barrageRuntime) leftRunning() []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	var out []string
+	for name, running := range b.machines {
+		if running {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// doRaw is do() without the testing.T: a goroutine may not call t.Fatalf, and a
+// helper that does turns a failure into undefined behaviour.
+func doRaw(ts *httptest.Server, method, path, body string) (int, map[string]any) {
+	req, err := http.NewRequest(method, ts.URL+path, strings.NewReader(body))
+	if err != nil {
+		return -1, nil
+	}
+	req.Header.Set("X-Auth-Token", "irrelevant-the-emulator-ignores-it")
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		return -1, nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var decoded map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&decoded)
+	return resp.StatusCode, decoded
+}
+
+// The barrage: what a Terraform apply does, which no other test here stages.
+//
+// Every concurrency test in this pack races one path against itself —
+// TestConcurrentPowerOnStartsTheMachineOnce here, its equivalents in
+// internal/providers/outscale and internal/providers/exoscale, and the rest. They hold defects that were once real and they are worth having.
+// What none of them can see, by construction, is two *different* paths, each
+// correctly locked on its own target, jointly breaking an invariant that spans
+// resources: an address the flexible pool issued and the subnet allocator issued
+// too, an identifier minted twice under load, a machine name claimed by two
+// servers.
+//
+// So this drives the served routes the way a client does — parallelism 10 is
+// Terraform's default — and then asks one question of the whole store, through
+// the provider-neutral sweep in internal/core/store/storetest.
+//
+// It is not a load test. Nothing here measures throughput, and the counts are
+// the smallest that make an interleaving likely rather than the largest a laptop
+// survives: a scenario nobody runs is a scenario nobody fixes.
+
+const (
+	barrageWorkers = 10
+	barrageRounds  = 4
+)
+
+// TestABarrageLeavesTheStoreCoherent fails without the per-target locking the
+// three packs share (machine.Binding.Serialise) and without the address
+// allocator's own lock.
+func TestABarrageLeavesTheStoreCoherent(t *testing.T) {
+	runtime := newBarrageRuntime()
+	ts, st := newBarrageServer(t, runtime)
+
+	var wg sync.WaitGroup
+	// Errors are collected rather than reported from the goroutines: t.Fatalf
+	// off the test goroutine is undefined, and this pack has already paid for a
+	// failure path that hung instead of failing.
+	problems := make(chan string, barrageWorkers*barrageRounds*8)
+
+	for w := range barrageWorkers {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			for round := range barrageRounds {
+				tag := fmt.Sprintf("w%d-r%d", worker, round)
+				barrageCycle(ts, tag, problems)
+			}
+		}(w)
+	}
+	wg.Wait()
+	close(problems)
+
+	// A barrage where every request failed would sweep clean and prove nothing.
+	// The count of refusals is therefore part of the verdict, not noise.
+	var refused []string
+	for p := range problems {
+		refused = append(refused, p)
+	}
+	if len(refused) > 0 {
+		t.Errorf("%d request(s) the barrage did not expect to fail:\n%s",
+			len(refused), strings.Join(firstFew(refused, 5), "\n"))
+	}
+
+	if found := storetest.Sweep(st.All()); len(found) != 0 {
+		t.Errorf("the store is incoherent after the barrage:\n%s", strings.Join(found, "\n"))
+	}
+
+	// The other half of the same invariant, and the one the store cannot answer
+	// on its own: the API describes nothing, so nothing must be running. An
+	// orphan here is a machine on the operator's host that no client can find,
+	// which is what the per-target lock exists to prevent.
+	if left := runtime.leftRunning(); len(left) != 0 {
+		t.Errorf("the API describes no server and %d machine(s) are still running: %v", len(left), left)
+	}
+}
+
+// barrageCycle is what one worker does: reserve an address, create a server
+// carrying it, take a snapshot of its root volume, then tear the lot down. Every
+// step goes through the served routes, because a barrage against internal
+// functions would prove the functions and not the API.
+func barrageCycle(ts *httptest.Server, tag string, problems chan<- string) {
+	status, ip := doRaw(ts, "POST", zoneURL+"/ips", `{}`)
+	if status != http.StatusCreated {
+		problems <- fmt.Sprintf("%s: ip create answered %d", tag, status)
+		return
+	}
+	ipObj, _ := ip["ip"].(map[string]any)
+	ipID, _ := ipObj["id"].(string)
+
+	status, created := doRaw(ts, "POST", zoneURL+"/servers",
+		`{"name":"barrage-`+tag+`","commercial_type":"DEV1-S","public_ips":["`+ipID+`"]}`)
+	if status != http.StatusCreated {
+		problems <- fmt.Sprintf("%s: server create answered %d", tag, status)
+		return
+	}
+	serverObj, _ := created["server"].(map[string]any)
+	serverID, _ := serverObj["id"].(string)
+	volumes, _ := serverObj["volumes"].(map[string]any)
+	root, _ := volumes["0"].(map[string]any)
+	rootID, _ := root["id"].(string)
+
+	// A private network and a NIC on it. This is the second address pool, and
+	// the reason it is here rather than left out: the flexible allocator and the
+	// subnet allocator are locked separately, and a barrage that never touches
+	// the second one cannot see it come unlocked — falsification said so before
+	// this block existed, by staying green with the NIC lock removed.
+	status, pn := doRaw(ts, "POST", regionURL+"/private-networks",
+		`{"name":"barrage-`+tag+`","subnets":["10.`+subnetOctet(tag)+`.0.0/24"]}`)
+	pnID := ""
+	if status == http.StatusCreated {
+		pnID, _ = pn["id"].(string)
+	}
+	if pnID != "" {
+		if status, _ := doRaw(ts, "POST", zoneURL+"/servers/"+serverID+"/private_nics",
+			`{"private_network_id":"`+pnID+`"}`); status != http.StatusCreated {
+			problems <- fmt.Sprintf("%s: private nic create answered %d", tag, status)
+		}
+	}
+
+	// A second path on the same resources, which is where a cross-path defect
+	// would live: snapshotting the root volume while other workers create and
+	// delete servers.
+	if rootID != "" {
+		if status, _ := doRaw(ts, "POST", zoneURL+"/snapshots",
+			`{"name":"barrage-`+tag+`","volume_id":"`+rootID+`"}`); status != http.StatusCreated {
+			problems <- fmt.Sprintf("%s: snapshot create answered %d", tag, status)
+		}
+	}
+
+	// Two concurrent power-ons of the same server, which is the shape CLAUDE.md
+	// records as once-real: the loser used to overwrite the winner's state and
+	// leave an orphan the API called "stopped".
+	var inner sync.WaitGroup
+	for range 2 {
+		inner.Add(1)
+		go func() {
+			defer inner.Done()
+			doRaw(ts, "POST", zoneURL+"/servers/"+serverID+"/action", `{"action":"poweron"}`)
+		}()
+	}
+	inner.Wait()
+
+	// Both power-ons are asked for, so the server must be running: the loser is
+	// serialised behind the winner and finds the machine already there. Without
+	// the per-target lock the loser reaches the runtime, is refused the name,
+	// and the server ends in a failed state — which nothing here noticed until
+	// falsification showed the barrage staying green with the lock removed. The
+	// published state is the one the effect produced, and asserting it is what
+	// makes that a control rather than a sentence.
+	if status, got := doRaw(ts, "GET", zoneURL+"/servers/"+serverID, ""); status == http.StatusOK {
+		server, _ := got["server"].(map[string]any)
+		if state, _ := server["state"].(string); state != "running" {
+			problems <- fmt.Sprintf("%s: after two concurrent poweron the server is %q, want running", tag, state)
+		}
+	}
+
+	doRaw(ts, "POST", zoneURL+"/servers/"+serverID+"/action", `{"action":"poweroff"}`)
+	if status, _ := doRaw(ts, "DELETE", zoneURL+"/servers/"+serverID, ""); status >= 400 {
+		problems <- fmt.Sprintf("%s: server delete answered %d", tag, status)
+	}
+	doRaw(ts, "DELETE", zoneURL+"/ips/"+ipID, "")
+	if pnID != "" {
+		doRaw(ts, "DELETE", regionURL+"/private-networks/"+pnID, "")
+	}
+}
+
+// subnetOctet gives each worker-round its own /24 inside 10.0.0.0/8, so the
+// barrage measures concurrent allocation rather than the overlap refusal, which
+// has its own test.
+func subnetOctet(tag string) string {
+	sum := 0
+	for _, c := range tag {
+		sum = (sum*31 + int(c)) % 250
+	}
+	return fmt.Sprintf("%d", sum+1)
+}
+
+func firstFew(all []string, n int) []string {
+	if len(all) <= n {
+		return all
+	}
+	return append(all[:n:n], fmt.Sprintf("… and %d more", len(all)-n))
+}
+
+// A restore landing in the middle of live traffic must end in one of the two
+// worlds, never a merge of both.
+//
+// This is the case no per-path test can stage: PUT /_feint/state replaces the
+// whole store while creates are in flight, and the two writers are correct on
+// their own. What must not happen is a store holding half the snapshot and half
+// the traffic — a world no client ever asked for, and one where a resource can
+// reference another that the other world deleted.
+func TestARestoreDuringTrafficLandsInOneWorld(t *testing.T) {
+	runtime := newBarrageRuntime()
+	ts, st := newBarrageServer(t, runtime)
+
+	// A world worth restoring, captured before the traffic starts.
+	_, before := doRaw(ts, "POST", zoneURL+"/ips", `{}`)
+	beforeIP, _ := before["ip"].(map[string]any)
+	beforeID, _ := beforeIP["id"].(string)
+
+	var snapshot bytes.Buffer
+	if err := st.Snapshot(&snapshot); err != nil {
+		t.Fatalf("take the snapshot to restore: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	// Traffic, until the restore has landed and a little after.
+	for w := range 4 {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			for i := 0; ; i++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				doRaw(ts, "POST", zoneURL+"/servers",
+					fmt.Sprintf(`{"name":"during-%d-%d","commercial_type":"DEV1-S"}`, worker, i))
+			}
+		}(w)
+	}
+
+	// The restore, through the served route rather than the store directly:
+	// that is the path an operator takes, and the one that has to hold.
+	req, err := http.NewRequest(http.MethodPut, ts.URL+"/_feint/state", bytes.NewReader(snapshot.Bytes()))
+	if err != nil {
+		close(stop)
+		wg.Wait()
+		t.Fatalf("build the restore: %v", err)
+	}
+	res, err := ts.Client().Do(req)
+	if err != nil {
+		close(stop)
+		wg.Wait()
+		t.Fatalf("restore during traffic: %v", err)
+	}
+	_ = res.Body.Close()
+	status := res.StatusCode
+	close(stop)
+	wg.Wait()
+
+	if status != http.StatusOK {
+		t.Fatalf("the restore answered %d, so this test measured nothing", status)
+	}
+
+	// Whatever the interleaving produced, the store must be coherent: no
+	// identifier issued twice, no address held twice, no runtime object claimed
+	// twice. A merge of two worlds is exactly what breaks those.
+	if found := storetest.Sweep(st.All()); len(found) != 0 {
+		t.Errorf("a restore during traffic left the store incoherent:\n%s", strings.Join(found, "\n"))
+	}
+
+	// And the restored world is present: the snapshot's own resource survived,
+	// or was overwritten by later traffic — but the store is not empty, which
+	// would mean the restore landed and then lost to a racing write of the
+	// whole map.
+	if _, found := st.Get("scaleway", "instance/ip", beforeID); !found && st.Len() == 0 {
+		t.Error("the restore landed in no world at all: the store is empty")
+	}
+}


### PR DESCRIPTION
Closes #134.

Every concurrency test here stages **one race, on one path, in one pack**. They hold defects that were once real. What none of them can see, by construction, is two *different* paths — each correctly locked on its own target — jointly breaking an invariant that spans resources.

Each pack now drives its own served routes from ten workers at once (Terraform's default parallelism), and the store is swept afterwards by a provider-neutral check in `internal/core/store/storetest`:

- no identifier issued twice;
- no address held by two resources of one **kind** (scoped to the kind on purpose: an address resource and the server attached to it legitimately share the string, and a naive check would fail every healthy store);
- no runtime object claimed by two resources.

Plus the case no per-path test can stage: **a snapshot restore racing live traffic**, which must land in one of the two worlds and never a merge of both.

## It found a real defect on its first run

Exoscale's elastic IP allocation was a read-modify-write over the store with **no lock**. Three addresses out of sixteen creates went to two resources each:

```
address 192.0.2.2 is held by two elastic-ip resources: 5d5faaad… and 1c4fb61c…
address 192.0.2.4 is held by two elastic-ip resources: 53b1b343… and 34aa1d36…
address 192.0.2.5 is held by two elastic-ip resources: 8fa8f8fa… and cf8ea728…
```

The Scaleway pack fixed that exact shape for its own pools long ago and this one never received it — *written twice, fixed once, alive in the other copy*, which `CLAUDE.md` names as the costliest pattern in this repository. Fixed with the lock held across the read **and** the write.

## Falsification shaped the scenario more than writing it did

Three findings, each of which left the barrage measuring nothing until it was fixed:

1. **A barrage on the ordinary sequential identifier generator hands out duplicates**, and the sweep then reports the harness rather than the pack. It uses an atomic counter — the way `newRuntimeTestServer` already did, after somebody met the same trap.
2. **The store-side barrage could not see `machine.Binding.Serialise` disappear.** With no runtime there is nothing slow between the read and the write, so two `poweron` requests write the same value. It now runs against a driver that takes a moment and refuses a duplicate name, and asserts the state the *effect* produced. Before that assertion, the barrage stayed green with the lock gone — three times.
3. **A barrage that never creates a private NIC cannot see the NIC allocator come unlocked**, and did not, until the cycle grew one.

All three locks are now falsifiable: neutralise any of them and the barrage goes red on the first attempt. The sweep itself is tested against stores broken on purpose *and* against a healthy one that looks broken — an instrument that finds nothing passes every barrage ever written.

## Where it lives

The sweep is in the core and reads nothing but `resource.Resource`, so a fourth pack inherits it by calling one function. It finds addresses **by shape** rather than by attribute name: keyed on each pack's spelling (`address`, `PublicIp`, `ipv4_address`) it would be a sweep a new pack escapes.

Runs under `-race` in `mise run check`, no runtime required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)