### PR TITLE
feat(drift): the upstream's own grouping reaches the tables, so a refusal reads as a refusal

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,36 +580,69 @@ what this emulator serves, declines on purpose, or has not triaged yet.
 
 #### Scaleway
 
-102 routes mounted, 32% of the measured upstream surface served.
+102 routes mounted. Of the 315 operations upstream declares: 32% served,
+67% declined on purpose, 0% untriaged.
 
-| Product | Served | Declined | Untriaged | Upstream |
+| Group | Served | Declined | Untriaged | Upstream |
 |---|--:|--:|--:|--:|
-| `block` | 22 | 5 | 0 | 27 |
-| `iam` | 5 | 78 | 0 | 83 |
 | `instance` | 48 | 102 | 0 | 150 |
+| `iam` | 5 | 78 | 0 | 83 |
+| `vpc` | 17 | 20 | 0 | 37 |
+| `block` | 22 | 5 | 0 | 27 |
 | `ipam` | 9 | 1 | 0 | 10 |
 | `marketplace` | 1 | 7 | 0 | 8 |
-| `vpc` | 17 | 20 | 0 | 37 |
 | **Total** | **102** | **213** | **0** | **315** |
 
 #### Outscale
 
-72 routes mounted, 27% of the measured upstream surface served.
+72 routes mounted. Of the 263 operations upstream declares: 27% served,
+65% declined on purpose, 6% untriaged.
 
-| Product | Served | Declined | Untriaged | Upstream |
+| Group | Served | Declined | Untriaged | Upstream |
 |---|--:|--:|--:|--:|
 | `oks` | 0 | 27 | 0 | 27 |
-| `osc` | 72 | 146 | 18 | 236 |
+| `Policy` | 0 | 24 | 0 | 24 |
+| `LoadBalancer` | 1 | 11 | 0 | 12 |
+| `Vm` | 10 | 2 | 0 | 12 |
+| `Nic` | 5 | 0 | 3 | 8 |
+| `UserGroup` | 0 | 8 | 0 | 8 |
+| `FlexibleGpu` | 0 | 7 | 0 | 7 |
+| `Volume` | 6 | 1 | 0 | 7 |
+| `Account` | 0 | 5 | 1 | 6 |
+| `IdentityProvider` | 0 | 6 | 0 | 6 |
+| `Image` | 4 | 2 | 0 | 6 |
+| `Listener` | 0 | 6 | 0 | 6 |
+| `PublicIp` | 6 | 0 | 0 | 6 |
+| `RouteTable` | 5 | 0 | 1 | 6 |
+| `Snapshot` | 3 | 3 | 0 | 6 |
+| `VirtualGateway` | 0 | 6 | 0 | 6 |
+| `VmGroup` | 0 | 6 | 0 | 6 |
+| `VpnConnection` | 0 | 6 | 0 | 6 |
+| *… 33 smaller groups* | 32 | 53 | 13 | 98 |
 | **Total** | **72** | **173** | **18** | **263** |
 
 #### Exoscale
 
-46 routes mounted, 12% of the measured upstream surface served.
+46 routes mounted. Of the 374 operations upstream declares: 12% served,
+67% declined on purpose, 20% untriaged.
 
-| Product | Served | Declined | Untriaged | Upstream |
+| Group | Served | Declined | Untriaged | Upstream |
 |---|--:|--:|--:|--:|
-| `exoscale` | 46 | 253 | 75 | 374 |
+| `dbaas` | 0 | 146 | 0 | 146 |
+| `compute` | 42 | 9 | 60 | 111 |
+| `sks` | 0 | 25 | 0 | 25 |
+| `ai` | 0 | 22 | 0 | 22 |
+| `iam` | 0 | 18 | 0 | 18 |
+| `kms` | 0 | 16 | 0 | 16 |
+| `block-storage` | 0 | 0 | 13 | 13 |
+| `dns` | 0 | 10 | 0 | 10 |
+| *… 6 smaller groups* | 4 | 7 | 2 | 13 |
 | **Total** | **46** | **253** | **75** | **374** |
+
+Rows are the provider's own grouping of its surface — Scaleway's SDK products,
+Outscale's API tags, the roots of Exoscale's tag hierarchy — never a grouping
+invented here. Groups under 2% of a surface fold into the *smaller groups* row
+of their table, counts intact, so no block-sized decision can hide in it.
 
 **Declined** is a decision, not a gap: an operation nobody intends to emulate,
 with the reason in the pack's `Declined()`. **Untriaged** is the honest column —

--- a/contracts/exoscale.json
+++ b/contracts/exoscale.json
@@ -8,1031 +8,1222 @@
   "add-external-source-to-security-group": {
    "path": "/security-group/{id}:add-source",
    "method": "PUT",
+   "group": "compute",
    "request": "add-external-source-to-security-group.Request",
    "response": "operation"
   },
   "add-instance-protection": {
    "path": "/instance/{id}:add-protection",
    "method": "PUT",
+   "group": "compute",
    "response": "operation"
   },
   "add-rule-to-security-group": {
    "path": "/security-group/{id}/rules",
    "method": "POST",
+   "group": "compute",
    "request": "add-rule-to-security-group.Request",
    "response": "operation"
   },
   "add-service-to-load-balancer": {
    "path": "/load-balancer/{id}/service",
    "method": "POST",
+   "group": "compute",
    "request": "add-service-to-load-balancer.Request",
    "response": "operation"
   },
   "assume-iam-role": {
    "path": "/iam-role/{id}/assume",
    "method": "POST",
+   "group": "iam",
    "request": "assume-iam-role.Request",
    "response": "assume-iam-role.Response"
   },
   "attach-block-storage-volume-to-instance": {
    "path": "/block-storage/{id}:attach",
    "method": "PUT",
+   "group": "block-storage",
    "request": "attach-block-storage-volume-to-instance.Request",
    "response": "operation"
   },
   "attach-dbaas-service-to-endpoint": {
    "path": "/dbaas-external-endpoint/{source-service-name}/attach",
    "method": "PUT",
+   "group": "dbaas",
    "request": "attach-dbaas-service-to-endpoint.Request",
    "response": "operation"
   },
   "attach-instance-to-elastic-ip": {
    "path": "/elastic-ip/{id}:attach",
    "method": "PUT",
+   "group": "compute",
    "request": "attach-instance-to-elastic-ip.Request",
    "response": "operation"
   },
   "attach-instance-to-private-network": {
    "path": "/private-network/{id}:attach",
    "method": "PUT",
+   "group": "compute",
    "request": "attach-instance-to-private-network.Request",
    "response": "operation"
   },
   "attach-instance-to-security-group": {
    "path": "/security-group/{id}:attach",
    "method": "PUT",
+   "group": "compute",
    "request": "attach-instance-to-security-group.Request",
    "response": "operation"
   },
   "attach-instance-to-subnet": {
    "path": "/vpc/{vpc-id}/subnet/{subnet-id}/attach",
    "method": "PUT",
+   "group": "compute",
    "request": "attach-instance-to-subnet.Request",
    "response": "operation"
   },
   "cancel-kms-key-deletion": {
    "path": "/kms-key/{id}/cancel-deletion",
    "method": "POST",
+   "group": "kms",
    "response": "success-response"
   },
   "copy-template": {
    "path": "/template/{id}",
    "method": "POST",
+   "group": "compute",
    "request": "copy-template.Request",
    "response": "operation"
   },
   "create-ai-api-key": {
    "path": "/ai/api-key",
    "method": "POST",
+   "group": "ai",
    "request": "create-ai-api-key-request",
    "response": "create-ai-api-key-response"
   },
   "create-anti-affinity-group": {
    "path": "/anti-affinity-group",
    "method": "POST",
+   "group": "compute",
    "request": "create-anti-affinity-group.Request",
    "response": "operation"
   },
   "create-api-key": {
    "path": "/api-key",
    "method": "POST",
+   "group": "iam",
    "request": "create-api-key.Request",
    "response": "iam-api-key-created"
   },
   "create-block-storage-snapshot": {
    "path": "/block-storage/{id}:create-snapshot",
    "method": "POST",
+   "group": "block-storage",
    "request": "create-block-storage-snapshot.Request",
    "response": "operation"
   },
   "create-block-storage-volume": {
    "path": "/block-storage",
    "method": "POST",
+   "group": "block-storage",
    "request": "create-block-storage-volume.Request",
    "response": "operation"
   },
   "create-dbaas-clickhouse-user": {
    "path": "/dbaas-clickhouse/{service-name}/user",
    "method": "POST",
+   "group": "dbaas",
    "request": "create-dbaas-clickhouse-user.Request",
    "response": "dbaas-user-clickhouse-secrets"
   },
   "create-dbaas-external-endpoint-datadog": {
    "path": "/dbaas-external-endpoint-datadog/{name}",
    "method": "POST",
+   "group": "dbaas",
    "request": "dbaas-endpoint-datadog-input-create",
    "response": "operation"
   },
   "create-dbaas-external-endpoint-elasticsearch": {
    "path": "/dbaas-external-endpoint-elasticsearch/{name}",
    "method": "POST",
+   "group": "dbaas",
    "request": "dbaas-endpoint-elasticsearch-input-create",
    "response": "operation"
   },
   "create-dbaas-external-endpoint-opensearch": {
    "path": "/dbaas-external-endpoint-opensearch/{name}",
    "method": "POST",
+   "group": "dbaas",
    "request": "dbaas-endpoint-opensearch-input-create",
    "response": "operation"
   },
   "create-dbaas-external-endpoint-prometheus": {
    "path": "/dbaas-external-endpoint-prometheus/{name}",
    "method": "POST",
+   "group": "dbaas",
    "request": "dbaas-endpoint-prometheus-payload",
    "response": "operation"
   },
   "create-dbaas-external-endpoint-rsyslog": {
    "path": "/dbaas-external-endpoint-rsyslog/{name}",
    "method": "POST",
+   "group": "dbaas",
    "request": "dbaas-endpoint-rsyslog-input-create",
    "response": "operation"
   },
   "create-dbaas-integration": {
    "path": "/dbaas-integration",
    "method": "POST",
+   "group": "dbaas",
    "request": "create-dbaas-integration.Request",
    "response": "operation"
   },
   "create-dbaas-kafka-schema-registry-acl-config": {
    "path": "/dbaas-kafka/{name}/schema-registry/acl-config",
    "method": "POST",
+   "group": "dbaas",
    "request": "dbaas-kafka-schema-registry-acl-entry",
    "response": "operation"
   },
   "create-dbaas-kafka-topic-acl-config": {
    "path": "/dbaas-kafka/{name}/topic/acl-config",
    "method": "POST",
+   "group": "dbaas",
    "request": "dbaas-kafka-topic-acl-entry",
    "response": "operation"
   },
   "create-dbaas-kafka-user": {
    "path": "/dbaas-kafka/{service-name}/user",
    "method": "POST",
+   "group": "dbaas",
    "request": "create-dbaas-kafka-user.Request",
    "response": "operation"
   },
   "create-dbaas-mysql-database": {
    "path": "/dbaas-mysql/{service-name}/database",
    "method": "POST",
+   "group": "dbaas",
    "request": "create-dbaas-mysql-database.Request",
    "response": "operation"
   },
   "create-dbaas-mysql-user": {
    "path": "/dbaas-mysql/{service-name}/user",
    "method": "POST",
+   "group": "dbaas",
    "request": "create-dbaas-mysql-user.Request",
    "response": "operation"
   },
   "create-dbaas-opensearch-user": {
    "path": "/dbaas-opensearch/{service-name}/user",
    "method": "POST",
+   "group": "dbaas",
    "request": "create-dbaas-opensearch-user.Request",
    "response": "operation"
   },
   "create-dbaas-pg-connection-pool": {
    "path": "/dbaas-postgres/{service-name}/connection-pool",
    "method": "POST",
+   "group": "dbaas",
    "request": "create-dbaas-pg-connection-pool.Request",
    "response": "operation"
   },
   "create-dbaas-pg-database": {
    "path": "/dbaas-postgres/{service-name}/database",
    "method": "POST",
+   "group": "dbaas",
    "request": "create-dbaas-pg-database.Request",
    "response": "operation"
   },
   "create-dbaas-pg-upgrade-check": {
    "path": "/dbaas-postgres/{service}/upgrade-check",
    "method": "POST",
+   "group": "dbaas",
    "request": "create-dbaas-pg-upgrade-check.Request",
    "response": "dbaas-task"
   },
   "create-dbaas-postgres-user": {
    "path": "/dbaas-postgres/{service-name}/user",
    "method": "POST",
+   "group": "dbaas",
    "request": "create-dbaas-postgres-user.Request",
    "response": "operation"
   },
   "create-dbaas-service-clickhouse": {
    "path": "/dbaas-clickhouse/{name}",
    "method": "POST",
+   "group": "dbaas",
    "request": "create-dbaas-service-clickhouse.Request",
    "response": "operation"
   },
   "create-dbaas-service-grafana": {
    "path": "/dbaas-grafana/{name}",
    "method": "POST",
+   "group": "dbaas",
    "request": "create-dbaas-service-grafana.Request",
    "response": "operation"
   },
   "create-dbaas-service-kafka": {
    "path": "/dbaas-kafka/{name}",
    "method": "POST",
+   "group": "dbaas",
    "request": "create-dbaas-service-kafka.Request",
    "response": "operation"
   },
   "create-dbaas-service-mysql": {
    "path": "/dbaas-mysql/{name}",
    "method": "POST",
+   "group": "dbaas",
    "request": "create-dbaas-service-mysql.Request",
    "response": "operation"
   },
   "create-dbaas-service-opensearch": {
    "path": "/dbaas-opensearch/{name}",
    "method": "POST",
+   "group": "dbaas",
    "request": "create-dbaas-service-opensearch.Request",
    "response": "operation"
   },
   "create-dbaas-service-pg": {
    "path": "/dbaas-postgres/{name}",
    "method": "POST",
+   "group": "dbaas",
    "request": "create-dbaas-service-pg.Request",
    "response": "operation"
   },
   "create-dbaas-service-thanos": {
    "path": "/dbaas-thanos/{name}",
    "method": "POST",
+   "group": "dbaas",
    "request": "create-dbaas-service-thanos.Request",
    "response": "operation"
   },
   "create-dbaas-service-valkey": {
    "path": "/dbaas-valkey/{name}",
    "method": "POST",
+   "group": "dbaas",
    "request": "create-dbaas-service-valkey.Request",
    "response": "operation"
   },
   "create-dbaas-task-migration-check": {
    "path": "/dbaas-task-migration-check/{service}",
    "method": "POST",
+   "group": "dbaas",
    "request": "create-dbaas-task-migration-check.Request",
    "response": "operation"
   },
   "create-dbaas-valkey-user": {
    "path": "/dbaas-valkey/{service-name}/user",
    "method": "POST",
+   "group": "dbaas",
    "request": "create-dbaas-valkey-user.Request",
    "response": "operation"
   },
   "create-deployment": {
    "path": "/ai/deployment",
    "method": "POST",
+   "group": "ai",
    "request": "create-deployment-request",
    "response": "operation"
   },
   "create-dns-domain": {
    "path": "/dns-domain",
    "method": "POST",
+   "group": "dns",
    "request": "create-dns-domain.Request",
    "response": "operation"
   },
   "create-dns-domain-record": {
    "path": "/dns-domain/{domain-id}/record",
    "method": "POST",
+   "group": "dns",
    "request": "create-dns-domain-record.Request",
    "response": "operation"
   },
   "create-elastic-ip": {
    "path": "/elastic-ip",
    "method": "POST",
+   "group": "compute",
    "request": "create-elastic-ip.Request",
    "response": "operation"
   },
   "create-iam-role": {
    "path": "/iam-role",
    "method": "POST",
+   "group": "iam",
    "request": "create-iam-role.Request",
    "response": "operation"
   },
   "create-instance": {
    "path": "/instance",
    "method": "POST",
+   "group": "compute",
    "request": "create-instance.Request",
    "response": "operation"
   },
   "create-instance-pool": {
    "path": "/instance-pool",
    "method": "POST",
+   "group": "compute",
    "request": "create-instance-pool.Request",
    "response": "operation"
   },
   "create-kms-key": {
    "path": "/kms-key",
    "method": "POST",
+   "group": "kms",
    "request": "create-kms-key-request",
    "response": "create-kms-key-response"
   },
   "create-load-balancer": {
    "path": "/load-balancer",
    "method": "POST",
+   "group": "compute",
    "request": "create-load-balancer.Request",
    "response": "operation"
   },
   "create-model": {
    "path": "/ai/model",
    "method": "POST",
+   "group": "ai",
    "request": "create-model-request",
    "response": "operation"
   },
   "create-private-network": {
    "path": "/private-network",
    "method": "POST",
+   "group": "compute",
    "request": "create-private-network.Request",
    "response": "operation"
   },
   "create-route": {
    "path": "/vpc/{vpc-id}/subnet/{subnet-id}/route",
    "method": "POST",
+   "group": "compute",
    "request": "create-route.Request",
    "response": "route"
   },
   "create-security-group": {
    "path": "/security-group",
    "method": "POST",
+   "group": "compute",
    "request": "create-security-group.Request",
    "response": "operation"
   },
   "create-sks-cluster": {
    "path": "/sks-cluster",
    "method": "POST",
+   "group": "sks",
    "request": "create-sks-cluster.Request",
    "response": "operation"
   },
   "create-sks-nodepool": {
    "path": "/sks-cluster/{id}/nodepool",
    "method": "POST",
+   "group": "sks",
    "request": "create-sks-nodepool.Request",
    "response": "operation"
   },
   "create-snapshot": {
    "path": "/instance/{id}:create-snapshot",
    "method": "POST",
+   "group": "compute",
    "response": "operation"
   },
   "create-subnet": {
    "path": "/vpc/{vpc-id}/subnet",
    "method": "POST",
+   "group": "compute",
    "request": "create-subnet.Request",
    "response": "operation"
   },
   "create-user": {
    "path": "/user",
    "method": "POST",
+   "group": "iam",
    "request": "create-user.Request",
    "response": "operation"
   },
   "create-vpc": {
    "path": "/vpc",
    "method": "POST",
+   "group": "compute",
    "request": "create-vpc.Request",
    "response": "operation"
   },
   "decrypt": {
    "path": "/kms-key/{id}/decrypt",
    "method": "POST",
+   "group": "kms",
    "request": "decrypt-request",
    "response": "decrypt-response"
   },
   "delete-ai-api-key": {
    "path": "/ai/api-key/{id}",
    "method": "DELETE",
+   "group": "ai",
    "response": "operation"
   },
   "delete-anti-affinity-group": {
    "path": "/anti-affinity-group/{id}",
    "method": "DELETE",
+   "group": "compute",
    "response": "operation"
   },
   "delete-api-key": {
    "path": "/api-key/{id}",
    "method": "DELETE",
+   "group": "iam",
    "response": "operation"
   },
   "delete-block-storage-snapshot": {
    "path": "/block-storage-snapshot/{id}",
    "method": "DELETE",
+   "group": "block-storage",
    "response": "operation"
   },
   "delete-block-storage-volume": {
    "path": "/block-storage/{id}",
    "method": "DELETE",
+   "group": "block-storage",
    "response": "operation"
   },
   "delete-dbaas-clickhouse-role": {
    "path": "/dbaas-clickhouse/{service-name}/role/{role-uuid}",
    "method": "DELETE",
+   "group": "dbaas",
    "response": "operation"
   },
   "delete-dbaas-clickhouse-user": {
    "path": "/dbaas-clickhouse/{service-name}/user/{user-uuid}",
    "method": "DELETE",
+   "group": "dbaas",
    "response": "operation"
   },
   "delete-dbaas-external-endpoint-datadog": {
    "path": "/dbaas-external-endpoint-datadog/{endpoint-id}",
    "method": "DELETE",
+   "group": "dbaas",
    "response": "operation"
   },
   "delete-dbaas-external-endpoint-elasticsearch": {
    "path": "/dbaas-external-endpoint-elasticsearch/{endpoint-id}",
    "method": "DELETE",
+   "group": "dbaas",
    "response": "operation"
   },
   "delete-dbaas-external-endpoint-opensearch": {
    "path": "/dbaas-external-endpoint-opensearch/{endpoint-id}",
    "method": "DELETE",
+   "group": "dbaas",
    "response": "operation"
   },
   "delete-dbaas-external-endpoint-prometheus": {
    "path": "/dbaas-external-endpoint-prometheus/{endpoint-id}",
    "method": "DELETE",
+   "group": "dbaas",
    "response": "operation"
   },
   "delete-dbaas-external-endpoint-rsyslog": {
    "path": "/dbaas-external-endpoint-rsyslog/{endpoint-id}",
    "method": "DELETE",
+   "group": "dbaas",
    "response": "operation"
   },
   "delete-dbaas-integration": {
    "path": "/dbaas-integration/{id}",
    "method": "DELETE",
+   "group": "dbaas",
    "response": "operation"
   },
   "delete-dbaas-kafka-schema-registry-acl-config": {
    "path": "/dbaas-kafka/{name}/schema-registry/acl-config/{acl-id}",
    "method": "DELETE",
+   "group": "dbaas",
    "response": "operation"
   },
   "delete-dbaas-kafka-topic-acl-config": {
    "path": "/dbaas-kafka/{name}/topic/acl-config/{acl-id}",
    "method": "DELETE",
+   "group": "dbaas",
    "response": "operation"
   },
   "delete-dbaas-kafka-user": {
    "path": "/dbaas-kafka/{service-name}/user/{username}",
    "method": "DELETE",
+   "group": "dbaas",
    "response": "operation"
   },
   "delete-dbaas-mysql-database": {
    "path": "/dbaas-mysql/{service-name}/database/{database-name}",
    "method": "DELETE",
+   "group": "dbaas",
    "response": "operation"
   },
   "delete-dbaas-mysql-user": {
    "path": "/dbaas-mysql/{service-name}/user/{username}",
    "method": "DELETE",
+   "group": "dbaas",
    "response": "operation"
   },
   "delete-dbaas-opensearch-user": {
    "path": "/dbaas-opensearch/{service-name}/user/{username}",
    "method": "DELETE",
+   "group": "dbaas",
    "response": "operation"
   },
   "delete-dbaas-pg-connection-pool": {
    "path": "/dbaas-postgres/{service-name}/connection-pool/{connection-pool-name}",
    "method": "DELETE",
+   "group": "dbaas",
    "response": "operation"
   },
   "delete-dbaas-pg-database": {
    "path": "/dbaas-postgres/{service-name}/database/{database-name}",
    "method": "DELETE",
+   "group": "dbaas",
    "response": "operation"
   },
   "delete-dbaas-postgres-user": {
    "path": "/dbaas-postgres/{service-name}/user/{username}",
    "method": "DELETE",
+   "group": "dbaas",
    "response": "operation"
   },
   "delete-dbaas-service": {
    "path": "/dbaas-service/{name}",
    "method": "DELETE",
+   "group": "dbaas",
    "response": "operation"
   },
   "delete-dbaas-service-clickhouse": {
    "path": "/dbaas-clickhouse/{name}",
    "method": "DELETE",
+   "group": "dbaas",
    "response": "operation"
   },
   "delete-dbaas-service-grafana": {
    "path": "/dbaas-grafana/{name}",
    "method": "DELETE",
+   "group": "dbaas",
    "response": "operation"
   },
   "delete-dbaas-service-kafka": {
    "path": "/dbaas-kafka/{name}",
    "method": "DELETE",
+   "group": "dbaas",
    "response": "operation"
   },
   "delete-dbaas-service-mysql": {
    "path": "/dbaas-mysql/{name}",
    "method": "DELETE",
+   "group": "dbaas",
    "response": "operation"
   },
   "delete-dbaas-service-opensearch": {
    "path": "/dbaas-opensearch/{name}",
    "method": "DELETE",
+   "group": "dbaas",
    "response": "operation"
   },
   "delete-dbaas-service-pg": {
    "path": "/dbaas-postgres/{name}",
    "method": "DELETE",
+   "group": "dbaas",
    "response": "operation"
   },
   "delete-dbaas-service-thanos": {
    "path": "/dbaas-thanos/{name}",
    "method": "DELETE",
+   "group": "dbaas",
    "response": "operation"
   },
   "delete-dbaas-service-valkey": {
    "path": "/dbaas-valkey/{name}",
    "method": "DELETE",
+   "group": "dbaas",
    "response": "operation"
   },
   "delete-dbaas-valkey-user": {
    "path": "/dbaas-valkey/{service-name}/user/{username}",
    "method": "DELETE",
+   "group": "dbaas",
    "response": "operation"
   },
   "delete-deployment": {
    "path": "/ai/deployment/{id}",
    "method": "DELETE",
+   "group": "ai",
    "response": "operation"
   },
   "delete-dns-domain": {
    "path": "/dns-domain/{id}",
    "method": "DELETE",
+   "group": "dns",
    "response": "operation"
   },
   "delete-dns-domain-record": {
    "path": "/dns-domain/{domain-id}/record/{record-id}",
    "method": "DELETE",
+   "group": "dns",
    "response": "operation"
   },
   "delete-elastic-ip": {
    "path": "/elastic-ip/{id}",
    "method": "DELETE",
+   "group": "compute",
    "response": "operation"
   },
   "delete-iam-role": {
    "path": "/iam-role/{id}",
    "method": "DELETE",
+   "group": "iam",
    "response": "operation"
   },
   "delete-instance": {
    "path": "/instance/{id}",
    "method": "DELETE",
+   "group": "compute",
    "response": "operation"
   },
   "delete-instance-pool": {
    "path": "/instance-pool/{id}",
    "method": "DELETE",
+   "group": "compute",
    "response": "operation"
   },
   "delete-load-balancer": {
    "path": "/load-balancer/{id}",
    "method": "DELETE",
+   "group": "compute",
    "response": "operation"
   },
   "delete-load-balancer-service": {
    "path": "/load-balancer/{id}/service/{service-id}",
    "method": "DELETE",
+   "group": "compute",
    "response": "operation"
   },
   "delete-model": {
    "path": "/ai/model/{id}",
    "method": "DELETE",
+   "group": "ai",
    "response": "operation"
   },
   "delete-private-network": {
    "path": "/private-network/{id}",
    "method": "DELETE",
+   "group": "compute",
    "response": "operation"
   },
   "delete-reverse-dns-elastic-ip": {
    "path": "/reverse-dns/elastic-ip/{id}",
    "method": "DELETE",
+   "group": "compute",
    "response": "operation"
   },
   "delete-reverse-dns-instance": {
    "path": "/reverse-dns/instance/{id}",
    "method": "DELETE",
+   "group": "compute",
    "response": "operation"
   },
   "delete-route": {
    "path": "/vpc/{vpc-id}/subnet/{subnet-id}/route/{id}",
    "method": "DELETE",
+   "group": "compute",
    "response": "empty"
   },
   "delete-rule-from-security-group": {
    "path": "/security-group/{id}/rules/{rule-id}",
    "method": "DELETE",
+   "group": "compute",
    "response": "operation"
   },
   "delete-security-group": {
    "path": "/security-group/{id}",
    "method": "DELETE",
+   "group": "compute",
    "response": "operation"
   },
   "delete-sks-cluster": {
    "path": "/sks-cluster/{id}",
    "method": "DELETE",
+   "group": "sks",
    "response": "operation"
   },
   "delete-sks-nodepool": {
    "path": "/sks-cluster/{id}/nodepool/{sks-nodepool-id}",
    "method": "DELETE",
+   "group": "sks",
    "response": "operation"
   },
   "delete-snapshot": {
    "path": "/snapshot/{id}",
    "method": "DELETE",
+   "group": "compute",
    "response": "operation"
   },
   "delete-ssh-key": {
    "path": "/ssh-key/{name}",
    "method": "DELETE",
+   "group": "compute",
    "response": "operation"
   },
   "delete-subnet": {
    "path": "/vpc/{vpc-id}/subnet/{id}",
    "method": "DELETE",
+   "group": "compute",
    "response": "empty"
   },
   "delete-template": {
    "path": "/template/{id}",
    "method": "DELETE",
+   "group": "compute",
    "response": "operation"
   },
   "delete-user": {
    "path": "/user/{id}",
    "method": "DELETE",
+   "group": "iam",
    "response": "operation"
   },
   "delete-vpc": {
    "path": "/vpc/{id}",
    "method": "DELETE",
+   "group": "compute",
    "response": "empty"
   },
   "detach-block-storage-volume": {
    "path": "/block-storage/{id}:detach",
    "method": "PUT",
+   "group": "block-storage",
    "response": "operation"
   },
   "detach-dbaas-service-from-endpoint": {
    "path": "/dbaas-external-endpoint/{source-service-name}/detach",
    "method": "PUT",
+   "group": "dbaas",
    "request": "detach-dbaas-service-from-endpoint.Request",
    "response": "operation"
   },
   "detach-instance-from-elastic-ip": {
    "path": "/elastic-ip/{id}:detach",
    "method": "PUT",
+   "group": "compute",
    "request": "detach-instance-from-elastic-ip.Request",
    "response": "operation"
   },
   "detach-instance-from-private-network": {
    "path": "/private-network/{id}:detach",
    "method": "PUT",
+   "group": "compute",
    "request": "detach-instance-from-private-network.Request",
    "response": "operation"
   },
   "detach-instance-from-security-group": {
    "path": "/security-group/{id}:detach",
    "method": "PUT",
+   "group": "compute",
    "request": "detach-instance-from-security-group.Request",
    "response": "operation"
   },
   "detach-instance-from-subnet": {
    "path": "/vpc/{vpc-id}/subnet/{subnet-id}/detach",
    "method": "PUT",
+   "group": "compute",
    "request": "detach-instance-from-subnet.Request",
    "response": "operation"
   },
   "disable-kms-key": {
    "path": "/kms-key/{id}/disable",
    "method": "POST",
+   "group": "kms",
    "response": "success-response"
   },
   "disable-kms-key-rotation": {
    "path": "/kms-key/{id}/disable-key-rotation",
    "method": "POST",
+   "group": "kms",
    "response": "disable-kms-key-rotation-response"
   },
   "enable-dbaas-mysql-writes": {
    "path": "/dbaas-mysql/{name}/enable/writes",
    "method": "PUT",
+   "group": "dbaas",
    "response": "operation"
   },
   "enable-kms-key": {
    "path": "/kms-key/{id}/enable",
    "method": "POST",
+   "group": "kms",
    "response": "success-response"
   },
   "enable-kms-key-rotation": {
    "path": "/kms-key/{id}/enable-key-rotation",
    "method": "POST",
+   "group": "kms",
    "request": "enable-kms-key-rotation-request",
    "response": "enable-kms-key-rotation-response"
   },
   "enable-tpm": {
    "path": "/instance/{id}:enable-tpm",
    "method": "POST",
+   "group": "compute",
    "response": "operation"
   },
   "encrypt": {
    "path": "/kms-key/{id}/encrypt",
    "method": "POST",
+   "group": "kms",
    "request": "encrypt-request",
    "response": "encrypt-response"
   },
   "evict-instance-pool-members": {
    "path": "/instance-pool/{id}:evict",
    "method": "PUT",
+   "group": "compute",
    "request": "evict-instance-pool-members.Request",
    "response": "operation"
   },
   "evict-sks-nodepool-members": {
    "path": "/sks-cluster/{id}/nodepool/{sks-nodepool-id}:evict",
    "method": "PUT",
+   "group": "sks",
    "request": "evict-sks-nodepool-members.Request",
    "response": "operation"
   },
   "export-snapshot": {
    "path": "/snapshot/{id}:export",
    "method": "POST",
+   "group": "compute",
    "response": "operation"
   },
   "generate-data-key": {
    "path": "/kms-key/{id}/generate-data-key",
    "method": "POST",
+   "group": "kms",
    "request": "generate-data-key-request",
    "response": "generate-data-key-response"
   },
   "generate-sks-cluster-kubeconfig": {
    "path": "/sks-cluster-kubeconfig/{id}",
    "method": "POST",
+   "group": "sks",
    "request": "sks-kubeconfig-request",
    "response": "generate-sks-cluster-kubeconfig.Response"
   },
   "generate-sks-karpenter-exoscale-nodeclass": {
    "path": "/sks-cluster/{id}/generate-karpenter-exoscale-nodeclass",
    "method": "PUT",
+   "group": "sks",
    "response": "generate-sks-karpenter-exoscale-nodeclass.Response"
   },
   "generate-sks-karpenter-nodepool": {
    "path": "/sks-cluster/{id}/generate-karpenter-nodepool",
    "method": "PUT",
+   "group": "sks",
    "response": "generate-sks-karpenter-nodepool.Response"
   },
   "get-active-nodepool-template": {
    "path": "/sks-template/{kube-version}/{variant}",
    "method": "GET",
+   "group": "sks",
    "response": "get-active-nodepool-template.Response"
   },
   "get-ai-api-key": {
    "path": "/ai/api-key/{id}",
    "method": "GET",
+   "group": "ai",
    "response": "get-ai-api-key-response"
   },
   "get-anti-affinity-group": {
    "path": "/anti-affinity-group/{id}",
    "method": "GET",
+   "group": "compute",
    "response": "anti-affinity-group"
   },
   "get-api-key": {
    "path": "/api-key/{id}",
    "method": "GET",
+   "group": "iam",
    "response": "iam-api-key"
   },
   "get-block-storage-snapshot": {
    "path": "/block-storage-snapshot/{id}",
    "method": "GET",
+   "group": "block-storage",
    "response": "block-storage-snapshot"
   },
   "get-block-storage-volume": {
    "path": "/block-storage/{id}",
    "method": "GET",
+   "group": "block-storage",
    "response": "block-storage-volume"
   },
   "get-console-proxy-url": {
    "path": "/console/{id}",
    "method": "GET",
+   "group": "compute",
    "response": "get-console-proxy-url.Response"
   },
   "get-dbaas-ca-certificate": {
    "path": "/dbaas-ca-certificate",
    "method": "GET",
+   "group": "dbaas",
    "response": "get-dbaas-ca-certificate.Response"
   },
   "get-dbaas-clickhouse-acl-config": {
    "path": "/dbaas-clickhouse/{service-name}/acl-config",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-clickhouse-acl-config"
   },
   "get-dbaas-external-endpoint-datadog": {
    "path": "/dbaas-external-endpoint-datadog/{endpoint-id}",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-external-endpoint-datadog-output"
   },
   "get-dbaas-external-endpoint-elasticsearch": {
    "path": "/dbaas-external-endpoint-elasticsearch/{endpoint-id}",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-endpoint-elasticsearch-output"
   },
   "get-dbaas-external-endpoint-opensearch": {
    "path": "/dbaas-external-endpoint-opensearch/{endpoint-id}",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-endpoint-opensearch-output"
   },
   "get-dbaas-external-endpoint-prometheus": {
    "path": "/dbaas-external-endpoint-prometheus/{endpoint-id}",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-endpoint-external-prometheus-output"
   },
   "get-dbaas-external-endpoint-rsyslog": {
    "path": "/dbaas-external-endpoint-rsyslog/{endpoint-id}",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-external-endpoint-rsyslog-output"
   },
   "get-dbaas-external-integration": {
    "path": "/dbaas-external-integration/{integration-id}",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-external-integration"
   },
   "get-dbaas-external-integration-settings-datadog": {
    "path": "/dbaas-external-integration-settings-datadog/{integration-id}",
    "method": "GET",
+   "group": "dbaas",
    "response": "get-dbaas-external-integration-settings-datadog.Response"
   },
   "get-dbaas-integration": {
    "path": "/dbaas-integration/{id}",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-integration"
   },
   "get-dbaas-kafka-acl-config": {
    "path": "/dbaas-kafka/{name}/acl-config",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-kafka-acls"
   },
   "get-dbaas-migration-status": {
    "path": "/dbaas-migration-status/{name}",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-migration-status"
   },
   "get-dbaas-opensearch-acl-config": {
    "path": "/dbaas-opensearch/{name}/acl-config",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-opensearch-acl-config"
   },
   "get-dbaas-service-clickhouse": {
    "path": "/dbaas-clickhouse/{name}",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-service-clickhouse"
   },
   "get-dbaas-service-grafana": {
    "path": "/dbaas-grafana/{name}",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-service-grafana"
   },
   "get-dbaas-service-kafka": {
    "path": "/dbaas-kafka/{name}",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-service-kafka"
   },
   "get-dbaas-service-logs": {
    "path": "/dbaas-service-logs/{service-name}",
    "method": "POST",
+   "group": "dbaas",
    "request": "get-dbaas-service-logs.Request",
    "response": "dbaas-service-logs"
   },
   "get-dbaas-service-metrics": {
    "path": "/dbaas-service-metrics/{service-name}",
    "method": "POST",
+   "group": "dbaas",
    "request": "get-dbaas-service-metrics.Request",
    "response": "get-dbaas-service-metrics.Response"
   },
   "get-dbaas-service-mysql": {
    "path": "/dbaas-mysql/{name}",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-service-mysql"
   },
   "get-dbaas-service-opensearch": {
    "path": "/dbaas-opensearch/{name}",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-service-opensearch"
   },
   "get-dbaas-service-pg": {
    "path": "/dbaas-postgres/{name}",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-service-pg"
   },
   "get-dbaas-service-thanos": {
    "path": "/dbaas-thanos/{name}",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-service-thanos"
   },
   "get-dbaas-service-type": {
    "path": "/dbaas-service-type/{service-type-name}",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-service-type"
   },
   "get-dbaas-service-valkey": {
    "path": "/dbaas-valkey/{name}",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-service-valkey"
   },
   "get-dbaas-settings-clickhouse": {
    "path": "/dbaas-settings-clickhouse",
    "method": "GET",
+   "group": "dbaas",
    "response": "get-dbaas-settings-clickhouse.Response"
   },
   "get-dbaas-settings-grafana": {
    "path": "/dbaas-settings-grafana",
    "method": "GET",
+   "group": "dbaas",
    "response": "get-dbaas-settings-grafana.Response"
   },
   "get-dbaas-settings-kafka": {
    "path": "/dbaas-settings-kafka",
    "method": "GET",
+   "group": "dbaas",
    "response": "get-dbaas-settings-kafka.Response"
   },
   "get-dbaas-settings-mysql": {
    "path": "/dbaas-settings-mysql",
    "method": "GET",
+   "group": "dbaas",
    "response": "get-dbaas-settings-mysql.Response"
   },
   "get-dbaas-settings-opensearch": {
    "path": "/dbaas-settings-opensearch",
    "method": "GET",
+   "group": "dbaas",
    "response": "get-dbaas-settings-opensearch.Response"
   },
   "get-dbaas-settings-pg": {
    "path": "/dbaas-settings-pg",
    "method": "GET",
+   "group": "dbaas",
    "response": "get-dbaas-settings-pg.Response"
   },
   "get-dbaas-settings-thanos": {
    "path": "/dbaas-settings-thanos",
    "method": "GET",
+   "group": "dbaas",
    "response": "get-dbaas-settings-thanos.Response"
   },
   "get-dbaas-settings-valkey": {
    "path": "/dbaas-settings-valkey",
    "method": "GET",
+   "group": "dbaas",
    "response": "get-dbaas-settings-valkey.Response"
   },
   "get-dbaas-task": {
    "path": "/dbaas-task/{service}/{id}",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-task"
   },
   "get-deploy-target": {
    "path": "/deploy-target/{id}",
    "method": "GET",
+   "group": "compute",
    "response": "deploy-target"
   },
   "get-deployment": {
    "path": "/ai/deployment/{id}",
    "method": "GET",
+   "group": "ai",
    "response": "get-deployment-response"
   },
   "get-deployment-logs": {
    "path": "/ai/deployment/{id}/logs",
    "method": "GET",
+   "group": "ai",
    "response": "get-deployment-logs-response"
   },
   "get-dns-domain": {
    "path": "/dns-domain/{id}",
    "method": "GET",
+   "group": "dns",
    "response": "dns-domain"
   },
   "get-dns-domain-record": {
    "path": "/dns-domain/{domain-id}/record/{record-id}",
    "method": "GET",
+   "group": "dns",
    "response": "dns-domain-record"
   },
   "get-dns-domain-zone-file": {
    "path": "/dns-domain/{id}/zone",
    "method": "GET",
+   "group": "dns",
    "response": "get-dns-domain-zone-file.Response"
   },
   "get-elastic-ip": {
    "path": "/elastic-ip/{id}",
    "method": "GET",
+   "group": "compute",
    "response": "elastic-ip"
   },
   "get-env-impact": {
    "path": "/env-impact/{period}",
    "method": "GET",
+   "group": "organization",
    "response": "env-impact-report"
   },
   "get-iam-organization-policy": {
    "path": "/iam-organization-policy",
    "method": "GET",
+   "group": "iam",
    "response": "iam-policy"
   },
   "get-iam-role": {
    "path": "/iam-role/{id}",
    "method": "GET",
+   "group": "iam",
    "response": "iam-role"
   },
   "get-impact-estimate": {
@@ -1049,969 +1240,1150 @@
   "get-inference-engine-help": {
    "path": "/ai/help/inference-engine-parameters",
    "method": "GET",
+   "group": "ai",
    "response": "get-inference-engine-help-response"
   },
   "get-instance": {
    "path": "/instance/{id}",
    "method": "GET",
+   "group": "compute",
    "response": "instance"
   },
   "get-instance-pool": {
    "path": "/instance-pool/{id}",
    "method": "GET",
+   "group": "compute",
    "response": "instance-pool"
   },
   "get-instance-type": {
    "path": "/instance-type/{id}",
    "method": "GET",
+   "group": "compute",
    "response": "instance-type"
   },
   "get-kms-key": {
    "path": "/kms-key/{id}",
    "method": "GET",
+   "group": "kms",
    "response": "get-kms-key-response"
   },
   "get-live-balance": {
    "path": "/live-balance",
    "method": "GET",
+   "group": "organization",
    "response": "live-balance"
   },
   "get-load-balancer": {
    "path": "/load-balancer/{id}",
    "method": "GET",
+   "group": "compute",
    "response": "load-balancer"
   },
   "get-load-balancer-service": {
    "path": "/load-balancer/{id}/service/{service-id}",
    "method": "GET",
+   "group": "compute",
    "response": "load-balancer-service"
   },
   "get-model": {
    "path": "/ai/model/{id}",
    "method": "GET",
+   "group": "ai",
    "response": "get-model-response"
   },
   "get-operation": {
    "path": "/operation/{id}",
    "method": "GET",
+   "group": "general",
    "response": "operation"
   },
   "get-organization": {
    "path": "/organization",
    "method": "GET",
+   "group": "organization",
    "response": "organization"
   },
   "get-private-network": {
    "path": "/private-network/{id}",
    "method": "GET",
+   "group": "compute",
    "response": "private-network"
   },
   "get-quota": {
    "path": "/quota/{entity}",
    "method": "GET",
+   "group": "quotas",
    "response": "quota"
   },
   "get-reverse-dns-elastic-ip": {
    "path": "/reverse-dns/elastic-ip/{id}",
    "method": "GET",
+   "group": "compute",
    "response": "reverse-dns-record"
   },
   "get-reverse-dns-instance": {
    "path": "/reverse-dns/instance/{id}",
    "method": "GET",
+   "group": "compute",
    "response": "reverse-dns-record"
   },
   "get-security-group": {
    "path": "/security-group/{id}",
    "method": "GET",
+   "group": "compute",
    "response": "security-group"
   },
   "get-sks-cluster": {
    "path": "/sks-cluster/{id}",
    "method": "GET",
+   "group": "sks",
    "response": "sks-cluster"
   },
   "get-sks-cluster-authority-cert": {
    "path": "/sks-cluster/{id}/authority/{authority}/cert",
    "method": "GET",
+   "group": "sks",
    "response": "get-sks-cluster-authority-cert.Response"
   },
   "get-sks-cluster-inspection": {
    "path": "/sks-cluster/{id}/inspection",
-   "method": "GET"
+   "method": "GET",
+   "group": "sks"
   },
   "get-sks-nodepool": {
    "path": "/sks-cluster/{id}/nodepool/{sks-nodepool-id}",
    "method": "GET",
+   "group": "sks",
    "response": "sks-nodepool"
   },
   "get-snapshot": {
    "path": "/snapshot/{id}",
    "method": "GET",
+   "group": "compute",
    "response": "snapshot"
   },
   "get-sos-presigned-url": {
    "path": "/sos/{bucket}/presigned-url",
    "method": "GET",
+   "group": "sos",
    "response": "get-sos-presigned-url.Response"
   },
   "get-ssh-key": {
    "path": "/ssh-key/{name}",
    "method": "GET",
+   "group": "compute",
    "response": "ssh-key"
   },
   "get-subnet": {
    "path": "/vpc/{vpc-id}/subnet/{id}",
    "method": "GET",
+   "group": "compute",
    "response": "subnet"
   },
   "get-template": {
    "path": "/template/{id}",
    "method": "GET",
+   "group": "compute",
    "response": "template"
   },
   "get-usage-report": {
    "path": "/usage-report",
    "method": "GET",
+   "group": "organization",
    "response": "get-usage-report.Response"
   },
   "get-user-org-consumption-quota": {
    "path": "/ai/quota",
    "method": "GET",
+   "group": "ai",
    "response": "org-consumption-quota-response"
   },
   "get-vpc": {
    "path": "/vpc/{id}",
    "method": "GET",
+   "group": "compute",
    "response": "vpc"
   },
   "list-ai-api-keys": {
    "path": "/ai/api-key",
    "method": "GET",
+   "group": "ai",
    "response": "list-ai-api-keys-response"
   },
   "list-ai-instance-types": {
    "path": "/ai/instance-type",
    "method": "GET",
+   "group": "ai",
    "response": "list-ai-instance-types-response"
   },
   "list-anti-affinity-groups": {
    "path": "/anti-affinity-group",
    "method": "GET",
+   "group": "compute",
    "response": "list-anti-affinity-groups.Response"
   },
   "list-api-keys": {
    "path": "/api-key",
    "method": "GET",
+   "group": "iam",
    "response": "list-api-keys.Response"
   },
   "list-block-storage-snapshots": {
    "path": "/block-storage-snapshot",
    "method": "GET",
+   "group": "block-storage",
    "response": "list-block-storage-snapshots.Response"
   },
   "list-block-storage-volumes": {
    "path": "/block-storage",
    "method": "GET",
+   "group": "block-storage",
    "response": "list-block-storage-volumes.Response"
   },
   "list-dbaas-clickhouse-roles": {
    "path": "/dbaas-clickhouse/{service-name}/role",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-clickhouse-roles"
   },
   "list-dbaas-clickhouse-users": {
    "path": "/dbaas-clickhouse/{service-name}/user",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-clickhouse-users"
   },
   "list-dbaas-external-endpoint-types": {
    "path": "/dbaas-external-endpoint-types",
    "method": "GET",
+   "group": "dbaas",
    "response": "list-dbaas-external-endpoint-types.Response"
   },
   "list-dbaas-external-endpoints": {
    "path": "/dbaas-external-endpoints",
    "method": "GET",
+   "group": "dbaas",
    "response": "list-dbaas-external-endpoints.Response"
   },
   "list-dbaas-external-integrations": {
    "path": "/dbaas-external-integrations/{service-name}",
    "method": "GET",
+   "group": "dbaas",
    "response": "list-dbaas-external-integrations.Response"
   },
   "list-dbaas-integration-settings": {
    "path": "/dbaas-integration-settings/{integration-type}/{source-type}/{dest-type}",
    "method": "GET",
+   "group": "dbaas",
    "response": "list-dbaas-integration-settings.Response"
   },
   "list-dbaas-integration-types": {
    "path": "/dbaas-integration-types",
    "method": "GET",
+   "group": "dbaas",
    "response": "list-dbaas-integration-types.Response"
   },
   "list-dbaas-service-types": {
    "path": "/dbaas-service-type",
    "method": "GET",
+   "group": "dbaas",
    "response": "list-dbaas-service-types.Response"
   },
   "list-dbaas-services": {
    "path": "/dbaas-service",
    "method": "GET",
+   "group": "dbaas",
    "response": "list-dbaas-services.Response"
   },
   "list-dbaas-valkey-users": {
    "path": "/dbaas-valkey/{service-name}/user",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-valkey-users"
   },
   "list-deploy-targets": {
    "path": "/deploy-target",
    "method": "GET",
+   "group": "compute",
    "response": "list-deploy-targets.Response"
   },
   "list-deployments": {
    "path": "/ai/deployment",
    "method": "GET",
+   "group": "ai",
    "response": "list-deployments-response"
   },
   "list-dns-domain-records": {
    "path": "/dns-domain/{domain-id}/record",
    "method": "GET",
+   "group": "dns",
    "response": "list-dns-domain-records.Response"
   },
   "list-dns-domains": {
    "path": "/dns-domain",
    "method": "GET",
+   "group": "dns",
    "response": "list-dns-domains.Response"
   },
   "list-elastic-ips": {
    "path": "/elastic-ip",
    "method": "GET",
+   "group": "compute",
    "response": "list-elastic-ips.Response"
   },
   "list-events": {
    "path": "/event",
-   "method": "GET"
+   "method": "GET",
+   "group": "audit-trail"
   },
   "list-iam-roles": {
    "path": "/iam-role",
    "method": "GET",
+   "group": "iam",
    "response": "list-iam-roles.Response"
   },
   "list-instance-pools": {
    "path": "/instance-pool",
    "method": "GET",
+   "group": "compute",
    "response": "list-instance-pools.Response"
   },
   "list-instance-types": {
    "path": "/instance-type",
    "method": "GET",
+   "group": "compute",
    "response": "list-instance-types.Response"
   },
   "list-instances": {
    "path": "/instance",
    "method": "GET",
+   "group": "compute",
    "response": "list-instances.Response"
   },
   "list-kms-key-rotations": {
    "path": "/kms-key/{id}/list-key-rotations",
    "method": "GET",
+   "group": "kms",
    "response": "list-kms-key-rotations-response"
   },
   "list-kms-keys": {
    "path": "/kms-key",
    "method": "GET",
+   "group": "kms",
    "response": "list-kms-keys-response"
   },
   "list-load-balancers": {
    "path": "/load-balancer",
    "method": "GET",
+   "group": "compute",
    "response": "list-load-balancers.Response"
   },
   "list-models": {
    "path": "/ai/model",
    "method": "GET",
+   "group": "ai",
    "response": "list-models-response"
   },
   "list-private-networks": {
    "path": "/private-network",
    "method": "GET",
+   "group": "compute",
    "response": "list-private-networks.Response"
   },
   "list-quotas": {
    "path": "/quota",
    "method": "GET",
+   "group": "quotas",
    "response": "list-quotas.Response"
   },
   "list-routes": {
    "path": "/vpc/{vpc-id}/subnet/{subnet-id}/route",
    "method": "GET",
+   "group": "compute",
    "response": "list-routes.Response"
   },
   "list-security-groups": {
    "path": "/security-group",
    "method": "GET",
+   "group": "compute",
    "response": "list-security-groups.Response"
   },
   "list-sks-cluster-deprecated-resources": {
    "path": "/sks-cluster-deprecated-resources/{id}",
-   "method": "GET"
+   "method": "GET",
+   "group": "sks"
   },
   "list-sks-cluster-versions": {
    "path": "/sks-cluster-version",
    "method": "GET",
+   "group": "sks",
    "response": "list-sks-cluster-versions.Response"
   },
   "list-sks-clusters": {
    "path": "/sks-cluster",
    "method": "GET",
+   "group": "sks",
    "response": "list-sks-clusters.Response"
   },
   "list-snapshots": {
    "path": "/snapshot",
    "method": "GET",
+   "group": "compute",
    "response": "list-snapshots.Response"
   },
   "list-sos-buckets-usage": {
    "path": "/sos-buckets-usage",
    "method": "GET",
+   "group": "sos",
    "response": "list-sos-buckets-usage.Response"
   },
   "list-ssh-keys": {
    "path": "/ssh-key",
    "method": "GET",
+   "group": "compute",
    "response": "list-ssh-keys.Response"
   },
   "list-subnets": {
    "path": "/vpc/{vpc-id}/subnet",
    "method": "GET",
+   "group": "compute",
    "response": "list-subnets.Response"
   },
   "list-templates": {
    "path": "/template",
    "method": "GET",
+   "group": "compute",
    "response": "list-templates.Response"
   },
   "list-users": {
    "path": "/user",
    "method": "GET",
+   "group": "iam",
    "response": "list-users.Response"
   },
   "list-vpc-routes": {
    "path": "/vpc/{vpc-id}/route",
    "method": "GET",
+   "group": "compute",
    "response": "list-vpc-routes.Response"
   },
   "list-vpcs": {
    "path": "/vpc",
    "method": "GET",
+   "group": "compute",
    "response": "list-vpcs.Response"
   },
   "list-zones": {
    "path": "/zone",
    "method": "GET",
+   "group": "general",
    "response": "list-zones.Response"
   },
   "promote-snapshot-to-template": {
    "path": "/snapshot/{id}:promote",
    "method": "POST",
+   "group": "compute",
    "request": "promote-snapshot-to-template.Request",
    "response": "operation"
   },
   "re-encrypt": {
    "path": "/kms-key/{id}/re-encrypt",
    "method": "POST",
+   "group": "kms",
    "request": "re-encrypt-request",
    "response": "re-encrypt-response"
   },
   "reboot-instance": {
    "path": "/instance/{id}:reboot",
    "method": "PUT",
+   "group": "compute",
    "response": "operation"
   },
   "register-ssh-key": {
    "path": "/ssh-key",
    "method": "POST",
+   "group": "compute",
    "request": "register-ssh-key.Request",
    "response": "operation"
   },
   "register-template": {
    "path": "/template",
    "method": "POST",
+   "group": "compute",
    "request": "register-template.Request",
    "response": "operation"
   },
   "remove-external-source-from-security-group": {
    "path": "/security-group/{id}:remove-source",
    "method": "PUT",
+   "group": "compute",
    "request": "remove-external-source-from-security-group.Request",
    "response": "operation"
   },
   "remove-instance-protection": {
    "path": "/instance/{id}:remove-protection",
    "method": "PUT",
+   "group": "compute",
    "response": "operation"
   },
   "replicate-kms-key": {
    "path": "/kms-key/{id}/replicate",
    "method": "POST",
+   "group": "kms",
    "request": "replicate-kms-key-request",
    "response": "success-response"
   },
   "reset-dbaas-clickhouse-user-password": {
    "path": "/dbaas-clickhouse/{service-name}/user/{username}/password/reset",
    "method": "PUT",
+   "group": "dbaas",
    "request": "reset-dbaas-clickhouse-user-password.Request",
    "response": "dbaas-user-clickhouse-secrets"
   },
   "reset-dbaas-grafana-user-password": {
    "path": "/dbaas-grafana/{service-name}/user/{username}/password/reset",
    "method": "PUT",
+   "group": "dbaas",
    "request": "reset-dbaas-grafana-user-password.Request",
    "response": "operation"
   },
   "reset-dbaas-kafka-user-password": {
    "path": "/dbaas-kafka/{service-name}/user/{username}/password/reset",
    "method": "PUT",
+   "group": "dbaas",
    "request": "reset-dbaas-kafka-user-password.Request",
    "response": "operation"
   },
   "reset-dbaas-mysql-user-password": {
    "path": "/dbaas-mysql/{service-name}/user/{username}/password/reset",
    "method": "PUT",
+   "group": "dbaas",
    "request": "reset-dbaas-mysql-user-password.Request",
    "response": "operation"
   },
   "reset-dbaas-opensearch-user-password": {
    "path": "/dbaas-opensearch/{service-name}/user/{username}/password/reset",
    "method": "PUT",
+   "group": "dbaas",
    "request": "reset-dbaas-opensearch-user-password.Request",
    "response": "operation"
   },
   "reset-dbaas-postgres-user-password": {
    "path": "/dbaas-postgres/{service-name}/user/{username}/password/reset",
    "method": "PUT",
+   "group": "dbaas",
    "request": "reset-dbaas-postgres-user-password.Request",
    "response": "operation"
   },
   "reset-dbaas-valkey-user-password": {
    "path": "/dbaas-valkey/{service-name}/user/{username}/password/reset",
    "method": "PUT",
+   "group": "dbaas",
    "request": "reset-dbaas-valkey-user-password.Request",
    "response": "operation"
   },
   "reset-elastic-ip-field": {
    "path": "/elastic-ip/{id}/{field}",
    "method": "DELETE",
+   "group": "compute",
    "response": "operation"
   },
   "reset-iam-organization-policy": {
    "path": "/iam-organization-policy:reset",
    "method": "POST",
+   "group": "iam",
    "response": "operation"
   },
   "reset-instance": {
    "path": "/instance/{id}:reset",
    "method": "PUT",
+   "group": "compute",
    "request": "reset-instance.Request",
    "response": "operation"
   },
   "reset-instance-field": {
    "path": "/instance/{id}/{field}",
    "method": "DELETE",
+   "group": "compute",
    "response": "operation"
   },
   "reset-instance-password": {
    "path": "/instance/{id}:reset-password",
    "method": "PUT",
+   "group": "compute",
    "response": "operation"
   },
   "reset-instance-pool-field": {
    "path": "/instance-pool/{id}/{field}",
    "method": "DELETE",
+   "group": "compute",
    "response": "operation"
   },
   "reset-load-balancer-field": {
    "path": "/load-balancer/{id}/{field}",
    "method": "DELETE",
+   "group": "compute",
    "response": "operation"
   },
   "reset-load-balancer-service-field": {
    "path": "/load-balancer/{id}/service/{service-id}/{field}",
    "method": "DELETE",
+   "group": "compute",
    "response": "operation"
   },
   "reset-private-network-field": {
    "path": "/private-network/{id}/{field}",
    "method": "DELETE",
+   "group": "compute",
    "response": "operation"
   },
   "resize-block-storage-volume": {
    "path": "/block-storage/{id}:resize-volume",
    "method": "PUT",
+   "group": "block-storage",
    "request": "resize-block-storage-volume.Request",
    "response": "block-storage-volume"
   },
   "resize-instance-disk": {
    "path": "/instance/{id}:resize-disk",
    "method": "PUT",
+   "group": "compute",
    "request": "resize-instance-disk.Request",
    "response": "operation"
   },
   "reveal-ai-api-key": {
    "path": "/ai/api-key/{id}/reveal",
    "method": "GET",
+   "group": "ai",
    "response": "reveal-ai-api-key-response"
   },
   "reveal-dbaas-clickhouse-user-password": {
    "path": "/dbaas-clickhouse/{service-name}/user/{username}/password/reveal",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-user-clickhouse-secrets"
   },
   "reveal-dbaas-grafana-user-password": {
    "path": "/dbaas-grafana/{service-name}/user/{username}/password/reveal",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-user-grafana-secrets"
   },
   "reveal-dbaas-kafka-connect-password": {
    "path": "/dbaas-kafka/{service-name}/connect/password/reveal",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-user-kafka-connect-secrets"
   },
   "reveal-dbaas-kafka-user-password": {
    "path": "/dbaas-kafka/{service-name}/user/{username}/password/reveal",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-user-kafka-secrets"
   },
   "reveal-dbaas-mysql-user-password": {
    "path": "/dbaas-mysql/{service-name}/user/{username}/password/reveal",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-user-mysql-secrets"
   },
   "reveal-dbaas-opensearch-user-password": {
    "path": "/dbaas-opensearch/{service-name}/user/{username}/password/reveal",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-user-opensearch-secrets"
   },
   "reveal-dbaas-postgres-user-password": {
    "path": "/dbaas-postgres/{service-name}/user/{username}/password/reveal",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-user-postgres-secrets"
   },
   "reveal-dbaas-thanos-user-password": {
    "path": "/dbaas-thanos/{service-name}/user/{username}/password/reveal",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-user-thanos-secrets"
   },
   "reveal-dbaas-valkey-user-password": {
    "path": "/dbaas-valkey/{service-name}/user/{username}/password/reveal",
    "method": "GET",
+   "group": "dbaas",
    "response": "dbaas-user-valkey-secrets"
   },
   "reveal-deployment-api-key": {
    "path": "/ai/deployment/{id}/api-key",
    "method": "GET",
+   "group": "ai",
    "response": "reveal-deployment-api-key-response"
   },
   "reveal-instance-password": {
    "path": "/instance/{id}:password",
    "method": "GET",
+   "group": "compute",
    "response": "instance-password"
   },
   "revert-instance-to-snapshot": {
    "path": "/instance/{instance-id}:revert-snapshot",
    "method": "POST",
+   "group": "compute",
    "request": "revert-instance-to-snapshot.Request",
    "response": "operation"
   },
   "rotate-ai-api-key": {
    "path": "/ai/api-key/{id}/rotate",
    "method": "POST",
+   "group": "ai",
    "response": "rotate-ai-api-key-response"
   },
   "rotate-kms-key": {
    "path": "/kms-key/{id}/rotate",
    "method": "POST",
+   "group": "kms",
    "response": "rotate-kms-key-response"
   },
   "rotate-sks-ccm-credentials": {
    "path": "/sks-cluster/{id}/rotate-ccm-credentials",
    "method": "PUT",
+   "group": "sks",
    "response": "operation"
   },
   "rotate-sks-csi-credentials": {
    "path": "/sks-cluster/{id}/rotate-csi-credentials",
    "method": "PUT",
+   "group": "sks",
    "response": "operation"
   },
   "rotate-sks-karpenter-credentials": {
    "path": "/sks-cluster/{id}/rotate-karpenter-credentials",
    "method": "PUT",
+   "group": "sks",
    "response": "operation"
   },
   "rotate-sks-operators-ca": {
    "path": "/sks-cluster/{id}/rotate-operators-ca",
    "method": "PUT",
+   "group": "sks",
    "response": "operation"
   },
   "scale-deployment": {
    "path": "/ai/deployment/{id}/scale",
    "method": "POST",
+   "group": "ai",
    "request": "scale-deployment-request",
    "response": "operation"
   },
   "scale-instance": {
    "path": "/instance/{id}:scale",
    "method": "PUT",
+   "group": "compute",
    "request": "scale-instance.Request",
    "response": "operation"
   },
   "scale-instance-pool": {
    "path": "/instance-pool/{id}:scale",
    "method": "PUT",
+   "group": "compute",
    "request": "scale-instance-pool.Request",
    "response": "operation"
   },
   "scale-sks-nodepool": {
    "path": "/sks-cluster/{id}/nodepool/{sks-nodepool-id}:scale",
    "method": "PUT",
+   "group": "sks",
    "request": "scale-sks-nodepool.Request",
    "response": "operation"
   },
   "schedule-kms-key-deletion": {
    "path": "/kms-key/{id}/schedule-deletion",
    "method": "POST",
+   "group": "kms",
    "request": "schedule-kms-key-deletion-request",
    "response": "schedule-kms-key-deletion-response"
   },
   "start-dbaas-clickhouse-maintenance": {
    "path": "/dbaas-clickhouse/{name}/maintenance/start",
    "method": "PUT",
+   "group": "dbaas",
    "response": "operation"
   },
   "start-dbaas-grafana-maintenance": {
    "path": "/dbaas-grafana/{name}/maintenance/start",
    "method": "PUT",
+   "group": "dbaas",
    "response": "operation"
   },
   "start-dbaas-kafka-maintenance": {
    "path": "/dbaas-kafka/{name}/maintenance/start",
    "method": "PUT",
+   "group": "dbaas",
    "response": "operation"
   },
   "start-dbaas-mysql-maintenance": {
    "path": "/dbaas-mysql/{name}/maintenance/start",
    "method": "PUT",
+   "group": "dbaas",
    "response": "operation"
   },
   "start-dbaas-opensearch-maintenance": {
    "path": "/dbaas-opensearch/{name}/maintenance/start",
    "method": "PUT",
+   "group": "dbaas",
    "response": "operation"
   },
   "start-dbaas-pg-maintenance": {
    "path": "/dbaas-postgres/{name}/maintenance/start",
    "method": "PUT",
+   "group": "dbaas",
    "response": "operation"
   },
   "start-dbaas-thanos-maintenance": {
    "path": "/dbaas-thanos/{name}/maintenance/start",
    "method": "PUT",
+   "group": "dbaas",
    "response": "operation"
   },
   "start-dbaas-valkey-maintenance": {
    "path": "/dbaas-valkey/{name}/maintenance/start",
    "method": "PUT",
+   "group": "dbaas",
    "response": "operation"
   },
   "start-instance": {
    "path": "/instance/{id}:start",
    "method": "PUT",
+   "group": "compute",
    "request": "start-instance.Request",
    "response": "operation"
   },
   "stop-dbaas-mysql-migration": {
    "path": "/dbaas-mysql/{name}/migration/stop",
    "method": "POST",
+   "group": "dbaas",
    "response": "operation"
   },
   "stop-dbaas-pg-migration": {
    "path": "/dbaas-postgres/{name}/migration/stop",
    "method": "POST",
+   "group": "dbaas",
    "response": "operation"
   },
   "stop-dbaas-valkey-migration": {
    "path": "/dbaas-valkey/{name}/migration/stop",
    "method": "POST",
+   "group": "dbaas",
    "response": "operation"
   },
   "stop-instance": {
    "path": "/instance/{id}:stop",
    "method": "PUT",
+   "group": "compute",
    "response": "operation"
   },
   "update-ai-api-key": {
    "path": "/ai/api-key/{id}",
    "method": "PATCH",
+   "group": "ai",
    "request": "update-ai-api-key-request",
    "response": "update-ai-api-key-response"
   },
   "update-block-storage-snapshot": {
    "path": "/block-storage-snapshot/{id}",
    "method": "PUT",
+   "group": "block-storage",
    "request": "update-block-storage-snapshot.Request",
    "response": "operation"
   },
   "update-block-storage-volume": {
    "path": "/block-storage/{id}",
    "method": "PUT",
+   "group": "block-storage",
    "request": "update-block-storage-volume.Request",
    "response": "operation"
   },
   "update-dbaas-external-endpoint-datadog": {
    "path": "/dbaas-external-endpoint-datadog/{endpoint-id}",
    "method": "PUT",
+   "group": "dbaas",
    "request": "dbaas-endpoint-datadog-input-update",
    "response": "operation"
   },
   "update-dbaas-external-endpoint-elasticsearch": {
    "path": "/dbaas-external-endpoint-elasticsearch/{endpoint-id}",
    "method": "PUT",
+   "group": "dbaas",
    "request": "dbaas-endpoint-elasticsearch-input-update",
    "response": "operation"
   },
   "update-dbaas-external-endpoint-opensearch": {
    "path": "/dbaas-external-endpoint-opensearch/{endpoint-id}",
    "method": "PUT",
+   "group": "dbaas",
    "request": "dbaas-endpoint-opensearch-input-update",
    "response": "operation"
   },
   "update-dbaas-external-endpoint-prometheus": {
    "path": "/dbaas-external-endpoint-prometheus/{endpoint-id}",
    "method": "PUT",
+   "group": "dbaas",
    "request": "dbaas-endpoint-prometheus-payload",
    "response": "operation"
   },
   "update-dbaas-external-endpoint-rsyslog": {
    "path": "/dbaas-external-endpoint-rsyslog/{endpoint-id}",
    "method": "PUT",
+   "group": "dbaas",
    "request": "dbaas-endpoint-rsyslog-input-update",
    "response": "operation"
   },
   "update-dbaas-external-integration-settings-datadog": {
    "path": "/dbaas-external-integration-settings-datadog/{integration-id}",
    "method": "POST",
+   "group": "dbaas",
    "request": "update-dbaas-external-integration-settings-datadog.Request",
    "response": "operation"
   },
   "update-dbaas-integration": {
    "path": "/dbaas-integration/{id}",
    "method": "PUT",
+   "group": "dbaas",
    "request": "update-dbaas-integration.Request",
    "response": "operation"
   },
   "update-dbaas-opensearch-acl-config": {
    "path": "/dbaas-opensearch/{name}/acl-config",
    "method": "PUT",
+   "group": "dbaas",
    "request": "dbaas-opensearch-acl-config",
    "response": "operation"
   },
   "update-dbaas-pg-connection-pool": {
    "path": "/dbaas-postgres/{service-name}/connection-pool/{connection-pool-name}",
    "method": "PUT",
+   "group": "dbaas",
    "request": "update-dbaas-pg-connection-pool.Request",
    "response": "operation"
   },
   "update-dbaas-postgres-allow-replication": {
    "path": "/dbaas-postgres/{service-name}/user/{username}/allow-replication",
    "method": "PUT",
+   "group": "dbaas",
    "request": "update-dbaas-postgres-allow-replication.Request",
    "response": "dbaas-postgres-users"
   },
   "update-dbaas-service-clickhouse": {
    "path": "/dbaas-clickhouse/{name}",
    "method": "PUT",
+   "group": "dbaas",
    "request": "update-dbaas-service-clickhouse.Request",
    "response": "operation"
   },
   "update-dbaas-service-grafana": {
    "path": "/dbaas-grafana/{name}",
    "method": "PUT",
+   "group": "dbaas",
    "request": "update-dbaas-service-grafana.Request",
    "response": "operation"
   },
   "update-dbaas-service-kafka": {
    "path": "/dbaas-kafka/{name}",
    "method": "PUT",
+   "group": "dbaas",
    "request": "update-dbaas-service-kafka.Request",
    "response": "operation"
   },
   "update-dbaas-service-mysql": {
    "path": "/dbaas-mysql/{name}",
    "method": "PUT",
+   "group": "dbaas",
    "request": "update-dbaas-service-mysql.Request",
    "response": "operation"
   },
   "update-dbaas-service-opensearch": {
    "path": "/dbaas-opensearch/{name}",
    "method": "PUT",
+   "group": "dbaas",
    "request": "update-dbaas-service-opensearch.Request",
    "response": "operation"
   },
   "update-dbaas-service-pg": {
    "path": "/dbaas-postgres/{name}",
    "method": "PUT",
+   "group": "dbaas",
    "request": "update-dbaas-service-pg.Request",
    "response": "operation"
   },
   "update-dbaas-service-thanos": {
    "path": "/dbaas-thanos/{name}",
    "method": "PUT",
+   "group": "dbaas",
    "request": "update-dbaas-service-thanos.Request",
    "response": "operation"
   },
   "update-dbaas-service-valkey": {
    "path": "/dbaas-valkey/{name}",
    "method": "PUT",
+   "group": "dbaas",
    "request": "update-dbaas-service-valkey.Request",
    "response": "operation"
   },
   "update-dbaas-valkey-user-access-control": {
    "path": "/dbaas-valkey/{service-name}/user/{username}",
    "method": "PUT",
+   "group": "dbaas",
    "request": "update-dbaas-valkey-user-access-control.Request",
    "response": "operation"
   },
   "update-deployment": {
    "path": "/ai/deployment/{id}",
    "method": "PATCH",
+   "group": "ai",
    "request": "update-deployment-request",
    "response": "operation"
   },
   "update-dns-domain-record": {
    "path": "/dns-domain/{domain-id}/record/{record-id}",
    "method": "PUT",
+   "group": "dns",
    "request": "update-dns-domain-record.Request",
    "response": "operation"
   },
   "update-elastic-ip": {
    "path": "/elastic-ip/{id}",
    "method": "PUT",
+   "group": "compute",
    "request": "update-elastic-ip.Request",
    "response": "operation"
   },
   "update-iam-organization-policy": {
    "path": "/iam-organization-policy",
    "method": "PUT",
+   "group": "iam",
    "request": "iam-policy",
    "response": "operation"
   },
   "update-iam-role": {
    "path": "/iam-role/{id}",
    "method": "PUT",
+   "group": "iam",
    "request": "update-iam-role.Request",
    "response": "operation"
   },
   "update-iam-role-policy": {
    "path": "/iam-role/{id}:policy",
    "method": "PUT",
+   "group": "iam",
    "request": "iam-policy",
    "response": "operation"
   },
   "update-instance": {
    "path": "/instance/{id}",
    "method": "PUT",
+   "group": "compute",
    "request": "update-instance.Request",
    "response": "operation"
   },
   "update-instance-pool": {
    "path": "/instance-pool/{id}",
    "method": "PUT",
+   "group": "compute",
    "request": "update-instance-pool.Request",
    "response": "operation"
   },
   "update-load-balancer": {
    "path": "/load-balancer/{id}",
    "method": "PUT",
+   "group": "compute",
    "request": "update-load-balancer.Request",
    "response": "operation"
   },
   "update-load-balancer-service": {
    "path": "/load-balancer/{id}/service/{service-id}",
    "method": "PUT",
+   "group": "compute",
    "request": "update-load-balancer-service.Request",
    "response": "operation"
   },
   "update-private-network": {
    "path": "/private-network/{id}",
    "method": "PUT",
+   "group": "compute",
    "request": "update-private-network.Request",
    "response": "operation"
   },
   "update-private-network-instance-ip": {
    "path": "/private-network/{id}:update-ip",
    "method": "PUT",
+   "group": "compute",
    "request": "update-private-network-instance-ip.Request",
    "response": "operation"
   },
   "update-reverse-dns-elastic-ip": {
    "path": "/reverse-dns/elastic-ip/{id}",
    "method": "POST",
+   "group": "compute",
    "request": "update-reverse-dns-elastic-ip.Request",
    "response": "operation"
   },
   "update-reverse-dns-instance": {
    "path": "/reverse-dns/instance/{id}",
    "method": "POST",
+   "group": "compute",
    "request": "update-reverse-dns-instance.Request",
    "response": "operation"
   },
   "update-sks-cluster": {
    "path": "/sks-cluster/{id}",
    "method": "PUT",
+   "group": "sks",
    "request": "update-sks-cluster.Request",
    "response": "operation"
   },
   "update-sks-nodepool": {
    "path": "/sks-cluster/{id}/nodepool/{sks-nodepool-id}",
    "method": "PUT",
+   "group": "sks",
    "request": "update-sks-nodepool.Request",
    "response": "operation"
   },
   "update-subnet": {
    "path": "/vpc/{vpc-id}/subnet/{id}",
    "method": "PUT",
+   "group": "compute",
    "request": "update-subnet.Request",
    "response": "subnet"
   },
   "update-template": {
    "path": "/template/{id}",
    "method": "PUT",
+   "group": "compute",
    "request": "update-template.Request",
    "response": "operation"
   },
   "update-user-role": {
    "path": "/user/{id}",
    "method": "PUT",
+   "group": "iam",
    "request": "update-user-role.Request",
    "response": "operation"
   },
   "update-vpc": {
    "path": "/vpc/{id}",
    "method": "PUT",
+   "group": "compute",
    "request": "update-vpc.Request",
    "response": "vpc"
   },
   "upgrade-sks-cluster": {
    "path": "/sks-cluster/{id}/upgrade",
    "method": "PUT",
+   "group": "sks",
    "request": "upgrade-sks-cluster.Request",
    "response": "operation"
   },
   "upgrade-sks-cluster-service-level": {
    "path": "/sks-cluster/{id}/upgrade-service-level",
    "method": "PUT",
+   "group": "sks",
    "response": "operation"
   }
  },

--- a/contracts/outscale.json
+++ b/contracts/outscale.json
@@ -8,1416 +8,1652 @@
   "AcceptNetPeering": {
    "path": "/AcceptNetPeering",
    "method": "POST",
+   "group": "NetPeering",
    "request": "AcceptNetPeeringRequest",
    "response": "AcceptNetPeeringResponse"
   },
   "AddUserToUserGroup": {
    "path": "/AddUserToUserGroup",
    "method": "POST",
+   "group": "UserGroup",
    "request": "AddUserToUserGroupRequest",
    "response": "AddUserToUserGroupResponse"
   },
   "CheckAuthentication": {
    "path": "/CheckAuthentication",
    "method": "POST",
+   "group": "Account",
    "request": "CheckAuthenticationRequest",
    "response": "CheckAuthenticationResponse"
   },
   "CreateAccessKey": {
    "path": "/CreateAccessKey",
    "method": "POST",
+   "group": "AccessKey",
    "request": "CreateAccessKeyRequest",
    "response": "CreateAccessKeyResponse"
   },
   "CreateAccount": {
    "path": "/CreateAccount",
    "method": "POST",
+   "group": "Account",
    "request": "CreateAccountRequest",
    "response": "CreateAccountResponse"
   },
   "CreateApiAccessRule": {
    "path": "/CreateApiAccessRule",
    "method": "POST",
+   "group": "ApiAccessRule",
    "request": "CreateApiAccessRuleRequest",
    "response": "CreateApiAccessRuleResponse"
   },
   "CreateCa": {
    "path": "/CreateCa",
    "method": "POST",
+   "group": "Ca",
    "request": "CreateCaRequest",
    "response": "CreateCaResponse"
   },
   "CreateClientGateway": {
    "path": "/CreateClientGateway",
    "method": "POST",
+   "group": "ClientGateway",
    "request": "CreateClientGatewayRequest",
    "response": "CreateClientGatewayResponse"
   },
   "CreateDedicatedGroup": {
    "path": "/CreateDedicatedGroup",
    "method": "POST",
+   "group": "DedicatedGroup",
    "request": "CreateDedicatedGroupRequest",
    "response": "CreateDedicatedGroupResponse"
   },
   "CreateDhcpOptions": {
    "path": "/CreateDhcpOptions",
    "method": "POST",
+   "group": "DhcpOption",
    "request": "CreateDhcpOptionsRequest",
    "response": "CreateDhcpOptionsResponse"
   },
   "CreateDirectLink": {
    "path": "/CreateDirectLink",
    "method": "POST",
+   "group": "DirectLink",
    "request": "CreateDirectLinkRequest",
    "response": "CreateDirectLinkResponse"
   },
   "CreateDirectLinkInterface": {
    "path": "/CreateDirectLinkInterface",
    "method": "POST",
+   "group": "DirectLinkInterface",
    "request": "CreateDirectLinkInterfaceRequest",
    "response": "CreateDirectLinkInterfaceResponse"
   },
   "CreateFlexibleGpu": {
    "path": "/CreateFlexibleGpu",
    "method": "POST",
+   "group": "FlexibleGpu",
    "request": "CreateFlexibleGpuRequest",
    "response": "CreateFlexibleGpuResponse"
   },
   "CreateImage": {
    "path": "/CreateImage",
    "method": "POST",
+   "group": "Image",
    "request": "CreateImageRequest",
    "response": "CreateImageResponse"
   },
   "CreateImageExportTask": {
    "path": "/CreateImageExportTask",
    "method": "POST",
+   "group": "Image",
    "request": "CreateImageExportTaskRequest",
    "response": "CreateImageExportTaskResponse"
   },
   "CreateInternetService": {
    "path": "/CreateInternetService",
    "method": "POST",
+   "group": "InternetService",
    "request": "CreateInternetServiceRequest",
    "response": "CreateInternetServiceResponse"
   },
   "CreateKeypair": {
    "path": "/CreateKeypair",
    "method": "POST",
+   "group": "Keypair",
    "request": "CreateKeypairRequest",
    "response": "CreateKeypairResponse"
   },
   "CreateListenerRule": {
    "path": "/CreateListenerRule",
    "method": "POST",
+   "group": "Listener",
    "request": "CreateListenerRuleRequest",
    "response": "CreateListenerRuleResponse"
   },
   "CreateLoadBalancer": {
    "path": "/CreateLoadBalancer",
    "method": "POST",
+   "group": "LoadBalancer",
    "request": "CreateLoadBalancerRequest",
    "response": "CreateLoadBalancerResponse"
   },
   "CreateLoadBalancerListeners": {
    "path": "/CreateLoadBalancerListeners",
    "method": "POST",
+   "group": "Listener",
    "request": "CreateLoadBalancerListenersRequest",
    "response": "CreateLoadBalancerListenersResponse"
   },
   "CreateLoadBalancerPolicy": {
    "path": "/CreateLoadBalancerPolicy",
    "method": "POST",
+   "group": "LoadBalancerPolicy",
    "request": "CreateLoadBalancerPolicyRequest",
    "response": "CreateLoadBalancerPolicyResponse"
   },
   "CreateLoadBalancerTags": {
    "path": "/CreateLoadBalancerTags",
    "method": "POST",
+   "group": "LoadBalancer",
    "request": "CreateLoadBalancerTagsRequest",
    "response": "CreateLoadBalancerTagsResponse"
   },
   "CreateNatService": {
    "path": "/CreateNatService",
    "method": "POST",
+   "group": "NatService",
    "request": "CreateNatServiceRequest",
    "response": "CreateNatServiceResponse"
   },
   "CreateNet": {
    "path": "/CreateNet",
    "method": "POST",
+   "group": "Net",
    "request": "CreateNetRequest",
    "response": "CreateNetResponse"
   },
   "CreateNetAccessPoint": {
    "path": "/CreateNetAccessPoint",
    "method": "POST",
+   "group": "NetAccessPoint",
    "request": "CreateNetAccessPointRequest",
    "response": "CreateNetAccessPointResponse"
   },
   "CreateNetPeering": {
    "path": "/CreateNetPeering",
    "method": "POST",
+   "group": "NetPeering",
    "request": "CreateNetPeeringRequest",
    "response": "CreateNetPeeringResponse"
   },
   "CreateNic": {
    "path": "/CreateNic",
    "method": "POST",
+   "group": "Nic",
    "request": "CreateNicRequest",
    "response": "CreateNicResponse"
   },
   "CreatePolicy": {
    "path": "/CreatePolicy",
    "method": "POST",
+   "group": "Policy",
    "request": "CreatePolicyRequest",
    "response": "CreatePolicyResponse"
   },
   "CreatePolicyVersion": {
    "path": "/CreatePolicyVersion",
    "method": "POST",
+   "group": "Policy",
    "request": "CreatePolicyVersionRequest",
    "response": "CreatePolicyVersionResponse"
   },
   "CreateProductType": {
    "path": "/CreateProductType",
    "method": "POST",
+   "group": "ProductType",
    "request": "CreateProductTypeRequest",
    "response": "CreateProductTypeResponse"
   },
   "CreatePublicIp": {
    "path": "/CreatePublicIp",
    "method": "POST",
+   "group": "PublicIp",
    "request": "CreatePublicIpRequest",
    "response": "CreatePublicIpResponse"
   },
   "CreateRoute": {
    "path": "/CreateRoute",
    "method": "POST",
+   "group": "Route",
    "request": "CreateRouteRequest",
    "response": "CreateRouteResponse"
   },
   "CreateRouteTable": {
    "path": "/CreateRouteTable",
    "method": "POST",
+   "group": "RouteTable",
    "request": "CreateRouteTableRequest",
    "response": "CreateRouteTableResponse"
   },
   "CreateSecurityGroup": {
    "path": "/CreateSecurityGroup",
    "method": "POST",
+   "group": "SecurityGroup",
    "request": "CreateSecurityGroupRequest",
    "response": "CreateSecurityGroupResponse"
   },
   "CreateSecurityGroupRule": {
    "path": "/CreateSecurityGroupRule",
    "method": "POST",
+   "group": "SecurityGroupRule",
    "request": "CreateSecurityGroupRuleRequest",
    "response": "CreateSecurityGroupRuleResponse"
   },
   "CreateServerCertificate": {
    "path": "/CreateServerCertificate",
    "method": "POST",
+   "group": "ServerCertificate",
    "request": "CreateServerCertificateRequest",
    "response": "CreateServerCertificateResponse"
   },
   "CreateSnapshot": {
    "path": "/CreateSnapshot",
    "method": "POST",
+   "group": "Snapshot",
    "request": "CreateSnapshotRequest",
    "response": "CreateSnapshotResponse"
   },
   "CreateSnapshotExportTask": {
    "path": "/CreateSnapshotExportTask",
    "method": "POST",
+   "group": "Snapshot",
    "request": "CreateSnapshotExportTaskRequest",
    "response": "CreateSnapshotExportTaskResponse"
   },
   "CreateSubnet": {
    "path": "/CreateSubnet",
    "method": "POST",
+   "group": "Subnet",
    "request": "CreateSubnetRequest",
    "response": "CreateSubnetResponse"
   },
   "CreateTags": {
    "path": "/CreateTags",
    "method": "POST",
+   "group": "Tag",
    "request": "CreateTagsRequest",
    "response": "CreateTagsResponse"
   },
   "CreateUser": {
    "path": "/CreateUser",
    "method": "POST",
+   "group": "User",
    "request": "CreateUserRequest",
    "response": "CreateUserResponse"
   },
   "CreateUserGroup": {
    "path": "/CreateUserGroup",
    "method": "POST",
+   "group": "UserGroup",
    "request": "CreateUserGroupRequest",
    "response": "CreateUserGroupResponse"
   },
   "CreateVirtualGateway": {
    "path": "/CreateVirtualGateway",
    "method": "POST",
+   "group": "VirtualGateway",
    "request": "CreateVirtualGatewayRequest",
    "response": "CreateVirtualGatewayResponse"
   },
   "CreateVmGroup": {
    "path": "/CreateVmGroup",
    "method": "POST",
+   "group": "VmGroup",
    "request": "CreateVmGroupRequest",
    "response": "CreateVmGroupResponse"
   },
   "CreateVmTemplate": {
    "path": "/CreateVmTemplate",
    "method": "POST",
+   "group": "VmTemplate",
    "request": "CreateVmTemplateRequest",
    "response": "CreateVmTemplateResponse"
   },
   "CreateVms": {
    "path": "/CreateVms",
    "method": "POST",
+   "group": "Vm",
    "request": "CreateVmsRequest",
    "response": "CreateVmsResponse"
   },
   "CreateVolume": {
    "path": "/CreateVolume",
    "method": "POST",
+   "group": "Volume",
    "request": "CreateVolumeRequest",
    "response": "CreateVolumeResponse"
   },
   "CreateVpnConnection": {
    "path": "/CreateVpnConnection",
    "method": "POST",
+   "group": "VpnConnection",
    "request": "CreateVpnConnectionRequest",
    "response": "CreateVpnConnectionResponse"
   },
   "CreateVpnConnectionRoute": {
    "path": "/CreateVpnConnectionRoute",
    "method": "POST",
+   "group": "VpnConnection",
    "request": "CreateVpnConnectionRouteRequest",
    "response": "CreateVpnConnectionRouteResponse"
   },
   "DeleteAccessKey": {
    "path": "/DeleteAccessKey",
    "method": "POST",
+   "group": "AccessKey",
    "request": "DeleteAccessKeyRequest",
    "response": "DeleteAccessKeyResponse"
   },
   "DeleteApiAccessRule": {
    "path": "/DeleteApiAccessRule",
    "method": "POST",
+   "group": "ApiAccessRule",
    "request": "DeleteApiAccessRuleRequest",
    "response": "DeleteApiAccessRuleResponse"
   },
   "DeleteCa": {
    "path": "/DeleteCa",
    "method": "POST",
+   "group": "Ca",
    "request": "DeleteCaRequest",
    "response": "DeleteCaResponse"
   },
   "DeleteClientGateway": {
    "path": "/DeleteClientGateway",
    "method": "POST",
+   "group": "ClientGateway",
    "request": "DeleteClientGatewayRequest",
    "response": "DeleteClientGatewayResponse"
   },
   "DeleteDedicatedGroup": {
    "path": "/DeleteDedicatedGroup",
    "method": "POST",
+   "group": "DedicatedGroup",
    "request": "DeleteDedicatedGroupRequest",
    "response": "DeleteDedicatedGroupResponse"
   },
   "DeleteDhcpOptions": {
    "path": "/DeleteDhcpOptions",
    "method": "POST",
+   "group": "DhcpOption",
    "request": "DeleteDhcpOptionsRequest",
    "response": "DeleteDhcpOptionsResponse"
   },
   "DeleteDirectLink": {
    "path": "/DeleteDirectLink",
    "method": "POST",
+   "group": "DirectLink",
    "request": "DeleteDirectLinkRequest",
    "response": "DeleteDirectLinkResponse"
   },
   "DeleteDirectLinkInterface": {
    "path": "/DeleteDirectLinkInterface",
    "method": "POST",
+   "group": "DirectLinkInterface",
    "request": "DeleteDirectLinkInterfaceRequest",
    "response": "DeleteDirectLinkInterfaceResponse"
   },
   "DeleteExportTask": {
    "path": "/DeleteExportTask",
    "method": "POST",
+   "group": "Task",
    "request": "DeleteExportTaskRequest",
    "response": "DeleteExportTaskResponse"
   },
   "DeleteFlexibleGpu": {
    "path": "/DeleteFlexibleGpu",
    "method": "POST",
+   "group": "FlexibleGpu",
    "request": "DeleteFlexibleGpuRequest",
    "response": "DeleteFlexibleGpuResponse"
   },
   "DeleteImage": {
    "path": "/DeleteImage",
    "method": "POST",
+   "group": "Image",
    "request": "DeleteImageRequest",
    "response": "DeleteImageResponse"
   },
   "DeleteInternetService": {
    "path": "/DeleteInternetService",
    "method": "POST",
+   "group": "InternetService",
    "request": "DeleteInternetServiceRequest",
    "response": "DeleteInternetServiceResponse"
   },
   "DeleteKeypair": {
    "path": "/DeleteKeypair",
    "method": "POST",
+   "group": "Keypair",
    "request": "DeleteKeypairRequest",
    "response": "DeleteKeypairResponse"
   },
   "DeleteListenerRule": {
    "path": "/DeleteListenerRule",
    "method": "POST",
+   "group": "Listener",
    "request": "DeleteListenerRuleRequest",
    "response": "DeleteListenerRuleResponse"
   },
   "DeleteLoadBalancer": {
    "path": "/DeleteLoadBalancer",
    "method": "POST",
+   "group": "LoadBalancer",
    "request": "DeleteLoadBalancerRequest",
    "response": "DeleteLoadBalancerResponse"
   },
   "DeleteLoadBalancerListeners": {
    "path": "/DeleteLoadBalancerListeners",
    "method": "POST",
+   "group": "Listener",
    "request": "DeleteLoadBalancerListenersRequest",
    "response": "DeleteLoadBalancerListenersResponse"
   },
   "DeleteLoadBalancerPolicy": {
    "path": "/DeleteLoadBalancerPolicy",
    "method": "POST",
+   "group": "LoadBalancerPolicy",
    "request": "DeleteLoadBalancerPolicyRequest",
    "response": "DeleteLoadBalancerPolicyResponse"
   },
   "DeleteLoadBalancerTags": {
    "path": "/DeleteLoadBalancerTags",
    "method": "POST",
+   "group": "LoadBalancer",
    "request": "DeleteLoadBalancerTagsRequest",
    "response": "DeleteLoadBalancerTagsResponse"
   },
   "DeleteNatService": {
    "path": "/DeleteNatService",
    "method": "POST",
+   "group": "NatService",
    "request": "DeleteNatServiceRequest",
    "response": "DeleteNatServiceResponse"
   },
   "DeleteNet": {
    "path": "/DeleteNet",
    "method": "POST",
+   "group": "Net",
    "request": "DeleteNetRequest",
    "response": "DeleteNetResponse"
   },
   "DeleteNetAccessPoint": {
    "path": "/DeleteNetAccessPoint",
    "method": "POST",
+   "group": "NetAccessPoint",
    "request": "DeleteNetAccessPointRequest",
    "response": "DeleteNetAccessPointResponse"
   },
   "DeleteNetPeering": {
    "path": "/DeleteNetPeering",
    "method": "POST",
+   "group": "NetPeering",
    "request": "DeleteNetPeeringRequest",
    "response": "DeleteNetPeeringResponse"
   },
   "DeleteNic": {
    "path": "/DeleteNic",
    "method": "POST",
+   "group": "Nic",
    "request": "DeleteNicRequest",
    "response": "DeleteNicResponse"
   },
   "DeletePolicy": {
    "path": "/DeletePolicy",
    "method": "POST",
+   "group": "Policy",
    "request": "DeletePolicyRequest",
    "response": "DeletePolicyResponse"
   },
   "DeletePolicyVersion": {
    "path": "/DeletePolicyVersion",
    "method": "POST",
+   "group": "Policy",
    "request": "DeletePolicyVersionRequest",
    "response": "DeletePolicyVersionResponse"
   },
   "DeleteProductType": {
    "path": "/DeleteProductType",
    "method": "POST",
+   "group": "ProductType",
    "request": "DeleteProductTypeRequest",
    "response": "DeleteProductTypeResponse"
   },
   "DeletePublicIp": {
    "path": "/DeletePublicIp",
    "method": "POST",
+   "group": "PublicIp",
    "request": "DeletePublicIpRequest",
    "response": "DeletePublicIpResponse"
   },
   "DeleteRoute": {
    "path": "/DeleteRoute",
    "method": "POST",
+   "group": "Route",
    "request": "DeleteRouteRequest",
    "response": "DeleteRouteResponse"
   },
   "DeleteRouteTable": {
    "path": "/DeleteRouteTable",
    "method": "POST",
+   "group": "RouteTable",
    "request": "DeleteRouteTableRequest",
    "response": "DeleteRouteTableResponse"
   },
   "DeleteSecurityGroup": {
    "path": "/DeleteSecurityGroup",
    "method": "POST",
+   "group": "SecurityGroup",
    "request": "DeleteSecurityGroupRequest",
    "response": "DeleteSecurityGroupResponse"
   },
   "DeleteSecurityGroupRule": {
    "path": "/DeleteSecurityGroupRule",
    "method": "POST",
+   "group": "SecurityGroupRule",
    "request": "DeleteSecurityGroupRuleRequest",
    "response": "DeleteSecurityGroupRuleResponse"
   },
   "DeleteServerCertificate": {
    "path": "/DeleteServerCertificate",
    "method": "POST",
+   "group": "ServerCertificate",
    "request": "DeleteServerCertificateRequest",
    "response": "DeleteServerCertificateResponse"
   },
   "DeleteSnapshot": {
    "path": "/DeleteSnapshot",
    "method": "POST",
+   "group": "Snapshot",
    "request": "DeleteSnapshotRequest",
    "response": "DeleteSnapshotResponse"
   },
   "DeleteSubnet": {
    "path": "/DeleteSubnet",
    "method": "POST",
+   "group": "Subnet",
    "request": "DeleteSubnetRequest",
    "response": "DeleteSubnetResponse"
   },
   "DeleteTags": {
    "path": "/DeleteTags",
    "method": "POST",
+   "group": "Tag",
    "request": "DeleteTagsRequest",
    "response": "DeleteTagsResponse"
   },
   "DeleteUser": {
    "path": "/DeleteUser",
    "method": "POST",
+   "group": "User",
    "request": "DeleteUserRequest",
    "response": "DeleteUserResponse"
   },
   "DeleteUserGroup": {
    "path": "/DeleteUserGroup",
    "method": "POST",
+   "group": "UserGroup",
    "request": "DeleteUserGroupRequest",
    "response": "DeleteUserGroupResponse"
   },
   "DeleteUserGroupPolicy": {
    "path": "/DeleteUserGroupPolicy",
    "method": "POST",
+   "group": "Policy",
    "request": "DeleteUserGroupPolicyRequest",
    "response": "DeleteUserGroupPolicyResponse"
   },
   "DeleteUserPolicy": {
    "path": "/DeleteUserPolicy",
    "method": "POST",
+   "group": "Policy",
    "request": "DeleteUserPolicyRequest",
    "response": "DeleteUserPolicyResponse"
   },
   "DeleteVirtualGateway": {
    "path": "/DeleteVirtualGateway",
    "method": "POST",
+   "group": "VirtualGateway",
    "request": "DeleteVirtualGatewayRequest",
    "response": "DeleteVirtualGatewayResponse"
   },
   "DeleteVmGroup": {
    "path": "/DeleteVmGroup",
    "method": "POST",
+   "group": "VmGroup",
    "request": "DeleteVmGroupRequest",
    "response": "DeleteVmGroupResponse"
   },
   "DeleteVmTemplate": {
    "path": "/DeleteVmTemplate",
    "method": "POST",
+   "group": "VmTemplate",
    "request": "DeleteVmTemplateRequest",
    "response": "DeleteVmTemplateResponse"
   },
   "DeleteVms": {
    "path": "/DeleteVms",
    "method": "POST",
+   "group": "Vm",
    "request": "DeleteVmsRequest",
    "response": "DeleteVmsResponse"
   },
   "DeleteVolume": {
    "path": "/DeleteVolume",
    "method": "POST",
+   "group": "Volume",
    "request": "DeleteVolumeRequest",
    "response": "DeleteVolumeResponse"
   },
   "DeleteVpnConnection": {
    "path": "/DeleteVpnConnection",
    "method": "POST",
+   "group": "VpnConnection",
    "request": "DeleteVpnConnectionRequest",
    "response": "DeleteVpnConnectionResponse"
   },
   "DeleteVpnConnectionRoute": {
    "path": "/DeleteVpnConnectionRoute",
    "method": "POST",
+   "group": "VpnConnection",
    "request": "DeleteVpnConnectionRouteRequest",
    "response": "DeleteVpnConnectionRouteResponse"
   },
   "DeregisterVmsInLoadBalancer": {
    "path": "/DeregisterVmsInLoadBalancer",
    "method": "POST",
+   "group": "LoadBalancer",
    "request": "DeregisterVmsInLoadBalancerRequest",
    "response": "DeregisterVmsInLoadBalancerResponse"
   },
   "DisableOutscaleLogin": {
    "path": "/DisableOutscaleLogin",
    "method": "POST",
+   "group": "IdentityProvider",
    "request": "DisableOutscaleLoginRequest",
    "response": "DisableOutscaleLoginResponse"
   },
   "DisableOutscaleLoginForUsers": {
    "path": "/DisableOutscaleLoginForUsers",
    "method": "POST",
+   "group": "IdentityProvider",
    "request": "DisableOutscaleLoginRequest",
    "response": "DisableOutscaleLoginResponse"
   },
   "DisableOutscaleLoginPerUsers": {
    "path": "/DisableOutscaleLoginPerUsers",
    "method": "POST",
+   "group": "IdentityProvider",
    "request": "DisableOutscaleLoginPerUsersRequest",
    "response": "DisableOutscaleLoginPerUsersResponse"
   },
   "EnableOutscaleLogin": {
    "path": "/EnableOutscaleLogin",
    "method": "POST",
+   "group": "IdentityProvider",
    "request": "EnableOutscaleLoginRequest",
    "response": "EnableOutscaleLoginResponse"
   },
   "EnableOutscaleLoginForUsers": {
    "path": "/EnableOutscaleLoginForUsers",
    "method": "POST",
+   "group": "IdentityProvider",
    "request": "EnableOutscaleLoginForUsersRequest",
    "response": "EnableOutscaleLoginForUsersResponse"
   },
   "EnableOutscaleLoginPerUsers": {
    "path": "/EnableOutscaleLoginPerUsers",
    "method": "POST",
+   "group": "IdentityProvider",
    "request": "EnableOutscaleLoginPerUsersRequest",
    "response": "EnableOutscaleLoginPerUsersResponse"
   },
   "LinkFlexibleGpu": {
    "path": "/LinkFlexibleGpu",
    "method": "POST",
+   "group": "FlexibleGpu",
    "request": "LinkFlexibleGpuRequest",
    "response": "LinkFlexibleGpuResponse"
   },
   "LinkInternetService": {
    "path": "/LinkInternetService",
    "method": "POST",
+   "group": "InternetService",
    "request": "LinkInternetServiceRequest",
    "response": "LinkInternetServiceResponse"
   },
   "LinkLoadBalancerBackendMachines": {
    "path": "/LinkLoadBalancerBackendMachines",
    "method": "POST",
+   "group": "LoadBalancer",
    "request": "LinkLoadBalancerBackendMachinesRequest",
    "response": "LinkLoadBalancerBackendMachinesResponse"
   },
   "LinkManagedPolicyToUserGroup": {
    "path": "/LinkManagedPolicyToUserGroup",
    "method": "POST",
+   "group": "Policy",
    "request": "LinkManagedPolicyToUserGroupRequest",
    "response": "LinkManagedPolicyToUserGroupResponse"
   },
   "LinkNic": {
    "path": "/LinkNic",
    "method": "POST",
+   "group": "Nic",
    "request": "LinkNicRequest",
    "response": "LinkNicResponse"
   },
   "LinkPolicy": {
    "path": "/LinkPolicy",
    "method": "POST",
+   "group": "Policy",
    "request": "LinkPolicyRequest",
    "response": "LinkPolicyResponse"
   },
   "LinkPrivateIps": {
    "path": "/LinkPrivateIps",
    "method": "POST",
+   "group": "Nic",
    "request": "LinkPrivateIpsRequest",
    "response": "LinkPrivateIpsResponse"
   },
   "LinkPublicIp": {
    "path": "/LinkPublicIp",
    "method": "POST",
+   "group": "PublicIp",
    "request": "LinkPublicIpRequest",
    "response": "LinkPublicIpResponse"
   },
   "LinkRouteTable": {
    "path": "/LinkRouteTable",
    "method": "POST",
+   "group": "RouteTable",
    "request": "LinkRouteTableRequest",
    "response": "LinkRouteTableResponse"
   },
   "LinkVirtualGateway": {
    "path": "/LinkVirtualGateway",
    "method": "POST",
+   "group": "VirtualGateway",
    "request": "LinkVirtualGatewayRequest",
    "response": "LinkVirtualGatewayResponse"
   },
   "LinkVolume": {
    "path": "/LinkVolume",
    "method": "POST",
+   "group": "Volume",
    "request": "LinkVolumeRequest",
    "response": "LinkVolumeResponse"
   },
   "PutUserGroupPolicy": {
    "path": "/PutUserGroupPolicy",
    "method": "POST",
+   "group": "Policy",
    "request": "PutUserGroupPolicyRequest",
    "response": "PutUserGroupPolicyResponse"
   },
   "PutUserPolicy": {
    "path": "/PutUserPolicy",
    "method": "POST",
+   "group": "Policy",
    "request": "PutUserPolicyRequest",
    "response": "PutUserPolicyResponse"
   },
   "ReadAccessKeys": {
    "path": "/ReadAccessKeys",
    "method": "POST",
+   "group": "AccessKey",
    "request": "ReadAccessKeysRequest",
    "response": "ReadAccessKeysResponse"
   },
   "ReadAccounts": {
    "path": "/ReadAccounts",
    "method": "POST",
+   "group": "Account",
    "request": "ReadAccountsRequest",
    "response": "ReadAccountsResponse"
   },
   "ReadAdminPassword": {
    "path": "/ReadAdminPassword",
    "method": "POST",
+   "group": "Vm",
    "request": "ReadAdminPasswordRequest",
    "response": "ReadAdminPasswordResponse"
   },
   "ReadApiAccessPolicy": {
    "path": "/ReadApiAccessPolicy",
    "method": "POST",
+   "group": "ApiAccessPolicy",
    "request": "ReadApiAccessPolicyRequest",
    "response": "ReadApiAccessPolicyResponse"
   },
   "ReadApiAccessRules": {
    "path": "/ReadApiAccessRules",
    "method": "POST",
+   "group": "ApiAccessRule",
    "request": "ReadApiAccessRulesRequest",
    "response": "ReadApiAccessRulesResponse"
   },
   "ReadApiLogs": {
    "path": "/ReadApiLogs",
    "method": "POST",
+   "group": "ApiLog",
    "request": "ReadApiLogsRequest",
    "response": "ReadApiLogsResponse"
   },
   "ReadCO2EmissionAccount": {
    "path": "/ReadCO2EmissionAccount",
    "method": "POST",
+   "group": "Account",
    "request": "ReadCO2EmissionAccountRequest",
    "response": "ReadCO2EmissionAccountResponse"
   },
   "ReadCas": {
    "path": "/ReadCas",
    "method": "POST",
+   "group": "Ca",
    "request": "ReadCasRequest",
    "response": "ReadCasResponse"
   },
   "ReadCatalog": {
    "path": "/ReadCatalog",
    "method": "POST",
+   "group": "Catalog",
    "request": "ReadCatalogRequest",
    "response": "ReadCatalogResponse"
   },
   "ReadCatalogs": {
    "path": "/ReadCatalogs",
    "method": "POST",
+   "group": "Catalog",
    "request": "ReadCatalogsRequest",
    "response": "ReadCatalogsResponse"
   },
   "ReadClientGateways": {
    "path": "/ReadClientGateways",
    "method": "POST",
+   "group": "ClientGateway",
    "request": "ReadClientGatewaysRequest",
    "response": "ReadClientGatewaysResponse"
   },
   "ReadConsoleOutput": {
    "path": "/ReadConsoleOutput",
    "method": "POST",
+   "group": "Vm",
    "request": "ReadConsoleOutputRequest",
    "response": "ReadConsoleOutputResponse"
   },
   "ReadConsumptionAccount": {
    "path": "/ReadConsumptionAccount",
    "method": "POST",
+   "group": "Account",
    "request": "ReadConsumptionAccountRequest",
    "response": "ReadConsumptionAccountResponse"
   },
   "ReadDedicatedGroups": {
    "path": "/ReadDedicatedGroups",
    "method": "POST",
+   "group": "DedicatedGroup",
    "request": "ReadDedicatedGroupsRequest",
    "response": "ReadDedicatedGroupsResponse"
   },
   "ReadDhcpOptions": {
    "path": "/ReadDhcpOptions",
    "method": "POST",
+   "group": "DhcpOption",
    "request": "ReadDhcpOptionsRequest",
    "response": "ReadDhcpOptionsResponse"
   },
   "ReadDirectLinkInterfaces": {
    "path": "/ReadDirectLinkInterfaces",
    "method": "POST",
+   "group": "DirectLinkInterface",
    "request": "ReadDirectLinkInterfacesRequest",
    "response": "ReadDirectLinkInterfacesResponse"
   },
   "ReadDirectLinks": {
    "path": "/ReadDirectLinks",
    "method": "POST",
+   "group": "DirectLink",
    "request": "ReadDirectLinksRequest",
    "response": "ReadDirectLinksResponse"
   },
   "ReadEntitiesLinkedToPolicy": {
    "path": "/ReadEntitiesLinkedToPolicy",
    "method": "POST",
+   "group": "Policy",
    "request": "ReadEntitiesLinkedToPolicyRequest",
    "response": "ReadEntitiesLinkedToPolicyResponse"
   },
   "ReadFlexibleGpuCatalog": {
    "path": "/ReadFlexibleGpuCatalog",
    "method": "POST",
+   "group": "FlexibleGpu",
    "request": "ReadFlexibleGpuCatalogRequest",
    "response": "ReadFlexibleGpuCatalogResponse"
   },
   "ReadFlexibleGpus": {
    "path": "/ReadFlexibleGpus",
    "method": "POST",
+   "group": "FlexibleGpu",
    "request": "ReadFlexibleGpusRequest",
    "response": "ReadFlexibleGpusResponse"
   },
   "ReadImageExportTasks": {
    "path": "/ReadImageExportTasks",
    "method": "POST",
+   "group": "Image",
    "request": "ReadImageExportTasksRequest",
    "response": "ReadImageExportTasksResponse"
   },
   "ReadImages": {
    "path": "/ReadImages",
    "method": "POST",
+   "group": "Image",
    "request": "ReadImagesRequest",
    "response": "ReadImagesResponse"
   },
   "ReadInternetServices": {
    "path": "/ReadInternetServices",
    "method": "POST",
+   "group": "InternetService",
    "request": "ReadInternetServicesRequest",
    "response": "ReadInternetServicesResponse"
   },
   "ReadKeypairs": {
    "path": "/ReadKeypairs",
    "method": "POST",
+   "group": "Keypair",
    "request": "ReadKeypairsRequest",
    "response": "ReadKeypairsResponse"
   },
   "ReadLinkedPolicies": {
    "path": "/ReadLinkedPolicies",
    "method": "POST",
+   "group": "Policy",
    "request": "ReadLinkedPoliciesRequest",
    "response": "ReadLinkedPoliciesResponse"
   },
   "ReadListenerRules": {
    "path": "/ReadListenerRules",
    "method": "POST",
+   "group": "Listener",
    "request": "ReadListenerRulesRequest",
    "response": "ReadListenerRulesResponse"
   },
   "ReadLoadBalancerTags": {
    "path": "/ReadLoadBalancerTags",
    "method": "POST",
+   "group": "LoadBalancer",
    "request": "ReadLoadBalancerTagsRequest",
    "response": "ReadLoadBalancerTagsResponse"
   },
   "ReadLoadBalancers": {
    "path": "/ReadLoadBalancers",
    "method": "POST",
+   "group": "LoadBalancer",
    "request": "ReadLoadBalancersRequest",
    "response": "ReadLoadBalancersResponse"
   },
   "ReadLocations": {
    "path": "/ReadLocations",
    "method": "POST",
+   "group": "Location",
    "request": "ReadLocationsRequest",
    "response": "ReadLocationsResponse"
   },
   "ReadManagedPoliciesLinkedToUserGroup": {
    "path": "/ReadManagedPoliciesLinkedToUserGroup",
    "method": "POST",
+   "group": "Policy",
    "request": "ReadManagedPoliciesLinkedToUserGroupRequest",
    "response": "ReadManagedPoliciesLinkedToUserGroupResponse"
   },
   "ReadNatServices": {
    "path": "/ReadNatServices",
    "method": "POST",
+   "group": "NatService",
    "request": "ReadNatServicesRequest",
    "response": "ReadNatServicesResponse"
   },
   "ReadNetAccessPointServices": {
    "path": "/ReadNetAccessPointServices",
    "method": "POST",
+   "group": "NetAccessPoint",
    "request": "ReadNetAccessPointServicesRequest",
    "response": "ReadNetAccessPointServicesResponse"
   },
   "ReadNetAccessPoints": {
    "path": "/ReadNetAccessPoints",
    "method": "POST",
+   "group": "NetAccessPoint",
    "request": "ReadNetAccessPointsRequest",
    "response": "ReadNetAccessPointsResponse"
   },
   "ReadNetPeerings": {
    "path": "/ReadNetPeerings",
    "method": "POST",
+   "group": "NetPeering",
    "request": "ReadNetPeeringsRequest",
    "response": "ReadNetPeeringsResponse"
   },
   "ReadNets": {
    "path": "/ReadNets",
    "method": "POST",
+   "group": "Net",
    "request": "ReadNetsRequest",
    "response": "ReadNetsResponse"
   },
   "ReadNics": {
    "path": "/ReadNics",
    "method": "POST",
+   "group": "Nic",
    "request": "ReadNicsRequest",
    "response": "ReadNicsResponse"
   },
   "ReadPolicies": {
    "path": "/ReadPolicies",
    "method": "POST",
+   "group": "Policy",
    "request": "ReadPoliciesRequest",
    "response": "ReadPoliciesResponse"
   },
   "ReadPolicy": {
    "path": "/ReadPolicy",
    "method": "POST",
+   "group": "Policy",
    "request": "ReadPolicyRequest",
    "response": "ReadPolicyResponse"
   },
   "ReadPolicyVersion": {
    "path": "/ReadPolicyVersion",
    "method": "POST",
+   "group": "Policy",
    "request": "ReadPolicyVersionRequest",
    "response": "ReadPolicyVersionResponse"
   },
   "ReadPolicyVersions": {
    "path": "/ReadPolicyVersions",
    "method": "POST",
+   "group": "Policy",
    "request": "ReadPolicyVersionsRequest",
    "response": "ReadPolicyVersionsResponse"
   },
   "ReadProductTypes": {
    "path": "/ReadProductTypes",
    "method": "POST",
+   "group": "ProductType",
    "request": "ReadProductTypesRequest",
    "response": "ReadProductTypesResponse"
   },
   "ReadPublicCatalog": {
    "path": "/ReadPublicCatalog",
    "method": "POST",
+   "group": "PublicCatalog",
    "request": "ReadPublicCatalogRequest",
    "response": "ReadPublicCatalogResponse"
   },
   "ReadPublicIpRanges": {
    "path": "/ReadPublicIpRanges",
    "method": "POST",
+   "group": "PublicIp",
    "request": "ReadPublicIpRangesRequest",
    "response": "ReadPublicIpRangesResponse"
   },
   "ReadPublicIps": {
    "path": "/ReadPublicIps",
    "method": "POST",
+   "group": "PublicIp",
    "request": "ReadPublicIpsRequest",
    "response": "ReadPublicIpsResponse"
   },
   "ReadQuotas": {
    "path": "/ReadQuotas",
    "method": "POST",
+   "group": "Quota",
    "request": "ReadQuotasRequest",
    "response": "ReadQuotasResponse"
   },
   "ReadRegions": {
    "path": "/ReadRegions",
    "method": "POST",
+   "group": "Region",
    "request": "ReadRegionsRequest",
    "response": "ReadRegionsResponse"
   },
   "ReadRouteTables": {
    "path": "/ReadRouteTables",
    "method": "POST",
+   "group": "RouteTable",
    "request": "ReadRouteTablesRequest",
    "response": "ReadRouteTablesResponse"
   },
   "ReadSecurityGroups": {
    "path": "/ReadSecurityGroups",
    "method": "POST",
+   "group": "SecurityGroup",
    "request": "ReadSecurityGroupsRequest",
    "response": "ReadSecurityGroupsResponse"
   },
   "ReadServerCertificates": {
    "path": "/ReadServerCertificates",
    "method": "POST",
+   "group": "ServerCertificate",
    "request": "ReadServerCertificatesRequest",
    "response": "ReadServerCertificatesResponse"
   },
   "ReadSnapshotExportTasks": {
    "path": "/ReadSnapshotExportTasks",
    "method": "POST",
+   "group": "Snapshot",
    "request": "ReadSnapshotExportTasksRequest",
    "response": "ReadSnapshotExportTasksResponse"
   },
   "ReadSnapshots": {
    "path": "/ReadSnapshots",
    "method": "POST",
+   "group": "Snapshot",
    "request": "ReadSnapshotsRequest",
    "response": "ReadSnapshotsResponse"
   },
   "ReadSubnets": {
    "path": "/ReadSubnets",
    "method": "POST",
+   "group": "Subnet",
    "request": "ReadSubnetsRequest",
    "response": "ReadSubnetsResponse"
   },
   "ReadSubregions": {
    "path": "/ReadSubregions",
    "method": "POST",
+   "group": "Subregion",
    "request": "ReadSubregionsRequest",
    "response": "ReadSubregionsResponse"
   },
   "ReadTags": {
    "path": "/ReadTags",
    "method": "POST",
+   "group": "Tag",
    "request": "ReadTagsRequest",
    "response": "ReadTagsResponse"
   },
   "ReadUnitPrice": {
    "path": "/ReadUnitPrice",
    "method": "POST",
+   "group": "Catalog",
    "request": "ReadUnitPriceRequest",
    "response": "ReadUnitPriceResponse"
   },
   "ReadUserGroup": {
    "path": "/ReadUserGroup",
    "method": "POST",
+   "group": "UserGroup",
    "request": "ReadUserGroupRequest",
    "response": "ReadUserGroupResponse"
   },
   "ReadUserGroupPolicies": {
    "path": "/ReadUserGroupPolicies",
    "method": "POST",
+   "group": "Policy",
    "request": "ReadUserGroupPoliciesRequest",
    "response": "ReadUserGroupPoliciesResponse"
   },
   "ReadUserGroupPolicy": {
    "path": "/ReadUserGroupPolicy",
    "method": "POST",
+   "group": "Policy",
    "request": "ReadUserGroupPolicyRequest",
    "response": "ReadUserGroupPolicyResponse"
   },
   "ReadUserGroups": {
    "path": "/ReadUserGroups",
    "method": "POST",
+   "group": "UserGroup",
    "request": "ReadUserGroupsRequest",
    "response": "ReadUserGroupsResponse"
   },
   "ReadUserGroupsPerUser": {
    "path": "/ReadUserGroupsPerUser",
    "method": "POST",
+   "group": "UserGroup",
    "request": "ReadUserGroupsPerUserRequest",
    "response": "ReadUserGroupsPerUserResponse"
   },
   "ReadUserPolicies": {
    "path": "/ReadUserPolicies",
    "method": "POST",
+   "group": "Policy",
    "request": "ReadUserPoliciesRequest",
    "response": "ReadUserPoliciesResponse"
   },
   "ReadUserPolicy": {
    "path": "/ReadUserPolicy",
    "method": "POST",
+   "group": "Policy",
    "request": "ReadUserPolicyRequest",
    "response": "ReadUserPolicyResponse"
   },
   "ReadUsers": {
    "path": "/ReadUsers",
    "method": "POST",
+   "group": "User",
    "request": "ReadUsersRequest",
    "response": "ReadUsersResponse"
   },
   "ReadVirtualGateways": {
    "path": "/ReadVirtualGateways",
    "method": "POST",
+   "group": "VirtualGateway",
    "request": "ReadVirtualGatewaysRequest",
    "response": "ReadVirtualGatewaysResponse"
   },
   "ReadVmGroups": {
    "path": "/ReadVmGroups",
    "method": "POST",
+   "group": "VmGroup",
    "request": "ReadVmGroupsRequest",
    "response": "ReadVmGroupsResponse"
   },
   "ReadVmTemplates": {
    "path": "/ReadVmTemplates",
    "method": "POST",
+   "group": "VmTemplate",
    "request": "ReadVmTemplatesRequest",
    "response": "ReadVmTemplatesResponse"
   },
   "ReadVmTypes": {
    "path": "/ReadVmTypes",
    "method": "POST",
+   "group": "Vm",
    "request": "ReadVmTypesRequest",
    "response": "ReadVmTypesResponse"
   },
   "ReadVms": {
    "path": "/ReadVms",
    "method": "POST",
+   "group": "Vm",
    "request": "ReadVmsRequest",
    "response": "ReadVmsResponse"
   },
   "ReadVmsHealth": {
    "path": "/ReadVmsHealth",
    "method": "POST",
+   "group": "LoadBalancer",
    "request": "ReadVmsHealthRequest",
    "response": "ReadVmsHealthResponse"
   },
   "ReadVmsState": {
    "path": "/ReadVmsState",
    "method": "POST",
+   "group": "Vm",
    "request": "ReadVmsStateRequest",
    "response": "ReadVmsStateResponse"
   },
   "ReadVmsStopHistory": {
    "path": "/ReadVmsStopHistory",
    "method": "POST",
+   "group": "Vm",
    "request": "ReadVmsStopHistoryRequest",
    "response": "ReadVmsStopHistoryResponse"
   },
   "ReadVolumeUpdateTasks": {
    "path": "/ReadVolumeUpdateTasks",
    "method": "POST",
+   "group": "Volume",
    "request": "ReadVolumeUpdateTasksRequest",
    "response": "ReadVolumeUpdateTasksResponse"
   },
   "ReadVolumes": {
    "path": "/ReadVolumes",
    "method": "POST",
+   "group": "Volume",
    "request": "ReadVolumesRequest",
    "response": "ReadVolumesResponse"
   },
   "ReadVpnConnections": {
    "path": "/ReadVpnConnections",
    "method": "POST",
+   "group": "VpnConnection",
    "request": "ReadVpnConnectionsRequest",
    "response": "ReadVpnConnectionsResponse"
   },
   "RebootVms": {
    "path": "/RebootVms",
    "method": "POST",
+   "group": "Vm",
    "request": "RebootVmsRequest",
    "response": "RebootVmsResponse"
   },
   "RegisterVmsInLoadBalancer": {
    "path": "/RegisterVmsInLoadBalancer",
    "method": "POST",
+   "group": "LoadBalancer",
    "request": "RegisterVmsInLoadBalancerRequest",
    "response": "RegisterVmsInLoadBalancerResponse"
   },
   "RejectNetPeering": {
    "path": "/RejectNetPeering",
    "method": "POST",
+   "group": "NetPeering",
    "request": "RejectNetPeeringRequest",
    "response": "RejectNetPeeringResponse"
   },
   "RemoveUserFromUserGroup": {
    "path": "/RemoveUserFromUserGroup",
    "method": "POST",
+   "group": "UserGroup",
    "request": "RemoveUserFromUserGroupRequest",
    "response": "RemoveUserFromUserGroupResponse"
   },
   "ScaleDownVmGroup": {
    "path": "/ScaleDownVmGroup",
    "method": "POST",
+   "group": "VmGroup",
    "request": "ScaleDownVmGroupRequest",
    "response": "ScaleDownVmGroupResponse"
   },
   "ScaleUpVmGroup": {
    "path": "/ScaleUpVmGroup",
    "method": "POST",
+   "group": "VmGroup",
    "request": "ScaleUpVmGroupRequest",
    "response": "ScaleUpVmGroupResponse"
   },
   "SetDefaultPolicyVersion": {
    "path": "/SetDefaultPolicyVersion",
    "method": "POST",
+   "group": "Policy",
    "request": "SetDefaultPolicyVersionRequest",
    "response": "SetDefaultPolicyVersionResponse"
   },
   "StartVms": {
    "path": "/StartVms",
    "method": "POST",
+   "group": "Vm",
    "request": "StartVmsRequest",
    "response": "StartVmsResponse"
   },
   "StopVms": {
    "path": "/StopVms",
    "method": "POST",
+   "group": "Vm",
    "request": "StopVmsRequest",
    "response": "StopVmsResponse"
   },
   "UnlinkFlexibleGpu": {
    "path": "/UnlinkFlexibleGpu",
    "method": "POST",
+   "group": "FlexibleGpu",
    "request": "UnlinkFlexibleGpuRequest",
    "response": "UnlinkFlexibleGpuResponse"
   },
   "UnlinkInternetService": {
    "path": "/UnlinkInternetService",
    "method": "POST",
+   "group": "InternetService",
    "request": "UnlinkInternetServiceRequest",
    "response": "UnlinkInternetServiceResponse"
   },
   "UnlinkLoadBalancerBackendMachines": {
    "path": "/UnlinkLoadBalancerBackendMachines",
    "method": "POST",
+   "group": "LoadBalancer",
    "request": "UnlinkLoadBalancerBackendMachinesRequest",
    "response": "UnlinkLoadBalancerBackendMachinesResponse"
   },
   "UnlinkManagedPolicyFromUserGroup": {
    "path": "/UnlinkManagedPolicyFromUserGroup",
    "method": "POST",
+   "group": "Policy",
    "request": "UnlinkManagedPolicyFromUserGroupRequest",
    "response": "UnlinkManagedPolicyFromUserGroupResponse"
   },
   "UnlinkNic": {
    "path": "/UnlinkNic",
    "method": "POST",
+   "group": "Nic",
    "request": "UnlinkNicRequest",
    "response": "UnlinkNicResponse"
   },
   "UnlinkPolicy": {
    "path": "/UnlinkPolicy",
    "method": "POST",
+   "group": "Policy",
    "request": "UnlinkPolicyRequest",
    "response": "UnlinkPolicyResponse"
   },
   "UnlinkPrivateIps": {
    "path": "/UnlinkPrivateIps",
    "method": "POST",
+   "group": "Nic",
    "request": "UnlinkPrivateIpsRequest",
    "response": "UnlinkPrivateIpsResponse"
   },
   "UnlinkPublicIp": {
    "path": "/UnlinkPublicIp",
    "method": "POST",
+   "group": "PublicIp",
    "request": "UnlinkPublicIpRequest",
    "response": "UnlinkPublicIpResponse"
   },
   "UnlinkRouteTable": {
    "path": "/UnlinkRouteTable",
    "method": "POST",
+   "group": "RouteTable",
    "request": "UnlinkRouteTableRequest",
    "response": "UnlinkRouteTableResponse"
   },
   "UnlinkVirtualGateway": {
    "path": "/UnlinkVirtualGateway",
    "method": "POST",
+   "group": "VirtualGateway",
    "request": "UnlinkVirtualGatewayRequest",
    "response": "UnlinkVirtualGatewayResponse"
   },
   "UnlinkVolume": {
    "path": "/UnlinkVolume",
    "method": "POST",
+   "group": "Volume",
    "request": "UnlinkVolumeRequest",
    "response": "UnlinkVolumeResponse"
   },
   "UpdateAccessKey": {
    "path": "/UpdateAccessKey",
    "method": "POST",
+   "group": "AccessKey",
    "request": "UpdateAccessKeyRequest",
    "response": "UpdateAccessKeyResponse"
   },
   "UpdateAccount": {
    "path": "/UpdateAccount",
    "method": "POST",
+   "group": "Account",
    "request": "UpdateAccountRequest",
    "response": "UpdateAccountResponse"
   },
   "UpdateApiAccessPolicy": {
    "path": "/UpdateApiAccessPolicy",
    "method": "POST",
+   "group": "ApiAccessPolicy",
    "request": "UpdateApiAccessPolicyRequest",
    "response": "UpdateApiAccessPolicyResponse"
   },
   "UpdateApiAccessRule": {
    "path": "/UpdateApiAccessRule",
    "method": "POST",
+   "group": "ApiAccessRule",
    "request": "UpdateApiAccessRuleRequest",
    "response": "UpdateApiAccessRuleResponse"
   },
   "UpdateCa": {
    "path": "/UpdateCa",
    "method": "POST",
+   "group": "Ca",
    "request": "UpdateCaRequest",
    "response": "UpdateCaResponse"
   },
   "UpdateDedicatedGroup": {
    "path": "/UpdateDedicatedGroup",
    "method": "POST",
+   "group": "DedicatedGroup",
    "request": "UpdateDedicatedGroupRequest",
    "response": "UpdateDedicatedGroupResponse"
   },
   "UpdateDirectLinkInterface": {
    "path": "/UpdateDirectLinkInterface",
    "method": "POST",
+   "group": "DirectLinkInterface",
    "request": "UpdateDirectLinkInterfaceRequest",
    "response": "UpdateDirectLinkInterfaceResponse"
   },
   "UpdateFlexibleGpu": {
    "path": "/UpdateFlexibleGpu",
    "method": "POST",
+   "group": "FlexibleGpu",
    "request": "UpdateFlexibleGpuRequest",
    "response": "UpdateFlexibleGpuResponse"
   },
   "UpdateImage": {
    "path": "/UpdateImage",
    "method": "POST",
+   "group": "Image",
    "request": "UpdateImageRequest",
    "response": "UpdateImageResponse"
   },
   "UpdateListenerRule": {
    "path": "/UpdateListenerRule",
    "method": "POST",
+   "group": "Listener",
    "request": "UpdateListenerRuleRequest",
    "response": "UpdateListenerRuleResponse"
   },
   "UpdateLoadBalancer": {
    "path": "/UpdateLoadBalancer",
    "method": "POST",
+   "group": "LoadBalancer",
    "request": "UpdateLoadBalancerRequest",
    "response": "UpdateLoadBalancerResponse"
   },
   "UpdateNet": {
    "path": "/UpdateNet",
    "method": "POST",
+   "group": "Net",
    "request": "UpdateNetRequest",
    "response": "UpdateNetResponse"
   },
   "UpdateNetAccessPoint": {
    "path": "/UpdateNetAccessPoint",
    "method": "POST",
+   "group": "NetAccessPoint",
    "request": "UpdateNetAccessPointRequest",
    "response": "UpdateNetAccessPointResponse"
   },
   "UpdateNic": {
    "path": "/UpdateNic",
    "method": "POST",
+   "group": "Nic",
    "request": "UpdateNicRequest",
    "response": "UpdateNicResponse"
   },
   "UpdateRoute": {
    "path": "/UpdateRoute",
    "method": "POST",
+   "group": "Route",
    "request": "UpdateRouteRequest",
    "response": "UpdateRouteResponse"
   },
   "UpdateRoutePropagation": {
    "path": "/UpdateRoutePropagation",
    "method": "POST",
+   "group": "VirtualGateway",
    "request": "UpdateRoutePropagationRequest",
    "response": "UpdateRoutePropagationResponse"
   },
   "UpdateRouteTableLink": {
    "path": "/UpdateRouteTableLink",
    "method": "POST",
+   "group": "RouteTable",
    "request": "UpdateRouteTableLinkRequest",
    "response": "UpdateRouteTableLinkResponse"
   },
   "UpdateServerCertificate": {
    "path": "/UpdateServerCertificate",
    "method": "POST",
+   "group": "ServerCertificate",
    "request": "UpdateServerCertificateRequest",
    "response": "UpdateServerCertificateResponse"
   },
   "UpdateSnapshot": {
    "path": "/UpdateSnapshot",
    "method": "POST",
+   "group": "Snapshot",
    "request": "UpdateSnapshotRequest",
    "response": "UpdateSnapshotResponse"
   },
   "UpdateSubnet": {
    "path": "/UpdateSubnet",
    "method": "POST",
+   "group": "Subnet",
    "request": "UpdateSubnetRequest",
    "response": "UpdateSubnetResponse"
   },
   "UpdateUser": {
    "path": "/UpdateUser",
    "method": "POST",
+   "group": "User",
    "request": "UpdateUserRequest",
    "response": "UpdateUserResponse"
   },
   "UpdateUserGroup": {
    "path": "/UpdateUserGroup",
    "method": "POST",
+   "group": "UserGroup",
    "request": "UpdateUserGroupRequest",
    "response": "UpdateUserGroupResponse"
   },
   "UpdateVm": {
    "path": "/UpdateVm",
    "method": "POST",
+   "group": "Vm",
    "request": "UpdateVmRequest",
    "response": "UpdateVmResponse"
   },
   "UpdateVmGroup": {
    "path": "/UpdateVmGroup",
    "method": "POST",
+   "group": "VmGroup",
    "request": "UpdateVmGroupRequest",
    "response": "UpdateVmGroupResponse"
   },
   "UpdateVmTemplate": {
    "path": "/UpdateVmTemplate",
    "method": "POST",
+   "group": "VmTemplate",
    "request": "UpdateVmTemplateRequest",
    "response": "UpdateVmTemplateResponse"
   },
   "UpdateVolume": {
    "path": "/UpdateVolume",
    "method": "POST",
+   "group": "Volume",
    "request": "UpdateVolumeRequest",
    "response": "UpdateVolumeResponse"
   },
   "UpdateVpnConnection": {
    "path": "/UpdateVpnConnection",
    "method": "POST",
+   "group": "VpnConnection",
    "request": "UpdateVpnConnectionRequest",
    "response": "UpdateVpnConnectionResponse"
   }

--- a/contracts/scaleway.json
+++ b/contracts/scaleway.json
@@ -8,162 +8,192 @@
   "block/v1.CreateSnapshot": {
    "path": "/block/v1/zones/{zone}/snapshots",
    "method": "POST",
+   "group": "Snapshot",
    "request": "block/v1.CreateSnapshot.Request",
    "response": "block/v1.scaleway.block.v1.Snapshot"
   },
   "block/v1.CreateVolume": {
    "path": "/block/v1/zones/{zone}/volumes",
    "method": "POST",
+   "group": "Volume",
    "request": "block/v1.CreateVolume.Request",
    "response": "block/v1.scaleway.block.v1.Volume"
   },
   "block/v1.DeleteSnapshot": {
    "path": "/block/v1/zones/{zone}/snapshots/{snapshot_id}",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "Snapshot"
   },
   "block/v1.DeleteVolume": {
    "path": "/block/v1/zones/{zone}/volumes/{volume_id}",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "Volume"
   },
   "block/v1.ExportSnapshotToObjectStorage": {
    "path": "/block/v1/zones/{zone}/snapshots/{snapshot_id}/export-to-object-storage",
    "method": "POST",
+   "group": "Snapshot",
    "request": "block/v1.ExportSnapshotToObjectStorage.Request",
    "response": "block/v1.scaleway.block.v1.Snapshot"
   },
   "block/v1.GetSnapshot": {
    "path": "/block/v1/zones/{zone}/snapshots/{snapshot_id}",
    "method": "GET",
+   "group": "Snapshot",
    "response": "block/v1.scaleway.block.v1.Snapshot"
   },
   "block/v1.GetVolume": {
    "path": "/block/v1/zones/{zone}/volumes/{volume_id}",
    "method": "GET",
+   "group": "Volume",
    "response": "block/v1.scaleway.block.v1.Volume"
   },
   "block/v1.ImportSnapshotFromObjectStorage": {
    "path": "/block/v1/zones/{zone}/snapshots/import-from-object-storage",
    "method": "POST",
+   "group": "Snapshot",
    "request": "block/v1.ImportSnapshotFromObjectStorage.Request",
    "response": "block/v1.scaleway.block.v1.Snapshot"
   },
   "block/v1.ListSnapshots": {
    "path": "/block/v1/zones/{zone}/snapshots",
    "method": "GET",
+   "group": "Snapshot",
    "response": "block/v1.scaleway.block.v1.ListSnapshotsResponse"
   },
   "block/v1.ListVolumeTypes": {
    "path": "/block/v1/zones/{zone}/volume-types",
    "method": "GET",
+   "group": "Volume Type",
    "response": "block/v1.scaleway.block.v1.ListVolumeTypesResponse"
   },
   "block/v1.ListVolumes": {
    "path": "/block/v1/zones/{zone}/volumes",
    "method": "GET",
+   "group": "Volume",
    "response": "block/v1.scaleway.block.v1.ListVolumesResponse"
   },
   "block/v1.UpdateSnapshot": {
    "path": "/block/v1/zones/{zone}/snapshots/{snapshot_id}",
    "method": "PATCH",
+   "group": "Snapshot",
    "request": "block/v1.UpdateSnapshot.Request",
    "response": "block/v1.scaleway.block.v1.Snapshot"
   },
   "block/v1.UpdateVolume": {
    "path": "/block/v1/zones/{zone}/volumes/{volume_id}",
    "method": "PATCH",
+   "group": "Volume",
    "request": "block/v1.UpdateVolume.Request",
    "response": "block/v1.scaleway.block.v1.Volume"
   },
   "block/v1alpha1.CreateSnapshot": {
    "path": "/block/v1alpha1/zones/{zone}/snapshots",
    "method": "POST",
+   "group": "Snapshot",
    "request": "block/v1alpha1.CreateSnapshot.Request",
    "response": "block/v1alpha1.scaleway.block.v1alpha1.Snapshot"
   },
   "block/v1alpha1.CreateVolume": {
    "path": "/block/v1alpha1/zones/{zone}/volumes",
    "method": "POST",
+   "group": "Volume",
    "request": "block/v1alpha1.CreateVolume.Request",
    "response": "block/v1alpha1.scaleway.block.v1alpha1.Volume"
   },
   "block/v1alpha1.DeleteSnapshot": {
    "path": "/block/v1alpha1/zones/{zone}/snapshots/{snapshot_id}",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "Snapshot"
   },
   "block/v1alpha1.DeleteVolume": {
    "path": "/block/v1alpha1/zones/{zone}/volumes/{volume_id}",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "Volume"
   },
   "block/v1alpha1.ExportSnapshotToObjectStorage": {
    "path": "/block/v1alpha1/zones/{zone}/snapshots/{snapshot_id}/export-to-object-storage",
    "method": "POST",
+   "group": "Snapshot",
    "request": "block/v1alpha1.ExportSnapshotToObjectStorage.Request",
    "response": "block/v1alpha1.scaleway.block.v1alpha1.Snapshot"
   },
   "block/v1alpha1.GetSnapshot": {
    "path": "/block/v1alpha1/zones/{zone}/snapshots/{snapshot_id}",
    "method": "GET",
+   "group": "Snapshot",
    "response": "block/v1alpha1.scaleway.block.v1alpha1.Snapshot"
   },
   "block/v1alpha1.GetVolume": {
    "path": "/block/v1alpha1/zones/{zone}/volumes/{volume_id}",
    "method": "GET",
+   "group": "Volume",
    "response": "block/v1alpha1.scaleway.block.v1alpha1.Volume"
   },
   "block/v1alpha1.ImportSnapshotFromObjectStorage": {
    "path": "/block/v1alpha1/zones/{zone}/snapshots/import-from-object-storage",
    "method": "POST",
+   "group": "Snapshot",
    "request": "block/v1alpha1.ImportSnapshotFromObjectStorage.Request",
    "response": "block/v1alpha1.scaleway.block.v1alpha1.Snapshot"
   },
   "block/v1alpha1.ImportSnapshotFromS3": {
    "path": "/block/v1alpha1/zones/{zone}/snapshots/import-from-s3",
    "method": "POST",
+   "group": "Snapshot",
    "request": "block/v1alpha1.ImportSnapshotFromS3.Request",
    "response": "block/v1alpha1.scaleway.block.v1alpha1.Snapshot"
   },
   "block/v1alpha1.ListSnapshots": {
    "path": "/block/v1alpha1/zones/{zone}/snapshots",
    "method": "GET",
+   "group": "Snapshot",
    "response": "block/v1alpha1.scaleway.block.v1alpha1.ListSnapshotsResponse"
   },
   "block/v1alpha1.ListVolumeTypes": {
    "path": "/block/v1alpha1/zones/{zone}/volume-types",
    "method": "GET",
+   "group": "Volume Type",
    "response": "block/v1alpha1.scaleway.block.v1alpha1.ListVolumeTypesResponse"
   },
   "block/v1alpha1.ListVolumes": {
    "path": "/block/v1alpha1/zones/{zone}/volumes",
    "method": "GET",
+   "group": "Volume",
    "response": "block/v1alpha1.scaleway.block.v1alpha1.ListVolumesResponse"
   },
   "block/v1alpha1.UpdateSnapshot": {
    "path": "/block/v1alpha1/zones/{zone}/snapshots/{snapshot_id}",
    "method": "PATCH",
+   "group": "Snapshot",
    "request": "block/v1alpha1.UpdateSnapshot.Request",
    "response": "block/v1alpha1.scaleway.block.v1alpha1.Snapshot"
   },
   "block/v1alpha1.UpdateVolume": {
    "path": "/block/v1alpha1/zones/{zone}/volumes/{volume_id}",
    "method": "PATCH",
+   "group": "Volume",
    "request": "block/v1alpha1.UpdateVolume.Request",
    "response": "block/v1alpha1.scaleway.block.v1alpha1.Volume"
   },
   "iam/v1alpha1.AddGroupMember": {
    "path": "/iam/v1alpha1/groups/{group_id}/add-member",
    "method": "POST",
+   "group": "Groups",
    "request": "iam/v1alpha1.AddGroupMember.Request",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.Group"
   },
   "iam/v1alpha1.AddGroupMembers": {
    "path": "/iam/v1alpha1/groups/{group_id}/add-members",
    "method": "POST",
+   "group": "Groups",
    "request": "iam/v1alpha1.AddGroupMembers.Request",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.Group"
   },
   "iam/v1alpha1.AddSamlCertificate": {
    "path": "/iam/v1alpha1/saml/{saml_id}/certificates",
    "method": "POST",
+   "group": "SAML",
    "request": "iam/v1alpha1.AddSamlCertificate.Request",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.SamlCertificate"
   },
@@ -176,135 +206,163 @@
   "iam/v1alpha1.ClonePolicy": {
    "path": "/iam/v1alpha1/policies/{policy_id}/clone",
    "method": "POST",
+   "group": "Policies",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.Policy"
   },
   "iam/v1alpha1.CreateAPIKey": {
    "path": "/iam/v1alpha1/api-keys",
    "method": "POST",
+   "group": "API Keys",
    "request": "iam/v1alpha1.CreateAPIKey.Request",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.APIKey"
   },
   "iam/v1alpha1.CreateApplication": {
    "path": "/iam/v1alpha1/applications",
    "method": "POST",
+   "group": "Applications",
    "request": "iam/v1alpha1.CreateApplication.Request",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.Application"
   },
   "iam/v1alpha1.CreateGroup": {
    "path": "/iam/v1alpha1/groups",
    "method": "POST",
+   "group": "Groups",
    "request": "iam/v1alpha1.CreateGroup.Request",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.Group"
   },
   "iam/v1alpha1.CreatePolicy": {
    "path": "/iam/v1alpha1/policies",
    "method": "POST",
+   "group": "Policies",
    "request": "iam/v1alpha1.CreatePolicy.Request",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.Policy"
   },
   "iam/v1alpha1.CreateSSHKey": {
    "path": "/iam/v1alpha1/ssh-keys",
    "method": "POST",
+   "group": "SSH Keys",
    "request": "iam/v1alpha1.CreateSSHKey.Request",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.SSHKey"
   },
   "iam/v1alpha1.CreateScimToken": {
    "path": "/iam/v1alpha1/scim/{scim_id}/tokens",
    "method": "POST",
+   "group": "SCIM",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.CreateScimTokenResponse"
   },
   "iam/v1alpha1.CreateUser": {
    "path": "/iam/v1alpha1/users",
    "method": "POST",
+   "group": "Users",
    "request": "iam/v1alpha1.CreateUser.Request",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.User"
   },
   "iam/v1alpha1.CreateUserMFAOTP": {
    "path": "/iam/v1alpha1/users/{user_id}/mfa-otp",
    "method": "POST",
+   "group": "Users",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.MFAOTP"
   },
   "iam/v1alpha1.DeleteAPIKey": {
    "path": "/iam/v1alpha1/api-keys/{access_key}",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "API Keys"
   },
   "iam/v1alpha1.DeleteApplication": {
    "path": "/iam/v1alpha1/applications/{application_id}",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "Applications"
   },
   "iam/v1alpha1.DeleteGroup": {
    "path": "/iam/v1alpha1/groups/{group_id}",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "Groups"
   },
   "iam/v1alpha1.DeleteJWT": {
    "path": "/iam/v1alpha1/jwts/{jti}",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "JWTs"
   },
   "iam/v1alpha1.DeletePolicy": {
    "path": "/iam/v1alpha1/policies/{policy_id}",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "Policies"
   },
   "iam/v1alpha1.DeleteSSHKey": {
    "path": "/iam/v1alpha1/ssh-keys/{ssh_key_id}",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "SSH Keys"
   },
   "iam/v1alpha1.DeleteSaml": {
    "path": "/iam/v1alpha1/saml/{saml_id}",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "SAML"
   },
   "iam/v1alpha1.DeleteSamlCertificate": {
    "path": "/iam/v1alpha1/saml-certificates/{certificate_id}",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "SAML"
   },
   "iam/v1alpha1.DeleteScim": {
    "path": "/iam/v1alpha1/scim/{scim_id}",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "SCIM"
   },
   "iam/v1alpha1.DeleteScimToken": {
    "path": "/iam/v1alpha1/scim-tokens/{token_id}",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "SCIM"
   },
   "iam/v1alpha1.DeleteUser": {
    "path": "/iam/v1alpha1/users/{user_id}",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "Users"
   },
   "iam/v1alpha1.DeleteUserMFAOTP": {
    "path": "/iam/v1alpha1/users/{user_id}/mfa-otp",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "Users"
   },
   "iam/v1alpha1.EnableOrganizationSaml": {
    "path": "/iam/v1alpha1/organizations/{organization_id}/saml",
    "method": "POST",
+   "group": "SAML",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.Saml"
   },
   "iam/v1alpha1.EnableOrganizationScim": {
    "path": "/iam/v1alpha1/organizations/{organization_id}/scim",
    "method": "POST",
+   "group": "SCIM",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.Scim"
   },
   "iam/v1alpha1.GetAPIKey": {
    "path": "/iam/v1alpha1/api-keys/{access_key}",
    "method": "GET",
+   "group": "API Keys",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.APIKey"
   },
   "iam/v1alpha1.GetApplication": {
    "path": "/iam/v1alpha1/applications/{application_id}",
    "method": "GET",
+   "group": "Applications",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.Application"
   },
   "iam/v1alpha1.GetGroup": {
    "path": "/iam/v1alpha1/groups/{group_id}",
    "method": "GET",
+   "group": "Groups",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.Group"
   },
   "iam/v1alpha1.GetJWT": {
    "path": "/iam/v1alpha1/jwts/{jti}",
    "method": "GET",
+   "group": "JWTs",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.JWT"
   },
   "iam/v1alpha1.GetLog": {
    "path": "/iam/v1alpha1/logs/{log_id}",
    "method": "GET",
+   "group": "Logs",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.Log"
   },
   "iam/v1alpha1.GetOrganization": {
@@ -315,41 +373,49 @@
   "iam/v1alpha1.GetOrganizationSaml": {
    "path": "/iam/v1alpha1/organizations/{organization_id}/saml",
    "method": "GET",
+   "group": "SAML",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.Saml"
   },
   "iam/v1alpha1.GetOrganizationScim": {
    "path": "/iam/v1alpha1/organizations/{organization_id}/scim",
    "method": "GET",
+   "group": "SCIM",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.Scim"
   },
   "iam/v1alpha1.GetOrganizationSecuritySettings": {
    "path": "/iam/v1alpha1/organizations/{organization_id}/security-settings",
    "method": "GET",
+   "group": "Security Settings",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.OrganizationSecuritySettings"
   },
   "iam/v1alpha1.GetPolicy": {
    "path": "/iam/v1alpha1/policies/{policy_id}",
    "method": "GET",
+   "group": "Policies",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.Policy"
   },
   "iam/v1alpha1.GetQuotum": {
    "path": "/iam/v1alpha1/quota/{quotum_name}",
    "method": "GET",
+   "group": "Quotas",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.Quotum"
   },
   "iam/v1alpha1.GetSSHKey": {
    "path": "/iam/v1alpha1/ssh-keys/{ssh_key_id}",
    "method": "GET",
+   "group": "SSH Keys",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.SSHKey"
   },
   "iam/v1alpha1.GetSamlCertificate": {
    "path": "/iam/v1alpha1/saml-certificates/{certificate_id}",
    "method": "GET",
+   "group": "SAML",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.SamlCertificate"
   },
   "iam/v1alpha1.GetUser": {
    "path": "/iam/v1alpha1/users/{user_id}",
    "method": "GET",
+   "group": "Users",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.User"
   },
   "iam/v1alpha1.GetUserConnections": {
@@ -370,81 +436,97 @@
   "iam/v1alpha1.ListAPIKeys": {
    "path": "/iam/v1alpha1/api-keys",
    "method": "GET",
+   "group": "API Keys",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.ListAPIKeysResponse"
   },
   "iam/v1alpha1.ListApplications": {
    "path": "/iam/v1alpha1/applications",
    "method": "GET",
+   "group": "Applications",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.ListApplicationsResponse"
   },
   "iam/v1alpha1.ListGracePeriods": {
    "path": "/iam/v1alpha1/grace-periods",
    "method": "GET",
+   "group": "Users",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.ListGracePeriodsResponse"
   },
   "iam/v1alpha1.ListGroups": {
    "path": "/iam/v1alpha1/groups",
    "method": "GET",
+   "group": "Groups",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.ListGroupsResponse"
   },
   "iam/v1alpha1.ListJWTs": {
    "path": "/iam/v1alpha1/jwts",
    "method": "GET",
+   "group": "JWTs",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.ListJWTsResponse"
   },
   "iam/v1alpha1.ListLogs": {
    "path": "/iam/v1alpha1/logs",
    "method": "GET",
+   "group": "Logs",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.ListLogsResponse"
   },
   "iam/v1alpha1.ListPermissionSets": {
    "path": "/iam/v1alpha1/permission-sets",
    "method": "GET",
+   "group": "Permission sets",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.ListPermissionSetsResponse"
   },
   "iam/v1alpha1.ListPolicies": {
    "path": "/iam/v1alpha1/policies",
    "method": "GET",
+   "group": "Policies",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.ListPoliciesResponse"
   },
   "iam/v1alpha1.ListQuota": {
    "path": "/iam/v1alpha1/quota",
    "method": "GET",
+   "group": "Quotas",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.ListQuotaResponse"
   },
   "iam/v1alpha1.ListRules": {
    "path": "/iam/v1alpha1/rules",
    "method": "GET",
+   "group": "Rules",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.ListRulesResponse"
   },
   "iam/v1alpha1.ListSSHKeys": {
    "path": "/iam/v1alpha1/ssh-keys",
    "method": "GET",
+   "group": "SSH Keys",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.ListSSHKeysResponse"
   },
   "iam/v1alpha1.ListSamlCertificates": {
    "path": "/iam/v1alpha1/saml/{saml_id}/certificates",
    "method": "GET",
+   "group": "SAML",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.ListSamlCertificatesResponse"
   },
   "iam/v1alpha1.ListScimTokens": {
    "path": "/iam/v1alpha1/scim/{scim_id}/tokens",
    "method": "GET",
+   "group": "SCIM",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.ListScimTokensResponse"
   },
   "iam/v1alpha1.ListUsers": {
    "path": "/iam/v1alpha1/users",
    "method": "GET",
+   "group": "Users",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.ListUsersResponse"
   },
   "iam/v1alpha1.LockUser": {
    "path": "/iam/v1alpha1/users/{user_id}/lock",
    "method": "POST",
+   "group": "Users",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.User"
   },
   "iam/v1alpha1.RemoveGroupMember": {
    "path": "/iam/v1alpha1/groups/{group_id}/remove-member",
    "method": "POST",
+   "group": "Groups",
    "request": "iam/v1alpha1.RemoveGroupMember.Request",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.Group"
   },
@@ -456,6 +538,7 @@
   "iam/v1alpha1.SetGroupMembers": {
    "path": "/iam/v1alpha1/groups/{group_id}/members",
    "method": "PUT",
+   "group": "Groups",
    "request": "iam/v1alpha1.SetGroupMembers.Request",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.Group"
   },
@@ -468,29 +551,34 @@
   "iam/v1alpha1.SetRules": {
    "path": "/iam/v1alpha1/rules",
    "method": "PUT",
+   "group": "Rules",
    "request": "iam/v1alpha1.SetRules.Request",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.SetRulesResponse"
   },
   "iam/v1alpha1.UnlockUser": {
    "path": "/iam/v1alpha1/users/{user_id}/unlock",
    "method": "POST",
+   "group": "Users",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.User"
   },
   "iam/v1alpha1.UpdateAPIKey": {
    "path": "/iam/v1alpha1/api-keys/{access_key}",
    "method": "PATCH",
+   "group": "API Keys",
    "request": "iam/v1alpha1.UpdateAPIKey.Request",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.APIKey"
   },
   "iam/v1alpha1.UpdateApplication": {
    "path": "/iam/v1alpha1/applications/{application_id}",
    "method": "PATCH",
+   "group": "Applications",
    "request": "iam/v1alpha1.UpdateApplication.Request",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.Application"
   },
   "iam/v1alpha1.UpdateGroup": {
    "path": "/iam/v1alpha1/groups/{group_id}",
    "method": "PATCH",
+   "group": "Groups",
    "request": "iam/v1alpha1.UpdateGroup.Request",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.Group"
   },
@@ -503,60 +591,70 @@
   "iam/v1alpha1.UpdateOrganizationSecuritySettings": {
    "path": "/iam/v1alpha1/organizations/{organization_id}/security-settings",
    "method": "PATCH",
+   "group": "Security Settings",
    "request": "iam/v1alpha1.UpdateOrganizationSecuritySettings.Request",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.OrganizationSecuritySettings"
   },
   "iam/v1alpha1.UpdatePolicy": {
    "path": "/iam/v1alpha1/policies/{policy_id}",
    "method": "PATCH",
+   "group": "Policies",
    "request": "iam/v1alpha1.UpdatePolicy.Request",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.Policy"
   },
   "iam/v1alpha1.UpdateSSHKey": {
    "path": "/iam/v1alpha1/ssh-keys/{ssh_key_id}",
    "method": "PATCH",
+   "group": "SSH Keys",
    "request": "iam/v1alpha1.UpdateSSHKey.Request",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.SSHKey"
   },
   "iam/v1alpha1.UpdateSaml": {
    "path": "/iam/v1alpha1/saml/{saml_id}",
    "method": "PATCH",
+   "group": "SAML",
    "request": "iam/v1alpha1.UpdateSaml.Request",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.Saml"
   },
   "iam/v1alpha1.UpdateUser": {
    "path": "/iam/v1alpha1/users/{user_id}",
    "method": "PATCH",
+   "group": "Users",
    "request": "iam/v1alpha1.UpdateUser.Request",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.User"
   },
   "iam/v1alpha1.UpdateUserPassword": {
    "path": "/iam/v1alpha1/users/{user_id}/update-password",
    "method": "POST",
+   "group": "Users",
    "request": "iam/v1alpha1.UpdateUserPassword.Request",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.User"
   },
   "iam/v1alpha1.UpdateUserUsername": {
    "path": "/iam/v1alpha1/users/{user_id}/update-username",
    "method": "POST",
+   "group": "Users",
    "request": "iam/v1alpha1.UpdateUserUsername.Request",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.User"
   },
   "iam/v1alpha1.ValidateUserMFAOTP": {
    "path": "/iam/v1alpha1/users/{user_id}/validate-mfa-otp",
    "method": "POST",
+   "group": "Users",
    "request": "iam/v1alpha1.ValidateUserMFAOTP.Request",
    "response": "iam/v1alpha1.scaleway.iam.v1alpha1.ValidateUserMFAOTPResponse"
   },
   "instance/v1.AttachServerFileSystem": {
    "path": "/instance/v1/zones/{zone}/servers/{server_id}/attach-filesystem",
    "method": "POST",
+   "group": "Instances",
    "request": "instance/v1.AttachServerFileSystem.Request",
    "response": "instance/v1.scaleway.instance.v1.AttachServerFileSystemResponse"
   },
   "instance/v1.AttachServerVolume": {
    "path": "/instance/v1/zones/{zone}/servers/{server_id}/attach-volume",
    "method": "POST",
+   "group": "Instances",
    "request": "instance/v1.AttachServerVolume.Request",
    "response": "instance/v1.scaleway.instance.v1.AttachServerVolumeResponse"
   },
@@ -568,112 +666,134 @@
   "instance/v1.CreateImage": {
    "path": "/instance/v1/zones/{zone}/images",
    "method": "POST",
+   "group": "Images",
    "request": "instance/v1.CreateImage.Request",
    "response": "instance/v1.scaleway.instance.v1.CreateImageResponse"
   },
   "instance/v1.CreateIp": {
    "path": "/instance/v1/zones/{zone}/ips",
    "method": "POST",
+   "group": "IPs",
    "request": "instance/v1.CreateIp.Request",
    "response": "instance/v1.scaleway.instance.v1.CreateIpResponse"
   },
   "instance/v1.CreatePlacementGroup": {
    "path": "/instance/v1/zones/{zone}/placement_groups",
    "method": "POST",
+   "group": "Placement Groups",
    "request": "instance/v1.CreatePlacementGroup.Request",
    "response": "instance/v1.scaleway.instance.v1.CreatePlacementGroupResponse"
   },
   "instance/v1.CreatePrivateNIC": {
    "path": "/instance/v1/zones/{zone}/servers/{server_id}/private_nics",
    "method": "POST",
+   "group": "Private NICs",
    "request": "instance/v1.CreatePrivateNIC.Request",
    "response": "instance/v1.scaleway.instance.v1.CreatePrivateNICResponse"
   },
   "instance/v1.CreateSecurityGroup": {
    "path": "/instance/v1/zones/{zone}/security_groups",
    "method": "POST",
+   "group": "Security Groups",
    "request": "instance/v1.CreateSecurityGroup.Request",
    "response": "instance/v1.scaleway.instance.v1.CreateSecurityGroupResponse"
   },
   "instance/v1.CreateSecurityGroupRule": {
    "path": "/instance/v1/zones/{zone}/security_groups/{security_group_id}/rules",
    "method": "POST",
+   "group": "Security Groups",
    "request": "instance/v1.CreateSecurityGroupRule.Request",
    "response": "instance/v1.scaleway.instance.v1.CreateSecurityGroupRuleResponse"
   },
   "instance/v1.CreateServer": {
    "path": "/instance/v1/zones/{zone}/servers",
    "method": "POST",
+   "group": "Instances",
    "request": "instance/v1.CreateServer.Request",
    "response": "instance/v1.scaleway.instance.v1.CreateServerResponse"
   },
   "instance/v1.CreateSnapshot": {
    "path": "/instance/v1/zones/{zone}/snapshots",
    "method": "POST",
+   "group": "Snapshots",
    "request": "instance/v1.CreateSnapshot.Request",
    "response": "instance/v1.scaleway.instance.v1.CreateSnapshotResponse"
   },
   "instance/v1.CreateVolume": {
    "path": "/instance/v1/zones/{zone}/volumes",
    "method": "POST",
+   "group": "Volumes",
    "request": "instance/v1.CreateVolume.Request",
    "response": "instance/v1.scaleway.instance.v1.CreateVolumeResponse"
   },
   "instance/v1.DeleteImage": {
    "path": "/instance/v1/zones/{zone}/images/{image_id}",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "Images"
   },
   "instance/v1.DeleteIp": {
    "path": "/instance/v1/zones/{zone}/ips/{ip}",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "IPs"
   },
   "instance/v1.DeletePlacementGroup": {
    "path": "/instance/v1/zones/{zone}/placement_groups/{placement_group_id}",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "Placement Groups"
   },
   "instance/v1.DeletePrivateNIC": {
    "path": "/instance/v1/zones/{zone}/servers/{server_id}/private_nics/{private_nic_id}",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "Private NICs"
   },
   "instance/v1.DeleteSecurityGroup": {
    "path": "/instance/v1/zones/{zone}/security_groups/{security_group_id}",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "Security Groups"
   },
   "instance/v1.DeleteSecurityGroupRule": {
    "path": "/instance/v1/zones/{zone}/security_groups/{security_group_id}/rules/{security_group_rule_id}",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "Security Groups"
   },
   "instance/v1.DeleteServer": {
    "path": "/instance/v1/zones/{zone}/servers/{server_id}",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "Instances"
   },
   "instance/v1.DeleteServerUserData": {
    "path": "/instance/v1/zones/{zone}/servers/{server_id}/user_data/{key}",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "User Data"
   },
   "instance/v1.DeleteSnapshot": {
    "path": "/instance/v1/zones/{zone}/snapshots/{snapshot_id}",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "Snapshots"
   },
   "instance/v1.DeleteVolume": {
    "path": "/instance/v1/zones/{zone}/volumes/{volume_id}",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "Volumes"
   },
   "instance/v1.DetachServerFileSystem": {
    "path": "/instance/v1/zones/{zone}/servers/{server_id}/detach-filesystem",
    "method": "POST",
+   "group": "Instances",
    "request": "instance/v1.DetachServerFileSystem.Request",
    "response": "instance/v1.scaleway.instance.v1.DetachServerFileSystemResponse"
   },
   "instance/v1.DetachServerVolume": {
    "path": "/instance/v1/zones/{zone}/servers/{server_id}/detach-volume",
    "method": "POST",
+   "group": "Instances",
    "request": "instance/v1.DetachServerVolume.Request",
    "response": "instance/v1.scaleway.instance.v1.DetachServerVolumeResponse"
   },
   "instance/v1.ExportSnapshot": {
    "path": "/instance/v1/zones/{zone}/snapshots/{snapshot_id}/export",
    "method": "POST",
+   "group": "Snapshots",
    "request": "instance/v1.ExportSnapshot.Request",
    "response": "instance/v1.scaleway.instance.v1.ExportSnapshotResponse"
   },
@@ -685,297 +805,352 @@
   "instance/v1.GetImage": {
    "path": "/instance/v1/zones/{zone}/images/{image_id}",
    "method": "GET",
+   "group": "Images",
    "response": "instance/v1.scaleway.instance.v1.GetImageResponse"
   },
   "instance/v1.GetIp": {
    "path": "/instance/v1/zones/{zone}/ips/{ip}",
    "method": "GET",
+   "group": "IPs",
    "response": "instance/v1.scaleway.instance.v1.GetIpResponse"
   },
   "instance/v1.GetPlacementGroup": {
    "path": "/instance/v1/zones/{zone}/placement_groups/{placement_group_id}",
    "method": "GET",
+   "group": "Placement Groups",
    "response": "instance/v1.scaleway.instance.v1.GetPlacementGroupResponse"
   },
   "instance/v1.GetPlacementGroupServers": {
    "path": "/instance/v1/zones/{zone}/placement_groups/{placement_group_id}/servers",
    "method": "GET",
+   "group": "Placement Groups",
    "response": "instance/v1.scaleway.instance.v1.GetPlacementGroupServersResponse"
   },
   "instance/v1.GetPrivateNIC": {
    "path": "/instance/v1/zones/{zone}/servers/{server_id}/private_nics/{private_nic_id}",
    "method": "GET",
+   "group": "Private NICs",
    "response": "instance/v1.scaleway.instance.v1.GetPrivateNICResponse"
   },
   "instance/v1.GetSecurityGroup": {
    "path": "/instance/v1/zones/{zone}/security_groups/{security_group_id}",
    "method": "GET",
+   "group": "Security Groups",
    "response": "instance/v1.scaleway.instance.v1.GetSecurityGroupResponse"
   },
   "instance/v1.GetSecurityGroupRule": {
    "path": "/instance/v1/zones/{zone}/security_groups/{security_group_id}/rules/{security_group_rule_id}",
    "method": "GET",
+   "group": "Security Groups",
    "response": "instance/v1.scaleway.instance.v1.GetSecurityGroupRuleResponse"
   },
   "instance/v1.GetServer": {
    "path": "/instance/v1/zones/{zone}/servers/{server_id}",
    "method": "GET",
+   "group": "Instances",
    "response": "instance/v1.scaleway.instance.v1.GetServerResponse"
   },
   "instance/v1.GetServerCompatibleTypes": {
    "path": "/instance/v1/zones/{zone}/servers/{server_id}/compatible-types",
    "method": "GET",
+   "group": "Instances",
    "response": "instance/v1.scaleway.instance.v1.ServerCompatibleTypes"
   },
   "instance/v1.GetServerTypesAvailability": {
    "path": "/instance/v1/zones/{zone}/products/servers/availability",
    "method": "GET",
+   "group": "Instance Types",
    "response": "instance/v1.scaleway.instance.v1.GetServerTypesAvailabilityResponse"
   },
   "instance/v1.GetServerUserData": {
    "path": "/instance/v1/zones/{zone}/servers/{server_id}/user_data/{key}",
    "method": "GET",
+   "group": "User Data",
    "response": "instance/v1.scaleway.std.File"
   },
   "instance/v1.GetSnapshot": {
    "path": "/instance/v1/zones/{zone}/snapshots/{snapshot_id}",
    "method": "GET",
+   "group": "Snapshots",
    "response": "instance/v1.scaleway.instance.v1.GetSnapshotResponse"
   },
   "instance/v1.GetVolume": {
    "path": "/instance/v1/zones/{zone}/volumes/{volume_id}",
    "method": "GET",
+   "group": "Volumes",
    "response": "instance/v1.scaleway.instance.v1.GetVolumeResponse"
   },
   "instance/v1.ListDefaultSecurityGroupRules": {
    "path": "/instance/v1/zones/{zone}/security_groups/default/rules",
    "method": "GET",
+   "group": "Security Groups",
    "response": "instance/v1.scaleway.instance.v1.ListSecurityGroupRulesResponse"
   },
   "instance/v1.ListImages": {
    "path": "/instance/v1/zones/{zone}/images",
    "method": "GET",
+   "group": "Images",
    "response": "instance/v1.scaleway.instance.v1.ListImagesResponse"
   },
   "instance/v1.ListIps": {
    "path": "/instance/v1/zones/{zone}/ips",
    "method": "GET",
+   "group": "IPs",
    "response": "instance/v1.scaleway.instance.v1.ListIpsResponse"
   },
   "instance/v1.ListPlacementGroups": {
    "path": "/instance/v1/zones/{zone}/placement_groups",
    "method": "GET",
+   "group": "Placement Groups",
    "response": "instance/v1.scaleway.instance.v1.ListPlacementGroupsResponse"
   },
   "instance/v1.ListPrivateNICs": {
    "path": "/instance/v1/zones/{zone}/servers/{server_id}/private_nics",
    "method": "GET",
+   "group": "Private NICs",
    "response": "instance/v1.scaleway.instance.v1.ListPrivateNICsResponse"
   },
   "instance/v1.ListSecurityGroupRules": {
    "path": "/instance/v1/zones/{zone}/security_groups/{security_group_id}/rules",
    "method": "GET",
+   "group": "Security Groups",
    "response": "instance/v1.scaleway.instance.v1.ListSecurityGroupRulesResponse"
   },
   "instance/v1.ListSecurityGroups": {
    "path": "/instance/v1/zones/{zone}/security_groups",
    "method": "GET",
+   "group": "Security Groups",
    "response": "instance/v1.scaleway.instance.v1.ListSecurityGroupsResponse"
   },
   "instance/v1.ListServerActions": {
    "path": "/instance/v1/zones/{zone}/servers/{server_id}/action",
    "method": "GET",
+   "group": "Instances",
    "response": "instance/v1.scaleway.instance.v1.ListServerActionsResponse"
   },
   "instance/v1.ListServerUserData": {
    "path": "/instance/v1/zones/{zone}/servers/{server_id}/user_data",
    "method": "GET",
+   "group": "User Data",
    "response": "instance/v1.scaleway.instance.v1.ListServerUserDataResponse"
   },
   "instance/v1.ListServers": {
    "path": "/instance/v1/zones/{zone}/servers",
    "method": "GET",
+   "group": "Instances",
    "response": "instance/v1.scaleway.instance.v1.ListServersResponse"
   },
   "instance/v1.ListServersTypes": {
    "path": "/instance/v1/zones/{zone}/products/servers",
    "method": "GET",
+   "group": "Instance Types",
    "response": "instance/v1.scaleway.instance.v1.ListServersTypesResponse"
   },
   "instance/v1.ListSnapshots": {
    "path": "/instance/v1/zones/{zone}/snapshots",
    "method": "GET",
+   "group": "Snapshots",
    "response": "instance/v1.scaleway.instance.v1.ListSnapshotsResponse"
   },
   "instance/v1.ListVolumes": {
    "path": "/instance/v1/zones/{zone}/volumes",
    "method": "GET",
+   "group": "Volumes",
    "response": "instance/v1.scaleway.instance.v1.ListVolumesResponse"
   },
   "instance/v1.ListVolumesTypes": {
    "path": "/instance/v1/zones/{zone}/products/volumes",
    "method": "GET",
+   "group": "Volume Types",
    "response": "instance/v1.scaleway.instance.v1.ListVolumesTypesResponse"
   },
   "instance/v1.ReleaseIpToIpam": {
    "path": "/instance/v1/zones/{zone}/ips/{ip_id}/release-to-ipam",
-   "method": "POST"
+   "method": "POST",
+   "group": "IPs"
   },
   "instance/v1.ServerAction": {
    "path": "/instance/v1/zones/{zone}/servers/{server_id}/action",
    "method": "POST",
+   "group": "Instances",
    "request": "instance/v1.ServerAction.Request",
    "response": "instance/v1.scaleway.instance.v1.ServerActionResponse"
   },
   "instance/v1.SetImage": {
    "path": "/instance/v1/zones/{zone}/images/{id}",
    "method": "PUT",
+   "group": "Images",
    "request": "instance/v1.SetImage.Request",
    "response": "instance/v1.scaleway.instance.v1.SetImageResponse"
   },
   "instance/v1.SetPlacementGroup": {
    "path": "/instance/v1/zones/{zone}/placement_groups/{placement_group_id}",
    "method": "PUT",
+   "group": "Placement Groups",
    "request": "instance/v1.SetPlacementGroup.Request",
    "response": "instance/v1.scaleway.instance.v1.SetPlacementGroupResponse"
   },
   "instance/v1.SetPlacementGroupServers": {
    "path": "/instance/v1/zones/{zone}/placement_groups/{placement_group_id}/servers",
    "method": "PUT",
+   "group": "Placement Groups",
    "request": "instance/v1.SetPlacementGroupServers.Request",
    "response": "instance/v1.scaleway.instance.v1.SetPlacementGroupServersResponse"
   },
   "instance/v1.SetSecurityGroup": {
    "path": "/instance/v1/zones/{zone}/security_groups/{id}",
    "method": "PUT",
+   "group": "Security Groups",
    "request": "instance/v1.SetSecurityGroup.Request",
    "response": "instance/v1.scaleway.instance.v1.SetSecurityGroupResponse"
   },
   "instance/v1.SetSecurityGroupRule": {
    "path": "/instance/v1/zones/{zone}/security_groups/{security_group_id}/rules/{security_group_rule_id}",
    "method": "PUT",
+   "group": "Security Groups",
    "request": "instance/v1.SetSecurityGroupRule.Request",
    "response": "instance/v1.scaleway.instance.v1.SetSecurityGroupRuleResponse"
   },
   "instance/v1.SetSecurityGroupRules": {
    "path": "/instance/v1/zones/{zone}/security_groups/{security_group_id}/rules",
    "method": "PUT",
+   "group": "Security Groups",
    "request": "instance/v1.SetSecurityGroupRules.Request",
    "response": "instance/v1.scaleway.instance.v1.SetSecurityGroupRulesResponse"
   },
   "instance/v1.SetServerUserData": {
    "path": "/instance/v1/zones/{zone}/servers/{server_id}/user_data/{key}",
-   "method": "PATCH"
+   "method": "PATCH",
+   "group": "User Data"
   },
   "instance/v1.SetSnapshot": {
    "path": "/instance/v1/zones/{zone}/snapshots/{snapshot_id}",
    "method": "PUT",
+   "group": "Snapshots",
    "request": "instance/v1.SetSnapshot.Request",
    "response": "instance/v1.scaleway.instance.v1.SetSnapshotResponse"
   },
   "instance/v1.SetVolume": {
    "path": "/instance/v1/zones/{zone}/volumes/{id}",
    "method": "PUT",
+   "group": "Volumes",
    "request": "instance/v1.SetVolume.Request",
    "response": "instance/v1.scaleway.instance.v1.SetVolumeResponse"
   },
   "instance/v1.UpdateImage": {
    "path": "/instance/v1/zones/{zone}/images/{image_id}",
    "method": "PATCH",
+   "group": "Images",
    "request": "instance/v1.UpdateImage.Request",
    "response": "instance/v1.scaleway.instance.v1.UpdateImageResponse"
   },
   "instance/v1.UpdateIp": {
    "path": "/instance/v1/zones/{zone}/ips/{ip}",
    "method": "PATCH",
+   "group": "IPs",
    "request": "instance/v1.UpdateIp.Request",
    "response": "instance/v1.scaleway.instance.v1.UpdateIpResponse"
   },
   "instance/v1.UpdatePlacementGroup": {
    "path": "/instance/v1/zones/{zone}/placement_groups/{placement_group_id}",
    "method": "PATCH",
+   "group": "Placement Groups",
    "request": "instance/v1.UpdatePlacementGroup.Request",
    "response": "instance/v1.scaleway.instance.v1.UpdatePlacementGroupResponse"
   },
   "instance/v1.UpdatePlacementGroupServers": {
    "path": "/instance/v1/zones/{zone}/placement_groups/{placement_group_id}/servers",
    "method": "PATCH",
+   "group": "Placement Groups",
    "request": "instance/v1.UpdatePlacementGroupServers.Request",
    "response": "instance/v1.scaleway.instance.v1.UpdatePlacementGroupServersResponse"
   },
   "instance/v1.UpdatePrivateNIC": {
    "path": "/instance/v1/zones/{zone}/servers/{server_id}/private_nics/{private_nic_id}",
    "method": "PATCH",
+   "group": "Private NICs",
    "request": "instance/v1.UpdatePrivateNIC.Request",
    "response": "instance/v1.scaleway.instance.v1.PrivateNIC"
   },
   "instance/v1.UpdateSecurityGroup": {
    "path": "/instance/v1/zones/{zone}/security_groups/{security_group_id}",
    "method": "PATCH",
+   "group": "Security Groups",
    "request": "instance/v1.UpdateSecurityGroup.Request",
    "response": "instance/v1.scaleway.instance.v1.UpdateSecurityGroupResponse"
   },
   "instance/v1.UpdateSecurityGroupRule": {
    "path": "/instance/v1/zones/{zone}/security_groups/{security_group_id}/rules/{security_group_rule_id}",
    "method": "PATCH",
+   "group": "Security Groups",
    "request": "instance/v1.UpdateSecurityGroupRule.Request",
    "response": "instance/v1.scaleway.instance.v1.UpdateSecurityGroupRuleResponse"
   },
   "instance/v1.UpdateServer": {
    "path": "/instance/v1/zones/{zone}/servers/{server_id}",
    "method": "PATCH",
+   "group": "Instances",
    "request": "instance/v1.UpdateServer.Request",
    "response": "instance/v1.scaleway.instance.v1.UpdateServerResponse"
   },
   "instance/v1.UpdateSnapshot": {
    "path": "/instance/v1/zones/{zone}/snapshots/{snapshot_id}",
    "method": "PATCH",
+   "group": "Snapshots",
    "request": "instance/v1.UpdateSnapshot.Request",
    "response": "instance/v1.scaleway.instance.v1.UpdateSnapshotResponse"
   },
   "instance/v1.UpdateVolume": {
    "path": "/instance/v1/zones/{zone}/volumes/{volume_id}",
    "method": "PATCH",
+   "group": "Volumes",
    "request": "instance/v1.UpdateVolume.Request",
    "response": "instance/v1.scaleway.instance.v1.UpdateVolumeResponse"
   },
   "ipam/v1.AttachIP": {
    "path": "/ipam/v1/regions/{region}/ips/{ip_id}/attach",
    "method": "POST",
+   "group": "IPs",
    "request": "ipam/v1.AttachIP.Request",
    "response": "ipam/v1.scaleway.ipam.v1.IP"
   },
   "ipam/v1.BookIP": {
    "path": "/ipam/v1/regions/{region}/ips",
    "method": "POST",
+   "group": "IPs",
    "request": "ipam/v1.BookIP.Request",
    "response": "ipam/v1.scaleway.ipam.v1.IP"
   },
   "ipam/v1.DetachIP": {
    "path": "/ipam/v1/regions/{region}/ips/{ip_id}/detach",
    "method": "POST",
+   "group": "IPs",
    "request": "ipam/v1.DetachIP.Request",
    "response": "ipam/v1.scaleway.ipam.v1.IP"
   },
   "ipam/v1.GetIP": {
    "path": "/ipam/v1/regions/{region}/ips/{ip_id}",
    "method": "GET",
+   "group": "IPs",
    "response": "ipam/v1.scaleway.ipam.v1.IP"
   },
   "ipam/v1.ListIPs": {
    "path": "/ipam/v1/regions/{region}/ips",
    "method": "GET",
+   "group": "IPs",
    "response": "ipam/v1.scaleway.ipam.v1.ListIPsResponse"
   },
   "ipam/v1.MoveIP": {
    "path": "/ipam/v1/regions/{region}/ips/{ip_id}/move",
    "method": "POST",
+   "group": "IPs",
    "request": "ipam/v1.MoveIP.Request",
    "response": "ipam/v1.scaleway.ipam.v1.IP"
   },
   "ipam/v1.ReleaseIP": {
    "path": "/ipam/v1/regions/{region}/ips/{ip_id}",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "IPs"
   },
   "ipam/v1.ReleaseIPSet": {
    "path": "/ipam/v1/regions/{region}/ip-sets/release",
@@ -985,228 +1160,272 @@
   "ipam/v1.UpdateIP": {
    "path": "/ipam/v1/regions/{region}/ips/{ip_id}",
    "method": "PATCH",
+   "group": "IPs",
    "request": "ipam/v1.UpdateIP.Request",
    "response": "ipam/v1.scaleway.ipam.v1.IP"
   },
   "marketplace/v2.GetCategory": {
    "path": "/marketplace/v2/categories/{category_id}",
    "method": "GET",
+   "group": "Marketplace Image Categories",
    "response": "marketplace/v2.scaleway.marketplace.v2.Category"
   },
   "marketplace/v2.GetImage": {
    "path": "/marketplace/v2/images/{image_id}",
    "method": "GET",
+   "group": "Marketplace Images",
    "response": "marketplace/v2.scaleway.marketplace.v2.Image"
   },
   "marketplace/v2.GetLocalImage": {
    "path": "/marketplace/v2/local-images/{local_image_id}",
    "method": "GET",
+   "group": "Marketplace Local Images",
    "response": "marketplace/v2.scaleway.marketplace.v2.LocalImage"
   },
   "marketplace/v2.GetVersion": {
    "path": "/marketplace/v2/versions/{version_id}",
    "method": "GET",
+   "group": "Marketplace Image Versions",
    "response": "marketplace/v2.scaleway.marketplace.v2.Version"
   },
   "marketplace/v2.ListCategories": {
    "path": "/marketplace/v2/categories",
    "method": "GET",
+   "group": "Marketplace Image Categories",
    "response": "marketplace/v2.scaleway.marketplace.v2.ListCategoriesResponse"
   },
   "marketplace/v2.ListImages": {
    "path": "/marketplace/v2/images",
    "method": "GET",
+   "group": "Marketplace Images",
    "response": "marketplace/v2.scaleway.marketplace.v2.ListImagesResponse"
   },
   "marketplace/v2.ListLocalImages": {
    "path": "/marketplace/v2/local-images",
    "method": "GET",
+   "group": "Marketplace Local Images",
    "response": "marketplace/v2.scaleway.marketplace.v2.ListLocalImagesResponse"
   },
   "marketplace/v2.ListVersions": {
    "path": "/marketplace/v2/versions",
    "method": "GET",
+   "group": "Marketplace Image Versions",
    "response": "marketplace/v2.scaleway.marketplace.v2.ListVersionsResponse"
   },
   "vpc/v2.AddPrivateNetworkS3Endpoint": {
    "path": "/vpc/v2/regions/{region}/s3-integration/{vpc_id}/private-networks",
    "method": "POST",
+   "group": "S3 integration",
    "request": "vpc/v2.AddPrivateNetworkS3Endpoint.Request",
    "response": "vpc/v2.scaleway.vpc.v2.AddPrivateNetworkS3EndpointResponse"
   },
   "vpc/v2.CreateIngressRule": {
    "path": "/vpc/v2/regions/{region}/ingress-rules",
    "method": "POST",
+   "group": "Ingress Rules",
    "request": "vpc/v2.CreateIngressRule.Request",
    "response": "vpc/v2.scaleway.vpc.v2.IngressRule"
   },
   "vpc/v2.CreatePrivateNetwork": {
    "path": "/vpc/v2/regions/{region}/private-networks",
    "method": "POST",
+   "group": "Private Networks",
    "request": "vpc/v2.CreatePrivateNetwork.Request",
    "response": "vpc/v2.scaleway.vpc.v2.PrivateNetwork"
   },
   "vpc/v2.CreateRoute": {
    "path": "/vpc/v2/regions/{region}/routes",
    "method": "POST",
+   "group": "Routes",
    "request": "vpc/v2.CreateRoute.Request",
    "response": "vpc/v2.scaleway.vpc.v2.Route"
   },
   "vpc/v2.CreateVPC": {
    "path": "/vpc/v2/regions/{region}/vpcs",
    "method": "POST",
+   "group": "VPCs",
    "request": "vpc/v2.CreateVPC.Request",
    "response": "vpc/v2.scaleway.vpc.v2.VPC"
   },
   "vpc/v2.CreateVPCConnector": {
    "path": "/vpc/v2/regions/{region}/vpc-connectors",
    "method": "POST",
+   "group": "VPC Connectors",
    "request": "vpc/v2.CreateVPCConnector.Request",
    "response": "vpc/v2.scaleway.vpc.v2.VPCConnector"
   },
   "vpc/v2.DeleteIngressRule": {
    "path": "/vpc/v2/regions/{region}/ingress-rules/{rule_id}",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "Ingress Rules"
   },
   "vpc/v2.DeletePrivateNetwork": {
    "path": "/vpc/v2/regions/{region}/private-networks/{private_network_id}",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "Private Networks"
   },
   "vpc/v2.DeletePrivateNetworkS3Endpoint": {
    "path": "/vpc/v2/regions/{region}/s3-integration/{vpc_id}/private-networks/{private_network_id}",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "S3 integration"
   },
   "vpc/v2.DeleteRoute": {
    "path": "/vpc/v2/regions/{region}/routes/{route_id}",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "Routes"
   },
   "vpc/v2.DeleteVPC": {
    "path": "/vpc/v2/regions/{region}/vpcs/{vpc_id}",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "VPCs"
   },
   "vpc/v2.DeleteVPCConnector": {
    "path": "/vpc/v2/regions/{region}/vpc-connectors/{vpc_connector_id}",
-   "method": "DELETE"
+   "method": "DELETE",
+   "group": "VPC Connectors"
   },
   "vpc/v2.DisableS3Endpoint": {
    "path": "/vpc/v2/regions/{region}/s3-integration/{vpc_id}/disable",
    "method": "POST",
+   "group": "S3 integration",
    "response": "vpc/v2.scaleway.vpc.v2.VPC"
   },
   "vpc/v2.EnableDHCP": {
    "path": "/vpc/v2/regions/{region}/private-networks/{private_network_id}/enable-dhcp",
    "method": "POST",
+   "group": "Private Networks",
    "response": "vpc/v2.scaleway.vpc.v2.PrivateNetwork"
   },
   "vpc/v2.EnableRouting": {
    "path": "/vpc/v2/regions/{region}/vpcs/{vpc_id}/enable-routing",
    "method": "POST",
+   "group": "VPCs",
    "response": "vpc/v2.scaleway.vpc.v2.VPC"
   },
   "vpc/v2.EnableS3Endpoint": {
    "path": "/vpc/v2/regions/{region}/s3-integration/{vpc_id}/enable",
    "method": "POST",
+   "group": "S3 integration",
    "response": "vpc/v2.scaleway.vpc.v2.VPC"
   },
   "vpc/v2.GetAcl": {
    "path": "/vpc/v2/regions/{region}/vpcs/{vpc_id}/acl-rules",
    "method": "GET",
+   "group": "Network ACLs",
    "response": "vpc/v2.scaleway.vpc.v2.GetAclResponse"
   },
   "vpc/v2.GetIngressRule": {
    "path": "/vpc/v2/regions/{region}/ingress-rules/{rule_id}",
    "method": "GET",
+   "group": "Ingress Rules",
    "response": "vpc/v2.scaleway.vpc.v2.IngressRule"
   },
   "vpc/v2.GetPrivateNetwork": {
    "path": "/vpc/v2/regions/{region}/private-networks/{private_network_id}",
    "method": "GET",
+   "group": "Private Networks",
    "response": "vpc/v2.scaleway.vpc.v2.PrivateNetwork"
   },
   "vpc/v2.GetRoute": {
    "path": "/vpc/v2/regions/{region}/routes/{route_id}",
    "method": "GET",
+   "group": "Routes",
    "response": "vpc/v2.scaleway.vpc.v2.Route"
   },
   "vpc/v2.GetVPC": {
    "path": "/vpc/v2/regions/{region}/vpcs/{vpc_id}",
    "method": "GET",
+   "group": "VPCs",
    "response": "vpc/v2.scaleway.vpc.v2.VPC"
   },
   "vpc/v2.GetVPCConnector": {
    "path": "/vpc/v2/regions/{region}/vpc-connectors/{vpc_connector_id}",
    "method": "GET",
+   "group": "VPC Connectors",
    "response": "vpc/v2.scaleway.vpc.v2.VPCConnector"
   },
   "vpc/v2.ListIngressRules": {
    "path": "/vpc/v2/regions/{region}/ingress-rules",
    "method": "GET",
+   "group": "Ingress Rules",
    "response": "vpc/v2.scaleway.vpc.v2.ListIngressRulesResponse"
   },
   "vpc/v2.ListPrivateNetworks": {
    "path": "/vpc/v2/regions/{region}/private-networks",
    "method": "GET",
+   "group": "Private Networks",
    "response": "vpc/v2.scaleway.vpc.v2.ListPrivateNetworksResponse"
   },
   "vpc/v2.ListSubnetOverlaps": {
    "path": "/vpc/v2/regions/{region}/vpc-connectors/{vpc_connector_id}/subnet-overlaps",
    "method": "GET",
+   "group": "VPC Connectors",
    "response": "vpc/v2.scaleway.vpc.v2.ListSubnetOverlapsResponse"
   },
   "vpc/v2.ListSubnets": {
    "path": "/vpc/v2/regions/{region}/subnets",
    "method": "GET",
+   "group": "Subnets",
    "response": "vpc/v2.scaleway.vpc.v2.ListSubnetsResponse"
   },
   "vpc/v2.ListVPCConnectors": {
    "path": "/vpc/v2/regions/{region}/vpc-connectors",
    "method": "GET",
+   "group": "VPC Connectors",
    "response": "vpc/v2.scaleway.vpc.v2.ListVPCConnectorsResponse"
   },
   "vpc/v2.ListVPCs": {
    "path": "/vpc/v2/regions/{region}/vpcs",
    "method": "GET",
+   "group": "VPCs",
    "response": "vpc/v2.scaleway.vpc.v2.ListVPCsResponse"
   },
   "vpc/v2.SetAcl": {
    "path": "/vpc/v2/regions/{region}/vpcs/{vpc_id}/acl-rules",
    "method": "PUT",
+   "group": "Network ACLs",
    "request": "vpc/v2.SetAcl.Request",
    "response": "vpc/v2.scaleway.vpc.v2.SetAclResponse"
   },
   "vpc/v2.SetPrivateNetworksS3Endpoint": {
    "path": "/vpc/v2/regions/{region}/s3-integration/{vpc_id}/private-networks",
    "method": "PUT",
+   "group": "S3 integration",
    "request": "vpc/v2.SetPrivateNetworksS3Endpoint.Request",
    "response": "vpc/v2.scaleway.vpc.v2.SetPrivateNetworksS3EndpointResponse"
   },
   "vpc/v2.UpdateIngressRule": {
    "path": "/vpc/v2/regions/{region}/ingress-rules/{rule_id}",
    "method": "PATCH",
+   "group": "Ingress Rules",
    "request": "vpc/v2.UpdateIngressRule.Request",
    "response": "vpc/v2.scaleway.vpc.v2.IngressRule"
   },
   "vpc/v2.UpdatePrivateNetwork": {
    "path": "/vpc/v2/regions/{region}/private-networks/{private_network_id}",
    "method": "PATCH",
+   "group": "Private Networks",
    "request": "vpc/v2.UpdatePrivateNetwork.Request",
    "response": "vpc/v2.scaleway.vpc.v2.PrivateNetwork"
   },
   "vpc/v2.UpdateRoute": {
    "path": "/vpc/v2/regions/{region}/routes/{route_id}",
    "method": "PATCH",
+   "group": "Routes",
    "request": "vpc/v2.UpdateRoute.Request",
    "response": "vpc/v2.scaleway.vpc.v2.Route"
   },
   "vpc/v2.UpdateVPC": {
    "path": "/vpc/v2/regions/{region}/vpcs/{vpc_id}",
    "method": "PATCH",
+   "group": "VPCs",
    "request": "vpc/v2.UpdateVPC.Request",
    "response": "vpc/v2.scaleway.vpc.v2.VPC"
   },
   "vpc/v2.UpdateVPCConnector": {
    "path": "/vpc/v2/regions/{region}/vpc-connectors/{vpc_connector_id}",
    "method": "PATCH",
+   "group": "VPC Connectors",
    "request": "vpc/v2.UpdateVPCConnector.Request",
    "response": "vpc/v2.scaleway.vpc.v2.VPCConnector"
   }

--- a/coverage/exoscale-coverage.json
+++ b/coverage/exoscale-coverage.json
@@ -23,29 +23,133 @@
       ]
     }
   ],
+  "groups": [
+    {
+      "group": "ai",
+      "total": 22,
+      "implemented": 0,
+      "declined": 22,
+      "unknown": 0
+    },
+    {
+      "group": "audit-trail",
+      "total": 1,
+      "implemented": 0,
+      "declined": 0,
+      "unknown": 1
+    },
+    {
+      "group": "block-storage",
+      "total": 13,
+      "implemented": 0,
+      "declined": 0,
+      "unknown": 13
+    },
+    {
+      "group": "compute",
+      "total": 111,
+      "implemented": 42,
+      "declined": 9,
+      "unknown": 60
+    },
+    {
+      "group": "dbaas",
+      "total": 146,
+      "implemented": 0,
+      "declined": 146,
+      "unknown": 0
+    },
+    {
+      "group": "dns",
+      "total": 10,
+      "implemented": 0,
+      "declined": 10,
+      "unknown": 0
+    },
+    {
+      "group": "exoscale",
+      "total": 2,
+      "implemented": 0,
+      "declined": 2,
+      "unknown": 0
+    },
+    {
+      "group": "general",
+      "total": 2,
+      "implemented": 2,
+      "declined": 0,
+      "unknown": 0
+    },
+    {
+      "group": "iam",
+      "total": 18,
+      "implemented": 0,
+      "declined": 18,
+      "unknown": 0
+    },
+    {
+      "group": "kms",
+      "total": 16,
+      "implemented": 0,
+      "declined": 16,
+      "unknown": 0
+    },
+    {
+      "group": "organization",
+      "total": 4,
+      "implemented": 0,
+      "declined": 3,
+      "unknown": 1
+    },
+    {
+      "group": "quotas",
+      "total": 2,
+      "implemented": 2,
+      "declined": 0,
+      "unknown": 0
+    },
+    {
+      "group": "sks",
+      "total": 25,
+      "implemented": 0,
+      "declined": 25,
+      "unknown": 0
+    },
+    {
+      "group": "sos",
+      "total": 2,
+      "implemented": 0,
+      "declined": 2,
+      "unknown": 0
+    }
+  ],
   "entries": [
     {
       "operation": "exoscale/v2.add-external-source-to-security-group",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.add-instance-protection",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
       "operation": "exoscale/v2.add-rule-to-security-group",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
       "operation": "exoscale/v2.add-service-to-load-balancer",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
@@ -53,12 +157,14 @@
       "product": "exoscale",
       "reason": "the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies",
       "version": "2.0.0",
+      "group": "iam",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.attach-block-storage-volume-to-instance",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "block-storage",
       "status": "unknown"
     },
     {
@@ -66,30 +172,35 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.attach-instance-to-elastic-ip",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
       "operation": "exoscale/v2.attach-instance-to-private-network",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.attach-instance-to-security-group",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
       "operation": "exoscale/v2.attach-instance-to-subnet",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
@@ -97,12 +208,14 @@
       "product": "exoscale",
       "reason": "a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing",
       "version": "2.0.0",
+      "group": "kms",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.copy-template",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
@@ -110,12 +223,14 @@
       "product": "exoscale",
       "reason": "inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station",
       "version": "2.0.0",
+      "group": "ai",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.create-anti-affinity-group",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
@@ -123,18 +238,21 @@
       "product": "exoscale",
       "reason": "the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies",
       "version": "2.0.0",
+      "group": "iam",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.create-block-storage-snapshot",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "block-storage",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.create-block-storage-volume",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "block-storage",
       "status": "unknown"
     },
     {
@@ -142,6 +260,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -149,6 +268,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -156,6 +276,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -163,6 +284,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -170,6 +292,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -177,6 +300,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -184,6 +308,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -191,6 +316,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -198,6 +324,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -205,6 +332,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -212,6 +340,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -219,6 +348,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -226,6 +356,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -233,6 +364,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -240,6 +372,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -247,6 +380,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -254,6 +388,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -261,6 +396,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -268,6 +404,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -275,6 +412,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -282,6 +420,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -289,6 +428,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -296,6 +436,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -303,6 +444,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -310,6 +452,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -317,6 +460,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -324,6 +468,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -331,6 +476,7 @@
       "product": "exoscale",
       "reason": "inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station",
       "version": "2.0.0",
+      "group": "ai",
       "status": "declined"
     },
     {
@@ -338,6 +484,7 @@
       "product": "exoscale",
       "reason": "authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet",
       "version": "2.0.0",
+      "group": "dns",
       "status": "declined"
     },
     {
@@ -345,12 +492,14 @@
       "product": "exoscale",
       "reason": "authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet",
       "version": "2.0.0",
+      "group": "dns",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.create-elastic-ip",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
@@ -358,18 +507,21 @@
       "product": "exoscale",
       "reason": "the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies",
       "version": "2.0.0",
+      "group": "iam",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.create-instance",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
       "operation": "exoscale/v2.create-instance-pool",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
@@ -377,12 +529,14 @@
       "product": "exoscale",
       "reason": "a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing",
       "version": "2.0.0",
+      "group": "kms",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.create-load-balancer",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
@@ -390,24 +544,28 @@
       "product": "exoscale",
       "reason": "inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station",
       "version": "2.0.0",
+      "group": "ai",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.create-private-network",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.create-route",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.create-security-group",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
@@ -415,6 +573,7 @@
       "product": "exoscale",
       "reason": "a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere",
       "version": "2.0.0",
+      "group": "sks",
       "status": "declined"
     },
     {
@@ -422,18 +581,21 @@
       "product": "exoscale",
       "reason": "a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere",
       "version": "2.0.0",
+      "group": "sks",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.create-snapshot",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.create-subnet",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
@@ -441,12 +603,14 @@
       "product": "exoscale",
       "reason": "the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies",
       "version": "2.0.0",
+      "group": "iam",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.create-vpc",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
@@ -454,6 +618,7 @@
       "product": "exoscale",
       "reason": "a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing",
       "version": "2.0.0",
+      "group": "kms",
       "status": "declined"
     },
     {
@@ -461,12 +626,14 @@
       "product": "exoscale",
       "reason": "inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station",
       "version": "2.0.0",
+      "group": "ai",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.delete-anti-affinity-group",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
@@ -474,18 +641,21 @@
       "product": "exoscale",
       "reason": "the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies",
       "version": "2.0.0",
+      "group": "iam",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.delete-block-storage-snapshot",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "block-storage",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.delete-block-storage-volume",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "block-storage",
       "status": "unknown"
     },
     {
@@ -493,6 +663,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -500,6 +671,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -507,6 +679,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -514,6 +687,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -521,6 +695,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -528,6 +703,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -535,6 +711,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -542,6 +719,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -549,6 +727,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -556,6 +735,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -563,6 +743,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -570,6 +751,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -577,6 +759,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -584,6 +767,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -591,6 +775,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -598,6 +783,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -605,6 +791,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -612,6 +799,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -619,6 +807,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -626,6 +815,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -633,6 +823,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -640,6 +831,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -647,6 +839,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -654,6 +847,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -661,6 +855,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -668,6 +863,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -675,6 +871,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -682,6 +879,7 @@
       "product": "exoscale",
       "reason": "inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station",
       "version": "2.0.0",
+      "group": "ai",
       "status": "declined"
     },
     {
@@ -689,6 +887,7 @@
       "product": "exoscale",
       "reason": "authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet",
       "version": "2.0.0",
+      "group": "dns",
       "status": "declined"
     },
     {
@@ -696,12 +895,14 @@
       "product": "exoscale",
       "reason": "authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet",
       "version": "2.0.0",
+      "group": "dns",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.delete-elastic-ip",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
@@ -709,30 +910,35 @@
       "product": "exoscale",
       "reason": "the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies",
       "version": "2.0.0",
+      "group": "iam",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.delete-instance",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
       "operation": "exoscale/v2.delete-instance-pool",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.delete-load-balancer",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.delete-load-balancer-service",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
@@ -740,12 +946,14 @@
       "product": "exoscale",
       "reason": "inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station",
       "version": "2.0.0",
+      "group": "ai",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.delete-private-network",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
@@ -753,6 +961,7 @@
       "product": "exoscale",
       "reason": "authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet",
       "version": "2.0.0",
+      "group": "compute",
       "status": "declined"
     },
     {
@@ -760,24 +969,28 @@
       "product": "exoscale",
       "reason": "authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet",
       "version": "2.0.0",
+      "group": "compute",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.delete-route",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.delete-rule-from-security-group",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
       "operation": "exoscale/v2.delete-security-group",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
@@ -785,6 +998,7 @@
       "product": "exoscale",
       "reason": "a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere",
       "version": "2.0.0",
+      "group": "sks",
       "status": "declined"
     },
     {
@@ -792,30 +1006,35 @@
       "product": "exoscale",
       "reason": "a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere",
       "version": "2.0.0",
+      "group": "sks",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.delete-snapshot",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.delete-ssh-key",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
       "operation": "exoscale/v2.delete-subnet",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.delete-template",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
@@ -823,18 +1042,21 @@
       "product": "exoscale",
       "reason": "the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies",
       "version": "2.0.0",
+      "group": "iam",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.delete-vpc",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.detach-block-storage-volume",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "block-storage",
       "status": "unknown"
     },
     {
@@ -842,30 +1064,35 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.detach-instance-from-elastic-ip",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
       "operation": "exoscale/v2.detach-instance-from-private-network",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.detach-instance-from-security-group",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
       "operation": "exoscale/v2.detach-instance-from-subnet",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
@@ -873,6 +1100,7 @@
       "product": "exoscale",
       "reason": "a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing",
       "version": "2.0.0",
+      "group": "kms",
       "status": "declined"
     },
     {
@@ -880,6 +1108,7 @@
       "product": "exoscale",
       "reason": "a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing",
       "version": "2.0.0",
+      "group": "kms",
       "status": "declined"
     },
     {
@@ -887,6 +1116,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -894,6 +1124,7 @@
       "product": "exoscale",
       "reason": "a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing",
       "version": "2.0.0",
+      "group": "kms",
       "status": "declined"
     },
     {
@@ -901,12 +1132,14 @@
       "product": "exoscale",
       "reason": "a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing",
       "version": "2.0.0",
+      "group": "kms",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.enable-tpm",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
@@ -914,12 +1147,14 @@
       "product": "exoscale",
       "reason": "a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing",
       "version": "2.0.0",
+      "group": "kms",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.evict-instance-pool-members",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
@@ -927,12 +1162,14 @@
       "product": "exoscale",
       "reason": "a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere",
       "version": "2.0.0",
+      "group": "sks",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.export-snapshot",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
@@ -940,6 +1177,7 @@
       "product": "exoscale",
       "reason": "a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing",
       "version": "2.0.0",
+      "group": "kms",
       "status": "declined"
     },
     {
@@ -947,6 +1185,7 @@
       "product": "exoscale",
       "reason": "a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere",
       "version": "2.0.0",
+      "group": "sks",
       "status": "declined"
     },
     {
@@ -954,6 +1193,7 @@
       "product": "exoscale",
       "reason": "a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere",
       "version": "2.0.0",
+      "group": "sks",
       "status": "declined"
     },
     {
@@ -961,6 +1201,7 @@
       "product": "exoscale",
       "reason": "a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere",
       "version": "2.0.0",
+      "group": "sks",
       "status": "declined"
     },
     {
@@ -968,6 +1209,7 @@
       "product": "exoscale",
       "reason": "a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere",
       "version": "2.0.0",
+      "group": "sks",
       "status": "declined"
     },
     {
@@ -975,12 +1217,14 @@
       "product": "exoscale",
       "reason": "inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station",
       "version": "2.0.0",
+      "group": "ai",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.get-anti-affinity-group",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
@@ -988,18 +1232,21 @@
       "product": "exoscale",
       "reason": "the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies",
       "version": "2.0.0",
+      "group": "iam",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.get-block-storage-snapshot",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "block-storage",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.get-block-storage-volume",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "block-storage",
       "status": "unknown"
     },
     {
@@ -1007,6 +1254,7 @@
       "product": "exoscale",
       "reason": "there is no console to proxy and no password to reveal: machines here are opened by the registered SSH key, and a URL or a password the emulator invented would claim an access nothing answers",
       "version": "2.0.0",
+      "group": "compute",
       "status": "declined"
     },
     {
@@ -1014,6 +1262,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1021,6 +1270,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1028,6 +1278,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1035,6 +1286,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1042,6 +1294,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1049,6 +1302,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1056,6 +1310,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1063,6 +1318,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1070,6 +1326,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1077,6 +1334,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1084,6 +1342,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1091,6 +1350,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1098,6 +1358,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1105,6 +1366,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1112,6 +1374,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1119,6 +1382,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1126,6 +1390,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1133,6 +1398,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1140,6 +1406,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1147,6 +1414,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1154,6 +1422,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1161,6 +1430,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1168,6 +1438,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1175,6 +1446,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1182,6 +1454,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1189,6 +1462,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1196,6 +1470,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1203,6 +1478,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1210,6 +1486,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1217,6 +1494,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1224,6 +1502,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1231,6 +1510,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1238,12 +1518,14 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.get-deploy-target",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
@@ -1251,6 +1533,7 @@
       "product": "exoscale",
       "reason": "inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station",
       "version": "2.0.0",
+      "group": "ai",
       "status": "declined"
     },
     {
@@ -1258,6 +1541,7 @@
       "product": "exoscale",
       "reason": "inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station",
       "version": "2.0.0",
+      "group": "ai",
       "status": "declined"
     },
     {
@@ -1265,6 +1549,7 @@
       "product": "exoscale",
       "reason": "authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet",
       "version": "2.0.0",
+      "group": "dns",
       "status": "declined"
     },
     {
@@ -1272,6 +1557,7 @@
       "product": "exoscale",
       "reason": "authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet",
       "version": "2.0.0",
+      "group": "dns",
       "status": "declined"
     },
     {
@@ -1279,12 +1565,14 @@
       "product": "exoscale",
       "reason": "authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet",
       "version": "2.0.0",
+      "group": "dns",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.get-elastic-ip",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
@@ -1292,6 +1580,7 @@
       "product": "exoscale",
       "reason": "there is no account behind this emulator and no consumption to report, so any figure here would be one it invented and somebody planned against",
       "version": "2.0.0",
+      "group": "organization",
       "status": "declined"
     },
     {
@@ -1299,6 +1588,7 @@
       "product": "exoscale",
       "reason": "the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies",
       "version": "2.0.0",
+      "group": "iam",
       "status": "declined"
     },
     {
@@ -1306,6 +1596,7 @@
       "product": "exoscale",
       "reason": "the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies",
       "version": "2.0.0",
+      "group": "iam",
       "status": "declined"
     },
     {
@@ -1327,24 +1618,28 @@
       "product": "exoscale",
       "reason": "inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station",
       "version": "2.0.0",
+      "group": "ai",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.get-instance",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
       "operation": "exoscale/v2.get-instance-pool",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.get-instance-type",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
@@ -1352,6 +1647,7 @@
       "product": "exoscale",
       "reason": "a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing",
       "version": "2.0.0",
+      "group": "kms",
       "status": "declined"
     },
     {
@@ -1359,18 +1655,21 @@
       "product": "exoscale",
       "reason": "there is no account behind this emulator and no consumption to report, so any figure here would be one it invented and somebody planned against",
       "version": "2.0.0",
+      "group": "organization",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.get-load-balancer",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.get-load-balancer-service",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
@@ -1378,30 +1677,35 @@
       "product": "exoscale",
       "reason": "inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station",
       "version": "2.0.0",
+      "group": "ai",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.get-operation",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "general",
       "status": "implemented"
     },
     {
       "operation": "exoscale/v2.get-organization",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "organization",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.get-private-network",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.get-quota",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "quotas",
       "status": "implemented"
     },
     {
@@ -1409,6 +1713,7 @@
       "product": "exoscale",
       "reason": "authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet",
       "version": "2.0.0",
+      "group": "compute",
       "status": "declined"
     },
     {
@@ -1416,12 +1721,14 @@
       "product": "exoscale",
       "reason": "authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet",
       "version": "2.0.0",
+      "group": "compute",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.get-security-group",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
@@ -1429,6 +1736,7 @@
       "product": "exoscale",
       "reason": "a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere",
       "version": "2.0.0",
+      "group": "sks",
       "status": "declined"
     },
     {
@@ -1436,6 +1744,7 @@
       "product": "exoscale",
       "reason": "a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere",
       "version": "2.0.0",
+      "group": "sks",
       "status": "declined"
     },
     {
@@ -1443,6 +1752,7 @@
       "product": "exoscale",
       "reason": "a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere",
       "version": "2.0.0",
+      "group": "sks",
       "status": "declined"
     },
     {
@@ -1450,12 +1760,14 @@
       "product": "exoscale",
       "reason": "a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere",
       "version": "2.0.0",
+      "group": "sks",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.get-snapshot",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
@@ -1463,24 +1775,28 @@
       "product": "exoscale",
       "reason": "object storage is refused across this project for a measured reason: clients build the S3 endpoint in code, so serving it needs DNS interception and a certificate, recorded in docs/limits.md",
       "version": "2.0.0",
+      "group": "sos",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.get-ssh-key",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
       "operation": "exoscale/v2.get-subnet",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.get-template",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
@@ -1488,6 +1804,7 @@
       "product": "exoscale",
       "reason": "there is no account behind this emulator and no consumption to report, so any figure here would be one it invented and somebody planned against",
       "version": "2.0.0",
+      "group": "organization",
       "status": "declined"
     },
     {
@@ -1495,12 +1812,14 @@
       "product": "exoscale",
       "reason": "inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station",
       "version": "2.0.0",
+      "group": "ai",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.get-vpc",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
@@ -1508,6 +1827,7 @@
       "product": "exoscale",
       "reason": "inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station",
       "version": "2.0.0",
+      "group": "ai",
       "status": "declined"
     },
     {
@@ -1515,12 +1835,14 @@
       "product": "exoscale",
       "reason": "inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station",
       "version": "2.0.0",
+      "group": "ai",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.list-anti-affinity-groups",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
@@ -1528,18 +1850,21 @@
       "product": "exoscale",
       "reason": "the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies",
       "version": "2.0.0",
+      "group": "iam",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.list-block-storage-snapshots",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "block-storage",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.list-block-storage-volumes",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "block-storage",
       "status": "unknown"
     },
     {
@@ -1547,6 +1872,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1554,6 +1880,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1561,6 +1888,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1568,6 +1896,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1575,6 +1904,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1582,6 +1912,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1589,6 +1920,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1596,6 +1928,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1603,6 +1936,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1610,12 +1944,14 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.list-deploy-targets",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
@@ -1623,6 +1959,7 @@
       "product": "exoscale",
       "reason": "inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station",
       "version": "2.0.0",
+      "group": "ai",
       "status": "declined"
     },
     {
@@ -1630,6 +1967,7 @@
       "product": "exoscale",
       "reason": "authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet",
       "version": "2.0.0",
+      "group": "dns",
       "status": "declined"
     },
     {
@@ -1637,18 +1975,21 @@
       "product": "exoscale",
       "reason": "authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet",
       "version": "2.0.0",
+      "group": "dns",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.list-elastic-ips",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
       "operation": "exoscale/v2.list-events",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "audit-trail",
       "status": "unknown"
     },
     {
@@ -1656,24 +1997,28 @@
       "product": "exoscale",
       "reason": "the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies",
       "version": "2.0.0",
+      "group": "iam",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.list-instance-pools",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.list-instance-types",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
       "operation": "exoscale/v2.list-instances",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
@@ -1681,6 +2026,7 @@
       "product": "exoscale",
       "reason": "a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing",
       "version": "2.0.0",
+      "group": "kms",
       "status": "declined"
     },
     {
@@ -1688,12 +2034,14 @@
       "product": "exoscale",
       "reason": "a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing",
       "version": "2.0.0",
+      "group": "kms",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.list-load-balancers",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
@@ -1701,30 +2049,35 @@
       "product": "exoscale",
       "reason": "inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station",
       "version": "2.0.0",
+      "group": "ai",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.list-private-networks",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.list-quotas",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "quotas",
       "status": "implemented"
     },
     {
       "operation": "exoscale/v2.list-routes",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.list-security-groups",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
@@ -1732,6 +2085,7 @@
       "product": "exoscale",
       "reason": "a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere",
       "version": "2.0.0",
+      "group": "sks",
       "status": "declined"
     },
     {
@@ -1739,6 +2093,7 @@
       "product": "exoscale",
       "reason": "a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere",
       "version": "2.0.0",
+      "group": "sks",
       "status": "declined"
     },
     {
@@ -1746,12 +2101,14 @@
       "product": "exoscale",
       "reason": "a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere",
       "version": "2.0.0",
+      "group": "sks",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.list-snapshots",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
@@ -1759,24 +2116,28 @@
       "product": "exoscale",
       "reason": "object storage is refused across this project for a measured reason: clients build the S3 endpoint in code, so serving it needs DNS interception and a certificate, recorded in docs/limits.md",
       "version": "2.0.0",
+      "group": "sos",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.list-ssh-keys",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
       "operation": "exoscale/v2.list-subnets",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.list-templates",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
@@ -1784,30 +2145,35 @@
       "product": "exoscale",
       "reason": "the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies",
       "version": "2.0.0",
+      "group": "iam",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.list-vpc-routes",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.list-vpcs",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.list-zones",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "general",
       "status": "implemented"
     },
     {
       "operation": "exoscale/v2.promote-snapshot-to-template",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
@@ -1815,36 +2181,42 @@
       "product": "exoscale",
       "reason": "a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing",
       "version": "2.0.0",
+      "group": "kms",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.reboot-instance",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
       "operation": "exoscale/v2.register-ssh-key",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
       "operation": "exoscale/v2.register-template",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.remove-external-source-from-security-group",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.remove-instance-protection",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
@@ -1852,6 +2224,7 @@
       "product": "exoscale",
       "reason": "a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing",
       "version": "2.0.0",
+      "group": "kms",
       "status": "declined"
     },
     {
@@ -1859,6 +2232,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1866,6 +2240,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1873,6 +2248,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1880,6 +2256,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1887,6 +2264,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1894,6 +2272,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1901,12 +2280,14 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.reset-elastic-ip-field",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
@@ -1914,18 +2295,21 @@
       "product": "exoscale",
       "reason": "the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies",
       "version": "2.0.0",
+      "group": "iam",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.reset-instance",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
       "operation": "exoscale/v2.reset-instance-field",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
@@ -1933,42 +2317,49 @@
       "product": "exoscale",
       "reason": "there is no console to proxy and no password to reveal: machines here are opened by the registered SSH key, and a URL or a password the emulator invented would claim an access nothing answers",
       "version": "2.0.0",
+      "group": "compute",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.reset-instance-pool-field",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.reset-load-balancer-field",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.reset-load-balancer-service-field",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.reset-private-network-field",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.resize-block-storage-volume",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "block-storage",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.resize-instance-disk",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
@@ -1976,6 +2367,7 @@
       "product": "exoscale",
       "reason": "inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station",
       "version": "2.0.0",
+      "group": "ai",
       "status": "declined"
     },
     {
@@ -1983,6 +2375,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1990,6 +2383,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -1997,6 +2391,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2004,6 +2399,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2011,6 +2407,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2018,6 +2415,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2025,6 +2423,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2032,6 +2431,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2039,6 +2439,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2046,6 +2447,7 @@
       "product": "exoscale",
       "reason": "inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station",
       "version": "2.0.0",
+      "group": "ai",
       "status": "declined"
     },
     {
@@ -2053,12 +2455,14 @@
       "product": "exoscale",
       "reason": "there is no console to proxy and no password to reveal: machines here are opened by the registered SSH key, and a URL or a password the emulator invented would claim an access nothing answers",
       "version": "2.0.0",
+      "group": "compute",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.revert-instance-to-snapshot",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
@@ -2066,6 +2470,7 @@
       "product": "exoscale",
       "reason": "inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station",
       "version": "2.0.0",
+      "group": "ai",
       "status": "declined"
     },
     {
@@ -2073,6 +2478,7 @@
       "product": "exoscale",
       "reason": "a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing",
       "version": "2.0.0",
+      "group": "kms",
       "status": "declined"
     },
     {
@@ -2080,6 +2486,7 @@
       "product": "exoscale",
       "reason": "a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere",
       "version": "2.0.0",
+      "group": "sks",
       "status": "declined"
     },
     {
@@ -2087,6 +2494,7 @@
       "product": "exoscale",
       "reason": "a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere",
       "version": "2.0.0",
+      "group": "sks",
       "status": "declined"
     },
     {
@@ -2094,6 +2502,7 @@
       "product": "exoscale",
       "reason": "a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere",
       "version": "2.0.0",
+      "group": "sks",
       "status": "declined"
     },
     {
@@ -2101,6 +2510,7 @@
       "product": "exoscale",
       "reason": "a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere",
       "version": "2.0.0",
+      "group": "sks",
       "status": "declined"
     },
     {
@@ -2108,18 +2518,21 @@
       "product": "exoscale",
       "reason": "inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station",
       "version": "2.0.0",
+      "group": "ai",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.scale-instance",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
       "operation": "exoscale/v2.scale-instance-pool",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
@@ -2127,6 +2540,7 @@
       "product": "exoscale",
       "reason": "a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere",
       "version": "2.0.0",
+      "group": "sks",
       "status": "declined"
     },
     {
@@ -2134,6 +2548,7 @@
       "product": "exoscale",
       "reason": "a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing",
       "version": "2.0.0",
+      "group": "kms",
       "status": "declined"
     },
     {
@@ -2141,6 +2556,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2148,6 +2564,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2155,6 +2572,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2162,6 +2580,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2169,6 +2588,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2176,6 +2596,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2183,6 +2604,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2190,12 +2612,14 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.start-instance",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
@@ -2203,6 +2627,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2210,6 +2635,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2217,12 +2643,14 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.stop-instance",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
@@ -2230,18 +2658,21 @@
       "product": "exoscale",
       "reason": "inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station",
       "version": "2.0.0",
+      "group": "ai",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.update-block-storage-snapshot",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "block-storage",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.update-block-storage-volume",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "block-storage",
       "status": "unknown"
     },
     {
@@ -2249,6 +2680,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2256,6 +2688,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2263,6 +2696,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2270,6 +2704,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2277,6 +2712,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2284,6 +2720,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2291,6 +2728,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2298,6 +2736,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2305,6 +2744,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2312,6 +2752,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2319,6 +2760,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2326,6 +2768,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2333,6 +2776,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2340,6 +2784,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2347,6 +2792,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2354,6 +2800,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2361,6 +2808,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2368,6 +2816,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2375,6 +2824,7 @@
       "product": "exoscale",
       "reason": "these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing",
       "version": "2.0.0",
+      "group": "dbaas",
       "status": "declined"
     },
     {
@@ -2382,6 +2832,7 @@
       "product": "exoscale",
       "reason": "inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station",
       "version": "2.0.0",
+      "group": "ai",
       "status": "declined"
     },
     {
@@ -2389,12 +2840,14 @@
       "product": "exoscale",
       "reason": "authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet",
       "version": "2.0.0",
+      "group": "dns",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.update-elastic-ip",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
@@ -2402,6 +2855,7 @@
       "product": "exoscale",
       "reason": "the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies",
       "version": "2.0.0",
+      "group": "iam",
       "status": "declined"
     },
     {
@@ -2409,6 +2863,7 @@
       "product": "exoscale",
       "reason": "the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies",
       "version": "2.0.0",
+      "group": "iam",
       "status": "declined"
     },
     {
@@ -2416,42 +2871,49 @@
       "product": "exoscale",
       "reason": "the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies",
       "version": "2.0.0",
+      "group": "iam",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.update-instance",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "implemented"
     },
     {
       "operation": "exoscale/v2.update-instance-pool",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.update-load-balancer",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.update-load-balancer-service",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.update-private-network",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.update-private-network-instance-ip",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
@@ -2459,6 +2921,7 @@
       "product": "exoscale",
       "reason": "authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet",
       "version": "2.0.0",
+      "group": "compute",
       "status": "declined"
     },
     {
@@ -2466,6 +2929,7 @@
       "product": "exoscale",
       "reason": "authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet",
       "version": "2.0.0",
+      "group": "compute",
       "status": "declined"
     },
     {
@@ -2473,6 +2937,7 @@
       "product": "exoscale",
       "reason": "a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere",
       "version": "2.0.0",
+      "group": "sks",
       "status": "declined"
     },
     {
@@ -2480,18 +2945,21 @@
       "product": "exoscale",
       "reason": "a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere",
       "version": "2.0.0",
+      "group": "sks",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.update-subnet",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
       "operation": "exoscale/v2.update-template",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
@@ -2499,12 +2967,14 @@
       "product": "exoscale",
       "reason": "the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies",
       "version": "2.0.0",
+      "group": "iam",
       "status": "declined"
     },
     {
       "operation": "exoscale/v2.update-vpc",
       "product": "exoscale",
       "version": "2.0.0",
+      "group": "compute",
       "status": "unknown"
     },
     {
@@ -2512,6 +2982,7 @@
       "product": "exoscale",
       "reason": "a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere",
       "version": "2.0.0",
+      "group": "sks",
       "status": "declined"
     },
     {
@@ -2519,6 +2990,7 @@
       "product": "exoscale",
       "reason": "a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere",
       "version": "2.0.0",
+      "group": "sks",
       "status": "declined"
     }
   ]

--- a/coverage/outscale-coverage.json
+++ b/coverage/outscale-coverage.json
@@ -21,6 +21,365 @@
       "unknown": 18
     }
   ],
+  "groups": [
+    {
+      "group": "AccessKey",
+      "total": 4,
+      "implemented": 0,
+      "declined": 4,
+      "unknown": 0
+    },
+    {
+      "group": "Account",
+      "total": 6,
+      "implemented": 0,
+      "declined": 5,
+      "unknown": 1
+    },
+    {
+      "group": "ApiAccessPolicy",
+      "total": 2,
+      "implemented": 0,
+      "declined": 2,
+      "unknown": 0
+    },
+    {
+      "group": "ApiAccessRule",
+      "total": 4,
+      "implemented": 0,
+      "declined": 4,
+      "unknown": 0
+    },
+    {
+      "group": "ApiLog",
+      "total": 1,
+      "implemented": 0,
+      "declined": 1,
+      "unknown": 0
+    },
+    {
+      "group": "Ca",
+      "total": 4,
+      "implemented": 0,
+      "declined": 4,
+      "unknown": 0
+    },
+    {
+      "group": "Catalog",
+      "total": 3,
+      "implemented": 0,
+      "declined": 3,
+      "unknown": 0
+    },
+    {
+      "group": "ClientGateway",
+      "total": 3,
+      "implemented": 0,
+      "declined": 3,
+      "unknown": 0
+    },
+    {
+      "group": "DedicatedGroup",
+      "total": 4,
+      "implemented": 0,
+      "declined": 4,
+      "unknown": 0
+    },
+    {
+      "group": "DhcpOption",
+      "total": 3,
+      "implemented": 1,
+      "declined": 0,
+      "unknown": 2
+    },
+    {
+      "group": "DirectLink",
+      "total": 3,
+      "implemented": 0,
+      "declined": 3,
+      "unknown": 0
+    },
+    {
+      "group": "DirectLinkInterface",
+      "total": 4,
+      "implemented": 0,
+      "declined": 4,
+      "unknown": 0
+    },
+    {
+      "group": "FlexibleGpu",
+      "total": 7,
+      "implemented": 0,
+      "declined": 7,
+      "unknown": 0
+    },
+    {
+      "group": "IdentityProvider",
+      "total": 6,
+      "implemented": 0,
+      "declined": 6,
+      "unknown": 0
+    },
+    {
+      "group": "Image",
+      "total": 6,
+      "implemented": 4,
+      "declined": 2,
+      "unknown": 0
+    },
+    {
+      "group": "InternetService",
+      "total": 5,
+      "implemented": 5,
+      "declined": 0,
+      "unknown": 0
+    },
+    {
+      "group": "Keypair",
+      "total": 3,
+      "implemented": 3,
+      "declined": 0,
+      "unknown": 0
+    },
+    {
+      "group": "Listener",
+      "total": 6,
+      "implemented": 0,
+      "declined": 6,
+      "unknown": 0
+    },
+    {
+      "group": "LoadBalancer",
+      "total": 12,
+      "implemented": 1,
+      "declined": 11,
+      "unknown": 0
+    },
+    {
+      "group": "LoadBalancerPolicy",
+      "total": 2,
+      "implemented": 0,
+      "declined": 2,
+      "unknown": 0
+    },
+    {
+      "group": "Location",
+      "total": 1,
+      "implemented": 0,
+      "declined": 1,
+      "unknown": 0
+    },
+    {
+      "group": "NatService",
+      "total": 3,
+      "implemented": 3,
+      "declined": 0,
+      "unknown": 0
+    },
+    {
+      "group": "Net",
+      "total": 4,
+      "implemented": 3,
+      "declined": 0,
+      "unknown": 1
+    },
+    {
+      "group": "NetAccessPoint",
+      "total": 5,
+      "implemented": 1,
+      "declined": 0,
+      "unknown": 4
+    },
+    {
+      "group": "NetPeering",
+      "total": 5,
+      "implemented": 0,
+      "declined": 0,
+      "unknown": 5
+    },
+    {
+      "group": "Nic",
+      "total": 8,
+      "implemented": 5,
+      "declined": 0,
+      "unknown": 3
+    },
+    {
+      "group": "Policy",
+      "total": 24,
+      "implemented": 0,
+      "declined": 24,
+      "unknown": 0
+    },
+    {
+      "group": "ProductType",
+      "total": 3,
+      "implemented": 0,
+      "declined": 3,
+      "unknown": 0
+    },
+    {
+      "group": "PublicCatalog",
+      "total": 1,
+      "implemented": 0,
+      "declined": 1,
+      "unknown": 0
+    },
+    {
+      "group": "PublicIp",
+      "total": 6,
+      "implemented": 6,
+      "declined": 0,
+      "unknown": 0
+    },
+    {
+      "group": "Quota",
+      "total": 1,
+      "implemented": 0,
+      "declined": 1,
+      "unknown": 0
+    },
+    {
+      "group": "Region",
+      "total": 1,
+      "implemented": 1,
+      "declined": 0,
+      "unknown": 0
+    },
+    {
+      "group": "Route",
+      "total": 3,
+      "implemented": 3,
+      "declined": 0,
+      "unknown": 0
+    },
+    {
+      "group": "RouteTable",
+      "total": 6,
+      "implemented": 5,
+      "declined": 0,
+      "unknown": 1
+    },
+    {
+      "group": "SecurityGroup",
+      "total": 3,
+      "implemented": 3,
+      "declined": 0,
+      "unknown": 0
+    },
+    {
+      "group": "SecurityGroupRule",
+      "total": 2,
+      "implemented": 2,
+      "declined": 0,
+      "unknown": 0
+    },
+    {
+      "group": "ServerCertificate",
+      "total": 4,
+      "implemented": 0,
+      "declined": 4,
+      "unknown": 0
+    },
+    {
+      "group": "Snapshot",
+      "total": 6,
+      "implemented": 3,
+      "declined": 3,
+      "unknown": 0
+    },
+    {
+      "group": "Subnet",
+      "total": 4,
+      "implemented": 3,
+      "declined": 0,
+      "unknown": 1
+    },
+    {
+      "group": "Subregion",
+      "total": 1,
+      "implemented": 1,
+      "declined": 0,
+      "unknown": 0
+    },
+    {
+      "group": "Tag",
+      "total": 3,
+      "implemented": 3,
+      "declined": 0,
+      "unknown": 0
+    },
+    {
+      "group": "Task",
+      "total": 1,
+      "implemented": 0,
+      "declined": 1,
+      "unknown": 0
+    },
+    {
+      "group": "User",
+      "total": 4,
+      "implemented": 0,
+      "declined": 4,
+      "unknown": 0
+    },
+    {
+      "group": "UserGroup",
+      "total": 8,
+      "implemented": 0,
+      "declined": 8,
+      "unknown": 0
+    },
+    {
+      "group": "VirtualGateway",
+      "total": 6,
+      "implemented": 0,
+      "declined": 6,
+      "unknown": 0
+    },
+    {
+      "group": "Vm",
+      "total": 12,
+      "implemented": 10,
+      "declined": 2,
+      "unknown": 0
+    },
+    {
+      "group": "VmGroup",
+      "total": 6,
+      "implemented": 0,
+      "declined": 6,
+      "unknown": 0
+    },
+    {
+      "group": "VmTemplate",
+      "total": 4,
+      "implemented": 0,
+      "declined": 4,
+      "unknown": 0
+    },
+    {
+      "group": "Volume",
+      "total": 7,
+      "implemented": 6,
+      "declined": 1,
+      "unknown": 0
+    },
+    {
+      "group": "VpnConnection",
+      "total": 6,
+      "implemented": 0,
+      "declined": 6,
+      "unknown": 0
+    },
+    {
+      "group": "oks",
+      "total": 27,
+      "implemented": 0,
+      "declined": 27,
+      "unknown": 0
+    }
+  ],
   "entries": [
     {
       "operation": "oks/Client.CreateCluster",
@@ -187,1327 +546,1563 @@
     {
       "operation": "osc/Client.AcceptNetPeering",
       "product": "osc",
+      "group": "NetPeering",
       "status": "unknown"
     },
     {
       "operation": "osc/Client.AddUserToUserGroup",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "UserGroup",
       "status": "declined"
     },
     {
       "operation": "osc/Client.CheckAuthentication",
       "product": "osc",
+      "group": "Account",
       "status": "unknown"
     },
     {
       "operation": "osc/Client.CreateAccessKey",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "AccessKey",
       "status": "declined"
     },
     {
       "operation": "osc/Client.CreateAccount",
       "product": "osc",
       "reason": "the emulator has one implicit account with no consumption and no price list, so anything here would be a figure it invented and somebody acted on",
+      "group": "Account",
       "status": "declined"
     },
     {
       "operation": "osc/Client.CreateApiAccessRule",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "ApiAccessRule",
       "status": "declined"
     },
     {
       "operation": "osc/Client.CreateCa",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "Ca",
       "status": "declined"
     },
     {
       "operation": "osc/Client.CreateClientGateway",
       "product": "osc",
       "reason": "each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one",
+      "group": "ClientGateway",
       "status": "declined"
     },
     {
       "operation": "osc/Client.CreateDedicatedGroup",
       "product": "osc",
       "reason": "GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal",
+      "group": "DedicatedGroup",
       "status": "declined"
     },
     {
       "operation": "osc/Client.CreateDhcpOptions",
       "product": "osc",
+      "group": "DhcpOption",
       "status": "unknown"
     },
     {
       "operation": "osc/Client.CreateDirectLink",
       "product": "osc",
       "reason": "each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one",
+      "group": "DirectLink",
       "status": "declined"
     },
     {
       "operation": "osc/Client.CreateDirectLinkInterface",
       "product": "osc",
       "reason": "each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one",
+      "group": "DirectLinkInterface",
       "status": "declined"
     },
     {
       "operation": "osc/Client.CreateFlexibleGpu",
       "product": "osc",
       "reason": "GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal",
+      "group": "FlexibleGpu",
       "status": "declined"
     },
     {
       "operation": "osc/Client.CreateImage",
       "product": "osc",
+      "group": "Image",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.CreateImageExportTask",
       "product": "osc",
       "reason": "Export tasks write an image or a snapshot into Object Storage, which is not emulated: the reasons are in docs/limits.md and none of them are about Outscale",
+      "group": "Image",
       "status": "declined"
     },
     {
       "operation": "osc/Client.CreateInternetService",
       "product": "osc",
+      "group": "InternetService",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.CreateKeypair",
       "product": "osc",
+      "group": "Keypair",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.CreateListenerRule",
       "product": "osc",
       "reason": "a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured",
+      "group": "Listener",
       "status": "declined"
     },
     {
       "operation": "osc/Client.CreateLoadBalancer",
       "product": "osc",
       "reason": "a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured",
+      "group": "LoadBalancer",
       "status": "declined"
     },
     {
       "operation": "osc/Client.CreateLoadBalancerListeners",
       "product": "osc",
       "reason": "a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured",
+      "group": "Listener",
       "status": "declined"
     },
     {
       "operation": "osc/Client.CreateLoadBalancerPolicy",
       "product": "osc",
       "reason": "a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured",
+      "group": "LoadBalancerPolicy",
       "status": "declined"
     },
     {
       "operation": "osc/Client.CreateLoadBalancerTags",
       "product": "osc",
       "reason": "a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured",
+      "group": "LoadBalancer",
       "status": "declined"
     },
     {
       "operation": "osc/Client.CreateNatService",
       "product": "osc",
+      "group": "NatService",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.CreateNet",
       "product": "osc",
+      "group": "Net",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.CreateNetAccessPoint",
       "product": "osc",
+      "group": "NetAccessPoint",
       "status": "unknown"
     },
     {
       "operation": "osc/Client.CreateNetPeering",
       "product": "osc",
+      "group": "NetPeering",
       "status": "unknown"
     },
     {
       "operation": "osc/Client.CreateNic",
       "product": "osc",
+      "group": "Nic",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.CreatePolicy",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "Policy",
       "status": "declined"
     },
     {
       "operation": "osc/Client.CreatePolicyVersion",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "Policy",
       "status": "declined"
     },
     {
       "operation": "osc/Client.CreateProductType",
       "product": "osc",
       "reason": "the emulator has one implicit account with no consumption and no price list, so anything here would be a figure it invented and somebody acted on",
+      "group": "ProductType",
       "status": "declined"
     },
     {
       "operation": "osc/Client.CreatePublicIp",
       "product": "osc",
+      "group": "PublicIp",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.CreateRoute",
       "product": "osc",
+      "group": "Route",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.CreateRouteTable",
       "product": "osc",
+      "group": "RouteTable",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.CreateSecurityGroup",
       "product": "osc",
+      "group": "SecurityGroup",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.CreateSecurityGroupRule",
       "product": "osc",
+      "group": "SecurityGroupRule",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.CreateServerCertificate",
       "product": "osc",
       "reason": "a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured",
+      "group": "ServerCertificate",
       "status": "declined"
     },
     {
       "operation": "osc/Client.CreateSnapshot",
       "product": "osc",
+      "group": "Snapshot",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.CreateSnapshotExportTask",
       "product": "osc",
       "reason": "Export tasks write an image or a snapshot into Object Storage, which is not emulated: the reasons are in docs/limits.md and none of them are about Outscale",
+      "group": "Snapshot",
       "status": "declined"
     },
     {
       "operation": "osc/Client.CreateSubnet",
       "product": "osc",
+      "group": "Subnet",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.CreateTags",
       "product": "osc",
+      "group": "Tag",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.CreateUser",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "User",
       "status": "declined"
     },
     {
       "operation": "osc/Client.CreateUserGroup",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "UserGroup",
       "status": "declined"
     },
     {
       "operation": "osc/Client.CreateVirtualGateway",
       "product": "osc",
       "reason": "each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one",
+      "group": "VirtualGateway",
       "status": "declined"
     },
     {
       "operation": "osc/Client.CreateVmGroup",
       "product": "osc",
       "reason": "GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal",
+      "group": "VmGroup",
       "status": "declined"
     },
     {
       "operation": "osc/Client.CreateVmTemplate",
       "product": "osc",
       "reason": "GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal",
+      "group": "VmTemplate",
       "status": "declined"
     },
     {
       "operation": "osc/Client.CreateVms",
       "product": "osc",
+      "group": "Vm",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.CreateVolume",
       "product": "osc",
+      "group": "Volume",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.CreateVpnConnection",
       "product": "osc",
       "reason": "each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one",
+      "group": "VpnConnection",
       "status": "declined"
     },
     {
       "operation": "osc/Client.CreateVpnConnectionRoute",
       "product": "osc",
       "reason": "each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one",
+      "group": "VpnConnection",
       "status": "declined"
     },
     {
       "operation": "osc/Client.DeleteAccessKey",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "AccessKey",
       "status": "declined"
     },
     {
       "operation": "osc/Client.DeleteApiAccessRule",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "ApiAccessRule",
       "status": "declined"
     },
     {
       "operation": "osc/Client.DeleteCa",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "Ca",
       "status": "declined"
     },
     {
       "operation": "osc/Client.DeleteClientGateway",
       "product": "osc",
       "reason": "each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one",
+      "group": "ClientGateway",
       "status": "declined"
     },
     {
       "operation": "osc/Client.DeleteDedicatedGroup",
       "product": "osc",
       "reason": "GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal",
+      "group": "DedicatedGroup",
       "status": "declined"
     },
     {
       "operation": "osc/Client.DeleteDhcpOptions",
       "product": "osc",
+      "group": "DhcpOption",
       "status": "unknown"
     },
     {
       "operation": "osc/Client.DeleteDirectLink",
       "product": "osc",
       "reason": "each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one",
+      "group": "DirectLink",
       "status": "declined"
     },
     {
       "operation": "osc/Client.DeleteDirectLinkInterface",
       "product": "osc",
       "reason": "each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one",
+      "group": "DirectLinkInterface",
       "status": "declined"
     },
     {
       "operation": "osc/Client.DeleteExportTask",
       "product": "osc",
       "reason": "Export tasks write an image or a snapshot into Object Storage, which is not emulated: the reasons are in docs/limits.md and none of them are about Outscale",
+      "group": "Task",
       "status": "declined"
     },
     {
       "operation": "osc/Client.DeleteFlexibleGpu",
       "product": "osc",
       "reason": "GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal",
+      "group": "FlexibleGpu",
       "status": "declined"
     },
     {
       "operation": "osc/Client.DeleteImage",
       "product": "osc",
+      "group": "Image",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.DeleteInternetService",
       "product": "osc",
+      "group": "InternetService",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.DeleteKeypair",
       "product": "osc",
+      "group": "Keypair",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.DeleteListenerRule",
       "product": "osc",
       "reason": "a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured",
+      "group": "Listener",
       "status": "declined"
     },
     {
       "operation": "osc/Client.DeleteLoadBalancer",
       "product": "osc",
       "reason": "a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured",
+      "group": "LoadBalancer",
       "status": "declined"
     },
     {
       "operation": "osc/Client.DeleteLoadBalancerListeners",
       "product": "osc",
       "reason": "a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured",
+      "group": "Listener",
       "status": "declined"
     },
     {
       "operation": "osc/Client.DeleteLoadBalancerPolicy",
       "product": "osc",
       "reason": "a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured",
+      "group": "LoadBalancerPolicy",
       "status": "declined"
     },
     {
       "operation": "osc/Client.DeleteLoadBalancerTags",
       "product": "osc",
       "reason": "a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured",
+      "group": "LoadBalancer",
       "status": "declined"
     },
     {
       "operation": "osc/Client.DeleteNatService",
       "product": "osc",
+      "group": "NatService",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.DeleteNet",
       "product": "osc",
+      "group": "Net",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.DeleteNetAccessPoint",
       "product": "osc",
+      "group": "NetAccessPoint",
       "status": "unknown"
     },
     {
       "operation": "osc/Client.DeleteNetPeering",
       "product": "osc",
+      "group": "NetPeering",
       "status": "unknown"
     },
     {
       "operation": "osc/Client.DeleteNic",
       "product": "osc",
+      "group": "Nic",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.DeletePolicy",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "Policy",
       "status": "declined"
     },
     {
       "operation": "osc/Client.DeletePolicyVersion",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "Policy",
       "status": "declined"
     },
     {
       "operation": "osc/Client.DeleteProductType",
       "product": "osc",
       "reason": "the emulator has one implicit account with no consumption and no price list, so anything here would be a figure it invented and somebody acted on",
+      "group": "ProductType",
       "status": "declined"
     },
     {
       "operation": "osc/Client.DeletePublicIp",
       "product": "osc",
+      "group": "PublicIp",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.DeleteRoute",
       "product": "osc",
+      "group": "Route",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.DeleteRouteTable",
       "product": "osc",
+      "group": "RouteTable",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.DeleteSecurityGroup",
       "product": "osc",
+      "group": "SecurityGroup",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.DeleteSecurityGroupRule",
       "product": "osc",
+      "group": "SecurityGroupRule",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.DeleteServerCertificate",
       "product": "osc",
       "reason": "a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured",
+      "group": "ServerCertificate",
       "status": "declined"
     },
     {
       "operation": "osc/Client.DeleteSnapshot",
       "product": "osc",
+      "group": "Snapshot",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.DeleteSubnet",
       "product": "osc",
+      "group": "Subnet",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.DeleteTags",
       "product": "osc",
+      "group": "Tag",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.DeleteUser",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "User",
       "status": "declined"
     },
     {
       "operation": "osc/Client.DeleteUserGroup",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "UserGroup",
       "status": "declined"
     },
     {
       "operation": "osc/Client.DeleteUserGroupPolicy",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "Policy",
       "status": "declined"
     },
     {
       "operation": "osc/Client.DeleteUserPolicy",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "Policy",
       "status": "declined"
     },
     {
       "operation": "osc/Client.DeleteVirtualGateway",
       "product": "osc",
       "reason": "each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one",
+      "group": "VirtualGateway",
       "status": "declined"
     },
     {
       "operation": "osc/Client.DeleteVmGroup",
       "product": "osc",
       "reason": "GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal",
+      "group": "VmGroup",
       "status": "declined"
     },
     {
       "operation": "osc/Client.DeleteVmTemplate",
       "product": "osc",
       "reason": "GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal",
+      "group": "VmTemplate",
       "status": "declined"
     },
     {
       "operation": "osc/Client.DeleteVms",
       "product": "osc",
+      "group": "Vm",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.DeleteVolume",
       "product": "osc",
+      "group": "Volume",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.DeleteVpnConnection",
       "product": "osc",
       "reason": "each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one",
+      "group": "VpnConnection",
       "status": "declined"
     },
     {
       "operation": "osc/Client.DeleteVpnConnectionRoute",
       "product": "osc",
       "reason": "each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one",
+      "group": "VpnConnection",
       "status": "declined"
     },
     {
       "operation": "osc/Client.DeregisterVmsInLoadBalancer",
       "product": "osc",
       "reason": "a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured",
+      "group": "LoadBalancer",
       "status": "declined"
     },
     {
       "operation": "osc/Client.DisableOutscaleLogin",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "IdentityProvider",
       "status": "declined"
     },
     {
       "operation": "osc/Client.DisableOutscaleLoginForUsers",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "IdentityProvider",
       "status": "declined"
     },
     {
       "operation": "osc/Client.DisableOutscaleLoginPerUsers",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "IdentityProvider",
       "status": "declined"
     },
     {
       "operation": "osc/Client.EnableOutscaleLogin",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "IdentityProvider",
       "status": "declined"
     },
     {
       "operation": "osc/Client.EnableOutscaleLoginForUsers",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "IdentityProvider",
       "status": "declined"
     },
     {
       "operation": "osc/Client.EnableOutscaleLoginPerUsers",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "IdentityProvider",
       "status": "declined"
     },
     {
       "operation": "osc/Client.LinkFlexibleGpu",
       "product": "osc",
       "reason": "GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal",
+      "group": "FlexibleGpu",
       "status": "declined"
     },
     {
       "operation": "osc/Client.LinkInternetService",
       "product": "osc",
+      "group": "InternetService",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.LinkLoadBalancerBackendMachines",
       "product": "osc",
       "reason": "a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured",
+      "group": "LoadBalancer",
       "status": "declined"
     },
     {
       "operation": "osc/Client.LinkManagedPolicyToUserGroup",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "Policy",
       "status": "declined"
     },
     {
       "operation": "osc/Client.LinkNic",
       "product": "osc",
+      "group": "Nic",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.LinkPolicy",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "Policy",
       "status": "declined"
     },
     {
       "operation": "osc/Client.LinkPrivateIps",
       "product": "osc",
+      "group": "Nic",
       "status": "unknown"
     },
     {
       "operation": "osc/Client.LinkPublicIp",
       "product": "osc",
+      "group": "PublicIp",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.LinkRouteTable",
       "product": "osc",
+      "group": "RouteTable",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.LinkVirtualGateway",
       "product": "osc",
       "reason": "each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one",
+      "group": "VirtualGateway",
       "status": "declined"
     },
     {
       "operation": "osc/Client.LinkVolume",
       "product": "osc",
+      "group": "Volume",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.PutUserGroupPolicy",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "Policy",
       "status": "declined"
     },
     {
       "operation": "osc/Client.PutUserPolicy",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "Policy",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadAccessKeys",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "AccessKey",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadAccounts",
       "product": "osc",
       "reason": "the emulator has one implicit account with no consumption and no price list, so anything here would be a figure it invented and somebody acted on",
+      "group": "Account",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadAdminPassword",
       "product": "osc",
+      "group": "Vm",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.ReadApiAccessPolicy",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "ApiAccessPolicy",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadApiAccessRules",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "ApiAccessRule",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadApiLogs",
       "product": "osc",
       "reason": "the trail records calls made against Outscale's platform, and nothing here made any of them",
+      "group": "ApiLog",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadCO2EmissionAccount",
       "product": "osc",
       "reason": "the emulator has one implicit account with no consumption and no price list, so anything here would be a figure it invented and somebody acted on",
+      "group": "Account",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadCas",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "Ca",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadCatalog",
       "product": "osc",
       "reason": "no client this project drives reads a price on its way to creating anything, which is the whole of it: where a catalogue is on a client's path the emulator does serve a fictional one, and docs/limits.md says so",
+      "group": "Catalog",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadCatalogs",
       "product": "osc",
       "reason": "no client this project drives reads a price on its way to creating anything, which is the whole of it: where a catalogue is on a client's path the emulator does serve a fictional one, and docs/limits.md says so",
+      "group": "Catalog",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadClientGateways",
       "product": "osc",
       "reason": "each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one",
+      "group": "ClientGateway",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadConsoleOutput",
       "product": "osc",
       "reason": "each answers a question about something that never happened here: a console nothing captured, a stop history nothing kept, migration tasks for updates applied immediately",
+      "group": "Vm",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadConsumptionAccount",
       "product": "osc",
       "reason": "the emulator has one implicit account with no consumption and no price list, so anything here would be a figure it invented and somebody acted on",
+      "group": "Account",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadDedicatedGroups",
       "product": "osc",
       "reason": "GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal",
+      "group": "DedicatedGroup",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadDhcpOptions",
       "product": "osc",
+      "group": "DhcpOption",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.ReadDirectLinkInterfaces",
       "product": "osc",
       "reason": "each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one",
+      "group": "DirectLinkInterface",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadDirectLinks",
       "product": "osc",
       "reason": "each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one",
+      "group": "DirectLink",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadEntitiesLinkedToPolicy",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "Policy",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadFlexibleGpuCatalog",
       "product": "osc",
       "reason": "no client this project drives reads a price on its way to creating anything, which is the whole of it: where a catalogue is on a client's path the emulator does serve a fictional one, and docs/limits.md says so",
+      "group": "FlexibleGpu",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadFlexibleGpus",
       "product": "osc",
       "reason": "GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal",
+      "group": "FlexibleGpu",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadImageExportTasks",
       "product": "osc",
       "reason": "Export tasks write an image or a snapshot into Object Storage, which is not emulated: the reasons are in docs/limits.md and none of them are about Outscale",
+      "group": "Image",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadImages",
       "product": "osc",
+      "group": "Image",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.ReadInternetServices",
       "product": "osc",
+      "group": "InternetService",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.ReadKeypairs",
       "product": "osc",
+      "group": "Keypair",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.ReadLinkedPolicies",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "Policy",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadListenerRules",
       "product": "osc",
       "reason": "a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured",
+      "group": "Listener",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadLoadBalancerTags",
       "product": "osc",
       "reason": "a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured",
+      "group": "LoadBalancer",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadLoadBalancers",
       "product": "osc",
+      "group": "LoadBalancer",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.ReadLocations",
       "product": "osc",
       "reason": "each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one",
+      "group": "Location",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadManagedPoliciesLinkedToUserGroup",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "Policy",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadNatServices",
       "product": "osc",
+      "group": "NatService",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.ReadNetAccessPointServices",
       "product": "osc",
+      "group": "NetAccessPoint",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.ReadNetAccessPoints",
       "product": "osc",
+      "group": "NetAccessPoint",
       "status": "unknown"
     },
     {
       "operation": "osc/Client.ReadNetPeerings",
       "product": "osc",
+      "group": "NetPeering",
       "status": "unknown"
     },
     {
       "operation": "osc/Client.ReadNets",
       "product": "osc",
+      "group": "Net",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.ReadNics",
       "product": "osc",
+      "group": "Nic",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.ReadPolicies",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "Policy",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadPolicy",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "Policy",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadPolicyVersion",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "Policy",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadPolicyVersions",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "Policy",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadProductTypes",
       "product": "osc",
       "reason": "the emulator has one implicit account with no consumption and no price list, so anything here would be a figure it invented and somebody acted on",
+      "group": "ProductType",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadPublicCatalog",
       "product": "osc",
       "reason": "no client this project drives reads a price on its way to creating anything, which is the whole of it: where a catalogue is on a client's path the emulator does serve a fictional one, and docs/limits.md says so",
+      "group": "PublicCatalog",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadPublicIpRanges",
       "product": "osc",
+      "group": "PublicIp",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.ReadPublicIps",
       "product": "osc",
+      "group": "PublicIp",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.ReadQuotas",
       "product": "osc",
       "reason": "the emulator has one implicit account with no consumption and no price list, so anything here would be a figure it invented and somebody acted on",
+      "group": "Quota",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadRegions",
       "product": "osc",
+      "group": "Region",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.ReadRouteTables",
       "product": "osc",
+      "group": "RouteTable",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.ReadSecurityGroups",
       "product": "osc",
+      "group": "SecurityGroup",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.ReadServerCertificates",
       "product": "osc",
       "reason": "a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured",
+      "group": "ServerCertificate",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadSnapshotExportTasks",
       "product": "osc",
       "reason": "Export tasks write an image or a snapshot into Object Storage, which is not emulated: the reasons are in docs/limits.md and none of them are about Outscale",
+      "group": "Snapshot",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadSnapshots",
       "product": "osc",
+      "group": "Snapshot",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.ReadSubnets",
       "product": "osc",
+      "group": "Subnet",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.ReadSubregions",
       "product": "osc",
+      "group": "Subregion",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.ReadTags",
       "product": "osc",
+      "group": "Tag",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.ReadUnitPrice",
       "product": "osc",
       "reason": "the emulator has one implicit account with no consumption and no price list, so anything here would be a figure it invented and somebody acted on",
+      "group": "Catalog",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadUserGroup",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "UserGroup",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadUserGroupPolicies",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "Policy",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadUserGroupPolicy",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "Policy",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadUserGroups",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "UserGroup",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadUserGroupsPerUser",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "UserGroup",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadUserPolicies",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "Policy",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadUserPolicy",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "Policy",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadUsers",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "User",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadVirtualGateways",
       "product": "osc",
       "reason": "each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one",
+      "group": "VirtualGateway",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadVmGroups",
       "product": "osc",
       "reason": "GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal",
+      "group": "VmGroup",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadVmTemplates",
       "product": "osc",
       "reason": "GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal",
+      "group": "VmTemplate",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadVmTypes",
       "product": "osc",
+      "group": "Vm",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.ReadVms",
       "product": "osc",
+      "group": "Vm",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.ReadVmsHealth",
       "product": "osc",
       "reason": "a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured",
+      "group": "LoadBalancer",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadVmsState",
       "product": "osc",
+      "group": "Vm",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.ReadVmsStopHistory",
       "product": "osc",
       "reason": "each answers a question about something that never happened here: a console nothing captured, a stop history nothing kept, migration tasks for updates applied immediately",
+      "group": "Vm",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadVolumeUpdateTasks",
       "product": "osc",
       "reason": "each answers a question about something that never happened here: a console nothing captured, a stop history nothing kept, migration tasks for updates applied immediately",
+      "group": "Volume",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ReadVolumes",
       "product": "osc",
+      "group": "Volume",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.ReadVpnConnections",
       "product": "osc",
       "reason": "each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one",
+      "group": "VpnConnection",
       "status": "declined"
     },
     {
       "operation": "osc/Client.RebootVms",
       "product": "osc",
+      "group": "Vm",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.RegisterVmsInLoadBalancer",
       "product": "osc",
       "reason": "a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured",
+      "group": "LoadBalancer",
       "status": "declined"
     },
     {
       "operation": "osc/Client.RejectNetPeering",
       "product": "osc",
+      "group": "NetPeering",
       "status": "unknown"
     },
     {
       "operation": "osc/Client.RemoveUserFromUserGroup",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "UserGroup",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ScaleDownVmGroup",
       "product": "osc",
       "reason": "GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal",
+      "group": "VmGroup",
       "status": "declined"
     },
     {
       "operation": "osc/Client.ScaleUpVmGroup",
       "product": "osc",
       "reason": "GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal",
+      "group": "VmGroup",
       "status": "declined"
     },
     {
       "operation": "osc/Client.SetDefaultPolicyVersion",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "Policy",
       "status": "declined"
     },
     {
       "operation": "osc/Client.StartVms",
       "product": "osc",
+      "group": "Vm",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.StopVms",
       "product": "osc",
+      "group": "Vm",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.UnlinkFlexibleGpu",
       "product": "osc",
       "reason": "GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal",
+      "group": "FlexibleGpu",
       "status": "declined"
     },
     {
       "operation": "osc/Client.UnlinkInternetService",
       "product": "osc",
+      "group": "InternetService",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.UnlinkLoadBalancerBackendMachines",
       "product": "osc",
       "reason": "a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured",
+      "group": "LoadBalancer",
       "status": "declined"
     },
     {
       "operation": "osc/Client.UnlinkManagedPolicyFromUserGroup",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "Policy",
       "status": "declined"
     },
     {
       "operation": "osc/Client.UnlinkNic",
       "product": "osc",
+      "group": "Nic",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.UnlinkPolicy",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "Policy",
       "status": "declined"
     },
     {
       "operation": "osc/Client.UnlinkPrivateIps",
       "product": "osc",
+      "group": "Nic",
       "status": "unknown"
     },
     {
       "operation": "osc/Client.UnlinkPublicIp",
       "product": "osc",
+      "group": "PublicIp",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.UnlinkRouteTable",
       "product": "osc",
+      "group": "RouteTable",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.UnlinkVirtualGateway",
       "product": "osc",
       "reason": "each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one",
+      "group": "VirtualGateway",
       "status": "declined"
     },
     {
       "operation": "osc/Client.UnlinkVolume",
       "product": "osc",
+      "group": "Volume",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.UpdateAccessKey",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "AccessKey",
       "status": "declined"
     },
     {
       "operation": "osc/Client.UpdateAccount",
       "product": "osc",
       "reason": "the emulator has one implicit account with no consumption and no price list, so anything here would be a figure it invented and somebody acted on",
+      "group": "Account",
       "status": "declined"
     },
     {
       "operation": "osc/Client.UpdateApiAccessPolicy",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "ApiAccessPolicy",
       "status": "declined"
     },
     {
       "operation": "osc/Client.UpdateApiAccessRule",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "ApiAccessRule",
       "status": "declined"
     },
     {
       "operation": "osc/Client.UpdateCa",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "Ca",
       "status": "declined"
     },
     {
       "operation": "osc/Client.UpdateDedicatedGroup",
       "product": "osc",
       "reason": "GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal",
+      "group": "DedicatedGroup",
       "status": "declined"
     },
     {
       "operation": "osc/Client.UpdateDirectLinkInterface",
       "product": "osc",
       "reason": "each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one",
+      "group": "DirectLinkInterface",
       "status": "declined"
     },
     {
       "operation": "osc/Client.UpdateFlexibleGpu",
       "product": "osc",
       "reason": "GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal",
+      "group": "FlexibleGpu",
       "status": "declined"
     },
     {
       "operation": "osc/Client.UpdateImage",
       "product": "osc",
+      "group": "Image",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.UpdateListenerRule",
       "product": "osc",
       "reason": "a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured",
+      "group": "Listener",
       "status": "declined"
     },
     {
       "operation": "osc/Client.UpdateLoadBalancer",
       "product": "osc",
       "reason": "a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured",
+      "group": "LoadBalancer",
       "status": "declined"
     },
     {
       "operation": "osc/Client.UpdateNet",
       "product": "osc",
+      "group": "Net",
       "status": "unknown"
     },
     {
       "operation": "osc/Client.UpdateNetAccessPoint",
       "product": "osc",
+      "group": "NetAccessPoint",
       "status": "unknown"
     },
     {
       "operation": "osc/Client.UpdateNic",
       "product": "osc",
+      "group": "Nic",
       "status": "unknown"
     },
     {
       "operation": "osc/Client.UpdateRoute",
       "product": "osc",
+      "group": "Route",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.UpdateRoutePropagation",
       "product": "osc",
       "reason": "each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one",
+      "group": "VirtualGateway",
       "status": "declined"
     },
     {
       "operation": "osc/Client.UpdateRouteTableLink",
       "product": "osc",
+      "group": "RouteTable",
       "status": "unknown"
     },
     {
       "operation": "osc/Client.UpdateServerCertificate",
       "product": "osc",
       "reason": "a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured",
+      "group": "ServerCertificate",
       "status": "declined"
     },
     {
       "operation": "osc/Client.UpdateSnapshot",
       "product": "osc",
       "reason": "UpdateSnapshot manages cross-account permissions, and the emulator has one implicit account: there is nobody to grant to",
+      "group": "Snapshot",
       "status": "declined"
     },
     {
       "operation": "osc/Client.UpdateSubnet",
       "product": "osc",
+      "group": "Subnet",
       "status": "unknown"
     },
     {
       "operation": "osc/Client.UpdateUser",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "User",
       "status": "declined"
     },
     {
       "operation": "osc/Client.UpdateUserGroup",
       "product": "osc",
       "reason": "the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies",
+      "group": "UserGroup",
       "status": "declined"
     },
     {
       "operation": "osc/Client.UpdateVm",
       "product": "osc",
+      "group": "Vm",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.UpdateVmGroup",
       "product": "osc",
       "reason": "GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal",
+      "group": "VmGroup",
       "status": "declined"
     },
     {
       "operation": "osc/Client.UpdateVmTemplate",
       "product": "osc",
       "reason": "GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal",
+      "group": "VmTemplate",
       "status": "declined"
     },
     {
       "operation": "osc/Client.UpdateVolume",
       "product": "osc",
+      "group": "Volume",
       "status": "implemented"
     },
     {
       "operation": "osc/Client.UpdateVpnConnection",
       "product": "osc",
       "reason": "each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one",
+      "group": "VpnConnection",
       "status": "declined"
     }
   ]

--- a/coverage/scaleway-coverage.json
+++ b/coverage/scaleway-coverage.json
@@ -124,6 +124,50 @@
       ]
     }
   ],
+  "groups": [
+    {
+      "group": "block",
+      "total": 27,
+      "implemented": 22,
+      "declined": 5,
+      "unknown": 0
+    },
+    {
+      "group": "iam",
+      "total": 83,
+      "implemented": 5,
+      "declined": 78,
+      "unknown": 0
+    },
+    {
+      "group": "instance",
+      "total": 150,
+      "implemented": 48,
+      "declined": 102,
+      "unknown": 0
+    },
+    {
+      "group": "ipam",
+      "total": 10,
+      "implemented": 9,
+      "declined": 1,
+      "unknown": 0
+    },
+    {
+      "group": "marketplace",
+      "total": 8,
+      "implemented": 1,
+      "declined": 7,
+      "unknown": 0
+    },
+    {
+      "group": "vpc",
+      "total": 37,
+      "implemented": 17,
+      "declined": 20,
+      "unknown": 0
+    }
+  ],
   "entries": [
     {
       "operation": "block/v1/API.CreateSnapshot",

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -204,298 +204,212 @@ disappears from the suite.
 Operations this pack knowingly does not serve, and why. Declining is a
 decision the drift gate records, which is what separates it from having
 missed one — and the reason is what separates a decision from a list.
+One line is one decision: the group upstream files the operations under,
+how many it covers, and the reason they share. The per-operation verdicts
+are in `coverage/`, one artefact per provider.
 
-- `block/v1/API.ExportSnapshotToObjectStorage` — it moves a snapshot's bytes through Object Storage, which is not emulated because the Terraform provider builds the S3 endpoint in code: supporting it needs DNS interception and a certificate, measured in docs/limits.md
-- `block/v1/API.ImportSnapshotFromObjectStorage` — it moves a snapshot's bytes through Object Storage, which is not emulated because the Terraform provider builds the S3 endpoint in code: supporting it needs DNS interception and a certificate, measured in docs/limits.md
-- `block/v1alpha1/API.ExportSnapshotToObjectStorage` — it moves a snapshot's bytes through Object Storage, which is not emulated because the Terraform provider builds the S3 endpoint in code: supporting it needs DNS interception and a certificate, measured in docs/limits.md
-- `block/v1alpha1/API.ImportSnapshotFromObjectStorage` — it moves a snapshot's bytes through Object Storage, which is not emulated because the Terraform provider builds the S3 endpoint in code: supporting it needs DNS interception and a certificate, measured in docs/limits.md
-- `block/v1alpha1/API.ImportSnapshotFromS3` — it moves a snapshot's bytes through Object Storage, which is not emulated because the Terraform provider builds the S3 endpoint in code: supporting it needs DNS interception and a certificate, measured in docs/limits.md
-- `iam/v1alpha1/API.AddGroupMember` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.AddGroupMembers` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.AddSamlCertificate` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.ClonePolicy` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.CreateAPIKey` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.CreateApplication` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.CreateGroup` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.CreateJWT` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.CreatePolicy` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.CreateScimToken` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.CreateUser` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.CreateUserMFAOTP` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.DeleteAPIKey` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.DeleteApplication` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.DeleteGroup` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.DeleteJWT` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.DeletePolicy` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.DeleteSaml` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.DeleteSamlCertificate` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.DeleteScim` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.DeleteScimToken` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.DeleteUser` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.DeleteUserMFAOTP` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.DeleteWebAuthnAuthenticator` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.EnableOrganizationSaml` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.EnableOrganizationScim` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.FinishUserWebAuthnRegistration` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.GetAPIKey` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.GetApplication` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.GetGroup` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.GetJWT` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.GetLog` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.GetOrganization` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.GetOrganizationSaml` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.GetOrganizationScim` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.GetOrganizationSecuritySettings` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.GetPolicy` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.GetQuotum` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.GetSamlCertificate` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.GetUser` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.GetUserConnections` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.InitiateUserConnection` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.JoinUserConnection` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.ListAPIKeys` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.ListApplications` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.ListGracePeriods` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.ListGroups` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.ListJWTs` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.ListLogs` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.ListPermissionSets` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.ListPolicies` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.ListQuota` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.ListRules` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.ListSamlCertificates` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.ListScimTokens` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.ListUserWebAuthnAuthenticators` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.ListUsers` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.LockUser` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.ParseSamlMetadata` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.RemoveGroupMember` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.RemoveUserConnection` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.SetGroupMembers` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.SetOrganizationAlias` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.SetRules` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.StartUserWebAuthnRegistration` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.UnlockUser` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.UpdateAPIKey` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.UpdateApplication` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.UpdateGroup` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.UpdateOrganizationLoginMethods` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.UpdateOrganizationSecuritySettings` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.UpdatePolicy` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.UpdateSaml` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.UpdateUser` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.UpdateUserPassword` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.UpdateUserUsername` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.UpdateWebAuthnAuthenticator` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `iam/v1alpha1/API.ValidateUserMFAOTP` — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
-- `instance/v1/API.ApplyBlockMigration` — there is no legacy storage behind this emulator to migrate from, so a plan would describe a move between two things that are the same store
-- `instance/v1/API.AttachServerFileSystem` — it mounts Scaleway's File Storage product, and there is no filesystem service behind this emulator for a machine to mount
-- `instance/v1/API.AttachVolume` — the SDK's hand-written helpers, deprecated upstream in favour of AttachServerVolume and DetachServerVolume, which this pack serves and which the CLI calls
-- `instance/v1/API.CheckBlockMigrationOrganizationQuotas` — capacity and quotas are the provider's fleet, and a local emulator that answered would be inventing headroom a client could plan against
-- `instance/v1/API.CreatePlacementGroup` — placement constrains which physical hosts run a machine, and every emulated machine runs on the single host that started feint, so any policy would be reported satisfied whatever it asked
-- `instance/v1/API.DeletePlacementGroup` — placement constrains which physical hosts run a machine, and every emulated machine runs on the single host that started feint, so any policy would be reported satisfied whatever it asked
-- `instance/v1/API.DetachServerFileSystem` — it mounts Scaleway's File Storage product, and there is no filesystem service behind this emulator for a machine to mount
-- `instance/v1/API.DetachVolume` — the SDK's hand-written helpers, deprecated upstream in favour of AttachServerVolume and DetachServerVolume, which this pack serves and which the CLI calls
-- `instance/v1/API.ExportSnapshot` — it writes into Object Storage, which is not emulated because the Terraform provider builds the S3 endpoint in code: supporting it needs DNS interception and a certificate, measured in docs/limits.md
-- `instance/v1/API.GetDashboard` — its thirteen counters span resources this pack does not serve, so every total would be short by the unemulated remainder with nothing saying which
-- `instance/v1/API.GetPlacementGroup` — placement constrains which physical hosts run a machine, and every emulated machine runs on the single host that started feint, so any policy would be reported satisfied whatever it asked
-- `instance/v1/API.GetPlacementGroupServers` — placement constrains which physical hosts run a machine, and every emulated machine runs on the single host that started feint, so any policy would be reported satisfied whatever it asked
-- `instance/v1/API.GetServerCompatibleTypes` — capacity and quotas are the provider's fleet, and a local emulator that answered would be inventing headroom a client could plan against
-- `instance/v1/API.GetServerTypesAvailability` — capacity and quotas are the provider's fleet, and a local emulator that answered would be inventing headroom a client could plan against
-- `instance/v1/API.ListDefaultSecurityGroupRules` — the seeded rule set is a value the SDK does not carry, so an invented list would state which ports a real client believes are open, and docs/limits.md records that these rules do filter packets
-- `instance/v1/API.ListPlacementGroups` — placement constrains which physical hosts run a machine, and every emulated machine runs on the single host that started feint, so any policy would be reported satisfied whatever it asked
-- `instance/v1/API.ListServerActions` — the server already publishes allowed_actions, derived from its state, so a second listing would be a second place to keep in step with the first
-- `instance/v1/API.ListVolumesTypes` — the emulator serves one volume type, b_ssd, because that is what its catalogue attaches, so a type list would describe capabilities nothing here can create
-- `instance/v1/API.PlanBlockMigration` — there is no legacy storage behind this emulator to migrate from, so a plan would describe a move between two things that are the same store
-- `instance/v1/API.ReleaseIPToIpam` — it hands an instance flexible IP over to IPAM's pool, and the public addresses of this emulator live and die with the instance product: IPAM here holds private-network addresses only
-- `instance/v1/API.SetPlacementGroup` — placement constrains which physical hosts run a machine, and every emulated machine runs on the single host that started feint, so any policy would be reported satisfied whatever it asked
-- `instance/v1/API.SetPlacementGroupServers` — placement constrains which physical hosts run a machine, and every emulated machine runs on the single host that started feint, so any policy would be reported satisfied whatever it asked
-- `instance/v1/API.UpdatePlacementGroup` — placement constrains which physical hosts run a machine, and every emulated machine runs on the single host that started feint, so any policy would be reported satisfied whatever it asked
-- `instance/v1/API.UpdatePlacementGroupServers` — placement constrains which physical hosts run a machine, and every emulated machine runs on the single host that started feint, so any policy would be reported satisfied whatever it asked
-- `instance/v1/API.UpdatePrivateNIC` — its request carries tags and nothing else, and the pack stores no tag on a private NIC, so it would answer success over a field nothing reads back
-- `instance/v1/MetadataAPI.DeleteUserData` — the metadata service answers on the link-local address 169.254.42.42, from inside the machine, to a caller that carries no credentials
-- `instance/v1/MetadataAPI.GetMetadata` — the metadata service answers on the link-local address 169.254.42.42, from inside the machine, to a caller that carries no credentials
-- `instance/v1/MetadataAPI.GetUserData` — the metadata service answers on the link-local address 169.254.42.42, from inside the machine, to a caller that carries no credentials
-- `instance/v1/MetadataAPI.ListUserData` — the metadata service answers on the link-local address 169.254.42.42, from inside the machine, to a caller that carries no credentials
-- `instance/v1/MetadataAPI.SetUserData` — the metadata service answers on the link-local address 169.254.42.42, from inside the machine, to a caller that carries no credentials
-- `instance/v2alpha1/API.AddSecurityGroupRules` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.AttachServerFileSystem` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.AttachServerIP` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.AttachServerPrivateNetworkInterface` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.AttachServerVolume` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.CheckTemplate` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.CreatePlacementGroup` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.CreatePrivateNetworkInterface` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.CreateSecurityGroup` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.CreateServer` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.CreateServerFromTemplate` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.CreateTemplate` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.DeletePlacementGroup` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.DeletePrivateNetworkInterface` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.DeleteSecurityGroup` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.DeleteSecurityGroupRules` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.DeleteServer` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.DeleteTemplate` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.DeleteTemplateUserData` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.DeleteUserData` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.DetachServerFileSystem` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.DetachServerIP` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.DetachServerPrivateNetworkInterface` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.DetachServerVolume` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.GetPlacementGroup` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.GetPrivateNetworkInterface` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.GetResourceCounts` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.GetSecurityGroup` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.GetServer` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.GetServerCloudInit` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.GetTemplate` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.GetTemplateCloudInit` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.GetTemplateUserData` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.GetUserData` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.ListPlacementGroups` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.ListPrivateNetworkInterfaces` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.ListSecurityGroups` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.ListServerTypes` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.ListServers` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.ListTemplateUserDataKeys` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.ListTemplates` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.ListUserDataKeys` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.PauseServer` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.RebootServer` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.SetSecurityGroupRules` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.SetServerCloudInit` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.SetServerDefaultIP` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.SetTemplateCloudInit` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.SetTemplateUserData` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.SetUserData` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.StartServer` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.StopAndDeleteServer` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.StopServer` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.UpdatePlacementGroup` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.UpdatePrivateNetworkInterface` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.UpdateSecurityGroup` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.UpdateSecurityGroupRule` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.UpdateServer` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/API.UpdateTemplate` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/VolumeAPI.CreateSnapshot` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/VolumeAPI.CreateVolume` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/VolumeAPI.DeleteSnapshot` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/VolumeAPI.DeleteVolume` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/VolumeAPI.ExportSnapshotToObjectStorage` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/VolumeAPI.GetSnapshot` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/VolumeAPI.GetVolume` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/VolumeAPI.ImportSnapshotFromObjectStorage` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/VolumeAPI.ListSnapshots` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/VolumeAPI.ListVolumeTypes` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/VolumeAPI.ListVolumes` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/VolumeAPI.UpdateSnapshot` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `instance/v2alpha1/VolumeAPI.UpdateVolume` — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
-- `ipam/v1alpha1/API.ListIPs` — ipam/v1alpha1 is the superseded draft of ipam/v1, which is served
-- `marketplace/v2/API.GetCategory` — the global image index spans every image Scaleway publishes in every zone, and the emulator answers from a small fixed table that would either list images it cannot boot or claim the catalogue is six entries long
-- `marketplace/v2/API.GetImage` — the global image index spans every image Scaleway publishes in every zone, and the emulator answers from a small fixed table that would either list images it cannot boot or claim the catalogue is six entries long
-- `marketplace/v2/API.GetLocalImage` — the CLI resolves its default image through ListLocalImages, which is served, so a per-id lookup would be a second door onto the same fixed table
-- `marketplace/v2/API.GetVersion` — the global image index spans every image Scaleway publishes in every zone, and the emulator answers from a small fixed table that would either list images it cannot boot or claim the catalogue is six entries long
-- `marketplace/v2/API.ListCategories` — the global image index spans every image Scaleway publishes in every zone, and the emulator answers from a small fixed table that would either list images it cannot boot or claim the catalogue is six entries long
-- `marketplace/v2/API.ListImages` — the global image index spans every image Scaleway publishes in every zone, and the emulator answers from a small fixed table that would either list images it cannot boot or claim the catalogue is six entries long
-- `marketplace/v2/API.ListVersions` — the global image index spans every image Scaleway publishes in every zone, and the emulator answers from a small fixed table that would either list images it cannot boot or claim the catalogue is six entries long
-- `vpc/v2/API.AddPrivateNetworkS3Endpoint` — they attach a private network to Object Storage, which is not emulated because the Terraform provider builds that endpoint in code, measured in docs/limits.md
-- `vpc/v2/API.CreateIngressRule` — no runtime mode enforces a rule at the VPC edge yet, and a filter recorded but never applied is indistinguishable from protection; served once the machine layer can program it under OVN
-- `vpc/v2/API.CreateVPCConnector` — it peers two VPCs, and isolation between two VPCs is the one property the bridge mode cannot deliver: joining them would report done what was never apart
-- `vpc/v2/API.DeleteIngressRule` — no runtime mode enforces a rule at the VPC edge yet, and a filter recorded but never applied is indistinguishable from protection; served once the machine layer can program it under OVN
-- `vpc/v2/API.DeletePrivateNetworkS3Endpoint` — they attach a private network to Object Storage, which is not emulated because the Terraform provider builds that endpoint in code, measured in docs/limits.md
-- `vpc/v2/API.DeleteVPCConnector` — it peers two VPCs, and isolation between two VPCs is the one property the bridge mode cannot deliver: joining them would report done what was never apart
-- `vpc/v2/API.DisableS3Endpoint` — they attach a private network to Object Storage, which is not emulated because the Terraform provider builds that endpoint in code, measured in docs/limits.md
-- `vpc/v2/API.EnableCustomRoutesPropagation` — the portal's API document does not describe it yet, and every route mounted here is checked against that document, so it cannot be served until the document catches up with the SDK
-- `vpc/v2/API.EnableS3Endpoint` — they attach a private network to Object Storage, which is not emulated because the Terraform provider builds that endpoint in code, measured in docs/limits.md
-- `vpc/v2/API.GetACL` — no runtime mode enforces a rule at the VPC edge yet, and a filter recorded but never applied is indistinguishable from protection; served once the machine layer can program it under OVN
-- `vpc/v2/API.GetIngressRule` — no runtime mode enforces a rule at the VPC edge yet, and a filter recorded but never applied is indistinguishable from protection; served once the machine layer can program it under OVN
-- `vpc/v2/API.GetVPCConnector` — it peers two VPCs, and isolation between two VPCs is the one property the bridge mode cannot deliver: joining them would report done what was never apart
-- `vpc/v2/API.ListIngressRules` — no runtime mode enforces a rule at the VPC edge yet, and a filter recorded but never applied is indistinguishable from protection; served once the machine layer can program it under OVN
-- `vpc/v2/API.ListSubnetOverlaps` — its request names a VPC connector and nothing else — it compares the subnets across a peering — and the connectors are declined below until OVN mode has measured peering
-- `vpc/v2/API.ListVPCConnectors` — it peers two VPCs, and isolation between two VPCs is the one property the bridge mode cannot deliver: joining them would report done what was never apart
-- `vpc/v2/API.SetACL` — no runtime mode enforces a rule at the VPC edge yet, and a filter recorded but never applied is indistinguishable from protection; served once the machine layer can program it under OVN
-- `vpc/v2/API.SetPrivateNetworksS3Endpoint` — they attach a private network to Object Storage, which is not emulated because the Terraform provider builds that endpoint in code, measured in docs/limits.md
-- `vpc/v2/API.UpdateIngressRule` — no runtime mode enforces a rule at the VPC edge yet, and a filter recorded but never applied is indistinguishable from protection; served once the machine layer can program it under OVN
-- `vpc/v2/API.UpdateVPCConnector` — it peers two VPCs, and isolation between two VPCs is the one property the bridge mode cannot deliver: joining them would report done what was never apart
-- `vpc/v2/RoutesWithNexthopAPI.ListRoutesWithNexthop` — the portal's API document does not describe it yet, and every route mounted here is checked against that document, so it cannot be served until the document catches up with the SDK
+- `block` — 5 operations — it moves a snapshot's bytes through Object Storage, which is not emulated because the Terraform provider builds the S3 endpoint in code: supporting it needs DNS interception and a certificate, measured in docs/limits.md
+- `iam` — 78 operations — the emulator accepts every credential on purpose, so serving users, policies and keys would describe an access control that nothing here enforces
+- `instance` — 72 operations — instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1
+- `instance` — 9 operations — placement constrains which physical hosts run a machine, and every emulated machine runs on the single host that started feint, so any policy would be reported satisfied whatever it asked
+- `instance` — 5 operations — the metadata service answers on the link-local address 169.254.42.42, from inside the machine, to a caller that carries no credentials
+- `instance` — 3 operations — capacity and quotas are the provider's fleet, and a local emulator that answered would be inventing headroom a client could plan against
+- `instance` — 2 operations — it mounts Scaleway's File Storage product, and there is no filesystem service behind this emulator for a machine to mount
+- `instance` — 2 operations — the SDK's hand-written helpers, deprecated upstream in favour of AttachServerVolume and DetachServerVolume, which this pack serves and which the CLI calls
+- `instance` — 2 operations — there is no legacy storage behind this emulator to migrate from, so a plan would describe a move between two things that are the same store
+- `instance` — 1 operation — it hands an instance flexible IP over to IPAM's pool, and the public addresses of this emulator live and die with the instance product: IPAM here holds private-network addresses only
+- `instance` — 1 operation — it writes into Object Storage, which is not emulated because the Terraform provider builds the S3 endpoint in code: supporting it needs DNS interception and a certificate, measured in docs/limits.md
+- `instance` — 1 operation — its request carries tags and nothing else, and the pack stores no tag on a private NIC, so it would answer success over a field nothing reads back
+- `instance` — 1 operation — its thirteen counters span resources this pack does not serve, so every total would be short by the unemulated remainder with nothing saying which
+- `instance` — 1 operation — the emulator serves one volume type, b_ssd, because that is what its catalogue attaches, so a type list would describe capabilities nothing here can create
+- `instance` — 1 operation — the seeded rule set is a value the SDK does not carry, so an invented list would state which ports a real client believes are open, and docs/limits.md records that these rules do filter packets
+- `instance` — 1 operation — the server already publishes allowed_actions, derived from its state, so a second listing would be a second place to keep in step with the first
+- `ipam` — 1 operation — ipam/v1alpha1 is the superseded draft of ipam/v1, which is served
+- `marketplace` — 6 operations — the global image index spans every image Scaleway publishes in every zone, and the emulator answers from a small fixed table that would either list images it cannot boot or claim the catalogue is six entries long
+- `marketplace` — 1 operation — the CLI resolves its default image through ListLocalImages, which is served, so a per-id lookup would be a second door onto the same fixed table
+- `vpc` — 7 operations — no runtime mode enforces a rule at the VPC edge yet, and a filter recorded but never applied is indistinguishable from protection; served once the machine layer can program it under OVN
+- `vpc` — 5 operations — it peers two VPCs, and isolation between two VPCs is the one property the bridge mode cannot deliver: joining them would report done what was never apart
+- `vpc` — 5 operations — they attach a private network to Object Storage, which is not emulated because the Terraform provider builds that endpoint in code, measured in docs/limits.md
+- `vpc` — 2 operations — the portal's API document does not describe it yet, and every route mounted here is checked against that document, so it cannot be served until the document catches up with the SDK
+- `vpc` — 1 operation — its request names a VPC connector and nothing else — it compares the subnets across a peering — and the connectors are declined below until OVN mode has measured peering
 
 ## Outscale
 
-### `osc`
+### `DhcpOption`
+
+| Method | Path | Upstream operation | Proven by |
+|---|---|---|---|
+| `POST` | `/api/v1/ReadDhcpOptions` | `osc/Client.ReadDhcpOptions` | `client` `contract` `shape` `probe` |
+
+### `Image`
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
 | `POST` | `/api/v1/CreateImage` | `osc/Client.CreateImage` | `client` `contract` `probe` `behaviour` |
-| `POST` | `/api/v1/CreateInternetService` | `osc/Client.CreateInternetService` | `client` `contract` `probe` `behaviour` |
-| `POST` | `/api/v1/CreateKeypair` | `osc/Client.CreateKeypair` | `client` `contract` `probe` `behaviour` |
-| `POST` | `/api/v1/CreateNatService` | `osc/Client.CreateNatService` | `client` `contract` `behaviour` |
-| `POST` | `/api/v1/CreateNet` | `osc/Client.CreateNet` | `client` `contract` `probe` `behaviour` `negative` |
-| `POST` | `/api/v1/CreateNic` | `osc/Client.CreateNic` | `client` `contract` `probe` `behaviour` |
-| `POST` | `/api/v1/CreatePublicIp` | `osc/Client.CreatePublicIp` | `client` `contract` `probe` `behaviour` |
-| `POST` | `/api/v1/CreateRouteTable` | `osc/Client.CreateRouteTable` | `client` `contract` `probe` `behaviour` |
-| `POST` | `/api/v1/CreateRoute` | `osc/Client.CreateRoute` | `client` `contract` `behaviour` |
-| `POST` | `/api/v1/CreateSecurityGroupRule` | `osc/Client.CreateSecurityGroupRule` | `client` `contract` `probe` `behaviour` |
-| `POST` | `/api/v1/CreateSecurityGroup` | `osc/Client.CreateSecurityGroup` | `client` `contract` `probe` `behaviour` |
-| `POST` | `/api/v1/CreateSnapshot` | `osc/Client.CreateSnapshot` | `client` `contract` `probe` `behaviour` |
-| `POST` | `/api/v1/CreateSubnet` | `osc/Client.CreateSubnet` | `client` `contract` `probe` `behaviour` `negative` |
-| `POST` | `/api/v1/CreateTags` | `osc/Client.CreateTags` | `client` `contract` `probe` `behaviour` |
-| `POST` | `/api/v1/CreateVms` | `osc/Client.CreateVms` | `client` `contract` `probe` `behaviour` `negative` |
-| `POST` | `/api/v1/CreateVolume` | `osc/Client.CreateVolume` | `client` `contract` `probe` `behaviour` |
 | `POST` | `/api/v1/DeleteImage` | `osc/Client.DeleteImage` | `client` `contract` `probe` `behaviour` |
-| `POST` | `/api/v1/DeleteInternetService` | `osc/Client.DeleteInternetService` | `client` `contract` `probe` `behaviour` |
-| `POST` | `/api/v1/DeleteKeypair` | `osc/Client.DeleteKeypair` | `client` `contract` `probe` `behaviour` |
-| `POST` | `/api/v1/DeleteNatService` | `osc/Client.DeleteNatService` | `client` `contract` `behaviour` |
-| `POST` | `/api/v1/DeleteNet` | `osc/Client.DeleteNet` | `client` `contract` `probe` `behaviour` `negative` |
-| `POST` | `/api/v1/DeleteNic` | `osc/Client.DeleteNic` | `client` `contract` `behaviour` |
-| `POST` | `/api/v1/DeletePublicIp` | `osc/Client.DeletePublicIp` | `client` `contract` `probe` `behaviour` `negative` |
-| `POST` | `/api/v1/DeleteRouteTable` | `osc/Client.DeleteRouteTable` | `client` `contract` `behaviour` |
-| `POST` | `/api/v1/DeleteRoute` | `osc/Client.DeleteRoute` | `client` `contract` `behaviour` |
-| `POST` | `/api/v1/DeleteSecurityGroupRule` | `osc/Client.DeleteSecurityGroupRule` | `client` `contract` `probe` `behaviour` |
-| `POST` | `/api/v1/DeleteSecurityGroup` | `osc/Client.DeleteSecurityGroup` | `client` `contract` `probe` `behaviour` |
-| `POST` | `/api/v1/DeleteSnapshot` | `osc/Client.DeleteSnapshot` | `client` `contract` `behaviour` |
-| `POST` | `/api/v1/DeleteSubnet` | `osc/Client.DeleteSubnet` | `client` `contract` `probe` `behaviour` |
-| `POST` | `/api/v1/DeleteTags` | `osc/Client.DeleteTags` | `contract` `probe` |
-| `POST` | `/api/v1/DeleteVms` | `osc/Client.DeleteVms` | `client` `contract` `probe` |
-| `POST` | `/api/v1/DeleteVolume` | `osc/Client.DeleteVolume` | `client` `contract` `probe` `behaviour` |
-| `POST` | `/api/v1/LinkInternetService` | `osc/Client.LinkInternetService` | `client` `contract` `probe` `behaviour` |
-| `POST` | `/api/v1/LinkNic` | `osc/Client.LinkNic` | `client` `contract` `behaviour` |
-| `POST` | `/api/v1/LinkPublicIp` | `osc/Client.LinkPublicIp` | `client` `contract` `probe` `behaviour` |
-| `POST` | `/api/v1/LinkRouteTable` | `osc/Client.LinkRouteTable` | `client` `contract` `behaviour` |
-| `POST` | `/api/v1/LinkVolume` | `osc/Client.LinkVolume` | `client` `contract` `probe` `behaviour` |
-| `POST` | `/api/v1/ReadAdminPassword` | `osc/Client.ReadAdminPassword` | `contract` `probe` |
-| `POST` | `/api/v1/ReadDhcpOptions` | `osc/Client.ReadDhcpOptions` | `client` `contract` `shape` `probe` |
 | `POST` | `/api/v1/ReadImages` | `osc/Client.ReadImages` | `client` `contract` `shape` `probe` `behaviour` |
+| `POST` | `/api/v1/UpdateImage` | `osc/Client.UpdateImage` | `client` `contract` `probe` `behaviour` `negative` |
+
+### `InternetService`
+
+| Method | Path | Upstream operation | Proven by |
+|---|---|---|---|
+| `POST` | `/api/v1/CreateInternetService` | `osc/Client.CreateInternetService` | `client` `contract` `probe` `behaviour` |
+| `POST` | `/api/v1/DeleteInternetService` | `osc/Client.DeleteInternetService` | `client` `contract` `probe` `behaviour` |
+| `POST` | `/api/v1/LinkInternetService` | `osc/Client.LinkInternetService` | `client` `contract` `probe` `behaviour` |
 | `POST` | `/api/v1/ReadInternetServices` | `osc/Client.ReadInternetServices` | `client` `contract` `shape` `probe` `behaviour` |
+| `POST` | `/api/v1/UnlinkInternetService` | `osc/Client.UnlinkInternetService` | `client` `contract` `probe` `behaviour` |
+
+### `Keypair`
+
+| Method | Path | Upstream operation | Proven by |
+|---|---|---|---|
+| `POST` | `/api/v1/CreateKeypair` | `osc/Client.CreateKeypair` | `client` `contract` `probe` `behaviour` |
+| `POST` | `/api/v1/DeleteKeypair` | `osc/Client.DeleteKeypair` | `client` `contract` `probe` `behaviour` |
 | `POST` | `/api/v1/ReadKeypairs` | `osc/Client.ReadKeypairs` | `client` `contract` `shape` `probe` `behaviour` |
+
+### `LoadBalancer`
+
+| Method | Path | Upstream operation | Proven by |
+|---|---|---|---|
 | `POST` | `/api/v1/ReadLoadBalancers` | `osc/Client.ReadLoadBalancers` | `client` `contract` `shape` `probe` |
+
+### `NatService`
+
+| Method | Path | Upstream operation | Proven by |
+|---|---|---|---|
+| `POST` | `/api/v1/CreateNatService` | `osc/Client.CreateNatService` | `client` `contract` `behaviour` |
+| `POST` | `/api/v1/DeleteNatService` | `osc/Client.DeleteNatService` | `client` `contract` `behaviour` |
 | `POST` | `/api/v1/ReadNatServices` | `osc/Client.ReadNatServices` | `client` `contract` `shape` `probe` `behaviour` |
-| `POST` | `/api/v1/ReadNetAccessPointServices` | `osc/Client.ReadNetAccessPointServices` | `contract` `shape` `probe` |
+
+### `Net`
+
+| Method | Path | Upstream operation | Proven by |
+|---|---|---|---|
+| `POST` | `/api/v1/CreateNet` | `osc/Client.CreateNet` | `client` `contract` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/DeleteNet` | `osc/Client.DeleteNet` | `client` `contract` `probe` `behaviour` `negative` |
 | `POST` | `/api/v1/ReadNets` | `osc/Client.ReadNets` | `client` `contract` `shape` `probe` `behaviour` |
+
+### `NetAccessPoint`
+
+| Method | Path | Upstream operation | Proven by |
+|---|---|---|---|
+| `POST` | `/api/v1/ReadNetAccessPointServices` | `osc/Client.ReadNetAccessPointServices` | `contract` `shape` `probe` |
+
+### `Nic`
+
+| Method | Path | Upstream operation | Proven by |
+|---|---|---|---|
+| `POST` | `/api/v1/CreateNic` | `osc/Client.CreateNic` | `client` `contract` `probe` `behaviour` |
+| `POST` | `/api/v1/DeleteNic` | `osc/Client.DeleteNic` | `client` `contract` `behaviour` |
+| `POST` | `/api/v1/LinkNic` | `osc/Client.LinkNic` | `client` `contract` `behaviour` |
 | `POST` | `/api/v1/ReadNics` | `osc/Client.ReadNics` | `client` `contract` `shape` `probe` `behaviour` |
+| `POST` | `/api/v1/UnlinkNic` | `osc/Client.UnlinkNic` | `client` `contract` `behaviour` |
+
+### `PublicIp`
+
+| Method | Path | Upstream operation | Proven by |
+|---|---|---|---|
+| `POST` | `/api/v1/CreatePublicIp` | `osc/Client.CreatePublicIp` | `client` `contract` `probe` `behaviour` |
+| `POST` | `/api/v1/DeletePublicIp` | `osc/Client.DeletePublicIp` | `client` `contract` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/LinkPublicIp` | `osc/Client.LinkPublicIp` | `client` `contract` `probe` `behaviour` |
 | `POST` | `/api/v1/ReadPublicIpRanges` | `osc/Client.ReadPublicIpRanges` | `contract` `shape` `probe` |
 | `POST` | `/api/v1/ReadPublicIps` | `osc/Client.ReadPublicIps` | `client` `contract` `shape` `probe` `behaviour` |
+| `POST` | `/api/v1/UnlinkPublicIp` | `osc/Client.UnlinkPublicIp` | `client` `contract` `probe` `behaviour` |
+
+### `Region`
+
+| Method | Path | Upstream operation | Proven by |
+|---|---|---|---|
 | `POST` | `/api/v1/ReadRegions` | `osc/Client.ReadRegions` | `client` `contract` `shape` `probe` |
+
+### `Route`
+
+| Method | Path | Upstream operation | Proven by |
+|---|---|---|---|
+| `POST` | `/api/v1/CreateRoute` | `osc/Client.CreateRoute` | `client` `contract` `behaviour` |
+| `POST` | `/api/v1/DeleteRoute` | `osc/Client.DeleteRoute` | `client` `contract` `behaviour` |
+| `POST` | `/api/v1/UpdateRoute` | `osc/Client.UpdateRoute` | `client` `contract` `behaviour` |
+
+### `RouteTable`
+
+| Method | Path | Upstream operation | Proven by |
+|---|---|---|---|
+| `POST` | `/api/v1/CreateRouteTable` | `osc/Client.CreateRouteTable` | `client` `contract` `probe` `behaviour` |
+| `POST` | `/api/v1/DeleteRouteTable` | `osc/Client.DeleteRouteTable` | `client` `contract` `behaviour` |
+| `POST` | `/api/v1/LinkRouteTable` | `osc/Client.LinkRouteTable` | `client` `contract` `behaviour` |
 | `POST` | `/api/v1/ReadRouteTables` | `osc/Client.ReadRouteTables` | `client` `contract` `shape` `probe` `behaviour` |
+| `POST` | `/api/v1/UnlinkRouteTable` | `osc/Client.UnlinkRouteTable` | `client` `contract` `behaviour` |
+
+### `SecurityGroup`
+
+| Method | Path | Upstream operation | Proven by |
+|---|---|---|---|
+| `POST` | `/api/v1/CreateSecurityGroup` | `osc/Client.CreateSecurityGroup` | `client` `contract` `probe` `behaviour` |
+| `POST` | `/api/v1/DeleteSecurityGroup` | `osc/Client.DeleteSecurityGroup` | `client` `contract` `probe` `behaviour` |
 | `POST` | `/api/v1/ReadSecurityGroups` | `osc/Client.ReadSecurityGroups` | `client` `contract` `shape` `probe` `behaviour` |
+
+### `SecurityGroupRule`
+
+| Method | Path | Upstream operation | Proven by |
+|---|---|---|---|
+| `POST` | `/api/v1/CreateSecurityGroupRule` | `osc/Client.CreateSecurityGroupRule` | `client` `contract` `probe` `behaviour` |
+| `POST` | `/api/v1/DeleteSecurityGroupRule` | `osc/Client.DeleteSecurityGroupRule` | `client` `contract` `probe` `behaviour` |
+
+### `Snapshot`
+
+| Method | Path | Upstream operation | Proven by |
+|---|---|---|---|
+| `POST` | `/api/v1/CreateSnapshot` | `osc/Client.CreateSnapshot` | `client` `contract` `probe` `behaviour` |
+| `POST` | `/api/v1/DeleteSnapshot` | `osc/Client.DeleteSnapshot` | `client` `contract` `behaviour` |
 | `POST` | `/api/v1/ReadSnapshots` | `osc/Client.ReadSnapshots` | `client` `contract` `shape` `probe` `behaviour` |
+
+### `Subnet`
+
+| Method | Path | Upstream operation | Proven by |
+|---|---|---|---|
+| `POST` | `/api/v1/CreateSubnet` | `osc/Client.CreateSubnet` | `client` `contract` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/DeleteSubnet` | `osc/Client.DeleteSubnet` | `client` `contract` `probe` `behaviour` |
 | `POST` | `/api/v1/ReadSubnets` | `osc/Client.ReadSubnets` | `client` `contract` `shape` `probe` `behaviour` |
+
+### `Subregion`
+
+| Method | Path | Upstream operation | Proven by |
+|---|---|---|---|
 | `POST` | `/api/v1/ReadSubregions` | `osc/Client.ReadSubregions` | `client` `contract` `shape` `probe` |
+
+### `Tag`
+
+| Method | Path | Upstream operation | Proven by |
+|---|---|---|---|
+| `POST` | `/api/v1/CreateTags` | `osc/Client.CreateTags` | `client` `contract` `probe` `behaviour` |
+| `POST` | `/api/v1/DeleteTags` | `osc/Client.DeleteTags` | `contract` `probe` |
 | `POST` | `/api/v1/ReadTags` | `osc/Client.ReadTags` | `client` `contract` `shape` `probe` `behaviour` |
+
+### `Vm`
+
+| Method | Path | Upstream operation | Proven by |
+|---|---|---|---|
+| `POST` | `/api/v1/CreateVms` | `osc/Client.CreateVms` | `client` `contract` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/DeleteVms` | `osc/Client.DeleteVms` | `client` `contract` `probe` |
+| `POST` | `/api/v1/ReadAdminPassword` | `osc/Client.ReadAdminPassword` | `contract` `probe` |
 | `POST` | `/api/v1/ReadVmTypes` | `osc/Client.ReadVmTypes` | `client` `contract` `shape` `probe` |
 | `POST` | `/api/v1/ReadVmsState` | `osc/Client.ReadVmsState` | `client` `contract` `shape` `probe` |
 | `POST` | `/api/v1/ReadVms` | `osc/Client.ReadVms` | `client` `contract` `shape` `probe` `behaviour` |
-| `POST` | `/api/v1/ReadVolumes` | `osc/Client.ReadVolumes` | `client` `contract` `shape` `probe` `behaviour` |
 | `POST` | `/api/v1/RebootVms` | `osc/Client.RebootVms` | `client` `contract` `probe` `behaviour` |
 | `POST` | `/api/v1/StartVms` | `osc/Client.StartVms` | `client` `contract` `probe` `behaviour` |
 | `POST` | `/api/v1/StopVms` | `osc/Client.StopVms` | `client` `contract` `probe` |
-| `POST` | `/api/v1/UnlinkInternetService` | `osc/Client.UnlinkInternetService` | `client` `contract` `probe` `behaviour` |
-| `POST` | `/api/v1/UnlinkNic` | `osc/Client.UnlinkNic` | `client` `contract` `behaviour` |
-| `POST` | `/api/v1/UnlinkPublicIp` | `osc/Client.UnlinkPublicIp` | `client` `contract` `probe` `behaviour` |
-| `POST` | `/api/v1/UnlinkRouteTable` | `osc/Client.UnlinkRouteTable` | `client` `contract` `behaviour` |
-| `POST` | `/api/v1/UnlinkVolume` | `osc/Client.UnlinkVolume` | `client` `contract` `probe` `behaviour` |
-| `POST` | `/api/v1/UpdateImage` | `osc/Client.UpdateImage` | `client` `contract` `probe` `behaviour` `negative` |
-| `POST` | `/api/v1/UpdateRoute` | `osc/Client.UpdateRoute` | `client` `contract` `behaviour` |
 | `POST` | `/api/v1/UpdateVm` | `osc/Client.UpdateVm` | `client` `contract` `probe` `negative` |
+
+### `Volume`
+
+| Method | Path | Upstream operation | Proven by |
+|---|---|---|---|
+| `POST` | `/api/v1/CreateVolume` | `osc/Client.CreateVolume` | `client` `contract` `probe` `behaviour` |
+| `POST` | `/api/v1/DeleteVolume` | `osc/Client.DeleteVolume` | `client` `contract` `probe` `behaviour` |
+| `POST` | `/api/v1/LinkVolume` | `osc/Client.LinkVolume` | `client` `contract` `probe` `behaviour` |
+| `POST` | `/api/v1/ReadVolumes` | `osc/Client.ReadVolumes` | `client` `contract` `shape` `probe` `behaviour` |
+| `POST` | `/api/v1/UnlinkVolume` | `osc/Client.UnlinkVolume` | `client` `contract` `probe` `behaviour` |
 | `POST` | `/api/v1/UpdateVolume` | `osc/Client.UpdateVolume` | `client` `contract` `probe` `behaviour` `negative` |
 
 ### Declined on purpose (173)
@@ -503,184 +417,51 @@ missed one — and the reason is what separates a decision from a list.
 Operations this pack knowingly does not serve, and why. Declining is a
 decision the drift gate records, which is what separates it from having
 missed one — and the reason is what separates a decision from a list.
+One line is one decision: the group upstream files the operations under,
+how many it covers, and the reason they share. The per-operation verdicts
+are in `coverage/`, one artefact per provider.
 
-- `oks/Client.CreateCluster` — a managed control plane on its own host and API version, which no route here mounts: answering any of it would describe a service the emulator does not run
-- `oks/Client.CreateProject` — a managed control plane on its own host and API version, which no route here mounts: answering any of it would describe a service the emulator does not run
-- `oks/Client.DeleteCluster` — a managed control plane on its own host and API version, which no route here mounts: answering any of it would describe a service the emulator does not run
-- `oks/Client.DeleteProject` — a managed control plane on its own host and API version, which no route here mounts: answering any of it would describe a service the emulator does not run
-- `oks/Client.GetCPSubregions` — a managed control plane on its own host and API version, which no route here mounts: answering any of it would describe a service the emulator does not run
-- `oks/Client.GetCluster` — a managed control plane on its own host and API version, which no route here mounts: answering any of it would describe a service the emulator does not run
-- `oks/Client.GetClusterTemplate` — a managed control plane on its own host and API version, which no route here mounts: answering any of it would describe a service the emulator does not run
-- `oks/Client.GetControlPlanePlans` — a managed control plane on its own host and API version, which no route here mounts: answering any of it would describe a service the emulator does not run
-- `oks/Client.GetKubeconfig` — a managed control plane on its own host and API version, which no route here mounts: answering any of it would describe a service the emulator does not run
-- `oks/Client.GetKubeconfigWithPubkeyNACL` — a managed control plane on its own host and API version, which no route here mounts: answering any of it would describe a service the emulator does not run
-- `oks/Client.GetKubernetesVersions` — a managed control plane on its own host and API version, which no route here mounts: answering any of it would describe a service the emulator does not run
-- `oks/Client.GetNetPeeringAcceptanceTemplate` — a managed control plane on its own host and API version, which no route here mounts: answering any of it would describe a service the emulator does not run
-- `oks/Client.GetNetPeeringRequestTemplate` — a managed control plane on its own host and API version, which no route here mounts: answering any of it would describe a service the emulator does not run
-- `oks/Client.GetNodepoolTemplate` — a managed control plane on its own host and API version, which no route here mounts: answering any of it would describe a service the emulator does not run
-- `oks/Client.GetProject` — a managed control plane on its own host and API version, which no route here mounts: answering any of it would describe a service the emulator does not run
-- `oks/Client.GetProjectNets` — a managed control plane on its own host and API version, which no route here mounts: answering any of it would describe a service the emulator does not run
-- `oks/Client.GetProjectPublicIps` — a managed control plane on its own host and API version, which no route here mounts: answering any of it would describe a service the emulator does not run
-- `oks/Client.GetProjectQuotas` — a managed control plane on its own host and API version, which no route here mounts: answering any of it would describe a service the emulator does not run
-- `oks/Client.GetProjectSnapshots` — a managed control plane on its own host and API version, which no route here mounts: answering any of it would describe a service the emulator does not run
-- `oks/Client.GetProjectTemplate` — a managed control plane on its own host and API version, which no route here mounts: answering any of it would describe a service the emulator does not run
-- `oks/Client.GetQuotas` — a managed control plane on its own host and API version, which no route here mounts: answering any of it would describe a service the emulator does not run
-- `oks/Client.ListAllClusters` — a managed control plane on its own host and API version, which no route here mounts: answering any of it would describe a service the emulator does not run
-- `oks/Client.ListClustersByProjectID` — a managed control plane on its own host and API version, which no route here mounts: answering any of it would describe a service the emulator does not run
-- `oks/Client.ListProjects` — a managed control plane on its own host and API version, which no route here mounts: answering any of it would describe a service the emulator does not run
-- `oks/Client.UpdateCluster` — a managed control plane on its own host and API version, which no route here mounts: answering any of it would describe a service the emulator does not run
-- `oks/Client.UpdateProject` — a managed control plane on its own host and API version, which no route here mounts: answering any of it would describe a service the emulator does not run
-- `oks/Client.UpgradeCluster` — a managed control plane on its own host and API version, which no route here mounts: answering any of it would describe a service the emulator does not run
-- `osc/Client.AddUserToUserGroup` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.CreateAccessKey` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.CreateAccount` — the emulator has one implicit account with no consumption and no price list, so anything here would be a figure it invented and somebody acted on
-- `osc/Client.CreateApiAccessRule` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.CreateCa` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.CreateClientGateway` — each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one
-- `osc/Client.CreateDedicatedGroup` — GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal
-- `osc/Client.CreateDirectLink` — each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one
-- `osc/Client.CreateDirectLinkInterface` — each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one
-- `osc/Client.CreateFlexibleGpu` — GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal
-- `osc/Client.CreateImageExportTask` — Export tasks write an image or a snapshot into Object Storage, which is not emulated: the reasons are in docs/limits.md and none of them are about Outscale
-- `osc/Client.CreateListenerRule` — a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured
-- `osc/Client.CreateLoadBalancer` — a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured
-- `osc/Client.CreateLoadBalancerListeners` — a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured
-- `osc/Client.CreateLoadBalancerPolicy` — a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured
-- `osc/Client.CreateLoadBalancerTags` — a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured
-- `osc/Client.CreatePolicy` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.CreatePolicyVersion` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.CreateProductType` — the emulator has one implicit account with no consumption and no price list, so anything here would be a figure it invented and somebody acted on
-- `osc/Client.CreateServerCertificate` — a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured
-- `osc/Client.CreateSnapshotExportTask` — Export tasks write an image or a snapshot into Object Storage, which is not emulated: the reasons are in docs/limits.md and none of them are about Outscale
-- `osc/Client.CreateUser` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.CreateUserGroup` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.CreateVirtualGateway` — each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one
-- `osc/Client.CreateVmGroup` — GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal
-- `osc/Client.CreateVmTemplate` — GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal
-- `osc/Client.CreateVpnConnection` — each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one
-- `osc/Client.CreateVpnConnectionRoute` — each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one
-- `osc/Client.DeleteAccessKey` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.DeleteApiAccessRule` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.DeleteCa` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.DeleteClientGateway` — each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one
-- `osc/Client.DeleteDedicatedGroup` — GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal
-- `osc/Client.DeleteDirectLink` — each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one
-- `osc/Client.DeleteDirectLinkInterface` — each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one
-- `osc/Client.DeleteExportTask` — Export tasks write an image or a snapshot into Object Storage, which is not emulated: the reasons are in docs/limits.md and none of them are about Outscale
-- `osc/Client.DeleteFlexibleGpu` — GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal
-- `osc/Client.DeleteListenerRule` — a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured
-- `osc/Client.DeleteLoadBalancer` — a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured
-- `osc/Client.DeleteLoadBalancerListeners` — a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured
-- `osc/Client.DeleteLoadBalancerPolicy` — a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured
-- `osc/Client.DeleteLoadBalancerTags` — a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured
-- `osc/Client.DeletePolicy` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.DeletePolicyVersion` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.DeleteProductType` — the emulator has one implicit account with no consumption and no price list, so anything here would be a figure it invented and somebody acted on
-- `osc/Client.DeleteServerCertificate` — a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured
-- `osc/Client.DeleteUser` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.DeleteUserGroup` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.DeleteUserGroupPolicy` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.DeleteUserPolicy` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.DeleteVirtualGateway` — each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one
-- `osc/Client.DeleteVmGroup` — GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal
-- `osc/Client.DeleteVmTemplate` — GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal
-- `osc/Client.DeleteVpnConnection` — each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one
-- `osc/Client.DeleteVpnConnectionRoute` — each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one
-- `osc/Client.DeregisterVmsInLoadBalancer` — a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured
-- `osc/Client.DisableOutscaleLogin` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.DisableOutscaleLoginForUsers` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.DisableOutscaleLoginPerUsers` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.EnableOutscaleLogin` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.EnableOutscaleLoginForUsers` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.EnableOutscaleLoginPerUsers` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.LinkFlexibleGpu` — GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal
-- `osc/Client.LinkLoadBalancerBackendMachines` — a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured
-- `osc/Client.LinkManagedPolicyToUserGroup` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.LinkPolicy` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.LinkVirtualGateway` — each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one
-- `osc/Client.PutUserGroupPolicy` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.PutUserPolicy` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.ReadAccessKeys` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.ReadAccounts` — the emulator has one implicit account with no consumption and no price list, so anything here would be a figure it invented and somebody acted on
-- `osc/Client.ReadApiAccessPolicy` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.ReadApiAccessRules` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.ReadApiLogs` — the trail records calls made against Outscale's platform, and nothing here made any of them
-- `osc/Client.ReadCO2EmissionAccount` — the emulator has one implicit account with no consumption and no price list, so anything here would be a figure it invented and somebody acted on
-- `osc/Client.ReadCas` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.ReadCatalog` — no client this project drives reads a price on its way to creating anything, which is the whole of it: where a catalogue is on a client's path the emulator does serve a fictional one, and docs/limits.md says so
-- `osc/Client.ReadCatalogs` — no client this project drives reads a price on its way to creating anything, which is the whole of it: where a catalogue is on a client's path the emulator does serve a fictional one, and docs/limits.md says so
-- `osc/Client.ReadClientGateways` — each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one
-- `osc/Client.ReadConsoleOutput` — each answers a question about something that never happened here: a console nothing captured, a stop history nothing kept, migration tasks for updates applied immediately
-- `osc/Client.ReadConsumptionAccount` — the emulator has one implicit account with no consumption and no price list, so anything here would be a figure it invented and somebody acted on
-- `osc/Client.ReadDedicatedGroups` — GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal
-- `osc/Client.ReadDirectLinkInterfaces` — each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one
-- `osc/Client.ReadDirectLinks` — each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one
-- `osc/Client.ReadEntitiesLinkedToPolicy` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.ReadFlexibleGpuCatalog` — no client this project drives reads a price on its way to creating anything, which is the whole of it: where a catalogue is on a client's path the emulator does serve a fictional one, and docs/limits.md says so
-- `osc/Client.ReadFlexibleGpus` — GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal
-- `osc/Client.ReadImageExportTasks` — Export tasks write an image or a snapshot into Object Storage, which is not emulated: the reasons are in docs/limits.md and none of them are about Outscale
-- `osc/Client.ReadLinkedPolicies` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.ReadListenerRules` — a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured
-- `osc/Client.ReadLoadBalancerTags` — a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured
-- `osc/Client.ReadLocations` — each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one
-- `osc/Client.ReadManagedPoliciesLinkedToUserGroup` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.ReadPolicies` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.ReadPolicy` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.ReadPolicyVersion` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.ReadPolicyVersions` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.ReadProductTypes` — the emulator has one implicit account with no consumption and no price list, so anything here would be a figure it invented and somebody acted on
-- `osc/Client.ReadPublicCatalog` — no client this project drives reads a price on its way to creating anything, which is the whole of it: where a catalogue is on a client's path the emulator does serve a fictional one, and docs/limits.md says so
-- `osc/Client.ReadQuotas` — the emulator has one implicit account with no consumption and no price list, so anything here would be a figure it invented and somebody acted on
-- `osc/Client.ReadServerCertificates` — a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured
-- `osc/Client.ReadSnapshotExportTasks` — Export tasks write an image or a snapshot into Object Storage, which is not emulated: the reasons are in docs/limits.md and none of them are about Outscale
-- `osc/Client.ReadUnitPrice` — the emulator has one implicit account with no consumption and no price list, so anything here would be a figure it invented and somebody acted on
-- `osc/Client.ReadUserGroup` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.ReadUserGroupPolicies` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.ReadUserGroupPolicy` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.ReadUserGroups` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.ReadUserGroupsPerUser` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.ReadUserPolicies` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.ReadUserPolicy` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.ReadUsers` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.ReadVirtualGateways` — each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one
-- `osc/Client.ReadVmGroups` — GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal
-- `osc/Client.ReadVmTemplates` — GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal
-- `osc/Client.ReadVmsHealth` — a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured
-- `osc/Client.ReadVmsStopHistory` — each answers a question about something that never happened here: a console nothing captured, a stop history nothing kept, migration tasks for updates applied immediately
-- `osc/Client.ReadVolumeUpdateTasks` — each answers a question about something that never happened here: a console nothing captured, a stop history nothing kept, migration tasks for updates applied immediately
-- `osc/Client.ReadVpnConnections` — each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one
-- `osc/Client.RegisterVmsInLoadBalancer` — a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured
-- `osc/Client.RemoveUserFromUserGroup` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.ScaleDownVmGroup` — GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal
-- `osc/Client.ScaleUpVmGroup` — GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal
-- `osc/Client.SetDefaultPolicyVersion` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.UnlinkFlexibleGpu` — GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal
-- `osc/Client.UnlinkLoadBalancerBackendMachines` — a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured
-- `osc/Client.UnlinkManagedPolicyFromUserGroup` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.UnlinkPolicy` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.UnlinkVirtualGateway` — each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one
-- `osc/Client.UpdateAccessKey` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.UpdateAccount` — the emulator has one implicit account with no consumption and no price list, so anything here would be a figure it invented and somebody acted on
-- `osc/Client.UpdateApiAccessPolicy` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.UpdateApiAccessRule` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.UpdateCa` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.UpdateDedicatedGroup` — GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal
-- `osc/Client.UpdateDirectLinkInterface` — each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one
-- `osc/Client.UpdateFlexibleGpu` — GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal
-- `osc/Client.UpdateListenerRule` — a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured
-- `osc/Client.UpdateLoadBalancer` — a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured
-- `osc/Client.UpdateRoutePropagation` — each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one
-- `osc/Client.UpdateServerCertificate` — a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured
-- `osc/Client.UpdateSnapshot` — UpdateSnapshot manages cross-account permissions, and the emulator has one implicit account: there is nobody to grant to
-- `osc/Client.UpdateUser` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.UpdateUserGroup` — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
-- `osc/Client.UpdateVmGroup` — GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal
-- `osc/Client.UpdateVmTemplate` — GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal
-- `osc/Client.UpdateVpnConnection` — each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one
+- `AccessKey` — 4 operations — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
+- `Account` — 5 operations — the emulator has one implicit account with no consumption and no price list, so anything here would be a figure it invented and somebody acted on
+- `ApiAccessPolicy` — 2 operations — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
+- `ApiAccessRule` — 4 operations — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
+- `ApiLog` — 1 operation — the trail records calls made against Outscale's platform, and nothing here made any of them
+- `Ca` — 4 operations — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
+- `Catalog` — 2 operations — no client this project drives reads a price on its way to creating anything, which is the whole of it: where a catalogue is on a client's path the emulator does serve a fictional one, and docs/limits.md says so
+- `Catalog` — 1 operation — the emulator has one implicit account with no consumption and no price list, so anything here would be a figure it invented and somebody acted on
+- `ClientGateway` — 3 operations — each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one
+- `DedicatedGroup` — 4 operations — GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal
+- `DirectLink` — 3 operations — each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one
+- `DirectLinkInterface` — 4 operations — each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one
+- `FlexibleGpu` — 6 operations — GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal
+- `FlexibleGpu` — 1 operation — no client this project drives reads a price on its way to creating anything, which is the whole of it: where a catalogue is on a client's path the emulator does serve a fictional one, and docs/limits.md says so
+- `IdentityProvider` — 6 operations — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
+- `Image` — 2 operations — Export tasks write an image or a snapshot into Object Storage, which is not emulated: the reasons are in docs/limits.md and none of them are about Outscale
+- `Listener` — 6 operations — a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured
+- `LoadBalancer` — 11 operations — a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured
+- `LoadBalancerPolicy` — 2 operations — a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured
+- `Location` — 1 operation — each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one
+- `Policy` — 24 operations — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
+- `ProductType` — 3 operations — the emulator has one implicit account with no consumption and no price list, so anything here would be a figure it invented and somebody acted on
+- `PublicCatalog` — 1 operation — no client this project drives reads a price on its way to creating anything, which is the whole of it: where a catalogue is on a client's path the emulator does serve a fictional one, and docs/limits.md says so
+- `Quota` — 1 operation — the emulator has one implicit account with no consumption and no price list, so anything here would be a figure it invented and somebody acted on
+- `ServerCertificate` — 4 operations — a load balancer is a data plane accepting real connections, and the emulator has none: creating one would hand out a DNS name resolving nowhere and a backend health nobody measured
+- `Snapshot` — 2 operations — Export tasks write an image or a snapshot into Object Storage, which is not emulated: the reasons are in docs/limits.md and none of them are about Outscale
+- `Snapshot` — 1 operation — UpdateSnapshot manages cross-account permissions, and the emulator has one implicit account: there is nobody to grant to
+- `Task` — 1 operation — Export tasks write an image or a snapshot into Object Storage, which is not emulated: the reasons are in docs/limits.md and none of them are about Outscale
+- `User` — 4 operations — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
+- `UserGroup` — 8 operations — the emulator accepts every credential on purpose, so serving user and policy management would describe an access control that nothing here applies
+- `VirtualGateway` — 6 operations — each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one
+- `Vm` — 2 operations — each answers a question about something that never happened here: a console nothing captured, a stop history nothing kept, migration tasks for updates applied immediately
+- `VmGroup` — 6 operations — GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal
+- `VmTemplate` — 4 operations — GPUs and dedicated hosts are hardware this station does not have, and the templates and groups above them are proprietary orchestration, out of scope here for the same reason as baremetal
+- `Volume` — 1 operation — each answers a question about something that never happened here: a console nothing captured, a stop history nothing kept, migration tasks for updates applied immediately
+- `VpnConnection` — 6 operations — each of these belongs to a link terminating on a network this machine is not on — a cross connect, a tunnel to a remote site — and the facility list and route propagation exist only to serve one
+- `oks` — 27 operations — a managed control plane on its own host and API version, which no route here mounts: answering any of it would describe a service the emulator does not run
 
 ## Exoscale
 
-### `exoscale`
+### `compute`
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
@@ -700,16 +481,12 @@ missed one — and the reason is what separates a decision from a list.
 | `GET` | `/v2/instance-type` | `exoscale/v2.list-instance-types` | `client` `contract` `shape` `probe` |
 | `GET` | `/v2/instance/{id}` | `exoscale/v2.get-instance` | `client` `contract` `probe` `behaviour` |
 | `GET` | `/v2/instance` | `exoscale/v2.list-instances` | `client` `contract` `shape` `probe` `behaviour` |
-| `GET` | `/v2/operation/{id}` | `exoscale/v2.get-operation` | `probe` |
-| `GET` | `/v2/quota/{name}` | `exoscale/v2.get-quota` | — |
-| `GET` | `/v2/quota` | `exoscale/v2.list-quotas` | `client` `contract` `probe` |
 | `GET` | `/v2/security-group/{id}` | `exoscale/v2.get-security-group` | `probe` |
 | `GET` | `/v2/security-group` | `exoscale/v2.list-security-groups` | `client` `contract` `shape` `probe` `behaviour` |
 | `GET` | `/v2/ssh-key/{name}` | `exoscale/v2.get-ssh-key` | `client` `contract` `behaviour` |
 | `GET` | `/v2/ssh-key` | `exoscale/v2.list-ssh-keys` | `client` `contract` `shape` `probe` `behaviour` |
 | `GET` | `/v2/template/{id}` | `exoscale/v2.get-template` | `client` `contract` `probe` |
 | `GET` | `/v2/template` | `exoscale/v2.list-templates` | `client` `contract` `shape` `probe` |
-| `GET` | `/v2/zone` | `exoscale/v2.list-zones` | `client` `contract` `shape` `probe` |
 | `POST` | `/v2/anti-affinity-group` | `exoscale/v2.create-anti-affinity-group` | `client` `contract` `probe` `behaviour` |
 | `POST` | `/v2/elastic-ip` | `exoscale/v2.create-elastic-ip` | `client` `contract` `probe` `behaviour` |
 | `POST` | `/v2/instance` | `exoscale/v2.create-instance` | `client` `contract` `probe` `behaviour` |
@@ -731,263 +508,38 @@ missed one — and the reason is what separates a decision from a list.
 | `PUT` | `/v2/security-group/{id}:attach` | `exoscale/v2.attach-instance-to-security-group` | `client` `contract` `probe` `behaviour` |
 | `PUT` | `/v2/security-group/{id}:detach` | `exoscale/v2.detach-instance-from-security-group` | `client` `contract` `probe` `behaviour` |
 
+### `general`
+
+| Method | Path | Upstream operation | Proven by |
+|---|---|---|---|
+| `GET` | `/v2/operation/{id}` | `exoscale/v2.get-operation` | `probe` |
+| `GET` | `/v2/zone` | `exoscale/v2.list-zones` | `client` `contract` `shape` `probe` |
+
+### `quotas`
+
+| Method | Path | Upstream operation | Proven by |
+|---|---|---|---|
+| `GET` | `/v2/quota/{name}` | `exoscale/v2.get-quota` | — |
+| `GET` | `/v2/quota` | `exoscale/v2.list-quotas` | `client` `contract` `probe` |
+
 ### Declined on purpose (253)
 
 Operations this pack knowingly does not serve, and why. Declining is a
 decision the drift gate records, which is what separates it from having
 missed one — and the reason is what separates a decision from a list.
+One line is one decision: the group upstream files the operations under,
+how many it covers, and the reason they share. The per-operation verdicts
+are in `coverage/`, one artefact per provider.
 
-- `exoscale/v2.assume-iam-role` — the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies
-- `exoscale/v2.attach-dbaas-service-to-endpoint` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.cancel-kms-key-deletion` — a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing
-- `exoscale/v2.create-ai-api-key` — inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station
-- `exoscale/v2.create-api-key` — the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies
-- `exoscale/v2.create-dbaas-clickhouse-user` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.create-dbaas-external-endpoint-datadog` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.create-dbaas-external-endpoint-elasticsearch` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.create-dbaas-external-endpoint-opensearch` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.create-dbaas-external-endpoint-prometheus` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.create-dbaas-external-endpoint-rsyslog` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.create-dbaas-integration` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.create-dbaas-kafka-schema-registry-acl-config` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.create-dbaas-kafka-topic-acl-config` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.create-dbaas-kafka-user` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.create-dbaas-mysql-database` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.create-dbaas-mysql-user` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.create-dbaas-opensearch-user` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.create-dbaas-pg-connection-pool` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.create-dbaas-pg-database` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.create-dbaas-pg-upgrade-check` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.create-dbaas-postgres-user` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.create-dbaas-service-clickhouse` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.create-dbaas-service-grafana` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.create-dbaas-service-kafka` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.create-dbaas-service-mysql` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.create-dbaas-service-opensearch` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.create-dbaas-service-pg` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.create-dbaas-service-thanos` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.create-dbaas-service-valkey` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.create-dbaas-task-migration-check` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.create-dbaas-valkey-user` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.create-deployment` — inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station
-- `exoscale/v2.create-dns-domain` — authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet
-- `exoscale/v2.create-dns-domain-record` — authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet
-- `exoscale/v2.create-iam-role` — the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies
-- `exoscale/v2.create-kms-key` — a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing
-- `exoscale/v2.create-model` — inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station
-- `exoscale/v2.create-sks-cluster` — a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere
-- `exoscale/v2.create-sks-nodepool` — a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere
-- `exoscale/v2.create-user` — the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies
-- `exoscale/v2.decrypt` — a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing
-- `exoscale/v2.delete-ai-api-key` — inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station
-- `exoscale/v2.delete-api-key` — the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies
-- `exoscale/v2.delete-dbaas-clickhouse-role` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.delete-dbaas-clickhouse-user` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.delete-dbaas-external-endpoint-datadog` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.delete-dbaas-external-endpoint-elasticsearch` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.delete-dbaas-external-endpoint-opensearch` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.delete-dbaas-external-endpoint-prometheus` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.delete-dbaas-external-endpoint-rsyslog` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.delete-dbaas-integration` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.delete-dbaas-kafka-schema-registry-acl-config` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.delete-dbaas-kafka-topic-acl-config` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.delete-dbaas-kafka-user` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.delete-dbaas-mysql-database` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.delete-dbaas-mysql-user` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.delete-dbaas-opensearch-user` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.delete-dbaas-pg-connection-pool` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.delete-dbaas-pg-database` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.delete-dbaas-postgres-user` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.delete-dbaas-service` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.delete-dbaas-service-clickhouse` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.delete-dbaas-service-grafana` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.delete-dbaas-service-kafka` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.delete-dbaas-service-mysql` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.delete-dbaas-service-opensearch` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.delete-dbaas-service-pg` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.delete-dbaas-service-thanos` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.delete-dbaas-service-valkey` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.delete-dbaas-valkey-user` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.delete-deployment` — inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station
-- `exoscale/v2.delete-dns-domain` — authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet
-- `exoscale/v2.delete-dns-domain-record` — authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet
-- `exoscale/v2.delete-iam-role` — the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies
-- `exoscale/v2.delete-model` — inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station
-- `exoscale/v2.delete-reverse-dns-elastic-ip` — authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet
-- `exoscale/v2.delete-reverse-dns-instance` — authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet
-- `exoscale/v2.delete-sks-cluster` — a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere
-- `exoscale/v2.delete-sks-nodepool` — a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere
-- `exoscale/v2.delete-user` — the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies
-- `exoscale/v2.detach-dbaas-service-from-endpoint` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.disable-kms-key` — a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing
-- `exoscale/v2.disable-kms-key-rotation` — a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing
-- `exoscale/v2.enable-dbaas-mysql-writes` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.enable-kms-key` — a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing
-- `exoscale/v2.enable-kms-key-rotation` — a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing
-- `exoscale/v2.encrypt` — a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing
-- `exoscale/v2.evict-sks-nodepool-members` — a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere
-- `exoscale/v2.generate-data-key` — a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing
-- `exoscale/v2.generate-sks-cluster-kubeconfig` — a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere
-- `exoscale/v2.generate-sks-karpenter-exoscale-nodeclass` — a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere
-- `exoscale/v2.generate-sks-karpenter-nodepool` — a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere
-- `exoscale/v2.get-active-nodepool-template` — a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere
-- `exoscale/v2.get-ai-api-key` — inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station
-- `exoscale/v2.get-api-key` — the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies
-- `exoscale/v2.get-console-proxy-url` — there is no console to proxy and no password to reveal: machines here are opened by the registered SSH key, and a URL or a password the emulator invented would claim an access nothing answers
-- `exoscale/v2.get-dbaas-ca-certificate` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-dbaas-clickhouse-acl-config` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-dbaas-external-endpoint-datadog` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-dbaas-external-endpoint-elasticsearch` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-dbaas-external-endpoint-opensearch` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-dbaas-external-endpoint-prometheus` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-dbaas-external-endpoint-rsyslog` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-dbaas-external-integration` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-dbaas-external-integration-settings-datadog` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-dbaas-integration` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-dbaas-kafka-acl-config` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-dbaas-migration-status` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-dbaas-opensearch-acl-config` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-dbaas-service-clickhouse` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-dbaas-service-grafana` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-dbaas-service-kafka` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-dbaas-service-logs` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-dbaas-service-metrics` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-dbaas-service-mysql` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-dbaas-service-opensearch` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-dbaas-service-pg` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-dbaas-service-thanos` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-dbaas-service-type` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-dbaas-service-valkey` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-dbaas-settings-clickhouse` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-dbaas-settings-grafana` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-dbaas-settings-kafka` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-dbaas-settings-mysql` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-dbaas-settings-opensearch` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-dbaas-settings-pg` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-dbaas-settings-thanos` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-dbaas-settings-valkey` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-dbaas-task` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.get-deployment` — inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station
-- `exoscale/v2.get-deployment-logs` — inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station
-- `exoscale/v2.get-dns-domain` — authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet
-- `exoscale/v2.get-dns-domain-record` — authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet
-- `exoscale/v2.get-dns-domain-zone-file` — authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet
-- `exoscale/v2.get-env-impact` — there is no account behind this emulator and no consumption to report, so any figure here would be one it invented and somebody planned against
-- `exoscale/v2.get-iam-organization-policy` — the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies
-- `exoscale/v2.get-iam-role` — the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies
-- `exoscale/v2.get-impact-estimate` — there is no account behind this emulator and no consumption to report, so any figure here would be one it invented and somebody planned against
-- `exoscale/v2.get-impact-report` — there is no account behind this emulator and no consumption to report, so any figure here would be one it invented and somebody planned against
-- `exoscale/v2.get-inference-engine-help` — inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station
-- `exoscale/v2.get-kms-key` — a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing
-- `exoscale/v2.get-live-balance` — there is no account behind this emulator and no consumption to report, so any figure here would be one it invented and somebody planned against
-- `exoscale/v2.get-model` — inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station
-- `exoscale/v2.get-reverse-dns-elastic-ip` — authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet
-- `exoscale/v2.get-reverse-dns-instance` — authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet
-- `exoscale/v2.get-sks-cluster` — a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere
-- `exoscale/v2.get-sks-cluster-authority-cert` — a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere
-- `exoscale/v2.get-sks-cluster-inspection` — a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere
-- `exoscale/v2.get-sks-nodepool` — a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere
-- `exoscale/v2.get-sos-presigned-url` — object storage is refused across this project for a measured reason: clients build the S3 endpoint in code, so serving it needs DNS interception and a certificate, recorded in docs/limits.md
-- `exoscale/v2.get-usage-report` — there is no account behind this emulator and no consumption to report, so any figure here would be one it invented and somebody planned against
-- `exoscale/v2.get-user-org-consumption-quota` — inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station
-- `exoscale/v2.list-ai-api-keys` — inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station
-- `exoscale/v2.list-ai-instance-types` — inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station
-- `exoscale/v2.list-api-keys` — the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies
-- `exoscale/v2.list-dbaas-clickhouse-roles` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.list-dbaas-clickhouse-users` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.list-dbaas-external-endpoint-types` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.list-dbaas-external-endpoints` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.list-dbaas-external-integrations` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.list-dbaas-integration-settings` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.list-dbaas-integration-types` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.list-dbaas-service-types` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.list-dbaas-services` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.list-dbaas-valkey-users` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.list-deployments` — inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station
-- `exoscale/v2.list-dns-domain-records` — authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet
-- `exoscale/v2.list-dns-domains` — authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet
-- `exoscale/v2.list-iam-roles` — the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies
-- `exoscale/v2.list-kms-key-rotations` — a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing
-- `exoscale/v2.list-kms-keys` — a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing
-- `exoscale/v2.list-models` — inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station
-- `exoscale/v2.list-sks-cluster-deprecated-resources` — a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere
-- `exoscale/v2.list-sks-cluster-versions` — a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere
-- `exoscale/v2.list-sks-clusters` — a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere
-- `exoscale/v2.list-sos-buckets-usage` — object storage is refused across this project for a measured reason: clients build the S3 endpoint in code, so serving it needs DNS interception and a certificate, recorded in docs/limits.md
-- `exoscale/v2.list-users` — the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies
-- `exoscale/v2.re-encrypt` — a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing
-- `exoscale/v2.replicate-kms-key` — a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing
-- `exoscale/v2.reset-dbaas-clickhouse-user-password` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.reset-dbaas-grafana-user-password` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.reset-dbaas-kafka-user-password` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.reset-dbaas-mysql-user-password` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.reset-dbaas-opensearch-user-password` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.reset-dbaas-postgres-user-password` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.reset-dbaas-valkey-user-password` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.reset-iam-organization-policy` — the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies
-- `exoscale/v2.reset-instance-password` — there is no console to proxy and no password to reveal: machines here are opened by the registered SSH key, and a URL or a password the emulator invented would claim an access nothing answers
-- `exoscale/v2.reveal-ai-api-key` — inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station
-- `exoscale/v2.reveal-dbaas-clickhouse-user-password` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.reveal-dbaas-grafana-user-password` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.reveal-dbaas-kafka-connect-password` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.reveal-dbaas-kafka-user-password` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.reveal-dbaas-mysql-user-password` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.reveal-dbaas-opensearch-user-password` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.reveal-dbaas-postgres-user-password` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.reveal-dbaas-thanos-user-password` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.reveal-dbaas-valkey-user-password` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.reveal-deployment-api-key` — inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station
-- `exoscale/v2.reveal-instance-password` — there is no console to proxy and no password to reveal: machines here are opened by the registered SSH key, and a URL or a password the emulator invented would claim an access nothing answers
-- `exoscale/v2.rotate-ai-api-key` — inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station
-- `exoscale/v2.rotate-kms-key` — a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing
-- `exoscale/v2.rotate-sks-ccm-credentials` — a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere
-- `exoscale/v2.rotate-sks-csi-credentials` — a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere
-- `exoscale/v2.rotate-sks-karpenter-credentials` — a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere
-- `exoscale/v2.rotate-sks-operators-ca` — a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere
-- `exoscale/v2.scale-deployment` — inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station
-- `exoscale/v2.scale-sks-nodepool` — a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere
-- `exoscale/v2.schedule-kms-key-deletion` — a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing
-- `exoscale/v2.start-dbaas-clickhouse-maintenance` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.start-dbaas-grafana-maintenance` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.start-dbaas-kafka-maintenance` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.start-dbaas-mysql-maintenance` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.start-dbaas-opensearch-maintenance` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.start-dbaas-pg-maintenance` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.start-dbaas-thanos-maintenance` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.start-dbaas-valkey-maintenance` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.stop-dbaas-mysql-migration` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.stop-dbaas-pg-migration` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.stop-dbaas-valkey-migration` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.update-ai-api-key` — inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station
-- `exoscale/v2.update-dbaas-external-endpoint-datadog` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.update-dbaas-external-endpoint-elasticsearch` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.update-dbaas-external-endpoint-opensearch` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.update-dbaas-external-endpoint-prometheus` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.update-dbaas-external-endpoint-rsyslog` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.update-dbaas-external-integration-settings-datadog` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.update-dbaas-integration` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.update-dbaas-opensearch-acl-config` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.update-dbaas-pg-connection-pool` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.update-dbaas-postgres-allow-replication` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.update-dbaas-service-clickhouse` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.update-dbaas-service-grafana` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.update-dbaas-service-kafka` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.update-dbaas-service-mysql` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.update-dbaas-service-opensearch` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.update-dbaas-service-pg` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.update-dbaas-service-thanos` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.update-dbaas-service-valkey` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.update-dbaas-valkey-user-access-control` — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
-- `exoscale/v2.update-deployment` — inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station
-- `exoscale/v2.update-dns-domain-record` — authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet
-- `exoscale/v2.update-iam-organization-policy` — the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies
-- `exoscale/v2.update-iam-role` — the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies
-- `exoscale/v2.update-iam-role-policy` — the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies
-- `exoscale/v2.update-reverse-dns-elastic-ip` — authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet
-- `exoscale/v2.update-reverse-dns-instance` — authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet
-- `exoscale/v2.update-sks-cluster` — a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere
-- `exoscale/v2.update-sks-nodepool` — a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere
-- `exoscale/v2.update-user-role` — the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies
-- `exoscale/v2.upgrade-sks-cluster` — a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere
-- `exoscale/v2.upgrade-sks-cluster-service-level` — a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere
+- `ai` — 22 operations — inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station
+- `compute` — 6 operations — authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet
+- `compute` — 3 operations — there is no console to proxy and no password to reveal: machines here are opened by the registered SSH key, and a URL or a password the emulator invented would claim an access nothing answers
+- `dbaas` — 146 operations — these are real database engines Exoscale runs and backs up, and a create answering that it is running would hand a client a connection string to nothing
+- `dns` — 10 operations — authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet
+- `exoscale` — 2 operations — there is no account behind this emulator and no consumption to report, so any figure here would be one it invented and somebody planned against
+- `iam` — 18 operations — the emulator accepts every credential on purpose, so serving roles and policies would describe an access control that nothing here applies
+- `kms` — 16 operations — a key management service that emulated its own cryptography would return ciphertext no real key ever produced, which is worse than refusing
+- `organization` — 3 operations — there is no account behind this emulator and no consumption to report, so any figure here would be one it invented and somebody planned against
+- `sks` — 25 operations — a managed Kubernetes control plane on hosts the emulator does not run, so a kubeconfig it issued would point nowhere
+- `sos` — 2 operations — object storage is refused across this project for a measured reason: clients build the S3 endpoint in code, so serving it needs DNS interception and a certificate, recorded in docs/limits.md
 <!-- routes:end -->

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -225,6 +225,8 @@ Usage:
                     Compare the upstream API surface with what the packs serve.
                     Scaleway and Outscale are read from an SDK checkout; Exoscale
                     publishes an OpenAPI document, so it is read with --contract.
+                    Given both, the SDK lists the operations and the contract adds
+                    the upstream's own grouping, which the SDK flattens away.
 
   feint probe      [--endpoint http://127.0.0.1:4599] [--contracts <dir>] [--provider <name>]
                     Drive every mounted route from its API description and check
@@ -646,7 +648,7 @@ func coverage(args []string, stdout, stderr io.Writer) int {
 		err      error
 	)
 	switch {
-	case *contractPath != "":
+	case *contractPath != "" && *sdk == "":
 		// A provider that publishes an OpenAPI document needs no SDK reader: the
 		// contract already lists its whole surface, and one artefact then feeds
 		// both the drift gate and the response check.
@@ -667,6 +669,18 @@ func coverage(args []string, stdout, stderr io.Writer) int {
 			return exitError
 		}
 		upstream, err = scan(*sdk)
+		// Given both, the SDK is the authority on which operations exist — its
+		// method names are what routes declare — and the contract only adds
+		// where the upstream's document files each one. Outscale is the case:
+		// oapi-codegen drops the document's 50 tags when it flattens every
+		// operation onto one Client, so without this join the whole surface
+		// renders as a single `osc` row.
+		if err == nil && *contractPath != "" {
+			var doc *contract.Doc
+			if doc, err = contract.Load(*contractPath); err == nil {
+				drift.Regroup(upstream, doc)
+			}
+		}
 	}
 	if err != nil {
 		fmt.Fprintf(stderr, "feint: %v\n", err)

--- a/internal/cli/docs.go
+++ b/internal/cli/docs.go
@@ -194,7 +194,11 @@ func docs(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "feint: %v\n", evErr)
 		return exitError
 	}
-	routesChanged, routesErr := spliceRoutes(*routesDoc, evidenceArt)
+	// The same artefacts the tables read decide which section a route files
+	// under, so the reference page and the README can never disagree on where
+	// an operation belongs.
+	opGroups := operationGroups(reports)
+	routesChanged, routesErr := spliceRoutes(*routesDoc, evidenceArt, opGroups)
 	if routesErr != nil {
 		fmt.Fprintf(stderr, "feint: %v\n", routesErr)
 		return exitError
@@ -307,7 +311,7 @@ func docs(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stdout, "%s updated\n", *limits)
 	}
 	if routesChanged {
-		if err := writeSplicedRoutes(*routesDoc, evidenceArt); err != nil {
+		if err := writeSplicedRoutes(*routesDoc, evidenceArt, opGroups); err != nil {
 			fmt.Fprintf(stderr, "feint: %v\n", err)
 			return exitError
 		}
@@ -447,6 +451,20 @@ func unmeasured(rep drift.CoverageFile, byProduct map[string]int) []string {
 	return out
 }
 
+// operationGroups maps every operation the coverage artefacts know to the group
+// it counts under — the upstream's own grouping, its product where the upstream
+// declares none. One map across providers, because operation names already
+// carry their provider's namespace and the route reference looks them up flat.
+func operationGroups(reports []drift.CoverageFile) map[string]string {
+	out := make(map[string]string)
+	for _, rep := range reports {
+		for _, e := range rep.Entries {
+			out[e.Operation] = e.GroupName()
+		}
+	}
+	return out
+}
+
 // loadCoverage reads every <provider>-coverage.json in dir, ordered by provider
 // so two runs render the same document.
 func loadCoverage(dir string) ([]drift.CoverageFile, error) {
@@ -473,9 +491,18 @@ func loadCoverage(dir string) ([]drift.CoverageFile, error) {
 }
 
 // renderCoverage builds the Markdown. One table per provider, its rows the
-// upstream products, because a product is the unit a decision is taken on: a
-// single row saying "Scaleway 49/179" hides that Instance is nearly done and VPC
-// is barely started.
+// upstream's own grouping of its surface, because a group is the unit a
+// decision is taken on: a single row saying "Scaleway 49/179" hides that
+// Instance is nearly done and VPC is barely started.
+//
+// The grouping is the upstream's, never one invented here: Scaleway's SDK
+// packages, Outscale's document tags, the roots of Exoscale's tag hierarchy.
+// Before the artefacts carried it, Scaleway showed six rows because its SDK has
+// a package per product while Outscale's 236 operations sat in one `osc` row
+// and Exoscale's 374 in one `exoscale` row — a difference that read as depth
+// when it was only SDK layout, and that hid the one distinction these tables
+// exist to make: Exoscale's "12% served" is 39% managed databases declined by
+// the roadmap, not 88% missing.
 func renderCoverage(reports []drift.CoverageFile, routes map[string]map[string]int) string {
 	// Most served first, name breaking the tie. Alphabetical would open on the
 	// least finished pack, and the order still has to be a function of the data
@@ -505,13 +532,23 @@ func renderCoverage(reports []drift.CoverageFile, routes map[string]map[string]i
 	for _, rep := range reports {
 		byProduct := routes[rep.Provider]
 		fmt.Fprintf(&b, "#### %s\n\n", strings.ToUpper(rep.Provider[:1])+rep.Provider[1:])
-		fmt.Fprintf(&b, "%d routes mounted, %s of the measured upstream surface served.\n\n",
-			routeTotal(byProduct), percent(rep.Implemented, rep.Total))
-		b.WriteString("| Product | Served | Declined | Untriaged | Upstream |\n")
+		// Three shares, not one: "12% served" alone reads as 88% missing, when
+		// most of the gap is operations somebody decided to refuse. The
+		// distinction between a refusal and an absence is the one these tables
+		// exist to make, so the headline makes it before the rows do.
+		fmt.Fprintf(&b, "%d routes mounted. Of the %d operations upstream declares: %s served,\n%s declined on purpose, %s untriaged.\n\n",
+			routeTotal(byProduct), rep.Total,
+			percent(rep.Implemented, rep.Total), percent(rep.Declined, rep.Total), percent(rep.Unknown, rep.Total))
+		named, rest, foldedGroups := foldSmallGroups(groupRows(rep), rep.Total)
+		b.WriteString("| Group | Served | Declined | Untriaged | Upstream |\n")
 		b.WriteString("|---|--:|--:|--:|--:|\n")
-		for _, p := range rep.Products {
+		for _, g := range named {
 			fmt.Fprintf(&b, "| `%s` | %d | %d | %d | %d |\n",
-				p.Product, p.Implemented, p.Declined, p.Unknown, p.Total)
+				g.Group, g.Implemented, g.Declined, g.Unknown, g.Total)
+		}
+		if foldedGroups > 0 {
+			fmt.Fprintf(&b, "| *… %d smaller groups* | %d | %d | %d | %d |\n",
+				foldedGroups, rest.Implemented, rest.Declined, rest.Unknown, rest.Total)
 		}
 		fmt.Fprintf(&b, "| **Total** | **%d** | **%d** | **%d** | **%d** |\n\n",
 			rep.Implemented, rep.Declined, rep.Unknown, rep.Total)
@@ -527,6 +564,10 @@ func renderCoverage(reports []drift.CoverageFile, routes map[string]map[string]i
 		}
 	}
 
+	b.WriteString("Rows are the provider's own grouping of its surface — Scaleway's SDK products,\n")
+	b.WriteString("Outscale's API tags, the roots of Exoscale's tag hierarchy — never a grouping\n")
+	b.WriteString("invented here. Groups under 2% of a surface fold into the *smaller groups* row\n")
+	b.WriteString("of their table, counts intact, so no block-sized decision can hide in it.\n\n")
 	b.WriteString("**Declined** is a decision, not a gap: an operation nobody intends to emulate,\n")
 	b.WriteString("with the reason in the pack's `Declined()`. **Untriaged** is the honest column —\n")
 	b.WriteString("upstream operations nobody has ruled on yet. A new one appearing there fails CI\n")
@@ -534,6 +575,72 @@ func renderCoverage(reports []drift.CoverageFile, routes map[string]map[string]i
 	b.WriteString("instead of following it by hand.\n")
 
 	return b.String()
+}
+
+// groupRows returns the rows of one provider's table: the upstream groups when
+// the artefact carries them, its products otherwise — an artefact written
+// before groups existed still renders, it just renders what it knows.
+func groupRows(rep drift.CoverageFile) []drift.GroupCount {
+	if len(rep.Groups) > 0 {
+		return rep.Groups
+	}
+	rows := make([]drift.GroupCount, 0, len(rep.Products))
+	for _, p := range rep.Products {
+		rows = append(rows, drift.GroupCount{
+			Group:       p.Product,
+			Total:       p.Total,
+			Implemented: p.Implemented,
+			Declined:    p.Declined,
+			Unknown:     p.Unknown,
+		})
+	}
+	return rows
+}
+
+// foldSmallGroups splits a provider's groups into the rows worth naming and one
+// explicit residual, so a 50-tag surface does not become a 50-row table.
+//
+// The floor is 2% of the provider's surface. It is a share rather than a count
+// so the same sentence holds for a 236-operation provider and a 374-operation
+// one, and it is what bounds the lie a fold can tell: nothing a reader would
+// call a block — Exoscale's 146 dbaas refusals, Outscale's 24 Policy ones —
+// can ever land in the residual, because a block is precisely a group too big
+// for the floor. Asserted by TestFoldSmallGroupsNeverFoldsABlockDecision, which
+// fails if a group at or above the floor stops being named.
+//
+// Named rows come back largest first, name breaking ties, because the table's
+// job is comparative and the biggest block is the first thing to compare. The
+// residual keeps exact counts: folding is about naming, never about numbers.
+// One small group folds into nothing — a residual of one would hide a name to
+// save no space.
+func foldSmallGroups(groups []drift.GroupCount, total int) (named []drift.GroupCount, rest drift.GroupCount, foldedGroups int) {
+	var small []drift.GroupCount
+	for _, g := range groups {
+		// Strictly under 2%: g is named when g.Total/total >= 1/50, kept in
+		// integers so the comparison is exact.
+		if g.Total*50 >= total {
+			named = append(named, g)
+		} else {
+			small = append(small, g)
+		}
+	}
+	if len(small) == 1 {
+		named = append(named, small[0])
+		small = nil
+	}
+	sort.SliceStable(named, func(i, j int) bool {
+		if named[i].Total != named[j].Total {
+			return named[i].Total > named[j].Total
+		}
+		return named[i].Group < named[j].Group
+	})
+	for _, g := range small {
+		rest.Total += g.Total
+		rest.Implemented += g.Implemented
+		rest.Declined += g.Declined
+		rest.Unknown += g.Unknown
+	}
+	return named, rest, len(small)
 }
 
 // renderBanner reproduces what `feint serve` prints on startup, so the example

--- a/internal/cli/docs_groups_test.go
+++ b/internal/cli/docs_groups_test.go
@@ -1,0 +1,107 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/drift"
+)
+
+// The fold exists so a 50-tag surface does not become a 50-row table, and its
+// one hard rule is that folding must never hide a decision: a group big enough
+// to be a block — Exoscale's 146 dbaas refusals — must always be named. These
+// are the tests the guards in docs.go cite.
+
+// exoscaleShaped is the real proportion that motivated the rule: one dominant
+// declined block, one started group, and a tail of small ones.
+func exoscaleShaped() []drift.GroupCount {
+	return []drift.GroupCount{
+		{Group: "dbaas", Total: 146, Declined: 146},
+		{Group: "compute", Total: 111, Implemented: 42, Declined: 9, Unknown: 60},
+		{Group: "sos", Total: 2, Declined: 2},
+		{Group: "quotas", Total: 2, Implemented: 2},
+		{Group: "audit-trail", Total: 1, Unknown: 1},
+	}
+}
+
+// Named by foldSmallGroups's own comment: this is the test that fails if a
+// group at or above the floor stops being named.
+func TestFoldSmallGroupsNeverFoldsABlockDecision(t *testing.T) {
+	named, rest, folded := foldSmallGroups(exoscaleShaped(), 262)
+
+	names := make([]string, 0, len(named))
+	for _, g := range named {
+		names = append(names, g.Group)
+	}
+	if strings.Join(names, ",") != "dbaas,compute" {
+		t.Fatalf("expected dbaas and compute named, largest first, got %v", names)
+	}
+	if folded != 3 {
+		t.Fatalf("expected 3 folded groups, got %d", folded)
+	}
+	// Folding is about naming, never about numbers: the residual keeps every
+	// count, so the columns still sum to the provider totals.
+	if rest.Total != 5 || rest.Implemented != 2 || rest.Declined != 2 || rest.Unknown != 1 {
+		t.Fatalf("the residual lost counts: %+v", rest)
+	}
+}
+
+func TestFoldSmallGroupsLeavesALoneSmallGroupNamed(t *testing.T) {
+	groups := []drift.GroupCount{
+		{Group: "instance", Total: 150, Implemented: 48, Declined: 102},
+		{Group: "marketplace", Total: 2, Declined: 2},
+	}
+	named, _, folded := foldSmallGroups(groups, 152)
+	if folded != 0 || len(named) != 2 {
+		t.Fatalf("a residual of one hides a name to save no space: named %v, folded %d", named, folded)
+	}
+}
+
+func TestGroupRowsFallBackToProductsForAnOlderArtefact(t *testing.T) {
+	rep := drift.CoverageFile{
+		Provider: "scaleway",
+		Products: []drift.ProductView{{Product: "instance", Total: 3, Implemented: 2, Declined: 1}},
+	}
+	rows := groupRows(rep)
+	if len(rows) != 1 || rows[0].Group != "instance" || rows[0].Total != 3 {
+		t.Fatalf("an artefact written before groups existed must still render its products: %+v", rows)
+	}
+}
+
+// One line is one decision: a group refused for one reason collapses to one
+// line however many operations it covers, and a group refused for two distinct
+// reasons keeps two, because those are two decisions.
+func TestDeclineBlocksFoldByDecisionNotByOperation(t *testing.T) {
+	declined := []emulator.Decline{
+		{Operation: "exoscale/v2.create-dbaas-a", Reason: "managed databases are refused"},
+		{Operation: "exoscale/v2.create-dbaas-b", Reason: "managed databases are refused"},
+		{Operation: "exoscale/v2.create-dbaas-c", Reason: "managed databases are refused"},
+		{Operation: "exoscale/v2.assume-iam-role", Reason: "credentials are accepted on purpose"},
+		{Operation: "exoscale/v2.list-iam-roles", Reason: "roles describe an access control nothing applies"},
+	}
+	groups := map[string]string{
+		"exoscale/v2.create-dbaas-a":  "dbaas",
+		"exoscale/v2.create-dbaas-b":  "dbaas",
+		"exoscale/v2.create-dbaas-c":  "dbaas",
+		"exoscale/v2.assume-iam-role": "iam",
+		"exoscale/v2.list-iam-roles":  "iam",
+	}
+	sectionOf := func(op string) string {
+		if g := groups[op]; g != "" {
+			return g
+		}
+		return productOf(op)
+	}
+	blocks := declineBlocks(declined, sectionOf)
+
+	if len(blocks) != 3 {
+		t.Fatalf("expected 3 decisions, got %d: %+v", len(blocks), blocks)
+	}
+	if blocks[0].group != "dbaas" || blocks[0].n != 3 {
+		t.Fatalf("expected the dbaas block first with its count intact: %+v", blocks[0])
+	}
+	if blocks[1].group != "iam" || blocks[1].n != 1 || blocks[2].group != "iam" || blocks[2].n != 1 {
+		t.Fatalf("two reasons are two decisions and both must survive: %+v", blocks[1:])
+	}
+}

--- a/internal/cli/docs_routes.go
+++ b/internal/cli/docs_routes.go
@@ -28,10 +28,19 @@ const (
 )
 
 // renderRoutes builds the reference body: every mounted route by provider and
-// product, each with the proofs it has earned, then what each pack declines
-// on purpose. evidence may be nil — an installed binary has no artefact — and
-// the page then says so instead of rendering a column of guesses.
-func renderRoutes(evidence *evidenceArtefact) (string, error) {
+// upstream group, each with the proofs it has earned, then what each pack
+// declines on purpose. evidence may be nil — an installed binary has no
+// artefact — and the page then says so instead of rendering a column of
+// guesses.
+//
+// groups maps an operation to the group the upstream's own document files it
+// under, read from the coverage artefacts so this page and the README tables
+// can never disagree on where an operation belongs. An operation the artefacts
+// do not know falls back to the first segment of its name — the product — which
+// is exactly what every section was before groups existed. The map may be
+// empty (an installed binary has no coverage/ either) and the page then keeps
+// its product sections rather than failing.
+func renderRoutes(evidence *evidenceArtefact, groups map[string]string) (string, error) {
 	srv, _, err := newServer(nil)
 	if err != nil {
 		return "", err
@@ -51,31 +60,40 @@ func renderRoutes(evidence *evidenceArtefact) (string, error) {
 	b.WriteString("counted.\n")
 	b.WriteString(evidenceLegend(evidence))
 
+	// The group an operation files under: the upstream's own grouping when the
+	// coverage artefacts carry it, the product segment of its name otherwise.
+	sectionOf := func(operation string) string {
+		if g := groups[operation]; g != "" {
+			return g
+		}
+		return productOf(operation)
+	}
+
 	for _, p := range srv.Packs() {
 		fmt.Fprintf(&b, "\n## %s\n\n", strings.ToUpper(p.Name()[:1])+p.Name()[1:])
 
-		byProduct := make(map[string][]string)
+		bySection := make(map[string][]string)
 		for _, r := range p.Routes() {
 			row := fmt.Sprintf("| `%s` | `%s` | `%s` |", r.Method, r.Path, r.Operation)
 			if evidence != nil {
 				row += fmt.Sprintf(" %s |", evidenceTokens(evidence.Operations[r.Operation]))
 			}
-			byProduct[productOf(r.Operation)] = append(byProduct[productOf(r.Operation)], row)
+			bySection[sectionOf(r.Operation)] = append(bySection[sectionOf(r.Operation)], row)
 		}
-		products := make([]string, 0, len(byProduct))
-		for product := range byProduct {
-			products = append(products, product)
+		sections := make([]string, 0, len(bySection))
+		for section := range bySection {
+			sections = append(sections, section)
 		}
-		sort.Strings(products)
+		sort.Strings(sections)
 
 		header := "| Method | Path | Upstream operation |\n|---|---|---|\n"
 		if evidence != nil {
 			header = "| Method | Path | Upstream operation | Proven by |\n|---|---|---|---|\n"
 		}
-		for _, product := range products {
-			rows := byProduct[product]
+		for _, section := range sections {
+			rows := bySection[section]
 			sort.Strings(rows)
-			fmt.Fprintf(&b, "### `%s`\n\n", product)
+			fmt.Fprintf(&b, "### `%s`\n\n", section)
 			b.WriteString(header)
 			for _, row := range rows {
 				b.WriteString(row)
@@ -85,7 +103,6 @@ func renderRoutes(evidence *evidenceArtefact) (string, error) {
 		}
 
 		declined := append([]emulator.Decline(nil), p.Declined()...)
-		sort.Slice(declined, func(i, j int) bool { return declined[i].Operation < declined[j].Operation })
 		fmt.Fprintf(&b, "### Declined on purpose (%d)\n\n", len(declined))
 		if len(declined) == 0 {
 			b.WriteString("Nothing yet: everything upstream declares is either served or untriaged.\n")
@@ -93,13 +110,67 @@ func renderRoutes(evidence *evidenceArtefact) (string, error) {
 		}
 		b.WriteString("Operations this pack knowingly does not serve, and why. Declining is a\n")
 		b.WriteString("decision the drift gate records, which is what separates it from having\n")
-		b.WriteString("missed one — and the reason is what separates a decision from a list.\n\n")
-		for _, d := range declined {
-			fmt.Fprintf(&b, "- `%s` — %s\n", d.Operation, d.Reason)
+		b.WriteString("missed one — and the reason is what separates a decision from a list.\n")
+		b.WriteString("One line is one decision: the group upstream files the operations under,\n")
+		b.WriteString("how many it covers, and the reason they share. The per-operation verdicts\n")
+		b.WriteString("are in `coverage/`, one artefact per provider.\n\n")
+		for _, block := range declineBlocks(declined, sectionOf) {
+			fmt.Fprintf(&b, "- `%s` — %s — %s\n", block.group, countNoun(block.n, "operation"), block.reason)
 		}
 	}
 
 	return b.String(), nil
+}
+
+// declineBlock is one refusal decision as the page states it: a group, how many
+// of its operations it covers, and the reason they share.
+type declineBlock struct {
+	group  string
+	n      int
+	reason string
+}
+
+// declineBlocks folds a pack's declined operations into decisions.
+//
+// The flat list this replaces was 253 bullets long for Exoscale — 146 of them
+// the same sentence about managed databases repeated verbatim — which buried
+// the eight other decisions it contained. The unit a reader weighs is the
+// decision, and a decision here is a group plus the reason its operations
+// share: 146 dbaas refusals collapse into one line saying 146, they do not
+// vanish. A group refused for several distinct reasons renders one line per
+// reason, because those are distinct decisions.
+//
+// Ordered by group, then by weight so a group's biggest refusal leads, reason
+// text breaking ties so two runs render the same bytes.
+func declineBlocks(declined []emulator.Decline, sectionOf func(string) string) []declineBlock {
+	type key struct{ group, reason string }
+	counts := make(map[key]int)
+	for _, d := range declined {
+		counts[key{sectionOf(d.Operation), d.Reason}]++
+	}
+	out := make([]declineBlock, 0, len(counts))
+	for k, n := range counts {
+		out = append(out, declineBlock{group: k.group, n: n, reason: k.reason})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].group != out[j].group {
+			return out[i].group < out[j].group
+		}
+		if out[i].n != out[j].n {
+			return out[i].n > out[j].n
+		}
+		return out[i].reason < out[j].reason
+	})
+	return out
+}
+
+// countNoun renders "1 operation" or "146 operations", because "operation(s)"
+// on a page a human reads is the writer passing their work to the reader.
+func countNoun(n int, noun string) string {
+	if n == 1 {
+		return fmt.Sprintf("%d %s", n, noun)
+	}
+	return fmt.Sprintf("%d %ss", n, noun)
 }
 
 // evidenceLegend states what each proof token asserts, and what is absent on
@@ -202,7 +273,7 @@ func loadEvidenceArtefact(path string) (*evidenceArtefact, error) {
 // it changed. Absent file, or a file without the markers: nothing to do, no
 // complaint — the same terms as the contract table, so `feint docs` still works
 // for somebody who installed the binary and has no docs/ directory.
-func spliceRoutes(path string, evidence *evidenceArtefact) (bool, error) {
+func spliceRoutes(path string, evidence *evidenceArtefact, groups map[string]string) (bool, error) {
 	if path == "" {
 		return false, nil
 	}
@@ -216,7 +287,7 @@ func spliceRoutes(path string, evidence *evidenceArtefact) (bool, error) {
 	if !strings.Contains(string(current), routesStartMarker) {
 		return false, nil
 	}
-	rendered, err := renderRoutes(evidence)
+	rendered, err := renderRoutes(evidence, groups)
 	if err != nil {
 		return false, err
 	}
@@ -228,12 +299,12 @@ func spliceRoutes(path string, evidence *evidenceArtefact) (bool, error) {
 }
 
 // writeSplicedRoutes writes what spliceRoutes reported as changed.
-func writeSplicedRoutes(path string, evidence *evidenceArtefact) error {
+func writeSplicedRoutes(path string, evidence *evidenceArtefact, groups map[string]string) error {
 	current, err := os.ReadFile(path) //nolint:gosec // operator-supplied path, by design
 	if err != nil {
 		return err
 	}
-	rendered, err := renderRoutes(evidence)
+	rendered, err := renderRoutes(evidence, groups)
 	if err != nil {
 		return err
 	}

--- a/internal/contract/contract.go
+++ b/internal/contract/contract.go
@@ -61,8 +61,14 @@ type Doc struct {
 
 // Operation ties an API call to the schemas on either side of it.
 type Operation struct {
-	Path     string `json:"path"`
-	Method   string `json:"method"`
+	Path   string `json:"path"`
+	Method string `json:"method"`
+	// Group is where the provider's own document files the operation: the root
+	// of its first tag's parent chain (Exoscale declares role under iam,
+	// dbaas-mysql under dbaas; Outscale declares a flat tag per resource).
+	// Empty when the document leaves the operation untagged — the readers fall
+	// back to the product rather than filing it somewhere plausible.
+	Group    string `json:"group,omitempty"`
 	Request  string `json:"request"`
 	Response string `json:"response"`
 }

--- a/internal/drift/coverage_file.go
+++ b/internal/drift/coverage_file.go
@@ -30,6 +30,16 @@ type CoverageFile struct {
 	Unknown     int           `json:"unknown"`
 	Orphans     []string      `json:"orphans"`
 	Products    []ProductView `json:"products"`
+	// Groups breaks the same surface down along the upstream's own grouping —
+	// Exoscale's tag hierarchy roots, Outscale's tags — falling back to the
+	// product where the upstream declares none, so the three sum to the same
+	// totals. Products stays what it is: the unit a scan is scoped and a whole
+	// surface declined on (`--products`, oks in one decision). Groups is what a
+	// reader compares: without it, Scaleway showed six rows because its SDK has
+	// a package per product while Outscale's 236 operations sat in one `osc`
+	// row, and the difference read as depth when it was only SDK layout.
+	// Additive: readers of the fields above are unaffected.
+	Groups []GroupCount `json:"groups,omitempty"`
 	// Entries is the per-operation verdict, sorted by operation name.
 	//
 	// It carries the reason a declined operation is declined, and that is the
@@ -102,6 +112,7 @@ func (r Report) File() CoverageFile {
 		Unknown:     r.Unknown,
 		Orphans:     r.Orphans,
 		Products:    views,
+		Groups:      r.Groups(),
 		Entries:     entries,
 	}
 }

--- a/internal/drift/group_test.go
+++ b/internal/drift/group_test.go
@@ -1,0 +1,175 @@
+package drift_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/contract"
+	"github.com/stephrobert/feint/internal/drift"
+)
+
+// The upstream grouping exists because the product view lied by layout: one
+// `osc` row of 236 operations next to six Scaleway rows read as a difference in
+// depth when it was only a difference in SDK generation. These tests hold the
+// three legs of the fix: the contract scan carries the group, the SDK scan can
+// borrow it, and the artefact publishes it.
+
+// flatWithGroups is the shape of a provider whose SDK layout is one product but
+// whose document files operations under groups — Exoscale exactly.
+func flatWithGroups() []drift.Operation {
+	return []drift.Operation{
+		{Name: "exoscale/v2.list-instances", Product: "exoscale", Group: "compute"},
+		{Name: "exoscale/v2.start-instance", Product: "exoscale", Group: "compute"},
+		{Name: "exoscale/v2.create-dbaas-service", Product: "exoscale", Group: "dbaas"},
+		// Untagged upstream: no group, and it must count under the product
+		// rather than under a name this project made up.
+		{Name: "exoscale/v2.get-impact-report", Product: "exoscale"},
+	}
+}
+
+func TestGroupsCountByUpstreamGroupAndFallBackToTheProduct(t *testing.T) {
+	rep := drift.Compare("exoscale", flatWithGroups(),
+		[]string{"exoscale/v2.list-instances"},
+		map[string]string{"exoscale/v2.create-dbaas-service": "managed databases are refused"},
+	)
+
+	groups := rep.Groups()
+	byName := make(map[string]drift.GroupCount, len(groups))
+	total := 0
+	for _, g := range groups {
+		byName[g.Group] = g
+		total += g.Total
+	}
+
+	if got := byName["compute"]; got.Total != 2 || got.Implemented != 1 || got.Unknown != 1 {
+		t.Fatalf("unexpected compute counts: %+v", got)
+	}
+	if got := byName["dbaas"]; got.Total != 1 || got.Declined != 1 {
+		t.Fatalf("the block refusal must stay visible under its own group: %+v", got)
+	}
+	// The fallback: an operation the upstream files nowhere counts under the
+	// product, so the group sums always reconcile with the report totals.
+	if got := byName["exoscale"]; got.Total != 1 || got.Unknown != 1 {
+		t.Fatalf("expected the untagged operation under its product: %+v", got)
+	}
+	if total != rep.Total {
+		t.Fatalf("groups sum to %d, the report says %d: a grouping that loses operations", total, rep.Total)
+	}
+}
+
+func TestTheArtefactCarriesTheGroups(t *testing.T) {
+	rep := drift.Compare("exoscale", flatWithGroups(),
+		[]string{"exoscale/v2.list-instances"},
+		map[string]string{"exoscale/v2.create-dbaas-service": "managed databases are refused"},
+	)
+
+	var buf bytes.Buffer
+	if err := rep.WriteJSON(&buf); err != nil {
+		t.Fatalf("write json: %v", err)
+	}
+	file, err := drift.LoadCoverage(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(file.Groups) == 0 {
+		t.Fatalf("the artefact carries no groups; the README renderer would fall back to the product fourre-tout")
+	}
+	names := make([]string, 0, len(file.Groups))
+	for _, g := range file.Groups {
+		names = append(names, g.Group)
+	}
+	if strings.Join(names, ",") != "compute,dbaas,exoscale" {
+		t.Fatalf("expected sorted groups compute,dbaas,exoscale, got %s", strings.Join(names, ","))
+	}
+
+	// The per-entry group travels too: the route reference files its sections
+	// from the entries, not from the summary.
+	var raw struct {
+		Entries []map[string]any `json:"entries"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &raw); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	seen := false
+	for _, e := range raw.Entries {
+		if e["operation"] == "exoscale/v2.list-instances" {
+			seen = true
+			if e["group"] != "compute" {
+				t.Fatalf("entry lost its group: %v", e)
+			}
+		}
+		if e["operation"] == "exoscale/v2.get-impact-report" {
+			if _, present := e["group"]; present {
+				t.Fatalf("an untagged operation must not be given a group on the wire: %v", e)
+			}
+		}
+	}
+	if !seen {
+		t.Fatalf("expected entry not found in the artefact")
+	}
+}
+
+// groupedContract is a minimal contract artefact whose document files ReadVms
+// under Vm and leaves ListSomething ungrouped, the way the extractor writes
+// contracts/outscale.json from their api.yaml.
+const groupedContract = `{
+  "provider": "outscale",
+  "apiVersion": "1.35.3",
+  "pathPrefix": "/api/v1",
+  "closedPolicy": "declared",
+  "operations": {
+    "ReadVms": {"path": "/ReadVms", "method": "POST", "group": "Vm"},
+    "ListSomething": {"path": "/ListSomething", "method": "POST"}
+  },
+  "schemas": {"Vm": {"closed": true}}
+}`
+
+func TestScanContractCarriesTheUpstreamGroup(t *testing.T) {
+	doc, err := contract.Read(strings.NewReader(groupedContract))
+	if err != nil {
+		t.Fatalf("read contract: %v", err)
+	}
+	ops, err := drift.ScanContract(doc)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	byName := make(map[string]drift.Operation, len(ops))
+	for _, op := range ops {
+		byName[op.Name] = op
+	}
+	if got := byName["outscale/api/v1.ReadVms"].Group; got != "Vm" {
+		t.Fatalf("expected the document's group Vm, got %q", got)
+	}
+	if got := byName["outscale/api/v1.ListSomething"].Group; got != "" {
+		t.Fatalf("an ungrouped operation must stay ungrouped, got %q", got)
+	}
+}
+
+// The SDK scan cannot know the groups — oapi-codegen flattens every operation
+// onto one Client and drops the document's tags — so Regroup joins what the SDK
+// found with where the document files it. Named by Regroup's own comment: this
+// is the test that fails if the join stops filling groups or starts inventing
+// them.
+func TestRegroupTakesGroupsFromTheContract(t *testing.T) {
+	doc, err := contract.Read(strings.NewReader(groupedContract))
+	if err != nil {
+		t.Fatalf("read contract: %v", err)
+	}
+	ops := []drift.Operation{
+		{Name: "osc/Client.ReadVms", Product: "osc"},
+		// A service the document does not cover — oks ships no OpenAPI document
+		// here — must keep its empty group and fall back to its product, not be
+		// filed under a name nobody upstream wrote.
+		{Name: "oks/Client.CreateCluster", Product: "oks"},
+	}
+	drift.Regroup(ops, doc)
+
+	if ops[0].Group != "Vm" {
+		t.Fatalf("expected ReadVms filed under Vm, got %q", ops[0].Group)
+	}
+	if ops[1].Group != "" {
+		t.Fatalf("an operation the document does not know must stay ungrouped, got %q", ops[1].Group)
+	}
+}

--- a/internal/drift/report.go
+++ b/internal/drift/report.go
@@ -34,7 +34,25 @@ type Entry struct {
 	// differ per version: a stable v1 addition is work, an alpha rewrite is a
 	// Declined() block, and a product total that mixes them hides the decision.
 	Version string `json:"version,omitempty"`
-	Status  Status `json:"status"`
+	// Group is the upstream's own grouping of the operation — Exoscale's tag
+	// hierarchy root, Outscale's tag — empty when the upstream declares none,
+	// and the entry then counts under its Product. It exists because a product
+	// total can be a fourre-tout: one `osc` row of 236 operations reads as one
+	// undifferentiated surface, when upstream files it under 50 named tags and
+	// the verdicts cluster cleanly along them.
+	Group  string `json:"group,omitempty"`
+	Status Status `json:"status"`
+}
+
+// GroupName is the group an entry counts under: the upstream's own grouping
+// when it declares one, the product otherwise. The fallback lives here, once,
+// because three renderers apply it and one of them forgetting would file the
+// same operation two different places on two pages.
+func (e Entry) GroupName() string {
+	if e.Group != "" {
+		return e.Group
+	}
+	return e.Product
 }
 
 // Report is the coverage of one provider.
@@ -70,7 +88,7 @@ func Compare(provider string, upstream []Operation, served []string, declined ma
 	matched := make(map[string]bool, len(servedSet))
 
 	for _, op := range upstream {
-		e := Entry{Operation: op.Name, Product: op.Product, Version: op.Version, Status: StatusUnknown}
+		e := Entry{Operation: op.Name, Product: op.Product, Version: op.Version, Group: op.Group, Status: StatusUnknown}
 		switch {
 		case servedSet[op.Name]:
 			e.Status = StatusImplemented
@@ -187,6 +205,50 @@ func (r Report) ByProduct() map[string]Report {
 		}
 		sub.Entries = append(sub.Entries, e)
 		out[e.Product] = sub
+	}
+	return out
+}
+
+// GroupCount is the coverage of one upstream group.
+type GroupCount struct {
+	Group       string `json:"group"`
+	Total       int    `json:"total"`
+	Implemented int    `json:"implemented"`
+	Declined    int    `json:"declined"`
+	Unknown     int    `json:"unknown"`
+}
+
+// Groups returns per-group counts for the report's entries, sorted by group
+// name so two runs produce the same artefact bytes. Entries whose upstream
+// declares no grouping count under their product, so the three providers'
+// tables can be rendered by one function and the sums always match the totals.
+func (r Report) Groups() []GroupCount {
+	counts := make(map[string]*GroupCount)
+	for _, e := range r.Entries {
+		name := e.GroupName()
+		gc, ok := counts[name]
+		if !ok {
+			gc = &GroupCount{Group: name}
+			counts[name] = gc
+		}
+		gc.Total++
+		switch e.Status {
+		case StatusImplemented:
+			gc.Implemented++
+		case StatusDeclined:
+			gc.Declined++
+		case StatusUnknown:
+			gc.Unknown++
+		}
+	}
+	names := make([]string, 0, len(counts))
+	for name := range counts {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]GroupCount, 0, len(names))
+	for _, name := range names {
+		out = append(out, *counts[name])
 	}
 	return out
 }

--- a/internal/drift/scan.go
+++ b/internal/drift/scan.go
@@ -34,6 +34,12 @@ type Operation struct {
 	// Version is the product's API version where the SDK carries one. Outscale's
 	// generated clients do not, and it stays empty rather than invented.
 	Version string
+	// Group is the upstream's own grouping of the operation, where a document
+	// declares one: the root of Exoscale's tag hierarchy, Outscale's flat tag.
+	// Scaleway needs none — its SDK layout already groups by product. Empty when
+	// nothing upstream groups the operation, and every reader then falls back to
+	// Product, so a provider without tags renders exactly as it did before.
+	Group string
 }
 
 // receiverName returns the type name of a method receiver, dereferencing the

--- a/internal/drift/scan_contract.go
+++ b/internal/drift/scan_contract.go
@@ -32,14 +32,42 @@ func ScanContract(doc *contract.Doc) ([]Operation, error) {
 
 	product := doc.Provider + doc.PathPrefix
 	ops := make([]Operation, 0, len(doc.Operations))
-	for name := range doc.Operations {
+	for name, op := range doc.Operations {
 		ops = append(ops, Operation{
 			Name:    product + "." + name,
 			Product: doc.Provider,
 			Version: doc.APIVersion,
+			// The document's own grouping, verbatim. Empty for an operation the
+			// document leaves untagged, and left empty here too: the fallback to
+			// Product is one decision, taken where the entries are read.
+			Group: op.Group,
 		})
 	}
 
 	sort.Slice(ops, func(i, j int) bool { return ops[i].Name < ops[j].Name })
 	return ops, nil
+}
+
+// Regroup fills each operation's Group from the grouping the provider's API
+// description declares, joining on the operation name.
+//
+// This exists for the provider whose surface is scanned from its Go SDK but
+// whose grouping only its OpenAPI document carries: oapi-codegen flattens all
+// 236 of Outscale's operations onto one Client and drops their tags, which is
+// how the coverage table came to show one `osc` row for a surface upstream
+// files under 50 tags. The SDK stays the authority on which operations exist —
+// its method names are what routes declare — and the document only says where
+// each one is filed.
+//
+// An operation the document does not know keeps its empty Group and falls back
+// to Product downstream: Outscale's oks service publishes no document here, and
+// inventing a grouping for it would be the exact translation this package
+// refuses to perform. Asserted by TestRegroupTakesGroupsFromTheContract, which
+// fails if the join stops filling groups or starts inventing them.
+func Regroup(ops []Operation, doc *contract.Doc) {
+	for i := range ops {
+		if op, _, ok := doc.OperationFor(ops[i].Name); ok && op.Group != "" {
+			ops[i].Group = op.Group
+		}
+	}
 }

--- a/tools/contract/extract-openapi.py
+++ b/tools/contract/extract-openapi.py
@@ -184,6 +184,48 @@ def success_body(op: dict) -> dict:
     return {}
 
 
+def tag_roots(spec: dict) -> dict:
+    """Map each declared tag to the root of its parent chain.
+
+    Exoscale's document declares a two-level hierarchy in its top-level tags
+    section: `role` carries `parent: iam`, `dbaas-mysql` carries `parent:
+    dbaas`. The root of that chain is the provider's own product-level
+    grouping, and it is what the coverage tables group by. Outscale declares
+    no hierarchy, so every tag is its own root and the mapping is empty.
+
+    A parent that is not itself a declared tag (Exoscale's `general`) is still
+    a valid root: the walk simply stops there. A cycle would make the walk
+    loop forever on a malformed document, so each chain refuses to revisit a
+    tag it has already seen.
+    """
+    parent = {t["name"]: t.get("parent") for t in spec.get("tags", []) if "name" in t}
+    roots = {}
+    for name in parent:
+        tag, seen = name, set()
+        while parent.get(tag) and tag not in seen:
+            seen.add(tag)
+            tag = parent[tag]
+        roots[name] = tag
+    return roots
+
+
+def group_of(op: dict, roots: dict) -> str | None:
+    """The upstream group an operation belongs to: the root of its first tag.
+
+    The first tag, because that is the one the provider files the operation
+    under (Exoscale's create-snapshot is tagged instance then snapshot, and
+    their own reference lists it under the instance product). The name is the
+    document's own, never translated: inventing a grouping is exactly what
+    reading tags exists to avoid. An operation with no tag gets no group, and
+    the readers say so rather than filing it somewhere plausible.
+    """
+    tags = op.get("tags") or []
+    if not tags:
+        return None
+    first = tags[0]
+    return roots.get(first, first)
+
+
 def path_prefix(spec: dict) -> str:
     """The path every operation hangs off, taken from the declared server URL.
 
@@ -203,6 +245,8 @@ def read_spec(path: str, args, schemas: dict, operations: dict) -> tuple[str, st
     with open(path) as f:
         spec = yaml.safe_load(f)
 
+    roots = tag_roots(spec)
+
     declared_closed = 0
     for name, sch in (spec.get("components", {}).get("schemas") or {}).items():
         if sch.get("additionalProperties") is False:
@@ -217,6 +261,8 @@ def read_spec(path: str, args, schemas: dict, operations: dict) -> tuple[str, st
                 continue
             oid = op["operationId"]
             entry = {"path": path, "method": method.upper()}
+            if group := group_of(op, roots):
+                entry["group"] = group
             if req := json_schema_of(op.get("requestBody"), schemas, oid + ".Request", args):
                 entry["request"] = req
             if resp := json_schema_of(success_body(op), schemas, oid + ".Response", args):

--- a/tools/drift/gate.sh
+++ b/tools/drift/gate.sh
@@ -40,7 +40,11 @@ case "$MODE" in
     status=0
     "$FEINT" coverage --sdk "$SCALEWAY_SDK" --products "$SCALEWAY_PRODUCTS" \
       --baseline coverage/scaleway-baseline.json || status=$?
+    # --contract on top of --sdk: the SDK lists the operations, the contract
+    # carries the tags their document files them under, which oapi-codegen
+    # flattens away. Without it every artefact row collapses back into `osc`.
     "$FEINT" coverage --provider outscale --sdk "$OUTSCALE_SDK" \
+      --contract contracts/outscale.json \
       --baseline coverage/outscale-baseline.json || status=$?
     "$FEINT" coverage --provider exoscale --contract contracts/exoscale.json \
       --baseline coverage/exoscale-baseline.json || status=$?
@@ -53,8 +57,10 @@ case "$MODE" in
     "$FEINT" coverage --sdk "$SCALEWAY_SDK" --products "$SCALEWAY_PRODUCTS" \
       --format json > coverage/scaleway-coverage.json
     "$FEINT" coverage --provider outscale --sdk "$OUTSCALE_SDK" \
+      --contract contracts/outscale.json \
       --baseline coverage/outscale-baseline.json --write-baseline
     "$FEINT" coverage --provider outscale --sdk "$OUTSCALE_SDK" \
+      --contract contracts/outscale.json \
       --format json > coverage/outscale-coverage.json
     "$FEINT" coverage --provider exoscale --contract contracts/exoscale.json \
       --baseline coverage/exoscale-baseline.json --write-baseline


### PR DESCRIPTION
# Summary

The coverage tables read as if Scaleway were six products deep while Outscale
and Exoscale were shallow: six rows against a 236-operation `osc` row and a
374-operation `exoscale` row. The difference was SDK layout, not depth — and it
hid the one distinction the tables exist to make. Exoscale's "12% served" reads
as 88% missing, when 39% of its surface is managed databases the roadmap
declines on purpose and only 20% is genuinely untriaged.

This change extracts the upstream's own grouping for Outscale and Exoscale, the
way it already existed for Scaleway, and renders it everywhere the surface is
published:

- **Measured, never invented.** `tools/contract/extract-openapi.py` records
  each operation's group in the contract artefact: the root of its first tag's
  parent chain (Exoscale's document declares `role` under `iam`, `dbaas-mysql`
  under `dbaas` — 14 roots), the tag itself where no hierarchy exists
  (Outscale, 50 flat tags), nothing where the operation is untagged (2 of
  Exoscale's, which fall back to the product).
- **The SDK stays the authority on which operations exist.** For Outscale the
  surface is still scanned from the Go SDK — its method names are what routes
  declare — and `drift.Regroup` only joins in where the document files each
  operation, because oapi-codegen flattens all of them onto one `Client` and
  drops the tags. `oks` ships no document here and keeps its product row
  rather than an invented grouping. `feint coverage` accepts `--sdk` and
  `--contract` together for exactly this; `gate.sh` passes both.
- **The artefacts carry it additively.** `coverage/*-coverage.json` gains a
  `groups` view beside `products` and a `group` per entry. Every present
  reader (`staleCoverage`, the page, the baselines) is untouched; the
  baselines do not change by a byte.
- **The README tables render groups, largest first**, with one headline making
  the three shares explicit: served, declined on purpose, untriaged. Groups
  under 2% of a surface fold into an explicit residual row with its counts
  intact. The floor is a share precisely so nothing block-sized — `dbaas`'s
  146 refusals, `Policy`'s 24 — can ever land in the residual.
- **`docs/routes.md` files its sections under the same groups**, read from the
  same artefacts so the two pages cannot disagree, and folds each pack's
  declined list into decisions: one line per group and shared reason.
  Exoscale's 253 near-identical bullets become eleven decisions, `dbaas`
  first; Outscale's 72 routes get 21 named entry points instead of one.

After the change, Exoscale's table opens with `dbaas 0/146 declined` and shows
`block-storage 0/0/13 untriaged`: the reader can finally tell a refusal from an
absence.

Both new guards were falsified in a copy outside the repository, per
`/falsify`: each mutation compiled alone and the named test failed without its
guard (`TestRegroupTakesGroupsFromTheContract`,
`TestFoldSmallGroupsNeverFoldsABlockDecision`).

## Type of change

- [ ] A route added or changed
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation
- [x] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes (gofmt, vet, golangci-lint, `go test -race`)
- [x] No new external Go dependency, or the pull request justifies it. The
      standard library covers routing, JSON and Go parsing; `go.mod` has three
      lines and a pre-commit hook keeps it that way — the tag reading lives in
      the existing Python extractor, which already parses YAML; Go reads only
      the versioned JSON artefacts
- [x] `internal/core` still knows no provider. If a change seemed to require it,
      the pack changed instead — nothing under `internal/core` is touched
- [x] Nothing in the diff could be written identically for another provider. If
      it could, it belongs in the core — the grouping fallback lives once, in
      `Entry.GroupName()` / `foldSmallGroups`, not per provider

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] I ran `mise run conformance` myself — not "it should pass". The full
      suite was run; `conformance:terraform:outscale` is red, and it is red on
      a bare `origin/main` checkout too (verified on `d54bb07`, detached, no
      diff applied: `FAIL: the destroyed Net still answers`), so the failure
      pre-exists this change, whose diff touches no serving path — only
      `internal/drift`, the docs renderers, the extractor and `gate.sh`. Every
      other leg is green
- [x] Every field name in the diff comes from the provider's SDK, their OpenAPI
      document, or a run of the real client, and I can say which: group names
      are the `tags` (and their `parent` links) of Outscale's
      `pkg/osc/api.yaml` and Exoscale's `source.yaml`, verbatim; operation
      names are unchanged and still come from the SDK scans

### When a route is added or changed — otherwise N/A

N/A — no route added or changed, no response byte differs. `mise run
drift:update` was still run and `coverage/` + `contracts/` are committed with
the change, since the artefact shape gained the `groups` view.

### When behaviour a client can observe changes — otherwise N/A

- [x] `docs/limits.md` updated if the change moves a documented limit — N/A, no
      limit moves
- [x] The README's generated tables regenerated (`mise run docs:coverage`) —
      done, plus `docs/routes.md`; `feint docs --check` and
      `tools/drift/gate.sh check` exit 0

### When `.github/workflows/` is touched — otherwise N/A

N/A — only `tools/drift/gate.sh` changed, which both callers already share; no
job renamed, the exit-code contract (0/1/2) is untouched.

### When a machine runtime is involved — otherwise N/A

N/A

## Related issues

None — follows from the README audit that found the tables visually favouring
Scaleway.
