### PR TITLE
feat(images): the emulator builds machine images that already carry sshd (#203)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -19,6 +19,37 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Ajouté
 
+- **L'émulateur construit ses propres images de machines, et elles portent un
+  démon ssh** (#203). Aucune image du serveur amont n'en a : mesuré sur
+  `images:ubuntu/24.04`, `ubuntu/24.04/cloud`, `debian/12/cloud` et
+  `alpine/3.21/cloud`, chacune regardée deux fois (dès que le conteneur répond,
+  puis après `cloud-init status --wait`), et les quatre ont répondu ABSENT avec
+  rien à l'écoute sur le port 22. Une machine en installait donc un au premier
+  démarrage, ce qui exigeait une sortie internet, donc du NAT, donc de placer
+  toute machine sur un pont géré. Et ce pont est la seconde adresse, publiée par
+  aucune API, qu'un serveur Scaleway portait ici et ne porte pas sur le vrai
+  cloud (#202, mesuré contre de vrais comptes Scaleway et Exoscale : une adresse
+  chacun, jamais deux). Une vraie image cloud embarque le démon : c'est donc la
+  forme fidèle et non un contournement.
+
+  `feint images` construit les cinq (ubuntu 24.04 et 22.04, debian 12, alpine
+  3.21, almalinux 9, une par famille de gabarit cloud-init), `feint images
+  --check` rapporte ce qui manque et rend 2, et `feint doctor` les nomme sans
+  jamais construire : une construction démarre un conteneur et prend des minutes,
+  effet de bord que ce projet demande au lieu de l'exécuter. Le pilote préfère
+  une image construite et **annonce** son repli vers l'amont plutôt que de
+  dégrader en silence.
+
+  `tools/images/verify.sh` tient ce qui compte, et c'est plus dur que « openssh
+  est installé » : chaque machine reçoit une NIC routée sur 203.0.113.0/24, que
+  rien ne route et que rien ne masquerade, donc elle n'a aucun chemin vers un
+  dépôt de paquets. Vingt contrôles sur les cinq images : réponse sur le port 22,
+  aucune sortie, **exactement une adresse**, et deux machines issues d'une même
+  image portant deux clés d'hôte différentes.
+
+  La surface CLI gagne un verbe, donc `cliSurfaceVersion` passe de 1 à 2. Rien de
+  ce dont un consommateur dépendait n'a changé de forme.
+
 - **Le contrôle de contrat regarde désormais dans le sens de l'omission, et le
   gate de conformance échoue sur ce qu'il trouve** (#88). Le gate attrapait un
   champ que l'émulateur invente et ne voyait pas celui qu'il oublie : un champ

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,37 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Added
 
+- **The emulator builds its own machine images, which carry an ssh daemon**
+  (#203). No image on the upstream server has one: measured on
+  `images:ubuntu/24.04`, `ubuntu/24.04/cloud`, `debian/12/cloud` and
+  `alpine/3.21/cloud`, each looked at twice — as early as the container answers
+  and again after `cloud-init status --wait` — and all four answered ABSENT with
+  nothing listening on port 22. So a machine installed one at first boot, which
+  is why it needed outbound internet, which is why it needed NAT, which is why
+  every machine was put on a managed bridge — and that bridge is the second,
+  unpublished address a Scaleway server carried here and does not carry on the
+  real cloud (#202, measured against real Scaleway and real Exoscale accounts:
+  one address each, never two). A real cloud image has the daemon in it, so this
+  is the faithful shape rather than a workaround.
+
+  `feint images` builds the five (ubuntu 24.04 and 22.04, debian 12, alpine 3.21,
+  almalinux 9, one per cloud-init template family), `feint images --check`
+  reports what is missing and exits 2, and `feint doctor` names them without ever
+  building — a build launches a container and takes minutes, which is a side
+  effect this project asks about rather than performs. The driver prefers a built
+  image and **announces** its fallback to the upstream one instead of degrading
+  in silence.
+
+  `tools/images/verify.sh` holds what matters, and it is harder than "openssh is
+  installed": each machine is given a routed NIC on 203.0.113.0/24, which nothing
+  routes and nothing masquerades, so it has no path to a package repository at
+  all. Twenty checks over the five images — answers on port 22, no outbound,
+  **exactly one address**, and two machines from one image carrying two different
+  host keys.
+
+  The CLI surface gains a verb, so `cliSurfaceVersion` moves from 1 to 2. Nothing
+  a consumer depended on changed shape.
+
 - **The contract check now looks in the omission direction, and the
   conformance gate fails on what it finds** (#88). The gate caught a field the
   emulator invents and could not see one it forgets: an absent field only

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -92,7 +92,7 @@ const (
 // TestTheFrozenSurfacesStillMatchTheirFixture, and a fixture regenerated
 // without bumping this constant fails TestASurfaceChangeDemandsItsVersionBump.
 // The procedure for a deliberate change is in RELEASING.md ("Frozen surfaces").
-const cliSurfaceVersion = 1
+const cliSurfaceVersion = 2
 
 // Run executes one command and returns the process exit code.
 func Run(args []string, stdout, stderr io.Writer) int {
@@ -145,6 +145,8 @@ func Run(args []string, stdout, stderr io.Writer) int {
 		return envCommand(args[2:], stdout, stderr)
 	case "doctor":
 		return doctor(args[2:], stdout, stderr)
+	case "images":
+		return images(args[2:], stdout, stderr)
 	case "snapshot":
 		return snapshot(args[2:], stdout, stderr)
 	case "version", "--version", "-v":
@@ -216,6 +218,12 @@ Usage:
                     Diagnose the host: the port, the machine runtime and what it
                     can prove, the clients, and the ssh trap. A warning never
                     fails; only a broken thing does.
+
+  feint images     [--vm auto] [--only ubuntu/24.04] [--check]
+                    Build the machine images, which carry an ssh daemon so a
+                    machine answers on port 22 without reaching a package
+                    repository. No upstream image ships one. --check reports
+                    what is missing and exits 2, building nothing.
 
   feint env <provider> [--shell bash|fish|powershell] [--endpoint <url>] [--unset]
                     The environment a real client of that provider needs.

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -192,7 +192,49 @@ func checkRuntime(ctx context.Context, mode string) []check {
 		})
 	}
 	out = append(out, checkIncusVersion(ctx))
+	out = append(out, checkImages(ctx, driver))
 	return out
+}
+
+// checkImages reports the machine images that are not on the host (#203).
+//
+// It diagnoses and never builds, deliberately. A build launches a container,
+// installs a package and publishes an image: minutes, and a side effect on the
+// operator's station. That is the same arbitration `--vm off` already makes,
+// and the reason `mise run serve` does not start machines unless asked. So this
+// names what is missing and the exact command that makes it, and the operator
+// decides.
+//
+// An image set that is complete says so as an ok rather than staying silent: a
+// diagnostic that only speaks when something is wrong leaves the reader unable
+// to tell "checked and fine" from "never looked".
+//
+// TestDoctorNamesTheMissingImagesAndHowToBuildThem fails without this.
+func checkImages(ctx context.Context, driver machine.Driver) check {
+	inventory, err := machine.ImageInventory(ctx, driver)
+	if err != nil {
+		return check{
+			title:  "could not read the machine images",
+			state:  verdictWarn,
+			detail: err.Error(),
+			fix:    "check that the Incus daemon answers, then run `feint images`",
+		}
+	}
+	missing := machine.MissingImages(inventory)
+	if len(missing) == 0 {
+		return check{
+			title:  fmt.Sprintf("%d machine image(s) present", len(inventory)),
+			state:  verdictOK,
+			detail: "each carries an ssh daemon, so a machine answers on port 22 without reaching a package repository",
+		}
+	}
+	return check{
+		title: fmt.Sprintf("%d machine image(s) missing", len(missing)),
+		state: verdictWarn,
+		detail: machine.ImageNames(missing) + " — no upstream image ships an ssh daemon, so " +
+			"a machine built from one installs it at first boot and needs outbound internet to do it",
+		fix: "feint images  (builds them locally; minutes, and it starts a container)",
+	}
 }
 
 // incusMinimum is the version below which NIC ACLs are refused, and the failure

--- a/internal/cli/doctor_images_test.go
+++ b/internal/cli/doctor_images_test.go
@@ -1,0 +1,90 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/machine"
+)
+
+// imageHost is a driver whose image list is dictated, so a test can stand on a
+// host it does not have.
+//
+// machine.Noop is embedded rather than the whole Driver interface reimplemented:
+// what is under test is the diagnostic, and everything else a driver does is
+// noise here. Adding LocalImages is what makes it an ImageLister, which is the
+// one behaviour that matters.
+type imageHost struct {
+	machine.Noop
+	held map[string]string
+}
+
+func (h imageHost) LocalImages(context.Context) (map[string]string, error) {
+	return h.held, nil
+}
+
+func hostWith(aliases ...string) imageHost {
+	held := map[string]string{}
+	for _, alias := range aliases {
+		held[alias] = "fingerprint"
+	}
+	return imageHost{held: held}
+}
+
+// The diagnostic names what is missing and how to build it (#203).
+//
+// A check that reports a problem without saying what to do sends the reader to
+// the source, which is the rule the `fix` field of every check exists for. Here
+// it matters more than usual: the reason an image is needed at all is three
+// steps away from the symptom — no upstream image ships an ssh daemon, so the
+// machine installs one at first boot, so it needs outbound network, so it needs
+// an interface nothing publishes.
+func TestDoctorNamesTheMissingImagesAndHowToBuildThem(t *testing.T) {
+	all := machine.RequiredImages()
+	if len(all) < 2 {
+		t.Skip("the image table needs two rows for this to mean anything")
+	}
+
+	// One built, the rest missing: the ordinary state of a station where
+	// somebody ran `feint images` before the table grew.
+	got := checkImages(context.Background(), hostWith(all[0].Alias()))
+	if got.state != verdictWarn {
+		t.Errorf("missing images reported as %v, want a warning", got.state)
+	}
+	for _, spec := range all[1:] {
+		if !strings.Contains(got.detail, spec.Name) {
+			t.Errorf("the diagnostic does not name %s: %q", spec.Name, got.detail)
+		}
+	}
+	if strings.Contains(got.detail, all[0].Name) {
+		t.Errorf("the diagnostic names an image the host holds: %q", got.detail)
+	}
+	if !strings.Contains(got.fix, "feint images") {
+		t.Errorf("the fix does not name the command that builds them: %q", got.fix)
+	}
+
+	// And the accepting half. A complete set says so rather than staying
+	// silent: a diagnostic that only speaks when something is wrong leaves the
+	// reader unable to tell "checked and fine" from "never looked".
+	var every []string
+	for _, spec := range all {
+		every = append(every, spec.Alias())
+	}
+	got = checkImages(context.Background(), hostWith(every...))
+	if got.state != verdictOK {
+		t.Errorf("a complete image set reported as %v, want ok (detail %q)", got.state, got.detail)
+	}
+}
+
+// A host that cannot answer must not read as a host with nothing missing.
+//
+// The same rule CapabilitiesOf applies to an undeclared capability. Reporting
+// "every image is present" because nobody could look is the shape of claim this
+// project exists to remove.
+func TestDoctorDoesNotReadSilenceAsACompleteImageSet(t *testing.T) {
+	got := checkImages(context.Background(), machine.Noop{})
+	if got.state == verdictOK {
+		t.Errorf("a driver that lists nothing reported an ok: %q / %q", got.title, got.detail)
+	}
+}

--- a/internal/cli/images.go
+++ b/internal/cli/images.go
@@ -1,0 +1,124 @@
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/stephrobert/feint/internal/core/machine"
+)
+
+// `feint images` builds the machine images this emulator boots (#203).
+//
+// Why the emulator ships its own. No image on the upstream server carries an ssh
+// daemon: measured on images:ubuntu/24.04, ubuntu/24.04/cloud, debian/12/cloud
+// and alpine/3.21/cloud, each looked at twice — as early as the container
+// answers and again after `cloud-init status --wait` — and all four answered
+// ABSENT with nothing listening on port 22.
+//
+// So a machine built from an upstream image installs one at first boot, which
+// needs outbound internet, which needs NAT, which is why every machine is put on
+// a managed bridge — and that bridge is the second, unpublished address a
+// Scaleway server carries here and does not carry on the real cloud. A real
+// cloud image has the daemon in it. This makes ours look like one.
+//
+// Separate from `doctor` on purpose: doctor diagnoses and this acts. Building
+// launches a container and takes minutes, which is a side effect on the
+// operator's station, and this project asks before those rather than after.
+func images(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("images", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	vm := fs.String("vm", "auto", "machine runtime to build with: auto, incus, incus-vm, incus-ovn")
+	only := fs.String("only", "", "build just this one, e.g. ubuntu/24.04")
+	checkOnly := fs.Bool("check", false, "report what is missing and exit 2 if anything is, building nothing")
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+
+	driver, err := machineDriver(*vm, stderr)
+	if err != nil {
+		fmt.Fprintf(stderr, "feint: %v\n", err)
+		return 1
+	}
+	if _, isNoop := driver.(machine.Noop); isNoop {
+		fmt.Fprintln(stderr, "feint: no machine runtime answers, so there is nowhere to build an image")
+		fmt.Fprintln(stderr, "       `feint doctor --vm incus` says what is missing")
+		return 1
+	}
+
+	ctx := context.Background()
+	inventory, err := machine.ImageInventory(ctx, driver)
+	if err != nil {
+		fmt.Fprintf(stderr, "feint: %v\n", err)
+		return 1
+	}
+
+	if *checkOnly {
+		return reportImages(inventory, *only, stdout)
+	}
+
+	builder, ok := driver.(interface {
+		BuildImage(context.Context, machine.ImageSpec, io.Writer) error
+	})
+	if !ok {
+		fmt.Fprintln(stderr, "feint: this runtime cannot build images")
+		return 1
+	}
+
+	built, skipped := 0, 0
+	for _, status := range inventory {
+		if *only != "" && *only != status.Spec.Name {
+			continue
+		}
+		if status.Present() {
+			fmt.Fprintf(stdout, "== %s already built (%s)\n", status.Spec.Alias(), short(status.Fingerprint))
+			skipped++
+			continue
+		}
+		fmt.Fprintf(stdout, "== %s\n", status.Spec.Alias())
+		if err := builder.BuildImage(ctx, status.Spec, stdout); err != nil {
+			fmt.Fprintf(stderr, "feint: %s: %v\n", status.Spec.Name, err)
+			return 1
+		}
+		built++
+	}
+
+	if built == 0 && skipped == 0 {
+		fmt.Fprintf(stderr, "feint: no image is called %q\n", *only)
+		return 1
+	}
+	fmt.Fprintf(stdout, "\n%d built, %d already present\n", built, skipped)
+	return 0
+}
+
+// reportImages prints the inventory and answers 2 when something is missing, the
+// exit code every other gate in this project uses for "the world moved and
+// nobody triaged it".
+func reportImages(inventory []machine.ImageStatus, only string, stdout io.Writer) int {
+	missing := 0
+	for _, status := range inventory {
+		if only != "" && only != status.Spec.Name {
+			continue
+		}
+		if status.Present() {
+			fmt.Fprintf(stdout, "  ok       %-16s %s\n", status.Spec.Name, short(status.Fingerprint))
+			continue
+		}
+		fmt.Fprintf(stdout, "  missing  %-16s from %s\n", status.Spec.Name, status.Spec.Source)
+		missing++
+	}
+	if missing > 0 {
+		fmt.Fprintf(stdout, "\n%d missing; `feint images` builds them\n", missing)
+		return 2
+	}
+	fmt.Fprintln(stdout, "\nevery machine image is present")
+	return 0
+}
+
+func short(fingerprint string) string {
+	if len(fingerprint) > 12 {
+		return fingerprint[:12]
+	}
+	return fingerprint
+}

--- a/internal/cli/testdata/frozen/cli.json
+++ b/internal/cli/testdata/frozen/cli.json
@@ -123,6 +123,135 @@
           ]
         }
       }
+    },
+    {
+      "schema_version": 2,
+      "content": {
+        "exit_codes": {
+          "drift": 2,
+          "error": 1,
+          "ok": 0
+        },
+        "verbs": {
+          "catalog": [
+            "--format"
+          ],
+          "clean": [
+            "--vm"
+          ],
+          "coverage": [
+            "--baseline",
+            "--contract",
+            "--fail-on-unknown",
+            "--format",
+            "--products",
+            "--provider",
+            "--sdk",
+            "--write-baseline"
+          ],
+          "docs": [
+            "--check",
+            "--coverage",
+            "--file"
+          ],
+          "doctor": [
+            "--addr",
+            "--vm"
+          ],
+          "env": [
+            "--endpoint",
+            "--shell",
+            "--unset"
+          ],
+          "evidence": [
+            "--endpoint",
+            "--join",
+            "--out",
+            "--shapes"
+          ],
+          "images": [
+            "--check",
+            "--only",
+            "--vm"
+          ],
+          "logs": [
+            "--addr",
+            "-f",
+            "-n"
+          ],
+          "probe": [
+            "--contracts",
+            "--endpoint",
+            "--provider"
+          ],
+          "proxy": [
+            "--addr",
+            "--max-body",
+            "--provider",
+            "--queue",
+            "--record",
+            "--upstream"
+          ],
+          "restart": [
+            "--addr",
+            "--timeout"
+          ],
+          "serve": [
+            "--addr",
+            "--cleanup",
+            "--contracts",
+            "--coverage",
+            "--log-level",
+            "--state",
+            "--vm"
+          ],
+          "shapes": [
+            "--check",
+            "--dir",
+            "--dry-run",
+            "--profile",
+            "--provider",
+            "--record"
+          ],
+          "snapshot": [
+            "--addr",
+            "--force",
+            "--format",
+            "--state"
+          ],
+          "start": [
+            "--detach",
+            "--foreground",
+            "--timeout"
+          ],
+          "status": [
+            "--addr",
+            "--coverage",
+            "--format"
+          ],
+          "stop": [
+            "--addr",
+            "--timeout"
+          ],
+          "transcript": [
+            "--against",
+            "--format",
+            "--shape"
+          ],
+          "ui": [
+            "--addr",
+            "--print"
+          ],
+          "version": [
+            "--version",
+            "-v"
+          ],
+          "wait": [
+            "--addr",
+            "--timeout"
+          ]
+        }
+      }
     }
   ]
 }

--- a/internal/core/machine/images.go
+++ b/internal/core/machine/images.go
@@ -1,0 +1,194 @@
+package machine
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// The machine images feint boots, and why it builds its own (#203).
+//
+// No image on the upstream server carries an ssh daemon. Measured on
+// images:ubuntu/24.04, ubuntu/24.04/cloud, debian/12/cloud and
+// alpine/3.21/cloud, each looked at twice — as early as the container answers
+// and again after `cloud-init status --wait` returns, so a daemon installed at
+// boot would still have been caught. All four answered ABSENT, with nothing
+// listening on port 22.
+//
+// So this emulator installs one at first boot, in
+// internal/core/cloudinit/templates/*.yaml.tmpl. That install is what needs
+// outbound internet; outbound is what needs NAT; NAT is why every machine is put
+// on a managed bridge; and that bridge is the second, unpublished address a
+// Scaleway server carries here and does not carry on the real cloud (#202).
+//
+// A real cloud image has the daemon in it — Scaleway does not apt-install
+// openssh when a server boots. Building one is therefore the faithful shape
+// rather than a workaround, and #202 cannot close honestly without it.
+//
+// TestEveryRequiredImageDeclaresItsSource fails without this table.
+
+// ImagePrefix is the alias namespace every image this emulator builds lives
+// under. It is also what makes an image ours: nothing outside this prefix is
+// ever deleted or rebuilt, the same rule Binding.ours and mustOwn apply to
+// machines and networks.
+const ImagePrefix = "feint"
+
+// ImageSpec is one image to build: where it comes from, and what has to be added
+// to it. Every field is data rather than a branch, so a fifth family is a row
+// and not a code change.
+type ImageSpec struct {
+	// Name is the family and version, e.g. "ubuntu/24.04". The alias is
+	// ImagePrefix + "/" + Name.
+	Name string
+	// Source is the upstream image to start from.
+	Source string
+	// Package carries the ssh daemon, under the name this family's package
+	// manager knows it by — "openssh" on Alpine, "openssh-server" elsewhere.
+	Package string
+	// Service is what enables it at boot: "ssh" on Debian and Ubuntu, "sshd"
+	// on Alpine and the RHEL family.
+	Service string
+	// Manager is the package manager: apt, apk or dnf.
+	Manager string
+}
+
+// Alias is the local image alias this spec publishes to.
+func (s ImageSpec) Alias() string { return ImagePrefix + "/" + s.Name }
+
+// RequiredImages is the set feint needs to boot machines.
+//
+// One row per cloud-init template family, and that is not a coincidence: an
+// image set narrower than internal/core/cloudinit/templates/ makes the templates
+// lie about distributions nobody can actually boot.
+func RequiredImages() []ImageSpec {
+	return []ImageSpec{
+		{Name: "ubuntu/24.04", Source: "images:ubuntu/24.04/cloud", Package: "openssh-server", Service: "ssh", Manager: "apt"},
+		{Name: "ubuntu/22.04", Source: "images:ubuntu/22.04/cloud", Package: "openssh-server", Service: "ssh", Manager: "apt"},
+		{Name: "debian/12", Source: "images:debian/12/cloud", Package: "openssh-server", Service: "ssh", Manager: "apt"},
+		{Name: "alpine/3.21", Source: "images:alpine/3.21/cloud", Package: "openssh", Service: "sshd", Manager: "apk"},
+		{Name: "almalinux/9", Source: "images:almalinux/9/cloud", Package: "openssh-server", Service: "sshd", Manager: "dnf"},
+	}
+}
+
+// ImageStatus is what the host holds for one required image.
+type ImageStatus struct {
+	Spec ImageSpec
+	// Fingerprint is what the local store answers, empty when the image is not
+	// there. It is reported rather than checked against a recorded value: an
+	// image built on two machines from the same source is not bit-identical, so
+	// pinning the fingerprint would fail for a reason that has nothing to do
+	// with the image being right.
+	Fingerprint string
+}
+
+// Present reports whether the image is in the local store.
+func (s ImageStatus) Present() bool { return s.Fingerprint != "" }
+
+// ImageLister is the part of a driver that can answer what images the host
+// holds. Optional, like Capable: a driver that cannot answer counts as holding
+// none, so the check reports work to do rather than asserting nothing is
+// missing.
+type ImageLister interface {
+	// LocalImages answers the alias to fingerprint mapping of every image the
+	// host holds under the emulator's own prefix.
+	LocalImages(ctx context.Context) (map[string]string, error)
+}
+
+// ImageInventory answers the status of every required image, sorted by name so
+// two runs report the same order.
+//
+// A driver that does not implement ImageLister yields every image as missing,
+// never as present: an undeclared property counts as absent, which is the same
+// rule CapabilitiesOf applies. Reporting "nothing is missing" because nobody
+// could look is the failure this project exists to remove.
+func ImageInventory(ctx context.Context, driver Driver) ([]ImageStatus, error) {
+	specs := RequiredImages()
+	sort.Slice(specs, func(i, j int) bool { return specs[i].Name < specs[j].Name })
+
+	held := map[string]string{}
+	if lister, ok := driver.(ImageLister); ok {
+		var err error
+		held, err = lister.LocalImages(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	out := make([]ImageStatus, 0, len(specs))
+	for _, spec := range specs {
+		out = append(out, ImageStatus{Spec: spec, Fingerprint: held[spec.Alias()]})
+	}
+	return out, nil
+}
+
+// MissingImages is the subset of the inventory that is not on the host.
+func MissingImages(inventory []ImageStatus) []ImageSpec {
+	var out []ImageSpec
+	for _, status := range inventory {
+		if !status.Present() {
+			out = append(out, status.Spec)
+		}
+	}
+	return out
+}
+
+// ImageNames joins the names of a spec list, for a one-line diagnostic.
+func ImageNames(specs []ImageSpec) string {
+	names := make([]string, 0, len(specs))
+	for _, spec := range specs {
+		names = append(names, spec.Name)
+	}
+	return strings.Join(names, ", ")
+}
+
+// installCommands is what turns the upstream image into ours, per package
+// manager. Data rather than a switch inside the build loop, so a family whose
+// manager is new is a row here and the build stays one shape.
+func installCommands(spec ImageSpec) ([][]string, error) {
+	switch spec.Manager {
+	case "apt":
+		return [][]string{
+			{"sh", "-c", "DEBIAN_FRONTEND=noninteractive apt-get update -qq"},
+			{"sh", "-c", "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends " + spec.Package},
+			{"systemctl", "enable", spec.Service},
+			{"sh", "-c", "apt-get clean && rm -rf /var/lib/apt/lists/*"},
+		}, nil
+	case "apk":
+		return [][]string{
+			{"apk", "add", "--no-cache", spec.Package},
+			{"rc-update", "add", spec.Service, "default"},
+		}, nil
+	case "dnf":
+		return [][]string{
+			{"sh", "-c", "dnf install -y -q " + spec.Package},
+			{"systemctl", "enable", spec.Service},
+			{"sh", "-c", "dnf clean all"},
+		}, nil
+	}
+	return nil, fmt.Errorf("no install recipe for package manager %q", spec.Manager)
+}
+
+// generaliseCommands strip what must never travel inside an image.
+//
+// Host keys above all. Baked in, every machine this emulator ever boots would
+// present the same fingerprint, and a user's known_hosts would accept any of
+// them for any other — a machine identity that is not an identity. cloud-init
+// regenerates them when they are absent, which is why they are removed rather
+// than left to be overwritten.
+//
+// TestTheBuildRemovesWhatMustNotTravelInAnImage holds the recipe here;
+// tools/images/verify.sh holds the property itself, by booting two machines from
+// one image and requiring two different host keys. The second is the one that
+// matters and it cannot live in a unit test: nothing here can boot a machine.
+func generaliseCommands() [][]string {
+	return [][]string{
+		{"sh", "-c", "rm -f /etc/ssh/ssh_host_*"},
+		{"sh", "-c", ": > /etc/machine-id"},
+		{"sh", "-c", "rm -f /var/lib/dbus/machine-id || true"},
+		// cloud-init must run again from scratch on machines built from this
+		// image, or the build's own first boot is the only one it ever has.
+		{"sh", "-c", "cloud-init clean --logs --seed 2>/dev/null || true"},
+		{"sh", "-c", "rm -rf /var/log/* /tmp/* 2>/dev/null || true"},
+	}
+}

--- a/internal/core/machine/images_test.go
+++ b/internal/core/machine/images_test.go
@@ -1,0 +1,202 @@
+package machine
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// The image table is data, and a row that names no source or no package is a
+// row that fails at build time on the operator's station rather than here.
+func TestEveryRequiredImageDeclaresItsSource(t *testing.T) {
+	seen := map[string]bool{}
+	for _, spec := range RequiredImages() {
+		if spec.Name == "" || spec.Source == "" || spec.Package == "" || spec.Service == "" {
+			t.Errorf("incomplete image spec: %+v", spec)
+		}
+		if seen[spec.Name] {
+			t.Errorf("%s is declared twice", spec.Name)
+		}
+		seen[spec.Name] = true
+		if !strings.HasPrefix(spec.Alias(), ImagePrefix+"/") {
+			t.Errorf("%s publishes outside the emulator's own prefix: %s", spec.Name, spec.Alias())
+		}
+		if _, err := installCommands(spec); err != nil {
+			t.Errorf("%s: %v", spec.Name, err)
+		}
+	}
+}
+
+// Every cloud-init template family must have an image, or the template promises
+// a distribution nobody can boot.
+//
+// The list is spelled here rather than read from the templates directory on
+// purpose: the point is that the two sets agree, and a check that derives one
+// from the other agrees with itself.
+func TestEveryCloudInitFamilyHasAnImage(t *testing.T) {
+	families := map[string]bool{}
+	for _, spec := range RequiredImages() {
+		families[strings.SplitN(spec.Name, "/", 2)[0]] = true
+	}
+	for _, want := range []string{"almalinux", "alpine", "debian", "ubuntu"} {
+		if !families[want] {
+			t.Errorf("internal/core/cloudinit/templates/%s.yaml.tmpl exists and no image does", want)
+		}
+	}
+}
+
+// A driver that cannot answer must yield every image as missing, never as
+// present.
+//
+// This is the same rule CapabilitiesOf applies to an undeclared capability, and
+// it matters more here than it looks: the opposite default would report "nothing
+// is missing" because nobody could look, which is the exact shape of claim this
+// project exists to remove.
+func TestADriverThatCannotListImagesReportsThemAllMissing(t *testing.T) {
+	inventory, err := ImageInventory(context.Background(), Noop{})
+	if err != nil {
+		t.Fatalf("inventory of a silent driver: %v", err)
+	}
+	if len(inventory) != len(RequiredImages()) {
+		t.Fatalf("inventory covers %d image(s), the table declares %d", len(inventory), len(RequiredImages()))
+	}
+	missing := MissingImages(inventory)
+	if len(missing) != len(RequiredImages()) {
+		t.Errorf("a driver that answers nothing reported %d missing of %d; silence must not read as present",
+			len(missing), len(RequiredImages()))
+	}
+}
+
+// The accepting half: an image the host holds is reported present, with its
+// fingerprint, and one it does not is not.
+//
+// Both halves, because a check that reported everything missing would pass the
+// test above and make `feint images` rebuild what already exists on every run.
+func TestAnImageTheHostHoldsIsReportedPresent(t *testing.T) {
+	specs := RequiredImages()
+	if len(specs) < 2 {
+		t.Skip("the table needs two rows for this to mean anything")
+	}
+	held := specs[0]
+
+	d := NewIncus()
+	d.runner = func(_ context.Context, args ...string) ([]byte, error) {
+		if strings.HasPrefix(strings.Join(args, " "), "image list") {
+			return []byte(held.Alias() + ",abc123def456\n"), nil
+		}
+		return nil, nil
+	}
+
+	inventory, err := ImageInventory(context.Background(), d)
+	if err != nil {
+		t.Fatalf("inventory: %v", err)
+	}
+	for _, status := range inventory {
+		switch status.Spec.Name {
+		case held.Name:
+			if !status.Present() {
+				t.Errorf("%s is on the host and was reported missing", held.Name)
+			}
+			if status.Fingerprint != "abc123def456" {
+				t.Errorf("fingerprint %q, want abc123def456", status.Fingerprint)
+			}
+		default:
+			if status.Present() {
+				t.Errorf("%s is not on the host and was reported present", status.Spec.Name)
+			}
+		}
+	}
+	if names := ImageNames(MissingImages(inventory)); strings.Contains(names, held.Name) {
+		t.Errorf("the missing list names an image the host holds: %s", names)
+	}
+}
+
+// Only the emulator's own images are ever reported.
+//
+// An operator's images are none of this code's business, and a list that
+// included them would be the first step towards a rebuild deleting one — the
+// same boundary mustOwn draws for instances and networks.
+func TestAnOperatorsOwnImagesAreNotReported(t *testing.T) {
+	d := NewIncus()
+	d.runner = func(_ context.Context, args ...string) ([]byte, error) {
+		if strings.HasPrefix(strings.Join(args, " "), "image list") {
+			return []byte("production-base,deadbeef00\n" + ImagePrefix + "/ubuntu/24.04,cafebabe11\n"), nil
+		}
+		return nil, nil
+	}
+	held, err := d.LocalImages(context.Background())
+	if err != nil {
+		t.Fatalf("LocalImages: %v", err)
+	}
+	if _, found := held["production-base"]; found {
+		t.Error("an image outside the emulator's prefix was reported as ours")
+	}
+	if held[ImagePrefix+"/ubuntu/24.04"] != "cafebabe11" {
+		t.Errorf("our own image was not reported: %v", held)
+	}
+}
+
+// The image must not carry host keys, and the build must say so by removing
+// them.
+//
+// Baked in, every machine this emulator boots would present one fingerprint and
+// a user's known_hosts would accept any of them for any other. cloud-init
+// regenerates them when absent, which is why they are removed rather than left
+// to be overwritten. tools/images/verify.sh holds the same property against two
+// real machines; this holds it against the recipe.
+func TestTheBuildRemovesWhatMustNotTravelInAnImage(t *testing.T) {
+	joined := ""
+	for _, command := range generaliseCommands() {
+		joined += strings.Join(command, " ") + "\n"
+	}
+	for _, want := range []string{"/etc/ssh/ssh_host_", "/etc/machine-id", "cloud-init clean"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("the build keeps %s in the image", want)
+		}
+	}
+}
+
+// The image the emulator built is preferred over the upstream one, and the
+// fallback is announced rather than silent.
+//
+// This is what makes #203 reach the machines: building images changes nothing
+// until the driver boots them. The accepting half and the refusing half are both
+// here, because a resolver that always returned the upstream ref would pass a
+// test that only checked the fallback, and one that always returned ours would
+// break every host that has not run `feint images`.
+func TestTheBuiltImageIsPreferredWhenTheHostHoldsIt(t *testing.T) {
+	withImages := func(aliases ...string) *Incus {
+		d := NewIncus()
+		d.runner = func(_ context.Context, args ...string) ([]byte, error) {
+			if strings.HasPrefix(strings.Join(args, " "), "image list") {
+				var out strings.Builder
+				for _, alias := range aliases {
+					out.WriteString(alias + ",fingerprint\n")
+				}
+				return []byte(out.String()), nil
+			}
+			return nil, nil
+		}
+		return d
+	}
+
+	ours := ImagePrefix + "/ubuntu/24.04"
+	if got := withImages(ours).resolveImage(context.Background(), "ubuntu:24.04"); got != ours {
+		t.Errorf("the host holds %s and the driver booted %s", ours, got)
+	}
+
+	// Nothing built: the upstream image, so a first contact still works.
+	if got := withImages().resolveImage(context.Background(), "ubuntu:24.04"); got != "images:ubuntu/24.04/cloud" {
+		t.Errorf("with no image built the driver must fall back upstream, got %s", got)
+	}
+
+	// A different version must not borrow another's image.
+	if got := withImages(ours).resolveImage(context.Background(), "ubuntu:22.04"); got != "images:ubuntu/22.04/cloud" {
+		t.Errorf("ubuntu:22.04 resolved to %s while only 24.04 is built", got)
+	}
+
+	// An explicit Incus reference is the caller naming an image; it is honoured.
+	if got := withImages(ours).resolveImage(context.Background(), "images:debian/13"); got != "images:debian/13" {
+		t.Errorf("an explicit reference was rewritten to %s", got)
+	}
+}

--- a/internal/core/machine/incus.go
+++ b/internal/core/machine/incus.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/netip"
 	"os"
 	"slices"
@@ -159,13 +160,54 @@ func (d *Incus) imageRef(image string) string {
 	// cloud-init, so it is the only one that can receive the default account and
 	// its keys, and it carries the Incus agent virtual machines need.
 	//
-	// It still ships no ssh daemon. Measured the hard way: the key lands in
-	// /root/.ssh/authorized_keys and nothing answers on port 22. The cloud-config
-	// the pack renders installs openssh-server for that reason. Canonical's own
-	// images would avoid the install, but the `ubuntu:` remote is not configured
-	// on every Incus installation, and depending on it makes the driver fail on
-	// machines where only `images:` exists.
+	// It ships no ssh daemon. Measured on four upstream images, each looked at
+	// twice, and all four answered ABSENT with nothing on port 22. That is why
+	// resolveImage below prefers the emulator's own build when it exists: the
+	// cloud-config still installs openssh-server, and an install at first boot is
+	// what forces a machine to have outbound internet (#203).
 	return fmt.Sprintf("%s:%s/%s/cloud", remote, name, version)
+}
+
+// resolveImage answers the image to boot: the emulator's own build when the host
+// holds it, the upstream one otherwise.
+//
+// The preference is the whole point of #203. An image feint built carries an ssh
+// daemon, so a machine from it answers on port 22 without reaching a package
+// repository — and a machine that needs no outbound needs no NAT, and therefore
+// no interface beyond the ones its provider's API publishes (#202).
+//
+// The fallback is deliberate and it is announced, never silent. Refusing to boot
+// because `feint images` has not been run would turn a first contact into a
+// failure; falling back without a word would reintroduce the boot-time install
+// and hide the reason a machine suddenly needs the network. So it degrades, and
+// says which and why.
+//
+// TestTheBuiltImageIsPreferredWhenTheHostHoldsIt fails without this.
+func (d *Incus) resolveImage(ctx context.Context, image string) string {
+	upstream := d.imageRef(image)
+	// An explicit Incus reference is the caller naming an image; honour it.
+	if strings.Contains(image, "/") {
+		return upstream
+	}
+	name, version, found := strings.Cut(image, ":")
+	if !found {
+		return upstream
+	}
+	alias := ImagePrefix + "/" + name + "/" + version
+
+	held, err := d.LocalImages(ctx)
+	if err != nil {
+		// Cannot tell: boot what has always worked rather than refuse.
+		return upstream
+	}
+	if _, ok := held[alias]; ok {
+		return alias
+	}
+	slog.Default().Warn("no image of ours for this system, booting the upstream one",
+		"image", image, "wanted", alias, "using", upstream,
+		"consequence", "the machine installs an ssh daemon at first boot and needs outbound network to do it",
+		"fix", "feint images")
+	return upstream
 }
 
 // DefaultMachineNetwork is the network a machine with no attachments boots on.
@@ -280,7 +322,7 @@ func (d *Incus) Start(ctx context.Context, spec Spec) (Machine, error) {
 		return Machine{}, fmt.Errorf("invalid network name %q", primary.Network)
 	}
 
-	args := []string{"init", d.imageRef(spec.Image), spec.Name}
+	args := []string{"init", d.resolveImage(ctx, spec.Image), spec.Name}
 	if d.VM {
 		args = append(args, "--vm")
 	}
@@ -302,7 +344,7 @@ func (d *Incus) Start(ctx context.Context, spec Spec) (Machine, error) {
 		args = append(args, "--config", "environment."+e)
 	}
 	if _, err := d.run(ctx, args...); err != nil {
-		return Machine{}, fmt.Errorf("create instance %s from %s: %w", spec.Name, d.imageRef(spec.Image), err)
+		return Machine{}, fmt.Errorf("create instance %s from %s: %w", spec.Name, d.resolveImage(ctx, spec.Image), err)
 	}
 
 	// Device keys, while the instance is cold. The address pin and the public

--- a/internal/core/machine/incus_images.go
+++ b/internal/core/machine/incus_images.go
@@ -1,0 +1,164 @@
+package machine
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+// builderName is the instance an image build runs in.
+//
+// Under the emulator's own machine prefix on purpose: a build interrupted
+// halfway leaves it behind, and `feint clean` sweeps what carries the prefix, so
+// the leftover is removed by the tool the operator already runs rather than by
+// remembering it exists.
+const builderName = "feint-imagebuild"
+
+// LocalImages implements ImageLister.
+//
+// Only aliases under the emulator's own prefix are reported. An operator's own
+// images are none of this code's business, and reporting them would be the first
+// step towards deleting one.
+func (d *Incus) LocalImages(ctx context.Context) (map[string]string, error) {
+	out, err := d.run(ctx, "image", "list", ImagePrefix+"/", "-f", "csv", "-c", "lf")
+	if err != nil {
+		return nil, fmt.Errorf("list local images: %w", err)
+	}
+	held := map[string]string{}
+	reader := csv.NewReader(strings.NewReader(string(out)))
+	reader.FieldsPerRecord = -1
+	for {
+		row, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read the image list: %w", err)
+		}
+		if len(row) < 2 {
+			continue
+		}
+		// One image can carry several aliases; the column is comma-joined
+		// inside a quoted field, so each is taken on its own.
+		for _, alias := range strings.Split(row[0], ",") {
+			alias = strings.TrimSpace(alias)
+			if strings.HasPrefix(alias, ImagePrefix+"/") {
+				held[alias] = strings.TrimSpace(row[1])
+			}
+		}
+	}
+	return held, nil
+}
+
+// BuildImage produces one image and publishes it under its alias.
+//
+// It launches the upstream image, installs the ssh daemon, strips what must not
+// travel, and publishes. Minutes, and a container running on the operator's
+// host, which is why nothing calls this without being asked: `feint doctor`
+// reports what is missing and names the command, it never builds.
+//
+// The builder is removed whether the build succeeded or not. A half-built
+// instance left running is the failure mode that makes people distrust a tool
+// that touches their machine.
+func (d *Incus) BuildImage(ctx context.Context, spec ImageSpec, progress io.Writer) error {
+	say := func(format string, args ...any) {
+		if progress != nil {
+			fmt.Fprintf(progress, "  "+format+"\n", args...)
+		}
+	}
+
+	_ = d.removeBuilder(ctx)
+	defer func() { _ = d.removeBuilder(ctx) }()
+
+	say("launching %s", spec.Source)
+	// Labelled like every other object this driver creates, so `feint clean`
+	// sweeps a builder an interrupted run left behind. An unlabelled leftover is
+	// one this emulator would refuse to touch, which is the right rule applied
+	// to the wrong object.
+	if _, err := d.run(ctx, "launch", spec.Source, builderName,
+		"--config", "user."+LabelKey+"=imagebuild"); err != nil {
+		return fmt.Errorf("launch %s: %w", spec.Source, err)
+	}
+	if err := d.waitForBuilder(ctx); err != nil {
+		return err
+	}
+
+	say("installing %s and enabling %s", spec.Package, spec.Service)
+	commands, err := installCommands(spec)
+	if err != nil {
+		return err
+	}
+	for _, command := range commands {
+		if err := d.execInBuilder(ctx, command); err != nil {
+			return err
+		}
+	}
+
+	say("removing host keys, machine id and cloud-init state")
+	for _, command := range generaliseCommands() {
+		// Best effort: a distribution without dbus has no dbus machine id to
+		// remove, and failing there would refuse an image for a file that was
+		// never supposed to exist.
+		_ = d.execInBuilder(ctx, command)
+	}
+
+	say("publishing %s", spec.Alias())
+	if _, err := d.run(ctx, "stop", builderName); err != nil {
+		return fmt.Errorf("stop the builder: %w", err)
+	}
+	// A previous alias would make `publish` fail rather than replace, and a
+	// rebuild is the ordinary way to pick up a security update. Best effort on
+	// purpose: the first build of an image has nothing to delete, and Incus
+	// answers "Image not found".
+	//
+	// That phrase is deliberately absent from isNotFound, and adding it there was
+	// the wrong fix: TestIsNotFoundStaysNarrow exists because a message about one
+	// kind of object passing for another is how a Remove once reported success and
+	// left an instance running. An image is not an instance. So the tolerance
+	// lives here, where it is scoped to one call whose failure cannot hide
+	// anything: a genuine conflict surfaces at publish, loudly.
+	_, _ = d.run(ctx, "image", "delete", spec.Alias())
+	if _, err := d.run(ctx, "publish", builderName, "--alias", spec.Alias()); err != nil {
+		return fmt.Errorf("publish %s: %w", spec.Alias(), err)
+	}
+	return nil
+}
+
+// waitForBuilder blocks until the builder answers and cloud-init has finished,
+// because installing a package while cloud-init is still holding the package
+// manager is a race that fails intermittently — the worst kind.
+func (d *Incus) waitForBuilder(ctx context.Context) error {
+	deadline := time.Now().Add(3 * time.Minute)
+	for time.Now().Before(deadline) {
+		if _, err := d.run(ctx, "exec", builderName, "--", "true"); err == nil {
+			// cloud-init is absent on some images and that is not an error.
+			_, _ = d.run(ctx, "exec", builderName, "--", "cloud-init", "status", "--wait")
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+	return fmt.Errorf("the build instance never answered")
+}
+
+func (d *Incus) execInBuilder(ctx context.Context, command []string) error {
+	args := append([]string{"exec", builderName, "--"}, command...)
+	if _, err := d.run(ctx, args...); err != nil {
+		return fmt.Errorf("%s in the build instance: %w", strings.Join(command, " "), err)
+	}
+	return nil
+}
+
+func (d *Incus) removeBuilder(ctx context.Context) error {
+	_, err := d.run(ctx, "delete", "--force", builderName)
+	if err != nil && !isNotFound(err) {
+		return err
+	}
+	return nil
+}

--- a/tools/images/build.sh
+++ b/tools/images/build.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Build the machine images feint boots, with an ssh daemon already in them.
+#
+#   tools/images/build.sh                 # every family
+#   tools/images/build.sh ubuntu/24.04    # one of them
+#
+# Why this exists (#203). No image on the upstream server carries an ssh daemon:
+# measured on images:ubuntu/24.04, ubuntu/24.04/cloud, debian/12/cloud and
+# alpine/3.21/cloud, looked at twice each — as early as the container answers and
+# again after `cloud-init status --wait` — and all four answered ABSENT with
+# nothing listening on port 22.
+#
+# So feint installs it at first boot, in
+# internal/core/cloudinit/templates/*.yaml.tmpl. That install is what needs
+# outbound internet; outbound is what needs NAT; NAT is why every machine is put
+# on a managed bridge; and that bridge is the second, unpublished address a
+# Scaleway server carries here and does not carry on the real cloud (#202).
+#
+# A real cloud image has the daemon in it. Scaleway does not apt-install openssh
+# when a server boots. So this is not a workaround, it is the faithful shape, and
+# #202 cannot close honestly without it.
+#
+# The recipe is deliberately `launch, install, publish` rather than distrobuilder:
+# it needs nothing installed that Incus does not already provide, and it produces
+# the image on the machine that will use it. distrobuilder buys reproducibility
+# from a declarative manifest and costs a build dependency; that trade is open
+# and recorded in #203, not settled here.
+set -euo pipefail
+
+ALIAS_PREFIX=feint
+BUILDER=feint-image-builder
+
+# family/version : upstream image, the package that carries sshd, the service
+# name, and the package manager. Four families because
+# internal/core/cloudinit/templates/ has four, and an image set narrower than the
+# templates makes the templates lie.
+targets() {
+  cat <<'LIST'
+ubuntu/24.04     images:ubuntu/24.04/cloud     openssh-server ssh   apt
+ubuntu/22.04     images:ubuntu/22.04/cloud     openssh-server ssh   apt
+debian/12        images:debian/12/cloud        openssh-server ssh   apt
+alpine/3.21      images:alpine/3.21/cloud      openssh        sshd  apk
+almalinux/9      images:almalinux/9/cloud      openssh-server sshd  dnf
+LIST
+}
+
+log() { printf '  %s\n' "$*"; }
+
+cleanup_builder() {
+  incus delete --force "$BUILDER" >/dev/null 2>&1 || true
+}
+
+install_ssh() {
+  local manager=$1 package=$2 service=$3
+  case "$manager" in
+    apt)
+      incus exec "$BUILDER" -- sh -c 'DEBIAN_FRONTEND=noninteractive apt-get update -qq'
+      incus exec "$BUILDER" -- sh -c \
+        "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends $package"
+      incus exec "$BUILDER" -- systemctl enable "$service"
+      incus exec "$BUILDER" -- sh -c 'apt-get clean && rm -rf /var/lib/apt/lists/*'
+      ;;
+    apk)
+      incus exec "$BUILDER" -- apk add --no-cache "$package"
+      incus exec "$BUILDER" -- rc-update add "$service" default
+      ;;
+    dnf)
+      incus exec "$BUILDER" -- sh -c "dnf install -y -q $package"
+      incus exec "$BUILDER" -- systemctl enable "$service"
+      incus exec "$BUILDER" -- sh -c 'dnf clean all'
+      ;;
+    *) echo "unknown package manager $manager" >&2; return 1 ;;
+  esac
+}
+
+# What must NOT travel in the image.
+#
+# Host keys above all: baked in, every machine this emulator ever boots would
+# present the same fingerprint, and a user's known_hosts would accept any of them
+# for any other. cloud-init regenerates them when they are absent, which is why
+# they are removed here rather than left "to be overwritten".
+#
+# The machine id goes for the same reason one level down: DHCP leases and
+# systemd identity derive from it.
+generalise() {
+  incus exec "$BUILDER" -- sh -c 'rm -f /etc/ssh/ssh_host_*'
+  incus exec "$BUILDER" -- sh -c ': > /etc/machine-id'
+  incus exec "$BUILDER" -- sh -c 'rm -f /var/lib/dbus/machine-id' || true
+  # cloud-init must run again from scratch on the machines built from this
+  # image, or its first boot here is the only first boot it ever has.
+  incus exec "$BUILDER" -- sh -c 'cloud-init clean --logs --seed 2>/dev/null || true'
+  incus exec "$BUILDER" -- sh -c 'rm -rf /var/log/* /tmp/* 2>/dev/null || true'
+}
+
+build_one() {
+  local name=$1 source=$2 package=$3 service=$4 manager=$5
+  local alias="$ALIAS_PREFIX/$name"
+
+  echo "== $alias  (from $source)"
+  cleanup_builder
+  log "launching the upstream image"
+  incus launch "$source" "$BUILDER" >/dev/null
+
+  log "waiting for it to answer"
+  for _ in $(seq 1 60); do
+    incus exec "$BUILDER" -- true >/dev/null 2>&1 && break
+    sleep 2
+  done
+  incus exec "$BUILDER" -- cloud-init status --wait >/dev/null 2>&1 || true
+
+  log "installing $package and enabling $service"
+  install_ssh "$manager" "$package" "$service"
+
+  log "removing what must not travel (host keys, machine id, cloud-init state)"
+  generalise
+
+  log "publishing"
+  incus stop "$BUILDER" >/dev/null
+  incus image delete "$alias" >/dev/null 2>&1 || true
+  incus publish "$BUILDER" --alias "$alias" >/dev/null
+  cleanup_builder
+
+  local fingerprint
+  fingerprint=$(incus image info "$alias" 2>/dev/null | awk '/^Fingerprint:/ {print $2}')
+  log "fingerprint: $fingerprint"
+  printf '%s %s\n' "$alias" "$fingerprint"
+}
+
+main() {
+  local want=${1:-}
+  local built=0
+  # Read the whole list first, and never iterate a stream the loop body will
+  # inherit as stdin: `incus launch` reads stdin as an InstancePut, so it ate the
+  # remaining lines and failed with "cannot construct !!str ubuntu/... into
+  # api.InstancePut". Measured, not anticipated.
+  local -a rows=()
+  local row
+  while IFS= read -r row; do
+    [ -n "$row" ] && rows+=("$row")
+  done < <(targets)
+
+  for row in "${rows[@]}"; do
+    # shellcheck disable=SC2086 # the table is ours and its fields never contain spaces
+    set -- $row
+    local name=$1 source=$2 package=$3 service=$4 manager=$5
+    if [ -n "$want" ] && [ "$want" != "$name" ]; then continue; fi
+    build_one "$name" "$source" "$package" "$service" "$manager" </dev/null
+    built=$((built + 1))
+    echo
+  done
+
+  if [ "$built" = "0" ]; then
+    echo "no target matched ${want:-<all>}" >&2
+    exit 1
+  fi
+
+  echo "== images now available locally"
+  incus image list "$ALIAS_PREFIX/" -f csv -c lfd 2>/dev/null | sed 's/^/   /'
+}
+
+trap cleanup_builder EXIT
+main "$@"

--- a/tools/images/verify.sh
+++ b/tools/images/verify.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Prove the built images answer on port 22 without ever reaching the network.
+#
+#   tools/images/verify.sh                 # every image built
+#   tools/images/verify.sh ubuntu/24.04    # one of them
+#
+# This is the assertion #203 asks for, and it is deliberately harder than
+# "openssh is installed": the machine is given a routed NIC carrying an address
+# out of 203.0.113.0/24 (TEST-NET-3, which nothing on earth routes and nothing
+# here masquerades), so it has no path to a package repository at all. A daemon
+# that answers under those conditions is a daemon that came with the image.
+#
+# It also holds two properties that a baked-in daemon would quietly break:
+#
+#   - the host keys differ between two machines from the same image. Baked in,
+#     every machine this emulator boots would present one fingerprint and a
+#     user's known_hosts would accept any of them for any other.
+#   - the machine carries exactly ONE address, which is the shape #202 is for.
+set -euo pipefail
+
+ALIAS_PREFIX=feint
+BASE=203.0.113
+NEXT_HOP=169.254.0.1
+failures=0
+
+log()  { printf '   %s\n' "$*"; }
+ok()   { printf '   ok   %s\n' "$*"; }
+bad()  { printf '   FAIL %s\n' "$*"; failures=$((failures + 1)); }
+
+parent_iface() { ip -o -4 route show default | awk '{print $5; exit}'; }
+
+# One machine from the image, with a single routed NIC and no way out.
+boot_isolated() {
+  local image=$1 name=$2 address=$3
+  incus delete --force "$name" >/dev/null 2>&1 || true
+  incus init "$image" "$name" >/dev/null
+  incus config device add "$name" eth0 nic \
+    nictype=routed parent="$(parent_iface)" \
+    ipv4.address="$address" ipv4.host_address="$NEXT_HOP" >/dev/null
+  # The netplan Incus documents for a routed NIC: the next hop is link-local and
+  # on-link, because a /32 has no subnet to reach it through.
+  incus config set "$name" cloud-init.network-config - <<YAML >/dev/null
+network:
+  version: 2
+  ethernets:
+    eth0:
+      addresses:
+        - $address/32
+      routes:
+        # 0.0.0.0/0 rather than the "default" keyword, and this is measured
+        # rather than stylistic: Debian 12's cloud-init rejects "to: default"
+        # with "Address default is not a valid ip address", aborts, and never
+        # reaches its ssh module — so the host keys this image deliberately does
+        # not carry are never regenerated and sshd cannot start. The failure
+        # reads as "the image has no ssh daemon", which is the opposite of what
+        # happened.
+        - to: 0.0.0.0/0
+          via: $NEXT_HOP
+          on-link: true
+YAML
+  incus start "$name" >/dev/null
+}
+
+# Is anything listening on port 22, read from the kernel rather than from a tool?
+#
+# The first version ran `ss -ltn`, which busybox does not ship. Alpine had sshd
+# running, netstat showed 0.0.0.0:22 LISTEN and rc-status said `started`, and
+# this function timed out for 150 seconds anyway — the harness failing before the
+# subject, which this repository has on record more than once.
+#
+# /proc/net/tcp needs no userspace at all: column 2 is HEXIP:HEXPORT and 22 is
+# 0x0016, column 4 is the socket state and 0A is LISTEN. Every kernel has it.
+listens_on_22() {
+  incus exec "$1" -- sh -c \
+    'grep -qiE "^ *[0-9]+: [0-9A-F]*:0016 .* 0A " /proc/net/tcp /proc/net/tcp6 2>/dev/null' \
+    >/dev/null 2>&1
+}
+
+wait_for_ssh() {
+  local name=$1 seconds=${2:-120}
+  local i=0
+  while [ "$i" -lt "$seconds" ]; do
+    if listens_on_22 "$name"; then
+      return 0
+    fi
+    sleep 2
+    i=$((i + 2))
+  done
+  return 1
+}
+
+host_key() {
+  incus exec "$1" -- sh -c \
+    'cat /etc/ssh/ssh_host_ed25519_key.pub 2>/dev/null || cat /etc/ssh/ssh_host_rsa_key.pub 2>/dev/null' \
+    2>/dev/null | awk '{print $2}'
+}
+
+verify_one() {
+  local name=$1
+  local image="$ALIAS_PREFIX/$name"
+  # Incus instance names take alphanumerics and hyphens only, so the family and
+  # version have to be flattened: ubuntu/24.04 -> ubuntu-24-04.
+  local slug="${name//[^A-Za-z0-9]/-}"
+  local a="verify-a-$slug"
+  local b="verify-b-$slug"
+
+  echo "== $image"
+  if ! incus image info "$image" >/dev/null 2>&1; then
+    bad "$image is not built; run tools/images/build.sh $name"
+    return
+  fi
+
+  boot_isolated "$image" "$a" "$BASE.201"
+  boot_isolated "$image" "$b" "$BASE.202"
+
+  if wait_for_ssh "$a" 150; then
+    ok "answers on port 22 with no route to any package repository"
+  else
+    bad "nothing listens on port 22 within 150s"
+    incus exec "$a" -- sh -c 'cloud-init status --long 2>/dev/null | head -5' || true
+  fi
+
+  # It really had no way out: if this reaches, the test proved nothing.
+  if incus exec "$a" -- ping -c 1 -W 3 1.1.1.1 >/dev/null 2>&1; then
+    bad "the machine reached the internet, so this run does not prove the image carries the daemon"
+  else
+    ok "no outbound: the daemon cannot have been downloaded"
+  fi
+
+  local count
+  count=$(incus exec "$a" -- ip -4 -o addr show 2>/dev/null | awk '$2 != "lo"' | wc -l)
+  if [ "$count" = "1" ]; then
+    ok "carries exactly one address, like a cloud VM"
+  else
+    bad "carries $count addresses; a cloud VM carries one (#202)"
+  fi
+
+  wait_for_ssh "$b" 150 || true
+  local ka kb
+  ka=$(host_key "$a"); kb=$(host_key "$b")
+  if [ -z "$ka" ] || [ -z "$kb" ]; then
+    bad "could not read a host key from both machines"
+  elif [ "$ka" = "$kb" ]; then
+    bad "two machines share one host key: the image baked it in"
+  else
+    ok "two machines, two host keys"
+  fi
+
+  incus delete --force "$a" >/dev/null 2>&1 || true
+  incus delete --force "$b" >/dev/null 2>&1 || true
+  echo
+}
+
+sweep() {
+  for leftover in $(incus list -f csv -c n 2>/dev/null | grep '^verify-' || true); do
+    incus delete --force "$leftover" >/dev/null 2>&1 || true
+  done
+}
+trap sweep EXIT
+
+if [ $# -gt 0 ]; then
+  verify_one "$1"
+else
+  for image in $(incus image list "$ALIAS_PREFIX/" -f csv -c l 2>/dev/null | cut -d, -f1); do
+    verify_one "${image#"$ALIAS_PREFIX"/}"
+  done
+fi
+
+echo
+if [ "$failures" -gt 0 ]; then
+  echo "$failures check(s) failed"
+  exit 1
+fi
+echo "every built image answers on port 22 with no network"


### PR DESCRIPTION
Closes #203. Blocks #202.

## The measurement that starts it

No image on the upstream server carries an ssh daemon. Four images, three
distributions, both variants, each looked at twice — as early as the container
answers and again after `cloud-init status --wait` returns, so a daemon installed
at boot would still be caught:

| image | at first answer | after cloud-init | listening on :22 |
|---|---|---|---|
| `images:ubuntu/24.04` | ABSENT | ABSENT | 0 |
| `images:ubuntu/24.04/cloud` | ABSENT | ABSENT | 0 |
| `images:debian/12/cloud` | ABSENT | ABSENT | 0 |
| `images:alpine/3.21/cloud` | ABSENT | ABSENT | 0 |

So this emulator installs one at first boot, and that install is the root of a
chain nobody had traced: it needs outbound internet → outbound needs NAT → NAT is
why every machine is put on a managed bridge → and that bridge is the second,
unpublished address a Scaleway server carries here.

## What the real clouds do

Measured on the author's own accounts, with their agreement, empty before and
after, every resource destroyed and the counts re-read:

- **Scaleway**, CLI defaults: `public_ip: 212.47.238.226`, one entry in
  `public_ips`, `private_ip: none`, `private_nics: 0`, and one `routed_ipv4` in
  the account. With `ip=none`: no address at all.
- **Exoscale**, defaults: `ip_address: 151.145.198.51`, no private network, no
  elastic IP.

**One address on both, never two.** The emulator's extra matches nothing (#202).

A real cloud image has the daemon in it — Scaleway does not `apt install
openssh-server` when a server boots. This is the faithful shape, not a
workaround.

## What lands

```
feint images            builds the five, one per cloud-init template family
feint images --check    what is missing, exit 2, building nothing
feint doctor            names them and the command, and never builds
```

`doctor` diagnoses and a dedicated verb acts, deliberately: a build launches a
container and takes minutes, which is a side effect this project asks about
rather than performs — the same arbitration `--vm off` already makes.

The driver **prefers** a built image and **announces** its fallback to the
upstream one. Refusing to boot because `feint images` had not been run would turn
a first contact into a failure; falling back silently would reintroduce the
boot-time install and hide why a machine suddenly needs the network.

## Proven, not asserted

`tools/images/verify.sh` gives each machine a routed NIC on 203.0.113.0/24 —
TEST-NET-3, which nothing routes and nothing masquerades — so it has no path to a
package repository at all. **Twenty checks over five images, all green:**

```
almalinux/9   ok ok ok ok
alpine/3.21   ok ok ok ok
debian/12     ok ok ok ok
ubuntu/22.04  ok ok ok ok
ubuntu/24.04  ok ok ok ok
```

per image: answers on port 22, **no outbound**, **exactly one address**, and two
machines from one image carrying **two different host keys**.

And the full chain still passes — `tools/conformance/scaleway/ssh.sh` registers a
key through the IAM API, boots a server from the built image, and logs in as
`root` over real ssh:

```
ok: key 55eda7a4-...
ok: server 5cd4e21a-...
ok: address 203.0.113.2
ok: logged in: ssh-conformance root 1
conformance: ssh round-trip passed
```

Zero fallback warnings in the emulator's log, so the machine really booted from
`feint/ubuntu/24.04`.

## Three defects the harness found in itself

Each recorded where it happened, because each would have accused the image:

- a `while read` loop fed `incus launch` its own target list on stdin, which
  parsed it as an `InstancePut`;
- the listening check ran `ss`, which busybox does not ship. Alpine had sshd
  listening and `rc-status` said `started`, and the check timed out for 150
  seconds anyway. It now reads `/proc/net/tcp`, which needs no userspace;
- the netplan said `to: default`, which Debian 12's cloud-init rejects with
  *"Address default is not a valid ip address"*. It aborted before its ssh
  module, so the host keys this image deliberately does not carry were never
  regenerated and sshd could not start. `0.0.0.0/0` fixed Debian and Alpine at
  once — my Alpine diagnosis ("no netplan") was wrong.

## One guard that was right and I was not

Adding `"image not found"` to `notFoundPhrases` made `TestIsNotFoundStaysNarrow`
red, and that test is correct: it exists because a message about one kind of
object passing for another once made a `Remove` report success while the instance
kept running. An image is not an instance. The tolerance now lives at the one
call whose failure can hide nothing — a real conflict still surfaces at publish.

`TestEveryDispatchedCommandIsInTheHelp` and `TestEveryCitedTestExists` also
caught incomplete work: a verb routed but undiscoverable, and two comments citing
tests that did not exist.

## Surface

The CLI gains a verb, so `cliSurfaceVersion` moves 1 → 2 and the frozen fixture
follows. Nothing a consumer depended on changed shape. CHANGELOG in both
languages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
