### PR TITLE
feat(frozen): a surface CI depends on only moves with its schema version

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -15,6 +15,27 @@ parce que c'est là-dessus que ce projet est jugé : **une forme de réponse qu'
 client peut observer**, et **une limite qui a bougé**. Une refactorisation qui ne
 change ni l'un ni l'autre a sa place dans `git log`.
 
+## [Unreleased]
+
+### Ajouté
+
+- **Ce dont la CI a le droit de dépendre est gelé par un test, pas par une
+  phrase** (#132). Les formes de `/_feint/health`, `/_feint/routes`,
+  `/_feint/conformance` et `/_feint/trace`, les verbes et drapeaux du CLI et
+  les codes de sortie (0 ok, 1 erreur, 2 dérive) ont désormais chacun une
+  fixture versionnée (l'arbre des champs, jamais une valeur), comparée par
+  `go test` sur chaque pull request. Les trois charges utiles objet gagnent un
+  champ `schema_version` (c'est la seule forme de réponse qu'un client peut
+  observer changer : une clé nouvelle, additive) pour qu'un pipeline puisse s'y
+  brancher ; ce qui garde le champ honnête est le gate, qui refuse un
+  changement de fixture sans mouvement de la version déclarée. La
+  régénération (`mise run frozen:update`) ajoute à l'historique de la fixture
+  et ne réécrit jamais une entrée. Chaque garde a été falsifiée dans une copie
+  hors dépôt : cinq mutations, cinq tests nommés qui mordent, et le changement
+  volontaire (forme, fixture et version ensemble) qui passe. La procédure pour
+  changer une surface gelée à dessein est dans RELEASING.fr.md (« Surfaces
+  gelées »).
+
 ## [0.8.0]
 
 ### Corrigé

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,25 @@ Two kinds of change deserve their own line whatever their size, because they are
 what this project is judged on: **a response shape a client can observe**, and
 **a limit that moved**. A refactor that changes neither belongs in `git log`.
 
+## [Unreleased]
+
+### Added
+
+- **What CI is allowed to depend on is frozen by a test, not by a sentence**
+  (#132). The shapes of `/_feint/health`, `/_feint/routes`,
+  `/_feint/conformance` and `/_feint/trace`, the CLI's verbs and flags, and the
+  exit codes (0 ok, 1 error, 2 drift) now each have a committed fixture — the
+  field tree, never a value — compared by `go test` on every pull request. The
+  three object payloads gain a `schema_version` field (this is the one shape
+  change a client can observe: a new key, additive) so a pipeline can branch on
+  it; what keeps the field honest is the gate, which refuses a fixture change
+  that does not move the declared version. Regeneration
+  (`mise run frozen:update`) appends to the fixture's history and never
+  rewrites an entry. Each guard was falsified in a copy outside the repository:
+  five mutations, five named tests biting, and the deliberate change — shape,
+  fixture and version moved together — passing. The procedure for changing a
+  frozen surface on purpose is in RELEASING.md ("Frozen surfaces").
+
 ## [0.8.0]
 
 ### Fixed

--- a/RELEASING.fr.md
+++ b/RELEASING.fr.md
@@ -132,6 +132,40 @@ casse est du côté propre de ce projet — les verbes et drapeaux du CLI, les c
 de sortie, la forme de `/_feint/*`, les formats d'état et de snapshot, et tout
 comportement émulé sur lequel un test aurait pu s'appuyer.
 
+### Surfaces gelées
+
+L'essentiel de cette liste n'est plus de la prose (#132). Les formes de
+`/_feint/health`, `/_feint/routes`, `/_feint/conformance` et `/_feint/trace`,
+les verbes et drapeaux du CLI et les codes de sortie ont chacun une fixture
+versionnée sous `internal/cli/testdata/frozen/` (l'arbre des champs, jamais une
+valeur), et deux tests les gardent sur chaque pull request :
+`TestTheFrozenSurfacesStillMatchTheirFixture` échoue quand une forme bouge sans
+sa fixture, et `TestASurfaceChangeDemandsItsVersionBump` échoue quand la fixture
+bouge sans la version déclarée. Les trois charges utiles objet servent cette
+version dans `schema_version`, pour qu'un consommateur puisse s'y brancher ; le
+gate est ce qui empêche le champ de mentir.
+
+Changer une de ces surfaces volontairement tient en quatre étapes, dans un même
+commit :
+
+1. changer le code ;
+2. `mise run frozen:update` : la nouvelle forme est ajoutée à l'historique de la
+   fixture, à la version suivante, sans jamais réécrire une entrée ;
+3. incrémenter la constante correspondante : `internal/core/emulator/schema.go`
+   pour les charges `/_feint/*`, `cliSurfaceVersion` dans
+   `internal/cli/cli.go` pour le CLI. Les tests restent rouges jusqu'à cette
+   étape, et c'est le but ;
+4. écrire la ligne de CHANGELOG dont l'incrément est le signal. Correctif ou
+   rupture, c'est la question ordinaire de cette section ; la fixture prouve
+   seulement que la surface a bougé, pas lequel des deux c'était.
+
+Ce qui n'est délibérément pas gelé : la prose du texte d'aide autour des verbes
+et drapeaux, les valeurs derrière chaque clé gelée (compteurs, identifiants,
+listes qui grandissent quand des routes se montent), et les champs de trace que
+seuls certains échanges portent (`unread`, `violations`). Un gel qui attraperait
+l'un d'eux rougirait sur des exécutions de routine et serait désarmé dans la
+semaine.
+
 La seule exception qui mérite d'être signalée : **une forme de réponse corrigée
 pour correspondre au document du provider est un correctif, pas une rupture**,
 même quand un test en aval affirmait la mauvaise. C'est tout le propos du projet,

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -125,6 +125,37 @@ wanted. What breaks is on this project's own side — the CLI's verbs and flags,
 the exit codes, the shape of `/_feint/*`, the state and snapshot formats, and
 any emulated behaviour a test could have relied on.
 
+### Frozen surfaces
+
+Most of that list is no longer prose (#132). The shapes of `/_feint/health`,
+`/_feint/routes`, `/_feint/conformance` and `/_feint/trace`, the CLI's verbs and
+flags, and the exit codes each have a committed fixture under
+`internal/cli/testdata/frozen/` — the field tree, never a value — and two tests
+gate them on every pull request:
+`TestTheFrozenSurfacesStillMatchTheirFixture` fails when a shape moves and the
+fixture did not, and `TestASurfaceChangeDemandsItsVersionBump` fails when the
+fixture moved and the declared version did not. The three object payloads serve
+that version as `schema_version`, so a consumer can branch on it; the gate is
+what keeps the field from lying.
+
+Changing one of these surfaces on purpose is four steps, in one commit:
+
+1. change the code;
+2. `mise run frozen:update` — it appends the new form to the fixture's history
+   at the next version, and never rewrites an entry;
+3. bump the matching constant: `internal/core/emulator/schema.go` for the
+   `/_feint/*` payloads, `cliSurfaceVersion` in `internal/cli/cli.go` for the
+   CLI — the tests stay red until this step, which is the point;
+4. write the CHANGELOG line the bump is the signal for. Whether it lands as a
+   fix or a break is this section's ordinary question; the fixture only proves
+   the surface moved, not which of the two it was.
+
+What is deliberately not frozen: the prose of the help text around the verbs
+and flags, the values behind every frozen key (counters, identifiers, lists
+that grow when routes are mounted), and the trace fields only some exchanges
+carry (`unread`, `violations`). A freeze that caught any of those would go red
+on routine runs and be disarmed within the week.
+
 The snapshot format is the one of those that says its own version. Since #133 a
 snapshot is `{"format": "feint-snapshot", "version": N, "resources": [...]}`, and
 `Restore` refuses anything it cannot account for: another version, another

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -82,6 +82,18 @@ const (
 	exitDrift = 2
 )
 
+// cliSurfaceVersion names the version of the CLI surface a CI is allowed to
+// depend on: the verbs, the flags the help declares for each, and the exit
+// codes above. It moves when any of those move — additions included, because
+// the number means "the surface changed", not "the surface broke"; the
+// CHANGELOG says which of the two it was.
+//
+// The surface itself is frozen in testdata/frozen/cli.json, compared by
+// TestTheFrozenSurfacesStillMatchTheirFixture, and a fixture regenerated
+// without bumping this constant fails TestASurfaceChangeDemandsItsVersionBump.
+// The procedure for a deliberate change is in RELEASING.md ("Frozen surfaces").
+const cliSurfaceVersion = 1
+
 // Run executes one command and returns the process exit code.
 func Run(args []string, stdout, stderr io.Writer) int {
 	if len(args) < 2 {

--- a/internal/cli/frozen_test.go
+++ b/internal/cli/frozen_test.go
@@ -1,0 +1,464 @@
+package cli
+
+// What CI is allowed to depend on is frozen by a test, not by a sentence (#132).
+//
+// The surfaces here — the JSON shape of /_feint/health, /_feint/routes,
+// /_feint/conformance and /_feint/trace, and the CLI's verbs, flags and exit
+// codes — are consumed by pipelines outside this repository. Each one has a
+// committed fixture under testdata/frozen/: a history of entries, every entry a
+// schema version and the canonical form observed under it. What is frozen is the
+// form — paths and JSON types, verb and flag names — never a value, because a
+// fixture holding an identifier or a timestamp goes red on every run and gets
+// disarmed within the week (this repository measured exactly that twice, which
+// is why internal/shape stores field trees and coverage/ carries no scan date).
+//
+// The gate has two teeth, and both are needed:
+//
+//   - TestTheFrozenSurfacesStillMatchTheirFixture fails when a shape moves and
+//     the fixture did not: the accidental change.
+//   - TestASurfaceChangeDemandsItsVersionBump fails when the fixture moved and
+//     the version the code declares did not: the regenerated-without-deciding
+//     change. Regeneration appends a history entry with the next version and
+//     never rewrites an old one, so the only way to move a shape under an
+//     unchanged version is to edit a committed history entry in place — a diff
+//     no review mistakes for routine.
+//
+// A deliberate change therefore goes: change the code, run
+// `mise run frozen:update`, bump the matching version constant (schema.go in
+// the emulator, cliSurfaceVersion here), and write the CHANGELOG line the bump
+// is the signal for.
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/transcript"
+)
+
+const frozenDir = "testdata/frozen"
+
+// frozenEntry is one version of a surface: the version declared for it and the
+// canonical content observed under that version.
+type frozenEntry struct {
+	SchemaVersion int             `json:"schema_version"`
+	Content       json.RawMessage `json:"content"`
+}
+
+// frozenFixture is the append-only history of a surface. The last entry is the
+// current promise; the ones before it are why in-place edits cannot hide.
+type frozenFixture struct {
+	History []frozenEntry `json:"history"`
+}
+
+// frozenSurface binds a name to what it currently renders and to the version
+// the code declares for it.
+type frozenSurface struct {
+	name string
+	// version is what the code says this surface's shape is worth. For the
+	// three object payloads it is also served on the wire as schema_version;
+	// /_feint/routes answers a bare array (see emulator/schema.go for why that
+	// stays), and the CLI has no wire at all.
+	version int
+	// content is the canonical form: field trees for the HTTP surfaces, verbs
+	// with flags and exit codes for the CLI.
+	content json.RawMessage
+}
+
+// TestTheFrozenSurfacesStillMatchTheirFixture is the freeze: the live form of
+// each surface equals the last committed entry of its fixture. It goes red on
+// any change of the form — a key added, removed or retyped, a verb or flag
+// appearing or going — and stays green across values, counters and timestamps.
+func TestTheFrozenSurfacesStillMatchTheirFixture(t *testing.T) {
+	for _, s := range observedSurfaces(t) {
+		t.Run(s.name, func(t *testing.T) {
+			fixture := loadFrozen(t, s.name)
+			last := fixture.History[len(fixture.History)-1]
+			if !sameJSON(t, last.Content, s.content) {
+				t.Errorf("the frozen surface %q moved:\n  committed: %s\n  observed:  %s\n"+
+					"If this change is deliberate: run `mise run frozen:update`, bump the surface's "+
+					"version constant (emulator/schema.go or cliSurfaceVersion), and add a CHANGELOG line.",
+					s.name, compactJSON(t, last.Content), compactJSON(t, s.content))
+			}
+		})
+	}
+}
+
+// TestASurfaceChangeDemandsItsVersionBump is the other tooth: the version the
+// code declares (and, for the object payloads, serves) equals the version of
+// the fixture's latest entry. After `mise run frozen:update` appends a new
+// entry, this stays red until the constant moves — which is the moment a human
+// decides the change and owes the CHANGELOG its line.
+func TestASurfaceChangeDemandsItsVersionBump(t *testing.T) {
+	for _, s := range observedSurfaces(t) {
+		t.Run(s.name, func(t *testing.T) {
+			fixture := loadFrozen(t, s.name)
+			last := fixture.History[len(fixture.History)-1]
+			if s.version != last.SchemaVersion {
+				t.Errorf("surface %q: the code declares schema version %d, the fixture's latest entry is %d.\n"+
+					"A frozen surface only moves with its version: bump the constant "+
+					"(emulator/schema.go or cliSurfaceVersion) and say what changed in the CHANGELOG.",
+					s.name, s.version, last.SchemaVersion)
+			}
+		})
+	}
+}
+
+// TestFrozenHistoryOnlyGrows refuses a fixture whose entries were reordered or
+// whose versions repeat: the history is the audit trail that makes an in-place
+// edit visible, so it must stay strictly increasing.
+func TestFrozenHistoryOnlyGrows(t *testing.T) {
+	for _, s := range observedSurfaces(t) {
+		fixture := loadFrozen(t, s.name)
+		prev := 0
+		for i, e := range fixture.History {
+			if e.SchemaVersion <= prev {
+				t.Errorf("surface %q: history entry %d has version %d after %d; versions must strictly increase",
+					s.name, i, e.SchemaVersion, prev)
+			}
+			prev = e.SchemaVersion
+		}
+	}
+}
+
+// TestExitCodesAreFrozen holds the exit-code promise the README makes and CI
+// depends on: 0 success, 1 error, 2 drift. The constants are compared against
+// the frozen fixture, and the two ends of the range are proven by running the
+// dispatcher rather than by reading the constants back: help answers 0, an
+// unknown verb answers 1, `status` answers 0 even when nothing runs (a stopped
+// emulator is a fact, not a failure), and a `wait` that times out answers 1,
+// never a fourth code. The drift paths return exitDrift and are each proven
+// where they live (baseline, shapes --check, docs --check); freezing the
+// constant here is what keeps those proofs meaning "2".
+func TestExitCodesAreFrozen(t *testing.T) {
+	fixture := loadFrozen(t, "cli")
+	var content struct {
+		ExitCodes map[string]int `json:"exit_codes"`
+	}
+	if err := json.Unmarshal(fixture.History[len(fixture.History)-1].Content, &content); err != nil {
+		t.Fatalf("decode the cli fixture content: %v", err)
+	}
+	for name, got := range map[string]int{"ok": exitOK, "error": exitError, "drift": exitDrift} {
+		if want, known := content.ExitCodes[name]; !known || got != want {
+			t.Errorf("exit code %q is %d, the frozen fixture says %d: CI depends on these", name, got, want)
+		}
+	}
+
+	var discard strings.Builder
+	if code := Run([]string{"feint", "help"}, &discard, &discard); code != exitOK {
+		t.Errorf("`feint help` exited %d, want %d", code, exitOK)
+	}
+	if code := Run([]string{"feint", "no-such-verb"}, &discard, &discard); code != exitError {
+		t.Errorf("an unknown verb exited %d, want %d", code, exitError)
+	}
+	// 127.0.0.1:1 is reserved and refuses connections at once, so neither call
+	// waits out its timeout against a service that could exist.
+	if code := Run([]string{"feint", "status", "--addr", "127.0.0.1:1"}, &discard, &discard); code != exitOK {
+		t.Errorf("`feint status` against nothing exited %d, want %d: not running is a fact, not a failure", code, exitOK)
+	}
+	if code := Run([]string{"feint", "wait", "--addr", "127.0.0.1:1", "--timeout", "50ms"}, &discard, &discard); code != exitError {
+		t.Errorf("a timed-out `feint wait` exited %d, want %d and never a fourth code", code, exitError)
+	}
+}
+
+// observedSurfaces renders every frozen surface once, from a live server for
+// the HTTP ones and from the dispatcher's own help for the CLI. When
+// FEINT_UPDATE_FROZEN is set it also appends any changed form to the fixture
+// history, at the next version — never rewriting an entry, which is what makes
+// the version test above able to demand the bump.
+func observedSurfaces(t *testing.T) []frozenSurface {
+	t.Helper()
+	surfaces := []frozenSurface{
+		{name: "health", version: emulator.HealthSchemaVersion, content: observeShape(t, "/_feint/health", nil)},
+		{name: "routes", version: emulator.RoutesSchemaVersion, content: observeShape(t, "/_feint/routes", nil)},
+		{name: "conformance", version: emulator.ConformanceSchemaVersion, content: observeShape(t, "/_feint/conformance",
+			// These maps are keyed by operation names: data, not schema. Their
+			// keys are collapsed so that mounting one more route — never a
+			// break, serving more of a provider's API is the point — cannot
+			// move the fixture.
+			[]string{"calls", "probes", "violations", "unread_request_fields", "evidence"})},
+		{name: "trace", version: emulator.TraceSchemaVersion, content: observeShape(t, "/_feint/trace", nil)},
+		{name: "cli", version: cliSurfaceVersion, content: cliSurfaceContent(t)},
+	}
+	if os.Getenv("FEINT_UPDATE_FROZEN") != "" {
+		for _, s := range surfaces {
+			updateFrozen(t, s)
+		}
+	}
+	return surfaces
+}
+
+// frozenServer serves the emulator once per test run, with enough traffic
+// through it that the optional parts of each payload exist to be observed: one
+// real client call carrying a query string, one synthetic probe call, and one
+// request nothing routes. Values stay out of the fixture by construction — only
+// the field tree is kept — so none of this drives volatility.
+var frozenBody = func() func(t *testing.T, path string) []byte {
+	var once sync.Once
+	bodies := map[string][]byte{}
+	var buildErr error
+	return func(t *testing.T, path string) []byte {
+		t.Helper()
+		once.Do(func() {
+			srv, _, err := newServer(nil)
+			if err != nil {
+				buildErr = err
+				return
+			}
+			ts := httptest.NewServer(srv.Handler())
+			defer ts.Close()
+
+			drive := func(path string, probe bool) error {
+				req, err := http.NewRequest(http.MethodGet, ts.URL+path, nil)
+				if err != nil {
+					return err
+				}
+				if probe {
+					req.Header.Set(emulator.ProbeHeader, "frozen-test")
+				}
+				res, err := ts.Client().Do(req)
+				if err != nil {
+					return err
+				}
+				return res.Body.Close()
+			}
+			for _, call := range []struct {
+				path  string
+				probe bool
+			}{
+				{"/instance/v1/zones/fr-par-1/servers?page=1", false},
+				{"/instance/v1/zones/fr-par-1/servers", true},
+				{"/no-such-route-anywhere", false},
+			} {
+				if err := drive(call.path, call.probe); err != nil {
+					buildErr = err
+					return
+				}
+			}
+
+			for _, path := range []string{"/_feint/health", "/_feint/routes", "/_feint/conformance", "/_feint/trace"} {
+				res, err := ts.Client().Get(ts.URL + path)
+				if err != nil {
+					buildErr = err
+					return
+				}
+				var body strings.Builder
+				if _, err := io.Copy(&body, res.Body); err != nil {
+					buildErr = err
+					return
+				}
+				if err := res.Body.Close(); err != nil {
+					buildErr = err
+					return
+				}
+				if res.StatusCode != http.StatusOK {
+					buildErr = fmt.Errorf("%s answered %d", path, res.StatusCode)
+					return
+				}
+				bodies[path] = []byte(body.String())
+			}
+		})
+		if buildErr != nil {
+			t.Fatalf("drive the emulator for the frozen surfaces: %v", buildErr)
+		}
+		body, known := bodies[path]
+		if !known {
+			t.Fatalf("no recorded body for %s", path)
+		}
+		return body
+	}
+}()
+
+// observeShape turns one live payload into its canonical content: the field
+// tree, with data-keyed maps collapsed under "*".
+func observeShape(t *testing.T, path string, dataKeyed []string) json.RawMessage {
+	t.Helper()
+	var decoded any
+	if err := json.Unmarshal(frozenBody(t, path), &decoded); err != nil {
+		t.Fatalf("decode %s: %v", path, err)
+	}
+	if top, isObject := decoded.(map[string]any); isObject {
+		for _, key := range dataKeyed {
+			m, isMap := top[key].(map[string]any)
+			if !isMap || len(m) == 0 {
+				continue
+			}
+			// The values, in key order, merged by the same walk that merges
+			// array elements: one entry per distinct field, whatever the keys.
+			keys := make([]string, 0, len(m))
+			for k := range m {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			values := make([]any, 0, len(m))
+			for _, k := range keys {
+				values = append(values, m[k])
+			}
+			top[key] = map[string]any{"*": values}
+		}
+	}
+	fields := transcript.FieldsOf(decoded)
+	content, err := json.Marshal(map[string]any{"fields": fields})
+	if err != nil {
+		t.Fatalf("marshal the canonical shape of %s: %v", path, err)
+	}
+	return content
+}
+
+// cliSurfaceContent is the canonical CLI surface: every verb the help renders
+// with the flags its entry declares, and the exit codes. Read from the rendered
+// help rather than from a list kept beside it, for the reason
+// TestEveryDispatchedCommandIsInTheHelp reads the dispatch from the source: a
+// second copy is the thing that drifts.
+func cliSurfaceContent(t *testing.T) json.RawMessage {
+	t.Helper()
+	verbs := verbsWithFlags(t)
+	// Guard of the guard: a parse that comes back near-empty is a broken
+	// harness, and a fixture regenerated from it would freeze nothing.
+	if len(verbs) < 15 {
+		t.Fatalf("only %d verbs parsed from the help: the parser is broken, not the surface", len(verbs))
+	}
+	content, err := json.Marshal(map[string]any{
+		"verbs":      verbs,
+		"exit_codes": map[string]int{"ok": exitOK, "error": exitError, "drift": exitDrift},
+	})
+	if err != nil {
+		t.Fatalf("marshal the CLI surface: %v", err)
+	}
+	return content
+}
+
+// verbsWithFlags parses the rendered help: a line "  feint <verb> " opens a
+// verb, its indented continuation lines belong to it, a line at column zero
+// closes it. Flags are every "-x" / "--xyz" token in the verb's block.
+func verbsWithFlags(t *testing.T) map[string][]string {
+	t.Helper()
+	var rendered strings.Builder
+	usage(&rendered)
+
+	verbLine := regexp.MustCompile(`^  feint ([a-z][a-z-]*) `)
+	// A flag token starts after a space, bracket, parenthesis or quote — never
+	// in the middle of a word, so "read-only" and "incus-vm" stay words.
+	flagToken := regexp.MustCompile(`(?:^|[\s\[("])(-{1,2}[a-zA-Z][a-zA-Z0-9-]*)`)
+
+	verbs := map[string][]string{}
+	current := ""
+	seen := map[string]map[string]bool{}
+	for _, line := range strings.Split(rendered.String(), "\n") {
+		if m := verbLine.FindStringSubmatch(line); m != nil {
+			current = m[1]
+			if verbs[current] == nil {
+				verbs[current] = []string{}
+				seen[current] = map[string]bool{}
+			}
+		} else if !strings.HasPrefix(line, " ") {
+			// Prose at column zero: the preamble, the exit-code paragraph.
+			// Whatever dashes it carries belong to no verb.
+			current = ""
+			continue
+		}
+		if current == "" {
+			continue
+		}
+		for _, m := range flagToken.FindAllStringSubmatch(line, -1) {
+			flag := m[1]
+			if !seen[current][flag] {
+				seen[current][flag] = true
+				verbs[current] = append(verbs[current], flag)
+			}
+		}
+	}
+	for _, flags := range verbs {
+		sort.Strings(flags)
+	}
+	return verbs
+}
+
+// loadFrozen reads a surface's fixture, and fails loudly on a missing or empty
+// one: a gate that skips what it cannot read is a gate somebody disarms by
+// deleting a file.
+func loadFrozen(t *testing.T, name string) frozenFixture {
+	t.Helper()
+	path := filepath.Join(frozenDir, name+".json")
+	raw, err := os.ReadFile(path) //nolint:gosec // a fixed testdata path
+	if err != nil {
+		t.Fatalf("read the frozen fixture %s: %v\n(regenerate with `mise run frozen:update`)", path, err)
+	}
+	var fixture frozenFixture
+	if err := json.Unmarshal(raw, &fixture); err != nil {
+		t.Fatalf("decode %s: %v", path, err)
+	}
+	if len(fixture.History) == 0 {
+		t.Fatalf("%s holds no history entry: nothing is frozen", path)
+	}
+	return fixture
+}
+
+// updateFrozen appends the observed content to the surface's history when it
+// changed, at the next version. It never rewrites an existing entry: the
+// version test is what then demands the constant follow.
+func updateFrozen(t *testing.T, s frozenSurface) {
+	t.Helper()
+	path := filepath.Join(frozenDir, s.name+".json")
+	var fixture frozenFixture
+	if raw, err := os.ReadFile(path); err == nil { //nolint:gosec // a fixed testdata path
+		if err := json.Unmarshal(raw, &fixture); err != nil {
+			t.Fatalf("decode %s before updating it: %v", path, err)
+		}
+	}
+	next := 1
+	if n := len(fixture.History); n > 0 {
+		last := fixture.History[n-1]
+		if sameJSON(t, last.Content, s.content) {
+			return
+		}
+		next = last.SchemaVersion + 1
+	}
+	fixture.History = append(fixture.History, frozenEntry{SchemaVersion: next, Content: s.content})
+	raw, err := json.MarshalIndent(fixture, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal %s: %v", path, err)
+	}
+	if err := os.MkdirAll(frozenDir, 0o750); err != nil {
+		t.Fatalf("create %s: %v", frozenDir, err)
+	}
+	if err := os.WriteFile(path, append(raw, '\n'), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	t.Logf("%s: appended schema version %d; bump the matching constant and write the CHANGELOG line", path, next)
+}
+
+// sameJSON compares two documents structurally, so formatting and map order
+// cannot fail the gate.
+func sameJSON(t *testing.T, a, b json.RawMessage) bool {
+	t.Helper()
+	var va, vb any
+	if err := json.Unmarshal(a, &va); err != nil {
+		t.Fatalf("decode for comparison: %v", err)
+	}
+	if err := json.Unmarshal(b, &vb); err != nil {
+		t.Fatalf("decode for comparison: %v", err)
+	}
+	return reflect.DeepEqual(va, vb)
+}
+
+func compactJSON(t *testing.T, raw json.RawMessage) string {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, raw); err != nil {
+		return string(raw)
+	}
+	return buf.String()
+}

--- a/internal/cli/testdata/frozen/cli.json
+++ b/internal/cli/testdata/frozen/cli.json
@@ -1,0 +1,128 @@
+{
+  "history": [
+    {
+      "schema_version": 1,
+      "content": {
+        "exit_codes": {
+          "drift": 2,
+          "error": 1,
+          "ok": 0
+        },
+        "verbs": {
+          "catalog": [
+            "--format"
+          ],
+          "clean": [
+            "--vm"
+          ],
+          "coverage": [
+            "--baseline",
+            "--contract",
+            "--fail-on-unknown",
+            "--format",
+            "--products",
+            "--provider",
+            "--sdk",
+            "--write-baseline"
+          ],
+          "docs": [
+            "--check",
+            "--coverage",
+            "--file"
+          ],
+          "doctor": [
+            "--addr",
+            "--vm"
+          ],
+          "env": [
+            "--endpoint",
+            "--shell",
+            "--unset"
+          ],
+          "evidence": [
+            "--endpoint",
+            "--join",
+            "--out",
+            "--shapes"
+          ],
+          "logs": [
+            "--addr",
+            "-f",
+            "-n"
+          ],
+          "probe": [
+            "--contracts",
+            "--endpoint",
+            "--provider"
+          ],
+          "proxy": [
+            "--addr",
+            "--max-body",
+            "--provider",
+            "--queue",
+            "--record",
+            "--upstream"
+          ],
+          "restart": [
+            "--addr",
+            "--timeout"
+          ],
+          "serve": [
+            "--addr",
+            "--cleanup",
+            "--contracts",
+            "--coverage",
+            "--log-level",
+            "--state",
+            "--vm"
+          ],
+          "shapes": [
+            "--check",
+            "--dir",
+            "--dry-run",
+            "--profile",
+            "--provider",
+            "--record"
+          ],
+          "snapshot": [
+            "--addr",
+            "--force",
+            "--format",
+            "--state"
+          ],
+          "start": [
+            "--detach",
+            "--foreground",
+            "--timeout"
+          ],
+          "status": [
+            "--addr",
+            "--coverage",
+            "--format"
+          ],
+          "stop": [
+            "--addr",
+            "--timeout"
+          ],
+          "transcript": [
+            "--against",
+            "--format",
+            "--shape"
+          ],
+          "ui": [
+            "--addr",
+            "--print"
+          ],
+          "version": [
+            "--version",
+            "-v"
+          ],
+          "wait": [
+            "--addr",
+            "--timeout"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/internal/cli/testdata/frozen/conformance.json
+++ b/internal/cli/testdata/frozen/conformance.json
@@ -1,0 +1,115 @@
+{
+  "history": [
+    {
+      "schema_version": 1,
+      "content": {
+        "fields": [
+          {
+            "path": "calls",
+            "type": "object"
+          },
+          {
+            "path": "calls.*",
+            "type": "array"
+          },
+          {
+            "path": "calls.*[]",
+            "type": "number"
+          },
+          {
+            "path": "contracts",
+            "type": "array"
+          },
+          {
+            "path": "evidence",
+            "type": "object"
+          },
+          {
+            "path": "evidence.*",
+            "type": "array"
+          },
+          {
+            "path": "evidence.*[]",
+            "type": "object"
+          },
+          {
+            "path": "evidence.*[].behaviour",
+            "type": "bool"
+          },
+          {
+            "path": "evidence.*[].contract",
+            "type": "string"
+          },
+          {
+            "path": "evidence.*[].dataplane",
+            "type": "bool"
+          },
+          {
+            "path": "evidence.*[].driven",
+            "type": "bool"
+          },
+          {
+            "path": "evidence.*[].negative",
+            "type": "bool"
+          },
+          {
+            "path": "evidence.*[].probed",
+            "type": "bool"
+          },
+          {
+            "path": "evidence.*[].shape",
+            "type": "string"
+          },
+          {
+            "path": "exercised",
+            "type": "number"
+          },
+          {
+            "path": "machines",
+            "type": "string"
+          },
+          {
+            "path": "probed",
+            "type": "number"
+          },
+          {
+            "path": "probes",
+            "type": "object"
+          },
+          {
+            "path": "probes.*",
+            "type": "array"
+          },
+          {
+            "path": "probes.*[]",
+            "type": "number"
+          },
+          {
+            "path": "schema_version",
+            "type": "number"
+          },
+          {
+            "path": "served",
+            "type": "number"
+          },
+          {
+            "path": "unread_request_fields",
+            "type": "object"
+          },
+          {
+            "path": "untouched",
+            "type": "array"
+          },
+          {
+            "path": "untouched[]",
+            "type": "string"
+          },
+          {
+            "path": "violations",
+            "type": "object"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/internal/cli/testdata/frozen/health.json
+++ b/internal/cli/testdata/frozen/health.json
@@ -1,0 +1,63 @@
+{
+  "history": [
+    {
+      "schema_version": 1,
+      "content": {
+        "fields": [
+          {
+            "path": "capabilities",
+            "type": "object"
+          },
+          {
+            "path": "capabilities.addresses",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.firewall",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.isolation",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.machines",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.own_kernel",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.private_from_host",
+            "type": "bool"
+          },
+          {
+            "path": "machines",
+            "type": "string"
+          },
+          {
+            "path": "providers",
+            "type": "array"
+          },
+          {
+            "path": "providers[]",
+            "type": "string"
+          },
+          {
+            "path": "resources",
+            "type": "number"
+          },
+          {
+            "path": "schema_version",
+            "type": "number"
+          },
+          {
+            "path": "status",
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/internal/cli/testdata/frozen/routes.json
+++ b/internal/cli/testdata/frozen/routes.json
@@ -1,0 +1,27 @@
+{
+  "history": [
+    {
+      "schema_version": 1,
+      "content": {
+        "fields": [
+          {
+            "path": "[]",
+            "type": "object"
+          },
+          {
+            "path": "[].method",
+            "type": "string"
+          },
+          {
+            "path": "[].operation",
+            "type": "string"
+          },
+          {
+            "path": "[].path",
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/internal/cli/testdata/frozen/trace.json
+++ b/internal/cli/testdata/frozen/trace.json
@@ -1,0 +1,71 @@
+{
+  "history": [
+    {
+      "schema_version": 1,
+      "content": {
+        "fields": [
+          {
+            "path": "count",
+            "type": "number"
+          },
+          {
+            "path": "exchanges",
+            "type": "array"
+          },
+          {
+            "path": "exchanges[]",
+            "type": "object"
+          },
+          {
+            "path": "exchanges[].method",
+            "type": "string"
+          },
+          {
+            "path": "exchanges[].mounted",
+            "type": "bool"
+          },
+          {
+            "path": "exchanges[].ms",
+            "type": "number"
+          },
+          {
+            "path": "exchanges[].operation",
+            "type": "string"
+          },
+          {
+            "path": "exchanges[].path",
+            "type": "string"
+          },
+          {
+            "path": "exchanges[].provider",
+            "type": "string"
+          },
+          {
+            "path": "exchanges[].query",
+            "type": "string"
+          },
+          {
+            "path": "exchanges[].seq",
+            "type": "number"
+          },
+          {
+            "path": "exchanges[].status",
+            "type": "number"
+          },
+          {
+            "path": "exchanges[].t",
+            "type": "string"
+          },
+          {
+            "path": "kept",
+            "type": "number"
+          },
+          {
+            "path": "schema_version",
+            "type": "number"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/internal/core/emulator/conformance.go
+++ b/internal/core/emulator/conformance.go
@@ -299,6 +299,12 @@ func (r *recorder) Write(b []byte) (int, error) {
 //
 // TestStatusCountsWhatAClientDrove in internal/cli fails without this.
 type ConformanceView struct {
+	// SchemaVersion says which shape of this document the reader holds, so a
+	// pipeline can branch on it. Its meaning is enforced by the frozen fixture
+	// (see schema.go): a shape change that does not move
+	// ConformanceSchemaVersion fails TestASurfaceChangeDemandsItsVersionBump
+	// in internal/cli.
+	SchemaVersion int `json:"schema_version"`
 	// Served is how many routes are mounted.
 	Served int `json:"served"`
 	// Exercised is how many of them a real client drove at least once. The
@@ -518,6 +524,7 @@ func (s *Server) handleConformance(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, ConformanceView{
+		SchemaVersion:       ConformanceSchemaVersion,
 		Served:              len(routes),
 		Exercised:           len(routes) - len(untouched),
 		Probed:              probedOnly,

--- a/internal/core/emulator/emulator.go
+++ b/internal/core/emulator/emulator.go
@@ -412,11 +412,12 @@ func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
 	// what this process can actually prove instead of hardcoding a mode name,
 	// and an operator can see what they have without reading a file.
 	writeJSON(w, http.StatusOK, map[string]any{
-		"status":       "ok",
-		"providers":    providers,
-		"resources":    s.env.Store.Len(),
-		"machines":     driver,
-		"capabilities": capabilities,
+		"schema_version": HealthSchemaVersion,
+		"status":         "ok",
+		"providers":      providers,
+		"resources":      s.env.Store.Len(),
+		"machines":       driver,
+		"capabilities":   capabilities,
 	})
 }
 

--- a/internal/core/emulator/events.go
+++ b/internal/core/emulator/events.go
@@ -291,7 +291,8 @@ func (s *Server) handleTrace(w http.ResponseWriter, _ *http.Request) {
 		out = append(out, json.RawMessage(e.data))
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
-		"count": len(out),
+		"schema_version": TraceSchemaVersion,
+		"count":          len(out),
 		// Said on the wire rather than left for a reader to discover by
 		// counting: a trace that silently held the last 256 of 4000 calls would
 		// make a script assert on a window it did not know it was looking

--- a/internal/core/emulator/schema.go
+++ b/internal/core/emulator/schema.go
@@ -1,0 +1,39 @@
+package emulator
+
+// The schema versions of the /_feint surfaces a CI is allowed to depend on.
+//
+// The moment a pipeline runs `curl /_feint/conformance | jq .`, that shape is a
+// public API, and until #132 nothing failed when it moved: a field could be
+// renamed in a patch release and the first person to notice would be the owner
+// of the broken pipeline. RELEASING.md named these surfaces as breaking; naming
+// is a sentence, and a sentence is not a control.
+//
+// Each constant below is served inside its payload, so a consumer can branch on
+// it. What keeps the field honest is the frozen fixture in
+// internal/cli/testdata/frozen/: the field tree of each response is committed,
+// TestTheFrozenSurfacesStillMatchTheirFixture compares the live answer against
+// it, and TestASurfaceChangeDemandsItsVersionBump refuses a fixture whose
+// latest entry does not carry the version served here. Changing a shape without
+// touching its constant therefore fails `go test`, which runs on every pull
+// request — the version field cannot lie, because the gate is what gives it its
+// meaning.
+//
+// A bump is a statement to consumers, so it belongs in the CHANGELOG next to
+// what moved. The procedure lives in RELEASING.md ("Frozen surfaces").
+const (
+	// HealthSchemaVersion is the shape of GET /_feint/health.
+	HealthSchemaVersion = 1
+	// RoutesSchemaVersion is the shape of GET /_feint/routes.
+	//
+	// This one is not on the wire: the endpoint answers a bare JSON array — the
+	// README documents `jq -r '.[].operation'` against it — and wrapping the
+	// array in an object to carry a version field would be exactly the break
+	// this file exists to prevent. The constant still pins the fixture, so the
+	// shape cannot move without a bump; if it ever must change, version 2 is
+	// the wrapped object, which then carries its version like the others.
+	RoutesSchemaVersion = 1
+	// ConformanceSchemaVersion is the shape of GET /_feint/conformance.
+	ConformanceSchemaVersion = 1
+	// TraceSchemaVersion is the shape of GET /_feint/trace.
+	TraceSchemaVersion = 1
+)

--- a/mise.toml
+++ b/mise.toml
@@ -55,6 +55,17 @@ description = "Everything CI runs on a pull request"
 depends = ["lint", "test", "shapes:check"]
 run = "echo 'local check passed'"
 
+[tasks."frozen:update"]
+description = "Regenerate the frozen CI-surface fixtures after a deliberate change; then bump the surface's version constant"
+# The fixtures freeze what CI is allowed to depend on: the shape of the
+# /_feint/* payloads and the CLI's verbs, flags and exit codes (#132). This
+# appends the observed form to the fixture's history at the next version and
+# never rewrites an entry — the tests stay red until the matching constant
+# (internal/core/emulator/schema.go, or cliSurfaceVersion in internal/cli)
+# follows, which is the gate: a shape cannot move while its version stands
+# still, and a bump owes the CHANGELOG its line.
+run = "FEINT_UPDATE_FROZEN=1 go test ./internal/cli -run 'TestTheFrozenSurfacesStillMatchTheirFixture'"
+
 [tasks."shapes:check"]
 description = "Fail if the emulator omits a field the recorded shapes prove the real cloud returns"
 depends = ["build"]


### PR DESCRIPTION
# Summary

What CI is allowed to depend on is frozen by a test, not by a sentence (#132).
The shapes of `/_feint/health`, `/_feint/routes`, `/_feint/conformance` and
`/_feint/trace`, the CLI's verbs and flags, and the exit codes (0 ok, 1 error,
2 drift) each get a committed fixture under `internal/cli/testdata/frozen/` —
an append-only history of `{schema_version, content}` entries, where content is
the **form** (field trees, verb and flag names) and never a value, so counters,
identifiers, timestamps and newly mounted routes cannot move it.

Two tests gate every pull request, and each needs the other:

- `TestTheFrozenSurfacesStillMatchTheirFixture` — the live form equals the
  fixture's latest entry. Catches the accidental change.
- `TestASurfaceChangeDemandsItsVersionBump` — the declared version (served as
  `schema_version` in the three object payloads, a constant for the rest)
  equals the latest entry's version. `mise run frozen:update` **appends** the
  new form at the next version and never rewrites an entry, so regenerating
  without deciding leaves this red until the constant moves — the version
  field cannot lie, which is what separates it from the `schema_version: 1`
  the external review proposed and this issue's title warns about.

`TestExitCodesAreFrozen` holds 0/1/2 against the fixture and proves the ends
behaviourally: help answers 0, an unknown verb 1, `status` 0 with nothing
running, a timed-out `wait` 1 and never a fourth code.

Deliberately **not** frozen (a freeze too wide is a brake, and gets disarmed):
the help's prose around the verbs, the values behind every frozen key, the
interior of `violations`/`unread_request_fields` map entries, and the trace
fields only some exchanges carry (`unread`, `violations`). `/_feint/routes`
stays a bare JSON array rather than gaining a wrapper to carry its version:
the README documents `jq '.[].operation'` against it, and reshaping it now
would be the very break this change exists to prevent. Its version pins the
fixture from `emulator/schema.go`; if it ever must change, version 2 is the
wrapped object.

**Falsified** in a copy outside the repository (six runs, each mutation
compiling, `go vet` checked): a field added to health → freeze test bites; a
constant bumped without the fixture → version test bites; `exitDrift = 3` →
exit-code test bites; a flag removed from the help → CLI freeze bites; a
fixture history appended without the constant → version test bites; and the
deliberate change (shape + fixture + constant together) passes, with baseline
and final runs green.

**Merge-order note:** this touches `/_feint/conformance` (one additive field,
`SchemaVersion`, on `emulator.ConformanceView`) while #88 works on the
contract gate and #156 on `internal/probe`. Neither `internal/contract` nor
`internal/probe` is modified here, but if #88 lands a change to the
conformance payload first, the fixture and `ConformanceSchemaVersion` here
must be regenerated on top — flag it at merge time.

RELEASING.md and RELEASING.fr.md gain a "Frozen surfaces" section with the
four-step contributor procedure; CHANGELOG.md and CHANGELOG.fr.md carry the
entry under Unreleased.

## Type of change

- [ ] A route added or changed
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation
- [x] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes (gofmt, vet, golangci-lint, `go test -race`)
- [x] No new external Go dependency, or the pull request justifies it. The
      standard library covers routing, JSON and Go parsing; `go.mod` has three
      lines and a pre-commit hook keeps it that way
- [x] `internal/core` still knows no provider. `schema.go` names feint's own
      surfaces only; the freeze test lives in `internal/cli`, which already
      mounts the packs
- [x] Nothing in the diff could be written identically for another provider.
      These are feint's own surfaces, not a provider's

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
      (`Assisted-by: Claude Code (claude-fable-5)`)
- [x] I ran `mise run conformance` myself — full run on this branch: scw,
      Terraform (both engines), oapi-cli, exo, the probe and the score, all
      green (168 of 220 routes proven; network suites skip without a runtime,
      as designed)
- [x] Every field name in the diff comes from the provider's SDK, their
      OpenAPI document, or a run of the real client, and I can say which: the
      diff introduces no provider field. `schema_version` is feint's own key
      on feint's own `/_feint/*` surfaces, and the fixtures record shapes the
      emulator already served

### When a route is added or changed — otherwise N/A

N/A — no provider route is added or changed. The `/_feint/*` endpoints are
feint's own surface (deliberately not `Route`s, see `mountSelf`), and the only
wire change is the additive `schema_version` key. `mise run drift:check` run
anyway: green, 0 unknown.

### When behaviour a client can observe changes — otherwise N/A

- [x] `docs/limits.md` updated if the change moves a documented limit — no
      limit moved; RELEASING (both languages) and CHANGELOG (both languages)
      carry the observable change instead
- [x] The README's generated tables regenerated — nothing to regenerate:
      `feint docs --check` green on this branch

### When `.github/workflows/` is touched — otherwise N/A

N/A — no workflow is touched. The gate is `go test`, which every existing
caller (`mise run check`, go.yml) already runs; the exit-code contract is now
itself a frozen surface.

### When a machine runtime is involved — otherwise N/A

N/A — nothing under `internal/core/machine` or `internal/core/cloudinit` is
touched, and no machine starts in any of the new tests.

## Related issues

Closes #132
