### PR TITLE
feat(install): one named AppArmor profile, instead of a sysctl nobody should flip

### DIFF
--- a/docs/limits.md
+++ b/docs/limits.md
@@ -103,15 +103,51 @@ matters:
 | `curl --resolve` / `--connect-to` | one command | works — proven landing `s3.fr-par.scw.cloud` and `<bucket>.s3.fr-par.scw.cloud` locally with a wildcard cert — but **curl only**; the SDK has no equivalent |
 | `HOSTALIASES` (glibc) | one process | only the cgo resolver, and only single-label names — **useless for a dotted FQDN** |
 | `LD_PRELOAD` getaddrinfo shim | one process | only cgo-resolver binaries. Measured: `scw` is dynamically linked with cgo getaddrinfo (interceptable); `exo` is static pure-Go (not). Terraform providers build `CGO_ENABLED=0` — **not interceptable** |
-| network namespace + bind-mounted `/etc/hosts` | disposable | needs unprivileged user namespaces, which this station **blocks** (`apparmor_restrict_unprivileged_userns=1`; `unshare -r` → `EPERM`) — increasingly the default |
+| network namespace + bind-mounted `/etc/hosts` | disposable | **works, with one named AppArmor profile.** The station sets `apparmor_restrict_unprivileged_userns=1`, and the first measurement read `unshare -r` → `EPERM` as "namespaces are blocked". Re-measured: the namespace is created and root maps fine; what the restriction removes is *capabilities inside it*, so `ip link add` answers `RTNETLINK: Operation not permitted`. `tools/install/apparmor/feint` grants `userns` to one binary path and the interface is created — see below |
 | edit `/etc/hosts` | whole machine, persistent | works for every client, but it is a **durable change to the operator's machine** — the thing the pitch forbids |
 
 So for the one blocked client — the pure-Go, statically linked AWS SDK inside the
-Scaleway Terraform provider, which offers no `--resolve` — the only mechanisms
-that reach it are the two that touch the machine durably (`/etc/hosts`) or need a
-privilege this station denies (a network namespace). The cheap, scoped
+Scaleway Terraform provider, which offers no `--resolve` — the cheap scoped
 mechanisms (`curl --resolve`, `HOSTALIASES`, an `LD_PRELOAD` shim) all miss it,
-each for a different reason.
+each for a different reason. What reaches it is a network namespace, and that
+one is available.
+
+#### The namespace row was wrong, and the correction is worth reading
+
+The first measurement concluded that this station blocks unprivileged user
+namespaces, from `unshare -r` answering `EPERM`. Re-measured with the exit codes
+read properly — the earlier reading took `$?` through a pipe, which is the
+false-verdict shape this repository keeps meeting — the three questions separate:
+
+| asked | answer |
+|---|---|
+| `unshare --user --net true` | **0** — the namespace is created |
+| a uid map putting this user at root inside it | **works** — `id -u` answers 0 |
+| `ip link add dummy0 type dummy` inside it | `RTNETLINK answers: Operation not permitted` |
+
+So the restriction does not stop the namespace. Ubuntu transitions the process
+into the stock `unprivileged_userns` profile, whose first line is
+`audit deny capability` — the namespace exists and is powerless, which is a
+better design than refusing outright and reads exactly the same from a script
+that only checks whether `unshare` failed.
+
+**The fix is one named profile, not a sysctl.**
+`tools/install/apparmor/feint` grants `userns` to the feint binary path and
+nothing else, in the same shape the distribution ships for `lxc-unshare`,
+`bwrap` and a dozen others. Setting `kernel.apparmor_restrict_unprivileged_userns=0`
+would lift the restriction for *every* program on the host; this lifts it for one
+path.
+
+Measured on a witness binary, both ways: with the profile loaded the interface is
+created; unload it and `RTNETLINK: Operation not permitted` comes straight back.
+
+```bash
+sudo install -m 0644 tools/install/apparmor/feint /etc/apparmor.d/feint
+sudo apparmor_parser -r /etc/apparmor.d/feint
+```
+
+Nothing in feint requires it. Without the profile, the paths that need a
+namespace refuse and say so; every other command works unchanged.
 
 ### 4. What the standard library gives for free
 

--- a/tools/install/apparmor/feint
+++ b/tools/install/apparmor/feint
@@ -1,0 +1,46 @@
+# AppArmor profile: let feint create an unprivileged user namespace.
+#
+# Why this exists, and why it is not a sysctl.
+#
+# Ubuntu 24.04 ships `kernel.apparmor_restrict_unprivileged_userns=1`, which
+# stops any unconfined program from creating a user namespace. It is a real
+# hardening: user namespaces are a large kernel attack surface, and most desktop
+# software has no business opening one.
+#
+# feint needs one for exactly one job — standing a network namespace up so a
+# recording can intercept a name the client resolves itself, measured in
+# docs/limits.md (#76). Without a namespace the alternatives are all worse: a
+# durable /etc/hosts edit, an LD_PRELOAD shim that misses statically linked Go
+# binaries, or turning the sysctl off for the whole machine.
+#
+# That last one is what this file exists to avoid. Setting the sysctl to 0 lifts
+# the restriction for *every* program on the host; this profile lifts it for one
+# path, and `flags=(unconfined)` means feint is otherwise no more confined than
+# it was — this grants a capability, it does not tighten or loosen anything else.
+#
+# It is the same shape the distribution itself ships for lxc-unshare, bwrap and
+# a dozen others: see /etc/apparmor.d/lxc-unshare.
+#
+# Install:
+#     sudo install -m 0644 tools/install/apparmor/feint /etc/apparmor.d/feint
+#     sudo apparmor_parser -r /etc/apparmor.d/feint
+#
+# Remove, and the restriction applies to feint again:
+#     sudo apparmor_parser -R /etc/apparmor.d/feint
+#     sudo rm /etc/apparmor.d/feint
+#
+# Nothing in feint requires this profile. Without it, the recording paths that
+# need a namespace refuse and say so; every other command works unchanged.
+
+abi <abi/4.0>,
+include <tunables/global>
+
+# The paths a feint binary is installed to, and the one a checkout builds.
+# An AppArmor profile keys on the executable path: a binary somewhere else is
+# not covered, which is the point — this grants nothing to an unknown file.
+profile feint /{usr/local/bin,usr/bin,home/*/.local/bin,home/*/go/bin}/feint flags=(unconfined) {
+  userns,
+
+  # Site-specific additions and overrides. See local/README for details.
+  include if exists <local/feint>
+}


### PR DESCRIPTION
`docs/limits.md` said this station blocks unprivileged user namespaces, from `unshare -r` answering `EPERM`. That reading took `$?` **through a pipe** — the false-verdict shape this repository keeps meeting.

Re-measured, the question splits in three and only the last one fails:

| asked | answer |
|---|---|
| `unshare --user --net true` | **0** — the namespace is created |
| a uid map putting this user at root inside it | **works** — `id -u` answers 0 |
| `ip link add dummy0 type dummy` inside it | `RTNETLINK answers: Operation not permitted` |

So the restriction does not stop the namespace. Ubuntu transitions the process into the stock `unprivileged_userns` profile, whose first line is `audit deny capability`: **the namespace exists and is powerless**. That is a better design than refusing outright, and it reads exactly the same from a script that only asks whether `unshare` failed.

## The fix is one named profile, not a sysctl

`tools/install/apparmor/feint` grants `userns` to the feint binary path and nothing else, in the shape the distribution already ships for `lxc-unshare`, `bwrap` and a dozen others.

Setting `kernel.apparmor_restrict_unprivileged_userns=0` would lift the restriction for **every program on the host**. This lifts it for one path — and `flags=(unconfined)` means feint is otherwise no more confined than before: it grants a capability rather than tightening or loosening anything else.

## Falsified both ways, on a witness binary

With the profile loaded, the interface is created. Unload it:

```
RTNETLINK answers: Operation not permitted
```

Nothing in feint requires it. Without the profile, the paths that need a namespace refuse and say so; every other command works unchanged. Removal is two commands, written at the top of the file.

`docs/limits.md` carries the correction rather than a quiet rewrite: the namespace row said a dead end, and the section under it now explains why that was wrong and what actually happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)