### PR TITLE
feat(core): the catalogue trap gets the cross-pack guard it never had (#218)

### DIFF
--- a/internal/cli/catalogue_test.go
+++ b/internal/cli/catalogue_test.go
@@ -1,0 +1,150 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/providers/exoscale"
+	"github.com/stephrobert/feint/internal/providers/outscale"
+	"github.com/stephrobert/feint/internal/providers/scaleway"
+)
+
+// Every pack serves the inventory its client reads before creating anything.
+//
+// This is trap #1 of CLAUDE.md, given a control it never had (#218). `scw
+// instance server create` reads the server types, the default image and the
+// resolved image before it posts a server; a 404 on any of them fails the command
+// with an error that names none of this. Each pack answers it with its own fixed
+// table, and until now nothing checked that across packs — so a fourth pack could
+// decline its inventory, pass every unit test it had, and be found out by a real
+// client on its first create.
+//
+// It lives here rather than in each pack for the reason the declines guard gives
+// one file over: a check copied into three packs is a check the fourth will not
+// have.
+
+func cataloguePacks(t *testing.T) []emulator.Pack {
+	t.Helper()
+	env := emulator.DefaultEnv()
+	return []emulator.Pack{scaleway.New(env), outscale.New(env), exoscale.New(env)}
+}
+
+// A pack that declares nothing is named, rather than skipped.
+//
+// Optional in the type system and required here on purpose: silence is exactly
+// how the trap is fallen into, so the absence has to be as loud as a wrong
+// answer. A pack that genuinely serves no inventory writes one entry saying so
+// and the next author cannot forget by accident.
+func TestEveryPackDeclaresTheCatalogueItsClientReads(t *testing.T) {
+	for _, pack := range cataloguePacks(t) {
+		catalogued, ok := pack.(emulator.Catalogued)
+		if !ok {
+			t.Errorf("%s declares no catalogue: a client reads an inventory before it can "+
+				"create anything, and nothing here says which routes that is", pack.Name())
+			continue
+		}
+		entries := catalogued.Catalogue()
+		if len(entries) == 0 {
+			t.Errorf("%s declares an empty catalogue", pack.Name())
+			continue
+		}
+		if unexplained := emulator.UnexplainedCatalogue(entries); len(unexplained) > 0 {
+			t.Errorf("%s declares catalogue routes that say nothing about what a client reads "+
+				"them for: %s", pack.Name(), strings.Join(unexplained, ", "))
+		}
+		if missing := emulator.CatalogueRoutesNotMounted(entries, pack.Routes()); len(missing) > 0 {
+			t.Errorf("%s declares catalogue routes it does not serve: %s — which is the trap "+
+				"itself, a catalogue that reads as present and answers 404",
+				pack.Name(), strings.Join(missing, ", "))
+		}
+	}
+}
+
+// And the answer is driven, because a mounted route proves nothing.
+//
+// A catalogue that answers `[]` fails a client exactly as a 404 does: the CLI
+// resolves a type or an image out of that list and finds nothing. So each entry
+// is called against a fresh emulator, and its collection must come back with at
+// least one item.
+func TestEveryDeclaredCatalogueAnswersSomething(t *testing.T) {
+	env := emulator.DefaultEnv()
+	packs := []emulator.Pack{scaleway.New(env), outscale.New(env), exoscale.New(env)}
+	srv, err := emulator.NewServer(env, packs...)
+	if err != nil {
+		t.Fatalf("build the server: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	for _, pack := range packs {
+		catalogued, ok := pack.(emulator.Catalogued)
+		if !ok {
+			continue // reported by the test above; not reported twice
+		}
+		for _, entry := range catalogued.Catalogue() {
+			// A path parameter is filled with the value a client would send.
+			// Only the zone appears in these routes, and only in one pack.
+			path := strings.ReplaceAll(entry.Path, "{zone}", "fr-par-1")
+			if strings.Contains(path, "{") {
+				t.Errorf("%s: %s carries a path parameter the guard cannot fill: %s",
+					pack.Name(), entry.Path, path)
+				continue
+			}
+
+			req, err := http.NewRequest(entry.Method, ts.URL+path, strings.NewReader("{}"))
+			if err != nil {
+				t.Fatalf("%s %s: %v", entry.Method, path, err)
+			}
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := ts.Client().Do(req)
+			if err != nil {
+				t.Fatalf("%s %s: %v", entry.Method, path, err)
+			}
+			var body map[string]any
+			decodeErr := json.NewDecoder(resp.Body).Decode(&body)
+			_ = resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("%s: %s %s answers %d — a client reading %s fails before it creates "+
+					"anything", pack.Name(), entry.Method, path, resp.StatusCode, entry.Reads)
+				continue
+			}
+			if decodeErr != nil {
+				t.Errorf("%s: %s %s did not answer JSON: %v", pack.Name(), entry.Method, path, decodeErr)
+				continue
+			}
+			// A list or an object, because the clouds differ and neither shape is
+			// wrong: Scaleway keys its server types by name
+			// ({"servers": {"DEV1-S": …}}), the other two answer arrays. What the
+			// guard is about is whether anything is in there.
+			count, found := collectionSize(body[entry.Collection])
+			if !found {
+				t.Errorf("%s: %s %s carries no %q; a client reading %s finds nothing to resolve",
+					pack.Name(), entry.Method, path, entry.Collection, entry.Reads)
+				continue
+			}
+			if count == 0 {
+				t.Errorf("%s: %s %s answers an empty %s — which fails a client exactly as a 404 "+
+					"does, since it resolves %s out of that list",
+					pack.Name(), entry.Method, path, entry.Collection, entry.Reads)
+			}
+		}
+	}
+}
+
+// collectionSize counts an inventory whatever shape the provider gives it, and
+// reports whether the key held one at all.
+func collectionSize(value any) (int, bool) {
+	switch held := value.(type) {
+	case []any:
+		return len(held), true
+	case map[string]any:
+		return len(held), true
+	default:
+		return 0, false
+	}
+}

--- a/internal/core/emulator/catalogue.go
+++ b/internal/core/emulator/catalogue.go
@@ -1,0 +1,77 @@
+package emulator
+
+import "strings"
+
+// The trap CLAUDE.md opens with, given a control.
+//
+// `scw instance server create` reads the server types, the default image, the
+// resolved image and then allocates an IP, before it creates anything. A 404 on
+// any one of them fails the command with an error that names none of this. An
+// emulator owns no inventory, and must serve one anyway — small, fixed, and
+// present.
+//
+// Each pack solves that with its own table, and nothing checked it across packs.
+// Declined() has such a check; the catalogues had none, so a fourth pack could
+// decline its inventory, pass every unit test, and discover the consequence when
+// a real client failed on its first create (#218).
+//
+// What a pack declares here is not documentation: the cross-pack test drives
+// every entry against a fresh emulator and requires a non-empty answer, because
+// a catalogue that answers `[]` fails a client exactly as a 404 does.
+
+// CatalogueEntry is one inventory route a client reads before it can create.
+type CatalogueEntry struct {
+	// Method and Path are the route as mounted, so the guard can drive it.
+	Method string
+	Path   string
+	// Reads says what a client reads it for, in a client's terms rather than the
+	// pack's — "the server types `scw instance server create` sizes from". Data
+	// rather than a comment, for the reason Decline.Reason is: whoever reads a
+	// failure here is not holding the pack open.
+	Reads string
+	// Collection names the JSON key holding the list, empty when the body is a
+	// bare array. The guard reads it to tell a served catalogue from an empty
+	// one, which is the whole point of driving the route.
+	Collection string
+}
+
+// Catalogued is the optional half of a Pack that serves an inventory.
+//
+// Optional in the type system, required in practice by the cross-pack guard: a
+// pack serving machines that declares nothing here is reported by name. Failing
+// loudly on a pack that genuinely has no inventory is the right direction — the
+// author writes one line saying so, and the next pack cannot forget silently.
+type Catalogued interface {
+	Catalogue() []CatalogueEntry
+}
+
+// UnexplainedCatalogue returns the entries that say nothing about what they are
+// for, the same discipline UnexplainedDeclines applies to a refusal.
+func UnexplainedCatalogue(entries []CatalogueEntry) []string {
+	var found []string
+	for _, entry := range entries {
+		if strings.TrimSpace(entry.Reads) == "" {
+			found = append(found, entry.Method+" "+entry.Path)
+		}
+	}
+	return found
+}
+
+// CatalogueRoutesNotMounted returns the declared entries that no route serves.
+//
+// This is the half that catches a decline: a pack can move an inventory route
+// into Declined() and leave the declaration behind, and the result is exactly
+// the trap — a catalogue that reads as served and answers 404.
+func CatalogueRoutesNotMounted(entries []CatalogueEntry, routes []Route) []string {
+	mounted := make(map[string]bool, len(routes))
+	for _, route := range routes {
+		mounted[route.Method+" "+route.Path] = true
+	}
+	var found []string
+	for _, entry := range entries {
+		if !mounted[entry.Method+" "+entry.Path] {
+			found = append(found, entry.Method+" "+entry.Path)
+		}
+	}
+	return found
+}

--- a/internal/providers/exoscale/catalog.go
+++ b/internal/providers/exoscale/catalog.go
@@ -221,3 +221,26 @@ func (p *Pack) quotaOf(name string, limit int, kind string) map[string]any {
 	}
 	return map[string]any{"resource": name, "limit": limit, "usage": usage}
 }
+
+// Catalogue is what a client reads here before it can create anything, declared
+// so the cross-pack guard can drive it (#218).
+//
+// A create names both by id, and `exo compute instance create` resolves both by
+// name through these lists first — so a declined inventory here fails the client
+// before it posts anything, exactly as it does in the two other packs.
+func (p *Pack) Catalogue() []emulator.CatalogueEntry {
+	return []emulator.CatalogueEntry{
+		{
+			Method:     "GET",
+			Path:       "/v2/instance-type",
+			Reads:      "the instance types a create sizes a machine from",
+			Collection: "instance-types",
+		},
+		{
+			Method:     "GET",
+			Path:       "/v2/template",
+			Reads:      "the templates a create boots from, and which carry the login",
+			Collection: "templates",
+		},
+	}
+}

--- a/internal/providers/outscale/catalog.go
+++ b/internal/providers/outscale/catalog.go
@@ -317,3 +317,26 @@ func (p *Pack) readPublicIPRanges(w http.ResponseWriter, r *http.Request) {
 		"ResponseContext": p.context(),
 	})
 }
+
+// Catalogue is what a client reads here before it can create anything, declared
+// so the cross-pack guard can drive it (#218).
+//
+// Same trap as the Scaleway pack, which learned it the hard way and left the
+// warning in this file: decline the inventory and the client fails on its first
+// create, on a route nobody thought about.
+func (p *Pack) Catalogue() []emulator.CatalogueEntry {
+	return []emulator.CatalogueEntry{
+		{
+			Method:     "POST",
+			Path:       pathPrefix + "ReadVmTypes",
+			Reads:      "the Vm types a client sizes a machine from",
+			Collection: "VmTypes",
+		},
+		{
+			Method:     "POST",
+			Path:       pathPrefix + "ReadImages",
+			Reads:      "the images a create names, and Terraform resolves through a filter",
+			Collection: "Images",
+		},
+	}
+}

--- a/internal/providers/scaleway/catalog.go
+++ b/internal/providers/scaleway/catalog.go
@@ -218,3 +218,35 @@ func (p *Pack) listLocalImages(w http.ResponseWriter, r *http.Request) {
 		"total_count": 1,
 	})
 }
+
+// Catalogue is what a client reads here before it can create anything, declared
+// so the cross-pack guard can drive it (#218).
+//
+// The list is the sequence `scw instance server create` actually walks, measured
+// with `scw -D`: the server types it sizes from, the marketplace image it
+// defaults to, and the image endpoint it resolves that default through. A 404 on
+// any one of them fails the command before it posts a server, with an error that
+// names none of this.
+func (p *Pack) Catalogue() []emulator.CatalogueEntry {
+	const zones = "/instance/v1/zones/{zone}"
+	return []emulator.CatalogueEntry{
+		{
+			Method:     "GET",
+			Path:       zones + "/products/servers",
+			Reads:      "the server types `scw instance server create` sizes a machine from",
+			Collection: "servers",
+		},
+		{
+			Method:     "GET",
+			Path:       "/marketplace/v2/local-images",
+			Reads:      "the image the CLI defaults to when the caller names none",
+			Collection: "local_images",
+		},
+		{
+			Method:     "GET",
+			Path:       zones + "/images",
+			Reads:      "the images a client lists, and resolves a named one through",
+			Collection: "images",
+		},
+	}
+}

--- a/tools/falsify/specs/catalogue-is-served.json
+++ b/tools/falsify/specs/catalogue-is-served.json
@@ -1,0 +1,28 @@
+{
+  "package": "./internal/cli/",
+  "mutations": [
+    {
+      "label": "a pack declines its server types, which is trap #1 of CLAUDE.md",
+      "file": "internal/providers/scaleway/pack.go",
+      "find": "\t\t{Method: \"GET\", Path: zones + \"/products/servers\", Operation: \"instance/v1/API.ListServersTypes\", Handler: p.listServerTypes},",
+      "replace": "\t\t{Method: \"GET\", Path: zones + \"/products/servers-declined\", Operation: \"instance/v1/API.ListServersTypes\", Handler: p.listServerTypes},",
+      "test": "TestEveryPackDeclaresTheCatalogueItsClientReads"
+    },
+    {
+      "label": "the inventory is mounted and empty, which fails a client exactly as a 404 does",
+      "package": "./internal/cli/",
+      "file": "internal/providers/exoscale/catalog.go",
+      "find": "\temulator.WriteJSON(w, http.StatusOK, map[string]any{\"instance-types\": instanceTypes})",
+      "replace": "\temulator.WriteJSON(w, http.StatusOK, map[string]any{\"instance-types\": instanceTypes[:0]})",
+      "test": "TestEveryDeclaredCatalogueAnswersSomething"
+    },
+    {
+      "label": "a catalogue entry says nothing about what a client reads it for",
+      "package": "./internal/cli/",
+      "file": "internal/providers/outscale/catalog.go",
+      "find": "\t\t\tReads:      \"the Vm types a client sizes a machine from\",",
+      "replace": "\t\t\tReads:      \"\",",
+      "test": "TestEveryPackDeclaresTheCatalogueItsClientReads"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #218.

`CLAUDE.md` opens with this one: **declining the catalogue breaks the CLI.**
`scw instance server create` reads the server types, the default image and the
resolved image before it posts anything, and a 404 on any of them fails the
command with an error that names none of this.

Three packs answer that with three fixed tables, and **nothing checked it across
packs.** `Declined()` has such a check; the catalogues had none — so a fourth
pack could decline its inventory, pass every unit test it had, and be found out
by a real client on its first create. The trap the documentation was written to
prevent, still open in the code.

## The guard

`emulator.Catalogued`, declared per pack the way `Declined()` is, and two
assertions in `internal/cli` where the declines guard already lives — because a
check copied into three packs is a check the fourth will not have.

**First**: every pack declares a catalogue, every entry says what a client reads
it for, and every declared route is *actually mounted*. That last one catches the
exact move the trap describes — a route quietly declined while the declaration
stays behind, so the catalogue reads as present and answers 404.

**Second, and the one that makes this more than bookkeeping**: every declared
entry is driven against a fresh emulator and its collection must come back
**non-empty**. A mounted route proves nothing. A catalogue answering `[]` fails a
client exactly as a 404 does, since the CLI resolves a type or an image out of
that list and finds nothing.

Both shapes are accepted, because neither is wrong: Scaleway keys its server
types by name (`{"servers": {"DEV1-S": …}}`), the other two answer arrays.

| pack | declared |
|---|---|
| scaleway | `products/servers`, `marketplace/v2/local-images`, `images` |
| outscale | `ReadVmTypes`, `ReadImages` |
| exoscale | `instance-type`, `template` |

## Optional in the type system, required by the guard

A pack implementing nothing is **reported by name**, not skipped. Silence is how
this trap is fallen into, so the absence has to be as loud as a wrong answer, and
a pack that genuinely serves no inventory writes one line saying so.

## Measured

| | |
|---|---|
| `go test ./...`, `mise run prepush` | green |
| `mise run conformance` | **exit 0**, 74 checks, 0 FAIL |
| `mise run falsify -- specs/catalogue-is-served.json` | 3 mutations, all bite |

The three: a declined route, an inventory served empty, and an entry that says
nothing about what it is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
