### PR TITLE
fix(machine): an unset northbound is the default applying, not OVN missing

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -208,9 +208,20 @@ installed", and it is not the health endpoint on its own either.
 `capabilities.isolation` used to follow the *mode* alone, so a host with no OVN
 at all reported `true` and failed at the first network creation. Since #181 the
 capability is verified against the host before it is published: an OVN mode
-whose `network.ovn.northbound_connection` is unset refuses at startup when it
-was asked for by name, and is passed over by `--vm auto` with its reason
-printed. **That probe is necessary and not sufficient**, and the difference is
+whose northbound database is absent refuses at startup when it was asked for by
+name, and is passed over by `--vm auto` with its reason printed.
+
+The probe asks the right question in the right order, and getting that wrong
+cost an afternoon on this project's own station: **an unset
+`network.ovn.northbound_connection` is the default applying, never an absence.**
+Incus does not store a key at its documented default, so `incus config get`
+answers empty on a perfectly wired host, and the first version of the probe read
+that as "no OVN" and refused a station where `ovn-nbctl show` answered. Setting
+the key by hand changes nothing, for the same reason. So the probe resolves the
+effective connection string, falling back to the documented default
+`unix:/run/ovn/ovnnb_db.sock`, and asks whether that socket **exists** — never
+whether this process can connect to it, because the socket is root-owned and
+`incusd` is what talks to it. **That probe is necessary and not sufficient**, and the difference is
 this section's whole point: a host whose northbound is wired and whose *uplink*
 is misconfigured still reports `true` and still cannot create a subnet.
 
@@ -356,8 +367,11 @@ ovs-vsctl set open_vswitch . \
 
 incus admin init --minimal
 
-# And Incus needs to know where the northbound one is.
-incus config set network.ovn.northbound_connection unix:/run/ovn/ovnnb_db.sock
+# Incus finds the northbound database on its own: network.ovn.northbound_connection
+# defaults to unix:/run/ovn/ovnnb_db.sock, which is where ovn-central puts it.
+# Setting it explicitly is a no-op — Incus does not store a key at its default —
+# so it is left out here rather than shown as a step that appears to do nothing.
+# Only a northbound on another host or another path needs the line.
 
 # An OVN network needs an uplink, and the uplink must be a managed bridge
 # carrying ipv4.ovn.ranges. `incus admin init --minimal` creates incusbr0

--- a/internal/core/machine/incus.go
+++ b/internal/core/machine/incus.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/netip"
+	"os"
 	"slices"
 	"strconv"
 	"strings"
@@ -62,6 +63,13 @@ type Incus struct {
 	// It proves what the driver sends, never what the runtime accepts. That
 	// second half is the conformance suite's job and cannot be faked.
 	runner func(ctx context.Context, args ...string) ([]byte, error)
+
+	// statPath replaces the filesystem lookup Verify uses to decide whether the
+	// OVN northbound socket exists, and is only ever set by a test. Existence,
+	// never a connection: the socket is root-owned (srwxr-x--- root root) and
+	// incusd is what talks to it, so a process running as the operator would be
+	// refused on a host where OVN works perfectly.
+	statPath func(string) (os.FileInfo, error)
 
 	// agentPoll overrides how often a virtual machine is asked whether its
 	// agent answers. Only a test sets it, for the same reason runner exists:

--- a/internal/core/machine/verify.go
+++ b/internal/core/machine/verify.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -46,6 +47,17 @@ var IncusMinimum = [3]int{6, 0, 4}
 // Reading it creates nothing and leaves nothing, which `auto` requires: it runs
 // at every startup, on hosts that are perfectly healthy.
 const ovnNorthbound = "network.ovn.northbound_connection"
+
+// ovnDefaultNorthbound is what Incus uses when nothing is configured, quoted
+// from the server settings reference rather than guessed. It is why a `config
+// get` on a healthy host answers nothing: Incus does not store a key at its
+// default, so the empty answer says "the default applies", not "OVN is absent".
+//
+// If this ever drifts, the failure is a refusal on a working host rather than a
+// false capability, which is the safe direction: the mode is declined with the
+// socket path named, so the operator can see immediately which path was looked
+// for.
+const ovnDefaultNorthbound = "unix:/run/ovn/ovnnb_db.sock"
 
 // serverVersion matches what `incus query /1.0` reports. The patch component is
 // optional because 7.2 is a real answer — an earlier version of the equivalent
@@ -96,11 +108,53 @@ func (d *Incus) ovnWired(ctx context.Context) (bool, string) {
 	if err != nil {
 		return false, "the daemon did not answer for " + ovnNorthbound
 	}
-	if strings.TrimSpace(string(out)) == "" {
-		return false, ovnNorthbound + " is unset, so no OVN network can be created " +
-			"(install ovn-central and ovn-host, and wire the northbound)"
+	// An empty answer is the default applying, not the setting being absent, and
+	// reading it as absence is the defect this branch was written to fix. Incus
+	// never stores a key at its documented default, so `config get` answers
+	// empty on a host where OVN is perfectly wired — measured on this project's
+	// own station on 2026-08-15, where `doctor --vm incus-ovn` refused the mode
+	// while ovn-central, ovn-host and openvswitch were all active and the
+	// northbound socket answered `ovn-nbctl show`.
+	//
+	// That is the same shape as the defect this file exists for, one turn later:
+	// #181 replaced a capability nobody measured with a check of a *form* (is the
+	// key set) where the question is a *property* (does the northbound answer).
+	// The test agreed with the code because it encoded the same wrong model —
+	// hostSaying("", …) was commented "no OVN wiring at all: the ordinary one".
+	conn := strings.TrimSpace(string(out))
+	if conn == "" {
+		conn = ovnDefaultNorthbound
 	}
+	path, isUnix := strings.CutPrefix(conn, "unix:")
+	if !isUnix {
+		// tcp: or ssl:, reachable from incusd and not necessarily from here.
+		// An undeclared property counts as absent, never as a refusal: this
+		// process cannot answer the question, so it does not get to fail it.
+		// The same policy the version check applies to an unreadable version.
+		return true, ""
+	}
+	info, err := d.stat(path)
+	if err != nil {
+		return false, ovnNorthbound + " is " + conn + " and that socket is absent, " +
+			"so no OVN network can be created (install ovn-central and ovn-host, " +
+			"and check that ovnnb_db is running)"
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		return false, ovnNorthbound + " is " + conn + " and " + path +
+			" is not a socket, so no OVN network can be created"
+	}
+	// Existence and nothing more. The socket is root-owned and incusd is what
+	// connects to it; dialling it from this process would refuse a working host
+	// on a permission this driver never needed.
 	return true, ""
+}
+
+// stat answers the filesystem, or the seam a test installed.
+func (d *Incus) stat(path string) (os.FileInfo, error) {
+	if d.statPath != nil {
+		return d.statPath(path)
+	}
+	return os.Stat(path)
 }
 
 // firewallAge reports whether the daemon is new enough to accept NIC ACLs.

--- a/internal/core/machine/verify_test.go
+++ b/internal/core/machine/verify_test.go
@@ -2,16 +2,46 @@ package machine
 
 import (
 	"context"
+	"io/fs"
+	"os"
 	"strings"
 	"testing"
+	"time"
 )
+
+// socketInfo is a FileInfo whose only interesting answer is that it is a socket.
+type socketInfo struct{}
+
+func (socketInfo) Name() string       { return "ovnnb_db.sock" }
+func (socketInfo) Size() int64        { return 0 }
+func (socketInfo) Mode() os.FileMode  { return os.ModeSocket | 0o750 }
+func (socketInfo) ModTime() time.Time { return time.Time{} }
+func (socketInfo) IsDir() bool        { return false }
+func (socketInfo) Sys() any           { return nil }
 
 // hostSaying builds an Incus driver whose CLI answers are dictated, so a test
 // can stand on a host it does not have. The runner is the same seam the
 // argument-level tests use; here it stands in for the host's answers rather
 // than recording the driver's questions.
 func hostSaying(ovnNB, version string) *Incus {
+	// The northbound socket exists unless a test says otherwise. That is the
+	// ordinary host: ovn-central running, nothing configured, because the
+	// setting is already at its default.
+	return hostSayingWithSocket(ovnNB, version, true)
+}
+
+// hostSayingWithSocket adds the half hostSaying assumes: whether the northbound
+// socket the connection string names is actually there. Existence is what the
+// driver checks and it is checked here, rather than a connection, because the
+// socket is root-owned and this process is not incusd.
+func hostSayingWithSocket(ovnNB, version string, socketExists bool) *Incus {
 	d := NewIncusOVN()
+	d.statPath = func(string) (os.FileInfo, error) {
+		if !socketExists {
+			return nil, fs.ErrNotExist
+		}
+		return socketInfo{}, nil
+	}
 	d.runner = func(_ context.Context, args ...string) ([]byte, error) {
 		joined := strings.Join(args, " ")
 		switch {
@@ -35,8 +65,11 @@ func hostSaying(ovnNB, version string) *Incus {
 // auto chose incus-ovn and /_feint/health published isolation until the first
 // network creation failed, blaming the address block.
 func TestVerifyNarrowsWhatTheHostCannotDeliver(t *testing.T) {
-	// A host with Incus and no OVN wiring at all: the ordinary one.
-	d := hostSaying("", "7.2")
+	// A host with Incus and no OVN at all: nothing configured, and no northbound
+	// socket either. Both halves matter, and the second is the whole correction —
+	// an unset key alone is the *default* applying, and this check read it as
+	// absence until it refused a station where OVN was running.
+	d := hostSayingWithSocket("", "7.2", false)
 	caps, unmet := d.Verify(context.Background())
 
 	if caps.Isolation {
@@ -56,6 +89,51 @@ func TestVerifyNarrowsWhatTheHostCannotDeliver(t *testing.T) {
 	if d.Capabilities().Isolation {
 		t.Error("Capabilities still publishes the flag's promise after Verify narrowed it")
 	}
+}
+
+// An unset northbound is the default applying, never an absence.
+//
+// This is the test that was missing, and its absence is why the guard shipped
+// wrong: `incus config get` answers empty for a key at its documented default,
+// and the default is `unix:/run/ovn/ovnnb_db.sock`. So the ordinary healthy
+// host — ovn-central running, nothing configured, because nothing needs to be —
+// answered empty and had its isolation taken away.
+//
+// Measured on this project's station on 2026-08-15: openvswitch-switch,
+// ovn-central and ovn-host all active, `ovn-nbctl show` answering on the
+// socket, and `feint doctor --vm incus-ovn` refusing the mode with
+// "network.ovn.northbound_connection is unset, so no OVN network can be
+// created". Setting the key by hand changed nothing, because Incus does not
+// store a value equal to the default — which is the observation that found the
+// bug.
+//
+// Both halves, because a probe that accepted everything would pass the first.
+func TestAnUnsetNorthboundIsTheDefaultAndNotAnAbsence(t *testing.T) {
+	// Nothing configured, socket there: the ordinary OVN host.
+	caps, unmet := mustVerifyBoth(t, hostSayingWithSocket("", "7.2", true))
+	if !caps.Isolation {
+		t.Errorf("a host with the northbound at its default lost isolation: %v", unmet)
+	}
+
+	// Nothing configured, socket absent: OVN is genuinely not there.
+	caps, unmet = mustVerifyBoth(t, hostSayingWithSocket("", "7.2", false))
+	if caps.Isolation {
+		t.Error("isolation survived a host with no northbound socket at all")
+	}
+	if len(unmet) != 1 || !strings.Contains(unmet[0], ovnDefaultNorthbound) {
+		t.Errorf("the refusal must name the socket it looked for, got %v", unmet)
+	}
+
+	// A remote northbound this process cannot reach: unknown is not a refusal,
+	// the same policy an unreadable version gets. incusd connects to it, not us.
+	if caps, _ := mustVerifyBoth(t, hostSayingWithSocket("tcp:10.0.0.1:6641", "7.2", false)); !caps.Isolation {
+		t.Error("a tcp northbound was refused on a filesystem check that cannot apply to it")
+	}
+}
+
+func mustVerifyBoth(t *testing.T, d *Incus) (Capabilities, []string) {
+	t.Helper()
+	return d.Verify(context.Background())
 }
 
 // The accepting half, on the same seam: a host that delivers keeps everything.

--- a/tools/falsify/specs/capabilities.json
+++ b/tools/falsify/specs/capabilities.json
@@ -9,11 +9,11 @@
       "test": "TestVerifyNarrowsWhatTheHostCannotDeliver"
     },
     {
-      "label": "an unset northbound connection counts as wired",
+      "label": "an absent northbound socket counts as wired",
       "file": "internal/core/machine/verify.go",
-      "find": "\tif strings.TrimSpace(string(out)) == \"\" {",
-      "replace": "\tif strings.TrimSpace(string(out)) == \"\\x00never\" {",
-      "test": "TestVerifyNarrowsWhatTheHostCannotDeliver"
+      "find": "\tinfo, err := d.stat(path)\n\tif err != nil {",
+      "replace": "\tinfo, err := d.stat(path)\n\tif err != nil && false {",
+      "test": "TestAnUnsetNorthboundIsTheDefaultAndNotAnAbsence"
     },
     {
       "label": "the version floor stops applying",
@@ -28,6 +28,13 @@
       "find": "\tgot, ok := parseVersion(payload.Environment.ServerVersion)\n\tif !ok {\n\t\treturn true, \"\"\n\t}",
       "replace": "\tgot, ok := parseVersion(payload.Environment.ServerVersion)\n\tif !ok {\n\t\treturn false, \"unreadable\"\n\t}",
       "test": "TestAnUnreadableVersionDoesNotCostTheCapability"
+    },
+    {
+      "label": "an unset key is read as an absence again, which refuses a healthy host",
+      "file": "internal/core/machine/verify.go",
+      "find": "\tif conn == \"\" {\n\t\tconn = ovnDefaultNorthbound\n\t}",
+      "replace": "\tif conn == \"\" && ovnDefaultNorthbound == \"\" {\n\t\tconn = ovnDefaultNorthbound\n\t}",
+      "test": "TestAnUnsetNorthboundIsTheDefaultAndNotAnAbsence"
     }
   ]
 }


### PR DESCRIPTION
## What happened

`feint doctor --vm incus-ovn` refused the mode on a station where OVN was
running — `openvswitch-switch`, `ovn-central` and `ovn-host` all active, and
`ovn-nbctl --db=unix:/run/ovn/ovnnb_db.sock show` answering:

```
FAIL  the --vm mode is not one this binary knows
      isolation: network.ovn.northbound_connection is unset, so no OVN
                 network can be created
```

The key was not unset. **It was at its default.** Incus does not store a value
equal to a documented default, so `incus config get` answers empty on a wired
host — and setting the key by hand changes nothing, which is the observation
that found this. The [server settings
reference](https://linuxcontainers.org/incus/docs/main/server_config/) gives the
default as `unix:/run/ovn/ovnnb_db.sock`, the very socket `ovn-central` creates.

## Why it got through

#181's probe checked a **form** — is the key set — where the question is a
**property**: does the northbound answer. That is the failure this repository
names most often, and it shipped inside the very file written to stop a
capability being claimed without measurement.

The test agreed with the code because it encoded the same wrong model:

```go
// A host with Incus and no OVN wiring at all: the ordinary one.
d := hostSaying("", "7.2")
```

An empty answer is the ordinary **healthy** host.

## What the probe does now

Resolve the effective connection string, falling back to the documented default
when nothing is configured, and for a `unix:` connection require the socket to
**exist**.

Existence and never a connection: the socket is `srwxr-x--- root root` and
`incusd` is what talks to it, so dialling it from this process would refuse a
working host on a permission this driver never needed — the same class of false
negative as the bug being fixed.

A `tcp:` or `ssl:` northbound is not refused. This process cannot answer the
question, so it does not get to fail it: the same policy an unreadable version
already gets.

## Proof

`TestAnUnsetNorthboundIsTheDefaultAndNotAnAbsence` holds three cases — default +
socket present keeps isolation, default + socket absent loses it and names the
path, remote northbound is left alone — and fails without the fix.

`tools/falsify/specs/capabilities.json` gains the mutation that restores the old
reading. Five mutations, all bite:

```
compiled=yes  the test bit   the verified set is never published, so the flag's promise stands
compiled=yes  the test bit   an absent northbound socket counts as wired
compiled=yes  the test bit   the version floor stops applying
compiled=yes  the test bit   an unreadable version costs the capability
compiled=yes  the test bit   an unset key is read as an absence again, which refuses a healthy host
```

Worth noting: that spec's fragment moved under this commit, and
`mise run falsify` said so rather than letting a stale declaration pass. #169
merged this morning and paid for itself the same day.

## Measured on the station that motivated it

```
ok    machine runtime: incus-ovn
      addresses true, firewall true, isolation true, own kernel false
ok    Incus 7.2.0, new enough for NIC ACLs
```

`mise run check` green, `feint docs --check` 0.

## Docs

`docs/install.md` stops showing `incus config set
network.ovn.northbound_connection` as an installation step — a no-op that looked
like the thing making OVN work — and states the rule that caused the confusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
