### PR TITLE
fix(packs): an exclusive resource has one live owner, and the core now asks (#214, #215)

### DIFF
--- a/internal/core/store/storetest/orphans.go
+++ b/internal/core/store/storetest/orphans.go
@@ -1,0 +1,82 @@
+package storetest
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/stephrobert/feint/internal/core/resource"
+)
+
+// An exclusive resource has one live owner, and this is the third time that
+// sentence has been written into a pack rather than into the core.
+//
+// Scaleway detaches a deleted server's volumes and, since #214, releases its
+// private NICs. Outscale detaches a terminated Vm's interfaces and, since #215,
+// unlinks its volumes. Each of those was found separately, by a different
+// symptom, months apart — and every one of them is the same fact: the pack
+// re-checked exclusivity on every link and on no death.
+//
+// What the symptom looks like from a client is worth stating, because it is the
+// reason this matters more than tidiness. The dependent record names an owner
+// that answers 404, so it is invisible to every listing scoped by that owner —
+// and it goes on holding something exclusive: an address the allocator will not
+// reissue, a volume LinkVolume refuses to attach anywhere else, a private network
+// that refuses to be deleted while something references it. There is no call left
+// that frees it. The user restarts the emulator.
+//
+// Sweep answers what is incoherent about a set of resources on its own terms.
+// This needs one thing Sweep cannot know: which attribute or runtime key names an
+// owner, and of what kind. So the pack declares that, and the invariant lives
+// here — the same split as Gone and Shared, for the same reason. A fourth pack
+// that forgets a death path fails a control it never had to remember to write.
+
+// Ownership is what a pack knows and the core cannot: that this resource belongs
+// to another, and which one.
+//
+// Returning ok=false means "this resource claims no owner", which is the normal
+// answer for most of them. Kind is compared as the pack stores it.
+type Ownership func(res *resource.Resource) (kind, id string, ok bool)
+
+// Orphans reports every resource whose declared owner is not in the store.
+//
+// Gone is honoured for the owner rather than for the dependent: a pack that keeps
+// a record its API calls dead — Outscale keeps a terminated Vm readable, because
+// the Terraform provider polls for that state — still owns nothing. A volume
+// still linked to a terminated Vm is exactly the defect this looks for, so an
+// owner that Gone reports as dead counts as absent.
+func Orphans(resources []*resource.Resource, owner Ownership, gone Gone) []string {
+	if owner == nil {
+		return nil
+	}
+
+	alive := map[string]bool{}
+	for _, res := range resources {
+		if res == nil {
+			continue
+		}
+		if gone != nil && gone(res) {
+			continue
+		}
+		alive[res.Kind+"/"+res.ID] = true
+	}
+
+	var found []string
+	for _, res := range resources {
+		if res == nil {
+			continue
+		}
+		kind, id, ok := owner(res)
+		if !ok || id == "" {
+			continue
+		}
+		if alive[kind+"/"+id] {
+			continue
+		}
+		found = append(found, fmt.Sprintf(
+			"%s %s still names %s %s, which no longer exists: whatever it holds exclusively "+
+				"is held for ever, and no client call can release it",
+			res.Kind, res.ID, kind, id))
+	}
+	sort.Strings(found)
+	return found
+}

--- a/internal/core/store/storetest/orphans_test.go
+++ b/internal/core/store/storetest/orphans_test.go
@@ -1,0 +1,72 @@
+package storetest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/resource"
+)
+
+func owned(kind, id, ownerKind, ownerID string) *resource.Resource {
+	return &resource.Resource{
+		Kind:    kind,
+		ID:      id,
+		Runtime: map[string]string{"owner-kind": ownerKind, "owner-id": ownerID},
+		Attrs:   map[string]any{},
+	}
+}
+
+// The declaration a pack makes: which key names an owner, and of what kind.
+func testOwnership(res *resource.Resource) (kind, id string, ok bool) {
+	kind, id = res.Runtime["owner-kind"], res.Runtime["owner-id"]
+	return kind, id, id != ""
+}
+
+// Both halves, because a control that reports everything passes every attack
+// test and makes the barrage useless.
+func TestOrphansReportsWhatOutlivedItsOwnerAndNothingElse(t *testing.T) {
+	server := &resource.Resource{Kind: "server", ID: "srv-1", Attrs: map[string]any{}}
+	live := owned("volume", "vol-live", "server", "srv-1")
+	stranded := owned("volume", "vol-stranded", "server", "srv-gone")
+	standalone := &resource.Resource{Kind: "volume", ID: "vol-free", Attrs: map[string]any{}}
+
+	found := Orphans([]*resource.Resource{server, live, stranded, standalone}, testOwnership, nil)
+	if len(found) != 1 {
+		t.Fatalf("want exactly one report, got %d:\n%s", len(found), strings.Join(found, "\n"))
+	}
+	if !strings.Contains(found[0], "vol-stranded") || !strings.Contains(found[0], "srv-gone") {
+		t.Errorf("the report names neither the resource nor the owner it lost: %q", found[0])
+	}
+}
+
+// The owner's liveness is the pack's word, not the store's. Outscale keeps a
+// terminated Vm readable because the Terraform provider polls for that state, so
+// the record is present and owns nothing — a volume still linked to it is exactly
+// the defect this looks for, and reading presence alone would miss it.
+func TestOrphansAsksThePackWhetherTheOwnerIsStillAlive(t *testing.T) {
+	dead := &resource.Resource{Kind: "vm", ID: "vm-1", State: "terminated", Attrs: map[string]any{}}
+	volume := owned("volume", "vol-1", "vm", "vm-1")
+	all := []*resource.Resource{dead, volume}
+
+	if found := Orphans(all, testOwnership, nil); len(found) != 0 {
+		t.Fatalf("with no liveness predicate the owner is present, so nothing is stranded:\n%s",
+			strings.Join(found, "\n"))
+	}
+
+	gone := func(res *resource.Resource) bool { return res.State == "terminated" }
+	found := Orphans(all, testOwnership, gone)
+	if len(found) != 1 {
+		t.Fatalf("a volume linked to a terminated Vm is stranded; got %d report(s):\n%s",
+			len(found), strings.Join(found, "\n"))
+	}
+}
+
+// A pack that declares no ownership gets no findings rather than a panic: the
+// same direction of failure as a nil Gone or a nil Shared, and the shape a pack
+// keeping its references on the owner legitimately has.
+func TestOrphansIsSilentWithoutADeclaration(t *testing.T) {
+	stranded := owned("volume", "vol-1", "server", "srv-gone")
+	if found := Orphans([]*resource.Resource{stranded}, nil, nil); found != nil {
+		t.Errorf("a pack that declares nothing was reported anyway: %v", found)
+	}
+}

--- a/internal/providers/exoscale/barrage_test.go
+++ b/internal/providers/exoscale/barrage_test.go
@@ -110,6 +110,13 @@ func TestAnExoscaleBarrageLeavesTheStoreCoherent(t *testing.T) {
 			len(refused), strings.Join(refused, "\n"))
 	}
 
+	// storetest.Orphans is not called here, and the reason belongs in the file
+	// rather than in a reader's head: this pack keeps its references on the owner
+	// and not on the dependent. An instance carries the ids of its elastic IPs
+	// and the networks it joined, so deleting the instance takes the reference
+	// with it and there is no record left naming something gone. The day a
+	// resource here names an instance, it declares Owns and joins the sweep the
+	// two other packs run (#215).
 	if found := storetest.Sweep(st.All(), nil, nil); len(found) != 0 {
 		t.Errorf("the store is incoherent after the barrage:\n%s", strings.Join(found, "\n"))
 	}

--- a/internal/providers/outscale/barrage_test.go
+++ b/internal/providers/outscale/barrage_test.go
@@ -121,6 +121,14 @@ func TestAnOutscaleBarrageLeavesTheStoreCoherent(t *testing.T) {
 
 	// The pack's own word on liveness: a terminated Vm keeps its record for
 	// ReadVms polling and holds nothing, so the sweep must not count it.
+	// An exclusive resource has one live owner, and a terminated Vm owns nothing:
+	// Gone says so, and the sweep below reads it for the owner rather than for the
+	// dependent, which is exactly the case #215 was filed for.
+	if found := storetest.Orphans(st.All(), outscale.Owns, outscale.Gone); len(found) != 0 {
+		t.Errorf("the barrage left resources naming an owner that is gone:\n%s",
+			strings.Join(found, "\n"))
+	}
+
 	if found := storetest.Sweep(st.All(), outscale.Gone, nil); len(found) != 0 {
 		t.Errorf("the store is incoherent after the barrage:\n%s", strings.Join(found, "\n"))
 	}

--- a/internal/providers/outscale/lostupdate_test.go
+++ b/internal/providers/outscale/lostupdate_test.go
@@ -128,3 +128,58 @@ func TestDeletionProtectionCanBeClearedByAnUpdate(t *testing.T) {
 		t.Fatalf("the Vm is still protected after the flag was cleared: %d %v", status, out)
 	}
 }
+
+// A terminated Vm released its interfaces and kept its volumes (#215).
+//
+// The volume then names a machine that is gone, so LinkVolume refuses to attach
+// it anywhere else and UnlinkVolume is the only way out — a call no client makes,
+// because from where the client stands the Vm is terminated and the volume is
+// supposed to be free. The emulator has to be restarted.
+//
+// The test drives the way out rather than reading the store: attach, kill the Vm,
+// attach the same volume to another one. That is the sequence a user is stuck in.
+func TestTerminatingAVmFreesItsVolumes(t *testing.T) {
+	ts, _ := newOutscaleBarrageServer(t)
+
+	vm := func(name string) string {
+		t.Helper()
+		_, out := post(t, ts, "CreateVms", `{"ImageId":"ami-12345678","VmType":"tinav4.c1r1p2"}`)
+		vms, _ := out["Vms"].([]any)
+		if len(vms) == 0 {
+			t.Fatalf("%s: no Vm in %v", name, out)
+		}
+		first, _ := vms[0].(map[string]any)
+		id, _ := first["VmId"].(string)
+		return id
+	}
+
+	doomed, survivor := vm("doomed"), vm("survivor")
+
+	_, out := post(t, ts, "CreateVolume", `{"SubregionName":"eu-west-2a","Size":10}`)
+	volume, _ := out["Volume"].(map[string]any)
+	volID, _ := volume["VolumeId"].(string)
+	if volID == "" {
+		t.Fatalf("no VolumeId in %v", out)
+	}
+
+	if status, out := post(t, ts, "LinkVolume",
+		`{"VolumeId":"`+volID+`","VmId":"`+doomed+`","DeviceName":"/dev/xvdb"}`); status != http.StatusOK {
+		t.Fatalf("link: status %d (%v)", status, out)
+	}
+	// The exclusivity is real before the Vm dies, or the assertion after it would
+	// pass on a volume nothing was holding.
+	if status, _ := post(t, ts, "LinkVolume",
+		`{"VolumeId":"`+volID+`","VmId":"`+survivor+`","DeviceName":"/dev/xvdb"}`); status == http.StatusOK {
+		t.Fatal("a linked volume was attached to a second Vm, so this test measures nothing")
+	}
+
+	post(t, ts, "StopVms", `{"VmIds":["`+doomed+`"]}`)
+	if status, out := post(t, ts, "DeleteVms", `{"VmIds":["`+doomed+`"]}`); status != http.StatusOK {
+		t.Fatalf("delete: status %d (%v)", status, out)
+	}
+
+	if status, out := post(t, ts, "LinkVolume",
+		`{"VolumeId":"`+volID+`","VmId":"`+survivor+`","DeviceName":"/dev/xvdb"}`); status != http.StatusOK {
+		t.Fatalf("the volume is still held by a terminated Vm: status %d (%v)", status, out)
+	}
+}

--- a/internal/providers/outscale/vms.go
+++ b/internal/providers/outscale/vms.go
@@ -703,6 +703,9 @@ func (p *Pack) deleteVms(w http.ResponseWriter, r *http.Request) {
 			// what stops a NIC from naming a terminated Vm for ever. The primary
 			// is derived and needs nothing.
 			p.detachNicsOf(res.ID)
+			// And its volumes, for the same reason and by the same rule: an
+			// exclusive resource has one live owner, and the owner just died.
+			p.detachVolumesOf(res.ID)
 			deleted = append(deleted, map[string]any{
 				"VmId":          res.ID,
 				"CurrentState":  stateTerminated,
@@ -840,4 +843,25 @@ func (p *Pack) vmView(res *resource.Resource) map[string]any {
 		"HostAction":  "stop",
 	}
 	return out
+}
+
+// Owns tells the shared orphan sweep which resources of this pack belong to
+// another, and to which one.
+//
+// The vocabulary is the provider's — LinkedVmId on a volume, LinkVmId on a NIC —
+// so it is declared here and the invariant lives in the core, the same split as
+// Gone above. What it catches is the defect #215 named: a volume that outlived
+// its Vm goes on refusing to attach anywhere else, and no client call frees it.
+func Owns(res *resource.Resource) (kind, id string, ok bool) {
+	switch res.Kind {
+	case kindVolume:
+		if vmID := stringOf(res.Attrs["LinkedVmId"]); vmID != "" {
+			return kindVM, vmID, true
+		}
+	case kindNic:
+		if vmID := stringOf(res.Attrs["LinkVmId"]); vmID != "" {
+			return kindVM, vmID, true
+		}
+	}
+	return "", "", false
 }

--- a/internal/providers/outscale/volumes.go
+++ b/internal/providers/outscale/volumes.go
@@ -392,3 +392,32 @@ func (p *Pack) readVmsState(w http.ResponseWriter, r *http.Request) {
 		"ResponseContext": p.context(),
 	})
 }
+
+// detachVolumesOf releases the volumes a terminated Vm held, the way
+// detachNicsOf releases its interfaces.
+//
+// Same invariant as the NICs and the same reason it was missed: an exclusive
+// resource has one live owner, and the pack re-checked that on every link and on
+// no death. A volume left carrying LinkedVmId names a machine that is gone, so
+// LinkVolume refuses to attach it anywhere else and UnlinkVolume is the only way
+// out — a call no client makes, because from the client's side the Vm is
+// terminated and the volume is supposed to be free. The emulator has to be
+// restarted.
+//
+// Unlinked and not deleted: this pack publishes DeleteOnVmDeletion false on every
+// volume link, and upstream is explicit that false means "the volume is not
+// deleted when terminating the VM". Deleting here would contradict what the same
+// pack tells the client one field earlier.
+//
+// TestTerminatingAVmFreesItsVolumes fails without this.
+func (p *Pack) detachVolumesOf(vmID string) {
+	for _, vol := range p.env.Store.List(kindVolume, resource.Tenant{Provider: Name}) {
+		if stringOf(vol.Attrs["LinkedVmId"]) != vmID {
+			continue
+		}
+		delete(vol.Attrs, "LinkedVmId")
+		delete(vol.Attrs, "DeviceName")
+		vol.State = volumeStateAvailable
+		p.env.Store.Commit(vol, p.env.Now())
+	}
+}

--- a/internal/providers/scaleway/barrage_test.go
+++ b/internal/providers/scaleway/barrage_test.go
@@ -220,6 +220,14 @@ func TestABarrageLeavesTheStoreCoherent(t *testing.T) {
 		t.Errorf("the store is incoherent after the barrage:\n%s", strings.Join(found, "\n"))
 	}
 
+	// An exclusive resource has one live owner. Sweep cannot ask that on its own
+	// — it does not know which key names an owner — so the pack declares it and
+	// the invariant lives in the core (#214, #215).
+	if found := storetest.Orphans(st.All(), scaleway.Owns, nil); len(found) != 0 {
+		t.Errorf("the barrage left resources naming an owner that is gone:\n%s",
+			strings.Join(found, "\n"))
+	}
+
 	// The other half of the same invariant, and the one the store cannot answer
 	// on its own: the API describes nothing, so nothing must be running. An
 	// orphan here is a machine on the operator's host that no client can find,

--- a/internal/providers/scaleway/privatenics.go
+++ b/internal/providers/scaleway/privatenics.go
@@ -468,3 +468,24 @@ func (p *Pack) privateNICView(res *resource.Resource) map[string]any {
 	out["ipam_ip_ids"] = ids
 	return out
 }
+
+// Owns is this pack's half of the shared orphan sweep: which of its resources
+// belong to another, and to which one.
+//
+// Two links, both of them exclusive and both of them found the hard way — a
+// volume that named a deleted server, then a NIC that did (#214). The vocabulary
+// is Scaleway's, so it is declared here; the invariant is everyone's, so it lives
+// in storetest.
+func Owns(res *resource.Resource) (kind, id string, ok bool) {
+	switch res.Kind {
+	case kindPrivateNIC, kindVolume:
+		if serverID := res.Runtime[runtimeServerKey]; serverID != "" {
+			return kindServer, serverID, true
+		}
+	case kindIPAMIP:
+		if nicID := res.Runtime[runtimeNICKey]; nicID != "" {
+			return kindPrivateNIC, nicID, true
+		}
+	}
+	return "", "", false
+}

--- a/tools/conformance/scaleway/scw-cli.sh
+++ b/tools/conformance/scaleway/scw-cli.sh
@@ -430,4 +430,54 @@ scw vpc private-network delete "$ipam_pn_id" region=fr-par >/dev/null \
 prove_end "$span"
 ok "booked, pinned, refused twice, listed, updated, released"
 
+# A server dies with its private NICs, and the network it was on becomes
+# deletable (#214). Driven by the CLI rather than read from the store, because
+# the failure this closes is a destroy that never converges: the NIC survived its
+# server, the network refused to go while something referenced it, and no call was
+# left that could remove the reference.
+echo "- a server dies with its private NICs, and the network goes after it"
+span="$(prove_begin behaviour)"
+nic_pn="$(scw vpc private-network create name=conformance-nic subnets.0=10.184.0.0/24 \
+            region=fr-par -o json)" || fail "private network create rejected: $nic_pn"
+nic_pn_id="$(printf '%s' "$nic_pn" | jq -r '.id')"
+[ -n "$nic_pn_id" ] && [ "$nic_pn_id" != null ] || fail "no id in the private network response: $nic_pn"
+
+nic_server="$(scw instance server create name=conformance-nic type=DEV1-S zone="$ZONE" -o json 2>&1)" \
+  || fail "create rejected by the CLI: $nic_server"
+nic_server_id="$(printf '%s' "$nic_server" | jq -r '.id // empty')"
+[ -n "$nic_server_id" ] || fail "no id in the create response: $nic_server"
+
+nic="$(scw instance private-nic create server-id="$nic_server_id" \
+         private-network-id="$nic_pn_id" zone="$ZONE" -o json 2>&1)" \
+  || fail "private nic create rejected: $nic"
+nic_id="$(printf '%s' "$nic" | jq -r '.id // .private_nic.id // empty')"
+[ -n "$nic_id" ] || fail "no id in the private nic response: $nic"
+
+# The address is booked before the delete, so the release after it is a change
+# and not the absence of anything.
+scw ipam ip list private-network-id="$nic_pn_id" region=fr-par -o json \
+  | jq -e 'length > 0' >/dev/null || fail "the attach booked no address: nothing to measure"
+
+scw instance server stop "$nic_server_id" zone="$ZONE" >/dev/null || fail "poweroff rejected"
+scw instance server delete "$nic_server_id" zone="$ZONE" >/dev/null || fail "delete rejected"
+
+neg="$(prove_begin negative)"
+if scw instance private-nic list server-id="$nic_server_id" zone="$ZONE" -o json >/dev/null 2>&1; then
+  fail "the NIC listing still answers for a deleted server"
+fi
+prove_end "$neg"
+
+# The address went back to the pool. Left behind it would be booked for ever:
+# the allocator is rebuilt from what IPAM holds.
+scw ipam ip list private-network-id="$nic_pn_id" region=fr-par -o json \
+  | jq -e 'length == 0' >/dev/null \
+  || fail "the network still holds an address after its only server was deleted"
+
+# And the network goes, which is the whole point: this is where a destroy used
+# to stop converging.
+scw vpc private-network delete "$nic_pn_id" region=fr-par >/dev/null \
+  || fail "the private network refuses to be deleted after its only server was removed"
+prove_end "$span"
+ok "NIC gone with its server, address released, network deleted"
+
 echo "conformance: scw CLI passed"

--- a/tools/falsify/specs/one-live-owner.json
+++ b/tools/falsify/specs/one-live-owner.json
@@ -1,0 +1,28 @@
+{
+  "package": "./internal/providers/outscale/",
+  "mutations": [
+    {
+      "label": "a terminated Vm keeps its volumes, so they can never be attached anywhere else",
+      "file": "internal/providers/outscale/vms.go",
+      "find": "\t\t\tp.detachVolumesOf(res.ID)",
+      "replace": "\t\t\tif false {\n\t\t\t\tp.detachVolumesOf(res.ID)\n\t\t\t}",
+      "test": "TestTerminatingAVmFreesItsVolumes"
+    },
+    {
+      "label": "the orphan sweep reports a resource whose owner is alive",
+      "package": "./internal/core/store/storetest/",
+      "file": "internal/core/store/storetest/orphans.go",
+      "find": "\t\tif alive[kind+\"/\"+id] {\n\t\t\tcontinue\n\t\t}",
+      "replace": "\t\tif alive[kind+\"/\"+id] && false {\n\t\t\tcontinue\n\t\t}",
+      "test": "TestOrphansReportsWhatOutlivedItsOwnerAndNothingElse"
+    },
+    {
+      "label": "the orphan sweep reads presence instead of asking the pack about liveness",
+      "package": "./internal/core/store/storetest/",
+      "file": "internal/core/store/storetest/orphans.go",
+      "find": "\t\tif gone != nil && gone(res) {\n\t\t\tcontinue\n\t\t}",
+      "replace": "\t\tif gone != nil && gone(res) && false {\n\t\t\tcontinue\n\t\t}",
+      "test": "TestOrphansAsksThePackWhetherTheOwnerIsStillAlive"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #214. Closes #215.

Two issues, one sentence — and the sentence had been written into three packs
instead of into the core.

## What each pack was missing

| pack | releases on death | kept | found by |
|---|---|---|---|
| Scaleway | volumes, addresses, **NICs** (#211) | — | #214, and this PR proves it with `scw` |
| Outscale | addresses, **NICs** | **volumes** | #215 |
| Exoscale | references live on the owner | — | nothing to strand |

**Scaleway.** #211 released the NICs; #214 also asked for the half that fix did
not carry — the proof through the real client. `scw` now creates a network,
attaches a server, deletes the server, deletes the network. That last line is
where a destroy used to stop converging: `deletePrivateNetwork` refuses while a
NIC references it, and nothing could remove the reference.

**Outscale.** A terminated Vm detached its interfaces and kept its volumes. The
volume names a machine that is gone, so `LinkVolume` refuses to attach it
anywhere else and `UnlinkVolume` is the only way out — a call **no client makes**,
because from where the client stands the Vm is terminated and the volume is free.
The user restarts the emulator.

The test drives that way out rather than reading the store: attach, kill the Vm,
attach the same volume to another one.

Unlinked and **not** deleted: this pack publishes `DeleteOnVmDeletion: false` on
every volume link, and upstream is explicit that false means the volume survives
termination. Deleting here would contradict what the same pack tells the client
one field earlier.

## The part #215 actually asked for

It asked whether the invariant belongs in the shared layer, having counted three
inconsistent copies. It does.

`storetest.Orphans` is it: the pack declares which key names an owner and of what
kind, the core does the rest. Same split as `Gone` and `Shared`, for the same
reason — a control recopied per pack is a control one pack forgets, and a fourth
would forget it for certain.

**Liveness is asked of the pack, not read off the store**, and that is the case
this exists for: Outscale keeps a terminated Vm readable because the Terraform
provider polls for that state, so the record is *present* and owns nothing.
Reading presence alone would have missed the very defect above — which is why
there is a test for exactly that.

**Exoscale does not call it**, and the reason is in its barrage rather than in a
reader's head: this pack keeps its references on the owner and not on the
dependent, so deleting an instance takes the reference with it. The day a
resource there names an instance, it declares `Owns`.

## Measured

| | |
|---|---|
| `go test ./...`, `mise run prepush` | green |
| `mise run conformance` | **exit 0**, 74 checks (one more: the new `scw` leg), 0 FAIL |
| `mise run falsify -- specs/one-live-owner.json` | 3 mutations, all bite |

The three: the volumes left linked, the sweep reporting a live owner, and the
sweep reading presence instead of asking the pack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
