### PR TITLE
refactor: the invariants three packs shared by copy now live once, and a leak they hid is closed

### DIFF
--- a/internal/cli/shapes_check.go
+++ b/internal/cli/shapes_check.go
@@ -318,10 +318,13 @@ func parentPath(path string) string {
 
 // callIdentity turns a read-list entry into the key the catalogue uses and the
 // request that produces it. The two must agree or the check compares an
-// operation with itself under another name and finds nothing.
+// operation with itself under another name and finds nothing — which is why
+// the Outscale identity comes from upstream.OutscaleCall, the same function
+// the recorder writes the catalogue with, rather than from a second copy here
+// that a fix in one would leave broken in the other.
 func callIdentity(p upstream.Provider, call string) (key, method, path string) {
 	if p == upstream.Outscale {
-		return "osc/Client." + call, http.MethodPost, "/api/v1/" + call
+		return upstream.OutscaleCall(call)
 	}
 	return http.MethodGet + " " + call, http.MethodGet, call
 }

--- a/internal/core/machine/isolate.go
+++ b/internal/core/machine/isolate.go
@@ -1,6 +1,9 @@
 package machine
 
-import "context"
+import (
+	"context"
+	"log/slog"
+)
 
 // Two emulated subnets are two real subnets, and upstream they do not reach each
 // other. Runtimes disagree on which way round that is: some join networks by
@@ -33,4 +36,91 @@ type Peerer interface {
 	// PeerNetworks makes the network reach exactly the given peers: missing
 	// peerings are created, in both their halves, and stale ones removed.
 	PeerNetworks(ctx context.Context, network string, peers []string) error
+}
+
+// IsolationMember is one network of a pack in a reconciliation pass.
+type IsolationMember struct {
+	// ID names the pack's resource, for the log line when the driver refuses.
+	ID string
+	// Network is the runtime network backing the resource. Empty means no
+	// backing network exists yet: the member is skipped as a target and never
+	// listed as a peer, because there is nothing to configure or to reach.
+	Network string
+	// Block is the CIDR a foreign list carries for this member. Empty means
+	// the member has no block to keep out (an unmanaged range), which excludes
+	// it from foreign lists only.
+	Block string
+}
+
+// ReconcileIsolation applies what every member may reach, over the whole set.
+//
+// Three packs had written this loop — vpc.go, isolate.go, privatenetworks.go —
+// and only the reachability predicate differed: same routed VPC for Scaleway,
+// same Net for Outscale, nothing for Exoscale, whose networks are each their
+// own segment upstream. The predicate is the provider knowledge, so it is the
+// parameter; the rest is the mechanism, and a control living in two packs out
+// of three is a control the third forgets, which is what #201 measured.
+//
+// A runtime with native isolation gets peer lists — its networks reach nothing
+// until joined, so the question is what to let in. One whose networks are born
+// joined gets each member's foreign blocks to keep out. Reconciled over all
+// members rather than patched for the one that moved: a patch has to be right
+// about what changed, and this only has to be right about what is.
+//
+// Failure is logged, never fatal: the control plane must keep answering when
+// no runtime is configured, which is the default and what CI uses. The return
+// says what happened — native peering, rule-set isolation, or nothing, when
+// the driver has neither capability — because at least one pack does extra
+// work (a security-group resync) only in the rule-set case.
+func ReconcileIsolation(ctx context.Context, driver Driver, log *slog.Logger, noun string,
+	members []IsolationMember, reachable func(from, to int) bool) (native, applied bool) {
+	if log == nil {
+		log = slog.Default()
+	}
+
+	if peerer, ok := driver.(Peerer); ok && peerer.NativeIsolation() {
+		for i, m := range members {
+			if m.Network == "" {
+				continue
+			}
+			peers := make([]string, 0, len(members))
+			for j, other := range members {
+				if j == i || other.Network == "" {
+					continue
+				}
+				if reachable(i, j) {
+					peers = append(peers, other.Network)
+				}
+			}
+			if err := peerer.PeerNetworks(ctx, m.Network, peers); err != nil {
+				log.Error("could not peer the "+noun+"'s network",
+					noun, m.ID, "network", m.Network, "error", err)
+			}
+		}
+		return true, true
+	}
+
+	isolator, ok := driver.(Isolator)
+	if !ok {
+		return false, false
+	}
+	for i, m := range members {
+		if m.Network == "" {
+			continue
+		}
+		foreign := make([]string, 0, len(members))
+		for j, other := range members {
+			if j == i || reachable(i, j) {
+				continue
+			}
+			if other.Block != "" {
+				foreign = append(foreign, other.Block)
+			}
+		}
+		if err := isolator.IsolateNetwork(ctx, m.Network, foreign); err != nil {
+			log.Error("could not isolate the "+noun+"'s network",
+				noun, m.ID, "network", m.Network, "error", err)
+		}
+	}
+	return false, true
 }

--- a/internal/core/machine/isolate_test.go
+++ b/internal/core/machine/isolate_test.go
@@ -1,0 +1,118 @@
+package machine_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/machine"
+)
+
+// peeringDriver is a runtime whose networks are born separate, recording what
+// each network was peered with.
+type peeringDriver struct {
+	machine.Noop
+	peers map[string][]string
+}
+
+func (d *peeringDriver) NativeIsolation() bool { return true }
+func (d *peeringDriver) PeerNetworks(_ context.Context, network string, peers []string) error {
+	d.peers[network] = peers
+	return nil
+}
+
+// rulesDriver is a runtime whose networks are born joined, recording the
+// foreign blocks each network was told to keep out.
+type rulesDriver struct {
+	machine.Noop
+	foreign map[string][]string
+}
+
+func (d *rulesDriver) IsolateNetwork(_ context.Context, network string, foreign []string) error {
+	d.foreign[network] = foreign
+	return nil
+}
+
+func threeMembers() []machine.IsolationMember {
+	return []machine.IsolationMember{
+		{ID: "pn-1", Network: "net-1", Block: "10.0.1.0/24"},
+		{ID: "pn-2", Network: "net-2", Block: "10.0.2.0/24"},
+		{ID: "pn-3", Network: "net-3", Block: "10.0.3.0/24"},
+	}
+}
+
+// Under native isolation, exactly the reachable members become peers: nothing
+// more — peering two foreign networks reports joined what upstream keeps
+// apart, the inverse of the property this project measures — and nothing less.
+func TestReconcilePeersExactlyTheReachableMembers(t *testing.T) {
+	driver := &peeringDriver{peers: map[string][]string{}}
+
+	// pn-1 and pn-2 reach each other; pn-3 reaches nobody.
+	native, applied := machine.ReconcileIsolation(t.Context(), driver, nil, "network",
+		threeMembers(), func(from, to int) bool { return from != 2 && to != 2 })
+	if !native || !applied {
+		t.Fatalf("native=%v applied=%v, want true,true for a native-isolation driver", native, applied)
+	}
+
+	if got := driver.peers["net-1"]; len(got) != 1 || got[0] != "net-2" {
+		t.Errorf("net-1 was peered with %v, want [net-2]", got)
+	}
+	if got := driver.peers["net-3"]; len(got) != 0 {
+		t.Errorf("net-3 was peered with %v, want nothing", got)
+	}
+}
+
+// Under rule-set isolation, each network keeps out exactly the blocks of the
+// members it cannot reach: a reachable neighbour in the foreign list severs
+// what the provider routes, and a foreign one missing from it joins what the
+// provider keeps apart.
+func TestReconcileKeepsOnlyForeignBlocksOut(t *testing.T) {
+	driver := &rulesDriver{foreign: map[string][]string{}}
+
+	native, applied := machine.ReconcileIsolation(t.Context(), driver, nil, "network",
+		threeMembers(), func(from, to int) bool { return from != 2 && to != 2 })
+	if native || !applied {
+		t.Fatalf("native=%v applied=%v, want false,true for a rule-set driver", native, applied)
+	}
+
+	if got := driver.foreign["net-1"]; len(got) != 1 || got[0] != "10.0.3.0/24" {
+		t.Errorf("net-1 keeps out %v, want [10.0.3.0/24]", got)
+	}
+	if got := driver.foreign["net-3"]; len(got) != 2 {
+		t.Errorf("net-3 keeps out %v, want both other blocks", got)
+	}
+}
+
+// A member with no backing network is neither configured nor named as a peer,
+// and a member with no block never appears in a foreign list: there is nothing
+// to configure and nothing to keep out, and a driver told to peer with an
+// empty name would refuse every reconciliation after it.
+func TestReconcileSkipsWhatHasNoNetworkOrNoBlock(t *testing.T) {
+	members := []machine.IsolationMember{
+		{ID: "pn-1", Network: "net-1", Block: "10.0.1.0/24"},
+		{ID: "pn-2", Network: "", Block: "10.0.2.0/24"},
+		{ID: "pn-3", Network: "net-3", Block: ""},
+	}
+	everyone := func(int, int) bool { return true }
+
+	peering := &peeringDriver{peers: map[string][]string{}}
+	machine.ReconcileIsolation(t.Context(), peering, nil, "network", members, everyone)
+	if _, configured := peering.peers[""]; configured {
+		t.Error("a member without a network was configured under its empty name")
+	}
+	if got := peering.peers["net-1"]; len(got) != 1 || got[0] != "net-3" {
+		t.Errorf("net-1 was peered with %v, want [net-3] only", got)
+	}
+
+	rules := &rulesDriver{foreign: map[string][]string{}}
+	nobody := func(int, int) bool { return false }
+	machine.ReconcileIsolation(t.Context(), rules, nil, "network", members, nobody)
+	if got := rules.foreign["net-1"]; len(got) != 1 || got[0] != "10.0.2.0/24" {
+		t.Errorf("net-1 keeps out %v, want [10.0.2.0/24]: a blockless member has nothing to keep out", got)
+	}
+
+	// And a driver with neither capability reports that nothing was applied,
+	// so a pack does not resync rule-carried state no rule carries.
+	if _, applied := machine.ReconcileIsolation(t.Context(), machine.Noop{}, nil, "network", members, nobody); applied {
+		t.Error("a capability-less driver reported an isolation it cannot have applied")
+	}
+}

--- a/internal/core/machine/serialise.go
+++ b/internal/core/machine/serialise.go
@@ -1,6 +1,6 @@
 package machine
 
-import "sync"
+import "github.com/stephrobert/feint/internal/core/serialise"
 
 // Serialising the lifecycle of one target is the half of the concurrency story
 // the store lock cannot cover.
@@ -21,57 +21,10 @@ import "sync"
 // global lock: a global one would queue every server in the session behind a
 // single launch, turning a correctness fix into a throughput bug. attachMu in
 // the Incus driver is the same idea one layer down, for interface allocation.
-
-// targetLocks is the set of targets currently held or waited on.
-var targetLocks = &keyedMutex{held: make(map[string]*heldLock)}
-
-type heldLock struct {
-	mu sync.Mutex
-	// refs counts holders and waiters, so the entry outlives the first
-	// unlock only while somebody still needs it.
-	refs int
-}
-
-type keyedMutex struct {
-	mu   sync.Mutex
-	held map[string]*heldLock
-}
-
-// lock blocks until key is free and returns the release.
 //
-// The entry is dropped once the last waiter is gone. Keeping it would grow the
-// map by one mutex for every resource id a session ever touched, and an
-// emulator that a client can turn into a memory sink is a defect of the same
-// family as the ones this lock closes.
-func (k *keyedMutex) lock(key string) func() {
-	k.mu.Lock()
-	l, ok := k.held[key]
-	if !ok {
-		l = &heldLock{}
-		k.held[key] = l
-	}
-	l.refs++
-	k.mu.Unlock()
-
-	l.mu.Lock()
-
-	// Once, because a caller that both defers the release and calls it on an
-	// early return would otherwise unlock a mutex it no longer holds, which
-	// panics and takes the server with it.
-	var once sync.Once
-	return func() {
-		once.Do(func() {
-			l.mu.Unlock()
-
-			k.mu.Lock()
-			l.refs--
-			if l.refs == 0 {
-				delete(k.held, key)
-			}
-			k.mu.Unlock()
-		})
-	}
-}
+// The mechanism itself lives in core/serialise, because it is not specific to
+// machines: a pack's address allocation needs the same named exclusion, and
+// the copy each pack used to carry is how a fixed race stayed alive elsewhere.
 
 // Serialise excludes every other action on the same target until the returned
 // function is called. A pack takes it before it reads the resource and holds it
@@ -88,5 +41,5 @@ func (k *keyedMutex) lock(key string) func() {
 // The key carries the provider, so two packs numbering their resources the same
 // way do not wait on each other.
 func (b Binding) Serialise(id string) func() {
-	return targetLocks.lock(b.Provider + "|" + id)
+	return serialise.Lock(b.Provider + "|" + id)
 }

--- a/internal/core/machine/serialise_test.go
+++ b/internal/core/machine/serialise_test.go
@@ -101,25 +101,8 @@ func TestSerialiseSeparatesProviders(t *testing.T) {
 	}
 }
 
-// A map that keeps one mutex per id a session ever touched is the memory sink an
-// emulator must not become. The refcount is what stops it, and it is exactly the
-// kind of bookkeeping that reads as correct and leaks.
-func TestSerialiseForgetsATargetOnceNobodyHoldsIt(t *testing.T) {
-	b := Binding{Provider: "scaleway"}
-
-	for i := range 100 {
-		unlock := b.Serialise(string(rune('a' + i%26)))
-		unlock()
-	}
-
-	targetLocks.mu.Lock()
-	held := len(targetLocks.held)
-	targetLocks.mu.Unlock()
-
-	if held != 0 {
-		t.Fatalf("%d target locks are still held after every caller left", held)
-	}
-}
+// The cleanup half — a target forgotten once nobody holds it — is measured in
+// core/serialise, where the map now lives: TestADomainIsForgottenOnceNobodyHoldsIt.
 
 // A release called twice unlocks a mutex the caller no longer holds, which
 // panics. Ordinary Go style produces it: a defer plus an explicit call on an

--- a/internal/core/machine/transition.go
+++ b/internal/core/machine/transition.go
@@ -1,0 +1,52 @@
+package machine
+
+import (
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/resource"
+	"github.com/stephrobert/feint/internal/core/store"
+)
+
+// Transition applies one change to one resource, holding that target for the
+// read, the runtime work and the write-back.
+//
+// This is the transactional half of a lifecycle action, and it is the same in
+// every pack: serialise the target, check it exists, run the change outside
+// the store lock — launching a container takes tens of seconds where the lock
+// takes microseconds — and write the result back conditionally, so a delete
+// landing mid-transition wins. Two packs had written it separately
+// (transitionOne in Outscale, transitionInstance in Exoscale), which is the
+// duplication that let a fixed defect survive in the other copy.
+//
+// What deliberately stays in the pack is everything a client can observe: the
+// states a change moves between are API surface, and a not-found is answered
+// in the pack's own error dialect. Transition only reports it, as
+// store.ErrNotFound, whether the resource was never there or was deleted
+// while its machine was transitioning — to the caller that asked for a state
+// the resource no longer has, the two are the same answer.
+func (b Binding) Transition(st *store.Store, now func() time.Time, kind, id string, change func(*resource.Resource)) error {
+	unlock := b.Serialise(id)
+	defer unlock()
+
+	res, found := st.Get(b.Provider, kind, id)
+	if !found {
+		return store.ErrNotFound
+	}
+
+	// The runtime work runs outside the store lock, on the copy Get handed
+	// out. Holding the write lock across a launch would queue every other
+	// request behind one machine starting.
+	change(res)
+
+	// The result is applied conditionally. Put replaces the whole resource,
+	// so it silently discarded anything another request had written in the
+	// meantime — a delete racing a lifecycle loop used to be undone, and the
+	// VM came back, address included.
+	return st.Update(b.Provider, kind, id, func(stored *resource.Resource) error {
+		stored.State = res.State
+		stored.Runtime = res.Runtime
+		stored.Attrs = res.Attrs
+		stored.Updated = now()
+		return nil
+	})
+}

--- a/internal/core/machine/transition_test.go
+++ b/internal/core/machine/transition_test.go
@@ -1,0 +1,100 @@
+package machine
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/resource"
+	"github.com/stephrobert/feint/internal/core/store"
+)
+
+func transitionFixture() (*store.Store, Binding, *resource.Resource) {
+	st := store.New()
+	b := Binding{Provider: "example"}
+	res := &resource.Resource{
+		ID:     "srv-1",
+		Kind:   "server",
+		Tenant: resource.Tenant{Provider: "example"},
+		State:  "stopped",
+		Attrs:  map[string]any{},
+	}
+	st.Put(res)
+	return st, b, res
+}
+
+// The change of one transition runs to completion before the next one reads.
+//
+// This is the property the two pack copies existed for: the runtime call runs
+// outside the store lock, so nothing else orders two writers on one target.
+// Without the hold, two concurrent poweron each called the runtime and the
+// loser overwrote the winner's state.
+func TestTransitionExcludesASecondActionOnTheTarget(t *testing.T) {
+	st, b, _ := transitionFixture()
+
+	var inside atomic.Int32
+	var overlap atomic.Bool
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := b.Transition(st, time.Now, "server", "srv-1", func(res *resource.Resource) {
+				if inside.Add(1) > 1 {
+					overlap.Store(true)
+				}
+				// Long enough that an unserialised caller is inside at the
+				// same time rather than merely likely to be.
+				time.Sleep(2 * time.Millisecond)
+				inside.Add(-1)
+				res.State = "running"
+			})
+			if err != nil {
+				t.Errorf("transition: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if overlap.Load() {
+		t.Fatal("two changes ran on one target at the same time")
+	}
+}
+
+// A delete landing while the change runs wins: the write-back is conditional,
+// and the resource stays deleted rather than coming back with the change's
+// state. The change deleting its own target is exactly what a concurrent
+// DELETE does from the store's point of view, since the change runs outside
+// the store lock.
+func TestADeleteLandingMidTransitionWins(t *testing.T) {
+	st, b, _ := transitionFixture()
+
+	err := b.Transition(st, time.Now, "server", "srv-1", func(res *resource.Resource) {
+		st.Delete("example", "server", "srv-1")
+		res.State = "running"
+	})
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("a transition over a deleted resource reported %v, want store.ErrNotFound", err)
+	}
+	if _, back := st.Get("example", "server", "srv-1"); back {
+		t.Fatal("the deleted resource came back: the write-back is not conditional")
+	}
+}
+
+// A target that never existed is reported before the change runs: the change
+// is the runtime work, and powering on a machine for a resource nobody stores
+// would leave a container no API describes.
+func TestTransitionRefusesAMissingTargetBeforeTheChange(t *testing.T) {
+	st, b, _ := transitionFixture()
+
+	ran := false
+	err := b.Transition(st, time.Now, "server", "srv-2", func(*resource.Resource) { ran = true })
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("a transition on a missing target reported %v, want store.ErrNotFound", err)
+	}
+	if ran {
+		t.Fatal("the change ran for a resource the store does not hold")
+	}
+}

--- a/internal/core/resource/resource.go
+++ b/internal/core/resource/resource.go
@@ -37,6 +37,28 @@ type Resource struct {
 	Runtime map[string]string
 }
 
+// New returns a resource stamped at now, with Created and Updated aligned and
+// an empty attribute map ready to fill.
+//
+// It exists because every pack opened every create with the same seven-line
+// literal, and the next pack would have copied it again. Only the invariant
+// part is taken: the identifier, the kind, the tenant, the state and the two
+// clocks — set from one moment, because a resource whose Created and Updated
+// disagree at birth reads as already modified. Attrs stays the caller's to
+// fill, since its keys are the provider's wire shape and no helper may know
+// them (rule 5).
+func New(id, kind string, t Tenant, state string, now time.Time) *Resource {
+	return &Resource{
+		ID:      id,
+		Kind:    kind,
+		Tenant:  t,
+		State:   state,
+		Created: now,
+		Updated: now,
+		Attrs:   map[string]any{},
+	}
+}
+
 // Clone returns a deep-enough copy: callers mutate the result without racing
 // against the store. Nested values inside Attrs are shared, so packs must treat
 // them as immutable once stored.

--- a/internal/core/resource/resource_test.go
+++ b/internal/core/resource/resource_test.go
@@ -1,0 +1,28 @@
+package resource_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/resource"
+)
+
+// The two properties New exists for, pinned: the clocks agree at birth — a
+// resource whose Created and Updated differ reads as already modified — and
+// Attrs is ready to fill, because every pack writes into it on the next line
+// and a nil map panics there.
+func TestNewAlignsTheClocksAndReadiesAttrs(t *testing.T) {
+	now := time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC)
+	res := resource.New("id-1", "server", resource.Tenant{Provider: "example"}, "stopped", now)
+
+	if !res.Created.Equal(now) || !res.Updated.Equal(now) {
+		t.Errorf("clocks: Created=%v Updated=%v, want both %v", res.Created, res.Updated, now)
+	}
+	if res.Attrs == nil {
+		t.Fatal("Attrs is nil: the first pack write into it panics")
+	}
+	res.Attrs["key"] = "value"
+	if res.State != "stopped" || res.Kind != "server" || res.ID != "id-1" {
+		t.Errorf("fields did not carry: %+v", res)
+	}
+}

--- a/internal/core/serialise/serialise.go
+++ b/internal/core/serialise/serialise.go
@@ -1,0 +1,81 @@
+// Package serialise provides keyed mutual exclusion: one lock per named
+// domain, held for the duration of a transaction the store lock cannot cover.
+//
+// It exists because every consumer used to grow its own copy of the same
+// mechanism. The machine binding kept a per-target map for lifecycle
+// transitions, and each provider pack carried a sync.Mutex for its address
+// allocation — rebuilt from the store, an address chosen, the result
+// persisted, a read-modify-write the store's own lock is blind to because it
+// only covers each single operation. That mutex was written once per pack, and
+// the concurrency barrage measured what copies cost: the double-allocation it
+// guards against was fixed in one pack and found alive in another, and a
+// fourth pack would have had to discover the need all over again.
+//
+// The domain is opaque. Callers compose it from whatever must be exclusive —
+// a provider and a resource id, a provider and an address pool — and this
+// package never parses it, so no provider name is ever known here (rule 5).
+// Two rules for composing one:
+//
+//   - carry the provider, so two packs numbering their resources the same way
+//     never wait on each other;
+//   - name the transaction, not the world: one domain per pool or per target,
+//     never one for the whole emulator, which would queue every request behind
+//     a single slow holder.
+package serialise
+
+import "sync"
+
+// locks is the process-wide set of domains currently held or waited on.
+var locks = &keyedMutex{held: make(map[string]*heldLock)}
+
+type heldLock struct {
+	mu sync.Mutex
+	// refs counts holders and waiters, so the entry outlives the first
+	// release only while somebody still needs it.
+	refs int
+}
+
+type keyedMutex struct {
+	mu   sync.Mutex
+	held map[string]*heldLock
+}
+
+// Lock blocks until domain is free and returns the release.
+//
+// The entry is dropped once the last waiter is gone. Keeping it would grow the
+// map by one mutex for every domain a session ever named, and an emulator that
+// a client can turn into a memory sink is a defect of the same family as the
+// races this lock closes.
+func Lock(domain string) (release func()) {
+	return locks.lock(domain)
+}
+
+func (k *keyedMutex) lock(key string) func() {
+	k.mu.Lock()
+	l, ok := k.held[key]
+	if !ok {
+		l = &heldLock{}
+		k.held[key] = l
+	}
+	l.refs++
+	k.mu.Unlock()
+
+	l.mu.Lock()
+
+	// Once, because a caller that both defers the release and calls it on an
+	// early return would otherwise unlock a mutex it no longer holds, which
+	// panics and takes the server with it.
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			l.mu.Unlock()
+
+			k.mu.Lock()
+			l.refs--
+			if l.refs == 0 {
+				delete(k.held, key)
+			}
+			k.mu.Unlock()
+		})
+	}
+}

--- a/internal/core/serialise/serialise_test.go
+++ b/internal/core/serialise/serialise_test.go
@@ -1,0 +1,104 @@
+package serialise
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// The property is exclusion on one domain. Everything else this package
+// promises hangs off it, so it is measured rather than assumed.
+func TestLockExcludesTwoHoldersOfOneDomain(t *testing.T) {
+	var inside atomic.Int32
+	var overlap atomic.Bool
+	var wg sync.WaitGroup
+
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			release := Lock("pool-1")
+			defer release()
+
+			if inside.Add(1) > 1 {
+				overlap.Store(true)
+			}
+			// Long enough that an unserialised caller is inside at the same
+			// time rather than merely likely to be.
+			time.Sleep(2 * time.Millisecond)
+			inside.Add(-1)
+		}()
+	}
+	wg.Wait()
+
+	if overlap.Load() {
+		t.Fatal("two holders were inside one domain at the same time")
+	}
+}
+
+// The accepting half, and it is not decoration: a single global lock passes
+// the test above and queues every domain of the process behind one slow
+// holder. The address pools of three packs and every machine target go through
+// this map, so "keyed" is a throughput property, not a naming convenience.
+func TestLockDoesNotQueueDifferentDomains(t *testing.T) {
+	const domains = 4
+	var arrived sync.WaitGroup
+	arrived.Add(domains)
+	release := make(chan struct{})
+	done := make(chan struct{})
+
+	for i := range domains {
+		go func() {
+			free := Lock(string(rune('a' + i)))
+			defer free()
+			arrived.Done()
+			<-release
+		}()
+	}
+
+	go func() {
+		arrived.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		close(release)
+		t.Fatal("four different domains could not be held at once: the lock is global, not per domain")
+	}
+	close(release)
+}
+
+// A map that keeps one mutex per domain a session ever named is the memory
+// sink an emulator must not become. The refcount is what stops it, and it is
+// exactly the kind of bookkeeping that reads as correct and leaks.
+func TestADomainIsForgottenOnceNobodyHoldsIt(t *testing.T) {
+	for i := range 100 {
+		release := Lock(string(rune('a' + i%26)))
+		release()
+	}
+
+	locks.mu.Lock()
+	held := len(locks.held)
+	locks.mu.Unlock()
+
+	if held != 0 {
+		t.Fatalf("%d domains are still held after every caller left", held)
+	}
+}
+
+// A release called twice unlocks a mutex the caller no longer holds, which
+// panics. Ordinary Go style produces it: a defer plus an explicit call on an
+// early return.
+func TestReleaseIsIdempotent(t *testing.T) {
+	release := Lock("pool-1")
+	release()
+	release()
+
+	// And the domain is still usable afterwards: a double release must not
+	// leave the lock held by a ghost.
+	again := Lock("pool-1")
+	again()
+}

--- a/internal/core/store/storetest/sweep.go
+++ b/internal/core/store/storetest/sweep.go
@@ -29,16 +29,33 @@ import (
 	"github.com/stephrobert/feint/internal/core/resource"
 )
 
+// Gone reports a resource the pack keeps in the store although its API says it
+// no longer exists — Outscale's terminated Vm, kept readable because the
+// Terraform provider polls ReadVms until it observes "terminated".
+//
+// The vocabulary of "no longer exists" is each provider's own (`terminated`,
+// `deleted`), and this package must not learn those words: CLAUDE.md's rule 5
+// names the watcher filter that once listed three provider prefixes in the
+// core as the shape to refuse. So liveness arrives as a predicate the pack
+// supplies, and the failure direction of forgetting it is the loud one: a nil
+// or stale predicate treats every resource as alive, which makes the sweep
+// stricter, never blinder.
+type Gone func(*resource.Resource) bool
+
 // Sweep reports every invariant the store broke, one line each, sorted so two
 // runs of the same failure read the same.
 //
 // Empty means coherent. The caller decides what to do about it — this returns
 // findings rather than calling t.Error, so a barrage can sweep repeatedly and
 // report only the first breach, and so the sweep itself is testable.
-func Sweep(resources []*resource.Resource) []string {
+//
+// gone is the pack's word on which resources no longer exist; nil means all of
+// them do. Only the address invariant reads it — an identifier is issued once
+// forever, and a runtime object claimed by a dead record is still an orphan.
+func Sweep(resources []*resource.Resource, gone Gone) []string {
 	var found []string
 	found = append(found, duplicateIdentifiers(resources)...)
-	found = append(found, sharedAddresses(resources)...)
+	found = append(found, sharedAddresses(resources, gone)...)
 	found = append(found, sharedRuntimeObjects(resources)...)
 	sort.Strings(found)
 	return found
@@ -68,7 +85,7 @@ func duplicateIdentifiers(resources []*resource.Resource) []string {
 	return found
 }
 
-// sharedAddresses: one address belongs to one resource of a kind.
+// sharedAddresses: one address belongs to one living resource of a kind.
 //
 // Scoped to the kind on purpose, and that is the difference between an invariant
 // and a false alarm: an address resource and the server it is attached to both
@@ -76,18 +93,30 @@ func duplicateIdentifiers(resources []*resource.Resource) []string {
 // would fail every healthy store. Two *servers* carrying it, or two *flexible
 // IPs*, is the double allocation this is for.
 //
+// Living, because a record a pack keeps for observability holds nothing. The
+// first version compared every resource of a kind whatever its state, and that
+// blind reading produced a false verdict, measured on 2026-08-16: a terminated
+// Vm's address legitimately reused by a new Vm was reported as "held by two vm
+// resources", and a correct allocator fix was reverted on the strength of it.
+// A control that measures something other than what it announces does not fail
+// loudly, it convicts the innocent. TestAGoneResourcesAddressIsNotShared fails
+// without the predicate being read.
+//
 // Addresses are found by shape rather than by attribute name, because the names
 // are each pack's own — `address`, `PublicIp`, `ipv4_address` — and a sweep
 // keyed on them is a sweep the fourth pack escapes. Anything that parses as an
 // IP is an address; a prefix like 10.0.0.0/24 is not, and is skipped, since a
 // subnet legitimately appears on the network and on everything placed in it.
-func sharedAddresses(resources []*resource.Resource) []string {
+func sharedAddresses(resources []*resource.Resource, gone Gone) []string {
 	// kind -> address -> the first resource holding it
 	byKind := map[string]map[string]string{}
 	var found []string
 
 	for _, res := range resources {
 		if res == nil {
+			continue
+		}
+		if gone != nil && gone(res) {
 			continue
 		}
 		held := byKind[res.Kind]

--- a/internal/core/store/storetest/sweep_test.go
+++ b/internal/core/store/storetest/sweep_test.go
@@ -45,7 +45,7 @@ func TestAHealthyStoreSweepsClean(t *testing.T) {
 
 	server.Runtime = map[string]string{"machine": "feint-scw-s1"}
 
-	if found := storetest.Sweep([]*resource.Resource{server, address, network, volA, volB}); len(found) != 0 {
+	if found := storetest.Sweep([]*resource.Resource{server, address, network, volA, volB}, nil); len(found) != 0 {
 		t.Errorf("a healthy store produced findings, so the sweep would cry wolf on every run:\n%s",
 			strings.Join(found, "\n"))
 	}
@@ -55,7 +55,7 @@ func TestTheSweepSeesAnIdentifierIssuedTwice(t *testing.T) {
 	found := storetest.Sweep([]*resource.Resource{
 		res("same", "instance/server", map[string]any{"name": "a"}),
 		res("same", "instance/ip", map[string]any{"address": "203.0.113.1"}),
-	})
+	}, nil)
 	if len(found) == 0 {
 		t.Fatal("two resources sharing an identifier swept clean, and the store keys on it")
 	}
@@ -68,7 +68,7 @@ func TestTheSweepSeesOneAddressAllocatedTwice(t *testing.T) {
 	found := storetest.Sweep([]*resource.Resource{
 		res("ip1", "instance/ip", map[string]any{"address": "203.0.113.9"}),
 		res("ip2", "instance/ip", map[string]any{"address": "203.0.113.9"}),
-	})
+	}, nil)
 	if len(found) == 0 {
 		t.Fatal("one address held by two resources of one kind swept clean")
 	}
@@ -83,7 +83,7 @@ func TestTheSweepSeesOneAddressAllocatedTwice(t *testing.T) {
 			"public_ips": []any{map[string]any{"address": "198.51.100.4"}}}),
 		res("s2", "instance/server", map[string]any{
 			"public_ips": []any{map[string]any{"address": "198.51.100.4"}}}),
-	})
+	}, nil)
 	if len(nested) == 0 {
 		t.Error("a duplicated address nested inside a list swept clean")
 	}
@@ -95,7 +95,7 @@ func TestTheSweepSeesTwoResourcesClaimingOneMachine(t *testing.T) {
 	b := res("s2", "instance/server", map[string]any{"name": "b"})
 	b.Runtime = map[string]string{"machine": "feint-scw-orphan"}
 
-	found := storetest.Sweep([]*resource.Resource{a, b})
+	found := storetest.Sweep([]*resource.Resource{a, b}, nil)
 	if len(found) == 0 {
 		t.Fatal("two resources naming one runtime machine swept clean: deleting either destroys the other's")
 	}
@@ -110,8 +110,39 @@ func TestTheSweepSurvivesANilResource(t *testing.T) {
 	found := storetest.Sweep([]*resource.Resource{
 		nil,
 		res("s1", "instance/server", map[string]any{"name": "a"}),
-	})
+	}, nil)
 	if len(found) != 0 {
 		t.Errorf("a nil element produced findings: %v", found)
+	}
+}
+
+// One address on two resources of one kind, one of them gone: not a breach.
+//
+// The blind reading of this exact store is the false verdict of 2026-08-16 — a
+// terminated Vm's address, legitimately reused, reported as a double
+// allocation, and a correct allocator fix reverted on the strength of it. The
+// liveness vocabulary stays the pack's: it arrives as the predicate, and nil
+// keeps the strict reading, which is the loud failure direction for a pack
+// that forgets to pass one.
+func TestAGoneResourcesAddressIsNotShared(t *testing.T) {
+	dead := res("vm-dead", "vm", map[string]any{"PrivateIp": "10.100.1.4"})
+	dead.State = "terminated"
+	live := res("vm-live", "vm", map[string]any{"PrivateIp": "10.100.1.4"})
+	both := []*resource.Resource{dead, live}
+	gone := func(r *resource.Resource) bool { return r.State == "terminated" }
+
+	if found := storetest.Sweep(both, gone); len(found) != 0 {
+		t.Errorf("an address inherited from a gone resource was reported shared:\n%s",
+			strings.Join(found, "\n"))
+	}
+
+	// Both halves: without the pack's word, the strict reading still bites —
+	// and two living holders stay a breach whatever predicate is passed.
+	if found := storetest.Sweep(both, nil); len(found) == 0 {
+		t.Error("with no liveness predicate the sweep stopped seeing the shared address at all")
+	}
+	dead.State = "running"
+	if found := storetest.Sweep(both, gone); len(found) == 0 {
+		t.Error("two living resources share an address and the predicate excused one of them")
 	}
 }

--- a/internal/providers/exoscale/antiaffinity.go
+++ b/internal/providers/exoscale/antiaffinity.go
@@ -42,17 +42,10 @@ func (p *Pack) createAntiAffinityGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	now := p.env.Now()
-	res := &resource.Resource{
-		ID:      p.env.NewID(),
-		Kind:    kindAntiAffinityGroup,
-		Tenant:  resource.Tenant{Provider: Name},
-		State:   "present",
-		Created: now,
-		Updated: now,
-		Attrs: map[string]any{
-			"name":        req.Name,
-			"description": req.Description,
-		},
+	res := resource.New(p.env.NewID(), kindAntiAffinityGroup, resource.Tenant{Provider: Name}, "present", now)
+	res.Attrs = map[string]any{
+		"name":        req.Name,
+		"description": req.Description,
 	}
 	p.env.Store.Put(res)
 	p.writeOperation(w, p.operationReferring(nounAntiAffinityGroup, res.ID))

--- a/internal/providers/exoscale/barrage_test.go
+++ b/internal/providers/exoscale/barrage_test.go
@@ -110,7 +110,7 @@ func TestAnExoscaleBarrageLeavesTheStoreCoherent(t *testing.T) {
 			len(refused), strings.Join(refused, "\n"))
 	}
 
-	if found := storetest.Sweep(st.All()); len(found) != 0 {
+	if found := storetest.Sweep(st.All(), nil); len(found) != 0 {
 		t.Errorf("the store is incoherent after the barrage:\n%s", strings.Join(found, "\n"))
 	}
 }

--- a/internal/providers/exoscale/elasticips.go
+++ b/internal/providers/exoscale/elasticips.go
@@ -151,18 +151,11 @@ func (p *Pack) createElasticIP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	now := p.env.Now()
-	res := &resource.Resource{
-		ID:      p.env.NewID(),
-		Kind:    kindElasticIP,
-		Tenant:  resource.Tenant{Provider: Name},
-		State:   "present",
-		Created: now,
-		Updated: now,
-		Attrs: map[string]any{
-			"ip":            ip,
-			"addressfamily": "inet4",
-			"description":   req.Description,
-		},
+	res := resource.New(p.env.NewID(), kindElasticIP, resource.Tenant{Provider: Name}, "present", now)
+	res.Attrs = map[string]any{
+		"ip":            ip,
+		"addressfamily": "inet4",
+		"description":   req.Description,
 	}
 	if req.Healthcheck != nil {
 		res.Attrs["healthcheck"] = req.Healthcheck

--- a/internal/providers/exoscale/elasticips.go
+++ b/internal/providers/exoscale/elasticips.go
@@ -142,8 +142,8 @@ func (p *Pack) createElasticIP(w http.ResponseWriter, r *http.Request) {
 	// Held across the read and the write, which is the whole point: the address
 	// is chosen from what the store holds and only becomes taken when the
 	// resource lands in it.
-	p.addresses.Lock()
-	defer p.addresses.Unlock()
+	unlock := p.lockAddresses()
+	defer unlock()
 
 	ip, ok := p.freeElasticAddress()
 	if !ok {

--- a/internal/providers/exoscale/lifecycle.go
+++ b/internal/providers/exoscale/lifecycle.go
@@ -29,34 +29,17 @@ import (
 // transitionInstance applies one change to one instance, holding that target
 // for the read, the runtime work and the write.
 //
-// Same discipline as the Outscale pack's transitionOne, through the shared
-// binding's per-target lock: the runtime call runs outside the store lock, and
-// the write-back is conditional so a delete landing mid-transition wins.
+// The mechanics — target serialised, existence before, runtime work outside
+// the store lock, conditional write-back so a delete landing mid-transition
+// wins — are machine.Binding.Transition, shared with the Outscale pack's
+// transitionOne rather than written a second time. What stays here is this
+// pack's dialect: a missing instance and one deleted mid-transition are the
+// same bare-message 404.
 // TestTwoLifecycleActionsOnOneInstanceDoNotRace fails without the lock.
 func (p *Pack) transitionInstance(w http.ResponseWriter, r *http.Request, change func(*resource.Resource)) (id string, ok bool) {
 	id = r.PathValue("id")
 
-	unlock := p.binding().Serialise(id)
-	defer unlock()
-
-	res, found := p.env.Store.Get(Name, kindInstance, id)
-	if !found {
-		writeError(w, http.StatusNotFound, "resource not found")
-		return id, false
-	}
-
-	change(res)
-
-	err := p.env.Store.Update(Name, kindInstance, id, func(stored *resource.Resource) error {
-		stored.State = res.State
-		stored.Runtime = res.Runtime
-		stored.Attrs = res.Attrs
-		stored.Updated = p.env.Now()
-		return nil
-	})
-	if err != nil {
-		// Deleted while its machine was transitioning: the caller asked for a
-		// state this resource no longer has.
+	if err := p.binding().Transition(p.env.Store, p.env.Now, kindInstance, id, change); err != nil {
 		writeError(w, http.StatusNotFound, "resource not found")
 		return id, false
 	}

--- a/internal/providers/exoscale/pack.go
+++ b/internal/providers/exoscale/pack.go
@@ -18,12 +18,12 @@ import (
 	"slices"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/stephrobert/feint/internal/core/cloudinit"
 	"github.com/stephrobert/feint/internal/core/emulator"
 	"github.com/stephrobert/feint/internal/core/resource"
+	"github.com/stephrobert/feint/internal/core/serialise"
 )
 
 // Name is the provider key.
@@ -51,20 +51,23 @@ const (
 // Pack implements emulator.Pack for Exoscale.
 type Pack struct {
 	env *emulator.Env
-	// addresses serializes elastic IP allocation, which is read-modify-write
-	// over the store: freeElasticAddress rebuilds the used set from what exists,
-	// answers the lowest free address, and the caller then stores it. Two
-	// requests interleaving there receive the same address.
-	//
-	// Not a precaution. The barrage of #134 found it on its first run — three
-	// addresses handed to two elastic IPs each, out of sixteen creates — and it
-	// is the same defect the Scaleway pack fixed for its own pools long ago and
-	// this one never received. CLAUDE.md names that shape: written twice, fixed
-	// once, alive in the other copy.
-	//
-	// TestAnExoscaleBarrageLeavesTheStoreCoherent fails without this.
-	addresses sync.Mutex
 }
+
+// lockAddresses serializes elastic IP and lease allocation, which is
+// read-modify-write over the store: freeElasticAddress rebuilds the used set
+// from what exists, answers the lowest free address, and the caller then
+// stores it. Two requests interleaving there receive the same address.
+//
+// Not a precaution. The barrage of #134 found it on its first run — three
+// addresses handed to two elastic IPs each, out of sixteen creates — and it
+// was the same defect the Scaleway pack fixed for its own pools long ago and
+// this one never received. CLAUDE.md names that shape: written twice, fixed
+// once, alive in the other copy — which is why the lock now lives in
+// core/serialise, shared with every pack, instead of being a mutex each one
+// remembers to grow.
+//
+// TestAnExoscaleBarrageLeavesTheStoreCoherent fails without this.
+func (p *Pack) lockAddresses() func() { return serialise.Lock(Name + "/addresses") }
 
 // New returns an Exoscale pack backed by env.
 func New(env *emulator.Env) *Pack { return &Pack{env: env} }
@@ -742,11 +745,11 @@ func (p *Pack) createInstance(w http.ResponseWriter, r *http.Request) {
 	//
 	// TestAnInstanceIsGivenAPublicAddressAtCreation fails without this.
 	if assignment, _ := res.Attrs["public-ip-assignment"].(string); assignment != "none" {
-		p.addresses.Lock()
+		unlock := p.lockAddresses()
 		if ip, ok := p.freeElasticAddress(); ok {
 			res.Attrs["public-ip"] = ip
 		}
-		p.addresses.Unlock()
+		unlock()
 	}
 	if ids := refIDs(req.AntiAffinityGroups); len(ids) > 0 {
 		res.Attrs[attrAntiAffinityGroupIDs] = ids

--- a/internal/providers/exoscale/pack.go
+++ b/internal/providers/exoscale/pack.go
@@ -701,32 +701,25 @@ func (p *Pack) createInstance(w http.ResponseWriter, r *http.Request) {
 
 	now := p.env.Now()
 	id := p.env.NewID()
-	res := &resource.Resource{
-		ID:      id,
-		Kind:    kindInstance,
-		Tenant:  resource.Tenant{Provider: Name},
-		State:   stoppedState,
-		Created: now,
-		Updated: now,
-		Attrs: map[string]any{
-			"name":          req.Name,
-			"instance-type": map[string]any{"id": req.InstanceType.ID},
-			"template":      map[string]any{"id": req.Template.ID},
-			"disk-size":     req.DiskSize,
-			// Echoed back because a client that attached them expects to read
-			// them, and because their absence is not "no keys" to a client, it
-			// is a missing field.
-			"ssh-keys":             p.sshKeyRefs(req.keyNames()),
-			"public-ip-assignment": orDefault(req.PublicIPAssignment, "inet4"),
-			"secureboot-enabled":   boolOr(req.SecurebootEnabled, false),
-			"tpm-enabled":          boolOr(req.TPMEnabled, false),
-			// Present even when empty — {} was measured on an instance created
-			// with no label, and an absent key is a different claim.
-			"labels": labelsToAttr(req.Labels),
-			// A stable address derived from the identifier: the real API
-			// publishes one per instance, and two runs must answer the same.
-			"mac-address": macAddressOf(id),
-		},
+	res := resource.New(id, kindInstance, resource.Tenant{Provider: Name}, stoppedState, now)
+	res.Attrs = map[string]any{
+		"name":          req.Name,
+		"instance-type": map[string]any{"id": req.InstanceType.ID},
+		"template":      map[string]any{"id": req.Template.ID},
+		"disk-size":     req.DiskSize,
+		// Echoed back because a client that attached them expects to read
+		// them, and because their absence is not "no keys" to a client, it
+		// is a missing field.
+		"ssh-keys":             p.sshKeyRefs(req.keyNames()),
+		"public-ip-assignment": orDefault(req.PublicIPAssignment, "inet4"),
+		"secureboot-enabled":   boolOr(req.SecurebootEnabled, false),
+		"tpm-enabled":          boolOr(req.TPMEnabled, false),
+		// Present even when empty — {} was measured on an instance created
+		// with no label, and an absent key is a different claim.
+		"labels": labelsToAttr(req.Labels),
+		// A stable address derived from the identifier: the real API
+		// publishes one per instance, and two runs must answer the same.
+		"mac-address": macAddressOf(id),
 	}
 	if req.UserData != "" {
 		res.Attrs["user-data"] = req.UserData

--- a/internal/providers/exoscale/privatenetworks.go
+++ b/internal/providers/exoscale/privatenetworks.go
@@ -203,8 +203,8 @@ func (p *Pack) createPrivateNetwork(w http.ResponseWriter, r *http.Request) {
 	// stored: the VNI is read-modify-write over the store, the exact shape the
 	// barrage of #134 caught on this pack's elastic addresses.
 	// TestConcurrentAllocationsShareNothing fails without it.
-	p.addresses.Lock()
-	defer p.addresses.Unlock()
+	unlock := p.lockAddresses()
+	defer unlock()
 
 	now := p.env.Now()
 	res := &resource.Resource{
@@ -262,7 +262,7 @@ func (p *Pack) createPrivateNetwork(w http.ResponseWriter, r *http.Request) {
 // freeVNI hands out the lowest unused VXLAN id, starting at 1 as their schema's
 // exclusive minimum of 0 demands. Computed from what exists rather than
 // counted, so a deleted network's id returns to the pool. Callers hold
-// p.addresses across the read and the write.
+// p.lockAddresses() across the read and the write.
 func (p *Pack) freeVNI() int {
 	used := map[int]bool{}
 	for _, res := range p.env.Store.List(kindPrivateNetwork, resource.Tenant{Provider: Name}) {
@@ -664,7 +664,7 @@ func (p *Pack) attachInstanceToPrivateNetwork(w http.ResponseWriter, r *http.Req
 
 	// The instance is held for the read, the lease, and the runtime attach,
 	// like every lifecycle path of this pack; the address allocation is its own
-	// read-modify-write over every instance's leases and holds p.addresses
+	// read-modify-write over every instance's leases and holds p.lockAddresses()
 	// across the read and the write, which is what the barrage checks.
 	unlock := p.binding().Serialise(req.Instance.ID)
 	defer unlock()
@@ -684,14 +684,14 @@ func (p *Pack) attachInstanceToPrivateNetwork(w http.ResponseWriter, r *http.Req
 }
 
 // takeLease reserves an address of the network's range for the instance and
-// records the membership, under one hold of p.addresses: choosing from what
+// records the membership, under one hold of p.lockAddresses(): choosing from what
 // exists and storing the choice must be one critical section, or two attaches
 // interleaving there receive the same address — the defect the barrage of #134
 // found on this pack's elastic pool. TestConcurrentAllocationsShareNothing
 // fails without it.
 func (p *Pack) takeLease(w http.ResponseWriter, pn *resource.Resource, instanceID, requested string) (string, bool) {
-	p.addresses.Lock()
-	defer p.addresses.Unlock()
+	unlock := p.lockAddresses()
+	defer unlock()
 
 	dhcp, managed := rangeOf(pn)
 	leaseIP := ""
@@ -856,10 +856,10 @@ func (p *Pack) updatePrivateNetworkInstanceIP(w http.ResponseWriter, r *http.Req
 }
 
 // moveLease points an existing membership at a new address, under the same
-// hold of p.addresses as takeLease and for the same reason.
+// hold of p.lockAddresses() as takeLease and for the same reason.
 func (p *Pack) moveLease(w http.ResponseWriter, pn *resource.Resource, dhcp managedRange, instanceID, requested string) bool {
-	p.addresses.Lock()
-	defer p.addresses.Unlock()
+	unlock := p.lockAddresses()
+	defer unlock()
 
 	addr, err := netip.ParseAddr(requested)
 	if err != nil || !addr.Is4() {

--- a/internal/providers/exoscale/privatenetworks.go
+++ b/internal/providers/exoscale/privatenetworks.go
@@ -207,20 +207,13 @@ func (p *Pack) createPrivateNetwork(w http.ResponseWriter, r *http.Request) {
 	defer unlock()
 
 	now := p.env.Now()
-	res := &resource.Resource{
-		ID:      p.env.NewID(),
-		Kind:    kindPrivateNetwork,
-		Tenant:  resource.Tenant{Provider: Name},
-		State:   "present",
-		Created: now,
-		Updated: now,
-		Attrs: map[string]any{
-			"name": name,
-			// The VXLAN id their schema declares on every network. Lowest free,
-			// so it is stable for a client that stored it and returns to the
-			// pool when the network goes.
-			"vni": p.freeVNI(),
-		},
+	res := resource.New(p.env.NewID(), kindPrivateNetwork, resource.Tenant{Provider: Name}, "present", now)
+	res.Attrs = map[string]any{
+		"name": name,
+		// The VXLAN id their schema declares on every network. Lowest free,
+		// so it is stable for a client that stored it and returns to the
+		// pool when the network goes.
+		"vni": p.freeVNI(),
 	}
 	if d := stringOf(req.Description); d != "" {
 		res.Attrs["description"] = d

--- a/internal/providers/exoscale/privatenetworks.go
+++ b/internal/providers/exoscale/privatenetworks.go
@@ -326,48 +326,25 @@ func (p *Pack) ensureBackingNetwork(ctx context.Context, res *resource.Resource,
 // What counts as foreign is an Exoscale question, and the answer is simpler
 // than Scaleway's: every private network is its own VXLAN segment upstream, so
 // every other network is foreign — there is no VPC routing to let through in
-// this batch. A runtime with native isolation gets an empty peer list; one
-// whose networks are born joined gets every other block to keep out.
+// this batch, and the predicate below says exactly that. The reconciliation —
+// empty peer lists under native isolation, every managed block to keep out
+// otherwise — is machine.ReconcileIsolation, shared with the two other packs.
 func (p *Pack) isolatePrivateNetworks(ctx context.Context) {
 	all := p.env.Store.List(kindPrivateNetwork, resource.Tenant{Provider: Name})
-
-	if peerer, ok := p.env.Machines.(machine.Peerer); ok && peerer.NativeIsolation() {
-		for _, pn := range all {
-			name := pn.Runtime[runtimeNetworkKey]
-			if name == "" {
-				continue
-			}
-			if err := peerer.PeerNetworks(ctx, name, nil); err != nil {
-				p.logger().Error("could not isolate the private network",
-					"private-network", pn.ID, "network", name, "error", err)
-			}
+	members := make([]machine.IsolationMember, len(all))
+	for i, pn := range all {
+		block := ""
+		if dhcp, managed := rangeOf(pn); managed {
+			block = dhcp.prefix.Masked().String()
 		}
-		return
-	}
-
-	isolator, ok := p.env.Machines.(machine.Isolator)
-	if !ok {
-		return
-	}
-	for _, pn := range all {
-		name := pn.Runtime[runtimeNetworkKey]
-		if name == "" {
-			continue
-		}
-		foreign := make([]string, 0, len(all))
-		for _, other := range all {
-			if other.ID == pn.ID {
-				continue
-			}
-			if dhcp, managed := rangeOf(other); managed {
-				foreign = append(foreign, dhcp.prefix.Masked().String())
-			}
-		}
-		if err := isolator.IsolateNetwork(ctx, name, foreign); err != nil {
-			p.logger().Error("could not isolate the private network",
-				"private-network", pn.ID, "network", name, "error", err)
+		members[i] = machine.IsolationMember{
+			ID:      pn.ID,
+			Network: pn.Runtime[runtimeNetworkKey],
+			Block:   block,
 		}
 	}
+	machine.ReconcileIsolation(ctx, p.env.Machines, p.logger(), "private-network",
+		members, func(int, int) bool { return false })
 }
 
 // ---- Reads ------------------------------------------------------------------

--- a/internal/providers/exoscale/privatenetworks_test.go
+++ b/internal/providers/exoscale/privatenetworks_test.go
@@ -341,7 +341,7 @@ func TestAnExternalSourceMustBeACIDR(t *testing.T) {
 // Two concurrent creates must not share a VXLAN id, and two concurrent
 // attaches must not share a lease: both allocations are read-modify-write over
 // the store, the exact shape the barrage of #134 caught on this pack's elastic
-// pool. Both halves fail without p.addresses held across the read and the
+// pool. Both halves fail without p.lockAddresses() held across the read and the
 // write.
 func TestConcurrentAllocationsShareNothing(t *testing.T) {
 	h := serve(t)

--- a/internal/providers/exoscale/securitygroups.go
+++ b/internal/providers/exoscale/securitygroups.go
@@ -73,17 +73,10 @@ func (p *Pack) createSecurityGroup(w http.ResponseWriter, r *http.Request) {
 	p.ensureDefaultSecurityGroup()
 
 	now := p.env.Now()
-	res := &resource.Resource{
-		ID:      p.env.NewID(),
-		Kind:    kindSecurityGroup,
-		Tenant:  resource.Tenant{Provider: Name},
-		State:   "present",
-		Created: now,
-		Updated: now,
-		Attrs: map[string]any{
-			"name":        req.Name,
-			"description": req.Description,
-		},
+	res := resource.New(p.env.NewID(), kindSecurityGroup, resource.Tenant{Provider: Name}, "present", now)
+	res.Attrs = map[string]any{
+		"name":        req.Name,
+		"description": req.Description,
 	}
 	p.env.Store.Put(res)
 	p.writeOperation(w, p.operationReferring(nounSecurityGroup, res.ID))

--- a/internal/providers/outscale/barrage_test.go
+++ b/internal/providers/outscale/barrage_test.go
@@ -119,7 +119,9 @@ func TestAnOutscaleBarrageLeavesTheStoreCoherent(t *testing.T) {
 			len(refused), strings.Join(refused, "\n"))
 	}
 
-	if found := storetest.Sweep(st.All()); len(found) != 0 {
+	// The pack's own word on liveness: a terminated Vm keeps its record for
+	// ReadVms polling and holds nothing, so the sweep must not count it.
+	if found := storetest.Sweep(st.All(), outscale.Gone); len(found) != 0 {
 		t.Errorf("the store is incoherent after the barrage:\n%s", strings.Join(found, "\n"))
 	}
 }

--- a/internal/providers/outscale/dhcpoptions.go
+++ b/internal/providers/outscale/dhcpoptions.go
@@ -38,19 +38,12 @@ func (p *Pack) defaultDhcpOptions() *resource.Resource {
 		}
 	}
 	now := p.env.Now()
-	res := &resource.Resource{
-		ID:      newID("dopt", p.env.NewID()),
-		Kind:    kindDhcpOptions,
-		Tenant:  resource.Tenant{Provider: Name},
-		State:   "available",
-		Created: now,
-		Updated: now,
-		Attrs: map[string]any{
-			"Default":           true,
-			"DomainName":        regionName + ".compute.internal",
-			"DomainNameServers": []any{"OutscaleProvidedDNS"},
-			"Tags":              []any{},
-		},
+	res := resource.New(newID("dopt", p.env.NewID()), kindDhcpOptions, resource.Tenant{Provider: Name}, "available", now)
+	res.Attrs = map[string]any{
+		"Default":           true,
+		"DomainName":        regionName + ".compute.internal",
+		"DomainNameServers": []any{"OutscaleProvidedDNS"},
+		"Tags":              []any{},
 	}
 	p.env.Store.Put(res)
 	return res
@@ -156,15 +149,8 @@ func (p *Pack) createDhcpOptions(w http.ResponseWriter, r *http.Request) {
 		attrs["NtpServers"] = req.NtpServers
 	}
 
-	res := &resource.Resource{
-		ID:      newID("dopt", p.env.NewID()),
-		Kind:    kindDhcpOptions,
-		Tenant:  resource.Tenant{Provider: Name},
-		State:   "available",
-		Created: now,
-		Updated: now,
-		Attrs:   attrs,
-	}
+	res := resource.New(newID("dopt", p.env.NewID()), kindDhcpOptions, resource.Tenant{Provider: Name}, "available", now)
+	res.Attrs = attrs
 	p.env.Store.Put(res)
 
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{

--- a/internal/providers/outscale/dhcpoptions.go
+++ b/internal/providers/outscale/dhcpoptions.go
@@ -216,8 +216,8 @@ func (p *Pack) deleteDhcpOptions(w http.ResponseWriter, r *http.Request) {
 	// Under the addressing lock, which is what serialises this scan against
 	// updateNet re-pointing a Net between the check and the delete.
 	// TestADhcpOptionsSetDoesNotDeleteUnderANet fails without the guard.
-	p.addresses.Lock()
-	defer p.addresses.Unlock()
+	unlock := p.lockAddresses()
+	defer unlock()
 	for _, net := range p.env.Store.List(kindNet, resource.Tenant{Provider: Name}) {
 		if stringOf(net.Attrs["DhcpOptionsSetId"]) == req.DhcpOptionsSetID {
 			p.conflict(w, "the DHCP options set "+req.DhcpOptionsSetID+

--- a/internal/providers/outscale/images.go
+++ b/internal/providers/outscale/images.go
@@ -130,32 +130,25 @@ func (p *Pack) createImage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	now := p.env.Now()
-	res := &resource.Resource{
-		ID:      newID("ami", p.env.NewID()),
-		Kind:    kindImage,
-		Tenant:  resource.Tenant{Provider: Name},
-		State:   "available",
-		Created: now,
-		Updated: now,
-		Attrs: map[string]any{
-			"ImageName":           req.ImageName,
-			"Description":         req.Description,
-			"Architecture":        orDefault(req.Architecture, "x86_64"),
-			"RootDeviceName":      orDefault(req.RootDeviceName, defaultRootDevice),
-			"RootDeviceType":      "bsu",
-			"ImageType":           "machine",
-			"BootModes":           bootModesOr(req.BootModes),
-			"ProductCodes":        productCodesOr(req.ProductCodes),
-			"SecureBoot":          false,
-			"TpmMandatory":        boolOr(req.TpmMandatory, false),
-			"StateComment":        map[string]any{},
-			"BlockDeviceMappings": mappings,
-			"PermissionsToLaunch": map[string]any{
-				"AccountIds":       []any{},
-				"GlobalPermission": false,
-			},
-			"Tags": []any{},
+	res := resource.New(newID("ami", p.env.NewID()), kindImage, resource.Tenant{Provider: Name}, "available", now)
+	res.Attrs = map[string]any{
+		"ImageName":           req.ImageName,
+		"Description":         req.Description,
+		"Architecture":        orDefault(req.Architecture, "x86_64"),
+		"RootDeviceName":      orDefault(req.RootDeviceName, defaultRootDevice),
+		"RootDeviceType":      "bsu",
+		"ImageType":           "machine",
+		"BootModes":           bootModesOr(req.BootModes),
+		"ProductCodes":        productCodesOr(req.ProductCodes),
+		"SecureBoot":          false,
+		"TpmMandatory":        boolOr(req.TpmMandatory, false),
+		"StateComment":        map[string]any{},
+		"BlockDeviceMappings": mappings,
+		"PermissionsToLaunch": map[string]any{
+			"AccountIds":       []any{},
+			"GlobalPermission": false,
 		},
+		"Tags": []any{},
 	}
 	p.env.Store.Put(res)
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{

--- a/internal/providers/outscale/internetservices.go
+++ b/internal/providers/outscale/internetservices.go
@@ -34,16 +34,9 @@ func (p *Pack) createInternetService(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	now := p.env.Now()
-	res := &resource.Resource{
-		ID:      newID("igw", p.env.NewID()),
-		Kind:    kindInternetService,
-		Tenant:  resource.Tenant{Provider: Name},
-		State:   "available",
-		Created: now,
-		Updated: now,
-		Attrs: map[string]any{
-			"Tags": []any{},
-		},
+	res := resource.New(newID("igw", p.env.NewID()), kindInternetService, resource.Tenant{Provider: Name}, "available", now)
+	res.Attrs = map[string]any{
+		"Tags": []any{},
 	}
 	p.env.Store.Put(res)
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{

--- a/internal/providers/outscale/isolate.go
+++ b/internal/providers/outscale/isolate.go
@@ -37,61 +37,21 @@ func (p *Pack) reachableFrom(subnet, other *resource.Resource) bool {
 
 // isolateNetworks reconciles what every subnet's backing network may reach.
 //
-// Called after any change to the set of subnets, because a new one changes what
-// its neighbours must keep out. Reconciled over all of them rather than patched
-// for the one that moved: a patch has to be right about what changed, and this
-// only has to be right about what is.
-//
-// Failure is logged, never fatal. The control plane must keep answering when no
-// runtime is configured, which is the default and what CI uses.
+// Called after any change to the set of subnets, because a new one changes
+// what its neighbours must keep out. The reconciliation is
+// machine.ReconcileIsolation, shared with the two other packs — this pack is
+// the one that had no isolation wiring at all until #201 — and only the
+// Outscale question above stays here, as the predicate.
 func (p *Pack) isolateNetworks(ctx context.Context) {
 	all := p.env.Store.List(kindSubnet, resource.Tenant{Provider: Name})
-
-	peerer, native := p.env.Machines.(machine.Peerer)
-	if native && peerer.NativeIsolation() {
-		for _, subnet := range all {
-			name := subnet.Runtime[runtimeNetworkKey]
-			if name == "" {
-				continue
-			}
-			peers := make([]string, 0, len(all))
-			for _, other := range all {
-				if other.ID == subnet.ID || other.Runtime[runtimeNetworkKey] == "" {
-					continue
-				}
-				if p.reachableFrom(subnet, other) {
-					peers = append(peers, other.Runtime[runtimeNetworkKey])
-				}
-			}
-			if err := peerer.PeerNetworks(ctx, name, peers); err != nil {
-				p.logger().Error("could not peer the subnet's network",
-					"subnet", subnet.ID, "network", name, "error", err)
-			}
-		}
-		return
-	}
-
-	isolator, ok := p.env.Machines.(machine.Isolator)
-	if !ok {
-		return
-	}
-	for _, subnet := range all {
-		name := subnet.Runtime[runtimeNetworkKey]
-		if name == "" {
-			continue
-		}
-		foreign := make([]string, 0, len(all))
-		for _, other := range all {
-			if other.ID == subnet.ID || p.reachableFrom(subnet, other) {
-				continue
-			}
-			if block := stringOf(other.Attrs["IpRange"]); block != "" {
-				foreign = append(foreign, block)
-			}
-		}
-		if err := isolator.IsolateNetwork(ctx, name, foreign); err != nil {
-			p.logger().Error("could not isolate the subnet's network",
-				"subnet", subnet.ID, "network", name, "error", err)
+	members := make([]machine.IsolationMember, len(all))
+	for i, subnet := range all {
+		members[i] = machine.IsolationMember{
+			ID:      subnet.ID,
+			Network: subnet.Runtime[runtimeNetworkKey],
+			Block:   stringOf(subnet.Attrs["IpRange"]),
 		}
 	}
+	machine.ReconcileIsolation(ctx, p.env.Machines, p.logger(), "subnet",
+		members, func(from, to int) bool { return p.reachableFrom(all[from], all[to]) })
 }

--- a/internal/providers/outscale/keypairs.go
+++ b/internal/providers/outscale/keypairs.go
@@ -77,26 +77,19 @@ func (p *Pack) createKeypair(w http.ResponseWriter, r *http.Request) {
 	}
 
 	now := p.env.Now()
-	res := &resource.Resource{
-		ID:      newKeypairID(p.env.NewID()),
-		Kind:    kindKeypair,
-		Tenant:  resource.Tenant{Provider: Name},
-		State:   "available",
-		Created: now,
-		Updated: now,
-		Attrs: map[string]any{
-			"KeypairName": req.KeypairName,
-			// The algorithm the client sent, not a constant. Hardcoding
-			// "ssh-rsa" made every key answer that, ed25519 ones included, and
-			// KeypairType is a declared schema field a client can filter on.
-			"KeypairType":        parsed.Algorithm,
-			"KeypairFingerprint": parsed.FingerprintMD5(),
-			// The material itself never leaves through the API: no Outscale
-			// response carries a PublicKey field, so it lives out of Attrs, in
-			// Runtime, where a view cannot pick it up by accident.
-		},
-		Runtime: map[string]string{runtimePublicKey: strings.TrimSpace(req.PublicKey)},
+	res := resource.New(newKeypairID(p.env.NewID()), kindKeypair, resource.Tenant{Provider: Name}, "available", now)
+	res.Attrs = map[string]any{
+		"KeypairName": req.KeypairName,
+		// The algorithm the client sent, not a constant. Hardcoding
+		// "ssh-rsa" made every key answer that, ed25519 ones included, and
+		// KeypairType is a declared schema field a client can filter on.
+		"KeypairType":        parsed.Algorithm,
+		"KeypairFingerprint": parsed.FingerprintMD5(),
+		// The material itself never leaves through the API: no Outscale
+		// response carries a PublicKey field, so it lives out of Attrs, in
+		// Runtime, where a view cannot pick it up by accident.
 	}
+	res.Runtime = map[string]string{runtimePublicKey: strings.TrimSpace(req.PublicKey)}
 	p.env.Store.Put(res)
 
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{

--- a/internal/providers/outscale/natservices.go
+++ b/internal/providers/outscale/natservices.go
@@ -54,22 +54,15 @@ func (p *Pack) createNatService(w http.ResponseWriter, r *http.Request) {
 	}
 
 	now := p.env.Now()
-	res := &resource.Resource{
-		ID:      newID("nat", p.env.NewID()),
-		Kind:    kindNatService,
-		Tenant:  resource.Tenant{Provider: Name},
-		State:   "available",
-		Created: now,
-		Updated: now,
-		Attrs: map[string]any{
-			"NetId":    stringOf(subnet.Attrs["NetId"]),
-			"SubnetId": req.SubnetID,
-			"PublicIps": []any{map[string]any{
-				"PublicIp":   stringOf(address.Attrs["PublicIp"]),
-				"PublicIpId": address.ID,
-			}},
-			"Tags": []any{},
-		},
+	res := resource.New(newID("nat", p.env.NewID()), kindNatService, resource.Tenant{Provider: Name}, "available", now)
+	res.Attrs = map[string]any{
+		"NetId":    stringOf(subnet.Attrs["NetId"]),
+		"SubnetId": req.SubnetID,
+		"PublicIps": []any{map[string]any{
+			"PublicIp":   stringOf(address.Attrs["PublicIp"]),
+			"PublicIpId": address.ID,
+		}},
+		"Tags": []any{},
 	}
 	p.env.Store.Put(res)
 

--- a/internal/providers/outscale/netpeerings.go
+++ b/internal/providers/outscale/netpeerings.go
@@ -160,23 +160,16 @@ func (p *Pack) createNetPeering(w http.ResponseWriter, r *http.Request) {
 	}
 
 	now := p.env.Now()
-	res := &resource.Resource{
-		ID:      newID("pcx", p.env.NewID()),
-		Kind:    kindNetPeering,
-		Tenant:  resource.Tenant{Provider: Name},
-		State:   state,
-		Created: now,
-		Updated: now,
-		Attrs: map[string]any{
-			"SourceNetId":     req.SourceNetID,
-			"SourceIpRange":   stringOf(source.Attrs["IpRange"]),
-			"AccepterNetId":   req.AccepterNetID,
-			"AccepterIpRange": stringOf(accepter.Attrs["IpRange"]),
-			// Stored once at create, so every read answers the same date:
-			// a timestamp recomputed per read is a permanent Terraform diff.
-			"ExpirationDate": now.UTC().Add(peeringExpiry).Format(expirationFormat),
-			"Tags":           []any{},
-		},
+	res := resource.New(newID("pcx", p.env.NewID()), kindNetPeering, resource.Tenant{Provider: Name}, state, now)
+	res.Attrs = map[string]any{
+		"SourceNetId":     req.SourceNetID,
+		"SourceIpRange":   stringOf(source.Attrs["IpRange"]),
+		"AccepterNetId":   req.AccepterNetID,
+		"AccepterIpRange": stringOf(accepter.Attrs["IpRange"]),
+		// Stored once at create, so every read answers the same date:
+		// a timestamp recomputed per read is a permanent Terraform diff.
+		"ExpirationDate": now.UTC().Add(peeringExpiry).Format(expirationFormat),
+		"Tags":           []any{},
 	}
 	p.env.Store.Put(res)
 

--- a/internal/providers/outscale/nets.go
+++ b/internal/providers/outscale/nets.go
@@ -123,8 +123,8 @@ func (p *Pack) createNet(w http.ResponseWriter, r *http.Request) {
 
 	// Held from the check to the store, or two concurrent creates both find the
 	// block free and both take it.
-	p.addresses.Lock()
-	defer p.addresses.Unlock()
+	unlock := p.lockAddresses()
+	defer unlock()
 
 	if other, clash := network.FirstOverlap(prefix, p.netPrefixes()); clash {
 		p.conflict(w, "IpRange "+prefix.String()+" overlaps the Net on "+other.String())
@@ -215,9 +215,9 @@ func (p *Pack) deleteNet(w http.ResponseWriter, r *http.Request) {
 	// this lock applies here, and it was applied to only one of the two.
 	//
 	// TestANetDoesNotDeleteUnderASubnetBeingCreated fails without this.
-	p.addresses.Lock()
+	unlock := p.lockAddresses()
 	if subnets := p.subnetsOf(req.NetID); len(subnets) > 0 {
-		p.addresses.Unlock()
+		unlock()
 		p.conflict(w, "the Net "+req.NetID+" still holds "+strconv.Itoa(len(subnets))+" subnet(s)")
 		return
 	}
@@ -225,7 +225,7 @@ func (p *Pack) deleteNet(w http.ResponseWriter, r *http.Request) {
 	// and Terraform's destroy order (unlink, delete gateway, delete Net) counts
 	// on the refusal to retry rather than to lose the gateway record.
 	if gw := p.linkedInternetServiceOf(req.NetID); gw != nil {
-		p.addresses.Unlock()
+		unlock()
 		p.conflict(w, "the Net "+req.NetID+" still has "+gw.ID+" linked")
 		return
 	}
@@ -234,14 +234,14 @@ func (p *Pack) deleteNet(w http.ResponseWriter, r *http.Request) {
 	// main/default marker.
 	for _, rtb := range p.routeTablesOf(req.NetID) {
 		if !isMainTable(rtb) {
-			p.addresses.Unlock()
+			unlock()
 			p.conflict(w, "the Net "+req.NetID+" still holds the route table "+rtb.ID)
 			return
 		}
 	}
 	for _, sg := range p.securityGroupsOf(req.NetID) {
 		if stringOf(sg.Attrs["SecurityGroupName"]) != "default" {
-			p.addresses.Unlock()
+			unlock()
 			p.conflict(w, "the Net "+req.NetID+" still holds the security group "+sg.ID)
 			return
 		}
@@ -256,7 +256,7 @@ func (p *Pack) deleteNet(w http.ResponseWriter, r *http.Request) {
 	for _, rtb := range p.routeTablesOf(req.NetID) {
 		p.env.Store.Delete(Name, kindRouteTable, rtb.ID)
 	}
-	p.addresses.Unlock()
+	unlock()
 
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
 		"ResponseContext": p.context(),
@@ -309,10 +309,10 @@ func (p *Pack) createSubnet(w http.ResponseWriter, r *http.Request) {
 	//
 	// TestSubnetCreateDoesNotHoldTheAddressingLockAcrossTheRuntime fails
 	// without this.
-	p.addresses.Lock()
+	unlock := p.lockAddresses()
 
 	if other, clash := network.FirstOverlap(prefix, p.subnetPrefixes(req.NetID)); clash {
-		p.addresses.Unlock()
+		unlock()
 		p.conflict(w, "IpRange "+prefix.String()+" overlaps the subnet on "+other.String())
 		return
 	}
@@ -338,7 +338,7 @@ func (p *Pack) createSubnet(w http.ResponseWriter, r *http.Request) {
 	// reservation, and it is what makes a concurrent create see the range as
 	// taken.
 	p.env.Store.Put(res)
-	p.addresses.Unlock()
+	unlock()
 
 	// The subnet is a real network on the runtime, which is what makes an
 	// address published here an address a machine can carry. Without a runtime
@@ -436,7 +436,7 @@ func (p *Pack) deleteSubnet(w http.ResponseWriter, r *http.Request) {
 	// and nothing in the test can widen it. So the lock is argued from the
 	// allocation path, which does hold it, and the race test is a regression net,
 	// not the proof. Saying which is which is the point.
-	p.addresses.Lock()
+	unlock := p.lockAddresses()
 	for _, vm := range p.env.Store.List(kindVM, resource.Tenant{Provider: Name}) {
 		// A terminated Vm holds nothing. It stays in the store because the
 		// Terraform provider polls ReadVms until it reports "terminated", and a
@@ -447,7 +447,7 @@ func (p *Pack) deleteSubnet(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		if stringOf(vm.Attrs["SubnetId"]) == req.SubnetID {
-			p.addresses.Unlock()
+			unlock()
 			p.conflict(w, "the Subnet "+req.SubnetID+" still holds "+vm.ID)
 			return
 		}
@@ -455,14 +455,14 @@ func (p *Pack) deleteSubnet(w http.ResponseWriter, r *http.Request) {
 	// A NAT service placed in the subnet blocks it the same way a Vm does; the
 	// real API refuses, and the destroy order relies on the refusal.
 	if nats := p.natServicesOf(req.SubnetID); len(nats) > 0 {
-		p.addresses.Unlock()
+		unlock()
 		p.conflict(w, "the Subnet "+req.SubnetID+" still holds "+nats[0].ID)
 		return
 	}
 	// Removed from the store under the lock, so a create that wakes up next
 	// fails to resolve it rather than placing a Vm in a Subnet being deleted.
 	p.env.Store.Delete(Name, kindSubnet, req.SubnetID)
-	p.addresses.Unlock()
+	unlock()
 
 	// The runtime call is slow and stays outside: the Subnet is already
 	// unreachable to every other handler by this point.

--- a/internal/providers/outscale/nets.go
+++ b/internal/providers/outscale/nets.go
@@ -132,23 +132,16 @@ func (p *Pack) createNet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	now := p.env.Now()
-	res := &resource.Resource{
-		ID:      newID("vpc", p.env.NewID()),
-		Kind:    kindNet,
-		Tenant:  resource.Tenant{Provider: Name},
-		State:   "available",
-		Created: now,
-		Updated: now,
-		Attrs: map[string]any{
-			"IpRange": prefix.String(),
-			"Tenancy": orDefault(req.Tenancy, "default"),
-			// The account's default set, which every real Net references. Its
-			// absence from this view was found by `feint transcript --against`
-			// on a real account, not by reading the SDK: the schema declares
-			// the field, but no required list would ever have flagged it.
-			"DhcpOptionsSetId": p.defaultDhcpOptions().ID,
-			"Tags":             []any{},
-		},
+	res := resource.New(newID("vpc", p.env.NewID()), kindNet, resource.Tenant{Provider: Name}, "available", now)
+	res.Attrs = map[string]any{
+		"IpRange": prefix.String(),
+		"Tenancy": orDefault(req.Tenancy, "default"),
+		// The account's default set, which every real Net references. Its
+		// absence from this view was found by `feint transcript --against`
+		// on a real account, not by reading the SDK: the schema declares
+		// the field, but no required list would ever have flagged it.
+		"DhcpOptionsSetId": p.defaultDhcpOptions().ID,
+		"Tags":             []any{},
 	}
 	p.env.Store.Put(res)
 
@@ -318,20 +311,13 @@ func (p *Pack) createSubnet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	now := p.env.Now()
-	res := &resource.Resource{
-		ID:      newID("subnet", p.env.NewID()),
-		Kind:    kindSubnet,
-		Tenant:  resource.Tenant{Provider: Name},
-		State:   "available",
-		Created: now,
-		Updated: now,
-		Attrs: map[string]any{
-			"IpRange":             prefix.String(),
-			"NetId":               req.NetID,
-			"SubregionName":       orDefault(req.SubregionName, subregionName),
-			"MapPublicIpOnLaunch": false,
-			"Tags":                []any{},
-		},
+	res := resource.New(newID("subnet", p.env.NewID()), kindSubnet, resource.Tenant{Provider: Name}, "available", now)
+	res.Attrs = map[string]any{
+		"IpRange":             prefix.String(),
+		"NetId":               req.NetID,
+		"SubregionName":       orDefault(req.SubregionName, subregionName),
+		"MapPublicIpOnLaunch": false,
+		"Tags":                []any{},
 	}
 
 	// Stored before the runtime call and before the lock is released: this is the

--- a/internal/providers/outscale/nics.go
+++ b/internal/providers/outscale/nics.go
@@ -286,20 +286,13 @@ func (p *Pack) createNic(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	now := p.env.Now()
-	nic := &resource.Resource{
-		ID:      newID("eni", p.env.NewID()),
-		Kind:    kindNic,
-		Tenant:  resource.Tenant{Provider: Name},
-		State:   "available",
-		Created: now,
-		Updated: now,
-		Attrs: map[string]any{
-			"SubnetId":    place.SubnetID,
-			"NetId":       place.NetID,
-			"PrivateIp":   place.Address.String(),
-			"Description": req.Description,
-			"State":       "available",
-		},
+	nic := resource.New(newID("eni", p.env.NewID()), kindNic, resource.Tenant{Provider: Name}, "available", now)
+	nic.Attrs = map[string]any{
+		"SubnetId":    place.SubnetID,
+		"NetId":       place.NetID,
+		"PrivateIp":   place.Address.String(),
+		"Description": req.Description,
+		"State":       "available",
 	}
 	if len(req.SecurityGroupIDs) > 0 {
 		nic.Attrs["SecurityGroupIds"] = req.SecurityGroupIDs

--- a/internal/providers/outscale/nics.go
+++ b/internal/providers/outscale/nics.go
@@ -274,10 +274,10 @@ func (p *Pack) createNic(w http.ResponseWriter, r *http.Request) {
 	// Under the addressing lock, and the address reserved before release: a NIC
 	// takes an address in the Subnet exactly as a Vm does, and two creates must
 	// not pick the same one.
-	p.addresses.Lock()
+	unlock := p.lockAddresses()
 	place, err := p.placeInSubnet(req.SubnetID)
 	if err != nil {
-		p.addresses.Unlock()
+		unlock()
 		if errors.Is(err, errUnknownSubnet) {
 			p.notFound(w, "Subnet", req.SubnetID)
 		} else {
@@ -305,7 +305,7 @@ func (p *Pack) createNic(w http.ResponseWriter, r *http.Request) {
 		nic.Attrs["SecurityGroupIds"] = req.SecurityGroupIDs
 	}
 	p.env.Store.Put(nic)
-	p.addresses.Unlock()
+	unlock()
 
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
 		"Nic":             p.storedNicView(nic),

--- a/internal/providers/outscale/pack.go
+++ b/internal/providers/outscale/pack.go
@@ -22,9 +22,9 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"sync"
 
 	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/serialise"
 )
 
 // Name is the provider key.
@@ -40,12 +40,17 @@ const (
 // Pack implements emulator.Pack for Outscale.
 type Pack struct {
 	env *emulator.Env
-	// addresses serialises the choice of a block, which is read-modify-write
-	// over the store: what is free is computed from what exists, and two
-	// concurrent creates without it both find the same range free and both take
-	// it. Terraform creates ten resources at a time by default.
-	addresses sync.Mutex
 }
+
+// lockAddresses serialises the choice of a block or an address, which is
+// read-modify-write over the store: what is free is computed from what exists,
+// and two concurrent creates without it both find the same range free and both
+// take it. Terraform creates ten resources at a time by default. The comments
+// at the call sites name it the addressing lock, because it also orders the
+// scans that keep a Net, a Subnet and a DHCP options set pointing at each
+// other. The lock itself lives in core/serialise, shared with every pack and
+// the machine binding, so the next pack does not have to rediscover it.
+func (p *Pack) lockAddresses() func() { return serialise.Lock(Name + "/addresses") }
 
 // New returns an Outscale pack backed by env.
 func New(env *emulator.Env) *Pack { return &Pack{env: env} }

--- a/internal/providers/outscale/placement.go
+++ b/internal/providers/outscale/placement.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"net/netip"
 
-	"github.com/stephrobert/feint/internal/core/network"
 	"github.com/stephrobert/feint/internal/core/resource"
 )
 
@@ -43,10 +42,19 @@ type placement struct {
 //
 // The address is allocated rather than invented, from the same allocator the
 // Subnet's own count is computed with, so what the API publishes as available
-// and what it hands out cannot disagree. Addresses already taken by other Vms in
-// the same Subnet are reserved first — the allocator is rebuilt per call because
-// the store is the state, and holding a long-lived allocator beside it is how
-// the two drift apart across a snapshot restore.
+// and what it hands out cannot disagree. The allocator is subnetAllocator's —
+// one constructor, not two. This function used to carry its own reservation
+// loops, and the copy differed from subnetAllocator on exactly one point: it
+// reserved the addresses of terminated Vms forever, so a Subnet slowly filled
+// with ghosts nothing could release, while deleteVms itself says upstream
+// frees the private address at termination. A first unification was reverted
+// on the verdict of the then state-blind sweep invariant, which reported the
+// legitimate reuse as a double allocation — the false verdict sweep.go now
+// records. The allocator is rebuilt per call because the store is the state,
+// and holding a long-lived allocator beside it is how the two drift apart
+// across a snapshot restore.
+//
+// TestATerminatedVmsAddressReturnsToItsSubnet fails without the release.
 func (p *Pack) placeInSubnet(subnetID string) (placement, error) {
 	subnet, found := p.env.Store.Get(Name, kindSubnet, subnetID)
 	if !found {
@@ -56,41 +64,9 @@ func (p *Pack) placeInSubnet(subnetID string) (placement, error) {
 	if err != nil {
 		return placement{}, err
 	}
-
-	allocator, err := network.NewAllocator(prefix, reservedPerSubnet)
+	allocator, err := p.subnetAllocator(subnetID)
 	if err != nil {
 		return placement{}, err
-	}
-	for _, vm := range p.env.Store.List(kindVM, resource.Tenant{Provider: Name}) {
-		if vm.Attrs["SubnetId"] != subnetID {
-			continue
-		}
-		taken, parseErr := netip.ParseAddr(stringOf(vm.Attrs["PrivateIp"]))
-		if parseErr == nil {
-			// A duplicate here is not worth failing a create over: the address
-			// is already out of the pool, which is the only thing that matters.
-			_ = allocator.Reserve(taken)
-		}
-	}
-	// Secondary interfaces hold an address in the same Subnet, so they are
-	// reserved too: without this a created NIC and a Vm could be handed the
-	// same address, which on a runtime is two interfaces fighting for one IP.
-	for _, nic := range p.env.Store.List(kindNic, resource.Tenant{Provider: Name}) {
-		if nic.Attrs["SubnetId"] != subnetID {
-			continue
-		}
-		if taken, parseErr := netip.ParseAddr(stringOf(nic.Attrs["PrivateIp"])); parseErr == nil {
-			_ = allocator.Reserve(taken)
-		}
-		// And the secondary addresses LinkPrivateIps assigned (#172). Without
-		// them a Vm created after a link is handed an address the NIC already
-		// holds, which is the very case the comment above warns about, one
-		// field further along. TestALinkedAddressIsNotHandedToTheNextVm.
-		for _, address := range secondaryAddresses(nic) {
-			if taken, parseErr := netip.ParseAddr(address); parseErr == nil {
-				_ = allocator.Reserve(taken)
-			}
-		}
 	}
 
 	address, err := allocator.Allocate()

--- a/internal/providers/outscale/placement_test.go
+++ b/internal/providers/outscale/placement_test.go
@@ -1,0 +1,82 @@
+package outscale_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/store/storetest"
+	"github.com/stephrobert/feint/internal/providers/outscale"
+)
+
+// A terminated Vm's private address returns to its Subnet.
+//
+// deleteVms says it itself: upstream keeps the private address of a stopped
+// Vm and releases it at termination. The allocator did only half — a
+// terminated Vm stayed in the store for ReadVms polling, and its address
+// stayed reserved with it, forever. A Subnet slowly filled with ghosts
+// nothing could release, which no real cloud does; on a /29 it takes three
+// machines to reach the lie.
+//
+// The sweep at the end is the other half of the story: this exact reuse is
+// what the state-blind invariant used to report as a double allocation, the
+// false verdict that got the first version of this fix reverted. The sweep
+// runs here with the pack's own word on liveness, so this test holds the
+// measure and the measured together and red flags whichever regresses.
+func TestATerminatedVmsAddressReturnsToItsSubnet(t *testing.T) {
+	ts, st := newOutscaleBarrageServer(t)
+
+	// A /29 holds three usable addresses: eight, minus the four Outscale
+	// reserves at the head, minus the broadcast.
+	_, subnetID := netAndSubnet(t, ts, "10.60.0.0/16", "10.60.1.0/29")
+
+	create := func() (int, string, string) {
+		status, out := postRaw(ts, "CreateVms",
+			fmt.Sprintf(`{"ImageId":"ami-00000001","SubnetId":%q,"BootOnCreation":false}`, subnetID))
+		vms, _ := out["Vms"].([]any)
+		if len(vms) == 0 {
+			return status, "", ""
+		}
+		vm, _ := vms[0].(map[string]any)
+		id, _ := vm["VmId"].(string)
+		address, _ := vm["PrivateIp"].(string)
+		return status, id, address
+	}
+
+	// Fill the Subnet.
+	ids := make([]string, 0, 3)
+	addresses := make([]string, 0, 3)
+	for i := range 3 {
+		status, id, address := create()
+		if status != http.StatusOK || address == "" {
+			t.Fatalf("create %d answered %d with address %q; the /29 should hold three", i, status, address)
+		}
+		ids = append(ids, id)
+		addresses = append(addresses, address)
+	}
+
+	// The fourth is refused: the pool is genuinely empty.
+	if status, _, _ := create(); status == http.StatusOK {
+		t.Fatal("a fourth Vm was placed in a full /29")
+	}
+
+	// Terminate one. The record stays readable — that is deliberate — but the
+	// address it held is free again.
+	if status, _ := postRaw(ts, "DeleteVms", fmt.Sprintf(`{"VmIds":[%q]}`, ids[0])); status != http.StatusOK {
+		t.Fatalf("DeleteVms answered %d", status)
+	}
+	status, _, reused := create()
+	if status != http.StatusOK {
+		t.Fatalf("after a termination the Subnet still refuses a create (%d): the dead reservation is back", status)
+	}
+	if reused != addresses[0] {
+		t.Errorf("the freed address was %s and the new Vm got %s", addresses[0], reused)
+	}
+
+	// And the invariant agrees, with the pack's own word on liveness: the
+	// terminated record still carries the address string, and holds nothing.
+	if found := storetest.Sweep(st.All(), outscale.Gone); len(found) != 0 {
+		t.Errorf("the sweep convicts the legitimate reuse:\n%s", strings.Join(found, "\n"))
+	}
+}

--- a/internal/providers/outscale/privateips.go
+++ b/internal/providers/outscale/privateips.go
@@ -211,7 +211,10 @@ func (p *Pack) subnetAllocator(subnetID string) (*network.Allocator, error) {
 		return nil, err
 	}
 	for _, vm := range p.env.Store.List(kindVM, resource.Tenant{Provider: Name}) {
-		if vm.State == stateTerminated || stringOf(vm.Attrs["SubnetId"]) != subnetID {
+		// Gone, not a state comparison: the same answer the sweep invariant
+		// reads, so what the invariant excuses and what this pool reuses
+		// cannot disagree.
+		if Gone(vm) || stringOf(vm.Attrs["SubnetId"]) != subnetID {
 			continue
 		}
 		if taken, parseErr := netip.ParseAddr(stringOf(vm.Attrs["PrivateIp"])); parseErr == nil {

--- a/internal/providers/outscale/privateips.go
+++ b/internal/providers/outscale/privateips.go
@@ -64,8 +64,8 @@ func (p *Pack) linkPrivateIps(w http.ResponseWriter, r *http.Request) {
 	// The allocation and the store write happen under one lock, for the reason
 	// placeInSubnet exists: two concurrent links must not be handed the same
 	// address, which on a runtime is two interfaces fighting for one IP.
-	p.addresses.Lock()
-	defer p.addresses.Unlock()
+	unlock := p.lockAddresses()
+	defer unlock()
 
 	nic, found := p.env.Store.Get(Name, kindNic, req.NicID)
 	if !found {
@@ -152,8 +152,8 @@ func (p *Pack) unlinkPrivateIps(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	p.addresses.Lock()
-	defer p.addresses.Unlock()
+	unlock := p.lockAddresses()
+	defer unlock()
 
 	nic, found := p.env.Store.Get(Name, kindNic, req.NicID)
 	if !found {

--- a/internal/providers/outscale/publicips.go
+++ b/internal/providers/outscale/publicips.go
@@ -149,7 +149,7 @@ func (p *Pack) createPublicIP(w http.ResponseWriter, r *http.Request) {
 
 	// Serialized like every other allocation: two concurrent creates must not
 	// pick the same address.
-	p.addresses.Lock()
+	unlock := p.lockAddresses()
 	taken := make(map[string]bool, 8)
 	for _, res := range p.env.Store.List(kindPublicIP, resource.Tenant{Provider: Name}) {
 		taken[stringOf(res.Attrs["PublicIp"])] = true
@@ -163,7 +163,7 @@ func (p *Pack) createPublicIP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if address == "" {
-		p.addresses.Unlock()
+		unlock()
 		p.conflict(w, "the emulated public block "+publicIPBase+"0/24 is exhausted; release an address first")
 		return
 	}
@@ -181,7 +181,7 @@ func (p *Pack) createPublicIP(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 	p.env.Store.Put(res)
-	p.addresses.Unlock()
+	unlock()
 
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
 		"PublicIp":        publicIPView(res),

--- a/internal/providers/outscale/publicips.go
+++ b/internal/providers/outscale/publicips.go
@@ -168,17 +168,10 @@ func (p *Pack) createPublicIP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	now := p.env.Now()
-	res := &resource.Resource{
-		ID:      newID("eipalloc", p.env.NewID()),
-		Kind:    kindPublicIP,
-		Tenant:  resource.Tenant{Provider: Name},
-		State:   "available",
-		Created: now,
-		Updated: now,
-		Attrs: map[string]any{
-			"PublicIp": address,
-			"Tags":     []any{},
-		},
+	res := resource.New(newID("eipalloc", p.env.NewID()), kindPublicIP, resource.Tenant{Provider: Name}, "available", now)
+	res.Attrs = map[string]any{
+		"PublicIp": address,
+		"Tags":     []any{},
 	}
 	p.env.Store.Put(res)
 	unlock()

--- a/internal/providers/outscale/securitygroups.go
+++ b/internal/providers/outscale/securitygroups.go
@@ -181,26 +181,19 @@ func (p *Pack) createSecurityGroup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	now := p.env.Now()
-	res := &resource.Resource{
-		ID:      newID("sg", p.env.NewID()),
-		Kind:    kindSecurityGroup,
-		Tenant:  resource.Tenant{Provider: Name},
-		State:   "available",
-		Created: now,
-		Updated: now,
-		Attrs: map[string]any{
-			"SecurityGroupName": req.SecurityGroupName,
-			"Description":       req.Description,
-			"InboundRules":      []any{},
-			"OutboundRules": []any{map[string]any{
-				"FromPortRange":       -1,
-				"ToPortRange":         -1,
-				"IpProtocol":          "-1",
-				"SecurityGroupRuleId": newID("sgr", p.env.NewID()),
-				"IpRanges":            []any{"0.0.0.0/0"},
-			}},
-			"Tags": []any{},
-		},
+	res := resource.New(newID("sg", p.env.NewID()), kindSecurityGroup, resource.Tenant{Provider: Name}, "available", now)
+	res.Attrs = map[string]any{
+		"SecurityGroupName": req.SecurityGroupName,
+		"Description":       req.Description,
+		"InboundRules":      []any{},
+		"OutboundRules": []any{map[string]any{
+			"FromPortRange":       -1,
+			"ToPortRange":         -1,
+			"IpProtocol":          "-1",
+			"SecurityGroupRuleId": newID("sgr", p.env.NewID()),
+			"IpRanges":            []any{"0.0.0.0/0"},
+		}},
+		"Tags": []any{},
 	}
 	if req.NetID != "" {
 		res.Attrs["NetId"] = req.NetID

--- a/internal/providers/outscale/snapshots.go
+++ b/internal/providers/outscale/snapshots.go
@@ -60,24 +60,17 @@ func (p *Pack) createSnapshot(w http.ResponseWriter, r *http.Request) {
 	size, _ := volume.Attrs["Size"].(int)
 
 	now := p.env.Now()
-	res := &resource.Resource{
-		ID:      newID("snap", p.env.NewID()),
-		Kind:    kindSnapshot,
-		Tenant:  resource.Tenant{Provider: Name},
-		State:   "completed",
-		Created: now,
-		Updated: now,
-		Attrs: map[string]any{
-			"VolumeId":    req.VolumeID,
-			"VolumeSize":  size,
-			"Description": req.Description,
-			"Progress":    100,
-			"PermissionsToCreateVolume": map[string]any{
-				"AccountIds":       []any{},
-				"GlobalPermission": false,
-			},
-			"Tags": []any{},
+	res := resource.New(newID("snap", p.env.NewID()), kindSnapshot, resource.Tenant{Provider: Name}, "completed", now)
+	res.Attrs = map[string]any{
+		"VolumeId":    req.VolumeID,
+		"VolumeSize":  size,
+		"Description": req.Description,
+		"Progress":    100,
+		"PermissionsToCreateVolume": map[string]any{
+			"AccountIds":       []any{},
+			"GlobalPermission": false,
 		},
+		"Tags": []any{},
 	}
 	p.env.Store.Put(res)
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{

--- a/internal/providers/outscale/updates.go
+++ b/internal/providers/outscale/updates.go
@@ -58,8 +58,8 @@ func (p *Pack) updateNet(w http.ResponseWriter, r *http.Request) {
 	// without it a set can be deleted between the existence check below and the
 	// Commit, and the Net ends up wearing an identifier that resolves to
 	// nothing — the exact relation the existence check exists to refuse.
-	p.addresses.Lock()
-	defer p.addresses.Unlock()
+	unlock := p.lockAddresses()
+	defer unlock()
 
 	// `default` is a keyword, not an identifier: their document defines it on
 	// this very field ("or `default` if you want to associate the default

--- a/internal/providers/outscale/vms.go
+++ b/internal/providers/outscale/vms.go
@@ -315,8 +315,8 @@ func (p *Pack) createVms(w http.ResponseWriter, r *http.Request) {
 // batch. Releasing between two Vms of one batch would let another create take an
 // address this one is about to use, so the whole batch allocates at once.
 func (p *Pack) allocateVms(req createVmsRequest, count int, now time.Time) ([]*resource.Resource, error) {
-	p.addresses.Lock()
-	defer p.addresses.Unlock()
+	unlock := p.lockAddresses()
+	defer unlock()
 
 	created := make([]*resource.Resource, 0, count)
 	for range count {

--- a/internal/providers/outscale/vms.go
+++ b/internal/providers/outscale/vms.go
@@ -319,19 +319,12 @@ func (p *Pack) allocateVms(req createVmsRequest, count int, now time.Time) ([]*r
 
 	created := make([]*resource.Resource, 0, count)
 	for range count {
-		res := &resource.Resource{
-			ID:      newVMID(p.env.NewID()),
-			Kind:    kindVM,
-			Tenant:  resource.Tenant{Provider: Name},
-			State:   stateStopped,
-			Created: now,
-			Updated: now,
-			Attrs: map[string]any{
-				"ImageId":              req.ImageID,
-				"VmType":               orDefault(req.VMType, defaultVMType),
-				"DeletionProtection":   boolOr(req.DeletionProtection, false),
-				"NestedVirtualization": boolOr(req.NestedVirtualization, false),
-			},
+		res := resource.New(newVMID(p.env.NewID()), kindVM, resource.Tenant{Provider: Name}, stateStopped, now)
+		res.Attrs = map[string]any{
+			"ImageId":              req.ImageID,
+			"VmType":               orDefault(req.VMType, defaultVMType),
+			"DeletionProtection":   boolOr(req.DeletionProtection, false),
+			"NestedVirtualization": boolOr(req.NestedVirtualization, false),
 		}
 		// The Subnet the client asked for, resolved before anything is stored: a
 		// Vm placed nowhere is not a Vm the client asked for. Reading it here,

--- a/internal/providers/outscale/vms.go
+++ b/internal/providers/outscale/vms.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stephrobert/feint/internal/core/cloudinit"
 	"github.com/stephrobert/feint/internal/core/emulator"
 	"github.com/stephrobert/feint/internal/core/resource"
-	"github.com/stephrobert/feint/internal/core/store"
 )
 
 // The Vm is Outscale's server. Field names and shapes come from the SDK: Vm for
@@ -577,43 +576,27 @@ func (p *Pack) transition(w http.ResponseWriter, r *http.Request, change func(*r
 // transitionOne applies one state change to one VM, holding that target for the
 // whole read, run and write.
 //
-// The lock is what makes the read worth anything. The runtime call is outside
-// the store lock on purpose, and Update only refuses to write back a resource
-// that is gone: it does not order two writers. Two concurrent StartVms on one VM
-// each launched a container, the second failed on the name the first had taken,
-// and the API described as stopped a machine that was running.
+// The mechanics are machine.Binding.Transition, shared with the Exoscale
+// pack's transitionInstance rather than written a second time: the lock is
+// what makes the read worth anything, the runtime call runs outside the store
+// lock, and the write-back is conditional so a delete racing this loop wins
+// instead of being undone. The resource Transition reads is re-read under the
+// lock rather than reused from the resolution loop, because that copy was
+// taken before it: deciding "already running" from a stale state is how the
+// short-circuit above stops short-circuiting.
 //
-// The resource is re-read here rather than reused from the resolution loop,
-// because that copy was taken before the lock: deciding "already running" from a
-// stale state is how the short-circuit above stops short-circuiting.
+// What stays here is the shape a client observes: the VmStateInfo row with the
+// previous state beside the new one, and a target deleted mid-transition
+// silently dropped from the answer.
 func (p *Pack) transitionOne(id string, change func(*resource.Resource) string) (map[string]any, bool) {
-	unlock := p.binding().Serialise(id)
-	defer unlock()
-
-	res, ok := p.env.Store.Get(Name, kindVM, id)
-	if !ok {
-		return nil, false
-	}
-
-	previous := res.State
-	// The runtime work runs outside the store lock. Launching a container takes
-	// tens of seconds, and holding the write lock for that would queue every
-	// other request behind one machine starting.
-	current := change(res)
-
-	// The result is applied atomically. Put replaces the whole resource, so it
-	// silently discarded anything another request had written in the meantime —
-	// a delete racing this loop used to be undone, and the VM came back.
-	err := p.env.Store.Update(Name, kindVM, id, func(stored *resource.Resource) error {
-		stored.State = res.State
-		stored.Runtime = res.Runtime
-		stored.Attrs = res.Attrs
-		stored.Updated = p.env.Now()
-		return nil
+	var previous, current string
+	err := p.binding().Transition(p.env.Store, p.env.Now, kindVM, id, func(res *resource.Resource) {
+		previous = res.State
+		current = change(res)
 	})
-	if errors.Is(err, store.ErrNotFound) {
-		// Deleted while its machine was transitioning. Not an error: the caller
-		// asked for a state this resource no longer has.
+	if err != nil {
+		// Missing, or deleted while its machine was transitioning. Not an
+		// error: the caller asked for a state this resource no longer has.
 		return nil, false
 	}
 	return map[string]any{

--- a/internal/providers/outscale/vms.go
+++ b/internal/providers/outscale/vms.go
@@ -709,6 +709,21 @@ func (p *Pack) deleteVms(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// Gone reports a resource this pack keeps in the store although its API says
+// it no longer exists. The terminated Vm is the one case: the record stays
+// readable because the Terraform provider polls ReadVms until it observes
+// "terminated" (TestATerminatedVmStaysReadable), but the machine is destroyed
+// and holds nothing — upstream releases the private address at termination.
+//
+// This is the pack's word on liveness, in the pack because the vocabulary is
+// the provider's (rule 5 keeps it out of the core). Two consumers must read
+// the same answer or the instrument convicts the innocent: the barrage sweep
+// takes it as its predicate, and subnetAllocator skips exactly what it names,
+// so what the invariant excuses and what the pool reuses cannot disagree.
+func Gone(res *resource.Resource) bool {
+	return res.Kind == kindVM && res.State == stateTerminated
+}
+
 // vmView renders a Vm. Only fields the pack actually knows are emitted: a
 // PrivateIp of "" would tell a client the machine has no address, where an
 // absent field tells it the emulator does not model one.

--- a/internal/providers/outscale/volumes.go
+++ b/internal/providers/outscale/volumes.go
@@ -68,21 +68,14 @@ func (p *Pack) createVolume(w http.ResponseWriter, r *http.Request) {
 	}
 
 	now := p.env.Now()
-	res := &resource.Resource{
-		ID:      newID("vol", p.env.NewID()),
-		Kind:    kindVolume,
-		Tenant:  resource.Tenant{Provider: Name},
-		State:   volumeStateAvailable,
-		Created: now,
-		Updated: now,
-		Attrs: map[string]any{
-			"SubregionName": req.SubregionName,
-			"Size":          size,
-			"VolumeType":    orDefault(req.VolumeType, defaultVolumeType),
-			"Iops":          req.Iops,
-			"ClientToken":   req.ClientToken,
-			"Tags":          []any{},
-		},
+	res := resource.New(newID("vol", p.env.NewID()), kindVolume, resource.Tenant{Provider: Name}, volumeStateAvailable, now)
+	res.Attrs = map[string]any{
+		"SubregionName": req.SubregionName,
+		"Size":          size,
+		"VolumeType":    orDefault(req.VolumeType, defaultVolumeType),
+		"Iops":          req.Iops,
+		"ClientToken":   req.ClientToken,
+		"Tags":          []any{},
 	}
 	if req.SnapshotID != "" {
 		// Stored only when there is one: the view copies Attrs verbatim, and the

--- a/internal/providers/scaleway/barrage_test.go
+++ b/internal/providers/scaleway/barrage_test.go
@@ -216,7 +216,7 @@ func TestABarrageLeavesTheStoreCoherent(t *testing.T) {
 			len(refused), strings.Join(firstFew(refused, 5), "\n"))
 	}
 
-	if found := storetest.Sweep(st.All()); len(found) != 0 {
+	if found := storetest.Sweep(st.All(), nil); len(found) != 0 {
 		t.Errorf("the store is incoherent after the barrage:\n%s", strings.Join(found, "\n"))
 	}
 
@@ -412,7 +412,7 @@ func TestARestoreDuringTrafficLandsInOneWorld(t *testing.T) {
 	// Whatever the interleaving produced, the store must be coherent: no
 	// identifier issued twice, no address held twice, no runtime object claimed
 	// twice. A merge of two worlds is exactly what breaks those.
-	if found := storetest.Sweep(st.All()); len(found) != 0 {
+	if found := storetest.Sweep(st.All(), nil); len(found) != 0 {
 		t.Errorf("a restore during traffic left the store incoherent:\n%s", strings.Join(found, "\n"))
 	}
 
@@ -517,7 +517,7 @@ func TestASharedNetworkUnderBarrageNeverHandsOutOneAddressTwice(t *testing.T) {
 	}
 
 	// The invariant the contention exists to test: one address, one resource.
-	if found := storetest.Sweep(st.All()); len(found) != 0 {
+	if found := storetest.Sweep(st.All(), nil); len(found) != 0 {
 		t.Errorf("one pool under contention produced an incoherent store:\n%s",
 			strings.Join(found, "\n"))
 	}

--- a/internal/providers/scaleway/block.go
+++ b/internal/providers/scaleway/block.go
@@ -151,22 +151,15 @@ func (p *Pack) createBlockVolume(w http.ResponseWriter, r *http.Request) {
 
 	project, _ := projectOf(textPtr(req.ProjectID))
 	now := p.env.Now()
-	res := &resource.Resource{
-		ID:      p.env.NewID(),
-		Kind:    kindBlockVolume,
-		Tenant:  resource.Tenant{Provider: Name, Project: project, Zone: zone},
-		State:   "available",
-		Created: now,
-		Updated: now,
-		Attrs: map[string]any{
-			"name":               req.Name,
-			"project":            project,
-			"tags":               orEmpty(slicePtr(req.Tags)),
-			"size":               size,
-			"zone":               zone,
-			"parent_snapshot_id": parent,
-			"perf_iops":          iopsOf(req.PerfIops),
-		},
+	res := resource.New(p.env.NewID(), kindBlockVolume, resource.Tenant{Provider: Name, Project: project, Zone: zone}, "available", now)
+	res.Attrs = map[string]any{
+		"name":               req.Name,
+		"project":            project,
+		"tags":               orEmpty(slicePtr(req.Tags)),
+		"size":               size,
+		"zone":               zone,
+		"parent_snapshot_id": parent,
+		"perf_iops":          iopsOf(req.PerfIops),
 	}
 	p.env.Store.Put(res)
 	emulator.WriteJSON(w, http.StatusCreated, p.blockVolumeView(res))
@@ -440,26 +433,19 @@ func (p *Pack) createBlockSnapshot(w http.ResponseWriter, r *http.Request) {
 
 	project, _ := projectOf(textPtr(req.ProjectID))
 	now := p.env.Now()
-	res := &resource.Resource{
-		ID:      p.env.NewID(),
-		Kind:    kindBlockSnapshot,
-		Tenant:  resource.Tenant{Provider: Name, Project: project, Zone: zone},
-		State:   "available",
-		Created: now,
-		Updated: now,
-		Attrs: map[string]any{
-			"name":    req.Name,
-			"project": project,
-			"tags":    orEmpty(slicePtr(req.Tags)),
-			"size":    volume.Attrs["size"],
-			"zone":    zone,
-			"public":  req.Public,
-			"parent_volume": map[string]any{
-				"id":     volume.ID,
-				"name":   textOf(volume.Attrs["name"]),
-				"type":   blockStorageClass,
-				"status": volume.State,
-			},
+	res := resource.New(p.env.NewID(), kindBlockSnapshot, resource.Tenant{Provider: Name, Project: project, Zone: zone}, "available", now)
+	res.Attrs = map[string]any{
+		"name":    req.Name,
+		"project": project,
+		"tags":    orEmpty(slicePtr(req.Tags)),
+		"size":    volume.Attrs["size"],
+		"zone":    zone,
+		"public":  req.Public,
+		"parent_volume": map[string]any{
+			"id":     volume.ID,
+			"name":   textOf(volume.Attrs["name"]),
+			"type":   blockStorageClass,
+			"status": volume.State,
 		},
 	}
 	p.env.Store.Put(res)

--- a/internal/providers/scaleway/images.go
+++ b/internal/providers/scaleway/images.go
@@ -240,30 +240,23 @@ func (p *Pack) createImage(w http.ResponseWriter, r *http.Request) {
 
 	project, organization := projectOf(textPtr(req.Project))
 	now := p.env.Now()
-	res := &resource.Resource{
-		ID:      p.env.NewID(),
-		Kind:    kindImage,
-		Tenant:  resource.Tenant{Provider: Name, Project: project, Zone: zone},
-		State:   "available",
-		Created: now,
-		Updated: now,
-		Attrs: map[string]any{
-			"name":         req.Name,
-			"arch":         orDefault(req.Arch, "x86_64"),
-			"organization": organization,
-			"project":      project,
-			"tags":         orEmpty(slicePtr(req.Tags)),
-			"zone":         zone,
-			"snapshot_id":  snapshot.ID,
-			// The server the snapshot's volume came from, when there was one.
-			// A string rather than null, which is what a real account returns.
-			"from_server": textOf(snapshot.Attrs["from_server"]),
-			"root_volume": map[string]any{
-				"id":          snapshot.ID,
-				"name":        textOf(snapshot.Attrs["name"]),
-				"size":        snapshot.Attrs["size"],
-				"volume_type": textOf(snapshot.Attrs["volume_type"]),
-			},
+	res := resource.New(p.env.NewID(), kindImage, resource.Tenant{Provider: Name, Project: project, Zone: zone}, "available", now)
+	res.Attrs = map[string]any{
+		"name":         req.Name,
+		"arch":         orDefault(req.Arch, "x86_64"),
+		"organization": organization,
+		"project":      project,
+		"tags":         orEmpty(slicePtr(req.Tags)),
+		"zone":         zone,
+		"snapshot_id":  snapshot.ID,
+		// The server the snapshot's volume came from, when there was one.
+		// A string rather than null, which is what a real account returns.
+		"from_server": textOf(snapshot.Attrs["from_server"]),
+		"root_volume": map[string]any{
+			"id":          snapshot.ID,
+			"name":        textOf(snapshot.Attrs["name"]),
+			"size":        snapshot.Attrs["size"],
+			"volume_type": textOf(snapshot.Attrs["volume_type"]),
 		},
 	}
 	p.env.Store.Put(res)

--- a/internal/providers/scaleway/ipam.go
+++ b/internal/providers/scaleway/ipam.go
@@ -189,7 +189,7 @@ func (p *Pack) getIPAMIP(w http.ResponseWriter, r *http.Request) {
 
 // bookIP reserves an address in a Private Network's subnet, which is the same
 // pool the NIC allocator draws from: both go through allocatorFor under
-// p.addresses, so a booked address and an allocated one cannot collide.
+// p.lockAddresses(), so a booked address and an allocated one cannot collide.
 //
 // Only the Private Network source is served. Upstream says the same thing of
 // itself — "not all sources are available for reservation", and picking a
@@ -245,8 +245,8 @@ func (p *Pack) bookIP(w http.ResponseWriter, r *http.Request) {
 	// Held from rebuild to Put, like every allocation in this pack: released
 	// earlier, a concurrent create rebuilds from a store that does not know
 	// about this address yet and hands it out again.
-	p.addresses.Lock()
-	defer p.addresses.Unlock()
+	unlock := p.lockAddresses()
+	defer unlock()
 
 	alloc, err := p.allocatorFor(pn)
 	if err != nil {
@@ -405,7 +405,7 @@ func (p *Pack) releaseIPAMIPSet(w http.ResponseWriter, r *http.Request) {
 	// The same lock, for the same reason releaseOne takes it: a delete frees an
 	// address, and freeing one while another request is allocating hands it out
 	// twice. Re-read under the lock, since the checks above ran outside it.
-	p.addresses.Lock()
+	unlock := p.lockAddresses()
 	for _, res := range batch {
 		current, found := p.env.Store.Get(Name, kindIPAMIP, res.ID)
 		if !found || ipamAttached(current) {
@@ -413,7 +413,7 @@ func (p *Pack) releaseIPAMIPSet(w http.ResponseWriter, r *http.Request) {
 		}
 		p.env.Store.Delete(Name, kindIPAMIP, current.ID)
 	}
-	p.addresses.Unlock()
+	unlock()
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -434,8 +434,8 @@ func (p *Pack) releaseOne(w http.ResponseWriter, res *resource.Resource) bool {
 	// one is exactly what frees an address: the read and the delete belong in the
 	// same critical section as the allocation they race.
 	// TestAReleasedAddressCannotBeTakenWhileItIsBeingAttached fails without this.
-	p.addresses.Lock()
-	defer p.addresses.Unlock()
+	unlock := p.lockAddresses()
+	defer unlock()
 
 	// Re-read under the lock. The caller resolved this resource outside it, and
 	// an attachment that landed in between is invisible to a stale clone.

--- a/internal/providers/scaleway/ipam.go
+++ b/internal/providers/scaleway/ipam.go
@@ -280,23 +280,16 @@ func (p *Pack) bookIP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	now := p.env.Now()
-	res := &resource.Resource{
-		ID:      p.env.NewID(),
-		Kind:    kindIPAMIP,
-		Tenant:  resource.Tenant{Provider: Name, Project: project, Zone: region},
-		State:   "available",
-		Created: now,
-		Updated: now,
-		Attrs: map[string]any{
-			"address":            netip.PrefixFrom(addr, alloc.Prefix().Bits()).String(),
-			"project_id":         project,
-			"is_ipv6":            false,
-			"tags":               orEmpty(req.Tags),
-			"private_network_id": pn.ID,
-			"vpc_id":             pn.Attrs["vpc_id"],
-			"subnet_id":          subnetIDOf(pn.ID),
-			attrBooked:           true,
-		},
+	res := resource.New(p.env.NewID(), kindIPAMIP, resource.Tenant{Provider: Name, Project: project, Zone: region}, "available", now)
+	res.Attrs = map[string]any{
+		"address":            netip.PrefixFrom(addr, alloc.Prefix().Bits()).String(),
+		"project_id":         project,
+		"is_ipv6":            false,
+		"tags":               orEmpty(req.Tags),
+		"private_network_id": pn.ID,
+		"vpc_id":             pn.Attrs["vpc_id"],
+		"subnet_id":          subnetIDOf(pn.ID),
+		attrBooked:           true,
 	}
 	if custom != nil {
 		res.Attrs[attrCustomMAC] = custom.MacAddress

--- a/internal/providers/scaleway/ipam_lock_internal_test.go
+++ b/internal/providers/scaleway/ipam_lock_internal_test.go
@@ -15,7 +15,7 @@ import (
 //
 // This is the defect an audit found in SW-4 and the reason it is tested from
 // inside the package rather than through a barrage. `bookIP` and
-// `createPrivateNIC` hold `p.addresses` from the moment they rebuild occupancy
+// `createPrivateNIC` hold `p.lockAddresses()` from the moment they rebuild occupancy
 // to the moment they store the result; `releaseOne` held nothing, while being
 // the operation that makes an address available again — `allocatorFor` rebuilds
 // occupancy from the IPAM resources alone, so deleting one is exactly what frees
@@ -59,8 +59,9 @@ func TestAReleasedAddressCannotBeTakenWhileItIsBeingAttached(t *testing.T) {
 	id, _ := booked["id"].(string)
 
 	// The allocator is busy, the way it is for the seconds another request
-	// spends between rebuilding occupancy and storing its result.
-	pack.addresses.Lock()
+	// spends between rebuilding occupancy and storing its result. The test
+	// holds the same domain the pack's own allocations take.
+	unlock := pack.lockAddresses()
 
 	done := make(chan int, 1)
 	go func() {
@@ -76,7 +77,7 @@ func TestAReleasedAddressCannotBeTakenWhileItIsBeingAttached(t *testing.T) {
 
 	select {
 	case status := <-done:
-		pack.addresses.Unlock()
+		unlock()
 		t.Fatalf("the release answered %d while the allocator was held: it frees an "+
 			"address without taking the lock every allocation takes", status)
 	case <-time.After(150 * time.Millisecond):
@@ -85,7 +86,7 @@ func TestAReleasedAddressCannotBeTakenWhileItIsBeingAttached(t *testing.T) {
 
 	// And it completes once the allocator is free: a release that never returned
 	// would satisfy the assertion above and break the product.
-	pack.addresses.Unlock()
+	unlock()
 	select {
 	case status := <-done:
 		if status != http.StatusNoContent {

--- a/internal/providers/scaleway/ips.go
+++ b/internal/providers/scaleway/ips.go
@@ -80,8 +80,8 @@ func (p *Pack) createIP(w http.ResponseWriter, r *http.Request) {
 	// Same lock as private addresses: rebuild, allocate, persist is a
 	// read-modify-write over the store, and two concurrent creates would
 	// otherwise receive the same address.
-	p.addresses.Lock()
-	defer p.addresses.Unlock()
+	unlock := p.lockAddresses()
+	defer unlock()
 
 	address, err := p.allocateFlexibleAddress()
 	if err != nil {
@@ -501,8 +501,8 @@ func (p *Pack) ensureDynamicAddress(res *resource.Resource) {
 		return
 	}
 
-	p.addresses.Lock()
-	defer p.addresses.Unlock()
+	unlock := p.lockAddresses()
+	defer unlock()
 	address, err := p.allocateFlexibleAddress()
 	if err != nil {
 		p.logger().Error("could not allocate a dynamic address",

--- a/internal/providers/scaleway/ips.go
+++ b/internal/providers/scaleway/ips.go
@@ -90,27 +90,20 @@ func (p *Pack) createIP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	now := p.env.Now()
-	res := &resource.Resource{
-		ID:      p.env.NewID(),
-		Kind:    kindIP,
-		Tenant:  resource.Tenant{Provider: Name, Project: project, Zone: zone},
-		State:   "detached",
-		Created: now,
-		Updated: now,
-		Attrs: map[string]any{
-			"address":      address.String(),
-			"reverse":      nil,
-			"server":       nil,
-			"organization": organization,
-			"project":      project,
-			"tags":         orEmpty(req.Tags),
-			"type":         orDefault(req.Type, "routed_ipv4"),
-			"prefix":       nil,
-			// A flexible IP is an IPAM address upstream, and the SDK carries the
-			// link. Serving an empty one would send a client looking for an
-			// address that does not exist there.
-			"ipam_id": "",
-		},
+	res := resource.New(p.env.NewID(), kindIP, resource.Tenant{Provider: Name, Project: project, Zone: zone}, "detached", now)
+	res.Attrs = map[string]any{
+		"address":      address.String(),
+		"reverse":      nil,
+		"server":       nil,
+		"organization": organization,
+		"project":      project,
+		"tags":         orEmpty(req.Tags),
+		"type":         orDefault(req.Type, "routed_ipv4"),
+		"prefix":       nil,
+		// A flexible IP is an IPAM address upstream, and the SDK carries the
+		// link. Serving an empty one would send a client looking for an
+		// address that does not exist there.
+		"ipam_id": "",
 	}
 	p.env.Store.Put(res)
 

--- a/internal/providers/scaleway/pack.go
+++ b/internal/providers/scaleway/pack.go
@@ -14,9 +14,9 @@ package scaleway
 import (
 	"net/http"
 	"slices"
-	"sync"
 
 	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/serialise"
 )
 
 // Name is the provider key used by the store and the coverage report.
@@ -25,20 +25,24 @@ const Name = "scaleway"
 // Pack implements emulator.Pack for Scaleway.
 type Pack struct {
 	env *emulator.Env
-	// defaults serializes the lazy provisioning of per-project inventory (the
-	// default security group). The store has no compare-and-set, so without it
-	// two concurrent first reads of a zone each create one.
-	defaults sync.Mutex
-	// addresses serializes address allocation, which is read-modify-write over
-	// the store: an allocator is rebuilt from what exists, hands out an address,
-	// and the result is persisted. Two requests interleaving there receive the
-	// same address, and Terraform creates ten resources at a time by default.
-	//
-	// One lock for every block rather than one per network: allocation is a
-	// handful of map operations, the contention is imperceptible, and a lock per
-	// resource would have to be created, found and eventually collected.
-	addresses sync.Mutex
 }
+
+// lockAddresses serialises address allocation, which is read-modify-write over
+// the store: an allocator is rebuilt from what exists, hands out an address,
+// and the result is persisted. Two requests interleaving there receive the
+// same address, and Terraform creates ten resources at a time by default.
+//
+// One domain for every block rather than one per network: allocation is a
+// handful of map operations, the contention is imperceptible, and a finer key
+// buys nothing. The lock itself lives in core/serialise, the same mechanism
+// every pack and the machine binding use, so the next pack does not have to
+// rediscover that it needs one.
+func (p *Pack) lockAddresses() func() { return serialise.Lock(Name + "/addresses") }
+
+// lockDefaults serialises the lazy provisioning of per-project inventory (the
+// default security group). The store has no compare-and-set, so without it
+// two concurrent first reads of a zone each create one.
+func (p *Pack) lockDefaults() func() { return serialise.Lock(Name + "/defaults") }
 
 // New returns a Scaleway pack backed by env.
 func New(env *emulator.Env) *Pack { return &Pack{env: env} }

--- a/internal/providers/scaleway/privatenics.go
+++ b/internal/providers/scaleway/privatenics.go
@@ -160,22 +160,15 @@ func (p *Pack) createPrivateNIC(w http.ResponseWriter, r *http.Request) {
 	}
 
 	now := p.env.Now()
-	res := &resource.Resource{
-		ID:      p.env.NewID(),
-		Kind:    kindPrivateNIC,
-		Tenant:  server.Tenant,
-		State:   "available",
-		Created: now,
-		Updated: now,
-		Attrs: map[string]any{
-			"private_network_id": pn.ID,
-			"mac_address":        macAddressOf(address),
-			"tags":               orEmpty(req.Tags),
-		},
-		Runtime: map[string]string{
-			runtimeServerKey:         server.ID,
-			runtimePrivateNetworkKey: pn.ID,
-		},
+	res := resource.New(p.env.NewID(), kindPrivateNIC, server.Tenant, "available", now)
+	res.Attrs = map[string]any{
+		"private_network_id": pn.ID,
+		"mac_address":        macAddressOf(address),
+		"tags":               orEmpty(req.Tags),
+	}
+	res.Runtime = map[string]string{
+		runtimeServerKey:         server.ID,
+		runtimePrivateNetworkKey: pn.ID,
 	}
 	p.env.Store.Put(res)
 

--- a/internal/providers/scaleway/privatenics.go
+++ b/internal/providers/scaleway/privatenics.go
@@ -114,8 +114,8 @@ func (p *Pack) createPrivateNIC(w http.ResponseWriter, r *http.Request) {
 	// this address, and hand out the same one. The booked path holds it too:
 	// checking an address is unattached and attaching it is the same
 	// read-modify-write.
-	p.addresses.Lock()
-	defer p.addresses.Unlock()
+	unlock := p.lockAddresses()
+	defer unlock()
 
 	// The client either names addresses it booked through ipam/v1, or receives
 	// one from the network's own block. Same pool both ways: the allocator is
@@ -243,7 +243,7 @@ func (p *Pack) createPrivateNIC(w http.ResponseWriter, r *http.Request) {
 
 // bookedIPsOf resolves the IPAM addresses a NIC create names, and refuses the
 // ones a create cannot take: an address of another network, another region, or
-// one something already holds. Resolved under p.addresses, which the caller
+// one something already holds. Resolved under p.lockAddresses(), which the caller
 // holds — the unattached check and the attachment must be one critical section.
 func (p *Pack) bookedIPsOf(w http.ResponseWriter, ids []string, pn, server *resource.Resource) ([]*resource.Resource, bool) {
 	booked := make([]*resource.Resource, 0, len(ids))

--- a/internal/providers/scaleway/routes.go
+++ b/internal/providers/scaleway/routes.go
@@ -87,19 +87,12 @@ func (p *Pack) createRoute(w http.ResponseWriter, r *http.Request) {
 	}
 
 	now := p.env.Now()
-	res := &resource.Resource{
-		ID:      p.env.NewID(),
-		Kind:    kindVPCRoute,
-		Tenant:  vpc.Tenant,
-		State:   "available",
-		Created: now,
-		Updated: now,
-		Attrs: map[string]any{
-			"description": req.Description,
-			"tags":        orEmpty(req.Tags),
-			"vpc_id":      vpc.ID,
-			"destination": destination.String(),
-		},
+	res := resource.New(p.env.NewID(), kindVPCRoute, vpc.Tenant, "available", now)
+	res.Attrs = map[string]any{
+		"description": req.Description,
+		"tags":        orEmpty(req.Tags),
+		"vpc_id":      vpc.ID,
+		"destination": destination.String(),
 	}
 	if req.NexthopResourceID != nil && *req.NexthopResourceID != "" {
 		res.Attrs["nexthop_resource_id"] = *req.NexthopResourceID

--- a/internal/providers/scaleway/securitygroups.go
+++ b/internal/providers/scaleway/securitygroups.go
@@ -493,8 +493,8 @@ func (p *Pack) deleteSecurityGroupRule(w http.ResponseWriter, r *http.Request) {
 // what keeps two concurrent reads from provisioning it twice; the store offers
 // no compare-and-set, and a duplicated default is a state no client expects.
 func (p *Pack) ensureDefaultSecurityGroup(zone, project string) *resource.Resource {
-	p.defaults.Lock()
-	defer p.defaults.Unlock()
+	unlock := p.lockDefaults()
+	defer unlock()
 
 	for _, res := range p.env.Store.List(kindSecurityGroup, resource.Tenant{Provider: Name, Project: project, Zone: zone}) {
 		if isProjectDefault(res) {

--- a/internal/providers/scaleway/securitygroups.go
+++ b/internal/providers/scaleway/securitygroups.go
@@ -596,27 +596,20 @@ func (p *Pack) newRule(w http.ResponseWriter, group *resource.Resource, req rule
 	}
 
 	now := p.env.Now()
-	res := &resource.Resource{
-		ID:      p.env.NewID(),
-		Kind:    kindSecurityGroupRule,
-		Tenant:  group.Tenant,
-		State:   "available",
-		Created: now,
-		Updated: now,
-		Attrs: map[string]any{
-			"protocol":  protocol,
-			"direction": direction,
-			"action":    action,
-			// The SDK decodes ip_range into scw.IPNet, which requires a CIDR:
-			// a bare address makes the client fail on the response it just got.
-			"ip_range":       ipRange,
-			"dest_port_from": portOrNil(req.DestPortFrom),
-			"dest_port_to":   portOrNil(req.DestPortTo),
-			"position":       position,
-			"editable":       deref(req.Editable, true),
-		},
-		Runtime: map[string]string{runtimeGroupKey: group.ID},
+	res := resource.New(p.env.NewID(), kindSecurityGroupRule, group.Tenant, "available", now)
+	res.Attrs = map[string]any{
+		"protocol":  protocol,
+		"direction": direction,
+		"action":    action,
+		// The SDK decodes ip_range into scw.IPNet, which requires a CIDR:
+		// a bare address makes the client fail on the response it just got.
+		"ip_range":       ipRange,
+		"dest_port_from": portOrNil(req.DestPortFrom),
+		"dest_port_to":   portOrNil(req.DestPortTo),
+		"position":       position,
+		"editable":       deref(req.Editable, true),
 	}
+	res.Runtime = map[string]string{runtimeGroupKey: group.ID}
 	return res, true
 }
 

--- a/internal/providers/scaleway/servers.go
+++ b/internal/providers/scaleway/servers.go
@@ -295,14 +295,7 @@ func (p *Pack) createServer(w http.ResponseWriter, r *http.Request) {
 
 	resolvedImageID, imageDisplay, imageLabel := resolveImage(req.Image)
 
-	res := &resource.Resource{
-		ID:      p.env.NewID(),
-		Kind:    kindServer,
-		Tenant:  resource.Tenant{Provider: Name, Project: project, Zone: zone},
-		State:   "stopped",
-		Created: now,
-		Updated: now,
-	}
+	res := resource.New(p.env.NewID(), kindServer, resource.Tenant{Provider: Name, Project: project, Zone: zone}, "stopped", now)
 	rootVol := p.rootVolume(res, req.Name, project, organization, req.Volumes["0"])
 
 	res.Attrs = map[string]any{

--- a/internal/providers/scaleway/snapshots.go
+++ b/internal/providers/scaleway/snapshots.go
@@ -105,23 +105,16 @@ func (p *Pack) createSnapshot(w http.ResponseWriter, r *http.Request) {
 
 	project, organization := projectOf(textPtr(req.Project))
 	now := p.env.Now()
-	res := &resource.Resource{
-		ID:      p.env.NewID(),
-		Kind:    kindSnapshot,
-		Tenant:  resource.Tenant{Provider: Name, Project: project, Zone: zone},
-		State:   "available",
-		Created: now,
-		Updated: now,
-		Attrs: map[string]any{
-			"name":         req.Name,
-			"organization": organization,
-			"project":      project,
-			"tags":         orEmpty(slicePtr(req.Tags)),
-			"volume_type":  volumeType,
-			"size":         size,
-			"zone":         zone,
-			"base_volume":  base,
-		},
+	res := resource.New(p.env.NewID(), kindSnapshot, resource.Tenant{Provider: Name, Project: project, Zone: zone}, "available", now)
+	res.Attrs = map[string]any{
+		"name":         req.Name,
+		"organization": organization,
+		"project":      project,
+		"tags":         orEmpty(slicePtr(req.Tags)),
+		"volume_type":  volumeType,
+		"size":         size,
+		"zone":         zone,
+		"base_volume":  base,
 	}
 	p.env.Store.Put(res)
 	emulator.WriteJSON(w, http.StatusCreated, map[string]any{"snapshot": p.snapshotView(res)})

--- a/internal/providers/scaleway/sshkeys.go
+++ b/internal/providers/scaleway/sshkeys.go
@@ -75,21 +75,14 @@ func (p *Pack) createSSHKey(w http.ResponseWriter, r *http.Request) {
 	project, organization := projectOf(req.ProjectID)
 	now := p.env.Now()
 
-	res := &resource.Resource{
-		ID:      p.env.NewID(),
-		Kind:    kindSSHKey,
-		Tenant:  resource.Tenant{Provider: Name, Project: project},
-		State:   "enabled",
-		Created: now,
-		Updated: now,
-		Attrs: map[string]any{
-			"name":            orDefault(req.Name, "key"),
-			"public_key":      strings.TrimSpace(req.PublicKey),
-			"fingerprint":     sshkey.FingerprintMD5(req.PublicKey),
-			"project_id":      project,
-			"organization_id": organization,
-			"disabled":        false,
-		},
+	res := resource.New(p.env.NewID(), kindSSHKey, resource.Tenant{Provider: Name, Project: project}, "enabled", now)
+	res.Attrs = map[string]any{
+		"name":            orDefault(req.Name, "key"),
+		"public_key":      strings.TrimSpace(req.PublicKey),
+		"fingerprint":     sshkey.FingerprintMD5(req.PublicKey),
+		"project_id":      project,
+		"organization_id": organization,
+		"disabled":        false,
 	}
 	p.env.Store.Put(res)
 

--- a/internal/providers/scaleway/vpc.go
+++ b/internal/providers/scaleway/vpc.go
@@ -250,9 +250,9 @@ func (p *Pack) createPrivateNetwork(w http.ResponseWriter, r *http.Request) {
 	// stored. Choosing and checking overlap without it meant two concurrent
 	// creates read the same state, picked the same free block, both passed
 	// FirstOverlap, and both took it — and Terraform creates ten resources at a
-	// time by default, which is the case p.addresses was introduced for.
-	p.addresses.Lock()
-	defer p.addresses.Unlock()
+	// time by default, which is the case p.lockAddresses() was introduced for.
+	unlock := p.lockAddresses()
+	defer unlock()
 
 	// The block is validated, not stored blindly. floci accepts any CIDR, never
 	// checks the mask, never checks overlap, and reports a fixed address count
@@ -494,8 +494,8 @@ func (p *Pack) enableDHCP(w http.ResponseWriter, r *http.Request) {
 // security group, it is lazy: the emulator has no notion of "a project was
 // created", so the first read is the only moment it can happen.
 func (p *Pack) ensureDefaultVPC(region, project string) *resource.Resource {
-	p.defaults.Lock()
-	defer p.defaults.Unlock()
+	unlock := p.lockDefaults()
+	defer unlock()
 
 	scope := resource.Tenant{Provider: Name, Project: project, Zone: region}
 	for _, res := range p.env.Store.List(kindVPC, scope) {

--- a/internal/providers/scaleway/vpc.go
+++ b/internal/providers/scaleway/vpc.go
@@ -537,65 +537,32 @@ func (p *Pack) newVPC(region, project, name string, isDefault bool) *resource.Re
 // isolate keeps the emulated subnets apart, which two managed bridges on one
 // host are not by themselves.
 //
-// What counts as foreign is a Scaleway question. Two Private Networks of one VPC
-// are routed to each other upstream when the VPC has routing enabled, so they
-// stay reachable here; everything else, another VPC or another project, is
-// rejected. Reconciled over every network because a new subnet changes what its
-// neighbours must keep out.
-//
-// A runtime with native isolation inverts the work: its networks reach nothing
-// until peered, so the question is no longer what to keep out but what to let
-// in, and the same reachability rule answers both.
+// What counts as foreign is a Scaleway question, and it is the only part
+// written here: two Private Networks of one VPC are routed to each other
+// upstream when the VPC has routing enabled, so they stay reachable;
+// everything else, another VPC or another project, is rejected. The
+// reconciliation itself — peer lists under native isolation, foreign blocks
+// otherwise, over every network because a new subnet changes what its
+// neighbours must keep out — is machine.ReconcileIsolation, shared with the
+// two other packs rather than copied a third time (#201 measured what the
+// copies cost).
 func (p *Pack) isolateNetworks(ctx context.Context) {
 	all := p.env.Store.List(kindPrivateNetwork, resource.Tenant{Provider: Name})
-
-	if peerer, ok := p.env.Machines.(machine.Peerer); ok && peerer.NativeIsolation() {
-		for _, pn := range all {
-			name := pn.Runtime[runtimeNetworkKey]
-			if name == "" {
-				continue
-			}
-			peers := make([]string, 0, len(all))
-			for _, other := range all {
-				if other.ID == pn.ID || other.Runtime[runtimeNetworkKey] == "" {
-					continue
-				}
-				if p.reachableFrom(pn, other) {
-					peers = append(peers, other.Runtime[runtimeNetworkKey])
-				}
-			}
-			if err := peerer.PeerNetworks(ctx, name, peers); err != nil {
-				p.logger().Error("could not peer the private network",
-					"private_network", pn.ID, "network", name, "error", err)
-			}
+	members := make([]machine.IsolationMember, len(all))
+	for i, pn := range all {
+		block, _ := pn.Attrs["subnet"].(string)
+		members[i] = machine.IsolationMember{
+			ID:      pn.ID,
+			Network: pn.Runtime[runtimeNetworkKey],
+			Block:   block,
 		}
-		// No group resync here: with native isolation the rule sets carry no
+	}
+	native, applied := machine.ReconcileIsolation(ctx, p.env.Machines, p.logger(), "private_network",
+		members, func(from, to int) bool { return p.reachableFrom(all[from], all[to]) })
+	if native || !applied {
+		// No group resync under native isolation: the rule sets carry no
 		// foreign blocks, so a subnet coming or going changes nothing in them.
 		return
-	}
-
-	isolator, ok := p.env.Machines.(machine.Isolator)
-	if !ok {
-		return
-	}
-	for _, pn := range all {
-		name := pn.Runtime[runtimeNetworkKey]
-		if name == "" {
-			continue
-		}
-		foreign := make([]string, 0, len(all))
-		for _, other := range all {
-			if other.ID == pn.ID || p.reachableFrom(pn, other) {
-				continue
-			}
-			if block, _ := other.Attrs["subnet"].(string); block != "" {
-				foreign = append(foreign, block)
-			}
-		}
-		if err := isolator.IsolateNetwork(ctx, name, foreign); err != nil {
-			p.logger().Error("could not isolate the private network",
-				"private_network", pn.ID, "network", name, "error", err)
-		}
 	}
 
 	// The rule sets carried by the machines say the same thing, and they are the

--- a/internal/providers/scaleway/vpc.go
+++ b/internal/providers/scaleway/vpc.go
@@ -276,23 +276,16 @@ func (p *Pack) createPrivateNetwork(w http.ResponseWriter, r *http.Request) {
 	}
 
 	now := p.env.Now()
-	res := &resource.Resource{
-		ID:      p.env.NewID(),
-		Kind:    kindPrivateNetwork,
-		Tenant:  resource.Tenant{Provider: Name, Project: project, Zone: region},
-		State:   "available",
-		Created: now,
-		Updated: now,
-		Attrs: map[string]any{
-			"name":                              orDefault(req.Name, "pn-"+prefix.Addr().String()),
-			"project_id":                        project,
-			"organization_id":                   defaultOrganization,
-			"vpc_id":                            vpc.ID,
-			"tags":                              orEmpty(req.Tags),
-			"dhcp_enabled":                      true,
-			"default_route_propagation_enabled": deref(req.DefaultRoutePropagationEnabled, false),
-			"subnet":                            prefix.String(),
-		},
+	res := resource.New(p.env.NewID(), kindPrivateNetwork, resource.Tenant{Provider: Name, Project: project, Zone: region}, "available", now)
+	res.Attrs = map[string]any{
+		"name":                              orDefault(req.Name, "pn-"+prefix.Addr().String()),
+		"project_id":                        project,
+		"organization_id":                   defaultOrganization,
+		"vpc_id":                            vpc.ID,
+		"tags":                              orEmpty(req.Tags),
+		"dhcp_enabled":                      true,
+		"default_route_propagation_enabled": deref(req.DefaultRoutePropagationEnabled, false),
+		"subnet":                            prefix.String(),
 	}
 	// The backing network is created before the resource is stored, and a
 	// failure is fatal to the request rather than logged.

--- a/internal/upstream/upstream.go
+++ b/internal/upstream/upstream.go
@@ -246,10 +246,27 @@ func (c *Client) once(ctx context.Context, call string) (trace.Exchange, error) 
 	return ex, nil
 }
 
+// OutscaleCall is the one place the Outscale dialect is written: the key the
+// shapes catalogue records an action under, and the request that produces it.
+// The key carries the SDK's own qualifier so a shape file and a route table
+// agree; the request is a POST on /api/v1/<Action>, which is the whole of
+// Outscale's URL structure.
+//
+// Exported because the shapes gate replays the same identity against the
+// emulator: written twice — here and in the gate — a fix in one survived
+// broken in the other, which is this repository's named failure pattern
+// (docs/fourth-pack.md measured it). Both callers consume this function, and
+// TestTheOutscaleCallIdentityIsPinned holds the values the recorded catalogues
+// on disk depend on.
+func OutscaleCall(action string) (key, method, path string) {
+	return "osc/Client." + action, http.MethodPost, "/api/v1/" + action
+}
+
 // request turns a call into a request, in the provider's own dialect.
 func (c *Client) request(call string) (method, path string, body []byte) {
 	if c.Provider == Outscale {
-		return http.MethodPost, "/api/v1/" + call, []byte("{}")
+		_, method, path := OutscaleCall(call)
+		return method, path, []byte("{}")
 	}
 	return http.MethodGet, call, nil
 }
@@ -259,7 +276,8 @@ func (c *Client) request(call string) (method, path string, body []byte) {
 // two are named by their path, which is what their operations are.
 func (c *Client) operationName(call string) string {
 	if c.Provider == Outscale {
-		return "osc/Client." + call
+		key, _, _ := OutscaleCall(call)
+		return key
 	}
 	return ""
 }

--- a/internal/upstream/upstream_test.go
+++ b/internal/upstream/upstream_test.go
@@ -267,3 +267,22 @@ func TestTomlValueReadsEveryQuotingTheFileMayUse(t *testing.T) {
 		t.Errorf("a missing key read as %q", got)
 	}
 }
+
+// The Outscale call identity — key prefix, method, path — is one exported
+// function with two consumers: the recorder here and the shapes gate in
+// internal/cli. The values are pinned because artefacts on disk depend on
+// them: shapes/outscale.json keys its operations "osc/Client.<Action>", and a
+// silent change would orphan every recorded catalogue while both consumers
+// kept agreeing with each other.
+func TestTheOutscaleCallIdentityIsPinned(t *testing.T) {
+	key, method, path := OutscaleCall("ReadVms")
+	if key != "osc/Client.ReadVms" {
+		t.Errorf("key = %q, want osc/Client.ReadVms", key)
+	}
+	if method != http.MethodPost {
+		t.Errorf("method = %q, want POST", method)
+	}
+	if path != "/api/v1/ReadVms" {
+		t.Errorf("path = %q, want /api/v1/ReadVms", path)
+	}
+}

--- a/tools/falsify/specs/address-domains.json
+++ b/tools/falsify/specs/address-domains.json
@@ -1,0 +1,28 @@
+{
+  "package": "./internal/providers/scaleway/",
+  "mutations": [
+    {
+      "label": "the scaleway addresses domain releases before the transaction, and a release no longer waits on an allocation",
+      "file": "internal/providers/scaleway/pack.go",
+      "find": "func (p *Pack) lockAddresses() func() { return serialise.Lock(Name + \"/addresses\") }",
+      "replace": "func (p *Pack) lockAddresses() func() {\n\tserialise.Lock(Name + \"/addresses\")()\n\treturn func() {}\n}",
+      "test": "TestAReleasedAddressCannotBeTakenWhileItIsBeingAttached"
+    },
+    {
+      "label": "the outscale addressing domain releases before the transaction, and concurrent creates share an address",
+      "file": "internal/providers/outscale/pack.go",
+      "find": "func (p *Pack) lockAddresses() func() { return serialise.Lock(Name + \"/addresses\") }",
+      "replace": "func (p *Pack) lockAddresses() func() {\n\tserialise.Lock(Name + \"/addresses\")()\n\treturn func() {}\n}",
+      "test": "TestConcurrentCreatesDoNotShareAnAddress",
+      "package": "./internal/providers/outscale/"
+    },
+    {
+      "label": "the exoscale addresses domain releases before the transaction, and concurrent allocations share",
+      "file": "internal/providers/exoscale/pack.go",
+      "find": "func (p *Pack) lockAddresses() func() { return serialise.Lock(Name + \"/addresses\") }",
+      "replace": "func (p *Pack) lockAddresses() func() {\n\tserialise.Lock(Name + \"/addresses\")()\n\treturn func() {}\n}",
+      "test": "TestConcurrentAllocationsShareNothing",
+      "package": "./internal/providers/exoscale/"
+    }
+  ]
+}

--- a/tools/falsify/specs/isolation-reconcile.json
+++ b/tools/falsify/specs/isolation-reconcile.json
@@ -1,0 +1,26 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "the peer list ignores reachability, and foreign networks are joined",
+      "file": "internal/core/machine/isolate.go",
+      "find": "\t\t\t\tif reachable(i, j) {\n\t\t\t\t\tpeers = append(peers, other.Network)\n\t\t\t\t}",
+      "replace": "\t\t\t\tif reachable(i, j) || true {\n\t\t\t\t\tpeers = append(peers, other.Network)\n\t\t\t\t}",
+      "test": "TestReconcilePeersExactlyTheReachableMembers"
+    },
+    {
+      "label": "the foreign list keeps reachable neighbours out too, severing what the provider routes",
+      "file": "internal/core/machine/isolate.go",
+      "find": "\t\t\tif j == i || reachable(i, j) {\n\t\t\t\tcontinue\n\t\t\t}",
+      "replace": "\t\t\tif j == i || (reachable(i, j) && false) {\n\t\t\t\tcontinue\n\t\t\t}",
+      "test": "TestReconcileKeepsOnlyForeignBlocksOut"
+    },
+    {
+      "label": "a member without a backing network is configured under its empty name",
+      "file": "internal/core/machine/isolate.go",
+      "find": "\t\tfor i, m := range members {\n\t\t\tif m.Network == \"\" {\n\t\t\t\tcontinue\n\t\t\t}\n\t\t\tpeers := make([]string, 0, len(members))",
+      "replace": "\t\tfor i, m := range members {\n\t\t\tif m.Network == \"\\x00never\" {\n\t\t\t\tcontinue\n\t\t\t}\n\t\t\tpeers := make([]string, 0, len(members))",
+      "test": "TestReconcileSkipsWhatHasNoNetworkOrNoBlock"
+    }
+  ]
+}

--- a/tools/falsify/specs/outscale-call-identity.json
+++ b/tools/falsify/specs/outscale-call-identity.json
@@ -1,0 +1,26 @@
+{
+  "package": "./internal/upstream/",
+  "mutations": [
+    {
+      "label": "the catalogue key prefix drifts, and every recorded shape file is orphaned in silence",
+      "file": "internal/upstream/upstream.go",
+      "find": "\treturn \"osc/Client.\" + action, http.MethodPost, \"/api/v1/\" + action",
+      "replace": "\treturn \"osc/Client2.\" + action, http.MethodPost, \"/api/v1/\" + action",
+      "test": "TestTheOutscaleCallIdentityIsPinned"
+    },
+    {
+      "label": "the path drifts, and both consumers agree on a request the API does not serve",
+      "file": "internal/upstream/upstream.go",
+      "find": "\treturn \"osc/Client.\" + action, http.MethodPost, \"/api/v1/\" + action",
+      "replace": "\treturn \"osc/Client.\" + action, http.MethodPost, \"/api/v2/\" + action",
+      "test": "TestTheOutscaleCallIdentityIsPinned"
+    },
+    {
+      "label": "the method drifts, and the gate probes with a verb the emulator routes nowhere",
+      "file": "internal/upstream/upstream.go",
+      "find": "\treturn \"osc/Client.\" + action, http.MethodPost, \"/api/v1/\" + action",
+      "replace": "\treturn \"osc/Client.\" + action, http.MethodGet, \"/api/v1/\" + action",
+      "test": "TestTheOutscaleCallIdentityIsPinned"
+    }
+  ]
+}

--- a/tools/falsify/specs/resource-new.json
+++ b/tools/falsify/specs/resource-new.json
@@ -1,0 +1,19 @@
+{
+  "package": "./internal/core/resource/",
+  "mutations": [
+    {
+      "label": "New stops readying Attrs, and the first pack write into it panics",
+      "file": "internal/core/resource/resource.go",
+      "find": "\t\tAttrs:   map[string]any{},",
+      "replace": "\t\tAttrs:   map[string]any(nil),",
+      "test": "TestNewAlignsTheClocksAndReadiesAttrs"
+    },
+    {
+      "label": "the clocks stop agreeing at birth, and every created resource reads as already modified",
+      "file": "internal/core/resource/resource.go",
+      "find": "\t\tCreated: now,\n\t\tUpdated: now,",
+      "replace": "\t\tCreated: now,\n\t\tUpdated: now.Add(time.Second),",
+      "test": "TestNewAlignsTheClocksAndReadiesAttrs"
+    }
+  ]
+}

--- a/tools/falsify/specs/serialise.json
+++ b/tools/falsify/specs/serialise.json
@@ -1,0 +1,28 @@
+{
+  "package": "./internal/core/serialise/",
+  "mutations": [
+    {
+      "label": "the refcount cleanup never fires, and the map keeps one mutex per domain forever",
+      "file": "internal/core/serialise/serialise.go",
+      "find": "\t\t\tl.refs--\n\t\t\tif l.refs == 0 {\n\t\t\t\tdelete(k.held, key)\n\t\t\t}",
+      "replace": "\t\t\tl.refs--\n\t\t\tif l.refs == 0 && false {\n\t\t\t\tdelete(k.held, key)\n\t\t\t}",
+      "test": "TestADomainIsForgottenOnceNobodyHoldsIt"
+    },
+    {
+      "label": "the target id falls out of the key, and every server queues behind one launch",
+      "file": "internal/core/machine/serialise.go",
+      "find": "\treturn serialise.Lock(b.Provider + \"|\" + id)",
+      "replace": "\treturn serialise.Lock(b.Provider + \"|\" + id[:0])",
+      "test": "TestSerialiseDoesNotQueueDifferentTargets",
+      "package": "./internal/core/machine/"
+    },
+    {
+      "label": "the provider falls out of the key, and two packs wait on each other's ids",
+      "file": "internal/core/machine/serialise.go",
+      "find": "\treturn serialise.Lock(b.Provider + \"|\" + id)",
+      "replace": "\treturn serialise.Lock(b.Provider[:0] + \"|\" + id)",
+      "test": "TestSerialiseSeparatesProviders",
+      "package": "./internal/core/machine/"
+    }
+  ]
+}

--- a/tools/falsify/specs/sweep-liveness.json
+++ b/tools/falsify/specs/sweep-liveness.json
@@ -1,0 +1,12 @@
+{
+  "package": "./internal/core/store/storetest/",
+  "mutations": [
+    {
+      "label": "the address invariant goes blind to liveness again, and convicts a legitimate reuse",
+      "file": "internal/core/store/storetest/sweep.go",
+      "find": "\t\tif gone != nil && gone(res) {\n\t\t\tcontinue\n\t\t}",
+      "replace": "\t\tif gone != nil && gone(res) && false {\n\t\t\tcontinue\n\t\t}",
+      "test": "TestAGoneResourcesAddressIsNotShared"
+    }
+  ]
+}

--- a/tools/falsify/specs/terminated-addresses.json
+++ b/tools/falsify/specs/terminated-addresses.json
@@ -1,0 +1,19 @@
+{
+  "package": "./internal/providers/outscale/",
+  "mutations": [
+    {
+      "label": "the dead reservation returns, and a Subnet fills with ghosts nothing can release",
+      "file": "internal/providers/outscale/privateips.go",
+      "find": "\t\tif Gone(vm) || stringOf(vm.Attrs[\"SubnetId\"]) != subnetID {\n\t\t\tcontinue\n\t\t}",
+      "replace": "\t\tif (Gone(vm) && false) || stringOf(vm.Attrs[\"SubnetId\"]) != subnetID {\n\t\t\tcontinue\n\t\t}",
+      "test": "TestATerminatedVmsAddressReturnsToItsSubnet"
+    },
+    {
+      "label": "the state-blind invariant returns, and convicts the legitimate reuse it once got reverted",
+      "file": "internal/core/store/storetest/sweep.go",
+      "find": "\t\tif gone != nil && gone(res) {\n\t\t\tcontinue\n\t\t}",
+      "replace": "\t\tif gone != nil && gone(res) && false {\n\t\t\tcontinue\n\t\t}",
+      "test": "TestATerminatedVmsAddressReturnsToItsSubnet"
+    }
+  ]
+}

--- a/tools/falsify/specs/transition.json
+++ b/tools/falsify/specs/transition.json
@@ -1,0 +1,26 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "the target releases before the change, and two actions run on one machine at once",
+      "file": "internal/core/machine/transition.go",
+      "find": "\tunlock := b.Serialise(id)\n\tdefer unlock()",
+      "replace": "\tunlock := b.Serialise(id)\n\tunlock()",
+      "test": "TestTransitionExcludesASecondActionOnTheTarget"
+    },
+    {
+      "label": "a failed write-back is retried unconditionally, and a deleted resource comes back",
+      "file": "internal/core/machine/transition.go",
+      "find": "\treturn st.Update(b.Provider, kind, id, func(stored *resource.Resource) error {\n\t\tstored.State = res.State\n\t\tstored.Runtime = res.Runtime\n\t\tstored.Attrs = res.Attrs\n\t\tstored.Updated = now()\n\t\treturn nil\n\t})",
+      "replace": "\terr := st.Update(b.Provider, kind, id, func(stored *resource.Resource) error {\n\t\tstored.State = res.State\n\t\tstored.Runtime = res.Runtime\n\t\tstored.Attrs = res.Attrs\n\t\tstored.Updated = now()\n\t\treturn nil\n\t})\n\tif err != nil {\n\t\tst.Put(res)\n\t}\n\treturn nil",
+      "test": "TestADeleteLandingMidTransitionWins"
+    },
+    {
+      "label": "a missing target no longer stops the change, and the runtime works for a resource nobody stores",
+      "file": "internal/core/machine/transition.go",
+      "find": "\tif !found {\n\t\treturn store.ErrNotFound\n\t}",
+      "replace": "\tif !found {\n\t\tres = &resource.Resource{Attrs: map[string]any{}}\n\t\t_ = store.ErrNotFound\n\t}",
+      "test": "TestTransitionRefusesAMissingTargetBeforeTheChange"
+    }
+  ]
+}


### PR DESCRIPTION
A factorisation pass before a fourth cloud, scoped by the repository's own rule:
**shapes must differ, behaviour must not be rewritten per provider**. Eight
commits, stacked, each reviewable on its own.

The model was `machine.Binding`: before it, every pack rewrote ~150 lines of
machine lifecycle when only a prefix, a login, an image and an address key
varied. The signal for what to look at next was mechanical — **any comment
saying "the same defect the other pack fixed" or "same discipline as the Outscale
pack"**. The code had several.

## What moved

| commit | before | after |
|---|---|---|
| `a5ee907` | 5 local locking systems: `machine`'s per-target map plus 4 `sync.Mutex` (Scaleway `addresses`+`defaults`, Outscale, Exoscale) | one `core/serialise.Lock(domain)`, domain opaque to the core, refcounted |
| `a903a86` | 3 packs, 25 lock sites around the same `List → rebuild → Allocate → Put` transaction | the same 25 sites through one core domain lock. **Granularity deliberately unchanged** — the barrage judges the current semantics |
| `0c6a1f7` | `transitionOne` (Outscale, 3 callers) and `transitionInstance` (Exoscale, 6 callers) | `Binding.Transition`: serialise the target, existence first, change outside the store lock, conditional write-back. **Observable states stay in the packs** |
| `66a09a8` | the Outscale call identity (prefix, method, path) written twice, in `internal/upstream` and in `shapes_check` | `upstream.OutscaleCall`, consumed by both — the remedy `docs/fourth-pack.md` prescribed |
| `5d31ec5` | 3 twin loops in `scaleway/vpc.go`, `outscale/isolate.go`, `exoscale/privatenetworks.go` | `machine.ReconcileIsolation(members, reachable)`; only the predicate stays per pack |
| `d43fc02` | 42 `&resource.Resource{…}` literals repeating id, kind, tenant, two aligned clocks | `resource.New`, 32 mechanical literals migrated. `Attrs` stays in the pack — the keys are the provider's wire shape |

## What the pass found, which is the point

The two Outscale allocator constructors **disagreed about what a dead machine
is**: one reserved terminated Vms' addresses, the other released them. Nobody
could see it while they lived apart.

Pulling that thread reached the control itself. `storetest.sharedAddresses`
compared addresses **without reading liveness**, so a terminated Vm counted as a
live one — and that false verdict is what made an earlier, correct unification
get reverted last night.

So: **`placeInSubnet` reserved terminated Vms' addresses forever**, while the
pack's own comment says Outscale releases the private address on termination. A
Subnet filled with ghosts nothing could release. Two commits, in that order:

- `e042787` fixes **the measurement**. `Sweep` takes a `Gone` predicate; the
  vocabulary (`terminated`, `deleted`) stays in the pack, because rule 5 keeps
  provider words out of the core — the comment cites the watcher filter as the
  shape to refuse. `nil` means the **strict** reading, so a pack that forgets its
  predicate gets a loud false positive pointing at the predicate, never a silent
  blind spot.
- `ad14066` fixes **the measured**. One allocator constructor, reading the same
  `Gone` as the sweep, with the comment saying why the two can no longer diverge.

## Red then green, demonstrated

`mise run falsify -- tools/falsify/specs/terminated-addresses.json`, run
independently of the agent that wrote it:

```
ok  the dead reservation returns, and a Subnet fills with ghosts nothing can release
ok  the state-blind invariant returns, and convicts the legitimate reuse it once got reverted
```

The second mutation restores the invariant that produced the false verdict, and a
named test goes red. **The control that misled us is now itself under test.**

## What was deliberately not factorised

As important as the rest, and the reason this is a pass rather than a rewrite:

- **error envelopes, pagination, `view()`, route tables, `Declined()`,
  catalogues, the Store** — untouched. These are where providers *must* differ,
  and a generic mapper over `view()` would recreate the leak this project exists
  to detect;
- **lock granularity** — no per-subnet domain; the barrage judges the current
  semantics;
- **`updateVm` and `deleteInstance`** stay outside `Transition`: mid-flight
  validations that write responses, and a delete is not a transition;
- **`orDefault` / `boolOr`** left duplicated. A `core/util` with fifteen trivial
  helpers would be worse.

## Measured

| | |
|---|---|
| `go test -race ./internal/providers/... -run Barrage` | green on all three packs |
| `FEINT_VM=incus-ovn mise run conformance` | **109 ok, 0 FAIL** — isolation held, over-isolation refused, every carried address published |
| `mise run falsify:all` | **18 falsifications**, 11 of them new |
| `mise run prepush` | green after each commit |

The OVN run matters here specifically: `ReconcileIsolation` moved into the core,
and unit tests prove what the driver is *sent*, never what the runtime *accepts*.

## Left open, named

`vmView` still publishes `PrivateIp` on a terminated Vm. Whether the real API
does is a response-shape question settled against the SDK, not in a factorisation
pass — but it is now visible: the address returns to the Subnet while the API
still shows it on the destroyed machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
