### PR TITLE
fix(release): the verify recipe names the workflow that signs, not the repository

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -19,6 +19,24 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Modifié
 
+- **La recette de vérification nomme le workflow de release, pas le dépôt**
+  (#129). `docs/install.md` publiait `--certificate-identity-regexp
+  'https://github.com/stephrobert/feint/.*'`, qui accepte **n'importe quel**
+  workflow de ce dépôt recevant un jour `id-token: write` — une affirmation sur
+  qui possède le dépôt, non sur ce qui a construit le fichier. Elle est
+  désormais ancrée sur `.github/workflows/release.yml@refs/tags/v`, et la
+  recette `gh` gagne `--signer-workflow`.
+
+  Les deux moitiés ont été exécutées contre la 0.7.3 publiée : la nouvelle
+  identité la vérifie, et pointée sur un autre workflow du même dépôt elle
+  refuse, en nommant ce qu'elle attendait et ce qu'elle a trouvé. L'ancienne
+  acceptait cet autre workflow — c'est la largeur qu'on ferme.
+
+  `tools/release/preflight.sh` extrait maintenant l'identité **depuis la page**
+  et l'exécute contre la release précédente, puis vérifie qu'elle sait encore
+  refuser. La recette qu'un lecteur copie et ce que le workflow signe ne peuvent
+  plus diverger en silence, ce qui est précisément ce qui s'était produit.
+
 - **Un barrage de trafic concurrent, et un balayage d'invariants sur le store**
   (#134). Chaque pack pilote désormais ses propres routes servies depuis dix
   travailleurs simultanés — le parallélisme par défaut de Terraform — puis le

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Changed
 
+- **The verify recipe names the release workflow, not the repository** (#129).
+  `docs/install.md` published `--certificate-identity-regexp
+  'https://github.com/stephrobert/feint/.*'`, which accepts **any** workflow of
+  this repository that ever gets `id-token: write` — a claim about who owns the
+  repository rather than about what built the file. It is now anchored on
+  `.github/workflows/release.yml@refs/tags/v`, and the `gh` recipe gains
+  `--signer-workflow`.
+
+  Both halves were run against the published 0.7.3: the new identity verifies it,
+  and pointed at another workflow of the same repository it refuses, naming what
+  it expected and what it got. The old one accepted that other workflow — the
+  width being closed.
+
+  `tools/release/preflight.sh` now extracts the identity **from the page** and
+  runs it against the previous release, then checks it can still refuse. The
+  recipe a reader copies and what the workflow signs cannot drift apart in
+  silence, which is what happened here.
+
 - **A barrage of concurrent traffic, and one invariant sweep over the store**
   (#134). Each pack now drives its own served routes from ten workers at once —
   Terraform's default parallelism — and the store is then swept by a

--- a/README.md
+++ b/README.md
@@ -147,8 +147,14 @@ curl -fsSLO "$base/checksums.txt.cosign.bundle"
 
 # Who produced the list, before trusting a single hash inside it. One
 # signature covers every artefact, because every hash is in this file.
+#
+# The identity names the release workflow and the tag ref, not the
+# repository: 'github.com/<slug>/.*' would accept any workflow here that
+# ever gets id-token: write, which is a claim about who owns the
+# repository rather than about what built this file. Anchored at both
+# ends, because an unanchored pattern matches anywhere in the string.
 cosign verify-blob --bundle checksums.txt.cosign.bundle \
-  --certificate-identity-regexp 'https://github.com/stephrobert/feint/.*' \
+  --certificate-identity-regexp '^https://github\.com/stephrobert/feint/\.github/workflows/release\.yml@refs/tags/v' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   checksums.txt
 
@@ -161,11 +167,14 @@ install -m 0755 "$asset" ~/.local/bin/feint
 
 With `gh`, which checks the build provenance instead: it proves which
 workflow and which commit produced the binary, where the signature above
-proves who published the list.
+proves who published the list. `--signer-workflow` is what makes the
+difference between an identity and a provenance: without it the check
+accepts anything this repository attested, whichever workflow did it.
 
 ```bash
 gh release download v0.7.3 --repo stephrobert/feint --pattern 'feint-linux-amd64'
-gh attestation verify feint-linux-amd64 --repo stephrobert/feint
+gh attestation verify feint-linux-amd64 --repo stephrobert/feint \
+  --signer-workflow stephrobert/feint/.github/workflows/release.yml
 ```
 
 | Binary | Control plane | `--vm`: real machines |

--- a/docs/install.md
+++ b/docs/install.md
@@ -32,8 +32,14 @@ curl -fsSLO "$base/checksums.txt.cosign.bundle"
 
 # Who produced the list, before trusting a single hash inside it. One
 # signature covers every artefact, because every hash is in this file.
+#
+# The identity names the release workflow and the tag ref, not the
+# repository: 'github.com/<slug>/.*' would accept any workflow here that
+# ever gets id-token: write, which is a claim about who owns the
+# repository rather than about what built this file. Anchored at both
+# ends, because an unanchored pattern matches anywhere in the string.
 cosign verify-blob --bundle checksums.txt.cosign.bundle \
-  --certificate-identity-regexp 'https://github.com/stephrobert/feint/.*' \
+  --certificate-identity-regexp '^https://github\.com/stephrobert/feint/\.github/workflows/release\.yml@refs/tags/v' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   checksums.txt
 
@@ -46,11 +52,14 @@ install -m 0755 "$asset" ~/.local/bin/feint
 
 With `gh`, which checks the build provenance instead: it proves which
 workflow and which commit produced the binary, where the signature above
-proves who published the list.
+proves who published the list. `--signer-workflow` is what makes the
+difference between an identity and a provenance: without it the check
+accepts anything this repository attested, whichever workflow did it.
 
 ```bash
 gh release download v0.7.3 --repo stephrobert/feint --pattern 'feint-linux-amd64'
-gh attestation verify feint-linux-amd64 --repo stephrobert/feint
+gh attestation verify feint-linux-amd64 --repo stephrobert/feint \
+  --signer-workflow stephrobert/feint/.github/workflows/release.yml
 ```
 
 | Binary | Control plane | `--vm`: real machines |

--- a/internal/cli/docs_release.go
+++ b/internal/cli/docs_release.go
@@ -156,8 +156,14 @@ func renderInstall(workflow, goMod, changelog string) (string, error) {
 	b.WriteString("curl -fsSLO \"$base/checksums.txt.cosign.bundle\"\n\n")
 	b.WriteString("# Who produced the list, before trusting a single hash inside it. One\n")
 	b.WriteString("# signature covers every artefact, because every hash is in this file.\n")
+	b.WriteString("#\n")
+	b.WriteString("# The identity names the release workflow and the tag ref, not the\n")
+	b.WriteString("# repository: 'github.com/<slug>/.*' would accept any workflow here that\n")
+	b.WriteString("# ever gets id-token: write, which is a claim about who owns the\n")
+	b.WriteString("# repository rather than about what built this file. Anchored at both\n")
+	b.WriteString("# ends, because an unanchored pattern matches anywhere in the string.\n")
 	b.WriteString("cosign verify-blob --bundle checksums.txt.cosign.bundle \\\n")
-	fmt.Fprintf(&b, "  --certificate-identity-regexp 'https://github.com/%s/.*' \\\n", slug)
+	fmt.Fprintf(&b, "  --certificate-identity-regexp '^https://github\\.com/%s/\\.github/workflows/release\\.yml@refs/tags/v' \\\n", regexpSlug(slug))
 	b.WriteString("  --certificate-oidc-issuer https://token.actions.githubusercontent.com \\\n")
 	b.WriteString("  checksums.txt\n\n")
 	b.WriteString("# Then the bytes against the list. Without --ignore-missing this fails on\n")
@@ -173,10 +179,13 @@ func renderInstall(workflow, goMod, changelog string) (string, error) {
 
 	b.WriteString("With `gh`, which checks the build provenance instead: it proves which\n")
 	b.WriteString("workflow and which commit produced the binary, where the signature above\n")
-	b.WriteString("proves who published the list.\n\n")
+	b.WriteString("proves who published the list. `--signer-workflow` is what makes the\n")
+	b.WriteString("difference between an identity and a provenance: without it the check\n")
+	b.WriteString("accepts anything this repository attested, whichever workflow did it.\n\n")
 	b.WriteString("```bash\n")
 	fmt.Fprintf(&b, "gh release download v%s --repo %s --pattern '%s'\n", version, slug, primary)
-	fmt.Fprintf(&b, "gh attestation verify %s --repo %s\n", primary, slug)
+	fmt.Fprintf(&b, "gh attestation verify %s --repo %s \\\n", primary, slug)
+	fmt.Fprintf(&b, "  --signer-workflow %s/.github/workflows/release.yml\n", slug)
 	b.WriteString("```\n\n")
 
 	b.WriteString(renderPlatformTable(names))
@@ -191,6 +200,14 @@ func renderInstall(workflow, goMod, changelog string) (string, error) {
 // shape and merging them is what produced "the published platforms are …", a
 // line a reader hears as "and they all work". The control-plane column is
 // computed from the runners; the --vm column is a property of Incus.
+// regexpSlug escapes the dots of an owner/repo so the identity pattern matches
+// that repository and not one whose name differs by a character the regexp reads
+// as "any". A slug is user input to this generator, and a dot is the cheapest
+// way a pattern silently widens.
+func regexpSlug(slug string) string {
+	return strings.ReplaceAll(slug, ".", `\\.`)
+}
+
 func renderPlatformTable(names []string) string {
 	exercised := make(map[string]bool)
 	for _, platform := range exercisedPlatforms(goWorkflow, conformanceWorkflow) {

--- a/tools/release/preflight.sh
+++ b/tools/release/preflight.sh
@@ -153,6 +153,59 @@ else
   ko "coverage/ or contracts/ has uncommitted changes" "commit them, or regenerate and commit"
 fi
 
+# --- the verification recipe the install page prints -------------------------
+
+# Run against the PREVIOUS release, with the exact identity docs/install.md
+# publishes, extracted from the page rather than retyped.
+#
+# The point is not to check cosign works. It is that the recipe a reader copies
+# is the one that matches what the release workflow actually signs: the two
+# drifted silently before #129, where the published identity accepted any
+# workflow of this repository — a claim about who owns the repo, not about what
+# built the file. A recipe nobody has run against a real artefact is a comment.
+#
+# The previous release, because this one does not exist yet. If it verifies, the
+# identity is right for the workflow that will sign the next one too, since the
+# same workflow signs both.
+recipe_identity="$(grep -o "\-\-certificate-identity-regexp '[^']*'" docs/install.md | head -1 | sed "s/.*'\(.*\)'/\1/")"
+if [ -z "$recipe_identity" ]; then
+  ko "docs/install.md publishes no cosign identity" "the generated install block changed shape; check internal/cli/docs_release.go"
+elif ! command -v cosign >/dev/null 2>&1; then
+  ok "cosign absent, verification recipe not exercised (CI runs it)"
+else
+  # The slug comes from the remote rather than a constant: a fork running this
+  # verifies its own releases, and a constant would send it to somebody else's.
+  slug="$(git remote get-url origin 2>/dev/null | sed -E 's#(git@|https://)github\.com[:/]##; s#\.git$##')"
+  previous="$(git tag --list 'v*' --sort=-v:refname | grep -v "^${VERSION}$" | head -1)"
+  workdir="$(mktemp -d)"
+  if [ -n "$previous" ] && gh release download "$previous" --repo "$slug" \
+       --pattern 'checksums.txt*' --dir "$workdir" >/dev/null 2>&1; then
+    if (cd "$workdir" && cosign verify-blob --bundle checksums.txt.cosign.bundle \
+          --certificate-identity-regexp "$recipe_identity" \
+          --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+          checksums.txt) >/dev/null 2>&1; then
+      # And it has to be able to fail: an identity that accepts everything
+      # verifies everything, which is the width #129 closed.
+      wrong="${recipe_identity/release/drift}"
+      if (cd "$workdir" && cosign verify-blob --bundle checksums.txt.cosign.bundle \
+            --certificate-identity-regexp "$wrong" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            checksums.txt) >/dev/null 2>&1; then
+        ko "the published identity accepts another workflow of this repository" \
+           "anchor it on .github/workflows/release.yml@refs/tags/v (#129)"
+      else
+        ok "the published verification recipe verifies $previous, and refuses another workflow"
+      fi
+    else
+      ko "the recipe in docs/install.md does not verify $previous" \
+         "the page and the release workflow disagree about who signs"
+    fi
+  else
+    ok "no previous release to verify the recipe against"
+  fi
+  rm -rf "$workdir"
+fi
+
 # --- the conformance claim --------------------------------------------------
 
 # Not run here: it needs the four clients installed, and a release cut from a


### PR DESCRIPTION
Closes #129. From the second pass of the external review.

`docs/install.md` published:

```
--certificate-identity-regexp 'https://github.com/stephrobert/feint/.*'
```

which accepts **any** workflow of this repository that ever gets `id-token: write`. That is a claim about who owns the repository, not about what built the file — and only `release.yml` builds and signs a release. The pattern was also unanchored, so it matched anywhere in the string.

Now:

```
--certificate-identity-regexp '^https://github\.com/stephrobert/feint/\.github/workflows/release\.yml@refs/tags/v'
```

and the `gh` recipe gains `--signer-workflow stephrobert/feint/.github/workflows/release.yml`.

## Run against the real release, both halves

The published **0.7.3**, not a reasoned argument.

**The new identity verifies it:**
```
Verified OK
```

**Pointed at another workflow of the same repository, it refuses** — and says what it expected against what the certificate actually carries:
```
Error: failed to verify certificate identity: no matching CertificateIdentity found,
last error: expected SAN value to match regex
"^https://github\.com/stephrobert/feint/\.github/workflows/drift\.yml@refs/tags/v",
got "https://github.com/stephrobert/feint/.github/workflows/release.yml@refs/tags/v0.7.3"
```

**The old identity accepted that other workflow:** `Verified OK`. That is the width being closed.

## The recipe cannot drift from what the workflow signs

`tools/release/preflight.sh` extracts the identity **from the page** rather than repeating it, runs it against the previous release, and then checks it can still refuse a different workflow. A verification that has never been seen to fail proves nothing — this repository's own rule, applied to an install document.

Falsified: put the old wide identity back in the page, and the preflight answers

```
✘ the published identity accepts another workflow of this repository
```

The slug comes from the git remote rather than a constant, so a fork verifies its own releases instead of somebody else's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)