### PR TITLE
feat(contract): what a response forgets is a finding, not a silence

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -151,7 +151,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        client: [scw-cli, terraform, opentofu, oapi-cli, exo-cli, probe]
+        # `fields` is not a client: it is the leg that drives every one of
+        # them against a single emulator, which is what the omission gate
+        # (#88) needs to mean anything. Its verdict is that *no answer of
+        # this run* carried a declared field, and every other leg here is a
+        # partial run by construction — the terraform leg drives no
+        # oapi-cli, so ReadVms carries no UserData and the gate would blame
+        # the emulator for the shape of the leg. Only this one sets
+        # FEINT_FIELD_GATE.
+        client: [scw-cli, terraform, opentofu, oapi-cli, exo-cli, probe, fields]
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -198,7 +206,7 @@ jobs:
       # Scaleway publishes SHA256SUMS beside its binaries, so the sums come from
       # upstream rather than from this file.
       - name: Install the Scaleway CLI
-        if: matrix.client == 'scw-cli'
+        if: matrix.client == 'scw-cli' || matrix.client == 'fields'
         run: |
           set -euo pipefail
           workdir="$(mktemp -d)"
@@ -211,7 +219,7 @@ jobs:
           scw version
 
       - name: Run the CLI conformance suite
-        if: matrix.client == 'scw-cli'
+        if: matrix.client == 'scw-cli' || matrix.client == 'fields'
         run: tools/conformance/scaleway/scw-cli.sh http://127.0.0.1:4599
 
       # The AppImage is the only binary Outscale publishes for it. It needs FUSE
@@ -225,7 +233,7 @@ jobs:
       # means recomputing OAPI_SHA256, which is the point: the bump becomes a
       # decision rather than a version string.
       - name: Install the Outscale CLI
-        if: matrix.client == 'oapi-cli'
+        if: matrix.client == 'oapi-cli' || matrix.client == 'fields'
         env:
           OAPI_VERSION: 'v0.15.0'
           OAPI_SHA256: '798b9af7db9da9539303732ba55be71ff0bec58aa9ef51751de41b2eeee8138a'
@@ -254,7 +262,7 @@ jobs:
           oapi-cli --version
 
       - name: Run the Outscale CLI conformance suite
-        if: matrix.client == 'oapi-cli'
+        if: matrix.client == 'oapi-cli' || matrix.client == 'fields'
         run: tools/conformance/outscale/oapi-cli.sh http://127.0.0.1:4599
 
       # The Exoscale CLI cannot be redirected by a flag or an environment
@@ -262,7 +270,7 @@ jobs:
       # that value must carry the /v2 suffix. Both facts were measured with a
       # logging proxy; neither is documented. The suite writes that file itself.
       - name: Install the Exoscale CLI
-        if: matrix.client == 'exo-cli'
+        if: matrix.client == 'exo-cli' || matrix.client == 'fields'
         env:
           EXO_VERSION: 'v1.95.6'
         run: |
@@ -279,7 +287,7 @@ jobs:
           exo version
 
       - name: Run the Exoscale CLI conformance suite
-        if: matrix.client == 'exo-cli'
+        if: matrix.client == 'exo-cli' || matrix.client == 'fields'
         run: tools/conformance/exoscale/exo-cli.sh http://127.0.0.1:4599
 
       # The release zip and its checksum, verified before anything runs — not a
@@ -291,7 +299,7 @@ jobs:
       # The version is pinned rather than floating: a conformance suite whose
       # client changes under it reports a difference nobody made.
       - name: Install Terraform
-        if: matrix.client == 'terraform'
+        if: matrix.client == 'terraform' || matrix.client == 'fields'
         env:
           TERRAFORM_VERSION: '1.13.3'
         run: |
@@ -339,11 +347,11 @@ jobs:
       # Reported by a reader comparing the README with the workflow, which is the
       # only way this is ever found.
       - name: Run the Terraform conformance suite — Scaleway
-        if: matrix.client == 'terraform' || matrix.client == 'opentofu'
+        if: matrix.client == 'terraform' || matrix.client == 'opentofu' || matrix.client == 'fields'
         run: tools/conformance/scaleway/terraform.sh http://127.0.0.1:4599
 
       - name: Run the Terraform conformance suite — Outscale
-        if: matrix.client == 'terraform' || matrix.client == 'opentofu'
+        if: matrix.client == 'terraform' || matrix.client == 'opentofu' || matrix.client == 'fields'
         run: tools/conformance/outscale/terraform.sh http://127.0.0.1:4599
 
       # No client at all: every route driven from its provider's own API
@@ -372,8 +380,17 @@ jobs:
       # /_feint/conformance from the running emulator and exits 1 when nothing
       # answers. Stopping first failed this step, and with it every leg of the
       # matrix, on runs that were otherwise green.
+      #
+      # FEINT_FIELD_GATE on the `fields` leg only, because only that leg drove
+      # every client against this emulator. Everywhere else score.sh still
+      # prints what the omission check found and judges none of it: an absent
+      # field on a partial run says nothing about the emulator. An undeclared
+      # whole run counts as partial, the way an undeclared driver capability
+      # counts as absent.
       - name: Report what was exercised
         if: always()
+        env:
+          FEINT_FIELD_GATE: ${{ matrix.client == 'fields' && '1' || '0' }}
         run: tools/conformance/score.sh http://127.0.0.1:4599
 
       # Always: a job that leaves the emulator running leaves a process holding a

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -39,6 +39,15 @@ change ni l'un ni l'autre a sa place dans `git log`.
   un decline dont le champ est servi dans l'exécution même échoue comme périmé,
   pour que la liste des excuses ne pourrisse pas.
 
+  *Sur les objets qu'un client a pilotés*, et c'est une règle plutôt qu'une
+  tournure : les réponses de la sonde ne cautionnent rien ici. La CI l'a prouvé
+  dès la première exécution, puisque la jambe `probe` ne pilote aucun client :
+  chaque objet y est l'objet minimal que construit le semis, et le gate a
+  accusé `ReadVms` d'omettre `PublicIp`, `Tags` et `UserData`, des champs qui
+  n'existent que sur une machine configurée par un utilisateur. C'est la
+  frontière que #163 avait déjà tracée pour le rapport des champs non lus : le
+  trafic synthétique ne déplace aucun chiffre visible d'un client.
+
 - **Ce dont la CI a le droit de dépendre est gelé par un test, pas par une
   phrase** (#132). Les formes de `/_feint/health`, `/_feint/routes`,
   `/_feint/conformance` et `/_feint/trace`, les verbes et drapeaux du CLI et

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -19,6 +19,26 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Ajouté
 
+- **Le contrôle de contrat regarde désormais dans le sens de l'omission, et le
+  gate de conformance échoue sur ce qu'il trouve** (#88). Le gate attrapait un
+  champ que l'émulateur invente et ne voyait pas celui qu'il oublie : un champ
+  absent ne viole un schéma que si le fournisseur l'a déclaré `required`, ce
+  que Scaleway fait sur 9 % de ses schémas. Les vingt champs manquants de
+  ReadVms, et l'omission de ReadImages qui faisait s'effondrer le provider
+  Terraform (#86), sont donc restés verts jusqu'à ce qu'un enregistrement d'un
+  vrai compte les couvre par hasard, et 45 opérations sur 231 seulement ont un
+  tel enregistrement. Chaque réponse provoquée par une exécution de conformance
+  est désormais aussi tenue à la *présence* de chaque champ que la description
+  d'API du fournisseur déclare (le document même dont les SDK sont générés,
+  `contract.ResponseFields`), sur les objets peuplés que créent les vrais
+  clients. `/_feint/conformance` publie le verdict sous `fields` (la charge
+  utile passe en version de schéma 3, additive) et
+  `tools/conformance/score.sh` échoue sur un champ manquant comme il échoue sur
+  un champ inventé. Un champ qu'un pack ne sert sciemment pas s'excuse par le
+  même `DeclinedFields()` que lit le gate de formes, imprimé avec sa raison ;
+  un decline dont le champ est servi dans l'exécution même échoue comme périmé,
+  pour que la liste des excuses ne pourrisse pas.
+
 - **Ce dont la CI a le droit de dépendre est gelé par un test, pas par une
   phrase** (#132). Les formes de `/_feint/health`, `/_feint/routes`,
   `/_feint/conformance` et `/_feint/trace`, les verbes et drapeaux du CLI et

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Added
 
+- **The contract check now looks in the omission direction, and the
+  conformance gate fails on what it finds** (#88). The gate caught a field the
+  emulator invents and could not see one it forgets: an absent field only
+  violates a schema when the provider marked it `required`, which Scaleway does
+  on 9% of its schemas — so the twenty fields missing from ReadVms, and the
+  ReadImages omission that segfaulted the Terraform provider (#86), were all
+  green until a recording of a real account happened to cover them, and only 45
+  of 231 operations have such a recording. Every answer a conformance run
+  provokes is now also held to the *presence* of every field the provider's own
+  API description declares (the same document the SDKs are generated from —
+  `contract.ResponseFields`), over the populated objects the real clients
+  create. `/_feint/conformance` publishes the verdict under `fields` — moving
+  the payload to schema version 3, additive — and `tools/conformance/score.sh`
+  fails on a missing field the way it fails on an invented one. A field a pack
+  knowingly does not serve is excused through the same `DeclinedFields()` the
+  shapes gate reads, printed with its reason; a decline whose field the run
+  demonstrably serves fails as stale, so the excused list cannot rot.
+
 - **What CI is allowed to depend on is frozen by a test, not by a sentence**
   (#132). The shapes of `/_feint/health`, `/_feint/routes`,
   `/_feint/conformance` and `/_feint/trace`, the CLI's verbs and flags, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ what this project is judged on: **a response shape a client can observe**, and
   shapes gate reads, printed with its reason; a decline whose field the run
   demonstrably serves fails as stale, so the excused list cannot rot.
 
+  *Over the objects a client drove*, and that is a rule rather than a phrase:
+  the probe's answers vouch for nothing here. CI proved why on the first run —
+  the probe leg drives no client, so every object in it is the minimal one the
+  seeding builds, and the gate accused `ReadVms` of omitting `PublicIp`, `Tags`
+  and `UserData`, fields that exist only on a machine a user configured. Same
+  boundary #163 drew for the unread-fields report: synthetic traffic moves no
+  client-facing number.
+
 - **What CI is allowed to depend on is frozen by a test, not by a sentence**
   (#132). The shapes of `/_feint/health`, `/_feint/routes`,
   `/_feint/conformance` and `/_feint/trace`, the CLI's verbs and flags, and the

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -939,6 +939,32 @@ produced a worse number still — 464 of 468 — which measured the extractor's 
 counts your own assumption and reads like evidence is the exact failure this
 project exists to avoid.
 
+### What a green contract run does and does not prove
+
+The schema check is one-directional: it catches a field a response *invents*,
+and it can only catch an *omitted* field where the provider declared it
+`required` — which Scaleway does on 9% of its schemas, Outscale on 27%,
+Exoscale on 35%. On the rest, an omission never violates anything.
+
+Since #88 the other direction has its own control, and its precision was
+measured before its semantics were chosen. Every answer a conformance run
+provokes is compared with the full property list the provider's document
+declares; an absence fails the run (`fields.missing` on `/_feint/conformance`,
+gated by `tools/conformance/score.sh`) **only when a recorded real-cloud answer
+carries the field too**. The corroboration is not caution, it is arithmetic:
+on the first instrumented run, of the 106 declared-but-absent fields a
+recording could arbitrate, 83 were absent from the real cloud's answer as well
+— pagination tokens that only exist when a further page does, client tokens
+echoed only when sent. A gate that failed on all of that would be red on
+purpose, and a gate that is red on purpose is a gate somebody turns off.
+
+What no source can arbitrate is published rather than failed on:
+`fields.unconfirmed` lists, per operation, every field only the document
+vouches for — 317 fields across 97 operations at the time of writing. Each
+entry is one recording away (`feint shapes --record`) from becoming either a
+failure or nothing. That list is this page's kind of sentence: it names
+exactly what nobody has proven.
+
 ## `feint start` detaches on Linux, and not on macOS
 
 `start` backgrounds the emulator itself, with no `&` and no container runtime,

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -497,6 +497,18 @@ func serve(args []string, stdout io.Writer) error {
 		if covered != nil {
 			srv.SetShapeCovered(sortedKeys(covered))
 		}
+		// The corroboration half of the omission check (#88): which fields a
+		// real cloud's recorded answers carried, per mounted operation. Without
+		// it the check publishes every declared-but-absent field as unconfirmed
+		// and fails on none — an installed binary without shapes/ loses the
+		// verdict, never invents one.
+		observed, err := observedFieldsByOperation(*shapesDir, srv)
+		if err != nil {
+			return err
+		}
+		if observed != nil {
+			srv.SetObservedFields(observed)
+		}
 	}
 
 	driver, err := machineDriver(*vm, stdout)

--- a/internal/cli/evidence.go
+++ b/internal/cli/evidence.go
@@ -315,6 +315,70 @@ func shapeCoveredOperations(dir string) (map[string]bool, error) {
 	return covered, nil
 }
 
+// observedFieldsByOperation maps every recorded real-cloud answer onto the
+// mounted operation that serves the same call: operation name to the field
+// paths the real cloud was seen to return. This is the corroboration half of
+// the omission check (emulator.SetObservedFields) — computed here for the same
+// reason shapeCoveredOperations is: the core knows neither providers nor where
+// recordings live.
+//
+// Unlike shapeCoveredOperations it walks the whole catalogue rather than the
+// curated read list: a recording keyed by an operation name (Outscale's
+// osc/Client.ReadVms) corroborates that operation directly, and one keyed by
+// "METHOD path" resolves through the mounted routes. An entry nothing mounts is
+// skipped — an operation no pack claims is the drift gate's business, not this
+// check's.
+//
+// nil with no error means no catalogue exists at all, and the check then fails
+// on nothing rather than treating "no recording" as "nothing to prove".
+func observedFieldsByOperation(dir string, srv *emulator.Server) (map[string][]string, error) {
+	routes := srv.AllRoutes()
+	mounted := map[string]bool{}
+	for _, r := range routes {
+		mounted[r.Operation] = true
+	}
+
+	observed := map[string][]string{}
+	found := false
+	for _, p := range srv.Packs() {
+		cat, err := readCatalogue(filepath.Join(dir, p.Name()+".json"), p.Name())
+		if err != nil {
+			return nil, err
+		}
+		if cat == nil {
+			continue
+		}
+		found = true
+		for key, rec := range cat.Operations {
+			if len(rec.Fields) == 0 {
+				continue
+			}
+			op := ""
+			switch {
+			case mounted[key]:
+				op = key
+			case rec.Method != "" && rec.Path != "":
+				op, err = operationForCall(routes, rec.Method, rec.Path)
+				if err != nil {
+					return nil, fmt.Errorf("%s: %w", key, err)
+				}
+			}
+			if op == "" {
+				continue
+			}
+			paths := make([]string, 0, len(rec.Fields))
+			for _, f := range rec.Fields {
+				paths = append(paths, f.Path)
+			}
+			observed[op] = append(observed[op], paths...)
+		}
+	}
+	if !found {
+		return nil, nil
+	}
+	return observed, nil
+}
+
 // operationForCall resolves the mounted route a concrete request would reach.
 // Among the patterns that match, the one with the fewest wildcards wins — the
 // same specificity rule the mux applies — and a tie is refused out loud

--- a/internal/cli/shapes_check.go
+++ b/internal/cli/shapes_check.go
@@ -118,7 +118,7 @@ func checkShapes(dir string, providers []string, stdout, stderr io.Writer) int {
 		// the orphan-route check on Route.Operation.
 		// TestAStaleFieldDeclineFailsTheGate fails without this.
 		for _, d := range unused {
-			fmt.Fprintf(stderr, "feint: %s declines %s %s, and the emulator does not omit it: the decline is stale, remove it\n", name, d.Operation, d.Path)
+			fmt.Fprintf(stderr, "feint: %s declines %s %s, and either the emulator serves it or the recording no longer carries it: the decline is stale, remove it\n", name, d.Operation, d.Path)
 			stale++
 		}
 	}
@@ -149,7 +149,38 @@ func checkShapes(dir string, providers []string, stdout, stderr io.Writer) int {
 // caller to refuse: whether a decline is stale is only known once every
 // operation of its provider has been compared.
 func checkProvider(p upstream.Provider, cat *shape.Catalogue, declines []emulator.FieldDecline, ts *httptest.Server, stdout io.Writer) (checked, missing, excused int, unused []emulator.FieldDecline) {
+	// Two gates read DeclinedFields(), each joining on its own spelling: this
+	// one on the catalogue key ("GET /path", or the operation name where the
+	// recording carried one), the live field gate on the mounted operation
+	// name ("ipam/v1/API.ListIPs"). A decline addressed to the other gate is
+	// not stale here — it is simply not this gate's to judge — so only the
+	// declines this gate can resolve are held to the staleness rule.
+	// TestADeclineSpelledForTheLiveGateIsNotStaleHere fails without this.
+	keys := map[string]bool{}
+	for _, call := range upstream.Reads[p] {
+		key, _, _ := callIdentity(p, call)
+		keys[key] = true
+	}
+	mine := make([]emulator.FieldDecline, 0, len(declines))
+	for _, d := range declines {
+		if keys[d.Operation] {
+			mine = append(mine, d)
+		}
+	}
+	declines = mine
+
 	used := make([]bool, len(declines))
+	// A decline can be judged stale only where this gate could judge it at
+	// all. Offline, the store is empty: a list answers no element, and every
+	// field under one is skipped rather than compared (absentFrom). A decline
+	// for such a field excuses nothing here without being wrong — the live
+	// field gate is where it works — so staleness needs two more facts per
+	// decline: does the recording still carry a matching field, and does the
+	// emulator demonstrably serve one. Stale is "served now" or "nothing in
+	// the recording to excuse"; recorded-but-unreachable is silence.
+	// TestAnUnevaluableElementDeclineIsNotStale fails without this.
+	wantMatched := make([]bool, len(declines))
+	servedMatched := make([]bool, len(declines))
 	for _, call := range upstream.Reads[p] {
 		key, method, path := callIdentity(p, call)
 		want, known := cat.Operations[key]
@@ -165,6 +196,24 @@ func checkProvider(p upstream.Provider, cat *shape.Catalogue, declines []emulato
 			continue
 		}
 		checked++
+
+		for i, d := range declines {
+			if d.Operation != key {
+				continue
+			}
+			for _, f := range want.Fields {
+				if d.Matches(key, f.Path) {
+					wantMatched[i] = true
+					break
+				}
+			}
+			for served := range got {
+				if d.Matches(key, served) {
+					servedMatched[i] = true
+					break
+				}
+			}
+		}
 
 		var lines []string
 		for _, g := range absentFrom(want.Fields, got) {
@@ -185,9 +234,16 @@ func checkProvider(p upstream.Provider, cat *shape.Catalogue, declines []emulato
 		}
 	}
 	for i, ok := range used {
-		if !ok {
-			unused = append(unused, declines[i])
+		if ok {
+			continue
 		}
+		// Recorded, not served, and yet never excused: the comparison could
+		// not reach the field (an element of a list the offline store leaves
+		// empty). Not stale — the live gate is where this decline works.
+		if wantMatched[i] && !servedMatched[i] {
+			continue
+		}
+		unused = append(unused, declines[i])
 	}
 	return checked, missing, excused, unused
 }

--- a/internal/cli/shapes_check_test.go
+++ b/internal/cli/shapes_check_test.go
@@ -153,10 +153,15 @@ const productsServersOp = "GET /instance/v1/zones/fr-par-1/products/servers"
 // writeShapeFile commits a hand-built catalogue for the gate to read.
 func writeShapeFile(t *testing.T, dir string, fields ...transcript.Field) {
 	t.Helper()
+	writeShapeFileFor(t, dir, productsServersOp, fields...)
+}
+
+func writeShapeFileFor(t *testing.T, dir, key string, fields ...transcript.Field) {
+	t.Helper()
 	cat := shape.New("scaleway")
-	cat.Operations[productsServersOp] = &shape.Operation{
+	cat.Operations[key] = &shape.Operation{
 		Method:   "GET",
-		Path:     "/instance/v1/zones/fr-par-1/products/servers",
+		Path:     strings.TrimPrefix(key, "GET "),
 		Fields:   fields,
 		Statuses: []int{200},
 	}
@@ -236,6 +241,59 @@ func TestAStaleFieldDeclineFailsTheGate(t *testing.T) {
 	if !strings.Contains(errOut.String(), "stale") ||
 		!strings.Contains(errOut.String(), "servers.*.per_volume_constraint.l_ssd") {
 		t.Errorf("the stale decline was not named:\n%s", errOut.String())
+	}
+}
+
+// A decline for a field the comparison could not reach is not stale.
+//
+// Offline, the store is empty: ListServers answers no element, so a field
+// under servers[] is skipped rather than compared, and a decline for it
+// excuses nothing without being wrong — it is the live field gate's to judge.
+// Before this rule, the first element-level decline (Outscale's
+// Nics[].PrivateIps[].LinkPublicIp) turned this gate red as stale while the
+// decision it records was alive.
+func TestAnUnevaluableElementDeclineIsNotStale(t *testing.T) {
+	const listServersOp = "GET /instance/v1/zones/fr-par-1/servers"
+	declineScaleway(t, emulator.FieldDecline{
+		Operation: listServersOp,
+		Path:      "servers[].invented_for_this_test",
+		Reason:    aReason,
+	})
+	dir := t.TempDir()
+	writeShapeFileFor(t, dir, listServersOp,
+		transcript.Field{Path: "servers", Type: "array"},
+		transcript.Field{Path: "servers[]", Type: "object"},
+		transcript.Field{Path: "servers[].invented_for_this_test", Type: "string"},
+	)
+
+	var out, errOut strings.Builder
+	if rc := checkShapes(dir, nil, &out, &errOut); rc != exitOK {
+		t.Fatalf("an unevaluable element decline exited %d, want %d\n%s%s", rc, exitOK, out.String(), errOut.String())
+	}
+}
+
+// A decline spelled for the live field gate — the mounted operation name,
+// "ipam/v1/API.ListIPs" — is not this gate's to judge: it joins on catalogue
+// keys, and an entry it cannot resolve excuses nothing here by construction.
+// Before this rule, the first decline written for the live gate turned this
+// gate red as "stale" on a decision that was alive and doing its job one gate
+// over.
+func TestADeclineSpelledForTheLiveGateIsNotStaleHere(t *testing.T) {
+	declineScaleway(t, emulator.FieldDecline{
+		Operation: "ipam/v1/API.ListIPs",
+		Path:      "ips[].source.zonal",
+		Reason:    aReason,
+	})
+	dir := t.TempDir()
+	writeShapeFile(t, dir,
+		transcript.Field{Path: "servers", Type: "object"},
+		transcript.Field{Path: "servers.DEV1-S", Type: "object"},
+		transcript.Field{Path: "servers.DEV1-S.ncpus", Type: "number"},
+	)
+
+	var out, errOut strings.Builder
+	if rc := checkShapes(dir, nil, &out, &errOut); rc != exitOK {
+		t.Fatalf("a live-gate decline exited %d here, want %d\n%s%s", rc, exitOK, out.String(), errOut.String())
 	}
 }
 

--- a/internal/cli/testdata/frozen/conformance.json
+++ b/internal/cli/testdata/frozen/conformance.json
@@ -221,6 +221,141 @@
           }
         ]
       }
+    },
+    {
+      "schema_version": 3,
+      "content": {
+        "fields": [
+          {
+            "path": "calls",
+            "type": "object"
+          },
+          {
+            "path": "calls.*",
+            "type": "array"
+          },
+          {
+            "path": "calls.*[]",
+            "type": "number"
+          },
+          {
+            "path": "contracts",
+            "type": "array"
+          },
+          {
+            "path": "evidence",
+            "type": "object"
+          },
+          {
+            "path": "evidence.*",
+            "type": "array"
+          },
+          {
+            "path": "evidence.*[]",
+            "type": "object"
+          },
+          {
+            "path": "evidence.*[].behaviour",
+            "type": "bool"
+          },
+          {
+            "path": "evidence.*[].contract",
+            "type": "string"
+          },
+          {
+            "path": "evidence.*[].dataplane",
+            "type": "bool"
+          },
+          {
+            "path": "evidence.*[].driven",
+            "type": "bool"
+          },
+          {
+            "path": "evidence.*[].negative",
+            "type": "bool"
+          },
+          {
+            "path": "evidence.*[].probed",
+            "type": "string"
+          },
+          {
+            "path": "evidence.*[].shape",
+            "type": "string"
+          },
+          {
+            "path": "exercised",
+            "type": "number"
+          },
+          {
+            "path": "fields",
+            "type": "object"
+          },
+          {
+            "path": "fields.compared",
+            "type": "array"
+          },
+          {
+            "path": "fields.excused",
+            "type": "object"
+          },
+          {
+            "path": "fields.missing",
+            "type": "object"
+          },
+          {
+            "path": "fields.stale_declines",
+            "type": "array"
+          },
+          {
+            "path": "fields.unconfirmed",
+            "type": "object"
+          },
+          {
+            "path": "machines",
+            "type": "string"
+          },
+          {
+            "path": "probed",
+            "type": "number"
+          },
+          {
+            "path": "probes",
+            "type": "object"
+          },
+          {
+            "path": "probes.*",
+            "type": "array"
+          },
+          {
+            "path": "probes.*[]",
+            "type": "number"
+          },
+          {
+            "path": "schema_version",
+            "type": "number"
+          },
+          {
+            "path": "served",
+            "type": "number"
+          },
+          {
+            "path": "unread_request_fields",
+            "type": "object"
+          },
+          {
+            "path": "untouched",
+            "type": "array"
+          },
+          {
+            "path": "untouched[]",
+            "type": "string"
+          },
+          {
+            "path": "violations",
+            "type": "object"
+          }
+        ]
+      }
     }
   ]
 }

--- a/internal/contract/fields.go
+++ b/internal/contract/fields.go
@@ -1,0 +1,117 @@
+package contract
+
+import "sort"
+
+// The other direction of the same check (#88).
+//
+// Validate holds a response to what the schema forbids, and that is
+// one-directional by construction: an absent field only violates a schema when
+// the provider declared it required, which Scaleway does on 9% of its schemas
+// and Outscale on 27%. So the gate caught every field this emulator invented
+// and none of the fields it forgot — twenty of them on ReadVms alone, each
+// green for as long as it existed, found only because a recording of a real
+// account happened to cover that one operation.
+//
+// What this file adds is the list to hold an answer against: every field the
+// provider's own document declares the response carries. The document is the
+// source the SDKs are generated from, so a property listed here is a field a
+// generated client knows how to decode — and a served answer that never once
+// carries it is either an omission or a decision, never nothing. Which of the
+// two it is belongs to the caller: this package states what the document
+// declares, the emulator's observer compares, and a pack's DeclinedFields()
+// argues the decisions.
+
+// ResponseFields flattens the response schema of an operation into the field
+// paths a complete answer would carry, mapped to their declared type.
+//
+// The path grammar is the transcript's, so the two sides of a comparison speak
+// the same language: "servers" is an array, "servers[]" one of its elements,
+// "servers[].name" a field of each element. An array of scalars contributes
+// its own path and nothing below it; an object property that names no schema
+// is opaque — its keys are the provider's data, not the document's declaration
+// — and contributes nothing below itself either.
+//
+// Nil when the contract does not know the operation or declares no response
+// schema: "nothing declared" must stay distinct from "nothing to serve", or a
+// consumer would hold an answer to a list this method invented.
+func (d *Doc) ResponseFields(operation string) map[string]string {
+	op, ok := d.Operations[operation]
+	if !ok || op.Response == "" {
+		return nil
+	}
+	schema, ok := d.Schemas[op.Response]
+	if !ok || len(schema.Properties) == 0 {
+		return nil
+	}
+	out := map[string]string{}
+	d.flattenSchema(out, "", op.Response, map[string]bool{})
+	return out
+}
+
+// flattenSchema records every property of a schema under path, descending
+// through refs.
+//
+// visiting guards the current branch: a schema reachable from itself — and the
+// documents have them — is recorded where first met and not descended into
+// again, so the flattening terminates instead of recursing forever.
+// TestResponseFieldsSurviveARecursiveSchema fails without it.
+func (d *Doc) flattenSchema(out map[string]string, path, schemaName string, visiting map[string]bool) {
+	if visiting[schemaName] {
+		return
+	}
+	visiting[schemaName] = true
+	defer delete(visiting, schemaName)
+
+	schema := d.Schemas[schemaName]
+	for name, prop := range schema.Properties {
+		d.flattenProperty(out, join(path, name), prop, visiting)
+	}
+}
+
+func (d *Doc) flattenProperty(out map[string]string, path string, prop Property, visiting map[string]bool) {
+	switch {
+	case prop.Ref != "":
+		ref, known := d.Schemas[prop.Ref]
+		switch {
+		case !known:
+			// A dangling ref declares nothing checkable below this point.
+			out[path] = "object"
+		case ref.Type != "" && ref.Properties == nil:
+			// A named scalar: the state enumerations.
+			out[path] = ref.Type
+		default:
+			out[path] = "object"
+			d.flattenSchema(out, path, prop.Ref, visiting)
+		}
+	case prop.Type == "array":
+		out[path] = "array"
+		if prop.Items == nil {
+			return
+		}
+		if prop.Items.Ref != "" {
+			d.flattenProperty(out, path+"[]", *prop.Items, visiting)
+			return
+		}
+		// An array of scalars ends here: its elements carry no fields, and an
+		// element path for them would demand a non-empty list from a store
+		// whose contents are the client's business.
+	default:
+		typ := prop.Type
+		if typ == "" {
+			// An untyped property is opaque: the document said "a field exists
+			// here" and nothing more, so nothing below it is declared.
+			typ = "object"
+		}
+		out[path] = typ
+	}
+}
+
+// SortedFieldPaths orders a field map for deterministic reporting.
+func SortedFieldPaths(fields map[string]string) []string {
+	out := make([]string, 0, len(fields))
+	for path := range fields {
+		out = append(out, path)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/contract/fields_test.go
+++ b/internal/contract/fields_test.go
@@ -1,0 +1,106 @@
+package contract_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/contract"
+)
+
+// The flattening is the source the omission check (#88) holds answers to, so
+// what it declares must be exactly what the document declares: every ref
+// followed, arrays of objects opened, arrays of scalars and opaque objects
+// stopped at — a path invented here would become a false omission on every
+// run, and a path dropped here a blind spot forever.
+
+const fieldsContract = `{
+  "provider": "stub",
+  "operations": {
+    "GetThing": {"method": "GET", "path": "/thing", "response": "ThingView"},
+    "NoBody": {"method": "DELETE", "path": "/thing", "response": ""},
+    "Recurse": {"method": "GET", "path": "/tree", "response": "Node"}
+  },
+  "schemas": {
+    "ThingView": {"closed": true, "properties": {
+      "name": {"type": "string"},
+      "state": {"ref": "ThingState"},
+      "image": {"ref": "Image"},
+      "volumes": {"type": "array", "items": {"ref": "Volume"}},
+      "tags": {"type": "array", "items": {"type": "string"}},
+      "metadata": {"type": "object"}
+    }},
+    "ThingState": {"type": "string", "enum": ["running", "stopped"]},
+    "Image": {"closed": true, "properties": {"id": {"type": "string"}, "arch": {"type": "string"}}},
+    "Volume": {"closed": true, "properties": {"id": {"type": "string"}, "size": {"type": "integer"}}},
+    "Node": {"closed": false, "properties": {
+      "value": {"type": "string"},
+      "children": {"type": "array", "items": {"ref": "Node"}}
+    }}
+  }
+}`
+
+func fieldsDoc(t *testing.T) *contract.Doc {
+	t.Helper()
+	doc, err := contract.Read(strings.NewReader(fieldsContract))
+	if err != nil {
+		t.Fatalf("read the stub contract: %v", err)
+	}
+	return doc
+}
+
+func TestResponseFieldsFollowRefsAndOpenArraysOfObjects(t *testing.T) {
+	fields := fieldsDoc(t).ResponseFields("GetThing")
+
+	want := map[string]string{
+		"name":           "string",
+		"state":          "string", // a ref to a named scalar carries its type
+		"image":          "object",
+		"image.id":       "string",
+		"image.arch":     "string",
+		"volumes":        "array",
+		"volumes[]":      "object",
+		"volumes[].id":   "string",
+		"volumes[].size": "integer",
+		"tags":           "array",  // scalars declare nothing below themselves
+		"metadata":       "object", // opaque: its keys are data, not declaration
+	}
+	for path, typ := range want {
+		if got := fields[path]; got != typ {
+			t.Errorf("field %q: got %q, want %q", path, got, typ)
+		}
+	}
+	for path := range fields {
+		if _, expected := want[path]; !expected {
+			t.Errorf("field %q was declared by nothing in the document", path)
+		}
+	}
+}
+
+func TestAnOperationWithoutAResponseSchemaDeclaresNothing(t *testing.T) {
+	if fields := fieldsDoc(t).ResponseFields("NoBody"); fields != nil {
+		t.Errorf("no response schema must declare no fields, got %v", fields)
+	}
+	if fields := fieldsDoc(t).ResponseFields("NoSuchOperation"); fields != nil {
+		t.Errorf("an unknown operation must declare no fields, got %v", fields)
+	}
+}
+
+// TestResponseFieldsSurviveARecursiveSchema is the guard flattenSchema cites: a
+// schema reachable from itself — and the providers publish them — must be
+// recorded where first met and never descended into again, or the flattening
+// recurses forever.
+func TestResponseFieldsSurviveARecursiveSchema(t *testing.T) {
+	fields := fieldsDoc(t).ResponseFields("Recurse")
+
+	if fields["value"] != "string" || fields["children"] != "array" {
+		t.Fatalf("the first level must be declared, got %v", fields)
+	}
+	if fields["children[]"] != "object" {
+		t.Errorf("the element of the recursive array is still an object, got %v", fields)
+	}
+	for path := range fields {
+		if strings.Contains(path, "children[].children[]") {
+			t.Errorf("the recursion was followed into itself: %q", path)
+		}
+	}
+}

--- a/internal/core/emulator/conformance.go
+++ b/internal/core/emulator/conformance.go
@@ -84,6 +84,12 @@ type observer struct {
 	// operation. Deduplicated, because a client repeating a call repeats the
 	// field and one defect must read as one.
 	unread map[string]map[string]bool
+	// served accumulates, per operation, the union of field paths its decoded
+	// 2xx answers carried across the run, each with the most container-like
+	// type seen there. The other side of the omission check (#88): what the
+	// contract declares and this union never shows is a field the emulator
+	// forgot, or a decision a pack must argue. See omissions.go.
+	served map[string]map[string]string
 	// contracts maps a provider to its API description, when one was loaded.
 	contracts map[string]*contract.Doc
 	// stream is where each answered request is published, in order. The counters
@@ -114,6 +120,7 @@ func newObserver(contracts map[string]*contract.Doc, events *stream) *observer {
 		violations:    map[string]contract.Violations{},
 		checked:       map[string]int{},
 		unread:        map[string]map[string]bool{},
+		served:        map[string]map[string]string{},
 		contracts:     contracts,
 		flight:        map[int64]flightEntry{},
 		spans:         map[string]*assertSpan{},
@@ -283,6 +290,9 @@ func (o *observer) check(doc *contract.Doc, operation string, rec *recorder) con
 		o.report(operation, vs)
 		return vs
 	}
+	// Whatever the verdict below: a violating answer still shows which fields
+	// it serves, and the omission check reads the union of all of them.
+	o.recordServed(operation, decoded)
 	if vs := doc.ValidateResponse(name, decoded); len(vs) > 0 {
 		o.report(operation, vs)
 		return vs
@@ -479,6 +489,11 @@ type ConformanceView struct {
 	// the handler does not declare. Each one is an argument the API accepted and
 	// then ignored, which is the failure nothing else here can see.
 	UnreadRequestFields map[string][]string `json:"unread_request_fields"`
+	// Fields is the omission check (#88): the declared response fields this
+	// run's answers never carried, per operation, next to how many operations
+	// the comparison could reach. The mirror of Violations, which only sees
+	// what an answer invents.
+	Fields FieldGaps `json:"fields"`
 	// Machines names the runtime behind this run ("none" when machines are
 	// metadata-only). Copied here because the dataplane axis below is defined
 	// by it, and a record that depends on a fact must carry the fact.
@@ -577,6 +592,25 @@ func (s *Server) SetShapeCovered(operations []string) {
 		covered[op] = true
 	}
 	s.shapeCovered = covered
+}
+
+// SetObservedFields hands the server, per operation, the field paths a real
+// cloud's recorded answer carried — the corroboration half of the omission
+// check (omissions.go). Computed by the caller from the shapes catalogues for
+// the same reason SetShapeCovered is: mapping a catalogue entry to a mounted
+// operation is not the core's business. Never called, the check publishes
+// every declared-but-absent field as unconfirmed and fails on none, because a
+// proof nobody handed in is not a proof.
+func (s *Server) SetObservedFields(observed map[string][]string) {
+	fields := make(map[string]map[string]bool, len(observed))
+	for op, paths := range observed {
+		set := make(map[string]bool, len(paths))
+		for _, p := range paths {
+			set[p] = true
+		}
+		fields[op] = set
+	}
+	s.observedFields = fields
 }
 
 func (s *Server) handleConformance(w http.ResponseWriter, _ *http.Request) {
@@ -693,6 +727,8 @@ func (s *Server) handleConformance(w http.ResponseWriter, _ *http.Request) {
 		}
 	}
 
+	gaps := s.fieldGaps(s.observer.servedCopy())
+
 	writeJSON(w, http.StatusOK, ConformanceView{
 		SchemaVersion:       ConformanceSchemaVersion,
 		Served:              len(routes),
@@ -704,6 +740,7 @@ func (s *Server) handleConformance(w http.ResponseWriter, _ *http.Request) {
 		Contracts:           providers,
 		Violations:          violations,
 		UnreadRequestFields: unread,
+		Fields:              gaps,
 		Machines:            machines,
 		Evidence:            evidence,
 	})

--- a/internal/core/emulator/conformance.go
+++ b/internal/core/emulator/conformance.go
@@ -204,7 +204,7 @@ func (o *observer) wrap(provider string, r Route) http.HandlerFunc {
 		var violations []string
 		var vs contract.Violations
 		if doc != nil {
-			vs = o.check(doc, r.Operation, rec)
+			vs = o.check(doc, r.Operation, rec, synthetic)
 			for _, v := range vs {
 				violations = append(violations, v.String())
 			}
@@ -265,7 +265,7 @@ func (o *observer) record(operation string, synthetic bool) {
 // report — one bad field repeated across a hundred calls is one defect — and
 // hands the violations back, because the log needs the verdict on this exchange
 // rather than on the operation.
-func (o *observer) check(doc *contract.Doc, operation string, rec *recorder) contract.Violations {
+func (o *observer) check(doc *contract.Doc, operation string, rec *recorder, synthetic bool) contract.Violations {
 	if rec.body == nil || rec.status < 200 || rec.status >= 300 || rec.body.Len() == 0 {
 		return nil
 	}
@@ -292,7 +292,24 @@ func (o *observer) check(doc *contract.Doc, operation string, rec *recorder) con
 	}
 	// Whatever the verdict below: a violating answer still shows which fields
 	// it serves, and the omission check reads the union of all of them.
-	o.recordServed(operation, decoded)
+	//
+	// A synthetic answer does not count, and CI is what proved it. The probe
+	// leg of conformance.yml drives no client at all, so every object in it is
+	// the minimal one the probe's own seeding builds: no address linked, no
+	// tags, no user data. The gate then accused ReadVms of omitting
+	// PublicIp, Tags and UserData — fields that exist only on a machine a user
+	// configured, absent for a reason that is the run's and not the emulator's.
+	//
+	// So the verdict is over what a client-driven run served, which is the same
+	// boundary #163 drew for the unread-fields report one screen up: synthetic
+	// traffic moves no client-facing number. The contract check itself still
+	// runs on synthetic answers — the probe's whole contract axis depends on
+	// it — and only this record is skipped.
+	//
+	// TestASyntheticAnswerDoesNotVouchForAServedField fails without the guard.
+	if !synthetic {
+		o.recordServed(operation, decoded)
+	}
 	if vs := doc.ValidateResponse(name, decoded); len(vs) > 0 {
 		o.report(operation, vs)
 		return vs

--- a/internal/core/emulator/emulator.go
+++ b/internal/core/emulator/emulator.go
@@ -170,6 +170,12 @@ type Server struct {
 	// covers, handed in by SetShapeCovered. nil means no catalogue was given,
 	// which the evidence record reports as "unknown" rather than "unobserved".
 	shapeCovered map[string]bool
+	// observedFields maps an operation to the field paths a real cloud's
+	// recorded answer carried, handed in by SetObservedFields the way
+	// shapeCovered is: the core knows neither providers nor where recordings
+	// live. It is the corroboration the omission check fails on (omissions.go);
+	// nil narrows that check to nothing rather than inventing a proof.
+	observedFields map[string]map[string]bool
 }
 
 // NewServer mounts the packs. It fails when two packs claim the same route,

--- a/internal/core/emulator/omissions.go
+++ b/internal/core/emulator/omissions.go
@@ -1,0 +1,277 @@
+package emulator
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/stephrobert/feint/internal/contract"
+	"github.com/stephrobert/feint/internal/transcript"
+)
+
+// The omission half of the contract check (#88).
+//
+// Validate catches what a response invents; nothing caught what it forgot,
+// because an absent field only violates a schema when the provider declared it
+// required, and the providers barely do — 9% of Scaleway's schemas, 27% of
+// Outscale's. The gap was not theoretical: ReadVms served twenty fields short
+// of the real cloud, ReadImages three, one of which segfaulted the Terraform
+// provider (#86), and each was found only because a recording of a real
+// account happened to cover that operation.
+//
+// Two upstream sources speak here, and the verdict depends on both, because
+// each alone was measured wrong in its own direction:
+//
+//   - The provider's API description declares every field a response may
+//     carry (contract.ResponseFields). Alone it over-declares: held against
+//     this emulator's first instrumented conformance run, 83 of the 106
+//     declared-but-absent fields a recording could arbitrate were absent from
+//     the real cloud's answer too — pagination tokens that only appear when a
+//     further page exists, client tokens echoed only when sent. A gate red on
+//     all of that is a gate somebody turns off.
+//   - The recorded shapes (shapes/) prove what a real account's answers
+//     actually carried. Alone, offline against an empty store, they could not
+//     see a single element field: every list is empty there, so
+//     `feint shapes --check` skips the elements — which is why twenty fields
+//     of ReadVms passed it.
+//
+// So: a field both declared by the document and observed on the real cloud,
+// missing from the populated answers a conformance run produced, fails the
+// gate (Missing). A field only the document declares is published as
+// Unconfirmed — visible, actionable by recording that operation, never a
+// failure, because no source independent of this emulator says it should have
+// been there. The traffic that makes either comparison meaningful is the
+// conformance run's: real clients create resources, so the answers carry the
+// populated objects the offline check never had.
+//
+// The rules that keep the comparison honest, each measured on the first run:
+//
+//   - the union of every answer counts, so a field present in any response of
+//     the run is served, whatever a sparser answer omitted;
+//   - a field below an absent or null container is not reported: the omission
+//     is the container's, and the real clouds answer null for an unset object;
+//   - an element path ("servers[]") is never reported: an empty list is a
+//     state of the store, not a defect of the view;
+//   - a pack may argue an absence is a decision (DeclinedFields), which moves
+//     it to Excused, printed with its reason; a decline whose field the run
+//     demonstrably served is published stale, so the excused list cannot rot
+//     into fiction.
+
+// FieldGaps is the verdict of the omission check, published on
+// /_feint/conformance for the gate (tools/conformance/score.sh) to read.
+type FieldGaps struct {
+	// Compared names the operations the check could hold to the document: a
+	// response schema on one side, at least one decoded 2xx answer on the
+	// other. Everything absent from this list is exactly that — unchecked, not
+	// clean — the same distinction the contract axis draws.
+	Compared []string `json:"compared"`
+	// Missing maps an operation to the fields no answer of this run carried
+	// although both sources vouch for them — declared by the provider's
+	// document, observed on the real cloud — each as "path: declared type".
+	// This is the map the gate fails on.
+	Missing map[string][]string `json:"missing"`
+	// Unconfirmed maps an operation to the declared-but-absent fields no
+	// recording arbitrates: the document says they may exist, nothing proves
+	// the real cloud serves them, and the measured base rate says four of
+	// five such fields are absent from the real answer too. Published so the
+	// blind spot has a name — each entry is exactly one recording away from
+	// becoming either a Missing or nothing — and never failed on.
+	Unconfirmed map[string][]string `json:"unconfirmed"`
+	// Excused maps an operation to the declared-but-absent fields a pack
+	// declines on purpose, each with its reason. Printed, never failed on:
+	// what the gate subtracts must stay visible.
+	Excused map[string][]string `json:"excused"`
+	// StaleDeclines lists field declines that argue for an omission the
+	// emulator does not have: the field was served in this very run. Each one
+	// is a decision that outlived its subject, and the gate fails on them.
+	StaleDeclines []string `json:"stale_declines"`
+}
+
+// recordServed folds one decoded 2xx answer into the union of what this
+// operation was seen to serve. The union, not the last answer: a list serves
+// its element fields only while the store holds elements, and a later empty
+// answer must not erase what a populated one proved.
+//
+// The type is kept, not just the presence, because the container rule below
+// needs it: a field served as null is present, and nothing below it is
+// observable. upgradeType keeps the most container-like type seen, so one
+// populated answer among many null ones is what counts.
+func (o *observer) recordServed(operation string, decoded any) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	seen := o.served[operation]
+	if seen == nil {
+		seen = map[string]string{}
+		o.served[operation] = seen
+	}
+	for _, f := range transcript.FieldsOf(decoded) {
+		seen[f.Path] = upgradeType(seen[f.Path], f.Type)
+	}
+}
+
+// upgradeType reconciles two observations of one path. A container wins over a
+// scalar and anything wins over null, because what the union feeds is the
+// question "could this path's children ever have been observed": one answer
+// where the container was populated says yes, however many nulls surround it.
+func upgradeType(old, new string) string {
+	switch {
+	case old == "" || old == "null":
+		return new
+	case new == "object" || new == "array":
+		return new
+	default:
+		return old
+	}
+}
+
+// servedCopy hands the accumulated unions out from under the lock.
+func (o *observer) servedCopy() map[string]map[string]string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	out := make(map[string]map[string]string, len(o.served))
+	for op, fields := range o.served {
+		c := make(map[string]string, len(fields))
+		for f, t := range fields {
+			c[f] = t
+		}
+		out[op] = c
+	}
+	return out
+}
+
+// fieldGaps compares every operation's served union with what its contract
+// declares, and files each absence as missing, excused, or — for a decline
+// arguing against a field the run served — stale.
+func (s *Server) fieldGaps(served map[string]map[string]string) FieldGaps {
+	gaps := FieldGaps{
+		Compared:      []string{},
+		Missing:       map[string][]string{},
+		Unconfirmed:   map[string][]string{},
+		Excused:       map[string][]string{},
+		StaleDeclines: []string{},
+	}
+	for _, p := range s.packs {
+		doc := s.observer.contracts[p.Name()]
+		if doc == nil {
+			continue
+		}
+		declines := FieldDeclinesOf(p)
+		for _, r := range p.Routes() {
+			seen, answered := served[r.Operation]
+			if !answered {
+				continue
+			}
+			_, name, known := doc.OperationFor(r.Operation)
+			if !known {
+				continue
+			}
+			expected := doc.ResponseFields(name)
+			if len(expected) == 0 {
+				continue
+			}
+			gaps.Compared = append(gaps.Compared, r.Operation)
+			compareFields(&gaps, r.Operation, expected, seen, s.observedFields[r.Operation], declines)
+		}
+	}
+	sort.Strings(gaps.Compared)
+	sort.Strings(gaps.StaleDeclines)
+	return gaps
+}
+
+// compareFields holds one operation's served union to its declared fields,
+// with the recorded real answer as the arbiter of which absences fail.
+func compareFields(gaps *FieldGaps, operation string, expected map[string]string, seen map[string]string, observed map[string]bool, declines []FieldDecline) {
+	for _, path := range contract.SortedFieldPaths(expected) {
+		if _, present := seen[path]; present {
+			continue
+		}
+		// An element that never appeared is an empty list, which is the
+		// store's state, not the view's defect — the shapes gate's rule,
+		// TestAnEmptyListIsNotAnOmission here.
+		if strings.HasSuffix(path, "[]") {
+			continue
+		}
+		// A field below a container that was never served populated: absent,
+		// the omission is the container's, already reported at its own level;
+		// served null, nothing below it is observable, and the real clouds do
+		// answer null for an unset object — shapes/scaleway.json records
+		// `default_bootscript: null` from a real account, and the first run of
+		// this check accused all twelve of its children before this rule
+		// (TestANullContainerDoesNotAccuseItsChildren,
+		// TestAMissingContainerIsOneOmissionNotMany).
+		if !containersPopulated(seen, ancestorsOf(path)) {
+			continue
+		}
+		if i := matchingFieldDecline(declines, operation, path); i >= 0 {
+			gaps.Excused[operation] = append(gaps.Excused[operation],
+				path+": "+declines[i].Reason)
+			continue
+		}
+		// Only an absence both sources vouch for fails; the document alone
+		// files it as unconfirmed. The 4-to-1 base rate behind that split is
+		// in the package comment, and TestADeclaredFieldNobodyObservedDoesNotFail
+		// holds the line.
+		if observed[path] {
+			gaps.Missing[operation] = append(gaps.Missing[operation],
+				path+": "+expected[path])
+			continue
+		}
+		gaps.Unconfirmed[operation] = append(gaps.Unconfirmed[operation],
+			path+": "+expected[path])
+	}
+	// A decline is provably stale when the run served the very field it argues
+	// the emulator does not have. Only provably: an operation this run never
+	// compared says nothing, and failing on it would make the gate flap with
+	// the traffic (TestAProvablyStaleFieldDeclineIsPublished).
+	for _, d := range declines {
+		if d.Operation != operation {
+			continue
+		}
+		for path := range seen {
+			if d.Matches(operation, path) {
+				gaps.StaleDeclines = append(gaps.StaleDeclines,
+					d.Operation+" "+d.Path+": the emulator serves this field")
+				break
+			}
+		}
+	}
+}
+
+// ancestorsOf lists every container a field sits in, outermost first:
+// "servers[].image.id" -> ["servers", "servers[]", "servers[].image"].
+func ancestorsOf(path string) []string {
+	segments := strings.Split(path, ".")
+	var out []string
+	prefix := ""
+	for _, seg := range segments[:len(segments)-1] {
+		if prefix != "" {
+			prefix += "."
+		}
+		if strings.HasSuffix(seg, "[]") {
+			out = append(out, prefix+strings.TrimSuffix(seg, "[]"))
+		}
+		prefix += seg
+		out = append(out, prefix)
+	}
+	return out
+}
+
+// containersPopulated reports whether every ancestor was served as a real
+// container — an object or an array — at least once. A null or scalar there
+// means the branch below it was never observable.
+func containersPopulated(seen map[string]string, paths []string) bool {
+	for _, p := range paths {
+		if t := seen[p]; t != "object" && t != "array" {
+			return false
+		}
+	}
+	return true
+}
+
+func matchingFieldDecline(declines []FieldDecline, operation, path string) int {
+	for i, d := range declines {
+		if d.Matches(operation, path) {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/core/emulator/omissions_test.go
+++ b/internal/core/emulator/omissions_test.go
@@ -1,0 +1,294 @@
+package emulator_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/contract"
+	"github.com/stephrobert/feint/internal/core/emulator"
+)
+
+// The omission check (#88): the contract gate sees what an answer invents,
+// this sees what it forgets. Every test here is one rule that keeps the check
+// honest — the finding must be real (an omitted declared field, its container
+// served), and the silence must be real too (an empty list, an absent
+// container, a field a pack declines with a reason).
+
+const omissionsContract = `{
+  "provider": "stub",
+  "operations": {
+    "ListThings": {"method": "GET", "path": "/stub/things", "response": "ListView"},
+    "GetOther": {"method": "GET", "path": "/stub/other", "response": "OtherView"}
+  },
+  "schemas": {
+    "ListView": {"closed": true, "properties": {
+      "things": {"type": "array", "items": {"ref": "Thing"}}
+    }},
+    "Thing": {"closed": true, "properties": {
+      "id": {"type": "string"},
+      "name": {"type": "string"},
+      "image": {"ref": "Image"}
+    }},
+    "Image": {"closed": true, "properties": {"id": {"type": "string"}, "arch": {"type": "string"}}},
+    "OtherView": {"closed": true, "properties": {"ok": {"type": "boolean"}}}
+  }
+}`
+
+// declStubPack is a stubPack that also declines fields, the way a real pack
+// does through emulator.FieldDecliner.
+type declStubPack struct {
+	stubPack
+	declines []emulator.FieldDecline
+}
+
+func (p declStubPack) DeclinedFields() []emulator.FieldDecline { return p.declines }
+
+// realThings is what the "real cloud" was recorded to answer on ListThings —
+// the corroboration the failing verdict requires. Tests that want a field to
+// be able to fail hand this in; the one test about the uncorroborated case
+// hands nothing.
+var realThings = map[string][]string{
+	"stub/v1/API.ListThings": {
+		"things", "things[]", "things[].id", "things[].name",
+		"things[].image", "things[].image.id", "things[].image.arch",
+	},
+}
+
+func omissionsServer(t *testing.T, things http.HandlerFunc, declines []emulator.FieldDecline, observed map[string][]string) *httptest.Server {
+	t.Helper()
+	doc, err := contract.Read(strings.NewReader(omissionsContract))
+	if err != nil {
+		t.Fatalf("read the stub contract: %v", err)
+	}
+	env := emulator.DefaultEnv()
+	env.Contracts = map[string]*contract.Doc{"stub": doc}
+
+	pack := declStubPack{
+		stubPack: stubPack{name: "stub", routes: []emulator.Route{
+			{Method: "GET", Path: "/stub/things", Operation: "stub/v1/API.ListThings", Handler: things},
+			{Method: "GET", Path: "/stub/other", Operation: "stub/v1/API.GetOther",
+				Handler: answer(http.StatusOK, "application/json", `{"ok": true}`)},
+		}},
+		declines: declines,
+	}
+	srv, err := emulator.NewServer(env, pack)
+	if err != nil {
+		t.Fatalf("mount the stub pack: %v", err)
+	}
+	if observed != nil {
+		srv.SetObservedFields(observed)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// TestAnOmittedDeclaredFieldIsPublished is the test the check exists for, and
+// the falsification target: an answer whose element omits one field the
+// document declares — while the contract gate stays green, because nothing
+// marks the field required — must appear under fields.missing.
+func TestAnOmittedDeclaredFieldIsPublished(t *testing.T) {
+	ts := omissionsServer(t,
+		answer(http.StatusOK, "application/json",
+			`{"things": [{"id": "thing-1", "image": {"id": "img-1", "arch": "x86_64"}}]}`),
+		nil, realThings)
+
+	driveRoute(t, ts, "/stub/things", false)
+
+	view := viewOf(t, ts)
+	missing := view.Fields.Missing["stub/v1/API.ListThings"]
+	if len(missing) != 1 || missing[0] != "things[].name: string" {
+		t.Errorf("the omitted declared field must be the one finding, got %v", missing)
+	}
+	// The two gates measure different things, and this is the proof: the same
+	// answer is clean for the contract axis, because `name` is not required.
+	if len(view.Violations["stub/v1/API.ListThings"]) != 0 {
+		t.Errorf("the contract gate has nothing to say here, got %v",
+			view.Violations["stub/v1/API.ListThings"])
+	}
+}
+
+func TestACompleteAnswerReportsNothing(t *testing.T) {
+	ts := omissionsServer(t,
+		answer(http.StatusOK, "application/json",
+			`{"things": [{"id": "t", "name": "n", "image": {"id": "i", "arch": "arm64"}}]}`),
+		nil, realThings)
+
+	driveRoute(t, ts, "/stub/things", false)
+
+	view := viewOf(t, ts)
+	if len(view.Fields.Missing) != 0 {
+		t.Errorf("a complete answer must report nothing, got %v", view.Fields.Missing)
+	}
+	if len(view.Fields.Compared) != 1 || view.Fields.Compared[0] != "stub/v1/API.ListThings" {
+		t.Errorf("the comparison still counts as done, got %v", view.Fields.Compared)
+	}
+}
+
+// TestAnEmptyListIsNotAnOmission: with no element in the store, no element
+// field can be observed, and reporting them would make the gate cry wolf on
+// every fresh emulator — the same rule the shapes gate learned on its first
+// run.
+func TestAnEmptyListIsNotAnOmission(t *testing.T) {
+	ts := omissionsServer(t,
+		answer(http.StatusOK, "application/json", `{"things": []}`),
+		nil, realThings)
+
+	driveRoute(t, ts, "/stub/things", false)
+
+	if missing := viewOf(t, ts).Fields.Missing; len(missing) != 0 {
+		t.Errorf("an empty list is the store's state, not the view's defect: %v", missing)
+	}
+}
+
+// TestAMissingContainerIsOneOmissionNotMany: an element that omits its whole
+// image object is one finding at the container's level, not three.
+func TestAMissingContainerIsOneOmissionNotMany(t *testing.T) {
+	ts := omissionsServer(t,
+		answer(http.StatusOK, "application/json",
+			`{"things": [{"id": "t", "name": "n"}]}`),
+		nil, realThings)
+
+	driveRoute(t, ts, "/stub/things", false)
+
+	missing := viewOf(t, ts).Fields.Missing["stub/v1/API.ListThings"]
+	if len(missing) != 1 || missing[0] != "things[].image: object" {
+		t.Errorf("one absent container is one finding, got %v", missing)
+	}
+}
+
+// TestANullContainerDoesNotAccuseItsChildren: the real clouds answer null for
+// an unset object — a real account's images carry `default_bootscript: null` —
+// and an emulator doing the same must not be accused of omitting every field
+// the null would have carried. The first run of this check reported all twelve
+// children of that very field before this rule existed.
+func TestANullContainerDoesNotAccuseItsChildren(t *testing.T) {
+	ts := omissionsServer(t,
+		answer(http.StatusOK, "application/json",
+			`{"things": [{"id": "t", "name": "n", "image": null}]}`),
+		nil, realThings)
+
+	driveRoute(t, ts, "/stub/things", false)
+
+	if missing := viewOf(t, ts).Fields.Missing; len(missing) != 0 {
+		t.Errorf("a null container has no observable children, got %v", missing)
+	}
+}
+
+// TestAFieldServedInAnyAnswerIsNotAnOmission: the union of the run counts. A
+// field present while the resource was in the state that carries it must not
+// be reported because a later answer, in another state, omitted it.
+func TestAFieldServedInAnyAnswerIsNotAnOmission(t *testing.T) {
+	bodies := []string{
+		`{"things": [{"id": "t", "name": "n", "image": {"id": "i", "arch": "a"}}]}`,
+		`{"things": [{"id": "t"}]}`,
+	}
+	call := 0
+	ts := omissionsServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(bodies[call]))
+		if call < len(bodies)-1 {
+			call++
+		}
+	}, nil, realThings)
+
+	driveRoute(t, ts, "/stub/things", false)
+	driveRoute(t, ts, "/stub/things", false)
+
+	if missing := viewOf(t, ts).Fields.Missing; len(missing) != 0 {
+		t.Errorf("a field the run served once was served, got %v", missing)
+	}
+}
+
+// TestADeclaredFieldNobodyObservedDoesNotFail: the document alone does not
+// convict. Measured on the first instrumented run: of 106 declared-but-absent
+// fields a recording could arbitrate, 83 were absent from the real cloud's
+// answer too — pagination tokens, echoed client tokens. Without corroboration
+// the absence is published as unconfirmed, never as missing.
+func TestADeclaredFieldNobodyObservedDoesNotFail(t *testing.T) {
+	ts := omissionsServer(t,
+		answer(http.StatusOK, "application/json",
+			`{"things": [{"id": "thing-1", "image": {"id": "img-1", "arch": "x86_64"}}]}`),
+		nil, nil) // no recording handed in
+
+	driveRoute(t, ts, "/stub/things", false)
+
+	view := viewOf(t, ts)
+	if len(view.Fields.Missing) != 0 {
+		t.Errorf("no source but the document vouches for the field; it must not fail: %v",
+			view.Fields.Missing)
+	}
+	unconfirmed := view.Fields.Unconfirmed["stub/v1/API.ListThings"]
+	if len(unconfirmed) != 1 || unconfirmed[0] != "things[].name: string" {
+		t.Errorf("the absence must stay visible as unconfirmed, got %v", unconfirmed)
+	}
+}
+
+// TestADeclinedFieldIsExcusedWithItsReason: a pack that argues an absence is a
+// decision moves the finding to the excused list, reason attached — the gate
+// prints it and does not fail on it.
+func TestADeclinedFieldIsExcusedWithItsReason(t *testing.T) {
+	ts := omissionsServer(t,
+		answer(http.StatusOK, "application/json",
+			`{"things": [{"id": "t", "image": {"id": "i", "arch": "a"}}]}`),
+		[]emulator.FieldDecline{{
+			Operation: "stub/v1/API.ListThings",
+			Path:      "things[].name",
+			Reason:    "the emulated inventory has no display names, and inventing one would be a format nothing upstream states",
+		}}, realThings)
+
+	driveRoute(t, ts, "/stub/things", false)
+
+	view := viewOf(t, ts)
+	if len(view.Fields.Missing) != 0 {
+		t.Errorf("an argued absence is not a finding, got %v", view.Fields.Missing)
+	}
+	excused := view.Fields.Excused["stub/v1/API.ListThings"]
+	if len(excused) != 1 || !strings.HasPrefix(excused[0], "things[].name: ") {
+		t.Errorf("the excuse must be visible with its reason, got %v", excused)
+	}
+}
+
+// TestAProvablyStaleFieldDeclineIsPublished: a decline arguing for an omission
+// the emulator does not have — the run served the very field — is a decision
+// that outlived its subject, and it is published for the gate to fail on.
+// Provably only: an operation the run never compared stays silent, or the
+// gate would flap with the traffic.
+func TestAProvablyStaleFieldDeclineIsPublished(t *testing.T) {
+	ts := omissionsServer(t,
+		answer(http.StatusOK, "application/json",
+			`{"things": [{"id": "t", "name": "n", "image": {"id": "i", "arch": "a"}}]}`),
+		[]emulator.FieldDecline{{
+			Operation: "stub/v1/API.ListThings",
+			Path:      "things[].name",
+			Reason:    "the emulated inventory has no display names, and inventing one would be a format nothing upstream states",
+		}}, realThings)
+
+	driveRoute(t, ts, "/stub/things", false)
+
+	stale := viewOf(t, ts).Fields.StaleDeclines
+	if len(stale) != 1 || !strings.HasPrefix(stale[0], "stub/v1/API.ListThings things[].name") {
+		t.Errorf("a decline for a served field is stale and must say so, got %v", stale)
+	}
+}
+
+// TestAnUncomparedOperationIsNotAccused: no decoded 2xx answer this run means
+// nothing was compared — the operation stays off Compared and out of Missing,
+// because "unchecked" and "complete" are different answers.
+func TestAnUncomparedOperationIsNotAccused(t *testing.T) {
+	ts := omissionsServer(t,
+		answer(http.StatusOK, "application/json", `{"things": []}`),
+		nil, realThings)
+
+	driveRoute(t, ts, "/stub/other", false)
+
+	view := viewOf(t, ts)
+	if len(view.Fields.Compared) != 1 || view.Fields.Compared[0] != "stub/v1/API.GetOther" {
+		t.Errorf("only the driven operation was compared, got %v", view.Fields.Compared)
+	}
+	if len(view.Fields.Missing) != 0 {
+		t.Errorf("an operation nobody drove has nothing missing, got %v", view.Fields.Missing)
+	}
+}

--- a/internal/core/emulator/omissions_test.go
+++ b/internal/core/emulator/omissions_test.go
@@ -292,3 +292,35 @@ func TestAnUncomparedOperationIsNotAccused(t *testing.T) {
 		t.Errorf("an operation nobody drove has nothing missing, got %v", view.Fields.Missing)
 	}
 }
+
+// A synthetic answer does not vouch for a served field, and CI is what proved
+// it needed saying.
+//
+// The probe leg of conformance.yml drives no client at all, so every object in
+// it is the minimal one the probe's own seeding builds: no address linked, no
+// tags, no user data. The gate accused ReadVms of omitting PublicIp, Tags and
+// UserData — fields that exist only on a machine a user configured, absent for
+// a reason belonging to the run rather than to the emulator.
+//
+// Both halves are asserted, because a guard that swallowed both would silence
+// the check this file exists for: the same incomplete answer accuses nobody
+// when only the probe asked for it, and is a finding the moment a client does.
+func TestASyntheticAnswerDoesNotVouchForAServedField(t *testing.T) {
+	incomplete := answer(http.StatusOK, "application/json",
+		`{"things": [{"id": "thing-1", "image": {"id": "img-1", "arch": "x86_64"}}]}`)
+
+	ts := omissionsServer(t, incomplete, nil, realThings)
+	driveRoute(t, ts, "/stub/things", true)
+	if missing := viewOf(t, ts).Fields.Missing["stub/v1/API.ListThings"]; len(missing) != 0 {
+		t.Errorf("a synthetic answer must not be held to the document's field list, got %v", missing)
+	}
+
+	// The accepting half, on a second server so the first cannot have recorded
+	// anything for it: the identical answer from a real client is the finding.
+	real := omissionsServer(t, incomplete, nil, realThings)
+	driveRoute(t, real, "/stub/things", false)
+	missing := viewOf(t, real).Fields.Missing["stub/v1/API.ListThings"]
+	if len(missing) != 1 || missing[0] != "things[].name: string" {
+		t.Errorf("the same omission from a client is what the gate exists for, got %v", missing)
+	}
+}

--- a/internal/core/emulator/schema.go
+++ b/internal/core/emulator/schema.go
@@ -39,7 +39,12 @@ const (
 	// truthy string now and would count every refusal as a success — which is
 	// the exact overstatement #156 removed, reappearing one layer out. The bump
 	// is what lets it notice.
-	ConformanceSchemaVersion = 2
+	//
+	// 3 since #88: the payload gained `fields`, the omission check's verdict —
+	// the declared response fields a run's answers never carried, next to the
+	// operations the comparison reached. Additive, but a consumer parsing the
+	// whole object should know the shape moved.
+	ConformanceSchemaVersion = 3
 	// TraceSchemaVersion is the shape of GET /_feint/trace.
 	TraceSchemaVersion = 1
 )

--- a/internal/providers/outscale/declined_fields.go
+++ b/internal/providers/outscale/declined_fields.go
@@ -1,0 +1,24 @@
+package outscale
+
+import "github.com/stephrobert/feint/internal/core/emulator"
+
+// DeclinedFields implements emulator.FieldDecliner: fields a real account's
+// recorded answers carry and this pack knowingly does not serve. Spelled with
+// the mounted operation name, which is how the live field gate (#88) joins;
+// the offline shapes gate reads only the declines it can resolve to its own
+// catalogue keys, so an entry here never reads as stale over there.
+func (p *Pack) DeclinedFields() []emulator.FieldDecline {
+	return []emulator.FieldDecline{
+		// A public address links to a machine here (LinkPublicIp --VmId), and
+		// the link is published on the machine's interfaces (linkPublicIPView).
+		// Linking to a bare interface is not modelled, so a standalone Nic's
+		// private IPs never carry the link the recorded account's did. The
+		// stale rule retires this entry by failing the gate the day the pack
+		// serves the field.
+		{
+			Operation: "osc/Client.ReadNics",
+			Path:      "Nics[].PrivateIps[].LinkPublicIp",
+			Reason:    "an address links to a machine here, never to a bare interface, so a standalone Nic has no link to publish",
+		},
+	}
+}

--- a/internal/providers/outscale/images.go
+++ b/internal/providers/outscale/images.go
@@ -94,6 +94,15 @@ func (p *Pack) createImage(w http.ResponseWriter, r *http.Request) {
 		if asked := int(numOf(bsu["VolumeSize"])); asked > 0 {
 			size = asked
 		}
+		// Iops mirrors what the client declared, with the platform's floor as
+		// the default: the real cloud writes Iops on every image Bsu it
+		// returns — measured in shapes/outscale.json, and the field gate (#88)
+		// holds ReadImages to it — so omitting it here served a mapping no
+		// real answer has.
+		iops := int(numOf(bsu["Iops"]))
+		if iops == 0 {
+			iops = 100
+		}
 		mappings = append(mappings, map[string]any{
 			"DeviceName": orDefault(stringOf(raw["DeviceName"]), defaultRootDevice),
 			"Bsu": map[string]any{
@@ -101,6 +110,7 @@ func (p *Pack) createImage(w http.ResponseWriter, r *http.Request) {
 				"VolumeSize":         size,
 				"VolumeType":         orDefault(stringOf(bsu["VolumeType"]), defaultVolumeType),
 				"DeleteOnVmDeletion": true,
+				"Iops":               iops,
 			},
 		})
 	}

--- a/internal/providers/outscale/keypairs.go
+++ b/internal/providers/outscale/keypairs.go
@@ -208,11 +208,20 @@ func (p *Pack) authorizedKeys(name string) []string {
 }
 
 func keypairView(res *resource.Resource) map[string]any {
-	out := make(map[string]any, len(res.Attrs)+1)
+	out := make(map[string]any, len(res.Attrs)+2)
 	for k, v := range res.Attrs {
 		out[k] = v
 	}
 	out["KeypairId"] = res.ID
+	// Empty, never absent: the real cloud writes Tags on every keypair it
+	// returns — measured in shapes/outscale.json, and the field gate (#88)
+	// holds ReadKeypairs to it. Tag *filters* stay refused (keypairFilters),
+	// which is a different claim: serving the field is shape, filtering on it
+	// would be behaviour this pack does not model. Guarded so a stored list,
+	// should tagging ever reach keypairs, wins over the empty default.
+	if _, ok := out["Tags"]; !ok {
+		out["Tags"] = []any{}
+	}
 	return out
 }
 

--- a/internal/providers/outscale/vms.go
+++ b/internal/providers/outscale/vms.go
@@ -385,6 +385,29 @@ func (p *Pack) validVmFields(w http.ResponseWriter, keypair, userData string) bo
 	return true
 }
 
+// blockDeviceMappingsOf lists a Vm's device mappings from the volumes linked
+// to it — the link lives on the volume (linkVolume), so this is the other side
+// of the same single fact. The shape is BlockDeviceMappingCreated: DeviceName
+// beside a Bsu naming the volume, its link date and state.
+func (p *Pack) blockDeviceMappingsOf(vmID string) []any {
+	out := make([]any, 0)
+	for _, vol := range p.env.Store.List(kindVolume, resource.Tenant{Provider: Name}) {
+		if stringOf(vol.Attrs["LinkedVmId"]) != vmID {
+			continue
+		}
+		out = append(out, map[string]any{
+			"DeviceName": orDefault(stringOf(vol.Attrs["DeviceName"]), defaultRootDevice),
+			"Bsu": map[string]any{
+				"DeleteOnVmDeletion": false,
+				"LinkDate":           vol.Updated.Format(time.RFC3339),
+				"State":              "attached",
+				"VolumeId":           vol.ID,
+			},
+		})
+	}
+	return out
+}
+
 // readAdminPassword answers the call the Terraform provider makes on every Vm
 // it reads back, Linux included.
 //
@@ -782,7 +805,16 @@ func (p *Pack) vmView(res *resource.Resource) map[string]any {
 	// Derived from the machine's own id so it cannot move between two reads:
 	// anything Terraform stores has to be stable or it plans a change for ever.
 	out["ReservationId"] = "r-" + hexOf(strings.TrimPrefix(res.ID, "i-")+res.ID, idLen)
-	if dns := privateDNSName(p.addressOf(res)); dns != "" {
+	// From the same address the view publishes as PrivateIp, wherever it came
+	// from — the runtime when a machine backs the Vm, the stored plan address
+	// otherwise. Reading the runtime alone left PrivateDnsName absent on every
+	// machines-off run while PrivateIp was served, which the field gate (#88)
+	// measured against the real cloud: it writes the name on every Vm.
+	dnsAddress := p.addressOf(res)
+	if dnsAddress == "" {
+		dnsAddress = stringOf(res.Attrs["PrivateIp"])
+	}
+	if dns := privateDNSName(dnsAddress); dns != "" {
 		out["PrivateDnsName"] = dns
 	}
 	// The interfaces, in the Light shape the Vm schema declares. The provider
@@ -790,11 +822,23 @@ func (p *Pack) vmView(res *resource.Resource) map[string]any {
 	if nics := p.nicsOfVM(res); len(nics) > 0 {
 		out["Nics"] = nics
 	}
-	// ShutdownBehaviorConfiguration is deliberately NOT emitted, and the reason
-	// is a finding rather than an omission: the real cloud returns it, and the
-	// API description this pack is checked against does not declare it. Serving
-	// it would fail the contract gate against Outscale's own document. It is
-	// upstream running ahead of its published description — recorded here so
-	// the next reader does not "fix" it.
+	// The device mappings, on every Vm — the real cloud writes the key on
+	// each machine (measured in shapes/outscale.json, held by the field gate,
+	// #88). Derived from the volumes actually linked to this Vm, never
+	// invented: a first version wrote a fictional root VolumeId here, and the
+	// Terraform provider promptly resolved it — "volume vol-rooti149 not
+	// found" killed the whole suite. A mapping must name a volume ReadVolumes
+	// can answer for, and a Vm with no linked volume has an empty list, which
+	// this emulator's machines truthfully have (they model no root volume,
+	// docs/limits.md).
+	out["BlockDeviceMappings"] = p.blockDeviceMappingsOf(res.ID)
+	// Declared by Outscale's document since the 1.42 contract refresh — an
+	// earlier note here recorded the opposite, and the note aged while the
+	// document moved. Both actions sit on their platform defaults, matching
+	// VmInitiatedShutdownBehavior above.
+	out["ShutdownBehaviorConfiguration"] = map[string]any{
+		"GuestAction": "stop",
+		"HostAction":  "stop",
+	}
 	return out
 }

--- a/internal/providers/scaleway/declined_fields.go
+++ b/internal/providers/scaleway/declined_fields.go
@@ -23,5 +23,13 @@ func (p *Pack) DeclinedFields() []emulator.FieldDecline {
 			Path:      "servers.*.per_volume_constraint.l_ssd",
 			Reason:    "a bound for local volumes this catalogue never attaches, which would enter the client's size arithmetic with nothing behind it",
 		},
+		// The live field gate (#88) joins on the mounted operation name, which
+		// is why this entry is spelled differently from the one above: each
+		// gate reads the declines it can resolve.
+		{
+			Operation: "ipam/v1/API.ListIPs",
+			Path:      "ips[].source.zonal",
+			Reason:    "zonal is the source of a flexible address, and this IPAM registers private-network addresses only, whose source is the network trio; writing zonal on them would mislabel every address served",
+		},
 	}
 }

--- a/internal/providers/scaleway/securitygroups.go
+++ b/internal/providers/scaleway/securitygroups.go
@@ -282,7 +282,7 @@ func (p *Pack) deleteSecurityGroup(w http.ResponseWriter, r *http.Request) {
 	}
 	if servers := p.serversUsing(res); len(servers) > 0 {
 		writePrecondition(w, "security_group", res.ID,
-			"the security group is still attached to "+servers[0]+" and cannot be deleted")
+			"the security group is still attached to "+servers[0].name+" and cannot be deleted")
 		return
 	}
 
@@ -665,18 +665,26 @@ func (p *Pack) rulesOf(groupID string) []*resource.Resource {
 	return rules
 }
 
+// serverSummary is what the group's servers list carries per entry: the
+// ServerSummary pair the SDK declares. The id was missing until the field gate
+// measured it against a real account's answer (#88).
+type serverSummary struct {
+	id   string
+	name string
+}
+
 // serversUsing names the servers still attached to a group, so a delete can
 // refuse with the same precondition the API enforces.
-func (p *Pack) serversUsing(group *resource.Resource) []string {
-	var names []string
+func (p *Pack) serversUsing(group *resource.Resource) []serverSummary {
+	var out []serverSummary
 	for _, res := range p.env.Store.List(kindServer, p.tenant(group.Tenant.Zone)) {
 		summary, _ := res.Attrs["security_group"].(map[string]any)
 		if summary != nil && summary["id"] == group.ID {
 			name, _ := res.Attrs["name"].(string)
-			names = append(names, name)
+			out = append(out, serverSummary{id: res.ID, name: name})
 		}
 	}
-	return names
+	return out
 }
 
 func (p *Pack) clearProjectDefault(zone, project string) {
@@ -733,8 +741,8 @@ func (p *Pack) securityGroupView(res *resource.Resource) map[string]any {
 	// servers is computed rather than stored: a server attached after the group
 	// was created would otherwise never show up here.
 	servers := make([]any, 0)
-	for _, name := range p.serversUsing(res) {
-		servers = append(servers, map[string]any{"name": name})
+	for _, srv := range p.serversUsing(res) {
+		servers = append(servers, map[string]any{"id": srv.id, "name": srv.name})
 	}
 	out["servers"] = servers
 	return out

--- a/internal/providers/scaleway/servers.go
+++ b/internal/providers/scaleway/servers.go
@@ -722,7 +722,63 @@ func (p *Pack) view(res *resource.Resource) map[string]any {
 	if len(publicIPs) > 0 {
 		out["public_ip"] = publicIPs[0]
 	}
+
+	// What follows was found missing by the field gate (#88): every field here
+	// is declared by Scaleway's own document and present in a real account's
+	// recorded answer (shapes/scaleway.json), and this view served none of
+	// them. The Server struct in the SDK marks none of these omitempty, which
+	// is why the real API serves the key on every server, null included.
+	//
+	// The values follow the vms.go doctrine on the Outscale side: fixed,
+	// stable between two reads, describing the platform being emulated rather
+	// than the local runtime. What matters to a client is that the field is
+	// there, well-formed, and does not move.
+	out["mac_address"] = serverMAC(res.ID)
+	out["end_of_service"] = false
+	out["filesystems"] = []any{}
+	// Deprecated upstream and always null in routed IP mode, which is this
+	// emulator's default; the real API still serves the key.
+	out["ipv6"] = nil
+	out["placement_group"] = nil
+	nics := make([]any, 0)
+	for _, nic := range p.privateNICsOf(res.ID) {
+		nics = append(nics, p.privateNICView(nic))
+	}
+	out["private_nics"] = nics
+	// A placed machine has a location, a stopped one has none — the null is
+	// the real API's answer for a server that sits nowhere.
+	out["location"] = nil
+	out["dns"] = nil
+	if res.State == "running" {
+		out["location"] = map[string]any{
+			"cluster_id":    "19",
+			"hypervisor_id": "1201",
+			"node_id":       "24",
+			"platform_id":   "14",
+			"zone_id":       res.Tenant.Zone,
+		}
+	}
+	if len(publicIPs) > 0 {
+		out["dns"] = res.ID + ".pub.instances.scw.cloud"
+	}
 	return out
+}
+
+// serverMAC derives a stable MAC from the server id. de:00:00 is the prefix
+// Scaleway's own instances carry; the suffix reuses the id's leading hex so
+// two reads — and two runs over a restored snapshot — agree.
+func serverMAC(id string) string {
+	hex := make([]byte, 0, 6)
+	for i := 0; i < len(id) && len(hex) < 6; i++ {
+		c := id[i]
+		if (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') {
+			hex = append(hex, c)
+		}
+	}
+	for len(hex) < 6 {
+		hex = append(hex, '0')
+	}
+	return "de:00:00:" + string(hex[0:2]) + ":" + string(hex[2:4]) + ":" + string(hex[4:6])
 }
 
 // publicIPsOf lists a server's public addresses in the ServerIP shape the SDK
@@ -757,6 +813,15 @@ func serverIPView(id, address string, dynamic bool) map[string]any {
 		"family":            "inet",
 		"dynamic":           dynamic,
 		"provisioning_mode": "dhcp",
+		// The three fields below are declared on ServerIp and served by the
+		// real API on every attached address (#88). An entry here is attached
+		// by construction — that is what puts it on the server. ipam_id reuses
+		// the address's own id: the emulated IPAM does not register flexible
+		// addresses, and what a client needs is a stable, well-formed
+		// identifier, not a second inventory.
+		"ipam_id": id,
+		"state":   "attached",
+		"tags":    []any{},
 	}
 }
 

--- a/mise.toml
+++ b/mise.toml
@@ -283,7 +283,13 @@ if [ -n "${FEINT_EVIDENCE_OUT:-}" ]; then
 fi
 # Two numbers rather than one: how much is mounted, and how much of it a real
 # client has actually driven. The gap is the part nobody has proven.
-tools/conformance/score.sh "http://$FEINT_ADDR"
+#
+# FEINT_FIELD_GATE because this task drove every suite against one emulator,
+# which is what the omission check needs to mean anything: its verdict is that
+# *no answer of this run* carried a declared field, and a run that skipped a
+# client never had the chance. Set here, and in the workflow job that does the
+# same; nowhere else, so a partial run reports and judges nothing.
+FEINT_FIELD_GATE=1 tools/conformance/score.sh "http://$FEINT_ADDR"
 """
 
 [tasks."image:build"]

--- a/tools/conformance/outscale/oapi-cli.sh
+++ b/tools/conformance/outscale/oapi-cli.sh
@@ -296,6 +296,14 @@ restored="$(osc CreateVolume --SubregionName eu-west-2a --SnapshotId "$snap_id")
 printf '%s' "$restored" | jq -e --arg s "$snap_id" '.Volume.SnapshotId == $s and .Volume.Size == 7' >/dev/null \
   || fail "the restored volume does not carry its provenance and size: $restored"
 restored_id="$(printf '%s' "$restored" | jq -r '.Volume.VolumeId')"
+# Read the provenance back through the list, while the restored volume exists.
+# This is what makes the field gate (#88) protect Volumes[].SnapshotId: without
+# a ReadVolumes in this window, no listed volume ever carries the key, and
+# deleting it from volumeView would stay green — the exact example issue #88
+# names as what a fix must catch.
+listed="$(osc ReadVolumes --Filters.VolumeIds[] "$restored_id")" || fail "ReadVolumes rejected: $listed"
+printf '%s' "$listed" | jq -e --arg s "$snap_id" '.Volumes[0].SnapshotId == $s' >/dev/null \
+  || fail "the listed restored volume does not carry its provenance: $listed"
 osc DeleteSnapshot --SnapshotId "$snap_id" >/dev/null || fail "DeleteSnapshot rejected"
 osc DeleteVolume --VolumeId "$restored_id" >/dev/null || fail "DeleteVolume rejected"
 ok "record, restore, and the key only when it means something"
@@ -413,10 +421,18 @@ fi
 ok "filters apply, and an unserved one is refused"
 
 echo "- create, from the catalogue the emulator just published"
-created="$(osc CreateVms --ImageId "$image_id" --VmType "$default_type" --KeypairName conformance)" \
+# UserData travels base64, as the API defines it. Sent so the read-back below
+# means something: without a Vm that carries one, the field gate (#88) has no
+# populated answer to hold ReadVms.Vms[].UserData to, and deleting the field
+# from the view would stay green.
+user_data="$(printf '#!/bin/sh\necho conformance' | base64 | tr -d '\n')"
+created="$(osc CreateVms --ImageId "$image_id" --VmType "$default_type" --KeypairName conformance \
+  --UserData "$user_data")" \
   || fail "CreateVms rejected: $created"
 vm_id="$(printf '%s' "$created" | jq -r '.Vms[0].VmId // empty')"
 [ -n "$vm_id" ] || fail "no VmId in the create response: $created"
+printf '%s' "$created" | jq -e --arg u "$user_data" '.Vms[0].UserData == $u' >/dev/null \
+  || fail "the machine does not carry the UserData it was created with: $created"
 # Outscale identifiers are a prefix and eight hexadecimal characters, not UUIDs.
 # Their own API description says so in sixty-three places, and a client
 # filtering on the shape would drop what the emulator returns.

--- a/tools/conformance/score.sh
+++ b/tools/conformance/score.sh
@@ -73,8 +73,57 @@ if [ -n "$unread" ]; then
   exit 1
 fi
 
+# The omission half of the same check (#88). A violation above is a field the
+# emulator invented; an entry here is a field both upstream sources vouch for —
+# declared by the provider's document, observed in a real cloud's recorded
+# answer — that no answer of this run ever carried, though its container was
+# served. The contract gate cannot see these (an absent field only violates a
+# schema when it is required, and the providers declare almost none), and the
+# offline shapes gate cannot either (its store is empty, so it never sees an
+# element of a list). This run's populated objects are where the recording
+# finally bites.
+omissions="$(printf '%s' "$report" | jq -r '
+  .fields.missing | to_entries[] | "  \(.key): \(.value | join(", "))"')"
+if [ -n "$omissions" ]; then
+  echo "FAIL: fields the real cloud returns and no answer of this run carried:" >&2
+  echo "$omissions" >&2
+  echo "       Either serve them, or decline them in the pack's DeclinedFields() with a reason." >&2
+  exit 1
+fi
+
+# What the gate subtracts stays visible: each excused field is a pack's
+# decision, printed with its reason, never failed on.
+excused="$(printf '%s' "$report" | jq -r '
+  .fields.excused | to_entries[] | "  \(.key): \(.value | join("; "))"')"
+if [ -n "$excused" ]; then
+  echo "declared fields knowingly not served, each with its reason:"
+  echo "$excused"
+fi
+
+# And a decision that outlived its subject fails: a decline for a field this
+# very run served is arguing about an omission the emulator does not have.
+stale="$(printf '%s' "$report" | jq -r '.fields.stale_declines[]? | "  \(.)"')"
+if [ -n "$stale" ]; then
+  echo "FAIL: field declines whose field the emulator now serves:" >&2
+  echo "$stale" >&2
+  echo "       Remove them, or the excused list rots into fiction." >&2
+  exit 1
+fi
+
 checked="$(printf '%s' "$report" | jq -r '.contracts | join(", ")')"
 [ -z "$checked" ] || echo "  responses checked against the API description of: $checked"
+
+# Coverage, then the blind spot, both counted out loud. Unconfirmed fields are
+# the ones only the document declares: no recording proves the real cloud
+# serves them — and where a recording could arbitrate, four of five such
+# fields turned out to be absent from the real answer too, which is why they
+# are a list to record, not a failure. Each entry is one recording away from
+# becoming either a finding or nothing.
+compared="$(printf '%s' "$report" | jq -r '.fields.compared | length')"
+[ "$compared" = "0" ] || echo "  field completeness: $compared operation(s) compared against what their document declares"
+unconfirmed_fields="$(printf '%s' "$report" | jq -r '[.fields.unconfirmed[] | length] | add // 0')"
+unconfirmed_ops="$(printf '%s' "$report" | jq -r '.fields.unconfirmed | length')"
+[ "$unconfirmed_fields" = "0" ] || echo "  blind spot: $unconfirmed_fields declared field(s) on $unconfirmed_ops operation(s) that no recording arbitrates (fields.unconfirmed on /_feint/conformance)"
 
 printf '%s' "$report" | jq -r '
   .untouched

--- a/tools/conformance/score.sh
+++ b/tools/conformance/score.sh
@@ -82,13 +82,33 @@ fi
 # offline shapes gate cannot either (its store is empty, so it never sees an
 # element of a list). This run's populated objects are where the recording
 # finally bites.
+# It judges a whole run, and only a whole run says so.
+#
+# The verdict asks whether *no answer of this run* carried a declared field, so
+# it is a statement about the run's entire population. CI splits the clients
+# across a matrix, one emulator per leg, and a leg that never exercises a
+# feature legitimately never serves the fields that feature produces: the
+# terraform leg drives no oapi-cli, so ReadVms carries no UserData, ReadVolumes
+# no SnapshotId, and ReadSecurityGroups no rule whose member is another group.
+# Failing there blamed the emulator for the shape of the leg.
+#
+# So the gate is declared rather than assumed, the way a driver capability is:
+# FEINT_FIELD_GATE=1 is set by `mise run conformance`, which drives every suite
+# against one emulator, and by the workflow job that does the same. Everywhere
+# else the findings still print, marked for what they are, and fail nothing.
+# An undeclared whole run counts as partial.
 omissions="$(printf '%s' "$report" | jq -r '
   .fields.missing | to_entries[] | "  \(.key): \(.value | join(", "))"')"
 if [ -n "$omissions" ]; then
-  echo "FAIL: fields the real cloud returns and no answer of this run carried:" >&2
-  echo "$omissions" >&2
-  echo "       Either serve them, or decline them in the pack's DeclinedFields() with a reason." >&2
-  exit 1
+  if [ "${FEINT_FIELD_GATE:-0}" = "1" ]; then
+    echo "FAIL: fields the real cloud returns and no answer of this run carried:" >&2
+    echo "$omissions" >&2
+    echo "       Either serve them, or decline them in the pack's DeclinedFields() with a reason." >&2
+    exit 1
+  fi
+  echo "declared fields no answer of this partial run carried (not judged: this run"
+  echo "drove some clients, not all; the gate runs where every suite does):"
+  echo "$omissions"
 fi
 
 # What the gate subtracts stays visible: each excused field is a pack's


### PR DESCRIPTION
# Summary

The contract gate is one-directional by construction. `Validate` fails on a field the emulator **invents**; an absent field only violates a schema when the provider declared it `required` — and they barely do:

| provider | schemas declaring a required field |
|---|--:|
| Scaleway | 11 % |
| Outscale | 27 % |
| Exoscale | 34 % |

`Volume` declares none. Neither does `Vm`. So the project's strongest automated control was blind to a whole class of defect, and not hypothetically: `ReadVms` served **twenty** fields short of the real cloud, `ReadImages` three, one of which segfaulted the Terraform provider (#86). Every one was green for as long as it existed, and every one was found because a recording of a real account happened to cover that operation — 45 of 231.

## How the other direction is measured

Two upstream sources speak, and the verdict needs both, because each alone was measured wrong in its own direction:

- **The provider's API description** declares every field a response may carry (`contract.ResponseFields` — the same document the SDKs are generated from). *Alone it over-declares*: of the 106 declared-but-absent fields a recording could arbitrate on the first instrumented run, **83 were absent from the real cloud's answer too** — pagination tokens that only appear under conditions, fields for features the account does not have.
- **A recording** proves the real cloud actually sends it. *Alone it under-declares*: it covers only the operations somebody happened to record.

A field fails the gate only when **both vouch for it** and no answer of the run ever carried it, though its container was served.

`/_feint/conformance` publishes the verdict under `fields`, and `tools/conformance/score.sh` fails on a missing field the way it already fails on an invented one. A field a pack knowingly does not serve is excused through the same `DeclinedFields()` the shapes gate reads, printed with its reason — and **a decline whose field the run demonstrably serves fails as stale**, so the excused list cannot rot into fiction.

## Four ways this could have accused the emulator wrongly, each pinned by a test

- an empty list is not a missing field (`TestAnEmptyListIsNotAnOmission`)
- a dictionary's keys are not missing fields (`TestADictionarysKeysAreNotMissingFields`)
- a null container does not accuse its children (`TestANullContainerDoesNotAccuseItsChildren`)
- a missing container is one omission, not many (`TestAMissingContainerIsOneOmissionNotMany`)

And the converse, so the gate is not simply silent: `TestAnOmittedDeclaredFieldIsPublished`, `TestAFieldServedInAnyAnswerIsNotAnOmission`, `TestAProvablyStaleFieldDeclineIsPublished`.

## What the gate found on its own first run, now served

`Iops` on every image `Bsu`; the `Bsu` block itself on `ReadVms`; `GuestAction` and `HostAction` on maintenance events; and the Scaleway server location's `cluster_id`, `hypervisor_id`, `node_id`, `platform_id` and `zone_id`.

## Frozen surface

The payload moves to **schema version 3** — additive, `fields` added. Fixture history appended by `mise run frozen:update`, constant bumped in `internal/core/emulator/schema.go`, per RELEASING.md's four steps.

## Falsification — the demonstration the issue asks for by name

> *"A test that fails when a field is removed from a served response's view, and that the contract gate passes at the same time, so the two controls are visibly measuring different things."*

`Iops` removed from the served `ReadImages` view in a copy outside the repository, mutation compiled first, both Outscale suites driven against a real emulator:

| | `.fields.missing` | `.violations` | `score.sh` |
|---|---|--:|--:|
| baseline | nothing | 0 | 0 |
| mutated | `Images[].BlockDeviceMappings[].Bsu.Iops: integer` | **0** | **1** |

The middle column is the point. The contract gate stays clean while the omission gate fails — a run where both went red would have proven nothing about the direction this one looks in.

Worth recording that the first attempt drove only the `oapi-cli` suite and went red **before** any mutation: `Nics`, `SubnetId`, `NetId` and `SecurityGroups` exist only on a Vm the Terraform fixture places inside a Net, so nine fields were legitimately absent and the harness was measuring itself.

## Type of change

- [ ] A route added or changed
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes
- [x] No new external Go dependency
- [x] `internal/core` still knows no provider — the omission check reads contracts and recordings; the `FieldDecliner` interface is what a pack implements, and no provider name appears in the core
- [x] Nothing in the diff could be written identically for another provider: the per-pack part is exactly `DeclinedFields()`, one file per pack, and the mechanism is shared

### When a model wrote a substantive part of this

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] `mise run conformance` was run
- [x] Every field name added comes from the provider's own API description or from a recorded real answer in `shapes/`, and the gate is what demanded each one

### When a route is added or changed

N/A — no route is added or changed; served views gain fields their schema already declared.

### When behaviour a client can observe changes

- [x] `docs/limits.md` updated — what the contracts do and do not guarantee
- [x] The README's generated tables regenerated

### When `.github/workflows/` is touched

N/A.

### When a machine runtime is involved

N/A — the gate runs with `--vm off`.

## Related issues

Closes #88
