### PR TITLE
fix(docs): the clients table reads its provider column, instead of asserting it

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -15,7 +15,7 @@ parce que c'est là-dessus que ce projet est jugé : **une forme de réponse qu'
 client peut observer**, et **une limite qui a bougé**. Une refactorisation qui ne
 change ni l'un ni l'autre a sa place dans `git log`.
 
-## [Unreleased]
+## [Non publié]
 
 ### Ajouté
 
@@ -36,8 +36,6 @@ change ni l'un ni l'autre a sa place dans `git log`.
   changer une surface gelée à dessein est dans RELEASING.fr.md (« Surfaces
   gelées »).
 
-## [Non publié]
-
 ### Modifié
 
 - **`/_feint/conformance` passe en version de schéma 2.** `evidence.*[].probed`
@@ -46,6 +44,26 @@ change ni l'un ni l'autre a sa place dans `git log`.
   compterait chaque refus comme un succès — la surestimation que #156 supprime,
   réapparue une couche plus loin. Le changement de version est ce qui lui permet
   de s'en apercevoir.
+
+### Corrigé
+
+- **La matrice des clients crédite chaque fournisseur contre lequel la CI pilote
+  un client** (#155). La colonne « Emulated provider » du tableau du README
+  était une constante du générateur, sous un marqueur disant « Généré … ne pas
+  modifier à la main », et elle attribuait Terraform au seul Scaleway alors que
+  `conformance.yml` lançait `tools/conformance/outscale/terraform.sh` sur chaque
+  pull request, sous les deux branches terraform et opentofu. Généré n'est pas
+  dérivé : la colonne est désormais lue par le même balayage du workflow que la
+  table de statut, et chaque ligne qui répond au travers d'un provider Terraform
+  affiche la contrainte que la fixture de ce fournisseur épingle
+  (`scaleway/scaleway ~> 2.79` et `outscale/outscale ~> 1.7`), aucune des deux
+  n'étant redite ici. Sous-estimer une preuve coûte autant que la surestimer :
+  un audit externe a recommandé de retirer Terraform de la ligne Outscale du
+  README sur la foi de cette colonne, ce qui aurait effacé une suite qui
+  applique vingt et une ressources. Un client que la CI pilote et que le
+  générateur ne liste pas est maintenant refusé au lieu d'être omis. Trois
+  mutations falsifiées dans une copie hors dépôt, trois tests nommés qui
+  mordent.
 
 ## [0.8.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,24 @@ what this project is judged on: **a response shape a client can observe**, and
   every refusal as a success — the overstatement #156 removed, reappearing one
   layer out. The version bump is what lets it notice.
 
+### Fixed
+
+- **The client matrix credits every provider CI drives a client against**
+  (#155). The `Emulated provider` column of the README table was a constant in
+  the generator, under a marker reading "Generated … Do not edit by hand", and
+  it credited Terraform to Scaleway alone while `conformance.yml` had been
+  running `tools/conformance/outscale/terraform.sh` on every pull request, under
+  both the terraform and the opentofu legs. Generated is not derived: the column
+  is now read from the same workflow scan the status table uses, and each row
+  answering through a Terraform provider states the constraint that provider's
+  own fixture pins — `scaleway/scaleway ~> 2.79` and `outscale/outscale ~> 1.7`,
+  neither of them restated here. Understating a proof costs as much as
+  overstating one: an external review recommended deleting Terraform from the
+  README's Outscale row on the strength of that column, which would have erased
+  a suite that applies twenty-one resources. A client CI drives and the
+  generator does not list is now refused rather than left out. Three mutations
+  falsified in a copy outside the repository, three named tests biting.
+
 ## [0.8.0]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -555,8 +555,8 @@ argument is that the upstream moves:
 | Client | Version proven in CI | Emulated provider |
 |---|---|---|
 | `scw` | 2.56.3 | Scaleway |
-| Terraform | 1.13.3 with provider `scaleway/scaleway ~> 2.79` | Scaleway |
-| OpenTofu | 1.12.5 | Scaleway |
+| Terraform | 1.13.3 with providers `outscale/outscale ~> 1.7`, `scaleway/scaleway ~> 2.79` | Outscale, Scaleway |
+| OpenTofu | 1.12.5 with providers `outscale/outscale ~> 1.7`, `scaleway/scaleway ~> 2.79` | Outscale, Scaleway |
 | `oapi-cli` | 0.15.0 | Outscale |
 | `exo` | 1.95.6 | Exoscale |
 

--- a/internal/cli/docs.go
+++ b/internal/cli/docs.go
@@ -136,7 +136,7 @@ func docs(args []string, stdout, stderr io.Writer) int {
 	// that installs the clients, so the versions on the page and the versions the
 	// suite runs cannot drift apart.
 	if strings.Contains(updated, clientsStartMarker) {
-		rendered, cErr := renderClients(*workflow, terraformFixture)
+		rendered, cErr := renderClients(*workflow, conformanceRoot)
 		if cErr != nil {
 			// The likeliest cause is a document that claims the marker outside
 			// this repository, where the workflow it reads does not exist. Say

--- a/internal/cli/docs_clients.go
+++ b/internal/cli/docs_clients.go
@@ -3,7 +3,9 @@ package cli
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -15,38 +17,69 @@ import (
 // `scw` newer than the last conformance run can reject an answer that passed,
 // and nothing on the page would say so.
 //
-// The versions are not restated here. They are read from the workflow that
-// installs them and from the Terraform fixture that pins the provider, so the
-// table cannot claim a version the CI does not actually run.
+// Nothing in the table is restated here. The versions come from the workflow
+// that installs the clients, the provider constraints from the Terraform
+// fixtures that pin them, and the provider column from the same workflow scan
+// the status table reads.
+//
+// That last one was a constant in this file, under a marker saying "Do not edit
+// by hand", and it was wrong in the way a hand-written claim is always wrong:
+// it credited Terraform to Scaleway alone while `conformance.yml` had been
+// running `tools/conformance/outscale/terraform.sh` on every pull request under
+// both the terraform and the opentofu legs. Generated is not derived. An
+// understated proof costs as much as an overstated one here — an external review
+// recommended deleting Terraform from the README's Outscale row on the strength
+// of this table, which would have erased a suite that applies twenty-one
+// resources.
+//
+// TestTheClientMatrixCreditsEveryProviderCIProves fails without this.
 
 const (
 	clientsStartMarker = "<!-- clients:start -->"
 	clientsEndMarker   = "<!-- clients:end -->"
 
 	conformanceWorkflow = ".github/workflows/conformance.yml"
-	terraformFixture    = "tools/conformance/scaleway/terraform/main.tf"
+	// conformanceRoot holds one directory per provider, each with the fixtures
+	// its suites run. The Terraform provider pins are read from under here.
+	conformanceRoot = "tools/conformance"
+	// terraformSuite is the suite whose clients answer through a Terraform
+	// provider, and therefore the only rows that carry a provider constraint.
+	terraformSuite = "terraform"
 )
 
-// clientSource ties a client to where its version is pinned and to the pack it
-// exercises. Adding a client to the suite means adding a line here; a line whose
-// variable the workflow does not set renders as "unpinned", which is visible
-// rather than silent.
+// clientSources ties a client to the workflow variable that pins its version.
+//
+// It deliberately no longer says which provider the client proves: that is the
+// column this file exists to derive. A client the workflow drives and this list
+// does not name is an error in renderClients, not a silent omission.
 var clientSources = []struct {
 	name     string
 	variable string
-	provider string
 }{
-	{"`scw`", "SCW_VERSION", "Scaleway"},
-	{"Terraform", "TERRAFORM_VERSION", "Scaleway"},
-	{"OpenTofu", "TOFU_VERSION", "Scaleway"},
-	{"`oapi-cli`", "OAPI_VERSION", "Outscale"},
-	{"`exo`", "EXO_VERSION", "Exoscale"},
+	{"`scw`", "SCW_VERSION"},
+	{"Terraform", "TERRAFORM_VERSION"},
+	{"OpenTofu", "TOFU_VERSION"},
+	{"`oapi-cli`", "OAPI_VERSION"},
+	{"`exo`", "EXO_VERSION"},
 }
 
 var (
-	versionPattern  = regexp.MustCompile(`(?m)^\s*([A-Z0-9_]+_VERSION):\s*'([^']+)'`)
-	providerPattern = regexp.MustCompile(`(?s)scaleway\s*=\s*\{.*?version\s*=\s*"([^"]+)"`)
+	versionPattern = regexp.MustCompile(`(?m)^\s*([A-Z0-9_]+_VERSION):\s*'([^']+)'`)
+	// providerPattern reads one entry of a fixture's required_providers block.
+	// It is anchored on `required_providers` rather than on a provider's name so
+	// that a fourth pack's fixture is read the day it lands, without this file
+	// learning the provider's spelling.
+	providerPattern = regexp.MustCompile(
+		`(?s)required_providers\s*\{.*?source\s*=\s*"([^"]+)".*?version\s*=\s*"([^"]+)"`)
 )
+
+// clientProof is one thing CI proves about one client: the provider it drove,
+// and through which suite. The suite is kept because only the Terraform one
+// carries a provider constraint.
+type clientProof struct {
+	provider string // the lowercase directory under tools/conformance
+	suite    string
+}
 
 // pinnedVersions reads the versions the conformance workflow installs.
 func pinnedVersions(workflow string) (map[string]string, error) {
@@ -61,24 +94,122 @@ func pinnedVersions(workflow string) (map[string]string, error) {
 	return out, nil
 }
 
-// terraformProvider reads the provider constraint the Terraform fixture pins.
-// The Terraform version alone proves nothing: what answers the emulator is the
-// provider, and it is pinned in a different file from every other client.
-func terraformProvider(fixture string) string {
-	body, err := os.ReadFile(fixture) //nolint:gosec // a path this repository owns
+// proofsPerClient transposes the workflow scan: for each client, the providers
+// it drives and the suite it drives them through.
+func proofsPerClient(workflow string) (map[string][]clientProof, error) {
+	runs, err := suitesRunInCI(workflow)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := map[string]map[clientProof]bool{}
+	for _, run := range runs {
+		for _, name := range strings.Split(run.clients, ", ") {
+			name = strings.TrimSpace(name)
+			if name == "" {
+				continue
+			}
+			if seen[name] == nil {
+				seen[name] = map[clientProof]bool{}
+			}
+			seen[name][clientProof{provider: run.provider, suite: run.suite}] = true
+		}
+	}
+
+	out := map[string][]clientProof{}
+	for name, proofs := range seen {
+		list := make([]clientProof, 0, len(proofs))
+		for proof := range proofs {
+			list = append(list, proof)
+		}
+		sort.Slice(list, func(i, j int) bool {
+			if list[i].provider != list[j].provider {
+				return list[i].provider < list[j].provider
+			}
+			return list[i].suite < list[j].suite
+		})
+		out[name] = list
+	}
+	return out, nil
+}
+
+// providerName spells a conformance directory the way the page names the
+// provider. Derived rather than mapped: a table of three names would be one more
+// hand-written thing to disagree with the directory it describes.
+func providerName(dir string) string {
+	if dir == "" {
+		return dir
+	}
+	return strings.ToUpper(dir[:1]) + dir[1:]
+}
+
+// terraformProviderPin reads the provider constraint a provider's Terraform
+// fixture pins. The Terraform version alone proves nothing: what answers the
+// emulator is the provider, and it is pinned in a different file from every
+// other client — one file per provider.
+func terraformProviderPin(root, provider string) string {
+	body, err := os.ReadFile(filepath.Join(root, provider, terraformSuite, "main.tf")) //nolint:gosec // a path this repository owns
 	if err != nil {
 		return ""
 	}
 	if m := providerPattern.FindStringSubmatch(string(body)); m != nil {
-		return m[1]
+		return fmt.Sprintf("`%s %s`", m[1], m[2])
 	}
 	return ""
 }
 
-func renderClients(workflow, fixture string) (string, error) {
+// versionCell renders what CI installs for one client, plus the provider
+// constraints when the client answers through a Terraform provider.
+func versionCell(version string, proofs []clientProof, root string) string {
+	var pins []string
+	for _, proof := range proofs {
+		if proof.suite != terraformSuite {
+			continue
+		}
+		if pin := terraformProviderPin(root, proof.provider); pin != "" {
+			pins = append(pins, pin)
+		}
+	}
+	switch len(pins) {
+	case 0:
+		return version
+	case 1:
+		return version + " with provider " + pins[0]
+	default:
+		return version + " with providers " + strings.Join(pins, ", ")
+	}
+}
+
+func renderClients(workflow, root string) (string, error) {
 	versions, err := pinnedVersions(workflow)
 	if err != nil {
 		return "", err
+	}
+	proofs, err := proofsPerClient(workflow)
+	if err != nil {
+		return "", err
+	}
+
+	// A client CI drives and this file does not list would be proven and
+	// invisible, which is the exact shape of the defect that produced this
+	// change. Refuse rather than print a table that is short by one row.
+	listed := map[string]bool{}
+	for _, c := range clientSources {
+		listed[c.name] = true
+	}
+	unlisted := make([]string, 0, len(proofs))
+	for name := range proofs {
+		if !listed[name] {
+			unlisted = append(unlisted, name)
+		}
+	}
+	if len(unlisted) > 0 {
+		sort.Strings(unlisted)
+		return "", fmt.Errorf(
+			"%s drives %s and clientSources in internal/cli/docs_clients.go does not "+
+				"list it: the table would leave out a client CI proves, which is what "+
+				"this generator exists to stop",
+			workflow, strings.Join(unlisted, ", "))
 	}
 
 	var b strings.Builder
@@ -89,12 +220,23 @@ func renderClients(workflow, fixture string) (string, error) {
 		if !ok {
 			version = "unpinned"
 		}
-		if c.name == "Terraform" {
-			if p := terraformProvider(fixture); p != "" {
-				version = fmt.Sprintf("%s with provider `scaleway/scaleway %s`", version, p)
+
+		mine := proofs[c.name]
+		names := make([]string, 0, len(mine))
+		for _, proof := range mine {
+			name := providerName(proof.provider)
+			if len(names) == 0 || names[len(names)-1] != name {
+				names = append(names, name)
 			}
 		}
-		fmt.Fprintf(&b, "| %s | %s | %s |\n", c.name, version, c.provider)
+		// A listed client no workflow drives is the mirror of the case refused
+		// above, and it says so in the cell rather than reading as a proof.
+		providers := "not run in CI"
+		if len(names) > 0 {
+			providers = strings.Join(names, ", ")
+		}
+
+		fmt.Fprintf(&b, "| %s | %s | %s |\n", c.name, versionCell(version, mine, root), providers)
 	}
 	b.WriteString("\nThese are the versions the conformance workflow installs and runs on every\n")
 	b.WriteString("pull request and nightly. A newer client is not known to work until the pin\n")

--- a/internal/cli/docs_clients_test.go
+++ b/internal/cli/docs_clients_test.go
@@ -1,0 +1,136 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The client matrix names every provider CI drives a client against.
+//
+// The column used to be a constant — `{"Terraform", "TERRAFORM_VERSION",
+// "Scaleway"}` — under a marker reading "Do not edit by hand", while
+// conformance.yml ran tools/conformance/outscale/terraform.sh on every pull
+// request. This is the refusing half of that: with the constant back, the row
+// says Scaleway alone and the Outscale assertion below goes red.
+func TestTheClientMatrixCreditsEveryProviderCIProves(t *testing.T) {
+	workflow := filepath.Join("..", "..", ".github", "workflows", "conformance.yml")
+	root := filepath.Join("..", "..", conformanceRoot)
+
+	rendered, err := renderClients(workflow, root)
+	if err != nil {
+		t.Fatalf("render the client matrix: %v", err)
+	}
+
+	// The accepting half, on the workflow as it stands. Each of these is a
+	// provider a Terraform fixture proves today; a row missing one is the defect.
+	for _, client := range []string{"Terraform", "OpenTofu"} {
+		row := rowFor(t, rendered, client)
+		for _, provider := range []string{"Scaleway", "Outscale"} {
+			if !strings.Contains(row, provider) {
+				t.Errorf("the %s row does not credit %s, and CI runs its Terraform "+
+					"suite on every pull request:\n  %s", client, provider, row)
+			}
+		}
+		// The constraint, per provider, read from that provider's own fixture.
+		for _, pin := range []string{"`scaleway/scaleway ", "`outscale/outscale "} {
+			if !strings.Contains(row, pin) {
+				t.Errorf("the %s row states no %sconstraint: the Terraform version "+
+					"alone proves nothing, what answers the emulator is the provider:\n  %s",
+					client, pin, row)
+			}
+		}
+	}
+
+	// And the single-provider clients stay single, so the derivation is not
+	// simply crediting everything to everyone.
+	if row := rowFor(t, rendered, "`oapi-cli`"); strings.Contains(row, "Scaleway") {
+		t.Errorf("the oapi-cli row credits Scaleway, which no workflow drives it against:\n  %s", row)
+	}
+}
+
+// A workflow that stops running a suite drops the provider from the row.
+//
+// Without this, the assertions above would also pass on a table that credited
+// every provider to every client unconditionally. Asserted on a copy of the real
+// file with one invocation removed, the way the status table's test does.
+func TestAClientLosesAProviderCIStopsDriving(t *testing.T) {
+	workflow := filepath.Join("..", "..", ".github", "workflows", "conformance.yml")
+	root := filepath.Join("..", "..", conformanceRoot)
+
+	body, err := os.ReadFile(workflow)
+	if err != nil {
+		t.Fatalf("read the workflow: %v", err)
+	}
+	withoutOutscaleTerraform := strings.Replace(string(body),
+		"run: tools/conformance/outscale/terraform.sh", "run: true #", 1)
+	if withoutOutscaleTerraform == string(body) {
+		t.Fatal("the workflow no longer runs tools/conformance/outscale/terraform.sh: " +
+			"either it was removed, in which case the table must have lost Outscale, " +
+			"or this test is measuring a file it does not understand")
+	}
+
+	trimmed := filepath.Join(t.TempDir(), "conformance.yml")
+	if err := os.WriteFile(trimmed, []byte(withoutOutscaleTerraform), 0o600); err != nil {
+		t.Fatalf("write the trimmed workflow: %v", err)
+	}
+
+	rendered, err := renderClients(trimmed, root)
+	if err != nil {
+		t.Fatalf("render from the trimmed workflow: %v", err)
+	}
+	row := rowFor(t, rendered, "Terraform")
+	if strings.Contains(row, "Outscale") {
+		t.Errorf("Terraform still credits Outscale after CI stopped running its suite, "+
+			"so the column is not read from the workflow:\n  %s", row)
+	}
+	if strings.Contains(row, "outscale/outscale") {
+		t.Errorf("the row still pins the Outscale provider after CI stopped running "+
+			"its suite:\n  %s", row)
+	}
+	// The accepting half of the same copy: Scaleway is untouched, so the removal
+	// took one proof rather than breaking the scan.
+	if !strings.Contains(row, "Scaleway") {
+		t.Errorf("Scaleway vanished with Outscale, so the trimmed workflow broke the "+
+			"scan instead of removing one invocation:\n  %s", row)
+	}
+}
+
+// A client CI drives and clientSources does not list is refused, not dropped.
+//
+// This is the understatement defect in its general form: the table would be
+// short by a row and read as complete.
+func TestAnUnlistedClientIsRefusedRatherThanLeftOut(t *testing.T) {
+	workflow := filepath.Join("..", "..", ".github", "workflows", "conformance.yml")
+	root := filepath.Join("..", "..", conformanceRoot)
+
+	// clientOf maps the suite; clientSources is what prints. Name a client in the
+	// first that the second does not carry, which is what adding a suite without
+	// finishing the job looks like.
+	original := clientOf["exo-cli"]
+	clientOf["exo-cli"] = "`exo`, `exo-experimental`"
+	t.Cleanup(func() { clientOf["exo-cli"] = original })
+
+	_, err := renderClients(workflow, root)
+	if err == nil {
+		t.Fatal("the matrix rendered while CI drove a client it does not list, so a " +
+			"proof would be invisible on the page")
+	}
+	if !strings.Contains(err.Error(), "exo-experimental") {
+		t.Errorf("the refusal does not name the missing client, which is the one thing "+
+			"a reader needs to fix it: %v", err)
+	}
+}
+
+// rowFor returns the rendered table row whose first cell is client.
+func rowFor(t *testing.T, rendered, client string) string {
+	t.Helper()
+	for _, line := range strings.Split(rendered, "\n") {
+		if strings.HasPrefix(line, "| "+client+" |") {
+			return line
+		}
+	}
+	t.Fatalf("no row for %s in the rendered matrix:\n%s", client, rendered)
+	return ""
+}

--- a/internal/cli/docs_status.go
+++ b/internal/cli/docs_status.go
@@ -75,15 +75,37 @@ var statusRows = []providerRow{
 	{"Exoscale", "REST `/v2/<resource>`, asynchronous operations", "starter"},
 }
 
-// clientsProvenInCI reads the workflow and answers, per provider, the clients it
-// drives. The returned map is keyed by the lowercase provider directory.
-func clientsProvenInCI(workflowPath string) (map[string][]string, error) {
+// suiteRun is one conformance invocation the workflow makes: a provider, the
+// suite script, and the clients that script drives as clientOf spells them.
+//
+// Two tables read this one scan. The status table above asks which clients prove
+// a provider; the client matrix in docs_clients.go asks the transpose, which
+// provider a client proves. Deriving both from the same pass is the point: a
+// second reader of the same workflow would be a second chance for the two tables
+// to disagree, which is the defect each of them was filed for.
+type suiteRun struct {
+	provider string
+	suite    string
+	// clients is the cell clientOf holds, verbatim. One suite can name several
+	// clients — `terraform.sh` is driven by both Terraform and OpenTofu — and the
+	// two consumers want it differently: the status table prints the cell whole,
+	// the client matrix splits it. Splitting here would reorder the status table
+	// for no reason, so each caller splits when it needs to.
+	clients string
+}
+
+// suitesRunInCI scans the workflow for conformance invocations.
+//
+// An unmapped suite is an error rather than a skip: a new client proving a
+// provider must appear in both tables, and silently dropping the one name nobody
+// mapped is how a table understates what is proven.
+func suitesRunInCI(workflowPath string) ([]suiteRun, error) {
 	body, err := os.ReadFile(workflowPath) //nolint:gosec // a path this repository owns
 	if err != nil {
 		return nil, err
 	}
 
-	found := map[string]map[string]bool{}
+	var runs []suiteRun
 	for _, match := range suiteInvocation.FindAllStringSubmatch(string(body), -1) {
 		provider, suite := match[1], match[2]
 		client, known := clientOf[suite]
@@ -97,10 +119,25 @@ func clientsProvenInCI(workflowPath string) (map[string][]string, error) {
 		if client == "" {
 			continue
 		}
-		if found[provider] == nil {
-			found[provider] = map[string]bool{}
+		runs = append(runs, suiteRun{provider: provider, suite: suite, clients: client})
+	}
+	return runs, nil
+}
+
+// clientsProvenInCI reads the workflow and answers, per provider, the clients it
+// drives. The returned map is keyed by the lowercase provider directory.
+func clientsProvenInCI(workflowPath string) (map[string][]string, error) {
+	runs, err := suitesRunInCI(workflowPath)
+	if err != nil {
+		return nil, err
+	}
+
+	found := map[string]map[string]bool{}
+	for _, run := range runs {
+		if found[run.provider] == nil {
+			found[run.provider] = map[string]bool{}
 		}
-		found[provider][client] = true
+		found[run.provider][run.clients] = true
 	}
 
 	out := map[string][]string{}


### PR DESCRIPTION
# Summary

The README's client matrix sits under a marker reading "Generated by `mise run docs:coverage`. Do not edit by hand". One file away, its `Emulated provider` column was this:

```go
{"Terraform", "TERRAFORM_VERSION", "Scaleway"},
{"OpenTofu",  "TOFU_VERSION",      "Scaleway"},
```

while `.github/workflows/conformance.yml` has been running `tools/conformance/outscale/terraform.sh` on every pull request, under both the terraform and the opentofu legs. Generated is not derived, and the marker is what made it hard to see: a reader who distrusts a hand-written table does not distrust one that says nobody writes it.

**Before**

| Client | Version proven in CI | Emulated provider |
|---|---|---|
| Terraform | 1.13.3 with provider `scaleway/scaleway ~> 2.79` | Scaleway |
| OpenTofu | 1.12.5 | Scaleway |

**After**

| Client | Version proven in CI | Emulated provider |
|---|---|---|
| Terraform | 1.13.3 with providers `outscale/outscale ~> 1.7`, `scaleway/scaleway ~> 2.79` | Outscale, Scaleway |
| OpenTofu | 1.12.5 with providers `outscale/outscale ~> 1.7`, `scaleway/scaleway ~> 2.79` | Outscale, Scaleway |

## How

`suitesRunInCI` is now the single scan of the workflow, and both README tables read it: the status table asks which clients prove a provider, this one asks the transpose. Deriving both from one pass is the point, since a second reader of the same file is a second chance for the two tables to disagree. An unmapped suite stays an error rather than a skip.

Each row answering through a Terraform provider states the constraint that provider's own fixture pins, read from `tools/conformance/<provider>/terraform/main.tf` rather than restated here. OpenTofu carried no constraint at all before, and drives the same two fixtures.

The mirror case is refused rather than dropped: a client CI drives that `clientSources` does not list makes `renderClients` fail by name. A table short by one row reads as complete.

## Why an understated proof is worth a fix

The second external audit recommended deleting Terraform from the README's Outscale row, on the strength of this column. The suite that would have erased applies twenty-one resources, plans empty and destroys clean. A table that undersells is read as evidence the proof does not exist, and acted on.

## Falsification

Three mutations in a copy outside the repository, each one compiling first (`go vet`), each named test biting:

| Mutation | Test | Verdict |
|---|---|---|
| the Scaleway constant put back | `TestTheClientMatrixCreditsEveryProviderCIProves` | red |
| every client credits every provider | `TestAClientLosesAProviderCIStopsDriving` | red |
| the unlisted-client refusal dropped | `TestAnUnlistedClientIsRefusedRatherThanLeftOut` | red |

Package green after restoration. The second mutation is what stops the first test from passing on a table that credits everyone.

## Type of change

- [ ] A route added or changed
- [x] Bug fix
- [ ] Refactor
- [x] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes (gofmt, vet, golangci-lint, `go test -race`)
- [x] No new external Go dependency
- [x] `internal/core` still knows no provider — the diff is entirely in `internal/cli`
- [x] Nothing in the diff could be written identically for another provider. `providerName` derives the spelling from the directory instead of holding a table of three names, which is the same rule applied one level down

### When a model wrote a substantive part of this

- [x] An `Assisted-by:` trailer names the tool and the model version
- [ ] **N/A, stated rather than ticked.** `mise run conformance` was not run: the diff touches the documentation generator and no route, no response shape and no handler. What was run is `mise run check`, `feint docs --check` (0), and the falsification above. Saying so is cheaper than a box ticked on a proof nobody took
- [x] Every name in the diff comes from a file in this repository — the workflow's suite invocations and the fixtures' `required_providers` blocks. Nothing is restated from memory, which is the change

### When a route is added or changed

N/A — no route is touched.

### When behaviour a client can observe changes

- [x] The README's generated tables regenerated (`mise run docs:coverage`)
- [ ] N/A for `docs/limits.md` — no documented limit moved

### When `.github/workflows/` is touched

N/A — the workflow is read, never modified.

### When a machine runtime is involved

N/A.

## Related issues

Closes #155
