### PR TITLE
docs(readme): the Plumber score comes back beside OpenSSF Scorecard

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -12,6 +12,7 @@
 [![Conformance](https://github.com/stephrobert/feint/actions/workflows/conformance.yml/badge.svg)](https://github.com/stephrobert/feint/actions/workflows/conformance.yml)
 [![Drift](https://github.com/stephrobert/feint/actions/workflows/drift.yml/badge.svg)](https://github.com/stephrobert/feint/actions/workflows/drift.yml)
 [![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/stephrobert/feint?label=OpenSSF%20Scorecard)](https://securityscorecards.dev/viewer/?uri=github.com/stephrobert/feint)
+[![Score Plumber](https://score.getplumber.io/github.com/stephrobert/feint.svg)](https://score.getplumber.io/github.com/stephrobert/feint)
 [![Zéro dépendance](https://img.shields.io/badge/dependencies-0-success)](./go.mod)
 [![Licence Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 [![Conformance](https://github.com/stephrobert/feint/actions/workflows/conformance.yml/badge.svg)](https://github.com/stephrobert/feint/actions/workflows/conformance.yml)
 [![Drift](https://github.com/stephrobert/feint/actions/workflows/drift.yml/badge.svg)](https://github.com/stephrobert/feint/actions/workflows/drift.yml)
 [![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/stephrobert/feint?label=OpenSSF%20Scorecard)](https://securityscorecards.dev/viewer/?uri=github.com/stephrobert/feint)
+[![Plumber compliance](https://score.getplumber.io/github.com/stephrobert/feint.svg)](https://score.getplumber.io/github.com/stephrobert/feint)
 [![Zero dependencies](https://img.shields.io/badge/dependencies-0-success)](./go.mod)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE)
 


### PR DESCRIPTION
The Plumber badge was removed by #98, in the pass that cut nine badges to five against the standard-readme specification. It is asked back, and it earns its line: `.github/workflows/plumber.yml` has run on every push since and is green, and the badge URL answers HTTP 200 with **"Plumber Score: A"** — fetched before this commit rather than assumed, because a badge that 404s is worse than no badge.

Placed next to OpenSSF Scorecard, since the two measure the same posture from different angles, and the count stays at six rather than drifting back toward nine. Labelled in each file's own language, the convention `README.fr.md` already follows.

`feint docs --check` is green: the badges sit outside every generated block. No Go file is touched.