### PR TITLE
chore(ci): the gates run before a push, and one of them can be run the way CI runs it

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@
 # would sit in this file doing nothing on every machine, which is the exact
 # failure this repository keeps finding elsewhere: a control that reads as one.
 # Declaring the types here makes the single documented command enough.
-default_install_hook_types: [pre-commit, commit-msg]
+default_install_hook_types: [pre-commit, commit-msg, pre-push]
 
 repos:
   # Conventional Commits, checked by the reference implementation rather than by
@@ -171,6 +171,29 @@ repos:
         entry: bash -c 'mise run contract:update && git diff --exit-code contracts/'
         pass_filenames: false
         files: ^(contracts/.*\.json|tools/contract/.*)$
+
+      # On pre-push, and only this one. The per-file hooks above run on what a
+      # commit touched; this runs the whole gate set on what is about to leave
+      # the machine, which is a different question — a branch can be green
+      # commit by commit and red as a whole, and two pull requests found that out
+      # in CI on 2026-08-15.
+      #
+      # Why these four and not `mise run conformance`: they are deterministic,
+      # offline, and take seconds. Conformance needs `scw`, `oapi-cli`, `exo` and
+      # Terraform installed and takes minutes; as a hook it would fail on a
+      # missing binary rather than on the code, and the reflex it would teach is
+      # `--no-verify`, which turns off every hook in this file at once. That is
+      # the same reasoning that keeps commitizen-branch out, one stage above.
+      #
+      # So conformance stays a deliberate step, and CLAUDE.md says when it is
+      # required. What a hook must never be is a gate somebody routinely skips.
+      - id: prepush
+        name: the gates a pull request will fail on
+        language: system
+        entry: mise run prepush
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]
 
       - id: trufflehog
         name: TruffleHog (secret scan)

--- a/CONTRIBUTING.fr.md
+++ b/CONTRIBUTING.fr.md
@@ -31,9 +31,51 @@ encore aux artefacts qu'elle décrit, qu'une réponse corresponde encore à la
 description d'API du provider. La CI attrape tout cela, mais des heures plus tard
 et devant tout le monde.
 
-Elle installe deux types de hooks, et le second se rate facilement : `pre-commit`
-et `commit-msg`. La configuration déclare les deux via
+Elle installe trois types de hooks, et les deux derniers se ratent facilement :
+`pre-commit`, `commit-msg` et `pre-push`. La configuration déclare les trois via
 `default_install_hook_types`, donc la commande seule suffit.
+
+### Avant de pousser
+
+Le hook `pre-push` lance `mise run prepush` : `check`, `docs:check`,
+`drift:check` et `shapes:check`. Déterministe, hors ligne, quelques secondes.
+C'est ce qu'une pull request refusera, sans jamais dépendre de la météo d'un
+runner.
+
+**Ce n'est pas suffisant**, et ce qui manque dépend de ce que vous avez changé :
+
+| ce que votre changement touche | à lancer en plus | ce que cela prouve |
+|---|---|---|
+| une route, une forme de réponse, une erreur | `mise run conformance` | qu'un vrai client passe encore |
+| un gate, un score, un verdict sur une exécution | `mise run conformance:leg -- <jambe>` | qu'il tient sur une exécution **partielle** |
+| une garde, une validation, un refus | la retirer dans une copie et lancer le test | que le test échoue sans elle |
+| `internal/core/machine`, un réseau, un pare-feu | `FEINT_VM=incus-ovn mise run conformance` | que le runtime accepte ce que le pilote envoie |
+| un artefact de `coverage/` | `mise run evidence:update` | que le registre n'a pas rétréci |
+
+**La deuxième ligne est celle qui a coûté deux pull requests rouges.**
+`mise run conformance` pilote toutes les suites contre un seul émulateur, ce qui
+est exactement la population qu'un verdict du genre *aucune réponse de cette
+exécution n'a porté ce champ* suppose : un gate qui juge une exécution y est vert
+**par construction**. La CI ne fait pas cela. Le workflow de conformance
+répartit les clients en matrice, un émulateur par jambe, si bien que toute jambe
+sauf `fields` est une exécution partielle : la jambe `probe` ne pilote aucun
+client, et la jambe `terraform` ne pilote pas `oapi-cli`.
+
+`mise run conformance:leg -- probe` reproduit une de ces jambes en local, et la
+reproduction est prouvée plutôt que supposée : en remettant la garde qui
+manquait, la jambe nomme localement les mêmes champs que le job en échec avait
+listés.
+
+La forme générale, qui vaut ailleurs : **un contrôle dont le verdict porte sur
+« cette exécution » doit être éprouvé sur l'exécution la plus pauvre qui le
+déclenchera, jamais sur la plus riche.** La plus riche est celle qu'on a sous la
+main, et c'est ce qui rend l'erreur si facile.
+
+`mise run conformance` n'est **délibérément pas** dans le hook. Il réclame `scw`,
+`oapi-cli`, `exo` et Terraform installés, et prend des minutes : en hook, il
+échouerait sur un binaire absent plutôt que sur votre code, et le réflexe qu'il
+enseignerait est `--no-verify`, qui désarme tous les hooks d'un coup. Un gate que
+l'on saute par habitude est pire que pas de gate.
 
 ### Si vous contribuez depuis un fork
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,9 +28,48 @@ declares its upstream operation, that no external dependency crept into
 describes, that a response still matches the provider's API description. CI
 catches all of it, but hours later and in front of everybody.
 
-It installs two hook types, and the second one is easy to miss: `pre-commit` and
-`commit-msg`. The configuration declares both through
+It installs three hook types, and the last two are easy to miss: `pre-commit`,
+`commit-msg` and `pre-push`. The configuration declares all three through
 `default_install_hook_types`, so the single command is enough.
+
+### Before you push
+
+The `pre-push` hook runs `mise run prepush`: `check`, `docs:check`,
+`drift:check` and `shapes:check`. Deterministic, offline, seconds. It is what a
+pull request will refuse without ever depending on a runner's weather.
+
+**It is not enough**, and what it misses depends on what you changed:
+
+| what your change touches | run as well | what that proves |
+|---|---|---|
+| a route, a response shape, an error | `mise run conformance` | that a real client still passes |
+| a gate, a score, a verdict about a run | `mise run conformance:leg -- <leg>` | that it holds on a **partial** run |
+| a guard, a validation, a refusal | remove it in a copy and run the test | that the test fails without it |
+| `internal/core/machine`, a network, a firewall | `FEINT_VM=incus-ovn mise run conformance` | that the runtime accepts what the driver sends |
+| an artefact under `coverage/` | `mise run evidence:update` | that the record did not narrow |
+
+**The second row is the one that cost two red pull requests.**
+`mise run conformance` drives every suite against a single emulator, which is
+exactly the population a verdict like *no answer of this run carried this field*
+assumes: a whole-run gate is green there **by construction**. CI does not do
+that. The conformance workflow splits the clients across a matrix, one emulator
+per leg, so every leg but `fields` is a partial run — the `probe` leg drives no
+client at all, and the `terraform` leg drives no `oapi-cli`.
+
+`mise run conformance:leg -- probe` reproduces one of those legs locally, and
+the reproduction is proved rather than assumed: put back the guard that was
+missing and the leg names, locally, the same fields the failing CI job listed.
+
+The general form, worth carrying elsewhere: **a check whose verdict is about
+"this run" must be exercised on the poorest run that will trigger it, never on
+the richest.** The richest is the one you have in front of you, which is what
+makes the mistake so easy.
+
+`mise run conformance` is deliberately **not** in the hook. It needs `scw`,
+`oapi-cli`, `exo` and Terraform installed and takes minutes; as a hook it would
+fail on a missing binary rather than on your code, and the reflex it would teach
+is `--no-verify`, which turns off every hook at once. A gate people routinely
+skip is worse than no gate.
 
 ### If you are contributing from a fork
 

--- a/mise.toml
+++ b/mise.toml
@@ -292,6 +292,33 @@ fi
 FEINT_FIELD_GATE=1 tools/conformance/score.sh "http://$FEINT_ADDR"
 """
 
+[tasks.prepush]
+description = "Everything a pull request will fail on that costs seconds and needs no client"
+depends = ["check", "docs:check", "drift:check", "shapes:check"]
+# What this is, and what it deliberately is not.
+#
+# These four are deterministic, offline, and take seconds: they can be a hook
+# without ever teaching anybody `--no-verify`, which is the failure mode
+# .pre-commit-config.yaml already documents for the pre-push stage.
+#
+# What they do NOT catch is the class that cost two red pull requests on #88:
+# a gate whose verdict is about "this run" is green under `mise run conformance`
+# by construction, because that task drives every suite against one emulator.
+# CI splits the clients across a matrix. `mise run conformance:leg -- <leg>`
+# reproduces one of those partial legs, and it is what to run when a change adds
+# or moves a gate. CLAUDE.md carries the decision table.
+run = "echo 'prepush passed - conformance and conformance:leg are the two it does not cover'"
+
+[tasks."conformance:leg"]
+description = "Reproduce one leg of the CI matrix locally: mise run conformance:leg -- probe"
+depends = ["build"]
+# The task above drives every suite against one emulator, so a gate whose
+# verdict is about "this run" is green there by construction. CI splits the
+# clients across a matrix and every leg but `fields` is a partial run. That
+# difference cost two red pull requests on #88, neither reproducible locally
+# until this existed. tools/conformance/leg.sh carries the detail.
+run = "tools/conformance/leg.sh"
+
 [tasks."image:build"]
 description = "Build the control-plane container image from a fresh static binary"
 # The image copies a prebuilt binary (see the Dockerfile for why); this builds

--- a/tools/conformance/leg.sh
+++ b/tools/conformance/leg.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Reproduce one leg of the conformance matrix, locally, exactly as CI runs it.
+#
+# Why this exists, and it is not a convenience. `mise run conformance` drives
+# every suite against one emulator, which is the population a whole-run verdict
+# assumes: a gate that judges a run is green there **by construction**. CI does
+# not do that. `.github/workflows/conformance.yml` splits the clients across a
+# matrix, one emulator per leg, so every leg but `fields` is a partial run.
+#
+# That difference cost two red pull requests on the omission gate (#88), both
+# invisible to a full local run:
+#
+#   - the `probe` leg drives no client, so every object in it is the minimal one
+#     the probe's seeding builds, and the gate reported UserData and Tags as
+#     omissions of the emulator;
+#   - the `terraform` and `opentofu` legs drive real clients but not all of
+#     them, so no volume comes from a snapshot and no rule names a group.
+#
+# So: before pushing a change that adds or moves a gate whose verdict is about
+# "this run", run it here against the leg that has the least to work with.
+#
+#     mise run conformance:leg -- probe
+#     mise run conformance:leg -- terraform
+#
+# `fields` is the whole-run leg, the only one where FEINT_FIELD_GATE is set,
+# and it is what `mise run conformance` already approximates.
+set -euo pipefail
+
+leg="${1:-}"
+endpoint="${2:-http://${FEINT_ADDR:-127.0.0.1:4599}}"
+addr="${endpoint#http://}"
+
+usage() {
+  cat >&2 <<'EOF'
+usage: mise run conformance:leg -- <leg>
+
+  scw-cli     the Scaleway CLI alone
+  terraform   both Terraform fixtures, one engine
+  opentofu    the same through OpenTofu
+  oapi-cli    the Outscale CLI alone
+  exo-cli     the Exoscale CLI alone
+  probe       the contract-driven probe alone, no client at all
+  fields      every client against one emulator, with the whole-run gate on
+
+The leg names are the matrix entries of .github/workflows/conformance.yml. A
+name that is not one of them is refused rather than guessed: a leg that silently
+ran something else would measure the wrong thing and report success.
+EOF
+  exit 2
+}
+
+case "$leg" in
+  scw-cli|terraform|opentofu|oapi-cli|exo-cli|probe|fields) ;;
+  *) usage ;;
+esac
+
+# --shapes is not passed: it is a `serve` flag whose default is already `shapes`,
+# and `start` spawns serve. Passing it here fails on an unknown flag, which is
+# how this line was found.
+./feint start --addr "$addr" --vm off --contracts contracts --timeout 60s
+trap './feint stop --addr '"$addr"' >/dev/null 2>&1 || true' EXIT
+
+case "$leg" in
+  scw-cli)
+    tools/conformance/scaleway/scw-cli.sh "$endpoint"
+    ;;
+  terraform|opentofu)
+    # Both fixtures, the way the workflow runs them on either engine.
+    tools/conformance/scaleway/terraform.sh "$endpoint"
+    tools/conformance/outscale/terraform.sh "$endpoint"
+    ;;
+  oapi-cli)
+    tools/conformance/outscale/oapi-cli.sh "$endpoint"
+    ;;
+  exo-cli)
+    tools/conformance/exoscale/exo-cli.sh "$endpoint"
+    ;;
+  probe)
+    ./feint probe --endpoint "$endpoint" --contracts contracts
+    ;;
+  fields)
+    tools/conformance/scaleway/scw-cli.sh "$endpoint"
+    tools/conformance/outscale/oapi-cli.sh "$endpoint"
+    tools/conformance/exoscale/exo-cli.sh "$endpoint"
+    tools/conformance/scaleway/terraform.sh "$endpoint"
+    tools/conformance/outscale/terraform.sh "$endpoint"
+    ;;
+esac
+
+# The same score step CI runs, with the same rule about the field gate: set only
+# on the whole-run leg. Everywhere else the omission findings print and judge
+# nothing, and seeing them print here is the point of running a partial leg.
+if [ "$leg" = "fields" ]; then
+  FEINT_FIELD_GATE=1 tools/conformance/score.sh "$endpoint"
+else
+  FEINT_FIELD_GATE=0 tools/conformance/score.sh "$endpoint"
+fi


### PR DESCRIPTION
Two pull requests went red on 2026-08-15 for the same reason, and **neither was reproducible locally**.

The omission gate (#88) asks whether *no answer of this run* carried a declared field, which is a statement about a whole run. `mise run conformance` drives every suite against one emulator, so a whole-run gate is green there **by construction**. CI does not do that: the matrix splits the clients, one emulator per leg, and every leg but `fields` is a partial run. The `probe` leg drives no client at all; the `terraform` leg drives no `oapi-cli`.

## `mise run conformance:leg -- <leg>`

Reproduces one CI leg locally, and the reproduction is **proved rather than claimed**: with the pre-fix guard put back in a copy outside the repository, the probe leg names locally the same fields the failing job listed.

| | CI job, before the fix | `conformance:leg -- probe`, guard reverted |
|---|---|---|
| ReadVms | `PublicIp`, `Tags`, `UserData` … | same |
| ReadVolumes | `SnapshotId` | same |
| ReadNics | `LinkPublicIp` | same |

Three harness failures had to be cleared before that verdict meant anything: an unknown `--shapes` flag on `start`, an assertion on the gate's exit code instead of on the harness's reach, and mise refusing an untrusted config file in the copy. Each looked exactly like the subject failing to reproduce.

## `mise run prepush`, and a hook

`check`, `docs:check`, `drift:check`, `shapes:check`. Deterministic, offline, seconds. A `pre-push` hook runs it.

`mise run conformance` is deliberately **not** in the hook: four third-party CLIs, minutes, and as a hook it would fail on a missing binary rather than on the code. The reflex it teaches is `--no-verify`, which turns off every hook at once — the same reasoning that already keeps `commitizen-branch` out of pre-push, written one stage above it in the same file.

## The rule, in CONTRIBUTING.md

A "Before you push" section in both languages, with the table of what to run for what changed, and the general form:

> A check whose verdict is about *this run* must be exercised on the poorest run that will trigger it, never on the richest. The richest is the one you have in front of you, which is what makes the mistake easy.

## Type of change

- [ ] A route added or changed
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation
- [x] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes — via `mise run prepush`, which is the point
- [x] No new external Go dependency
- [x] `internal/core` still knows no provider — no Go file is touched
- [x] Nothing in the diff could be written identically for another provider

### When a model wrote a substantive part of this

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] `mise run conformance:leg -- probe` was run, twice: once as it stands, and once with the pre-fix guard restored in a copy outside the repository, which is what proves the harness reaches the failure
- [x] Every leg name comes from the matrix in `conformance.yml`, and a name that is not one of them is refused rather than guessed

### When a route is added or changed

N/A — no route is touched.

### When behaviour a client can observe changes

- [ ] N/A — no emulated behaviour changes; `feint docs --check` returns 0

### When `.github/workflows/` is touched

N/A — the workflow is read and reproduced, never modified.

### When a machine runtime is involved

N/A — the leg script runs with `--vm off`.