### PR TITLE
docs(releasing): what you may depend on, and for how long (#178)

### DIFF
--- a/RELEASING.fr.md
+++ b/RELEASING.fr.md
@@ -118,6 +118,68 @@ cosign verify-blob --bundle checksums.txt.cosign.bundle \
 sha256sum -c checksums.txt --ignore-missing
 ```
 
+## Ce sur quoi vous pouvez compter, et pour combien de temps
+
+Les surfaces ci-dessous sont tout ce qui est couvert. **Ce qui n'y figure pas ne
+porte aucune promesse**, et le dire franchement est le sujet : un émulateur qui
+promettrait tout son comportement promettrait une copie mouvante de trois clouds.
+
+| surface | signal | gelée dans |
+|---|---|---|
+| `/_feint/health` | `schema_version` | `internal/cli/testdata/frozen/health.json` |
+| `/_feint/routes` | `schema_version` | `internal/cli/testdata/frozen/routes.json` |
+| `/_feint/conformance` | `schema_version` | `internal/cli/testdata/frozen/conformance.json` |
+| `/_feint/trace` | `schema_version` | `internal/cli/testdata/frozen/trace.json` |
+| les verbes, drapeaux et codes de sortie du CLI | `cliSurfaceVersion` | `internal/cli/testdata/frozen/cli.json` |
+| les formats d'état et de snapshot | la version du document | `internal/cli/snapshot.go` |
+
+**Servir davantage de l'API d'un provider n'est jamais cassant**, quelle que soit
+l'ampleur du changement. C'est cette asymétrie qui rend la fenêtre tenable : la
+surface qui peut casser est petite et énumérée ci-dessus, et tout ce qu'un pack
+gagne atterrit en dehors.
+
+### Le préavis
+
+**Une version mineure.** Un champ ou un verbe qui disparaît est déprécié dans une
+version et retiré au plus tôt dans la suivante, et les deux événements sont des
+lignes du `CHANGELOG.md`. Une dépréciation qui apparaît et disparaît dans la même
+version n'en est pas une.
+
+Une version plutôt qu'un nombre généreux, délibérément. C'est un projet 0.x tenu
+par une personne, et ce dépôt a déjà mesuré ce que coûte une condition
+intenable : l'étiquette *preview* d'Exoscale attendait le tracker de quelqu'un
+d'autre et est restée fausse pendant des mois. Une promesse d'une version
+mineure, tenue, vaut mieux qu'une plus longue qui sera rompue.
+
+### Le signal
+
+Chaque charge utile ci-dessus porte `schema_version`, et il bouge quand la forme
+bouge, ajouts compris, parce que le nombre veut dire *la surface a changé* et non
+*la surface a cassé*. `cliSurfaceVersion` fait la même chose pour les verbes, les
+drapeaux et les codes de sortie. Un fixture régénéré sans que sa constante suive
+fait échouer la CI.
+
+### La sortie de secours
+
+Un consommateur qui lit une version qu'il ne connaît pas doit **s'arrêter plutôt
+que deviner**. Les formes sont additives à l'intérieur d'une version, donc une
+version inconnue **supérieure** se lit sans risque pour les champs déjà connus ;
+une version inconnue **inférieure** signifie que l'émulateur est plus ancien que
+ce que le pipeline attend, et que les champs espérés peuvent ne pas exister
+encore.
+
+Concrètement, et c'est toute la recette :
+
+```bash
+version="$(curl -sf localhost:4599/_feint/conformance | jq -r '.schema_version')"
+[ "$version" -ge 3 ] || { echo "feint est plus ancien que ce pipeline n'attend"; exit 1; }
+```
+
+Lire un champ sans vérifier est ce qui casse en silence : `probed` est passé de
+booléen à chaîne, et un pipeline qui le traitait comme vrai comptait chaque refus
+comme un succès. C'est ce chemin que #170 mesure ; cette section est ce contre
+quoi il le mesure.
+
 ## Versionnage
 
 [Semantic Versioning](https://semver.org/lang/fr/). Avant 1.0, la version mineure

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -112,6 +112,66 @@ cosign verify-blob --bundle checksums.txt.cosign.bundle \
 sha256sum -c checksums.txt --ignore-missing
 ```
 
+## What you may depend on, and for how long
+
+The surfaces below are the whole of it. **Anything not on this list carries no
+promise at all**, and saying so plainly is the point: an emulator that promised
+its whole behaviour would be promising a moving copy of three clouds.
+
+| surface | signal | frozen as |
+|---|---|---|
+| `/_feint/health` | `schema_version` | `internal/cli/testdata/frozen/health.json` |
+| `/_feint/routes` | `schema_version` | `internal/cli/testdata/frozen/routes.json` |
+| `/_feint/conformance` | `schema_version` | `internal/cli/testdata/frozen/conformance.json` |
+| `/_feint/trace` | `schema_version` | `internal/cli/testdata/frozen/trace.json` |
+| the CLI's verbs, flags and exit codes | `cliSurfaceVersion` | `internal/cli/testdata/frozen/cli.json` |
+| the state and snapshot formats | the document's own version | `internal/cli/snapshot.go` |
+
+**Serving more of a provider's API is never breaking**, however much it changes.
+That asymmetry is what makes this window affordable: the surface that can break
+is small and enumerated above, and everything a provider pack gains lands outside
+it.
+
+### The notice
+
+**One minor release.** A field or a verb that is going away is deprecated in one
+release and removed no earlier than the next, and both events are lines in
+`CHANGELOG.md` — a deprecation that appears and disappears in the same release is
+not one.
+
+One release rather than a generous number, deliberately. This is a 0.x project
+with one maintainer, and this repository has already measured what an unkeepable
+condition costs: the Exoscale *preview* label waited on somebody else's tracker
+and stayed wrong for months. A promise of one minor version, kept, is worth more
+than a longer one that is broken.
+
+### The signal
+
+Every payload above carries `schema_version`, and it moves when the shape moves —
+additions included, because the number means *the surface changed*, not *the
+surface broke*. `cliSurfaceVersion` does the same for the verbs, the flags and
+the exit codes. A fixture regenerated without its constant moving fails CI.
+
+### The escape
+
+A consumer that reads a version it does not know should **stop rather than
+guess**. The shapes are additive within a version, so an unknown *higher* version
+is safe to read for the fields you already know; an unknown *lower* one means the
+emulator is older than your pipeline expects and the fields you rely on may not
+be there yet.
+
+Concretely, and this is the whole recipe:
+
+```bash
+version="$(curl -sf localhost:4599/_feint/conformance | jq -r '.schema_version')"
+[ "$version" -ge 3 ] || { echo "feint is older than this pipeline expects"; exit 1; }
+```
+
+Reading a field without checking is what breaks silently: `probed` went from a
+boolean to a string, and a pipeline treating it as truthy counted every refusal
+as a success. That path is what #170 measures; this section is what it measures
+against.
+
 ## Versioning
 
 [Semantic Versioning](https://semver.org/). Before 1.0, the minor version moves

--- a/internal/cli/docs_banner_test.go
+++ b/internal/cli/docs_banner_test.go
@@ -128,13 +128,24 @@ func TestEveryBannerAnchorResolves(t *testing.T) {
 	}
 }
 
+// between answers what lies between two markers, searching for the second one
+// *after* the first.
+//
+// Searching the whole document for the end marker was the first version, and it
+// returned an empty section every time the end marker also occurred earlier —
+// which for a heading like "\n## " it always does. The section then read as
+// absent and the test blamed the document.
 func between(s, start, end string) string {
 	from := strings.Index(s, start)
-	to := strings.Index(s, end)
-	if from < 0 || to < 0 || to < from {
+	if from < 0 {
 		return ""
 	}
-	return s[from+len(start) : to]
+	rest := s[from+len(start):]
+	to := strings.Index(rest, end)
+	if to < 0 {
+		return rest
+	}
+	return rest[:to]
 }
 
 func repoRoot(t *testing.T) string {

--- a/internal/cli/support_window_test.go
+++ b/internal/cli/support_window_test.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The support window names exactly the surfaces that are frozen (#178).
+//
+// A policy with no control is prose, and this repository has measured what that
+// costs: #171 was filed for two sentences that said the same thing in two files
+// and were enforced in neither. The window below is cheap to keep honest, so it
+// is kept honest.
+//
+// The failure this prevents is the one that will actually happen: somebody
+// freezes a sixth surface, the fixture directory grows, and the policy keeps
+// promising five. A user reading it would then depend on something the project
+// never agreed to support — or miss something it does.
+func TestTheSupportWindowNamesEveryFrozenSurface(t *testing.T) {
+	root := repoRoot(t)
+
+	entries, err := os.ReadDir(filepath.Join(root, "internal", "cli", "testdata", "frozen"))
+	if err != nil {
+		t.Skipf("no frozen fixtures to compare against: %v", err)
+	}
+	policy, err := os.ReadFile(filepath.Join(root, "RELEASING.md"))
+	if err != nil {
+		t.Fatalf("read the policy: %v", err)
+	}
+	section := between(string(policy), "## What you may depend on, and for how long", "\n## ")
+	if section == "" {
+		t.Fatal("RELEASING.md carries no support window")
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		if !strings.Contains(section, entry.Name()) {
+			t.Errorf("%s is frozen and the support window does not name it: a user cannot tell "+
+				"whether it is covered", entry.Name())
+		}
+	}
+
+	// And the other direction: a surface the policy promises must exist, or the
+	// promise is about a file nobody ships.
+	for _, line := range strings.Split(section, "\n") {
+		for _, field := range strings.Fields(line) {
+			name := strings.Trim(field, "`|")
+			if !strings.HasSuffix(name, ".json") || !strings.Contains(name, "frozen/") {
+				continue
+			}
+			if _, err := os.Stat(filepath.Join(root, name)); err != nil {
+				t.Errorf("the support window promises %s and it does not exist", name)
+			}
+		}
+	}
+}
+
+// The window states a notice, a signal and an escape, because a policy missing
+// any of the three answers nothing a consumer actually asks.
+//
+// Checked by their anchors rather than by their wording: the point is that the
+// three questions are answered somewhere a reader can find, not that they are
+// answered in a sentence this test dictates.
+func TestTheSupportWindowAnswersTheThreeQuestions(t *testing.T) {
+	root := repoRoot(t)
+	policy, err := os.ReadFile(filepath.Join(root, "RELEASING.md"))
+	if err != nil {
+		t.Fatalf("read the policy: %v", err)
+	}
+	section := between(string(policy), "## What you may depend on, and for how long", "\n## ")
+
+	for _, want := range []string{"### The notice", "### The signal", "### The escape"} {
+		if !strings.Contains(section, want) {
+			t.Errorf("the support window has no %q: a consumer is left to infer it", want)
+		}
+	}
+	// The escape has to be a recipe rather than an intention, or it is the
+	// "whatever happened last time" this issue was filed against.
+	if !strings.Contains(section, "schema_version") || !strings.Contains(section, "exit 1") {
+		t.Error("the escape names no version to read and no way to stop; it is an intention, not a path")
+	}
+}


### PR DESCRIPTION
Closes #178.

## The gap

`RELEASING.md` said what *breaking* means, and #132 froze the surfaces and gave
three of them a `schema_version`. The other half of a promise was missing: **for
how long.** A user wiring `/_feint/conformance` into a pipeline had no way to
answer whether a previous shape keeps being served, whether a flag is deprecated
before it is removed, or how much notice a removal gets.

The answer was "whatever happened last time", which is not a policy — and nothing
in the repository said the answer did not exist.

## Four answers, one section

| | |
|---|---|
| **the surface** | the frozen list, named, and nothing else. What is not on it carries **no promise at all**, and saying so plainly is the point |
| **the notice** | one minor release; both the deprecation and the removal are lines in `CHANGELOG.md` |
| **the signal** | `schema_version` for the payloads, `cliSurfaceVersion` for the verbs, flags and exit codes |
| **the escape** | read the version, stop rather than guess — with the recipe, not the intention |

**One release rather than a generous number, deliberately.** This is a 0.x
project with one maintainer, and the repository has already measured what an
unkeepable condition costs: the Exoscale *preview* label waited on somebody
else's tracker and stayed wrong for months. A promise of one minor version, kept,
is worth more than a longer one that is broken.

The window is affordable because of an asymmetry this project already had and had
never written down as a promise: **serving more of a provider's API is never
breaking**, however much it changes. Everything a pack gains lands outside the
list.

## A policy with a control

Prose alone would put this in the same category as the two sentences #171 was
filed for. Two tests hold it:

- the window **names every fixture** in `internal/cli/testdata/frozen` and
  promises none that does not exist — so freezing a sixth surface without
  covering it fails, which is the failure that will actually happen;
- it **answers the notice, the signal and the escape**, the last as a runnable
  recipe rather than an intention.

## One defect, in the helper rather than the document

`between()` searched the whole file for its end marker, so a section ending at
`"\n## "` was reported empty because an earlier heading matched first. The
section read as absent and the test blamed the document. It searches after the
start marker now.

## Both languages

`RELEASING.fr.md` gets the same section — for a bilingual repository, leaving it
out would be the same gap moved one file along. The fixture lists are identical
in both, checked rather than trusted.

`go test ./...` 18 packages, `golangci-lint` clean, `feint docs --check` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
