### PR TITLE
fix(core): one emulated address reaches one machine, whatever the pack allows (#213)

### DIFF
--- a/docs/limits.md
+++ b/docs/limits.md
@@ -616,6 +616,34 @@ Bounds, stated rather than implied:
   never routed, because a restored snapshot carries these values verbatim.
   `TestAPoisonedStoredAddressIsNeverRouted` holds the refusal.
 
+### One address reaches one machine, and Exoscale is why that needs saying
+
+Exoscale's Elastic IP is designed to be held by **several instances at once**: an
+Elastic IP carries a healthcheck, and the platform sends the address to whichever
+instance is passing it. Measured on `ch-gva-2` rather than assumed — `exo compute
+instance elastic-ip attach` was accepted twice for one address, and both instances
+then reported holding `185.19.28.243`.
+
+The emulator keeps that in its control plane, because it is what the real one
+does: both instances go on listing the Elastic IP, and a client reading either of
+them sees what Exoscale would show.
+
+**The runtime cannot follow.** Two containers answering ARP for one `/32` make the
+host pick arbitrarily, and an emulator that publishes an address its machine may
+or may not carry has given up the one thing it exists to promise. So the address
+is routed to **the most recently attached instance**, and taken back from the
+previous holder before it is handed over.
+
+That rule is feint's, not Exoscale's. There is no healthcheck here, and inventing
+an election would put a winner in a client's hands that nothing measured. If you
+are testing a failover, the emulator will not perform it: attach the address to
+the instance you want to reach.
+
+The same bookkeeping serves all three packs (`machine.Binding.RouteAddress`), so
+the runtime carries one address on one machine whatever the pack's API allows —
+Scaleway moving a flexible IP on request, Outscale refusing without `AllowRelink`,
+Exoscale accepting both holders.
+
 ## Subnet isolation depends on the runtime mode
 
 Upstream, two private networks of two different VPCs do not reach each other.

--- a/internal/core/machine/placement.go
+++ b/internal/core/machine/placement.go
@@ -1,0 +1,105 @@
+package machine
+
+import (
+	"context"
+	"sync"
+)
+
+// One address, one machine — enforced where the address actually lands rather
+// than in each pack's idea of who may hold it.
+//
+// The three packs disagree at the API, and they are right to: the clouds
+// disagree. Scaleway moves a flexible IP to the server you name. Outscale refuses
+// unless the request passes AllowRelink, which is its own documented default.
+// Exoscale accepts the same Elastic IP on several instances at once — measured on
+// ch-gva-2, where two instances both reported holding 185.19.28.243, and it is
+// the whole point of the healthcheck an Elastic IP carries.
+//
+// So the control planes must differ, and #213 asked for the shared part to be the
+// bookkeeping. This is it. Whatever a pack allows its client to record, the
+// runtime carries an emulated address on at most one machine, because the
+// alternative is not a second opinion but a coin toss: two containers answering
+// ARP for one /32, the host picking arbitrarily, and the API describing both as
+// holders. An emulator that publishes an address its machine may or may not carry
+// has given up the only thing it was built to promise.
+//
+// What this deliberately does not do is elect. Exoscale's platform elects by
+// healthcheck; feint has no healthcheck and does not invent one, so the address
+// follows the most recent attach and docs/limits.md says so. Guessing the winner
+// would be worse than naming the rule.
+
+// placements records which machine an emulated address is routed to, keyed by
+// provider so two packs numbering their addresses the same way do not collide.
+//
+// Package-level for the same reason serialise.Lock is: Binding is a value built
+// per call, so state that must outlive one request cannot live in it.
+var placements sync.Map // string -> string
+
+func placementKey(provider, address string) string { return provider + "|" + address }
+
+// RouteAddress gives the address to one machine and takes it back from whichever
+// machine had it.
+//
+// The order matters and is not an implementation detail: the previous holder is
+// unrouted first, so no instant exists where two machines carry the address. Both
+// packs that got this right wrote the same sentence about it in their own file —
+// "moving the address means taking it back first" — which is how it came to be
+// written twice and missing the third time.
+//
+// A failure to unroute the previous holder is returned rather than swallowed. The
+// caller wanted the address moved, and a move whose first half failed has left
+// the address where it was.
+func (b Binding) RouteAddress(ctx context.Context, router Router, spec AddressSpec) error {
+	if router == nil || spec.Address == "" || spec.Machine == "" {
+		return nil
+	}
+	key := placementKey(b.Provider, spec.Address)
+
+	if held, ok := placements.Load(key); ok {
+		if previous, _ := held.(string); previous != "" && previous != spec.Machine {
+			if err := router.UnrouteAddress(ctx, previous, spec.Address); err != nil {
+				return err
+			}
+		}
+	}
+	if err := router.RouteAddress(ctx, spec); err != nil {
+		return err
+	}
+	placements.Store(key, spec.Machine)
+	return nil
+}
+
+// UnrouteAddress takes the address back and forgets the placement.
+//
+// The machine name is honoured rather than assumed: a pack may unroute from a
+// machine that no longer holds the address — a delete arriving after a move, say
+// — and forgetting the placement then would leave the current holder unknown, so
+// the next move would not take it back from anybody. Only a call naming the
+// recorded holder clears the record.
+func (b Binding) UnrouteAddress(ctx context.Context, router Router, machine, address string) error {
+	if router == nil || address == "" {
+		return nil
+	}
+	err := router.UnrouteAddress(ctx, machine, address)
+
+	key := placementKey(b.Provider, address)
+	if held, ok := placements.Load(key); ok {
+		if current, _ := held.(string); current == machine || machine == "" {
+			placements.Delete(key)
+		}
+	}
+	return err
+}
+
+// ForgetPlacements drops every recorded placement for this provider. Tests use
+// it; nothing else should, because an emulator that forgets where an address is
+// stops taking it back.
+func (b Binding) ForgetPlacements() {
+	prefix := b.Provider + "|"
+	placements.Range(func(key, _ any) bool {
+		if name, _ := key.(string); len(name) > len(prefix) && name[:len(prefix)] == prefix {
+			placements.Delete(key)
+		}
+		return true
+	})
+}

--- a/internal/core/machine/placement_test.go
+++ b/internal/core/machine/placement_test.go
@@ -1,0 +1,151 @@
+package machine
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+type placementRouter struct {
+	mu       sync.Mutex
+	routed   []AddressSpec
+	unrouted [][2]string
+	failNext error
+}
+
+func (r *placementRouter) RouteAddress(_ context.Context, spec AddressSpec) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.routed = append(r.routed, spec)
+	return nil
+}
+
+func (r *placementRouter) UnrouteAddress(_ context.Context, machine, address string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if err := r.failNext; err != nil {
+		r.failNext = nil
+		return err
+	}
+	r.unrouted = append(r.unrouted, [2]string{machine, address})
+	return nil
+}
+
+func placementFixture(t *testing.T) (Binding, *placementRouter) {
+	t.Helper()
+	b := Binding{Provider: "example"}
+	b.ForgetPlacements()
+	t.Cleanup(b.ForgetPlacements)
+	return b, &placementRouter{}
+}
+
+// Moving an address takes it back first, and the order is the property: an
+// address routed to the new machine before being withdrawn from the old one
+// leaves an instant with two machines answering for one /32, which is precisely
+// what a client cannot debug.
+func TestRouteAddressTakesItBackFromThePreviousHolderFirst(t *testing.T) {
+	b, router := placementFixture(t)
+	ctx := context.Background()
+
+	if err := b.RouteAddress(ctx, router, AddressSpec{Machine: "one", Address: "192.0.2.7"}); err != nil {
+		t.Fatalf("first route: %v", err)
+	}
+	if len(router.unrouted) != 0 {
+		t.Fatalf("the first placement withdrew from somebody: %v", router.unrouted)
+	}
+
+	if err := b.RouteAddress(ctx, router, AddressSpec{Machine: "two", Address: "192.0.2.7"}); err != nil {
+		t.Fatalf("second route: %v", err)
+	}
+	if len(router.unrouted) != 1 || router.unrouted[0] != [2]string{"one", "192.0.2.7"} {
+		t.Fatalf("the previous holder was not withdrawn: %v", router.unrouted)
+	}
+	if len(router.routed) != 2 || router.routed[1].Machine != "two" {
+		t.Fatalf("the address did not reach the new machine: %v", router.routed)
+	}
+}
+
+// A move whose withdrawal failed has not moved anything, so it must not report
+// success and must not record a placement that never happened — the next move
+// would then take the address back from the wrong machine.
+func TestRouteAddressReportsAFailedWithdrawalInsteadOfMovingAnyway(t *testing.T) {
+	b, router := placementFixture(t)
+	ctx := context.Background()
+
+	if err := b.RouteAddress(ctx, router, AddressSpec{Machine: "one", Address: "192.0.2.7"}); err != nil {
+		t.Fatalf("first route: %v", err)
+	}
+	router.failNext = context.DeadlineExceeded
+	if err := b.RouteAddress(ctx, router, AddressSpec{Machine: "two", Address: "192.0.2.7"}); err == nil {
+		t.Fatal("a move whose withdrawal failed reported success")
+	}
+	if len(router.routed) != 1 {
+		t.Errorf("the address reached the second machine although the first still held it: %v", router.routed)
+	}
+
+	// And the record still names the first machine, so a later move withdraws
+	// from the machine that actually has it.
+	router.failNext = nil
+	if err := b.RouteAddress(ctx, router, AddressSpec{Machine: "two", Address: "192.0.2.7"}); err != nil {
+		t.Fatalf("retry: %v", err)
+	}
+	if len(router.unrouted) != 1 || router.unrouted[0][0] != "one" {
+		t.Errorf("the retry withdrew from %v, not from the machine that held it", router.unrouted)
+	}
+}
+
+// Re-routing to the same machine is the ordinary repair path — a pack replays
+// routes on every read of a running machine — and must not withdraw the address
+// from the machine it is about to give it back to.
+func TestRouteAddressDoesNotWithdrawFromTheMachineItIsRoutingTo(t *testing.T) {
+	b, router := placementFixture(t)
+	ctx := context.Background()
+
+	for range 3 {
+		if err := b.RouteAddress(ctx, router, AddressSpec{Machine: "one", Address: "192.0.2.7"}); err != nil {
+			t.Fatalf("route: %v", err)
+		}
+	}
+	if len(router.unrouted) != 0 {
+		t.Errorf("a replay withdrew the address it was replacing: %v", router.unrouted)
+	}
+}
+
+// An unroute naming a machine that no longer holds the address must not erase the
+// record of who does. A delete arriving after a move is exactly that, and
+// forgetting there would leave the current holder unknown — so the next move
+// would take the address back from nobody and two machines would carry it.
+func TestUnrouteAddressKeepsThePlacementWhenAnotherMachineHoldsIt(t *testing.T) {
+	b, router := placementFixture(t)
+	ctx := context.Background()
+
+	_ = b.RouteAddress(ctx, router, AddressSpec{Machine: "one", Address: "192.0.2.7"})
+	_ = b.RouteAddress(ctx, router, AddressSpec{Machine: "two", Address: "192.0.2.7"})
+	if err := b.UnrouteAddress(ctx, router, "one", "192.0.2.7"); err != nil {
+		t.Fatalf("late unroute: %v", err)
+	}
+
+	before := len(router.unrouted)
+	_ = b.RouteAddress(ctx, router, AddressSpec{Machine: "three", Address: "192.0.2.7"})
+	if len(router.unrouted) != before+1 || router.unrouted[before][0] != "two" {
+		t.Errorf("the move withdrew from %v; the holder was two", router.unrouted[before:])
+	}
+}
+
+// Two providers numbering their addresses the same way do not take each other's
+// routes back. RFC 5737 gives each pack its own block, but the emulated blocks
+// are configuration and the key must not depend on them staying distinct.
+func TestPlacementsAreKeptPerProvider(t *testing.T) {
+	first, router := placementFixture(t)
+	second := Binding{Provider: "other"}
+	second.ForgetPlacements()
+	t.Cleanup(second.ForgetPlacements)
+	ctx := context.Background()
+
+	_ = first.RouteAddress(ctx, router, AddressSpec{Machine: "one", Address: "192.0.2.7"})
+	_ = second.RouteAddress(ctx, router, AddressSpec{Machine: "two", Address: "192.0.2.7"})
+
+	if len(router.unrouted) != 0 {
+		t.Errorf("one pack took another pack's address back: %v", router.unrouted)
+	}
+}

--- a/internal/providers/exoscale/elasticip_routing_test.go
+++ b/internal/providers/exoscale/elasticip_routing_test.go
@@ -185,3 +185,85 @@ func TestAPoisonedElasticIPIsNeverRouted(t *testing.T) {
 		t.Errorf("the poisoned address rode a boot: %v", rt.bootedAddresses())
 	}
 }
+
+// One Elastic IP, two instances, one machine carrying it (#213).
+//
+// The control plane accepting both attachments is not the defect, and the
+// measurement is what settled that. On ch-gva-2, `exo compute instance
+// elastic-ip attach` was accepted twice for one address and both instances then
+// reported holding 185.19.28.243 — which is the whole point of the healthcheck an
+// Elastic IP carries. Refusing the second attach would have made this emulator
+// diverge from the cloud it imitates, and it is the second time in this milestone
+// that an audit finding asked for exactly that.
+//
+// What cannot be honoured is the runtime half. Two containers answering ARP for
+// one /32 make the host pick arbitrarily while the API describes both as holders,
+// so the address goes to the most recent attach and is taken back from the
+// previous one. feint has no healthcheck and does not invent an election;
+// docs/limits.md names the rule.
+func TestAnElasticIPReachesOneMachineAtATime(t *testing.T) {
+	h, rt, env := routedServe(t)
+	// The placement registry outlives one server, being package state keyed by
+	// provider — so a test that did not clear it would read the previous test's
+	// holder and pass for the wrong reason.
+	binding := machine.Binding{Provider: "exoscale"}
+	binding.ForgetPlacements()
+	t.Cleanup(binding.ForgetPlacements)
+	_ = env
+
+	first, eipID, address := anAttachedInstance(t, h)
+
+	status, created := call(t, h, "POST", "/v2/instance", `{
+		"name": "second",
+		"instance-type": {"id": "21624abb-764e-4def-81d7-9fc54b5957fb"},
+		"template": {"id": "11111111-1111-4111-8111-111111111111"},
+		"disk-size": 10
+	}`)
+	if status.Code != http.StatusOK {
+		t.Fatalf("create the second instance: status %d", status.Code)
+	}
+	ref, _ := created["reference"].(map[string]any)
+	second, _ := ref["id"].(string)
+	if second == "" {
+		t.Fatalf("the create operation names no resource: %v", created)
+	}
+	if status, _ := call(t, h, "PUT", "/v2/instance/"+second+":start", ""); status.Code != http.StatusOK {
+		t.Fatalf("start the second instance: status %d", status.Code)
+	}
+
+	before := len(rt.withdrew)
+	if status, out := call(t, h, "PUT", "/v2/elastic-ip/"+eipID+":attach",
+		`{"instance":{"id":"`+second+`"}}`); status.Code != http.StatusOK {
+		t.Fatalf("the second attach was refused with %d (%v); ch-gva-2 accepts it",
+			status.Code, out)
+	}
+
+	// The control plane keeps both, because the real one does.
+	for _, id := range []string{first, second} {
+		status, inst := call(t, h, "GET", "/v2/instance/"+id, "")
+		if status.Code != http.StatusOK {
+			t.Fatalf("get %s: status %d", id, status.Code)
+		}
+		eips, _ := inst["elastic-ips"].([]any)
+		held := false
+		for _, raw := range eips {
+			if entry, ok := raw.(map[string]any); ok {
+				if got, _ := entry["id"].(string); got == eipID {
+					held = true
+				}
+			}
+		}
+		if !held {
+			t.Errorf("instance %s no longer lists the elastic IP; the real cloud lets both hold it", id)
+		}
+	}
+
+	// And the runtime carries it once: the previous holder was unrouted before
+	// the new one was routed, so no instant has two machines on one address.
+	if len(rt.withdrew) == before {
+		t.Fatal("the address was routed to the second machine without being taken back from the first")
+	}
+	if !has(rt.withdrew[before:], address) {
+		t.Errorf("the withdrawal names %v, not the address that moved (%s)", rt.withdrew[before:], address)
+	}
+}

--- a/internal/providers/exoscale/elasticips.go
+++ b/internal/providers/exoscale/elasticips.go
@@ -67,7 +67,19 @@ func (p *Pack) routeElasticIP(ctx context.Context, address string, inst *resourc
 			"address", address, "instance", inst.ID)
 		return
 	}
-	if err := router.RouteAddress(ctx, machine.AddressSpec{Machine: name, Address: address}); err != nil {
+	// Through the binding rather than straight at the router, because this pack
+	// lets several instances hold one Elastic IP — which is what the real cloud
+	// does, measured on ch-gva-2, where two instances both reported holding
+	// 185.19.28.243. The control plane is right to allow it; the runtime cannot
+	// honour it, since two containers answering ARP for one /32 make the host
+	// pick arbitrarily while the API describes both as holders.
+	//
+	// So the address goes to the most recent attach and is taken back from the
+	// previous holder. Upstream elects by healthcheck; feint has none and does
+	// not invent one — docs/limits.md names the rule instead.
+	//
+	// TestAnElasticIPReachesOneMachineAtATime fails without this.
+	if err := p.binding().RouteAddress(ctx, router, machine.AddressSpec{Machine: name, Address: address}); err != nil {
 		p.logger().Error("could not route the elastic IP to the machine",
 			"address", address, "instance", inst.ID, "error", err)
 	}
@@ -85,7 +97,7 @@ func (p *Pack) unrouteElasticIP(ctx context.Context, address string, inst *resou
 	if inst != nil {
 		name = inst.Runtime[p.binding().RuntimeKey]
 	}
-	if err := router.UnrouteAddress(ctx, name, address); err != nil {
+	if err := p.binding().UnrouteAddress(ctx, router, name, address); err != nil {
 		p.logger().Error("could not stop routing the elastic IP",
 			"address", address, "error", err)
 	}

--- a/internal/providers/outscale/publicips.go
+++ b/internal/providers/outscale/publicips.go
@@ -90,7 +90,10 @@ func (p *Pack) routeLinkedIP(ctx context.Context, address string, vm *resource.R
 			"address", address, "vm", vm.ID)
 		return
 	}
-	if err := router.RouteAddress(ctx, machine.AddressSpec{Machine: name, Address: address}); err != nil {
+	// Through the binding: this pack refuses to move a linked address unless the
+	// request passes AllowRelink, which is the real API's own default, and the
+	// runtime half of that move is the same in all three packs (#213).
+	if err := p.binding().RouteAddress(ctx, router, machine.AddressSpec{Machine: name, Address: address}); err != nil {
 		p.logger().Error("could not route the public IP to the machine",
 			"address", address, "vm", vm.ID, "error", err)
 	}
@@ -108,7 +111,7 @@ func (p *Pack) unrouteLinkedIP(ctx context.Context, address string, vm *resource
 	if vm != nil {
 		machineName = vm.Runtime[p.binding().RuntimeKey]
 	}
-	if err := router.UnrouteAddress(ctx, machineName, address); err != nil {
+	if err := p.binding().UnrouteAddress(ctx, router, machineName, address); err != nil {
 		p.logger().Error("could not stop routing the public IP",
 			"address", address, "error", err)
 	}

--- a/internal/providers/scaleway/ips.go
+++ b/internal/providers/scaleway/ips.go
@@ -347,7 +347,11 @@ func (p *Pack) routeAddress(ctx context.Context, address string, server *resourc
 	// On the network the server lives on, when it has one: a public address on
 	// the runtime's default bridge would answer, and would sit on an interface
 	// the emulated topology says nothing about.
-	if err := router.RouteAddress(ctx, machine.AddressSpec{
+	// Through the binding, which takes the address back from its previous holder
+	// before handing it over: this pack moves a flexible IP to the server the
+	// client names, and the move used to be written here rather than shared, which
+	// is how a third pack came to be missing it entirely (#213).
+	if err := p.binding().RouteAddress(ctx, router, machine.AddressSpec{
 		Machine: name,
 		Address: address,
 		Network: p.privateNetworkNameOf(server),
@@ -407,7 +411,7 @@ func (p *Pack) detachAddress(ctx context.Context, ip *resource.Resource) {
 			}
 		}
 	}
-	if err := router.UnrouteAddress(ctx, holder, address); err != nil {
+	if err := p.binding().UnrouteAddress(ctx, router, holder, address); err != nil {
 		p.logger().Error("could not stop routing the flexible IP",
 			"ip", ip.ID, "address", address, "error", err)
 	}
@@ -529,7 +533,7 @@ func (p *Pack) releaseDynamicAddress(ctx context.Context, res *resource.Resource
 	if !ok || !emulatedAddress(address) {
 		return
 	}
-	if err := router.UnrouteAddress(ctx, res.Runtime[runtimeMachineKey], address); err != nil {
+	if err := p.binding().UnrouteAddress(ctx, router, res.Runtime[runtimeMachineKey], address); err != nil {
 		p.logger().Error("could not stop routing the dynamic address",
 			"address", address, "server", res.ID, "error", err)
 	}

--- a/tools/falsify/specs/one-machine-per-address.json
+++ b/tools/falsify/specs/one-machine-per-address.json
@@ -1,0 +1,48 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "an address is routed to a new machine without being taken back from the old one",
+      "file": "internal/core/machine/placement.go",
+      "find": "\t\tif previous, _ := held.(string); previous != \"\" && previous != spec.Machine {",
+      "replace": "\t\tif previous, _ := held.(string); previous != \"\" && previous != spec.Machine && false {",
+      "test": "TestRouteAddressTakesItBackFromThePreviousHolderFirst"
+    },
+    {
+      "label": "a move whose withdrawal failed carries on and routes the address anyway",
+      "file": "internal/core/machine/placement.go",
+      "find": "\t\t\tif err := router.UnrouteAddress(ctx, previous, spec.Address); err != nil {\n\t\t\t\treturn err\n\t\t\t}",
+      "replace": "\t\t\tif err := router.UnrouteAddress(ctx, previous, spec.Address); err != nil && false {\n\t\t\t\treturn err\n\t\t\t}",
+      "test": "TestRouteAddressReportsAFailedWithdrawalInsteadOfMovingAnyway"
+    },
+    {
+      "label": "a replay withdraws the address from the machine it is routing it to",
+      "file": "internal/core/machine/placement.go",
+      "find": "previous != \"\" && previous != spec.Machine {",
+      "replace": "previous != \"\" && (previous != spec.Machine || true) {",
+      "test": "TestRouteAddressDoesNotWithdrawFromTheMachineItIsRoutingTo"
+    },
+    {
+      "label": "a late unroute forgets who actually holds the address",
+      "file": "internal/core/machine/placement.go",
+      "find": "\t\tif current, _ := held.(string); current == machine || machine == \"\" {",
+      "replace": "\t\tif current, _ := held.(string); current == machine || machine == \"\" || true {",
+      "test": "TestUnrouteAddressKeepsThePlacementWhenAnotherMachineHoldsIt"
+    },
+    {
+      "label": "placements are keyed on the address alone, so two packs take each other's routes back",
+      "file": "internal/core/machine/placement.go",
+      "find": "func placementKey(provider, address string) string { return provider + \"|\" + address }",
+      "replace": "func placementKey(provider, address string) string { _ = provider; return address }",
+      "test": "TestPlacementsAreKeptPerProvider"
+    },
+    {
+      "label": "the Exoscale attach routes the address without moving it off the previous instance",
+      "package": "./internal/providers/exoscale/",
+      "file": "internal/providers/exoscale/elasticips.go",
+      "find": "\tif err := p.binding().RouteAddress(ctx, router, machine.AddressSpec{Machine: name, Address: address}); err != nil {",
+      "replace": "\t_ = p.binding()\n\tif err := router.RouteAddress(ctx, machine.AddressSpec{Machine: name, Address: address}); err != nil {",
+      "test": "TestAnElasticIPReachesOneMachineAtATime"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #213.

The audit reported three behaviours when a client attaches an address another
machine holds — one steals it, one refuses, one routes the same `/32` to two
machines — and asked for **one decision in the shared layer**.

Half of that premise does not survive a measurement.

## The three control planes must differ, because the clouds do

Exoscale's Elastic IP is **meant** to be held by several instances at once: the
address carries a healthcheck, and the platform sends it to whichever instance is
passing. Measured on `ch-gva-2` rather than assumed:

```
$ exo compute instance elastic-ip attach feint-eip-a 185.19.28.243   # accepted
$ exo compute instance elastic-ip attach feint-eip-b 185.19.28.243   # accepted

feint-eip-a: ip 92.39.62.182  elastic ['185.19.28.243']
feint-eip-b: ip 92.39.61.24   elastic ['185.19.28.243']
```

So the pack accepting both attachments is **fidelity**. Refusing the second would
have made this emulator diverge from the cloud it imitates — the second time in
this milestone an audit finding asked for exactly that.

| pack | on attaching a held address | why it is right |
|---|---|---|
| Scaleway | moves it to the named server | what the API does |
| Outscale | refuses without `AllowRelink` | the API's own documented default |
| Exoscale | both instances hold it | measured above |

The issue anticipated this and said so: *if the three genuinely differ, that is a
per-pack field and the shared part is the bookkeeping.*

## The bookkeeping is what was missing

`machine.Binding.RouteAddress` records which machine an emulated address is routed
to, and takes it back before handing it over. Two packs had written that sentence
in their own file — *"moving the address means taking it back first"* — which is
how it came to be written twice and **missing the third time**. All three go
through it now.

Two things are properties rather than implementation details, and both are
asserted:

- **the order** — routing before withdrawing leaves an instant with two machines
  answering for one `/32`;
- **a failed withdrawal returns** — a move whose first half failed has left the
  address where it was, and recording a placement that never happened would make
  the *next* move withdraw from the wrong machine.

## What is invented, and is named as such

feint has no healthcheck, so it does not elect: the address follows the **most
recent attach**. That rule is ours, not Exoscale's, and `docs/limits.md` says so
rather than leaving a client to infer a failover the emulator will not perform.

## Measured

| | |
|---|---|
| `go test ./...`, `mise run prepush` | green |
| `mise run conformance` | **exit 0**, 74 checks, 0 FAIL |
| `FEINT_VM=incus-ovn mise run conformance` | **exit 0**, 111 checks, 0 FAIL |
| `mise run falsify -- specs/one-machine-per-address.json` | 6 mutations, all bite |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
