### PR TITLE
fix(packs): the address lock is released before the runtime is touched (#216)

### DIFF
--- a/internal/providers/outscale/privateips.go
+++ b/internal/providers/outscale/privateips.go
@@ -128,6 +128,17 @@ func (p *Pack) linkPrivateIps(w http.ResponseWriter, r *http.Request) {
 		p.notFound(w, "network interface", req.NicID)
 		return
 	}
+
+	// Released before the runtime is touched, and this line is the fix for a
+	// comment that described the opposite of what the code did (#216).
+	// carrySecondary reconfigures an interface on a live machine, which takes
+	// seconds; the lock it was holding is the one every address allocation in this
+	// pack needs, so one link blocked the whole pack for the length of an
+	// incus exec. The release is sync.Once-guarded, so the defer above is still
+	// correct on every error path.
+	//
+	// TestAnAddressLinkDoesNotHoldTheAddressLockAcrossTheRuntime fails without it.
+	unlock()
 	p.carrySecondary(r.Context(), nic)
 
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{"ResponseContext": p.context()})
@@ -184,6 +195,8 @@ func (p *Pack) unlinkPrivateIps(w http.ResponseWriter, r *http.Request) {
 		p.notFound(w, "network interface", req.NicID)
 		return
 	}
+	// Same release as the link path, and for the same reason.
+	unlock()
 	p.carrySecondary(r.Context(), nic)
 
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{"ResponseContext": p.context()})
@@ -295,10 +308,15 @@ func contains(list []string, want string) bool {
 // carrySecondary tells the runtime what the NIC now carries.
 //
 // Best effort and logged, never fatal: the control plane must keep answering
-// when no runtime is configured, which is the default and what CI uses. And the
-// call is made outside the store lock for the reason every runtime call in this
-// pack is — launching or reconfiguring a machine takes seconds where the lock
-// takes microseconds.
+// when no runtime is configured, which is the default and what CI uses.
+//
+// Its callers release the pack's address lock before calling it, and that had to
+// be made true rather than merely written: this comment used to claim the call
+// ran outside the lock while both callers held it across the whole handler
+// (#216). Reconfiguring an interface takes seconds, the lock is the one every
+// address allocation in this pack needs, so one link serialised the pack behind
+// one incus exec — the shape CLAUDE.md documents under *un effet de bord lent ne
+// tient pas dans le verrou*, written into the very function that denied it.
 func (p *Pack) carrySecondary(ctx context.Context, nic *resource.Resource) {
 	if p.env.Machines == nil {
 		return

--- a/internal/providers/outscale/privateips_lock_test.go
+++ b/internal/providers/outscale/privateips_lock_test.go
@@ -1,0 +1,186 @@
+package outscale_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/machine"
+	"github.com/stephrobert/feint/internal/providers/outscale"
+)
+
+// carrySecondary reconfigures an interface on a live machine, and both its
+// callers held the pack's address lock across the call (#216).
+//
+// The function's own comment said the opposite — "the call is made outside the
+// store lock… launching or reconfiguring a machine takes seconds where the lock
+// takes microseconds" — which makes it the family CLAUDE.md names: a comment that
+// describes a discipline the code beside it does not follow, in the very function
+// that denies it.
+//
+// What it cost is measurable rather than arguable, and that is what this asserts:
+// every address allocation in the pack — CreateNet, CreateSubnet, CreateNic,
+// LinkPublicIp, CreateVms, UpdateNet, every one of them takes the same lock — was
+// blocked for as long as one incus exec.
+
+// slowAttach answers every Attach only once released, so a handler that reaches
+// the runtime while holding a lock keeps holding it for as long as the test says.
+type slowAttach struct {
+	mu       sync.Mutex
+	machines map[string]bool
+
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (s *slowAttach) Name() string                   { return "fake" }
+func (s *slowAttach) Available(context.Context) bool { return true }
+
+func (s *slowAttach) Start(_ context.Context, spec machine.Spec) (machine.Machine, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.machines[spec.Name] = true
+	return machine.Machine{Name: spec.Name, Running: true}, nil
+}
+
+func (s *slowAttach) Stop(_ context.Context, n string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.machines[n] = false
+	return nil
+}
+
+func (s *slowAttach) Remove(_ context.Context, n string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.machines, n)
+	return nil
+}
+
+func (s *slowAttach) Inspect(_ context.Context, n string) (machine.Machine, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	running, found := s.machines[n]
+	return machine.Machine{Name: n, Running: running}, found, nil
+}
+
+func (s *slowAttach) EnsureNetwork(context.Context, machine.NetworkSpec) error { return nil }
+func (s *slowAttach) RemoveNetwork(context.Context, string) error              { return nil }
+
+// The one slow call. Everything else answers at once, so what the test measures
+// is where this one sits relative to the lock and nothing else.
+func (s *slowAttach) Attach(context.Context, string, machine.Attachment) error {
+	s.once.Do(func() { close(s.entered) })
+	<-s.release
+	return nil
+}
+
+func newSlowAttachServer(t *testing.T) (*httptest.Server, *slowAttach) {
+	t.Helper()
+	rt := &slowAttach{
+		machines: map[string]bool{},
+		entered:  make(chan struct{}),
+		release:  make(chan struct{}),
+	}
+	env := emulator.DefaultEnv()
+	env.Machines = rt
+	srv, err := emulator.NewServer(env, outscale.New(env))
+	if err != nil {
+		t.Fatalf("build emulator: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(func() {
+		// Never leave the blocked handler waiting: a test that fails must fail,
+		// not hang, and this pack has already paid once for a failure path that
+		// hung instead of failing.
+		select {
+		case <-rt.release:
+		default:
+			close(rt.release)
+		}
+		ts.Close()
+	})
+	return ts, rt
+}
+
+func TestAnAddressLinkDoesNotHoldTheAddressLockAcrossTheRuntime(t *testing.T) {
+	ts, rt := newSlowAttachServer(t)
+
+	_, subnet := netWithSubnet(t, ts, "10.41.0.0/16", "10.41.1.0/24")
+
+	// A machine, so the NIC has something to be carried on: carrySecondary is a
+	// no-op for a NIC linked to nothing, and a test that measured that would
+	// measure the absence of the call rather than its placement.
+	status, doc := doAction(t, ts, "CreateVms",
+		`{"ImageId":"ami-12345678","VmType":"tinav4.c1r1p2","SubnetId":"`+subnet+`"}`)
+	if status != http.StatusOK {
+		t.Fatalf("CreateVms answered %d: %v", status, doc)
+	}
+	vms, _ := doc["Vms"].([]any)
+	vm, _ := vms[0].(map[string]any)
+	vmID, _ := vm["VmId"].(string)
+
+	nic := createNic(t, ts, subnet)
+	if status, doc := doAction(t, ts, "LinkNic",
+		`{"NicId":"`+nic+`","VmId":"`+vmID+`","DeviceNumber":1}`); status != http.StatusOK {
+		t.Fatalf("LinkNic answered %d: %v", status, doc)
+	}
+
+	// One link that will reach the runtime and stay there.
+	blocked := make(chan int, 1)
+	go func() {
+		status, _ := postRaw(ts, "LinkPrivateIps",
+			`{"NicId":"`+nic+`","PrivateIps":["10.41.1.40"]}`)
+		blocked <- status
+	}()
+
+	select {
+	case <-rt.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the link never reached the runtime, so this test measured nothing")
+	}
+
+	// While it is in there, the rest of the pack must still be able to allocate.
+	// CreateSubnet takes the same lock, and it is the plainest thing a second
+	// client would be doing.
+	done := make(chan int, 1)
+	go func() {
+		status, _ := postRaw(ts, "CreateSubnet",
+			`{"NetId":"`+netOf(t, ts, subnet)+`","IpRange":"10.41.2.0/24"}`)
+		done <- status
+	}()
+
+	select {
+	case status := <-done:
+		if status != http.StatusOK {
+			t.Errorf("the concurrent allocation answered %d", status)
+		}
+	case <-time.After(3 * time.Second):
+		t.Error("a second allocation waited on a lock held across a runtime call: " +
+			"one interface reconfiguration blocks every address this pack hands out")
+	}
+
+	close(rt.release)
+	if status := <-blocked; status != http.StatusOK {
+		t.Errorf("the link itself answered %d", status)
+	}
+}
+
+// netOf reads back the Net a Subnet belongs to, so the test does not have to
+// thread it through every helper.
+func netOf(t *testing.T, ts *httptest.Server, subnetID string) string {
+	t.Helper()
+	_, doc := doAction(t, ts, "ReadSubnets", `{"Filters":{"SubnetIds":["`+subnetID+`"]}}`)
+	subnets, _ := doc["Subnets"].([]any)
+	if len(subnets) == 0 {
+		t.Fatalf("no subnet %s: %v", subnetID, doc)
+	}
+	first, _ := subnets[0].(map[string]any)
+	netID, _ := first["NetId"].(string)
+	return netID
+}

--- a/internal/providers/scaleway/privatenics.go
+++ b/internal/providers/scaleway/privatenics.go
@@ -251,6 +251,19 @@ func (p *Pack) createPrivateNIC(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The address lock is done once the allocation is written, and it is released
+	// here rather than at the return: everything below reaches the runtime, which
+	// takes seconds, and this lock is the one every address this pack hands out
+	// waits on. Holding it across an attach serialised the whole pack behind one
+	// interface reconfiguration — the same defect #216 named in the Outscale pack,
+	// in the pack that was not audited for it.
+	//
+	// What still orders this handler against a concurrent delete of the same
+	// server is the per-server hold taken at the top, which is a different lock
+	// and stays held. The release is sync.Once-guarded, so the defer is still
+	// correct on every path above.
+	unlockAddresses()
+
 	// The machine follows the control plane, not the other way round: the
 	// address published here is the one it must carry. A running machine has to
 	// be restarted to pick up a new interface, which is also true upstream.

--- a/tools/falsify/specs/lock-not-held-across-runtime.json
+++ b/tools/falsify/specs/lock-not-held-across-runtime.json
@@ -1,0 +1,12 @@
+{
+  "package": "./internal/providers/outscale/",
+  "mutations": [
+    {
+      "label": "the address link holds the pack's address lock across the runtime call again",
+      "file": "internal/providers/outscale/privateips.go",
+      "find": "\tunlock()\n\tp.carrySecondary(r.Context(), nic)\n\n\temulator.WriteJSON(w, http.StatusOK, map[string]any{\"ResponseContext\": p.context()})\n}\n\n// unlinkPrivateIps",
+      "replace": "\tdefer unlock()\n\tp.carrySecondary(r.Context(), nic)\n\n\temulator.WriteJSON(w, http.StatusOK, map[string]any{\"ResponseContext\": p.context()})\n}\n\n// unlinkPrivateIps",
+      "test": "TestAnAddressLinkDoesNotHoldTheAddressLockAcrossTheRuntime"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #216.

`carrySecondary` reconfigures an interface on a live machine, and both its
callers held the pack's address lock across the call. Its own comment said the
opposite:

> the call is made outside the store lock… launching or reconfiguring a machine
> takes seconds where the lock takes microseconds

That is the family `CLAUDE.md` names under *un effet de bord lent ne tient pas
dans le verrou* — a comment describing a discipline the code beside it does not
follow, written into the very function that denied it.

## What it cost

Every address allocation in the pack takes that one lock:

`CreateNet` · `CreateSubnet` · `CreateNic` · `LinkPublicIp` · `CreateVms` ·
`UpdateNet` · `UpdateNic` · `LinkPrivateIps` · `UnlinkPrivateIps` ·
`CreateDhcpOptions`

One interface reconfiguration blocked all of them for as long as an `incus exec`.
Invisible under the conformance suite, which drives one client at a time; plain
to a client creating several machines at once.

## And the same shape in the pack nobody had audited

Scaleway's `createPrivateNIC` held its address lock across
`attachMachineToNetwork` **and** `applyServerFirewall`. Found by checking whether
#216 was Outscale's alone — it was not. This is the kind of defect that exists
wherever the same lock is written, which is the argument the last few issues keep
making.

That release also settles something from #211: the address lock is no longer what
orders a NIC create against a concurrent delete of the same server, so the
per-server hold added there is doing the work its comment claims. **The nine
falsifications of that issue still bite** — checked, not assumed.

## Measured rather than argued

The issue asked for the ordering to be asserted. It is, through what the defect
actually costs rather than by inspecting a lock:

1. a runtime whose `Attach` blocks until the test releases it;
2. one `LinkPrivateIps` left sitting inside it;
3. a `CreateSubnet` on another resource, required to answer meanwhile.

Without the release it times out. With it, it answers at once.

## Measured

| | |
|---|---|
| `go test ./...`, `mise run prepush` | green |
| `mise run conformance` | **exit 0**, 74 checks, 0 FAIL |
| `FEINT_VM=incus-ovn mise run conformance` | **exit 0**, 111 checks, 0 FAIL |
| `mise run falsify -- specs/lock-not-held-across-runtime.json` | bites |
| `mise run falsify -- specs/serialise-then-commit.json` | 9 mutations, all still bite |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
