### PR TITLE
feat(falsify): a falsification is declared beside its guard, and replayed (#169)

### DIFF
--- a/.github/workflows/falsify.yml
+++ b/.github/workflows/falsify.yml
@@ -1,0 +1,110 @@
+# Replaying the falsifications (#169).
+#
+# A falsification proves a test bites on the day it is run. Every guard of the
+# 0.9 train was falsified by hand, once, in a throwaway script that was deleted
+# with the branch — so each of those verdicts was a claim about the past, and
+# this repository has already shipped one that was false. The 0.8.0 CHANGELOG
+# says "neutralise any of the three locks and the barrage goes red on the first
+# attempt"; the lock was later removed and thirty runs stayed green.
+#
+# So the mutations are declared beside the guards they neutralise
+# (tools/falsify/specs/) and replayed here. A guard whose test has stopped
+# biting fails this run, naming the pair, instead of ageing quietly.
+#
+# Why this can be a hard red where runtime-proof.yml cannot: this workflow
+# builds nothing but Go and talks to nothing. No Incus, no OVN, no third-party
+# release server, no network weather. Its verdict is a property of the tree, and
+# the same input gives the same answer every night.
+#
+# Why it is still not on pull_request: it copies the tree and runs `go test` once
+# per mutation, twenty-three times as of this commit, and that cost grows with
+# every guard the project adds — which is the direction we want it to grow in.
+# Nightly plus dispatch keeps the incentive pointing the right way: declaring one
+# more mutation must never be the thing that makes pull requests slower.
+name: Falsify
+
+on:
+  schedule:
+    # Offset from conformance.yml (03:43) and runtime-proof.yml (02:31): three
+    # nightly workflows that never contend for the same minute.
+    - cron: '17 4 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  replay:
+    name: Every declared falsification still holds
+    runs-on: ubuntu-24.04
+    # Each mutation is a fresh copy plus a package build and one test run. The
+    # first copy pays for the whole module's compilation; the rest hit the cache.
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.26.6'
+          # No go.sum to key a cache on: the zero-dependency rule keeps this
+          # module dependency-free.
+          cache: false
+
+      # The harness against its own history first. It refuses a mutation that
+      # does not compile, because that mistake voided three verdicts in one day
+      # and looks exactly like success — every test fails, including the one
+      # being falsified. If the rule itself has rotted, the replay below would
+      # report on a rule nobody checked.
+      - name: The harness, against the mistakes it was written for
+        run: python3 tools/falsify/falsify.py --selftest
+
+      # The tree must be green before anything is mutated. A copy that is already
+      # red makes every verdict void: the test would fail for a reason that has
+      # nothing to do with the guard. falsify.py checks this per package, but a
+      # whole-tree run here says so in one line rather than eight.
+      - name: The tree is green before it is broken
+        run: go test ./...
+
+      - name: Replay every declared falsification
+        run: python3 tools/falsify/falsify.py --all tools/falsify/specs
+
+      # And the replay's own claim, measured rather than asserted: a test whose
+      # assertion has been loosened until it cannot fail must fail this workflow
+      # and not `go test`. Without this step the job above proves that eight
+      # specs are green, which is what it would also print if it had stopped
+      # measuring anything.
+      - name: The replay catches a test that stopped biting
+        run: python3 tools/falsify/proof.py
+
+      # The replay's own inventory, in the run summary: which guards are covered
+      # and which are not. A list that only ever grows by somebody remembering to
+      # add to it is a list that stops matching the code, which is the failure
+      # mode #88 paid for with its stale check.
+      - name: What is covered
+        if: always()
+        run: |
+          set -euo pipefail
+          {
+            echo "## Declared falsifications"
+            echo
+            echo "| spec | mutations |"
+            echo "|---|--:|"
+            for spec in tools/falsify/specs/*.json; do
+              count="$(jq '.mutations | length' "${spec}")"
+              echo "| \`$(basename "${spec}" .json)\` | ${count} |"
+            done
+            echo
+            echo "Each row is a guard whose test was required to fail without it,"
+            echo "on this tree, tonight. A guard that is not listed has never been"
+            echo "falsified, or was falsified once in a branch that no longer exists."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CONTRIBUTING.fr.md
+++ b/CONTRIBUTING.fr.md
@@ -48,7 +48,7 @@ runner.
 |---|---|---|
 | une route, une forme de réponse, une erreur | `mise run conformance` | qu'un vrai client passe encore |
 | un gate, un score, un verdict sur une exécution | `mise run conformance:leg -- <jambe>` | qu'il tient sur une exécution **partielle** |
-| une garde, une validation, un refus | `mise run falsify -- <spec.json>` | que le test échoue sans elle |
+| une garde, une validation, un refus | `mise run falsify -- <spec.json>`, puis la déclarer dans `tools/falsify/specs/` | que le test échoue sans elle, les jours suivants aussi |
 | `internal/core/machine`, un réseau, un pare-feu | `FEINT_VM=incus-ovn mise run conformance` | que le runtime accepte ce que le pilote envoie |
 | un artefact de `coverage/` | `mise run evidence:update` | que le registre n'a pas rétréci |
 
@@ -103,6 +103,25 @@ if (err != nil && false) || n == 0 {
 contre leurs corrections, et `mise run prepush` le lance. Les deux moitiés
 comptent : une règle qui refuserait toute mutation passerait la première et
 rendrait l'outil inutile.
+
+**Déclarer la mutation, pas seulement la lancer.** Une falsification prouve qu'un
+test mord *le jour où on la lance*, et une exécution unique dans une branche qui
+disparaît ensuite ne laisse qu'une affirmation sur le passé. Ce dépôt en a déjà
+publié une qui était fausse : le CHANGELOG de 0.8.0 dit que neutraliser
+n'importe lequel des trois verrous fait rougir le barrage, et trente exécutions
+sont ensuite restées vertes avec un verrou retiré. La mutation va donc dans
+`tools/falsify/specs/`, à côté de la garde, et `mise run falsify:all` les rejoue
+toutes chaque nuit (`.github/workflows/falsify.yml`).
+
+Le premier rejeu complet a trouvé quatre specs sur huit qui ne tenaient plus, et
+rien de tout cela n'était une pourriture de l'émulateur : trois mutations étaient
+écrites dans le style suppressif, une nommait deux gardes qu'une réécriture
+ultérieure avait retirées, et une déclarait un test qui ne correspondait pas à la
+garde placée dessous. Ce dernier cas a compilé et a laissé le test nommé vert,
+c'est celui pour lequel le rejeu existe, et aucun `go test` ne peut le voir.
+`mise run falsify:proof` est cette affirmation mesurée : il desserre une
+assertion jusqu'à ce qu'elle ne puisse plus échouer, puis exige que le rejeu
+rougisse en la nommant pendant que la suite reste verte.
 
 `mise run conformance` n'est **délibérément pas** dans le hook. Il réclame `scw`,
 `oapi-cli`, `exo` et Terraform installés, et prend des minutes : en hook, il

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ pull request will refuse without ever depending on a runner's weather.
 |---|---|---|
 | a route, a response shape, an error | `mise run conformance` | that a real client still passes |
 | a gate, a score, a verdict about a run | `mise run conformance:leg -- <leg>` | that it holds on a **partial** run |
-| a guard, a validation, a refusal | `mise run falsify -- <spec.json>` | that the test fails without it |
+| a guard, a validation, a refusal | `mise run falsify -- <spec.json>`, then declare it in `tools/falsify/specs/` | that the test fails without it, on every later day too |
 | `internal/core/machine`, a network, a firewall | `FEINT_VM=incus-ovn mise run conformance` | that the runtime accepts what the driver sends |
 | an artefact under `coverage/` | `mise run evidence:update` | that the record did not narrow |
 
@@ -96,6 +96,23 @@ if (err != nil && false) || n == 0 {
 `mise run falsify -- --selftest` holds that rule against those four real cases
 and against their fixes, and `mise run prepush` runs it. Both halves matter: a
 rule that refused every mutation would pass the first and make the tool useless.
+
+**Declare the mutation, do not just run it.** A falsification proves a test bites
+*on the day it is run*, and one run in a branch that later disappears leaves a
+claim about the past. This repository has already published one that was false —
+the 0.8.0 CHANGELOG says neutralising any of three locks reds the barrage, and
+thirty runs later stayed green with a lock removed. So the mutation goes in
+`tools/falsify/specs/`, beside the guard, and `mise run falsify:all` replays
+every one of them nightly (`.github/workflows/falsify.yml`).
+
+The first full replay found four of eight specs no longer holding, and none of
+it was rot in the emulator: three mutations were written in the deleting style,
+one named two guards a later rewrite had removed, and one declared a test that
+did not match the guard under it. That last one compiled and left the named test
+green, which is the case the replay exists for, and which no amount of `go test`
+can see. `mise run falsify:proof` is that claim measured: it loosens an assertion
+until it cannot fail, then requires the replay to go red naming it while the
+suite stays green.
 
 `mise run conformance` is deliberately **not** in the hook. It needs `scw`,
 `oapi-cli`, `exo` and Terraform installed and takes minutes; as a hook it would

--- a/docs/conformance.fr.md
+++ b/docs/conformance.fr.md
@@ -209,6 +209,7 @@ dans la semaine.
 | les vrais clients, un par un | | ✔ | ✔ | demandé à la CI |
 | le gate d'omission (exécution entière) | | ✔ (jambe `fields`) | ✔ | demandé à la CI |
 | le runtime de machines, dans les deux modes | | | ✔ | |
+| chaque falsification déclarée mord encore | | | ✔ | |
 | les surfaces gelées et leurs versions | ✔ | ✔ | | ✔ |
 
 La preuve adossée au runtime n'est délibérément pas sur le chemin des pull
@@ -227,7 +228,8 @@ Quatre phrases gouvernent chaque maillon ci-dessus. Chacune a été payée.
   survit des mois parce qu'il se lit comme une preuve. `/falsify` en est la forme
   exécutable : retirer la garde dans une copie hors du dépôt, et exiger que le
   test nommé rougisse. La mutation doit compiler, sans quoi tous les tests
-  échouent et cela ressemble exactement à une réussite.
+  échouent et cela ressemble exactement à une réussite. Ces mutations sont
+  déclarées et rejouées, c'est la section ci-dessous.
 - **Généré n'est pas dérivé.** Un bloc sous un marqueur « ne pas modifier à la
   main » dont le contenu est une constante un fichier plus loin est une
   affirmation écrite à la main déguisée en générateur. C'est arrivé deux fois.
@@ -239,34 +241,75 @@ Quatre phrases gouvernent chaque maillon ci-dessus. Chacune a été payée.
   recommandé de retirer une suite Terraform du README parce qu'un tableau ne la
   créditait pas. Cette suite appliquait vingt et une ressources et passait.
 
+## Les gardes, rejouées
+
+Tout ce qui précède est tenu par des tests, et un test peut cesser de mordre sans
+que personne s'en aperçoive. Ce n'est pas une hypothèse ici : le CHANGELOG de
+0.8.0 affirme que *neutraliser n'importe lequel des trois verrous fait rougir le
+barrage dès la première tentative*, et trente exécutions consécutives sont
+ensuite restées vertes avec un verrou retiré. Une falsification prouve qu'un test
+mord **le jour où on la lance**, et chaque falsification du train 0.9 a été lancée
+une fois, à la main, dans un script supprimé avec sa branche.
+
+Les mutations sont donc déclarées à côté de la garde qu'elles neutralisent, dans
+`tools/falsify/specs/*.json` (le fichier, la modification exacte, et le test qui
+doit rougir), et rejouées chaque nuit :
+
+```bash
+mise run falsify:all           # toutes les falsifications déclarées
+mise run falsify -- tools/falsify/specs/mispointed.json   # une seule
+mise run falsify:selftest      # le harnais contre sa propre histoire
+```
+
+Chaque mutation s'applique dans une copie hors de l'arbre de travail, une à la
+fois, et quatre verdicts sont distingués plutôt que confondus :
+
+| verdict | ce que cela veut dire |
+|---|---|
+| le test a mordu | la garde est mesurée, aujourd'hui |
+| **le test est resté vert** | la garde n'est pas mesurée, et c'est le test qu'il faut corriger |
+| **n'a pas compilé** | verdict nul, pas favorable : tous les tests échouent, ce qui se lit comme un succès |
+| **ne s'applique pas** | le code a bougé sous la déclaration |
+
+Ce sont les deux derniers qui justifient de lancer tout cela. Avertir n'a pas
+suffi (l'erreur de compilation a annulé trois verdicts en une journée, dans trois
+issues sans rapport), donc le harnais refuse une mutation qui perd un nom que
+l'expression d'origine utilisait, et exige la forme neutralisante (`… && false`,
+`(… || true)`).
+
+Le premier rejeu complet a payé son coût immédiatement, et pas en trouvant une
+pourriture dans l'émulateur. Sur huit specs, quatre ne tenaient plus : trois
+étaient écrites dans le style suppressif que la règle refuse, une nommait deux
+gardes que la forme finale de #179 avait retirées, et une déclarait un test qui
+ne correspondait pas à la garde placée dessous, deux conditions `synthetic`
+distantes d'un écran dans le même fichier, l'une relevant de #88 et l'autre de
+#163. Ce dernier cas est celui pour lequel le rejeu existe : la mutation a
+compilé, et le test nommé est resté vert.
+
 ## Ce qui n'est pas encore fermé
 
-Trois maillons de la chaîne ci-dessus sont énoncés sans être appliqués. Ce sont
-des issues ouvertes, et elles sont nommées ici parce qu'une page qui ne
-décrirait que la moitié terminée serait le défaut que ce projet supprime.
+Un maillon de la chaîne ci-dessus est énoncé sans être appliqué. C'est une issue
+ouverte, et elle est nommée ici parce qu'une page qui ne décrirait que la moitié
+terminée serait le défaut que ce projet supprime.
 
-- **Une falsification prouve qu'un test mord le jour où on la lance, et rien ne
-  la relance** ([#169](https://github.com/stephrobert/feint/issues/169)). Chaque
-  mécanisme a été falsifié à sa pull request ; rien ne rejoue ces mutations. Une
-  affirmation de falsification a déjà été fausse dans ce dépôt : trente
-  exécutions vertes avec un verrou retiré, consignées dans le CHANGELOG de
-  0.8.0.
 - **Rien ne mesure ce qu'une release fait à un consommateur**
   ([#170](https://github.com/stephrobert/feint/issues/170)). `schema_version` est
   le signal qui permet à un pipeline de s'apercevoir d'une cassure ; rien ne
   vérifie qu'un pipeline **puisse** s'en apercevoir. `probed` est passé de
   booléen à chaîne, et un consommateur qui le lit comme vrai compte chaque refus
   comme un succès.
-- **La règle de fraîcheur du registre de preuves est écrite deux fois et
-  appliquée nulle part**
-  ([#171](https://github.com/stephrobert/feint/issues/171)). *Supprimer une
-  assertion de conformance doit rétrograder les opérations qu'elle prouvait*
-  figure dans `internal/cli/evidence.go` et dans `mise.toml`, et aucun test ne
-  tient l'une ou l'autre phrase.
 
-Tant que ces trois-là ne sont pas fermées, l'énoncé honnête est celui par lequel
-cette page commence : la chaîne est mesurée, maillon par maillon, et ces trois
-maillons-là sont mesurés par de la prose.
+Tant qu'elle n'est pas fermée, l'énoncé honnête est celui par lequel cette page
+commence : la chaîne est mesurée, maillon par maillon, et ce maillon-là est
+mesuré par de la prose.
+
+Les deux autres que cette section listait sont fermées et repliées dans la page
+ci-dessus. [#171](https://github.com/stephrobert/feint/issues/171) a donné au
+registre de preuves une provenance que la jointure compare, de sorte que
+supprimer une assertion de conformance rétrograde ce qu'elle prouvait au lieu de
+rester une phrase écrite deux fois ;
+[#169](https://github.com/stephrobert/feint/issues/169) est le rejeu décrit une
+section plus haut.
 
 ## Lire les chiffres soi-même
 

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -192,6 +192,7 @@ those would go red on routine runs and be disarmed within the week.
 | the real clients, per client | | ✔ | ✔ | asked of CI |
 | the omission gate (whole run) | | ✔ (`fields` leg) | ✔ | asked of CI |
 | the machine runtime, both modes | | | ✔ | |
+| every declared falsification still bites | | | ✔ | |
 | frozen surfaces and their versions | ✔ | ✔ | | ✔ |
 
 The machine-runtime proof is deliberately not on the pull-request path. A gate
@@ -208,7 +209,8 @@ Four sentences govern every link above. Each was paid for.
   fix written in prose and never asserted survives for months because it reads
   like evidence. `/falsify` is the executable form: remove the guard in a copy
   outside the repository, and require the named test to go red — the mutation
-  must compile, or every test fails and that looks exactly like success.
+  must compile, or every test fails and that looks exactly like success. The
+  mutations are declared and replayed, which is the section below.
 - **Generated is not derived.** A block under a "do not edit by hand" marker
   whose content is a constant one file away is a hand-written claim wearing a
   generator's clothes. It happened, twice.
@@ -219,30 +221,70 @@ Four sentences govern every link above. Each was paid for.
   once recommended deleting a Terraform suite from the README because a table
   did not credit it. The suite applied twenty-one resources and passed.
 
+## The guards, replayed
+
+Everything above is held by tests, and a test can stop biting without anybody
+noticing. That is not a hypothetical here: the 0.8.0 CHANGELOG states that
+*neutralising any of the three locks makes the barrage go red on the first
+attempt*, and thirty consecutive runs later stayed green with a lock removed. A
+falsification proves a test bites **on the day it is run**, and every falsification
+of the 0.9 train was run once, by hand, in a script deleted with its branch.
+
+So the mutations are declared next to the guards they neutralise, in
+`tools/falsify/specs/*.json` — file, exact edit, and the test that must go red —
+and replayed nightly:
+
+```bash
+mise run falsify:all           # every declared falsification
+mise run falsify -- tools/falsify/specs/mispointed.json   # one of them
+mise run falsify:selftest      # the harness against its own history
+```
+
+Each mutation is applied in a copy outside the working tree, one at a time, and
+three verdicts are distinguished rather than merged:
+
+| verdict | what it means |
+|---|---|
+| the test bit | the guard is measured, today |
+| **test still passed** | the guard is not measured, and the test is what to fix |
+| **did not compile** | void, not favourable: every test fails, which reads like success |
+| **did not apply** | the code moved out from under the declaration |
+
+The last two are the ones that make this worth running. Warning about them was
+not enough — the compile mistake voided three verdicts in one day, in three
+unrelated issues — so the harness refuses a mutation that drops a name the
+original expression used, and demands the neutralising form (`… && false`,
+`(… || true)`) instead.
+
+The first full replay was worth its cost immediately, and not by finding rot in
+the emulator. Of eight specs, four did not hold: three had been written in the
+deleting style the rule refuses, one named two guards that #179's final form had
+removed, and one declared a test that did not correspond to the guard beneath it
+— two `synthetic` conditions one screen apart in the same file, one belonging to
+#88 and the other to #163. That last one is the case the replay exists for: the
+mutation compiled, and the named test stayed green.
+
 ## What is not closed yet
 
-Three links in the chain above are stated but not enforced. They are open
-issues, and they are named here because a page describing only the finished half
-would be the defect this project removes.
+One link in the chain above is stated but not enforced. It is an open issue, and
+it is named here because a page describing only the finished half would be the
+defect this project removes.
 
-- **A falsification proves a test bites on the day it is run, and nothing runs
-  it again** ([#169](https://github.com/stephrobert/feint/issues/169)). Each
-  mechanism was falsified at its pull request; nothing replays those mutations.
-  A falsification claim in this repository has already been false — thirty green
-  runs with a lock removed, recorded in the 0.8.0 CHANGELOG.
 - **Nothing measures what a release does to a consumer**
   ([#170](https://github.com/stephrobert/feint/issues/170)). `schema_version` is
   the signal that lets a pipeline notice a break; nothing checks that a pipeline
   *can* notice. `probed` went from boolean to string, and a consumer reading it
   as truthy counts every refusal as a success.
-- **The evidence record's freshness rule is written twice and enforced nowhere**
-  ([#171](https://github.com/stephrobert/feint/issues/171)). *Deleting a
-  conformance assertion must demote the operations it proved* appears in
-  `internal/cli/evidence.go` and in `mise.toml`, and no test holds either
-  sentence.
 
-Until those close, the honest statement is the one this page opens with: the
-chain is measured, link by link, and these three links are measured by prose.
+Until it closes, the honest statement is the one this page opens with: the chain
+is measured, link by link, and this link is measured by prose.
+
+The other two this section listed are now closed and folded into the page above.
+[#171](https://github.com/stephrobert/feint/issues/171) gave the evidence record
+a provenance the join compares, so deleting a conformance assertion demotes what
+it proved instead of being a sentence written twice;
+[#169](https://github.com/stephrobert/feint/issues/169) is the replay described
+one section up.
 
 ## Reading the numbers yourself
 

--- a/mise.toml
+++ b/mise.toml
@@ -319,6 +319,39 @@ depends = ["check", "docs:check", "drift:check", "shapes:check", "falsify:selfte
 # or moves a gate. CLAUDE.md carries the decision table.
 run = "echo 'prepush passed - conformance and conformance:leg are the two it does not cover'"
 
+[tasks."falsify:all"]
+description = "Replay every declared falsification, so a guard whose test stopped biting fails a run"
+# #169. A falsification proves a test bites on the day it is run, and every
+# verdict of the 0.9 train was taken once, by hand, in a script deleted with its
+# branch. That makes each of them a claim about the past, and this repository has
+# already published one that was false: the 0.8.0 CHANGELOG says "neutralise any
+# of the three locks and the barrage goes red on the first attempt", and thirty
+# runs later stayed green with a lock removed.
+#
+# Minutes, not seconds — one tree copy and one `go test` per mutation — so this
+# is deliberately out of `prepush` and out of the pull-request path, the same
+# arbitration runtime-proof.yml makes for #125. It runs nightly
+# (.github/workflows/falsify.yml) and on demand here.
+#
+# The first replay was worth its cost immediately: of eight specs, four did not
+# hold. Three were refused by the harness's own conservative rule and had to be
+# rewritten in the neutralising style; the fourth named two guards that #179's
+# final form had removed, so two mutations had been describing code that no
+# longer existed anywhere.
+run = "python3 tools/falsify/falsify.py --all tools/falsify/specs"
+
+[tasks."falsify:proof"]
+description = "Weaken a test so it cannot fail, and require the replay to name it"
+# #169's acceptance criterion, tooled instead of demonstrated once. The replay
+# above is only worth its minutes if it catches a test that has stopped biting,
+# and `go test` is precisely what cannot see one: an assertion loosened while
+# chasing an unrelated red still passes, forever.
+#
+# So this weakens one, in a copy outside the tree, and asserts both halves — the
+# suite green, the replay red and naming the test. Writing that proof as a script
+# beside a pull request would have reproduced the fault it closes.
+run = "python3 tools/falsify/proof.py"
+
 [tasks."falsify:selftest"]
 description = "Prove the falsification harness refuses the three mutations that voided a verdict"
 # Cheap, offline, no Go build: it holds the rule against the three real mistakes

--- a/tools/falsify/falsify.py
+++ b/tools/falsify/falsify.py
@@ -116,10 +116,23 @@ RESERVED = {
 # the same class of mistake.
 IDENT = re.compile(r"(?<![.\w])[A-Za-z_][A-Za-z0-9_]*")
 
+# Go's three literal forms, so their contents never look like code. Interpreted
+# strings and runes admit backslash escapes; a raw string runs to its closing
+# backquote and holds no escapes at all.
+LITERAL = re.compile(r'"(?:[^"\\\n]|\\.)*"' r"|`[^`]*`" r"|'(?:[^'\\\n]|\\.)*'", re.S)
+
 
 def identifiers(text):
-    """The identifiers a fragment of Go uses, minus keywords and builtins."""
-    return {name for name in IDENT.findall(text) if name not in RESERVED}
+    """The identifiers a fragment of Go uses, minus keywords and builtins.
+
+    String contents are removed first, and that is not tidiness. Without it the
+    rule read `no route matches this path` as code and refused the mutation for
+    dropping `this` — a word in a sentence, in the one guard of #179 whose whole
+    subject is what the answer says. A tool that refuses a valid falsification
+    is worse than no tool: it teaches the author to stop declaring the awkward
+    ones, which are the guards most worth replaying.
+    """
+    return {name for name in IDENT.findall(LITERAL.sub('""', text)) if name not in RESERVED}
 
 
 # A short declaration inside the fragment: `x := ...` or `x, ok := ...`.
@@ -155,11 +168,29 @@ def orphaned_by_declaration(find, replace):
 
 
 def dropped_identifiers(find, replace):
-    """Names the mutation would leave unused, which Go refuses to compile.
+    """Names the mutation removes from the fragment, whether or not Go minds.
 
-    Two ways that happens, and both have cost a verdict here: a term is deleted
-    and the name goes with it, or the name survives only in a declaration the
-    fragment carries.
+    Two ways a removal costs a verdict, and both have happened here: a term is
+    deleted and the name goes with it, or the name survives only in a
+    declaration the fragment carries. Either leaves an unused name, Go refuses
+    to compile, every test in the package fails, and that reads exactly like the
+    guard being proven.
+
+    This is deliberately conservative and says so where it refuses: it cannot
+    see the rest of the file, so it flags every name that leaves the fragment,
+    including the many that would still compile. Replaying the 0.9 train against
+    it found three such: `IncusMinimum` is a package-level var used at four
+    other sites, `synthetic` and `health` are locals used further down their own
+    functions. All three mutations would have built.
+
+    Refusing them anyway is the trade this tool makes, and the reason is that
+    the alternative is worse. The check that would let them through is the
+    compiler, which the harness already runs — but by then the copy exists, the
+    package is built, and a void verdict has cost what a real one costs. The
+    rewrite it demands takes one operator (`&& false`, `|| true`) and produces a
+    strictly better mutation: one that changes a truth value and nothing else,
+    so the test that goes red is answering about the guard rather than about
+    whatever else the deleted term was doing.
     """
     lost = identifiers(find) - identifiers(replace)
     return sorted(lost | set(orphaned_by_declaration(find, replace)))
@@ -228,9 +259,46 @@ HISTORY = [
 ]
 
 
+# Valid mutations the rule must not refuse. The first is the one that made this
+# list necessary: the rule read the contents of a Go string as code, so changing
+# a sentence looked like dropping a name. The rest are the neutralising rewrites
+# the 0.9 specs now carry, kept here so the accepted style is asserted and not
+# only demonstrated.
+ACCEPTED = [
+    (
+        'return "no route matches this path, but it is served under " +',
+        'return "no route matches " + path + ", but it is served under " +',
+        "a word inside a string is not an identifier",
+    ),
+    (
+        "if olderThan(got, IncusMinimum) {",
+        "if olderThan(got, IncusMinimum) && false {",
+        "a condition made never true, every name still evaluated",
+    ),
+    (
+        "if rec.status < 400 && !synthetic {",
+        "if rec.status < 400 && (!synthetic || true) {",
+        "a term neutralised by disjunction rather than deleted",
+    ),
+    (
+        "if err != nil || health.Resources == 0 {",
+        "if err != nil || (health.Resources == 0 && false) {",
+        "one branch of a disjunction disarmed, both still read",
+    ),
+]
+
+
 def selftest():
     """Prove the rule on the three mistakes it was written for."""
     failures = 0
+    for find, replace, why in ACCEPTED:
+        lost = dropped_identifiers(find, replace)
+        if lost:
+            print(f"!! the rule refuses a valid mutation, losing {lost}: {why}")
+            failures += 1
+        else:
+            print(f"ok  accepted, {why}")
+    print()
     for find, broken, safe, orphan in HISTORY:
         lost = dropped_identifiers(find, broken)
         if orphan not in lost:
@@ -251,17 +319,69 @@ def selftest():
         print(f"{failures} failure(s): the rule does not hold its own history")
         return 1
     print(
-        f"the rule refuses all {len(HISTORY)} historical mistakes and accepts "
-        f"all {len(HISTORY)} fixes"
+        f"the rule refuses all {len(HISTORY)} historical mistakes, accepts all "
+        f"{len(HISTORY)} fixes, and accepts {len(ACCEPTED)} valid mutations it "
+        f"has refused at some point"
     )
     return 0
+
+
+def every_spec(directory):
+    """Every spec in the directory, sorted, so two runs report the same order."""
+    return sorted(
+        os.path.join(directory, name) for name in os.listdir(directory) if name.endswith(".json")
+    )
+
+
+def replay_all(directory):
+    """Run every declared falsification (#169).
+
+    A falsification proves a test bites on the day it is run. Nothing ran them
+    again, so each one was a claim about the past — and this repository has
+    already shipped a falsification claim that was false: "neutralise any of the
+    three locks and the barrage goes red on the first attempt", thirty green runs
+    with the lock removed, recorded in the 0.8.0 CHANGELOG.
+
+    Every spec, one after another. A spec whose fragment no longer applies is a
+    failure and not a skip: code moved under it, so it has silently stopped
+    measuring, which is the exact thing this replay exists to catch.
+    """
+    specs = every_spec(directory)
+    if not specs:
+        return refuse(f"{directory} holds no spec, so a replay would measure nothing")
+
+    print(f"replaying {len(specs)} falsification(s)\n")
+    failed = []
+    for spec in specs:
+        print("=" * 72)
+        print(f"== {os.path.basename(spec)}")
+        print("=" * 72)
+        if main([argv0, spec]) != 0:
+            failed.append(os.path.basename(spec))
+        print()
+
+    print("#" * 72)
+    if failed:
+        print(f"{len(failed)} of {len(specs)} falsifications no longer hold: {', '.join(failed)}")
+        print(
+            "A guard whose test stopped biting is a guard that stopped working, "
+            "and the test is what has to be fixed rather than the spec."
+        )
+        return 1
+    print(f"all {len(specs)} falsifications still hold")
+    return 0
+
+
+argv0 = "falsify.py"
 
 
 def main(argv):
     if len(argv) == 2 and argv[1] == "--selftest":
         return selftest()
+    if len(argv) == 3 and argv[1] == "--all":
+        return replay_all(argv[2])
     if len(argv) != 2:
-        return refuse("usage: falsify.py <spec.json> | --selftest")
+        return refuse("usage: falsify.py <spec.json> | --all <dir> | --selftest")
     spec_path = argv[1]
     with open(spec_path, encoding="utf-8") as fh:
         spec = json.load(fh)
@@ -281,11 +401,16 @@ def main(argv):
         lost = dropped_identifiers(m["find"], m["replace"])
         if lost:
             return refuse(
-                f"{m['label']!r} drops {', '.join(lost)}, which Go will refuse to "
-                f"compile as an unused variable — and a mutation that does not build "
-                f"fails every test, which looks exactly like the guard being proven.\n"
+                f"{m['label']!r} drops {', '.join(lost)} from the fragment.\n"
+                f"        This harness requires every name in `find` to survive into "
+                f"`replace`. It has not checked whether Go would mind here — it cannot "
+                f"see the rest of the file — and the rule is conservative on purpose: "
+                f"a deleted term that orphans a name fails every test in the package, "
+                f"which reads exactly like the guard being proven.\n"
                 f"        Neutralise the condition instead of deleting the term: keep "
-                f"every name evaluated and make the expression never true."
+                f"every name evaluated and make the expression never true "
+                f"(`… && false`, `(… || true)`). The mutation then changes a truth "
+                f"value and nothing else."
             )
 
     src = os.getcwd()

--- a/tools/falsify/proof.py
+++ b/tools/falsify/proof.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Falsify the replay itself: weaken a test so it can no longer fail, and require
+the replay to name it while the ordinary suite stays green.
+
+    mise run falsify:proof
+
+This is #169's acceptance criterion, word for word:
+
+    "Deliberately break one test — weaken an assertion so it can no longer fail
+     — and the harness goes red naming that test, while `mise run check` stays
+     green."
+
+Both halves are asserted, and the second is the one that carries the claim. A
+run where `go test` also went red would prove nothing about the direction this
+harness looks in: it would only prove that a broken tree is a broken tree.
+
+Why this lives in the repository rather than in a script beside a pull request:
+that is the exact defect #169 was filed for. Every falsification of the 0.9 train
+was run once, by hand, in a file deleted with its branch, so each verdict became
+a claim about the past. Writing the proof of the replay as one more throwaway
+would have reproduced the fault while closing it.
+
+The weakening is deliberately the shape a test really rots into. Nobody deletes
+a test; somebody loosens an assertion while chasing an unrelated red, and what is
+left still runs, still reads the value, and can no longer tell the two answers
+apart.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+EXCLUDE = {".git", ".upstream", ".terraform", "notes", ".claude"}
+
+TEST_FILE = "internal/core/emulator/mispointed_test.go"
+TEST = "TestAmbiguityIsStatedRatherThanResolved"
+PKG = "./internal/core/emulator/"
+SPEC = "tools/falsify/specs/mispointed.json"
+
+# `got` is the sentence the hint produced. The strong form requires both
+# candidate prefixes to appear, which is the property #179 added; the weak form
+# passes on any sentence holding a slash, so it passes equally on the answer that
+# names both and on the answer that names one.
+#
+# The first attempt at this weakening was not one: `&&` over the same substring
+# still failed under the mutation, because that mutation really does remove
+# "/v2/" from the answer. A falsification has to be checked against what its
+# mutation produces, not against what the mutation is called — which is the same
+# mistake, one level up, that the replay exists to catch.
+STRONG = '\tif !strings.Contains(got, "/v2/") || !strings.Contains(got, "/other/") {'
+WEAK = '\tif !strings.Contains(got, "/") {'
+
+
+def ignore(src):
+    def inner(directory, names):
+        dropped = [n for n in names if n in EXCLUDE]
+        # The built binary, when the working tree has one: it is large, it is
+        # not an input, and copying it doubles the cost of every run.
+        if os.path.abspath(directory) == os.path.abspath(src) and os.path.isfile(
+            os.path.join(directory, "feint")
+        ):
+            dropped.append("feint")
+        return dropped
+
+    return inner
+
+
+def run(dst, cmd):
+    # The same containment falsify.py uses: three concurrent Go builds once took
+    # the author's station down, and this one nests a build inside a build.
+    return subprocess.run(
+        ["systemd-run", "--user", "--scope", "-q", "-p", "MemoryMax=8G", "-p", "MemorySwapMax=0"]
+        + cmd,
+        cwd=dst,
+        capture_output=True,
+        text=True,
+    )
+
+
+def main():
+    src = os.getcwd()
+    if not os.path.isfile(os.path.join(src, SPEC)):
+        print(f"falsify: run this from the repository root ({SPEC} not found)", file=sys.stderr)
+        return 2
+
+    # mkdtemp rather than a predictable path: this copy is about to be compiled
+    # and executed, and a name somebody else can plant a symlink at is not one.
+    dst = tempfile.mkdtemp(prefix="falsify-proof-")
+    try:
+        shutil.copytree(src, dst, ignore=ignore(src), symlinks=True, dirs_exist_ok=True)
+        print(f"copied the tree to {dst}")
+
+        path = os.path.join(dst, TEST_FILE)
+        with open(path, encoding="utf-8") as fh:
+            source = fh.read()
+        if STRONG not in source:
+            print(
+                f"falsify: the assertion to weaken is no longer in {TEST_FILE}.\n"
+                f"        {TEST} was rewritten, so this proof has to be rewritten with "
+                f"it — which is the point, and not a reason to delete it.",
+                file=sys.stderr,
+            )
+            return 2
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(source.replace(STRONG, WEAK, 1))
+        print(f"weakened {TEST}: the assertion runs and can no longer distinguish\n")
+
+        failures = 0
+
+        suite = run(dst, ["go", "test", "-count=1", PKG])
+        if suite.returncode == 0:
+            print(f"ok  `go test {PKG}` is green with {TEST} unable to fail")
+        else:
+            print(f"!! `go test {PKG}` went red, so this proves nothing about the replay")
+            print(suite.stdout[-2000:])
+            failures += 1
+
+        replay = run(dst, ["python3", "tools/falsify/falsify.py", SPEC])
+        named = TEST in replay.stdout and "TEST STILL PASSED" in replay.stdout
+        if replay.returncode != 0 and named:
+            print(f"ok  the replay is red and names {TEST}")
+        else:
+            print(f"!! the replay did not catch it (exit {replay.returncode}, named={named})")
+            print(replay.stdout[-3000:])
+            failures += 1
+
+        print()
+        if failures:
+            print(f"{failures} half(s) failed: #169's claim is not proven on this tree")
+            return 1
+        print("a test that stopped biting fails the replay and not the suite")
+        return 0
+    finally:
+        shutil.rmtree(dst, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/falsify/specs/capabilities.json
+++ b/tools/falsify/specs/capabilities.json
@@ -1,0 +1,33 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "the verified set is never published, so the flag's promise stands",
+      "file": "internal/core/machine/capabilities.go",
+      "find": "\tif d.verified != nil {\n\t\treturn *d.verified\n\t}",
+      "replace": "\tif d.verified != nil && false {\n\t\treturn *d.verified\n\t}",
+      "test": "TestVerifyNarrowsWhatTheHostCannotDeliver"
+    },
+    {
+      "label": "an unset northbound connection counts as wired",
+      "file": "internal/core/machine/verify.go",
+      "find": "\tif strings.TrimSpace(string(out)) == \"\" {",
+      "replace": "\tif strings.TrimSpace(string(out)) == \"\\x00never\" {",
+      "test": "TestVerifyNarrowsWhatTheHostCannotDeliver"
+    },
+    {
+      "label": "the version floor stops applying",
+      "file": "internal/core/machine/verify.go",
+      "find": "\tif olderThan(got, IncusMinimum) {",
+      "replace": "\tif olderThan(got, IncusMinimum) && false {",
+      "test": "TestVerifyRefusesTheFirewallBelowTheFloor"
+    },
+    {
+      "label": "an unreadable version costs the capability, which turns a blind spot into a refusal",
+      "file": "internal/core/machine/verify.go",
+      "find": "\tgot, ok := parseVersion(payload.Environment.ServerVersion)\n\tif !ok {\n\t\treturn true, \"\"\n\t}",
+      "replace": "\tgot, ok := parseVersion(payload.Environment.ServerVersion)\n\tif !ok {\n\t\treturn false, \"unreadable\"\n\t}",
+      "test": "TestAnUnreadableVersionDoesNotCostTheCapability"
+    }
+  ]
+}

--- a/tools/falsify/specs/clients-matrix.json
+++ b/tools/falsify/specs/clients-matrix.json
@@ -1,0 +1,26 @@
+{
+  "package": "./internal/cli/",
+  "mutations": [
+    {
+      "label": "the provider column becomes a constant again (the original defect)",
+      "file": "internal/cli/docs_clients.go",
+      "find": "\t\tmine := proofs[c.name]",
+      "replace": "\t\tmine := proofs[c.name]\n\t\t_ = mine\n\t\tmine = []clientProof{{provider: \"scaleway\", suite: terraformSuite}}",
+      "test": "TestTheClientMatrixCreditsEveryProviderCIProves"
+    },
+    {
+      "label": "the column stops following the workflow, every client credits every provider",
+      "file": "internal/cli/docs_clients.go",
+      "find": "\t\tmine := proofs[c.name]",
+      "replace": "\t\tmine := proofs[c.name]\n\t\t_ = mine\n\t\tmine = []clientProof{{provider: \"outscale\", suite: terraformSuite}, {provider: \"scaleway\", suite: terraformSuite}}",
+      "test": "TestAClientLosesAProviderCIStopsDriving"
+    },
+    {
+      "label": "an unlisted client is dropped instead of refused",
+      "file": "internal/cli/docs_clients.go",
+      "find": "\tif len(unlisted) > 0 {",
+      "replace": "\tif false && len(unlisted) > 0 {",
+      "test": "TestAnUnlistedClientIsRefusedRatherThanLeftOut"
+    }
+  ]
+}

--- a/tools/falsify/specs/mispointed.json
+++ b/tools/falsify/specs/mispointed.json
@@ -1,0 +1,49 @@
+{
+  "package": "./internal/core/emulator/",
+  "mutations": [
+    {
+      "label": "a wildcard-only tail counts, so every route ending in {id} answers",
+      "file": "internal/core/emulator/mispointed.go",
+      "find": "\tif literals == 0 {\n\t\treturn \"\", false\n\t}",
+      "replace": "\tif literals < 0 {\n\t\treturn \"\", false\n\t}",
+      "test": "TestAnUnclaimedPathNamesThePrefixItIsMissing"
+    },
+    {
+      "label": "the doubled prefix goes back to naming a served operation as unserved",
+      "file": "internal/providers/outscale/pack.go",
+      "find": "\tif doubled := strings.TrimPrefix(pathPrefix, \"/\"); strings.HasPrefix(action, doubled) {",
+      "replace": "\tif doubled := strings.TrimPrefix(pathPrefix, \"/\"); strings.HasPrefix(action, doubled) && false {",
+      "test": "TestAMispointedOutscaleClientIsToldWhichSideIsWrong",
+      "package": "./internal/providers/outscale/"
+    },
+    {
+      "label": "the deprecated prefix is no longer claimed",
+      "file": "internal/providers/outscale/pack.go",
+      "find": "\tif strings.HasPrefix(r.URL.Path, legacyPrefix) {",
+      "replace": "\tif strings.HasPrefix(r.URL.Path, legacyPrefix) && false {",
+      "test": "TestAMispointedOutscaleClientIsToldWhichSideIsWrong",
+      "package": "./internal/providers/outscale/"
+    },
+    {
+      "label": "only the first candidate is named, and the answer sounds certain",
+      "file": "internal/core/emulator/mispointed.go",
+      "find": "\t\tstrings.Join(prefixes, \" and \") +",
+      "replace": "\t\tstrings.Join(prefixes[:1], \" and \") +",
+      "test": "TestAmbiguityIsStatedRatherThanResolved"
+    },
+    {
+      "label": "the prefix the log records carries the path the client chose",
+      "file": "internal/core/emulator/mispointed.go",
+      "find": "\t\tprefixes = append(prefixes, prefix)",
+      "replace": "\t\tprefixes = append(prefixes, prefix+path)",
+      "test": "TestTheLogCarriesNothingTheClientChose"
+    },
+    {
+      "label": "the answer repeats the path back, which is what needed an allow-list defending it",
+      "file": "internal/core/emulator/mispointed.go",
+      "find": "\treturn \"no route matches this path, but it is served under \" +",
+      "replace": "\treturn \"no route matches \" + path + \", but it is served under \" +",
+      "test": "TestTheAnswerNeverRepeatsWhatTheClientSent"
+    }
+  ]
+}

--- a/tools/falsify/specs/omissions.json
+++ b/tools/falsify/specs/omissions.json
@@ -1,0 +1,12 @@
+{
+  "package": "./internal/core/emulator/",
+  "mutations": [
+    {
+      "label": "a synthetic answer vouches for a served field, and the omission gate reads its own probe",
+      "file": "internal/core/emulator/conformance.go",
+      "find": "\tif !synthetic {\n\t\to.recordServed(operation, decoded)",
+      "replace": "\tif !synthetic || true {\n\t\to.recordServed(operation, decoded)",
+      "test": "TestASyntheticAnswerDoesNotVouchForAServedField"
+    }
+  ]
+}

--- a/tools/falsify/specs/probe-seeds.json
+++ b/tools/falsify/specs/probe-seeds.json
@@ -1,0 +1,34 @@
+{
+  "package": "./internal/probe/",
+  "mutations": [
+    {
+      "label": "the pool hands back nothing, so every identifier is invented again",
+      "file": "internal/probe/values.go",
+      "find": "func (p *pool) take(product, typeFold string) (string, bool) {\n\tp.mu.Lock()",
+      "replace": "func (p *pool) take(product, typeFold string) (string, bool) {\n\tif true {\n\t\treturn \"\", false\n\t}\n\tp.mu.Lock()",
+      "test": "TestAGetIsProbedAgainstAnIdentifierThatExists"
+    },
+    {
+      "label": "a create no longer contributes what it made",
+      "file": "internal/probe/values.go",
+      "find": "func (p *pool) record(step Step, typeFold, id string, depth int) {",
+      "replace": "func (p *pool) record(step Step, typeFold, id string, depth int) {\n\tif true {\n\t\treturn\n\t}",
+      "test": "TestASeededCreateFillsWhatTheRunHolds"
+    },
+    {
+      "label": "the hinted branch of a choice is left empty",
+      "file": "internal/probe/values.go",
+      "find": "func optionalValue(doc *contract.Doc, step Step, schemaName, field string, prop contract.Property, pool *pool, top bool) (any, bool) {",
+      "replace": "func optionalValue(doc *contract.Doc, step Step, schemaName, field string, prop contract.Property, pool *pool, top bool) (any, bool) {\n\tif true {\n\t\treturn nil, false\n\t}",
+      "test": "TestTheHintedBranchOfAChoiceIsFilled"
+    },
+    {
+      "label": "a seeded body feeds the unread-fields report, which then accuses the probe",
+      "file": "internal/core/emulator/conformance.go",
+      "find": "\t\tif rec.status < 400 && !synthetic {",
+      "replace": "\t\tif rec.status < 400 && (!synthetic || true) {",
+      "test": "TestAProbedFieldIsNotAnUnreadField",
+      "package": "./internal/core/emulator/"
+    }
+  ]
+}

--- a/tools/falsify/specs/stop-discards.json
+++ b/tools/falsify/specs/stop-discards.json
@@ -1,0 +1,26 @@
+{
+  "package": "./internal/cli/",
+  "mutations": [
+    {
+      "label": "the notice never fires, which is the silence #182 was filed for",
+      "file": "internal/cli/lifecycle.go",
+      "find": "\thealth, err := fetchHealth(inst.Addr)\n\tif err != nil || health.Resources == 0 {\n\t\treturn \"\"\n\t}",
+      "replace": "\thealth, err := fetchHealth(inst.Addr)\n\tif err != nil || health.Resources >= 0 {\n\t\treturn \"\"\n\t}",
+      "test": "TestStopSaysWhatItIsAboutToDiscard"
+    },
+    {
+      "label": "it fires on a --state run too, the warning people learn to ignore",
+      "file": "internal/cli/lifecycle.go",
+      "find": "\t\tif arg == \"--state\" || strings.HasPrefix(arg, \"--state=\") {\n\t\t\treturn \"\"\n\t\t}",
+      "replace": "\t\tif arg == \"--state\\x00never\" || strings.HasPrefix(arg, \"--state\\x00never=\") {\n\t\t\treturn \"\"\n\t\t}",
+      "test": "TestStopSaysWhatItIsAboutToDiscard"
+    },
+    {
+      "label": "it fires on an empty store, where there is nothing to discard",
+      "file": "internal/cli/lifecycle.go",
+      "find": "\tif err != nil || health.Resources == 0 {",
+      "replace": "\tif err != nil || (health.Resources == 0 && false) {",
+      "test": "TestStopSaysWhatItIsAboutToDiscard"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #169.

## What was wrong

A falsification proves a test bites **on the day it is run**. Every guard of the
0.9 train was falsified once, by hand, in a script deleted with its branch, so
each of those verdicts became a claim about the past. This repository has already
published one that was false: the 0.8.0 CHANGELOG says neutralising any of three
locks reds the barrage on the first attempt, and thirty runs later stayed green
with a lock removed.

## What this does

The mutations move next to the guards they neutralise, in `tools/falsify/specs/`,
and something replays them. Six specs converted from the throwaway scripts of
#155, #163, #88, #179, #181 and #182, joining the two that already existed:
**8 specs, 28 mutations, all of which now bite.**

```bash
mise run falsify:all        # every declared falsification
mise run falsify:proof      # the replay catches a test that stopped biting
mise run falsify:selftest   # the rule against its own history (already in prepush)
```

Nightly and on dispatch (`.github/workflows/falsify.yml`), never on
`pull_request`: it copies the tree and builds once per mutation, and that cost
grows with every guard the project adds, which is the direction it should grow
in. Declaring one more mutation must never be the thing that makes pull requests
slower.

## What the first replay found

Four of eight specs did not hold, and none of it was rot in the emulator:

- three mutations were written in the deleting style the harness refuses;
- `mispointed.json` named two guards that #179's final form had removed, so two
  declarations described code that no longer existed anywhere;
- `omissions.json` declared `TestASyntheticAnswerDoesNotVouchForAServedField`
  over the guard of `TestAProbedFieldIsNotAnUnreadField` — two `synthetic`
  conditions one screen apart in `conformance.go`, one belonging to #88 and the
  other to #163. **The mutation compiled and the named test stayed green**,
  which is exactly the case the replay exists for and the one no `go test` can
  see.

## Two defects in the harness itself

Both found by running it rather than by reasoning about it:

- `identifiers()` read the contents of Go string literals as code, so changing a
  sentence looked like dropping a name. It refused the one #179 guard whose whole
  subject is what the answer says.
- The refusal message asserted *"Go will refuse to compile as an unused
  variable"* — a compile outcome the tool never measured. Three of the mutations
  it refused on that ground would have built (`IncusMinimum` is a package-level
  var used at four other sites; `synthetic` and `health` are locals used further
  down their own functions). The rule stays conservative on purpose, and now says
  so instead of claiming a verdict it does not have.

## How the claim is proven

`tools/falsify/proof.py` loosens an assertion until it cannot fail, then requires
the replay to go red naming the test **while `go test` stays green** — #169's
acceptance criterion, in the repository rather than in a script beside a pull
request, because writing it as a throwaway would have reproduced the fault it
closes. It is a nightly step, not a sentence.

The first attempt at that weakening was not one: `&&` over the same substring
still failed under the mutation, because that mutation really does remove `/v2/`
from the answer. A falsification has to be checked against what its mutation
produces, not against what the mutation is called.

## Measured locally

| | |
|---|---|
| `mise run falsify:all` | 8/8 specs, 28/28 mutations bit |
| `mise run falsify:proof` | both halves: suite green, replay red naming the test |
| `mise run falsify -- --selftest` | 4 historical mistakes refused, 4 fixes and 4 valid mutations accepted |
| `mise run check` | green |
| `feint docs --check` | 0 |
| `actionlint` + `zizmor --min-severity low` | clean |

## Docs

`docs/conformance.md` and `.fr.md` gain the section and lose two entries from
*what is not closed yet*: #169 here, and #171, which was closed this morning and
whose pull request left the page saying otherwise. `CONTRIBUTING`,
`.claude/commands/falsify.md` and the gate table follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
