### PR TITLE
fix(conformance): the destroy check asks about its own Net, not about every Net

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -19,6 +19,19 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Corrigé
 
+- **Une assertion de destruction distingue deux pannes** (trouvé en levant une
+  réserve sur #152). La suite Terraform Outscale demandait si l'émulateur ne
+  détenait **aucun** Net, ce qui n'est vrai que lorsqu'elle en est la seule
+  créatrice sur un émulateur neuf. Exécutée sur un banc qu'un autre run avait
+  touché, elle annonçait « the destroyed Net still answers » alors que la
+  destruction avait parfaitement fonctionné : le message accusait le sujet pour
+  l'état du banc.
+
+  Elle demande désormais si le Net **de ce run** a disparu, le nomme quand ce
+  n'est pas le cas, et dit franchement quand des ressources d'un autre run
+  traînent encore. Falsifié : faire survivre un Net à son propre delete fait
+  échouer la suite en nommant l'identifiant.
+
 - **Le tableau de statut est généré depuis le workflow qui le prouve** (signalé
   par un lecteur comparant le README à la CI). Il annonçait Outscale prouvé par
   `oapi-cli` et Terraform. Les deux étaient vrais du dépôt et un seul l'était de

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Fixed
 
+- **A destroy assertion told two failures apart** (found while lifting a
+  reserve on #152). The Outscale Terraform suite asked whether the emulator held
+  *no* Net at all, which is true only when it is the sole creator against a
+  fresh emulator. Run against a bench another run had touched, it announced "the
+  destroyed Net still answers" while the destroy had worked perfectly: the
+  message blamed the subject for the state of the bench.
+
+  It now asks whether *this run's* Net is gone, names it when it is not, and says
+  plainly when somebody else's resources are still around. Falsified: make the
+  emulator keep a Net through its own delete and the suite fails naming the
+  identifier.
+
 - **The status table is generated from the workflow that proves it** (reported
   by a reader comparing the README with CI). It said Outscale was proven by
   `oapi-cli` and Terraform. Both were true of the repository and only one was

--- a/tools/conformance/outscale/terraform.sh
+++ b/tools/conformance/outscale/terraform.sh
@@ -248,6 +248,9 @@ case "$plan_status" in
 esac
 
 echo "- destroy"
+# The Net this run created, read before it is destroyed: the check below asks
+# whether *this* Net is gone, not whether the emulator holds none at all.
+net_id="$("$TF" output -raw net_id 2>/dev/null || true)"
 "$TF" destroy -no-color -auto-approve -var "endpoint=$ENDPOINT" >/dev/null
 DESTROYED=1
 
@@ -259,8 +262,33 @@ DESTROYED=1
 # than still running.
 nets="$(curl -sf -X POST "$ENDPOINT/api/v1/ReadNets" -H 'Content-Type: application/json' -d '{}')" \
   || fail "ReadNets rejected"
-printf '%s' "$nets" | jq -e '.Nets | length == 0' >/dev/null \
-  || fail "the destroyed Net still answers: $nets"
+# Scoped to the Net this run made, and that scoping is the fix for a false
+# verdict rather than a refinement.
+#
+# The check read `.Nets | length == 0` — no Net anywhere — which is true only
+# when this suite is the sole creator against a fresh emulator. Run it against
+# an emulator another run had touched and it announced "the destroyed Net still
+# answers" while the destroy had worked perfectly: the message blamed the
+# subject for the state of the bench. Reproduced on this station, and green on
+# the same commit from a clean start.
+#
+# Two failures, told apart, because they need different actions: a Net that
+# outlived its own destroy is a defect in the emulator, and a Net somebody else
+# left is a dirty bench.
+if [ -n "$net_id" ]; then
+  if printf '%s' "$nets" | jq -e --arg n "$net_id" 'any(.Nets[]?; .NetId == $n)' >/dev/null; then
+    fail "the Net this run created ($net_id) outlived its own destroy: $nets"
+  fi
+  others="$(printf '%s' "$nets" | jq -r '.Nets | length')"
+  if [ "$others" != "0" ]; then
+    echo "  note: $others Net(s) from another run are still here; this suite's own is gone"
+  fi
+else
+  # No output to scope by, so fall back to the old question and say so: a check
+  # that cannot name what it is looking for must not pretend it did.
+  printf '%s' "$nets" | jq -e '.Nets | length == 0' >/dev/null \
+    || fail "no net_id output to scope by, and the emulator still holds a Net: $nets"
+fi
 
 vms="$(curl -sf -X POST "$ENDPOINT/api/v1/ReadVms" -H 'Content-Type: application/json' \
         -d "{\"Filters\":{\"VmIds\":[\"$vm_id\"]}}")" || fail "ReadVms rejected"


### PR DESCRIPTION
Lifts the reserve raised on #152.

The Outscale Terraform suite asserted `.Nets | length == 0` after destroy — *no Net anywhere* — which holds only when it is the sole creator against a fresh emulator. Run against a bench another run had touched, it announced **"the destroyed Net still answers"** while the destroy had worked perfectly.

The message blamed the subject for the state of the bench. Same family as the two false verdicts fixed yesterday: a check that cannot tell two causes apart ends up naming one at random.

## Reproduced three ways before and after

| Bench | Before | After |
|---|---|---|
| Clean | passes | passes |
| A foreign Net left before the run | **"the destroyed Net still answers"** | passes, with `note: 1 Net(s) from another run are still here; this suite's own is gone` |
| The suite's own Net survives its destroy | fails | fails, **naming it** |

## Falsified

Keep the Net through its delete in a copy outside the repository — the mutation compiles — and the suite says:

```
FAIL: the Net this run created (vpc-15283524) outlived its own destroy: {"Nets":[…]}
```

## What it does when it cannot scope

With no `net_id` output to scope by, it falls back to the old question **and says that is what it did**. A check that cannot name what it is looking for must not pretend it did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)