### PR TITLE
feat(evidence): provenance gates the join, so a proof cannot outlive its evidence

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -96,6 +96,36 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Modifié
 
+- **La règle de fraîcheur du registre de preuves devient un contrôle** (#171).
+  « Supprimer une assertion de conformance rétrograde les opérations qu'elle
+  prouvait » était écrit deux fois, dans `internal/cli/evidence.go` et dans
+  `mise.toml`, et tenu par rien : `grep -rn demotes --include='*_test.go'` ne
+  rendait rien. Ce critère est ce qui sépare un registre d'un record absolu, et
+  tous les chiffres publiés par ce projet reposent dessus.
+
+  `coverage/evidence.json` passe en **version 3** et gagne `generated_from` : les
+  empreintes des contrats, des enregistrements et des suites de conformance. Ce
+  ne sont pas des métadonnées posées à côté du registre, elles **gardent la
+  jointure**. Deux passes fusionnent en prenant la réponse la plus forte sur
+  chaque axe, ce qui n'est sûr que tant que les deux lisent les mêmes entrées :
+  une passe produite depuis d'autres est désormais refusée en nommant lesquelles.
+  Retirez une assertion d'une suite et l'empreinte des suites bouge, ce qui rend
+  le registre précédent injoignable, ce qui est la phrase ci-dessus, appliquée.
+  Des empreintes des entrées plutôt qu'un SHA git : reproductibles depuis un
+  checkout, encore une réponse sur un arbre sale, et elles répondent à « les
+  entrées ont-elles bougé ? » plutôt qu'à « quel commit était sorti ? ».
+
+  Deux défauts ont été trouvés en corrigeant celui-là, de la même famille.
+  `runtimesLost` répondait « rien de perdu » à toute erreur de lecture, si bien
+  que le changement de version aurait désarmé le garde de non-régression au
+  moment précis où il compte le plus ; un fichier absent et un fichier illisible
+  sont désormais deux réponses distinctes. Et la jointure construisait un
+  registre neuf sans reporter la provenance, si bien que tout artefact régénéré
+  portait trois empreintes vides, qui se comparent égales à trois empreintes
+  vides : le nouveau gate aurait tout accepté en ayant l'apparence d'un contrôle.
+  Les tests unitaires passaient d'un bout à l'autre ; c'est la lecture du fichier
+  que l'outil venait d'écrire qui l'a trouvé.
+
 - **`feint stop` dit ce qu'il s'apprête à jeter** (#182). Le store est en
   mémoire et `docs/limits.md` l'énonce dans une table de cycle de vie, mais cette
   phrase vit sur une page qu'un utilisateur lit **après** s'être fait avoir :

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,33 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Changed
 
+- **The evidence record's freshness rule becomes a control** (#171). *Deleting a
+  conformance assertion demotes the operations it proved* was written twice, in
+  `internal/cli/evidence.go` and in `mise.toml`, and held by nothing:
+  `grep -rn demotes --include='*_test.go'` answered nothing. That criterion is
+  what separates a record from a high-water mark, and every figure this project
+  publishes rests on it.
+
+  `coverage/evidence.json` moves to **version 3** and gains `generated_from`:
+  digests of the contracts, the recordings and the conformance suites. Not
+  metadata beside the record — it gates the join. Two legs merge by taking the
+  stronger answer per axis, which is safe only while both read the same inputs,
+  so a leg produced from others is now refused by name. Remove an assertion from
+  a suite and the suite digest moves, which makes the previous record unjoinable,
+  which is the sentence above, enforced. Digests of the inputs rather than a git
+  SHA: reproducible from a checkout, still an answer on a dirty tree, and they
+  answer *did the inputs move?* instead of *which commit was checked out?*.
+
+  Two defects were found while fixing that one, both the same family. `runtimesLost`
+  answered "nothing lost" to every read failure, so bumping the version would
+  have disarmed the narrowing guard on the one regeneration where it matters
+  most; an absent file and an unreadable one are now different answers. And the
+  join built a fresh record without carrying the provenance, so every regenerated
+  artefact held three empty digests — which compare equal to three empty digests,
+  making the new gate accept everything while reading like a control. The unit
+  tests passed throughout; reading the file the tool had just written is what
+  found it.
+
 - **`feint stop` says what it is about to discard** (#182). The store is memory
   and `docs/limits.md` states it in a lifecycle table, but that sentence lives on
   a page a user reads *after* being bitten: four resources existed, `stop` said

--- a/coverage/evidence.json
+++ b/coverage/evidence.json
@@ -1,10 +1,15 @@
 {
   "format": "feint-evidence",
-  "version": 2,
+  "version": 3,
   "machines": [
     "incus",
     "none"
   ],
+  "generated_from": {
+    "contracts": "7dd2353c6a25c3fa",
+    "shapes": "c73ca6ca03ceac5b",
+    "suites": "d6dd6b22856907d3"
+  },
   "operations": {
     "block/v1/API.CreateSnapshot": {
       "driven": false,
@@ -1947,7 +1952,7 @@
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
-      "behaviour": true,
+      "behaviour": false,
       "negative": false
     },
     "vpc/v2/API.CreateVPC": {
@@ -1956,7 +1961,7 @@
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
-      "behaviour": true,
+      "behaviour": false,
       "negative": false
     },
     "vpc/v2/API.DeletePrivateNetwork": {

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -205,9 +205,9 @@ disappears from the suite.
 | `PATCH` | `/vpc/v2/regions/{region}/vpcs/{vpc_id}` | `vpc/v2/API.UpdateVPC` | `contract` `probe` |
 | `POST` | `/vpc/v2/regions/{region}/private-networks/{pnID}/enable-dhcp` | `vpc/v2/API.EnableDHCP` | `contract` `probe` |
 | `POST` | `/vpc/v2/regions/{region}/private-networks` | `vpc/v2/API.CreatePrivateNetwork` | `client` `contract` `runtime` `probe` `behaviour` |
-| `POST` | `/vpc/v2/regions/{region}/routes` | `vpc/v2/API.CreateRoute` | `client` `contract` `runtime` `probe` `behaviour` |
+| `POST` | `/vpc/v2/regions/{region}/routes` | `vpc/v2/API.CreateRoute` | `client` `contract` `runtime` `probe` |
 | `POST` | `/vpc/v2/regions/{region}/vpcs/{vpc_id}/enable-routing` | `vpc/v2/API.EnableRouting` | `contract` `probe` |
-| `POST` | `/vpc/v2/regions/{region}/vpcs` | `vpc/v2/API.CreateVPC` | `client` `contract` `runtime` `probe` `behaviour` |
+| `POST` | `/vpc/v2/regions/{region}/vpcs` | `vpc/v2/API.CreateVPC` | `client` `contract` `runtime` `probe` |
 
 ### Declined on purpose (213)
 

--- a/internal/cli/evidence.go
+++ b/internal/cli/evidence.go
@@ -39,7 +39,7 @@ import (
 // its probed: true is precisely the value this version exists not to carry.
 const (
 	evidenceFormat  = "feint-evidence"
-	evidenceVersion = 2
+	evidenceVersion = 3
 )
 
 // evidenceArtefact is coverage/evidence.json.
@@ -49,20 +49,37 @@ type evidenceArtefact struct {
 	// Machines lists the runtime behind each contributing run, sorted. The
 	// dataplane axis only means something next to this list.
 	Machines []string `json:"machines"`
+	// GeneratedFrom digests what this record was produced from (#171). It is
+	// not decoration: --join refuses an artefact whose inputs differ, so a
+	// suite that loses an assertion makes the previous record unjoinable and
+	// the level it carried cannot survive. See provenance.go.
+	GeneratedFrom provenance `json:"generated_from"`
 	// Operations maps every mounted operation to its evidence.
 	Operations map[string]emulator.Evidence `json:"operations"`
 }
 
 // runtimesLost reads the record already at path and answers the runtimes it was
-// earned under that this one does not reach. A missing or unreadable file loses
-// nothing: the first write of an artefact is not a narrowing.
+// earned under that this one does not reach.
+//
+// A file that is not there loses nothing: the first write of an artefact is not
+// a narrowing. A file that *is* there and cannot be read is a different answer
+// and now says so, because the two were the same for as long as this guard
+// existed and that is how a guard stops working in silence: bumping
+// evidenceVersion makes the committed record unreadable to the new binary, so
+// "unreadable means nothing lost" would disarm the check on the one
+// regeneration where it matters most. Found while bumping it, for #171.
 //
 // "none" is not a runtime. A record earned with machines off and rewritten with
 // machines off narrows nothing, and one that gains a runtime is a widening.
-func runtimesLost(path string, next *evidenceArtefact) []string {
+func runtimesLost(path string, next *evidenceArtefact) ([]string, error) {
 	existing, err := readEvidence(path)
-	if err != nil || existing == nil {
-		return nil
+	switch {
+	case os.IsNotExist(err):
+		return nil, nil
+	case err != nil:
+		return nil, err
+	case existing == nil:
+		return nil, nil
 	}
 	reached := map[string]bool{}
 	for _, m := range next.Machines {
@@ -76,7 +93,7 @@ func runtimesLost(path string, next *evidenceArtefact) []string {
 		lost = append(lost, m)
 	}
 	sort.Strings(lost)
-	return lost
+	return lost, nil
 }
 
 func evidence(args []string, stdout, stderr io.Writer) int {
@@ -84,6 +101,8 @@ func evidence(args []string, stdout, stderr io.Writer) int {
 	endpoint := fs.String("endpoint", "http://"+DefaultAddr, "the running emulator to read /_feint/conformance from")
 	shapesDir := fs.String("shapes", "shapes", "directory of observed real-cloud shapes; the shape axis is resolved from it (empty to leave the run's answer)")
 	out := fs.String("out", filepath.Join("coverage", "evidence.json"), "where to write the artefact")
+	contractsDir := fs.String("contracts", "contracts", "directory of API descriptions, digested into the record's provenance")
+	suitesDir := fs.String("suites", filepath.Join("tools", "conformance"), "directory of conformance suites, digested into the record's provenance")
 	join := fs.String("join", "", "an artefact from another leg of the same regeneration, merged in (fresh runs only; see the header comment)")
 	allowNarrowing := fs.Bool("allow-narrowing", false,
 		"write even when this run reaches fewer runtimes than the record it replaces; "+
@@ -102,11 +121,18 @@ func evidence(args []string, stdout, stderr io.Writer) int {
 		return exitError
 	}
 
+	from, err := provenanceOf(*contractsDir, *shapesDir, *suitesDir)
+	if err != nil {
+		fmt.Fprintf(stderr, "feint: %v\n", err)
+		return exitError
+	}
+
 	art := &evidenceArtefact{
-		Format:     evidenceFormat,
-		Version:    evidenceVersion,
-		Machines:   []string{view.Machines},
-		Operations: view.Evidence,
+		Format:        evidenceFormat,
+		Version:       evidenceVersion,
+		Machines:      []string{view.Machines},
+		GeneratedFrom: from,
+		Operations:    view.Evidence,
 	}
 
 	// The shape axis is static — a property of the catalogue, not of the run —
@@ -136,6 +162,17 @@ func evidence(args []string, stdout, stderr io.Writer) int {
 			fmt.Fprintf(stderr, "feint: %v\n", err)
 			return exitError
 		}
+		// The gate the criterion always named and nothing enforced. Joining
+		// takes the stronger answer per axis, which is safe only while both
+		// legs read the same inputs; an artefact produced from others would let
+		// a level survive the evidence that earned it.
+		if moved := from.differsFrom(other.GeneratedFrom); len(moved) > 0 {
+			fmt.Fprintf(stderr,
+				"feint: %s was produced from different %s, so joining it would carry a "+
+					"level this run did not earn; regenerate both legs together\n",
+				*join, strings.Join(moved, " and "))
+			return exitError
+		}
 		art = joinEvidence(art, other)
 	}
 
@@ -158,7 +195,19 @@ func evidence(args []string, stdout, stderr io.Writer) int {
 	// file before joining the runtime one.
 	// TestEvidenceRefusesToNarrowTheRuntimesItWasEarnedUnder fails without this.
 	if !*allowNarrowing {
-		if lost := runtimesLost(*out, art); len(lost) > 0 {
+		lost, err := runtimesLost(*out, art)
+		if err != nil {
+			// The comparison could not be made, so this write is unchecked. Said
+			// out loud rather than treated as "nothing lost", which is what it
+			// used to be: a record that cannot be compared is not a record that
+			// proves nothing was dropped.
+			fmt.Fprintf(stderr, "feint: %s cannot be compared with this run (%v), so "+
+				"nothing checks whether this write narrows the record.\n"+
+				"Pass --allow-narrowing if replacing it wholesale is what you meant.\n",
+				*out, err)
+			return exitError
+		}
+		if len(lost) > 0 {
 			fmt.Fprintf(stderr, "feint: %s was earned under %s and this run only reaches %s, "+
 				"so writing it would drop every proof taken under %s.\n"+
 				"Run `mise run evidence:update` on a host that can start machines, or pass "+
@@ -238,7 +287,19 @@ func joinEvidence(a, b *evidenceArtefact) *evidenceArtefact {
 		ev.Shape = strongerShape(ev.Shape, other.Shape)
 		ops[op] = ev
 	}
-	return &evidenceArtefact{Format: evidenceFormat, Version: evidenceVersion, Machines: names, Operations: ops}
+	// The provenance of the run doing the joining, carried rather than rebuilt.
+	// Dropping it was the first version of this function under #171, and the
+	// consequence was worse than a missing field: three empty digests compare
+	// equal to three empty digests, so the gate that refuses a stale leg would
+	// have accepted everything while looking like a control. Found by reading
+	// the regenerated artefact instead of trusting the tests, which passed.
+	return &evidenceArtefact{
+		Format:        evidenceFormat,
+		Version:       evidenceVersion,
+		Machines:      names,
+		GeneratedFrom: a.GeneratedFrom,
+		Operations:    ops,
+	}
 }
 
 // strongerProbe keeps the fuller validation: a validated success over a

--- a/internal/cli/evidence_test.go
+++ b/internal/cli/evidence_test.go
@@ -272,14 +272,14 @@ func TestEvidenceRefusesToNarrowTheRuntimesItWasEarnedUnder(t *testing.T) {
 		Machines:   []string{"none"},
 		Operations: map[string]emulator.Evidence{"instance/v1/API.ListServers": {}},
 	}
-	lost := runtimesLost(path, offOnly)
+	lost, _ := runtimesLost(path, offOnly)
 	if len(lost) != 1 || lost[0] != "incus" {
 		t.Fatalf("narrowing to machines-off reported %v as lost, want [incus]", lost)
 	}
 
 	// The accepting halves, because a guard that refuses every write would pass
 	// the assertion above and stop the tool working.
-	if lost := runtimesLost(path, earned); len(lost) != 0 {
+	if lost, _ := runtimesLost(path, earned); len(lost) != 0 {
 		t.Errorf("rewriting the same runtimes reported %v as lost", lost)
 	}
 	wider := &evidenceArtefact{
@@ -287,11 +287,11 @@ func TestEvidenceRefusesToNarrowTheRuntimesItWasEarnedUnder(t *testing.T) {
 		Machines:   []string{"incus", "incus-ovn", "none"},
 		Operations: earned.Operations,
 	}
-	if lost := runtimesLost(path, wider); len(lost) != 0 {
+	if lost, _ := runtimesLost(path, wider); len(lost) != 0 {
 		t.Errorf("gaining a runtime reported %v as lost", lost)
 	}
 	// And the first write of an artefact narrows nothing.
-	if lost := runtimesLost(filepath.Join(dir, "absent.json"), offOnly); len(lost) != 0 {
+	if lost, _ := runtimesLost(filepath.Join(dir, "absent.json"), offOnly); len(lost) != 0 {
 		t.Errorf("writing where no record exists reported %v as lost", lost)
 	}
 }

--- a/internal/cli/provenance.go
+++ b/internal/cli/provenance.go
@@ -1,0 +1,151 @@
+package cli
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// What produced a record, and why that is a control rather than metadata (#171).
+//
+// The rule the evidence artefact lives under was stated twice, in prose, and
+// held by nothing:
+//
+//	internal/cli/evidence.go: "the /falsify criterion is that deleting a
+//	conformance assertion demotes the operations it proved"
+//	mise.toml: "Removing an assertion from a suite and re-running this task must
+//	demote the operations it proved — that is the falsification the record lives
+//	under."
+//
+// `grep -rn demotes --include='*_test.go'` answered nothing. That criterion is
+// what separates a record from a high-water mark: if a proof can outlive the
+// assertion that produced it, deleting a conformance check raises nothing and
+// lowers nothing, and every figure this project publishes rests on it.
+//
+// The join is where the risk is concrete. Two legs are merged by taking the
+// stronger answer per axis, which is safe *only* because both are fresh — a
+// convention the caller was trusted to respect, and nothing more.
+//
+// So provenance is not printed beside the record, it gates the join: an artefact
+// whose inputs differ from this run's cannot contribute a level. Remove an
+// assertion from a suite and the suite digest moves, which makes the previous
+// artefact unjoinable, which is exactly the sentence above, enforced.
+//
+// TestAJoinRefusesAnArtefactFromOtherInputs fails without this.
+
+// provenance is the digest of everything a regeneration reads.
+//
+// Digests of the inputs rather than a git SHA, deliberately: a digest is
+// reproducible from a checkout, it still answers on a dirty tree where somebody
+// is regenerating locally, and it answers the question that matters — did the
+// inputs move? — instead of which commit happened to be checked out.
+type provenance struct {
+	// Contracts is the API descriptions every response is validated against.
+	Contracts string `json:"contracts"`
+	// Shapes is the recorded real-cloud answers the shape and field axes read.
+	Shapes string `json:"shapes"`
+	// Suites is the conformance scripts. This is the one that moves when an
+	// assertion is added or removed, which is what makes the join gate mean
+	// what the criterion says.
+	Suites string `json:"suites"`
+}
+
+// provenanceOf digests the three input sets. A directory that does not exist
+// digests to "absent" rather than failing: `feint evidence` is runnable from a
+// tree without recordings, and refusing there would trade a missing input for a
+// missing command.
+func provenanceOf(contractsDir, shapesDir, suitesDir string) (provenance, error) {
+	contracts, err := digestTree(contractsDir, ".json")
+	if err != nil {
+		return provenance{}, err
+	}
+	shapes, err := digestTree(shapesDir, ".json")
+	if err != nil {
+		return provenance{}, err
+	}
+	suites, err := digestTree(suitesDir, ".sh")
+	if err != nil {
+		return provenance{}, err
+	}
+	return provenance{Contracts: contracts, Shapes: shapes, Suites: suites}, nil
+}
+
+// digestTree hashes every file under root with the given suffix, path and
+// content both, in sorted order.
+//
+// Sorted because two runs on the same tree must produce the same string:
+// filesystem order is not a promise, and a digest that changes on its own would
+// refuse every join and be disabled within the week. The path is hashed beside
+// the content so that renaming a suite is a change, which it is.
+func digestTree(root, suffix string) (string, error) {
+	if root == "" {
+		return "absent", nil
+	}
+	info, err := os.Stat(root)
+	if os.IsNotExist(err) {
+		return "absent", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("%s is not a directory", root)
+	}
+
+	var paths []string
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, suffix) {
+			return nil
+		}
+		paths = append(paths, path)
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	sort.Strings(paths)
+
+	sum := sha256.New()
+	for _, path := range paths {
+		body, err := os.ReadFile(path) //nolint:gosec // a directory the caller named
+		if err != nil {
+			return "", err
+		}
+		// The relative path, so the digest does not move with the checkout's
+		// location: two people regenerating from different directories must
+		// agree, or the gate refuses their joins for no reason.
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return "", err
+		}
+		sum.Write([]byte(rel))
+		sum.Write([]byte{0})
+		sum.Write(body)
+		sum.Write([]byte{0})
+	}
+	return hex.EncodeToString(sum.Sum(nil))[:16], nil
+}
+
+// differsFrom answers the inputs that moved between two records, empty when
+// they were produced from the same ones.
+func (p provenance) differsFrom(other provenance) []string {
+	var moved []string
+	if p.Contracts != other.Contracts {
+		moved = append(moved, "contracts")
+	}
+	if p.Shapes != other.Shapes {
+		moved = append(moved, "shapes")
+	}
+	if p.Suites != other.Suites {
+		moved = append(moved, "suites")
+	}
+	return moved
+}

--- a/internal/cli/provenance_test.go
+++ b/internal/cli/provenance_test.go
@@ -1,0 +1,180 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+)
+
+// A digest that answers the question it is asked, and no other (#171).
+//
+// The gate below rests entirely on this: if the digest moved on its own, every
+// join would be refused and the gate would be disabled within the week; if it
+// stayed still when a suite changed, the criterion it enforces would be a
+// sentence again.
+func TestTheDigestMovesWithTheInputsAndNotOtherwise(t *testing.T) {
+	dir := t.TempDir()
+	suites := filepath.Join(dir, "conformance", "scaleway")
+	if err := os.MkdirAll(suites, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	script := filepath.Join(suites, "scw-cli.sh")
+	write := func(body string) {
+		t.Helper()
+		if err := os.WriteFile(script, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	write("assert one\nassert two\n")
+	first, err := digestTree(filepath.Join(dir, "conformance"), ".sh")
+	if err != nil {
+		t.Fatalf("digest: %v", err)
+	}
+
+	// Twice on unchanged inputs: the same answer, or the gate refuses joins for
+	// no reason and somebody removes it.
+	again, err := digestTree(filepath.Join(dir, "conformance"), ".sh")
+	if err != nil {
+		t.Fatalf("digest: %v", err)
+	}
+	if first != again {
+		t.Errorf("two digests of unchanged inputs disagree: %q then %q", first, again)
+	}
+
+	// An assertion removed from a suite — the exact case the criterion names.
+	write("assert one\n")
+	fewer, err := digestTree(filepath.Join(dir, "conformance"), ".sh")
+	if err != nil {
+		t.Fatalf("digest: %v", err)
+	}
+	if fewer == first {
+		t.Error("removing an assertion from a suite left the digest unchanged, so the " +
+			"record could still be joined and the proof would outlive its evidence")
+	}
+
+	// A file of another kind is not an input: the digest names what it reads.
+	if err := os.WriteFile(filepath.Join(suites, "notes.md"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	unrelated, err := digestTree(filepath.Join(dir, "conformance"), ".sh")
+	if err != nil {
+		t.Fatalf("digest: %v", err)
+	}
+	if unrelated != fewer {
+		t.Error("a file the record never reads moved the digest, which makes the gate " +
+			"fire on changes it has no opinion about")
+	}
+
+	// An absent directory is stated rather than an error: `feint evidence` runs
+	// from trees with no recordings, and refusing there would trade a missing
+	// input for a missing command.
+	absent, err := digestTree(filepath.Join(dir, "nothing-here"), ".json")
+	if err != nil {
+		t.Fatalf("an absent directory must not be an error: %v", err)
+	}
+	if absent != "absent" {
+		t.Errorf("an absent directory must say so, got %q", absent)
+	}
+}
+
+// The join gate, both halves.
+//
+// This is the control the criterion never had. Removing an assertion from a
+// suite moves the suite digest, which makes the previous leg unjoinable, which
+// is what stops a level surviving the evidence that earned it.
+func TestAJoinRefusesAnArtefactFromOtherInputs(t *testing.T) {
+	same := provenance{Contracts: "aaa", Shapes: "bbb", Suites: "ccc"}
+
+	if moved := same.differsFrom(same); len(moved) != 0 {
+		t.Errorf("two legs of one regeneration must join, got %v refused", moved)
+	}
+
+	for _, tc := range []struct {
+		name  string
+		other provenance
+		want  string
+	}{
+		{"a suite lost an assertion", provenance{"aaa", "bbb", "different"}, "suites"},
+		{"a contract was re-extracted", provenance{"different", "bbb", "ccc"}, "contracts"},
+		{"a recording was added", provenance{"aaa", "different", "ccc"}, "shapes"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			moved := same.differsFrom(tc.other)
+			if len(moved) != 1 || moved[0] != tc.want {
+				t.Errorf("the refusal must name what moved, want [%s] got %v", tc.want, moved)
+			}
+		})
+	}
+
+	// And it names every input that moved, not the first: a reader fixing one
+	// and re-running only to be refused again learns to distrust the message.
+	all := same.differsFrom(provenance{"x", "y", "z"})
+	if len(all) != 3 {
+		t.Errorf("every moved input must be named, got %v", all)
+	}
+}
+
+// The written record carries its provenance, and the gate is not vacuous.
+//
+// This is the test that would have caught the first version of #171: the join
+// built a fresh artefact and dropped the field, so every regenerated record
+// carried three empty digests — and three empty digests compare equal to three
+// empty digests, which means the gate refusing a stale leg would have accepted
+// everything while reading like a control. The unit tests passed throughout;
+// what found it was looking at the file the tool had just written.
+func TestTheJoinedRecordKeepsItsProvenance(t *testing.T) {
+	from := provenance{Contracts: "c0ffee", Shapes: "5ha9e5", Suites: "5u17e5"}
+	fresh := &evidenceArtefact{
+		Format: evidenceFormat, Version: evidenceVersion,
+		Machines: []string{"none"}, GeneratedFrom: from,
+		Operations: map[string]emulator.Evidence{"a/v1/API.X": {Driven: true}},
+	}
+	other := &evidenceArtefact{
+		Format: evidenceFormat, Version: evidenceVersion,
+		Machines: []string{"incus"}, GeneratedFrom: from,
+		Operations: map[string]emulator.Evidence{"a/v1/API.X": {Dataplane: true}},
+	}
+
+	joined := joinEvidence(fresh, other)
+	if joined.GeneratedFrom != from {
+		t.Errorf("the join lost the provenance: %+v", joined.GeneratedFrom)
+	}
+	// And it is not the zero value, which is the shape that made the gate
+	// vacuous: a record whose digests are empty matches every other such record.
+	if joined.GeneratedFrom == (provenance{}) {
+		t.Error("the joined record carries empty digests, so the join gate would " +
+			"accept any stale leg while looking like a control")
+	}
+}
+
+// A record that cannot be read is not a record that proves nothing was dropped.
+//
+// runtimesLost answered "nothing lost" to every read failure, which made the two
+// answers indistinguishable: a first write, and a file this binary cannot parse.
+// Bumping evidenceVersion for #171 is exactly the second case, so the guard
+// would have gone quiet on the one regeneration where it matters most.
+func TestAnUnreadableRecordIsNotAnAbsentOne(t *testing.T) {
+	dir := t.TempDir()
+	next := &evidenceArtefact{Machines: []string{"none"}}
+
+	// Absent: nothing to compare, and that is not a narrowing.
+	lost, err := runtimesLost(filepath.Join(dir, "never-written.json"), next)
+	if err != nil || lost != nil {
+		t.Errorf("a first write must lose nothing quietly, got %v / %v", lost, err)
+	}
+
+	// Present and from another version: the comparison cannot be made, and the
+	// caller must hear about it rather than be told nothing was lost.
+	other := filepath.Join(dir, "old.json")
+	body := `{"format":"feint-evidence","version":1,"machines":["incus"],"operations":{}}`
+	if err := os.WriteFile(other, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runtimesLost(other, next); err == nil {
+		t.Error("a record this binary cannot read reported no error, so a narrowing " +
+			"would be written unchecked while the guard looked like it ran")
+	}
+}

--- a/tools/falsify/falsify.py
+++ b/tools/falsify/falsify.py
@@ -126,22 +126,30 @@ def identifiers(text):
 DECLARED = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_,\s]*?)\s*:=", re.MULTILINE)
 
 
-def orphaned_by_declaration(replace):
-    """Names the replacement declares and then never uses again.
+def uses_of(name, text):
+    return len(re.findall(r"(?<![.\w])" + re.escape(name) + r"\b", text))
 
-    Presence alone is not enough, and an end-to-end run is what proved it: a
-    fragment that carries its own `fe, ok := p.(FirewallEnforcer)` line keeps the
-    word `fe` on both sides of any rewrite, so the set difference below saw
-    nothing lost while Go saw an unused variable. This models the rule Go
-    actually applies — declared, then used somewhere other than its declaration.
+
+def orphaned_by_declaration(find, replace):
+    """Names the replacement declares and stops using, which the original used.
+
+    Presence alone is not enough, and an end-to-end run proved it: a fragment
+    carrying its own `fe, ok := p.(FirewallEnforcer)` line keeps the word `fe` on
+    both sides of any rewrite, so a set difference sees nothing lost while Go
+    sees an unused variable.
+
+    Comparative rather than absolute, and a second end-to-end run proved that
+    too: a fragment can declare a name it uses *after* the fragment ends, as
+    `sum := sha256.New()` does, and judging the replacement alone refused a
+    perfectly good mutation. What matters is whether the mutation made it worse —
+    the count falling to its declaration alone, from more than that.
     """
     orphans = []
     for match in DECLARED.finditer(replace):
         for name in (n.strip() for n in match.group(1).split(",")):
             if not name or name == "_" or name in RESERVED:
                 continue
-            uses = len(re.findall(r"(?<![.\w])" + re.escape(name) + r"\b", replace))
-            if uses <= 1:
+            if uses_of(name, replace) <= 1 < uses_of(name, find):
                 orphans.append(name)
     return sorted(set(orphans))
 
@@ -154,7 +162,7 @@ def dropped_identifiers(find, replace):
     fragment carries.
     """
     lost = identifiers(find) - identifiers(replace)
-    return sorted(lost | set(orphaned_by_declaration(replace)))
+    return sorted(lost | set(orphaned_by_declaration(find, replace)))
 
 
 def copy_tree(src, dst):

--- a/tools/falsify/specs/evidence-freshness.json
+++ b/tools/falsify/specs/evidence-freshness.json
@@ -1,0 +1,34 @@
+{
+  "package": "./internal/cli/",
+  "mutations": [
+    {
+      "label": "the digest ignores what a file contains, so removing an assertion moves nothing",
+      "file": "internal/cli/provenance.go",
+      "find": "\t\tsum.Write([]byte(rel))\n\t\tsum.Write([]byte{0})\n\t\tsum.Write(body)",
+      "replace": "\t\tsum.Write([]byte(rel))\n\t\tsum.Write([]byte{0})\n\t\t_ = body",
+      "test": "TestTheDigestMovesWithTheInputsAndNotOtherwise"
+    },
+    {
+      "label": "a moved input is no longer named, so a join is refused without a reason",
+      "file": "internal/cli/provenance.go",
+      "find": "\tif p.Suites != other.Suites {\n\t\tmoved = append(moved, \"suites\")\n\t}",
+      "replace": "\tif p.Suites != other.Suites && false {\n\t\tmoved = append(moved, \"suites\")\n\t}",
+      "test": "TestAJoinRefusesAnArtefactFromOtherInputs"
+    },
+    {
+      "label": "the join keeps only part of the provenance, so the gate compares less than it says",
+      "file": "internal/cli/evidence.go",
+      "find": "\t\tGeneratedFrom: a.GeneratedFrom,\n\t\tOperations:    ops,",
+      "replace": "\t\tGeneratedFrom: provenance{Suites: a.GeneratedFrom.Suites},\n\t\tOperations:    ops,",
+      "test": "TestTheJoinedRecordKeepsItsProvenance"
+    },
+    {
+      "label": "an unreadable record is treated as an absent one again",
+      "file": "internal/cli/evidence.go",
+      "find": "\tcase err != nil:\n\t\treturn nil, err",
+      "replace": "\tcase err != nil:\n\t\treturn nil, nil",
+      "test": "TestAnUnreadableRecordIsNotAnAbsentOne"
+    }
+  ],
+  "note": "The sort in digestTree carries no mutation: any deterministic reordering still makes two runs agree, so the determinism test cannot distinguish it. It guards against filesystem walk order varying between runs, which no test here can induce. Recorded rather than faked, the way #182's error branch is."
+}


### PR DESCRIPTION
> *Deleting a conformance assertion demotes the operations it proved*

Written twice — `internal/cli/evidence.go` and `mise.toml` — and held by nothing:

```console
$ grep -rn demotes --include='*_test.go' internal/
$
```

That criterion is what separates a record from a high-water mark. If a proof can outlive the assertion that produced it, deleting a check raises nothing and lowers nothing, and **every figure this project publishes rests on it**.

## Provenance is the mechanism, not the decoration

The artefact moves to **version 3** and gains `generated_from`:

```json
"generated_from": {
  "contracts": "7dd2353c6a25c3fa",
  "shapes":    "c73ca6ca03ceac5b",
  "suites":    "d6dd6b22856907d3"
}
```

It **gates the join**. Two legs merge by taking the stronger answer per axis, which is safe only while both read the same inputs, so a leg produced from others is refused by name. Remove an assertion from a suite → the suite digest moves → the previous record becomes unjoinable. The sentence, enforced.

Digests of the inputs rather than a git SHA: reproducible from a checkout, still an answer on a dirty tree where somebody regenerates locally, and they answer *did the inputs move?* instead of *which commit was checked out?*.

## Two more defects surfaced while fixing that one

Both the same family as the issue itself — a guard that stops working in silence.

**`runtimesLost` answered "nothing lost" to every read failure.** An absent file and a file this binary cannot parse were the same answer. Bumping `evidenceVersion` is exactly the second case, so this very change would have disarmed the narrowing guard on the one regeneration where it matters most.

**`joinEvidence` did not carry the provenance.** Every regenerated artefact held three empty digests — and three empty digests compare equal to three empty digests, so the new gate would have accepted every stale leg **while reading exactly like a control**. The unit tests passed throughout. What found it was reading the file the tool had just written.

## The artefact

Regenerated from two fresh legs, machines `incus` and `none`, verified against the record it replaces: **231 operations, same runtimes, no narrowing.**

## Falsification

`mise run falsify -- tools/falsify/specs/evidence-freshness.json` — four mutations, four tests bitten:

| mutation | test |
|---|---|
| the digest ignores file contents | `TestTheDigestMovesWithTheInputsAndNotOtherwise` |
| a moved input is no longer named | `TestAJoinRefusesAnArtefactFromOtherInputs` |
| the join keeps only part of the provenance | `TestTheJoinedRecordKeepsItsProvenance` |
| an unreadable record is treated as absent | `TestAnUnreadableRecordIsNotAnAbsentOne` |

**The sort in `digestTree` carries none, and the spec says so.** Any *deterministic* reordering still makes two runs agree, so the determinism test cannot distinguish it; it guards against filesystem walk order varying between runs, which no test here can induce. Recorded rather than faked, the way #182's error branch is.

The harness gained a fix on the way: its declaration rule judged the replacement alone and refused `sum := sha256.New()`, a name declared in the fragment and used after it. It compares now — a name is orphaned when the mutation takes its use count *down* to its declaration, not when it was always one.

## Type of change

- [ ] A route added or changed
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes, via `mise run prepush`
- [x] No new external Go dependency — `crypto/sha256` is stdlib
- [x] `internal/core` still knows no provider — the change is in `internal/cli`
- [x] Nothing in the diff could be written identically for another provider

### When a model wrote a substantive part of this

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] **`mise run conformance` was run** — twice, as the two legs of `mise run evidence:update`, with the Incus runtime
- [x] Every digest and count above is read from the file the tool wrote, not recalled

### When a route is added or changed

N/A.

### When behaviour a client can observe changes

- [x] `coverage/evidence.json` and `docs/routes.md` regenerated; `feint docs --check` returns 0
- [x] The artefact version bump is a breaking change under RELEASING.md, and a bump now requires one deliberate regeneration — the old record cannot be compared, which is what a version bump means

### When `.github/workflows/` is touched

N/A.

### When a machine runtime is involved

- [x] Tested with `FEINT_VM=incus` — the second leg of the regeneration
- [x] Nothing the emulator did not create was touched
- [x] The run leaves nothing behind

## Related issues

Closes #171
