### PR TITLE
fix(core): the transactional half of a read-that-writes lives in the shared layer (#211)

### DIFF
--- a/internal/core/machine/observe.go
+++ b/internal/core/machine/observe.go
@@ -1,0 +1,79 @@
+package machine
+
+import (
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/resource"
+	"github.com/stephrobert/feint/internal/core/store"
+)
+
+// Observe is Transition for a read that writes, and there are more of those than
+// the word "read" suggests.
+//
+// A virtual machine gets its address tens of seconds after it starts, so no pack
+// can publish one at create time. All three fill it in on the next read instead —
+// which turns GET into a writer, through a door nobody thinks of as mutating.
+// Outscale's readVms says so in a comment and serialises; Scaleway's getServer
+// and Exoscale's getInstance and listInstances did neither, and that is the
+// asymmetry #211 was filed for.
+//
+// The race it closes is not theoretical, and it is worse than a lost field:
+//
+//	getServer            reads the server, sees running, asks the runtime
+//	                     for its address — tens of seconds
+//	serverAction poweroff takes the lock, stops the machine, withdraws the
+//	                     address, commits "stopped"
+//	getServer            commits its copy: "running", address and all
+//
+// Commit refuses to resurrect a *deleted* resource and orders nothing else, so
+// the read wins and the emulator ends up describing as running a machine that is
+// stopped. That is the exact lie this project exists to avoid, arriving through
+// a GET.
+//
+// Two differences from Transition, and both are why this is a second entry point
+// rather than a flag on the first:
+//
+//   - the resource is re-read *inside* the hold, so the copy the caller renders
+//     cannot predate the lock it just took. Serialising around a copy fetched
+//     earlier still writes back a stale read, which is what readVms did;
+//   - the write-back is conditional on look() reporting a change. Committing
+//     unconditionally would stamp Updated on every GET, and Updated is
+//     modification_date on the wire: a client that diffs it would see a resource
+//     change every time it looked at it.
+//
+// The resource is returned so the caller renders what was written rather than
+// what it read, and store.ErrNotFound covers both "never existed" and "deleted
+// while the runtime was answering" — to a caller holding a copy of something the
+// store no longer has, those are the same answer.
+func (b Binding) Observe(
+	st *store.Store,
+	now func() time.Time,
+	kind, id string,
+	look func(*resource.Resource) bool,
+) (*resource.Resource, error) {
+	unlock := b.Serialise(id)
+	defer unlock()
+
+	res, found := st.Get(b.Provider, kind, id)
+	if !found {
+		return nil, store.ErrNotFound
+	}
+
+	// Outside the store lock on purpose: look() reaches the runtime, and holding
+	// a store-wide lock across a runtime call would queue every other request in
+	// the process behind one machine answering.
+	if !look(res) {
+		return res, nil
+	}
+
+	if err := st.Update(b.Provider, kind, id, func(stored *resource.Resource) error {
+		stored.State = res.State
+		stored.Runtime = res.Runtime
+		stored.Attrs = res.Attrs
+		stored.Updated = now()
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return res, nil
+}

--- a/internal/core/machine/observe_test.go
+++ b/internal/core/machine/observe_test.go
@@ -1,0 +1,134 @@
+package machine
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/resource"
+	"github.com/stephrobert/feint/internal/core/store"
+)
+
+// A read that writes is still a write, and all three packs have one: the address
+// of a virtual machine arrives tens of seconds after the start, so every pack
+// publishes it on the next GET. Observe is the transactional half of that, and
+// these are the two properties a per-pack version kept getting wrong (#211).
+
+// The copy handed to look() is read inside the hold, not before it.
+//
+// Outscale's readVms was the one pack that had noticed a read writes, and it
+// still serialised around a copy List had produced earlier: the lock ordered the
+// write-back and not the read it was built on, so the handler wrote back a
+// resource it had seen before anybody else's change landed.
+// The write it must not miss is the one that lands *while the second caller is
+// waiting for the lock*, so the two are ordered with channels rather than left to
+// the scheduler: a first Observe holds the target and changes it, a second is
+// already blocked on the lock, and what the second one's look sees is the whole
+// question. Reading before the lock and reading after it give different answers
+// only in that window, which is why a version of this test that wrote first and
+// called afterwards passed against both — and said so under falsification.
+func TestObserveReadsInsideTheHold(t *testing.T) {
+	st, b, _ := transitionFixture()
+
+	holding := make(chan struct{})
+	waiting := make(chan struct{})
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		_, _ = b.Observe(st, time.Now, "server", "srv-1", func(res *resource.Resource) bool {
+			// The hold is established; let the second caller pile up behind it.
+			close(holding)
+			<-waiting
+			res.State = "running"
+			return true
+		})
+	}()
+
+	<-holding
+	// The second caller starts now, so whatever copy it ends up with, it asked
+	// for it before the first one had written anything.
+	second := make(chan string, 1)
+	go func() {
+		_, _ = b.Observe(st, time.Now, "server", "srv-1", func(res *resource.Resource) bool {
+			second <- res.State
+			return false
+		})
+	}()
+	// Nothing here can prove the second goroutine has reached the lock, so the
+	// window is opened generously instead: this only has to be long enough that
+	// a Get placed before the lock has run.
+	time.Sleep(20 * time.Millisecond)
+	close(waiting)
+	<-done
+
+	if seen := <-second; seen != "running" {
+		t.Errorf("the second look saw %q; it was handed a copy read before the hold, so its "+
+			"write-back would undo what the first one had just committed", seen)
+	}
+}
+
+// Nothing is written when the look reports nothing new, and that is not a
+// micro-optimisation: Updated is modification_date on the wire, so committing on
+// every read would make a resource appear to change every time a client looked at
+// it — and Terraform diffs on exactly that.
+func TestObserveWritesNothingWhenNothingChanged(t *testing.T) {
+	st, b, _ := transitionFixture()
+
+	before, _ := st.Get("example", "server", "srv-1")
+	if _, err := b.Observe(st, func() time.Time { return before.Updated.Add(time.Hour) },
+		"server", "srv-1", func(res *resource.Resource) bool {
+			// A look may touch the copy and still conclude nothing is new; what
+			// decides is the verdict, not whether the copy was written to.
+			res.Attrs["scratch"] = "value"
+			return false
+		}); err != nil {
+		t.Fatalf("observe: %v", err)
+	}
+
+	after, _ := st.Get("example", "server", "srv-1")
+	if !after.Updated.Equal(before.Updated) {
+		t.Errorf("a read with nothing to report stamped Updated: %v became %v", before.Updated, after.Updated)
+	}
+	if _, wrote := after.Attrs["scratch"]; wrote {
+		t.Error("a read with nothing to report wrote its scratch copy back to the store")
+	}
+}
+
+// And the write-back stays conditional: a resource deleted while the runtime was
+// answering must stay deleted, or a GET resurrects what a DELETE removed.
+func TestObserveDoesNotResurrectADeletedTarget(t *testing.T) {
+	st, b, _ := transitionFixture()
+
+	_, err := b.Observe(st, time.Now, "server", "srv-1", func(res *resource.Resource) bool {
+		// The delete lands while the runtime is answering. Same store, no hold:
+		// this is DELETE arriving on another connection.
+		st.Delete("example", "server", "srv-1")
+		res.State = "running"
+		return true
+	})
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("observe reported %v; the caller must learn the resource is gone", err)
+	}
+	if _, found := st.Get("example", "server", "srv-1"); found {
+		t.Error("the read brought back a deleted server, address and all")
+	}
+}
+
+// A missing target costs no runtime call: asking a runtime about a resource that
+// does not exist is work done for a 404, and on a slow driver it is seconds of it.
+func TestObserveRefusesAMissingTargetBeforeTheLook(t *testing.T) {
+	st, b, _ := transitionFixture()
+
+	looked := false
+	_, err := b.Observe(st, time.Now, "server", "srv-absent", func(*resource.Resource) bool {
+		looked = true
+		return true
+	})
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("observe reported %v, want ErrNotFound", err)
+	}
+	if looked {
+		t.Error("the look ran on a resource that does not exist")
+	}
+}

--- a/internal/core/machine/transition.go
+++ b/internal/core/machine/transition.go
@@ -24,29 +24,23 @@ import (
 // store.ErrNotFound, whether the resource was never there or was deleted
 // while its machine was transitioning — to the caller that asked for a state
 // the resource no longer has, the two are the same answer.
+// A lifecycle action always writes back — the client asked for a state change,
+// and the answer is whatever the runtime produced. So this is Observe with the
+// question already answered, and the two share one implementation: the
+// transactional half written twice is how a fixed defect survives in the copy,
+// which is the history of this very function.
 func (b Binding) Transition(st *store.Store, now func() time.Time, kind, id string, change func(*resource.Resource)) error {
-	unlock := b.Serialise(id)
-	defer unlock()
-
-	res, found := st.Get(b.Provider, kind, id)
-	if !found {
-		return store.ErrNotFound
-	}
-
-	// The runtime work runs outside the store lock, on the copy Get handed
-	// out. Holding the write lock across a launch would queue every other
-	// request behind one machine starting.
-	change(res)
-
-	// The result is applied conditionally. Put replaces the whole resource,
-	// so it silently discarded anything another request had written in the
-	// meantime — a delete racing a lifecycle loop used to be undone, and the
-	// VM came back, address included.
-	return st.Update(b.Provider, kind, id, func(stored *resource.Resource) error {
-		stored.State = res.State
-		stored.Runtime = res.Runtime
-		stored.Attrs = res.Attrs
-		stored.Updated = now()
-		return nil
+	_, err := b.Observe(st, now, kind, id, func(res *resource.Resource) bool {
+		// The runtime work runs outside the store lock, on the copy Get handed
+		// out. Holding the write lock across a launch would queue every other
+		// request behind one machine starting.
+		//
+		// The result is then applied conditionally. Put replaces the whole
+		// resource, so it silently discarded anything another request had
+		// written in the meantime — a delete racing a lifecycle loop used to be
+		// undone, and the VM came back, address included.
+		change(res)
+		return true
 	})
+	return err
 }

--- a/internal/core/store/storetest/lostupdate.go
+++ b/internal/core/store/storetest/lostupdate.go
@@ -1,0 +1,116 @@
+package storetest
+
+import (
+	"fmt"
+	"sync"
+)
+
+// The shared control for the half of the concurrency story a sweep cannot see.
+//
+// Sweep reads the store once the traffic has stopped and reports what is
+// incoherent about it: two resources holding one address, a runtime object named
+// twice. What it cannot see is a write the API acknowledged and the store then
+// dropped, because the result is perfectly coherent — it is simply not what the
+// client was told had happened.
+//
+// That is the defect a per-target lock prevents, and it kept being written once
+// per pack: Outscale ordered its update, Exoscale mutated inside store.Update,
+// and Scaleway's took no order at all and lost fields under load (#211). Three
+// packs, one property, so the property lives here and each pack declares only
+// its own traffic — the same split as Sweep.
+//
+// The mechanism it catches is stated by the store itself, on Commit: "State,
+// Runtime and Attrs are taken from the copy wholesale, so a concurrent write to
+// a *different* field of the same resource is still lost". Two handlers reading
+// the same resource, changing one field each and committing whole maps built
+// from their own stale read: the second erases the first, and both answered 200.
+
+// Write is one concurrent updater in a NoLostUpdate run: how to send its change,
+// and how to read back the field it must have left behind.
+//
+// Got is called once the traffic has stopped, so it reads the settled value. A
+// Write whose Apply the API refused is reported as a refusal rather than as a
+// lost field: an update that never landed proves nothing about ordering, and
+// counting it as a loss would turn a pack's own validation into a race report.
+type Write struct {
+	// Field names what this updater owns, and appears in the failure.
+	Field string
+	// Apply sends one update and reports whether the API accepted it.
+	Apply func() bool
+	// Got reads what the resource carries for Field now.
+	Got func() string
+	// Want is what Got must return once every updater has finished.
+	Want string
+}
+
+// Trial builds the writers for one run, on a target nothing else has touched.
+//
+// A factory rather than a fixed list, and the difference is the whole control.
+// The first version of this ran each writer many times against one resource, on
+// the reasoning that more contention finds more races. It found none, and
+// falsification said so: with the ordering removed, the test stayed green.
+//
+// Repetition hides this defect instead of exposing it. What is lost is a field
+// whose value the winner's copy predates, and after a few rounds every writer's
+// reads already carry every other writer's value — so the last commit, whoever
+// wins it, writes a map that has everything. The loss is only visible while some
+// field still has a value nobody else has read yet, which is to say on the
+// first write to a fresh resource.
+//
+// So each trial gets its own target and each writer fires once.
+type Trial func(round int) []Write
+
+// NoLostUpdate runs `trials` independent trials and reports every field a trial
+// acknowledged and then lost.
+//
+// Trials rather than rounds: one trial can be won in an order that happens to
+// lose nothing, so a single one proves little either way. Repeating on fresh
+// targets is what turns "this interleaving was fine" into "no interleaving loses
+// a field", and it is the repetition that costs nothing in signal.
+func NoLostUpdate(trials int, build Trial) []string {
+	if trials < 1 {
+		trials = 1
+	}
+
+	var found []string
+	for trial := range trials {
+		writes := build(trial)
+		refusals := make([]string, len(writes))
+
+		var wg sync.WaitGroup
+		for i, write := range writes {
+			wg.Add(1)
+			go func(i int, write Write) {
+				defer wg.Done()
+				if !write.Apply() {
+					// Recorded rather than returned: a goroutine cannot fail a
+					// test, and a refusal is the pack's own validation talking,
+					// not a race.
+					refusals[i] = fmt.Sprintf(
+						"%s: the API refused its update on trial %d, so this run measured nothing about it",
+						write.Field, trial+1)
+				}
+			}(i, write)
+		}
+		wg.Wait()
+
+		for i, write := range writes {
+			if refusals[i] != "" {
+				found = append(found, refusals[i])
+				continue
+			}
+			if got := write.Got(); got != write.Want {
+				found = append(found, fmt.Sprintf(
+					"trial %d, %s: the API acknowledged %q and the resource carries %q — a "+
+						"concurrent update on another field overwrote it, so this handler is "+
+						"not ordered on its target",
+					trial+1, write.Field, write.Want, got))
+			}
+		}
+		// One report is the news; a hundred is the same news, harder to read.
+		if len(found) > 0 {
+			return found
+		}
+	}
+	return nil
+}

--- a/internal/providers/exoscale/lostupdate_test.go
+++ b/internal/providers/exoscale/lostupdate_test.go
@@ -1,0 +1,92 @@
+package exoscale_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/store/storetest"
+)
+
+// The same property as the two packs beside it, driven with this pack's own
+// traffic: PUT /v2/instance/{id}, one field per writer, a fresh instance per
+// trial.
+//
+// This pack is right for a third reason, and it is the best of the three:
+// updateInstance mutates inside store.Update, so the read, the change and the
+// write are one critical section held by the store itself. There is no window to
+// lose a field in, and no lock for a later reader to forget.
+//
+// Running the shared control here anyway is the point of #211: a property proven
+// once per pack is a property the fourth pack will be missing, and the one that
+// had no ordering at all had simply been the one nobody audited.
+func TestConcurrentUpdatesKeepEveryAcknowledgedField(t *testing.T) {
+	h, _ := newExoscaleBarrageServer(t)
+
+	found := storetest.NoLostUpdate(40, func(trial int) []storetest.Write {
+		status, created := callRaw(h, "POST", "/v2/instance", fmt.Sprintf(`{
+			"name": "before-%d",
+			"instance-type": {"id": "21624abb-764e-4def-81d7-9fc54b5957fb"},
+			"template": {"id": "11111111-1111-4111-8111-111111111111"},
+			"disk-size": 10
+		}`, trial))
+		if status != http.StatusOK {
+			t.Fatalf("trial %d create: status %d (%v)", trial, status, created)
+		}
+		ref, _ := created["reference"].(map[string]any)
+		id, _ := ref["id"].(string)
+		if id == "" {
+			t.Fatalf("the create operation names no resource: %v", created)
+		}
+
+		update := func(body string) bool {
+			status, _ := callRaw(h, "PUT", "/v2/instance/"+id, body)
+			return status == http.StatusOK
+		}
+		field := func(read func(map[string]any) string) func() string {
+			return func() string {
+				status, out := callRaw(h, "GET", "/v2/instance/"+id, "")
+				if status != http.StatusOK {
+					return fmt.Sprintf("<get answered %d>", status)
+				}
+				return read(out)
+			}
+		}
+
+		return []storetest.Write{
+			{
+				Field: "name",
+				Apply: func() bool { return update(`{"name":"after"}`) },
+				Got: field(func(out map[string]any) string {
+					name, _ := out["name"].(string)
+					return name
+				}),
+				Want: "after",
+			},
+			{
+				Field: "user-data",
+				Apply: func() bool { return update(`{"user-data":"YmFycmFnZQ=="}`) },
+				Got: field(func(out map[string]any) string {
+					data, _ := out["user-data"].(string)
+					return data
+				}),
+				Want: "YmFycmFnZQ==",
+			},
+			{
+				Field: "labels",
+				Apply: func() bool { return update(`{"labels":{"barrage":"yes"}}`) },
+				Got: field(func(out map[string]any) string {
+					labels, _ := out["labels"].(map[string]any)
+					value, _ := labels["barrage"].(string)
+					return value
+				}),
+				Want: "yes",
+			},
+		}
+	})
+
+	if len(found) > 0 {
+		t.Errorf("the update path lost a field it had acknowledged:\n%s", strings.Join(found, "\n"))
+	}
+}

--- a/internal/providers/exoscale/pack.go
+++ b/internal/providers/exoscale/pack.go
@@ -651,12 +651,20 @@ func (p *Pack) listInstances(w http.ResponseWriter, r *http.Request) {
 	for _, res := range list {
 		// A virtual machine gets its address tens of seconds after it starts,
 		// so a create cannot wait for one. It is filled in here instead, on the
-		// read a client is making anyway.
-		if p.refresh(r.Context(), res) && !p.env.Store.Commit(res, p.env.Now()) {
-			// Deleted while its address was being discovered.
+		// read a client is making anyway — which makes a list a writer too, and
+		// it is held per instance rather than across the whole listing: one lock
+		// for the loop would queue every instance behind the slowest runtime
+		// answer, and the exclusion this needs is per target (#211).
+		//
+		// Observe re-reads inside the hold, so the copy rendered here cannot
+		// predate the lock. A resource deleted meanwhile drops out of the
+		// answer rather than being resurrected by the read.
+		fresh, err := p.binding().Observe(p.env.Store, p.env.Now, kindInstance, res.ID,
+			func(res *resource.Resource) bool { return p.refresh(r.Context(), res) })
+		if err != nil {
 			continue
 		}
-		instances = append(instances, p.view(res))
+		instances = append(instances, p.view(fresh))
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{"instances": instances})
 }
@@ -796,12 +804,13 @@ func macAddressOf(id string) string {
 
 func (p *Pack) getInstance(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
-	res, ok := p.env.Store.Get(Name, kindInstance, id)
-	if !ok {
-		writeError(w, http.StatusNotFound, "resource not found")
-		return
-	}
-	if p.refresh(r.Context(), res) && !p.env.Store.Commit(res, p.env.Now()) {
+	// This read writes: the address arrives tens of seconds after the start, and
+	// the refresh is what publishes it. Held through the shared Observe, so a
+	// stop landing while the runtime answers is not undone by a GET that began
+	// before it (#211).
+	res, err := p.binding().Observe(p.env.Store, p.env.Now, kindInstance, id,
+		func(res *resource.Resource) bool { return p.refresh(r.Context(), res) })
+	if err != nil {
 		writeError(w, http.StatusNotFound, "resource not found")
 		return
 	}

--- a/internal/providers/outscale/lostupdate_test.go
+++ b/internal/providers/outscale/lostupdate_test.go
@@ -1,0 +1,130 @@
+package outscale_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/store/storetest"
+)
+
+// The same property as the two packs beside it, driven with this pack's own
+// traffic: POST /api/v1/UpdateVm, one field per writer.
+//
+// This pack was already right — updateVm holds the per-target lock, and says why
+// in a comment naming an audit. It runs the shared control anyway, and that is
+// the point of #211: a discipline that only exists where an audit already bit is
+// a discipline the next pack will be missing. Here it is a regression test for a
+// correct handler; in the pack that lacked it, it was the failure.
+func TestConcurrentUpdatesKeepEveryAcknowledgedField(t *testing.T) {
+	ts, _ := newOutscaleBarrageServer(t)
+	// One keypair for the whole run: it has to exist before UpdateVm will take
+	// its name, and validVmFields refusing an unknown one is a guard, not a race.
+	post(t, ts, "CreateKeypair",
+		`{"KeypairName":"barrage-key","PublicKey":"ssh-ed25519 AAAAC3Nz fake@feint"}`)
+
+	found := storetest.NoLostUpdate(40, func(trial int) []storetest.Write {
+		_, out := post(t, ts, "CreateVms", `{"ImageId":"ami-12345678","VmType":"tinav4.c1r1p2"}`)
+		vms, _ := out["Vms"].([]any)
+		if len(vms) == 0 {
+			t.Fatalf("create: no Vm in %v", out)
+		}
+		vm, _ := vms[0].(map[string]any)
+		id, _ := vm["VmId"].(string)
+		if id == "" {
+			t.Fatalf("create: no VmId in %v", vm)
+		}
+		// Stopped first: UpdateVm refuses several fields on a running machine, and a
+		// refusal would make the run measure the guard instead of the ordering.
+		post(t, ts, "StopVms", `{"VmIds":["`+id+`"]}`)
+
+		update := func(body string) bool {
+			status, _ := postRaw(ts, "UpdateVm", body)
+			return status == http.StatusOK
+		}
+		field := func(name string) func() string {
+			return func() string {
+				_, out := post(t, ts, "ReadVms", `{"Filters":{"VmIds":["`+id+`"]}}`)
+				vms, _ := out["Vms"].([]any)
+				if len(vms) == 0 {
+					return "<the Vm is gone>"
+				}
+				vm, _ := vms[0].(map[string]any)
+				switch value := vm[name].(type) {
+				case string:
+					return value
+				case bool:
+					return fmt.Sprintf("%v", value)
+				default:
+					raw, _ := json.Marshal(value)
+					return string(raw)
+				}
+			}
+		}
+
+		return []storetest.Write{
+			{
+				Field: "KeypairName",
+				Apply: func() bool { return update(`{"VmId":"` + id + `","KeypairName":"barrage-key"}`) },
+				Got:   field("KeypairName"),
+				Want:  "barrage-key",
+			},
+			{
+				Field: "UserData",
+				Apply: func() bool { return update(`{"VmId":"` + id + `","UserData":"YmFycmFnZQ=="}`) },
+				Got:   field("UserData"),
+				Want:  "YmFycmFnZQ==",
+			},
+			{
+				Field: "DeletionProtection",
+				Apply: func() bool { return update(`{"VmId":"` + id + `","DeletionProtection":true}`) },
+				Got:   field("DeletionProtection"),
+				Want:  "true",
+			},
+		}
+	})
+
+	if len(found) > 0 {
+		t.Errorf("the update path lost a field it had acknowledged:\n%s", strings.Join(found, "\n"))
+	}
+}
+
+// The shared control above found this while looking for something else, which is
+// the argument for running it on a pack that was already right.
+//
+// UpdateVmRequest declares DeletionProtection upstream ("if true, you cannot
+// delete the VM unless you change this parameter back to false"), and this pack
+// read the flag on the delete, wrote it at create, and dropped it on the update.
+// So protection could be set and never cleared: the one request that undoes it
+// answered 200 and changed nothing, which is the worse half — the client is told
+// the change landed.
+func TestDeletionProtectionCanBeClearedByAnUpdate(t *testing.T) {
+	ts, _ := newOutscaleBarrageServer(t)
+
+	_, out := post(t, ts, "CreateVms",
+		`{"ImageId":"ami-12345678","VmType":"tinav4.c1r1p2","DeletionProtection":true}`)
+	vms, _ := out["Vms"].([]any)
+	vm, _ := vms[0].(map[string]any)
+	id, _ := vm["VmId"].(string)
+	post(t, ts, "StopVms", `{"VmIds":["`+id+`"]}`)
+
+	// The flag is doing its job first: without this the test could pass on a
+	// machine nothing was protecting.
+	if status, _ := post(t, ts, "DeleteVms", `{"VmIds":["`+id+`"]}`); status == http.StatusOK {
+		t.Fatal("a protected Vm was deleted, so this test measures nothing")
+	}
+
+	status, updated := post(t, ts, "UpdateVm", `{"VmId":"`+id+`","DeletionProtection":false}`)
+	if status != http.StatusOK {
+		t.Fatalf("clearing the protection answered %d: %v", status, updated)
+	}
+	got, _ := updated["Vm"].(map[string]any)
+	if protected, _ := got["DeletionProtection"].(bool); protected {
+		t.Error("the update answered 200 and gave the flag back set")
+	}
+	if status, out := post(t, ts, "DeleteVms", `{"VmIds":["`+id+`"]}`); status != http.StatusOK {
+		t.Fatalf("the Vm is still protected after the flag was cleared: %d %v", status, out)
+	}
+}

--- a/internal/providers/outscale/vms.go
+++ b/internal/providers/outscale/vms.go
@@ -93,6 +93,15 @@ type updateVMRequest struct {
 	KeypairName      string   `json:"KeypairName"`
 	UserData         string   `json:"UserData"`
 	SecurityGroupIDs []string `json:"SecurityGroupIds"`
+	// DeletionProtection was declared by UpdateVmRequest upstream and read by
+	// nobody here, so the flag could be set at create and never cleared: the
+	// delete honoured it, the update silently dropped it, and a client that had
+	// protected a machine had no way left to remove it. Answering 200 to that
+	// request is the worse half — the client is told the change landed.
+	//
+	// A pointer because false is the value that matters: a plain bool cannot
+	// tell "clear the protection" from "this request says nothing about it".
+	DeletionProtection *bool `json:"DeletionProtection"`
 }
 
 func (p *Pack) readVms(w http.ResponseWriter, r *http.Request) {
@@ -113,27 +122,22 @@ func (p *Pack) readVms(w http.ResponseWriter, r *http.Request) {
 		}
 		// A virtual machine gets its address tens of seconds after it starts,
 		// so a create cannot wait for one. It is filled in here instead, on the
-		// read a client is making anyway.
-		// This read writes: a virtual machine gets its address late, and the
-		// refresh publishes it. So it is serialised like every other writer —
-		// an audit noted that a read could otherwise lose a concurrent write,
-		// which is the same defect as UpdateVm's, through a door nobody thinks
-		// of as mutating.
-		refreshed := func() bool {
-			unlock := p.binding().Serialise(res.ID)
-			defer unlock()
-			if !p.refreshMachine(r.Context(), res) {
-				return true
-			}
-			// Committed, not Put: this read ran outside the store lock and a
-			// delete may have landed since. A false return means it did, and
-			// the Vm belongs in nobody's answer.
-			return p.env.Store.Commit(res, p.env.Now())
-		}()
-		if !refreshed {
+		// read a client is making anyway. That makes this read a writer, through
+		// a door nobody thinks of as mutating.
+		//
+		// This pack was the only one that had noticed, and it still wrote back a
+		// copy List had handed out *before* the lock was taken. Observe re-reads
+		// inside the hold, which is the half a per-pack version keeps missing —
+		// and the reason the transactional shape lives in the shared layer now
+		// rather than in whichever pack an audit reached first (#211).
+		fresh, err := p.binding().Observe(p.env.Store, p.env.Now, kindVM, res.ID,
+			func(res *resource.Resource) bool { return p.refreshMachine(r.Context(), res) })
+		if err != nil {
+			// Deleted while its address was being discovered: the Vm belongs in
+			// nobody's answer.
 			continue
 		}
-		vms = append(vms, p.vmView(res))
+		vms = append(vms, p.vmView(fresh))
 	}
 
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
@@ -482,6 +486,10 @@ func (p *Pack) updateVm(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.UserData != "" {
 		res.Attrs["UserData"] = req.UserData
+	}
+	// TestDeletionProtectionCanBeClearedByAnUpdate fails without this.
+	if req.DeletionProtection != nil {
+		res.Attrs["DeletionProtection"] = *req.DeletionProtection
 	}
 	if !p.env.Store.Commit(res, p.env.Now()) {
 		p.notFound(w, "Vm", res.ID)

--- a/internal/providers/scaleway/lostupdate_test.go
+++ b/internal/providers/scaleway/lostupdate_test.go
@@ -1,0 +1,271 @@
+package scaleway_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/store/storetest"
+)
+
+// The update path is a read-modify-write, and it was the only one of the three
+// packs' that ordered nothing (#211).
+//
+// Outscale holds the per-target lock around UpdateVm; Exoscale mutates inside
+// store.Update, which is read-modify-write under the store's own write lock;
+// Scaleway read a copy, changed a field and committed the whole Attrs map. The
+// store documents what that costs, on Commit itself: it "does not merge", so a
+// concurrent write to a different field of the same resource is lost — and both
+// clients were told 200.
+//
+// The property lives in the core (storetest.NoLostUpdate) so a fourth pack fails
+// this rather than merely differing from the three. What is Scaleway's own is the
+// traffic below: PATCH /servers/{id}, one field per writer, a fresh server per
+// trial.
+func TestConcurrentUpdatesKeepEveryAcknowledgedField(t *testing.T) {
+	ts := newTestServer(t)
+	const zone = "/instance/v1/zones/fr-par-1"
+
+	found := storetest.NoLostUpdate(40, func(trial int) []storetest.Write {
+		status, out := do(t, ts, "POST", zone+"/servers",
+			fmt.Sprintf(`{"name":"before-%d","commercial_type":"DEV1-S"}`, trial))
+		if status != http.StatusCreated {
+			t.Fatalf("trial %d create: status %d", trial, status)
+		}
+		server, _ := out["server"].(map[string]any)
+		id, _ := server["id"].(string)
+
+		// A goroutine may not call t.Fatalf, so the request helper here reports
+		// rather than fails.
+		patch := func(body string) bool {
+			status, _ := doRaw(ts, "PATCH", zone+"/servers/"+id, body)
+			return status == http.StatusOK
+		}
+		field := func(name string) func() string {
+			return func() string {
+				status, out := do(t, ts, "GET", zone+"/servers/"+id, "")
+				if status != http.StatusOK {
+					t.Fatalf("get: status %d", status)
+				}
+				server, _ := out["server"].(map[string]any)
+				switch value := server[name].(type) {
+				case string:
+					return value
+				case bool:
+					return fmt.Sprintf("%v", value)
+				case []any:
+					parts := make([]string, 0, len(value))
+					for _, v := range value {
+						parts = append(parts, fmt.Sprintf("%v", v))
+					}
+					return strings.Join(parts, ",")
+				default:
+					return fmt.Sprintf("%v", value)
+				}
+			}
+		}
+
+		// Three fields, three writers, none of them touching another's. Whatever
+		// interleaving happens, each of the three values was acknowledged and
+		// must still be there: they cannot legitimately overwrite one another.
+		return []storetest.Write{
+			{
+				Field: "name",
+				Apply: func() bool { return patch(`{"name":"after"}`) },
+				Got:   field("name"),
+				Want:  "after",
+			},
+			{
+				Field: "tags",
+				Apply: func() bool { return patch(`{"tags":["barrage"]}`) },
+				Got:   field("tags"),
+				Want:  "barrage",
+			},
+			{
+				Field: "protected",
+				Apply: func() bool { return patch(`{"protected":true}`) },
+				Got:   field("protected"),
+				Want:  "true",
+			},
+		}
+	})
+
+	if len(found) > 0 {
+		t.Errorf("the update path lost a field it had acknowledged:\n%s", strings.Join(found, "\n"))
+	}
+}
+
+// A NIC create reads the server, writes a NIC and an address beside it, and then
+// writes the server back — and none of that was ordered against a concurrent
+// delete of the same server.
+//
+// The write-back used to be a Put, which reinserts unconditionally, so a DELETE
+// landing in the window was undone and the server came back with its volumes and
+// its address. It is a Commit now, and the handler re-reads the server under the
+// hold, so the resurrection is answered twice over.
+//
+// Three guards answer it and none of them is spare, which took two wrong answers
+// to establish. The hold alone still stranded a NIC on trial 10, because serverOf
+// reads before the lock exists and a delete that had already finished by then
+// goes unseen. The re-read alone leaves the window open on the other side. And
+// p.lockAddresses(), which does serialise NIC creates against each other, is not
+// the lock deleteServer takes, so it orders nothing here.
+//
+// What the barrage measures is the pair working together; each half is falsified
+// on its own by tools/falsify/specs/serialise-then-commit.json.
+//
+// Trials rather than one run: written when a delete released nothing, any
+// completed attach left an orphan and once was enough. Once the delete learned to
+// release its NICs, an orphan needs an attach landing in the narrow window after
+// that release, and repetition is what keeps the assertion worth making.
+const nicBarrageTrials = 12
+
+func TestAttachingANICDoesNotResurrectADeletedServer(t *testing.T) {
+	runtime := newBarrageRuntime()
+	ts, st := newBarrageServer(t, runtime)
+	const zone = "/instance/v1/zones/fr-par-1"
+	const region = "/vpc/v2/regions/fr-par"
+
+	// One network per attacher, shared by every trial: the handler refuses a
+	// second NIC on a network the server already has, and that refusal returns
+	// before anything is written — so sharing one network within a trial would
+	// measure the guard rather than the race. Across trials the servers differ,
+	// so the networks can be reused.
+	const attachers = 8
+	networks := make([]string, 0, attachers)
+	for i := range attachers {
+		status, out := do(t, ts, "POST", region+"/private-networks",
+			fmt.Sprintf(`{"name":"barrage-%d","subnets":["10.%d.0.0/24"]}`, i, 60+i))
+		if status != http.StatusOK && status != http.StatusCreated {
+			t.Fatalf("private network %d: status %d (%v)", i, status, out)
+		}
+		pnID, _ := out["id"].(string)
+		if pnID == "" {
+			t.Fatalf("private network %d: no id in %v", i, out)
+		}
+		networks = append(networks, pnID)
+	}
+
+	for trial := range nicBarrageTrials {
+		status, out := do(t, ts, "POST", zone+"/servers",
+			fmt.Sprintf(`{"name":"victim-%d","commercial_type":"DEV1-S"}`, trial))
+		if status != http.StatusCreated {
+			t.Fatalf("trial %d create: status %d", trial, status)
+		}
+		server, _ := out["server"].(map[string]any)
+		id, _ := server["id"].(string)
+
+		var wg sync.WaitGroup
+		deleted := make(chan int, 1)
+		for _, pnID := range networks {
+			wg.Add(1)
+			go func(pnID string) {
+				defer wg.Done()
+				doRaw(ts, "POST", zone+"/servers/"+id+"/private_nics",
+					`{"private_network_id":"`+pnID+`"}`)
+			}(pnID)
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// The create leaves the server stopped, which is the state a delete
+			// needs, so this is one call.
+			status, _ := doRaw(ts, "DELETE", zone+"/servers/"+id, "")
+			deleted <- status
+		}()
+		wg.Wait()
+		close(deleted)
+
+		if status := <-deleted; status != http.StatusNoContent {
+			t.Fatalf("trial %d: the delete answered %d, so this run measured nothing", trial, status)
+		}
+		if status, _ := do(t, ts, "GET", zone+"/servers/"+id, ""); status != http.StatusNotFound {
+			t.Fatalf("trial %d: the server came back after a 204 delete: get answers %d", trial, status)
+		}
+
+		// The half Commit cannot answer. A NIC left naming a deleted server is
+		// invisible to a client — every list is scoped by server — and it holds
+		// an address the pool will not hand out again.
+		var orphans []string
+		for _, res := range st.All() {
+			if res.Kind != "instance/private-nic" {
+				continue
+			}
+			if res.Runtime["server"] == id {
+				orphans = append(orphans, res.ID)
+			}
+		}
+		if len(orphans) > 0 {
+			t.Fatalf("trial %d: %d private NIC(s) outlived the server they name (%s): %s",
+				trial, len(orphans), id, strings.Join(orphans, ", "))
+		}
+	}
+}
+
+// The barrage above found this while looking for a race, and it is not one: no
+// concurrency is needed. A server deleted while it carries a private NIC left the
+// NIC and its IPAM address in the store, sequentially, every time.
+//
+// What that costs is an address nobody can reach and nobody can reclaim. A NIC
+// listing is scoped by its server, so a client cannot see it once the server
+// answers 404, while the address stays in IPAM — and the network's allocator is
+// rebuilt from what IPAM holds, so it never offers that address again. Repeated
+// create-attach-delete empties the subnet.
+//
+// Measured on fr-par-1 rather than assumed: attaching a server to a private
+// network booked two addresses there, and deleting the server left the network
+// with none.
+func TestDeletingAServerReleasesItsPrivateNICs(t *testing.T) {
+	ts := newTestServer(t)
+	const zone = "/instance/v1/zones/fr-par-1"
+	const region = "/vpc/v2/regions/fr-par"
+
+	_, out := do(t, ts, "POST", zone+"/servers", `{"name":"victim","commercial_type":"DEV1-S"}`)
+	server, _ := out["server"].(map[string]any)
+	id, _ := server["id"].(string)
+
+	status, out := do(t, ts, "POST", region+"/private-networks",
+		`{"name":"one","subnets":["10.77.0.0/24"]}`)
+	if status != http.StatusOK && status != http.StatusCreated {
+		t.Fatalf("private network: status %d", status)
+	}
+	pnID, _ := out["id"].(string)
+
+	status, out = do(t, ts, "POST", zone+"/servers/"+id+"/private_nics",
+		`{"private_network_id":"`+pnID+`"}`)
+	if status != http.StatusCreated {
+		t.Fatalf("attach: status %d (%v)", status, out)
+	}
+
+	// The address is there before the delete, or the assertion after it would
+	// pass on a network that never held one.
+	status, out = do(t, ts, "GET", "/ipam/v1/regions/fr-par/ips?private_network_id="+pnID, "")
+	if status != http.StatusOK {
+		t.Fatalf("ipam list: status %d", status)
+	}
+	if total, _ := out["total_count"].(float64); total < 1 {
+		t.Fatalf("the attach booked no address, so this test measures nothing: %v", out)
+	}
+
+	if status, _ := do(t, ts, "DELETE", zone+"/servers/"+id, ""); status != http.StatusNoContent {
+		t.Fatalf("delete: status %d", status)
+	}
+
+	// The NIC is gone with its server.
+	if status, _ := do(t, ts, "GET", zone+"/servers/"+id+"/private_nics", ""); status != http.StatusNotFound {
+		t.Errorf("the NIC listing still answers %d for a deleted server", status)
+	}
+	// And the address went back to the pool, which is the half a client can act
+	// on: the allocator is rebuilt from IPAM, so an address left here is an
+	// address the network has permanently lost.
+	status, out = do(t, ts, "GET", "/ipam/v1/regions/fr-par/ips?private_network_id="+pnID, "")
+	if status != http.StatusOK {
+		t.Fatalf("ipam list: status %d", status)
+	}
+	if total, _ := out["total_count"].(float64); total != 0 {
+		t.Errorf("the network still holds %v address(es) after its only server was deleted: %v",
+			total, out)
+	}
+}

--- a/internal/providers/scaleway/privatenics.go
+++ b/internal/providers/scaleway/privatenics.go
@@ -84,6 +84,40 @@ func (p *Pack) createPrivateNIC(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Held for the whole handler. p.lockAddresses() below serialises NIC creates
+	// against each other, but it is not the lock deleteServer takes, so nothing
+	// ordered this handler against a delete of the server it is attaching to.
+	//
+	// What that costs is not the resurrection it looks like — Commit answers that
+	// — but a NIC and an IPAM address stored beside a server that is gone by the
+	// time the handler reaches its write-back. The address then stays booked
+	// forever: the allocator is rebuilt from what IPAM holds, and the NIC is
+	// invisible to every client, since NIC listings are scoped by server.
+	//
+	// Taken before p.lockAddresses() because serverAction already establishes
+	// that order — it holds the server, then allocates an address — and one
+	// direction everywhere is what keeps two callers from meeting head on.
+	//
+	// TestAttachingANICDoesNotResurrectADeletedServer fails without this.
+	unlock := p.binding().Serialise(server.ID)
+	defer unlock()
+
+	// And the target is read again inside the hold, because the hold alone is not
+	// enough: serverOf answered before the lock existed, so a delete that had
+	// already finished by then leaves this handler working from a copy of
+	// something that no longer exists. Measured, not assumed — with only the hold,
+	// the barrage below still stranded a NIC on trial 10.
+	//
+	// The two together close it from both sides: the re-read rules out a delete
+	// that landed before the lock, the hold rules out one landing after.
+	//
+	// TestAttachingANICDoesNotResurrectADeletedServer fails without this too.
+	server, found := p.env.Store.Get(Name, kindServer, server.ID)
+	if !found {
+		writeNotFound(w, "server", r.PathValue("id"))
+		return
+	}
+
 	var req createPrivateNICRequest
 	if err := emulator.DecodeJSON(r, &req); err != nil {
 		writeInvalidArguments(w, ArgumentError{ArgumentName: "body", Reason: "format", HelpMessage: err.Error()})
@@ -114,8 +148,8 @@ func (p *Pack) createPrivateNIC(w http.ResponseWriter, r *http.Request) {
 	// this address, and hand out the same one. The booked path holds it too:
 	// checking an address is unattached and attaching it is the same
 	// read-modify-write.
-	unlock := p.lockAddresses()
-	defer unlock()
+	unlockAddresses := p.lockAddresses()
+	defer unlockAddresses()
 
 	// The client either names addresses it booked through ipam/v1, or receives
 	// one from the network's own block. Same pool both ways: the allocator is
@@ -204,8 +238,18 @@ func (p *Pack) createPrivateNIC(w http.ResponseWriter, r *http.Request) {
 	// server.private_ip is deliberately not set: the SDK marks it deprecated and
 	// "always null when routed_ip_enabled is True", which every server here is.
 	// A client reads the address through this NIC and ipam/v1.
-	server.Updated = p.env.Now()
-	p.env.Store.Put(server)
+	//
+	// Commit, not Put, and it is the rule the repository already states: Put
+	// reinserts unconditionally, so attaching a NIC to a server a concurrent
+	// DELETE had just removed brought the server back — with its address, its
+	// volumes and a machine nobody would think to stop. The server is also held
+	// above, so this write cannot be built on a copy older than the lock.
+	//
+	// TestAttachingANICDoesNotResurrectADeletedServer fails without this.
+	if !p.env.Store.Commit(server, p.env.Now()) {
+		writeNotFound(w, "server", server.ID)
+		return
+	}
 
 	// The machine follows the control plane, not the other way round: the
 	// address published here is the one it must carry. A running machine has to
@@ -268,6 +312,28 @@ func (p *Pack) deletePrivateNIC(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	p.releaseNIC(res)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// releaseNIC gives back what a gone NIC held, and both doors to that state call
+// it: DELETE on the NIC itself, and the delete of the server carrying it.
+//
+// Two doors, one function, for the reason releaseServerResources already states
+// about volumes and addresses — written twice, they came to disagree twice. This
+// one was not written twice, it was written once: deleting a server left its
+// NICs and their addresses in the store, with no concurrency needed to see it.
+// The NIC then named a server answering 404, invisible to a client because every
+// NIC listing is scoped by server, while the address it held stayed booked and
+// the network's allocator never handed it out again — so a subnet emptied over
+// repeated create-attach-delete cycles.
+//
+// Measured on fr-par-1 before it was changed: attaching a server to a private
+// network booked two IPAM addresses, and deleting the server left the network
+// with none. The real API takes the NIC and its addresses with the server.
+//
+// TestDeletingAServerReleasesItsPrivateNICs fails without this.
+func (p *Pack) releaseNIC(res *resource.Resource) {
 	// An allocated address goes back to the pool by disappearing from the
 	// store: the allocator is rebuilt from what IPAM holds, so nothing to
 	// release here. A booked one is the client's — it was reserved through
@@ -288,7 +354,6 @@ func (p *Pack) deletePrivateNIC(w http.ResponseWriter, r *http.Request) {
 		p.env.Store.Delete(Name, kindIPAMIP, ip.ID)
 	}
 	p.env.Store.Delete(Name, kindPrivateNIC, res.ID)
-	w.WriteHeader(http.StatusNoContent)
 }
 
 // nicsOnNetwork lists the NICs sitting on a Private Network. The VPC product

--- a/internal/providers/scaleway/servers.go
+++ b/internal/providers/scaleway/servers.go
@@ -385,20 +385,32 @@ func (p *Pack) getServer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	id := r.PathValue("id")
-	res, found := p.env.Store.Get(Name, kindServer, id)
-	if !found || res.Tenant.Zone != zone {
+
+	// The zone is answered before anything else, and from a plain read: a server
+	// of another zone does not exist for this caller, and asking a runtime about
+	// it would be work done for a 404.
+	if res, found := p.env.Store.Get(Name, kindServer, id); !found || res.Tenant.Zone != zone {
 		writeNotFound(w, "server", id)
 		return
 	}
+
 	// A virtual machine gets its address after it boots, so a read is where it
-	// becomes visible.
-	if p.refreshMachine(r.Context(), res) {
-		if !p.env.Store.Commit(res, p.env.Now()) {
-			// Deleted while its address was being discovered. Answering the copy
-			// we hold would hand the client a server the next read denies.
-			writeNotFound(w, "server", id)
-			return
-		}
+	// becomes visible — which makes this GET a writer, and it was the only one of
+	// the three packs' reads that held nothing while it wrote (#211). Observe
+	// holds the server across the runtime call and writes back conditionally, so
+	// a poweroff landing in that window is not undone by the read that started
+	// before it.
+	refreshed := false
+	res, err := p.binding().Observe(p.env.Store, p.env.Now, kindServer, id,
+		func(res *resource.Resource) bool {
+			refreshed = p.refreshMachine(r.Context(), res)
+			return refreshed
+		})
+	if err != nil {
+		writeNotFound(w, "server", id)
+		return
+	}
+	if refreshed {
 		// The machine just proved reachable, so the guest half of its public
 		// addresses can finally land — a virtual machine's agent answers long
 		// after poweron returned. Idempotent for a machine already served.
@@ -413,6 +425,26 @@ func (p *Pack) updateServer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	id := r.PathValue("id")
+
+	// The read, the change and the write-back are one operation, so the target is
+	// held across all three.
+	//
+	// Commit was already conditional here, so a delete landing mid-update wins.
+	// Conditional is not ordered, though, and the store says so about itself:
+	// Commit "does not merge — State, Runtime and Attrs are taken from the copy
+	// wholesale, so a concurrent write to a *different* field of the same
+	// resource is still lost". Two updates, one naming the server and the other
+	// tagging it, each committed a whole Attrs map built from its own stale read,
+	// and the loser's field vanished with a 200 in hand.
+	//
+	// This is also the only one of the three packs' update paths that had no
+	// ordering: Outscale holds the same lock, and Exoscale mutates inside
+	// store.Update, which is read-modify-write under the store's own write lock.
+	//
+	// TestConcurrentUpdatesKeepEveryAcknowledgedField fails without this line.
+	unlock := p.binding().Serialise(id)
+	defer unlock()
+
 	res, found := p.env.Store.Get(Name, kindServer, id)
 	if !found || res.Tenant.Zone != zone {
 		writeNotFound(w, "server", id)
@@ -533,10 +565,23 @@ func (p *Pack) deleteServer(w http.ResponseWriter, r *http.Request) {
 // had just been destroyed.
 //
 // TestTerminateReleasesWhatDeleteReleases fails without this.
+// Private NICs go with the server, and that is the third thing this function had
+// to learn rather than the first: volumes, then addresses, then these. Each time
+// the shape was the same — something the server held stayed in the store naming a
+// server that answers 404 — and each time it took a different symptom to notice.
+//
+// Here the symptom is an address nobody can reach and nobody can reclaim: a NIC
+// listing is scoped by server, so a client cannot see the NIC, while its IPAM
+// address stays booked and the network's allocator, rebuilt from what IPAM holds,
+// never offers it again. Measured against fr-par-1, which releases both with the
+// server.
 func (p *Pack) releaseServerResources(ctx context.Context, id, zone string) {
 	for _, vol := range p.volumesOf(id) {
 		p.detachVolume(vol)
 		p.env.Store.Put(vol)
+	}
+	for _, nic := range p.privateNICsOf(id) {
+		p.releaseNIC(nic)
 	}
 	p.releaseAddressesOf(ctx, id, zone)
 }

--- a/tools/falsify/specs/serialise-then-commit.json
+++ b/tools/falsify/specs/serialise-then-commit.json
@@ -1,0 +1,73 @@
+{
+  "package": "./internal/providers/scaleway/",
+  "mutations": [
+    {
+      "label": "the update path stops ordering its target, and concurrent updates lose each other's fields",
+      "file": "internal/providers/scaleway/servers.go",
+      "find": "\t// TestConcurrentUpdatesKeepEveryAcknowledgedField fails without this line.\n\tunlock := p.binding().Serialise(id)\n\tdefer unlock()\n\n\tres, found := p.env.Store.Get(Name, kindServer, id)",
+      "replace": "\t// TestConcurrentUpdatesKeepEveryAcknowledgedField fails without this line.\n\tunlock := p.binding().Serialise(id)\n\tunlock()\n\n\tres, found := p.env.Store.Get(Name, kindServer, id)",
+      "test": "TestConcurrentUpdatesKeepEveryAcknowledgedField"
+    },
+    {
+      "label": "a NIC create stops holding the server, so a delete lands between its NIC and its write-back",
+      "file": "internal/providers/scaleway/privatenics.go",
+      "find": "\tunlock := p.binding().Serialise(server.ID)\n\tdefer unlock()",
+      "replace": "\tunlock := p.binding().Serialise(server.ID)\n\tunlock()",
+      "test": "TestAttachingANICDoesNotResurrectADeletedServer"
+    },
+    {
+      "label": "a NIC create trusts the copy it read before the hold, so a finished delete goes unseen",
+      "file": "internal/providers/scaleway/privatenics.go",
+      "find": "\tserver, found := p.env.Store.Get(Name, kindServer, server.ID)\n\tif !found {\n\t\twriteNotFound(w, \"server\", r.PathValue(\"id\"))\n\t\treturn\n\t}",
+      "replace": "\tif fresh, found := p.env.Store.Get(Name, kindServer, server.ID); found {\n\t\tserver = fresh\n\t} else if false {\n\t\twriteNotFound(w, \"server\", r.PathValue(\"id\"))\n\t\treturn\n\t}",
+      "test": "TestAttachingANICDoesNotResurrectADeletedServer"
+    },
+    {
+      "label": "Observe hands the look a copy read before the hold",
+      "package": "./internal/core/machine/",
+      "file": "internal/core/machine/observe.go",
+      "find": "\tunlock := b.Serialise(id)\n\tdefer unlock()\n\n\tres, found := st.Get(b.Provider, kind, id)",
+      "replace": "\tres, found := st.Get(b.Provider, kind, id)\n\tunlock := b.Serialise(id)\n\tdefer unlock()",
+      "test": "TestObserveReadsInsideTheHold"
+    },
+    {
+      "label": "Observe writes back on every read, stamping Updated where nothing changed",
+      "package": "./internal/core/machine/",
+      "file": "internal/core/machine/observe.go",
+      "find": "\tif !look(res) {\n\t\treturn res, nil\n\t}",
+      "replace": "\tif !look(res) && false {\n\t\treturn res, nil\n\t}",
+      "test": "TestObserveWritesNothingWhenNothingChanged"
+    },
+    {
+      "label": "Observe reinserts unconditionally, so a read resurrects a deleted resource",
+      "package": "./internal/core/machine/",
+      "file": "internal/core/machine/observe.go",
+      "find": "\tif err := st.Update(b.Provider, kind, id, func(stored *resource.Resource) error {",
+      "replace": "\tst.Put(res)\n\tif err := st.Update(b.Provider, kind, id, func(stored *resource.Resource) error {",
+      "test": "TestObserveDoesNotResurrectADeletedTarget"
+    },
+    {
+      "label": "Observe asks the runtime about a resource that does not exist",
+      "package": "./internal/core/machine/",
+      "file": "internal/core/machine/observe.go",
+      "find": "\tres, found := st.Get(b.Provider, kind, id)\n\tif !found {\n\t\treturn nil, store.ErrNotFound\n\t}",
+      "replace": "\tres, found := st.Get(b.Provider, kind, id)\n\tif !found {\n\t\tres = &resource.Resource{ID: id, Kind: kind}\n\t\tdefer func() { _ = store.ErrNotFound }()\n\t}",
+      "test": "TestObserveRefusesAMissingTargetBeforeTheLook"
+    },
+    {
+      "label": "a deleted server leaves its private NICs and their addresses behind",
+      "file": "internal/providers/scaleway/servers.go",
+      "find": "\tfor _, nic := range p.privateNICsOf(id) {\n\t\tp.releaseNIC(nic)\n\t}",
+      "replace": "\tfor _, nic := range p.privateNICsOf(id) {\n\t\tif false {\n\t\t\tp.releaseNIC(nic)\n\t\t}\n\t}",
+      "test": "TestDeletingAServerReleasesItsPrivateNICs"
+    },
+    {
+      "label": "UpdateVm goes back to dropping DeletionProtection, so protection cannot be cleared",
+      "package": "./internal/providers/outscale/",
+      "file": "internal/providers/outscale/vms.go",
+      "find": "\tif req.DeletionProtection != nil {\n\t\tres.Attrs[\"DeletionProtection\"] = *req.DeletionProtection\n\t}",
+      "replace": "\tif req.DeletionProtection != nil && false {\n\t\tres.Attrs[\"DeletionProtection\"] = *req.DeletionProtection\n\t}",
+      "test": "TestDeletionProtectionCanBeClearedByAnUpdate"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #211.

Three packs, one discipline, applied where an audit had already bitten and
nowhere else.

## Which paths were actually affected

The issue named four. Walking every handler that reaches the machine layer
between reading a resource and writing it back gave twelve candidates and five
real ones — and corrected the issue on two counts: `updateServer` **does** write
back conditionally (it was the *lock* it lacked), and `moveLease` mutates inside
`store.Update`, so it was a false positive of my own scan.

| path | held? | writes | verdict |
|---|---|---|---|
| outscale `readVms` | held | Commit | held a copy read **before** the lock |
| outscale `updateVm` | held | Commit | correct |
| outscale `deleteVms` | held | Commit | correct |
| scaleway `serverAction` | held | Commit | correct |
| scaleway `getServer` | **unheld** | Commit | fixed |
| scaleway `updateServer` | **unheld** | Commit | fixed |
| scaleway `createPrivateNIC` | **unheld** | **Put** | fixed |
| exoscale `getInstance` | **unheld** | Commit | fixed |
| exoscale `listInstances` | **unheld** | Commit | fixed |
| exoscale `updateInstance` | n/a | `store.Update` | correct, and the best of the three |

## `Observe`, and the four reads that write

A virtual machine gets its address tens of seconds after it starts, so no pack
publishes one at create time. All three fill it in on the next read — which makes
GET a writer, through a door nobody thinks of as mutating.

The race is worse than a lost field:

```
getServer             reads a running server, asks the runtime for its
                      address — tens of seconds
serverAction poweroff takes the lock, stops the machine, withdraws the
                      address, commits "stopped"
getServer             commits its copy: "running", address and all
```

`Commit` refuses to resurrect a *deleted* resource and orders nothing else, so
**the read wins** and the emulator describes as running a machine that is
stopped. That is the lie this project exists to avoid, arriving through a GET.

`Binding.Observe` holds the target, **re-reads inside the hold**, runs the look
outside the store lock, and writes back **only when something changed**.
`Transition` is now that function with the answer already known, so the
transactional shape exists once rather than once per pack.

Both details are load-bearing and both are asserted:

- **the re-read** — Outscale's version serialised around a copy `List` produced
  earlier, so the lock ordered the write-back and not the read it was built on;
- **the conditional write-back** — `Updated` is `modification_date` on the wire,
  and committing on every GET would make a resource appear to change every time
  a client looked at it.

## The shared control the issue asked for

`storetest.NoLostUpdate` lives in the core, keyed on nothing but the traffic each
pack declares — the same split as `Sweep`. All three packs run it. A fourth pack
fails it rather than merely differing.

**Writing it taught something worth keeping.** The first version repeated each
writer against one resource, on the reasoning that contention finds races. It
found none, and falsification said so. Repetition *hides* this defect: after a
few rounds every writer's reads already carry every other writer's value, so the
last commit writes a map that has everything. The loss is only visible while some
field still has a value nobody else has read. Fresh target per trial, one write
each.

## What the same control found on the way

- **`UpdateVm` dropped `DeletionProtection`.** Declared by `UpdateVmRequest`
  upstream, read by nobody here — so a flag set at create could never be cleared,
  and the request that undoes it answered 200 and changed nothing. Found by
  running the shared control against a pack that was *already right*, which is
  the argument for running it there.
- **Deleting a server left its private NICs behind**, with no concurrency needed.
  The NIC then named a server answering 404 — invisible, since NIC listings are
  scoped by server — while its IPAM address stayed booked and the allocator,
  rebuilt from what IPAM holds, never offered it again. **Measured on fr-par-1**:
  attaching a server to a private network booked two addresses, and deleting the
  server left the network with none.

## Two wrong answers, corrected by falsification rather than by argument

The per-server hold in `createPrivateNIC` was first justified by resurrection —
falsification refused it, because `Commit` already answers that. It was then
removed as redundant with `p.lockAddresses()` — the barrage refused *that*,
because the address lock is not the lock `deleteServer` takes. The hold alone
still stranded a NIC on trial 10, since `serverOf` reads before the lock exists.

Hold **and** re-read, closing the window from both sides, each half falsifiable
on its own precisely because neither is sufficient alone.

## Measured

| | |
|---|---|
| `go test ./...`, `mise run prepush` | green |
| `mise run conformance` | **exit 0**, 73 checks, 0 FAIL, 188/244 routes driven |
| `FEINT_VM=incus-ovn mise run conformance` | **exit 0**, 110 checks, 0 FAIL |
| `mise run falsify -- specs/serialise-then-commit.json` | 9 mutations, all bite |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
