### PR TITLE
fix(machine): ApplyFirewall asks whether the instance is ours, and the sweep looks across kinds (#209, #210)

### DIFF
--- a/internal/core/machine/incus_firewall.go
+++ b/internal/core/machine/incus_firewall.go
@@ -138,6 +138,23 @@ func (d *Incus) ApplyFirewall(ctx context.Context, machine string, binding Firew
 	if !safeName.MatchString(machine) {
 		return fmt.Errorf("invalid machine name %q", machine)
 	}
+	// Well formed is not authorised, and this path had only the first half.
+	//
+	// safeName answers "could this become a command argument safely". It accepts
+	// `production-database` and every other name on the host. The name arrives
+	// from Resource.Runtime, which `PUT /_feint/state` and `feint snapshot load`
+	// restore verbatim — snapshot.go documents the format as meant to outlive its
+	// instance and be loaded into another one — so a crafted snapshot named any
+	// instance and this call edited its network devices.
+	//
+	// RemoveFirewall already asks the question. The list of guarded paths forgot
+	// that *installing* a rule set on somebody else's NIC is as much a change as
+	// removing one: reconfiguring paths belong in it, not only destructive ones.
+	//
+	// TestApplyFirewallRefusesAnInstanceTheEmulatorDidNotCreate fails without this.
+	if err := d.mustOwnInstance(ctx, machine); err != nil {
+		return err
+	}
 	devices, err := d.networkDevices(ctx, machine)
 	if err != nil {
 		return err

--- a/internal/core/machine/incus_firewall_test.go
+++ b/internal/core/machine/incus_firewall_test.go
@@ -45,6 +45,16 @@ func (f *fakeRuntime) run(_ context.Context, args ...string) ([]byte, error) {
 			return []byte(answer), nil
 		}
 	}
+	// The ownership probe answers "ours" unless a test says otherwise.
+	//
+	// Every machine in these tests is one the emulator created, so that is the
+	// case a fixture should not have to restate; a test about the *refusal*
+	// declares the empty label explicitly, which is the half worth spelling out.
+	// Without this default, adding the guard to ApplyFirewall turned four
+	// unrelated tests red for a reason none of them is about.
+	if strings.HasPrefix(key, "config get ") && strings.Contains(key, "user."+LabelKey) {
+		return []byte("feint\n"), nil
+	}
 	return nil, nil
 }
 
@@ -350,5 +360,78 @@ func TestFirewallNameIsStableAndFitsAnInterface(t *testing.T) {
 	// A second pack uses another prefix, and the two must not collide on one id.
 	if other := FirewallName("osc", id); other == first {
 		t.Fatalf("two providers produced the same name %q for one id", first)
+	}
+}
+
+// ApplyFirewall refuses an instance the emulator did not create (#209).
+//
+// safeName answers "could this become a command argument safely" and accepts
+// `production-database` like every other name on the host. The machine name
+// arrives from Resource.Runtime, which PUT /_feint/state and `feint snapshot
+// load` restore verbatim, so a crafted snapshot named any instance and this
+// call edited its network devices.
+//
+// RemoveFirewall already asked the question. The guarded list forgot that
+// installing a rule set on somebody else's NIC is as much a change as removing
+// one — a reconfiguring path, not only a destructive one.
+//
+// The assertion is on the arguments, not on the error: what matters is that no
+// command carrying the foreign name is ever emitted, which is what the runner
+// seam exists to measure.
+func TestApplyFirewallRefusesAnInstanceTheEmulatorDidNotCreate(t *testing.T) {
+	const foreign = "production-database"
+	f := &fakeRuntime{answers: map[string]string{
+		// The label is absent: this instance is the operator's, not ours.
+		"config get " + foreign: "",
+		"/1.0/instances/":       twoNICs,
+		"/1.0/networks/":        `{"type": "bridge"}`,
+	}}
+	d := newFakeDriver(f)
+
+	err := d.ApplyFirewall(context.Background(), foreign, FirewallBinding{
+		Names:          []string{"sg-one"},
+		DefaultIngress: "drop",
+		DefaultEgress:  "allow",
+	})
+	if err == nil {
+		t.Fatal("a firewall was applied to an instance the emulator never created")
+	}
+
+	for _, command := range f.commands() {
+		if !strings.Contains(command, foreign) {
+			continue
+		}
+		// Reading the label is the question itself, so it is allowed to name it.
+		if strings.HasPrefix(command, "config get ") {
+			continue
+		}
+		t.Errorf("a command reached the operator's own instance: %s", command)
+	}
+}
+
+// And the accepting half. A guard that refused everything would pass the test
+// above and leave the product unable to attach a security group at all.
+func TestApplyFirewallStillWorksOnOurOwnInstance(t *testing.T) {
+	f := &fakeRuntime{answers: map[string]string{
+		"/1.0/instances/srv": twoNICs,
+		"/1.0/networks/":     `{"type": "bridge"}`,
+	}}
+	d := newFakeDriver(f)
+
+	if err := d.ApplyFirewall(context.Background(), "srv", FirewallBinding{
+		Names:          []string{"sg-one"},
+		DefaultIngress: "drop",
+		DefaultEgress:  "allow",
+	}); err != nil {
+		t.Fatalf("the guard refused an instance the emulator created: %v", err)
+	}
+	var applied bool
+	for _, command := range f.commands() {
+		if strings.Contains(command, "security.acls") {
+			applied = true
+		}
+	}
+	if !applied {
+		t.Errorf("no rule set was applied:\n%s", strings.Join(f.commands(), "\n"))
 	}
 }

--- a/internal/core/machine/ownership_test.go
+++ b/internal/core/machine/ownership_test.go
@@ -175,9 +175,11 @@ func TestPeerNetworksRefusesForeignNetworksOnEitherEnd(t *testing.T) {
 }
 
 func TestUnrouteAddressRefusesAnInstanceWithoutTheEmulatorsLabel(t *testing.T) {
-	// The fake answers nothing for `config get`, which is what an unlabelled
-	// instance looks like: it exists, and it is not ours.
-	f := &fakeRuntime{}
+	// The empty label is what an unlabelled instance looks like: it exists, and
+	// it is not ours. Declared rather than left to the fake's silence — since
+	// #209 the fake answers "ours" by default, because that is the case every
+	// other test is about, and the refusal is the half worth spelling out.
+	f := &fakeRuntime{answers: map[string]string{"config get production-database": ""}}
 	d := newFakeDriver(f)
 
 	err := d.UnrouteAddress(context.Background(), "production-database", "10.0.0.5")

--- a/internal/core/store/storetest/sweep.go
+++ b/internal/core/store/storetest/sweep.go
@@ -42,6 +42,12 @@ import (
 // stricter, never blinder.
 type Gone func(*resource.Resource) bool
 
+// Shared reports two resources that may hold one address without it being a
+// defect — a record that *is* an address and the machine it is attached to, for
+// instance. The relation is the pack's knowledge, so the pack declares it; nil
+// means no pair is exempt, which is the strict reading.
+type Shared func(a, b *resource.Resource) bool
+
 // Sweep reports every invariant the store broke, one line each, sorted so two
 // runs of the same failure read the same.
 //
@@ -52,10 +58,15 @@ type Gone func(*resource.Resource) bool
 // gone is the pack's word on which resources no longer exist; nil means all of
 // them do. Only the address invariant reads it — an identifier is issued once
 // forever, and a runtime object claimed by a dead record is still an orphan.
-func Sweep(resources []*resource.Resource, gone Gone) []string {
+//
+// shared is the pack's word on which pairs may hold one address without it being
+// a defect; nil means none may. Both are the pack's knowledge rather than the
+// core's, for the reason CLAUDE.md's rule 5 gives: this package must not learn
+// three providers' vocabularies to do its job.
+func Sweep(resources []*resource.Resource, gone Gone, shared Shared) []string {
 	var found []string
 	found = append(found, duplicateIdentifiers(resources)...)
-	found = append(found, sharedAddresses(resources, gone)...)
+	found = append(found, sharedAddresses(resources, gone, shared)...)
 	found = append(found, sharedRuntimeObjects(resources)...)
 	sort.Strings(found)
 	return found
@@ -107,9 +118,27 @@ func duplicateIdentifiers(resources []*resource.Resource) []string {
 // keyed on them is a sweep the fourth pack escapes. Anything that parses as an
 // IP is an address; a prefix like 10.0.0.0/24 is not, and is skipped, since a
 // subnet legitimately appears on the network and on everything placed in it.
-func sharedAddresses(resources []*resource.Resource, gone Gone) []string {
-	// kind -> address -> the first resource holding it
-	byKind := map[string]map[string]string{}
+func sharedAddresses(resources []*resource.Resource, gone Gone, shared Shared) []string {
+	// address -> the first resource holding it, across every kind (#210).
+	//
+	// This used to be keyed by kind, so it only compared machines with machines
+	// and NICs with NICs. Its own header promises one address handed to two
+	// resources, and the cross-kind case — the one that actually happens, since
+	// a pool is shared by everything placed in it — was invisible. Proven by a
+	// probe: two live resources of different kinds carrying one address, zero
+	// findings.
+	//
+	// Some pairs share an address legitimately, and pretending otherwise would
+	// only move the false control rather than remove it: a Scaleway server and
+	// the instance/ip record that *is* its flexible address both carry it, and
+	// widening the comparison made TestAHealthyStoreSweepsClean red on exactly
+	// that pair. Measured, not foreseen — a probe over the three barrages had
+	// shown nothing, because their workload does not build that pair.
+	//
+	// So the exemption is declared by the pack that knows the relation, through
+	// Shared, and nil means the strict reading: a pack that forgets gets a loud
+	// false positive naming both resources, never a silent blind spot.
+	held := map[string]*resource.Resource{}
 	var found []string
 
 	for _, res := range resources {
@@ -119,19 +148,19 @@ func sharedAddresses(resources []*resource.Resource, gone Gone) []string {
 		if gone != nil && gone(res) {
 			continue
 		}
-		held := byKind[res.Kind]
-		if held == nil {
-			held = map[string]string{}
-			byKind[res.Kind] = held
-		}
 		for _, addr := range addressesIn(res.Attrs) {
-			if first, clash := held[addr]; clash && first != res.ID {
+			first, clash := held[addr]
+			// The exemption is asked only once there is something to exempt:
+			// computing it first passed a nil `first` to the pack's predicate,
+			// which dereferenced it. The harness caught that by refusing to
+			// measure on a red tree, which is what that refusal is for.
+			if clash && first.ID != res.ID && (shared == nil || !shared(first, res)) {
 				found = append(found, fmt.Sprintf(
-					"address %s is held by two %s resources: %s and %s",
-					addr, res.Kind, first, res.ID))
+					"address %s is held by two live resources: %s (%s) and %s (%s)",
+					addr, first.ID, first.Kind, res.ID, res.Kind))
 				continue
 			}
-			held[addr] = res.ID
+			held[addr] = res
 		}
 	}
 	return found

--- a/internal/core/store/storetest/sweep_test.go
+++ b/internal/core/store/storetest/sweep_test.go
@@ -45,9 +45,25 @@ func TestAHealthyStoreSweepsClean(t *testing.T) {
 
 	server.Runtime = map[string]string{"machine": "feint-scw-s1"}
 
-	if found := storetest.Sweep([]*resource.Resource{server, address, network, volA, volB}, nil); len(found) != 0 {
+	// The server and the address record hold one address, legitimately: the
+	// record *is* the flexible IP, the server carries it. Since the invariant
+	// compares across kinds (#210), that pair has to be declared — and declaring
+	// it is the point, because the alternative is a control that stays silent
+	// about every collision in order to stay silent about this one.
+	attached := func(a, b *resource.Resource) bool {
+		kinds := map[string]bool{a.Kind: true, b.Kind: true}
+		return kinds["instance/server"] && kinds["instance/ip"]
+	}
+	if found := storetest.Sweep([]*resource.Resource{server, address, network, volA, volB},
+		nil, attached); len(found) != 0 {
 		t.Errorf("a healthy store produced findings, so the sweep would cry wolf on every run:\n%s",
 			strings.Join(found, "\n"))
+	}
+
+	// And without the declaration the pair is reported, which is what makes the
+	// exemption a decision rather than a default.
+	if found := storetest.Sweep([]*resource.Resource{server, address}, nil, nil); len(found) == 0 {
+		t.Error("an undeclared pair sharing an address was not reported; the strict reading is the default")
 	}
 }
 
@@ -55,7 +71,7 @@ func TestTheSweepSeesAnIdentifierIssuedTwice(t *testing.T) {
 	found := storetest.Sweep([]*resource.Resource{
 		res("same", "instance/server", map[string]any{"name": "a"}),
 		res("same", "instance/ip", map[string]any{"address": "203.0.113.1"}),
-	}, nil)
+	}, nil, nil)
 	if len(found) == 0 {
 		t.Fatal("two resources sharing an identifier swept clean, and the store keys on it")
 	}
@@ -68,7 +84,7 @@ func TestTheSweepSeesOneAddressAllocatedTwice(t *testing.T) {
 	found := storetest.Sweep([]*resource.Resource{
 		res("ip1", "instance/ip", map[string]any{"address": "203.0.113.9"}),
 		res("ip2", "instance/ip", map[string]any{"address": "203.0.113.9"}),
-	}, nil)
+	}, nil, nil)
 	if len(found) == 0 {
 		t.Fatal("one address held by two resources of one kind swept clean")
 	}
@@ -83,7 +99,7 @@ func TestTheSweepSeesOneAddressAllocatedTwice(t *testing.T) {
 			"public_ips": []any{map[string]any{"address": "198.51.100.4"}}}),
 		res("s2", "instance/server", map[string]any{
 			"public_ips": []any{map[string]any{"address": "198.51.100.4"}}}),
-	}, nil)
+	}, nil, nil)
 	if len(nested) == 0 {
 		t.Error("a duplicated address nested inside a list swept clean")
 	}
@@ -95,7 +111,7 @@ func TestTheSweepSeesTwoResourcesClaimingOneMachine(t *testing.T) {
 	b := res("s2", "instance/server", map[string]any{"name": "b"})
 	b.Runtime = map[string]string{"machine": "feint-scw-orphan"}
 
-	found := storetest.Sweep([]*resource.Resource{a, b}, nil)
+	found := storetest.Sweep([]*resource.Resource{a, b}, nil, nil)
 	if len(found) == 0 {
 		t.Fatal("two resources naming one runtime machine swept clean: deleting either destroys the other's")
 	}
@@ -110,7 +126,7 @@ func TestTheSweepSurvivesANilResource(t *testing.T) {
 	found := storetest.Sweep([]*resource.Resource{
 		nil,
 		res("s1", "instance/server", map[string]any{"name": "a"}),
-	}, nil)
+	}, nil, nil)
 	if len(found) != 0 {
 		t.Errorf("a nil element produced findings: %v", found)
 	}
@@ -131,18 +147,55 @@ func TestAGoneResourcesAddressIsNotShared(t *testing.T) {
 	both := []*resource.Resource{dead, live}
 	gone := func(r *resource.Resource) bool { return r.State == "terminated" }
 
-	if found := storetest.Sweep(both, gone); len(found) != 0 {
+	if found := storetest.Sweep(both, gone, nil); len(found) != 0 {
 		t.Errorf("an address inherited from a gone resource was reported shared:\n%s",
 			strings.Join(found, "\n"))
 	}
 
 	// Both halves: without the pack's word, the strict reading still bites —
 	// and two living holders stay a breach whatever predicate is passed.
-	if found := storetest.Sweep(both, nil); len(found) == 0 {
+	if found := storetest.Sweep(both, nil, nil); len(found) == 0 {
 		t.Error("with no liveness predicate the sweep stopped seeing the shared address at all")
 	}
 	dead.State = "running"
-	if found := storetest.Sweep(both, gone); len(found) == 0 {
+	if found := storetest.Sweep(both, gone, nil); len(found) == 0 {
 		t.Error("two living resources share an address and the predicate excused one of them")
+	}
+}
+
+// One address handed to two resources is a finding whatever their kinds (#210).
+//
+// The invariant used to be keyed by kind, so it compared machines with machines
+// and never a machine with anything else — while its own header promised the
+// general case. A probe proved the blindness: two live resources of different
+// kinds carrying one address, zero findings.
+//
+// That is worse than a missing control. This sweep is the barrage's invariant on
+// all three packs, and a green barrage was being read as "no address is shared".
+// The same file's liveness blindness had already produced a false verdict that
+// got a correct fix reverted (#208).
+func TestAnAddressSharedAcrossKindsIsReported(t *testing.T) {
+	resources := []*resource.Resource{
+		{ID: "i-1", Kind: "vm", Attrs: map[string]any{"PrivateIp": "10.0.0.4"}},
+		{ID: "lb-1", Kind: "load-balancer", Attrs: map[string]any{"address": "10.0.0.4"}},
+	}
+	found := storetest.Sweep(resources, nil, nil)
+	if len(found) == 0 {
+		t.Fatal("two live resources of different kinds hold 10.0.0.4 and the sweep said nothing")
+	}
+	if !strings.Contains(found[0], "10.0.0.4") ||
+		!strings.Contains(found[0], "i-1") || !strings.Contains(found[0], "lb-1") {
+		t.Errorf("the finding must name the address and both holders, got %q", found[0])
+	}
+
+	// The accepting half: one resource carrying an address twice is not a
+	// collision with itself, and two resources on different addresses are fine.
+	clean := []*resource.Resource{
+		{ID: "i-1", Kind: "vm", Attrs: map[string]any{
+			"PrivateIp": "10.0.0.4", "PublicIp": "203.0.113.4"}},
+		{ID: "i-2", Kind: "vm", Attrs: map[string]any{"PrivateIp": "10.0.0.5"}},
+	}
+	if found := storetest.Sweep(clean, nil, nil); len(found) != 0 {
+		t.Errorf("a clean set was reported as sharing: %v", found)
 	}
 }

--- a/internal/providers/exoscale/barrage_test.go
+++ b/internal/providers/exoscale/barrage_test.go
@@ -110,7 +110,7 @@ func TestAnExoscaleBarrageLeavesTheStoreCoherent(t *testing.T) {
 			len(refused), strings.Join(refused, "\n"))
 	}
 
-	if found := storetest.Sweep(st.All(), nil); len(found) != 0 {
+	if found := storetest.Sweep(st.All(), nil, nil); len(found) != 0 {
 		t.Errorf("the store is incoherent after the barrage:\n%s", strings.Join(found, "\n"))
 	}
 }

--- a/internal/providers/outscale/barrage_test.go
+++ b/internal/providers/outscale/barrage_test.go
@@ -121,7 +121,7 @@ func TestAnOutscaleBarrageLeavesTheStoreCoherent(t *testing.T) {
 
 	// The pack's own word on liveness: a terminated Vm keeps its record for
 	// ReadVms polling and holds nothing, so the sweep must not count it.
-	if found := storetest.Sweep(st.All(), outscale.Gone); len(found) != 0 {
+	if found := storetest.Sweep(st.All(), outscale.Gone, nil); len(found) != 0 {
 		t.Errorf("the store is incoherent after the barrage:\n%s", strings.Join(found, "\n"))
 	}
 }

--- a/internal/providers/outscale/placement_test.go
+++ b/internal/providers/outscale/placement_test.go
@@ -76,7 +76,7 @@ func TestATerminatedVmsAddressReturnsToItsSubnet(t *testing.T) {
 
 	// And the invariant agrees, with the pack's own word on liveness: the
 	// terminated record still carries the address string, and holds nothing.
-	if found := storetest.Sweep(st.All(), outscale.Gone); len(found) != 0 {
+	if found := storetest.Sweep(st.All(), outscale.Gone, nil); len(found) != 0 {
 		t.Errorf("the sweep convicts the legitimate reuse:\n%s", strings.Join(found, "\n"))
 	}
 }

--- a/internal/providers/scaleway/barrage_test.go
+++ b/internal/providers/scaleway/barrage_test.go
@@ -216,7 +216,7 @@ func TestABarrageLeavesTheStoreCoherent(t *testing.T) {
 			len(refused), strings.Join(firstFew(refused, 5), "\n"))
 	}
 
-	if found := storetest.Sweep(st.All(), nil); len(found) != 0 {
+	if found := storetest.Sweep(st.All(), nil, nil); len(found) != 0 {
 		t.Errorf("the store is incoherent after the barrage:\n%s", strings.Join(found, "\n"))
 	}
 
@@ -412,7 +412,7 @@ func TestARestoreDuringTrafficLandsInOneWorld(t *testing.T) {
 	// Whatever the interleaving produced, the store must be coherent: no
 	// identifier issued twice, no address held twice, no runtime object claimed
 	// twice. A merge of two worlds is exactly what breaks those.
-	if found := storetest.Sweep(st.All(), nil); len(found) != 0 {
+	if found := storetest.Sweep(st.All(), nil, nil); len(found) != 0 {
 		t.Errorf("a restore during traffic left the store incoherent:\n%s", strings.Join(found, "\n"))
 	}
 
@@ -517,7 +517,7 @@ func TestASharedNetworkUnderBarrageNeverHandsOutOneAddressTwice(t *testing.T) {
 	}
 
 	// The invariant the contention exists to test: one address, one resource.
-	if found := storetest.Sweep(st.All(), nil); len(found) != 0 {
+	if found := storetest.Sweep(st.All(), nil, nil); len(found) != 0 {
 		t.Errorf("one pool under contention produced an incoherent store:\n%s",
 			strings.Join(found, "\n"))
 	}

--- a/tools/falsify/specs/firewall-ownership.json
+++ b/tools/falsify/specs/firewall-ownership.json
@@ -1,0 +1,12 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "the ownership question is no longer asked before a firewall is applied",
+      "file": "internal/core/machine/incus_firewall.go",
+      "find": "\tif err := d.mustOwnInstance(ctx, machine); err != nil {\n\t\treturn err\n\t}",
+      "replace": "\tif err := d.mustOwnInstance(ctx, machine); err != nil && false {\n\t\treturn err\n\t}",
+      "test": "TestApplyFirewallRefusesAnInstanceTheEmulatorDidNotCreate"
+    }
+  ]
+}

--- a/tools/falsify/specs/sweep-cross-kind.json
+++ b/tools/falsify/specs/sweep-cross-kind.json
@@ -1,0 +1,19 @@
+{
+  "package": "./internal/core/store/storetest/",
+  "mutations": [
+    {
+      "label": "the invariant is scoped by kind again, and a cross-kind collision goes unseen",
+      "file": "internal/core/store/storetest/sweep.go",
+      "find": "\t\t\tif clash && first.ID != res.ID && (shared == nil || !shared(first, res)) {",
+      "replace": "\t\t\tif clash && first.ID != res.ID && first.Kind == res.Kind && (shared == nil || !shared(first, res)) {",
+      "test": "TestAnAddressSharedAcrossKindsIsReported"
+    },
+    {
+      "label": "every pair is exempt, so the control reports nothing at all",
+      "file": "internal/core/store/storetest/sweep.go",
+      "find": "\t\t\tif clash && first.ID != res.ID && (shared == nil || !shared(first, res)) {",
+      "replace": "\t\t\tif clash && first.ID != res.ID && (shared == nil || !shared(first, res)) && false {",
+      "test": "TestAnAddressSharedAcrossKindsIsReported"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #209. Closes #210.

The first two findings of the second factorisation audit, both **verified in the
code here** before being written down — an audit finding that turns out wrong
becomes a wrong issue somebody else treats as a fact.

## #209 — a reconfiguring path with half a guard

`ApplyFirewall` validated the machine name with `safeName`, then edited that
instance's NIC devices.

`safeName` answers *could this become a command argument safely*. It accepts
`production-database` and every other name on the host. The name arrives from
`Resource.Runtime`, which `PUT /_feint/state` and `feint snapshot load` restore
**verbatim** — `snapshot.go` documents the format as meant to outlive its
instance and be loaded into another one.

`RemoveFirewall` already asked the ownership question. The guarded list forgot
that **installing** a rule set on somebody else's NIC is as much a change as
removing one: reconfiguring paths belong in it, not only destructive ones.
`mustOwnInstance` existed and was simply not called.

Asserted through the `runner` seam, both halves: no command carrying a foreign
name is emitted, and a rule set still reaches a machine the emulator created.

## #210 — an invariant blind to the case its own header describes

`sharedAddresses` keyed its bookkeeping on `res.Kind`, so it compared machines
with machines and NICs with NICs while promising *one address handed to two
resources*. The cross-kind case — the one that happens, since a pool is shared by
everything placed in it — was invisible.

That is worse than a missing control. This is the barrage's invariant on all
three packs, and a green barrage was read as "no address is shared". **The same
file's liveness blindness had just produced a false verdict that got a correct
fix reverted** (#208).

### The measurement corrected me twice

A probe over the three barrages showed **zero findings** with the comparison
ignoring kind entirely, so strict looked viable. Then
`TestAHealthyStoreSweepsClean` went red on a pair the barrages never build: a
Scaleway server and the `instance/ip` record that *is* its flexible address both
carry it, legitimately.

So the exemption is declared by the pack that knows the relation, through a
`Shared` predicate, `nil` meaning the strict reading — the same shape and the
same direction of failure as `Gone`: a pack that forgets gets a **loud false
positive naming both resources**, never a silent blind spot.

Both halves are asserted: the declared pair accepted, the undeclared one
reported.

## One defect of my own, caught by the harness

The exemption was computed before knowing there was a collision, so a nil `first`
reached the pack's predicate and it dereferenced. `falsify` **refused to measure
on a red tree** rather than reporting a guard as proven — which is exactly what
that refusal is for, and the third time this week it has paid for itself.

## Measured

| | |
|---|---|
| `go test ./...` | 20 packages |
| `golangci-lint`, `gofmt` | clean |
| `mise run falsify -- specs/firewall-ownership.json` | bites |
| `mise run falsify -- specs/sweep-cross-kind.json` | both mutations bite |
| barrage, three packs | green |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
