### PR TITLE
feat(probe): the probe seeds what it needs, so a refusal is a verdict rather than a shortage

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -36,6 +36,35 @@ change ni l'un ni l'autre a sa place dans `git log`.
   changer une surface gelée à dessein est dans RELEASING.fr.md (« Surfaces
   gelées »).
 
+- **La sonde sème ce dont elle a besoin, si bien qu'un refus est un verdict et
+  non une pénurie** (#163). Avant de sonder une opération, la sonde fait
+  désormais exister ce que cette opération réclame, à partir du schéma de
+  requête du contrat lui-même et des ressources qu'elle a créées plus tôt dans
+  la même exécution : les créations sont ordonnées producteurs d'abord, les
+  lectures passent deux fois autour, et le démontage reflète le semis. Aucun
+  identifiant n'est inventé : chacun vient d'une création réelle contre
+  l'émulateur, ce qui est précisément l'origine des 404 d'avant. Face à
+  l'artefact qu'il remplace, tous deux régénérés de la même façon :
+  `probed: response` **85 → 204**, `refusal` **106 → 4**, `none` **40 → 23**.
+  102 des refus et 17 des opérations que la sonde n'atteignait pas valident
+  désormais une forme de succès ; rien n'a reculé. L'axe contrat suit,
+  **181 → 207 propres**, car une opération qui n'allait jamais au-delà d'un
+  refus n'avait aucun corps de succès à contrôler. `driven`, `dataplane`,
+  `behaviour` et `negative` ne bougent pas, ce qui est la forme attendue : le
+  semis déplace du trafic synthétique, rien de ce qu'un client pilote.
+
+  Ce qui refuse encore est nommé plutôt que caché, puisque tout l'objet de #156
+  était de cesser de compter une arrivée comme une preuve. Quatre opérations :
+  `get-deploy-target` (le pack sert un inventaire vide et n'en crée jamais,
+  `catalog.go` l'écrit en toutes lettres), `update-private-network-instance-ip`,
+  `LinkPublicIp` et `UnlinkPublicIp`, chacune réclamant une instance qu'une
+  sonde synthétique ne démarre pas. Vingt-trois ne sont jamais sondées : vingt
+  ne déclarent aucun schéma de réponse, il n'y a donc aucune forme de succès à
+  valider et les appeler ne prouverait que leur réponse ; les trois dernières
+  prennent un paramètre de chemin qui n'est pas un identifiant, à savoir
+  `{entity}` pour un quota, `{field}` pour la remise à zéro d'un champ et
+  `{key}` pour une clé de user data.
+
 ### Modifié
 
 - **`/_feint/conformance` passe en version de schéma 2.** `evidence.*[].probed`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,33 @@ what this project is judged on: **a response shape a client can observe**, and
   fixture and version moved together — passing. The procedure for changing a
   frozen surface on purpose is in RELEASING.md ("Frozen surfaces").
 
+- **The probe seeds what it needs, so a refusal is a verdict rather than a
+  shortage** (#163). Before probing an operation, the probe now brings into
+  being what that operation needs, from the contract's own request schema and
+  from resources it created earlier in the same run: creates are ordered
+  producers-first, reads run twice around them, and the teardown mirrors the
+  seeding. No identifier is invented — every one comes from a real create
+  against the emulator, which is how the 404s appeared in the first place.
+  Against the artefact this replaces, both regenerated the same way:
+  `probed: response` **85 → 204**, `refusal` **106 → 4**, `none` **40 → 23**.
+  102 of the refusals and 17 of the operations the probe never reached now
+  validate a success shape; nothing regressed. The contract axis follows,
+  **181 → 207 clean**, because an operation that never got past a refusal had
+  no success body to check. `driven`, `dataplane`, `behaviour` and `negative`
+  are unchanged, which is the expected shape of this: seeding moves synthetic
+  traffic and nothing a client drives.
+
+  What still refuses, named rather than hidden, because the point of #156 was to
+  stop counting arrivals as proof. Four operations: `get-deploy-target` (the
+  pack serves an empty inventory and never creates one, as `catalog.go` says in
+  those words), `update-private-network-instance-ip`, `LinkPublicIp` and
+  `UnlinkPublicIp` (each needs an instance a synthetic prober does not start).
+  Twenty-three are never probed: twenty declare no response schema at all, so
+  there is no success shape to validate and calling them would prove only that
+  they answered, and three take a path parameter that is not an identifier —
+  `{entity}` for a quota, `{field}` for a field reset, `{key}` for a user-data
+  key.
+
 ### Changed
 
 - **`/_feint/conformance` moves to schema version 2.** `evidence.*[].probed`

--- a/contracts/scaleway.json
+++ b/contracts/scaleway.json
@@ -2487,8 +2487,12 @@
     "project_id"
    ],
    "properties": {
-    "from_empty": {},
-    "from_snapshot": {},
+    "from_empty": {
+     "ref": "block/v1.scaleway.block.v1.CreateVolumeRequest.FromEmpty"
+    },
+    "from_snapshot": {
+     "ref": "block/v1.scaleway.block.v1.CreateVolumeRequest.FromSnapshot"
+    },
     "kms_key_id": {
      "type": "string"
     },
@@ -2944,8 +2948,12 @@
     "project_id"
    ],
    "properties": {
-    "from_empty": {},
-    "from_snapshot": {},
+    "from_empty": {
+     "ref": "block/v1alpha1.scaleway.block.v1alpha1.CreateVolumeRequest.FromEmpty"
+    },
+    "from_snapshot": {
+     "ref": "block/v1alpha1.scaleway.block.v1alpha1.CreateVolumeRequest.FromSnapshot"
+    },
     "name": {
      "type": "string"
     },
@@ -3575,7 +3583,9 @@
     "email": {
      "type": "string"
     },
-    "member": {},
+    "member": {
+     "ref": "iam/v1alpha1.scaleway.iam.v1alpha1.CreateUserRequest.Member"
+    },
     "organization_id": {
      "type": "string"
     },

--- a/coverage/evidence.json
+++ b/coverage/evidence.json
@@ -8,8 +8,8 @@
   "operations": {
     "block/v1/API.CreateSnapshot": {
       "driven": false,
-      "probed": "refusal",
-      "contract": "unchecked",
+      "probed": "response",
+      "contract": "clean",
       "dataplane": false,
       "shape": "unobserved",
       "behaviour": false,
@@ -17,8 +17,8 @@
     },
     "block/v1/API.CreateVolume": {
       "driven": false,
-      "probed": "refusal",
-      "contract": "unchecked",
+      "probed": "response",
+      "contract": "clean",
       "dataplane": false,
       "shape": "unobserved",
       "behaviour": false,
@@ -44,8 +44,8 @@
     },
     "block/v1/API.GetSnapshot": {
       "driven": false,
-      "probed": "refusal",
-      "contract": "unchecked",
+      "probed": "response",
+      "contract": "clean",
       "dataplane": false,
       "shape": "unobserved",
       "behaviour": false,
@@ -53,7 +53,7 @@
     },
     "block/v1/API.GetVolume": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -89,8 +89,8 @@
     },
     "block/v1/API.UpdateSnapshot": {
       "driven": false,
-      "probed": "refusal",
-      "contract": "unchecked",
+      "probed": "response",
+      "contract": "clean",
       "dataplane": false,
       "shape": "unobserved",
       "behaviour": false,
@@ -98,8 +98,8 @@
     },
     "block/v1/API.UpdateVolume": {
       "driven": false,
-      "probed": "refusal",
-      "contract": "unchecked",
+      "probed": "response",
+      "contract": "clean",
       "dataplane": false,
       "shape": "unobserved",
       "behaviour": false,
@@ -107,7 +107,7 @@
     },
     "block/v1alpha1/API.CreateSnapshot": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -116,7 +116,7 @@
     },
     "block/v1alpha1/API.CreateVolume": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -143,7 +143,7 @@
     },
     "block/v1alpha1/API.GetSnapshot": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -152,8 +152,8 @@
     },
     "block/v1alpha1/API.GetVolume": {
       "driven": true,
-      "probed": "refusal",
-      "contract": "unchecked",
+      "probed": "response",
+      "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
       "behaviour": false,
@@ -188,8 +188,8 @@
     },
     "block/v1alpha1/API.UpdateSnapshot": {
       "driven": false,
-      "probed": "refusal",
-      "contract": "unchecked",
+      "probed": "response",
+      "contract": "clean",
       "dataplane": false,
       "shape": "unobserved",
       "behaviour": false,
@@ -197,7 +197,7 @@
     },
     "block/v1alpha1/API.UpdateVolume": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -206,7 +206,7 @@
     },
     "exoscale/v2.add-external-source-to-security-group": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -215,7 +215,7 @@
     },
     "exoscale/v2.add-instance-protection": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -224,7 +224,7 @@
     },
     "exoscale/v2.add-rule-to-security-group": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -233,7 +233,7 @@
     },
     "exoscale/v2.attach-instance-to-elastic-ip": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -242,7 +242,7 @@
     },
     "exoscale/v2.attach-instance-to-private-network": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -251,7 +251,7 @@
     },
     "exoscale/v2.attach-instance-to-security-group": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -278,7 +278,7 @@
     },
     "exoscale/v2.create-instance": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -305,7 +305,7 @@
     },
     "exoscale/v2.delete-anti-affinity-group": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -314,7 +314,7 @@
     },
     "exoscale/v2.delete-elastic-ip": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -323,7 +323,7 @@
     },
     "exoscale/v2.delete-instance": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -332,7 +332,7 @@
     },
     "exoscale/v2.delete-private-network": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -341,8 +341,8 @@
     },
     "exoscale/v2.delete-rule-from-security-group": {
       "driven": false,
-      "probed": "refusal",
-      "contract": "unchecked",
+      "probed": "response",
+      "contract": "clean",
       "dataplane": false,
       "shape": "unobserved",
       "behaviour": false,
@@ -350,7 +350,7 @@
     },
     "exoscale/v2.delete-security-group": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -359,7 +359,7 @@
     },
     "exoscale/v2.delete-ssh-key": {
       "driven": true,
-      "probed": "none",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -368,7 +368,7 @@
     },
     "exoscale/v2.detach-instance-from-elastic-ip": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -377,7 +377,7 @@
     },
     "exoscale/v2.detach-instance-from-private-network": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -386,7 +386,7 @@
     },
     "exoscale/v2.detach-instance-from-security-group": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -395,7 +395,7 @@
     },
     "exoscale/v2.get-anti-affinity-group": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -413,8 +413,8 @@
     },
     "exoscale/v2.get-elastic-ip": {
       "driven": false,
-      "probed": "refusal",
-      "contract": "unchecked",
+      "probed": "response",
+      "contract": "clean",
       "dataplane": false,
       "shape": "unobserved",
       "behaviour": false,
@@ -422,7 +422,7 @@
     },
     "exoscale/v2.get-instance": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -440,8 +440,8 @@
     },
     "exoscale/v2.get-operation": {
       "driven": false,
-      "probed": "refusal",
-      "contract": "unchecked",
+      "probed": "response",
+      "contract": "clean",
       "dataplane": false,
       "shape": "unobserved",
       "behaviour": false,
@@ -449,7 +449,7 @@
     },
     "exoscale/v2.get-private-network": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -467,8 +467,8 @@
     },
     "exoscale/v2.get-security-group": {
       "driven": false,
-      "probed": "refusal",
-      "contract": "unchecked",
+      "probed": "response",
+      "contract": "clean",
       "dataplane": false,
       "shape": "unobserved",
       "behaviour": false,
@@ -476,7 +476,7 @@
     },
     "exoscale/v2.get-ssh-key": {
       "driven": true,
-      "probed": "none",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -485,7 +485,7 @@
     },
     "exoscale/v2.get-template": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -593,7 +593,7 @@
     },
     "exoscale/v2.reboot-instance": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -602,7 +602,7 @@
     },
     "exoscale/v2.register-ssh-key": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -611,7 +611,7 @@
     },
     "exoscale/v2.remove-external-source-from-security-group": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -620,7 +620,7 @@
     },
     "exoscale/v2.remove-instance-protection": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -629,8 +629,8 @@
     },
     "exoscale/v2.reset-instance": {
       "driven": false,
-      "probed": "refusal",
-      "contract": "unchecked",
+      "probed": "response",
+      "contract": "clean",
       "dataplane": false,
       "shape": "unobserved",
       "behaviour": false,
@@ -647,7 +647,7 @@
     },
     "exoscale/v2.resize-instance-disk": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -656,7 +656,7 @@
     },
     "exoscale/v2.scale-instance": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -665,7 +665,7 @@
     },
     "exoscale/v2.start-instance": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -674,7 +674,7 @@
     },
     "exoscale/v2.stop-instance": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -683,8 +683,8 @@
     },
     "exoscale/v2.update-elastic-ip": {
       "driven": false,
-      "probed": "refusal",
-      "contract": "unchecked",
+      "probed": "response",
+      "contract": "clean",
       "dataplane": false,
       "shape": "unobserved",
       "behaviour": false,
@@ -692,8 +692,8 @@
     },
     "exoscale/v2.update-instance": {
       "driven": false,
-      "probed": "refusal",
-      "contract": "unchecked",
+      "probed": "response",
+      "contract": "clean",
       "dataplane": false,
       "shape": "unobserved",
       "behaviour": false,
@@ -701,8 +701,8 @@
     },
     "exoscale/v2.update-private-network": {
       "driven": false,
-      "probed": "refusal",
-      "contract": "unchecked",
+      "probed": "response",
+      "contract": "clean",
       "dataplane": false,
       "shape": "unobserved",
       "behaviour": false,
@@ -719,8 +719,8 @@
     },
     "iam/v1alpha1/API.CreateSSHKey": {
       "driven": false,
-      "probed": "refusal",
-      "contract": "unchecked",
+      "probed": "response",
+      "contract": "clean",
       "dataplane": false,
       "shape": "unobserved",
       "behaviour": false,
@@ -737,8 +737,8 @@
     },
     "iam/v1alpha1/API.GetSSHKey": {
       "driven": false,
-      "probed": "refusal",
-      "contract": "unchecked",
+      "probed": "response",
+      "contract": "clean",
       "dataplane": false,
       "shape": "unobserved",
       "behaviour": false,
@@ -755,8 +755,8 @@
     },
     "iam/v1alpha1/API.UpdateSSHKey": {
       "driven": false,
-      "probed": "refusal",
-      "contract": "unchecked",
+      "probed": "response",
+      "contract": "clean",
       "dataplane": false,
       "shape": "unobserved",
       "behaviour": false,
@@ -764,7 +764,7 @@
     },
     "instance/v1/API.AttachServerVolume": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -782,7 +782,7 @@
     },
     "instance/v1/API.CreateImage": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -791,7 +791,7 @@
     },
     "instance/v1/API.CreatePrivateNIC": {
       "driven": true,
-      "probed": "none",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -809,7 +809,7 @@
     },
     "instance/v1/API.CreateSecurityGroupRule": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -827,7 +827,7 @@
     },
     "instance/v1/API.CreateSnapshot": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -836,7 +836,7 @@
     },
     "instance/v1/API.CreateVolume": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -926,7 +926,7 @@
     },
     "instance/v1/API.DetachServerVolume": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -935,7 +935,7 @@
     },
     "instance/v1/API.GetIP": {
       "driven": true,
-      "probed": "none",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -953,7 +953,7 @@
     },
     "instance/v1/API.GetPrivateNIC": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -962,7 +962,7 @@
     },
     "instance/v1/API.GetSecurityGroup": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -971,7 +971,7 @@
     },
     "instance/v1/API.GetSecurityGroupRule": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -980,7 +980,7 @@
     },
     "instance/v1/API.GetServer": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -998,7 +998,7 @@
     },
     "instance/v1/API.GetSnapshot": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1007,7 +1007,7 @@
     },
     "instance/v1/API.GetVolume": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1034,7 +1034,7 @@
     },
     "instance/v1/API.ListPrivateNICs": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1043,7 +1043,7 @@
     },
     "instance/v1/API.ListSecurityGroupRules": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1061,7 +1061,7 @@
     },
     "instance/v1/API.ListServerUserData": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1106,7 +1106,7 @@
     },
     "instance/v1/API.ServerAction": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1115,7 +1115,7 @@
     },
     "instance/v1/API.SetSecurityGroupRules": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1133,7 +1133,7 @@
     },
     "instance/v1/API.UpdateIP": {
       "driven": true,
-      "probed": "none",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1142,8 +1142,8 @@
     },
     "instance/v1/API.UpdateImage": {
       "driven": false,
-      "probed": "refusal",
-      "contract": "unchecked",
+      "probed": "response",
+      "contract": "clean",
       "dataplane": false,
       "shape": "unobserved",
       "behaviour": false,
@@ -1151,7 +1151,7 @@
     },
     "instance/v1/API.UpdateSecurityGroup": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1160,7 +1160,7 @@
     },
     "instance/v1/API.UpdateSecurityGroupRule": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1169,8 +1169,8 @@
     },
     "instance/v1/API.UpdateServer": {
       "driven": false,
-      "probed": "refusal",
-      "contract": "unchecked",
+      "probed": "response",
+      "contract": "clean",
       "dataplane": false,
       "shape": "unobserved",
       "behaviour": false,
@@ -1178,8 +1178,8 @@
     },
     "instance/v1/API.UpdateSnapshot": {
       "driven": false,
-      "probed": "refusal",
-      "contract": "unchecked",
+      "probed": "response",
+      "contract": "clean",
       "dataplane": false,
       "shape": "unobserved",
       "behaviour": false,
@@ -1187,8 +1187,8 @@
     },
     "instance/v1/API.UpdateVolume": {
       "driven": false,
-      "probed": "refusal",
-      "contract": "unchecked",
+      "probed": "response",
+      "contract": "clean",
       "dataplane": false,
       "shape": "unobserved",
       "behaviour": false,
@@ -1196,8 +1196,8 @@
     },
     "ipam/v1/API.AttachIP": {
       "driven": false,
-      "probed": "refusal",
-      "contract": "unchecked",
+      "probed": "response",
+      "contract": "clean",
       "dataplane": false,
       "shape": "unobserved",
       "behaviour": false,
@@ -1205,7 +1205,7 @@
     },
     "ipam/v1/API.BookIP": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1214,8 +1214,8 @@
     },
     "ipam/v1/API.DetachIP": {
       "driven": false,
-      "probed": "refusal",
-      "contract": "unchecked",
+      "probed": "response",
+      "contract": "clean",
       "dataplane": false,
       "shape": "unobserved",
       "behaviour": false,
@@ -1223,7 +1223,7 @@
     },
     "ipam/v1/API.GetIP": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1241,8 +1241,8 @@
     },
     "ipam/v1/API.MoveIP": {
       "driven": false,
-      "probed": "refusal",
-      "contract": "unchecked",
+      "probed": "response",
+      "contract": "clean",
       "dataplane": false,
       "shape": "unobserved",
       "behaviour": false,
@@ -1268,7 +1268,7 @@
     },
     "ipam/v1/API.UpdateIP": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1286,7 +1286,7 @@
     },
     "osc/Client.CreateImage": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1304,7 +1304,7 @@
     },
     "osc/Client.CreateKeypair": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1313,7 +1313,7 @@
     },
     "osc/Client.CreateNatService": {
       "driven": true,
-      "probed": "none",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1322,7 +1322,7 @@
     },
     "osc/Client.CreateNet": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1331,7 +1331,7 @@
     },
     "osc/Client.CreateNic": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1349,7 +1349,7 @@
     },
     "osc/Client.CreateRoute": {
       "driven": true,
-      "probed": "none",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1358,7 +1358,7 @@
     },
     "osc/Client.CreateRouteTable": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1376,7 +1376,7 @@
     },
     "osc/Client.CreateSecurityGroupRule": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1385,7 +1385,7 @@
     },
     "osc/Client.CreateSnapshot": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1394,7 +1394,7 @@
     },
     "osc/Client.CreateSubnet": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1430,7 +1430,7 @@
     },
     "osc/Client.DeleteImage": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1448,7 +1448,7 @@
     },
     "osc/Client.DeleteKeypair": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1457,7 +1457,7 @@
     },
     "osc/Client.DeleteNatService": {
       "driven": true,
-      "probed": "none",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1466,7 +1466,7 @@
     },
     "osc/Client.DeleteNet": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1475,7 +1475,7 @@
     },
     "osc/Client.DeleteNic": {
       "driven": true,
-      "probed": "none",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1484,7 +1484,7 @@
     },
     "osc/Client.DeletePublicIp": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1493,7 +1493,7 @@
     },
     "osc/Client.DeleteRoute": {
       "driven": true,
-      "probed": "none",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1502,7 +1502,7 @@
     },
     "osc/Client.DeleteRouteTable": {
       "driven": true,
-      "probed": "none",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1511,7 +1511,7 @@
     },
     "osc/Client.DeleteSecurityGroup": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1520,7 +1520,7 @@
     },
     "osc/Client.DeleteSecurityGroupRule": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1529,7 +1529,7 @@
     },
     "osc/Client.DeleteSnapshot": {
       "driven": true,
-      "probed": "none",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1538,7 +1538,7 @@
     },
     "osc/Client.DeleteSubnet": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1574,7 +1574,7 @@
     },
     "osc/Client.LinkInternetService": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1583,7 +1583,7 @@
     },
     "osc/Client.LinkNic": {
       "driven": true,
-      "probed": "none",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1601,7 +1601,7 @@
     },
     "osc/Client.LinkRouteTable": {
       "driven": true,
-      "probed": "none",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1826,7 +1826,7 @@
     },
     "osc/Client.RebootVms": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1853,7 +1853,7 @@
     },
     "osc/Client.UnlinkInternetService": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1862,7 +1862,7 @@
     },
     "osc/Client.UnlinkNic": {
       "driven": true,
-      "probed": "none",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1880,7 +1880,7 @@
     },
     "osc/Client.UnlinkRouteTable": {
       "driven": true,
-      "probed": "none",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1889,7 +1889,7 @@
     },
     "osc/Client.UnlinkVolume": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1898,7 +1898,7 @@
     },
     "osc/Client.UpdateImage": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1907,7 +1907,7 @@
     },
     "osc/Client.UpdateRoute": {
       "driven": true,
-      "probed": "none",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1943,7 +1943,7 @@
     },
     "vpc/v2/API.CreateRoute": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -2015,7 +2015,7 @@
     },
     "vpc/v2/API.GetRoute": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -2069,8 +2069,8 @@
     },
     "vpc/v2/API.UpdateRoute": {
       "driven": false,
-      "probed": "refusal",
-      "contract": "unchecked",
+      "probed": "response",
+      "contract": "clean",
       "dataplane": false,
       "shape": "unobserved",
       "behaviour": false,

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -85,34 +85,34 @@ disappears from the suite.
 | `DELETE` | `/block/v1/zones/{zone}/volumes/{id}` | `block/v1/API.DeleteVolume` | `client` `runtime` `behaviour` |
 | `DELETE` | `/block/v1alpha1/zones/{zone}/snapshots/{id}` | `block/v1alpha1/API.DeleteSnapshot` | `client` `runtime` `behaviour` `negative` |
 | `DELETE` | `/block/v1alpha1/zones/{zone}/volumes/{id}` | `block/v1alpha1/API.DeleteVolume` | `client` `runtime` `behaviour` |
-| `GET` | `/block/v1/zones/{zone}/snapshots/{id}` | `block/v1/API.GetSnapshot` | `probe-refusal` |
+| `GET` | `/block/v1/zones/{zone}/snapshots/{id}` | `block/v1/API.GetSnapshot` | `contract` `probe` |
 | `GET` | `/block/v1/zones/{zone}/snapshots` | `block/v1/API.ListSnapshots` | `contract` `shape` `probe` |
 | `GET` | `/block/v1/zones/{zone}/volume-types` | `block/v1/API.ListVolumeTypes` | `contract` `probe` |
-| `GET` | `/block/v1/zones/{zone}/volumes/{id}` | `block/v1/API.GetVolume` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
+| `GET` | `/block/v1/zones/{zone}/volumes/{id}` | `block/v1/API.GetVolume` | `client` `contract` `runtime` `probe` `behaviour` |
 | `GET` | `/block/v1/zones/{zone}/volumes` | `block/v1/API.ListVolumes` | `contract` `shape` `probe` |
-| `GET` | `/block/v1alpha1/zones/{zone}/snapshots/{id}` | `block/v1alpha1/API.GetSnapshot` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
+| `GET` | `/block/v1alpha1/zones/{zone}/snapshots/{id}` | `block/v1alpha1/API.GetSnapshot` | `client` `contract` `runtime` `probe` `behaviour` |
 | `GET` | `/block/v1alpha1/zones/{zone}/snapshots` | `block/v1alpha1/API.ListSnapshots` | `client` `contract` `runtime` `probe` `behaviour` |
 | `GET` | `/block/v1alpha1/zones/{zone}/volume-types` | `block/v1alpha1/API.ListVolumeTypes` | `client` `contract` `runtime` `probe` |
-| `GET` | `/block/v1alpha1/zones/{zone}/volumes/{id}` | `block/v1alpha1/API.GetVolume` | `client` `runtime` `probe-refusal` |
+| `GET` | `/block/v1alpha1/zones/{zone}/volumes/{id}` | `block/v1alpha1/API.GetVolume` | `client` `contract` `runtime` `probe` |
 | `GET` | `/block/v1alpha1/zones/{zone}/volumes` | `block/v1alpha1/API.ListVolumes` | `client` `contract` `runtime` `probe` `behaviour` |
-| `PATCH` | `/block/v1/zones/{zone}/snapshots/{id}` | `block/v1/API.UpdateSnapshot` | `probe-refusal` |
-| `PATCH` | `/block/v1/zones/{zone}/volumes/{id}` | `block/v1/API.UpdateVolume` | `probe-refusal` |
-| `PATCH` | `/block/v1alpha1/zones/{zone}/snapshots/{id}` | `block/v1alpha1/API.UpdateSnapshot` | `probe-refusal` |
-| `PATCH` | `/block/v1alpha1/zones/{zone}/volumes/{id}` | `block/v1alpha1/API.UpdateVolume` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `POST` | `/block/v1/zones/{zone}/snapshots` | `block/v1/API.CreateSnapshot` | `probe-refusal` |
-| `POST` | `/block/v1/zones/{zone}/volumes` | `block/v1/API.CreateVolume` | `probe-refusal` |
-| `POST` | `/block/v1alpha1/zones/{zone}/snapshots` | `block/v1alpha1/API.CreateSnapshot` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `POST` | `/block/v1alpha1/zones/{zone}/volumes` | `block/v1alpha1/API.CreateVolume` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
+| `PATCH` | `/block/v1/zones/{zone}/snapshots/{id}` | `block/v1/API.UpdateSnapshot` | `contract` `probe` |
+| `PATCH` | `/block/v1/zones/{zone}/volumes/{id}` | `block/v1/API.UpdateVolume` | `contract` `probe` |
+| `PATCH` | `/block/v1alpha1/zones/{zone}/snapshots/{id}` | `block/v1alpha1/API.UpdateSnapshot` | `contract` `probe` |
+| `PATCH` | `/block/v1alpha1/zones/{zone}/volumes/{id}` | `block/v1alpha1/API.UpdateVolume` | `client` `contract` `runtime` `probe` `behaviour` |
+| `POST` | `/block/v1/zones/{zone}/snapshots` | `block/v1/API.CreateSnapshot` | `contract` `probe` |
+| `POST` | `/block/v1/zones/{zone}/volumes` | `block/v1/API.CreateVolume` | `contract` `probe` |
+| `POST` | `/block/v1alpha1/zones/{zone}/snapshots` | `block/v1alpha1/API.CreateSnapshot` | `client` `contract` `runtime` `probe` `behaviour` |
+| `POST` | `/block/v1alpha1/zones/{zone}/volumes` | `block/v1alpha1/API.CreateVolume` | `client` `contract` `runtime` `probe` `behaviour` |
 
 ### `iam`
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
 | `DELETE` | `/iam/v1alpha1/ssh-keys/{id}` | `iam/v1alpha1/API.DeleteSSHKey` | — |
-| `GET` | `/iam/v1alpha1/ssh-keys/{id}` | `iam/v1alpha1/API.GetSSHKey` | `probe-refusal` |
+| `GET` | `/iam/v1alpha1/ssh-keys/{id}` | `iam/v1alpha1/API.GetSSHKey` | `contract` `probe` |
 | `GET` | `/iam/v1alpha1/ssh-keys` | `iam/v1alpha1/API.ListSSHKeys` | `contract` `shape` `probe` |
-| `PATCH` | `/iam/v1alpha1/ssh-keys/{id}` | `iam/v1alpha1/API.UpdateSSHKey` | `probe-refusal` |
-| `POST` | `/iam/v1alpha1/ssh-keys` | `iam/v1alpha1/API.CreateSSHKey` | `probe-refusal` |
+| `PATCH` | `/iam/v1alpha1/ssh-keys/{id}` | `iam/v1alpha1/API.UpdateSSHKey` | `contract` `probe` |
+| `POST` | `/iam/v1alpha1/ssh-keys` | `iam/v1alpha1/API.CreateSSHKey` | `contract` `probe` |
 
 ### `instance`
 
@@ -129,57 +129,57 @@ disappears from the suite.
 | `DELETE` | `/instance/v1/zones/{zone}/volumes/{id}` | `instance/v1/API.DeleteVolume` | `client` `runtime` `behaviour` `negative` |
 | `GET` | `/instance/v1/zones/{zone}/images/{id}` | `instance/v1/API.GetImage` | `client` `contract` `runtime` `probe` `behaviour` |
 | `GET` | `/instance/v1/zones/{zone}/images` | `instance/v1/API.ListImages` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
-| `GET` | `/instance/v1/zones/{zone}/ips/{id}` | `instance/v1/API.GetIP` | `client` `contract` `runtime` `behaviour` `negative` |
+| `GET` | `/instance/v1/zones/{zone}/ips/{id}` | `instance/v1/API.GetIP` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 | `GET` | `/instance/v1/zones/{zone}/ips` | `instance/v1/API.ListIPs` | `contract` `shape` `probe` |
 | `GET` | `/instance/v1/zones/{zone}/products/servers` | `instance/v1/API.ListServersTypes` | `client` `contract` `shape` `runtime` `probe` |
-| `GET` | `/instance/v1/zones/{zone}/security_groups/{id}/rules/{ruleID}` | `instance/v1/API.GetSecurityGroupRule` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `GET` | `/instance/v1/zones/{zone}/security_groups/{id}/rules` | `instance/v1/API.ListSecurityGroupRules` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `GET` | `/instance/v1/zones/{zone}/security_groups/{id}` | `instance/v1/API.GetSecurityGroup` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
+| `GET` | `/instance/v1/zones/{zone}/security_groups/{id}/rules/{ruleID}` | `instance/v1/API.GetSecurityGroupRule` | `client` `contract` `runtime` `probe` `behaviour` |
+| `GET` | `/instance/v1/zones/{zone}/security_groups/{id}/rules` | `instance/v1/API.ListSecurityGroupRules` | `client` `contract` `runtime` `probe` `behaviour` |
+| `GET` | `/instance/v1/zones/{zone}/security_groups/{id}` | `instance/v1/API.GetSecurityGroup` | `client` `contract` `runtime` `probe` `behaviour` |
 | `GET` | `/instance/v1/zones/{zone}/security_groups` | `instance/v1/API.ListSecurityGroups` | `client` `contract` `shape` `runtime` `probe` |
-| `GET` | `/instance/v1/zones/{zone}/servers/{id}/private_nics/{nicID}` | `instance/v1/API.GetPrivateNIC` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `GET` | `/instance/v1/zones/{zone}/servers/{id}/private_nics` | `instance/v1/API.ListPrivateNICs` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
+| `GET` | `/instance/v1/zones/{zone}/servers/{id}/private_nics/{nicID}` | `instance/v1/API.GetPrivateNIC` | `client` `contract` `runtime` `probe` `behaviour` |
+| `GET` | `/instance/v1/zones/{zone}/servers/{id}/private_nics` | `instance/v1/API.ListPrivateNICs` | `client` `contract` `runtime` `probe` `behaviour` |
 | `GET` | `/instance/v1/zones/{zone}/servers/{id}/user_data/{key}` | `instance/v1/API.GetServerUserData` | — |
-| `GET` | `/instance/v1/zones/{zone}/servers/{id}/user_data` | `instance/v1/API.ListServerUserData` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `GET` | `/instance/v1/zones/{zone}/servers/{id}` | `instance/v1/API.GetServer` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
+| `GET` | `/instance/v1/zones/{zone}/servers/{id}/user_data` | `instance/v1/API.ListServerUserData` | `client` `contract` `runtime` `probe` `behaviour` |
+| `GET` | `/instance/v1/zones/{zone}/servers/{id}` | `instance/v1/API.GetServer` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 | `GET` | `/instance/v1/zones/{zone}/servers` | `instance/v1/API.ListServers` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
-| `GET` | `/instance/v1/zones/{zone}/snapshots/{id}` | `instance/v1/API.GetSnapshot` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
+| `GET` | `/instance/v1/zones/{zone}/snapshots/{id}` | `instance/v1/API.GetSnapshot` | `client` `contract` `runtime` `probe` `behaviour` |
 | `GET` | `/instance/v1/zones/{zone}/snapshots` | `instance/v1/API.ListSnapshots` | `contract` `shape` `probe` |
-| `GET` | `/instance/v1/zones/{zone}/volumes/{id}` | `instance/v1/API.GetVolume` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
+| `GET` | `/instance/v1/zones/{zone}/volumes/{id}` | `instance/v1/API.GetVolume` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 | `GET` | `/instance/v1/zones/{zone}/volumes` | `instance/v1/API.ListVolumes` | `contract` `shape` `probe` |
-| `PATCH` | `/instance/v1/zones/{zone}/images/{id}` | `instance/v1/API.UpdateImage` | `probe-refusal` |
-| `PATCH` | `/instance/v1/zones/{zone}/ips/{id}` | `instance/v1/API.UpdateIP` | `client` `contract` `runtime` |
-| `PATCH` | `/instance/v1/zones/{zone}/security_groups/{id}/rules/{ruleID}` | `instance/v1/API.UpdateSecurityGroupRule` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `PATCH` | `/instance/v1/zones/{zone}/security_groups/{id}` | `instance/v1/API.UpdateSecurityGroup` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
+| `PATCH` | `/instance/v1/zones/{zone}/images/{id}` | `instance/v1/API.UpdateImage` | `contract` `probe` |
+| `PATCH` | `/instance/v1/zones/{zone}/ips/{id}` | `instance/v1/API.UpdateIP` | `client` `contract` `runtime` `probe` |
+| `PATCH` | `/instance/v1/zones/{zone}/security_groups/{id}/rules/{ruleID}` | `instance/v1/API.UpdateSecurityGroupRule` | `client` `contract` `runtime` `probe` `behaviour` |
+| `PATCH` | `/instance/v1/zones/{zone}/security_groups/{id}` | `instance/v1/API.UpdateSecurityGroup` | `client` `contract` `runtime` `probe` `behaviour` |
 | `PATCH` | `/instance/v1/zones/{zone}/servers/{id}/user_data/{key}` | `instance/v1/API.SetServerUserData` | — |
-| `PATCH` | `/instance/v1/zones/{zone}/servers/{id}` | `instance/v1/API.UpdateServer` | `probe-refusal` |
-| `PATCH` | `/instance/v1/zones/{zone}/snapshots/{id}` | `instance/v1/API.UpdateSnapshot` | `probe-refusal` |
-| `PATCH` | `/instance/v1/zones/{zone}/volumes/{id}` | `instance/v1/API.UpdateVolume` | `probe-refusal` |
-| `POST` | `/instance/v1/zones/{zone}/images` | `instance/v1/API.CreateImage` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
+| `PATCH` | `/instance/v1/zones/{zone}/servers/{id}` | `instance/v1/API.UpdateServer` | `contract` `probe` |
+| `PATCH` | `/instance/v1/zones/{zone}/snapshots/{id}` | `instance/v1/API.UpdateSnapshot` | `contract` `probe` |
+| `PATCH` | `/instance/v1/zones/{zone}/volumes/{id}` | `instance/v1/API.UpdateVolume` | `contract` `probe` |
+| `POST` | `/instance/v1/zones/{zone}/images` | `instance/v1/API.CreateImage` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/instance/v1/zones/{zone}/ips` | `instance/v1/API.CreateIP` | `client` `contract` `runtime` `probe` `behaviour` |
-| `POST` | `/instance/v1/zones/{zone}/security_groups/{id}/rules` | `instance/v1/API.CreateSecurityGroupRule` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
+| `POST` | `/instance/v1/zones/{zone}/security_groups/{id}/rules` | `instance/v1/API.CreateSecurityGroupRule` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/instance/v1/zones/{zone}/security_groups` | `instance/v1/API.CreateSecurityGroup` | `client` `contract` `runtime` `probe` `behaviour` |
-| `POST` | `/instance/v1/zones/{zone}/servers/{id}/action` | `instance/v1/API.ServerAction` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `POST` | `/instance/v1/zones/{zone}/servers/{id}/attach-volume` | `instance/v1/API.AttachServerVolume` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `POST` | `/instance/v1/zones/{zone}/servers/{id}/detach-volume` | `instance/v1/API.DetachServerVolume` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `POST` | `/instance/v1/zones/{zone}/servers/{id}/private_nics` | `instance/v1/API.CreatePrivateNIC` | `client` `contract` `runtime` `behaviour` |
+| `POST` | `/instance/v1/zones/{zone}/servers/{id}/action` | `instance/v1/API.ServerAction` | `client` `contract` `runtime` `probe` `behaviour` |
+| `POST` | `/instance/v1/zones/{zone}/servers/{id}/attach-volume` | `instance/v1/API.AttachServerVolume` | `client` `contract` `runtime` `probe` `behaviour` |
+| `POST` | `/instance/v1/zones/{zone}/servers/{id}/detach-volume` | `instance/v1/API.DetachServerVolume` | `client` `contract` `runtime` `probe` `behaviour` |
+| `POST` | `/instance/v1/zones/{zone}/servers/{id}/private_nics` | `instance/v1/API.CreatePrivateNIC` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/instance/v1/zones/{zone}/servers` | `instance/v1/API.CreateServer` | `client` `contract` `runtime` `probe` `behaviour` |
-| `POST` | `/instance/v1/zones/{zone}/snapshots` | `instance/v1/API.CreateSnapshot` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `POST` | `/instance/v1/zones/{zone}/volumes` | `instance/v1/API.CreateVolume` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `PUT` | `/instance/v1/zones/{zone}/security_groups/{id}/rules` | `instance/v1/API.SetSecurityGroupRules` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
+| `POST` | `/instance/v1/zones/{zone}/snapshots` | `instance/v1/API.CreateSnapshot` | `client` `contract` `runtime` `probe` `behaviour` |
+| `POST` | `/instance/v1/zones/{zone}/volumes` | `instance/v1/API.CreateVolume` | `client` `contract` `runtime` `probe` `behaviour` |
+| `PUT` | `/instance/v1/zones/{zone}/security_groups/{id}/rules` | `instance/v1/API.SetSecurityGroupRules` | `client` `contract` `runtime` `probe` `behaviour` |
 
 ### `ipam`
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
 | `DELETE` | `/ipam/v1/regions/{region}/ips/{ipID}` | `ipam/v1/API.ReleaseIP` | `client` `runtime` `behaviour` |
-| `GET` | `/ipam/v1/regions/{region}/ips/{ipID}` | `ipam/v1/API.GetIP` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
+| `GET` | `/ipam/v1/regions/{region}/ips/{ipID}` | `ipam/v1/API.GetIP` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 | `GET` | `/ipam/v1/regions/{region}/ips` | `ipam/v1/API.ListIPs` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
-| `PATCH` | `/ipam/v1/regions/{region}/ips/{ipID}` | `ipam/v1/API.UpdateIP` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
+| `PATCH` | `/ipam/v1/regions/{region}/ips/{ipID}` | `ipam/v1/API.UpdateIP` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/ipam/v1/regions/{region}/ip-sets/release` | `ipam/v1/API.ReleaseIPSet` | — |
-| `POST` | `/ipam/v1/regions/{region}/ips/{ipID}/attach` | `ipam/v1/API.AttachIP` | `probe-refusal` |
-| `POST` | `/ipam/v1/regions/{region}/ips/{ipID}/detach` | `ipam/v1/API.DetachIP` | `probe-refusal` |
-| `POST` | `/ipam/v1/regions/{region}/ips/{ipID}/move` | `ipam/v1/API.MoveIP` | `probe-refusal` |
-| `POST` | `/ipam/v1/regions/{region}/ips` | `ipam/v1/API.BookIP` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
+| `POST` | `/ipam/v1/regions/{region}/ips/{ipID}/attach` | `ipam/v1/API.AttachIP` | `contract` `probe` |
+| `POST` | `/ipam/v1/regions/{region}/ips/{ipID}/detach` | `ipam/v1/API.DetachIP` | `contract` `probe` |
+| `POST` | `/ipam/v1/regions/{region}/ips/{ipID}/move` | `ipam/v1/API.MoveIP` | `contract` `probe` |
+| `POST` | `/ipam/v1/regions/{region}/ips` | `ipam/v1/API.BookIP` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 
 ### `marketplace`
 
@@ -196,16 +196,16 @@ disappears from the suite.
 | `DELETE` | `/vpc/v2/regions/{region}/vpcs/{vpc_id}` | `vpc/v2/API.DeleteVPC` | `client` `runtime` `behaviour` |
 | `GET` | `/vpc/v2/regions/{region}/private-networks/{pnID}` | `vpc/v2/API.GetPrivateNetwork` | `client` `contract` `runtime` `probe` `behaviour` |
 | `GET` | `/vpc/v2/regions/{region}/private-networks` | `vpc/v2/API.ListPrivateNetworks` | `contract` `shape` `probe` |
-| `GET` | `/vpc/v2/regions/{region}/routes/{routeID}` | `vpc/v2/API.GetRoute` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
+| `GET` | `/vpc/v2/regions/{region}/routes/{routeID}` | `vpc/v2/API.GetRoute` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 | `GET` | `/vpc/v2/regions/{region}/subnets` | `vpc/v2/API.ListSubnets` | `contract` `probe` |
 | `GET` | `/vpc/v2/regions/{region}/vpcs/{vpc_id}` | `vpc/v2/API.GetVPC` | `client` `contract` `runtime` `probe` `behaviour` |
 | `GET` | `/vpc/v2/regions/{region}/vpcs` | `vpc/v2/API.ListVPCs` | `contract` `shape` `probe` |
 | `PATCH` | `/vpc/v2/regions/{region}/private-networks/{pnID}` | `vpc/v2/API.UpdatePrivateNetwork` | `contract` `probe` |
-| `PATCH` | `/vpc/v2/regions/{region}/routes/{routeID}` | `vpc/v2/API.UpdateRoute` | `probe-refusal` |
+| `PATCH` | `/vpc/v2/regions/{region}/routes/{routeID}` | `vpc/v2/API.UpdateRoute` | `contract` `probe` |
 | `PATCH` | `/vpc/v2/regions/{region}/vpcs/{vpc_id}` | `vpc/v2/API.UpdateVPC` | `contract` `probe` |
 | `POST` | `/vpc/v2/regions/{region}/private-networks/{pnID}/enable-dhcp` | `vpc/v2/API.EnableDHCP` | `contract` `probe` |
 | `POST` | `/vpc/v2/regions/{region}/private-networks` | `vpc/v2/API.CreatePrivateNetwork` | `client` `contract` `runtime` `probe` `behaviour` |
-| `POST` | `/vpc/v2/regions/{region}/routes` | `vpc/v2/API.CreateRoute` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
+| `POST` | `/vpc/v2/regions/{region}/routes` | `vpc/v2/API.CreateRoute` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/vpc/v2/regions/{region}/vpcs/{vpc_id}/enable-routing` | `vpc/v2/API.EnableRouting` | `contract` `probe` |
 | `POST` | `/vpc/v2/regions/{region}/vpcs` | `vpc/v2/API.CreateVPC` | `client` `contract` `runtime` `probe` `behaviour` |
 
@@ -255,10 +255,10 @@ are in `coverage/`, one artefact per provider.
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `POST` | `/api/v1/CreateImage` | `osc/Client.CreateImage` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `POST` | `/api/v1/DeleteImage` | `osc/Client.DeleteImage` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
+| `POST` | `/api/v1/CreateImage` | `osc/Client.CreateImage` | `client` `contract` `runtime` `probe` `behaviour` |
+| `POST` | `/api/v1/DeleteImage` | `osc/Client.DeleteImage` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/api/v1/ReadImages` | `osc/Client.ReadImages` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
-| `POST` | `/api/v1/UpdateImage` | `osc/Client.UpdateImage` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
+| `POST` | `/api/v1/UpdateImage` | `osc/Client.UpdateImage` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 
 ### `InternetService`
 
@@ -266,16 +266,16 @@ are in `coverage/`, one artefact per provider.
 |---|---|---|---|
 | `POST` | `/api/v1/CreateInternetService` | `osc/Client.CreateInternetService` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/api/v1/DeleteInternetService` | `osc/Client.DeleteInternetService` | `client` `contract` `runtime` `probe` `behaviour` |
-| `POST` | `/api/v1/LinkInternetService` | `osc/Client.LinkInternetService` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
+| `POST` | `/api/v1/LinkInternetService` | `osc/Client.LinkInternetService` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/api/v1/ReadInternetServices` | `osc/Client.ReadInternetServices` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
-| `POST` | `/api/v1/UnlinkInternetService` | `osc/Client.UnlinkInternetService` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
+| `POST` | `/api/v1/UnlinkInternetService` | `osc/Client.UnlinkInternetService` | `client` `contract` `runtime` `probe` `behaviour` |
 
 ### `Keypair`
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `POST` | `/api/v1/CreateKeypair` | `osc/Client.CreateKeypair` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `POST` | `/api/v1/DeleteKeypair` | `osc/Client.DeleteKeypair` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
+| `POST` | `/api/v1/CreateKeypair` | `osc/Client.CreateKeypair` | `client` `contract` `runtime` `probe` `behaviour` |
+| `POST` | `/api/v1/DeleteKeypair` | `osc/Client.DeleteKeypair` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/api/v1/ReadKeypairs` | `osc/Client.ReadKeypairs` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 
 ### `LoadBalancer`
@@ -288,16 +288,16 @@ are in `coverage/`, one artefact per provider.
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `POST` | `/api/v1/CreateNatService` | `osc/Client.CreateNatService` | `client` `contract` `runtime` `behaviour` |
-| `POST` | `/api/v1/DeleteNatService` | `osc/Client.DeleteNatService` | `client` `contract` `runtime` `behaviour` |
+| `POST` | `/api/v1/CreateNatService` | `osc/Client.CreateNatService` | `client` `contract` `runtime` `probe` `behaviour` |
+| `POST` | `/api/v1/DeleteNatService` | `osc/Client.DeleteNatService` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/api/v1/ReadNatServices` | `osc/Client.ReadNatServices` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 
 ### `Net`
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `POST` | `/api/v1/CreateNet` | `osc/Client.CreateNet` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
-| `POST` | `/api/v1/DeleteNet` | `osc/Client.DeleteNet` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
+| `POST` | `/api/v1/CreateNet` | `osc/Client.CreateNet` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/DeleteNet` | `osc/Client.DeleteNet` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 | `POST` | `/api/v1/ReadNets` | `osc/Client.ReadNets` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 
 ### `NetAccessPoint`
@@ -310,18 +310,18 @@ are in `coverage/`, one artefact per provider.
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `POST` | `/api/v1/CreateNic` | `osc/Client.CreateNic` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `POST` | `/api/v1/DeleteNic` | `osc/Client.DeleteNic` | `client` `contract` `runtime` `behaviour` |
-| `POST` | `/api/v1/LinkNic` | `osc/Client.LinkNic` | `client` `contract` `runtime` `behaviour` |
+| `POST` | `/api/v1/CreateNic` | `osc/Client.CreateNic` | `client` `contract` `runtime` `probe` `behaviour` |
+| `POST` | `/api/v1/DeleteNic` | `osc/Client.DeleteNic` | `client` `contract` `runtime` `probe` `behaviour` |
+| `POST` | `/api/v1/LinkNic` | `osc/Client.LinkNic` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/api/v1/ReadNics` | `osc/Client.ReadNics` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
-| `POST` | `/api/v1/UnlinkNic` | `osc/Client.UnlinkNic` | `client` `contract` `runtime` `behaviour` |
+| `POST` | `/api/v1/UnlinkNic` | `osc/Client.UnlinkNic` | `client` `contract` `runtime` `probe` `behaviour` |
 
 ### `PublicIp`
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
 | `POST` | `/api/v1/CreatePublicIp` | `osc/Client.CreatePublicIp` | `client` `contract` `runtime` `probe` `behaviour` |
-| `POST` | `/api/v1/DeletePublicIp` | `osc/Client.DeletePublicIp` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
+| `POST` | `/api/v1/DeletePublicIp` | `osc/Client.DeletePublicIp` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 | `POST` | `/api/v1/LinkPublicIp` | `osc/Client.LinkPublicIp` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
 | `POST` | `/api/v1/ReadPublicIpRanges` | `osc/Client.ReadPublicIpRanges` | `contract` `shape` `probe` |
 | `POST` | `/api/v1/ReadPublicIps` | `osc/Client.ReadPublicIps` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
@@ -337,49 +337,49 @@ are in `coverage/`, one artefact per provider.
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `POST` | `/api/v1/CreateRoute` | `osc/Client.CreateRoute` | `client` `contract` `runtime` `behaviour` |
-| `POST` | `/api/v1/DeleteRoute` | `osc/Client.DeleteRoute` | `client` `contract` `runtime` `behaviour` |
-| `POST` | `/api/v1/UpdateRoute` | `osc/Client.UpdateRoute` | `client` `contract` `runtime` `behaviour` |
+| `POST` | `/api/v1/CreateRoute` | `osc/Client.CreateRoute` | `client` `contract` `runtime` `probe` `behaviour` |
+| `POST` | `/api/v1/DeleteRoute` | `osc/Client.DeleteRoute` | `client` `contract` `runtime` `probe` `behaviour` |
+| `POST` | `/api/v1/UpdateRoute` | `osc/Client.UpdateRoute` | `client` `contract` `runtime` `probe` `behaviour` |
 
 ### `RouteTable`
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `POST` | `/api/v1/CreateRouteTable` | `osc/Client.CreateRouteTable` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `POST` | `/api/v1/DeleteRouteTable` | `osc/Client.DeleteRouteTable` | `client` `contract` `runtime` `behaviour` |
-| `POST` | `/api/v1/LinkRouteTable` | `osc/Client.LinkRouteTable` | `client` `contract` `runtime` `behaviour` |
+| `POST` | `/api/v1/CreateRouteTable` | `osc/Client.CreateRouteTable` | `client` `contract` `runtime` `probe` `behaviour` |
+| `POST` | `/api/v1/DeleteRouteTable` | `osc/Client.DeleteRouteTable` | `client` `contract` `runtime` `probe` `behaviour` |
+| `POST` | `/api/v1/LinkRouteTable` | `osc/Client.LinkRouteTable` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/api/v1/ReadRouteTables` | `osc/Client.ReadRouteTables` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
-| `POST` | `/api/v1/UnlinkRouteTable` | `osc/Client.UnlinkRouteTable` | `client` `contract` `runtime` `behaviour` |
+| `POST` | `/api/v1/UnlinkRouteTable` | `osc/Client.UnlinkRouteTable` | `client` `contract` `runtime` `probe` `behaviour` |
 
 ### `SecurityGroup`
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
 | `POST` | `/api/v1/CreateSecurityGroup` | `osc/Client.CreateSecurityGroup` | `client` `contract` `runtime` `probe` `behaviour` |
-| `POST` | `/api/v1/DeleteSecurityGroup` | `osc/Client.DeleteSecurityGroup` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
+| `POST` | `/api/v1/DeleteSecurityGroup` | `osc/Client.DeleteSecurityGroup` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/api/v1/ReadSecurityGroups` | `osc/Client.ReadSecurityGroups` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 
 ### `SecurityGroupRule`
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `POST` | `/api/v1/CreateSecurityGroupRule` | `osc/Client.CreateSecurityGroupRule` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `POST` | `/api/v1/DeleteSecurityGroupRule` | `osc/Client.DeleteSecurityGroupRule` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
+| `POST` | `/api/v1/CreateSecurityGroupRule` | `osc/Client.CreateSecurityGroupRule` | `client` `contract` `runtime` `probe` `behaviour` |
+| `POST` | `/api/v1/DeleteSecurityGroupRule` | `osc/Client.DeleteSecurityGroupRule` | `client` `contract` `runtime` `probe` `behaviour` |
 
 ### `Snapshot`
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `POST` | `/api/v1/CreateSnapshot` | `osc/Client.CreateSnapshot` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `POST` | `/api/v1/DeleteSnapshot` | `osc/Client.DeleteSnapshot` | `client` `contract` `runtime` `behaviour` |
+| `POST` | `/api/v1/CreateSnapshot` | `osc/Client.CreateSnapshot` | `client` `contract` `runtime` `probe` `behaviour` |
+| `POST` | `/api/v1/DeleteSnapshot` | `osc/Client.DeleteSnapshot` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/api/v1/ReadSnapshots` | `osc/Client.ReadSnapshots` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 
 ### `Subnet`
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `POST` | `/api/v1/CreateSubnet` | `osc/Client.CreateSubnet` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
-| `POST` | `/api/v1/DeleteSubnet` | `osc/Client.DeleteSubnet` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
+| `POST` | `/api/v1/CreateSubnet` | `osc/Client.CreateSubnet` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/DeleteSubnet` | `osc/Client.DeleteSubnet` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/api/v1/ReadSubnets` | `osc/Client.ReadSubnets` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 
 ### `Subregion`
@@ -406,7 +406,7 @@ are in `coverage/`, one artefact per provider.
 | `POST` | `/api/v1/ReadVmTypes` | `osc/Client.ReadVmTypes` | `client` `contract` `shape` `runtime` `probe` |
 | `POST` | `/api/v1/ReadVmsState` | `osc/Client.ReadVmsState` | `client` `contract` `shape` `runtime` `probe` |
 | `POST` | `/api/v1/ReadVms` | `osc/Client.ReadVms` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
-| `POST` | `/api/v1/RebootVms` | `osc/Client.RebootVms` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
+| `POST` | `/api/v1/RebootVms` | `osc/Client.RebootVms` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/api/v1/StartVms` | `osc/Client.StartVms` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/api/v1/StopVms` | `osc/Client.StopVms` | `client` `contract` `runtime` `probe` |
 | `POST` | `/api/v1/UpdateVm` | `osc/Client.UpdateVm` | `client` `contract` `runtime` `probe` `negative` |
@@ -419,7 +419,7 @@ are in `coverage/`, one artefact per provider.
 | `POST` | `/api/v1/DeleteVolume` | `osc/Client.DeleteVolume` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/api/v1/LinkVolume` | `osc/Client.LinkVolume` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/api/v1/ReadVolumes` | `osc/Client.ReadVolumes` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
-| `POST` | `/api/v1/UnlinkVolume` | `osc/Client.UnlinkVolume` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
+| `POST` | `/api/v1/UnlinkVolume` | `osc/Client.UnlinkVolume` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/api/v1/UpdateVolume` | `osc/Client.UpdateVolume` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 
 ### Declined on purpose (173)
@@ -475,65 +475,65 @@ are in `coverage/`, one artefact per provider.
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `DELETE` | `/v2/anti-affinity-group/{id}` | `exoscale/v2.delete-anti-affinity-group` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `DELETE` | `/v2/elastic-ip/{id}` | `exoscale/v2.delete-elastic-ip` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `DELETE` | `/v2/instance/{id}` | `exoscale/v2.delete-instance` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
+| `DELETE` | `/v2/anti-affinity-group/{id}` | `exoscale/v2.delete-anti-affinity-group` | `client` `contract` `runtime` `probe` `behaviour` |
+| `DELETE` | `/v2/elastic-ip/{id}` | `exoscale/v2.delete-elastic-ip` | `client` `contract` `runtime` `probe` `behaviour` |
+| `DELETE` | `/v2/instance/{id}` | `exoscale/v2.delete-instance` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 | `DELETE` | `/v2/private-network/{id}/{field}` | `exoscale/v2.reset-private-network-field` | — |
-| `DELETE` | `/v2/private-network/{id}` | `exoscale/v2.delete-private-network` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
-| `DELETE` | `/v2/security-group/{id}/rules/{rule}` | `exoscale/v2.delete-rule-from-security-group` | `probe-refusal` |
-| `DELETE` | `/v2/security-group/{id}` | `exoscale/v2.delete-security-group` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `DELETE` | `/v2/ssh-key/{name}` | `exoscale/v2.delete-ssh-key` | `client` `contract` `runtime` `behaviour` |
-| `GET` | `/v2/anti-affinity-group/{id}` | `exoscale/v2.get-anti-affinity-group` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
+| `DELETE` | `/v2/private-network/{id}` | `exoscale/v2.delete-private-network` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `DELETE` | `/v2/security-group/{id}/rules/{rule}` | `exoscale/v2.delete-rule-from-security-group` | `contract` `probe` |
+| `DELETE` | `/v2/security-group/{id}` | `exoscale/v2.delete-security-group` | `client` `contract` `runtime` `probe` `behaviour` |
+| `DELETE` | `/v2/ssh-key/{name}` | `exoscale/v2.delete-ssh-key` | `client` `contract` `runtime` `probe` `behaviour` |
+| `GET` | `/v2/anti-affinity-group/{id}` | `exoscale/v2.get-anti-affinity-group` | `client` `contract` `runtime` `probe` `behaviour` |
 | `GET` | `/v2/anti-affinity-group` | `exoscale/v2.list-anti-affinity-groups` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 | `GET` | `/v2/deploy-target/{id}` | `exoscale/v2.get-deploy-target` | `probe-refusal` |
 | `GET` | `/v2/deploy-target` | `exoscale/v2.list-deploy-targets` | `contract` `shape` `probe` |
-| `GET` | `/v2/elastic-ip/{id}` | `exoscale/v2.get-elastic-ip` | `probe-refusal` |
+| `GET` | `/v2/elastic-ip/{id}` | `exoscale/v2.get-elastic-ip` | `contract` `probe` |
 | `GET` | `/v2/elastic-ip` | `exoscale/v2.list-elastic-ips` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 | `GET` | `/v2/instance-type/{id}` | `exoscale/v2.get-instance-type` | `client` `contract` `runtime` `probe` |
 | `GET` | `/v2/instance-type` | `exoscale/v2.list-instance-types` | `client` `contract` `shape` `runtime` `probe` |
-| `GET` | `/v2/instance/{id}` | `exoscale/v2.get-instance` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
+| `GET` | `/v2/instance/{id}` | `exoscale/v2.get-instance` | `client` `contract` `runtime` `probe` `behaviour` |
 | `GET` | `/v2/instance` | `exoscale/v2.list-instances` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
-| `GET` | `/v2/private-network/{id}` | `exoscale/v2.get-private-network` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
+| `GET` | `/v2/private-network/{id}` | `exoscale/v2.get-private-network` | `client` `contract` `runtime` `probe` `behaviour` |
 | `GET` | `/v2/private-network` | `exoscale/v2.list-private-networks` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
-| `GET` | `/v2/security-group/{id}` | `exoscale/v2.get-security-group` | `probe-refusal` |
+| `GET` | `/v2/security-group/{id}` | `exoscale/v2.get-security-group` | `contract` `probe` |
 | `GET` | `/v2/security-group` | `exoscale/v2.list-security-groups` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
-| `GET` | `/v2/ssh-key/{name}` | `exoscale/v2.get-ssh-key` | `client` `contract` `runtime` `behaviour` |
+| `GET` | `/v2/ssh-key/{name}` | `exoscale/v2.get-ssh-key` | `client` `contract` `runtime` `probe` `behaviour` |
 | `GET` | `/v2/ssh-key` | `exoscale/v2.list-ssh-keys` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
-| `GET` | `/v2/template/{id}` | `exoscale/v2.get-template` | `client` `contract` `runtime` `probe-refusal` |
+| `GET` | `/v2/template/{id}` | `exoscale/v2.get-template` | `client` `contract` `runtime` `probe` |
 | `GET` | `/v2/template` | `exoscale/v2.list-templates` | `client` `contract` `shape` `runtime` `probe` |
 | `POST` | `/v2/anti-affinity-group` | `exoscale/v2.create-anti-affinity-group` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/v2/elastic-ip` | `exoscale/v2.create-elastic-ip` | `client` `contract` `runtime` `probe` `behaviour` |
-| `POST` | `/v2/instance` | `exoscale/v2.create-instance` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
+| `POST` | `/v2/instance` | `exoscale/v2.create-instance` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/v2/private-network` | `exoscale/v2.create-private-network` | `client` `contract` `runtime` `probe` `behaviour` |
-| `POST` | `/v2/security-group/{id}/rules` | `exoscale/v2.add-rule-to-security-group` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
+| `POST` | `/v2/security-group/{id}/rules` | `exoscale/v2.add-rule-to-security-group` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/v2/security-group` | `exoscale/v2.create-security-group` | `client` `contract` `runtime` `probe` `behaviour` |
-| `POST` | `/v2/ssh-key` | `exoscale/v2.register-ssh-key` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `PUT` | `/v2/elastic-ip/{id}:attach` | `exoscale/v2.attach-instance-to-elastic-ip` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `PUT` | `/v2/elastic-ip/{id}:detach` | `exoscale/v2.detach-instance-from-elastic-ip` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `PUT` | `/v2/elastic-ip/{id}` | `exoscale/v2.update-elastic-ip` | `probe-refusal` |
-| `PUT` | `/v2/instance/{id}:add-protection` | `exoscale/v2.add-instance-protection` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `PUT` | `/v2/instance/{id}:reboot` | `exoscale/v2.reboot-instance` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `PUT` | `/v2/instance/{id}:remove-protection` | `exoscale/v2.remove-instance-protection` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `PUT` | `/v2/instance/{id}:reset` | `exoscale/v2.reset-instance` | `probe-refusal` |
-| `PUT` | `/v2/instance/{id}:resize-disk` | `exoscale/v2.resize-instance-disk` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `PUT` | `/v2/instance/{id}:scale` | `exoscale/v2.scale-instance` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `PUT` | `/v2/instance/{id}:start` | `exoscale/v2.start-instance` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `PUT` | `/v2/instance/{id}:stop` | `exoscale/v2.stop-instance` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `PUT` | `/v2/instance/{id}` | `exoscale/v2.update-instance` | `probe-refusal` |
-| `PUT` | `/v2/private-network/{id}:attach` | `exoscale/v2.attach-instance-to-private-network` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `PUT` | `/v2/private-network/{id}:detach` | `exoscale/v2.detach-instance-from-private-network` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
+| `POST` | `/v2/ssh-key` | `exoscale/v2.register-ssh-key` | `client` `contract` `runtime` `probe` `behaviour` |
+| `PUT` | `/v2/elastic-ip/{id}:attach` | `exoscale/v2.attach-instance-to-elastic-ip` | `client` `contract` `runtime` `probe` `behaviour` |
+| `PUT` | `/v2/elastic-ip/{id}:detach` | `exoscale/v2.detach-instance-from-elastic-ip` | `client` `contract` `runtime` `probe` `behaviour` |
+| `PUT` | `/v2/elastic-ip/{id}` | `exoscale/v2.update-elastic-ip` | `contract` `probe` |
+| `PUT` | `/v2/instance/{id}:add-protection` | `exoscale/v2.add-instance-protection` | `client` `contract` `runtime` `probe` `behaviour` |
+| `PUT` | `/v2/instance/{id}:reboot` | `exoscale/v2.reboot-instance` | `client` `contract` `runtime` `probe` `behaviour` |
+| `PUT` | `/v2/instance/{id}:remove-protection` | `exoscale/v2.remove-instance-protection` | `client` `contract` `runtime` `probe` `behaviour` |
+| `PUT` | `/v2/instance/{id}:reset` | `exoscale/v2.reset-instance` | `contract` `probe` |
+| `PUT` | `/v2/instance/{id}:resize-disk` | `exoscale/v2.resize-instance-disk` | `client` `contract` `runtime` `probe` `behaviour` |
+| `PUT` | `/v2/instance/{id}:scale` | `exoscale/v2.scale-instance` | `client` `contract` `runtime` `probe` `behaviour` |
+| `PUT` | `/v2/instance/{id}:start` | `exoscale/v2.start-instance` | `client` `contract` `runtime` `probe` `behaviour` |
+| `PUT` | `/v2/instance/{id}:stop` | `exoscale/v2.stop-instance` | `client` `contract` `runtime` `probe` `behaviour` |
+| `PUT` | `/v2/instance/{id}` | `exoscale/v2.update-instance` | `contract` `probe` |
+| `PUT` | `/v2/private-network/{id}:attach` | `exoscale/v2.attach-instance-to-private-network` | `client` `contract` `runtime` `probe` `behaviour` |
+| `PUT` | `/v2/private-network/{id}:detach` | `exoscale/v2.detach-instance-from-private-network` | `client` `contract` `runtime` `probe` `behaviour` |
 | `PUT` | `/v2/private-network/{id}:update-ip` | `exoscale/v2.update-private-network-instance-ip` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
-| `PUT` | `/v2/private-network/{id}` | `exoscale/v2.update-private-network` | `probe-refusal` |
-| `PUT` | `/v2/security-group/{id}:add-source` | `exoscale/v2.add-external-source-to-security-group` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `PUT` | `/v2/security-group/{id}:attach` | `exoscale/v2.attach-instance-to-security-group` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `PUT` | `/v2/security-group/{id}:detach` | `exoscale/v2.detach-instance-from-security-group` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `PUT` | `/v2/security-group/{id}:remove-source` | `exoscale/v2.remove-external-source-from-security-group` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
+| `PUT` | `/v2/private-network/{id}` | `exoscale/v2.update-private-network` | `contract` `probe` |
+| `PUT` | `/v2/security-group/{id}:add-source` | `exoscale/v2.add-external-source-to-security-group` | `client` `contract` `runtime` `probe` `behaviour` |
+| `PUT` | `/v2/security-group/{id}:attach` | `exoscale/v2.attach-instance-to-security-group` | `client` `contract` `runtime` `probe` `behaviour` |
+| `PUT` | `/v2/security-group/{id}:detach` | `exoscale/v2.detach-instance-from-security-group` | `client` `contract` `runtime` `probe` `behaviour` |
+| `PUT` | `/v2/security-group/{id}:remove-source` | `exoscale/v2.remove-external-source-from-security-group` | `client` `contract` `runtime` `probe` `behaviour` |
 
 ### `general`
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `GET` | `/v2/operation/{id}` | `exoscale/v2.get-operation` | `probe-refusal` |
+| `GET` | `/v2/operation/{id}` | `exoscale/v2.get-operation` | `contract` `probe` |
 | `GET` | `/v2/zone` | `exoscale/v2.list-zones` | `client` `contract` `shape` `runtime` `probe` |
 
 ### `quotas`

--- a/internal/cli/probe.go
+++ b/internal/cli/probe.go
@@ -118,11 +118,14 @@ func mountedRoutes(endpoint string) ([]contract.MountedRoute, error) {
 	return out, nil
 }
 
-// routesOf keeps the routes one contract knows about.
+// routesOf keeps the routes one contract describes — name, method and path,
+// not name alone: Outscale's document resolves any bare operationId, and a
+// Scaleway route matched by name used to be probed against the Outscale path
+// (see contract.Doc.Owns).
 func routesOf(routes []contract.MountedRoute, doc *contract.Doc) []contract.MountedRoute {
 	out := make([]contract.MountedRoute, 0, len(routes))
 	for _, r := range routes {
-		if _, _, known := doc.OperationFor(r.Operation); known {
+		if doc.Owns(r) {
 			out = append(out, r)
 		}
 	}

--- a/internal/contract/contract_test.go
+++ b/internal/contract/contract_test.go
@@ -197,3 +197,30 @@ func TestViolationsAreOrdered(t *testing.T) {
 		}
 	}
 }
+
+// TestAProbePlansOnlyTheRoutesItsDocumentDescribes: resolving a name is not
+// owning a route. Outscale's contract keys on bare operationIds, so Scaleway's
+// instance/v1/API.CreateImage resolved in it too, and the probe planned a
+// Scaleway route against the Outscale path — the verdict then landed on
+// whichever route the call actually hit. Owns demands the method and the path,
+// not the name alone.
+func TestAProbePlansOnlyTheRoutesItsDocumentDescribes(t *testing.T) {
+	doc, err := contract.Read(strings.NewReader(`{
+	  "provider": "stub",
+	  "pathPrefix": "/api/v1",
+	  "operations": {"CreateImage": {"method": "POST", "path": "/CreateImage", "response": "V"}},
+	  "schemas": {"V": {"closed": false, "properties": {"ok": {"type": "boolean"}}}}
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	owned := contract.MountedRoute{Method: "POST", Path: "/api/v1/CreateImage", Operation: "osc/Client.CreateImage"}
+	if !doc.Owns(owned) {
+		t.Errorf("the route the document describes is owned: %+v", owned)
+	}
+	foreign := contract.MountedRoute{Method: "POST", Path: "/instance/v1/zones/{zone}/images", Operation: "instance/v1/API.CreateImage"}
+	if doc.Owns(foreign) {
+		t.Errorf("a route that only shares the operation's bare name is not owned: %+v", foreign)
+	}
+}

--- a/internal/contract/routes.go
+++ b/internal/contract/routes.go
@@ -58,6 +58,24 @@ func (d *Doc) CheckRoutes(routes []MountedRoute) []RouteMismatch {
 	return out
 }
 
+// Owns reports whether this document actually describes one mounted route:
+// the operation resolves, and the route serves it at the method and path the
+// document declares.
+//
+// Resolving the name alone is not ownership. Outscale's contract keys on bare
+// operationIds, so Scaleway's instance/v1/API.CreateImage resolves in it too —
+// and the probe then planned Scaleway's route against Outscale's path, called
+// /api/v1/CreateImage under a Scaleway label, and recorded the verdict on
+// whichever route the call actually hit. One document, one route table:
+// TestAProbePlansOnlyTheRoutesItsDocumentDescribes fails without this.
+func (d *Doc) Owns(r MountedRoute) bool {
+	op, _, known := d.OperationFor(r.Operation)
+	if !known {
+		return false
+	}
+	return op.Method == r.Method && samePath(d.PathPrefix+op.Path, r.Path)
+}
+
 // samePath compares two path templates, ignoring what the parameters are called.
 //
 // A document writes /instance/{id} where another writes /instance/{instance-id},

--- a/internal/core/emulator/conformance.go
+++ b/internal/core/emulator/conformance.go
@@ -177,7 +177,16 @@ func (o *observer) wrap(provider string, r Route) http.HandlerFunc {
 		// Before the recorder wrapped every request there was no status to read
 		// without a contract, so this rule applied to half the runs. It applies
 		// to all of them now, which can only remove false positives.
-		if rec.status < 400 {
+		//
+		// And only a request a real client made. The report's question — and
+		// the gate's own wording — is "fields a real client sent that no
+		// handler read": the seeded probe (#163) fills every optional field
+		// the schema declares and the run can satisfy, so its bodies name
+		// fields no handler reads by design, and counting them failed the
+		// gate on traffic no client ever sends. The same boundary as the
+		// score itself: synthetic traffic moves no client-facing number.
+		// TestAProbedFieldIsNotAnUnreadField fails without the condition.
+		if rec.status < 400 && !synthetic {
 			o.recordUnread(r.Operation, unread)
 		}
 		// The contract verdict is carried on the exchange, not only counted per

--- a/internal/core/emulator/probe_evidence_test.go
+++ b/internal/core/emulator/probe_evidence_test.go
@@ -173,3 +173,47 @@ func TestAnAnswerOverThePageSizeBoundEarnsNothing(t *testing.T) {
 		t.Errorf("an answer over the bound it was asked earns nothing, got %q", got)
 	}
 }
+
+// TestAProbedFieldIsNotAnUnreadField holds the report to its own wording:
+// "fields a real client sent that no handler read". The seeded probe (#163)
+// fills every optional field the schema declares and the run can satisfy, so
+// its bodies name fields no handler reads by design — counting them failed
+// the conformance gate on traffic no client ever sends. The same field from a
+// real client still lands in the report, which is the half that must not be
+// lost by the exclusion.
+func TestAProbedFieldIsNotAnUnreadField(t *testing.T) {
+	ignoring := func(w http.ResponseWriter, r *http.Request) {
+		var narrow struct{}
+		_ = emulator.DecodeJSON(r, &narrow)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok": true}`))
+	}
+	ts := probeServer(t, ignoring, okList(`["a"]`))
+
+	send := func(probe bool) {
+		t.Helper()
+		req, err := http.NewRequest(http.MethodGet, ts.URL+"/stub/plain",
+			strings.NewReader(`{"stray": "value"}`)) //nolint:noctx // a local test server
+		if err != nil {
+			t.Fatal(err)
+		}
+		if probe {
+			req.Header.Set(emulator.ProbeHeader, "1")
+		}
+		resp, err := ts.Client().Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = resp.Body.Close()
+	}
+
+	send(true)
+	if unread := viewOf(t, ts).UnreadRequestFields["stub/v1/API.OpPlain"]; len(unread) != 0 {
+		t.Errorf("a synthetic body must not feed the unread-fields report, got %v", unread)
+	}
+
+	send(false)
+	if unread := viewOf(t, ts).UnreadRequestFields["stub/v1/API.OpPlain"]; len(unread) != 1 {
+		t.Errorf("the same field from a real client is the defect the report exists for, got %v", unread)
+	}
+}

--- a/internal/probe/plan.go
+++ b/internal/probe/plan.go
@@ -20,6 +20,18 @@ type Step struct {
 	Request string
 	// Skip says why this step will not run, empty when it will.
 	Skip string
+	// Product is the contract-key prefix ("block/v1" out of
+	// "block/v1.CreateVolume"), empty for the providers whose document is flat.
+	// It scopes the pool: a block volume and an instance volume share a word
+	// and nothing else.
+	Product string
+	// Makes is the folded resource type a success of this step brings into
+	// being ("volume"), empty for steps that create nothing. Derived from the
+	// operation's own name; it is what the planner's seeding order and the
+	// pool's created tier key on.
+	Makes string
+	// Kind says which phase the step belongs to.
+	Kind opKind
 }
 
 // Plan orders the routes so that what produces an identifier runs before what
@@ -30,10 +42,15 @@ type Step struct {
 // a machine reads the catalogue first, and so does this. Creates follow, and
 // deletes come last so the run leaves the store as it found it.
 //
-// Within a group the order is the contract's own, which is alphabetical, so two
-// runs plan the same thing. Nothing here tries to sort creates among themselves
-// by dependency: an identifier is resolved by whatever earlier call returned it,
-// and when none did, the step says so instead of running.
+// Within the creates the order is the seeding order (#163): a step that needs a
+// volume_id runs after the step whose name says it makes volumes. Before this,
+// creates ran alphabetically, CreateSnapshot arrived before the CreateVolume it
+// depends on, and the guaranteed refusal that followed was counted as if the
+// operation could answer nothing else. TestAConsumerRunsAfterItsProducer fails
+// without the ordering. Everything is derived from the contract and the
+// operations' own names: nothing here writes a scenario by hand, and an
+// operation whose needs no step produces still runs — against the wrong
+// identifier, into the refusal that honestly describes it.
 func Plan(doc *contract.Doc, routes []contract.MountedRoute) ([]Step, error) {
 	if doc == nil {
 		return nil, fmt.Errorf("no contract to plan from")
@@ -56,7 +73,10 @@ func Plan(doc *contract.Doc, routes []contract.MountedRoute) ([]Step, error) {
 			Method:    route.Method,
 			Path:      op.Path,
 			Request:   op.Request,
+			Product:   productOf(name),
 		}
+		step.Kind = kind(name, route.Method)
+		step.Makes = makes(name, step.Kind)
 		if op.Response == "" {
 			// Nothing to validate against, so calling it would prove only that
 			// it answered. Said out loud: these are what the extraction reports
@@ -64,7 +84,7 @@ func Plan(doc *contract.Doc, routes []contract.MountedRoute) ([]Step, error) {
 			step.Skip = "the contract declares no response schema"
 		}
 
-		switch kind(name, route.Method) {
+		switch step.Kind {
 		case kindDelete:
 			deletes = append(deletes, step)
 		case kindCreate:
@@ -76,8 +96,9 @@ func Plan(doc *contract.Doc, routes []contract.MountedRoute) ([]Step, error) {
 
 	byName := func(s []Step) { sort.Slice(s, func(i, j int) bool { return s[i].Contract < s[j].Contract }) }
 	byName(reads)
-	byName(creates)
 	byName(deletes)
+	rank := orderCreates(doc, creates)
+	orderDeletes(doc, deletes, rank)
 
 	// Reads run twice, and the second pass is what makes most of the plan
 	// reachable. The first finds an empty account, so nothing is harvested and
@@ -90,6 +111,283 @@ func Plan(doc *contract.Doc, routes []contract.MountedRoute) ([]Step, error) {
 	plan = append(plan, reads...)
 	plan = append(plan, deletes...)
 	return plan, nil
+}
+
+// orderCreates sorts the create steps so producers run before consumers, and
+// returns each resource type's rank for the teardown to mirror.
+//
+// Kahn's algorithm over the needs/makes edges, with the contract's own
+// alphabetical order inside each layer so two runs plan the same thing. A cycle
+// — two creates each naming a type the other makes — falls back to name order
+// for whatever remains, which is the old behaviour, stated rather than special.
+func orderCreates(doc *contract.Doc, creates []Step) map[string]int {
+	sort.Slice(creates, func(i, j int) bool { return creates[i].Contract < creates[j].Contract })
+
+	// A type is pending while a not-yet-ordered step makes it.
+	pending := map[string]int{}
+	for _, s := range creates {
+		if s.Makes != "" {
+			pending[s.Makes]++
+		}
+	}
+
+	needsOf := make([][]string, len(creates))
+	for i, s := range creates {
+		needsOf[i] = needs(doc, s)
+	}
+
+	ordered := make([]Step, 0, len(creates))
+	rank := map[string]int{}
+	done := make([]bool, len(creates))
+	place := func(i int) {
+		done[i] = true
+		if m := creates[i].Makes; m != "" {
+			if _, seen := rank[m]; !seen {
+				rank[m] = len(ordered)
+			}
+		}
+		ordered = append(ordered, creates[i])
+	}
+	for len(ordered) < len(creates) {
+		// One whole layer per sweep, against the pending set as it stood
+		// before the sweep. Placing steps mid-sweep unblocked whatever
+		// happened to sort after its producer and not before: Exoscale's
+		// remove-instance-protection ran the sweep create-instance landed in,
+		// while add-instance-protection waited for the next one — so the
+		// protection was added back after being removed, and delete-instance
+		// refused a resource the plan itself had locked
+		// (TestALayerRunsInNameOrder).
+		var layer []int
+		for i, s := range creates {
+			if done[i] {
+				continue
+			}
+			blocked := false
+			for _, need := range needsOf[i] {
+				if need == "resource" {
+					// A need that names only "resource" — Outscale's
+					// CreateTags — is satisfied by anything, so it waits for
+					// everything: it runs once every producer has run.
+					for made, left := range pending {
+						if made != s.Makes && left > 0 {
+							blocked = true
+							break
+						}
+					}
+				} else if need != s.Makes && pending[need] > 0 {
+					blocked = true
+				}
+				if blocked {
+					break
+				}
+			}
+			if !blocked {
+				layer = append(layer, i)
+			}
+		}
+		if len(layer) == 0 {
+			// A dependency cycle — Outscale's CreateImage wants a Vm and
+			// CreateVms wants an image. Release the first remaining step by
+			// name and keep sorting: everything the cycle does not bind stays
+			// correctly ordered, and the released step gets the retry pass
+			// (Run) once its needs exist. Releasing everything at once was the
+			// first version, and it dumped the whole provider back into
+			// alphabetical order for one cycle.
+			for i := range creates {
+				if !done[i] {
+					layer = []int{i}
+					break
+				}
+			}
+		}
+		for _, i := range layer {
+			place(i)
+		}
+		for _, i := range layer {
+			if m := creates[i].Makes; m != "" {
+				pending[m]--
+			}
+		}
+	}
+	copy(creates, ordered)
+	return rank
+}
+
+// orderDeletes sorts the teardown as the mirror of the seeding: what was made
+// last is unmade first, so DeleteSubnet runs before the DeleteNet that would
+// otherwise refuse a net still holding subnets. Unlinking sorts before
+// deleting at equal depth — an attachment must come off before either of its
+// ends can go — and name order settles the rest.
+func orderDeletes(doc *contract.Doc, deletes []Step, rank map[string]int) {
+	depth := func(s Step) int {
+		deepest := -1
+		for _, need := range needs(doc, s) {
+			if r, known := rank[need]; known && r > deepest {
+				deepest = r
+			}
+		}
+		// The type the step destroys counts too: DeleteRoute names no route
+		// id — a route is addressed by table and destination — and without
+		// this its depth was its table's, the reverse-name tie-break put
+		// DeleteRouteTable first, and the route died with its table before
+		// its own delete was measured.
+		if r, known := rank[unmakes(s.Contract)]; known && r > deepest {
+			deepest = r
+		}
+		return deepest
+	}
+	unlinks := func(s Step) bool {
+		verb := strings.ToLower(leafOf(s.Contract))
+		return strings.HasPrefix(verb, "unlink") || strings.HasPrefix(verb, "detach")
+	}
+	sort.SliceStable(deletes, func(i, j int) bool {
+		di, dj := depth(deletes[i]), depth(deletes[j])
+		if di != dj {
+			return di > dj
+		}
+		ui, uj := unlinks(deletes[i]), unlinks(deletes[j])
+		if ui != uj {
+			return ui
+		}
+		// Reverse name order at equal depth, because the creates ran in name
+		// order: DeleteSecurityGroupRule after DeleteSecurityGroup deleted a
+		// rule inside a group already gone.
+		return deletes[i].Contract > deletes[j].Contract
+	})
+}
+
+// needs lists the resource types one step's call will look for: its path
+// parameters, and the identifier fields of its request schema — optional ones
+// included, because the seeding fills them when their type exists and the
+// order must make that possible.
+func needs(doc *contract.Doc, s Step) []string {
+	seen := map[string]bool{}
+	var out []string
+	add := func(t string) {
+		if t != "" && !seen[t] {
+			seen[t] = true
+			out = append(out, t)
+		}
+	}
+
+	rest := s.Path
+	for {
+		open := strings.Index(rest, "{")
+		if open < 0 {
+			break
+		}
+		closing := strings.Index(rest[open:], "}")
+		if closing < 0 {
+			break
+		}
+		param := rest[open+1 : open+closing]
+		switch strings.ToLower(param) {
+		case "zone", "region":
+		default:
+			if isID(param) {
+				add(typeOfIDField(param))
+			} else if t := lastCollection(rest[:open]); t != "" {
+				add(t)
+			}
+		}
+		rest = rest[open+closing+1:]
+	}
+
+	addSchema(doc, s.Request, add, map[string]bool{})
+	return out
+}
+
+// addSchema walks one request schema for identifier fields, refs included —
+// BookIP's need for a private network lives one level down, in its source.
+func addSchema(doc *contract.Doc, name string, add func(string), visiting map[string]bool) {
+	if name == "" || visiting[name] {
+		return
+	}
+	visiting[name] = true
+	schema := doc.Schemas[name]
+	for field, prop := range schema.Properties {
+		if isID(field) {
+			add(typeOfIDField(field))
+			continue
+		}
+		if prop.Ref != "" {
+			// The field's own name is a need too: Exoscale's detach bodies say
+			// {"instance": {"id": …}}, and a teardown order that missed the
+			// instance need ran delete-instance before the detaches that still
+			// address it.
+			add(foldField(field))
+			addSchema(doc, prop.Ref, add, visiting)
+		}
+		if prop.Type == "object" && prop.Ref == "" {
+			add(foldField(field))
+		}
+	}
+}
+
+// productOf reads the product qualifier off a contract key:
+// "block/v1.CreateVolume" → "block/v1", "ReadVms" → "".
+func productOf(contractName string) string {
+	if dot := strings.LastIndex(contractName, "."); dot >= 0 && strings.Contains(contractName[:dot], "/") {
+		return contractName[:dot]
+	}
+	return ""
+}
+
+// leafOf strips the product qualifier: "block/v1.CreateVolume" → CreateVolume.
+func leafOf(contractName string) string {
+	if dot := strings.LastIndex(contractName, "."); dot >= 0 {
+		return contractName[dot+1:]
+	}
+	return contractName
+}
+
+// makes names the resource type a create-kind operation brings into being,
+// read from the operation's own name: CreateVolume → volume, register-ssh-key
+// → sshkey, add-rule-to-security-group → rule, BookIP → ip. Link operations
+// make their own link (LinkPublicIp answers a LinkPublicIpId), so the whole
+// name is the type. Empty for everything else: an update makes nothing.
+func makes(contractName string, k opKind) string {
+	if k != kindCreate {
+		return ""
+	}
+	leaf := leafOf(contractName)
+	lower := strings.ToLower(leaf)
+	for _, verb := range []string{"create", "register", "book", "add"} {
+		if !strings.HasPrefix(lower, verb) {
+			continue
+		}
+		made := strings.TrimPrefix(leaf[len(verb):], "-")
+		for _, cut := range []string{"-to-", "-from-"} {
+			if i := strings.Index(made, cut); i >= 0 {
+				made = made[:i]
+			}
+		}
+		return foldField(singular(made))
+	}
+	if strings.HasPrefix(lower, "link") || strings.HasPrefix(lower, "attach") {
+		return foldField(leaf)
+	}
+	return ""
+}
+
+// unmakes names the resource type a delete-kind operation removes, read from
+// its name the same way makes reads creations: DeleteRoute → route.
+func unmakes(contractName string) string {
+	leaf := leafOf(contractName)
+	lower := strings.ToLower(leaf)
+	for _, verb := range []string{"delete", "terminate", "release", "unlink", "detach", "remove"} {
+		if !strings.HasPrefix(lower, verb) {
+			continue
+		}
+		gone := strings.TrimPrefix(leaf[len(verb):], "-")
+		for _, cut := range []string{"-to-", "-from-"} {
+			if i := strings.Index(gone, cut); i >= 0 {
+				gone = gone[:i]
+			}
+		}
+		return foldField(singular(gone))
+	}
+	return ""
 }
 
 type opKind int

--- a/internal/probe/probe.go
+++ b/internal/probe/probe.go
@@ -36,11 +36,16 @@
 //
 // # Where it refuses to guess
 //
-// An identifier is never invented. Values come from what earlier calls in the
-// plan returned, and an operation needing one that nothing produces makes the
-// planning fail with a message naming it. Inventing an id would be an invented
-// format dressed up as automation, which is the one thing this project never
-// does: a shape comes from the provider's own SDK or not at all.
+// An identifier is never invented. The plan seeds what its calls will need
+// (#163): creates run before the operations that use their products, each
+// body is built from the contract's own request schema, and every identifier
+// comes from what an earlier call in the same run returned — typed, so a
+// server id never stands in for a volume id. An operation needing something
+// nothing produces still runs when any real identifier exists to refuse, and
+// is skipped with the missing value named when none does. Inventing an id
+// would be an invented format dressed up as automation, which is the one
+// thing this project never does: a shape comes from the provider's own SDK or
+// not at all.
 package probe
 
 import (
@@ -195,10 +200,42 @@ func (r *Runner) Run(ctx context.Context, routes []contract.MountedRoute) (Repor
 		client = &http.Client{Timeout: 30 * time.Second}
 	}
 
+	lastCreate := -1
+	for i, step := range plan {
+		if step.Kind == kindCreate {
+			lastCreate = i
+		}
+	}
+
 	pool := newPool()
 	report := Report{Provider: r.Doc.Provider}
-	for _, step := range plan {
+	for i, step := range plan {
 		report.Results = append(report.Results, r.call(ctx, client, step, pool))
+
+		if i == lastCreate {
+			// The retry half of the seeding (#163): a create the plan could
+			// not order — a dependency cycle, or a need only a later create
+			// satisfies — gets exactly one second attempt while the pool holds
+			// everything the first pass made and before the second read pass
+			// measures the result. Only steps that produced nothing are
+			// retried, so nothing is created twice, and the first result is
+			// replaced only when the retry did better: a promotion must come
+			// from a real answer, never from double counting.
+			// TestAnUnorderableCreateIsRetriedOnce fails without this pass.
+			for j := range report.Results {
+				res, retried := report.Results[j], plan[j]
+				if retried.Kind != kindCreate {
+					continue
+				}
+				if res.Skipped == "" && !res.Refused && res.Err == nil && res.Status < 300 {
+					continue
+				}
+				retry := r.call(ctx, client, retried, pool)
+				if retry.Skipped == "" && retry.Err == nil && retry.Status < 300 && !retry.Refused {
+					report.Results[j] = retry
+				}
+			}
+		}
 	}
 	return report, nil
 }
@@ -210,7 +247,7 @@ func (r *Runner) call(ctx context.Context, client *http.Client, step Step, pool 
 		return result
 	}
 
-	body, err := minimalBody(r.Doc, step.Request, pool)
+	body, err := minimalBody(r.Doc, step, step.Request, pool)
 	if err != nil {
 		// Not a failure: the contract does not let us build this call honestly,
 		// and inventing the missing value is the one thing this must not do.
@@ -218,7 +255,7 @@ func (r *Runner) call(ctx context.Context, client *http.Client, step Step, pool 
 		return result
 	}
 
-	path, err := pool.fill(step.Path)
+	path, err := pool.fill(step.Product, step.Path)
 	if err != nil {
 		result.Skipped = err.Error()
 		return result
@@ -245,8 +282,12 @@ func (r *Runner) call(ctx context.Context, client *http.Client, step Step, pool 
 	result.Violations = r.Doc.ValidateResponse(step.Contract, decoded)
 
 	// Whatever came back feeds the calls that follow: this is how a create finds
-	// the identifier a delete needs, without a scenario written by hand.
-	pool.harvest(decoded)
+	// the identifier a delete needs, without a scenario written by hand. The
+	// name the create sent is kept too, because it is now the name of a real
+	// resource: Exoscale addresses an SSH key by name, and the only place that
+	// name ever appears is the request that registered it.
+	pool.harvest(r.Doc, step, decoded)
+	pool.harvestSentName(step, body)
 
 	if len(result.Violations) > 0 {
 		return result

--- a/internal/probe/probe_test.go
+++ b/internal/probe/probe_test.go
@@ -92,11 +92,11 @@ func TestEveryRouteAnswersItsContract(t *testing.T) {
 	}
 }
 
-// Scaleway is probed too, and expected to prove less. Its document declares no
-// request schema at all — the bodies are inline, which the extraction cannot
-// name — so only the operations that take no body are reachable. Stated as a
-// test so the day the extraction learns inline bodies, the gain is visible
-// rather than assumed.
+// Scaleway is probed like the others; what it cannot prove is the family of
+// operations whose exchanges the document gives no schema for (the 204
+// deletes, the user-data files). Failures here are contract disagreements the
+// seeded run provoked — the block lists ignoring per_page were found exactly
+// this way.
 func TestScalewayProbesWhatItsDocumentAllows(t *testing.T) {
 	report := runProbe(t, scaleway.Name)
 	for _, failure := range report.Failures() {

--- a/internal/probe/seed_internal_test.go
+++ b/internal/probe/seed_internal_test.go
@@ -231,3 +231,37 @@ func TestTheGenericParameterNeverAnswersWithATenant(t *testing.T) {
 		t.Errorf("takeAny must answer with infrastructure, never a tenant or a request: %v", got)
 	}
 }
+
+// TestTheHintedBranchOfAChoiceIsFilled: block/v1's CreateVolume declares
+// from_empty and from_snapshot, optional both, "precisely one must be set" in
+// prose only. The hint table names from_empty as the branch a fresh run can
+// always satisfy; without the fill the create is a guaranteed refusal and the
+// whole block family stays unreachable — the /falsify hook for the hint
+// family.
+func TestTheHintedBranchOfAChoiceIsFilled(t *testing.T) {
+	doc := docOf(t, `{
+	  "provider": "stub",
+	  "operations": {"CreateVolume": {"method": "POST", "path": "/volumes", "request": "Req", "response": "V"}},
+	  "schemas": {
+	    "Req": {"closed": true, "required": ["name"], "properties": {
+	      "name": {"type": "string"},
+	      "from_empty": {"ref": "FromEmpty"},
+	      "from_snapshot": {"ref": "FromSnapshot"}
+	    }},
+	    "FromEmpty":    {"closed": true, "required": ["size"], "properties": {"size": {"type": "integer"}}},
+	    "FromSnapshot": {"closed": true, "required": ["snapshot_id"], "properties": {"snapshot_id": {"type": "string"}}},
+	    "V": {"closed": false, "properties": {"ok": {"type": "boolean"}}}
+	  }
+	}`)
+	body, err := minimalBody(doc, Step{Kind: kindCreate}, "Req", newPool())
+	if err != nil {
+		t.Fatal(err)
+	}
+	from, ok := body["from_empty"].(map[string]any)
+	if !ok || from["size"] != 1 {
+		t.Errorf("the hinted branch must be filled from its own schema, got %v", body["from_empty"])
+	}
+	if _, present := body["from_snapshot"]; present {
+		t.Errorf("the other branch stays absent — precisely one must be set: %v", body)
+	}
+}

--- a/internal/probe/seed_internal_test.go
+++ b/internal/probe/seed_internal_test.go
@@ -1,0 +1,233 @@
+package probe
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/contract"
+)
+
+// Internal tests for the pool and the planner: the properties here — tiering,
+// determinism, ordering — are what the end-to-end seed tests rest on, and each
+// one exists because its absence was measured as wrong verdicts, never as a
+// crash.
+
+func docOf(t *testing.T, body string) *contract.Doc {
+	t.Helper()
+	doc, err := contract.Read(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("read doc: %v", err)
+	}
+	return doc
+}
+
+const planDoc = `{
+  "provider": "stub",
+  "operations": {
+    "CreateVolume":   {"method": "POST", "path": "/volumes", "request": "CreateVolumeRequest", "response": "V"},
+    "CreateSnapshot": {"method": "POST", "path": "/snapshots", "request": "CreateSnapshotRequest", "response": "V"},
+    "CreateServer":   {"method": "POST", "path": "/servers", "response": "V"},
+    "AddProtection":    {"method": "POST", "path": "/servers/{server_id}/protect", "response": "V"},
+    "RemoveProtection": {"method": "POST", "path": "/servers/{server_id}/unprotect", "response": "V"},
+    "DeleteVolume":   {"method": "DELETE", "path": "/volumes/{volume_id}", "response": "V"},
+    "DeleteSnapshot": {"method": "DELETE", "path": "/snapshots/{snapshot_id}", "response": "V"}
+  },
+  "schemas": {
+    "CreateVolumeRequest":   {"closed": true, "properties": {"name": {"type": "string"}}},
+    "CreateSnapshotRequest": {"closed": true, "properties": {"volume_id": {"type": "string"}}},
+    "V": {"closed": false, "properties": {"ok": {"type": "boolean"}}}
+  }
+}`
+
+var planRoutes = []contract.MountedRoute{
+	{Method: "POST", Path: "/volumes", Operation: "stub/v1/API.CreateVolume"},
+	{Method: "POST", Path: "/snapshots", Operation: "stub/v1/API.CreateSnapshot"},
+	{Method: "POST", Path: "/servers", Operation: "stub/v1/API.CreateServer"},
+	{Method: "POST", Path: "/servers/{server_id}/protect", Operation: "stub/v1/API.AddProtection"},
+	{Method: "POST", Path: "/servers/{server_id}/unprotect", Operation: "stub/v1/API.RemoveProtection"},
+	{Method: "DELETE", Path: "/volumes/{volume_id}", Operation: "stub/v1/API.DeleteVolume"},
+	{Method: "DELETE", Path: "/snapshots/{snapshot_id}", Operation: "stub/v1/API.DeleteSnapshot"},
+}
+
+func positions(plan []Step) map[string]int {
+	out := map[string]int{}
+	for i, s := range plan {
+		out[s.Operation] = i // last occurrence, which is the one that matters
+	}
+	return out
+}
+
+// TestAConsumerRunsAfterItsProducer: CreateSnapshot names a volume_id, so it
+// runs after CreateVolume whatever the alphabet says — alphabetically it comes
+// first, and that order was the guaranteed refusal #163 measured.
+func TestAConsumerRunsAfterItsProducer(t *testing.T) {
+	plan, err := Plan(docOf(t, planDoc), planRoutes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	at := positions(plan)
+	if at["stub/v1/API.CreateSnapshot"] < at["stub/v1/API.CreateVolume"] {
+		t.Errorf("CreateSnapshot must follow the CreateVolume that seeds it: %v", at)
+	}
+}
+
+// TestALayerRunsInNameOrder: both protection steps depend on the server, and
+// they must run in name order within their layer — add, then remove. The
+// mid-sweep version ran remove in the producer's own sweep and add in the
+// next, so the run ended protected and delete-instance refused a lock the
+// plan itself had taken.
+func TestALayerRunsInNameOrder(t *testing.T) {
+	plan, err := Plan(docOf(t, planDoc), planRoutes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	at := positions(plan)
+	server := at["stub/v1/API.CreateServer"]
+	add, remove := at["stub/v1/API.AddProtection"], at["stub/v1/API.RemoveProtection"]
+	if add < server || remove < server {
+		t.Fatalf("both protection steps need the server first: %v", at)
+	}
+	if remove < add {
+		t.Errorf("within one layer the order is the name order — add before remove: %v", at)
+	}
+}
+
+// TestTeardownMirrorsTheSeeding: the snapshot was cut from the volume, so it
+// dies first. Depth comes from the producers' ranks, and the volume's delete
+// running first would refuse — a volume with snapshots is in use.
+func TestTeardownMirrorsTheSeeding(t *testing.T) {
+	plan, err := Plan(docOf(t, planDoc), planRoutes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	at := positions(plan)
+	if at["stub/v1/API.DeleteSnapshot"] > at["stub/v1/API.DeleteVolume"] {
+		t.Errorf("teardown mirrors seeding: the snapshot dies before its volume: %v", at)
+	}
+}
+
+// TestTheEnumSentinelIsNotChosen: Scaleway's documents put the proto3 zero
+// value first, and unknown_action is a value the emulator refuses like the
+// real API does. Sending it measures the sentinel, not the operation.
+func TestTheEnumSentinelIsNotChosen(t *testing.T) {
+	got := chooseEnum([]any{"unknown_action", "poweron", "poweroff"})
+	if got != "poweron" {
+		t.Errorf("chooseEnum picked %v, want the first non-sentinel value", got)
+	}
+	if got := chooseEnum([]any{"unknown_only"}); got != "unknown_only" {
+		t.Errorf("with only the sentinel to choose from, it is still the answer: %v", got)
+	}
+}
+
+// TestARefToAScalarSchemaYieldsAScalar: instance/v1's arch references a bare
+// enum schema, and the nested walk used to answer an object for it — the
+// emulator refused the JSON type itself ("cannot unmarshal object into … type
+// string").
+func TestARefToAScalarSchemaYieldsAScalar(t *testing.T) {
+	doc := docOf(t, `{
+	  "provider": "stub",
+	  "operations": {"CreateImage": {"method": "POST", "path": "/images", "request": "Req", "response": "V"}},
+	  "schemas": {
+	    "Req":  {"closed": true, "required": ["arch"], "properties": {"arch": {"ref": "Arch"}}},
+	    "Arch": {"closed": false, "type": "string", "enum": ["unknown_arch", "x86_64", "arm"]},
+	    "V":    {"closed": false, "properties": {"ok": {"type": "boolean"}}}
+	  }
+	}`)
+	body, err := minimalBody(doc, Step{Kind: kindCreate}, "Req", newPool())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if body["arch"] != "x86_64" {
+		t.Errorf("arch must be the first usable enum value, got %v", body["arch"])
+	}
+}
+
+// TestACreateOnlyVouchesForItsOwnPayload: a create's response embeds the
+// resources it references — CreateServer carries the catalogue image it
+// booted from — and filing those as "created" made UpdateImage try to change
+// the catalogue. Only the payload's own two levels earn the created tier.
+func TestACreateOnlyVouchesForItsOwnPayload(t *testing.T) {
+	doc := docOf(t, `{
+	  "provider": "stub",
+	  "operations": {"CreateServer": {"method": "POST", "path": "/servers", "response": "ServerView"}},
+	  "schemas": {
+	    "ServerView": {"closed": false, "properties": {"server": {"ref": "Server"}}},
+	    "Server": {"closed": false, "properties": {"id": {"type": "string"}}},
+	    "V": {"closed": false, "properties": {"ok": {"type": "boolean"}}}
+	  }
+	}`)
+	pool := newPool()
+	step := Step{Operation: "CreateServer", Contract: "CreateServer", Kind: kindCreate, Makes: "server"}
+	pool.harvest(doc, step, map[string]any{
+		"server": map[string]any{
+			"id":    "srv-1",
+			"image": map[string]any{"id": "img-catalogue"},
+		},
+	})
+
+	if got, _ := pool.take("", "server"); got != "srv-1" {
+		t.Errorf("the create vouches for its own id: %v", got)
+	}
+	byProduct := pool.ids["image"]
+	if byProduct == nil || byProduct[""] == nil {
+		t.Fatal("the embedded image id is still harvested, as observed")
+	}
+	if len(byProduct[""].created) != 0 {
+		t.Errorf("an embedded reference must not enter the created tier: %+v", byProduct[""])
+	}
+	if len(byProduct[""].observed) != 1 || byProduct[""].observed[0] != "img-catalogue" {
+		t.Errorf("the embedded image lands in the observed tier: %+v", byProduct[""])
+	}
+}
+
+// TestHarvestIsDeterministic: the walk iterates maps, Go iterates maps in
+// random order, and an order that varies makes take() answer different ids on
+// identical runs — verdicts that flap between runs are the exact
+// non-reproducibility #163 forbids.
+func TestHarvestIsDeterministic(t *testing.T) {
+	doc := docOf(t, `{
+	  "provider": "stub",
+	  "operations": {"ListThings": {"method": "GET", "path": "/things", "response": "V"}},
+	  "schemas": {"V": {"closed": false, "properties": {"ok": {"type": "boolean"}}}}
+	}`)
+	response := map[string]any{
+		"alpha_id": "a", "beta_id": "b", "gamma_id": "c",
+		"things": []any{
+			map[string]any{"id": "t1"}, map[string]any{"id": "t2"},
+		},
+	}
+	step := Step{Operation: "ListThings", Contract: "ListThings"}
+
+	reference := newPool()
+	reference.harvest(doc, step, response)
+	for range 50 {
+		pool := newPool()
+		pool.harvest(doc, step, response)
+		if !reflect.DeepEqual(pool.ids, reference.ids) {
+			t.Fatalf("two harvests of one response disagree:\n%v\n%v", pool.ids, reference.ids)
+		}
+	}
+}
+
+// TestTheGenericParameterNeverAnswersWithATenant: "any resource" excludes the
+// ids that are not resources — a request id, the account — because each once
+// stood in for a resource and bought an invented refusal (CreateTags tagging
+// the account id).
+func TestTheGenericParameterNeverAnswersWithATenant(t *testing.T) {
+	doc := docOf(t, `{
+	  "provider": "stub",
+	  "operations": {"CreateNet": {"method": "POST", "path": "/nets", "response": "V"}},
+	  "schemas": {"V": {"closed": false, "properties": {"ok": {"type": "boolean"}}}}
+	}`)
+	pool := newPool()
+	step := Step{Operation: "CreateNet", Contract: "CreateNet", Kind: kindCreate, Makes: "net"}
+	pool.harvest(doc, step, map[string]any{
+		"RequestId": "req-1",
+		"AccountId": "acc-1",
+		"NetId":     "net-1",
+	})
+	if got, ok := pool.takeAny("ResourceId"); !ok || got != "net-1" {
+		t.Errorf("takeAny must answer with infrastructure, never a tenant or a request: %v", got)
+	}
+}

--- a/internal/probe/seed_test.go
+++ b/internal/probe/seed_test.go
@@ -1,0 +1,300 @@
+package probe_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/contract"
+	"github.com/stephrobert/feint/internal/probe"
+)
+
+// The seeding half of the probe (#163): before an operation is probed, the run
+// brings into being what that operation needs — from the contract's own request
+// schema and from what its own earlier calls returned. These tests drive the
+// whole Runner against small hand-built servers, because the property under
+// test is end to end: a Get must end up exercised against an identifier that
+// exists, and fall back to a refusal when its seed is taken away. Removing a
+// seeding rule must turn the matching test red — that is the /falsify criterion
+// the issue states.
+
+// seedDoc declares a little cloud with a dependency in it: a snapshot is cut
+// from a volume, and both are readable by id.
+const seedDoc = `{
+  "provider": "stub",
+  "errorSchema": "StubError",
+  "operations": {
+    "CreateVolume":   {"method": "POST", "path": "/volumes", "request": "CreateVolumeRequest", "response": "VolumeView"},
+    "CreateSnapshot": {"method": "POST", "path": "/snapshots", "request": "CreateSnapshotRequest", "response": "SnapshotView"},
+    "GetVolume":      {"method": "GET", "path": "/volumes/{volume_id}", "response": "VolumeView"},
+    "GetSnapshot":    {"method": "GET", "path": "/snapshots/{snapshot_id}", "response": "SnapshotView"}
+  },
+  "schemas": {
+    "CreateVolumeRequest":   {"closed": true, "properties": {"name": {"type": "string"}}},
+    "CreateSnapshotRequest": {"closed": true, "properties": {"volume_id": {"type": "string"}}},
+    "VolumeView":   {"closed": true, "properties": {"volume": {"ref": "Volume"}}},
+    "SnapshotView": {"closed": true, "properties": {"snapshot": {"ref": "Snapshot"}}},
+    "Volume":   {"closed": true, "properties": {"id": {"type": "string"}}},
+    "Snapshot": {"closed": true, "properties": {"id": {"type": "string"}}},
+    "StubError": {"closed": false, "required": ["message"], "properties": {"message": {"type": "string"}}}
+  }
+}`
+
+// seedServer emulates that little cloud with the strictness the real packs
+// have: a snapshot of no volume is refused, a read of an absent id is a 404 in
+// the declared error shape.
+func seedServer() http.Handler {
+	var volumeID, snapshotID string
+	refuse := func(w http.ResponseWriter, status int, msg string) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(map[string]any{"message": msg})
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /volumes", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Name string `json:"name"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if req.Name == "" {
+			refuse(w, 400, "name is required")
+			return
+		}
+		volumeID = "vol-1"
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"volume": map[string]any{"id": volumeID}})
+	})
+	mux.HandleFunc("POST /snapshots", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			VolumeID string `json:"volume_id"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if req.VolumeID == "" || req.VolumeID != volumeID {
+			refuse(w, 400, "volume_id is required and must exist")
+			return
+		}
+		snapshotID = "snap-1"
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"snapshot": map[string]any{"id": snapshotID}})
+	})
+	mux.HandleFunc("GET /volumes/{id}", func(w http.ResponseWriter, r *http.Request) {
+		if r.PathValue("id") != volumeID || volumeID == "" {
+			refuse(w, 404, "no such volume")
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"volume": map[string]any{"id": volumeID}})
+	})
+	mux.HandleFunc("GET /snapshots/{id}", func(w http.ResponseWriter, r *http.Request) {
+		if r.PathValue("id") != snapshotID || snapshotID == "" {
+			refuse(w, 404, "no such snapshot")
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"snapshot": map[string]any{"id": snapshotID}})
+	})
+	return mux
+}
+
+var seedRoutes = []contract.MountedRoute{
+	{Method: "POST", Path: "/volumes", Operation: "stub/v1/API.CreateVolume"},
+	{Method: "POST", Path: "/snapshots", Operation: "stub/v1/API.CreateSnapshot"},
+	{Method: "GET", Path: "/volumes/{volume_id}", Operation: "stub/v1/API.GetVolume"},
+	{Method: "GET", Path: "/snapshots/{snapshot_id}", Operation: "stub/v1/API.GetSnapshot"},
+}
+
+func runSeeded(t *testing.T, docJSON string, handler http.Handler, routes []contract.MountedRoute) probe.Report {
+	t.Helper()
+	doc, err := contract.Read(strings.NewReader(docJSON))
+	if err != nil {
+		t.Fatalf("read the stub contract: %v", err)
+	}
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	runner := &probe.Runner{Doc: doc, Base: ts.URL, Client: ts.Client()}
+	report, err := runner.Run(context.Background(), routes)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	return report
+}
+
+func lastResult(report probe.Report, operation string) probe.Result {
+	var out probe.Result
+	for _, res := range report.Results {
+		if res.Operation == operation {
+			out = res
+		}
+	}
+	return out
+}
+
+// TestAGetIsProbedAgainstAnIdentifierThatExists is the issue in one test: the
+// probe seeds a volume, then a snapshot of it, and both Gets validate their
+// success shape instead of the guaranteed 404 an empty account answers. The
+// snapshot's create itself only succeeds because the seeding filled its
+// optional volume_id with the id the volume's create returned — no identifier
+// is invented anywhere.
+func TestAGetIsProbedAgainstAnIdentifierThatExists(t *testing.T) {
+	report := runSeeded(t, seedDoc, seedServer(), seedRoutes)
+	if failures := report.Failures(); len(failures) > 0 {
+		t.Fatalf("nothing here disagrees with the contract: %v", failures)
+	}
+	for _, op := range []string{
+		"stub/v1/API.CreateVolume", "stub/v1/API.CreateSnapshot",
+		"stub/v1/API.GetVolume", "stub/v1/API.GetSnapshot",
+	} {
+		res := lastResult(report, op)
+		if res.Refused || res.Skipped != "" || res.Status >= 300 {
+			t.Errorf("%s must reach its success shape with the seeds in place, got %+v", op, res)
+		}
+	}
+}
+
+// TestASeededCreateFillsWhatTheRunHolds pins the fill rule itself: volume_id
+// is optional in the schema, so before the seeding the snapshot's create sent
+// an empty body and could only be refused. Take the volume producer out of the
+// mounted routes — the family's seed — and the snapshot must fall back to that
+// refusal: a promotion that survives the removal of its seed is not a
+// promotion (#163's /falsify criterion, run here on every `go test`).
+func TestASeededCreateFillsWhatTheRunHolds(t *testing.T) {
+	report := runSeeded(t, seedDoc, seedServer(), seedRoutes)
+	if res := lastResult(report, "stub/v1/API.CreateSnapshot"); res.Refused || res.Status != 201 {
+		t.Fatalf("with a volume seeded, the snapshot create must succeed: %+v", res)
+	}
+
+	unseeded := make([]contract.MountedRoute, 0, len(seedRoutes)-1)
+	for _, r := range seedRoutes {
+		if r.Operation != "stub/v1/API.CreateVolume" {
+			unseeded = append(unseeded, r)
+		}
+	}
+	report = runSeeded(t, seedDoc, seedServer(), unseeded)
+	if res := lastResult(report, "stub/v1/API.CreateSnapshot"); !res.Refused {
+		t.Fatalf("without its seed the snapshot create must fall back to a refusal, got %+v", res)
+	}
+	if res := lastResult(report, "stub/v1/API.GetSnapshot"); !res.Refused && res.Skipped == "" {
+		t.Fatalf("without the chain's root nothing downstream may pass: %+v", res)
+	}
+}
+
+// TestAPathParameterIsAnsweredByItsOwnKind pins the typed lookup: the wrong-
+// type identifiers were where the 404 refusals of #163 came from — {server_id}
+// answered by an organisation id. Here the server holds a volume and a
+// snapshot with distinct ids and refuses a read of the wrong one; only a typed
+// pool can pass both reads in one run.
+func TestAPathParameterIsAnsweredByItsOwnKind(t *testing.T) {
+	report := runSeeded(t, seedDoc, seedServer(), seedRoutes)
+	for _, op := range []string{"stub/v1/API.GetVolume", "stub/v1/API.GetSnapshot"} {
+		if res := lastResult(report, op); res.Refused || res.Status != 200 {
+			t.Errorf("%s got %+v: a typed pool answers each parameter with its own kind", op, res)
+		}
+	}
+}
+
+// cycleDoc declares the knot Outscale really has: an image is made from a
+// machine, a machine is made from an image. Neither create can be ordered
+// after the other.
+const cycleDoc = `{
+  "provider": "stub",
+  "errorSchema": "StubError",
+  "operations": {
+    "CreateImage": {"method": "POST", "path": "/images", "request": "CreateImageRequest", "response": "ImageView"},
+    "CreateVm":    {"method": "POST", "path": "/vms", "request": "CreateVmRequest", "response": "VmView"}
+  },
+  "schemas": {
+    "CreateImageRequest": {"closed": true, "properties": {"vm_id": {"type": "string"}}},
+    "CreateVmRequest":    {"closed": true, "properties": {"image_id": {"type": "string"}}},
+    "ImageView": {"closed": true, "properties": {"image": {"ref": "Image"}}},
+    "VmView":    {"closed": true, "properties": {"vm": {"ref": "Vm"}}},
+    "Image": {"closed": true, "properties": {"id": {"type": "string"}}},
+    "Vm":    {"closed": true, "properties": {"id": {"type": "string"}}},
+    "StubError": {"closed": false, "required": ["message"], "properties": {"message": {"type": "string"}}}
+  }
+}`
+
+// TestAnUnorderableCreateIsRetriedOnce: the cycle forces one of the two to run
+// first and fail — the machine can boot without an image here, the image
+// cannot exist without a machine — and the retry pass, run after the create
+// phase with the pool full, is what turns that planned failure into the
+// success the operation can actually produce. Without the retry, CreateImage
+// stays a refusal forever, by construction.
+func TestAnUnorderableCreateIsRetriedOnce(t *testing.T) {
+	var vmID string
+	refuse := func(w http.ResponseWriter, msg string) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{"message": msg})
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /images", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			VMID string `json:"vm_id"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if req.VMID == "" || req.VMID != vmID {
+			refuse(w, "an image is cut from a machine")
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"image": map[string]any{"id": "img-1"}})
+	})
+	mux.HandleFunc("POST /vms", func(w http.ResponseWriter, _ *http.Request) {
+		vmID = "vm-1"
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"vm": map[string]any{"id": vmID}})
+	})
+
+	routes := []contract.MountedRoute{
+		{Method: "POST", Path: "/images", Operation: "stub/v1/API.CreateImage"},
+		{Method: "POST", Path: "/vms", Operation: "stub/v1/API.CreateVm"},
+	}
+	report := runSeeded(t, cycleDoc, mux, routes)
+	if res := lastResult(report, "stub/v1/API.CreateImage"); res.Refused || res.Status != 201 {
+		t.Fatalf("the retry pass must give the cycle's loser its second chance: %+v", res)
+	}
+}
+
+// vocabDoc declares one operation whose only obstacle is a format: the schema
+// says string, the server validates an OpenSSH public key — exactly what all
+// three real packs do.
+const vocabDoc = `{
+  "provider": "stub",
+  "errorSchema": "StubError",
+  "operations": {
+    "CreateKey": {"method": "POST", "path": "/keys", "request": "CreateKeyRequest", "response": "KeyView"}
+  },
+  "schemas": {
+    "CreateKeyRequest": {"closed": true, "required": ["public_key"], "properties": {"public_key": {"type": "string"}}},
+    "KeyView": {"closed": true, "properties": {"key": {"ref": "Key"}}},
+    "Key": {"closed": true, "properties": {"id": {"type": "string"}}},
+    "StubError": {"closed": false, "required": ["message"], "properties": {"message": {"type": "string"}}}
+  }
+}`
+
+// TestTheVocabularySeedsWhatAFormatFieldNeeds: a public_key filled with the
+// generic probe string is a guaranteed refusal on every provider, and the
+// vocabulary's fixed sample key is what turns the operation probeable. Remove
+// the vocabulary entry and this fails — the /falsify hook for the format
+// family.
+func TestTheVocabularySeedsWhatAFormatFieldNeeds(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /keys", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			PublicKey string `json:"public_key"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if !strings.HasPrefix(req.PublicKey, "ssh-ed25519 ") || len(strings.Fields(req.PublicKey)) < 2 {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]any{"message": "not an OpenSSH public key"})
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"key": map[string]any{"id": "key-1"}})
+	})
+	routes := []contract.MountedRoute{{Method: "POST", Path: "/keys", Operation: "stub/v1/API.CreateKey"}}
+	report := runSeeded(t, vocabDoc, mux, routes)
+	if res := lastResult(report, "stub/v1/API.CreateKey"); res.Refused || res.Status != 201 {
+		t.Fatalf("the sample key must satisfy an OpenSSH validation: %+v", res)
+	}
+}

--- a/internal/probe/values.go
+++ b/internal/probe/values.go
@@ -10,17 +10,24 @@ import (
 )
 
 // minimalBody builds the smallest request the contract accepts: the required
-// fields and nothing else.
+// fields, plus the optional fields the run can honestly satisfy — an identifier
+// the run already holds, a name the run already recorded, or a field the value
+// vocabulary below covers.
 //
-// Nothing else on purpose. Filling optional fields would mean choosing values
-// the document does not constrain — a commercial type, an image name — and those
-// live in the emulated catalogue, not in the schema. A probe that guessed them
-// would be inventing a format, which no part of this emulator is allowed to do.
+// Optional fields outside those three rules are never filled. Filling them
+// would mean choosing values the document does not constrain — a commercial
+// type, an image name — and those live in the emulated catalogue, not in the
+// schema. A probe that guessed them would be inventing a format, which no part
+// of this emulator is allowed to do.
 //
 // A required field that is an identifier is taken from what earlier calls
 // returned. When nothing produced it, this fails with the field named, and the
 // caller skips the step rather than sending a value nobody can justify.
-func minimalBody(doc *contract.Doc, schemaName string, pool *pool) (map[string]any, error) {
+func minimalBody(doc *contract.Doc, step Step, schemaName string, pool *pool) (map[string]any, error) {
+	return buildBody(doc, step, schemaName, pool, true)
+}
+
+func buildBody(doc *contract.Doc, step Step, schemaName string, pool *pool, top bool) (map[string]any, error) {
 	body := map[string]any{}
 	if schemaName == "" {
 		// No request schema. Either the operation takes no body, or the document
@@ -40,22 +47,167 @@ func minimalBody(doc *contract.Doc, schemaName string, pool *pool) (map[string]a
 		if !declared {
 			return nil, fmt.Errorf("%s requires %s and does not declare it", schemaName, field)
 		}
-		value, err := valueFor(doc, field, prop, pool)
+		value, err := valueFor(doc, step, field, prop, pool)
 		if err != nil {
 			return nil, err
 		}
 		body[field] = value
 	}
+
+	// The seeding half (#163): an optional field is filled when, and only when,
+	// the run already holds what it names. This is what lets a create succeed
+	// instead of refusing for the want of a field its own schema marks
+	// optional — instance/v1's CreateVolume refuses a body without name, block's
+	// CreateSnapshot refuses one without volume_id, and both fields are
+	// optional in the extracted document. TestASeededCreateFillsWhatTheRunHolds
+	// fails without this loop.
+	names := make([]string, 0, len(schema.Properties))
+	for name := range schema.Properties {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, field := range names {
+		if _, done := body[field]; done {
+			continue
+		}
+		value, ok := optionalValue(doc, step, schemaName, field, schema.Properties[field], pool, top)
+		if ok {
+			body[field] = value
+		}
+	}
 	return body, nil
 }
 
-// valueFor produces one field's value, from the pool when it is an identifier
-// and from the schema when the schema constrains it.
-func valueFor(doc *contract.Doc, field string, prop contract.Property, pool *pool) (any, error) {
-	// An enumerated field has its answer in the document. First value, so two
-	// runs send the same thing.
+// optionalValue fills one optional field, under the rules that keep a fill
+// honest: a value the document itself pins (an enum), a format the vocabulary
+// covers, an identifier or a name the run already holds, or a field the hint
+// table names. Reports false when the field should stay absent.
+//
+// The rules are self-limiting on purpose: an identifier is filled only when a
+// value of its own type exists, so kms_key_id or nexthop_vpc_connector_id —
+// fields whose type nothing in a run produces — stay absent, and the refusals
+// the emulator reserves for them stay reachable.
+func optionalValue(doc *contract.Doc, step Step, schemaName, field string, prop contract.Property, pool *pool, top bool) (any, bool) {
+	fold := foldField(field)
+
+	// A field the value vocabulary marks as fillable-when-optional: today the
+	// CIDR family, whose absence is what made vpc/v2's CreateRoute unreachable.
+	if sample, vocab := cidrFields[fold]; vocab {
+		if prop.Type == "" || prop.Type == "string" {
+			return sample, true
+		}
+	}
+	hinted := fillWhenOptional[fold] || fillWhenOptional[qualifiedField(schemaName, fold)]
+	if hinted && prop.Ref != "" {
+		nested, err := buildBody(doc, step, prop.Ref, pool, false)
+		if err != nil {
+			return nil, false
+		}
+		return nested, true
+	}
+	if hinted && prop.Type == "array" && prop.Items != nil && prop.Items.Ref != "" {
+		item, err := buildBody(doc, step, prop.Items.Ref, pool, false)
+		if err != nil || len(item) == 0 {
+			return nil, false
+		}
+		return []any{item}, true
+	}
+
+	// The format vocabulary's optional half: a public key or a MAC left out of
+	// a body is, on every emulated path that names one, the whole reason the
+	// call refuses — Outscale's CreateKeypair deliberately refuses to invent a
+	// keypair, and IPAM's attach family validates the MAC before anything
+	// else. An optional enum is filled too, from the document's own values:
+	// Scaleway's ServerAction without an action is a refusal by definition.
+	if sample, known := sampleFor(field); known && (prop.Type == "" || prop.Type == "string") {
+		return sample, true
+	}
 	if len(prop.Enum) > 0 {
-		return prop.Enum[0], nil
+		return chooseEnum(prop.Enum), true
+	}
+	if prop.Ref != "" {
+		if nested, known := doc.Schemas[prop.Ref]; known && nested.Properties == nil && len(nested.Enum) > 0 {
+			return chooseEnum(nested.Enum), true
+		}
+	}
+
+	// An identifier the run holds. Same take as a required identifier, minus
+	// the failure: absence means absence, not a skip.
+	if isID(field) && (prop.Type == "" || prop.Type == "string") {
+		if value, found := pool.take(step.Product, typeOfIDField(field)); found {
+			return value, true
+		}
+		return nil, false
+	}
+	// An undescribed object named after a resource the run holds, same rule as
+	// valueFor's: {"instance": {"id": …}} is how Exoscale bodies point at one.
+	if prop.Type == "object" && prop.Ref == "" {
+		if value, found := pool.take(step.Product, fold); found {
+			return map[string]any{"id": value}, true
+		}
+	}
+
+	// A name the run recorded, for the providers that address a resource by
+	// name: Outscale's DeleteKeypair carries KeypairName and no identifier at
+	// all. A bare "name" on a create is filled with the probe's own constant,
+	// which is also what makes the created resource findable by name later.
+	if strings.HasSuffix(fold, "name") && (prop.Type == "" || prop.Type == "string") {
+		if value, found := pool.takeName(strings.TrimSuffix(fold, "name")); found {
+			return value, true
+		}
+		if top && fold == "name" && step.Kind == kindCreate {
+			return probeValue, true
+		}
+	}
+	return nil, false
+}
+
+// qualifiedField keys a hint by the schema it applies to:
+// "setsecuritygrouprules.request.rules".
+func qualifiedField(schemaName, fold string) string {
+	leaf := schemaName
+	if slash := strings.LastIndex(leaf, "/"); slash >= 0 {
+		leaf = leaf[slash+1:]
+	}
+	if dot := strings.Index(leaf, "."); dot >= 0 {
+		leaf = leaf[dot+1:]
+	}
+	return foldField(leaf) + "." + fold
+}
+
+// probeValue is the string sent for every unconstrained text field.
+const probeValue = "feint-probe"
+
+// chooseEnum picks one value out of an enumeration, deterministically: the
+// first value that is not the "unspecified" sentinel. Scaleway's documents put
+// the proto3 zero value first (unknown_action, unknown_direction), a value the
+// emulator — like the real API — refuses; sending it would measure the
+// sentinel, not the operation (TestTheEnumSentinelIsNotChosen).
+func chooseEnum(values []any) any {
+	for _, v := range values {
+		if text, ok := v.(string); ok && strings.HasPrefix(strings.ToLower(text), "unknown") {
+			continue
+		}
+		return v
+	}
+	return values[0]
+}
+
+// valueFor produces one required field's value, from the pool when it is an
+// identifier and from the schema when the schema constrains it. Required is
+// what turns an empty pool into an error: the call cannot be built honestly.
+func valueFor(doc *contract.Doc, step Step, field string, prop contract.Property, pool *pool) (any, error) {
+	// An enumerated field has its answer in the document. Always the same one,
+	// so two runs send the same thing.
+	if len(prop.Enum) > 0 {
+		return chooseEnum(prop.Enum), nil
+	}
+
+	// The value vocabulary: fields whose type is a string to the schema and a
+	// format to the emulator. Checked before the identifier rule so a
+	// public_key is never mistaken for one.
+	if sample, known := sampleFor(field); known {
+		return sample, nil
 	}
 
 	switch {
@@ -63,18 +215,47 @@ func valueFor(doc *contract.Doc, field string, prop contract.Property, pool *poo
 		if prop.Items == nil {
 			return []any{}, nil
 		}
-		item, err := valueFor(doc, singular(field), *prop.Items, pool)
+		item, err := valueFor(doc, step, singular(field), *prop.Items, pool)
 		if err != nil {
 			return nil, err
 		}
 		return []any{item}, nil
 
 	case prop.Ref != "":
-		nested, err := minimalBody(doc, prop.Ref, pool)
+		nested, known := doc.Schemas[prop.Ref]
+		if known && nested.Properties == nil && nested.Type != "" {
+			// A reference to a bare scalar — Scaleway's enum types, like
+			// instance/v1's Arch. Before this, the nested walk answered an
+			// object and the emulator refused the JSON type itself
+			// (TestARefToAScalarSchemaYieldsAScalar).
+			return valueFor(doc, step, field, contract.Property{Type: nested.Type, Enum: nested.Enum}, pool)
+		}
+		built, err := buildBody(doc, step, prop.Ref, pool, false)
 		if err != nil {
 			return nil, err
 		}
-		return nested, nil
+		// A reference named after a resource the run holds is that resource:
+		// Exoscale's create-instance says {"template": {…}}, the template
+		// schema declares an id, and the id of a real template is the one
+		// honest thing to put there (TestASeededCreateFillsWhatTheRunHolds).
+		if _, hasID := built["id"]; !hasID {
+			if _, declares := nested.Properties["id"]; declares {
+				if value, found := pool.take(step.Product, foldField(field)); found {
+					built["id"] = value
+				}
+			}
+		}
+		return built, nil
+
+	case prop.Type == "object":
+		// An object the document does not describe. When its field names a
+		// resource the run holds — Exoscale's attach bodies carry
+		// {"instance": {"id": …}} — the identifier is the one honest thing to
+		// put inside; otherwise an empty object is.
+		if value, found := pool.take(step.Product, foldField(field)); found {
+			return map[string]any{"id": value}, nil
+		}
+		return map[string]any{}, nil
 
 	case prop.Type == "boolean":
 		return false, nil
@@ -84,22 +265,159 @@ func valueFor(doc *contract.Doc, field string, prop contract.Property, pool *poo
 
 	// A string. If it looks like an identifier, it must come from somewhere
 	// real; anything else is a name the emulator will not validate.
-	if looksLikeID(field) {
-		if value, found := pool.take(field); found {
+	if isID(field) {
+		if typeOfIDField(field) == "resource" {
+			// A field that says only "resource" means any resource: Outscale's
+			// CreateTags tags whatever the ids name. Any identifier the run
+			// created is an honest answer.
+			if value, found := pool.takeAny(field); found {
+				return value, nil
+			}
+		}
+		if value, found := pool.take(step.Product, typeOfIDField(field)); found {
+			return value, nil
+		}
+		if value, found := pool.takeAny(field); found {
+			// Nothing of this type exists, so the call cannot succeed — but it
+			// can still be refused, and a refusal in the declared error shape
+			// is a verdict (#156). An identifier of the wrong kind is still an
+			// identifier something answered, never one this probe made up.
 			return value, nil
 		}
 		return nil, fmt.Errorf("%s is an identifier and nothing in the plan produced one", field)
 	}
-	return "feint-probe", nil
+	if strings.HasSuffix(foldField(field), "name") {
+		if value, found := pool.takeName(strings.TrimSuffix(foldField(field), "name")); found {
+			return value, nil
+		}
+	}
+	return probeValue, nil
 }
 
-// looksLikeID recognises the fields whose value has to exist. All three
-// providers name them the same way, in their own case: VmId, ImageId, net-id,
-// private_network_id.
-func looksLikeID(field string) bool {
-	lower := strings.ToLower(strings.TrimSuffix(strings.ToLower(field), "s"))
-	return strings.HasSuffix(lower, "id") || strings.HasSuffix(lower, "-id") ||
-		strings.HasSuffix(lower, "_id")
+// The value vocabulary. Each entry is a field whose schema type is string and
+// whose value the emulator validates as a format; the sample is a fixed,
+// syntactically valid instance of that format, the same way "feint-probe"
+// stands for every unconstrained name. All providers' spellings live side by
+// side, the same doctrine as the verb table in plan.go. Removing an entry must
+// drop the operations it feeds back to refusal: /falsify replays that, and
+// TestTheVocabularySeedsWhatAFormatFieldNeeds pins each family.
+const (
+	// cidrSample is RFC 5737 TEST-NET-1: a block reserved for documentation,
+	// which an emulator's private inventory can carve without colliding with
+	// anything real.
+	cidrSample = "192.0.2.0/24"
+	// destinationSample is TEST-NET-2, and it is a different block on purpose:
+	// a created Net carries cidrSample, so a route whose destination reused it
+	// would collide with the implicit local route every route table is born
+	// with — Outscale answered "the destination already has a route", and the
+	// refusal was this probe's own making.
+	destinationSample = "198.51.100.0/24"
+	// macSample is a locally-administered unicast MAC (x2 prefix), the address
+	// family reserved for exactly this kind of synthetic interface.
+	macSample = "02:00:00:00:00:01"
+	// sshKeySample is a real ed25519 public key generated once for this probe
+	// and thrown away private-half first; it exists because all three providers
+	// refuse to store a string that does not parse as an OpenSSH public key —
+	// the alternative is generating keys at probe time, and a probe must send
+	// the same thing twice.
+	sshKeySample = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC6ycFhUIlDdSHUOy5rF+z9dJdV1zLc6UGCXAAIPI50e feint-probe"
+	// flowSample is Outscale's own vocabulary for a rule's direction: the
+	// document types Flow as a bare string, and the SDK's docstring says
+	// "Inbound or Outbound" (osc-sdk-go, CreateSecurityGroupRuleRequest.Flow).
+	flowSample = "Inbound"
+)
+
+// cidrFields names the fields that carry an IP block. destination is Scaleway's
+// route spelling; the others are the three providers' subnet spellings.
+var cidrFields = map[string]string{
+	"iprange":            cidrSample,
+	"ipranges":           cidrSample,
+	"cidr":               cidrSample,
+	"destination":        destinationSample,
+	"destinationiprange": destinationSample,
+}
+
+// fillWhenOptional names the optional reference fields worth filling: the
+// document marks them optional because they are one branch of a choice it
+// cannot express. block/v1's CreateVolume declares from_empty and from_snapshot
+// with "precisely one must be set" in prose; from_empty is the branch whose
+// requirements a fresh run can always meet (a size, not a snapshot).
+var fillWhenOptional = map[string]bool{
+	"fromempty": true,
+	// A MoveIP without to_resource is a detach — ipam's own handler treats it
+	// so — and a probe that means "move" must say where to.
+	"toresource": true,
+	// SetSecurityGroupRules with no rules is a wipe: it replaced the rule the
+	// run had just created, and every later read of that rule found a 404 the
+	// probe had caused itself. Qualified by schema, because "rules" alone
+	// would also fill Outscale's CreateSecurityGroupRule, whose one-rule form
+	// already works.
+	"setsecuritygrouprules.request.rules": true,
+}
+
+// idAliases names the fields that hold an identifier without saying so:
+// Scaleway's CreateImage types root_volume as a string, and its document says
+// "the UID of the snapshot" in prose. One entry per finding, each cited; a
+// field absent from here and from isID stays a plain string.
+var idAliases = map[string]string{
+	"rootvolume": "snapshot",
+	// Outscale's GatewayId holds an internet service id: CreateRoute's own
+	// docstring says "the ID of an internet service or virtual gateway", and
+	// the emulator serves the first.
+	"gateway": "internetservice",
+}
+
+// sampleFor answers the vocabulary for one field, whatever the provider's
+// casing.
+func sampleFor(field string) (string, bool) {
+	fold := foldField(field)
+	switch {
+	case strings.HasSuffix(fold, "publickey"):
+		return sshKeySample, true
+	case strings.HasSuffix(fold, "macaddress"):
+		return macSample, true
+	case fold == "flow":
+		return flowSample, true
+	}
+	if sample, ok := cidrFields[fold]; ok {
+		return sample, true
+	}
+	return "", false
+}
+
+// foldField normalises a field name across the three providers' casings:
+// VmId, vm_id and vm-id all fold to "vmid".
+func foldField(name string) string {
+	return strings.ToLower(strings.NewReplacer("_", "", "-", "").Replace(name))
+}
+
+// isID recognises the fields whose value has to exist. All three providers
+// name them the same way, in their own case: VmId, ImageId, net-id,
+// private_network_id — plus the aliased few whose name hides it.
+func isID(field string) bool {
+	fold := strings.TrimSuffix(foldField(field), "s")
+	if _, aliased := idAliases[fold]; aliased {
+		return true
+	}
+	return strings.HasSuffix(fold, "id") && fold != "id"
+}
+
+// typeOfIDField names the resource an identifier field addresses: VmId → vm,
+// private_network_ids → privatenetwork. This is what lets a harvested server id
+// answer for server_id and never for volume_id — the wrong-type identifiers
+// were where the 404 refusals of #163 came from.
+func typeOfIDField(field string) string {
+	fold := strings.TrimSuffix(foldField(field), "s")
+	// Aliases resolve both spellings: root_volume carries no id suffix,
+	// GatewayId does, and both name a type other than their own word.
+	if alias, ok := idAliases[fold]; ok {
+		return alias
+	}
+	bare := strings.TrimSuffix(fold, "id")
+	if alias, ok := idAliases[bare]; ok {
+		return alias
+	}
+	return bare
 }
 
 // singular turns a plural field name into the key its elements are harvested
@@ -111,41 +429,57 @@ func singular(field string) string {
 	return field
 }
 
-// pool holds the identifiers earlier calls returned, keyed by the field name
-// they arrived under, folded.
+// pool holds what earlier calls returned: identifiers by the type of resource
+// they belong to, and names for the resources their provider addresses by
+// name.
 //
-// This is what replaces a scenario written by hand: a create answers with an id,
-// and the delete that follows takes it from here. Nothing else is remembered,
-// because nothing else is safe to reuse.
+// This is what replaces a scenario written by hand: a create answers with an
+// id, and the delete that follows takes it from here. Two tiers per type,
+// because where a value came from decides what it may stand for:
+//
+//   - created: what this run's own creates brought into being. Preferred
+//     always, because it is the only tier a verdict may safely rest on — an
+//     id harvested from a listing can name a leftover of whatever suite ran
+//     before, and a verdict that changes with the store's history is the
+//     defect this issue's reproducibility clause names.
+//   - observed: what listings published — the emulated catalogue's images and
+//     templates, mostly. Good enough to address what the run cannot create,
+//     never preferred over what it did.
 type pool struct {
-	mu     sync.Mutex
-	values map[string][]string
+	mu sync.Mutex
+	// ids: resource type → product → tiered values.
+	ids map[string]map[string]*tier
+	// names: resource type → the names recorded for it ("" for a bare name).
+	names map[string][]string
+	// coords are the path parameters no call produces because they are not
+	// resources: a zone and a region are coordinates, and every provider's
+	// paths carry one. The values are the emulator's own defaults, which is
+	// what makes them safe: a zone it does not know is refused, and the probe
+	// would be measuring its own bad guess rather than the emulator.
+	coords map[string]string
 }
 
-// seeds are the path parameters no call produces because they are not resources:
-// a zone and a region are coordinates, and every provider's paths carry one.
-//
-// The values are the emulator's own defaults, which is what makes them safe: a
-// zone it does not know is refused, and the probe would be measuring its own
-// bad guess rather than the emulator.
-var seeds = map[string]string{
-	"zone":   "fr-par-1",
-	"region": "fr-par",
+type tier struct {
+	created  []string
+	observed []string
 }
 
 func newPool() *pool {
-	values := map[string][]string{}
-	for key, value := range seeds {
-		values[key] = []string{value}
+	return &pool{
+		ids:   map[string]map[string]*tier{},
+		names: map[string][]string{},
+		coords: map[string]string{
+			"zone":   "fr-par-1",
+			"region": "fr-par",
+		},
 	}
-	return &pool{values: values}
 }
 
 // fill substitutes a path's parameters. It reports the first one it cannot
 // satisfy, so the step is skipped with a reason rather than sent with a literal
 // brace — which is what every Scaleway route did on the first run, and produced
 // a wall of 400s that said nothing.
-func (p *pool) fill(path string) (string, error) {
+func (p *pool) fill(product, path string) (string, error) {
 	out := path
 	for {
 		open := strings.Index(out, "{")
@@ -158,13 +492,7 @@ func (p *pool) fill(path string) (string, error) {
 		}
 		name := out[open+1 : open+closing]
 
-		value, found := p.take(name)
-		if !found {
-			// Path parameters are named for what they hold rather than by their
-			// type: {id} under /servers is a server id. Tried both ways before
-			// giving up.
-			value, found = p.takeAny(name)
-		}
+		value, found := p.pathValue(product, out[:open], name)
 		if !found {
 			return "", fmt.Errorf("%s is a path parameter and nothing in the plan produced one", name)
 		}
@@ -172,67 +500,329 @@ func (p *pool) fill(path string) (string, error) {
 	}
 }
 
-// takeAny answers a generic parameter name — {id}, {ipID} — with any identifier
-// harvested so far. Deliberately loose: the alternative is a table mapping every
-// path to the resource it addresses, which is a second source of truth to keep
-// in step with the document.
-func (p *pool) takeAny(name string) (string, bool) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if !looksLikeID(name) && strings.ToLower(name) != "id" {
-		return "", false
+// pathValue resolves one path parameter: a coordinate, a typed identifier, a
+// name for the name-addressed resources, and only then any identifier at all.
+//
+// The typed lookup is what changed for #163. {server_id} used to be answered by
+// whatever identifier was harvested first — an organisation id, mostly — and
+// the guaranteed 404 that follows is exactly the refusal this issue measures.
+// The type is read from the parameter's own name, or from the collection
+// segment before it when the parameter is generic ({id}, {ip}):
+// /snapshots/{snapshot_id} and /v2/template/{id} both name their resource.
+// TestAPathParameterIsAnsweredByItsOwnKind fails without the typed lookup.
+func (p *pool) pathValue(product, prefix, param string) (string, bool) {
+	if value, ok := p.coords[strings.ToLower(param)]; ok {
+		return value, true
 	}
-	keys := make([]string, 0, len(p.values))
-	for key := range p.values {
-		if _, isSeed := seeds[key]; !isSeed && len(p.values[key]) > 0 {
-			keys = append(keys, key)
+
+	candidates := []string{}
+	if t := typeOfIDField(param); t != "" && isID(param) {
+		candidates = append(candidates, t)
+	}
+	if t := lastCollection(prefix); t != "" {
+		candidates = append(candidates, t)
+	}
+	for _, t := range candidates {
+		if value, found := p.take(product, t); found {
+			return value, true
 		}
 	}
-	if len(keys) == 0 {
-		return "", false
+	if strings.ToLower(param) == "name" {
+		if t := lastCollection(prefix); t != "" {
+			if value, found := p.takeName(t); found {
+				return value, true
+			}
+		}
 	}
-	sort.Strings(keys)
-	return p.values[keys[0]][0], true
+	// Nothing of the right kind exists. An identifier of the wrong kind keeps
+	// the call — and the refusal verdict it earns — reachable; inventing one
+	// would not (#163 forbids it, and it is what produced the 404s).
+	return p.takeAny(param)
 }
 
-func (p *pool) take(field string) (string, bool) {
+// lastCollection names the resource of the last concrete path segment before a
+// parameter: ".../snapshots/" → snapshot, "/v2/template/" → template.
+func lastCollection(prefix string) string {
+	segments := strings.Split(strings.Trim(prefix, "/"), "/")
+	for i := len(segments) - 1; i >= 0; i-- {
+		s := segments[i]
+		if s == "" || strings.HasPrefix(s, "{") {
+			continue
+		}
+		if colon := strings.Index(s, ":"); colon >= 0 {
+			s = s[:colon]
+		}
+		return foldField(singular(s))
+	}
+	return ""
+}
+
+// take answers one identifier of the named type: this run's own creations
+// first, the same product before the neighbours, listings last.
+func (p *pool) take(product, typeFold string) (string, bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	return p.takeLocked(field)
+	byProduct, found := p.ids[typeFold]
+	if !found {
+		return "", false
+	}
+	products := make([]string, 0, len(byProduct))
+	for prod := range byProduct {
+		products = append(products, prod)
+	}
+	sort.Strings(products)
+	ordered := make([]string, 0, len(products)+1)
+	ordered = append(ordered, product)
+	for _, prod := range products {
+		if prod != product {
+			ordered = append(ordered, prod)
+		}
+	}
+	for _, prod := range ordered {
+		if t := byProduct[prod]; t != nil && len(t.created) > 0 {
+			// The newest creation, not the first: a run can make the same kind
+			// twice — SetSecurityGroupRules replaces the rule an earlier
+			// create made — and only the newest is certain to still exist.
+			// Listings stay first-value: a catalogue's order is stable.
+			return t.created[len(t.created)-1], true
+		}
+	}
+	for _, prod := range ordered {
+		if t := byProduct[prod]; t != nil && len(t.observed) > 0 {
+			return t.observed[0], true
+		}
+	}
+	return "", false
 }
 
-func (p *pool) takeLocked(field string) (string, bool) {
-	got, found := p.values[strings.ToLower(field)]
-	if !found || len(got) == 0 {
-		// A plural field takes a singular value: VmIds is satisfied by a VmId.
-		got, found = p.values[strings.ToLower(singular(field))]
-		if !found || len(got) == 0 {
-			return "", false
-		}
+// takeName answers a recorded name for one resource type; "" matches the bare
+// "name" fields.
+func (p *pool) takeName(typeFold string) (string, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	got := p.names[typeFold]
+	if len(got) == 0 {
+		return "", false
 	}
 	return got[0], true
 }
 
-// harvest records every identifier a response carried, at any depth.
-func (p *pool) harvest(value any) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.walk(value)
+// notAResource names the identifier types takeAny must never answer with:
+// they are real ids of things that are not infrastructure — a request, the
+// account itself, a tenant — and every one of them once stood in for "any
+// resource" and bought a refusal the probe had invented.
+var notAResource = map[string]bool{
+	"account":      true,
+	"organization": true,
+	"project":      true,
+	"request":      true,
 }
 
-func (p *pool) walk(value any) {
+// takeAny answers a generic parameter with any identifier harvested so far,
+// created tier first, keys in stable order. It exists so an operation nobody
+// can seed still gets called and still earns its refusal verdict; a typed
+// lookup that found nothing must never quietly invent instead.
+func (p *pool) takeAny(name string) (string, bool) {
+	if !isID(name) && strings.ToLower(name) != "id" {
+		return "", false
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	types := make([]string, 0, len(p.ids))
+	for t := range p.ids {
+		if !notAResource[t] {
+			types = append(types, t)
+		}
+	}
+	sort.Strings(types)
+	for _, pick := range []func(*tier) []string{
+		func(t *tier) []string { return t.created },
+		func(t *tier) []string { return t.observed },
+	} {
+		for _, t := range types {
+			products := make([]string, 0, len(p.ids[t]))
+			for prod := range p.ids[t] {
+				products = append(products, prod)
+			}
+			sort.Strings(products)
+			for _, prod := range products {
+				if values := pick(p.ids[t][prod]); len(values) > 0 {
+					return values[len(values)-1], true
+				}
+			}
+		}
+	}
+	return "", false
+}
+
+// harvest records what one response carried: every identifier, typed by the
+// context it appeared in, and every name.
+//
+// The type comes from the response itself, never from a table kept beside it:
+// a field named VmId types its own value; an id inside {"server": {…}} or
+// {"servers": […]} is typed by the wrapper; a bare top-level object is typed by
+// the operation's own response schema (block/v1's Volume answers unwrapped);
+// and an Exoscale operation's reference is typed by the command it links to
+// ("get-private-network" names what was just made). What a create-kind step
+// returns lands in the created tier; what a listing shows stays observed.
+func (p *pool) harvest(doc *contract.Doc, step Step, value any) {
+	context := ""
+	if op, ok := doc.Operations[step.Contract]; ok {
+		context = schemaLeaf(op.Response)
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.walk(step, value, context, 0)
+}
+
+// schemaLeaf folds a schema name to the resource it describes:
+// "block/v1.scaleway.block.v1.Volume" → volume, "operation" → operation.
+// Response wrappers ("CreateServerResponse", "ListServersResponse") answer
+// nothing: their inner wrapper keys carry the context instead.
+func schemaLeaf(name string) string {
+	if name == "" {
+		return ""
+	}
+	leaf := name
+	if dot := strings.LastIndex(leaf, "."); dot >= 0 {
+		leaf = leaf[dot+1:]
+	}
+	if strings.HasSuffix(leaf, "Response") || strings.HasSuffix(leaf, "Request") {
+		return ""
+	}
+	return foldField(leaf)
+}
+
+// walk records a response's identifiers. depth counts map descents — the
+// top-level object is 0, a value under one of its keys is 1 — and arrays do
+// not count: an item of a list sits at its list's depth.
+func (p *pool) walk(step Step, value any, context string, depth int) {
 	switch typed := value.(type) {
 	case map[string]any:
-		for key, nested := range typed {
-			if text, ok := nested.(string); ok && text != "" && looksLikeID(key) {
-				folded := strings.ToLower(key)
-				p.values[folded] = append(p.values[folded], text)
+		// The Exoscale operation envelope: the reference says, in the
+		// document's own words, what resource the operation touched.
+		if ref, ok := typed["reference"].(map[string]any); ok {
+			if id, ok := ref["id"].(string); ok && id != "" {
+				refType := step.Makes
+				if command, ok := ref["command"].(string); ok {
+					if t := typeOfCommand(command); t != "" {
+						refType = t
+					}
+				}
+				if refType != "" {
+					p.record(step, refType, id, depth+1)
+				}
 			}
-			p.walk(nested)
+		}
+		if id, ok := typed["id"].(string); ok && id != "" && context != "" {
+			p.record(step, context, id, depth+1)
+		}
+		// Keys in sorted order: a map walked in Go's random order would append
+		// ids in a different order on every run, take() answers the first one,
+		// and the verdicts would flap with it — the exact non-reproducibility
+		// this issue forbids (TestHarvestIsDeterministic).
+		keys := make([]string, 0, len(typed))
+		for key := range typed {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			nested := typed[key]
+			if text, ok := nested.(string); ok && text != "" {
+				if isID(key) {
+					p.record(step, typeOfIDField(key), text, depth+1)
+				}
+				if fold := foldField(key); strings.HasSuffix(fold, "name") {
+					p.recordName(step, strings.TrimSuffix(fold, "name"), context, text)
+				}
+			}
+			p.walk(step, nested, contextOfKey(key, context), depth+1)
 		}
 	case []any:
 		for _, item := range typed {
-			p.walk(item)
+			p.walk(step, item, context, depth)
 		}
 	}
+}
+
+// contextOfKey types the values under one wrapper key: {"server": {…}} and
+// {"servers": […]} both say server. Keys that are not resource words —
+// "items", "data" — still produce a fold, and a fold nothing ever asks for is
+// harmless.
+func contextOfKey(key, parent string) string {
+	fold := foldField(singular(key))
+	if fold == "" {
+		return parent
+	}
+	return fold
+}
+
+// typeOfCommand reads the resource out of an Exoscale reference command:
+// "get-private-network" → privatenetwork.
+func typeOfCommand(command string) string {
+	for _, verb := range []string{"get-", "list-"} {
+		if strings.HasPrefix(command, verb) {
+			return foldField(strings.TrimPrefix(command, verb))
+		}
+	}
+	return ""
+}
+
+// record files one identifier. The created tier takes what a create-kind
+// step's own payload carries — depth 2 at most: the top-level id, or the id
+// one wrapper down ({"server": {"id": …}}). Deeper finds are references to
+// other resources and stay observed whoever answered them: CreateServer's
+// response embeds the catalogue image and the default security group, and
+// filing those as "created" made UpdateImage try to change the catalogue
+// (TestACreateOnlyVouchesForItsOwnPayload).
+func (p *pool) record(step Step, typeFold, id string, depth int) {
+	byProduct := p.ids[typeFold]
+	if byProduct == nil {
+		byProduct = map[string]*tier{}
+		p.ids[typeFold] = byProduct
+	}
+	t := byProduct[step.Product]
+	if t == nil {
+		t = &tier{}
+		byProduct[step.Product] = t
+	}
+	if step.Kind == kindCreate && depth <= 2 {
+		t.created = append(t.created, id)
+		return
+	}
+	t.observed = append(t.observed, id)
+}
+
+// recordName files a name under the type it belongs to. A bare "name" field is
+// typed by its wrapper ({"keypair": {"name": …}} → keypair) or recorded
+// untyped; a compound one carries its own type (KeypairName → keypair).
+func (p *pool) recordName(step Step, explicit, context, name string) {
+	typeFold := explicit
+	if typeFold == "" {
+		typeFold = context
+	}
+	// Created names first: the run's own names are the ones its deletes must
+	// address. Observed names still land, for the name-addressed reads.
+	if step.Kind == kindCreate {
+		p.names[typeFold] = append([]string{name}, p.names[typeFold]...)
+		return
+	}
+	p.names[typeFold] = append(p.names[typeFold], name)
+}
+
+// harvestSentName records the name a successful create carried, under the type
+// it made. A created resource's name is as real as its id — and for the
+// name-addressed resources (Exoscale's SSH keys) it is the only handle the
+// response ever gives back.
+func (p *pool) harvestSentName(step Step, body map[string]any) {
+	if step.Kind != kindCreate || step.Makes == "" {
+		return
+	}
+	name, ok := body["name"].(string)
+	if !ok || name == "" {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.names[step.Makes] = append([]string{name}, p.names[step.Makes]...)
 }

--- a/internal/providers/scaleway/block.go
+++ b/internal/providers/scaleway/block.go
@@ -301,8 +301,14 @@ func (p *Pack) listBlockVolumes(w http.ResponseWriter, r *http.Request) {
 		}
 		out = append(out, p.blockVolumeView(res))
 	}
+	// Paged like every other list of this pack. This list predates the helper
+	// and served everything whatever the client asked; invisible while the
+	// emulated account never held two block volumes, measured the day the
+	// probe seeded them (TestBlockListsHonourThePageSize fails without it).
+	page := parsePage(r)
+	start, end := page.slice(len(out))
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"volumes":     out,
+		"volumes":     out[start:end],
 		"total_count": len(out),
 	})
 }
@@ -501,8 +507,11 @@ func (p *Pack) listBlockSnapshots(w http.ResponseWriter, r *http.Request) {
 		}
 		out = append(out, p.blockSnapshotView(res))
 	}
+	// Same paging, same reason as listBlockVolumes above.
+	page := parsePage(r)
+	start, end := page.slice(len(out))
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"snapshots":   out,
+		"snapshots":   out[start:end],
 		"total_count": len(out),
 	})
 }

--- a/internal/providers/scaleway/block_test.go
+++ b/internal/providers/scaleway/block_test.go
@@ -401,3 +401,43 @@ func TestABlockVolumeRestoredSmallerThanItsSnapshotIsRefused(t *testing.T) {
 		t.Errorf("with no size the volume is %v, and its snapshot is %v", same["size"], snap["size"])
 	}
 }
+
+// TestBlockListsHonourThePageSize: both block lists predate the pack's paging
+// helper and served everything whatever the client asked. Invisible while the
+// emulated account never held two block volumes; the seeded probe (#163) made
+// two and measured `per_page=1` answering both. The refusal to regress is
+// cheap: two volumes, two snapshots, one page of one.
+func TestBlockListsHonourThePageSize(t *testing.T) {
+	ts := newTestServer(t)
+
+	for _, name := range []string{"first", "second"} {
+		status, created := do(t, ts, "POST", blockURL+"/volumes",
+			`{"name":"`+name+`","from_empty":{"size":10000000000}}`)
+		if status != http.StatusCreated {
+			t.Fatalf("create volume %s: expected 201, got %d (%v)", name, status, created)
+		}
+		id, _ := created["id"].(string)
+		status, snapped := do(t, ts, "POST", blockURL+"/snapshots",
+			`{"name":"snap-`+name+`","volume_id":"`+id+`"}`)
+		if status != http.StatusCreated {
+			t.Fatalf("create snapshot of %s: expected 201, got %d (%v)", name, status, snapped)
+		}
+	}
+
+	for _, list := range []struct{ path, field string }{
+		{"/volumes", "volumes"},
+		{"/snapshots", "snapshots"},
+	} {
+		status, got := do(t, ts, "GET", blockURL+list.path+"?per_page=1", "")
+		if status != http.StatusOK {
+			t.Fatalf("list %s: expected 200, got %d (%v)", list.path, status, got)
+		}
+		items, _ := got[list.field].([]any)
+		if len(items) != 1 {
+			t.Errorf("%s?per_page=1 answered %d items, and the parameter is served on every other list", list.path, len(items))
+		}
+		if count, _ := got["total_count"].(float64); count != 2 {
+			t.Errorf("%s total_count is %v, and the page must not shrink it", list.path, got["total_count"])
+		}
+	}
+}

--- a/tools/contract/extract-openapi.py
+++ b/tools/contract/extract-openapi.py
@@ -124,6 +124,18 @@ def property_shape(prop: dict) -> dict:
             return {"type": wrapped}
         return {"ref": ref_name(prop["$ref"])}
 
+    # A nullable reference — `oneOf: [$ref X, type: "null"]` — is the reference:
+    # the validator already accepts null everywhere, so the wrapper only hid the
+    # shape. Scaleway writes its exclusive request branches this way (block/v1's
+    # CreateVolume.from_empty), and dropping the oneOf left the property with no
+    # shape at all, which the probe read as "nothing to build" and the emulator
+    # answered with the refusal #163 measured.
+    if "oneOf" in prop:
+        refs = [b for b in prop["oneOf"] if "$ref" in b]
+        others = [b for b in prop["oneOf"] if "$ref" not in b and b.get("type") != "null"]
+        if len(refs) == 1 and not others:
+            return property_shape(refs[0])
+
     out: dict = {}
     kind = scalar_type(prop.get("type"))
     if kind:


### PR DESCRIPTION
# Summary

#156 turned `probed` from an arrival into a verdict and measured the overstatement it had been hiding: a large block of operations had only ever seen a refusal. This issue was about those, and the diagnosis it opened with holds — they were not the emulator being strict, they were **the probe arriving empty-handed**.

The probe now seeds. Before probing an operation it brings into being what that operation needs, from the contract's own request schema and from resources it created earlier in the same run: creates are ordered producers-first (Kahn over the needs/makes edges, contract order inside each layer so two runs plan the same thing), reads run twice around them, and the teardown mirrors the seeding. **No identifier is invented** — every one comes from a real create against the emulator, which is how the 404s appeared in the first place.

## The numbers

Both artefacts regenerated by `mise run evidence:update`, two fresh legs, machines `incus` and `none`:

| axis | before | after |
|---|--:|--:|
| `probed: response` | 85 | **204** |
| `probed: refusal` | 106 | **4** |
| `probed: none` | 40 | **23** |
| `contract: clean` | 181 | **207** |

102 refusals and 17 never-probed operations now validate a success shape. **Nothing regressed** — the only transitions are `refusal → response` and `none → response`. The contract axis follows because an operation that never got past a refusal had no success body to check. `driven` (178), `dataplane` (178), `behaviour` (158) and `negative` (21) are unchanged, which is the expected shape: seeding moves synthetic traffic and nothing a client drives.

## What still refuses, and why — the deliverable the issue asked for

Read from `/_feint/trace` rather than inferred from the handlers.

**Four refusals.**

| operation | status | why it cannot be seeded |
|---|---|---|
| `exoscale/v2.get-deploy-target` | 404 | the pack serves an empty inventory and never creates one — `catalog.go` says *"can only miss: nothing here ever creates one"* |
| `exoscale/v2.update-private-network-instance-ip` | 400 | needs an instance attached to the network |
| `osc/Client.LinkPublicIp` | — | needs a Vm to link to |
| `osc/Client.UnlinkPublicIp` | 400 | the same |

The last three need a machine a synthetic prober does not start, which is the category the issue named in advance.

**Twenty-three never probed**, classified from the contracts:

- **20 declare no response schema at all** — every `Delete*` and `Release*`, plus `SetServerUserData`. There is no success shape to validate, so calling them would prove only that they answered, which is exactly the arrival `probed` stopped being.
- **3 take a path parameter that is not an identifier**: `{entity}` for `get-quota`, `{field}` for `reset-private-network-field`, `{key}` for `GetServerUserData`. Nothing creates a value of that kind, by construction.

## Falsification

**Four unit mutations**, each compiling first (`go vet`), each named test biting:

| mutation | test | verdict |
|---|---|---|
| the pool hands back nothing | `TestAGetIsProbedAgainstAnIdentifierThatExists` | red |
| a create no longer contributes what it made | `TestASeededCreateFillsWhatTheRunHolds` | red |
| the hinted branch of a choice left empty | `TestTheHintedBranchOfAChoiceIsFilled` | red |
| the synthetic exclusion removed | `TestAProbedFieldIsNotAnUnreadField` | red |

**And the runtime falsification the issue asks for by name** — *"remove the seeding for one family and those operations fall back to `refusal` on the next run"*. Seeding removed for the `block` family alone, against a real emulator:

```
fell back  block/v1/API.CreateSnapshot: response -> refusal
fell back  block/v1/API.GetSnapshot:    response -> refusal
fell back  block/v1/API.GetVolume:      response -> refusal
fell back  block/v1/API.UpdateSnapshot: response -> refusal
fell back  block/v1/API.UpdateVolume:   response -> refusal
survived   block/v1/API.CreateVolume     (needs no seeded identifier)
survived   block/v1/API.ListSnapshots    (needs no seeded identifier)
survived   block/v1/API.ListVolumeTypes  (needs no seeded identifier)
survived   block/v1/API.ListVolumes      (needs no seeded identifier)
```

Exactly the identifier-consuming operations fall back; the listings and the family's root create keep answering, because they consume nothing the seed produced. Worth recording that the first version of this check demanded all nine fall back and reported a correct result as inconclusive — the criterion was wrong, not the seeding.

## One thing the seeding pulled in behind it

The unread-fields report answers, in its own words, *"fields a real client sent that no handler read"*. A seeded body fills every optional field the schema declares, so it names fields no handler reads by design, and counting them failed the conformance gate on traffic no client ever sends. Synthetic exchanges are now excluded from that report — the same boundary the score already draws. The same field arriving from a real client still lands in it, which is the half `TestAProbedFieldIsNotAnUnreadField` asserts second: an exclusion that swallowed both would remove the defect the report exists for.

## Type of change

- [ ] A route added or changed
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes
- [x] No new external Go dependency
- [x] `internal/core` still knows no provider — the seeding lives in `internal/probe`, driven by the contracts
- [x] Nothing in the diff could be written identically for another provider: the seeding reads each provider's own contract, and the one place a provider is named is `contracts/scaleway.json`, which is extracted

### When a model wrote a substantive part of this

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] `mise run conformance` was run — twice, as the two legs of `mise run evidence:update`, plus one off-leg run on its own while diagnosing
- [x] Every field name comes from the providers' own API descriptions in `contracts/`, which is what the probe reads

### When a route is added or changed

N/A — no route is added or changed. `contracts/scaleway.json` moves because the extraction produces it.

### When behaviour a client can observe changes

- [x] The generated tables regenerated — `docs/routes.md` turns `probe-refusal` into `probe` where a success shape is now validated
- [ ] N/A for `docs/limits.md` — no documented limit moved

### When `.github/workflows/` is touched

N/A.

### When a machine runtime is involved

- [x] Tested with `FEINT_VM=incus` — the second leg of the regeneration
- [x] Nothing the emulator did not create was touched
- [x] The run leaves nothing behind — `incus list` is empty after it

## Related issues

Closes #163
