### PR TITLE
docs(roadmap): the Now section says what merged, not what was being built

### DIFF
--- a/docs/roadmap.fr.md
+++ b/docs/roadmap.fr.md
@@ -38,7 +38,9 @@ leurs comptes le 30 juillet 2026 et chacun était faux quinze jours plus tard
 
 ### L'image conteneur, control plane seul, livrée avec la release
 
-C'est une décision plus qu'une fonctionnalité, donc la voici par écrit :
+**Livrée par #150**, et publiée pour la première fois avec la 0.8.0.
+
+C'était une décision plus qu'une fonctionnalité, donc la voici par écrit :
 **l'image exécute `feint serve` avec `--vm off`, et n'émule rien d'autre que le
 plan de contrôle.** La question qui la retenait (où atterriraient des machines
 démarrées dans un conteneur) est résolue comme le reste du projet la résout
@@ -47,19 +49,19 @@ sans lui en CI, et `serve` au premier plan est exactement ce qu'attend un point
 d'entrée de conteneur. Qui a besoin de vraies machines exécute le binaire sur
 un hôte avec Incus ; c'est le chemin documenté et il le reste.
 
-Pourquoi maintenant : l'image est le format dans lequel un émulateur se
-consomme. Chaque canal d'adoption plus bas (testcontainers, un fichier compose,
-un bloc `services:` de GitLab CI) l'attend, et chaque semaine sans image est
-une semaine où un utilisateur potentiel écrit le nom d'un concurrent dans son
-fichier compose. Ce que l'image ne doit jamais devenir : le mode nominal. Le
-binaire statique qui se détache tout seul est la seule chose qu'aucun émulateur
-comparable ne sait faire, et mener avec Docker l'effacerait.
+Pourquoi elle est passée avant les canaux d'adoption : l'image est le format
+dans lequel un émulateur se consomme, et chaque canal plus bas (testcontainers,
+un fichier compose, un bloc `services:` de GitLab CI) l'attend. Ce que l'image
+ne doit jamais devenir : le mode nominal. Le binaire statique qui se détache
+tout seul est la seule chose qu'aucun émulateur comparable ne sait faire, et
+mener avec Docker l'effacerait.
 
-**Preuve :** le workflow de release pousse une image multi-architecture sur
-ghcr.io, et un job de CI fait tourner la suite de conformance Scaleway depuis
-l'hôte contre l'émulateur qui tourne dans cette image.
+**Prouvée par :** `release.yml` publie une image multi-architecture sur
+ghcr.io, et le job `image` de `conformance.yml` fait tourner la suite de
+conformance Scaleway depuis l'hôte contre l'émulateur qui tourne dans cette
+image, sur chaque pull request.
 
-### Le scénario golden image sur Scaleway : une moitié livrée, l'autre en cours
+### Le scénario golden image sur Scaleway : les deux moitiés livrées
 
 Le manque le plus coûteux de la surface servie n'a jamais été un pourcentage,
 c'est un scénario : construire une image avec Packer ou un script `scw`,
@@ -76,15 +78,20 @@ le refus, #115 la décision). La colonne « untriaged » d'`instance` dans les
 tableaux générés lit zéro, par décision : ce qui n'a pas été servi (les
 placement groups entre autres) est décliné avec sa raison dans le pack.
 
-**La seconde moitié est SW-3 (#8), en cours.** `block/v1` et le volume racine
-`sbs_volume` : le piège mesuré de [limits.md](limits.md) où le provider relit
-un volume à travers une API qu'aucun pack ne sert, et où l'apply meurt sur un
-404. Cet élément se termine quand cette section de limites se termine.
+**La seconde moitié est livrée avec SW-3 (#8, mergée en #138).** `block/v1` et
+le volume racine `sbs_volume` ont refermé le piège mesuré de
+[limits.md](limits.md), où le provider relisait un volume à travers une API
+qu'aucun pack ne servait et où l'apply mourait sur un 404. Cette page ouvre
+désormais sa section volume racine sur `sbs_volume` qui fonctionne, ce qui était
+la définition de la fin de cet élément.
 
-**Preuve :** `terraform apply` avec un `scaleway_block_volume` et un volume
-racine `sbs_volume`, second plan vide, destroy propre, en conformance ; et la
-section `b_ssd`/`sbs_volume` de [limits.md](limits.md) supprimée plutôt que
-mise à jour.
+Un détail mérite d'être gardé, parce qu'il a été trouvé par le client et non en
+lisant le SDK : `scw` 2.56.3 appelle `/block/v1alpha1` là où le provider
+Terraform appelle `/block/v1`. Les deux sont servis, par les mêmes handlers.
+
+**Prouvée par :** `terraform apply` avec un `scaleway_block_volume` et un volume
+racine `sbs_volume`, un second plan vide et un destroy propre, dans la suite de
+conformance Scaleway.
 
 ### Exoscale était étiqueté preview, et l'étiquette est tombée à EXO-2
 
@@ -221,13 +228,13 @@ documents archivés expliquent comment chaque lot a été découpé.
    Exoscale** : **faite.** OSC-2 a amené `terraform apply`, second plan vide
    et destroy propre en conformance ; EXO-2 a amené le cycle de vie sous `exo`
    et fait tomber l'étiquette *preview*, comme consigné plus haut.
-3. **Le scénario golden image Scaleway** : **à moitié faite.** SW-2 (#7) est
-   mergée ; SW-3 (#8) est en cours. Voir l'élément « Maintenant », qui est
-   cette vague.
-4. **Des réseaux qui routent** : **Outscale fait, deux ouverts.** OSC-3 est
-   mergée : le `examples/net_vm` du provider applique, re-planifie vide et
-   détruit. SW-4 (#11, cycle de vie IPAM et le reste de vpc) et EXO-3 (#9,
-   réseaux privés) restent, groupés sous la règle de preuve réseau : sous OVN
+3. **Le scénario golden image Scaleway** : **faite.** SW-2 (#7) mergée en #131,
+   SW-3 (#8) en #138. Voir l'élément « Maintenant », qui est cette vague.
+4. **Des réseaux qui routent** : **Outscale et Exoscale faits, un ouvert.**
+   OSC-3 est mergée : le `examples/net_vm` du provider applique, re-planifie
+   vide et détruit. EXO-3 (#9) est mergée en #161 : un réseau privé est une
+   plage, et un attachement y prend un bail. SW-4 (#11, cycle de vie IPAM et le
+   reste de vpc) reste, sous la règle de preuve réseau : sous OVN
    l'affirmation est vérifiée, ailleurs elle est sautée, et aucun document ne
    dit « isolé » sans nommer le mode.
 5. **Le stockage sur les deux starters** : **Outscale fait, Exoscale
@@ -263,10 +270,10 @@ comme affirmation.
 | **OSC-2** | 2 | `ProductCodes`, mot de passe admin, tags, volume racine : le premier `terraform apply` Outscale | fait (#6) |
 | **EXO-2** | 2 | cycle de vie, groupes de sécurité, IP élastiques : l'étiquette *preview* tombe | fait (#5) |
 | **SW-2** | 3 | snapshots, images, attachement de volume | fait (#7) |
-| **SW-3** | 3 | `block/v1` et le volume racine `sbs_volume` | en cours (#8) |
+| **SW-3** | 3 | `block/v1` et le volume racine `sbs_volume` | faite (#8) |
 | **OSC-3** | 4 | réseau routable : `examples/net_vm` applique | fait (#10) |
 | **SW-4** | 4 | cycle de vie IPAM et le reste de vpc | ouvert (#11) |
-| **EXO-3** | 4 | réseaux privés et attachement d'instance | ouvert (#9) |
+| **EXO-3** | 4 | réseaux privés et attachement d'instance | faite (#9) |
 | **OSC-4** | 5 | volumes, snapshots, images | fait (#13) |
 | **EXO-4** | 5 | stockage bloc | ouvert (#12) |
 | **SW-5** | 6 | `lb/v1` ZonedAPI | ouvert (#17) |
@@ -709,25 +716,33 @@ c'est la réponse pour quiconque a besoin de S3 ce mois-ci.
 celles du README : `scw` pointé sur MinIO via `SCW_S3_ENDPOINT` dépose et
 relit un objet.
 
-### La compatibilité des snapshots entre versions : déposée comme #133, comportement actuel mesuré
+### La compatibilité des snapshots entre versions : réglée par #133, mergée en #140
 
-`feint snapshot` est livré, donc la question a cessé d'être hypothétique, et
-la revue externe a forcé la mesure que cet élément attendait : aujourd'hui le
-snapshot ne porte **aucun champ de version**, et `store.Restore` décode avec
-`encoding/json` nu, donc **un champ que cette version ne connaît pas est
-abandonné en silence et la restauration réussit** ; exactement le best effort
-que ce projet refuse partout ailleurs. #133 porte la règle (*compris ou
-refusé*), le format (`{"format": "feint-snapshot", "version": 1, ...}`) et la
-table de comportement pour chaque cas, y compris un snapshot hérité en
-tableau nu. Le cas adjacent que cet élément a toujours nommé (charger un
-snapshot pendant qu'un runtime de machines tourne, ce qui remplace le store
-sans réconcilier les machines réelles) appartient à #135, où vivent le crash
-et le redémarrage déterministes.
+`feint snapshot` est livré, donc la question a cessé d'être hypothétique, et une
+revue externe a forcé la mesure que cet élément attendait : le snapshot ne
+portait **aucun champ de version**, et `store.Restore` décodait avec
+`encoding/json` nu, donc un champ que cette version ne connaissait pas était
+abandonné en silence et la restauration réussissait, exactement le best effort
+que ce projet refuse partout ailleurs.
 
-**Preuve :** celle de #133 : une fixture de snapshot par version se restaure
-en aller-retour complet ; une fixture portant un champ d'enveloppe inconnu est
-refusée en nommant le champ ; une version future est refusée en nommant les
-deux versions.
+C'est désormais une enveloppe, `{"format": "feint-snapshot", "version": 1,
+"resources": [...]}`, et `Restore` refuse ce dont il ne peut pas rendre compte :
+un autre format, une autre version, un champ inconnu. Un tableau nu hérité est
+reconnu comme tel et refusé par son nom, plutôt qu'au travers d'une erreur de
+décodeur illisible. Faire bouger `snapshotVersion` est un changement cassant au
+sens de RELEASING.fr.md, ce qui est précisément ce qui rend le champ utile.
+
+Le cas adjacent que cet élément a toujours nommé (charger un snapshot pendant
+qu'un runtime de machines tourne, ce qui remplace le store sans réconcilier les
+machines réelles) appartenait à #135, close elle aussi, mergée en #141 : ce qui
+survit à un émulateur mort est dit une fois, constaté au redémarrage, et prouvé
+par un kill.
+
+**Prouvée par :** la table de comportement que #133 réclamait, un test par
+ligne, dans `internal/core/store` : `TestASnapshotOfThisVersionRoundTrips`,
+`TestASnapshotFromTheFutureIsRefused`,
+`TestALegacyBareArrayIsRefusedWithARemedy` et
+`TestARestoredResourceKeepsItsIdentity`.
 
 ### Un quatrième provider
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -31,7 +31,9 @@ archives now, under [history/](history/).
 
 ### The container image, control-plane only, shipped with the release
 
-This is a decision more than a feature, so here it is in writing: **the image
+**Landed with #150**, and first published with 0.8.0.
+
+This was a decision more than a feature, so here it is in writing: **the image
 runs `feint serve` with `--vm off`, and emulates nothing but the control
 plane.** The question that held it back, where machines started inside a
 container would land, is answered the way the rest of the project already
@@ -40,18 +42,17 @@ without one in CI, and `serve` in the foreground is exactly what a container
 entrypoint wants. Anyone who needs real machines runs the binary on a host with
 Incus, which is the documented path and stays so.
 
-Why now: the image is the format an emulator is consumed in. Every adoption
-channel below (testcontainers, a compose file, a `services:` block in GitLab CI)
-waits on it, and each week without one is a week a potential user writes a
-competitor's name into their compose file instead. What the image must never
-become is the nominal mode: the self-detaching static binary is the one thing
-none of the comparable emulators can do, and leading with Docker would erase it.
+Why it came before the adoption channels: the image is the format an emulator is
+consumed in, and every channel below (testcontainers, a compose file, a
+`services:` block in GitLab CI) waits on it. What the image must never become is
+the nominal mode: the self-detaching static binary is the one thing none of the
+comparable emulators can do, and leading with Docker would erase it.
 
-**Evidence:** the release workflow pushes a multi-arch image to ghcr.io, and a
-CI job runs the Scaleway conformance suite from the host against the emulator
-running inside that image.
+**Proven by:** `release.yml` publishes a multi-arch image to ghcr.io, and
+`conformance.yml`'s `image` job runs the Scaleway conformance suite from the
+host against the emulator running inside that image, on every pull request.
 
-### The golden-image workflow on Scaleway: half landed, half in progress
+### The golden-image workflow on Scaleway: both halves landed
 
 The most expensive gap in the served surface was never a percentage, it was a
 scenario: build an image with Packer or a `scw` script, attach a volume with an
@@ -67,15 +68,19 @@ refusal, #115 the decision). The `instance` untriaged column in the generated
 tables reads zero, by decision: what was not served (placement groups among
 them) is declined with its reason in the pack.
 
-**The second half is SW-3 (#8), in progress.** `block/v1` and the `sbs_volume`
-root volume — the measured trap in [limits.md](limits.md) where the provider
-reads a volume back through an API no pack serves, and the apply dies on a 404.
-This item ends when that limit's section ends.
+**The second half landed with SW-3 (#8, merged as #138).** `block/v1` and the
+`sbs_volume` root volume closed the measured trap in [limits.md](limits.md),
+where the provider read a volume back through an API no pack served and the
+apply died on a 404. That page now opens its root-volume section with
+`sbs_volume` working, which is what ending the item meant.
 
-**Evidence:** `terraform apply` with a `scaleway_block_volume` and an
-`sbs_volume` root volume, empty second plan, clean destroy, in conformance —
-and the `b_ssd`/`sbs_volume` section of [limits.md](limits.md) deleted rather
-than updated.
+One detail worth keeping, because it was found by the client rather than by
+reading the SDK: `scw` 2.56.3 calls `/block/v1alpha1` while the Terraform
+provider calls `/block/v1`. Both are served, from the same handlers.
+
+**Proven by:** `terraform apply` with a `scaleway_block_volume` and an
+`sbs_volume` root volume, an empty second plan and a clean destroy, in the
+Scaleway conformance suite.
 
 ### Exoscale was labelled preview, and the label came off at EXO-2
 
@@ -207,12 +212,13 @@ the archived documents explain how each batch was cut.
    Exoscale** — **done.** OSC-2 brought `terraform apply`, an empty second
    plan and a clean destroy into conformance; EXO-2 brought the lifecycle
    under `exo` and took the *preview* label off, as recorded above.
-3. **The Scaleway golden-image scenario** — **half done.** SW-2 (#7) is
-   merged; SW-3 (#8) is in progress. See the "Now" item, which is this wave.
-4. **Networks that route** — **Outscale done, two open.** OSC-3 is merged: the
-   provider's own `examples/net_vm` applies, re-plans empty and destroys.
-   SW-4 (#11, IPAM lifecycle and the rest of vpc) and EXO-3 (#9, private
-   networks) remain, grouped under the network-evidence rule: under OVN the
+3. **The Scaleway golden-image scenario** — **done.** SW-2 (#7) merged as #131,
+   SW-3 (#8) as #138. See the "Now" item, which is this wave.
+4. **Networks that route** — **Outscale and Exoscale done, one open.** OSC-3 is
+   merged: the provider's own `examples/net_vm` applies, re-plans empty and
+   destroys. EXO-3 (#9) merged as #161: a private network is a range, and an
+   attach leases from it. SW-4 (#11, IPAM lifecycle and the rest of vpc)
+   remains, under the network-evidence rule: under OVN the
    claim is asserted, elsewhere it is skipped, and no document says "isolated"
    without naming the mode.
 5. **Storage on the two starters** — **Outscale done, Exoscale open.** OSC-4
@@ -244,10 +250,10 @@ the table carries the state as an issue reference rather than a claim.
 | **OSC-2** | 2 | `ProductCodes`, admin password, tags, root volume — the first Outscale `terraform apply` | done (#6) |
 | **EXO-2** | 2 | instance lifecycle, security groups, elastic IPs — the *preview* label comes off | done (#5) |
 | **SW-2** | 3 | snapshots, images, volume attach | done (#7) |
-| **SW-3** | 3 | `block/v1` and the `sbs_volume` root volume | in progress (#8) |
+| **SW-3** | 3 | `block/v1` and the `sbs_volume` root volume | done (#8) |
 | **OSC-3** | 4 | routable networking — `examples/net_vm` applies | done (#10) |
 | **SW-4** | 4 | IPAM lifecycle and the rest of vpc | open (#11) |
-| **EXO-3** | 4 | private networks and instance attachment | open (#9) |
+| **EXO-3** | 4 | private networks and instance attachment | done (#9) |
 | **OSC-4** | 5 | volumes, snapshots, images | done (#13) |
 | **EXO-4** | 5 | block storage | open (#12) |
 | **SW-5** | 6 | `lb/v1` ZonedAPI | open (#17) |
@@ -672,23 +678,31 @@ needs S3 this month.
 **Evidence:** the page's commands are executed in CI the way the README's are:
 `scw` pointed at MinIO through `SCW_S3_ENDPOINT` puts and gets an object.
 
-### Snapshot compatibility across versions — filed as #133, with the current behaviour measured
+### Snapshot compatibility across versions — settled by #133, merged as #140
 
-`feint snapshot` shipped, so the question stopped being hypothetical, and the
-external review forced the measurement this item was waiting for: today the
-snapshot carries **no version field**, and `store.Restore` decodes with plain
-`encoding/json`, so **a field this version does not know is silently dropped
-and the restore succeeds** — the exact best-effort this project refuses
-everywhere else. #133 carries the rule (*understood or refused*), the format
-(`{"format": "feint-snapshot", "version": 1, ...}`), and the behaviour table
-for every case including a legacy bare-array snapshot. The adjacent case this
-item always named — loading a snapshot while a machine runtime runs, which
-replaces the store without reconciling the real machines — is #135's, where
-crash and restart determinism live.
+`feint snapshot` shipped, so the question stopped being hypothetical, and an
+external review forced the measurement this item was waiting for: the snapshot
+carried **no version field**, and `store.Restore` decoded with plain
+`encoding/json`, so a field that version did not know was silently dropped and
+the restore succeeded — the exact best-effort this project refuses everywhere
+else.
 
-**Evidence:** as #133 states — a fixture snapshot per version restores
-round-trip complete; one carrying an unknown envelope field is refused naming
-the field; a future version is refused naming both versions.
+It is now an envelope, `{"format": "feint-snapshot", "version": 1,
+"resources": [...]}`, and `Restore` refuses what it cannot account for: another
+format, another version, an unknown field. A legacy bare array is recognised as
+such and refused by name rather than through a decoder error nobody can read.
+Bumping `snapshotVersion` is a breaking change under RELEASING.md, which is what
+makes the field worth carrying.
+
+The adjacent case this item always named — loading a snapshot while a machine
+runtime runs, which replaces the store without reconciling the real machines —
+belonged to #135, and that closed too, merged as #141: what survives a dead
+emulator is stated once, noticed at restart, and proven by a kill.
+
+**Proven by:** the behaviour table #133 asked for, one test per row, in
+`internal/core/store`: `TestASnapshotOfThisVersionRoundTrips`,
+`TestASnapshotFromTheFutureIsRefused`, `TestALegacyBareArrayIsRefusedWithARemedy`
+and `TestARestoredResourceKeepsItsIdentity`.
 
 ### A fourth provider
 


### PR DESCRIPTION
# Summary

`docs/roadmap.md` and `docs/roadmap.fr.md` described as being built three things `main` already proves, and a fourth turned up while checking them. Every claim below was verified against the tracker before being rewritten.

| Claim, before | Reality |
|---|---|
| The container image, urgent and unbuilt: *"each week without one is a week a potential user writes a competitor's name into their compose file"* | Merged as #150, shipped with 0.8.0 |
| *"The second half is SW-3 (#8), in progress"* — in the prose, the sequence list and the wave table | #8 closed, merged as #138 |
| *"today the snapshot carries no version field, and `store.Restore` decodes with plain `encoding/json`"* | #133 closed as #140, and #135 with it as #141 |
| EXO-3 (#9) *"open"* in the sequence and the wave table — **not in #157**, found while checking the rest | #9 closed, merged as #161 |

## What each section says now

- **The image**: `release.yml` publishes the multi-arch image to ghcr.io, and `conformance.yml`'s `image` job runs the Scaleway suite against the emulator inside that image on every pull request.
- **SW-3**: both halves landed, and `limits.md` already opens its root-volume section with `sbs_volume` working. The one detail kept is the `/block/v1alpha1` versus `/block/v1` split between `scw` 2.56.3 and the Terraform provider — found by running the client, not by reading the SDK, and both are served from the same handlers.
- **The snapshot**: the envelope, what `Restore` refuses (another format, another version, an unknown field, a legacy bare array refused by name), and that bumping `snapshotVersion` is breaking under RELEASING.md. The four tests holding the behaviour table are named rather than promised: `TestASnapshotOfThisVersionRoundTrips`, `TestASnapshotFromTheFutureIsRefused`, `TestALegacyBareArrayIsRefusedWithARemedy`, `TestARestoredResourceKeepsItsIdentity`.
- **EXO-3**: done, merged as #161.

## Why this is not put on a rail

#157 asks for the generated-block treatment where a claim is a figure an artefact can produce. None of these is one: they are issue states, and `feint docs --check` runs offline and cannot read a tracker.

An internal-consistency test would not have caught it either — the prose and the wave table agreed with each other and were both wrong. So these markers stay editorial, and the change says so rather than adding a mechanism that cannot work. That is the issue's own reading, and it is why it names each false claim instead of asking for one.

## The direction of the error

Every one of these **understated**. A reader planning against "Now" concluded the image did not exist and a snapshot was unsafe to keep, so three of the project's strongest recent proofs were invisible in the one document that says what is being built. This repository has already measured what an understated proof costs: an external review recommended deleting the Outscale Terraform suite from the README because a table did not claim it.

## Type of change

- [ ] A route added or changed
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes — unchanged, the diff is two Markdown files and no Go file is touched
- [x] No new external Go dependency
- [x] `internal/core` still knows no provider
- [x] Nothing in the diff could be written identically for another provider

### When a model wrote a substantive part of this

- [x] An `Assisted-by:` trailer names the tool and the model version
- [ ] **N/A, stated rather than ticked.** `mise run conformance` was not run: no Go file, no route, no response shape is touched. Every factual claim was instead verified against the tracker — `gh issue view` on #7, #8, #9, #11, #133, #135, #150 — and against the files named, before being written
- [x] Every name in the diff comes from this repository or from the tracker, and I can say which

### When a route is added or changed

N/A.

### When behaviour a client can observe changes

- [ ] N/A — the roadmap carries no generated block, and `feint docs --check` does not read it

### When `.github/workflows/` is touched

N/A — workflows are named, never modified.

### When a machine runtime is involved

N/A.

## Related issues

Closes #157
