### PR TITLE
feat(proxy): interception keeps a client the plain recorder loses to republishing

### DIFF
--- a/.github/workflows/userns-probe.yml
+++ b/.github/workflows/userns-probe.yml
@@ -1,0 +1,59 @@
+name: userns probe
+
+# Measure, on a GitHub hosted runner, whether a disposable network namespace is
+# reachable there — the question docs/limits.md (#76) leaves open and that the
+# recording-by-interception path depends on for CI reproducibility.
+#
+# "What works on the author's station proves nothing about a runner, and #125
+# showed these machines are more permissive than assumed." So this asks, on the
+# runner itself, the same three questions the station was re-measured with, plus
+# whether rootless podman gives a container its own namespace and hosts file. It
+# runs on demand, reads nothing, writes nothing, and pulls in no third-party
+# action — there is nothing here to pin and nothing to leak.
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  probe:
+    name: three-way user namespace probe
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      # First step of every job here: monitor egress and block the runner from
+      # being tampered with. This job pulls nothing and reaches nowhere, so audit
+      # records an empty list, which is the point — the probe touches only the
+      # kernel's namespace machinery.
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: probe
+        # set +e: every line is a measurement, and a non-zero exit is a datum,
+        # not a failure of the job. The job only fails if the shell itself breaks.
+        run: |
+          set +e
+          echo "## runner"
+          echo "kernel: $(uname -r)"
+          echo "apparmor_restrict_unprivileged_userns: $(cat /proc/sys/kernel/apparmor_restrict_unprivileged_userns 2>/dev/null || echo absent)"
+          echo
+          echo "## 1. bare namespace creation"
+          unshare --user --net true; echo "exit=$?"
+          echo
+          echo "## 2. map this user to root inside it"
+          unshare --user --map-root-user --net id -u; echo "exit=$?"
+          echo
+          echo "## 3. create an interface inside it"
+          unshare --user --map-root-user --net sh -c 'ip link add dummy0 type dummy; echo "ip-link exit=$?"; ip link set lo up; echo "lo-up exit=$?"'
+          echo "outer exit=$?"
+          echo
+          echo "## 4. rootless podman: own netns + own /etc/hosts, no host trace"
+          if command -v podman >/dev/null 2>&1; then
+            podman run --rm --add-host=probe.example:127.0.0.1 alpine getent hosts probe.example; echo "podman exit=$?"
+            echo "host /etc/hosts mentions probe.example: $(grep -c probe.example /etc/hosts)"
+          else
+            echo "podman: not installed on this runner image"
+          fi

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -103,15 +103,51 @@ matters:
 | `curl --resolve` / `--connect-to` | one command | works — proven landing `s3.fr-par.scw.cloud` and `<bucket>.s3.fr-par.scw.cloud` locally with a wildcard cert — but **curl only**; the SDK has no equivalent |
 | `HOSTALIASES` (glibc) | one process | only the cgo resolver, and only single-label names — **useless for a dotted FQDN** |
 | `LD_PRELOAD` getaddrinfo shim | one process | only cgo-resolver binaries. Measured: `scw` is dynamically linked with cgo getaddrinfo (interceptable); `exo` is static pure-Go (not). Terraform providers build `CGO_ENABLED=0` — **not interceptable** |
-| network namespace + bind-mounted `/etc/hosts` | disposable | needs unprivileged user namespaces, which this station **blocks** (`apparmor_restrict_unprivileged_userns=1`; `unshare -r` → `EPERM`) — increasingly the default |
+| network namespace + bind-mounted `/etc/hosts` | disposable | **works, with one named AppArmor profile.** The station sets `apparmor_restrict_unprivileged_userns=1`, and the first measurement read `unshare -r` → `EPERM` as "namespaces are blocked". Re-measured: the namespace is created and root maps fine; what the restriction removes is *capabilities inside it*, so `ip link add` answers `RTNETLINK: Operation not permitted`. `tools/install/apparmor/feint` grants `userns` to one binary path and the interface is created — see below |
 | edit `/etc/hosts` | whole machine, persistent | works for every client, but it is a **durable change to the operator's machine** — the thing the pitch forbids |
 
 So for the one blocked client — the pure-Go, statically linked AWS SDK inside the
-Scaleway Terraform provider, which offers no `--resolve` — the only mechanisms
-that reach it are the two that touch the machine durably (`/etc/hosts`) or need a
-privilege this station denies (a network namespace). The cheap, scoped
+Scaleway Terraform provider, which offers no `--resolve` — the cheap scoped
 mechanisms (`curl --resolve`, `HOSTALIASES`, an `LD_PRELOAD` shim) all miss it,
-each for a different reason.
+each for a different reason. What reaches it is a network namespace, and that
+one is available.
+
+#### The namespace row was wrong, and the correction is worth reading
+
+The first measurement concluded that this station blocks unprivileged user
+namespaces, from `unshare -r` answering `EPERM`. Re-measured with the exit codes
+read properly — the earlier reading took `$?` through a pipe, which is the
+false-verdict shape this repository keeps meeting — the three questions separate:
+
+| asked | answer |
+|---|---|
+| `unshare --user --net true` | **0** — the namespace is created |
+| a uid map putting this user at root inside it | **works** — `id -u` answers 0 |
+| `ip link add dummy0 type dummy` inside it | `RTNETLINK answers: Operation not permitted` |
+
+So the restriction does not stop the namespace. Ubuntu transitions the process
+into the stock `unprivileged_userns` profile, whose first line is
+`audit deny capability` — the namespace exists and is powerless, which is a
+better design than refusing outright and reads exactly the same from a script
+that only checks whether `unshare` failed.
+
+**The fix is one named profile, not a sysctl.**
+`tools/install/apparmor/feint` grants `userns` to the feint binary path and
+nothing else, in the same shape the distribution ships for `lxc-unshare`,
+`bwrap` and a dozen others. Setting `kernel.apparmor_restrict_unprivileged_userns=0`
+would lift the restriction for *every* program on the host; this lifts it for one
+path.
+
+Measured on a witness binary, both ways: with the profile loaded the interface is
+created; unload it and `RTNETLINK: Operation not permitted` comes straight back.
+
+```bash
+sudo install -m 0644 tools/install/apparmor/feint /etc/apparmor.d/feint
+sudo apparmor_parser -r /etc/apparmor.d/feint
+```
+
+Nothing in feint requires it. Without the profile, the paths that need a
+namespace refuse and say so; every other command works unchanged.
 
 ### 4. What the standard library gives for free
 

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -159,6 +159,10 @@ bucket name containing a dot (`my.bucket.s3.<region>.scw.cloud`) is not covered 
 measured, `curl` refuses it. There is no DNS server in the standard library, but
 per number 3 the measured case does not need one.
 
+This is no longer a projection: `internal/proxy/intercept.go` mints exactly that
+CA and leaf from the standard library alone, and `feint proxy --intercept` serves
+the recorder over TLS with it. See number 6.
+
 ### 5. What is dangerous when it is on — and it is not the certificate
 
 A process that trusts a feint-minted CA **and** resolves a real cloud hostname to
@@ -171,17 +175,64 @@ a stale emulator (silent, and the exact failure this project exists to avoid).
 Whatever is ever retained here must scope the redirect as narrowly as the cert —
 a devcontainer with its own hosts file, an explicit and temporary entry the
 operator makes and removes — and must never install a CA into the system store or
-edit `/etc/hosts` on the operator's behalf.
+edit `/etc/hosts` on the operator's behalf. Number 6 is how that scoping is done
+in practice: the redirect lives in a namespace the client owns, never in the
+operator's own `/etc/hosts`.
+
+### 6. Built, and where the redirect is now permitted
+
+The two halves stopped being a projection. `feint proxy --intercept
+<host>[,<host>]` serves the recorder (see `docs/proxy.md`) over HTTPS with a
+certificate `internal/proxy/intercept.go` mints from the standard library alone:
+a short-lived, non-CA leaf covering the names a redirected client will address. It
+writes the CA to a temporary file for `SSL_CERT_FILE`, prints the redirect recipe,
+and removes the CA on exit. The scoping number 5 demands is structural here — the
+command installs nothing into the system store and writes no `/etc/hosts`, because
+it has no code that could.
+
+That leaves one question, and number 3 answered it for the station: where the
+*name* resolves to loopback, disposably and without a durable trace. Measured
+across the places an operator actually has, rather than assumed:
+
+| place | verdict | how, and what it costs the machine |
+|---|---|---|
+| a rootless container (podman, docker) | **works, no host trace** | the container has its own network namespace and its own `/etc/hosts`; `--add-host=<name>:host-gateway` redirects the name and `SSL_CERT_FILE` carries the CA. It reaches the namespace through the setuid `newuidmap` helper, a path the `apparmor_restrict_unprivileged_userns` sysctl does not touch, so it needs no profile — measured here, `grep <name> /etc/hosts` on the host stays empty afterwards |
+| feint's own user + network namespace | **works with the named profile** | `tools/install/apparmor/feint` (number 3); feint itself opens the namespace, so the profile covers it. A separately-launched `unshare` or `ip` is not covered, by design, and that is the right architecture: a tool that asks the operator for `sudo unshare` has already lost *no trace* |
+| Incus container (`--vm incus`) | **works** | a container is a namespace; already piloted by this repository |
+| a GitHub hosted runner (`ubuntu-24.04`) | **the container path works; feint's own namespace needs the profile** | measured, not assumed (workflow run `31791022679`, `.github/workflows/userns-probe.yml`, image `20260810.271`, kernel `6.17-azure`): the runner carries the *same* `apparmor_restrict_unprivileged_userns=1`. Bare namespace creates (`exit 0`), the root map is refused (`exit 1`) — an unconfined `unshare` is as powerless here as on the station. Rootless podman works out of the box and leaves no host trace (`grep` on the host stays empty), so the container row is the portable CI path. feint's own namespace would need `tools/install/apparmor/feint` loaded first, which a runner permits through passwordless sudo |
+
+The through-line: in every permitted place the redirect is as disposable and as
+narrowly scoped as `SSL_CERT_FILE` itself. It lives in a namespace the operator's
+next *real* apply never enters, and it vanishes when that namespace does — which is
+exactly what number 5 says any retained redirect must do.
+
+**Why this was built now: #92, not S3.** The driver was the recorder, not Object
+Storage. `feint proxy` records a real client by being its configured endpoint, but
+a cloud that republishes its own address in a response body walks the client away:
+Exoscale's `GET /v2/zone` hands back `https://api-ch-gva-2.exoscale.com/v2`, the
+client follows it, and a session worth about ninety exchanges recorded **eight**
+(#92). The plain proxy cannot hold a client it does not resolve for. Interception
+can: with the republished name resolving to the proxy in a namespace of its own and
+the CA trusted, the client follows the republished address straight back and the
+whole session is kept. `TestInterceptionRecordsThePostHandoffExchanges` reproduces
+it without an account — one session driven twice against the same recorder, the
+republished name resolving to the proxy, then away — and records the whole thing
+one way, only the pre-handoff exchange the other. Eight-of-ninety, and the fix, on
+one run.
 
 ### The verdict
 
-**Refused, now with numbers behind it — and the refusal changes shape.** Object
-Storage through Terraform stays out, not because the certificate is a project of
-its own (it is under 100 lines of standard library, and every Go client including
-the Terraform plugin accepts it through one process-scoped environment variable),
-but because reaching the single hardcoded endpoint needs a name redirect that, on
-a hardened Linux, no client-scoped mechanism delivers for a static pure-Go plugin
-— leaving only machine-touching options that the *no trace* pitch forbids.
+**Refused, now with numbers behind it — and the refusal changes shape twice.**
+Object Storage through Terraform stays out, but no longer for the reason first
+written. The certificate was never the project it was called: it is `feint proxy
+--intercept`, under 100 lines of standard library, accepted by every Go client
+including the Terraform plugin through one process-scoped environment variable. And
+the name redirect, first read as undeliverable without touching the machine, is
+deliverable after all — in a namespace the client owns (number 6): a rootless
+container, or feint's own namespace under one named profile. What is left is not a
+feasibility wall but an operator ceremony — the client must run inside that
+namespace — and whether the S3-through-Terraform corner is worth that ceremony is a
+product call, the only thing still holding the refusal.
 
 The blocker is one product on one client, so the MinIO + `SCW_S3_ENDPOINT` page
 remains the right answer for the S3 workflow, and the refusal caps coverage by

--- a/internal/cli/proxy.go
+++ b/internal/cli/proxy.go
@@ -2,11 +2,13 @@ package cli
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -38,6 +40,7 @@ func proxyCommand(args []string, _ io.Writer, stderr io.Writer) int {
 	maxBody := fs.Int("max-body", proxy.DefaultMaxBody, "record at most this many bytes of each body; the rest is declared, never silently cut")
 	queue := fs.Int("queue", proxy.DefaultQueue, "how many exchanges may wait to be written before one is dropped")
 	expose := fs.Bool("expose-to-network", false, "listen off loopback, which offers this proxy's transcript and this cloud account to the network")
+	intercept := fs.String("intercept", "", "serve HTTPS with a locally-minted certificate for these comma-separated hostnames, so a client redirected to this proxy by name (a container's own /etc/hosts) trusts it and lands here; see docs/limits.md #76")
 	if err := fs.Parse(args); err != nil {
 		return exitError
 	}
@@ -94,7 +97,9 @@ func proxyCommand(args []string, _ io.Writer, stderr io.Writer) int {
 	fmt.Fprintf(stderr, "  upstream  %s\n", target)
 	fmt.Fprintf(stderr, "  recording %s\n", *record)
 	fmt.Fprintf(stderr, "  naming    %s\n", namingOf(*provider))
-	fmt.Fprintf(stderr, "  point a client at http://%s and drive it as usual\n", *addr)
+	if *intercept == "" {
+		fmt.Fprintf(stderr, "  point a client at http://%s and drive it as usual\n", *addr)
+	}
 
 	srv := &http.Server{
 		Addr:    *addr,
@@ -107,12 +112,29 @@ func proxyCommand(args []string, _ io.Writer, stderr io.Writer) int {
 		ReadHeaderTimeout: 30 * time.Second,
 	}
 
+	// serve is the listener the run blocks on. Plain HTTP by default; HTTPS with a
+	// minted certificate when --intercept names the hosts a redirected client will
+	// address. The certificate half of #76: everything after this is identical.
+	serve := srv.ListenAndServe
+	if *intercept != "" {
+		cfg, cleanup, err := setUpInterception(*intercept, *addr, stderr)
+		if err != nil {
+			_ = writer.Close()
+			_ = closeOut()
+			fmt.Fprintf(stderr, "feint: %v\n", err)
+			return exitError
+		}
+		defer cleanup()
+		srv.TLSConfig = cfg
+		serve = func() error { return srv.ListenAndServeTLS("", "") }
+	}
+
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
 	errs := make(chan error, 1)
 	go func() {
-		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if err := serve(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errs <- err
 		}
 	}()
@@ -189,6 +211,64 @@ func checkProxyAddr(addr string, expose bool) error {
 	return fmt.Errorf("refusing to listen on %s: every request through this proxy carries a real "+
 		"credential, and off loopback anyone who can reach the port can relay through it and "+
 		"land in your transcript. Pass --expose-to-network if that is what you want", addr)
+}
+
+// setUpInterception mints the certificate a redirected client must trust, writes
+// its CA where SSL_CERT_FILE can find it, and prints the two-line recipe that
+// makes the redirect disposable.
+//
+// It writes nothing durable and installs nothing: the CA lands in a temporary
+// file that cleanup removes, never in the system trust store, and the name
+// redirect is left to the operator's own namespace — a container's /etc/hosts —
+// never this machine's. That scoping is the safety argument of docs/limits.md's
+// #76 section, and this function keeps to it by construction: it cannot touch the
+// operator's /etc/hosts because it never writes one.
+func setUpInterception(hosts, addr string, stderr io.Writer) (*tls.Config, func(), error) {
+	names := splitHosts(hosts)
+	if len(names) == 0 {
+		return nil, nil, fmt.Errorf("--intercept was given no hostname")
+	}
+	ic, err := proxy.MintInterceptor(names...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("mint the interception certificate: %w", err)
+	}
+	caFile, err := os.CreateTemp("", "feint-intercept-ca-*.pem")
+	if err != nil {
+		return nil, nil, fmt.Errorf("create the CA file: %w", err)
+	}
+	caPath := caFile.Name()
+	_ = caFile.Close()
+	if err := ic.WriteCA(caPath); err != nil {
+		_ = os.Remove(caPath)
+		return nil, nil, err
+	}
+
+	_, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		port = "4600"
+	}
+	fmt.Fprintf(stderr, "  intercepting HTTPS for %s\n", strings.Join(names, ", "))
+	fmt.Fprintf(stderr, "  CA written to %s (a temporary file, removed on exit)\n", caPath)
+	fmt.Fprintln(stderr, "  point a client at this proxy by name, in a namespace of its own, e.g.:")
+	fmt.Fprintf(stderr, "    export SSL_CERT_FILE=%s\n", caPath)
+	for _, n := range names {
+		fmt.Fprintf(stderr, "    # resolve %s to this proxy (a container's own /etc/hosts, never yours):\n", n)
+		fmt.Fprintf(stderr, "    #   podman run --add-host=%s:host-gateway ... , proxy reachable on :%s\n", n, port)
+	}
+	return ic.ServerTLSConfig(), func() { _ = os.Remove(caPath) }, nil
+}
+
+// splitHosts turns the comma list --intercept takes into trimmed, non-empty
+// names. A trailing comma or a stray space must not become an empty hostname the
+// mint then refuses.
+func splitHosts(list string) []string {
+	var out []string
+	for _, part := range strings.Split(list, ",") {
+		if p := strings.TrimSpace(part); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 // proxyTable builds the route table an exchange is named from.

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -1,0 +1,186 @@
+package proxy
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"os"
+	"time"
+
+	"crypto/tls"
+)
+
+// Interceptor is the certificate half of DNS/TLS interception (#76), minted from
+// the standard library alone and nothing else.
+//
+// It is what lets a real client be redirected to this proxy by *name* rather
+// than by configuration. A client whose endpoint is hardcoded, or one handed a
+// republished address in a response body (Exoscale's `GET /v2/zone`, which is
+// what defeated the plain proxy in #92), does not read SCW_API_URL or an
+// endpoint file for that call: it resolves the name and connects. Two knobs,
+// both measured in docs/limits.md, make it land here instead:
+//
+//   - the name resolves to loopback, done in a network namespace the client owns
+//     — a container's own /etc/hosts, never the operator's — so it is disposable
+//     and leaves no trace on the machine;
+//   - the client trusts the leaf this mints, done with SSL_CERT_FILE pointed at
+//     [Interceptor.WriteCA]'s output, which every Go client (scw, exo, and the
+//     Terraform plugin, inheriting the parent's environment) honours.
+//
+// The safety argument of the #76 section rests entirely on that scoping. A
+// process that trusts this CA *and* resolves a real cloud hostname to loopback
+// is exactly how a real `terraform apply` silently hits a local emulator, so the
+// redirect must be as narrow as the certificate. This type helps keep it narrow:
+// the CA is minted to a caller-supplied path (a namespace's temporary file), the
+// leaf is short-lived and not itself a CA (it cannot be repurposed as a trust
+// anchor), and neither half is ever installed into the operator's system store.
+type Interceptor struct {
+	tlsConfig *tls.Config
+	caPEM     []byte
+	pool      *x509.CertPool
+	hosts     []string
+}
+
+// leafValidity bounds how long a minted leaf is accepted.
+//
+// A recording session is minutes; a day is generous and still short enough that
+// a certificate forgotten inside a disposed namespace cannot quietly become a
+// durable trust anchor. This is the bound TestAMintedLeafIsShortLivedAndNotACA
+// pins: raise it to a year or mark the leaf IsCA and that test fails.
+const leafValidity = 24 * time.Hour
+
+// MintInterceptor builds a fresh CA and one leaf covering hosts.
+//
+// Plain names (`api-ch-gva-2.exoscale.com`) and single-level wildcards
+// (`*.s3.fr-par.scw.cloud`) are both accepted, which is the exact pair the #76
+// measurement found the Scaleway S3 case needs.
+//
+// It refuses an empty host set, and an empty name within it: a certificate
+// covering nothing redirects nothing, and returning one would hand back a proxy
+// that answers TLS for no name the caller asked about — the silent no-op this
+// tool exists to avoid. TestMintInterceptorRefusesNoHost fails without the guard.
+func MintInterceptor(hosts ...string) (*Interceptor, error) {
+	if len(hosts) == 0 {
+		return nil, fmt.Errorf("no host to intercept: a certificate covering nothing redirects nothing")
+	}
+	for _, h := range hosts {
+		if h == "" {
+			return nil, fmt.Errorf("an empty host name cannot be intercepted")
+		}
+	}
+
+	notBefore := time.Now().Add(-time.Minute)
+	notAfter := time.Now().Add(leafValidity)
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate the CA key: %w", err)
+	}
+	caTmpl := &x509.Certificate{
+		SerialNumber:          serial(),
+		Subject:               pkix.Name{CommonName: "feint interception CA"},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		return nil, fmt.Errorf("sign the CA: %w", err)
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		return nil, fmt.Errorf("parse the CA back: %w", err)
+	}
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate the leaf key: %w", err)
+	}
+	leafTmpl := &x509.Certificate{
+		SerialNumber: serial(),
+		Subject:      pkix.Name{CommonName: hosts[0]},
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     append([]string(nil), hosts...),
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, &leafKey.PublicKey, caKey)
+	if err != nil {
+		return nil, fmt.Errorf("sign the leaf: %w", err)
+	}
+
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caPEM) {
+		return nil, fmt.Errorf("the minted CA does not parse as a trust root")
+	}
+
+	return &Interceptor{
+		tlsConfig: &tls.Config{
+			MinVersion: tls.VersionTLS12,
+			Certificates: []tls.Certificate{{
+				Certificate: [][]byte{leafDER, caDER},
+				PrivateKey:  leafKey,
+				Leaf:        leafTmpl,
+			}},
+		},
+		caPEM: caPEM,
+		pool:  pool,
+		hosts: append([]string(nil), hosts...),
+	}, nil
+}
+
+// serial draws a random 128-bit certificate serial. Two certificates minted in
+// the same second must differ, or a client that has seen one rejects the other
+// as a duplicate; a counter would collide across two proxy processes, a random
+// draw does not.
+func serial() *big.Int {
+	max := new(big.Int).Lsh(big.NewInt(1), 128)
+	n, err := rand.Int(rand.Reader, max)
+	if err != nil {
+		// rand.Reader failing is a broken machine, not a condition to paper over
+		// with a fixed serial that would then collide.
+		panic("feint: crypto/rand is unavailable: " + err.Error())
+	}
+	return n
+}
+
+// ServerTLSConfig is the configuration the proxy's listener serves. It presents
+// the minted leaf for every intercepted name.
+func (i *Interceptor) ServerTLSConfig() *tls.Config { return i.tlsConfig.Clone() }
+
+// CAPEM is the CA in PEM, the bytes [Interceptor.WriteCA] writes. A caller that
+// keeps its own trust pool (a client in this process, a test) appends these.
+func (i *Interceptor) CAPEM() []byte { return append([]byte(nil), i.caPEM...) }
+
+// CAPool trusts the minted CA and nothing else. It is what a client in the same
+// process (a test, or a client library the operator embeds) sets as its root, in
+// place of the SSL_CERT_FILE a separate process reads.
+func (i *Interceptor) CAPool() *x509.CertPool { return i.pool }
+
+// Hosts are the names the leaf covers.
+func (i *Interceptor) Hosts() []string { return append([]string(nil), i.hosts...) }
+
+// WriteCA writes the CA in PEM to path, for a client to trust through
+// SSL_CERT_FILE.
+//
+// 0644 rather than 0600: SSL_CERT_FILE is read by whatever the operator runs,
+// commonly a client in a container under a different uid than the writer, and a
+// public trust root carries no secret — the private key never leaves this
+// process. The path is caller-supplied precisely so it can be a namespace's
+// temporary file that vanishes with the namespace, which is the scoping the
+// safety argument depends on.
+func (i *Interceptor) WriteCA(path string) error {
+	if err := os.WriteFile(path, i.caPEM, 0o644); err != nil { //nolint:gosec // a public CA, no secret; must be readable by the client process
+		return fmt.Errorf("write the interception CA to %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/proxy/intercept_test.go
+++ b/internal/proxy/intercept_test.go
@@ -1,0 +1,282 @@
+package proxy_test
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stephrobert/feint/internal/proxy"
+)
+
+// The host a real Exoscale account hands the client in `GET /v2/zone`, and the
+// one that walked the client away from the plain proxy in #92. It is not the
+// proxy; that is the whole point.
+const republishedHost = "api-ch-gva-2.exoscale.com"
+
+// configuredHost is the name the operator points the client's endpoint at: the
+// proxy, reached by a name the leaf covers, standing in for whatever the exo
+// config file holds. The first call of the session lands here — recorded in both
+// runs — before the cloud republishes republishedHost.
+const configuredHost = "proxy.feint.test"
+
+// TestInterceptionRecordsThePostHandoffExchanges is the #92 proof.
+//
+// A session is driven twice against the same recording proxy. It differs in one
+// thing only: whether the name the cloud republishes in its first answer
+// resolves back to the proxy (interception on) or away to the cloud
+// (interception off) — the in-process stand-in for a container's own /etc/hosts.
+// Off, the proxy records the one exchange before the handoff and the client
+// takes everything after somewhere the transcript cannot see, which is the
+// eight-of-ninety #92 measured. On, every exchange of the session lands on the
+// proxy and the transcript is complete.
+//
+// Remove the interception (mint no cert, do not redirect) and the recorded count
+// collapses back to one: that is the condition for interception counting as the
+// fix rather than a claim.
+func TestInterceptionRecordsThePostHandoffExchanges(t *testing.T) {
+	// followUps is how many calls the client makes after it has read the
+	// republished endpoint. The real session was about ninety; a dozen is enough
+	// to tell "the one before the handoff" from "all of them" without pretending
+	// to reproduce a real account's exact traffic.
+	const followUps = 12
+
+	// interceptor covers the configured proxy name and the republished name.
+	// Minted once, shared by both runs so the only variable is the redirect.
+	interceptor, err := proxy.MintInterceptor(configuredHost, republishedHost)
+	if err != nil {
+		t.Fatalf("mint the interceptor: %v", err)
+	}
+
+	// The cloud the proxy forwards to. Its zone answer republishes republishedHost,
+	// exactly as a real account does; every other route is a stub the session can
+	// walk. Plain HTTP: the proxy speaks TLS to the client and HTTP to its upstream,
+	// so nothing here needs an upstream trust root.
+	var upstreamHits int
+	cloud := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits++
+		if r.URL.Path == "/v2/zone" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"zones": []map[string]any{{
+					"name":         "ch-gva-2",
+					"api-endpoint": "https://" + republishedHost + "/v2",
+				}},
+			})
+			return
+		}
+		_, _ = io.WriteString(w, "{}")
+	}))
+	defer cloud.Close()
+
+	// awayHits stands in for the real cloud the client reaches when nothing
+	// redirects the republished name: where the eighty-two lost exchanges of #92
+	// actually went. The proxy never sees these. It serves a certificate valid for
+	// the republished name (minted with the same tool), which the client trusts
+	// the way it would trust the real cloud through the system store.
+	awayInterceptor, err := proxy.MintInterceptor(republishedHost)
+	if err != nil {
+		t.Fatalf("mint the away cloud's certificate: %v", err)
+	}
+	var awayHits int
+	away := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		awayHits++
+		_, _ = io.WriteString(w, "{}")
+	}))
+	away.TLS = awayInterceptor.ServerTLSConfig()
+	away.StartTLS()
+	defer away.Close()
+
+	run := func(t *testing.T, intercept bool) (recorded int, handedHosts map[string]int64) {
+		t.Helper()
+		upstreamHits, awayHits = 0, 0
+
+		target, err := url.Parse(cloud.URL)
+		if err != nil {
+			t.Fatalf("parse the upstream: %v", err)
+		}
+		path := filepath.Join(t.TempDir(), "run.jsonl")
+		file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+		if err != nil {
+			t.Fatalf("open the transcript: %v", err)
+		}
+		writer := proxy.NewWriter(file, 0)
+		p, err := proxy.New(proxy.Options{Upstream: target, Writer: writer})
+		if err != nil {
+			t.Fatalf("build the proxy: %v", err)
+		}
+
+		// The proxy listens over TLS with the minted leaf. This is where the
+		// client's configured endpoint points, and where interception sends the
+		// republished name too.
+		front := httptest.NewUnstartedServer(p)
+		front.TLS = interceptor.ServerTLSConfig()
+		front.StartTLS()
+		proxyAddr := front.Listener.Addr().String()
+
+		// The client trusts the interceptor CA (the SSL_CERT_FILE half) so it will
+		// speak to the proxy, and — off interception — the away cloud's CA too,
+		// which stands for the real cloud a client already trusts through the
+		// system store.
+		roots := interceptor.CAPool()
+		if !intercept {
+			roots = roots.Clone()
+			if !roots.AppendCertsFromPEM(awayInterceptor.CAPEM()) {
+				t.Fatal("the away cloud's CA does not parse")
+			}
+		}
+		// The dialer is the /etc/hosts stand-in. The configured proxy name always
+		// resolves to the proxy; the republished name resolves to the proxy on
+		// interception, to the away cloud off it.
+		redirect := map[string]string{configuredHost + ":443": proxyAddr}
+		if intercept {
+			redirect[republishedHost+":443"] = proxyAddr
+		} else {
+			redirect[republishedHost+":443"] = away.Listener.Addr().String()
+		}
+		client := &http.Client{Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				if to, ok := redirect[addr]; ok {
+					addr = to
+				}
+				return (&net.Dialer{}).DialContext(ctx, network, addr)
+			},
+			TLSClientConfig: &tls.Config{RootCAs: roots, MinVersion: tls.VersionTLS12},
+		}}
+
+		// The session: the client is configured to talk to the proxy (by a covered
+		// name), reads the zone, then follows the republished api-endpoint for the
+		// rest — the exact shape that lost the client in #92.
+		endpoint := driveSession(t, client, "https://"+configuredHost, followUps)
+		if endpoint != "https://"+republishedHost+"/v2" {
+			t.Fatalf("the cloud did not republish its address: got %q", endpoint)
+		}
+
+		front.Close()
+		if err := writer.Close(); err != nil {
+			t.Fatalf("close the writer: %v", err)
+		}
+		if err := file.Close(); err != nil {
+			t.Fatalf("close the transcript: %v", err)
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read the transcript: %v", err)
+		}
+		_, hosts := p.HandedElsewhere()
+		return len(read(t, raw)), hosts
+	}
+
+	t.Run("without interception the transcript stops at the handoff", func(t *testing.T) {
+		recorded, hosts := run(t, false)
+		if recorded != 1 {
+			t.Errorf("without interception the proxy should record only the pre-handoff exchange, got %d", recorded)
+		}
+		if awayHits != followUps {
+			t.Errorf("the client should have taken all %d follow-ups away from the proxy, the away cloud saw %d", followUps, awayHits)
+		}
+		if hosts[republishedHost] == 0 {
+			t.Errorf("the proxy should have reported the handoff to %s, saw %v", republishedHost, hosts)
+		}
+	})
+
+	t.Run("with interception the whole session is recorded", func(t *testing.T) {
+		recorded, _ := run(t, true)
+		if want := 1 + followUps; recorded != want {
+			t.Errorf("with interception the proxy should record the whole session (%d), got %d", want, recorded)
+		}
+		if awayHits != 0 {
+			t.Errorf("with interception nothing should reach the away cloud, it saw %d", awayHits)
+		}
+	})
+}
+
+// driveSession runs the client the way #92's session ran: one call to the
+// configured endpoint, read the republished api-endpoint, then that many calls
+// against it. It returns the republished endpoint so the caller can assert the
+// cloud handed one out at all.
+func driveSession(t *testing.T, client *http.Client, endpoint string, followUps int) string {
+	t.Helper()
+
+	res, err := client.Get(endpoint + "/v2/zone")
+	if err != nil {
+		t.Fatalf("GET /v2/zone: %v", err)
+	}
+	var body struct {
+		Zones []struct {
+			APIEndpoint string `json:"api-endpoint"`
+		} `json:"zones"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		t.Fatalf("decode /v2/zone: %v", err)
+	}
+	_ = res.Body.Close()
+	if len(body.Zones) == 0 {
+		t.Fatal("no zone in the answer")
+	}
+	api := body.Zones[0].APIEndpoint
+
+	for i := 0; i < followUps; i++ {
+		res, err := client.Get(api + "/instance")
+		if err != nil {
+			t.Fatalf("follow-up %d to %s: %v", i, api, err)
+		}
+		_, _ = io.Copy(io.Discard, res.Body)
+		_ = res.Body.Close()
+	}
+	return api
+}
+
+// TestMintInterceptorRefusesNoHost pins the guard in MintInterceptor: a
+// certificate covering nothing redirects nothing, so minting one is refused.
+// Remove the guard and this fails — the mint returns a usable-looking
+// interceptor for an empty name set.
+func TestMintInterceptorRefusesNoHost(t *testing.T) {
+	if _, err := proxy.MintInterceptor(); err == nil {
+		t.Error("minting an interceptor for no host should be refused")
+	}
+	if _, err := proxy.MintInterceptor("a.example", ""); err == nil {
+		t.Error("minting an interceptor with an empty host name should be refused")
+	}
+}
+
+// TestAMintedLeafIsShortLivedAndNotACA pins the safety scoping: the leaf a client
+// is asked to trust cannot itself sign further certificates, and it expires
+// within the day. Mark it IsCA, or stretch its validity past leafValidity, and
+// this fails — which is the condition for the safety argument in docs/limits.md
+// resting on a checked property rather than a comment.
+func TestAMintedLeafIsShortLivedAndNotACA(t *testing.T) {
+	interceptor, err := proxy.MintInterceptor(republishedHost)
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	cfg := interceptor.ServerTLSConfig()
+	if len(cfg.Certificates) == 0 {
+		t.Fatal("the interceptor presents no certificate")
+	}
+	leaf, err := x509.ParseCertificate(cfg.Certificates[0].Certificate[0])
+	if err != nil {
+		t.Fatalf("parse the leaf: %v", err)
+	}
+	if leaf.IsCA {
+		t.Error("the leaf a client trusts must not itself be a CA")
+	}
+	// leafValidity is a day; NotBefore is backdated a minute for clock skew, so
+	// the span is a shade over a day. Anything approaching a year is the
+	// regression this guards against.
+	if d := leaf.NotAfter.Sub(leaf.NotBefore); d > 25*time.Hour {
+		t.Errorf("the leaf lives too long (%s): a forgotten cert must not become a durable anchor", d)
+	}
+	if len(leaf.DNSNames) != 1 || !strings.EqualFold(leaf.DNSNames[0], republishedHost) {
+		t.Errorf("the leaf should cover exactly the intercepted host, covers %v", leaf.DNSNames)
+	}
+}

--- a/tools/install/apparmor/feint
+++ b/tools/install/apparmor/feint
@@ -1,0 +1,46 @@
+# AppArmor profile: let feint create an unprivileged user namespace.
+#
+# Why this exists, and why it is not a sysctl.
+#
+# Ubuntu 24.04 ships `kernel.apparmor_restrict_unprivileged_userns=1`, which
+# stops any unconfined program from creating a user namespace. It is a real
+# hardening: user namespaces are a large kernel attack surface, and most desktop
+# software has no business opening one.
+#
+# feint needs one for exactly one job — standing a network namespace up so a
+# recording can intercept a name the client resolves itself, measured in
+# docs/limits.md (#76). Without a namespace the alternatives are all worse: a
+# durable /etc/hosts edit, an LD_PRELOAD shim that misses statically linked Go
+# binaries, or turning the sysctl off for the whole machine.
+#
+# That last one is what this file exists to avoid. Setting the sysctl to 0 lifts
+# the restriction for *every* program on the host; this profile lifts it for one
+# path, and `flags=(unconfined)` means feint is otherwise no more confined than
+# it was — this grants a capability, it does not tighten or loosen anything else.
+#
+# It is the same shape the distribution itself ships for lxc-unshare, bwrap and
+# a dozen others: see /etc/apparmor.d/lxc-unshare.
+#
+# Install:
+#     sudo install -m 0644 tools/install/apparmor/feint /etc/apparmor.d/feint
+#     sudo apparmor_parser -r /etc/apparmor.d/feint
+#
+# Remove, and the restriction applies to feint again:
+#     sudo apparmor_parser -R /etc/apparmor.d/feint
+#     sudo rm /etc/apparmor.d/feint
+#
+# Nothing in feint requires this profile. Without it, the recording paths that
+# need a namespace refuse and say so; every other command works unchanged.
+
+abi <abi/4.0>,
+include <tunables/global>
+
+# The paths a feint binary is installed to, and the one a checkout builds.
+# An AppArmor profile keys on the executable path: a binary somewhere else is
+# not covered, which is the point — this grants nothing to an unknown file.
+profile feint /{usr/local/bin,usr/bin,home/*/.local/bin,home/*/go/bin}/feint flags=(unconfined) {
+  userns,
+
+  # Site-specific additions and overrides. See local/README for details.
+  include if exists <local/feint>
+}


### PR DESCRIPTION
# Summary

Interception, built. `feint proxy` records a real client by being its configured
endpoint, but a cloud that republishes its own address in a response body walks
the client away: Exoscale's `GET /v2/zone` hands back
`https://api-ch-gva-2.exoscale.com/v2`, the client follows it, and a session worth
about ninety exchanges recorded **eight** (#92). The plain proxy cannot hold a
client it does not resolve for.

This delivers the certificate half of #76, measured there and now built with the
standard library alone (`internal/proxy/intercept.go`, no dependency):

- `MintInterceptor` mints a short-lived, non-CA leaf covering the redirected
  names; `feint proxy --intercept <host>[,<host>]` serves the recorder over HTTPS,
  writes the CA to a temporary file for `SSL_CERT_FILE`, prints the redirect
  recipe, and removes the CA on exit. It installs nothing into the system store
  and writes no `/etc/hosts` — the command has no code that could.
- With the name redirect done in a namespace the client owns, the client follows
  the republished address straight back to the recorder and the whole session is
  kept.

**Where the redirect is permitted, measured not assumed** (`docs/limits.md` §6):

| place | verdict |
|---|---|
| rootless container (podman/docker) | works, no host trace, no profile — the setuid `newuidmap` path the userns sysctl does not touch |
| feint's own namespace | works with `tools/install/apparmor/feint` |
| Incus container (`--vm incus`) | works |
| GitHub hosted `ubuntu-24.04` | measured (run `31791022679`): same `apparmor_restrict_unprivileged_userns=1` as the station — bare namespace creates, root map refused; **rootless podman works out of the box, no trace** — the portable CI path |

`TestInterceptionRecordsThePostHandoffExchanges` reproduces #92 without an account:
one session driven twice against the same recorder, the republished name resolving
to the proxy then away, recording the whole session one way (13) and only the
pre-handoff exchange the other (1). Eight-of-ninety, and the fix, on one run.

> Stacked on `feat/apparmor-userns-profile` (base set to it) so review sees only
> the three commits here. That branch's correction to the #76 namespace row is
> what this completes; retarget to `main` once it merges.

## Type of change

- [ ] A route added or changed
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation
- [x] Chore / tooling
- [ ] Security / supply chain

(Primarily a new capability in `internal/proxy` plus the docs it closes and a CI
probe; no provider route changed.)

## Checklist

### Always

- [x] `mise run check` passes (gofmt, vet, golangci-lint, `go test -race`)
- [x] No new external Go dependency — the CA and leaf are pure `crypto/x509` and
      `crypto/tls`; `go.mod` is untouched
- [x] `internal/core` still knows no provider — the interception lives in
      `internal/proxy` and names no pack; the republished host in the test is test
      data, not core knowledge
- [x] Nothing in the diff could be written identically for another provider. The
      recorder and the CA minting are provider-neutral by construction (the
      handoff detector already refuses to name a provider); the one Exoscale name
      is in a test fixture

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
- [ ] I ran `mise run conformance` myself — **N/A**: no route or response shape
      changed, so no real client can observe a difference. The proof this change
      needs is the recording round-trip, which its own test drives end to end over
      real TLS
- [x] Every field name in the diff comes from a source I can name: the republished
      shape (`api-endpoint`, `zones`) is Exoscale's, matching
      `internal/providers/exoscale/catalog.go`; the certificate fields are the
      standard library's

### When a route is added or changed — otherwise N/A

N/A — no route added or changed.

### When behaviour a client can observe changes — otherwise N/A

- [x] `docs/limits.md` updated — the #76 section is completed: the certificate
      half is built, §6 records where the redirect is permitted, and the stale
      verdict clause is corrected
- [ ] README generated tables — **N/A**, no coverage change (`feint docs --check`
      green, `drift:check` green)

### When `.github/workflows/` is touched — otherwise N/A

- [x] Every action pinned to a full SHA with a `# vX.Y.Z` comment — the one action
      used, `harden-runner`, is pinned to the repo's existing `v2.20.0` SHA
- [x] `step-security/harden-runner` is the job's first step
- [x] `permissions:` is least-privilege — `permissions: {}`, the job reads and
      writes nothing
- [x] No job renamed — the workflow is new (`userns probe`), required checks
      unaffected
- [x] The exit-code contract still holds — the probe is a measurement, `set +e`
      so a non-zero namespace answer is a datum; the job fails only if the shell
      itself breaks

### When a machine runtime is involved — otherwise N/A

N/A — `internal/core/machine` is untouched. The namespace where the redirect runs
is the operator's own container or feint's namespace under the apparmor profile,
not a code path in this change.

## Related issues

Refs #76, #92. The runner half of #76 is now measured (run `31791022679`).
