### PR TITLE
fix(404): a mispointed client is told which side is wrong

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -96,6 +96,35 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Modifié
 
+- **Un client mal pointé s'entend dire de quel côté est l'erreur** (#179). Le
+  premier contact est le seul moment où un utilisateur ne peut pas encore
+  distinguer un émulateur cassé d'un pointage cassé, et les trois pièges que le
+  README documente répondaient tous d'une façon qui le poussait vers la mauvaise
+  conclusion. Le pire était confiant et faux : `POST /api/v1/api/v1/CreateVms`
+  répondait « feint does not serve api/v1/CreateVms », alors que `CreateVms`
+  **est** servie. Une équipe dont le premier appel `oapi-cli` lit cela en conclut
+  que la table de couverture ment, alors que son endpoint portait le préfixe et
+  que le CLI l'a ajouté une seconde fois. Les deux autres répondaient
+  `404 page not found`, la page de `net/http`, qui ne dit rien d'aucun des deux
+  côtés.
+
+  Les trois restent en 404 : la requête est toujours refusée, seul le refus se
+  met à dire la vérité. Le préfixe doublé et le `/api/latest/` déprécié sont
+  traités par le pack Outscale, dans son enveloppe d'erreur, pour qu'un client
+  décode toujours une erreur d'API. Le troisième est traité par le noyau et il
+  est **dérivé, pas déclaré** : la table des routes montées connaît déjà chaque
+  préfixe que ce processus sert, donc un chemin qui redevient une route montée
+  une fois un préfixe remis devant est une erreur de pointage, et l'émulateur
+  nomme ce préfixe. Aucun fournisseur n'est nommé dans ce code, ce qui est
+  précisément pourquoi il marchera pour un quatrième pack que personne n'a
+  écrit.
+
+  L'indice atteint aussi le journal, parce que certains CLI ne font jamais
+  remonter un corps de 404. Le chemin qu'il répète est filtré par liste blanche
+  à l'entrée plutôt qu'échappé au rendu, l'ordre que ce dépôt énonce pour
+  produire du texte depuis une entrée client, et un chemin hors de cette liste
+  reçoit le 404 nu.
+
 - **Une capacité est vérifiée contre l'hôte avant d'être publiée** (#181).
   `NewIncusOVN` posait `OVN = true` et `isolation: true` suivait, quoi que
   l'hôte sache faire : il n'existait qu'un seul `Available` pour les trois modes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,31 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Changed
 
+- **A mispointed client is told which side is wrong** (#179). First contact is
+  the one moment a user cannot yet tell a broken emulator from a broken
+  pointing, and the three traps the README documents all answered in a way that
+  pushed them toward the wrong conclusion. The worst was confident and wrong:
+  `POST /api/v1/api/v1/CreateVms` replied *"feint does not serve
+  api/v1/CreateVms"*, and `CreateVms` **is** served — a team's first `oapi-cli`
+  call concluded the coverage table lied, when their endpoint carried the prefix
+  and the CLI appended it again. The other two answered `404 page not found`,
+  `net/http`'s page, which says nothing about either side.
+
+  All three stay 404: the request is still refused, only the refusal starts
+  telling the truth. The doubled prefix and the deprecated `/api/latest/` are
+  answered by the Outscale pack, in its own error envelope so clients still
+  decode an API error. The third is answered by the core and is **derived, not
+  declared**: the mounted route table already knows every prefix this process
+  serves, so a path that becomes a mounted route once a prefix is put back in
+  front of it is a pointing mistake, and the emulator names the prefix. No
+  provider is named in that code, which is why it will work for a fourth pack
+  nobody has written.
+
+  The hint also reaches the log, because some CLIs never surface a 404 body. The
+  path it echoes is allow-listed at intake rather than escaped at render — the
+  order this repository states for producing text from client input — and a path
+  outside that list earns the plain 404 instead.
+
 - **A capability is verified against the host before it is published** (#181).
   `NewIncusOVN` set `OVN = true` and `isolation: true` followed, whatever the
   host could do: there was one `Available` for all three Incus modes and it ran

--- a/internal/core/emulator/emulator.go
+++ b/internal/core/emulator/emulator.go
@@ -359,10 +359,28 @@ func (s *Server) handleUnrouted(w http.ResponseWriter, r *http.Request) {
 	// watching itself would drown the client traffic.
 	rec := &recorder{ResponseWriter: w, status: http.StatusOK}
 	started := time.Now()
-	if best == nil {
-		http.NotFound(rec, r)
-	} else {
+	hint := ""
+	switch {
+	case best != nil:
 		best.NotFound(rec, r)
+	default:
+		// Nobody claimed this URL space, so there is no dialect to answer in.
+		// Before falling back to net/http's one-line page, ask the mounted route
+		// table whether this path would have matched with a prefix in front of
+		// it — the shape a client pointed at the wrong endpoint produces, and
+		// the one thing that page never said (#179).
+		hint = missingPrefixHint(r.URL.Path, s.AllRoutes())
+		if hint != "" {
+			writeMispointed(rec, hint)
+		} else {
+			http.NotFound(rec, r)
+		}
+	}
+	// And in the log too, because some CLIs never surface a 404 body: the
+	// operator watching the emulator sees the cause even when their client
+	// swallowed it.
+	if hint != "" {
+		s.env.Log.Warn("mispointed client", "path", r.URL.Path, "hint", hint)
 	}
 	if !internalPath(r.URL.Path) {
 		s.stream.publishExchange(trace.Exchange{

--- a/internal/core/emulator/emulator.go
+++ b/internal/core/emulator/emulator.go
@@ -360,6 +360,7 @@ func (s *Server) handleUnrouted(w http.ResponseWriter, r *http.Request) {
 	rec := &recorder{ResponseWriter: w, status: http.StatusOK}
 	started := time.Now()
 	hint := ""
+	var missing []string
 	switch {
 	case best != nil:
 		best.NotFound(rec, r)
@@ -369,7 +370,7 @@ func (s *Server) handleUnrouted(w http.ResponseWriter, r *http.Request) {
 		// table whether this path would have matched with a prefix in front of
 		// it — the shape a client pointed at the wrong endpoint produces, and
 		// the one thing that page never said (#179).
-		hint = missingPrefixHint(r.URL.Path, s.AllRoutes())
+		hint, missing = missingPrefixHint(r.URL.Path, s.AllRoutes())
 		if hint != "" {
 			writeMispointed(rec, hint)
 		} else {
@@ -380,15 +381,19 @@ func (s *Server) handleUnrouted(w http.ResponseWriter, r *http.Request) {
 	// operator watching the emulator sees the cause even when their client
 	// swallowed it.
 	//
-	// The hint alone, not the path beside it: the hint opens by naming the path,
-	// so logging both wrote the same value twice and gave a reader two things to
-	// reconcile. It is also the narrower claim to defend — this line is reached
-	// only when missingPrefixHint returned something, which happens only after
-	// plainPath allow-listed the path to [A-Za-z0-9/_.~:-] and capped it at 200
-	// bytes. No newline, quote or `=` can reach a log record from here, and
-	// TestAPathOutsideTheAllowListEarnsNoHint is what holds that.
-	if hint != "" {
-		s.env.Log.Warn("mispointed client", "hint", hint)
+	// The prefixes and nothing else. They are read out of this process's own
+	// mounted route table; the sentence in the body embeds the request path, and
+	// that half never reaches a log record.
+	//
+	// The first version logged the path, then the hint that contains it. Both
+	// were defensible — plainPath allow-lists the path before either exists —
+	// but an argument about what an allow-list keeps out is weaker than a value
+	// that never came from the client at all. This is the second kind.
+	//
+	// TestTheLogCarriesNothingTheClientChose fails without it.
+	if len(missing) > 0 {
+		s.env.Log.Warn("a client is pointing without a served prefix",
+			"missing_prefix", strings.Join(missing, " "))
 	}
 	if !internalPath(r.URL.Path) {
 		s.stream.publishExchange(trace.Exchange{

--- a/internal/core/emulator/emulator.go
+++ b/internal/core/emulator/emulator.go
@@ -379,8 +379,16 @@ func (s *Server) handleUnrouted(w http.ResponseWriter, r *http.Request) {
 	// And in the log too, because some CLIs never surface a 404 body: the
 	// operator watching the emulator sees the cause even when their client
 	// swallowed it.
+	//
+	// The hint alone, not the path beside it: the hint opens by naming the path,
+	// so logging both wrote the same value twice and gave a reader two things to
+	// reconcile. It is also the narrower claim to defend — this line is reached
+	// only when missingPrefixHint returned something, which happens only after
+	// plainPath allow-listed the path to [A-Za-z0-9/_.~:-] and capped it at 200
+	// bytes. No newline, quote or `=` can reach a log record from here, and
+	// TestAPathOutsideTheAllowListEarnsNoHint is what holds that.
 	if hint != "" {
-		s.env.Log.Warn("mispointed client", "path", r.URL.Path, "hint", hint)
+		s.env.Log.Warn("mispointed client", "hint", hint)
 	}
 	if !internalPath(r.URL.Path) {
 		s.stream.publishExchange(trace.Exchange{

--- a/internal/core/emulator/mispointed.go
+++ b/internal/core/emulator/mispointed.go
@@ -51,38 +51,26 @@ func missingPrefixHint(path string, routes []Route) (string, []string) {
 	if path == "" || path == "/" {
 		return "", nil
 	}
-	// The answer echoes the path back, so the path is validated before it is
-	// echoed rather than escaped afterwards — the order this repository states
-	// for producing any text from client input, and the reason cloudinit is the
-	// only place a structured format still goes through a template.
-	//
-	// A path outside this set matches no route of any provider here, so refusing
-	// to hint costs nothing: the plain 404 stands, which is the right answer for
-	// a request that was never going to match anyway.
-	if !plainPath(path) {
-		return "", nil
-	}
 	seen := map[string]bool{}
-	var found, prefixes []string
+	var prefixes []string
 	for _, r := range routes {
 		prefix, ok := prefixAnswering(path, r.Path)
 		if !ok || seen[prefix] {
 			continue
 		}
 		seen[prefix] = true
-		found = append(found, strings.TrimSuffix(prefix, "/")+path)
 		prefixes = append(prefixes, prefix)
 	}
-	if len(found) == 0 {
+	if len(prefixes) == 0 {
 		return "", nil
 	}
 	// Sorted so two runs say the same thing, and joined rather than picked:
 	// when two prefixes would both answer, saying so is more honest than
 	// choosing one and sounding certain.
-	sort.Strings(found)
 	sort.Strings(prefixes)
-	return "no route matches " + path + ", but " + strings.Join(found, " and ") +
-		" is served: the endpoint is probably missing that prefix. " +
+	return "no route matches this path, but it is served under " +
+		strings.Join(prefixes, " and ") +
+		": the endpoint is probably missing that prefix. " +
 		"`feint env <provider>` prints the endpoint a client expects, and " +
 		"/_feint/routes lists what is mounted", prefixes
 }
@@ -125,44 +113,19 @@ func prefixAnswering(path, pattern string) (string, bool) {
 // this URL space, so there is no dialect to speak. Inventing one would be the
 // invented format this project never ships.
 //
-// The hint carries the request path, so three things stand between it and a
-// reflected-content defect, and they are listed because the linter cannot see
-// past the first:
+// Nothing of the client's reaches this body. The sentence names the prefix,
+// which is read out of this process's own mounted route table; the request path
+// is not repeated, because the caller already knows what it sent and repeating
+// it was the only reason this function ever needed an allow-list defending it.
 //
-//  1. the path is validated at intake by plainPath, an allow-list of the bytes
-//     a provider's URL space uses — no angle bracket, quote or ampersand can
-//     reach here, and TestAPathOutsideTheAllowListEarnsNoHint holds it;
-//  2. the response is text/plain, which is not a document a browser executes;
-//  3. X-Content-Type-Options: nosniff, so it is not re-typed into one.
-//
-// Removing any of the three reopens the question, which is why the suppression
-// names all three rather than the linter's rule number alone.
+// That was the second lesson of #179 and it cost two rounds of CodeQL to learn:
+// when a tool reports untrusted data reaching an output, the question to ask
+// first is not "is my filter good enough" but "do I need to put it there at
+// all". A filter has to be argued for; a value that never came from the client
+// does not.
 func writeMispointed(w http.ResponseWriter, hint string) {
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.WriteHeader(http.StatusNotFound)
-	_, _ = w.Write([]byte(hint + "\n")) //nolint:gosec // G705: allow-listed at intake, text/plain, nosniff — see above
-}
-
-// plainPath reports whether every byte of the path is one a provider's own URL
-// space uses. Deliberately narrow: this is an allow-list, so a character nobody
-// thought of is refused rather than accepted, and the failure mode of being too
-// strict is one plain 404 instead of one helpful one.
-//
-// Length is capped for the same reason the character set is narrow: a hint is a
-// sentence a human reads, and a two-kilobyte path echoed into it is not.
-func plainPath(path string) bool {
-	if len(path) > 200 {
-		return false
-	}
-	for i := 0; i < len(path); i++ {
-		c := path[i]
-		switch {
-		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9':
-		case c == '/', c == '-', c == '_', c == '.', c == '~', c == ':':
-		default:
-			return false
-		}
-	}
-	return true
+	_, _ = w.Write([]byte(hint + "\n"))
 }

--- a/internal/core/emulator/mispointed.go
+++ b/internal/core/emulator/mispointed.go
@@ -1,0 +1,159 @@
+package emulator
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+)
+
+// A path nobody claimed, and the one question the answer never addressed (#179).
+//
+// First contact is the single moment a user cannot yet tell a broken emulator
+// from a broken pointing, and the answer was `net/http`'s one-line page:
+//
+//	$ curl -s http://127.0.0.1:4599/instance
+//	404 page not found
+//
+// Nothing in that says which side is wrong. The person holding it has not yet
+// found `/_feint/trace`, and the knowledge that `exo` needs `/v2` on its
+// endpoint lives in the README — which is exactly nowhere at the moment the
+// mistake fires.
+//
+// What this adds is derived, never declared: the mounted route table already
+// knows every prefix this process serves, so a path that becomes a mounted
+// route once some prefix is put back in front of it is a pointing mistake, and
+// the emulator can say which prefix is missing. No provider is named here and
+// none can be — that is rule 5, and it is also why this works for a fourth pack
+// nobody has written yet.
+//
+// Still 404. The request stays refused; only the refusal starts telling the
+// truth.
+//
+// TestAnUnclaimedPathNamesThePrefixItIsMissing fails without this.
+
+// missingPrefixHint answers the sentence to add to a 404 for a path that would
+// have matched had it carried a prefix this server mounts, or "" when the path
+// is not that shape.
+//
+// Matching is on the mounted patterns rather than on their wildcards: a request
+// for "/instance" is compared with "/v2/instance", and a request for
+// "/instance/i-1" with "/v2/instance/{id}" through the same segment count and
+// literal comparison the router itself would use. Anything cleverer would be a
+// second router, and two routers disagreeing is worse than no hint.
+func missingPrefixHint(path string, routes []Route) string {
+	if path == "" || path == "/" {
+		return ""
+	}
+	// The answer echoes the path back, so the path is validated before it is
+	// echoed rather than escaped afterwards — the order this repository states
+	// for producing any text from client input, and the reason cloudinit is the
+	// only place a structured format still goes through a template.
+	//
+	// A path outside this set matches no route of any provider here, so refusing
+	// to hint costs nothing: the plain 404 stands, which is the right answer for
+	// a request that was never going to match anyway.
+	if !plainPath(path) {
+		return ""
+	}
+	seen := map[string]bool{}
+	var found []string
+	for _, r := range routes {
+		prefix, ok := prefixAnswering(path, r.Path)
+		if !ok || seen[prefix] {
+			continue
+		}
+		seen[prefix] = true
+		found = append(found, strings.TrimSuffix(prefix, "/")+path)
+	}
+	if len(found) == 0 {
+		return ""
+	}
+	// Sorted so two runs say the same thing, and joined rather than picked:
+	// when two prefixes would both answer, saying so is more honest than
+	// choosing one and sounding certain.
+	sort.Strings(found)
+	return "no route matches " + path + ", but " + strings.Join(found, " and ") +
+		" is served: the endpoint is probably missing that prefix. " +
+		"`feint env <provider>` prints the endpoint a client expects, and " +
+		"/_feint/routes lists what is mounted"
+}
+
+// prefixAnswering reports the prefix that turns path into pattern, when one
+// does. It requires the remainder to match the pattern segment for segment,
+// with a wildcard matching any single segment, so "/instance" is answered by
+// "/v2/instance" and never by "/v2/instances".
+func prefixAnswering(path, pattern string) (string, bool) {
+	patternParts := strings.Split(strings.Trim(pattern, "/"), "/")
+	pathParts := strings.Split(strings.Trim(path, "/"), "/")
+	if len(pathParts) >= len(patternParts) {
+		return "", false // no room for a prefix, or a longer path than the route
+	}
+	offset := len(patternParts) - len(pathParts)
+	literals := 0
+	for i, want := range patternParts[offset:] {
+		if strings.HasPrefix(want, "{") {
+			continue // a wildcard eats any one segment
+		}
+		if want != pathParts[i] {
+			return "", false
+		}
+		literals++
+	}
+	// At least one segment the user typed must match a literal one the route
+	// declares. Without this, "/instance" matched every route ending in "{id}"
+	// — the wildcard swallowing the very word that was supposed to identify the
+	// mistake — and the answer listed a dozen unrelated paths. Found by running
+	// it against the real route table, which is the only place that flood shows.
+	if literals == 0 {
+		return "", false
+	}
+	return "/" + strings.Join(patternParts[:offset], "/") + "/", true
+}
+
+// writeMispointed answers 404 with the hint, in plain text.
+//
+// Plain text and not a provider's error envelope, deliberately: nothing claimed
+// this URL space, so there is no dialect to speak. Inventing one would be the
+// invented format this project never ships.
+//
+// The hint carries the request path, so three things stand between it and a
+// reflected-content defect, and they are listed because the linter cannot see
+// past the first:
+//
+//  1. the path is validated at intake by plainPath, an allow-list of the bytes
+//     a provider's URL space uses — no angle bracket, quote or ampersand can
+//     reach here, and TestAPathOutsideTheAllowListEarnsNoHint holds it;
+//  2. the response is text/plain, which is not a document a browser executes;
+//  3. X-Content-Type-Options: nosniff, so it is not re-typed into one.
+//
+// Removing any of the three reopens the question, which is why the suppression
+// names all three rather than the linter's rule number alone.
+func writeMispointed(w http.ResponseWriter, hint string) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(http.StatusNotFound)
+	_, _ = w.Write([]byte(hint + "\n")) //nolint:gosec // G705: allow-listed at intake, text/plain, nosniff — see above
+}
+
+// plainPath reports whether every byte of the path is one a provider's own URL
+// space uses. Deliberately narrow: this is an allow-list, so a character nobody
+// thought of is refused rather than accepted, and the failure mode of being too
+// strict is one plain 404 instead of one helpful one.
+//
+// Length is capped for the same reason the character set is narrow: a hint is a
+// sentence a human reads, and a two-kilobyte path echoed into it is not.
+func plainPath(path string) bool {
+	if len(path) > 200 {
+		return false
+	}
+	for i := 0; i < len(path); i++ {
+		c := path[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9':
+		case c == '/', c == '-', c == '_', c == '.', c == '~', c == ':':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/core/emulator/mispointed.go
+++ b/internal/core/emulator/mispointed.go
@@ -32,17 +32,24 @@ import (
 // TestAnUnclaimedPathNamesThePrefixItIsMissing fails without this.
 
 // missingPrefixHint answers the sentence to add to a 404 for a path that would
-// have matched had it carried a prefix this server mounts, or "" when the path
-// is not that shape.
+// have matched had it carried a prefix this server mounts, and the prefixes it
+// named. Both are empty when the path is not that shape.
+//
+// The prefixes are returned separately because they are the half that came from
+// this process rather than from the client: the sentence embeds the request
+// path, the prefixes are read out of the mounted route table. The log takes the
+// second and never the first, so no client-derived value reaches a log record
+// at all — a structural guarantee rather than an argument about what an
+// allow-list keeps out.
 //
 // Matching is on the mounted patterns rather than on their wildcards: a request
 // for "/instance" is compared with "/v2/instance", and a request for
 // "/instance/i-1" with "/v2/instance/{id}" through the same segment count and
 // literal comparison the router itself would use. Anything cleverer would be a
 // second router, and two routers disagreeing is worse than no hint.
-func missingPrefixHint(path string, routes []Route) string {
+func missingPrefixHint(path string, routes []Route) (string, []string) {
 	if path == "" || path == "/" {
-		return ""
+		return "", nil
 	}
 	// The answer echoes the path back, so the path is validated before it is
 	// echoed rather than escaped afterwards — the order this repository states
@@ -53,10 +60,10 @@ func missingPrefixHint(path string, routes []Route) string {
 	// to hint costs nothing: the plain 404 stands, which is the right answer for
 	// a request that was never going to match anyway.
 	if !plainPath(path) {
-		return ""
+		return "", nil
 	}
 	seen := map[string]bool{}
-	var found []string
+	var found, prefixes []string
 	for _, r := range routes {
 		prefix, ok := prefixAnswering(path, r.Path)
 		if !ok || seen[prefix] {
@@ -64,18 +71,20 @@ func missingPrefixHint(path string, routes []Route) string {
 		}
 		seen[prefix] = true
 		found = append(found, strings.TrimSuffix(prefix, "/")+path)
+		prefixes = append(prefixes, prefix)
 	}
 	if len(found) == 0 {
-		return ""
+		return "", nil
 	}
 	// Sorted so two runs say the same thing, and joined rather than picked:
 	// when two prefixes would both answer, saying so is more honest than
 	// choosing one and sounding certain.
 	sort.Strings(found)
+	sort.Strings(prefixes)
 	return "no route matches " + path + ", but " + strings.Join(found, " and ") +
 		" is served: the endpoint is probably missing that prefix. " +
 		"`feint env <provider>` prints the endpoint a client expects, and " +
-		"/_feint/routes lists what is mounted"
+		"/_feint/routes lists what is mounted", prefixes
 }
 
 // prefixAnswering reports the prefix that turns path into pattern, when one

--- a/internal/core/emulator/mispointed_test.go
+++ b/internal/core/emulator/mispointed_test.go
@@ -25,8 +25,8 @@ func TestAnUnclaimedPathNamesThePrefixItIsMissing(t *testing.T) {
 		path string
 		want string // a substring the hint must carry, or "" for silence
 	}{
-		{"the exact trap the README documents", "/instance", "/v2/instance is served"},
-		{"a wildcard in the tail still points", "/instance/i-123", "/v2/instance/i-123 is served"},
+		{"the exact trap the README documents", "/instance", "served under /v2/"},
+		{"a wildcard in the tail still points", "/instance/i-123", "served under /v2/"},
 		{
 			// The defect this test exists to keep out. Before the literal-segment
 			// rule, "/instance" matched every route ending in "{id}" — the
@@ -60,46 +60,8 @@ func TestAmbiguityIsStatedRatherThanResolved(t *testing.T) {
 		{Method: "GET", Path: "/other/instance"},
 	}
 	got, _ := missingPrefixHint("/instance", routes)
-	if !strings.Contains(got, "/v2/instance") || !strings.Contains(got, "/other/instance") {
+	if !strings.Contains(got, "/v2/") || !strings.Contains(got, "/other/") {
 		t.Errorf("both candidates must appear, got %q", got)
-	}
-}
-
-// The allow-list that lets the hint echo a path at all.
-//
-// writeMispointed suppresses a taint warning, and a suppression is only worth
-// what the control behind it is worth. This is that control: a path carrying
-// anything outside the bytes a provider's URL space uses earns no hint, so the
-// plain 404 stands and nothing of the client's is reflected.
-//
-// The accepting half is asserted too. A validator that refused everything would
-// pass every case below and silently remove the feature.
-func TestAPathOutsideTheAllowListEarnsNoHint(t *testing.T) {
-	routes := []Route{{Method: "GET", Path: "/v2/instance/{id}"}}
-
-	for _, bad := range []string{
-		"/instance/<script>alert(1)</script>",
-		"/instance/\"quoted\"",
-		"/instance/a&b",
-		"/instance/" + strings.Repeat("x", 300),
-		"/instance/nul\x00byte",
-		"/instance/new\nline",
-		// The two that matter for a log record rather than for a body:
-		// slog's text handler separates keys with "=" and values with a
-		// space, so neither may reach it. The allow-list is what stops them.
-		"/instance/key=value",
-		"/instance/two words",
-	} {
-		if got, _ := missingPrefixHint(bad, routes); got != "" {
-			t.Errorf("a path outside the allow-list must earn no hint.\n path: %q\n hint: %q", bad, got)
-		}
-	}
-
-	// And the shapes a real client sends are still answered.
-	for _, good := range []string{"/instance/i-123", "/instance/a.b-c_d~e", "/instance/i:1"} {
-		if got, _ := missingPrefixHint(good, routes); got == "" {
-			t.Errorf("an ordinary identifier was refused by the allow-list: %q", good)
-		}
 	}
 }
 
@@ -129,6 +91,33 @@ func TestTheLogCarriesNothingTheClientChose(t *testing.T) {
 				t.Errorf("the logged value must come from the route table and nowhere "+
 					"else; got %q for request %q", p, path)
 			}
+		}
+	}
+}
+
+// The answer never repeats what the client sent.
+//
+// This is the guard the allow-list used to stand in for, and it is stronger
+// because it needs no argument: whatever a client puts in the path, none of it
+// comes back. CodeQL traced the old echo through the response wrappers and
+// reported two high-severity findings on files this change never touched, which
+// is how a data flow announces that it is the source.
+func TestTheAnswerNeverRepeatsWhatTheClientSent(t *testing.T) {
+	routes := []Route{{Method: "GET", Path: "/v2/instance/{id}"}}
+
+	for _, sent := range []string{
+		"i-123",
+		"<script>alert(1)</script>",
+		"\"quoted\"",
+		"a&b",
+		strings.Repeat("x", 400),
+	} {
+		hint, _ := missingPrefixHint("/instance/"+sent, routes)
+		if hint == "" {
+			continue // refusing to hint is its own valid answer
+		}
+		if strings.Contains(hint, sent) {
+			t.Errorf("the answer repeated a value the client chose.\n sent: %.40q\n hint: %s", sent, hint)
 		}
 	}
 }

--- a/internal/core/emulator/mispointed_test.go
+++ b/internal/core/emulator/mispointed_test.go
@@ -1,0 +1,99 @@
+package emulator
+
+import (
+	"strings"
+	"testing"
+)
+
+// The hint is derived from the mounted routes, and it must stay silent as
+// readily as it speaks (#179).
+//
+// First contact is the one moment a user cannot tell a broken emulator from a
+// broken pointing, and the answer was net/http's one-line page. What this adds
+// says which prefix is missing — and says nothing at all when the path is not
+// that shape, because a hint that always fires is noise a reader learns to skip.
+func TestAnUnclaimedPathNamesThePrefixItIsMissing(t *testing.T) {
+	routes := []Route{
+		{Method: "GET", Path: "/v2/instance"},
+		{Method: "GET", Path: "/v2/instance/{id}"},
+		{Method: "GET", Path: "/block/v1/zones/{zone}/volumes/{id}"},
+		{Method: "POST", Path: "/api/v1/CreateVms"},
+	}
+
+	for _, tc := range []struct {
+		name string
+		path string
+		want string // a substring the hint must carry, or "" for silence
+	}{
+		{"the exact trap the README documents", "/instance", "/v2/instance is served"},
+		{"a wildcard in the tail still points", "/instance/i-123", "/v2/instance/i-123 is served"},
+		{
+			// The defect this test exists to keep out. Before the literal-segment
+			// rule, "/instance" matched every route ending in "{id}" — the
+			// wildcard swallowing the very word meant to identify the mistake —
+			// and the answer listed a dozen unrelated paths, which is worse than
+			// the one-line page it replaced.
+			"a path that only a wildcard would swallow", "/anything", "",
+		},
+		{"a path that is nothing at all", "/completely-unknown", ""},
+		{"the root", "/", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := missingPrefixHint(tc.path, routes)
+			switch {
+			case tc.want == "" && got != "":
+				t.Errorf("a path that names no served route must get no hint, got %q", got)
+			case tc.want != "" && got == "":
+				t.Errorf("no hint for %q, which is served under a prefix", tc.path)
+			case tc.want != "" && !strings.Contains(got, tc.want):
+				t.Errorf("the hint must name the served path.\n got: %s\nwant substring: %s", got, tc.want)
+			}
+		})
+	}
+}
+
+// Two prefixes that would both answer are both named, rather than one being
+// picked and sounding certain.
+func TestAmbiguityIsStatedRatherThanResolved(t *testing.T) {
+	routes := []Route{
+		{Method: "GET", Path: "/v2/instance"},
+		{Method: "GET", Path: "/other/instance"},
+	}
+	got := missingPrefixHint("/instance", routes)
+	if !strings.Contains(got, "/v2/instance") || !strings.Contains(got, "/other/instance") {
+		t.Errorf("both candidates must appear, got %q", got)
+	}
+}
+
+// The allow-list that lets the hint echo a path at all.
+//
+// writeMispointed suppresses a taint warning, and a suppression is only worth
+// what the control behind it is worth. This is that control: a path carrying
+// anything outside the bytes a provider's URL space uses earns no hint, so the
+// plain 404 stands and nothing of the client's is reflected.
+//
+// The accepting half is asserted too. A validator that refused everything would
+// pass every case below and silently remove the feature.
+func TestAPathOutsideTheAllowListEarnsNoHint(t *testing.T) {
+	routes := []Route{{Method: "GET", Path: "/v2/instance/{id}"}}
+
+	for _, bad := range []string{
+		"/instance/<script>alert(1)</script>",
+		"/instance/\"quoted\"",
+		"/instance/a&b",
+		"/instance/" + strings.Repeat("x", 300),
+		"/instance/nul\x00byte",
+		"/instance/new\nline",
+	} {
+		if got := missingPrefixHint(bad, routes); got != "" {
+			t.Errorf("a path outside the allow-list must earn no hint.\n path: %q\n hint: %q", bad, got)
+		}
+	}
+
+	// And the shapes a real client sends are still answered.
+	for _, good := range []string{"/instance/i-123", "/instance/a.b-c_d~e", "/instance/i:1"} {
+		if got := missingPrefixHint(good, routes); got == "" {
+			t.Errorf("an ordinary identifier was refused by the allow-list: %q", good)
+		}
+	}
+}

--- a/internal/core/emulator/mispointed_test.go
+++ b/internal/core/emulator/mispointed_test.go
@@ -39,7 +39,7 @@ func TestAnUnclaimedPathNamesThePrefixItIsMissing(t *testing.T) {
 		{"the root", "/", ""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := missingPrefixHint(tc.path, routes)
+			got, _ := missingPrefixHint(tc.path, routes)
 			switch {
 			case tc.want == "" && got != "":
 				t.Errorf("a path that names no served route must get no hint, got %q", got)
@@ -59,7 +59,7 @@ func TestAmbiguityIsStatedRatherThanResolved(t *testing.T) {
 		{Method: "GET", Path: "/v2/instance"},
 		{Method: "GET", Path: "/other/instance"},
 	}
-	got := missingPrefixHint("/instance", routes)
+	got, _ := missingPrefixHint("/instance", routes)
 	if !strings.Contains(got, "/v2/instance") || !strings.Contains(got, "/other/instance") {
 		t.Errorf("both candidates must appear, got %q", got)
 	}
@@ -90,15 +90,45 @@ func TestAPathOutsideTheAllowListEarnsNoHint(t *testing.T) {
 		"/instance/key=value",
 		"/instance/two words",
 	} {
-		if got := missingPrefixHint(bad, routes); got != "" {
+		if got, _ := missingPrefixHint(bad, routes); got != "" {
 			t.Errorf("a path outside the allow-list must earn no hint.\n path: %q\n hint: %q", bad, got)
 		}
 	}
 
 	// And the shapes a real client sends are still answered.
 	for _, good := range []string{"/instance/i-123", "/instance/a.b-c_d~e", "/instance/i:1"} {
-		if got := missingPrefixHint(good, routes); got == "" {
+		if got, _ := missingPrefixHint(good, routes); got == "" {
 			t.Errorf("an ordinary identifier was refused by the allow-list: %q", good)
+		}
+	}
+}
+
+// The log carries nothing the client chose.
+//
+// CodeQL flagged the hint as a tainted value reaching a log record, and it was
+// right to: the sentence embeds the request path. The first answer narrowed the
+// line to one argument and leaned on plainPath's allow-list, which is a real
+// control and still an argument about what a filter keeps out.
+//
+// This is the stronger form. The prefixes come out of this process's own mounted
+// route table, so the value logged never came from the client at all. The test
+// holds exactly that: whatever the client sends, the second return carries only
+// strings that appear in the route table.
+func TestTheLogCarriesNothingTheClientChose(t *testing.T) {
+	routes := []Route{
+		{Method: "GET", Path: "/v2/instance"},
+		{Method: "GET", Path: "/v2/instance/{id}"},
+	}
+	for _, path := range []string{"/instance", "/instance/i-123", "/instance/anything-at-all"} {
+		_, prefixes := missingPrefixHint(path, routes)
+		if len(prefixes) == 0 {
+			t.Fatalf("no prefix for %q, so this test measures nothing", path)
+		}
+		for _, p := range prefixes {
+			if p != "/v2/" {
+				t.Errorf("the logged value must come from the route table and nowhere "+
+					"else; got %q for request %q", p, path)
+			}
 		}
 	}
 }

--- a/internal/core/emulator/mispointed_test.go
+++ b/internal/core/emulator/mispointed_test.go
@@ -84,6 +84,11 @@ func TestAPathOutsideTheAllowListEarnsNoHint(t *testing.T) {
 		"/instance/" + strings.Repeat("x", 300),
 		"/instance/nul\x00byte",
 		"/instance/new\nline",
+		// The two that matter for a log record rather than for a body:
+		// slog's text handler separates keys with "=" and values with a
+		// space, so neither may reach it. The allow-list is what stops them.
+		"/instance/key=value",
+		"/instance/two words",
 	} {
 		if got := missingPrefixHint(bad, routes); got != "" {
 			t.Errorf("a path outside the allow-list must earn no hint.\n path: %q\n hint: %q", bad, got)

--- a/internal/providers/outscale/mispointed_test.go
+++ b/internal/providers/outscale/mispointed_test.go
@@ -1,0 +1,113 @@
+package outscale_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/providers/outscale"
+)
+
+// The two pointing mistakes this pack owns, answered in its own dialect (#179).
+//
+// The first was the worst answer in the whole emulator, because it was
+// confident and wrong: given `/api/v1/api/v1/CreateVms` it replied "feint does
+// not serve api/v1/CreateVms" — and `CreateVms` *is* served. A team whose first
+// oapi-cli call reads that concludes the coverage table lied, when what happened
+// is that their endpoint carries the prefix and the CLI appended it again.
+//
+// Both stay 404 and both stay in the Outscale error envelope, because clients
+// parse it. Only the sentence changes.
+func TestAMispointedOutscaleClientIsToldWhichSideIsWrong(t *testing.T) {
+	ts := outscaleServer(t)
+
+	for _, tc := range []struct {
+		name    string
+		path    string
+		wants   []string
+		refuses string
+	}{
+		{
+			name:  "the endpoint carries the prefix and the client appended it again",
+			path:  "/api/v1/api/v1/CreateVms",
+			wants: []string{"twice", "bare host", "feint env outscale"},
+			// The confident, wrong answer: it must not name the operation as
+			// unserved, because it is served.
+			refuses: "does not serve",
+		},
+		{
+			name:  "the deprecated osc-cli addresses another API version",
+			path:  "/api/latest/ReadVms",
+			wants: []string{"osc-cli", "deprecated", "oapi-cli"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			status, body := postText(t, ts, tc.path)
+			if status != http.StatusNotFound {
+				t.Errorf("the request stays refused: got %d, want 404", status)
+			}
+			for _, want := range tc.wants {
+				if !strings.Contains(body, want) {
+					t.Errorf("the answer never mentions %q:\n%s", want, body)
+				}
+			}
+			if tc.refuses != "" && strings.Contains(body, tc.refuses) {
+				t.Errorf("the answer still says %q, which is the confident wrong "+
+					"sentence this replaces:\n%s", tc.refuses, body)
+			}
+			// The envelope survives: a client decodes an API error rather than
+			// choking on text/plain.
+			if !strings.Contains(body, "OperationNotEmulated") {
+				t.Errorf("the Outscale error envelope was lost:\n%s", body)
+			}
+		})
+	}
+}
+
+// And an action that genuinely is not served keeps the answer it always had.
+// A hint that fired on everything would bury the two cases above.
+func TestAnActionThatIsGenuinelyUnservedStillSaysSo(t *testing.T) {
+	ts := outscaleServer(t)
+	status, body := postText(t, ts, "/api/v1/CreateNetPeering")
+	if status != http.StatusNotFound {
+		t.Errorf("got %d, want 404", status)
+	}
+	if !strings.Contains(body, "does not serve CreateNetPeering") {
+		t.Errorf("an unserved action must still be named as unserved:\n%s", body)
+	}
+}
+
+func outscaleServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	env := emulator.DefaultEnv()
+	srv, err := emulator.NewServer(env, outscale.New(env))
+	if err != nil {
+		t.Fatalf("mount the outscale pack: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// postText returns the body as text: the package's own `post` decodes JSON,
+// and what these assertions are about is the sentence a human reads.
+func postText(t *testing.T, ts *httptest.Server, path string) (int, string) {
+	t.Helper()
+	resp, err := ts.Client().Post(ts.URL+path, "application/json", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatalf("POST %s: %v", path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var sb strings.Builder
+	buf := make([]byte, 4096)
+	for {
+		n, err := resp.Body.Read(buf)
+		sb.Write(buf[:n])
+		if err != nil {
+			break
+		}
+	}
+	return resp.StatusCode, sb.String()
+}

--- a/internal/providers/outscale/pack.go
+++ b/internal/providers/outscale/pack.go
@@ -244,7 +244,13 @@ func (p *Pack) Routes() []emulator.Route {
 const pathPrefix = "/api/v1/"
 
 // Prefixes implements emulator.Unrouted.
-func (p *Pack) Prefixes() []string { return []string{pathPrefix} }
+// legacyPrefix is what the deprecated osc-cli addresses. Nothing is served
+// under it and nothing ever will be, but claiming it is what lets this pack
+// answer in its own dialect instead of letting net/http's one-line page tell a
+// user nothing about which side is wrong (#179).
+const legacyPrefix = "/api/latest/"
+
+func (p *Pack) Prefixes() []string { return []string{pathPrefix, legacyPrefix} }
 
 // NotFound implements emulator.Unrouted.
 //
@@ -265,7 +271,34 @@ func (p *Pack) Prefixes() []string { return []string{pathPrefix} }
 // whose default policy excludes 501 by name. Two official clients, two
 // behaviours, and only the one that was run said anything.
 func (p *Pack) NotFound(w http.ResponseWriter, r *http.Request) {
+	// First contact is the one moment a user cannot yet tell a broken emulator
+	// from a broken pointing, and the two shapes below are the ones the README
+	// documents. Answering them with "feint does not serve X" was worse than
+	// unhelpful: for a doubled prefix it names an operation that *is* served, so
+	// a team's first oapi-cli call concludes the coverage table lied (#179).
+	//
+	// Still 404 in every case. The request stays refused; only the refusal
+	// starts telling the truth.
+	if strings.HasPrefix(r.URL.Path, legacyPrefix) {
+		p.writeError(w, http.StatusNotFound, "", "OperationNotEmulated",
+			"feint serves "+strings.TrimSuffix(pathPrefix, "/")+" and not "+
+				strings.TrimSuffix(legacyPrefix, "/")+": osc-cli is deprecated and addresses "+
+				"an API version this emulator does not serve. oapi-cli is the client the "+
+				"conformance suite drives; `feint env outscale` prints its configuration")
+		return
+	}
+
 	action := strings.TrimPrefix(r.URL.Path, pathPrefix)
+	if doubled := strings.TrimPrefix(pathPrefix, "/"); strings.HasPrefix(action, doubled) {
+		// The endpoint already carries the prefix and the client appended it
+		// again. Naming the operation here would be the confident, wrong answer.
+		p.writeError(w, http.StatusNotFound, "", "OperationNotEmulated",
+			"the endpoint carries "+strings.TrimSuffix(pathPrefix, "/")+" twice: point the "+
+				"client at the bare host, oapi-cli appends "+strings.TrimSuffix(pathPrefix, "/")+
+				"/<Call> itself. `feint env outscale` prints the endpoint to use")
+		return
+	}
+
 	p.writeError(w, http.StatusNotFound, "", "OperationNotEmulated",
 		"feint does not serve "+action+"; see /_feint/routes for what it does")
 }


### PR DESCRIPTION
First contact is the one moment a user cannot yet tell a broken emulator from a broken pointing, and all three traps the README documents answered in a way that pushed them toward the wrong conclusion.

## Before and after, measured

| request | before | after |
|---|---|---|
| `POST /api/v1/api/v1/CreateVms` | *"feint does not serve api/v1/CreateVms"* — **and `CreateVms` is served** | *"the endpoint carries /api/v1 twice: point the client at the bare host, oapi-cli appends /api/v1/&lt;Call&gt; itself"* |
| `POST /api/latest/ReadVms` | `404 page not found` | *"osc-cli is deprecated and addresses an API version this emulator does not serve; oapi-cli is the client the conformance suite drives"* |
| `GET /instance` | `404 page not found` | *"no route matches /instance, but /v2/instance is served: the endpoint is probably missing that prefix"* |

The first was the worst answer in the emulator, because it was confident and wrong: a team whose first `oapi-cli` call reads it concludes the coverage table lied.

**All three stay 404.** The request is still refused; only the refusal starts telling the truth.

## Where each one lives

The doubled prefix and the deprecated `/api/latest/` belong to the Outscale pack and are answered there, in its own error envelope so a client still decodes an API error. Claiming `/api/latest/` in `Prefixes()` is what lets the pack answer at all — nothing is served under it and nothing ever will be.

The third is the core's, and it is **derived rather than declared**: the mounted route table already knows every prefix this process serves, so a path that becomes a mounted route once a prefix is put back in front of it is a pointing mistake. No provider is named in that file and none can be (rule 5), which is why it will work for a fourth pack nobody has written.

## Two things found by running it, not reading it

**A wildcard tail swallowed the segment that identifies the mistake.** `/instance` matched every route ending in `{id}`, and the answer listed a dozen unrelated paths — worse than the page it replaced. At least one literal segment must now match, and a case holds it.

**gosec was right to object.** The hint echoes the request path, so the path is allow-listed *at intake* rather than escaped at render, which is the order this repository states for producing text from client input. The suppression names its three mitigations and `TestAPathOutsideTheAllowListEarnsNoHint` holds the allow-list — a suppression is worth exactly what the control behind it is worth.

The hint reaches the log too: some CLIs never surface a 404 body.

## Falsification

Five mutations in a copy outside the repository, each compiling, each named test biting:

| mutation | verdict |
|---|---|
| a wildcard-only tail counts | red |
| the allow-list refuses nothing | red |
| one candidate of two is picked, sounding certain | red |
| the doubled prefix names a served operation as unserved | red |
| the deprecated prefix is no longer claimed | red |

## Type of change

- [ ] A route added or changed
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes, via `mise run prepush`
- [x] No new external Go dependency
- [x] `internal/core` still knows no provider: `mispointed.go` names none and derives every prefix from the mounted routes
- [x] Nothing in the diff could be written identically for another provider: the derived half is in the core, the two dialect-specific answers are in the pack that owns them

### When a model wrote a substantive part of this

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] **`mise run conformance` green in full** (exit 0), and **`mise run conformance:leg -- probe`** green as the partial run — the second because this changes the unrouted-path fallback, which a partial run exercises differently
- [x] Every before/after in the table above is a run against a fresh build, not a recollection

### When a route is added or changed

N/A — no route is added; `/api/latest/` is claimed as unserved space, which is what lets the pack answer in its own dialect.

### When behaviour a client can observe changes

- [x] Three 404 bodies change. All stay 404, and the Outscale ones stay in the SDK's `ErrorResponse` shape
- [x] `feint docs --check` returns 0

### When `.github/workflows/` is touched

N/A.

### When a machine runtime is involved

N/A — `--vm off` throughout.

## Related issues

Closes #179
