### PR TITLE
fix(machine): a capability is what the host answers, not what the flag promised

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -96,6 +96,39 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Modifié
 
+- **Une capacité est vérifiée contre l'hôte avant d'être publiée** (#181).
+  `NewIncusOVN` posait `OVN = true` et `isolation: true` suivait, quoi que
+  l'hôte sache faire : il n'existait qu'un seul `Available` pour les trois modes
+  Incus, et il lançait `incus list`, si bien que sur tout hôte dont le démon
+  répond, le pilote OVN se déclarait disponible. `internal/cli/cli.go` portait
+  un commentaire garantissant un repli qui ne pouvait donc jamais se déclencher :
+  la classe de défaut que CLAUDE.md nomme, posée sur la ligne qui choisit ce qui
+  tourne sur la machine de l'opérateur.
+
+  Mesuré sur un hôte Incus 7.2 sans aucun câblage OVN : `--vm auto` choisissait
+  `incus-ovn` et `/_feint/health` publiait `isolation: true`, jusqu'à ce que la
+  première création de réseau échoue en disant au client que le bloc d'adresses
+  était déjà pris. Une capacité fausse est strictement pire qu'aucune, puisque
+  ce projet envoie tout consommateur vers `capabilities.isolation` plutôt que
+  vers un nom de mode.
+
+  `Verify` interroge désormais l'hôte, une fois, au démarrage, par deux lectures
+  qui ne créent rien : `network.ovn.northbound_connection` pour l'isolation, et
+  la version du démon contre le plancher 6.0.4 pour le pare-feu, ce même
+  plancher que cite `feint doctor`, déplacé dans `internal/core/machine` pour
+  que les deux ne puissent plus diverger. Sur ce même hôte, `auto` affiche
+  maintenant `incus-ovn passed over` avec la raison et retombe sur le pont qui
+  fonctionne ; `--vm incus-ovn` demandé par son nom refuse au démarrage en
+  nommant la moitié manquante, code 1. Une version illisible conserve la
+  capacité au lieu de la perdre : un manque de diagnostic ne doit pas devenir
+  une capacité perdue.
+
+  La limite est énoncée plutôt que passée sous silence : un northbound câblé est
+  nécessaire et non suffisant, donc un hôte dont l'**uplink** est mal configuré
+  publie encore l'isolation et échoue encore à la première création.
+  `docs/install.md` le dit, et dit pourquoi sa propre preuve est un vrai
+  `CreateSubnet` plutôt que l'endpoint.
+
 - **`/_feint/health` passe en version de schéma 2 et dit quels packs livrent
   réellement une capacité** (#180). `(*Incus).Capabilities()` déclarait
   `firewall: true` dans tous les modes, un seul jeu pour tout le processus, et

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,35 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Changed
 
+- **A capability is verified against the host before it is published** (#181).
+  `NewIncusOVN` set `OVN = true` and `isolation: true` followed, whatever the
+  host could do: there was one `Available` for all three Incus modes and it ran
+  `incus list`, so on any host whose daemon answers the OVN driver reported
+  available. `internal/cli/cli.go` carried a comment vouching for a fall-through
+  that could therefore never trigger — the defect class CLAUDE.md names, sitting
+  on the line that chooses what runs on the operator's host.
+
+  Measured on an Incus 7.2 host with no OVN wiring: `--vm auto` chose
+  `incus-ovn` and `/_feint/health` published `isolation: true`, until the first
+  network creation failed and told the client the address block was already in
+  use. A false capability is strictly worse than none, because this project
+  sends every consumer to `capabilities.isolation` rather than to a mode name.
+
+  `Verify` now asks the host, once, at startup, with two reads that create
+  nothing: `network.ovn.northbound_connection` for isolation, and the daemon
+  version against the 6.0.4 floor for the firewall — the same floor
+  `feint doctor` cites, moved to `internal/core/machine` so the two cannot
+  drift. On the same host, `auto` now prints `incus-ovn passed over` with the
+  reason and lands on the bridge that works; `--vm incus-ovn` asked for by name
+  refuses at startup naming the missing half, exit 1. An unreadable version
+  keeps the capability rather than losing it: a diagnostic gap must not become a
+  lost capability.
+
+  The bound is stated rather than glossed: a wired northbound is necessary and
+  not sufficient, so a host whose *uplink* is misconfigured still publishes
+  isolation and still fails at the first create. `docs/install.md` says so, and
+  says why its own proof is a real `CreateSubnet` rather than the endpoint.
+
 - **`/_feint/health` moves to schema version 2, and says which packs deliver a
   capability** (#180). `(*Incus).Capabilities()` declared `firewall: true` in
   every mode, one set for the whole process, and this project tells a consumer

--- a/docs/install.md
+++ b/docs/install.md
@@ -203,13 +203,22 @@ the same 6.0.4, and says what to install, which is the point of having it.
 
 Every command below was executed on a fresh virtual machine of the release
 named, by `tools/install/ansible/site.yml`. The check is not "the packages
-installed", and it is not the health endpoint on its own either:
-`capabilities.isolation` follows the *mode*, so a host whose OVN uplink is
-misconfigured reports `true` while being unable to create a single subnet. What
-the play asserts is a real `CreateNet` followed by a real `CreateSubnet` through
-the emulated API — the second is the call that needs OVN actually wired — and
-only then the isolation capability, which is the claim the whole setup exists
-for: two subnets of two different VPCs unable to reach each other.
+installed", and it is not the health endpoint on its own either.
+
+`capabilities.isolation` used to follow the *mode* alone, so a host with no OVN
+at all reported `true` and failed at the first network creation. Since #181 the
+capability is verified against the host before it is published: an OVN mode
+whose `network.ovn.northbound_connection` is unset refuses at startup when it
+was asked for by name, and is passed over by `--vm auto` with its reason
+printed. **That probe is necessary and not sufficient**, and the difference is
+this section's whole point: a host whose northbound is wired and whose *uplink*
+is misconfigured still reports `true` and still cannot create a subnet.
+
+So what the play asserts is a real `CreateNet` followed by a real `CreateSubnet`
+through the emulated API — the second is the call that needs OVN actually wired,
+uplink included — and only then the isolation capability, which is the claim the
+whole setup exists for: two subnets of two different VPCs unable to reach each
+other.
 
 | Release | Incus from | OVN from | Verdict |
 |---|---|---|---|

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -332,9 +332,38 @@ Every one of these is also a mise task: run "mise tasks" to list them.
 func machineDriver(mode string, stdout io.Writer) (machine.Driver, error) {
 	ctx := context.Background()
 
+	// verify asks the host what it delivers, once, before anything is published.
+	//
+	// Before #181 a mode's capabilities were a function of the flag: NewIncusOVN
+	// set OVN and `isolation: true` followed, on a host with no OVN wiring at
+	// all. Measured on 2026-08-15: `--vm auto` chose incus-ovn on an ordinary
+	// Incus 7.2 host and /_feint/health published isolation until the first
+	// network creation failed and blamed the address block.
+	//
+	// The narrowing is announced rather than silent, because a capability that
+	// quietly drops is how a suite starts skipping what it used to assert.
+	verify := func(d machine.Driver) []string {
+		v, ok := d.(interface {
+			Verify(context.Context) (machine.Capabilities, []string)
+		})
+		if !ok {
+			return nil
+		}
+		_, unmet := v.Verify(ctx)
+		return unmet
+	}
+
 	requested := func(d machine.Driver) (machine.Driver, error) {
 		if !d.Available(ctx) {
 			return nil, fmt.Errorf("--vm %s requested but the Incus daemon does not answer", mode)
+		}
+		// Asked for by name, and the host cannot serve it: refuse at startup
+		// naming the missing half, the same shape as the line above. Accepting
+		// it would publish a capability the first create disproves, and blame
+		// the client for it.
+		if unmet := verify(d); len(unmet) > 0 {
+			return nil, fmt.Errorf("--vm %s requested but this host cannot deliver it:\n  %s",
+				mode, strings.Join(unmet, "\n  "))
 		}
 		return d, nil
 	}
@@ -356,8 +385,27 @@ func machineDriver(mode string, stdout io.Writer) (machine.Driver, error) {
 			if !d.Available(ctx) {
 				continue
 			}
+			// The fall-through the comment above always claimed. It could never
+			// trigger while Available was one `incus list` for all three modes:
+			// a mode whose defining capability the host cannot deliver is passed
+			// over, so the ordinary host that never installed OVN lands on the
+			// bridge that works instead of on a promise that does not.
+			declared := machine.CapabilitiesOf(d)
+			unmet := verify(d)
 			caps := machine.CapabilitiesOf(d)
+			if declared.Isolation && !caps.Isolation {
+				// Isolation is the only reason this mode is tried first, so a
+				// host that cannot deliver it gets the next mode rather than
+				// this one with its reason removed. Said out loud: a runtime
+				// chosen differently from what the operator would expect is
+				// exactly the kind of decision that must not be silent.
+				fmt.Fprintf(stdout, "%s passed over: %s\n", d.Name(), strings.Join(unmet, "; "))
+				continue
+			}
 			fmt.Fprintf(stdout, "machine runtime: %s (isolation: %v)\n", d.Name(), caps.Isolation)
+			for _, why := range unmet {
+				fmt.Fprintf(stdout, "  the host narrowed this: %s\n", why)
+			}
 			if !caps.Isolation {
 				fmt.Fprintln(stdout,
 					"  subnets of different VPCs will reach each other; install ovn-central and ovn-host for isolation")

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -198,7 +198,12 @@ func checkRuntime(ctx context.Context, mode string) []check {
 // incusMinimum is the version below which NIC ACLs are refused, and the failure
 // looks like a bug in this emulator rather than a version floor: a security
 // group is created, attached, and enforces nothing.
-var incusMinimum = [3]int{6, 0, 4}
+//
+// Read from the runtime rather than declared here since #181: `serve` checks the
+// same floor before publishing `firewall: true`, and two copies is how the two
+// drift — the diagnostic saying one thing and the capability another, which is
+// exactly the shape of defect that issue was filed for.
+var incusMinimum = machine.IncusMinimum
 
 // incusRecommended is the series every measurement in docs/limits.md was taken
 // on, and the one docs/install.md installs. It is not a floor: a 6.0.4 host runs
@@ -213,13 +218,11 @@ var incusRecommended = [2]int{7, 2}
 // diagnostics both cite it. Written once: the two strings below used to spell
 // "6.0.4" out beside incusMinimum, so a change to the floor would have moved the
 // check without moving what it tells the operator to install.
-func versionText(parts []int) string {
-	out := make([]string, len(parts))
-	for i, p := range parts {
-		out[i] = strconv.Itoa(p)
-	}
-	return strings.Join(out, ".")
-}
+//
+// It forwards to the runtime's copy for the same reason the floor does: the
+// startup line that narrows a capability cites the same version, in the same
+// spelling.
+func versionText(parts []int) string { return machine.VersionText(parts) }
 
 func checkIncusVersion(ctx context.Context) check {
 	cmd := exec.CommandContext(ctx, "incus", "version") //nolint:gosec // a fixed binary name

--- a/internal/core/machine/capabilities.go
+++ b/internal/core/machine/capabilities.go
@@ -111,6 +111,12 @@ func (Noop) Capabilities() Capabilities { return Capabilities{} }
 // separates two VPC's subnets by construction NATs the host away from their
 // insides, so the two claims cannot both be true of one Incus mode.
 func (d *Incus) Capabilities() Capabilities {
+	// What the host answered wins over what the flag promised (#181). Verify
+	// narrows this set once at startup; before that, and in a test that builds a
+	// driver directly, the declaration below is what there is.
+	if d.verified != nil {
+		return *d.verified
+	}
 	return Capabilities{
 		Machines:        true,
 		Addresses:       true,

--- a/internal/core/machine/incus.go
+++ b/internal/core/machine/incus.go
@@ -69,6 +69,12 @@ type Incus struct {
 	// can hold in milliseconds.
 	agentPoll time.Duration
 
+	// verified is what the host answered when Verify ran, and it is what
+	// Capabilities publishes once it is set. Nil means nobody asked, which is
+	// the case in a test that builds a driver directly: the declared set is then
+	// the honest answer, because no host was consulted to contradict it.
+	verified *Capabilities
+
 	// attachMu serialises interface allocation. Attach reads the device list and
 	// then adds a device under a name it believes free; two concurrent calls
 	// without the lock pick the same name, and the loser's attachment silently

--- a/internal/core/machine/verify.go
+++ b/internal/core/machine/verify.go
@@ -1,0 +1,171 @@
+package machine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Capabilities answered by the host, not promised by the flag (#181).
+//
+// `Capabilities()` used to be a pure function of the driver's own fields:
+// `NewIncusOVN` set `OVN = true` and `Isolation` followed, whatever the host
+// could actually do. There was one `Available` for all three Incus modes and it
+// ran `incus list`, so on any host whose daemon answers, the OVN driver reported
+// available. `internal/cli/cli.go` carried a comment vouching for a fall-through
+// that could therefore never trigger:
+//
+//	The guess is cheap to make safe: the OVN driver's own availability check
+//	creates nothing, so a probe that fails costs one call and falls through to
+//	the bridge.
+//
+// That probe did not exist. Measured on 2026-08-15 on a host running Incus 7.2
+// with no OVN wiring at all: `--vm auto` selected `incus-ovn` and
+// `/_feint/health` published `isolation: true`, until the first network
+// creation failed and blamed the address block.
+//
+// A false capability is strictly worse than none here, because this project
+// tells every consumer to key on `capabilities.isolation` rather than on a mode
+// name. A suite obeying that rule asserts what the host cannot deliver.
+//
+// TestVerifyNarrowsWhatTheHostCannotDeliver fails without this.
+
+// IncusMinimum is the daemon version below which NIC ACLs are refused, and the
+// failure looks like a bug in this emulator rather than a version floor: a
+// security group is created, attached, and enforces nothing.
+//
+// It lives here rather than in the diagnostics because two callers need it and
+// a second copy is how the two drift — the same failure shape #171 was filed
+// for, expressed in versions. `feint doctor` reads it from here.
+var IncusMinimum = [3]int{6, 0, 4}
+
+// ovnNorthbound is the server setting an OVN network cannot be created without.
+// Reading it creates nothing and leaves nothing, which `auto` requires: it runs
+// at every startup, on hosts that are perfectly healthy.
+const ovnNorthbound = "network.ovn.northbound_connection"
+
+// serverVersion matches what `incus query /1.0` reports. The patch component is
+// optional because 7.2 is a real answer — an earlier version of the equivalent
+// check in the diagnostics demanded three components and reported "could not
+// read the version" on a perfectly good installation.
+var serverVersion = regexp.MustCompile(`^(\d+)\.(\d+)(?:\.(\d+))?`)
+
+// Verify asks the host what it can actually deliver and narrows the declared
+// capabilities to it. It returns the verified set and, for each capability the
+// flag promised and the host cannot deliver, one sentence naming what was
+// checked and what answered.
+//
+// What it does not do, stated because the boundary matters: a wired northbound
+// connection is necessary for an OVN network and not sufficient. A host whose
+// uplink is misconfigured still reports the northbound and still fails at the
+// first create — docs/install.md documents that case and this probe does not
+// close it. What it does close is the ordinary host, the one that never
+// installed OVN, which is the host most likely to meet `auto`.
+//
+// Both calls are reads. Neither creates a network, touches the uplink, or
+// leaves a trace.
+func (d *Incus) Verify(ctx context.Context) (Capabilities, []string) {
+	declared := d.Capabilities()
+	verified := declared
+	var unmet []string
+
+	if declared.Isolation {
+		if wired, why := d.ovnWired(ctx); !wired {
+			verified.Isolation = false
+			unmet = append(unmet, "isolation: "+why)
+		}
+	}
+
+	if declared.Firewall {
+		if ok, why := d.firewallAge(ctx); !ok {
+			verified.Firewall = false
+			unmet = append(unmet, "firewall: "+why)
+		}
+	}
+
+	d.verified = &verified
+	return verified, unmet
+}
+
+// ovnWired reports whether the daemon has a northbound connection configured.
+func (d *Incus) ovnWired(ctx context.Context) (bool, string) {
+	out, err := d.run(ctx, "config", "get", ovnNorthbound)
+	if err != nil {
+		return false, "the daemon did not answer for " + ovnNorthbound
+	}
+	if strings.TrimSpace(string(out)) == "" {
+		return false, ovnNorthbound + " is unset, so no OVN network can be created " +
+			"(install ovn-central and ovn-host, and wire the northbound)"
+	}
+	return true, ""
+}
+
+// firewallAge reports whether the daemon is new enough to accept NIC ACLs.
+//
+// Unreadable is not refused: a daemon that answers `incus list` and whose
+// version this cannot parse is far more likely to be a format change than an
+// old release, and refusing there would turn a diagnostic gap into a lost
+// capability. The version that is read and too old is refused, loudly.
+func (d *Incus) firewallAge(ctx context.Context) (bool, string) {
+	out, err := d.run(ctx, "query", "/1.0")
+	if err != nil {
+		return true, ""
+	}
+	var payload struct {
+		Environment struct {
+			ServerVersion string `json:"server_version"`
+		} `json:"environment"`
+	}
+	if json.Unmarshal(out, &payload) != nil {
+		return true, ""
+	}
+	got, ok := parseVersion(payload.Environment.ServerVersion)
+	if !ok {
+		return true, ""
+	}
+	if olderThan(got, IncusMinimum) {
+		return false, fmt.Sprintf(
+			"the daemon is %s and NIC ACLs are refused below %s, so a security group "+
+				"attaches and enforces nothing",
+			payload.Environment.ServerVersion, VersionText(IncusMinimum[:]))
+	}
+	return true, ""
+}
+
+// parseVersion reads "7.2" or "6.0.4" into a comparable tuple.
+func parseVersion(s string) ([3]int, bool) {
+	var out [3]int
+	m := serverVersion.FindStringSubmatch(strings.TrimSpace(s))
+	if len(m) < 3 {
+		return out, false
+	}
+	for i := range out {
+		if m[i+1] != "" {
+			out[i], _ = strconv.Atoi(m[i+1])
+		}
+	}
+	return out, true
+}
+
+func olderThan(got, floor [3]int) bool {
+	for i := range got {
+		if got[i] != floor[i] {
+			return got[i] < floor[i]
+		}
+	}
+	return false
+}
+
+// VersionText renders a version tuple the way the documentation and the
+// diagnostics both cite it, so a change to the floor moves every sentence that
+// tells an operator what to install.
+func VersionText(parts []int) string {
+	out := make([]string, len(parts))
+	for i, p := range parts {
+		out[i] = strconv.Itoa(p)
+	}
+	return strings.Join(out, ".")
+}

--- a/internal/core/machine/verify_test.go
+++ b/internal/core/machine/verify_test.go
@@ -1,0 +1,118 @@
+package machine
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// hostSaying builds an Incus driver whose CLI answers are dictated, so a test
+// can stand on a host it does not have. The runner is the same seam the
+// argument-level tests use; here it stands in for the host's answers rather
+// than recording the driver's questions.
+func hostSaying(ovnNB, version string) *Incus {
+	d := NewIncusOVN()
+	d.runner = func(_ context.Context, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		switch {
+		case strings.HasPrefix(joined, "config get "+ovnNorthbound):
+			return []byte(ovnNB + "\n"), nil
+		case joined == "query /1.0":
+			return []byte(`{"environment": {"server_version": "` + version + `"}}`), nil
+		}
+		return nil, nil
+	}
+	return d
+}
+
+// TestVerifyNarrowsWhatTheHostCannotDeliver is the refusing half, and the defect
+// #181 was filed for.
+//
+// `NewIncusOVN` set OVN and `isolation: true` followed, whatever the host could
+// do. There was one `Available` for all three Incus modes and it ran
+// `incus list`, so the fall-through `--vm auto` was documented to rely on could
+// never trigger. Measured on 2026-08-15 on an Incus 7.2 host with no OVN wiring:
+// auto chose incus-ovn and /_feint/health published isolation until the first
+// network creation failed, blaming the address block.
+func TestVerifyNarrowsWhatTheHostCannotDeliver(t *testing.T) {
+	// A host with Incus and no OVN wiring at all: the ordinary one.
+	d := hostSaying("", "7.2")
+	caps, unmet := d.Verify(context.Background())
+
+	if caps.Isolation {
+		t.Error("isolation survived a host with no northbound connection: this is " +
+			"the capability a suite keying on it would assert and the host cannot deliver")
+	}
+	if len(unmet) != 1 || !strings.Contains(unmet[0], ovnNorthbound) {
+		t.Errorf("the narrowing must name what was checked and what answered, got %v", unmet)
+	}
+	// And what the host does deliver is kept: a probe that refused everything
+	// would pass this test's first half and break the product.
+	if !caps.Machines || !caps.Addresses || !caps.Firewall {
+		t.Errorf("verification removed capabilities the host answers for: %+v", caps)
+	}
+	// Capabilities publishes the verified set from now on, which is the point:
+	// the flag's promise is not what /_feint/health carries.
+	if d.Capabilities().Isolation {
+		t.Error("Capabilities still publishes the flag's promise after Verify narrowed it")
+	}
+}
+
+// The accepting half, on the same seam: a host that delivers keeps everything.
+func TestVerifyKeepsWhatTheHostDelivers(t *testing.T) {
+	d := hostSaying("tcp:10.0.0.1:6641", "7.2")
+	caps, unmet := d.Verify(context.Background())
+
+	if len(unmet) != 0 {
+		t.Errorf("a wired host narrows nothing, got %v", unmet)
+	}
+	if !caps.Isolation {
+		t.Error("isolation was removed on a host whose northbound is wired: the probe " +
+			"refuses what it should accept, which breaks the mode it exists to protect")
+	}
+}
+
+// The firewall floor is the daemon's, and it is the same constant the
+// diagnostics cite. 6.0.0 is not a hypothetical: it is what Ubuntu 24.04 ships
+// and will not move past, and on it `security.acls` on a NIC is refused, so a
+// security group attaches and enforces nothing.
+func TestVerifyRefusesTheFirewallBelowTheFloor(t *testing.T) {
+	d := hostSaying("tcp:10.0.0.1:6641", "6.0.0")
+	caps, unmet := d.Verify(context.Background())
+
+	if caps.Firewall {
+		t.Error("firewall survived a daemon below the floor: a group is created, " +
+			"attached, and enforces nothing, while health says it is delivered")
+	}
+	if len(unmet) != 1 || !strings.Contains(unmet[0], VersionText(IncusMinimum[:])) {
+		t.Errorf("the narrowing must cite the floor it applied, got %v", unmet)
+	}
+	// The floor itself, on the boundary rather than near it.
+	if exact := hostSaying("tcp:10.0.0.1:6641", VersionText(IncusMinimum[:])); !mustVerify(t, exact).Firewall {
+		t.Error("the floor version itself was refused: 6.0.4 runs everything this emulator asks for")
+	}
+}
+
+// An unreadable version keeps the capability rather than losing it.
+//
+// A daemon that answers `incus list` and whose version this cannot parse is far
+// more likely to be a format change than an old release. Refusing there would
+// turn a diagnostic gap into a lost capability, and the operator would have no
+// way to tell the two apart.
+func TestAnUnreadableVersionDoesNotCostTheCapability(t *testing.T) {
+	d := hostSaying("tcp:10.0.0.1:6641", "not a version")
+	caps, unmet := d.Verify(context.Background())
+
+	if !caps.Firewall {
+		t.Error("an unparseable version cost the firewall capability")
+	}
+	if len(unmet) != 0 {
+		t.Errorf("nothing was disproven, so nothing must be narrowed, got %v", unmet)
+	}
+}
+
+func mustVerify(t *testing.T, d *Incus) Capabilities {
+	t.Helper()
+	caps, _ := d.Verify(context.Background())
+	return caps
+}


### PR DESCRIPTION
`NewIncusOVN` set `OVN = true` and `isolation: true` followed, **whatever the host could do**. There was one `Available` for all three Incus modes and it ran `incus list`, so on any host whose daemon answers the OVN driver reported available — and `internal/cli/cli.go` carried a comment vouching for a fall-through that could therefore never trigger:

> The guess is cheap to make safe: the OVN driver's own availability check creates nothing, so a probe that fails costs one call and falls through to the bridge.

That probe did not exist. This is the defect class CLAUDE.md names, three audits deep, sitting on the line that chooses **what runs on the operator's host**.

## Measured before writing anything, on this station

Incus 7.2, no OVN wiring, `network.ovn.northbound_connection` unset, no OVN network:

```console
$ ./feint serve --vm auto
machine runtime: incus-ovn (isolation: true)
$ curl -s .../_feint/health | jq -c '{machines, isolation: .capabilities.isolation}'
{"machines":"incus-ovn","isolation":true}
```

The failure arrived at the first network creation, telling the client the address block was most likely already in use: loud, and blaming the wrong culprit.

**After, on the same station:**

```console
$ ./feint serve --vm auto
incus-ovn passed over: isolation: network.ovn.northbound_connection is unset,
  so no OVN network can be created (install ovn-central and ovn-host, and wire the northbound)
machine runtime: incus (isolation: false)

$ ./feint serve --vm incus-ovn ; echo $?
feint: --vm incus-ovn requested but this host cannot deliver it:
  isolation: network.ovn.northbound_connection is unset, ...
1
```

`--vm incus` is still accepted, which is the half a guard that refuses everything would also pass.

## Why a false capability is worse than none

This project sends every consumer to `capabilities.isolation` rather than to a mode name. That rule is right, and it makes a false capability strictly worse: a suite obeying it asserts what the host cannot deliver, or skips what it could have proven.

## The probe creates nothing

Two reads, no network created, no uplink touched, no trace left — `auto` runs at every startup, on hosts that are perfectly healthy:

| capability | read | floor |
|---|---|---|
| isolation | `incus config get network.ovn.northbound_connection` | unset means no OVN network can exist |
| firewall | `incus query /1.0` → `environment.server_version` | 6.0.4, below which NIC ACLs are refused |

**The floor moved** to `internal/core/machine` rather than being copied into `serve`. Doctor had the only copy and serve had none; two copies is how a diagnostic says one thing and a capability another, which is #171's shape expressed in versions.

**An unreadable version keeps the capability.** A daemon that answers `incus list` and whose version this cannot parse is far more likely to be a format change than an old release; refusing there would turn a diagnostic gap into a lost capability, with no way for the operator to tell the two apart.

## The bound, stated rather than glossed

A wired northbound is **necessary and not sufficient**. A host whose *uplink* is misconfigured still publishes isolation and still fails at the first create. `docs/install.md` says so, and says why its own proof is a real `CreateSubnet` rather than the endpoint.

## Falsification

Four mutations in a copy outside the repository, each named test biting:

| mutation | test | verdict |
|---|---|---|
| the verified set is never published | `TestVerifyNarrowsWhatTheHostCannotDeliver` | red |
| an unset northbound counts as wired | same | red |
| the version floor stops applying | `TestVerifyRefusesTheFirewallBelowTheFloor` | red |
| an unreadable version costs the capability | `TestAnUnreadableVersionDoesNotCostTheCapability` | red |

**Two did not compile on the first attempt** — `if false {` left the variable they neutralised unused — so their verdicts were void rather than favourable, and both were rewritten to keep it live.

## Type of change

- [ ] A route added or changed
- [x] Bug fix
- [ ] Refactor
- [x] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes, via `mise run prepush`
- [x] No new external Go dependency
- [x] `internal/core` still knows no provider
- [x] Nothing in the diff could be written identically for another provider: this is the runtime layer, shared by all three packs

### When a model wrote a substantive part of this

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] **`mise run conformance` was run in full and passed** (exit 0)
- [x] Every claim was measured on this host before being written: the before, the after, the refusal and its exit code are all runs, not recollections

### When a route is added or changed

N/A.

### When behaviour a client can observe changes

- [x] `docs/install.md` updated: what the probe closes, and the case it does not
- [x] `feint docs --check` returns 0

### When `.github/workflows/` is touched

N/A.

### When a machine runtime is involved

- [x] Tested against the real Incus on this station, in the failing configuration and the working one
- [x] Nothing the emulator did not create was touched: both probes are reads
- [x] The run leaves nothing behind

## Related issues

Closes #181
