### PR TITLE
docs(conformance): the whole chain on one page, including the links that are prose

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -322,6 +322,11 @@ donc les recopier ici serait en faire une seconde source qui se périmerait.
 Ce qui est refusé, et pourquoi, est dans [docs/routes.md](docs/routes.md). Ce qui
 n'est délibérément pas émulé est dans [docs/limits.md](docs/limits.md).
 
+Comment tout cela gagne le droit d'être appelé *prouvé*, c'est-à-dire la chaîne
+qui va de la description d'API du fournisseur jusqu'à un pipeline qui lit un
+chiffre dans cet émulateur, ce que chaque maillon prouve, et quels maillons ne
+sont pas encore appliqués : [docs/conformance.fr.md](docs/conformance.fr.md).
+
 ---
 
 ## Commandes

--- a/README.md
+++ b/README.md
@@ -532,6 +532,11 @@ the protocol is right and a real client drives a real workload, but the surface
 is still thin: see the coverage tables below, and
 [docs/limits.md](docs/limits.md) for what that costs you.
 
+How any of this earns the word *proven* — the chain from the provider's own API
+description down to a pipeline reading a number out of this emulator, what each
+link proves, and which links are not enforced yet — is
+[docs/conformance.md](docs/conformance.md).
+
 Exoscale has no Terraform column, and that is not a gap in this emulator. The
 provider honours `EXOSCALE_API_ENDPOINT` for one of the two clients it builds
 and reaches the real cloud with the other, so an apply splits between here and a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -119,6 +119,12 @@ without the second, "not done yet" and "out of scope" become the same thing.
 A change that makes any of the three inoperative is a bad change, even if it
 simplifies the code.
 
+Those three are the first links of a longer chain — the contract, the two
+witnesses that drive it, the recordings that look in the omission direction, the
+seven-axis evidence record, and the versioned surface a pipeline reads.
+[The conformance system](conformance.md) describes the whole of it, what each
+link proves, and which links are stated but not yet enforced.
+
 ## Adding a provider
 
 Nothing outside `internal/providers/<name>/` should need to change. A pack

--- a/docs/conformance.fr.md
+++ b/docs/conformance.fr.md
@@ -1,0 +1,282 @@
+# Le système de conformance
+
+**Autre langue :** [English](./conformance.md)
+
+L'affirmation de ce projet tient en une phrase : *le client officiel ne doit pas
+voir la différence*. Cette page est ce qui tient cette phrase honnête : la
+chaîne entière, depuis la description d'API du fournisseur jusqu'à un pipeline
+qui lit un chiffre dans cet émulateur, et ce que chaque maillon prouve ou ne
+prouve pas.
+
+Elle existe parce que la chaîne est désormais assez longue pour qu'aucun gate
+seul ne l'explique, et parce qu'un lecteur mérite de savoir quels maillons sont
+fermés et lesquels ne le sont pas. Les maillons ouverts sont nommés à la fin,
+avec leurs issues. Une page qui ne décrirait que la moitié terminée serait
+exactement le défaut que ce projet passe son temps à supprimer.
+
+L'[architecture](architecture.md) décrit l'organisation du code ;
+[limits.md](limits.md) décrit ce que l'émulateur ne fait délibérément pas. Cette
+page décrit comment quoi que ce soit ici obtient le droit d'être appelé
+*prouvé*.
+
+> [!NOTE]
+> L'anglais est la source. En cas de désaccord entre les deux pages,
+> [la version anglaise](conformance.md) fait foi.
+
+## La chaîne
+
+```text
+                      le SDK upstream du fournisseur
+                                   │
+              scan de surface ─────┴───── baseline      gate de dérive
+                                   │
+                   artefact de description d'API
+                             (contracts/)
+                                   │
+                 ┌─────────────────┴─────────────────┐
+                 │                                   │
+        un vrai client pilote              la sonde pilote chaque
+     (scw, oapi-cli, exo, Terraform)      route depuis le contrat
+                 │                                   │
+                 │        enregistrements d'un vrai cloud
+                 │                 (shapes/)
+                 │                     │             │
+                 └─────────┬───────────┴─────────────┘
+                           │
+                    le registre de preuves
+                 (sept axes, jamais additionnés)
+                           │
+                   /_feint/conformance
+                    + schema_version
+                           │
+                  un consommateur en CI
+```
+
+Chaque flèche est un endroit où une affirmation peut se perdre ou s'inventer, et
+chacune a son propre contrôle ci-dessous.
+
+## Maillon 1 : l'upstream, mesuré plutôt que suivi
+
+Ce qui distingue ce projet, c'est que **l'API est mesurée, pas suivie à la
+main**. Scaleway a ajouté 363 opérations et en a retiré 25 en douze mois :
+personne ne suit cela de tête.
+
+- **Le scan de surface** (`internal/drift`) lit le SDK Go officiel du
+  fournisseur, généré depuis leur IDL et donc exact. Aucun appel réseau, aucune
+  supposition. Il lit tous les fichiers `.go` non-test, pas seulement les
+  générés, parce que Scaleway écrit à la main des points d'entrée publics dans
+  `*_utils.go` qui délèguent à des méthodes générées non exportées.
+- **La baseline** (`coverage/*-baseline.json`) est versionnée. Une opération qui
+  apparaît upstream et que personne n'a triée fait échouer la CI avec le code de
+  sortie 2.
+- **Le tri est binaire et explicite.** Une opération est servie, ou elle est
+  dans `Declined()` avec sa raison en commentaire. « Pas encore fait » et « hors
+  périmètre » ne sont pas la même chose, et une déclinaison qui ne dit ni l'un
+  ni l'autre est une opération non triée déguisée en décision.
+
+Chaque semaine, `.github/workflows/drift.yml` scanne et ouvre une pull request
+quand quelque chose a bougé. Le travail humain est le tri.
+
+## Maillon 2 : le contrat, et ce qu'une exécution verte ne prouve pas
+
+`contracts/` porte la description d'API de chaque fournisseur, extraite de leur
+propre document. Chaque réponse que l'émulateur écrit avec `--contracts` est
+validée contre elle, et une violation fait échouer l'exécution.
+
+Ce contrôle est **unidirectionnel**, et le dire n'est pas une réserve : c'est la
+raison d'être du maillon 4. Il attrape un champ que l'émulateur **invente**, et
+il ne peut attraper un champ **omis** que là où le fournisseur l'a marqué
+`required`, ce que Scaleway fait sur 11 % de ses schémas.
+[limits.md](limits.md#what-a-green-contract-run-does-and-does-not-prove) porte le
+détail mesuré, y compris pourquoi les trois descriptions ne se valent pas.
+
+## Maillon 3 : deux témoins, et aucun ne remplace l'autre
+
+**Un vrai client** est la seule chose qui puisse prouver l'affirmation,
+puisqu'elle porte sur les clients. `tools/conformance/<fournisseur>/` pilote
+`scw`, `oapi-cli`, `exo`, Terraform et OpenTofu contre l'émulateur. Ce qu'une
+suite affirme est ce qui est prouvé, rien de plus : deux défauts ont porté
+`driven` pendant tout le temps où ils étaient faux.
+
+**La sonde** (`internal/probe`) pilote chaque route montée depuis la description
+d'API du fournisseur, ce qui est plus large que tout ensemble de cas que
+quelqu'un aurait pensé à écrire. Depuis #163 elle **sème** : avant de sonder une
+opération, elle fait exister ce que cette opération réclame, depuis le schéma de
+requête du contrat et depuis les ressources qu'elle a créées plus tôt dans la
+même exécution. Aucun identifiant n'est inventé : chacun vient d'une création
+réelle contre l'émulateur.
+
+La sonde prouve le **protocole, pas le comportement**. Un inventaire vide bien
+formé passe. Les curseurs et les filtres ne sont pas exercés. C'est pourquoi les
+deux chiffres sont rapportés séparément et **jamais additionnés** : une route que
+la sonde a atteinte reste sur la liste tant qu'un client ne l'a pas pilotée.
+
+Le trafic synthétique est écarté partout où un chiffre s'adresse à un
+utilisateur : il n'alimente ni le rapport des champs non lus, ni le verdict
+d'omission, ni le score visible d'un client. La règle tient en une phrase, *le
+trafic synthétique ne déplace aucun chiffre visible d'un client*, et elle est
+appliquée, pas seulement énoncée.
+
+## Maillon 4 : les enregistrements, seule source qui regarde dans l'autre sens
+
+`feint proxy` enregistre un vrai client contre un vrai cloud ; `feint shapes`
+distille ces échanges en un arbre de champs par opération, versionné sous
+`shapes/`, sans aucune valeur, seulement des noms et des types.
+
+C'est le **seul** contrôle du dépôt qui regarde dans la direction de l'omission,
+et #88 en a fait un gate. Un champ déclaré fait échouer une exécution quand
+**les deux** sources le cautionnent, à savoir le document le déclare et un
+enregistrement le porte, et qu'aucune réponse de l'exécution ne l'a jamais porté
+alors que son conteneur était servi.
+
+Les deux moitiés sont nécessaires, et chacune seule a été mesurée fausse :
+
+- le document seul **sur-déclare** : sur 106 champs déclarés mais absents qu'un
+  enregistrement pouvait arbitrer, 83 étaient absents de la réponse du vrai
+  cloud aussi ;
+- un enregistrement seul **sous-déclare** : il ne couvre que ce que quelqu'un a
+  enregistré.
+
+Ce qu'aucune source ne peut arbitrer est **publié plutôt que sanctionné**, sous
+`fields.unconfirmed`. Chaque entrée est à un `feint shapes --record` de devenir
+soit un constat, soit rien.
+
+Le verdict porte sur une **exécution entière**, et une exécution le déclare :
+`FEINT_FIELD_GATE=1` est posé par `mise run conformance` et par la jambe
+`fields` du workflow de conformance, qui pilotent tous les clients contre un
+seul émulateur. Partout ailleurs les constats s'impriment et ne jugent rien,
+parce qu'une jambe qui n'exerce jamais une fonctionnalité ne sert légitimement
+jamais les champs que cette fonctionnalité produit. Une exécution entière non
+déclarée compte comme partielle.
+
+## Maillon 5 : le registre de preuves, sept axes, jamais additionnés
+
+`coverage/evidence.json` est ce à quoi tout ce qui précède aboutit, opération par
+opération. Sept axes, chacun répondant à une question différente, chacun voulant
+dire exactement ce que son nom dit et rien de plus :
+
+| axe | ce qu'il dit | ce qu'il ne dit pas |
+|---|---|---|
+| `driven` | un vrai client a atteint cette opération | que la suite ait affirmé quoi que ce soit dessus |
+| `probed` | `response`, `refusal` ou `none` : ce que la sonde a **validé** | que le comportement, les curseurs ou les filtres marchent |
+| `contract` | `clean`, `violating` ou `unchecked` | qu'une opération non contrôlée aille bien |
+| `dataplane` | elle a été pilotée avec un runtime de machines configuré | qu'une assertion au niveau machine l'ait nommée |
+| `shape` | une réponse enregistrée d'un vrai cloud la couvre | que chaque champ ait été comparé |
+| `behaviour` | le cycle de vie complet d'une ressource a été observé dans une portée d'assertion déclarée | que l'effet propre de cette opération ait été affirmé |
+| `negative` | elle a réellement répondu 4xx là où une suite exigeait un refus | que chaque refus qu'elle doit ait été reproduit |
+
+**Ils ne sont jamais additionnés.** Un chiffre unique laisserait un axe faible se
+faire porter par un axe fort, ce qui est la version arithmétique de la
+surestimation que ce projet existe pour éviter. `contract: unchecked` n'est pas
+une réussite, et `probed: refusal` ne dit pas qu'une forme de succès ait jamais
+été vue.
+
+Le registre est régénéré par `mise run evidence:update` depuis **deux passes
+fraîches**, machines éteintes avec la sonde, puis machines allumées, jointes en
+prenant la réponse la plus forte sur chaque axe. Cette jointure n'est sûre *que*
+parce que les deux passes sont fraîches, et un rétrécissement est refusé : un
+artefact qui perd un runtime échoue au lieu de publier discrètement une vérité
+plus petite.
+
+## Maillon 6 : la surface publiée, et sa version
+
+`/_feint/health`, `/_feint/routes`, `/_feint/conformance` et `/_feint/trace` sont
+ce qu'un pipeline lit. Depuis #132, chacun a une fixture versionnée sous
+`internal/cli/testdata/frozen/`, l'arbre des champs et jamais une valeur, et deux
+tests les gardent :
+
+- une forme qui bouge sans que la fixture bouge échoue ;
+- une fixture qui bouge sans que le `schema_version` déclaré bouge échoue.
+
+L'historique est en ajout seul. Changer une surface gelée à dessein tient en
+quatre étapes dans un seul commit, écrites dans
+[RELEASING.fr.md](../RELEASING.fr.md).
+
+Ce qui n'est **délibérément pas** gelé : la prose autour des verbes, les valeurs
+derrière chaque clé, et les champs que seuls certains échanges portent. Un gel
+qui attraperait cela rougirait sur des exécutions ordinaires et serait désarmé
+dans la semaine.
+
+## Où tourne chaque gate
+
+| gate | pre-commit | pull request | nuit | release |
+|---|:-:|:-:|:-:|:-:|
+| `gofmt`, `vet`, `golangci-lint`, `go test -race` | ✔ | ✔ | | ✔ |
+| chaque route déclare son opération upstream | ✔ | ✔ | | ✔ |
+| les sections générées correspondent à leurs artefacts | ✔ | ✔ | | ✔ |
+| les routes correspondent à la description d'API | ✔ | ✔ | | ✔ |
+| dérive contre la baseline (code 2) | | ✔ | ✔ | ✔ |
+| les vrais clients, un par un | | ✔ | ✔ | demandé à la CI |
+| le gate d'omission (exécution entière) | | ✔ (jambe `fields`) | ✔ | demandé à la CI |
+| le runtime de machines, dans les deux modes | | | ✔ | |
+| les surfaces gelées et leurs versions | ✔ | ✔ | | ✔ |
+
+La preuve adossée au runtime n'est délibérément pas sur le chemin des pull
+requests. Un gate qui rougit selon la météo du runner finit désarmé, ce qui est
+pire que de ne pas tourner ; sa promotion se gagne par la mesure, à savoir
+quatorze exécutions nocturnes vertes consécutives, comptées par un job plutôt que
+par la mémoire de quelqu'un (#125).
+
+## Les règles auxquelles tout obéit
+
+Quatre phrases gouvernent chaque maillon ci-dessus. Chacune a été payée.
+
+- **Un commentaire n'est pas un contrôle.** Quand un défaut est corrigé, le
+  commentaire cite le test qui échoue sans le correctif. Trois audits ont
+  prouvé, indépendamment, qu'un correctif rédigé en prose et jamais affirmé
+  survit des mois parce qu'il se lit comme une preuve. `/falsify` en est la forme
+  exécutable : retirer la garde dans une copie hors du dépôt, et exiger que le
+  test nommé rougisse. La mutation doit compiler, sans quoi tous les tests
+  échouent et cela ressemble exactement à une réussite.
+- **Généré n'est pas dérivé.** Un bloc sous un marqueur « ne pas modifier à la
+  main » dont le contenu est une constante un fichier plus loin est une
+  affirmation écrite à la main déguisée en générateur. C'est arrivé deux fois.
+- **Une propriété non déclarée vaut absente.** Une capacité de pilote que
+  personne ne déclare est manquante, donc un contrôle se saute au lieu
+  d'affirmer ce que personne n'a promis. Une exécution qui ne déclare pas
+  qu'elle était entière compte comme partielle.
+- **Sous-estimer une preuve coûte autant que la surestimer.** Un audit externe a
+  recommandé de retirer une suite Terraform du README parce qu'un tableau ne la
+  créditait pas. Cette suite appliquait vingt et une ressources et passait.
+
+## Ce qui n'est pas encore fermé
+
+Trois maillons de la chaîne ci-dessus sont énoncés sans être appliqués. Ce sont
+des issues ouvertes, et elles sont nommées ici parce qu'une page qui ne
+décrirait que la moitié terminée serait le défaut que ce projet supprime.
+
+- **Une falsification prouve qu'un test mord le jour où on la lance, et rien ne
+  la relance** ([#169](https://github.com/stephrobert/feint/issues/169)). Chaque
+  mécanisme a été falsifié à sa pull request ; rien ne rejoue ces mutations. Une
+  affirmation de falsification a déjà été fausse dans ce dépôt : trente
+  exécutions vertes avec un verrou retiré, consignées dans le CHANGELOG de
+  0.8.0.
+- **Rien ne mesure ce qu'une release fait à un consommateur**
+  ([#170](https://github.com/stephrobert/feint/issues/170)). `schema_version` est
+  le signal qui permet à un pipeline de s'apercevoir d'une cassure ; rien ne
+  vérifie qu'un pipeline **puisse** s'en apercevoir. `probed` est passé de
+  booléen à chaîne, et un consommateur qui le lit comme vrai compte chaque refus
+  comme un succès.
+- **La règle de fraîcheur du registre de preuves est écrite deux fois et
+  appliquée nulle part**
+  ([#171](https://github.com/stephrobert/feint/issues/171)). *Supprimer une
+  assertion de conformance doit rétrograder les opérations qu'elle prouvait*
+  figure dans `internal/cli/evidence.go` et dans `mise.toml`, et aucun test ne
+  tient l'une ou l'autre phrase.
+
+Tant que ces trois-là ne sont pas fermées, l'énoncé honnête est celui par lequel
+cette page commence : la chaîne est mesurée, maillon par maillon, et ces trois
+maillons-là sont mesurés par de la prose.
+
+## Lire les chiffres soi-même
+
+```bash
+feint serve --contracts contracts &
+curl -s localhost:4599/_feint/conformance | jq '.evidence["instance/v1/API.ListServers"]'
+curl -s localhost:4599/_feint/health | jq '{schema_version, capabilities}'
+```
+
+Les tableaux générés du [README](../README.fr.md) et de
+[docs/routes.md](routes.md) sont rendus depuis les mêmes artefacts, par
+`mise run docs:coverage`, et `feint docs --check` sort en 2 quand une page et son
+artefact ne s'accordent pas.

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -1,0 +1,258 @@
+# The conformance system
+
+**Read this in another language:** [Français](./conformance.fr.md)
+
+This project's claim is one sentence: *the official client cannot tell the
+difference*. This page is how that sentence is kept honest — the whole chain,
+from the provider's own API description down to a pipeline that reads a number
+out of this emulator, and what each link does and does not prove.
+
+It exists because the chain is now long enough that no single gate explains it,
+and because a reader deserves to know which links are closed and which are not.
+The open ones are named at the end, with their issues. A page that only
+described the finished half would be the exact defect this project spends its
+time removing.
+
+[Architecture](architecture.md) covers how the code is laid out;
+[limits.md](limits.md) covers what the emulator deliberately does not do. This
+page covers how anything here gets to be called *proven*.
+
+## The chain
+
+```text
+                       the provider's upstream SDK
+                                   │
+                    surface scan ──┴── baseline          drift gate
+                                   │
+                          API description artefact
+                              (contracts/)
+                                   │
+                 ┌─────────────────┴─────────────────┐
+                 │                                   │
+         a real client drives              the probe drives every
+      (scw, oapi-cli, exo, Terraform)       route from the contract
+                 │                                   │
+                 │           recordings of a real cloud
+                 │                (shapes/)
+                 │                     │             │
+                 └─────────┬───────────┴─────────────┘
+                           │
+                    the evidence record
+                 (seven axes, never summed)
+                           │
+                   /_feint/conformance
+                    + schema_version
+                           │
+                     a CI consumer
+```
+
+Every arrow is a place a claim can be lost or invented, and each has its own
+control below.
+
+## Link 1 — the upstream, measured rather than followed
+
+The differentiator of this project is that **the API is measured, not tracked by
+hand**. Scaleway added 363 operations and removed 25 in twelve months; nobody
+follows that from memory.
+
+- **The surface scan** (`internal/drift`) reads the provider's official Go SDK,
+  which is generated from their IDL and therefore exact. No network call, no
+  guess. It reads every non-test `.go` file, not only the generated ones,
+  because Scaleway hand-writes public entry points in `*_utils.go` that delegate
+  to unexported generated methods.
+- **The baseline** (`coverage/*-baseline.json`) is versioned. An operation that
+  appears upstream and that nobody triaged fails CI with exit code 2.
+- **Triage is binary and explicit.** An operation is served, or it is in
+  `Declined()` with its reason in a comment. *Not done yet* and *out of scope*
+  are not the same thing, and a decline that says neither is an untriaged
+  operation wearing a decision's clothes.
+
+Weekly, `.github/workflows/drift.yml` scans and opens a pull request when
+something moved. The human work is triage.
+
+## Link 2 — the contract, and what a green run does not prove
+
+`contracts/` holds each provider's API description, extracted from their own
+document. Every response the emulator writes while `--contracts` is on is
+validated against it, and a violation fails the run.
+
+This control is **one-directional**, and saying so is not a caveat, it is the
+reason link 4 exists: it catches a field the emulator *invents*, and it can only
+catch an *omitted* field where the provider marked it `required` — Scaleway does
+on 11% of its schemas. [limits.md](limits.md#what-a-green-contract-run-does-and-does-not-prove)
+carries the measured detail, including why the three descriptions are not
+equally strong.
+
+## Link 3 — two witnesses, and neither is the other
+
+**A real client** is the only thing that can prove the claim, because the claim
+is about clients. `tools/conformance/<provider>/` drives `scw`, `oapi-cli`,
+`exo`, Terraform and OpenTofu against the emulator. What a suite asserts is what
+is proven; nothing more. Two defects were `driven` the whole time they were
+wrong.
+
+**The probe** (`internal/probe`) drives every mounted route from the provider's
+own API description, which is broader than any set of cases somebody thought to
+write. Since #163 it *seeds*: before probing an operation it brings into being
+what that operation needs, from the contract's request schema and from resources
+it created earlier in the same run. No identifier is invented — every one comes
+from a real create against the emulator.
+
+The probe proves **protocol, not behaviour**. A well-shaped empty inventory
+passes. Cursors and filters are not exercised. That is why the two numbers are
+reported separately and **never added**: a route the probe reached stays on the
+backlog until a client drives it.
+
+Synthetic traffic is fenced off wherever a number faces a user: it feeds no
+unread-fields report, no omission verdict, and no client-facing score. The rule
+is one sentence — *synthetic traffic moves no client-facing number* — and it is
+enforced, not stated.
+
+## Link 4 — the recordings, the only source that looks the other way
+
+`feint proxy` records a real client against a real cloud; `feint shapes` distils
+those exchanges into a field tree per operation, committed under `shapes/` with
+no values, only names and types.
+
+This is the **only** control in the repository that looks in the omission
+direction, and #88 made it a gate. A declared field fails a run when **both**
+sources vouch for it — the document declares it and a recording carries it — and
+no answer of the run ever carried it, though its container was served.
+
+Both halves are needed, and each alone was measured wrong:
+
+- the document alone **over-declares**: of 106 declared-but-absent fields a
+  recording could arbitrate, 83 were absent from the real cloud's answer too;
+- a recording alone **under-declares**: it covers only what somebody recorded.
+
+What no source can arbitrate is **published rather than failed on**, under
+`fields.unconfirmed`. Each entry is one `feint shapes --record` away from
+becoming either a finding or nothing.
+
+The verdict is over **a whole run**, and a run says so: `FEINT_FIELD_GATE=1` is
+set by `mise run conformance` and by the `fields` leg of the conformance
+workflow, which drive every client against a single emulator. Everywhere else
+the findings print and judge nothing, because a leg that never exercises a
+feature legitimately never serves the fields that feature produces. An
+undeclared whole run counts as partial.
+
+## Link 5 — the evidence record, seven axes, never summed
+
+`coverage/evidence.json` is what all of the above adds up to, per operation.
+Seven axes, each answering a different question, each meaning exactly what its
+name says and no more:
+
+| axis | what it says | what it does not say |
+|---|---|---|
+| `driven` | a real client reached this operation | that the suite asserted anything about it |
+| `probed` | `response`, `refusal` or `none` — what the probe *validated* | that behaviour, cursors or filters work |
+| `contract` | `clean`, `violating` or `unchecked` | that an unchecked operation is fine |
+| `dataplane` | it was driven while a machine runtime was configured | that a machine-level assertion named it |
+| `shape` | a recorded real-cloud answer covers it | that every field was compared |
+| `behaviour` | a resource's full lifecycle was observed inside a declared assertion span | that this operation's own effect was asserted |
+| `negative` | it really answered 4xx where a suite demanded a refusal | that every refusal it owes was reproduced |
+
+**They are never summed.** A single number would let a weak axis carry a strong
+one, which is the arithmetic version of the overstatement this project exists to
+avoid. `contract: unchecked` is not a pass, and `probed: refusal` does not say a
+success shape was ever seen.
+
+The record is regenerated by `mise run evidence:update` from **two fresh legs** —
+machines off with the probe, then machines on — joined by taking the stronger
+answer per axis. That join is safe *only* because both legs are fresh, and a
+narrowing is refused: an artefact that loses a runtime fails rather than
+publishing a smaller truth quietly.
+
+## Link 6 — the published surface, and its version
+
+`/_feint/health`, `/_feint/routes`, `/_feint/conformance` and `/_feint/trace`
+are what a pipeline reads. Since #132 each has a committed fixture under
+`internal/cli/testdata/frozen/` — the field tree, never a value — and two tests
+gate them:
+
+- a shape that moves while the fixture does not fails;
+- a fixture that moves while the declared `schema_version` does not fails.
+
+The history is append-only. Changing a frozen surface on purpose is four steps
+in one commit, written out in [RELEASING.md](../RELEASING.md#frozen-surfaces).
+
+What is deliberately **not** frozen: the prose around the verbs, the values
+behind every key, and the fields only some exchanges carry. A freeze that caught
+those would go red on routine runs and be disarmed within the week.
+
+## Where each gate runs
+
+| gate | pre-commit | pull request | nightly | release |
+|---|:-:|:-:|:-:|:-:|
+| `gofmt`, `vet`, `golangci-lint`, `go test -race` | ✔ | ✔ | | ✔ |
+| every route declares its upstream operation | ✔ | ✔ | | ✔ |
+| generated sections match their artefacts | ✔ | ✔ | | ✔ |
+| routes match the provider's API description | ✔ | ✔ | | ✔ |
+| drift against the baseline (exit 2) | | ✔ | ✔ | ✔ |
+| the real clients, per client | | ✔ | ✔ | asked of CI |
+| the omission gate (whole run) | | ✔ (`fields` leg) | ✔ | asked of CI |
+| the machine runtime, both modes | | | ✔ | |
+| frozen surfaces and their versions | ✔ | ✔ | | ✔ |
+
+The machine-runtime proof is deliberately not on the pull-request path. A gate
+that reds on runner weather gets disarmed, which is worse than not running; its
+promotion is earned by measurement — fourteen consecutive green scheduled runs,
+counted by a job rather than by somebody's memory (#125).
+
+## The rules the whole thing obeys
+
+Four sentences govern every link above. Each was paid for.
+
+- **A comment is not a control.** When a defect is fixed, the comment cites the
+  test that fails without the fix. Three audits proved, independently, that a
+  fix written in prose and never asserted survives for months because it reads
+  like evidence. `/falsify` is the executable form: remove the guard in a copy
+  outside the repository, and require the named test to go red — the mutation
+  must compile, or every test fails and that looks exactly like success.
+- **Generated is not derived.** A block under a "do not edit by hand" marker
+  whose content is a constant one file away is a hand-written claim wearing a
+  generator's clothes. It happened, twice.
+- **An undeclared property counts as absent.** A driver capability nobody
+  declares is missing, so a check skips rather than asserting what nobody
+  promised. A run that does not declare it was whole counts as partial.
+- **Understating a proof costs as much as overstating one.** An external review
+  once recommended deleting a Terraform suite from the README because a table
+  did not credit it. The suite applied twenty-one resources and passed.
+
+## What is not closed yet
+
+Three links in the chain above are stated but not enforced. They are open
+issues, and they are named here because a page describing only the finished half
+would be the defect this project removes.
+
+- **A falsification proves a test bites on the day it is run, and nothing runs
+  it again** ([#169](https://github.com/stephrobert/feint/issues/169)). Each
+  mechanism was falsified at its pull request; nothing replays those mutations.
+  A falsification claim in this repository has already been false — thirty green
+  runs with a lock removed, recorded in the 0.8.0 CHANGELOG.
+- **Nothing measures what a release does to a consumer**
+  ([#170](https://github.com/stephrobert/feint/issues/170)). `schema_version` is
+  the signal that lets a pipeline notice a break; nothing checks that a pipeline
+  *can* notice. `probed` went from boolean to string, and a consumer reading it
+  as truthy counts every refusal as a success.
+- **The evidence record's freshness rule is written twice and enforced nowhere**
+  ([#171](https://github.com/stephrobert/feint/issues/171)). *Deleting a
+  conformance assertion must demote the operations it proved* appears in
+  `internal/cli/evidence.go` and in `mise.toml`, and no test holds either
+  sentence.
+
+Until those close, the honest statement is the one this page opens with: the
+chain is measured, link by link, and these three links are measured by prose.
+
+## Reading the numbers yourself
+
+```bash
+feint serve --contracts contracts &
+curl -s localhost:4599/_feint/conformance | jq '.evidence["instance/v1/API.ListServers"]'
+curl -s localhost:4599/_feint/health | jq '{schema_version, capabilities}'
+```
+
+The generated tables in the [README](../README.md#status) and in
+[docs/routes.md](routes.md) are rendered from the same artefacts, by
+`mise run docs:coverage`, and `feint docs --check` exits 2 when a page and its
+artefact disagree.

--- a/docs/roadmap.fr.md
+++ b/docs/roadmap.fr.md
@@ -502,6 +502,12 @@ routes démontre désormais l'architecture ; ce qu'il ne démontre pas encore,
 c'est ce qu'un run vert prouve.** Dépenser les prochaines versions en preuves
 plutôt qu'en surface est la proposition.
 
+Ce que cette piste a construit est désormais décrit de bout en bout dans
+[docs/conformance.fr.md](conformance.fr.md) : la chaîne qui va de la description
+d'API du fournisseur jusqu'à un pipeline lisant un chiffre dans l'émulateur, ce
+que chaque maillon prouve, et les trois maillons énoncés mais pas encore
+appliqués (#169, #170, #171).
+
 Les issues, chacune portant sa propre preuve :
 
 - **#123** : ce qui est prouvé d'une opération devient un ensemble d'axes de

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -481,6 +481,12 @@ already leans towards: **the route count now demonstrates the architecture;
 what it does not yet demonstrate is how much a green run proves.** Spending the
 next versions on proofs rather than surface is the proposal.
 
+What that track has built is now described end to end in
+[docs/conformance.md](conformance.md): the chain from the provider's own API
+description to a pipeline reading a number out of the emulator, what each link
+proves, and the three links that are stated but not yet enforced (#169, #170,
+#171).
+
 The issues, each carrying its own evidence:
 
 - **#123** — what is proven about an operation becomes a set of named proof


### PR DESCRIPTION
# Summary

Nine mechanisms landed in the 0.9 train and no page describes how they fit together. A reader could find the contract check in `limits.md`, the frozen surfaces in `RELEASING.md`, the drift machinery in `architecture.md` and the seven axes in a Go struct comment, and still not know what this emulator means when it says *proven*.

`docs/conformance.md` is that page, with its French twin.

## What it does

Walks the chain link by link, and for each states what it proves **and what it does not**:

```
upstream SDK → surface scan + baseline → API description artefact
   → a real client drives  |  the probe drives every route
   → recordings of a real cloud (the only source looking at omissions)
   → the seven-axis evidence record, never summed
   → /_feint/conformance + schema_version
   → a CI consumer
```

The axes are quoted from their own definitions in `conformance.go` rather than paraphrased. Paraphrasing them is how `probed` came to mean an arrival, which #156 had to undo.

It carries **a table of where each gate runs** — pre-commit, pull request, nightly, release — which nothing stated in one place before. That table is what turns the runtime proof's absence from the pull-request path into a stated decision rather than an oversight.

## What it names

Three links are stated in prose and enforced nowhere, and they get their own section with their issue numbers:

- nothing replays a falsification (#169) — and one falsification claim in this repository has already been false;
- nothing measures what a release does to a consumer (#170) — `probed` went boolean → string;
- the evidence record's freshness rule is written twice, in `evidence.go` and `mise.toml`, with no test behind it (#171).

A page describing only the finished half would be the exact defect this project spends its time removing.

## Pointers

From the four pages a reader arrives on: the README's status section in both languages, `architecture.md` where the three drift mechanisms are introduced as the first links of a longer chain, and the roadmap's proof track in both languages.

## Type of change

- [ ] A route added or changed
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes — no Go file is touched
- [x] No new external Go dependency
- [x] `internal/core` still knows no provider
- [x] Nothing in the diff could be written identically for another provider

### When a model wrote a substantive part of this

- [x] An `Assisted-by:` trailer names the tool and the model version
- [ ] **N/A, stated rather than ticked.** `mise run conformance` was not run: the diff is Markdown only, touches no generated block, no route, no shape. What was checked is `feint docs --check` (0), every internal link resolving to a file that exists, and every axis definition read from `internal/core/emulator/conformance.go` rather than recalled
- [x] Every figure and mechanism named in the page comes from the code, an artefact or a CHANGELOG entry, and I can say which

### When a route is added or changed

N/A.

### When behaviour a client can observe changes

- [x] No generated block is touched; `feint docs --check` returns 0

### When `.github/workflows/` is touched

N/A — workflows are described, not modified.

### When a machine runtime is involved

N/A.

## Related issues

Describes the system #169, #170 and #171 complete.