### PR TITLE
fix(scaleway): the protection flag governs the actions it was measured to govern (#212)

### DIFF
--- a/internal/providers/scaleway/errors.go
+++ b/internal/providers/scaleway/errors.go
@@ -18,6 +18,8 @@ type APIError struct {
 	Resource     string          `json:"resource,omitempty"`
 	ResourceID   string          `json:"resource_id,omitempty"`
 	CurrentState string          `json:"current_state,omitempty"`
+	Precondition string          `json:"precondition,omitempty"`
+	HelpMessage  string          `json:"help_message,omitempty"`
 	Details      []ArgumentError `json:"details,omitempty"`
 }
 
@@ -73,5 +75,26 @@ func writeTransientState(w http.ResponseWriter, kind, id, state string) {
 		Resource:     kind,
 		ResourceID:   id,
 		CurrentState: state,
+	})
+}
+
+// writePreconditionFailed answers an action the server's own condition forbids.
+//
+// Body and status are copied from a measurement against fr-par-1 rather than
+// derived from the SDK, which gives the shape of the error but never says which
+// one an endpoint picks. Four actions on a protected server answered, verbatim:
+//
+//	400 {"type": "precondition_failed", "message": "precondition is not
+//	     respected", "precondition": "protected_resource",
+//	     "help_message": "server is protected"}
+//
+// 400 and not 412, which is the status the name would suggest and the reason
+// this is worth a comment.
+func writePreconditionFailed(w http.ResponseWriter, precondition, help string) {
+	emulator.WriteJSON(w, http.StatusBadRequest, APIError{
+		Type:         "precondition_failed",
+		Message:      "precondition is not respected",
+		Precondition: precondition,
+		HelpMessage:  help,
 	})
 }

--- a/internal/providers/scaleway/protection_test.go
+++ b/internal/providers/scaleway/protection_test.go
@@ -1,0 +1,198 @@
+package scaleway_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// The protection flag was stored at create, stored again at update, published on
+// every read, and consulted by nothing (#212).
+//
+// Everything below is measured against fr-par-1 rather than reasoned about,
+// because the measurement reversed the issue that asked for it. The runs are
+// named in the comments of servers.go; what they established is:
+//
+//	poweroff / stop_in_place / reboot / terminate  400 precondition_failed
+//	                                               precondition protected_resource
+//	                                               help_message "server is protected"
+//	backup, and poweron on a stopped server        accepted
+//	DELETE /servers/{id} on a stopped server       204, and a 404 after it
+//	allowed_actions, running + protected           ["backup"]
+//	allowed_actions, stopped + protected           ["poweron", "backup"]
+
+// protect is the door a client actually uses, PATCH rather than a store poke, so
+// the test exercises the same path Terraform does.
+func protect(t *testing.T, ts *httptest.Server, zone, id string, on bool) {
+	t.Helper()
+	body := `{"protected":false}`
+	if on {
+		body = `{"protected":true}`
+	}
+	status, out := do(t, ts, "PATCH", zone+"/servers/"+id, body)
+	if status != http.StatusOK {
+		t.Fatalf("protect(%v): status %d", on, status)
+	}
+	server, _ := out["server"].(map[string]any)
+	if got, _ := server["protected"].(bool); got != on {
+		t.Fatalf("protect(%v) answered protected=%v", on, got)
+	}
+}
+
+func newProtectedServer(t *testing.T, ts *httptest.Server, zone string, running bool) string {
+	t.Helper()
+	status, out := do(t, ts, "POST", zone+"/servers", `{"name":"demo","commercial_type":"DEV1-S"}`)
+	if status != http.StatusCreated {
+		t.Fatalf("create: status %d", status)
+	}
+	server, _ := out["server"].(map[string]any)
+	id, _ := server["id"].(string)
+	if running {
+		if status, _ := do(t, ts, "POST", zone+"/servers/"+id+"/action", `{"action":"poweron"}`); status != http.StatusAccepted {
+			t.Fatalf("poweron: status %d", status)
+		}
+	}
+	protect(t, ts, zone, id, true)
+	return id
+}
+
+// Every action that stops or destroys the machine is refused, in the dialect the
+// API uses for it.
+//
+// The body is asserted field by field and not merely the status: the SDK reads
+// `type` to pick a struct and `precondition` to tell one failure from another, so
+// a 400 carrying the wrong type is an opaque error where a typed one belongs —
+// and a client branching on errors.As stops seeing it.
+func TestProtectionRefusesEveryStoppingAction(t *testing.T) {
+	ts := newTestServer(t)
+	const zone = "/instance/v1/zones/fr-par-1"
+	id := newProtectedServer(t, ts, zone, true)
+
+	for _, action := range []string{"poweroff", "stop_in_place", "reboot", "terminate"} {
+		status, out := do(t, ts, "POST", zone+"/servers/"+id+"/action", `{"action":"`+action+`"}`)
+		if status != http.StatusBadRequest {
+			t.Errorf("%s on a protected server: status %d, want 400", action, status)
+			continue
+		}
+		for field, want := range map[string]string{
+			"type":         "precondition_failed",
+			"message":      "precondition is not respected",
+			"precondition": "protected_resource",
+			"help_message": "server is protected",
+		} {
+			if got, _ := out[field].(string); got != want {
+				t.Errorf("%s answered %s=%q, want %q", action, field, got, want)
+			}
+		}
+	}
+
+	// And the machine is still there, running: a refusal that half-applied would
+	// be worse than none, since the client is told nothing happened.
+	status, out := do(t, ts, "GET", zone+"/servers/"+id, "")
+	if status != http.StatusOK {
+		t.Fatalf("the protected server is gone: status %d", status)
+	}
+	server, _ := out["server"].(map[string]any)
+	if got, _ := server["state"].(string); got != "running" {
+		t.Fatalf("after four refused actions the server is %q, want running", got)
+	}
+}
+
+// The accepting half. A guard that refuses everything passes every attack test
+// and breaks the product, and here the API itself draws the line: backup and
+// poweron are allowed on a protected server.
+func TestProtectionLeavesTheOtherActionsAlone(t *testing.T) {
+	ts := newTestServer(t)
+	const zone = "/instance/v1/zones/fr-par-1"
+	id := newProtectedServer(t, ts, zone, false)
+
+	for _, action := range []string{"backup", "poweron"} {
+		if status, _ := do(t, ts, "POST", zone+"/servers/"+id+"/action", `{"action":"`+action+`"}`); status != http.StatusAccepted {
+			t.Errorf("%s on a protected server: status %d, want 202", action, status)
+		}
+	}
+	status, out := do(t, ts, "GET", zone+"/servers/"+id, "")
+	if status != http.StatusOK {
+		t.Fatalf("get: status %d", status)
+	}
+	server, _ := out["server"].(map[string]any)
+	if got, _ := server["state"].(string); got != "running" {
+		t.Fatalf("a protected server refused to start: state %q", got)
+	}
+}
+
+// Once the flag is cleared the machine stops again, so protection is a state and
+// not a one-way door. Without this, a guard that never lets go would look right
+// to every test above.
+func TestClearingTheProtectionRestoresTheActions(t *testing.T) {
+	ts := newTestServer(t)
+	const zone = "/instance/v1/zones/fr-par-1"
+	id := newProtectedServer(t, ts, zone, true)
+
+	protect(t, ts, zone, id, false)
+	if status, _ := do(t, ts, "POST", zone+"/servers/"+id+"/action", `{"action":"poweroff"}`); status != http.StatusAccepted {
+		t.Fatalf("poweroff after unprotecting: status %d, want 202", status)
+	}
+}
+
+// The DELETE verb goes through, and this test exists to keep it that way.
+//
+// #212 asked for the opposite in good faith. Two runs against fr-par-1 answered
+// 204 on a server whose protection a fresh GET had just confirmed, so refusing
+// here would be an emulator inventing a rule its cloud does not have — which is
+// the one failure this project is built to prevent.
+func TestProtectionDoesNotBlockTheDeleteVerb(t *testing.T) {
+	ts := newTestServer(t)
+	const zone = "/instance/v1/zones/fr-par-1"
+	id := newProtectedServer(t, ts, zone, false)
+
+	if status, _ := do(t, ts, "DELETE", zone+"/servers/"+id, ""); status != http.StatusNoContent {
+		t.Fatalf("DELETE on a protected server: status %d, want 204 (measured on fr-par-1)", status)
+	}
+	if status, _ := do(t, ts, "GET", zone+"/servers/"+id, ""); status != http.StatusNotFound {
+		t.Fatalf("the server survived its delete: status %d", status)
+	}
+}
+
+// allowed_actions carries the same news as the refusals, and a client reads it to
+// decide what to offer rather than firing an action to find out.
+func TestProtectionShrinksTheAllowedActions(t *testing.T) {
+	ts := newTestServer(t)
+	const zone = "/instance/v1/zones/fr-par-1"
+
+	list := func(id string) map[string]bool {
+		t.Helper()
+		status, out := do(t, ts, "GET", zone+"/servers/"+id, "")
+		if status != http.StatusOK {
+			t.Fatalf("get: status %d", status)
+		}
+		server, _ := out["server"].(map[string]any)
+		actions, _ := server["allowed_actions"].([]any)
+		set := make(map[string]bool, len(actions))
+		for _, action := range actions {
+			if name, ok := action.(string); ok {
+				set[name] = true
+			}
+		}
+		return set
+	}
+
+	id := newProtectedServer(t, ts, zone, true)
+	running := list(id)
+	for _, gone := range []string{"poweroff", "stop_in_place", "reboot", "terminate"} {
+		if running[gone] {
+			t.Errorf("a protected running server still advertises %s: %v", gone, running)
+		}
+	}
+	if !running["backup"] {
+		t.Errorf("a protected running server advertises no backup: %v", running)
+	}
+
+	// Unprotected, the same server lists terminate — which this pack omitted
+	// until the measurement listed it, so a client reading the list to decide
+	// whether it could destroy the server was told no.
+	protect(t, ts, zone, id, false)
+	if free := list(id); !free["terminate"] {
+		t.Errorf("an unprotected running server advertises no terminate: %v", free)
+	}
+}

--- a/internal/providers/scaleway/servers.go
+++ b/internal/providers/scaleway/servers.go
@@ -319,7 +319,7 @@ func (p *Pack) createServer(w http.ResponseWriter, r *http.Request) {
 		"enable_ipv6":         deref(req.EnableIPv6, false),
 		"state_detail":        "",
 		"security_group":      securityGroup,
-		"allowed_actions":     []any{"poweron", "backup"},
+		"allowed_actions":     allowedActions(res.State, deref(req.Protected, false)),
 		"maintenances":        []any{},
 		// Kept so the machine driver knows which catalogue image stands in for
 		// the requested cloud image. Empty when the identifier resolved to
@@ -432,6 +432,11 @@ func (p *Pack) updateServer(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Protected != nil {
 		res.Attrs["protected"] = *req.Protected
+		// The list travels with the flag. On fr-par-1, a PATCH that protects a
+		// running server makes the next GET answer ["backup"] alone, and the
+		// client that reads it to decide what to offer must see that without
+		// waiting for an action to be refused.
+		res.Attrs["allowed_actions"] = allowedActions(res.State, *req.Protected)
 	}
 	// The restriction is the SDK's own, quoted in UpdateServerRequest:
 	// "Cannot be changed if the Instance is not in `stopped` state." Refusing it
@@ -490,6 +495,18 @@ func (p *Pack) deleteServer(w http.ResponseWriter, r *http.Request) {
 		writeTransientState(w, "server", id, res.State)
 		return
 	}
+	// No protection check here, and that is measured rather than overlooked.
+	//
+	// #212 asked for one, on the reasonable-sounding ground that a stored flag
+	// named `protected` should protect. Two runs against fr-par-1, each setting
+	// the flag and confirming it with a fresh GET before deleting, answered 204
+	// and left a 404 behind. The flag guards the action endpoint — poweroff,
+	// stop_in_place, reboot, terminate all answer precondition_failed — and this
+	// verb is not one of them.
+	//
+	// Written down because the intuition is strong enough that somebody will come
+	// back to add the check. TestProtectionDoesNotBlockTheDeleteVerb fails if they
+	// do.
 	// A stopped server should hold no dynamic address; a restored snapshot may
 	// claim otherwise, and the OVN uplink route would outlive the machine.
 	p.releaseDynamicAddress(r.Context(), res)
@@ -557,6 +574,23 @@ func (p *Pack) serverAction(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The protection flag was stored at create and at update, published on every
+	// read, and consulted nowhere (#212). A field that round-trips perfectly and
+	// governs nothing reads as a feature, which is the *un commentaire n'est pas
+	// un contrôle* family arriving through data rather than prose.
+	//
+	// Which door it closes was measured on fr-par-1, and the measurement reversed
+	// the issue: DELETE removes a protected server with 204, twice over. It is the
+	// action endpoint that refuses, for every action that stops or destroys the
+	// machine. Implementing the intuition would have made this emulator diverge
+	// from the cloud it imitates.
+	//
+	// TestProtectionRefusesEveryStoppingAction fails without this.
+	if stopsTheMachine(req.Action) && protectedServer(res) {
+		writePreconditionFailed(w, "protected_resource", "server is protected")
+		return
+	}
+
 	now := p.env.Now()
 	switch req.Action {
 	case "poweron", "reboot":
@@ -589,7 +623,7 @@ func (p *Pack) serverAction(w http.ResponseWriter, r *http.Request) {
 			// and never routed (#116).
 			p.routeServerAddresses(r.Context(), res)
 		}
-		res.Attrs["allowed_actions"] = allowedActions(res.State)
+		res.Attrs["allowed_actions"] = allowedActions(res.State, protectedServer(res))
 	case "poweroff", "stop_in_place":
 		// Two actions, two states, and the difference is not cosmetic: the SDK
 		// declares `stopped in place` alongside `stopped`
@@ -604,7 +638,7 @@ func (p *Pack) serverAction(w http.ResponseWriter, r *http.Request) {
 		if req.Action == "stop_in_place" {
 			res.State = "stopped in place"
 		}
-		res.Attrs["allowed_actions"] = allowedActions(res.State)
+		res.Attrs["allowed_actions"] = allowedActions(res.State, protectedServer(res))
 		// Stopping withdraws the address: one the API publishes and nothing
 		// answers on is the defect this project exists to avoid. The dynamic
 		// address goes entirely — upstream releases it on stop, and that is
@@ -653,22 +687,73 @@ func (p *Pack) serverAction(w http.ResponseWriter, r *http.Request) {
 	emulator.WriteJSON(w, http.StatusAccepted, map[string]any{"task": task(p.env.NewID(), "server_"+req.Action, now)})
 }
 
+// stopsTheMachine names the actions protection refuses.
+//
+// The four were measured one by one against fr-par-1 on a protected running
+// server, and every one answered precondition_failed / protected_resource. The
+// two that do not appear were measured on the same server and are allowed:
+// backup, and poweron on a stopped one. So the flag guards the machine's
+// running state, not the record — which is also why DELETE goes through.
+func stopsTheMachine(action string) bool {
+	switch action {
+	case "poweroff", "stop_in_place", "reboot", "terminate":
+		return true
+	}
+	return false
+}
+
+// protectedServer reads the flag off a stored server.
+//
+// Through a type assertion because Attrs is map[string]any and a restored
+// snapshot decodes JSON into it: whatever the pack wrote as a bool comes back a
+// bool, but a hand-written snapshot may carry anything at all, and the zero
+// value of a failed assertion is the safe reading of "not protected" — refusing
+// an action nobody protected would be the worse failure.
+func protectedServer(res *resource.Resource) bool {
+	protected, _ := res.Attrs["protected"].(bool)
+	return protected
+}
+
 // allowedActions is what a client may do next, which follows from the state
 // rather than from the action that was asked for. Deriving it is what keeps a
 // failed start from advertising poweroff on a server that never came up.
-func allowedActions(state string) []any {
+//
+// Protection subtracts from that list rather than replacing it, which is the
+// only reading consistent with what fr-par-1 answered: a protected running
+// server lists ["backup"] alone, a protected stopped one ["poweron", "backup"],
+// and those are exactly the lists left once the four refused actions are
+// removed. Standby was not measured — no client this suite drives reaches it
+// protected — so it is derived the same way rather than guessed at separately.
+func allowedActions(state string, protected bool) []any {
+	var actions []any
 	switch state {
 	case "running":
-		return []any{"poweroff", "reboot", "stop_in_place", "backup"}
+		// terminate belongs here and was missing until the same measurement
+		// listed it: an unprotected running server answers ["poweroff",
+		// "terminate", "reboot", "stop_in_place", "backup"]. A client reading
+		// the list to decide whether it may destroy the server was being told
+		// no.
+		actions = []any{"poweroff", "terminate", "reboot", "stop_in_place", "backup"}
 	case "stopped in place":
 		// Standby keeps the machine and its local storage, so powering it fully
 		// off is the operation that follows from here as much as starting it
 		// again. Listed rather than omitted: a client reading allowed_actions to
 		// decide would otherwise have no way out of standby but a boot.
-		return []any{"poweron", "poweroff", "backup"}
+		actions = []any{"poweron", "poweroff", "backup"}
 	default:
-		return []any{"poweron", "backup"}
+		actions = []any{"poweron", "backup"}
 	}
+	if !protected {
+		return actions
+	}
+	kept := make([]any, 0, len(actions))
+	for _, action := range actions {
+		if name, ok := action.(string); ok && stopsTheMachine(name) {
+			continue
+		}
+		kept = append(kept, action)
+	}
+	return kept
 }
 
 // task mirrors the Task object the API returns for asynchronous actions. The

--- a/tools/conformance/scaleway/scw-cli.sh
+++ b/tools/conformance/scaleway/scw-cli.sh
@@ -75,6 +75,44 @@ prove_end "$neg"
 prove_end "$span"
 ok "deleted, and gone"
 
+# The protection flag, whose behaviour was measured against fr-par-1 rather than assumed (#212):
+# it closes the action endpoint, not the DELETE verb. Both halves are driven here, because the
+# surprising half is the one a future reader will want to "fix".
+echo "- protection: the flag closes the actions and not the delete"
+span="$(prove_begin behaviour)"
+prot="$(scw instance server create name=conformance-protected type=DEV1-S zone="$ZONE" -o json 2>&1)" \
+  || fail "create rejected by the CLI: $prot"
+prot_id="$(printf '%s' "$prot" | jq -r '.id // empty')"
+[ -n "$prot_id" ] || fail "no id in the create response: $prot"
+
+scw instance server update "$prot_id" protected=true zone="$ZONE" -o json \
+  | jq -e '.protected == true' >/dev/null || fail "the flag did not come back from the update"
+
+neg="$(prove_begin negative)"
+if scw instance server stop "$prot_id" zone="$ZONE" >/dev/null 2>&1; then
+  fail "stop accepted on a protected server; fr-par-1 answers precondition_failed"
+fi
+prove_end "$neg"
+
+# The client is told before it tries, which is what allowed_actions is for.
+scw instance server get "$prot_id" zone="$ZONE" -o json \
+  | jq -e '(.allowed_actions | index("poweroff")) == null and (.allowed_actions | index("backup")) != null' \
+    >/dev/null || fail "a protected server still advertises poweroff"
+
+scw instance server update "$prot_id" protected=false zone="$ZONE" -o json >/dev/null \
+  || fail "clearing the flag rejected"
+scw instance server stop "$prot_id" zone="$ZONE" >/dev/null \
+  || fail "poweroff rejected once the protection was cleared"
+
+# And the half that reverses the intuition: a protected server deletes. Two runs against
+# fr-par-1, each confirming the flag with a fresh GET first, answered 204.
+scw instance server update "$prot_id" protected=true zone="$ZONE" -o json >/dev/null \
+  || fail "setting the flag back rejected"
+scw instance server delete "$prot_id" zone="$ZONE" >/dev/null \
+  || fail "delete refused a protected server, which fr-par-1 does not"
+prove_end "$span"
+ok "stop refused, delete allowed, flag cleared and honoured again"
+
 # Security groups. A fresh project already owns one, so the first list must return it: every
 # client reads the existing groups before it creates anything.
 echo "- security groups: the project default exists"

--- a/tools/falsify/specs/server-protection.json
+++ b/tools/falsify/specs/server-protection.json
@@ -1,0 +1,33 @@
+{
+  "package": "./internal/providers/scaleway/",
+  "mutations": [
+    {
+      "label": "the protection flag is stored and published again, and governs nothing",
+      "file": "internal/providers/scaleway/servers.go",
+      "find": "\tif stopsTheMachine(req.Action) && protectedServer(res) {",
+      "replace": "\tif stopsTheMachine(req.Action) && protectedServer(res) && false {",
+      "test": "TestProtectionRefusesEveryStoppingAction"
+    },
+    {
+      "label": "protection refuses every action instead of the four that stop the machine",
+      "file": "internal/providers/scaleway/servers.go",
+      "find": "\tif stopsTheMachine(req.Action) && protectedServer(res) {",
+      "replace": "\tif (stopsTheMachine(req.Action) || true) && protectedServer(res) {",
+      "test": "TestProtectionLeavesTheOtherActionsAlone"
+    },
+    {
+      "label": "the DELETE verb refuses a protected server, which fr-par-1 does not",
+      "file": "internal/providers/scaleway/servers.go",
+      "find": "\tp.releaseDynamicAddress(r.Context(), res)\n\tp.removeMachine(r.Context(), res)\n\tp.env.Store.Delete(Name, kindServer, id)\n\tp.releaseServerResources(r.Context(), id, zone)\n\tw.WriteHeader(http.StatusNoContent)",
+      "replace": "\tif protectedServer(res) {\n\t\twritePreconditionFailed(w, \"protected_resource\", \"server is protected\")\n\t\treturn\n\t}\n\tp.releaseDynamicAddress(r.Context(), res)\n\tp.removeMachine(r.Context(), res)\n\tp.env.Store.Delete(Name, kindServer, id)\n\tp.releaseServerResources(r.Context(), id, zone)\n\tw.WriteHeader(http.StatusNoContent)",
+      "test": "TestProtectionDoesNotBlockTheDeleteVerb"
+    },
+    {
+      "label": "allowed_actions keeps advertising what protection refuses",
+      "file": "internal/providers/scaleway/servers.go",
+      "find": "\tif !protected {\n\t\treturn actions\n\t}",
+      "replace": "\tif !protected || true {\n\t\treturn actions\n\t}",
+      "test": "TestProtectionShrinksTheAllowedActions"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #212.

`protected` was written at create, written again at update, published on every
read, and consulted by nothing. A field that round-trips perfectly and governs
nothing reads as a feature: the *un commentaire n'est pas un contrôle* family,
arriving through data rather than through prose.

## The measurement reversed the issue

#212 asked for a refusal in `deleteServer`, on the reasonable ground that a flag
named `protected` should protect. **Implementing that would have made the
emulator diverge from the cloud it imitates.**

Four runs against fr-par-1, each confirming the flag with a fresh `GET` before
acting:

| door, on a protected server | fr-par-1 answers |
|---|---|
| `DELETE /servers/{id}` (stopped) | **204**, and 404 after it — measured twice |
| `poweroff` `stop_in_place` `reboot` `terminate` | 400 `precondition_failed` / `protected_resource` / `"server is protected"` |
| `backup`, and `poweron` on a stopped server | accepted |
| `allowed_actions`, running + protected | `["backup"]` |
| `allowed_actions`, stopped + protected | `["poweron", "backup"]` |

The flag guards the machine's **running state**, not the record. So the refusal
lands on the action endpoint, and `deleteServer` gains a comment naming the runs
plus `TestProtectionDoesNotBlockTheDeleteVerb`, which fails if somebody adds the
check the issue asked for. The intuition is strong enough that somebody will.

The status is **400**, not the 412 the name suggests — exactly the kind of detail
no amount of reading the SDK produces. `scw/errors.go` gives the shape of
`PreconditionFailedError`; it never says which endpoint picks it.

## Two more things the same measurement found

- `allowed_actions` on a running server omitted `terminate`, so a client reading
  the list to decide whether it could destroy a server was told no.
- The list did not move with the flag. fr-par-1 shrinks it on the PATCH that sets
  it, because a client is meant to learn this **before** it fires an action.

## The other two packs

Checked, as the issue asked. Both already right — for their own cloud, which is
not the same rule:

| pack | door it closes | source |
|---|---|---|
| Outscale | delete | `api.yaml`: "if true, you cannot delete the VM" |
| Exoscale | delete | OpenAPI: "Set instance **destruction** protection" |
| Scaleway | the stopping actions | measured, above |

Three packs, three doors, and the asymmetry is upstream's rather than ours. Worth
recording: the standing rule here is that behaviour must not differ between packs,
and this is the case where making it uniform would be the defect.

## Measured

| | |
|---|---|
| `go test ./...`, `mise run prepush` | green |
| `mise run conformance` | **exit 0**, 73 checks, 0 FAIL |
| `scw` drives both halves | `stop` refused on a protected server, `delete` accepted on one |
| `mise run falsify -- specs/server-protection.json` | 4 mutations, all bite |

The four falsifications: the guard removed, the guard widened to every action,
the check added to `DELETE`, and the list left unshrunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
