### PR TITLE
docs(roadmap): the environment becomes the thing that travels, after 1.0

### DIFF
--- a/docs/roadmap.fr.md
+++ b/docs/roadmap.fr.md
@@ -749,6 +749,62 @@ Rien de tout cela ne porte de jalon, et rien ne devrait en porter avant la
 sortie de la 1.0 : une direction avec une date est une promesse, et cette page a
 passé un an à apprendre ce que coûte une promesse intenable.
 
+### Puis le runtime cesse d'être une seule machine
+
+L'étape suivante n'est pas un émulateur plus gros, c'est le même moteur avec un
+autre runtime en dessous :
+
+```text
+API Scaleway ─┐
+API Outscale  ├──►  le modèle normalisé  ──►  un vrai cluster Incus
+API Exoscale ─┘                               OVN, stockage, placement
+```
+
+`terraform apply` inchangé, `runtime.mode` passé de `incus` à un cluster, et les
+ressources réellement créées sur du matériel que quelqu'un possède. Ce que cela
+vaut la peine de formuler avec soin :
+
+**Feint matérialise son modèle cloud sur un vrai cluster. Il ne gère pas le
+cluster.** Le premier garde le moteur qui existe (un dialecte, un modèle, un
+runtime) et remplace un hôte par plusieurs. Le second revient à assumer tout le
+cycle de vie opérationnel du matériel de quelqu'un : supervision, sauvegarde,
+PKI, secrets, IAM global, GitOps, catalogue de services. C'est OpenStack plus
+Proxmox plus Backstage à la fois, et ce projet ferait mal les trois.
+
+La contrainte d'architecture est celle qui existe déjà et qui n'a jamais été
+éprouvée à cette échelle : **aucun code de cluster dans les packs**. Trois
+dialectes atteignent un modèle normalisé, et le runtime ne voit que le modèle.
+`machine.Binding` tient cette ligne aujourd'hui pour un hôte ; un cluster est le
+premier vrai test de savoir si elle a été tracée au bon endroit. Si un pack
+apprend ce qu'est un nœud, l'abstraction était mal placée.
+
+#195 porte le runtime : placement, capacités qui répondent pour le cluster et
+non pour le membre qui a décroché, et `feint doctor --cluster`.
+
+Et #196 porte la question qui doit être tranchée **avant** que quoi que ce soit
+ne sorte, parce que la prendre implicitement est la façon dont un projet
+contracte une obligation que personne n'a acceptée : **Feint gère-t-il un jour
+une ressource dont la perte compterait ?** Tout ce qu'il crée aujourd'hui est
+jetable par construction, et tout l'argument de sûreté repose là-dessus. Un
+homelab contient les deux sortes. Le mode laboratoire reste dans l'ADN du
+projet ; le mode persistant fait passer le coût d'un `feint clean` malheureux
+d'une réexécution au week-end de quelqu'un, et un audit a déjà transformé un
+snapshot forgé en `delete --force` sur le pont par défaut d'un hôte.
+
+### L'ordre, si tout cela se fait
+
+| | |
+|---|---|
+| 1.0 | l'émulateur, stable et mesuré |
+| 1.1 | les environnements portables : #189 à #192 |
+| 1.2 | le runtime devient un cluster : #195, après réponse à #196 |
+| 1.3 | le modèle se matérialise sur un homelab |
+| 1.4 | dérive, assertions réseau, fautes injectées : #193, #194, #26, #124 |
+
+Écrit comme un ordre et non comme un calendrier. Rien de tout cela n'a de date,
+et la seule chose que cette page ait appris à éviter est une promesse dont
+quelqu'un d'autre tient la condition.
+
 ---
 
 ## Plus tard : décidé, pas planifié

--- a/docs/roadmap.fr.md
+++ b/docs/roadmap.fr.md
@@ -606,6 +606,151 @@ passent.
 
 ---
 
+## Après la 1.0 : c'est l'environnement qui devient portable
+
+C'est la direction produit, écrite avant qu'une ligne n'en soit construite pour
+que la frontière soit sur la page plutôt que dans la tête de quelqu'un. **Rien
+ici n'est planifié**, et rien n'appartient à une version 0.x.
+
+### La phrase
+
+**Feint n'est pas un Devbox généraliste. Feint est le Devbox de votre
+environnement cloud.**
+
+Devbox rend les **outils** d'un développeur reproductibles : paquets, versions,
+shell. Ce problème est résolu, par Devbox, Nix, mise et les dev containers, et
+ce projet n'a rien à faire à le résoudre une seconde fois. Ce qui ne l'est pas,
+c'est l'autre moitié : deux développeurs sur un même dépôt n'obtiennent pas le
+même **cloud** contre lequel travailler, et la CI non plus.
+
+Feint tient déjà l'essentiel des pièces. Un plan de contrôle que trois clients
+officiels pilotent, un runtime de machines avec de vrais réseaux et pare-feu, un
+format de snapshot conçu pour survivre à son instance, une image conteneur, des
+capacités de runtime déclarées, et un registre de preuves qui dit lesquelles
+sont prouvées. Ce qui manque, c'est ce qui relie tout cela à un dépôt.
+
+### La forme
+
+Un fichier qui décrit comment **lever l'environnement**, jamais ce qu'est
+l'infrastructure, jamais quels outils installer :
+
+```yaml
+# feint.yaml
+version: 1
+
+cloud:
+  provider: scaleway
+
+runtime:
+  mode: incus-ovn
+
+iac:
+  engine: opentofu
+  directory: terraform
+
+ready:
+  - ssh:web-01
+  - tcp:web-01:80
+```
+
+Puis `feint up`, et un collègue qui a cloné le dépôt obtient le même petit
+cloud : plan de contrôle démarré, client configuré, IaC appliquée, machines
+joignables, points d'entrée affichés.
+
+### Trois choses à ne jamais confondre
+
+C'est la contrainte de conception, et s'y tromper ferait de Feint un mauvais
+Terraform :
+
+| quoi | dit | où cela vit |
+|---|---|---|
+| `feint.yaml` | comment lever l'environnement | ce projet |
+| Terraform / OpenTofu | ce qu'est l'infrastructure | le dépôt de l'utilisateur |
+| un snapshot | quel est l'état courant | un artefact, partagé comme un fichier |
+
+`feint.yaml` ne doit jamais gagner un bloc de ressource. Le jour où il décrit un
+subnet, ce projet a commencé à réécrire Terraform, en moins bien.
+
+### Ce que cela ne doit pas devenir
+
+Le risque n'est pas technique, il est de périmètre. Ce dépôt s'est construit sur
+une discipline (émulation mesurée, refus explicites, un registre qui dit ce qui
+n'est pas prouvé) et une liste de fonctionnalités que personne n'a mesurées la
+dissoudrait plus vite que n'importe quel défaut.
+
+Donc, explicitement dehors : gestion de paquets, gestion de secrets, gestion de
+shell, développement distant, intégration IDE, registre d'environnements,
+synchronisation collaborative. Devbox se **compose** avec Feint, il n'est pas
+absorbé par lui.
+
+La première étape tient en **quatre primitives, pas une de plus** : le fichier,
+`up`, `down`, et l'export d'un environnement qu'un tiers peut reproduire.
+
+### Pourquoi cela vaut la peine
+
+Deux choses que ce projet possède déjà le rendent plus fort ici que les outils
+comparables.
+
+**Un vrai plan de données.** Les Cloud Pods de LocalStack partagent l'état, et
+leur intégration aux dev containers en fait un composant d'environnement
+reproductible : la direction est juste et ils y sont arrivés les premiers. Ce
+qu'ils n'ont pas, ce sont des machines dans lesquelles un développeur entre en
+`ssh`, sur des subnets réellement séparés. Feint les a, sous OVN, et c'est
+`capabilities.isolation` qui le dit plutôt qu'une affirmation.
+
+**La même déclaration en CI.** `feint up` sur un portable et `feint up` dans un
+workflow lisent un seul fichier, et la différence de runtime est **déclarée**
+plutôt que découverte : le plan de contrôle seul là où aucun runtime n'existe,
+des machines là où il y en a un. C'est la forme honnête du « ça marche chez
+moi », et c'est la pièce qui colle exactement à la doctrine existante du projet.
+
+### Le critère, qui est ce qui empêche la dilution
+
+**Une fonctionnalité appartient à Feint si elle aide à créer, reproduire,
+observer ou éprouver un environnement cloud local.** La gouvernance, la posture
+de conformité, l'identité d'entreprise et un catalogue de plateforme généraliste
+sont d'autres produits, et le dire ici coûte moins cher que de le découvrir
+trois fonctionnalités plus tard.
+
+Ce critère nomme aussi mieux le positionnement que « plateforme cloud locale » :
+ce que cela devient est un **laboratoire cloud**, et ces mots conservent le test,
+l'expérimentation et la preuve, c'est-à-dire ce que ce dépôt a réellement
+construit.
+
+### Les axes, et ceux qui existaient déjà
+
+Quatre primitives d'abord, pas une de plus :
+
+| # | primitive |
+|---|---|
+| #189 | la déclaration d'environnement |
+| #190 | `feint up` et `feint down` |
+| #191 | un environnement qu'un tiers peut reproduire |
+| #192 | la même déclaration sur un portable et en CI |
+
+Puis les axes qui exploitent ce que ce projet possède et que les outils
+comparables n'ont pas : de vraies machines, de vrais réseaux, et un registre qui
+dit ce qui est prouvé.
+
+| # | axe | pourquoi il est nôtre |
+|---|---|---|
+| #193 | simulation de dérive | modifier le cloud **derrière** Terraform est la seule situation qu'aucun test ici n'a jamais produite |
+| #194 | assertions réseau | OVN sait répondre à « la base est-elle joignable » plutôt qu'à « la règle est-elle déclarée » |
+| #26 | injection de fautes | déjà déposée ; les retries, le backoff et l'idempotence n'ont jamais été testés contre un refus |
+| #124 | cohérence éventuelle | déjà déposée ; un waiter que personne n'attend est un waiter que personne n'a testé |
+| #73 | enregistrer et rejouer | déjà déposée ; un transcript attaché à une issue est un bug que n'importe qui reproduit |
+
+Trois de ces cinq étaient ouvertes avant que cette direction ne soit écrite.
+Cela mérite d'être relevé plutôt que passé sous silence : elles ont été déposées
+une à une, pour des raisons locales, et elles se révèlent être la même idée.
+Nommer la direction est ce qui en fait un plan plutôt qu'un arriéré.
+
+Rien de tout cela ne porte de jalon, et rien ne devrait en porter avant la
+sortie de la 1.0 : une direction avec une date est une promesse, et cette page a
+passé un an à apprendre ce que coûte une promesse intenable.
+
+---
+
 ## Plus tard : décidé, pas planifié
 
 ### `--vm` se fait prouver par la CI, sur un runner que personne ne possède : suivi par #125

--- a/docs/roadmap.fr.md
+++ b/docs/roadmap.fr.md
@@ -749,47 +749,58 @@ Rien de tout cela ne porte de jalon, et rien ne devrait en porter avant la
 sortie de la 1.0 : une direction avec une date est une promesse, et cette page a
 passé un an à apprendre ce que coûte une promesse intenable.
 
-### Puis le runtime cesse d'être une seule machine
+### Puis le runtime appartient à un autre projet
 
-L'étape suivante n'est pas un émulateur plus gros, c'est le même moteur avec un
-autre runtime en dessous :
+L'étape évidente serait d'apprendre les clusters à ce pilote. C'est la mauvaise,
+et dire pourquoi est la chose la plus utile de cette page.
+
+Feint mélange délibérément deux choses, et pour un émulateur c'est juste :
 
 ```text
-API Scaleway ─┐
-API Outscale  ├──►  le modèle normalisé  ──►  un vrai cluster Incus
-API Exoscale ─┘                               OVN, stockage, placement
+le dialecte d'API d'un fournisseur  +  un runtime local
 ```
 
-`terraform apply` inchangé, `runtime.mode` passé de `incus` à un cluster, et les
-ressources réellement créées sur du matériel que quelqu'un possède. Ce que cela
-vaut la peine de formuler avec soin :
+Matérialiser sur du matériel réel et persistant rend la seconde moitié assez
+importante pour mériter son propre contrat. Un petit IaaS au-dessus d'Incus
+répond à une autre question que celle de ce projet, et répondre aux deux dans un
+seul binaire est la façon dont un dépôt se retrouve avec deux produits et n'en
+réussit aucun.
 
-**Feint matérialise son modèle cloud sur un vrai cluster. Il ne gère pas le
-cluster.** Le premier garde le moteur qui existe (un dialecte, un modèle, un
-runtime) et remplace un hôte par plusieurs. Le second revient à assumer tout le
-cycle de vie opérationnel du matériel de quelqu'un : supervision, sauvegarde,
-PKI, secrets, IAM global, GitOps, catalogue de services. C'est OpenStack plus
-Proxmox plus Backstage à la fois, et ce projet ferait mal les trois.
+D'où la séparation :
 
-La contrainte d'architecture est celle qui existe déjà et qui n'a jamais été
-éprouvée à cette échelle : **aucun code de cluster dans les packs**. Trois
-dialectes atteignent un modèle normalisé, et le runtime ne voit que le modèle.
-`machine.Binding` tient cette ligne aujourd'hui pour un hôte ; un cluster est le
-premier vrai test de savoir si elle a été tracée au bon endroit. Si un pack
-apprend ce qu'est un nœud, l'abstraction était mal placée.
+```text
+API Scaleway ──┐
+API Outscale  ─┼──►  Feint  ──►  une API cloud  ──►  Incus / OVN / stockage
+API Exoscale  ─┘  compatibilité   le projet d'un autre
+```
 
-#195 porte le runtime : placement, capacités qui répondent pour le cluster et
-non pour le membre qui a décroché, et `feint doctor --cluster`.
+Feint garde sa question (*mon code écrit pour ce fournisseur fonctionne-t-il ?*)
+et gagne un backend de runtime de plus, à côté de `off`, `incus` et
+`incus-ovn`. L'autre projet répond à *où cette infrastructure se matérialise-t-elle
+réellement ?*, et s'utilise sans Feint du tout : son propre CLI, son propre SDK,
+son propre provider Terraform.
 
-Et #196 porte la question qui doit être tranchée **avant** que quoi que ce soit
-ne sorte, parce que la prendre implicitement est la façon dont un projet
-contracte une obligation que personne n'a acceptée : **Feint gère-t-il un jour
-une ressource dont la perte compterait ?** Tout ce qu'il crée aujourd'hui est
-jetable par construction, et tout l'argument de sûreté repose là-dessus. Un
-homelab contient les deux sortes. Le mode laboratoire reste dans l'ADN du
-projet ; le mode persistant fait passer le coût d'un `feint clean` malheureux
-d'une réexécution au week-end de quelqu'un, et un audit a déjà transformé un
-snapshot forgé en `delete --force` sur le pont par défaut d'un hôte.
+**Le couplage est le protocole, pas un paquet.** Aucun
+`import github.com/…/feint/internal/…` dans ce projet, et aucun dans l'autre
+sens. Un contrat HTTP est une frontière qui survit à une réécriture dans un
+autre langage ; un paquet Go partagé est une frontière qui se dissout à la
+première fois où quelqu'un a besoin d'un champ de plus. C'est la règle du noyau
+neutre d'`internal/core`, appliquée un cran au-dessus.
+
+Deux conséquences à écrire avant que quiconque ne construise l'un des deux côtés.
+
+**Son API doit être asynchrone dès le premier commit.** Un `POST /instances` qui
+répond `202` avec une opération à interroger n'est pas un raffinement à ajouter
+plus tard : le rétro-adapter revient à changer tous les clients qui ont consommé
+la forme synchrone. Feint peut répondre `running` immédiatement parce qu'il
+émule ; un vrai plan de contrôle ne le peut pas. C'est aussi pourquoi #124
+compte ici : un émulateur qui ne répond jamais qu'instantanément est un
+émulateur contre lequel le code d'attente de personne n'a été testé.
+
+**Ce qui appartient à ce dépôt est un backend et sa frontière.** L'API de
+l'autre projet, son ordonnanceur, son IPAM et son authentification ne sont pas
+des issues d'ici, et les y déposer serait le premier pas vers la refusion des
+deux.
 
 ### L'ordre, si tout cela se fait
 
@@ -797,8 +808,8 @@ snapshot forgé en `delete --force` sur le pont par défaut d'un hôte.
 |---|---|
 | 1.0 | l'émulateur, stable et mesuré |
 | 1.1 | les environnements portables : #189 à #192 |
-| 1.2 | le runtime devient un cluster : #195, après réponse à #196 |
-| 1.3 | le modèle se matérialise sur un homelab |
+| 1.2 | un backend de runtime de plus, parlant un contrat HTTP : #195 |
+| 1.3 | ce contrat a un cloud derrière lui, dans son propre dépôt |
 | 1.4 | dérive, assertions réseau, fautes injectées : #193, #194, #26, #124 |
 
 Écrit comme un ordre et non comme un calendrier. Rien de tout cela n'a de date,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -577,6 +577,146 @@ surface cannot keep growing if the suite that proves it becomes the bottleneck.
 
 ---
 
+## After 1.0: the environment becomes the thing that travels
+
+This is the product direction, written down before any of it is built so that
+the boundary is on the page rather than in somebody's head. **Nothing here is
+scheduled**, and none of it belongs to a 0.x release.
+
+### The sentence
+
+**Feint is not a general-purpose Devbox. Feint is the Devbox of your cloud
+environment.**
+
+Devbox makes a developer's *tools* reproducible — packages, versions, shell.
+That problem is solved, by Devbox, Nix, mise and dev containers, and this project
+has no business re-solving it. What is not solved is the other half: two
+developers on the same repository do not get the same *cloud* to develop
+against, and neither does CI.
+
+Feint already holds most of the pieces. A control plane three official clients
+drive, a machine runtime with real networks and firewalls, a snapshot format
+designed to outlive its instance, a container image, declared runtime
+capabilities, and an evidence record that says which of all that is proven. What
+is missing is the thing that ties them to a repository.
+
+### The shape
+
+One file describing how to *bring the environment up* — never what the
+infrastructure is, and never which tools to install:
+
+```yaml
+# feint.yaml
+version: 1
+
+cloud:
+  provider: scaleway
+
+runtime:
+  mode: incus-ovn
+
+iac:
+  engine: opentofu
+  directory: terraform
+
+ready:
+  - ssh:web-01
+  - tcp:web-01:80
+```
+
+Then `feint up`, and a colleague who cloned the repository gets the same small
+cloud: the control plane started, the client configured, the IaC applied, the
+machines reachable, and the endpoints printed.
+
+### Three things that must not be confused
+
+This is the design constraint, and getting it wrong would turn Feint into a
+worse Terraform:
+
+| what | says | where it lives |
+|---|---|---|
+| `feint.yaml` | how to bring the environment up | this project |
+| Terraform / OpenTofu | what the infrastructure is | the user's repository |
+| a snapshot | what the state currently is | an artefact, shared as a file |
+
+`feint.yaml` must never grow a resource block. The moment it describes a subnet,
+this project has started rewriting Terraform badly.
+
+### What it must not become
+
+The risk here is not technical, it is scope. This repository was built with a
+discipline — measured emulation, explicit refusals, a record that says what is
+unproven — and a list of features nobody measured would dissolve it faster than
+any bug.
+
+So, explicitly out: package management, secret management, shell management,
+remote development, IDE integration, an environment registry, collaborative
+sync. Devbox composes with Feint; it is not absorbed by it.
+
+The first step is **four primitives and no more**: the file, `up`, `down`, and
+exporting an environment somebody else can reproduce.
+
+### Why it is worth doing at all
+
+Two things this project already has make it stronger here than the comparable
+tools.
+
+**A real dataplane.** LocalStack's Cloud Pods share state, and its dev-container
+integration makes it a component of a reproducible environment — the direction
+is right and they got there first. What they do not have is machines a
+developer can `ssh` into, on subnets that are actually separate. Feint does,
+under OVN, and `capabilities.isolation` is what says so rather than a claim.
+
+**The same declaration in CI.** `feint up` on a laptop and `feint up` in a
+workflow read one file, and the runtime difference is *declared* rather than
+discovered: the control plane alone where no runtime exists, machines where one
+does. That is the honest form of "it works on my machine", and it is the one
+piece of this that fits the project's existing doctrine exactly.
+
+### The criterion, which is what keeps this from dissolving
+
+**A feature belongs to Feint if it helps create, reproduce, observe or test a
+local cloud environment.** Governance, compliance posture, enterprise identity
+and a general platform catalogue are other products, and saying so here is
+cheaper than discovering it three features in.
+
+That criterion also names the positioning better than "local cloud platform"
+does: what this becomes is a **cloud lab** — the words keep the testing, the
+experimenting and the proving, which is what this repository has actually built.
+
+### The axes, and the ones that already existed
+
+Four primitives first, and no more:
+
+| # | primitive |
+|---|---|
+| #189 | the environment declaration |
+| #190 | `feint up` and `feint down` |
+| #191 | an environment somebody else can reproduce |
+| #192 | the same declaration on a laptop and in CI |
+
+Then the axes that exploit what this project has and the comparable tools do
+not — real machines, real networks, and a record that says what is proven:
+
+| # | axis | why it is ours |
+|---|---|---|
+| #193 | drift simulation | changing the cloud *behind* Terraform is the one situation no test here has ever produced |
+| #194 | network assertions | OVN can answer "is the database reachable" instead of "is the rule declared" |
+| #26 | fault injection | already filed; retries, backoff and idempotence have never been tested against a refusal |
+| #124 | eventual consistency | already filed; a waiter nobody waits for is a waiter nobody tested |
+| #73 | record and replay | already filed; a transcript attached to an issue is a bug anybody can reproduce |
+
+Three of those five were open before this direction was written down. That is
+worth noticing rather than glossing: they were filed one at a time, for local
+reasons, and they turn out to be the same idea. Naming the direction is what
+makes them a plan instead of a backlog.
+
+None of it carries a milestone, and none should until 1.0 is out: a direction
+with a date is a promise, and this page has spent a year learning what an
+unkeepable promise costs.
+
+---
+
 ## Later, decided, not scheduled
 
 ### `--vm` gets proven by CI, on a runner nobody owns — tracked by #125

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -715,46 +715,54 @@ None of it carries a milestone, and none should until 1.0 is out: a direction
 with a date is a promise, and this page has spent a year learning what an
 unkeepable promise costs.
 
-### And then the runtime stops being one machine
+### And then the runtime is somebody else's project
 
-The step after that is not a bigger emulator, it is the same engine with a
-different runtime underneath:
+The obvious next step is to teach this driver about clusters. It is the wrong
+one, and saying why is the most useful thing on this page.
+
+Feint deliberately mixes two things, and for an emulator that is correct:
 
 ```text
-Scaleway API ─┐
-Outscale API  ├──►  the normalised model  ──►  a real Incus cluster
-Exoscale API ─┘                                OVN, storage, placement
+a provider's API dialect  +  a local runtime
 ```
 
-`terraform apply` unchanged, `runtime.mode` moved from `incus` to a cluster, and
-the resources are really created on hardware somebody owns. What that is worth
-saying carefully:
+Materialising on real, persistent hardware makes the second half important
+enough to deserve its own contract. A small IaaS above Incus answers a different
+question from the one this project answers, and answering both in one binary is
+how a repository acquires two products and does neither well.
 
-**Feint materialises its cloud model on a real cluster. It does not manage the
-cluster.** The first keeps the engine that exists — a dialect, a model, a
-runtime — and swaps one host for several. The second means owning the
-operational lifecycle of somebody's hardware: monitoring, backup, PKI, secrets,
-global IAM, GitOps, a service catalogue. That is OpenStack and Proxmox and
-Backstage at once, and this project would do all three badly.
+So the split:
 
-The architecture constraint is the one that already exists and has never been
-tested at this scale: **no cluster code in the packs**. Three dialects reach one
-normalised model, and the runtime sees only the model. `machine.Binding` holds
-that line today for one host; a cluster is the first real test of whether it was
-drawn in the right place. If a provider pack learns what a node is, the
-abstraction was wrong.
+```text
+Scaleway API ──┐
+Outscale API  ─┼──►  Feint  ──►  a cloud API  ──►  Incus / OVN / storage
+Exoscale API  ─┘   compatibility   somebody else's project
+```
 
-#195 carries the runtime — placement, capabilities that answer for the cluster
-rather than for whichever member replied, and `feint doctor --cluster`.
+Feint keeps its question — *does my code written for this provider work?* — and
+gains one more runtime backend beside `off`, `incus` and `incus-ovn`. The other
+project answers *where does this infrastructure actually materialise?*, and is
+usable without Feint at all: its own CLI, its own SDK, its own Terraform
+provider.
 
-And #196 carries the question that must be answered *before* any of it ships,
-because taking it implicitly is how a project acquires an obligation nobody
-agreed to: **does Feint ever manage a resource whose loss would matter?**
-Everything it creates today is disposable by construction, and the whole safety
-argument rests on that. A homelab holds both kinds. Lab mode stays inside this
-project's DNA; persistent mode changes what `feint clean` costs from a rerun to
-somebody's weekend, and an audit has already turned a crafted snapshot into a
-`delete --force` on a host's default bridge.
+**The coupling is the protocol, not a package.** No `import
+github.com/…/feint/internal/…` in that project and none the other way. An HTTP
+contract is a boundary that survives a rewrite in another language; a shared Go
+package is a boundary that dissolves the first time somebody needs one more
+field. This is the neutral-core rule of `internal/core`, applied one level up.
+
+Two consequences worth writing down before anybody builds either side.
+
+**Its API should be asynchronous from the first commit.** `POST /instances`
+answering `202` with an operation to poll is not a refinement to add later:
+retrofitting it means changing every client that ever consumed the synchronous
+shape. Feint can answer `running` immediately because it emulates; a real
+control plane cannot. That is also why #124 matters here — an emulator that only
+ever answers instantly is one nobody's waiter code was tested against.
+
+**What belongs to this repository is one backend and its boundary.** The other
+project's API, its scheduler, its IPAM and its authentication are not issues
+here, and filing them here would be the first step in merging the two again.
 
 ### The order, if all of it happens
 
@@ -762,8 +770,8 @@ somebody's weekend, and an audit has already turned a crafted snapshot into a
 |---|---|
 | 1.0 | the emulator, stable and measured |
 | 1.1 | portable environments — #189 to #192 |
-| 1.2 | the runtime is a cluster — #195, after #196 is answered |
-| 1.3 | the model materialises on a homelab |
+| 1.2 | one more runtime backend, speaking an HTTP contract — #195 |
+| 1.3 | that contract has a cloud behind it, in its own repository |
 | 1.4 | drift, network assertions, injected failures — #193, #194, #26, #124 |
 
 Written as an order rather than a schedule. None of it has a date, and the one

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -715,6 +715,61 @@ None of it carries a milestone, and none should until 1.0 is out: a direction
 with a date is a promise, and this page has spent a year learning what an
 unkeepable promise costs.
 
+### And then the runtime stops being one machine
+
+The step after that is not a bigger emulator, it is the same engine with a
+different runtime underneath:
+
+```text
+Scaleway API ─┐
+Outscale API  ├──►  the normalised model  ──►  a real Incus cluster
+Exoscale API ─┘                                OVN, storage, placement
+```
+
+`terraform apply` unchanged, `runtime.mode` moved from `incus` to a cluster, and
+the resources are really created on hardware somebody owns. What that is worth
+saying carefully:
+
+**Feint materialises its cloud model on a real cluster. It does not manage the
+cluster.** The first keeps the engine that exists — a dialect, a model, a
+runtime — and swaps one host for several. The second means owning the
+operational lifecycle of somebody's hardware: monitoring, backup, PKI, secrets,
+global IAM, GitOps, a service catalogue. That is OpenStack and Proxmox and
+Backstage at once, and this project would do all three badly.
+
+The architecture constraint is the one that already exists and has never been
+tested at this scale: **no cluster code in the packs**. Three dialects reach one
+normalised model, and the runtime sees only the model. `machine.Binding` holds
+that line today for one host; a cluster is the first real test of whether it was
+drawn in the right place. If a provider pack learns what a node is, the
+abstraction was wrong.
+
+#195 carries the runtime — placement, capabilities that answer for the cluster
+rather than for whichever member replied, and `feint doctor --cluster`.
+
+And #196 carries the question that must be answered *before* any of it ships,
+because taking it implicitly is how a project acquires an obligation nobody
+agreed to: **does Feint ever manage a resource whose loss would matter?**
+Everything it creates today is disposable by construction, and the whole safety
+argument rests on that. A homelab holds both kinds. Lab mode stays inside this
+project's DNA; persistent mode changes what `feint clean` costs from a rerun to
+somebody's weekend, and an audit has already turned a crafted snapshot into a
+`delete --force` on a host's default bridge.
+
+### The order, if all of it happens
+
+| | |
+|---|---|
+| 1.0 | the emulator, stable and measured |
+| 1.1 | portable environments — #189 to #192 |
+| 1.2 | the runtime is a cluster — #195, after #196 is answered |
+| 1.3 | the model materialises on a homelab |
+| 1.4 | drift, network assertions, injected failures — #193, #194, #26, #124 |
+
+Written as an order rather than a schedule. None of it has a date, and the one
+thing this page has learned to avoid is a promise whose condition somebody else
+controls.
+
 ---
 
 ## Later, decided, not scheduled


### PR DESCRIPTION
A product direction, written before a line of it is built so the boundary sits on the page rather than in somebody's head. **Nothing here is scheduled** and none of it belongs to a 0.x release.

## The sentence

> **Feint is not a general-purpose Devbox. Feint is the Devbox of your cloud environment.**

Devbox, Nix, mise and dev containers make a developer's *tools* reproducible, and that problem is solved. What is not solved is that two developers on one repository do not get the same *cloud* to develop against, and neither does CI.

## The design constraint

Getting this wrong makes Feint a worse Terraform:

| what | says | where it lives |
|---|---|---|
| `feint.yaml` | how to bring the environment up | this project |
| Terraform / OpenTofu | what the infrastructure is | the user's repository |
| a snapshot | what the state currently is | an artefact |

The day that file grows a resource block, or a `packages:` list, this project has started rewriting somebody else's tool badly.

## The criterion

> **A feature belongs here if it helps create, reproduce, observe or test a local cloud environment.**

Governance, compliance posture, enterprise identity and a platform catalogue are other products. That criterion also names the positioning better than *local cloud platform* does: what this becomes is a **cloud lab**, and those words keep the testing and the proving the repository actually built.

## What is filed

Four primitives, and no more:

| # | primitive |
|---|---|
| #189 | the environment declaration |
| #190 | `feint up` and `feint down` |
| #191 | an environment somebody else can reproduce |
| #192 | the same declaration on a laptop and in CI |

Then the axes that exploit what the comparable tools do not have:

| # | axis |
|---|---|
| #193 | drift simulation — changing the cloud *behind* Terraform, which no test here has ever produced |
| #194 | network assertions — asking OVN whether the database is reachable, not whether the rule is declared |
| #195 | the runtime becomes a cluster |
| #196 | **decision**: does Feint ever manage a resource whose loss would matter? |

**Three of the five axes were already open** — fault injection (#26), eventual consistency (#124), record/replay (#73). They were filed one at a time for local reasons and turn out to be the same idea. Naming the direction is what makes them a plan instead of a backlog.

## The boundary on the homelab step

> **Feint materialises its cloud model on a real cluster. It does not manage the cluster.**

The first keeps the engine that exists. The second means owning the operational lifecycle of somebody's hardware. #196 exists because taking that implicitly — by shipping a cluster runtime that happens to work on persistent storage — is how a project acquires an obligation nobody agreed to. Everything Feint creates today is disposable by construction, and an audit has already turned a crafted snapshot into a `delete --force` on a host's default bridge.

## Type of change

- [ ] A route added or changed
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes — no Go file is touched
- [x] No new external Go dependency
- [x] `internal/core` still knows no provider
- [x] Nothing in the diff could be written identically for another provider

### When a model wrote a substantive part of this

- [x] An `Assisted-by:` trailer names the tool and the model version
- [ ] **N/A, stated rather than ticked.** `mise run conformance` was not run: two Markdown files, no route, no shape. `feint docs --check` returns 0, with a binary built from this branch — the first run answered 2 from a stale binary carrying another branch's routes, which is worth recording because it looked exactly like a real staleness
- [x] Every existing issue referenced was read before being cited, and the three that already covered an axis are linked rather than duplicated

### When a route is added or changed

N/A.

### When behaviour a client can observe changes

N/A — nothing the emulator serves changes.

### When `.github/workflows/` is touched

N/A.

### When a machine runtime is involved

N/A.