### PR TITLE
fix(ci): one action, one pin, and a test that says so

### DIFF
--- a/.github/workflows/runtime-proof.yml
+++ b/.github/workflows/runtime-proof.yml
@@ -361,7 +361,7 @@ jobs:
       contents: read
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 

--- a/internal/cli/actionpins_test.go
+++ b/internal/cli/actionpins_test.go
@@ -1,0 +1,96 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// One action, one pin, across every workflow.
+//
+// A stale pin does not look stale. `step-security/harden-runner@6c439dc8… #
+// v2.12.2` sat in one job of one workflow while the other twenty-three
+// invocations were on v2.20.0, and the old one carried three published
+// advisories. Plumber caught it on `main` — after the merge, which is the wrong
+// end of the pipeline for something a comparison of two lines answers.
+//
+// The mistake worth naming is how it got there: the SHA was written from memory
+// instead of copied from the pins the repository already holds. Nothing else in
+// the file would tell you, because a pinned SHA is opaque by design — the
+// trailing `# v2.12.2` is a comment, and a comment is not a control.
+//
+// So this compares them. It does not know which version is current, and it must
+// not: that is the advisory scanner's job and it does it better. What this
+// answers is narrower and cheaper — the repository must not disagree with
+// itself about which build of an action it trusts.
+func TestEveryWorkflowPinsAnActionToOneSHA(t *testing.T) {
+	root := moduleRoot(t)
+	dir := filepath.Join(root, ".github", "workflows")
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read the workflow directory: %v", err)
+	}
+
+	// `uses: owner/repo@<sha>` and the version comment that follows, which is
+	// how every workflow here pins.
+	pin := regexp.MustCompile(`uses:\s+([A-Za-z0-9._/-]+)@([a-f0-9]{40})(?:\s+#\s*(\S+))?`)
+
+	type site struct{ workflow, sha, version string }
+	seen := map[string][]site{}
+	total := 0
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yml") {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join(dir, entry.Name())) //nolint:gosec // paths from the walk
+		if err != nil {
+			t.Fatalf("read %s: %v", entry.Name(), err)
+		}
+		for _, m := range pin.FindAllStringSubmatch(string(body), -1) {
+			action, sha, version := m[1], m[2], m[3]
+			seen[action] = append(seen[action], site{entry.Name(), sha, version})
+			total++
+		}
+	}
+
+	if total == 0 {
+		t.Fatal("no pinned action was found in .github/workflows: the pattern no longer " +
+			"matches how this repository pins, and this test would pass while measuring nothing")
+	}
+
+	for action, sites := range seen {
+		shas := map[string][]string{}
+		for _, s := range sites {
+			label := s.workflow
+			if s.version != "" {
+				label += " (" + s.version + ")"
+			}
+			shas[s.sha] = append(shas[s.sha], label)
+		}
+		if len(shas) < 2 {
+			continue
+		}
+		// Sorted so two runs of the same disagreement read the same, and so the
+		// message names every side rather than an arbitrary one.
+		keys := make([]string, 0, len(shas))
+		for sha := range shas {
+			keys = append(keys, sha)
+		}
+		sort.Strings(keys)
+
+		var detail strings.Builder
+		for _, sha := range keys {
+			where := shas[sha]
+			sort.Strings(where)
+			detail.WriteString("\n  " + sha[:12] + "… in " + strings.Join(where, ", "))
+		}
+		t.Errorf("%s is pinned to %d different SHAs, so one of them is the one nobody "+
+			"updated and it is invisible without this comparison:%s",
+			action, len(shas), detail.String())
+	}
+}


### PR DESCRIPTION
Plumber went red on `main`, and it was mine.

```
CRIT [ISSUE-703] job "runtime-proof/streak" references
"step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49"
— published advisories: GHSA-46g3-37rh-v698, GHSA-g699-3x6g-wm3g, GHSA-cpmj-h4f6-r6pq

Status: FAILED (score E — 30.0/100, required ≥ B)
```

The `streak` job added yesterday pinned `harden-runner` to **v2.12.2**, while the other **23** invocations in this repository are on **v2.20.0**:

```
23  step-security/harden-runner@bf7454d0… # v2.20.0
 1  step-security/harden-runner@6c439dc8… # v2.12.2
```

## How it got there, which is the part worth fixing

The SHA was written **from memory** rather than copied from the pins the repository already holds. Nothing in the file could tell you: a pinned SHA is opaque by design, and the trailing `# v2.12.2` is a comment.

The advisory scanner caught it **after the merge** — the wrong end of the pipeline for something a comparison of two lines answers.

## The control

The pin is corrected, and the comparison is now a test. It deliberately does **not** know which version is current — that is the scanner's job and it does it better. What it answers is narrower and cheaper: *this repository must not disagree with itself about which build of an action it trusts.*

Falsified — put the old SHA back in one job:

```
step-security/harden-runner is pinned to 2 different SHAs, so one of them is
the one nobody updated and it is invisible without this comparison:
  6c439dc8bdf8… in runtime-proof.yml (v2.12.2)
  bf7454d06d71… in conformance.yml (v2.20.0), go.yml (v2.20.0), …
```

It also refuses to pass on an empty match, so a change in how this repository pins cannot turn it into a test that measures nothing.

`mise run check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)