### PR TITLE
chore(falsify): the harness refuses the mutation that voided three verdicts

### DIFF
--- a/CONTRIBUTING.fr.md
+++ b/CONTRIBUTING.fr.md
@@ -48,7 +48,7 @@ runner.
 |---|---|---|
 | une route, une forme de réponse, une erreur | `mise run conformance` | qu'un vrai client passe encore |
 | un gate, un score, un verdict sur une exécution | `mise run conformance:leg -- <jambe>` | qu'il tient sur une exécution **partielle** |
-| une garde, une validation, un refus | la retirer dans une copie et lancer le test | que le test échoue sans elle |
+| une garde, une validation, un refus | `mise run falsify -- <spec.json>` | que le test échoue sans elle |
 | `internal/core/machine`, un réseau, un pare-feu | `FEINT_VM=incus-ovn mise run conformance` | que le runtime accepte ce que le pilote envoie |
 | un artefact de `coverage/` | `mise run evidence:update` | que le registre n'a pas rétréci |
 
@@ -70,6 +70,39 @@ La forme générale, qui vaut ailleurs : **un contrôle dont le verdict porte su
 « cette exécution » doit être éprouvé sur l'exécution la plus pauvre qui le
 déclenchera, jamais sur la plus riche.** La plus riche est celle qu'on a sous la
 main, et c'est ce qui rend l'erreur si facile.
+
+### Falsifier une garde
+
+Un test qui passe ne prouve rien par lui-même : il peut affirmer quelque chose
+qui était déjà vrai. `mise run falsify -- tools/falsify/specs/<nom>.json` retire
+la garde dans une copie **hors** du dépôt et exige que le test nommé rougisse.
+
+Il refuse une forme de mutation d'emblée, avant toute copie, et la raison est
+mesurée plutôt que théorique. En une seule journée d'août 2026, la même erreur a
+annulé un verdict trois fois, dans trois issues sans rapport :
+
+```go
+if ok && fe.EnforcesFirewall() {   ->  if ok {        // fe devient inutilisée
+if strings.TrimSpace(s) == "" {    ->  if false {     // s  devient inutilisée
+if err != nil || n == 0 {          ->  if n == 0 {    // err devient inutilisée
+```
+
+Go refuse de compiler une variable inutilisée, donc chaque mutation cassait la
+compilation. Or une mutation qui ne compile pas fait échouer **tous** les tests,
+ce qui ressemble exactement à une garde prouvée. Donc : **ne jamais supprimer le
+terme qui mentionne un nom.** Neutralisez la condition en gardant chaque nom
+évalué :
+
+```go
+if ok && fe != nil {
+if strings.TrimSpace(s) == "\x00never" {
+if (err != nil && false) || n == 0 {
+```
+
+`mise run falsify -- --selftest` tient cette règle contre ces quatre cas réels et
+contre leurs corrections, et `mise run prepush` le lance. Les deux moitiés
+comptent : une règle qui refuserait toute mutation passerait la première et
+rendrait l'outil inutile.
 
 `mise run conformance` n'est **délibérément pas** dans le hook. Il réclame `scw`,
 `oapi-cli`, `exo` et Terraform installés, et prend des minutes : en hook, il

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ pull request will refuse without ever depending on a runner's weather.
 |---|---|---|
 | a route, a response shape, an error | `mise run conformance` | that a real client still passes |
 | a gate, a score, a verdict about a run | `mise run conformance:leg -- <leg>` | that it holds on a **partial** run |
-| a guard, a validation, a refusal | remove it in a copy and run the test | that the test fails without it |
+| a guard, a validation, a refusal | `mise run falsify -- <spec.json>` | that the test fails without it |
 | `internal/core/machine`, a network, a firewall | `FEINT_VM=incus-ovn mise run conformance` | that the runtime accepts what the driver sends |
 | an artefact under `coverage/` | `mise run evidence:update` | that the record did not narrow |
 
@@ -64,6 +64,38 @@ The general form, worth carrying elsewhere: **a check whose verdict is about
 "this run" must be exercised on the poorest run that will trigger it, never on
 the richest.** The richest is the one you have in front of you, which is what
 makes the mistake so easy.
+
+### Falsifying a guard
+
+A test that passes proves nothing on its own: it may be asserting something that
+was already true. `mise run falsify -- tools/falsify/specs/<name>.json` removes
+the guard in a copy **outside** the repository and requires the named test to go
+red.
+
+It refuses one mutation shape outright, before copying anything, and the reason
+is measured rather than theoretical. On one day in August 2026 the same mistake
+voided a verdict three times, in three unrelated issues:
+
+```go
+if ok && fe.EnforcesFirewall() {   ->  if ok {        // fe is now unused
+if strings.TrimSpace(s) == "" {    ->  if false {     // s  is now unused
+if err != nil || n == 0 {          ->  if n == 0 {    // err is now unused
+```
+
+Go refuses to compile an unused variable, so each mutation broke the build — and
+a mutation that does not build fails *every* test, which looks exactly like the
+guard being proven. So: **never delete the term that mentions a name.**
+Neutralise the condition with every name still evaluated:
+
+```go
+if ok && fe != nil {
+if strings.TrimSpace(s) == "\x00never" {
+if (err != nil && false) || n == 0 {
+```
+
+`mise run falsify -- --selftest` holds that rule against those four real cases
+and against their fixes, and `mise run prepush` runs it. Both halves matter: a
+rule that refused every mutation would pass the first and make the tool useless.
 
 `mise run conformance` is deliberately **not** in the hook. It needs `scw`,
 `oapi-cli`, `exo` and Terraform installed and takes minutes; as a hook it would

--- a/mise.toml
+++ b/mise.toml
@@ -292,9 +292,19 @@ fi
 FEINT_FIELD_GATE=1 tools/conformance/score.sh "http://$FEINT_ADDR"
 """
 
+[tasks.falsify]
+description = "Run a falsification spec, or prove the harness on its own history: mise run falsify -- --selftest"
+# The procedure was followed by hand until the same mistake voided a verdict
+# three times in one day, in three unrelated issues: a mutation that deletes the
+# term mentioning a variable leaves it unused, Go refuses to compile, and every
+# test fails — which looks exactly like the guard being proven. Warning about it
+# was not enough, so the harness refuses it. tools/falsify/falsify.py carries the
+# rule and the three cases it was written for.
+run = "python3 tools/falsify/falsify.py"
+
 [tasks.prepush]
 description = "Everything a pull request will fail on that costs seconds and needs no client"
-depends = ["check", "docs:check", "drift:check", "shapes:check"]
+depends = ["check", "docs:check", "drift:check", "shapes:check", "falsify:selftest"]
 # What this is, and what it deliberately is not.
 #
 # These four are deterministic, offline, and take seconds: they can be a hook
@@ -308,6 +318,13 @@ depends = ["check", "docs:check", "drift:check", "shapes:check"]
 # reproduces one of those partial legs, and it is what to run when a change adds
 # or moves a gate. CLAUDE.md carries the decision table.
 run = "echo 'prepush passed - conformance and conformance:leg are the two it does not cover'"
+
+[tasks."falsify:selftest"]
+description = "Prove the falsification harness refuses the three mutations that voided a verdict"
+# Cheap, offline, no Go build: it holds the rule against the three real mistakes
+# of 2026-08-15 and against the three fixes. Both halves, because a rule that
+# refused every mutation would pass the first half and make the tool useless.
+run = "python3 tools/falsify/falsify.py --selftest"
 
 [tasks."conformance:leg"]
 description = "Reproduce one leg of the CI matrix locally: mise run conformance:leg -- probe"

--- a/tools/falsify/falsify.py
+++ b/tools/falsify/falsify.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""Run a falsification: remove a guard in a copy outside the repository, and
+require the test that names it to fail.
+
+    mise run falsify -- tools/falsify/specs/<name>.json
+
+Why this exists as a program rather than as a habit. `/falsify` was a procedure
+followed by hand, and on 2026-08-15 the same mistake voided a verdict three
+times in one day, across three unrelated issues:
+
+    if ok && fe.EnforcesFirewall() {   ->  if ok {                 # fe orphaned
+    if strings.TrimSpace(s) == "" {    ->  if false {              # s orphaned
+    if err != nil || n == 0 {          ->  if n == 0 {             # err orphaned
+
+Go refuses to compile an unused variable, so each mutation broke the build. A
+mutation that does not build makes *every* test fail, which looks exactly like
+the guard being proven — the failure mode `.claude/commands/falsify.md` already
+warned about, met three times anyway. Warning was not enough; this refuses.
+
+The rule it enforces, and it is the one that would have caught all three:
+
+    A MUTATION MUST NOT DROP AN IDENTIFIER THE ORIGINAL EXPRESSION USED.
+
+Neutralise a condition by making it never true while every name stays evaluated
+(`x && false`, `x == "\\x00never"`, `(err != nil && false) || ...`), never by
+deleting the term that mentions it.
+
+The spec is JSON:
+
+    {
+      "package": "./internal/cli/",
+      "mutations": [
+        {
+          "label": "the notice never fires",
+          "file": "internal/cli/lifecycle.go",
+          "find": "if err != nil || health.Resources == 0 {",
+          "replace": "if err != nil || health.Resources >= 0 {",
+          "test": "TestStopSaysWhatItIsAboutToDiscard",
+          "package": "./internal/cli/"
+        }
+      ]
+    }
+
+Per-mutation `package` is optional and falls back to the top-level one.
+"""
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+EXCLUDE = {".git", ".upstream", ".terraform", "notes", ".claude"}
+
+# Go keywords and predeclared names are not identifiers a mutation "uses": they
+# appear on both sides of every rewrite and would make the check vacuous.
+RESERVED = {
+    "break",
+    "case",
+    "chan",
+    "const",
+    "continue",
+    "default",
+    "defer",
+    "else",
+    "fallthrough",
+    "for",
+    "func",
+    "go",
+    "goto",
+    "if",
+    "import",
+    "interface",
+    "map",
+    "package",
+    "range",
+    "return",
+    "select",
+    "struct",
+    "switch",
+    "type",
+    "var",
+    "true",
+    "false",
+    "nil",
+    "len",
+    "cap",
+    "make",
+    "new",
+    "append",
+    "copy",
+    "delete",
+    "panic",
+    "recover",
+    "print",
+    "println",
+    "string",
+    "int",
+    "bool",
+    "byte",
+    "rune",
+    "error",
+    "any",
+}
+
+# Identifiers that are not preceded by a dot. A name after a selector is a field
+# or a method — dropping `EnforcesFirewall` from `fe.EnforcesFirewall()` orphans
+# nothing, while dropping `fe` orphans a variable and breaks the build. The
+# selftest found this on its first run: without the lookbehind the rule refused
+# `if ok && fe != nil {`, which is the safe form it exists to recommend.
+#
+# Package names stay in scope on purpose: an unused import is a compile error in
+# Go exactly as an unused variable is, so `strings` dropped from a fragment is
+# the same class of mistake.
+IDENT = re.compile(r"(?<![.\w])[A-Za-z_][A-Za-z0-9_]*")
+
+
+def identifiers(text):
+    """The identifiers a fragment of Go uses, minus keywords and builtins."""
+    return {name for name in IDENT.findall(text) if name not in RESERVED}
+
+
+# A short declaration inside the fragment: `x := ...` or `x, ok := ...`.
+DECLARED = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_,\s]*?)\s*:=", re.MULTILINE)
+
+
+def orphaned_by_declaration(replace):
+    """Names the replacement declares and then never uses again.
+
+    Presence alone is not enough, and an end-to-end run is what proved it: a
+    fragment that carries its own `fe, ok := p.(FirewallEnforcer)` line keeps the
+    word `fe` on both sides of any rewrite, so the set difference below saw
+    nothing lost while Go saw an unused variable. This models the rule Go
+    actually applies — declared, then used somewhere other than its declaration.
+    """
+    orphans = []
+    for match in DECLARED.finditer(replace):
+        for name in (n.strip() for n in match.group(1).split(",")):
+            if not name or name == "_" or name in RESERVED:
+                continue
+            uses = len(re.findall(r"(?<![.\w])" + re.escape(name) + r"\b", replace))
+            if uses <= 1:
+                orphans.append(name)
+    return sorted(set(orphans))
+
+
+def dropped_identifiers(find, replace):
+    """Names the mutation would leave unused, which Go refuses to compile.
+
+    Two ways that happens, and both have cost a verdict here: a term is deleted
+    and the name goes with it, or the name survives only in a declaration the
+    fragment carries.
+    """
+    lost = identifiers(find) - identifiers(replace)
+    return sorted(lost | set(orphaned_by_declaration(replace)))
+
+
+def copy_tree(src, dst):
+    def ignore(directory, names):
+        out = [n for n in names if n in EXCLUDE]
+        if (
+            os.path.abspath(directory) == os.path.abspath(src)
+            and "feint" in names
+            and os.path.isfile(os.path.join(directory, "feint"))
+        ):
+            out.append("feint")
+        return out
+
+    if os.path.exists(dst):
+        shutil.rmtree(dst)
+    shutil.copytree(src, dst, ignore=ignore, symlinks=True)
+
+
+def run(dst, cmd):
+    """Every command is capped, so a runaway cannot take the station with it."""
+    return subprocess.run(
+        ["systemd-run", "--user", "--scope", "-q", "-p", "MemoryMax=8G", "-p", "MemorySwapMax=0"]
+        + cmd,
+        cwd=dst,
+        capture_output=True,
+        text=True,
+    )
+
+
+def refuse(message):
+    print(f"falsify: {message}", file=sys.stderr)
+    return 2
+
+
+# The mutations that voided a verdict on 2026-08-15, and the safe form
+# each one should have taken. This is the rule's own falsification: it is not
+# invented cases, it is what actually happened, in unrelated issues, plus the
+# fourth shape an end-to-end run of this harness found afterwards.
+HISTORY = [
+    # (find, broken replacement, safe replacement, the name that was orphaned)
+    ("if ok && fe.EnforcesFirewall() {", "if ok {", "if ok && fe != nil {", "fe"),
+    (
+        'if strings.TrimSpace(string(out)) == "" {',
+        "if false {",
+        'if strings.TrimSpace(string(out)) == "\\x00never" {',
+        "out",
+    ),
+    (
+        "if err != nil || health.Resources == 0 {",
+        "if health.Resources == 0 {",
+        "if (err != nil && false) || health.Resources == 0 {",
+        "err",
+    ),
+    # The fourth, found by running the harness end to end rather than by
+    # reasoning about it: when the fragment carries its own declaration, the name
+    # survives on both sides and a set difference sees nothing.
+    (
+        "fe, ok := p.(FirewallEnforcer)\n\t\tif ok && fe.EnforcesFirewall() {",
+        "fe, ok := p.(FirewallEnforcer)\n\t\tif ok {",
+        "fe, ok := p.(FirewallEnforcer)\n\t\tif ok && fe != nil {",
+        "fe",
+    ),
+]
+
+
+def selftest():
+    """Prove the rule on the three mistakes it was written for."""
+    failures = 0
+    for find, broken, safe, orphan in HISTORY:
+        lost = dropped_identifiers(find, broken)
+        if orphan not in lost:
+            print(f"!! the rule accepts a mutation that orphans {orphan}: {broken}")
+            failures += 1
+        else:
+            print(f"ok  refused, {orphan} would be orphaned: {broken}")
+        # And the accepting half, which matters as much: a rule that refused
+        # every mutation would pass the checks above and make the tool useless.
+        still = dropped_identifiers(find, safe)
+        if still:
+            print(f"!! the rule refuses the safe form too, losing {still}: {safe}")
+            failures += 1
+        else:
+            print(f"    accepted, every name kept: {safe}")
+    print()
+    if failures:
+        print(f"{failures} failure(s): the rule does not hold its own history")
+        return 1
+    print(
+        f"the rule refuses all {len(HISTORY)} historical mistakes and accepts "
+        f"all {len(HISTORY)} fixes"
+    )
+    return 0
+
+
+def main(argv):
+    if len(argv) == 2 and argv[1] == "--selftest":
+        return selftest()
+    if len(argv) != 2:
+        return refuse("usage: falsify.py <spec.json> | --selftest")
+    spec_path = argv[1]
+    with open(spec_path, encoding="utf-8") as fh:
+        spec = json.load(fh)
+
+    mutations = spec.get("mutations") or []
+    if not mutations:
+        return refuse(f"{spec_path} declares no mutation, so a run would measure nothing")
+
+    # Every shape check first, before a single file is copied. A run that is
+    # going to be void should cost nothing and say why.
+    for m in mutations:
+        for key in ("label", "file", "find", "replace", "test"):
+            if not m.get(key):
+                return refuse(f"a mutation is missing {key!r}: {m.get('label', m)}")
+        if m["find"] == m["replace"]:
+            return refuse(f"{m['label']!r} replaces a fragment with itself")
+        lost = dropped_identifiers(m["find"], m["replace"])
+        if lost:
+            return refuse(
+                f"{m['label']!r} drops {', '.join(lost)}, which Go will refuse to "
+                f"compile as an unused variable — and a mutation that does not build "
+                f"fails every test, which looks exactly like the guard being proven.\n"
+                f"        Neutralise the condition instead of deleting the term: keep "
+                f"every name evaluated and make the expression never true."
+            )
+
+    src = os.getcwd()
+    # mkdtemp rather than a name built from the spec: a predictable path under
+    # /tmp is a symlink somebody else can plant, and this copy is about to be
+    # compiled and executed. bandit refused the first version and was right.
+    dst = tempfile.mkdtemp(
+        prefix="falsify-" + os.path.basename(spec_path).removesuffix(".json") + "-"
+    )
+    print(f"copying the repository to {dst}", flush=True)
+    copy_tree(src, dst)
+
+    default_pkg = spec.get("package", "./...")
+    packages = sorted({m.get("package", default_pkg) for m in mutations})
+
+    base = run(dst, ["go", "test", "-count=1", *packages])
+    if base.returncode != 0:
+        print(
+            "the copy is red before any mutation, so nothing below measures a guard",
+            file=sys.stderr,
+        )
+        print(base.stdout[-2500:], file=sys.stderr)
+        shutil.rmtree(dst, ignore_errors=True)
+        return 2
+    print("baseline: green\n")
+
+    verdicts, pristine = [], {}
+    for m in mutations:
+        path = os.path.join(dst, m["file"])
+        if m["file"] not in pristine:
+            with open(path, encoding="utf-8") as fh:
+                pristine[m["file"]] = fh.read()
+        body = pristine[m["file"]]
+        if m["find"] not in body:
+            verdicts.append((m["label"], "DID NOT APPLY", "-"))
+            print(f"!! {m['label']}: fragment not found in {m['file']}\n")
+            continue
+
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(body.replace(m["find"], m["replace"], 1))
+
+        pkg = m.get("package", default_pkg)
+        vet = run(dst, ["go", "vet", pkg])
+        if vet.returncode != 0:
+            # The identifier check above should make this unreachable. If it
+            # fires, the rule missed a shape and the rule is what needs work.
+            verdicts.append((m["label"], "DID NOT COMPILE (void)", "no"))
+            print(f"!! {m['label']}: does not build, verdict void")
+            print(vet.stderr[-900:])
+        else:
+            res = run(dst, ["go", "test", "-count=1", "-run", m["test"], pkg])
+            bit = res.returncode != 0
+            verdicts.append((m["label"], "the test bit" if bit else "TEST STILL PASSED", "yes"))
+            print(
+                f"{'ok ' if bit else '!! '}{m['label']}\n    {m['test']}: "
+                f"{'red' if bit else 'STILL GREEN'}\n"
+            )
+
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(pristine[m["file"]])
+
+    final = run(dst, ["go", "test", "-count=1", *packages])
+    print("=" * 72)
+    for label, verdict, compiled in verdicts:
+        print(f"  compiled={compiled:3}  {verdict:24}  {label}")
+    ok_final = final.returncode == 0
+    print(f"\nafter restoration: {'green' if ok_final else 'RED — the restore is broken'}")
+    if not ok_final:
+        print(final.stdout[-2000:], file=sys.stderr)
+    shutil.rmtree(dst, ignore_errors=True)
+
+    everything_bit = all(v[1] == "the test bit" for v in verdicts)
+    return 0 if (everything_bit and ok_final) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tools/falsify/specs/enforcement.json
+++ b/tools/falsify/specs/enforcement.json
@@ -1,0 +1,27 @@
+{
+  "package": "./internal/core/emulator/",
+  "mutations": [
+    {
+      "label": "every pack is named, the way the process-global capability did",
+      "file": "internal/core/emulator/enforcement.go",
+      "find": "\t\tfe, ok := p.(FirewallEnforcer)\n\t\tif ok && fe.EnforcesFirewall() {",
+      "replace": "\t\tfe, ok := p.(FirewallEnforcer)\n\t\tif ok && fe != nil {",
+      "test": "TestEnforcementNamesOnlyThePacksThatWireIt"
+    },
+    {
+      "label": "the empty list marshals to null, and a consumer iterating it breaks",
+      "file": "internal/core/emulator/enforcement.go",
+      "find": "\tfirewall := []string{}",
+      "replace": "\tvar firewall []string",
+      "test": "TestEnforcementPublishesAnEmptyListRatherThanNoKey"
+    },
+    {
+      "label": "the pack drops its declaration while still wiring the firewall",
+      "file": "internal/providers/scaleway/firewall.go",
+      "find": "func (p *Pack) EnforcesFirewall() bool { return true }",
+      "replace": "func (p *Pack) EnforcesFirewall() bool { return false }",
+      "test": "TestEveryPackThatWiresTheFirewallSaysSo",
+      "package": "./internal/cli/"
+    }
+  ]
+}


### PR DESCRIPTION
`/falsify` was a procedure followed by hand. On 2026-08-15 the same mistake voided a verdict **three times in one day**, in three unrelated issues:

```go
if ok && fe.EnforcesFirewall() {   ->  if ok {         // fe orphaned
if strings.TrimSpace(s) == "" {    ->  if false {      // s  orphaned
if err != nil || n == 0 {          ->  if n == 0 {     // err orphaned
```

Go refuses to compile an unused variable, so each mutation broke the build — and a mutation that does not build fails **every** test, which looks exactly like the guard being proven. `.claude/commands/falsify.md` already warned about that failure mode, in prose, and it was met three times anyway.

Warning was not enough. This refuses, before copying anything, with the fix in the message:

```console
$ python3 tools/falsify/falsify.py /tmp/bad-spec.json
falsify: 'the mistake I made three times' drops fe, which Go will refuse to compile
as an unused variable — and a mutation that does not build fails every test, which
looks exactly like the guard being proven.
        Neutralise the condition instead of deleting the term: keep every name
        evaluated and make the expression never true.
$ echo $?
2
```

## The rule, and the shape it missed at first

**A mutation must not leave a name unused.** Two ways that happens, and the second was found by running the harness end to end rather than by reasoning about it:

1. a term is deleted and the name goes with it — caught by a set difference;
2. the fragment carries its own `fe, ok := ...` line, so the word survives on both sides, the difference sees nothing, and Go still sees an unused variable. The check therefore also models Go's real rule: **declared, then used somewhere other than its declaration.**

## Two things earned their place immediately

**The selftest**, on its first run, refused `if ok && fe != nil` — the safe form the rule exists to recommend — because a method name after a selector looked like a dropped identifier. Names after a dot are fields and methods and orphan nothing; package names stay in scope, since an unused import is the same class of compile error.

**The pre-commit hooks**, refusing the first commit three times over: a nested `if` ruff would rather see combined, a formatting drift, and a bandit finding worth keeping — a predictable `/tmp` path is a symlink somebody else can plant, and this copy is about to be compiled and executed. `mkdtemp` now.

## What runs, and where

| command | what it does |
|---|---|
| `mise run falsify -- <spec.json>` | copy out, baseline green, per-mutation vet + test, restore, final green |
| `mise run falsify -- --selftest` | holds the rule against the four real cases **and** their four fixes |
| `mise run prepush` | runs the selftest — offline, no Go build, seconds |

Both halves matter: a rule that refused every mutation would pass the refusing half and make the tool useless.

`tools/falsify/specs/enforcement.json` is a worked example, run end to end: three mutations, three tests bitten, green after restoration.

## Type of change

- [ ] A route added or changed
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation
- [x] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes, via `mise run prepush`
- [x] No new external Go dependency — the harness is stdlib Python, like the contract extraction
- [x] `internal/core` still knows no provider — no Go file is touched
- [x] Nothing in the diff could be written identically for another provider

### When a model wrote a substantive part of this

- [x] An `Assisted-by:` trailer names the tool and the model version
- [ ] **N/A, stated rather than ticked.** `mise run conformance` was not run: no Go file, no route, no response shape is touched. What was run is the harness itself, end to end on a real spec, plus a deliberately bad spec to prove the refusal
- [x] Every case in the selftest is a mutation that actually happened in this repository today, not an invented one

### When a route is added or changed

N/A.

### When behaviour a client can observe changes

N/A — nothing the emulator serves changes.

### When `.github/workflows/` is touched

N/A.

### When a machine runtime is involved

N/A.
