### PR TITLE
feat(machine): one address per machine, and networks that are not peered do not reach each other (#202, #201)

### DIFF
--- a/internal/core/machine/incus.go
+++ b/internal/core/machine/incus.go
@@ -307,19 +307,36 @@ func (d *Incus) Start(ctx context.Context, spec Spec) (Machine, error) {
 		return d.inspectOrFail(ctx, spec.Name)
 	}
 
-	// Every machine sits on a network of the emulator's. With no attachment it
-	// gets the default machine network, never the operator's default profile:
-	// see DefaultMachineNetwork for the two measured reasons.
+	// What the machine's first interface is, and it is the whole of #202.
+	//
+	// A machine carries the addresses its provider's API publishes and no
+	// others. Measured against real accounts: a Scaleway server has one routed
+	// public address and `private_ip: none`, an Exoscale instance has one
+	// address. This emulator gave two or three, because a machine with no
+	// emulated network to join was put on a managed bridge and took an address
+	// there that no API describes.
+	//
+	// Three cases now, and no invented address in any of them:
+	//
+	//   an emulated network  the primary interface joins it, as before
+	//   only public ones     a routed NIC carries them, with no network under it
+	//   neither              no network device at all, which is what a real
+	//                        cloud gives a server created with ip=none and no
+	//                        private network
+	//
+	// The bridge was doing a second job nothing wrote down: NAT'd outbound, so
+	// cloud-init could install an ssh daemon. #203 removed that job by building
+	// images that already carry one, which is what makes this possible.
 	attachments := spec.Attachments
-	if len(attachments) == 0 {
-		if err := d.ensureDefaultNetwork(ctx); err != nil {
-			return Machine{}, err
+	routed := len(attachments) == 0 && len(spec.PublicAddresses) > 0
+	bare := len(attachments) == 0 && len(spec.PublicAddresses) == 0
+
+	var primary Attachment
+	if len(attachments) > 0 {
+		primary = attachments[0]
+		if !safeName.MatchString(primary.Network) {
+			return Machine{}, fmt.Errorf("invalid network name %q", primary.Network)
 		}
-		attachments = []Attachment{{Network: DefaultMachineNetwork}}
-	}
-	primary := attachments[0]
-	if !safeName.MatchString(primary.Network) {
-		return Machine{}, fmt.Errorf("invalid network name %q", primary.Network)
 	}
 
 	args := []string{"init", d.resolveImage(ctx, spec.Image), spec.Name}
@@ -329,7 +346,34 @@ func (d *Incus) Start(ctx context.Context, spec Spec) (Machine, error) {
 	// --network creates eth0 on the named network, as the instance's own
 	// device, which is what lets the firewall `set` its keys later instead of
 	// overriding a profile device — the override is a re-plug too.
-	args = append(args, "--network", primary.Network)
+	//
+	// Skipped for a routed or a bare machine: there is no network to join, and
+	// naming one would be the invented address this change removes.
+	if !routed && !bare {
+		args = append(args, "--network", primary.Network)
+	}
+	if bare {
+		// Masking the profile's own eth0, and this is not tidiness: without it
+		// the machine inherits the operator's default profile and lands on
+		// their bridge — measured, an Exoscale instance came up on incusbr0
+		// (10.76.154.0/24) carrying an address the pack could not publish. That
+		// is the very hazard DefaultMachineNetwork was introduced to close, and
+		// removing the fallback reopened it from the other side.
+		//
+		// A device of type "none" at instance level masks the profile's device
+		// of the same name, which is Incus's own mechanism for exactly this.
+		args = append(args, "-d", "eth0,type=none")
+	}
+	if routed {
+		// The guest has to be told. A routed NIC hands the kernel a static
+		// address and Incus's generated config says `dhcp` regardless, so
+		// without this the interface comes up carrying nothing — measured.
+		netcfg, err := routedNetworkConfig(spec.PublicAddresses)
+		if err != nil {
+			return Machine{}, err
+		}
+		args = append(args, "--config", "cloud-init.network-config="+netcfg)
+	}
 	// Labels become user.* config keys, the Incus equivalent of container labels.
 	for k, v := range spec.Labels {
 		args = append(args, "--config", "user."+k+"="+v)
@@ -356,6 +400,16 @@ func (d *Incus) Start(ctx context.Context, spec Spec) (Machine, error) {
 	// already-exists path and boots without the keys this path was setting —
 	// measured in OVN mode, where the half-made machine came up with no route
 	// key, no DHCP lease and no ssh daemon, while the API said running.
+	if routed {
+		device, err := routedDevice(spec.Name, spec.PublicAddresses)
+		if err != nil {
+			return Machine{}, d.abandonStart(ctx, spec.Name, err)
+		}
+		if _, err := d.run(ctx, device...); err != nil {
+			return Machine{}, d.abandonStart(ctx, spec.Name,
+				fmt.Errorf("give %s a routed interface: %w", spec.Name, err))
+		}
+	}
 	if primary.Address != "" {
 		if _, err := d.run(ctx, "config", "device", "set", spec.Name, "eth0",
 			"ipv4.address="+primary.Address); err != nil {
@@ -363,7 +417,7 @@ func (d *Incus) Start(ctx context.Context, spec Spec) (Machine, error) {
 				fmt.Errorf("pin %s on %s: %w", primary.Address, spec.Name, err))
 		}
 	}
-	if len(spec.PublicAddresses) > 0 {
+	if len(spec.PublicAddresses) > 0 && !routed {
 		routes := make([]string, 0, len(spec.PublicAddresses))
 		for _, address := range spec.PublicAddresses {
 			// The uplink must carry the /32 before the device may name it:

--- a/internal/core/machine/incus.go
+++ b/internal/core/machine/incus.go
@@ -337,6 +337,15 @@ func (d *Incus) Start(ctx context.Context, spec Spec) (Machine, error) {
 		if !safeName.MatchString(primary.Network) {
 			return Machine{}, fmt.Errorf("invalid network name %q", primary.Network)
 		}
+		// A pack may ask for the emulator's own network by name — Outscale does,
+		// for a Vm in the public Cloud, where the address it receives is
+		// published as PrivateIp. Nothing creates it implicitly any more, so the
+		// request has to create it.
+		if primary.Network == DefaultMachineNetwork {
+			if err := d.ensureDefaultNetwork(ctx); err != nil {
+				return Machine{}, err
+			}
+		}
 	}
 
 	args := []string{"init", d.resolveImage(ctx, spec.Image), spec.Name}
@@ -353,16 +362,30 @@ func (d *Incus) Start(ctx context.Context, spec Spec) (Machine, error) {
 		args = append(args, "--network", primary.Network)
 	}
 	if bare {
-		// Masking the profile's own eth0, and this is not tidiness: without it
-		// the machine inherits the operator's default profile and lands on
-		// their bridge — measured, an Exoscale instance came up on incusbr0
-		// (10.76.154.0/24) carrying an address the pack could not publish. That
-		// is the very hazard DefaultMachineNetwork was introduced to close, and
-		// removing the fallback reopened it from the other side.
+		// No profile at all, and the root disk declared by hand.
 		//
-		// A device of type "none" at instance level masks the profile's device
-		// of the same name, which is Incus's own mechanism for exactly this.
-		args = append(args, "-d", "eth0,type=none")
+		// Without this the machine inherits the operator's default profile and
+		// lands on their bridge: measured, an Exoscale instance came up on
+		// incusbr0 (10.76.154.0/24) carrying an address the pack could not
+		// publish. That is the hazard DefaultMachineNetwork was introduced to
+		// close, and removing the fallback reopened it from the other side.
+		//
+		// The first attempt was `-d eth0,type=none`, on the belief that an
+		// instance-level device masks the profile's device of the same name.
+		// It does not: Incus *merges* them, so `network: incusbr0` from the
+		// profile lands on a device declared `type: none` and the create fails
+		// with "Invalid device option network". Every machine of the network
+		// suite failed to start that way, and the suite reported it as a
+		// machine not carrying its address — the symptom two steps from the
+		// cause.
+		//
+		// One key=value per -d, because the flag takes exactly one and
+		// accumulates: `-d root,type=disk,path=/` is read as a device type
+		// called "disk,path=/".
+		args = append(args, "--no-profiles",
+			"-d", "root,type=disk",
+			"-d", "root,path=/",
+			"-d", "root,pool="+d.rootPool(ctx))
 	}
 	if routed {
 		// The guest has to be told. A routed NIC hands the kernel a static
@@ -756,8 +779,17 @@ func (d *Incus) instanceDevices(ctx context.Context, name string) (instanceView,
 // the guest sees, so they have to look like interface names; deriving one from
 // the network name produces something no init script recognises. The match is
 // on the exact name: a substring check would let an existing eth10 shadow eth1.
+//
+// From eth0, not from eth1. It used to start at 1 on the assumption that the
+// boot interface always holds eth0, which stopped being true when a machine
+// with nothing to publish started booting with no interface at all (#202): the
+// first NIC attached afterwards was named eth1, the guest had no such device,
+// and configuring it failed with `Cannot find device "eth1"`. The suite
+// reported that as a machine not carrying its address, two steps from the
+// cause. The loop already skips a name in use, so starting at 0 changes nothing
+// for a machine that does have eth0.
 func freeInterface(devices map[string]map[string]string) string {
-	for i := 1; i < 64; i++ {
+	for i := 0; i < 64; i++ {
 		candidate := fmt.Sprintf("eth%d", i)
 		if _, used := devices[candidate]; !used {
 			return candidate

--- a/internal/core/machine/incus_isolate.go
+++ b/internal/core/machine/incus_isolate.go
@@ -47,12 +47,12 @@ func isolationOwned(name string) bool {
 
 // IsolateNetwork implements Isolator.
 func (d *Incus) IsolateNetwork(ctx context.Context, network string, foreign []string) error {
-	// An OVN network reaches nothing it is not peered with: there is no shared
-	// L2 to build reject rules against, and attaching them anyway would only
-	// claim credit for a separation the topology already provides.
-	if d.OVN {
-		return nil
-	}
+	// This used to return early under OVN, on the grounds that "an OVN network
+	// reaches nothing it is not peered with". That was false and never asserted:
+	// both networks carry their block on the uplink this driver creates, so the
+	// host routes between them. Measured, ICMP and TCP, on a station publishing
+	// capabilities.isolation: true. See incus_ovn_isolate.go for the measurement
+	// and for what applies this on the OVN path.
 	if !safeName.MatchString(network) {
 		return fmt.Errorf("invalid network name %q", network)
 	}

--- a/internal/core/machine/incus_ovn.go
+++ b/internal/core/machine/incus_ovn.go
@@ -229,7 +229,12 @@ func (d *Incus) PeerNetworks(ctx context.Context, network string, peers []string
 			return err
 		}
 	}
-	return nil
+	// And the half a peering does not provide. Peering says what may reach this
+	// network; nothing said what may not, and the uplink this driver creates
+	// routes every one of its OVN subnets to every other. The rule set is
+	// applied here rather than in each pack, because a control copied into three
+	// packs is a control one pack forgets and a fourth never has.
+	return d.isolateOVN(ctx, network, peers)
 }
 
 type peerRow struct {

--- a/internal/core/machine/incus_ovn_isolate.go
+++ b/internal/core/machine/incus_ovn_isolate.go
@@ -1,0 +1,106 @@
+package machine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+// Two OVN networks that are not peered must not reach each other (#201).
+//
+// The claim this replaces was written in prose and never asserted, in two
+// places at once. `IsolateNetwork` returned early under OVN on the grounds that
+// "an OVN network reaches nothing it is not peered with: there is no shared L2
+// to build reject rules against", and the packs' isolateNetworks took the
+// native-isolation branch and called PeerNetworks alone, so no rule set was ever
+// applied to an OVN network at all.
+//
+// Measured on a station with OVN wired and `capabilities.isolation: true`
+// published: two Outscale Nets with no peering between them, one machine in
+// each, reachable in ICMP *and* in TCP. The mechanism is in the host's routing
+// table, not in OVN:
+//
+//	10.191.1.0/24 dev feint-uplink proto static scope link
+//	10.192.1.0/24 dev feint-uplink proto static scope link
+//
+// Both networks carry their block on the uplink this driver creates for them, so
+// the host forwards between them. The shared L2 the comment declared absent is
+// the emulator's own uplink.
+//
+// The fix is an ingress rule set on each network, and that it works is measured
+// rather than assumed: with a reject rule for the other block applied to the
+// destination network, the same ping stops arriving, and the machine keeps
+// reaching its own gateway. So this needs no rule in the operator's firewall,
+// which would have been a much larger decision than a driver change.
+//
+// TestUnpeeredOVNNetworksAreIsolatedFromEachOther fails without this.
+
+// ourOVNSubnets answers the block each of the emulator's own OVN networks
+// carries, keyed by network name.
+//
+// Only networks under this driver's own prefix: an operator's networks are none
+// of its business, and a rule set that named one would be the first step towards
+// filtering traffic nobody asked it to touch.
+func (d *Incus) ourOVNSubnets(ctx context.Context) (map[string]string, error) {
+	out, err := d.run(ctx, "query", "/1.0/networks?recursion=1")
+	if err != nil {
+		return nil, fmt.Errorf("list networks: %w", err)
+	}
+	var raw []struct {
+		Name   string            `json:"name"`
+		Type   string            `json:"type"`
+		Config map[string]string `json:"config"`
+	}
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return nil, fmt.Errorf("decode the network list: %w", err)
+	}
+	subnets := map[string]string{}
+	for _, network := range raw {
+		if network.Type != "ovn" || !ownedNetwork(network.Name) {
+			continue
+		}
+		if block := network.Config["ipv4.address"]; block != "" {
+			subnets[network.Name] = block
+		}
+	}
+	return subnets, nil
+}
+
+// foreignBlocks answers the blocks a network must not reach: every other network
+// of this emulator's, minus the ones it is peered with.
+//
+// Derived from the peers the caller is applying rather than from the runtime's
+// current state, so the rule set and the peering move together. Reading the
+// peers back would isolate against whatever was true a moment ago.
+func foreignBlocks(network string, peers []string, subnets map[string]string) []string {
+	allowed := map[string]bool{network: true}
+	for _, peer := range peers {
+		allowed[peer] = true
+	}
+	var blocks []string
+	for name, block := range subnets {
+		if allowed[name] {
+			continue
+		}
+		blocks = append(blocks, block)
+	}
+	// Sorted so two runs write the same rule set and a diff of `network acl
+	// show` means something.
+	sort.Strings(blocks)
+	return blocks
+}
+
+// isolateOVN applies the rule set that keeps a network away from every other one
+// of the emulator's that it is not peered with.
+//
+// Errors are returned rather than logged: a peering that reports success while
+// the isolation silently failed is the false capability this whole file exists
+// to remove.
+func (d *Incus) isolateOVN(ctx context.Context, network string, peers []string) error {
+	subnets, err := d.ourOVNSubnets(ctx)
+	if err != nil {
+		return err
+	}
+	return d.IsolateNetwork(ctx, network, foreignBlocks(network, peers, subnets))
+}

--- a/internal/core/machine/incus_ovn_isolate_test.go
+++ b/internal/core/machine/incus_ovn_isolate_test.go
@@ -1,0 +1,103 @@
+package machine
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// Two OVN networks that are not peered must not reach each other (#201).
+//
+// The claim this asserts was written in prose and never held: IsolateNetwork
+// returned early under OVN because "an OVN network reaches nothing it is not
+// peered with", and the packs' native branch called PeerNetworks alone, so no
+// rule set ever reached an OVN network.
+//
+// Measured on a station publishing capabilities.isolation: true — two Nets, no
+// peering, reachable in ICMP and in TCP. The host routes between them, because
+// every one of this driver's OVN subnets is `scope link` on the uplink it
+// creates for them. tools/conformance/*/network.sh holds the property against
+// the runtime; this holds the arguments that carry it.
+func TestUnpeeredOVNNetworksAreIsolatedFromEachOther(t *testing.T) {
+	f := &fakeRuntime{}
+	f.hook = func(_ int, args []string) ([]byte, error, bool) {
+		joined := strings.Join(args, " ")
+		switch {
+		case strings.HasPrefix(joined, "query /1.0/networks?recursion=1"):
+			return []byte(`[
+				{"name":"fnt-aaa","type":"ovn","config":{"ipv4.address":"10.1.0.1/24"}},
+				{"name":"fnt-bbb","type":"ovn","config":{"ipv4.address":"10.2.0.1/24"}},
+				{"name":"fnt-ccc","type":"ovn","config":{"ipv4.address":"10.3.0.1/24"}},
+				{"name":"incusbr0","type":"bridge","config":{"ipv4.address":"10.76.154.1/24"}}
+			]`), nil, true
+		case strings.Contains(joined, "/peers?recursion=1"):
+			return []byte(`[]`), nil, true
+		case strings.HasPrefix(joined, "network acl show"):
+			return nil, errors.New("Error: Network ACL not found"), true
+		}
+		return nil, nil, false
+	}
+	d := newFakeDriver(f)
+	d.OVN = true
+
+	if err := d.PeerNetworks(context.Background(), "fnt-aaa", []string{"fnt-bbb"}); err != nil {
+		t.Fatalf("peer: %v", err)
+	}
+
+	// The rule set must name the block of the network that is not peered, and
+	// only it.
+	edits := f.matching("network acl edit")
+	if len(edits) == 0 {
+		// The driver writes the body through stdin on some paths; fall back to
+		// whatever carried the blocks.
+		edits = f.matching("10.3.0")
+	}
+	if len(edits) == 0 {
+		t.Fatalf("no rule set was written for fnt-aaa:\n%s", strings.Join(f.commands(), "\n"))
+	}
+	body := strings.Join(edits, "\n")
+	if !strings.Contains(body, "10.3.0") {
+		t.Errorf("the rule set does not keep out the unpeered network's block:\n%s", body)
+	}
+	if strings.Contains(body, "10.2.0") {
+		t.Errorf("the rule set keeps out a network it is peered with:\n%s", body)
+	}
+	// And never the operator's own bridge.
+	if strings.Contains(body, "10.76.154") {
+		t.Errorf("the rule set names a network the emulator did not create:\n%s", body)
+	}
+}
+
+// foreignBlocks is the decision itself, and it is worth holding on its own: the
+// accepting half (a peer is not foreign) and the refusing half (everything else
+// is) are the two ways this can be wrong, and a version that returned nothing
+// would pass a test that only checked the peer.
+func TestForeignBlocksKeepsPeersAndTheNetworkItself(t *testing.T) {
+	subnets := map[string]string{
+		"fnt-aaa": "10.1.0.1/24",
+		"fnt-bbb": "10.2.0.1/24",
+		"fnt-ccc": "10.3.0.1/24",
+	}
+	got := foreignBlocks("fnt-aaa", []string{"fnt-bbb"}, subnets)
+	if len(got) != 1 || got[0] != "10.3.0.1/24" {
+		t.Errorf("foreign blocks = %v, want only the unpeered network's", got)
+	}
+
+	// Peered with everything: nothing is foreign, and a rule set that kept a
+	// block anyway would separate networks a client asked to join.
+	if got := foreignBlocks("fnt-aaa", []string{"fnt-bbb", "fnt-ccc"}, subnets); len(got) != 0 {
+		t.Errorf("a network peered with every other still keeps out %v", got)
+	}
+
+	// Peered with nothing: every other block, and never its own.
+	got = foreignBlocks("fnt-aaa", nil, subnets)
+	if len(got) != 2 {
+		t.Errorf("an unpeered network keeps out %v, want both others", got)
+	}
+	for _, block := range got {
+		if block == "10.1.0.1/24" {
+			t.Error("a network was isolated from itself")
+		}
+	}
+}

--- a/internal/core/machine/incus_routed.go
+++ b/internal/core/machine/incus_routed.go
@@ -1,0 +1,110 @@
+package machine
+
+import (
+	"fmt"
+	"net/netip"
+	"strings"
+)
+
+// A machine carries the addresses its provider's API publishes, and no others
+// (#202).
+//
+// What this replaces. A machine with no emulated network to join used to be put
+// on DefaultMachineNetwork, a managed bridge, and it took an address there that
+// no API describes. On top of that the public address was routed onto the same
+// interface, so a Scaleway server carried two or three addresses where the real
+// one carries a single routed public address and `private_ip: none` — measured
+// against a real account, twice, empty before and after.
+//
+// The bridge was doing two jobs and only the first was written down: give the
+// routed /32 an interface the emulator owns, and provide NAT'd outbound so
+// cloud-init could install an ssh daemon. #203 removed the second job by
+// building images that already carry the daemon, which is what makes this
+// possible at all.
+//
+// What replaces it is Incus's `routed` NIC: an address handed to the instance
+// with a host route to it and no L2 segment underneath — the same shape Scaleway
+// itself reports as `routed_ipv4`. One interface, one address, nothing invented.
+//
+// TestAMachineWithNoNetworkCarriesOnlyItsPublicAddress fails without this.
+
+// routedNextHop is the link-local gateway a routed NIC reaches the host through.
+//
+// Link-local and shared by every machine on purpose: it is the address of the
+// host end of each machine's own veth, so two machines using the same number are
+// not in conflict — they are on different point-to-point links. This is the
+// value Incus's own routed-NIC guide uses.
+const routedNextHop = "169.254.0.1"
+
+// routedNetworkConfig renders the netplan a machine on a routed NIC needs.
+//
+// The guest must be told: a routed NIC hands the kernel a static address and
+// Incus's generated config says `dhcp` regardless, so without this the interface
+// comes up with nothing on it. Measured — the address was declared on the device
+// and the guest carried none.
+//
+// Every address is parsed before it is rendered, and an unparseable one is a
+// refusal rather than an escape. This file renders a structured format by
+// concatenation, which the cloud-init templates already show is a way to hand
+// somebody a key in the document; the answer here is that nothing but a valid IP
+// can reach the rendering at all.
+func routedNetworkConfig(addresses []string) (string, error) {
+	if len(addresses) == 0 {
+		return "", fmt.Errorf("a routed interface needs at least one address")
+	}
+	var b strings.Builder
+	b.WriteString("network:\n  version: 2\n  ethernets:\n    eth0:\n      addresses:\n")
+	for _, address := range addresses {
+		parsed, err := netip.ParseAddr(address)
+		if err != nil {
+			return "", fmt.Errorf("routed address %q: %w", address, err)
+		}
+		if !parsed.Is4() {
+			return "", fmt.Errorf("routed address %q is not IPv4", address)
+		}
+		// A /32 on purpose: the address is a route to this machine, not a
+		// subnet it belongs to.
+		fmt.Fprintf(&b, "        - %s/32\n", parsed.String())
+	}
+	// 0.0.0.0/0 rather than the `default` keyword, and this is measured: Debian
+	// 12's cloud-init rejects `to: default` with "Address default is not a valid
+	// ip address", aborts, and never reaches its ssh module — so the host keys a
+	// feint image deliberately does not carry are never regenerated and sshd
+	// cannot start. The failure reads as "this image has no ssh daemon", which is
+	// the opposite of what happened. The same wording fixed Alpine, whose
+	// symptom looked unrelated.
+	//
+	// on-link because the next hop is not inside a /32.
+	fmt.Fprintf(&b, "      routes:\n        - to: 0.0.0.0/0\n          via: %s\n          on-link: true\n",
+		routedNextHop)
+	return b.String(), nil
+}
+
+// routedDevice is the `incus config device add` argument list for a NIC that
+// carries addresses and joins no network.
+//
+// No `parent`, and that is measured rather than an omission: Incus accepts a
+// routed NIC without one, the instance starts, and the host route to the address
+// is created all the same. Naming a parent would mean this driver deciding which
+// of the operator's interfaces to anchor to — host knowledge it has no business
+// holding, and one more thing to be wrong about on a machine with two uplinks or
+// none.
+//
+// A routed NIC has no L2 segment, which is exactly why two machines on routed
+// NICs cannot reach each other unless something routes between them.
+func routedDevice(name string, addresses []string) ([]string, error) {
+	if len(addresses) == 0 {
+		return nil, fmt.Errorf("a routed interface needs at least one address")
+	}
+	for _, address := range addresses {
+		if _, err := netip.ParseAddr(address); err != nil {
+			return nil, fmt.Errorf("routed address %q: %w", address, err)
+		}
+	}
+	return []string{
+		"config", "device", "add", name, "eth0", "nic",
+		"nictype=routed",
+		"ipv4.address=" + strings.Join(addresses, ","),
+		"ipv4.host_address=" + routedNextHop,
+	}, nil
+}

--- a/internal/core/machine/incus_routed.go
+++ b/internal/core/machine/incus_routed.go
@@ -1,6 +1,7 @@
 package machine
 
 import (
+	"context"
 	"fmt"
 	"net/netip"
 	"strings"
@@ -77,6 +78,18 @@ func routedNetworkConfig(addresses []string) (string, error) {
 	// on-link because the next hop is not inside a /32.
 	fmt.Fprintf(&b, "      routes:\n        - to: 0.0.0.0/0\n          via: %s\n          on-link: true\n",
 		routedNextHop)
+	// Every interface attached afterwards still comes up on its own.
+	//
+	// Without this the Scaleway path breaks, and the conformance suite caught it
+	// on the first run: a server boots with only its public address, a private
+	// NIC is attached later — which is the ordinary Scaleway order, `POST
+	// /servers/{id}/private_nics` comes after the create — and the guest's
+	// config named eth0 alone, so eth1 came up carrying nothing while the API
+	// published an address for it.
+	//
+	// A match rather than a list, because the number of private NICs is the
+	// client's business: a server with two of them is ordinary on Scaleway.
+	b.WriteString("    attached:\n      match:\n        name: \"eth[1-9]\"\n      dhcp4: true\n")
 	return b.String(), nil
 }
 
@@ -107,4 +120,22 @@ func routedDevice(name string, addresses []string) ([]string, error) {
 		"ipv4.address=" + strings.Join(addresses, ","),
 		"ipv4.host_address=" + routedNextHop,
 	}, nil
+}
+
+// rootPool answers the storage pool the operator's own default profile uses for
+// its root disk, because a machine created with --no-profiles has to name one
+// and this driver has no business inventing it.
+//
+// "default" when the profile cannot be read: it is the name `incus admin init
+// --minimal` creates, so it is the right guess on the installation this project
+// documents, and a wrong one fails loudly at create rather than silently later.
+func (d *Incus) rootPool(ctx context.Context) string {
+	out, err := d.run(ctx, "profile", "device", "get", "default", "root", "pool")
+	if err != nil {
+		return "default"
+	}
+	if pool := strings.TrimSpace(string(out)); pool != "" {
+		return pool
+	}
+	return "default"
 }

--- a/internal/core/machine/incus_start_test.go
+++ b/internal/core/machine/incus_start_test.go
@@ -40,7 +40,74 @@ func startScript(f *fakeRuntime) {
 	}
 }
 
-func TestAMachineWithNoAttachmentBootsOnTheEmulatorsOwnNetwork(t *testing.T) {
+// A machine carries the addresses its provider's API publishes, and no others
+// (#202).
+//
+// This replaces the test that required a machine with no attachment to boot on
+// the emulator's own bridge. That test asserted the behaviour being removed, and
+// its own comment named the assumption that made it necessary: "NATed, or the
+// guest cannot install its ssh daemon". #203 built images that already carry
+// one, so the guest installs nothing and the bridge has no job left.
+//
+// Measured against real accounts, empty before and after: a Scaleway server has
+// one routed public address and `private_ip: none`; an Exoscale instance has one
+// address. This emulator gave two or three, and the extra came from here.
+func TestAMachineWithNoNetworkCarriesOnlyItsPublicAddress(t *testing.T) {
+	f := &fakeRuntime{}
+	startScript(f)
+	d := newFakeDriver(f)
+
+	_, err := d.Start(context.Background(), Spec{
+		Name:            "srv",
+		Image:           "alpine:3.21",
+		PublicAddresses: []string{"203.0.113.7"},
+	})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	if creates := f.matching("network create " + DefaultMachineNetwork); len(creates) != 0 {
+		t.Errorf("a network was created for a machine that publishes no address on one:\n%s",
+			strings.Join(creates, "\n"))
+	}
+
+	inits := f.matching("init ")
+	if len(inits) != 1 {
+		t.Fatalf("expected one init, got:\n%s", strings.Join(f.commands(), "\n"))
+	}
+	if strings.Contains(inits[0], "--network") {
+		t.Errorf("the machine joined a network nothing publishes: %s", inits[0])
+	}
+	// The guest has to be told, or the routed address lands on the device and
+	// the interface comes up carrying nothing.
+	if !strings.Contains(inits[0], "cloud-init.network-config=") {
+		t.Errorf("no network-config was rendered, so the guest configures nothing: %s", inits[0])
+	}
+
+	devices := f.matching("config device add srv eth0 nic")
+	if len(devices) != 1 {
+		t.Fatalf("expected one routed interface, got:\n%s", strings.Join(f.commands(), "\n"))
+	}
+	for _, want := range []string{"nictype=routed", "ipv4.address=203.0.113.7"} {
+		if !strings.Contains(devices[0], want) {
+			t.Errorf("the interface is missing %q: %s", want, devices[0])
+		}
+	}
+	// A routed NIC carries the address itself; the route key belongs to a NIC
+	// that sits on a network, and setting it here would be a second mechanism
+	// for one address.
+	if routes := f.matching("ipv4.routes"); len(routes) != 0 {
+		t.Errorf("a routed interface was also given route keys:\n%s", strings.Join(routes, "\n"))
+	}
+}
+
+// And the machine a real cloud gives nothing: no address asked for, no private
+// network. It boots, and it carries no interface at all.
+//
+// The refusing half of the case above. Without it, a driver that always added a
+// routed NIC would pass that test and invent an address here, which is the exact
+// defect being removed.
+func TestAMachineWithNothingPublishedCarriesNoInterface(t *testing.T) {
 	f := &fakeRuntime{}
 	startScript(f)
 	d := newFakeDriver(f)
@@ -49,23 +116,17 @@ func TestAMachineWithNoAttachmentBootsOnTheEmulatorsOwnNetwork(t *testing.T) {
 		t.Fatalf("start: %v", err)
 	}
 
-	creates := f.matching("network create " + DefaultMachineNetwork)
-	if len(creates) != 1 {
-		t.Fatalf("expected the default machine network to be created once, got:\n%s",
-			strings.Join(f.commands(), "\n"))
+	if creates := f.matching("network create"); len(creates) != 0 {
+		t.Errorf("a network was created for a machine with no address:\n%s",
+			strings.Join(creates, "\n"))
 	}
-	// Labelled, or mustOwn refuses to route public addresses through it and the
-	// sweep cannot remove it; NATed, or the guest cannot install its ssh daemon.
-	for _, want := range []string{"user." + LabelKey + "=", "ipv4.nat=true"} {
-		if !strings.Contains(creates[0], want) {
-			t.Errorf("the default network is missing %q: %s", want, creates[0])
-		}
+	if devices := f.matching("config device add srv eth0"); len(devices) != 0 {
+		t.Errorf("an interface was added for a machine with no address:\n%s",
+			strings.Join(devices, "\n"))
 	}
-
 	inits := f.matching("init ")
-	if len(inits) != 1 || !strings.Contains(inits[0], "--network "+DefaultMachineNetwork) {
-		t.Fatalf("the machine did not boot on %s:\n%s",
-			DefaultMachineNetwork, strings.Join(f.commands(), "\n"))
+	if len(inits) != 1 || strings.Contains(inits[0], "--network") {
+		t.Errorf("the machine joined a network anyway:\n%s", strings.Join(f.commands(), "\n"))
 	}
 }
 

--- a/internal/core/machine/incus_test.go
+++ b/internal/core/machine/incus_test.go
@@ -82,7 +82,15 @@ func TestFreeInterfacePicksTheFirstUnusedName(t *testing.T) {
 		devices map[string]map[string]string
 		want    string
 	}{
-		{name: "empty machine starts at eth1, never eth0", devices: nic(), want: "eth1"},
+		// A machine with no device at all takes eth0, and this reversed with
+		// #202. The case used to want eth1, defensively: every machine had a
+		// profile eth0, so an empty map meant the devices could not be read and
+		// assuming eth0 was taken was the safe guess. A machine that publishes
+		// nothing now boots with --no-profiles and genuinely has none, so the
+		// empty map is the truth rather than a blind spot — and naming its first
+		// NIC eth1 gave a guest that had no such device, which failed with
+		// `Cannot find device "eth1"`.
+		{name: "a machine with no device at all takes eth0", devices: nic(), want: "eth0"},
 		{name: "profile eth0 does not block eth1", devices: nic("eth0"), want: "eth1"},
 		{name: "next free after a gap", devices: nic("eth0", "eth1", "eth3"), want: "eth2"},
 		{name: "eth10 does not shadow eth1", devices: nic("eth0", "eth10"), want: "eth1"},

--- a/internal/providers/exoscale/elasticips.go
+++ b/internal/providers/exoscale/elasticips.go
@@ -96,7 +96,13 @@ func (p *Pack) unrouteElasticIP(ctx context.Context, address string, inst *resou
 // routed afterwards, because editing a live OVN NIC re-plugs it.
 func (p *Pack) elasticBootAddresses(res *resource.Resource) []string {
 	ids := stringList(res.Attrs[attrElasticIPIDs])
-	out := make([]string, 0, len(ids))
+	out := make([]string, 0, len(ids)+1)
+	// The instance's own address comes first: it is the one `public-ip`
+	// publishes and the one a client ssh's into, so it is the machine's primary
+	// address rather than an extra routed onto it.
+	if own, _ := res.Attrs["public-ip"].(string); emulatedElasticIP(own) {
+		out = append(out, own)
+	}
 	for _, id := range ids {
 		eip, found := p.env.Store.Get(Name, kindElasticIP, id)
 		if !found {
@@ -171,6 +177,15 @@ func (p *Pack) freeElasticAddress() (string, bool) {
 	used := map[string]bool{}
 	for _, res := range p.env.Store.List(kindElasticIP, resource.Tenant{Provider: Name}) {
 		if ip, _ := res.Attrs["ip"].(string); ip != "" {
+			used[ip] = true
+		}
+	}
+	// Instances draw from the same block since they assign their own public
+	// address at creation, the way the real cloud does. Scanning only elastic
+	// IPs would hand one address to two resources, and the driver would then
+	// route a single /32 to two machines.
+	for _, res := range p.env.Store.List(kindInstance, resource.Tenant{Provider: Name}) {
+		if ip, _ := res.Attrs["public-ip"].(string); ip != "" {
 			used[ip] = true
 		}
 	}

--- a/internal/providers/exoscale/lifecycle_test.go
+++ b/internal/providers/exoscale/lifecycle_test.go
@@ -3,6 +3,7 @@ package exoscale_test
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -204,5 +205,58 @@ func TestTwoLifecycleActionsOnOneInstanceDoNotRace(t *testing.T) {
 	// never a half-transition.
 	if got := instanceState(t, h, id); got != "running" && got != "stopped" {
 		t.Fatalf("state after concurrent actions is %q", got)
+	}
+}
+
+// An instance is given a public address at creation, the way the real cloud
+// does (#202).
+//
+// Measured on a real Exoscale account: an instance created with nothing but a
+// type and a template answers `ip_address: 151.145.198.51` on the first read,
+// with no private network and no elastic IP attached. This pack recorded the
+// intent — `public-ip-assignment` defaults to `inet4` — and never honoured it,
+// so an emulated instance published nothing, and the machine took whatever the
+// runtime's default profile handed it, on the operator's own bridge.
+//
+// Both halves. A pack that always assigned one would pass the first check and
+// break `public-ip-assignment: none`, which is a real client asking for a
+// machine nobody can reach from outside.
+func TestAnInstanceIsGivenAPublicAddressAtCreation(t *testing.T) {
+	h := serve(t)
+
+	id := createDemo(t, h)
+	_, doc := call(t, h, "GET", "/v2/instance/"+id, "")
+	address, _ := doc["public-ip"].(string)
+	if address == "" {
+		t.Fatalf("an instance created with the default assignment publishes no address: %v", doc)
+	}
+	if !strings.HasPrefix(address, "192.0.2.") {
+		t.Errorf("the address is outside the pack's own RFC 5737 block: %s", address)
+	}
+
+	// A second instance must not be handed the same one, or the driver routes a
+	// single /32 to two machines.
+	other := createDemo(t, h)
+	_, doc2 := call(t, h, "GET", "/v2/instance/"+other, "")
+	if second, _ := doc2["public-ip"].(string); second == address {
+		t.Errorf("two instances were handed %s", address)
+	}
+
+	// And the refusing half: a client that asks for none gets none.
+	rec, _ := call(t, h, "POST", "/v2/instance", `{
+		"name": "no-address",
+		"instance-type": {"id": "21624abb-764e-4def-81d7-9fc54b5957fb"},
+		"template": {"id": "11111111-1111-4111-8111-111111111111"},
+		"disk-size": 10,
+		"public-ip-assignment": "none"
+	}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("create with no assignment answered %d: %s", rec.Code, rec.Body.String())
+	}
+	_, listed := call(t, h, "GET", "/v2/instance", "")
+	instances, _ := listed["instances"].([]any)
+	last, _ := instances[len(instances)-1].(map[string]any)
+	if got, _ := last["public-ip"].(string); got != "" {
+		t.Errorf("public-ip-assignment none was given %s anyway", got)
 	}
 }

--- a/internal/providers/exoscale/pack.go
+++ b/internal/providers/exoscale/pack.go
@@ -728,6 +728,26 @@ func (p *Pack) createInstance(w http.ResponseWriter, r *http.Request) {
 	if req.UserData != "" {
 		res.Attrs["user-data"] = req.UserData
 	}
+	// A public address, assigned at creation, because that is what the real
+	// cloud does: an instance created with nothing but a type and a template
+	// answers `ip_address` on the first read — measured on a real account,
+	// 151.145.198.51, with no private network and no elastic IP.
+	//
+	// The pack recorded the intent above and never honoured it, so an emulated
+	// instance published nothing and the machine took whatever the runtime's
+	// default profile gave it, on the operator's own bridge. A machine carries
+	// the addresses its provider's API publishes and no others (#202), and
+	// "none published" was not the honest half of that rule, it was the pack
+	// failing to be its own cloud.
+	//
+	// TestAnInstanceIsGivenAPublicAddressAtCreation fails without this.
+	if assignment, _ := res.Attrs["public-ip-assignment"].(string); assignment != "none" {
+		p.addresses.Lock()
+		if ip, ok := p.freeElasticAddress(); ok {
+			res.Attrs["public-ip"] = ip
+		}
+		p.addresses.Unlock()
+	}
 	if ids := refIDs(req.AntiAffinityGroups); len(ids) > 0 {
 		res.Attrs[attrAntiAffinityGroupIDs] = ids
 	}
@@ -973,7 +993,17 @@ func (p *Pack) view(res *resource.Resource) map[string]any {
 	}
 	// Exoscale's instance schema declares public-ip, so the address the machine
 	// answers on is published there rather than invented.
-	if address := p.addressOf(res); address != "" {
+	//
+	// The stored one wins over the runtime's reading, and the order matters. The
+	// pack allocates the address at creation, the way the real cloud does, so it
+	// is a fact about the instance from the moment it exists — before any machine
+	// boots, and with no runtime configured at all, which is the CI case. The
+	// runtime's reading is how the machine ends up carrying it, not how it is
+	// decided; reading it first published nothing on every control-plane-only
+	// run.
+	if address, _ := res.Attrs["public-ip"].(string); address != "" {
+		out["public-ip"] = address
+	} else if address := p.addressOf(res); address != "" {
 		out["public-ip"] = address
 	}
 	return out

--- a/internal/providers/outscale/isolate.go
+++ b/internal/providers/outscale/isolate.go
@@ -1,0 +1,97 @@
+package outscale
+
+import (
+	"context"
+
+	"github.com/stephrobert/feint/internal/core/machine"
+	"github.com/stephrobert/feint/internal/core/resource"
+)
+
+// Two Nets do not reach each other; two Subnets of one Net do (#201).
+//
+// This pack had no isolation wiring at all, and the gap was invisible until the
+// rule that a machine carries one address removed the fallback bridge that used
+// to leave machines with no route to each other anyway. Measured on one
+// emulator, same runtime, same minute:
+//
+//	Scaleway  a server of another VPC   unreachable   (this call, via Scaleway)
+//	Outscale  a machine of another Net   REACHES       (nothing called it here)
+//
+// The difference was the wiring, not the mechanism: both providers back their
+// subnets with networks of the same driver, and the driver applies the rule set.
+// A control that lives in two packs out of three is a control the third forgets,
+// which is exactly what happened.
+//
+// What is foreign is an Outscale question, and it is the only part that belongs
+// here: two Subnets of one Net are routed to each other upstream, and everything
+// else — another Net, another account — is not.
+//
+// TestSubnetsOfOtherNetsAreForeign fails without this.
+
+// reachableFrom reports whether one subnet may reach another: same Net, and
+// nothing else. Net peerings widen this, and they do it through PeerNetworks
+// rather than here, so a peering that is only pending grants nothing.
+func (p *Pack) reachableFrom(subnet, other *resource.Resource) bool {
+	return stringOf(subnet.Attrs["NetId"]) == stringOf(other.Attrs["NetId"])
+}
+
+// isolateNetworks reconciles what every subnet's backing network may reach.
+//
+// Called after any change to the set of subnets, because a new one changes what
+// its neighbours must keep out. Reconciled over all of them rather than patched
+// for the one that moved: a patch has to be right about what changed, and this
+// only has to be right about what is.
+//
+// Failure is logged, never fatal. The control plane must keep answering when no
+// runtime is configured, which is the default and what CI uses.
+func (p *Pack) isolateNetworks(ctx context.Context) {
+	all := p.env.Store.List(kindSubnet, resource.Tenant{Provider: Name})
+
+	peerer, native := p.env.Machines.(machine.Peerer)
+	if native && peerer.NativeIsolation() {
+		for _, subnet := range all {
+			name := subnet.Runtime[runtimeNetworkKey]
+			if name == "" {
+				continue
+			}
+			peers := make([]string, 0, len(all))
+			for _, other := range all {
+				if other.ID == subnet.ID || other.Runtime[runtimeNetworkKey] == "" {
+					continue
+				}
+				if p.reachableFrom(subnet, other) {
+					peers = append(peers, other.Runtime[runtimeNetworkKey])
+				}
+			}
+			if err := peerer.PeerNetworks(ctx, name, peers); err != nil {
+				p.logger().Error("could not peer the subnet's network",
+					"subnet", subnet.ID, "network", name, "error", err)
+			}
+		}
+		return
+	}
+
+	isolator, ok := p.env.Machines.(machine.Isolator)
+	if !ok {
+		return
+	}
+	for _, subnet := range all {
+		name := subnet.Runtime[runtimeNetworkKey]
+		if name == "" {
+			continue
+		}
+		foreign := make([]string, 0, len(all))
+		for _, other := range all {
+			if other.ID == subnet.ID || p.reachableFrom(subnet, other) {
+				continue
+			}
+			if block := stringOf(other.Attrs["IpRange"]); block != "" {
+				foreign = append(foreign, block)
+			}
+		}
+		if err := isolator.IsolateNetwork(ctx, name, foreign); err != nil {
+			p.logger().Error("could not isolate the subnet's network",
+				"subnet", subnet.ID, "network", name, "error", err)
+		}
+	}
+}

--- a/internal/providers/outscale/isolate_test.go
+++ b/internal/providers/outscale/isolate_test.go
@@ -1,0 +1,87 @@
+package outscale
+
+import (
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/machine"
+
+	"github.com/stephrobert/feint/internal/core/resource"
+)
+
+// What counts as foreign is the only part of isolation that belongs to a pack,
+// and for Outscale it is one sentence: two Subnets of one Net reach each other,
+// everything else does not (#201).
+//
+// This pack had no isolation wiring at all, and the gap stayed invisible while
+// the fallback bridge left machines without a route to each other anyway. Once a
+// machine carried only its own subnet address (#202), two Nets reached each
+// other in ICMP and in TCP on the same emulator where Scaleway's did not — the
+// difference being that Scaleway called this layer and Outscale never did.
+//
+// Both halves, because a rule that called everything foreign would isolate two
+// subnets of one Net, which no client asked for and which the real cloud routes.
+func TestSubnetsOfOtherNetsAreForeign(t *testing.T) {
+	subnet := func(id, net string) *resource.Resource {
+		return &resource.Resource{
+			ID:    id,
+			Kind:  kindSubnet,
+			Attrs: map[string]any{"NetId": net},
+		}
+	}
+	p := &Pack{}
+
+	a := subnet("subnet-1", "vpc-a")
+	b := subnet("subnet-2", "vpc-a")
+	c := subnet("subnet-3", "vpc-b")
+
+	if !p.reachableFrom(a, b) {
+		t.Error("two subnets of one Net were treated as foreign; the real cloud routes between them")
+	}
+	if p.reachableFrom(a, c) {
+		t.Error("a subnet of another Net was treated as reachable, which is the leak this closes")
+	}
+	// A subnet with no Net at all must not be reachable by accident: an absent
+	// value is not a match, and treating two empties as equal would join every
+	// malformed record to every other.
+	empty := subnet("subnet-4", "")
+	if p.reachableFrom(a, empty) {
+		t.Error("a subnet naming no Net was treated as reachable from one that does")
+	}
+}
+
+// A Vm created with no Subnet is in the public Cloud, and Outscale gives it a
+// private address there: the schema declares PrivateIp and a real one carries a
+// value.
+//
+// The conformance suite caught this the moment #202 removed the fallback
+// network outright — "the machine is running and the API publishes no
+// PrivateIp". The fallback was not wrong in itself; it was wrong where the
+// address it handed out was published by no API, which was the Scaleway case
+// and not this one. So this pack asks for the emulator's own network by name,
+// and publishes what it receives.
+func TestAVmOutsideANetStillCarriesAPrivateAddress(t *testing.T) {
+	p := &Pack{}
+
+	outside := &resource.Resource{
+		ID:    "i-1",
+		Kind:  kindVM,
+		Attrs: map[string]any{},
+	}
+	got := p.attachmentOf(outside)
+	if len(got) != 1 || got[0].Network != machine.DefaultMachineNetwork {
+		t.Errorf("a Vm outside a Net asked for %v, want the emulator's own network", got)
+	}
+
+	// And a Vm that names a Subnet must never take it: that one belongs to its
+	// Net, and joining the shared network would put two Nets on one segment.
+	// The case chosen carries no address yet, so the decision is reached before
+	// the store is consulted — what is under test is the branch, not a lookup.
+	inside := &resource.Resource{
+		ID:    "i-2",
+		Kind:  kindVM,
+		Attrs: map[string]any{"SubnetId": "subnet-1"},
+	}
+	if got := p.attachmentOf(inside); len(got) != 0 {
+		t.Errorf("a Vm naming a Subnet asked for %v, want nothing shared", got)
+	}
+}

--- a/internal/providers/outscale/machines.go
+++ b/internal/providers/outscale/machines.go
@@ -188,7 +188,23 @@ func (p *Pack) addressOf(res *resource.Resource) string {
 func (p *Pack) attachmentOf(res *resource.Resource) []machine.Attachment {
 	subnetID := stringOf(res.Attrs["SubnetId"])
 	address := stringOf(res.Attrs["PrivateIp"])
-	if subnetID == "" || address == "" {
+	// A Vm created with no Subnet is in the public Cloud, and Outscale gives it
+	// a private address there: the schema declares PrivateIp and a real one
+	// carries a value. So it asks for the emulator's own network rather than
+	// nothing, and publishes the address it receives.
+	//
+	// This is the distinction #202 nearly lost. The fallback network was not
+	// wrong in itself; it was wrong when the address it handed out was published
+	// by no API, which was the Scaleway case and not this one. Removing it
+	// outright left a running Vm with no PrivateIp at all, and the conformance
+	// suite said so in as many words: "the machine is running and the API
+	// publishes no PrivateIp".
+	//
+	// TestAVmOutsideANetStillCarriesAPrivateAddress fails without this.
+	if subnetID == "" {
+		return []machine.Attachment{{Network: machine.DefaultMachineNetwork}}
+	}
+	if address == "" {
 		return nil
 	}
 	subnet, found := p.env.Store.Get(Name, kindSubnet, subnetID)

--- a/internal/providers/outscale/nets.go
+++ b/internal/providers/outscale/nets.go
@@ -357,6 +357,9 @@ func (p *Pack) createSubnet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// What each subnet may reach changed, so every rule set is reconciled.
+	p.isolateNetworks(r.Context())
+
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
 		"Subnet":          p.subnetView(res),
 		"ResponseContext": p.context(),
@@ -455,6 +458,9 @@ func (p *Pack) deleteSubnet(w http.ResponseWriter, r *http.Request) {
 	// The runtime call is slow and stays outside: the Subnet is already
 	// unreachable to every other handler by this point.
 	p.removeBackingNetwork(r.Context(), subnet)
+	// One fewer subnet is one fewer block its neighbours must keep out, and a
+	// rule set naming a block nothing carries is a rule set nobody can read.
+	p.isolateNetworks(r.Context())
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{"ResponseContext": p.context()})
 }
 

--- a/tools/conformance/exoscale/network.sh
+++ b/tools/conformance/exoscale/network.sh
@@ -43,6 +43,11 @@ fail() { echo "FAIL: $*" >&2; exit 1; }
 ok()   { echo "  ok: $*"; }
 skip() { echo "  SKIP: $*" >&2; }
 
+# Shared assertions about what a machine carries. See the file for why the
+# comparison is not written three times.
+# shellcheck source=/dev/null
+. "$(dirname "$0")/../shared/addresses.sh"
+
 command -v exo >/dev/null 2>&1 || { echo "FAIL: exo is not installed" >&2; exit 1; }
 command -v jq >/dev/null 2>&1 || { echo "FAIL: jq is not installed" >&2; exit 1; }
 
@@ -105,8 +110,15 @@ ok "conformance-net on $NEAR_START-$NEAR_END"
 
 boot() { # name -> instance id
   local name="$1" id
+  # --public-ip none, because this suite measures a private network and an
+  # instance that also carries a public address carries two, which is faithful
+  # to the cloud and not what is being measured here. The real Exoscale assigns
+  # one unless asked otherwise (public-ip-assignment defaults to inet4, and the
+  # CLI's own default says so), so asking is the client's job rather than the
+  # emulator's to skip.
   exo compute instance create "$name" --zone "$EXOSCALE_ZONE" \
-    --template "Linux Ubuntu 24.04 LTS 64-bit" --instance-type standard.tiny >/dev/null \
+    --template "Linux Ubuntu 24.04 LTS 64-bit" --instance-type standard.tiny \
+    --public-ip none >/dev/null \
     || fail "instance $name was not created"
   id="$(exo -O json compute instance list | jq -r --arg n "$name" '.[] | select(.name == $n) | .id')"
   [ -n "$id" ] || fail "instance $name is not in the list after create"
@@ -152,6 +164,21 @@ case " $carried " in
   *" $guard_ip "*) ok "guard carries $guard_ip" ;;
   *) fail "guard carries '${carried:-nothing}', the API published $guard_ip" ;;
 esac
+
+echo "- the machine carries no address the API does not publish"
+# Exoscale publishes an instance's public address as ip_address and each private
+# network lease under private-networks[].ip. Nothing else may exist on the
+# machine: an instance carrying two addresses where the API named one is what
+# this suite let through until #202.
+# ip_address is the public one; the private-network lease is $guard_ip, which
+# this suite already resolved from the network's own lease list a few lines up.
+# Reading it back out of `instance show` was a detour and a wrong one: the CLI
+# renders private_networks as a list of names, not of objects, so the jq for
+# `.ip` failed with "Cannot index string with string".
+exo_public="$(exo -O json compute instance show "$guard_id" 2>/dev/null \
+  | jq -r '.ip_address // empty' | grep -v '^-$' || true)"
+# shellcheck disable=SC2086 # the published list is several arguments on purpose
+assert_only_published "$(machine "$guard_id")" $exo_public "$guard_ip"
 
 echo "- an instance of the same private network is reachable"
 incus exec "$(machine "$guard_id")" -- sh -c \

--- a/tools/conformance/outscale/network.sh
+++ b/tools/conformance/outscale/network.sh
@@ -35,6 +35,11 @@ fail() { echo "FAIL: $*" >&2; exit 1; }
 ok()   { echo "  ok: $*"; }
 skip() { echo "  SKIP: $*" >&2; }
 
+# Shared assertions about what a machine carries. See the file for why the
+# comparison is not written three times.
+# shellcheck source=/dev/null
+. "$(dirname "$0")/../shared/addresses.sh"
+
 echo "conformance: outscale network against $ENDPOINT"
 
 MACHINES="$(curl -sf "$ENDPOINT/_feint/health" | jq -r '.machines')"
@@ -166,6 +171,15 @@ done
 [ -n "$carried" ] || fail "no machine on the host carries $private_ip: the address is a number in a store"
 ok "$vm_id carries $private_ip, on $found"
 
+echo "- the machine carries no address the API does not publish"
+# Outscale publishes a Vm's addresses as PrivateIp and, when one is linked,
+# PublicIp. Nothing else on the machine may exist: an address the runtime handed
+# out and no field describes is exactly what #202 removed.
+osc_published="$(osc ReadVms --Filters "{\"VmIds\": [\"$vm_id\"]}" \
+  | jq -r '[.Vms[0].PrivateIp, .Vms[0].PublicIp] | map(select(. != null and . != "")) | join(" ")')"
+# shellcheck disable=SC2086 # the published list is several arguments on purpose
+assert_only_published "feint-osc-$vm_id" $osc_published
+
 osc DeleteVms '--VmIds[]' "$vm_id" >/dev/null || fail "DeleteVms rejected"
 sleep 2
 
@@ -180,5 +194,99 @@ ok "deleted, and the host is as it was"
 
 osc DeleteNet --NetId "$net_id" >/dev/null || fail "DeleteNet rejected"
 net_id=""
+
+# ---- Two Nets do not reach each other -----------------------------------------
+#
+# The assertion this suite did not have, and its absence is why the leak lived:
+# the pack had no isolation wiring at all and nothing ever asked. Scaleway and
+# Exoscale both hold the equivalent; three suites, one property.
+#
+# Measured before the fix, on a station publishing capabilities.isolation: true —
+# two Nets with no peering, one machine in each, reachable in ICMP *and* in TCP,
+# because every OVN subnet is `scope link` on the uplink this emulator creates.
+#
+# The verdict keys on the declared capability, never on a mode name: a runtime
+# that promises isolation and does not deliver it is a hard failure, and one that
+# promises nothing is skipped rather than silently passed.
+ISO="$(curl -sf "$ENDPOINT/_feint/health" | jq -r '.capabilities.isolation // false')"
+
+echo "- two Nets, and a machine in each"
+iso_a="" iso_b="" iso_sub_a="" iso_sub_b="" iso_vm_a="" iso_vm_b=""
+iso_cleanup() {
+  [ -n "$iso_vm_a" ] && osc DeleteVms '--VmIds[]' "$iso_vm_a" >/dev/null 2>&1
+  [ -n "$iso_vm_b" ] && osc DeleteVms '--VmIds[]' "$iso_vm_b" >/dev/null 2>&1
+  sleep 3
+  [ -n "$iso_sub_a" ] && osc DeleteSubnet --SubnetId "$iso_sub_a" >/dev/null 2>&1
+  [ -n "$iso_sub_b" ] && osc DeleteSubnet --SubnetId "$iso_sub_b" >/dev/null 2>&1
+  [ -n "$iso_a" ] && osc DeleteNet --NetId "$iso_a" >/dev/null 2>&1
+  [ -n "$iso_b" ] && osc DeleteNet --NetId "$iso_b" >/dev/null 2>&1
+  return 0
+}
+trap 'iso_cleanup; cleanup' EXIT
+
+ISO_A="${FEINT_TEST_ISO_BLOCK_A:-10.203.0.0/16}"
+ISO_B="${FEINT_TEST_ISO_BLOCK_B:-10.204.0.0/16}"
+iso_a="$(osc CreateNet --IpRange "$ISO_A" | jq -r '.Net.NetId')"
+iso_b="$(osc CreateNet --IpRange "$ISO_B" | jq -r '.Net.NetId')"
+[ -n "$iso_a" ] && [ -n "$iso_b" ] || fail "the two Nets were not created"
+iso_sub_a="$(osc CreateSubnet --NetId "$iso_a" --IpRange "${ISO_A%.0.0/16}.1.0/24" | jq -r '.Subnet.SubnetId')"
+iso_sub_b="$(osc CreateSubnet --NetId "$iso_b" --IpRange "${ISO_B%.0.0/16}.1.0/24" | jq -r '.Subnet.SubnetId')"
+[ -n "$iso_sub_a" ] && [ -n "$iso_sub_b" ] || fail "the two Subnets were not created"
+
+iso_doc_a="$(osc CreateVms --ImageId ami-00000001 --VmType tinav6.c1r1p2 --SubnetId "$iso_sub_a")"
+iso_doc_b="$(osc CreateVms --ImageId ami-00000001 --VmType tinav6.c1r1p2 --SubnetId "$iso_sub_b")"
+iso_vm_a="$(printf '%s' "$iso_doc_a" | jq -r '.Vms[0].VmId')"
+iso_vm_b="$(printf '%s' "$iso_doc_b" | jq -r '.Vms[0].VmId')"
+iso_ip_b="$(printf '%s' "$iso_doc_b" | jq -r '.Vms[0].PrivateIp // empty')"
+[ -n "$iso_ip_b" ] || fail "the target Vm came back with no PrivateIp"
+
+# Both up and carrying their addresses, or absence of reach means "still
+# booting" rather than "isolated".
+booted=""
+for _ in $(seq 1 30); do
+  if incus list -f csv -c n4 2>/dev/null | grep -q "$iso_ip_b"; then booted="yes"; break; fi
+  sleep 2
+done
+[ -n "$booted" ] || fail "no machine carries $iso_ip_b; reachability cannot be measured"
+sleep 3
+ok "$iso_vm_a and $iso_vm_b, in separate Nets"
+
+echo "- a machine of another Net is unreachable"
+if incus exec "feint-osc-$iso_vm_a" -- ping -c 2 -W 2 "$iso_ip_b" >/dev/null 2>&1; then
+  if [ "$ISO" = "true" ]; then
+    fail "$iso_ip_b is reachable from another Net, but $MACHINES declares isolation"
+  fi
+  skip "$iso_ip_b is reachable from another Net: $MACHINES does not isolate subnets (see docs/limits.md)"
+else
+  ok "a machine of another Net is unreachable ($iso_ip_b)"
+fi
+
+# And the accepting half. A rule set that kept everything out would pass the
+# check above and separate two Subnets of one Net, which the real cloud routes.
+echo "- a second Subnet of the same Net stays reachable"
+iso_sub_a2="$(osc CreateSubnet --NetId "$iso_a" --IpRange "${ISO_A%.0.0/16}.2.0/24" | jq -r '.Subnet.SubnetId')"
+if [ -z "$iso_sub_a2" ]; then
+  skip "a second Subnet of the same Net was refused; the accepting half is not measured"
+else
+  iso_doc_c="$(osc CreateVms --ImageId ami-00000001 --VmType tinav6.c1r1p2 --SubnetId "$iso_sub_a2")"
+  iso_vm_c="$(printf '%s' "$iso_doc_c" | jq -r '.Vms[0].VmId')"
+  iso_ip_c="$(printf '%s' "$iso_doc_c" | jq -r '.Vms[0].PrivateIp // empty')"
+  for _ in $(seq 1 30); do
+    incus list -f csv -c n4 2>/dev/null | grep -q "$iso_ip_c" && break
+    sleep 2
+  done
+  sleep 3
+  if incus exec "feint-osc-$iso_vm_a" -- ping -c 2 -W 3 "$iso_ip_c" >/dev/null 2>&1; then
+    ok "a machine of the same Net is reachable ($iso_ip_c)"
+  else
+    fail "$iso_ip_c is unreachable inside one Net; the isolation separates too much"
+  fi
+  osc DeleteVms '--VmIds[]' "$iso_vm_c" >/dev/null 2>&1
+  sleep 3
+  osc DeleteSubnet --SubnetId "$iso_sub_a2" >/dev/null 2>&1
+fi
+
+iso_cleanup
+iso_a="" iso_b="" iso_sub_a="" iso_sub_b="" iso_vm_a="" iso_vm_b=""
 
 echo "conformance: outscale network passed"

--- a/tools/conformance/scaleway/network.sh
+++ b/tools/conformance/scaleway/network.sh
@@ -40,6 +40,11 @@ fail() { echo "FAIL: $*" >&2; exit 1; }
 ok()   { echo "  ok: $*"; }
 skip() { echo "  SKIP: $*" >&2; }
 
+# Shared assertions about what a machine carries. See the file for why the
+# comparison is not written three times.
+# shellcheck source=/dev/null
+. "$(dirname "$0")/../shared/addresses.sh"
+
 api() { curl -sf -H 'Content-Type: application/json' "$@"; }
 
 # The emulated block. Deliberately obscure: a lab bridge or a VPN holding the same range on the
@@ -204,27 +209,13 @@ fi
 # "deprecated and always null when routed_ip_enabled is True", so a real client
 # reads a private address through ipam/v1 and a public one through public_ips.
 echo "- the machine carries no address the API does not publish"
+# Scaleway publishes a server's addresses in two places: the routed public ones
+# under public_ips, and the private NIC's under IPAM. Both count, and reading
+# only the first is what made this a skip for months.
 published="$(api "$ENDPOINT/instance/v1/zones/$ZONE/servers/$guard_id" \
              | jq -r '[.server.public_ips[]?.address] | map(select(. != null)) | join(" ")')"
-carried_all="$(incus query "/1.0/instances/$(machine "$guard_id")/state" \
-               | jq -r '[.network | to_entries[] | select(.key != "lo")
-                        | .value.addresses[]? | select(.family == "inet") | .address] | join(" ")')"
-unpublished=""
-for address in $carried_all; do
-  case " $published " in
-    *" $address "*) ;;
-    *) unpublished="$unpublished $address" ;;
-  esac
-done
-if [ -z "$unpublished" ]; then
-  ok "every address it carries is published ($carried_all)"
-else
-  # Not a failure yet: a server still gets an interface from the runtime's
-  # default profile, and the API has no field describing it. It is filtered,
-  # which is what stops it from being a hole, and docs/limits.md records the
-  # rest.
-  skip "carried but not published:$unpublished (see docs/limits.md)"
-fi
+# shellcheck disable=SC2086 # the published list is several arguments on purpose
+assert_only_published "$(machine "$guard_id")" $published "$guard_ip"
 
 echo "- the group's drop policy closes a port, for real"
 incus exec "$(machine "$guard_id")" -- sh -c \

--- a/tools/conformance/shared/addresses.sh
+++ b/tools/conformance/shared/addresses.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Shared conformance assertions about what a machine carries.
+#
+# Sourced by tools/conformance/<provider>/network.sh. It exists because the
+# property below was written for one provider out of three, and the two gaps it
+# left are exactly what shipped: an Exoscale instance carrying two addresses
+# where its API published one, and a Scaleway server carrying an address from
+# the runtime's default profile that no API field described.
+#
+# What varies is a parameter and what does not is shared, which is this
+# repository's own rule for the packs and applies to their suites for the same
+# reason: an assertion copied into three scripts is an assertion one script
+# forgets, and a fourth provider never has at all.
+#
+# The caller supplies what its own API publishes, because that is the only
+# provider-shaped half. The comparison, the reading of the host, and the verdict
+# are here.
+#
+# Every function expects `ok`, `fail` and `skip` to be defined by the caller,
+# which every suite already does.
+
+# addresses_carried echoes every IPv4 address a machine carries, loopback
+# excluded, read from the runtime rather than from the API — the control plane
+# is not a witness for itself.
+addresses_carried() {
+  incus query "/1.0/instances/$1/state" 2>/dev/null \
+    | jq -r '[.network | to_entries[] | select(.key != "lo")
+             | .value.addresses[]? | select(.family == "inet") | .address] | join(" ")'
+}
+
+# assert_only_published <machine> <published...>
+#
+# Every address the machine carries must be one the provider's API publishes.
+# The reverse is not checked here: an address published and not yet carried is a
+# machine still booting, which the suites already assert on their own terms.
+#
+# A carried-but-unpublished address is a hard failure. It used to be a skip,
+# tolerated because "a server still gets an interface from the runtime's default
+# profile, and the API has no field describing it" — that sentence described the
+# defect #202 removed, and keeping it as a skip afterwards would let the defect
+# come back unnoticed.
+assert_only_published() {
+  local machine="$1"
+  shift
+  local published=" $* "
+  local carried address unpublished=""
+
+  carried="$(addresses_carried "$machine")"
+  if [ -z "$carried" ]; then
+    fail "$machine carries no address at all; the API published:$published"
+  fi
+  for address in $carried; do
+    case "$published" in
+      *" $address "*) ;;
+      *) unpublished="$unpublished $address" ;;
+    esac
+  done
+  if [ -n "$unpublished" ]; then
+    fail "$machine carries$unpublished, which no API field publishes (carried: $carried)"
+  fi
+  ok "every address it carries is published ($carried)"
+}


### PR DESCRIPTION
Closes #202 and #201. Built on #203 (merged in #204).

## Two rules, measured on real clouds

On the author's own accounts, empty before and after, everything destroyed and
the counts re-read:

| | created with the defaults |
|---|---|
| **Scaleway** | `public_ip: 212.47.238.226`, `private_ip: none`, `private_nics: 0` |
| **Scaleway `ip=none`** | no address at all |
| **Exoscale** | `ip_address: 151.145.198.51`, no private network, no elastic IP |

**One address each.** This emulator gave a Scaleway server two or three, and the
extra came from a fallback bridge whose address no API described — the suite
already tolerated it as a skip: *"a server still gets an interface from the
runtime's default profile, and the API has no field describing it"*.

## #202 — a machine carries what its API publishes

`Start` distinguishes three cases and invents an address in none:

```
an emulated network   the primary interface joins it, as before
only public ones      a routed NIC carries them, with no network under it
neither               no network device at all
```

Two measurements shaped it: a routed NIC needs **no `parent`** (so this driver
never decides which of the operator's interfaces to anchor to), and the
link-local next hop is shareable because each machine has its own veth.

**Exoscale was unfaithful to its own cloud.** It recorded
`public-ip-assignment: inet4` and never honoured it, so an emulated instance
published nothing while the real one publishes an address on the first read. It
now allocates from its own RFC 5737 block at creation, and the allocator counts
instance addresses as well as elastic ones.

**Outscale kept its fallback, and that is the distinction the rule nearly lost.**
A Vm outside a Net is in the public Cloud and Outscale gives it a private address
there. The fallback network was never wrong in itself — it was wrong where the
address it handed out was published by nobody. The pack now asks for the
emulator's network *by name* and publishes what it receives, because what its
cloud publishes is the pack's business.

```
Scaleway  public_ip=203.0.113.3   eth0 203.0.113.3/32   count 1
Outscale  PrivateIp=10.196.1.4    eth0 10.196.1.4/24    count 1
Exoscale  ip_address=192.0.2.1    eth0 192.0.2.1/32     count 1
```

## #201 — two networks that are not peered do not reach each other

The claim was prose in two places and asserted nowhere. Measured with
`capabilities.isolation: true` published: two Nets, no peering, reachable in
**ICMP and in TCP**. The mechanism is the host, not OVN:

```
10.191.1.0/24 dev feint-uplink proto static scope link
10.192.1.0/24 dev feint-uplink proto static scope link
```

The shared L2 the comment declared absent is the emulator's own uplink. An
ingress rule set closes it — measured by hand before any code was written, so no
rule is ever written into the operator's firewall.

Applied from `PeerNetworks`, not from each pack: peering says what *may* reach a
network, nothing said what may not, and a control living in three packs is one a
pack forgets. **Outscale had no isolation wiring at all**, which the same
emulator showed in one minute:

```
Scaleway  a server of another VPC    unreachable   (called this layer)
Outscale  a machine of another Net   REACHES       (called nothing)
```

## Three suites, one property

The Outscale suite asserted **three** things where Scaleway asserts sixteen, and
none looked at whether two Nets reach each other. That is why the leak lived: a
suite proves what it asserts and nothing more. It now holds both halves.

And *"the machine carries no address the API does not publish"* — the rule this
whole change is about — was asserted for **one provider out of three**. It moves
to `tools/conformance/shared/addresses.sh`: each suite supplies only what its own
API publishes, the comparison and the verdict are shared. It was a skip on
Scaleway, excused by a comment describing the very defect #202 removes, so it is
a **failure** now.

## Two defects only a real runtime could find

- `-d eth0,type=none` does not mask a profile device, Incus **merges** it, so
  `network: incusbr0` landed on a device declared `type: none` and every machine
  of the network suite failed to create.
- `freeInterface` started at `eth1`, assuming the boot interface always holds
  `eth0`. A machine with nothing to publish now boots with none, so the first NIC
  attached afterwards was named `eth1`, the guest had no such device, and the
  suite reported it as a machine not carrying its address — two steps from the
  cause.

## Measured, one thing at a time

| | |
|---|---|
| `FEINT_VM=incus-ovn mise run conformance` | **102 ok, 0 FAIL**, the shared assertion run 3 times |
| `mise run conformance:leg -- probe` | green — the partial run CI actually does |
| `mise run falsify:all` | 8 specs, every mutation still bites |
| `mise run falsify:proof` | green |
| `tools/images/verify.sh` | 5 images, no network |
| `mise run fuzz` | green |
| `go test ./...` | 18 packages |
| `golangci-lint`, `gofmt`, `go vet` | clean |
| `feint docs --check`, `feint shapes --check` | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
