### PR TITLE
fix(outscale): AvailableIpsCount is read from the pool that hands the addresses out (#217)

### DIFF
--- a/internal/providers/outscale/nets.go
+++ b/internal/providers/outscale/nets.go
@@ -483,33 +483,25 @@ func (p *Pack) subnetView(res *resource.Resource) map[string]any {
 	out["SubnetId"] = res.ID
 	out["State"] = res.State
 
-	// Computed from the mask *and* from what is allocated, which is what the
-	// comment on this view has always claimed and what it did not do: a fresh
-	// allocator was built and nothing reserved, so a /24 with three machines in
-	// it still answered 251. The conformance suite only ever read empty subnets,
-	// so it proved the mask half and the comment asserted the rest.
+	// From the allocator that hands the addresses out, and from nothing else.
+	//
+	// This used to rebuild its own reservation loop, and the two drifted exactly
+	// where a second computation of one truth always drifts: at the corner the
+	// first one learned about later. subnetAllocator reserves machines, primary
+	// NIC addresses and the secondary ones; this loop reserved machines only, and
+	// read liveness as a state comparison where the allocator asks Gone.
+	//
+	// Measured before it was changed, on a /28 holding one NIC with two secondary
+	// addresses: the subnet published 11 available and 8 creates succeeded. A
+	// client sizing a pool on that figure — a Terraform count, a loop — plans
+	// against three addresses the emulator will refuse to hand out.
 	//
 	// A stored count would go stale the moment an address is taken; this one
-	// cannot, because it is derived on every read.
+	// cannot, because it is derived on every read from the one pool.
 	//
-	// TestAvailableIpsCountFollowsTheMachines fails without the reservation loop.
-	if prefix, err := prefixOf(res, "IpRange"); err == nil {
-		if allocator, err := network.NewAllocator(prefix, reservedPerSubnet); err == nil {
-			for _, vm := range p.env.Store.List(kindVM, resource.Tenant{Provider: Name}) {
-				// Same reason as the delete guard above: a terminated machine
-				// occupies no address.
-				if vm.State == stateTerminated {
-					continue
-				}
-				if stringOf(vm.Attrs["SubnetId"]) != res.ID {
-					continue
-				}
-				if taken, parseErr := netip.ParseAddr(stringOf(vm.Attrs["PrivateIp"])); parseErr == nil {
-					_ = allocator.Reserve(taken)
-				}
-			}
-			out["AvailableIpsCount"] = allocator.Available()
-		}
+	// TestAvailableIpsCountAgreesWithWhatACreateWillDo fails without this.
+	if allocator, err := p.subnetAllocator(res.ID); err == nil {
+		out["AvailableIpsCount"] = allocator.Available()
 	}
 	return out
 }

--- a/internal/providers/outscale/privateips_test.go
+++ b/internal/providers/outscale/privateips_test.go
@@ -233,3 +233,93 @@ func countPrimary(entries []map[string]any) int {
 	}
 	return n
 }
+
+// The count a client reads before it creates must be the count the create will
+// honour (#217).
+//
+// AvailableIpsCount rebuilt its own reservation loop instead of asking
+// subnetAllocator, and the two drifted exactly where a second computation of one
+// truth always drifts: at the corner the first one learned about later. The
+// allocator reserves machines, primary NIC addresses and secondary ones, and
+// reads liveness through Gone; the view's loop reserved machines only, and
+// compared a state.
+//
+// Measured before the fix, on the subnet below: 11 published, 8 creates
+// accepted. A Terraform count sized on that figure plans against three addresses
+// the emulator refuses to hand out — and a plan that cannot apply is worse than a
+// smaller number, because nothing says which of the two was wrong.
+//
+// The assertion is the agreement itself rather than a figure: hard-coding 8 would
+// pass just as well against a second wrong computation.
+func TestAvailableIpsCountAgreesWithWhatACreateWillDo(t *testing.T) {
+	ts := newServer(t)
+	_, subnet := netWithSubnet(t, ts, "10.51.0.0/16", "10.51.1.0/28")
+
+	available := func() int {
+		t.Helper()
+		_, doc := doAction(t, ts, "ReadSubnets", `{"Filters":{"SubnetIds":["`+subnet+`"]}}`)
+		subnets, _ := doc["Subnets"].([]any)
+		if len(subnets) == 0 {
+			t.Fatalf("no subnet in %v", doc)
+		}
+		first, _ := subnets[0].(map[string]any)
+		count, ok := first["AvailableIpsCount"].(float64)
+		if !ok {
+			t.Fatalf("the subnet publishes no AvailableIpsCount: %v", first)
+		}
+		return int(count)
+	}
+
+	// The three holders the view's own loop could not see: a NIC's primary
+	// address and two secondary ones.
+	nic := createNic(t, ts, subnet)
+	if status, doc := doAction(t, ts, "LinkPrivateIps",
+		`{"NicId":"`+nic+`","SecondaryPrivateIpCount":2}`); status != http.StatusOK {
+		t.Fatalf("LinkPrivateIps answered %d: %v", status, doc)
+	}
+
+	published := available()
+	if published < 1 {
+		t.Fatalf("the subnet publishes %d available, so this test measures nothing", published)
+	}
+
+	made := 0
+	for range published + 5 {
+		status, _ := doAction(t, ts, "CreateVms",
+			`{"ImageId":"ami-12345678","VmType":"tinav4.c1r1p2","SubnetId":"`+subnet+`"}`)
+		if status != http.StatusOK {
+			break
+		}
+		made++
+	}
+	if made != published {
+		t.Errorf("the subnet published %d available addresses and accepted %d creates: "+
+			"a client sizing a pool on that figure plans against addresses the emulator refuses",
+			published, made)
+	}
+	if left := available(); left != 0 {
+		t.Errorf("every address is taken and the subnet still publishes %d available", left)
+	}
+
+	// And the count comes back when a machine dies, which is the half a stale
+	// second computation would also get wrong — the allocator reads Gone, so the
+	// view now does too.
+	_, doc := doAction(t, ts, "ReadVms", `{"Filters":{"SubnetIds":["`+subnet+`"]}}`)
+	vms, _ := doc["Vms"].([]any)
+	if len(vms) == 0 {
+		t.Fatalf("no Vm to terminate: %v", doc)
+	}
+	first, _ := vms[0].(map[string]any)
+	vmID, _ := first["VmId"].(string)
+	doAction(t, ts, "StopVms", `{"VmIds":["`+vmID+`"]}`)
+	if status, doc := doAction(t, ts, "DeleteVms", `{"VmIds":["`+vmID+`"]}`); status != http.StatusOK {
+		t.Fatalf("DeleteVms answered %d: %v", status, doc)
+	}
+	if back := available(); back != 1 {
+		t.Errorf("a terminated Vm gave back %d addresses, want 1", back)
+	}
+	if status, doc := doAction(t, ts, "CreateVms",
+		`{"ImageId":"ami-12345678","VmType":"tinav4.c1r1p2","SubnetId":"`+subnet+`"}`); status != http.StatusOK {
+		t.Errorf("the address a terminated Vm gave back cannot be used: %d %v", status, doc)
+	}
+}

--- a/tools/falsify/specs/one-pool-one-count.json
+++ b/tools/falsify/specs/one-pool-one-count.json
@@ -1,0 +1,12 @@
+{
+  "package": "./internal/providers/outscale/",
+  "mutations": [
+    {
+      "label": "the published count rebuilds its own reservation loop instead of asking the allocator",
+      "file": "internal/providers/outscale/nets.go",
+      "find": "\tif allocator, err := p.subnetAllocator(res.ID); err == nil {\n\t\tout[\"AvailableIpsCount\"] = allocator.Available()\n\t}",
+      "replace": "\tif allocator, err := p.subnetAllocator(res.ID); err == nil {\n\t\t_ = allocator\n\t\tif prefix, prefixErr := prefixOf(res, \"IpRange\"); prefixErr == nil {\n\t\t\tif own, allocErr := network.NewAllocator(prefix, reservedPerSubnet); allocErr == nil {\n\t\t\t\tfor _, vm := range p.env.Store.List(kindVM, resource.Tenant{Provider: Name}) {\n\t\t\t\t\tif vm.State == stateTerminated || stringOf(vm.Attrs[\"SubnetId\"]) != res.ID {\n\t\t\t\t\t\tcontinue\n\t\t\t\t\t}\n\t\t\t\t\tif taken, parseErr := netip.ParseAddr(stringOf(vm.Attrs[\"PrivateIp\"])); parseErr == nil {\n\t\t\t\t\t\t_ = own.Reserve(taken)\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\tout[\"AvailableIpsCount\"] = own.Available()\n\t\t\t}\n\t\t}\n\t}",
+      "test": "TestAvailableIpsCountAgreesWithWhatACreateWillDo"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #217.

`subnetView` rebuilt its own reservation loop instead of asking
`subnetAllocator`, and the two had **already** drifted — exactly where a second
computation of one truth always drifts: at the corner the first one learned about
later.

| | reserves | reads liveness |
|---|---|---|
| `subnetAllocator` | Vms, primary NIC addresses, **secondary addresses** | `Gone(vm)` |
| the view's own loop | Vms | `vm.State == stateTerminated` |

## Measured before it was changed

On a `/28` holding one NIC with two secondary addresses:

```
published AvailableIpsCount : 11
creates actually accepted   :  8
```

The three the loop could not see were the NIC's own address and its two
secondaries.

What that costs is worse than a wrong number. A Terraform `count` sized on the
published figure plans against addresses the emulator refuses to hand out, and a
plan that cannot apply says nothing about **which** of the two figures was wrong.

## One computation

`subnetView` derives from `subnetAllocator` and nothing else. Still computed on
every read rather than stored, for the reason its comment always gave: a stored
count goes stale the moment an address is taken.

## The test asserts the agreement, not a figure

Hard-coding 8 would pass just as well against a second wrong computation. So it
fills the subnet until a create is refused and requires the two numbers to match,
then terminates a machine and requires the address to come back **and to be
usable** — the half the state comparison got wrong.

## Measured

| | |
|---|---|
| `go test ./...`, `mise run prepush` | green |
| `mise run conformance` | **exit 0**, 74 checks, 0 FAIL |
| `mise run falsify -- specs/one-pool-one-count.json` | reintroducing the second loop turns the test red |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
