### PR TITLE
fix(lifecycle): stop says what it is about to discard

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -96,6 +96,22 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Modifié
 
+- **`feint stop` dit ce qu'il s'apprête à jeter** (#182). Le store est en
+  mémoire et `docs/limits.md` l'énonce dans une table de cycle de vie, mais cette
+  phrase vit sur une page qu'un utilisateur lit **après** s'être fait avoir :
+  quatre ressources existaient, `stop` a dit `stopped`, et rien d'autre.
+  `restart` est le cas le plus aigu, puisqu'un opérateur y recourt en pleine
+  session et le paie de tout son jeu d'essai.
+
+  Désormais une ligne sur stderr, avant le signal, qui nomme le compte et la
+  sortie de secours : ``discarding 4 resource(s) (started without --state);
+  `feint snapshot save <name>` before stopping would have kept them``. Jamais une
+  question, jamais un refus, puisque la CI pilote `stop` et que ses codes de
+  sortie sont une surface gelée. Elle se tait quand `--state` est enregistré,
+  quand le store est vide, et quand l'instance ne répond plus : un avertissement
+  à chaque arrêt sain est le motif que l'on apprend à ignorer. Le compte vient de
+  l'endpoint que `status` lit déjà, donc les deux ne peuvent pas diverger.
+
 - **Un client mal pointé s'entend dire de quel côté est l'erreur** (#179). Le
   premier contact est le seul moment où un utilisateur ne peut pas encore
   distinguer un émulateur cassé d'un pointage cassé, et les trois pièges que le

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,21 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Changed
 
+- **`feint stop` says what it is about to discard** (#182). The store is memory
+  and `docs/limits.md` states it in a lifecycle table, but that sentence lives on
+  a page a user reads *after* being bitten: four resources existed, `stop` said
+  `stopped`, and nothing else. `restart` is the sharper case, since an operator
+  reaches for it mid-session and pays with the whole fixture.
+
+  One line on stderr now, before the signal, naming the count and the way out:
+  ``discarding 4 resource(s) (started without --state); `feint snapshot save
+  <name>` before stopping would have kept them``. Never a prompt and never a
+  refusal, because CI drives `stop` and its exit codes are a frozen surface. It
+  stays quiet when `--state` was recorded, when the store is empty, and when the
+  instance no longer answers — a warning on every healthy stop is the pattern
+  people are trained to ignore. The count comes from the endpoint `status`
+  already reads, so the two cannot disagree.
+
 - **A mispointed client is told which side is wrong** (#179). First contact is
   the one moment a user cannot yet tell a broken emulator from a broken
   pointing, and the three traps the README documents all answered in a way that

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -410,11 +410,19 @@ where a runtime is configured).
 
 | Event | The store | The machines, networks and rule sets |
 |---|---|---|
-| Graceful exit (Ctrl-C, SIGTERM, `feint stop`) | lost (saved first with `--state`) | stay, labelled `user.feint.provider` |
+| Graceful exit (Ctrl-C, SIGTERM, `feint stop`) | lost, and **said out loud**: `feint stop` names the count it is about to discard when no `--state` was recorded (saved first with `--state`) | stay, labelled `user.feint.provider` |
 | Graceful exit with `--cleanup` | lost (saved first with `--state`) | swept before exit, counted out loud |
 | SIGKILL, crash, power loss | lost | stay, labelled — nothing had a chance to run |
-| Restart | starts empty | **named, never adopted**: startup warns "labelled machines from a previous run exist; nothing was adopted, `feint clean` removes them", listing them by name |
+| Restart | starts empty, with the same notice `stop` prints, because `restart` goes through it | **named, never adopted**: startup warns "labelled machines from a previous run exist; nothing was adopted, `feint clean` removes them", listing them by name |
 | `feint clean` | untouched (it is a separate process) | everything labelled is removed; the runtime is queried, and the sweep reports what it could not remove instead of claiming success |
+
+The store's own line was documentation only until #182. The model was right and
+this page stated it, but the sentence was read *after* being bitten: an operator
+reaching for `restart` mid-session paid with the whole fixture and learnt why
+here, later. `stop` now says it at the moment it happens, on stderr, once, and
+only when something is actually lost: with `--state` recorded it stays quiet,
+because a warning on every healthy stop is the pattern people are trained to
+ignore.
 
 Why restart never adopts: the store that gave those machines meaning died with
 the previous process. A machine resurrected from the runtime would be state

--- a/internal/cli/discard_test.go
+++ b/internal/cli/discard_test.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// What a stop is about to throw away, said at the moment it happens (#182).
+//
+// The store is memory and docs/limits.md says so in its lifecycle table, but
+// that sentence lives on a page a user reads after being bitten. `restart` is
+// the sharper case: an operator reaches for it mid-session and pays with the
+// whole fixture.
+//
+// Every case below is one of that issue's "what must not happen", and the
+// silent ones matter as much as the loud one: a warning on every healthy stop
+// is the pattern people are trained to ignore.
+func TestStopSaysWhatItIsAboutToDiscard(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		args      []string
+		resources int
+		answers   bool // does the health endpoint answer at all
+		truncated bool // does it answer with a body that decodes only halfway
+		want      string
+	}{
+		{
+			name:      "resources held and no --state recorded",
+			args:      []string{"serve", "--addr", "x", "--vm", "off"},
+			resources: 4,
+			answers:   true,
+			want:      "discarding 4 resource(s)",
+		},
+		{
+			name:      "--state recorded, so nothing is lost",
+			args:      []string{"serve", "--addr", "x", "--state", "/tmp/s.json"},
+			resources: 4,
+			answers:   true,
+			want:      "",
+		},
+		{
+			name:      "--state=value spelled with an equals sign",
+			args:      []string{"serve", "--addr", "x", "--state=/tmp/s.json"},
+			resources: 4,
+			answers:   true,
+			want:      "",
+		},
+		{
+			name:      "an empty store loses nothing",
+			args:      []string{"serve", "--addr", "x"},
+			resources: 0,
+			answers:   true,
+			want:      "",
+		},
+		{
+			name:      "an instance that no longer answers is stopped as before",
+			args:      []string{"serve", "--addr", "x"},
+			resources: 4,
+			answers:   false,
+			want:      "",
+		},
+		{
+			// The case that makes the error branch load-bearing rather than
+			// decorative. A truncated body decodes far enough to set the count
+			// and then fails: trusting it would accuse a stop of discarding
+			// four resources on the word of a response that never arrived
+			// whole. Found by falsifying — the first version of this test used
+			// a 500, whose empty body leaves the count at zero, so the
+			// zero-check caught it and the error branch proved nothing.
+			name:      "a truncated answer is not trusted for its count",
+			args:      []string{"serve", "--addr", "x"},
+			resources: 4,
+			truncated: true,
+			answers:   true,
+			want:      "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if !tc.answers {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				if tc.truncated {
+					_, _ = fmt.Fprintf(w, `{"status": "ok", "resources": %d`, tc.resources)
+					return
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"status": "ok", "resources": tc.resources,
+				})
+			}))
+			t.Cleanup(ts.Close)
+
+			inst := &Instance{Addr: strings.TrimPrefix(ts.URL, "http://"), Args: tc.args}
+			got := discardNotice(inst)
+
+			switch {
+			case tc.want == "" && got != "":
+				t.Errorf("nothing is being lost here, so the stop must stay quiet; got %q", got)
+			case tc.want != "" && !strings.Contains(got, tc.want):
+				t.Errorf("the notice must name what is lost.\n got: %q\nwant substring: %q", got, tc.want)
+			}
+			if got != "" && !strings.Contains(got, "snapshot save") {
+				t.Errorf("the notice must name the way out, not only the loss: %q", got)
+			}
+		})
+	}
+}

--- a/internal/cli/lifecycle.go
+++ b/internal/cli/lifecycle.go
@@ -271,6 +271,12 @@ func stop(args []string, stdout, stderr io.Writer) int {
 	case Alive:
 	}
 
+	// What this stop is about to throw away, said at the moment it happens
+	// rather than on a page read afterwards (#182).
+	if notice := discardNotice(inst); notice != "" {
+		fmt.Fprint(stderr, notice)
+	}
+
 	if err := syscall.Kill(inst.PID, syscall.SIGTERM); err != nil && !errors.Is(err, syscall.ESRCH) {
 		fmt.Fprintf(stderr, "feint: %v\n", err)
 		return exitError
@@ -426,4 +432,52 @@ func logs(args []string, stdout, stderr io.Writer) int {
 			time.Sleep(200 * time.Millisecond)
 		}
 	}
+}
+
+// discardNotice answers the line to print before a stop that will lose the
+// session's resources, or "" when it will not.
+//
+// The store is memory and `docs/limits.md` says so in its lifecycle table, but
+// that sentence lives on a page a user reads *after* being bitten. At the only
+// moment the information is actionable, the verb that destroys the session was
+// mute (#182). `restart` is the sharper case: an operator reaches for it
+// mid-session and pays with the whole fixture.
+//
+// Three properties, each one a "what must not happen" from that issue:
+//
+//   - it never fires when --state was recorded, because the data is being kept
+//     and a warning on every healthy stop is the pattern people are trained to
+//     ignore. That check comes first, so a --state run pays no request at all;
+//   - the count comes from the endpoint `status` already reads, never from a
+//     second reader that could drift from it;
+//   - it is best-effort. An instance that no longer answers health is stopped
+//     exactly as before, within the same timeout, and the notice is dropped
+//     rather than waited for.
+//
+// One honest note about that last line, because falsifying it is what found it.
+// The `err != nil` half of the condition is **not load-bearing today**: measured
+// on Go 1.26, json.Decoder.Decode buffers the whole value before assigning, so a
+// truncated or refused answer leaves Resources at zero and the second half
+// already returns "". No mutation can distinguish the two, and a guard no test
+// can distinguish is not a control — it is kept as stated insurance against a
+// future encoding/json that assigns as it parses, which would turn a failed read
+// into a false accusation. Stated rather than implied, so nobody later reads it
+// as a proven guard.
+//
+// stderr, one line, never a prompt and never a refusal: CI drives stop, and its
+// exit codes are a frozen surface.
+//
+// TestStopSaysWhatItIsAboutToDiscard fails without this.
+func discardNotice(inst *Instance) string {
+	for _, arg := range inst.Args {
+		if arg == "--state" || strings.HasPrefix(arg, "--state=") {
+			return ""
+		}
+	}
+	health, err := fetchHealth(inst.Addr)
+	if err != nil || health.Resources == 0 {
+		return ""
+	}
+	return fmt.Sprintf("feint: discarding %d resource(s) (started without --state); "+
+		"`feint snapshot save <name>` before stopping would have kept them\n", health.Resources)
 }


### PR DESCRIPTION
The store is memory and `docs/limits.md` states it in a lifecycle table. The model is right; the sentence lives on a page a user reads **after** being bitten.

Measured with one Outscale `CreateNet` into a fresh emulator:

```console
$ feint status | grep resources
  resources  4
$ feint stop
stopped 127.0.0.1:4621 (pid 312178)
```

Four resources existed. `stop` said `stopped`, and nothing else. `restart` is the sharper case: an operator reaches for it mid-session and pays with the whole fixture.

## After

```console
$ feint stop --addr 127.0.0.1:4681
feint: discarding 4 resource(s) (started without --state); `feint snapshot save <name>` before stopping would have kept them
stopped 127.0.0.1:4681 (pid 570598)

$ feint stop --addr 127.0.0.1:4680      # started with --state
stopped 127.0.0.1:4680 (pid 570635)
```

`restart` inherits it by going through `stop`, verified against a real instance.

## Each silence is a rule from the issue

| situation | notice | why |
|---|---|---|
| resources held, no `--state` | **yes** | the only case where something is lost |
| `--state` recorded | no | the data is kept; a warning on every healthy stop is the pattern people are trained to ignore |
| empty store | no | nothing to lose |
| instance no longer answers | no | best-effort; the stop is unchanged and the notice is dropped, never waited for |

Never a prompt and never a refusal: CI drives `stop` and its exit codes are a frozen surface. The count comes from the endpoint `status` already reads, never from a second reader that could drift from it.

## One honest note the falsification produced

Three of four mutations bit. **The fourth could not**, and that is recorded in the code rather than tidied away: the `err != nil` half of the condition is not load-bearing today, because `json.Decoder.Decode` buffers the whole value before assigning, so a truncated or refused answer leaves the count at zero and the second half already answers.

Measured with a three-case program rather than reasoned about:

```
"{\"status\": \"ok\", \"resources\": 4"   -> resources=0 err=unexpected EOF
"{\"status\": \"ok\", \"resources\": 4}"  -> resources=4 err=<nil>
```

The branch stays as **declared insurance** against a future `encoding/json` that assigns as it parses, and the comment says exactly that. A guard no test can distinguish is not a control, and nobody should reread it in six months as a proven one.

| mutation | verdict |
|---|---|
| the notice never fires | red |
| it fires on a `--state` run too | red |
| it fires on an empty store | red |
| the error branch | **no mutation distinguishes it — recorded, not claimed** |

## Type of change

- [ ] A route added or changed
- [x] Bug fix
- [ ] Refactor
- [x] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes, via `mise run prepush`
- [x] No new external Go dependency
- [x] `internal/core` still knows no provider — the change is entirely in `internal/cli`
- [x] Nothing in the diff could be written identically for another provider

### When a model wrote a substantive part of this

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] **`mise run conformance` green in full** (exit 0) — it calls `stop` on every run, which is the control that matters here
- [x] Every before/after above is a run against a fresh build

### When a route is added or changed

N/A.

### When behaviour a client can observe changes

- [x] `docs/limits.md` updated: the lifecycle table's "lost" row is now also *said* at the moment it happens
- [x] `feint docs --check` returns 0

### When `.github/workflows/` is touched

N/A.

### When a machine runtime is involved

N/A — `--vm off` throughout.

## Related issues

Closes #182
