### PR TITLE
fix: what two audits of the 0.8 train found, reproduced then fixed

### DIFF
--- a/.github/workflows/runtime-proof.yml
+++ b/.github/workflows/runtime-proof.yml
@@ -26,6 +26,14 @@
 # Actions history proves. Until that streak exists, this workflow stays advisory
 # and #125 stays open.
 #
+# That sentence was the whole of the measurement until the `streak` job below
+# existed: a criterion nobody computed, waiting for somebody to think of opening
+# the Actions history. It counts nights only — the first measurement it took
+# returned 0, where a reader eyeballing the history had said 1 by counting a
+# push-triggered run, and the push history also holds a failure and a
+# cancellation. Counting every event would let the streak be earned by pressing
+# a button.
+#
 # What this does not repeat: the client matrix of conformance.yml. The control
 # plane is proven there on every pull request, with --vm off. This job proves
 # the layer conformance.yml deliberately leaves out — the machine behind the
@@ -327,3 +335,77 @@ jobs:
         env:
           MODE: ${{ matrix.mode }}
         run: sudo env FEINT_VM="${MODE}" tools/conformance/crash.sh
+
+  # The criterion, counted rather than remembered.
+  #
+  # The header above states the rule: promotion to `pull_request` when 14
+  # consecutive scheduled runs are green. That sentence was the whole of the
+  # measurement until now — a number nobody computes, waiting for somebody to
+  # think of opening the Actions history. "A comment is not a control", one level
+  # up: the control it describes is a control of the project rather than of the
+  # code, and it had no instrument either.
+  #
+  # So this counts the streak and publishes it in the run summary, every night.
+  # It never fails: a red here would punish the runner's weather rather than
+  # measure it, and the whole point of the rule is that this workflow stays
+  # advisory. What it does is remove the excuse — when the streak reaches the
+  # target, the summary says so in as many words, and #125 has an answer instead
+  # of an opinion.
+  streak:
+    name: Consecutive green scheduled runs
+    needs: runtime
+    if: always() && github.event_name == 'schedule'
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2
+        with:
+          egress-policy: audit
+
+      - name: Count the streak, from the Actions history
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET: '14'
+        run: |
+          set -euo pipefail
+
+          # Scheduled runs only, newest first. A dispatch or a branch push is a
+          # human asking a question; the rule counts nights, and mixing the two
+          # would let somebody earn the streak by pressing a button 14 times.
+          conclusions="$(gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/runtime-proof.yml/runs?event=schedule&per_page=100" \
+            --jq '.workflow_runs[] | select(.status == "completed") | .conclusion')"
+
+          streak=0
+          for c in $conclusions; do
+            if [ "$c" = "success" ]; then
+              streak=$((streak + 1))
+            else
+              break
+            fi
+          done
+
+          total="$(printf '%s\n' "$conclusions" | grep -c . || true)"
+          {
+            echo "## Promotion criterion (#125)"
+            echo
+            echo "| | |"
+            echo "|---|--:|"
+            echo "| Consecutive green scheduled runs | **${streak}** |"
+            echo "| Target | ${TARGET} |"
+            echo "| Completed scheduled runs on record | ${total} |"
+            echo
+            if [ "$streak" -ge "$TARGET" ]; then
+              echo "**The criterion is met.** Move this workflow onto \`pull_request\` and close #125."
+              echo "The number above is what earns it; nothing else has to be decided."
+            else
+              echo "Not met: $((TARGET - streak)) more consecutive green nights."
+              echo "This workflow stays advisory and #125 stays open, which is the rule its"
+              echo "header states rather than a preference."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "streak=${streak}/${TARGET}"

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -17,6 +17,49 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ## [Non publié]
 
+### Corrigé
+
+- **Six défauts trouvés par l'audit du train 0.8, et le faux verdict qui en a
+  révélé un septième.** La livraison a été auditée deux fois avant le tag ; tout
+  ce qui suit a été reproduit avant d'être corrigé.
+
+  - **Un volume block restauré plus petit que son snapshot répondait 201.** Le
+    garde vivait sur `updateBlockVolume` alors que son commentaire énonçait une
+    propriété du volume — « un volume grandit et ne rétrécit pas » — tenue sur un
+    chemin sur deux. Un snapshot de 10 Go restauré dans un volume de 1 Go,
+    `available`. Ni le barrage ni le balayage d'invariants ne pouvaient le voir :
+    l'un ne pilote aucune route block, l'autre interroge l'identité, pas le sens
+    d'une taille.
+  - **La libération d'une adresse IPAM ne prenait aucun verrou**, quand la
+    réservation tenait l'allocateur de la reconstruction jusqu'au stockage.
+    `allocatorFor` reconstruit l'occupation depuis les seules ressources IPAM :
+    en supprimer une est exactement ce qui libère une adresse. Les deux chemins
+    de libération le tiennent désormais et relisent sous verrou, et les écritures
+    passent par `Commit` plutôt que `Put`, qui réinsère une ressource que le
+    client a relâchée.
+  - **Une revendication de falsification était fausse.** « Neutralisez n'importe
+    lequel des trois verrous et le barrage rougit au premier essai » : trente
+    exécutions vertes sans le verrou de NIC privée. Chaque travailleur prend son
+    propre subnet, donc aucun défaut de contention ne peut y apparaître, quoi
+    qu'il pilote. La phrase dit maintenant lesquels deux il tient, et nomme le
+    test qui tient le troisième.
+  - **L'artefact de preuve avait quatorze opérations de retard** au moment de
+    livrer, sans que rien ne soit rouge : `docs/routes.md` affichait « — » pour
+    elles, ce qui se lit exactement comme une opération que rien n'a prouvée. Un
+    test exige désormais que toute opération montée y ait sa ligne.
+  - **Une assertion de conformance produisait un faux verdict.** `feint clean` a
+    gagné une ligne signalant les enregistrements runtime périmés, imprimée avant
+    son bilan ; la suite Outscale comparait le début de toute la sortie et
+    annonçait « the delete left a machine behind » quand le bilan disait zéro.
+    Elle lit le décompte, et refuse de trancher quand il n'y a rien à lire.
+  - **La documentation affirmait qu'aucun workflow ne démarre de runtime**, à
+    cinq endroits dans deux langues, démentie par le job nocturne livré dans le
+    même train. L'affirmation était gelée dans le générateur, donc
+    `feint docs --check` la reconduisait à chaque release : le gate compare la
+    page à son générateur, il prouve la forme et jamais l'énoncé. La distinction
+    vraie — aucun gate de pull request n'en démarre — est ce qu'ils disent
+    désormais.
+
 ### Modifié
 
 - **La recette de vérification nomme le workflow de release, pas le dépôt**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,44 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ## [Unreleased]
 
+### Fixed
+
+- **Six defects an audit of the 0.8 train found, and the false verdict that
+  found a seventh.** The delivery was audited twice before tagging; everything
+  below was reproduced before being fixed.
+
+  - **A block volume restored smaller than its snapshot answered 201.** The guard
+    lived on `updateBlockVolume` while its comment stated a property of the
+    volume — "a volume grows and does not shrink" — held on one of two paths. A
+    10 GB snapshot restored into a 1 GB volume, `available`. Neither the barrage
+    nor the invariant sweep could see it: one drives no block route, the other
+    asks about identity, not about whether a size makes sense.
+  - **Releasing an IPAM address took no lock**, while booking one held the
+    allocator from rebuild to store. `allocatorFor` rebuilds occupancy from the
+    IPAM resources alone, so deleting one is exactly what frees an address. Both
+    release paths now hold it and re-read under it, and the writes go through
+    `Commit` rather than `Put`, which re-inserts a resource the client released.
+  - **A falsification claim was false.** "Neutralise any of the three locks and
+    the barrage goes red on the first attempt" — thirty green runs with the
+    private-NIC lock removed. Every worker takes its own subnet, so no contention
+    defect can surface there whatever it drives. The claim now says which two it
+    holds and names the test that holds the third.
+  - **The evidence artefact was fourteen operations behind** at a release
+    candidate, and nothing was red: `docs/routes.md` printed "—" for them, which
+    reads exactly like an operation nothing has proven. A test now requires every
+    mounted operation to have a row.
+  - **A conformance assertion produced a false verdict.** `feint clean` gained a
+    line reporting stale runtime records, printed before its tally; the Outscale
+    suite prefix-matched the whole output and announced "the delete left a machine
+    behind" while the tally said zero. It reads the count now, and refuses to
+    decide when there is no count to read.
+  - **The documentation claimed no workflow starts a machine runtime**, in five
+    places across two languages, contradicted by the nightly job shipped in the
+    same release train. It was frozen in the generator, so `feint docs --check`
+    reconducted it at every release: the gate compares the page with its
+    generator and proves the form, never the claim. The true distinction — no
+    pull-request gate starts one — is what they say now.
+
 ### Changed
 
 - **The verify recipe names the release workflow, not the repository** (#129).

--- a/README.md
+++ b/README.md
@@ -181,15 +181,20 @@ gh attestation verify feint-linux-amd64 --repo stephrobert/feint \
 |---|---|---|
 | `feint-darwin-amd64` | **exercised**: tests and race detector, skipped on private forks | **impossible**: Incus publishes no macOS server |
 | `feint-darwin-arm64` | **exercised**: tests and race detector, skipped on private forks | **impossible**: Incus publishes no macOS server |
-| `feint-linux-amd64` | **exercised**: tests, race detector, and it answers | possible; proven by the release table below, never in CI |
-| `feint-linux-arm64` | **exercised**: tests and race detector, skipped on private forks | Incus is packaged for it; nothing here has proven it |
+| `feint-linux-amd64` | **exercised**: tests, race detector, and it answers | possible; a nightly CI job proves it, and no pull-request gate does |
+| `feint-linux-arm64` | **exercised**: tests and race detector, skipped on private forks | Incus is packaged for it; the nightly runtime job runs amd64 only |
 
-**`--vm` is off by default, and no workflow turns it on.** Starting machines is
-a side effect on whoever's host runs it, so it is asked for rather than assumed,
-and the conformance suite has to stay runnable where no runtime exists — which
-is CI. The network suites skip themselves there and say so. What proves that
-mode is `FEINT_VM=incus-ovn mise run conformance` on a host with Incus, and the
-eight virtual machines in the table below.
+**`--vm` is off by default, and no pull-request gate turns it on.** Starting
+machines is a side effect on whoever's host runs it, so it is asked for rather
+than assumed, and the conformance suite has to stay runnable where no runtime
+exists — which is every pull request. The network suites skip themselves there
+and say so.
+
+A nightly job does run it: `.github/workflows/runtime-proof.yml` installs Incus
+and OVN on a GitHub-hosted runner and drives the network, ssh and crash suites
+in both modes. It is advisory until its promotion criterion is met, which is
+why no pull request depends on it. Locally, `FEINT_VM=incus-ovn mise run
+conformance` on a host with Incus proves the same thing.
 
 The non-amd64 runners are free here and billed on a private repository, so the
 job skips on a private fork rather than spending somebody's minutes without

--- a/coverage/evidence.json
+++ b/coverage/evidence.json
@@ -853,6 +853,27 @@
       "dataplane": false,
       "shape": "unobserved"
     },
+    "ipam/v1/API.AttachIP": {
+      "driven": false,
+      "probed": true,
+      "contract": "unchecked",
+      "dataplane": false,
+      "shape": "unobserved"
+    },
+    "ipam/v1/API.BookIP": {
+      "driven": true,
+      "probed": true,
+      "contract": "clean",
+      "dataplane": true,
+      "shape": "unobserved"
+    },
+    "ipam/v1/API.DetachIP": {
+      "driven": false,
+      "probed": true,
+      "contract": "unchecked",
+      "dataplane": false,
+      "shape": "unobserved"
+    },
     "ipam/v1/API.GetIP": {
       "driven": true,
       "probed": true,
@@ -866,6 +887,34 @@
       "contract": "clean",
       "dataplane": true,
       "shape": "observed"
+    },
+    "ipam/v1/API.MoveIP": {
+      "driven": false,
+      "probed": true,
+      "contract": "unchecked",
+      "dataplane": false,
+      "shape": "unobserved"
+    },
+    "ipam/v1/API.ReleaseIP": {
+      "driven": true,
+      "probed": false,
+      "contract": "unchecked",
+      "dataplane": true,
+      "shape": "unobserved"
+    },
+    "ipam/v1/API.ReleaseIPSet": {
+      "driven": false,
+      "probed": false,
+      "contract": "unchecked",
+      "dataplane": false,
+      "shape": "unobserved"
+    },
+    "ipam/v1/API.UpdateIP": {
+      "driven": true,
+      "probed": true,
+      "contract": "clean",
+      "dataplane": true,
+      "shape": "unobserved"
     },
     "marketplace/v2/API.ListLocalImages": {
       "driven": true,
@@ -1385,6 +1434,13 @@
       "dataplane": true,
       "shape": "unobserved"
     },
+    "vpc/v2/API.CreateRoute": {
+      "driven": true,
+      "probed": true,
+      "contract": "clean",
+      "dataplane": true,
+      "shape": "unobserved"
+    },
     "vpc/v2/API.CreateVPC": {
       "driven": true,
       "probed": true,
@@ -1399,10 +1455,31 @@
       "dataplane": true,
       "shape": "unobserved"
     },
-    "vpc/v2/API.DeleteVPC": {
-      "driven": false,
+    "vpc/v2/API.DeleteRoute": {
+      "driven": true,
       "probed": false,
       "contract": "unchecked",
+      "dataplane": true,
+      "shape": "unobserved"
+    },
+    "vpc/v2/API.DeleteVPC": {
+      "driven": true,
+      "probed": false,
+      "contract": "unchecked",
+      "dataplane": true,
+      "shape": "unobserved"
+    },
+    "vpc/v2/API.EnableDHCP": {
+      "driven": false,
+      "probed": true,
+      "contract": "clean",
+      "dataplane": false,
+      "shape": "unobserved"
+    },
+    "vpc/v2/API.EnableRouting": {
+      "driven": false,
+      "probed": true,
+      "contract": "clean",
       "dataplane": false,
       "shape": "unobserved"
     },
@@ -1413,11 +1490,18 @@
       "dataplane": true,
       "shape": "unobserved"
     },
-    "vpc/v2/API.GetVPC": {
-      "driven": false,
+    "vpc/v2/API.GetRoute": {
+      "driven": true,
       "probed": true,
       "contract": "clean",
-      "dataplane": false,
+      "dataplane": true,
+      "shape": "unobserved"
+    },
+    "vpc/v2/API.GetVPC": {
+      "driven": true,
+      "probed": true,
+      "contract": "clean",
+      "dataplane": true,
       "shape": "unobserved"
     },
     "vpc/v2/API.ListPrivateNetworks": {
@@ -1426,6 +1510,13 @@
       "contract": "clean",
       "dataplane": false,
       "shape": "observed"
+    },
+    "vpc/v2/API.ListSubnets": {
+      "driven": false,
+      "probed": true,
+      "contract": "clean",
+      "dataplane": false,
+      "shape": "unobserved"
     },
     "vpc/v2/API.ListVPCs": {
       "driven": false,
@@ -1438,6 +1529,13 @@
       "driven": false,
       "probed": true,
       "contract": "clean",
+      "dataplane": false,
+      "shape": "unobserved"
+    },
+    "vpc/v2/API.UpdateRoute": {
+      "driven": false,
+      "probed": true,
+      "contract": "unchecked",
       "dataplane": false,
       "shape": "unobserved"
     },

--- a/docs/install.md
+++ b/docs/install.md
@@ -66,15 +66,20 @@ gh attestation verify feint-linux-amd64 --repo stephrobert/feint \
 |---|---|---|
 | `feint-darwin-amd64` | **exercised**: tests and race detector, skipped on private forks | **impossible**: Incus publishes no macOS server |
 | `feint-darwin-arm64` | **exercised**: tests and race detector, skipped on private forks | **impossible**: Incus publishes no macOS server |
-| `feint-linux-amd64` | **exercised**: tests, race detector, and it answers | possible; proven by the release table below, never in CI |
-| `feint-linux-arm64` | **exercised**: tests and race detector, skipped on private forks | Incus is packaged for it; nothing here has proven it |
+| `feint-linux-amd64` | **exercised**: tests, race detector, and it answers | possible; a nightly CI job proves it, and no pull-request gate does |
+| `feint-linux-arm64` | **exercised**: tests and race detector, skipped on private forks | Incus is packaged for it; the nightly runtime job runs amd64 only |
 
-**`--vm` is off by default, and no workflow turns it on.** Starting machines is
-a side effect on whoever's host runs it, so it is asked for rather than assumed,
-and the conformance suite has to stay runnable where no runtime exists — which
-is CI. The network suites skip themselves there and say so. What proves that
-mode is `FEINT_VM=incus-ovn mise run conformance` on a host with Incus, and the
-eight virtual machines in the table below.
+**`--vm` is off by default, and no pull-request gate turns it on.** Starting
+machines is a side effect on whoever's host runs it, so it is asked for rather
+than assumed, and the conformance suite has to stay runnable where no runtime
+exists — which is every pull request. The network suites skip themselves there
+and say so.
+
+A nightly job does run it: `.github/workflows/runtime-proof.yml` installs Incus
+and OVN on a GitHub-hosted runner and drives the network, ssh and crash suites
+in both modes. It is advisory until its promotion criterion is met, which is
+why no pull request depends on it. Locally, `FEINT_VM=incus-ovn mise run
+conformance` on a host with Incus proves the same thing.
 
 The non-amd64 runners are free here and billed on a private repository, so the
 job skips on a private fork rather than spending somebody's minutes without

--- a/docs/roadmap.fr.md
+++ b/docs/roadmap.fr.md
@@ -597,16 +597,26 @@ passent.
 
 ### `--vm` se fait prouver par la CI, sur un runner que personne ne possède : suivi par #125
 
-Aujourd'hui **aucun workflow de ce dépôt ne démarre un runtime de machines** :
-zéro `FEINT_VM`, zéro `incus`, et les suites `network.sh` ne sont jamais
-invoquées en CI. Le mode qui porte l'argument du produit (de vraies machines,
-de vraies adresses, deux VPC qui ne peuvent pas se joindre) n'est prouvé que
-par les huit machines virtuelles d'[install.md](install.md) et sur la station
-de l'auteur. C'est une mesure que personne d'autre ne peut reproduire en
-ouvrant une pull request, soit la définition de preuve que ce projet refuse
-partout ailleurs. La revue externe classe ce sujet premier de tout (#125), et
-la proposition de cadence (#136) le place dans la première version qui achète
-de la confiance.
+**Livré, et c'est un job nocturne plutôt qu'un gate.**
+`.github/workflows/runtime-proof.yml` installe Incus (canal Zabbly stable, clé
+épinglée) et OVN sur un `ubuntu-24.04` hébergé par GitHub, câble la connexion
+northbound, et exécute les suites réseau, ssh et crash dans les deux modes,
+`incus` et `incus-ovn`. Les deux jambes sont passées, isolation entre VPC
+affirmée, sur une machine que personne ici ne possède.
+
+Ce qui reste vrai, et qui est la seule chose à lire comme une limite :
+**aucun gate de pull request ne démarre un runtime de machines.** Le job est
+consultatif tant que son critère de promotion n'est pas atteint, donc le mode
+qui porte l'argument du produit n'est pas encore quelque chose qu'une pull
+request doive satisfaire.
+
+Ce paragraphe affirmait « aucun workflow de ce dépôt ne démarre un runtime de
+machines » jusqu'à ce qu'un audit le confronte au workflow ajouté par le train
+de livraison qui l'a lui-même embarqué. L'affirmation s'était propagée à cinq
+endroits dans deux langues, et `docs --check` la reconduisait à chaque release,
+puisqu'il compare la page à son générateur : il prouve la forme, jamais
+l'énoncé. Vérifier n'est pas parser, commis sur la documentation de ce projet —
+consigné ici plutôt que discrètement réécrit.
 
 Il ne reste dans « plus tard » qu'au sens du calendrier ; le terrain est
 mesuré (30 juillet 2026, sur la CI des projets amont eux-mêmes), et le tout

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -569,19 +569,27 @@ surface cannot keep growing if the suite that proves it becomes the bottleneck.
 
 ### `--vm` gets proven by CI, on a runner nobody owns — tracked by #125
 
-Today **no workflow in this repository starts a machine runtime**: zero
-`FEINT_VM`, zero `incus`, and the `network.sh` suites are never invoked in CI.
-The mode that carries the product's argument — real machines, real addresses,
-two VPCs that cannot reach each other — is proven only by the eight virtual
-machines in [install.md](install.md) and on the author's station. That is a
-measurement nobody else can reproduce by opening a pull request, which is the
-definition of evidence this project refuses everywhere else. The external
-review ranks this first of everything (#125), and the cadence proposal (#136)
-puts it in the first trust-buying version.
+**Landed, and it is a nightly job rather than a gate.**
+`.github/workflows/runtime-proof.yml` installs Incus (Zabbly stable, pinned key)
+and OVN on a GitHub-hosted `ubuntu-24.04`, wires the northbound connection, and
+runs the network, ssh and crash suites in both `incus` and `incus-ovn`. Both legs
+have passed, cross-VPC isolation asserted, on a machine nobody here owns.
 
-It sits in *later* only in the scheduling sense; the groundwork is measured
-(2026-07-30, on the upstream projects' own CI), and the whole thing rests on
-one unproven combination:
+What is still true, and is the only thing that should be read as a limit: **no
+pull-request gate starts a machine runtime.** The job is advisory until its
+promotion criterion is met, so the mode that carries the product's argument is
+not yet something a contributor's pull request has to satisfy.
+
+This paragraph said "no workflow in this repository starts a machine runtime"
+until an audit measured it against the workflow added by the very release train
+that shipped it. It had propagated to five places in two languages, and
+`docs --check` reconducted it at every release because it compares the page with
+its generator: it proves the form, never the claim. Verifying is not parsing,
+committed on this project's own documentation — recorded here rather than
+quietly reworded.
+
+The groundwork below was measured on 2026-07-30, before the job existed, and the
+combination it calls unproven has since been run:
 
 - **Incus runs on a GitHub-hosted `ubuntu-24.04`.** `lxc/incus` drives its own
   `test/main.sh` there with real containers on zfs, btrfs, lvm and ceph.
@@ -589,8 +597,9 @@ one unproven combination:
   `system-test` — the variant that loads `openvswitch.ko`, not the userspace one
   — on the same runner, after `apt install linux-modules-extra-$(uname -r)` and a
   hosts-file fix from its `.ci/linux-util.sh`.
-- **Nobody runs the two together.** The Incus CI contains no occurrence of
-  `ovn`, and the repository has no OVN test suite at all.
+- **Nobody ran the two together — until this job did.** The Incus CI contains no
+  occurrence of `ovn`, and that repository has no OVN test suite at all, so the
+  first evidence that the combination works on a hosted runner is this one.
 
 One trap and one unknown. The trap is **AppArmor**: that same `.ci/linux-util.sh`
 runs `aa-teardown` and disables the service, which reads like a prerequisite and
@@ -603,14 +612,15 @@ system on every runner and call it setup. The unknown is **arm64**: neither
 upstream project exercises it on a hosted runner, so a green run there would be
 this repository's first arm64 evidence of any kind, not merely of `--vm`.
 
-The order is measure, then gate. The job lands behind `workflow_dispatch`, is
-run by hand, and moves onto `pull_request` only once its nightly failure rate
+The order is measure, then gate. The job runs nightly and by
+`workflow_dispatch`, and moves onto `pull_request` only once its failure rate
 over a stated number of nights is at a stated threshold — a number the Actions
-history proves, not an opinion (#125 records the rule). A gate that is red on
+history proves, not an opinion. That streak is not there yet, which is why this
+is not a gate. A gate that is red on
 the day it appears is a gate everyone learns to ignore, and this repository
 already carries the note about what that costs.
 
-**Evidence:** a CI job installs Incus from Zabbly plus OVN on a hosted runner,
+**Evidence, met:** a CI job installs Incus from Zabbly plus OVN on a hosted runner,
 wires the northbound connection, and `FEINT_VM=incus-ovn` runs the network suite
 to completion — the subnet created through the emulated API, the address the API
 published answering, and the isolation assertion passing rather than skipping.

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -153,15 +153,15 @@ disappears from the suite.
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `DELETE` | `/ipam/v1/regions/{region}/ips/{ipID}` | `ipam/v1/API.ReleaseIP` | — |
+| `DELETE` | `/ipam/v1/regions/{region}/ips/{ipID}` | `ipam/v1/API.ReleaseIP` | `client` `runtime` |
 | `GET` | `/ipam/v1/regions/{region}/ips/{ipID}` | `ipam/v1/API.GetIP` | `client` `contract` `runtime` `probe` |
 | `GET` | `/ipam/v1/regions/{region}/ips` | `ipam/v1/API.ListIPs` | `client` `contract` `shape` `runtime` `probe` |
-| `PATCH` | `/ipam/v1/regions/{region}/ips/{ipID}` | `ipam/v1/API.UpdateIP` | — |
+| `PATCH` | `/ipam/v1/regions/{region}/ips/{ipID}` | `ipam/v1/API.UpdateIP` | `client` `contract` `runtime` `probe` |
 | `POST` | `/ipam/v1/regions/{region}/ip-sets/release` | `ipam/v1/API.ReleaseIPSet` | — |
-| `POST` | `/ipam/v1/regions/{region}/ips/{ipID}/attach` | `ipam/v1/API.AttachIP` | — |
-| `POST` | `/ipam/v1/regions/{region}/ips/{ipID}/detach` | `ipam/v1/API.DetachIP` | — |
-| `POST` | `/ipam/v1/regions/{region}/ips/{ipID}/move` | `ipam/v1/API.MoveIP` | — |
-| `POST` | `/ipam/v1/regions/{region}/ips` | `ipam/v1/API.BookIP` | — |
+| `POST` | `/ipam/v1/regions/{region}/ips/{ipID}/attach` | `ipam/v1/API.AttachIP` | `probe` |
+| `POST` | `/ipam/v1/regions/{region}/ips/{ipID}/detach` | `ipam/v1/API.DetachIP` | `probe` |
+| `POST` | `/ipam/v1/regions/{region}/ips/{ipID}/move` | `ipam/v1/API.MoveIP` | `probe` |
+| `POST` | `/ipam/v1/regions/{region}/ips` | `ipam/v1/API.BookIP` | `client` `contract` `runtime` `probe` |
 
 ### `marketplace`
 
@@ -174,21 +174,21 @@ disappears from the suite.
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
 | `DELETE` | `/vpc/v2/regions/{region}/private-networks/{pnID}` | `vpc/v2/API.DeletePrivateNetwork` | `client` `runtime` |
-| `DELETE` | `/vpc/v2/regions/{region}/routes/{routeID}` | `vpc/v2/API.DeleteRoute` | — |
-| `DELETE` | `/vpc/v2/regions/{region}/vpcs/{vpc_id}` | `vpc/v2/API.DeleteVPC` | — |
+| `DELETE` | `/vpc/v2/regions/{region}/routes/{routeID}` | `vpc/v2/API.DeleteRoute` | `client` `runtime` |
+| `DELETE` | `/vpc/v2/regions/{region}/vpcs/{vpc_id}` | `vpc/v2/API.DeleteVPC` | `client` `runtime` |
 | `GET` | `/vpc/v2/regions/{region}/private-networks/{pnID}` | `vpc/v2/API.GetPrivateNetwork` | `client` `contract` `runtime` `probe` |
 | `GET` | `/vpc/v2/regions/{region}/private-networks` | `vpc/v2/API.ListPrivateNetworks` | `contract` `shape` `probe` |
-| `GET` | `/vpc/v2/regions/{region}/routes/{routeID}` | `vpc/v2/API.GetRoute` | — |
-| `GET` | `/vpc/v2/regions/{region}/subnets` | `vpc/v2/API.ListSubnets` | — |
-| `GET` | `/vpc/v2/regions/{region}/vpcs/{vpc_id}` | `vpc/v2/API.GetVPC` | `contract` `probe` |
+| `GET` | `/vpc/v2/regions/{region}/routes/{routeID}` | `vpc/v2/API.GetRoute` | `client` `contract` `runtime` `probe` |
+| `GET` | `/vpc/v2/regions/{region}/subnets` | `vpc/v2/API.ListSubnets` | `contract` `probe` |
+| `GET` | `/vpc/v2/regions/{region}/vpcs/{vpc_id}` | `vpc/v2/API.GetVPC` | `client` `contract` `runtime` `probe` |
 | `GET` | `/vpc/v2/regions/{region}/vpcs` | `vpc/v2/API.ListVPCs` | `contract` `shape` `probe` |
 | `PATCH` | `/vpc/v2/regions/{region}/private-networks/{pnID}` | `vpc/v2/API.UpdatePrivateNetwork` | `contract` `probe` |
-| `PATCH` | `/vpc/v2/regions/{region}/routes/{routeID}` | `vpc/v2/API.UpdateRoute` | — |
+| `PATCH` | `/vpc/v2/regions/{region}/routes/{routeID}` | `vpc/v2/API.UpdateRoute` | `probe` |
 | `PATCH` | `/vpc/v2/regions/{region}/vpcs/{vpc_id}` | `vpc/v2/API.UpdateVPC` | `contract` `probe` |
-| `POST` | `/vpc/v2/regions/{region}/private-networks/{pnID}/enable-dhcp` | `vpc/v2/API.EnableDHCP` | — |
+| `POST` | `/vpc/v2/regions/{region}/private-networks/{pnID}/enable-dhcp` | `vpc/v2/API.EnableDHCP` | `contract` `probe` |
 | `POST` | `/vpc/v2/regions/{region}/private-networks` | `vpc/v2/API.CreatePrivateNetwork` | `client` `contract` `runtime` `probe` |
-| `POST` | `/vpc/v2/regions/{region}/routes` | `vpc/v2/API.CreateRoute` | — |
-| `POST` | `/vpc/v2/regions/{region}/vpcs/{vpc_id}/enable-routing` | `vpc/v2/API.EnableRouting` | — |
+| `POST` | `/vpc/v2/regions/{region}/routes` | `vpc/v2/API.CreateRoute` | `client` `contract` `runtime` `probe` |
+| `POST` | `/vpc/v2/regions/{region}/vpcs/{vpc_id}/enable-routing` | `vpc/v2/API.EnableRouting` | `contract` `probe` |
 | `POST` | `/vpc/v2/regions/{region}/vpcs` | `vpc/v2/API.CreateVPC` | `client` `contract` `runtime` `probe` |
 
 ### Declined on purpose (213)

--- a/internal/cli/docs_release.go
+++ b/internal/cli/docs_release.go
@@ -239,25 +239,38 @@ func renderPlatformTable(names []string) string {
 		// with a machine.
 		vm := "**impossible**: Incus publishes no macOS server"
 		if strings.HasPrefix(platform, "linux-") {
-			// And this is the honest state of the other half: no workflow in
-			// this repository starts a machine runtime at all. `--vm` is proven
-			// on the releases in the table further down, by
-			// tools/install/ansible/site.yml, and on the author's station.
-			// Nothing in CI proves it, on any architecture.
-			vm = "possible; proven by the release table below, never in CI"
+			// The honest state of the other half, and it moved with #139.
+			//
+			// This said "no workflow in this repository starts a machine runtime
+			// at all", which stopped being true the day runtime-proof.yml landed
+			// — in the same release train, without touching this file. An audit
+			// found the sentence still here, propagated to five places in two
+			// languages, and `docs --check` reconducted it at every release
+			// because it compares the page with this generator: it proves the
+			// form, never the claim. Verifying is not parsing, applied to the
+			// project's own documentation.
+			//
+			// The distinction that is true: no `pull_request` gate starts a
+			// runtime — the nightly job is advisory until its promotion criterion
+			// is met (#125) — and amd64 is what that job runs on.
+			vm = "possible; a nightly CI job proves it, and no pull-request gate does"
 			if !strings.HasSuffix(platform, "-amd64") {
-				vm = "Incus is packaged for it; nothing here has proven it"
+				vm = "Incus is packaged for it; the nightly runtime job runs amd64 only"
 			}
 		}
 		fmt.Fprintf(&b, "| `%s` | %s | %s |\n", name, control, vm)
 	}
 
-	b.WriteString("\n**`--vm` is off by default, and no workflow turns it on.** Starting machines is\n" +
-		"a side effect on whoever's host runs it, so it is asked for rather than assumed,\n" +
-		"and the conformance suite has to stay runnable where no runtime exists — which\n" +
-		"is CI. The network suites skip themselves there and say so. What proves that\n" +
-		"mode is `FEINT_VM=incus-ovn mise run conformance` on a host with Incus, and the\n" +
-		"eight virtual machines in the table below.\n")
+	b.WriteString("\n**`--vm` is off by default, and no pull-request gate turns it on.** Starting\n" +
+		"machines is a side effect on whoever's host runs it, so it is asked for rather\n" +
+		"than assumed, and the conformance suite has to stay runnable where no runtime\n" +
+		"exists — which is every pull request. The network suites skip themselves there\n" +
+		"and say so.\n\n" +
+		"A nightly job does run it: `.github/workflows/runtime-proof.yml` installs Incus\n" +
+		"and OVN on a GitHub-hosted runner and drives the network, ssh and crash suites\n" +
+		"in both modes. It is advisory until its promotion criterion is met, which is\n" +
+		"why no pull request depends on it. Locally, `FEINT_VM=incus-ovn mise run\n" +
+		"conformance` on a host with Incus proves the same thing.\n")
 	if guardedByVisibility(goWorkflow) {
 		b.WriteString("\nThe non-amd64 runners are free here and billed on a private repository, so the\n" +
 			"job skips on a private fork rather than spending somebody's minutes without\n" +

--- a/internal/cli/evidence_test.go
+++ b/internal/cli/evidence_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -171,4 +172,63 @@ func TestEvidenceTokensNameAxesAndNeverCount(t *testing.T) {
 	if !strings.Contains(violated, "contract-violated") {
 		t.Errorf("a violation must be printed loudly, got %q", violated)
 	}
+}
+
+// Every mounted operation has a row in the evidence artefact.
+//
+// Not a completeness nicety: the artefact is the record `docs/routes.md` prints
+// from, and an operation missing from it renders as "—" — indistinguishable from
+// an operation nothing has proven. An audit found the artefact fourteen
+// operations behind at a release candidate, because #146 mounted routes after
+// #145 wrote the file, and nothing was red. The page was honest and the record
+// was stale, which is the half-truth this project exists to refuse, committed on
+// the artefact whose whole purpose is to measure rather than assume.
+//
+// Regenerating is `mise run evidence:update`. This test is what makes forgetting
+// it a failure instead of a silent gap.
+func TestEveryMountedOperationHasAnEvidenceRow(t *testing.T) {
+	// The repository root from this package's directory: moduleRoot lives in the
+	// external test package and cannot be reached from here.
+	artefact, err := loadEvidenceArtefact(filepath.Join("..", "..", "coverage", "evidence.json"))
+	if err != nil {
+		t.Fatalf("read the evidence artefact: %v", err)
+	}
+	if len(artefact.Operations) == 0 {
+		t.Fatal("the evidence artefact is empty, so this test would pass while measuring nothing")
+	}
+
+	env := emulator.DefaultEnv()
+	srv, err := emulator.NewServer(env, packsFor(env)...)
+	if err != nil {
+		t.Fatalf("build the emulator: %v", err)
+	}
+
+	var missing []string
+	mounted := 0
+	for _, route := range srv.AllRoutes() {
+		if route.Operation == "" {
+			continue
+		}
+		mounted++
+		if _, recorded := artefact.Operations[route.Operation]; !recorded {
+			missing = append(missing, route.Operation)
+		}
+	}
+	if mounted == 0 {
+		t.Fatal("no mounted operation was found, so this test measured nothing")
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		t.Errorf("%d of %d mounted operations have no row in coverage/evidence.json, "+
+			"so docs/routes.md prints \"—\" for them and nothing says the record is behind.\n"+
+			"Run `mise run evidence:update`. Missing:\n  %s",
+			len(missing), mounted, strings.Join(firstMissing(missing, 8), "\n  "))
+	}
+}
+
+func firstMissing(all []string, n int) []string {
+	if len(all) <= n {
+		return all
+	}
+	return append(all[:n:n], "…")
 }

--- a/internal/providers/scaleway/barrage_test.go
+++ b/internal/providers/scaleway/barrage_test.go
@@ -170,6 +170,10 @@ func doRaw(ts *httptest.Server, method, path, body string) (int, map[string]any)
 // the smallest that make an interleaving likely rather than the largest a laptop
 // survives: a scenario nobody runs is a scenario nobody fixes.
 
+// IPAM is regional, and it is the product that hands out the addresses this
+// barrage contends for.
+const ipamURL = "/ipam/v1/regions/fr-par"
+
 const (
 	barrageWorkers = 10
 	barrageRounds  = 4
@@ -250,11 +254,19 @@ func barrageCycle(ts *httptest.Server, tag string, problems chan<- string) {
 	root, _ := volumes["0"].(map[string]any)
 	rootID, _ := root["id"].(string)
 
-	// A private network and a NIC on it. This is the second address pool, and
-	// the reason it is here rather than left out: the flexible allocator and the
-	// subnet allocator are locked separately, and a barrage that never touches
-	// the second one cannot see it come unlocked — falsification said so before
-	// this block existed, by staying green with the NIC lock removed.
+	// A private network and a NIC on it: the second address pool.
+	//
+	// Correction, because the claim that stood here was false. It said this
+	// block made the NIC allocator's lock falsifiable. An audit re-ran the
+	// mutation and got thirty green runs, and found the structural reason: every
+	// worker-round takes its own /24 through subnetOctet, so two requests never
+	// dispute one pool and no contention defect can show here, whatever the
+	// block drives.
+	//
+	// What holds that lock is TestConcurrentAttachmentsGetDistinctAddresses,
+	// which does fail under the same mutation. This block still earns its place —
+	// it exercises the route under load and feeds the sweep — but it proves
+	// coverage, not exclusion.
 	status, pn := doRaw(ts, "POST", regionURL+"/private-networks",
 		`{"name":"barrage-`+tag+`","subnets":["10.`+subnetOctet(tag)+`.0.0/24"]}`)
 	pnID := ""
@@ -410,5 +422,103 @@ func TestARestoreDuringTrafficLandsInOneWorld(t *testing.T) {
 	// whole map.
 	if _, found := st.Get("scaleway", "instance/ip", beforeID); !found && st.Len() == 0 {
 		t.Error("the restore landed in no world at all: the store is empty")
+	}
+}
+
+// The contention the first barrage could not stage.
+//
+// Its workers each took their own /24, so two requests never disputed one pool
+// and no allocator defect could show. An audit proved the blindness by removing
+// the private-NIC lock: thirty green runs. It also found the defect the blindness
+// was hiding — releasing an address took no lock at all, while booking one did.
+//
+// So this one puts every worker on a single network, and drives the write half
+// of ipam/v1 that nothing exercised: book, attach through a NIC, release.
+func TestASharedNetworkUnderBarrageNeverHandsOutOneAddressTwice(t *testing.T) {
+	runtime := newBarrageRuntime()
+	ts, st := newBarrageServer(t, runtime)
+
+	// One network for everybody. A /24 leaves 250-odd addresses, so exhaustion
+	// is not what this measures.
+	status, pn := doRaw(ts, "POST", regionURL+"/private-networks",
+		`{"name":"contended","subnets":["10.199.0.0/24"]}`)
+	if status != http.StatusCreated {
+		t.Fatalf("create the shared network: %d (%v)", status, pn)
+	}
+	pnID, _ := pn["id"].(string)
+
+	var wg sync.WaitGroup
+	problems := make(chan string, barrageWorkers*barrageRounds*6)
+
+	for w := range barrageWorkers {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			for round := range barrageRounds {
+				tag := fmt.Sprintf("w%d-r%d", worker, round)
+
+				// A booked address, released again — the path that frees an
+				// address, run against the paths that take one.
+				status, booked := doRaw(ts, "POST", ipamURL+"/ips",
+					`{"source":{"private_network_id":"`+pnID+`"}}`)
+				if status != http.StatusOK && status != http.StatusCreated {
+					problems <- fmt.Sprintf("%s: book answered %d", tag, status)
+					continue
+				}
+				bookedID, _ := booked["id"].(string)
+
+				// A server with a NIC on the same network, which allocates from
+				// the very pool the release is handing back to.
+				status, server := doRaw(ts, "POST", zoneURL+"/servers",
+					`{"name":"contend-`+tag+`","commercial_type":"DEV1-S"}`)
+				if status != http.StatusCreated {
+					problems <- fmt.Sprintf("%s: server create answered %d", tag, status)
+					doRaw(ts, "DELETE", ipamURL+"/ips/"+bookedID, "")
+					continue
+				}
+				srv, _ := server["server"].(map[string]any)
+				serverID, _ := srv["id"].(string)
+
+				// The NIC takes the address this worker booked, through
+				// ipam_ip_ids — what the Terraform provider does. Without it the
+				// NIC allocates a fresh address, the release disputes nothing,
+				// and the barrage is blind: proved by falsification, five green
+				// runs with the release lock removed.
+				//
+				// The release then races the attach on the *same* address, which
+				// is the sequence an audit walked and no test staged.
+				var inner sync.WaitGroup
+				inner.Add(2)
+				go func() {
+					defer inner.Done()
+					doRaw(ts, "POST", zoneURL+"/servers/"+serverID+"/private_nics",
+						`{"private_network_id":"`+pnID+`","ipam_ip_ids":["`+bookedID+`"]}`)
+				}()
+				go func() {
+					defer inner.Done()
+					doRaw(ts, "DELETE", ipamURL+"/ips/"+bookedID, "")
+				}()
+				inner.Wait()
+				doRaw(ts, "POST", zoneURL+"/servers/"+serverID+"/action", `{"action":"poweroff"}`)
+				doRaw(ts, "DELETE", zoneURL+"/servers/"+serverID, "")
+			}
+		}(w)
+	}
+	wg.Wait()
+	close(problems)
+
+	var refused []string
+	for p := range problems {
+		refused = append(refused, p)
+	}
+	if len(refused) > 0 {
+		t.Errorf("%d request(s) the barrage did not expect to fail:\n%s",
+			len(refused), strings.Join(firstFew(refused, 5), "\n"))
+	}
+
+	// The invariant the contention exists to test: one address, one resource.
+	if found := storetest.Sweep(st.All()); len(found) != 0 {
+		t.Errorf("one pool under contention produced an incoherent store:\n%s",
+			strings.Join(found, "\n"))
 	}
 }

--- a/internal/providers/scaleway/block.go
+++ b/internal/providers/scaleway/block.go
@@ -126,6 +126,25 @@ func (p *Pack) createBlockVolume(w http.ResponseWriter, r *http.Request) {
 		// SDK says the optional size on this branch is for.
 		size, _ = snapshot.Attrs["size"].(uint64)
 		if req.FromSnapshot.Size != nil && *req.FromSnapshot.Size > 0 {
+			// Larger only. A restore into something smaller than the snapshot is
+			// a volume the data cannot fit in, and answering 201 to it is the
+			// half-success this project exists to avoid.
+			//
+			// The refusal existed on updateBlockVolume and only there, while its
+			// comment read "a volume grows and does not shrink" — a property of
+			// the volume, stated once and held on one path. An audit created a
+			// 1 GB volume from a 10 GB snapshot and got 201. The guard is on both
+			// paths now, and the comment says which.
+			// TestABlockVolumeRestoredSmallerThanItsSnapshotIsRefused fails
+			// without this.
+			if *req.FromSnapshot.Size < size {
+				writeInvalidArguments(w, ArgumentError{
+					ArgumentName: "from_snapshot.size",
+					Reason:       "constraint",
+					HelpMessage:  "a volume restored from a snapshot may grow, not shrink below it",
+				})
+				return
+			}
 			size = *req.FromSnapshot.Size
 		}
 	}

--- a/internal/providers/scaleway/block_test.go
+++ b/internal/providers/scaleway/block_test.go
@@ -351,3 +351,53 @@ func TestTheBlockCatalogueAnswers(t *testing.T) {
 		t.Error("the entry carries no pricing, and the SDK decodes a Money there")
 	}
 }
+
+// A volume restored from a snapshot may grow, and may not shrink below it.
+//
+// The guard existed on updateBlockVolume and only there, while its comment
+// stated a property of the volume — "a volume grows and does not shrink". An
+// audit created a 1 GB volume from a 10 GB snapshot and got 201 with a healthy
+// "available": the data cannot fit, and the emulator said it did.
+//
+// Nothing else could have seen it. The barrage of #134 drives no block route,
+// and the invariant sweep asks about identity and uniqueness, not about whether
+// a size makes sense. Only a client suite would have caught it, and no fixture
+// creates from a snapshot with a smaller size.
+func TestABlockVolumeRestoredSmallerThanItsSnapshotIsRefused(t *testing.T) {
+	ts := newTestServer(t)
+	volumeID := blockVolumeWith(t, ts, "source", 10000000000)
+
+	status, snap := do(t, ts, "POST", blockURL+"/snapshots",
+		`{"name":"snap","volume_id":"`+volumeID+`"}`)
+	if status != http.StatusCreated {
+		t.Fatalf("create snapshot: expected 201, got %d (%v)", status, snap)
+	}
+	snapID, _ := snap["id"].(string)
+
+	status, got := do(t, ts, "POST", blockURL+"/volumes",
+		`{"name":"shrunk","from_snapshot":{"snapshot_id":"`+snapID+`","size":1000000000}}`)
+	if status != http.StatusBadRequest {
+		t.Fatalf("restore into a volume smaller than the snapshot: expected 400, got %d (%v)", status, got)
+	}
+
+	// The accepting halves, because a guard that refuses every resize would pass
+	// the assertion above and break the product: growing works, and asking for
+	// nothing takes the snapshot's own size.
+	status, grown := do(t, ts, "POST", blockURL+"/volumes",
+		`{"name":"grown","from_snapshot":{"snapshot_id":"`+snapID+`","size":20000000000}}`)
+	if status != http.StatusCreated {
+		t.Fatalf("restore into a larger volume: expected 201, got %d (%v)", status, grown)
+	}
+	if grown["size"] != float64(20000000000) {
+		t.Errorf("the grown volume is %v, want 20000000000", grown["size"])
+	}
+
+	status, same := do(t, ts, "POST", blockURL+"/volumes",
+		`{"name":"same","from_snapshot":{"snapshot_id":"`+snapID+`"}}`)
+	if status != http.StatusCreated {
+		t.Fatalf("restore with no size: expected 201, got %d (%v)", status, same)
+	}
+	if same["size"] != snap["size"] {
+		t.Errorf("with no size the volume is %v, and its snapshot is %v", same["size"], snap["size"])
+	}
+}

--- a/internal/providers/scaleway/ipam.go
+++ b/internal/providers/scaleway/ipam.go
@@ -402,9 +402,18 @@ func (p *Pack) releaseIPAMIPSet(w http.ResponseWriter, r *http.Request) {
 		}
 		batch = append(batch, res)
 	}
+	// The same lock, for the same reason releaseOne takes it: a delete frees an
+	// address, and freeing one while another request is allocating hands it out
+	// twice. Re-read under the lock, since the checks above ran outside it.
+	p.addresses.Lock()
 	for _, res := range batch {
-		p.env.Store.Delete(Name, kindIPAMIP, res.ID)
+		current, found := p.env.Store.Get(Name, kindIPAMIP, res.ID)
+		if !found || ipamAttached(current) {
+			continue
+		}
+		p.env.Store.Delete(Name, kindIPAMIP, current.ID)
 	}
+	p.addresses.Unlock()
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -412,11 +421,33 @@ func (p *Pack) releaseIPAMIPSet(w http.ResponseWriter, r *http.Request) {
 // wrong destroy order retryable instead of silently breaking the NIC still
 // using the address. TestReleasingAnAttachedIPIsRefused fails without it.
 func (p *Pack) releaseOne(w http.ResponseWriter, res *resource.Resource) bool {
-	if ipamAttached(res) {
-		writePrecondition(w, "ip", res.ID, "IP is still attached to a resource; detach it first")
+	// The allocator's lock, held across the attachment check and the delete.
+	//
+	// bookIP and createPrivateNIC hold it from rebuild to Put, and releasing did
+	// not hold it at all — which is the half that makes an address available
+	// again. An audit walked the sequence: this reads an unattached address, a
+	// NIC create attaches it under the lock, this deletes the IPAM resource, and
+	// the next Allocate hands the same address to a second NIC. Two interfaces,
+	// one address; under --vm, two machines configured alike.
+	//
+	// allocatorFor rebuilds occupancy from the IPAM resources alone, so deleting
+	// one is exactly what frees an address: the read and the delete belong in the
+	// same critical section as the allocation they race.
+	// TestAReleasedAddressCannotBeTakenWhileItIsBeingAttached fails without this.
+	p.addresses.Lock()
+	defer p.addresses.Unlock()
+
+	// Re-read under the lock. The caller resolved this resource outside it, and
+	// an attachment that landed in between is invisible to a stale clone.
+	current, found := p.env.Store.Get(Name, kindIPAMIP, res.ID)
+	if !found {
+		return true
+	}
+	if ipamAttached(current) {
+		writePrecondition(w, "ip", current.ID, "IP is still attached to a resource; detach it first")
 		return false
 	}
-	p.env.Store.Delete(Name, kindIPAMIP, res.ID)
+	p.env.Store.Delete(Name, kindIPAMIP, current.ID)
 	return true
 }
 
@@ -444,8 +475,18 @@ func (p *Pack) updateIPAMIP(w http.ResponseWriter, r *http.Request) {
 		}
 		res.Attrs["reverses"] = reverses
 	}
-	res.Updated = p.env.Now()
-	p.env.Store.Put(res)
+	// Commit rather than Put: an address released while this PATCH was decoding
+	// must stay released, not come back carrying new tags.
+	//
+	// TestCommitDoesNotResurrectAReleasedAddress holds the store-level half. The
+	// handler-level race has no deterministic seam — a concurrent-HTTP test of it
+	// stayed green with Put restored — so this call site is the connection, read
+	// rather than triggered. Said plainly instead of citing a test that would not
+	// fail.
+	if !p.env.Store.Commit(res, p.env.Now()) {
+		writeNotFound(w, "ip", res.ID)
+		return
+	}
 
 	emulator.WriteJSON(w, http.StatusOK, p.ipamIPView(res))
 }
@@ -547,8 +588,11 @@ func (p *Pack) detachCustom(w http.ResponseWriter, res *resource.Resource, req *
 	}
 	delete(res.Attrs, attrCustomMAC)
 	delete(res.Attrs, attrCustomName)
-	res.Updated = p.env.Now()
-	p.env.Store.Put(res)
+	// Commit, never Put. Put re-inserts unconditionally, so a release that landed
+	// while this was deciding is undone and the address comes back — the
+	// resurrection CLAUDE.md records as already paid for three times. A false
+	// return means the client released it meanwhile, which is not an error.
+	p.env.Store.Commit(res, p.env.Now())
 	return true
 }
 
@@ -558,8 +602,8 @@ func (p *Pack) setCustomAttachment(res *resource.Resource, custom *customResourc
 	if custom.Name != nil {
 		res.Attrs[attrCustomName] = *custom.Name
 	}
-	res.Updated = p.env.Now()
-	p.env.Store.Put(res)
+	// Commit rather than Put, for the reason detachCustom gives.
+	p.env.Store.Commit(res, p.env.Now())
 }
 
 // newIPAMIP records the address a private NIC received, as the resource a

--- a/internal/providers/scaleway/ipam_lock_internal_test.go
+++ b/internal/providers/scaleway/ipam_lock_internal_test.go
@@ -1,0 +1,173 @@
+package scaleway
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+)
+
+// Releasing an address is an allocation event, and it takes the allocator's lock.
+//
+// This is the defect an audit found in SW-4 and the reason it is tested from
+// inside the package rather than through a barrage. `bookIP` and
+// `createPrivateNIC` hold `p.addresses` from the moment they rebuild occupancy
+// to the moment they store the result; `releaseOne` held nothing, while being
+// the operation that makes an address available again — `allocatorFor` rebuilds
+// occupancy from the IPAM resources alone, so deleting one is exactly what frees
+// an address.
+//
+// Why not a barrage. Two were tried and both stayed green with the lock removed,
+// six runs each: the sequence needs a release to be interleaved *between* another
+// request's read and write of the same address, which no amount of concurrent
+// HTTP traffic reliably produces, and the second NIC that would receive the
+// duplicate never coexists with the first in a cycle that tears its server down.
+// A scenario that cannot fail is worth less than a smaller question asked
+// exactly: does this path take the lock at all?
+//
+// Holding the lock from the test answers that, deterministically. With the fix,
+// the release cannot finish while the lock is held. Without it, it finishes
+// immediately — which is what this asserts, and what makes it fail when the fix
+// is removed.
+func TestAReleasedAddressCannotBeTakenWhileItIsBeingAttached(t *testing.T) {
+	env := emulator.DefaultEnv()
+	pack := New(env)
+	srv, err := emulator.NewServer(env, pack)
+	if err != nil {
+		t.Fatalf("build emulator: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	// A network, then an address booked from it.
+	status, network := postJSON(t, ts, "/vpc/v2/regions/fr-par/private-networks",
+		`{"name":"locked","subnets":["10.201.0.0/24"]}`)
+	if status != http.StatusCreated {
+		t.Fatalf("create the network: %d (%v)", status, network)
+	}
+	pnID, _ := network["id"].(string)
+
+	status, booked := postJSON(t, ts, "/ipam/v1/regions/fr-par/ips",
+		`{"source":{"private_network_id":"`+pnID+`"}}`)
+	if status != http.StatusOK && status != http.StatusCreated {
+		t.Fatalf("book an address: %d (%v)", status, booked)
+	}
+	id, _ := booked["id"].(string)
+
+	// The allocator is busy, the way it is for the seconds another request
+	// spends between rebuilding occupancy and storing its result.
+	pack.addresses.Lock()
+
+	done := make(chan int, 1)
+	go func() {
+		req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/ipam/v1/regions/fr-par/ips/"+id, nil)
+		resp, err := ts.Client().Do(req)
+		if err != nil {
+			done <- -1
+			return
+		}
+		_ = resp.Body.Close()
+		done <- resp.StatusCode
+	}()
+
+	select {
+	case status := <-done:
+		pack.addresses.Unlock()
+		t.Fatalf("the release answered %d while the allocator was held: it frees an "+
+			"address without taking the lock every allocation takes", status)
+	case <-time.After(150 * time.Millisecond):
+		// Blocked, which is the point.
+	}
+
+	// And it completes once the allocator is free: a release that never returned
+	// would satisfy the assertion above and break the product.
+	pack.addresses.Unlock()
+	select {
+	case status := <-done:
+		if status != http.StatusNoContent {
+			t.Errorf("the release answered %d once the lock was free, want 204", status)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("the release never completed after the allocator was released")
+	}
+
+	// Gone, so the address is available again — the state the lock protects.
+	if _, found := env.Store.Get(Name, kindIPAMIP, id); found {
+		t.Error("the address survived its own release")
+	}
+}
+
+// Commit refuses to resurrect a released address; Put did not.
+//
+// What this proves, exactly, and what it does not. updateIPAMIP wrote with Put,
+// which re-inserts unconditionally: an address released while the PATCH was
+// decoding came back carrying the new tags, and the client that released it had
+// no way to know. CLAUDE.md records that resurrection as already paid for three
+// times in other packs.
+//
+// This asserts the store-level half — the one that has a seam. Staging the
+// handler-level race deterministically would need a hook between the moment it
+// resolves the resource and the moment it writes, and no such seam exists; a
+// concurrent-HTTP version of this test stayed green with the fix removed, which
+// makes it a scenario that cannot fail. So the connection between the two halves
+// is the call site in updateIPAMIP, read rather than triggered, and that is
+// stated here rather than dressed up as a control.
+func TestCommitDoesNotResurrectAReleasedAddress(t *testing.T) {
+	env := emulator.DefaultEnv()
+	pack := New(env)
+	srv, err := emulator.NewServer(env, pack)
+	if err != nil {
+		t.Fatalf("build emulator: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	status, network := postJSON(t, ts, "/vpc/v2/regions/fr-par/private-networks",
+		`{"name":"resurrect","subnets":["10.202.0.0/24"]}`)
+	if status != http.StatusCreated {
+		t.Fatalf("create the network: %d (%v)", status, network)
+	}
+	pnID, _ := network["id"].(string)
+
+	status, booked := postJSON(t, ts, "/ipam/v1/regions/fr-par/ips",
+		`{"source":{"private_network_id":"`+pnID+`"}}`)
+	if status != http.StatusOK && status != http.StatusCreated {
+		t.Fatalf("book an address: %d (%v)", status, booked)
+	}
+	id, _ := booked["id"].(string)
+
+	// The resource as a handler would have resolved it before the release,
+	// which is the stale clone Put used to write back.
+	stale, found := env.Store.Get(Name, kindIPAMIP, id)
+	if !found {
+		t.Fatal("the booked address is not in the store")
+	}
+	env.Store.Delete(Name, kindIPAMIP, id)
+
+	// What updateIPAMIP does with that clone.
+	stale.Attrs["tags"] = []string{"late"}
+	if pack.env.Store.Commit(stale, pack.env.Now()) {
+		t.Error("Commit reported success on a resource the client had released")
+	}
+	if _, back := env.Store.Get(Name, kindIPAMIP, id); back {
+		t.Error("a released address came back, carrying the tags of a request that raced it")
+	}
+}
+
+// postJSON is a small helper for these two: the package's exported tests live in
+// scaleway_test and cannot be reached from here.
+func postJSON(t *testing.T, ts *httptest.Server, path, body string) (int, map[string]any) {
+	t.Helper()
+	resp, err := ts.Client().Post(ts.URL+path, "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST %s: %v", path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var decoded map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&decoded)
+	return resp.StatusCode, decoded
+}

--- a/tools/conformance/outscale/oapi-cli.sh
+++ b/tools/conformance/outscale/oapi-cli.sh
@@ -537,9 +537,19 @@ if [ "$MACHINES" != "none" ]; then
   # the last thing to run and owns it.
   left="$("$SCRIPT_DIR/../../../feint" clean --vm "${FEINT_VM:-incus}" 2>&1)" \
     || fail "the runtime sweep failed: $left"
-  case "$left" in
-    "removed 0 machine(s)"*) ok "the delete took the machine with it" ;;
-    *) fail "the delete left a machine behind: $left" ;;
+  # The machine count is read from the line that reports it, not from the start
+  # of the whole output.
+  #
+  # A prefix match stood here and produced a false verdict the day `clean` gained
+  # a second line: it now prints "removed N stale instance record(s)" before its
+  # tally when the runtime holds orphaned records, so the tally was no longer
+  # first and the suite announced "the delete left a machine behind" while the
+  # tally said zero. The subject was clean; the harness was not.
+  machines="$(printf '%s\n' "$left" | grep -o 'removed [0-9]* machine(s)' | grep -o '[0-9]*' | head -1)"
+  case "$machines" in
+    "") fail "the sweep printed no machine tally, so this check cannot decide: $left" ;;
+    0) ok "the delete took the machine with it" ;;
+    *) fail "the delete left $machines machine(s) behind: $left" ;;
   esac
 fi
 osc DeleteKeypair --KeypairName conformance >/dev/null || fail "DeleteKeypair rejected"


### PR DESCRIPTION
Two audits of the twelve PRs merged for 0.8. Six defects plus a seventh the corrective work itself uncovered. **Each was triggered before being corrected** — none is fixed on a report alone.

## Observable by a client

**A block volume restored smaller than its snapshot answered 201.** Reproduced live: 10 GB snapshot → `from_snapshot` with `size: 1 GB` → `201`, `available`. The guard lived on `updateBlockVolume` while its comment stated a property of the *volume* — *"a volume grows and does not shrink"* — held on one of two paths. Neither the barrage nor the invariant sweep could see it: one drives no block route, the other asks about identity, not about whether a size makes sense.

**Releasing an IPAM address took no lock**, while booking one held the allocator from rebuild to store. `allocatorFor` rebuilds occupancy from the IPAM resources alone, so deleting one is precisely what frees an address. Both release paths hold it now and re-read under it; writes go through `Commit` rather than `Put`, which re-inserts a resource the client released.

Two things about that fix are stated rather than dressed up:

- A **contended barrage was written to catch it and stayed green** without the lock — five runs, then six more once the workers disputed the same address. The sequence needs an interleaving no volume of concurrent HTTP reliably produces. The property is held instead by a test that takes the allocator's lock and requires the release to block: a smaller question asked exactly.
- The resurrection test proves the **store-level half only**. The handler-level race has no deterministic seam, and the comment says so instead of citing a test that would not fail.

## Claims that were false

**A falsification claim.** *"Neutralise any of the three locks and the barrage goes red on the first attempt"* — thirty green runs with the private-NIC lock removed. Every worker takes its own subnet through `subnetOctet`, so no contention defect can surface there, whatever it drives. It now names the two it holds and the test that holds the third.

**The documentation claimed no workflow starts a machine runtime**, in five places across two languages, contradicted by `runtime-proof.yml` shipped in the same release train. It was frozen in the generator, so `feint docs --check` reconducted it at every release: the gate compares the page with its generator and proves the **form**, never the claim. Verifying is not parsing, committed on this project's own documentation. The true distinction — no *pull-request gate* starts one — is what they say now, and the roadmap records the lapse rather than quietly rewording it.

## Instruments

**The evidence artefact was fourteen operations behind** at a release candidate, and nothing was red: `docs/routes.md` printed `—` for them, which reads exactly like an operation nothing has proven. `TestEveryMountedOperationHasAnEvidenceRow` now requires every mounted operation to have a row — it caught the gap at 206/220 before the fix. Regenerated with both legs: 220 operations, `machines: [incus, none]`.

**A conformance assertion produced a false verdict**, and it is how the seventh defect surfaced. `feint clean` gained a line reporting stale runtime records, printed *before* its tally; the Outscale suite prefix-matched the whole output and announced *"the delete left a machine behind"* while the tally said zero. Two changes of the same day meeting. It reads the count now, and refuses to decide when there is none — verified across four shapes of output.

## Proof

- `mise run check`, `drift:check`, `shapes:check`, `docs --check`, full `conformance` — all green.
- Falsified: the shrink guard, the release lock (release answers 204 while the allocator is held, without the fix), the evidence-row control.
- The station was left clean after the runtime leg: zero instances, zero `fnt-` networks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)