### PR TITLE
fix(health): a capability the driver declares is not a capability a pack delivers

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -96,6 +96,33 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Modifié
 
+- **`/_feint/health` passe en version de schéma 2 et dit quels packs livrent
+  réellement une capacité** (#180). `(*Incus).Capabilities()` déclarait
+  `firewall: true` dans tous les modes, un seul jeu pour tout le processus, et
+  ce projet demande à un consommateur de se brancher sur cette capacité plutôt
+  que sur un nom de mode. Or seul `internal/providers/scaleway/firewall.go`
+  remettait une règle au runtime : un groupe de sécurité Outscale ou Exoscale
+  était créé, renvoyé, puis réconcilié sur rien, pendant que le même processus
+  répondait `firewall: true`. Un utilisateur suivant ce conseil sondait un port
+  qu'un groupe en refus par défaut aurait dû fermer, le trouvait ouvert, et on
+  lui avait dit que le pare-feu était livré. Un 200 qui ment.
+
+  La charge utile gagne `enforced`, indexée par capacité, nommant les packs qui
+  lui confient du travail : `capabilities.firewall` dit ce que le runtime **peut**
+  faire, `enforced.firewall` dit qui le lui demande, et le contrôle honnête est
+  la conjonction des deux. Un pack le déclare en implémentant
+  `emulator.FirewallEnforcer` ; celui qui ne le fait pas n'apparaît nulle part,
+  suivant la règle constante voulant qu'une capacité non déclarée vaille absente.
+  La documentation seule ne pouvait pas refermer cela : l'affirmation est lue
+  depuis un endpoint, par un programme, au moment où elle compte.
+
+  `TestEveryPackThatWiresTheFirewallSaysSo` compare chaque déclaration à la
+  présence de `machine.Firewaller` dans les sources non-test du pack, si bien que
+  l'affirmation ne peut plus diverger du code, dans un sens comme dans l'autre.
+  Le README nomme Scaleway là où il ne nommait aucun fournisseur, et
+  `docs/limits.md` énonce le manque pour les deux packs qui ne le livrent pas,
+  dont l'un n'avait aucune phrase nulle part.
+
 - **`/_feint/conformance` passe en version de schéma 2.** `evidence.*[].probed`
   était un booléen et vaut désormais `response`, `refusal` ou `none` (#156). Un
   consommateur testant `probed === true` lirait une chaîne toujours vraie et

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,32 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Changed
 
+- **`/_feint/health` moves to schema version 2, and says which packs deliver a
+  capability** (#180). `(*Incus).Capabilities()` declared `firewall: true` in
+  every mode, one set for the whole process, and this project tells a consumer
+  to key on that capability rather than on a mode name. Only
+  `internal/providers/scaleway/firewall.go` ever handed a rule to the runtime:
+  an Outscale or Exoscale security group was created, echoed back and
+  reconciled onto nothing, while the same process answered `firewall: true`. A
+  user following the advice probed a port a deny-default group should have
+  closed, found it open, and had been told the firewall was delivered — a 200
+  that lies.
+
+  The payload gains `enforced`, keyed by capability, naming the packs that hand
+  work to it: `capabilities.firewall` is what the runtime *can* do,
+  `enforced.firewall` is who asks it to, and the honest check is both. A pack
+  declares it by implementing `emulator.FirewallEnforcer`; one that does not
+  appears nowhere, the standing rule that an undeclared capability counts as
+  absent. Documentation alone could not have closed this: the claim is read from
+  an endpoint, by a program, at the moment it matters.
+
+  `TestEveryPackThatWiresTheFirewallSaysSo` compares each declaration with
+  whether the pack's own non-test source references `machine.Firewaller`, so
+  the claim cannot drift from the code in either direction. The README names
+  Scaleway where it used to name no provider, and `docs/limits.md` states the
+  gap for the two packs that do not deliver it — one of which had no sentence
+  anywhere.
+
 - **`/_feint/conformance` moves to schema version 2.** `evidence.*[].probed`
   was a boolean and is now one of `response`, `refusal` or `none` (#156). A
   consumer branching on `probed === true` would read a truthy string and count

--- a/README.md
+++ b/README.md
@@ -452,9 +452,22 @@ by the install play yet.
 
 This is what separates Feint from a mock server, and it is measured rather than
 claimed: the block a client asks for is the block it gets, the address the API
-publishes is the address the machine carries, a security group's default policy
-closes a port for real, and authorising it afterwards opens it without restarting
-anything.
+publishes is the address the machine carries, **a Scaleway** security group's
+default policy closes a port for real, and authorising it afterwards opens it
+without restarting anything.
+
+That provider name is load-bearing. Only Scaleway hands its rules to the
+runtime; an Outscale or Exoscale security group is served, echoed back and
+enforced on nothing (#180). `/_feint/health` answers which packs deliver it, so
+a program can ask rather than assume:
+
+```bash
+curl -s localhost:4599/_feint/health | jq '{capabilities, enforced}'
+```
+
+`capabilities.firewall` says the runtime *can* enforce rules;
+`enforced.firewall` says who asks it to. Reading only the first is what this
+page used to invite.
 
 ### The modes are not equivalent, and one difference matters
 

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -1195,12 +1195,43 @@ shape of a plan, never to test where traffic goes. The day a nexthop is worth
 programming for real, it will arrive as a declared driver capability, measured
 under OVN, not as a silent upgrade of these records.
 
-## Whether a security group filters is not measured
+## Only Scaleway hands a security group to the runtime
+
+`internal/providers/scaleway/firewall.go` is the only file in any pack that
+references `machine.Firewaller`. An **Outscale** or **Exoscale** security group
+is served as a control plane, echoed back, and reconciled onto nothing: with a
+runtime configured, every port of the machine stays open whatever the group
+says, and the API answers success on every rule.
+
+That was published as the opposite until #180. `(*Incus).Capabilities()`
+declares `firewall: true` in every mode, one set for the whole process, and this
+repository tells a consumer to key on the capability rather than on a mode name.
+Following that advice, a user probed a port a deny-default group should have
+closed and found it answering.
+
+`/_feint/health` now carries both halves, and the honest check is their
+conjunction:
+
+```console
+$ curl -s localhost:4599/_feint/health | jq '{capabilities: .capabilities.firewall, enforced: .enforced.firewall}'
+{
+  "capabilities": true,
+  "enforced": ["scaleway"]
+}
+```
+
+`capabilities.firewall` is what the runtime can do. `enforced.firewall` is who
+asks it to. A pack absent from that list either does not wire it or has not
+said, and a consumer cannot tell those apart — which is intended, because both
+mean the same thing to whoever is about to open a socket.
+
+## Whether a Scaleway security group filters is not measured under every mode
 
 The security-group family — `CreateSecurityGroup`, its rules, and the groups a
-machine and its interfaces wear — is served as a control plane. Whether those
-rules are *enforced* on traffic under `FEINT_VM=incus-ovn` has **not been
-measured**, and this section says so rather than claiming a limit.
+machine and its interfaces wear — is served as a control plane by all three
+packs. For Scaleway the rules reach the runtime; whether they are *enforced* on
+traffic under `FEINT_VM=incus-ovn` has **not been measured**, and this section
+says so rather than claiming a limit.
 
 The distinction is the one the firewall section above makes for Scaleway, where
 enforcement is measured within stated bounds. Nothing equivalent has been run

--- a/internal/cli/enforcement_test.go
+++ b/internal/cli/enforcement_test.go
@@ -1,0 +1,101 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+)
+
+// The declaration is held against the source, not against a list somebody keeps.
+//
+// #180 was a claim that had drifted from the code: `capabilities.firewall` was
+// true for the whole process while one pack of three handed a rule to the
+// runtime. Replacing it with a per-pack declaration only moves the drift unless
+// something compares the declaration with what the pack actually does — the
+// same reasoning that stopped the README's client matrix being a constant.
+//
+// So the truth is read where it lives: a pack wires the firewall when a
+// non-test file of its own references machine.Firewaller. Nothing else counts,
+// and in particular a comment does not: the marker is the type, which the
+// compiler resolves.
+//
+// This is what fails if a pack starts handing rules over and forgets to say so,
+// and equally if a pack says so and hands nothing over. Both directions matter:
+// the first understates and the second is the defect #180 was filed for.
+func TestEveryPackThatWiresTheFirewallSaysSo(t *testing.T) {
+	// Relative rather than through moduleRoot: that helper lives in package
+	// cli_test, and this test needs packsFor, which is unexported. A second copy
+	// of the root finder would be one fact in two places.
+	packsDir := filepath.Join("..", "providers")
+
+	entries, err := os.ReadDir(packsDir)
+	if err != nil {
+		t.Fatalf("read the packs directory: %v", err)
+	}
+
+	wires := map[string]bool{}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		found, err := referencesFirewaller(filepath.Join(packsDir, entry.Name()))
+		if err != nil {
+			t.Fatalf("read pack %s: %v", entry.Name(), err)
+		}
+		wires[entry.Name()] = found
+	}
+	if len(wires) == 0 {
+		t.Fatal("no pack directory was read, so this test would pass while measuring nothing")
+	}
+
+	declares := map[string]bool{}
+	for _, p := range packsFor(emulator.DefaultEnv()) {
+		fe, ok := p.(emulator.FirewallEnforcer)
+		declares[p.Name()] = ok && fe.EnforcesFirewall()
+	}
+
+	for name, actually := range wires {
+		declared, mounted := declares[name]
+		if !mounted {
+			// A directory that mounts no pack is not this test's business.
+			continue
+		}
+		switch {
+		case actually && !declared:
+			t.Errorf("%s references machine.Firewaller and does not implement "+
+				"EnforcesFirewall: /_feint/health understates what it delivers, and a "+
+				"user is told not to rely on something that works", name)
+		case !actually && declared:
+			t.Errorf("%s declares EnforcesFirewall and no non-test file of it "+
+				"references machine.Firewaller: this is the claim #180 was filed for, "+
+				"a capability published for a pack that hands nothing to the runtime", name)
+		}
+	}
+}
+
+// referencesFirewaller reports whether any non-test Go file directly under dir
+// names machine.Firewaller. Non-test on purpose: a fake in a test file proves
+// the pack can be tested, never that it wires anything.
+func referencesFirewaller(dir string) (bool, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false, err
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join(dir, name)) //nolint:gosec // a path this repository owns
+		if err != nil {
+			return false, err
+		}
+		if strings.Contains(string(body), "machine.Firewaller") {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/internal/cli/testdata/frozen/health.json
+++ b/internal/cli/testdata/frozen/health.json
@@ -58,6 +58,77 @@
           }
         ]
       }
+    },
+    {
+      "schema_version": 2,
+      "content": {
+        "fields": [
+          {
+            "path": "capabilities",
+            "type": "object"
+          },
+          {
+            "path": "capabilities.addresses",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.firewall",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.isolation",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.machines",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.own_kernel",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.private_from_host",
+            "type": "bool"
+          },
+          {
+            "path": "enforced",
+            "type": "object"
+          },
+          {
+            "path": "enforced.firewall",
+            "type": "array"
+          },
+          {
+            "path": "enforced.firewall[]",
+            "type": "string"
+          },
+          {
+            "path": "machines",
+            "type": "string"
+          },
+          {
+            "path": "providers",
+            "type": "array"
+          },
+          {
+            "path": "providers[]",
+            "type": "string"
+          },
+          {
+            "path": "resources",
+            "type": "number"
+          },
+          {
+            "path": "schema_version",
+            "type": "number"
+          },
+          {
+            "path": "status",
+            "type": "string"
+          }
+        ]
+      }
     }
   ]
 }

--- a/internal/core/emulator/emulator.go
+++ b/internal/core/emulator/emulator.go
@@ -417,6 +417,11 @@ func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
 	// it matters. A conformance suite gating on `capabilities.isolation` asserts
 	// what this process can actually prove instead of hardcoding a mode name,
 	// and an operator can see what they have without reading a file.
+	// And which packs hand work to those capabilities (#180). The driver's set
+	// is one for the whole process; wiring is per pack, and publishing only the
+	// first told a user the firewall was delivered for three packs when one
+	// delivered it. The honest check is both: capabilities.firewall says the
+	// runtime can, enforced.firewall says who asks it to.
 	writeJSON(w, http.StatusOK, map[string]any{
 		"schema_version": HealthSchemaVersion,
 		"status":         "ok",
@@ -424,6 +429,7 @@ func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
 		"resources":      s.env.Store.Len(),
 		"machines":       driver,
 		"capabilities":   capabilities,
+		"enforced":       enforcement(s.packs),
 	})
 }
 

--- a/internal/core/emulator/enforcement.go
+++ b/internal/core/emulator/enforcement.go
@@ -1,0 +1,71 @@
+package emulator
+
+import "sort"
+
+// Which packs hand work to a capability the driver declares (#180).
+//
+// `/_feint/health` publishes the machine driver's capabilities, and this
+// repository tells a consumer to key on them rather than on a mode name. That
+// advice was sound and the answer was not: `Capabilities` describes what the
+// *driver* can do, and it is one set for the whole process, while handing rules
+// to that driver is something each *pack* does or does not do.
+//
+// Measured on 2026-08-15: `(*Incus).Capabilities()` declared `firewall: true`
+// in every mode, and `internal/providers/scaleway/firewall.go` was the only
+// file in any pack that touched `machine.Firewaller`. So an Outscale or
+// Exoscale security group was created, echoed back, and reconciled onto
+// nothing, while the same process answered `firewall: true`. A user following
+// the project's own advice probed a port a deny-default group should close,
+// found it open, and had been told the firewall was delivered. A 200 that lies.
+//
+// Documentation alone could not close that: the claim is read from an endpoint,
+// by a program, at the moment it matters. So the endpoint says it.
+//
+// The shape is a list per capability rather than a per-pack capability set, and
+// deliberately: only the capabilities that are provably per-pack belong here,
+// and adding one later is additive. A pack that implements nothing appears
+// nowhere, which is this project's standing rule — an undeclared capability
+// counts as absent, so a check skips instead of asserting what nobody promised.
+//
+// TestEnforcementNamesOnlyThePacksThatWireIt fails without this.
+
+// FirewallEnforcer is implemented by a pack that hands its security-group rules
+// to the machine runtime. Implementing it is a claim the pack's own suite must
+// be able to prove; not implementing it is the honest default.
+type FirewallEnforcer interface {
+	// EnforcesFirewall reports whether this pack reconciles its rules onto the
+	// machines that carry them. It answers about the pack, not about the
+	// driver: a pack that wires the handoff says true even where the process
+	// runs with no runtime at all, because what the user needs to know is
+	// whether pointing a runtime at it would change anything.
+	EnforcesFirewall() bool
+}
+
+// enforcement answers, per capability, the packs that hand work to it. The
+// value is what `/_feint/health` publishes under `enforced`.
+//
+// Absent from a list means one of two things and the caller cannot tell them
+// apart, which is intended: the pack does not wire it, or the pack has not said.
+// Both are "do not rely on it here".
+func enforcement(packs []Pack) map[string][]string {
+	out := map[string][]string{}
+
+	// Not `var firewall []string`: a nil slice marshals to `null`, and a
+	// consumer iterating the list would break on the very process where no pack
+	// wires anything. Found by TestEnforcementPublishesAnEmptyListRatherThanNoKey
+	// on its first run.
+	firewall := []string{}
+	for _, p := range packs {
+		fe, ok := p.(FirewallEnforcer)
+		if ok && fe.EnforcesFirewall() {
+			firewall = append(firewall, p.Name())
+		}
+	}
+	sort.Strings(firewall)
+	// The key exists even when empty: a consumer distinguishing "no pack wires
+	// it" from "this build does not publish the field" needs the key to be
+	// there, and an absent key would read as the older payload.
+	out["firewall"] = firewall
+
+	return out
+}

--- a/internal/core/emulator/enforcement_test.go
+++ b/internal/core/emulator/enforcement_test.go
@@ -1,0 +1,107 @@
+package emulator_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+)
+
+// enforcingPack is a stubPack that wires the firewall; plain stubPack does not.
+type enforcingPack struct {
+	stubPack
+	wires bool
+}
+
+func (p enforcingPack) EnforcesFirewall() bool { return p.wires }
+
+// TestEnforcementNamesOnlyThePacksThatWireIt holds `/_feint/health`'s `enforced`
+// key to the one thing it claims: which packs hand work to a capability the
+// driver declares.
+//
+// Both halves are asserted, and the refusing half is the one this exists for.
+// Before #180 the endpoint published `firewall: true` from the driver alone,
+// for the whole process, while one pack of three handed a rule over — so a user
+// who followed this project's own advice and keyed on the capability probed a
+// port a deny-default group should have closed and found it open.
+//
+// The third pack is the case that matters most: a pack that implements the
+// interface and answers false must be as absent as one that never implemented
+// it. "Wires it and says no" and "never said" are the same thing to a consumer,
+// and both mean do not rely on it here.
+func TestEnforcementNamesOnlyThePacksThatWireIt(t *testing.T) {
+	env := emulator.DefaultEnv()
+	srv, err := emulator.NewServer(env,
+		enforcingPack{stubPack: stubPack{name: "wires"}, wires: true},
+		enforcingPack{stubPack: stubPack{name: "declines"}, wires: false},
+		stubPack{name: "silent"},
+	)
+	if err != nil {
+		t.Fatalf("mount the stub packs: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	resp, err := ts.Client().Get(ts.URL + "/_feint/health") //nolint:noctx // a local test server
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var health struct {
+		Enforced map[string][]string `json:"enforced"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&health); err != nil {
+		t.Fatalf("decode health: %v", err)
+	}
+
+	firewall, present := health.Enforced["firewall"]
+	if !present {
+		t.Fatal("health publishes no `enforced.firewall`: a consumer cannot tell " +
+			"\"no pack wires it\" from \"this build does not say\"")
+	}
+	if len(firewall) != 1 || firewall[0] != "wires" {
+		t.Errorf("enforced.firewall must name the pack that hands rules over and "+
+			"only that one, got %v", firewall)
+	}
+}
+
+// And the key survives a process with no pack wiring anything: empty, not
+// missing. An absent key reads as the older payload, which is the shape a
+// consumer branches on schema_version to avoid.
+func TestEnforcementPublishesAnEmptyListRatherThanNoKey(t *testing.T) {
+	env := emulator.DefaultEnv()
+	srv, err := emulator.NewServer(env, stubPack{name: "silent"})
+	if err != nil {
+		t.Fatalf("mount the stub pack: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	resp, err := ts.Client().Get(ts.URL + "/_feint/health") //nolint:noctx // a local test server
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var raw map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		t.Fatalf("decode health: %v", err)
+	}
+	enforced, ok := raw["enforced"].(map[string]any)
+	if !ok {
+		t.Fatalf("health carries no `enforced` object, got %T", raw["enforced"])
+	}
+	list, ok := enforced["firewall"].([]any)
+	if !ok {
+		t.Fatalf("`enforced.firewall` is absent or not a list, got %T", enforced["firewall"])
+	}
+	if len(list) != 0 {
+		t.Errorf("no pack wires the firewall here, so the list must be empty, got %v", list)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("health answered %d", resp.StatusCode)
+	}
+}

--- a/internal/core/emulator/schema.go
+++ b/internal/core/emulator/schema.go
@@ -22,7 +22,15 @@ package emulator
 // what moved. The procedure lives in RELEASING.md ("Frozen surfaces").
 const (
 	// HealthSchemaVersion is the shape of GET /_feint/health.
-	HealthSchemaVersion = 1
+	//
+	// 2 since #180: the payload gained `enforced`, an object keyed by capability
+	// naming the packs that hand work to it. Additive, but it changes what the
+	// endpoint *means*: `capabilities.firewall` alone said the runtime can
+	// enforce rules, and a consumer read it as "my security groups are
+	// enforced". One pack of three handed a rule over. The honest check is both
+	// keys, so a consumer that branches on the version can tell whether it is
+	// talking to a build that can answer the second question at all.
+	HealthSchemaVersion = 2
 	// RoutesSchemaVersion is the shape of GET /_feint/routes.
 	//
 	// This one is not on the wire: the endpoint answers a bare JSON array — the

--- a/internal/providers/scaleway/firewall.go
+++ b/internal/providers/scaleway/firewall.go
@@ -329,3 +329,17 @@ func (p *Pack) removeFirewall(ctx context.Context, group *resource.Resource) {
 			"security_group", group.ID, "error", err)
 	}
 }
+
+// EnforcesFirewall implements emulator.FirewallEnforcer: this pack reconciles a
+// security group onto the machines that carry it, so a runtime able to enforce
+// rules is handed them.
+//
+// It answers about the pack and not about the process, which is why it is a
+// constant rather than a look at p.env.Machines. `/_feint/health` publishes the
+// driver's capabilities beside this, and a consumer needs both: what the runtime
+// can do, and who asks it to. Reading the first alone is what told a user the
+// firewall was delivered for three packs when only this one delivered it (#180).
+//
+// The day this pack stops handing rules over, this line is what has to change,
+// and TestEnforcementNamesOnlyThePacksThatWireIt is what notices if it does not.
+func (p *Pack) EnforcesFirewall() bool { return true }


### PR DESCRIPTION
`/_feint/health` published **one capability set for the whole process**, read from the machine driver, and this repository tells a consumer to key on it rather than on a mode name. That advice was sound; the answer was not.

## The measurement

```console
$ grep -rln 'machine.Firewaller' internal/providers/*/
internal/providers/scaleway/firewall.go
```

One file, in one pack. An Outscale or Exoscale security group was created, echoed back, and reconciled onto nothing: with a runtime configured every port of the machine stayed open whatever the group said, while the same process answered `firewall: true` and the API answered success on every rule.

A user who followed the project's own advice probed a port a deny-default group should have closed, found it answering, and **had been told the firewall was delivered**. A 200 that lies.

## Why documentation could not close it

The claim is read from an endpoint, by a program, at the moment it matters. So the endpoint says it:

```json
"capabilities": { "firewall": true },
"enforced":     { "firewall": ["scaleway"] }
```

`capabilities.firewall` is what the runtime **can** do. `enforced.firewall` is **who asks it to**. The honest check is their conjunction.

A pack declares by implementing `emulator.FirewallEnforcer`; one that does not appears nowhere — the standing rule that an undeclared capability counts as absent. A consumer cannot tell *does not wire it* from *has not said*, and that is intended: both mean the same thing to whoever is about to open a socket.

The object is a list per capability rather than a per-pack capability set, because only the capabilities that are provably per-pack belong in it, and adding one later is additive.

## The declaration is held against the source

`TestEveryPackThatWiresTheFirewallSaysSo` compares each pack's declaration with whether its own **non-test** files reference `machine.Firewaller`, and fails in both directions:

| drift | what it costs | caught |
|---|---|---|
| wires it, does not say | understates what it delivers | yes |
| says it, wires nothing | **the defect this PR removes** | yes |

## Frozen surface

Schema version **2**, fixture history appended by `mise run frozen:update`, constant bumped: RELEASING.md's four steps.

## Documentation

The README named **no provider** for "a security group's default policy closes a port for real", the same half-truth shape CLAUDE.md forbids for isolation. It names Scaleway now, and points at the endpoint. `docs/limits.md` gains the gap for the two packs that do not deliver it; Exoscale had no sentence anywhere, although EXO-2 put "security groups" in the title that removed the preview label.

## Falsification

Four mutations in a copy outside the repository, each compiling first, each named test biting:

| mutation | test | verdict |
|---|---|---|
| every pack named, as the process-global capability did | `TestEnforcementNamesOnlyThePacksThatWireIt` | red |
| a pack that answers false is named anyway | same | red |
| the empty list marshals to `null` | `TestEnforcementPublishesAnEmptyListRatherThanNoKey` | red |
| the pack drops its declaration | `TestEveryPackThatWiresTheFirewallSaysSo` | red |

The first attempt at the second mutation did not compile, so its verdict was **void rather than favourable**, and it was rewritten. The third bit on its very first run, before any mutation: a nil slice marshals to `null`, which would have broken a consumer iterating the list on exactly the process where no pack wires anything.

## Type of change

- [ ] A route added or changed
- [x] Bug fix
- [ ] Refactor
- [x] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes, via `mise run prepush`
- [x] No new external Go dependency
- [x] `internal/core` still knows no provider: `enforcement.go` names none, and the pack declares through an optional interface, the same pattern as `FieldDecliner`
- [x] Nothing in the diff could be written identically for another provider: the shared half is in the core, the per-pack half is one method

### When a model wrote a substantive part of this

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] **`mise run conformance` was run in full and passed** (exit 0), because a published response shape moved
- [x] Every claim comes from the source: the grep above, `capabilities.go`, and the pack files, not from recall

### When a route is added or changed

N/A: no route is added or changed.

### When behaviour a client can observe changes

- [x] `docs/limits.md` updated: a limit is now stated that was missing for one pack entirely
- [x] Generated tables regenerated; `feint docs --check` returns 0

### When `.github/workflows/` is touched

N/A.

### When a machine runtime is involved

- [ ] N/A for a runtime run: no driver code changes. What changes is what the process *says* about the driver, and the conformance suite reads it with `--vm off`

## Related issues

Closes #180
