### PR TITLE
fix(conformance): four verdicts that measured less than they claimed (#219)

### DIFF
--- a/tools/conformance/exoscale/network.sh
+++ b/tools/conformance/exoscale/network.sh
@@ -47,6 +47,8 @@ skip() { echo "  SKIP: $*" >&2; }
 # comparison is not written three times.
 # shellcheck source=/dev/null
 . "$(dirname "$0")/../shared/addresses.sh"
+# shellcheck source=/dev/null
+. "$(dirname "$0")/../shared/verdicts.sh"
 
 command -v exo >/dev/null 2>&1 || { echo "FAIL: exo is not installed" >&2; exit 1; }
 command -v jq >/dev/null 2>&1 || { echo "FAIL: jq is not installed" >&2; exit 1; }
@@ -84,12 +86,19 @@ sweep_runtime() {
   printf '  sweep: %s\n' "${out%%$'\n'*}"
 }
 
-cleanup_ids=()
+# The list lives in a file rather than in an array, and that is the fix for a
+# sweep that swept nothing (#219): boot() ends with `echo "$id"` and every caller
+# writes `id="$(boot …)"`, which is a subshell — so `cleanup_ids+=("$id")` inside
+# it updated a copy that died with the subshell, and the trap ran on an empty
+# list. Every machine the suite created stayed on the operator's host, and the
+# suite reported a clean exit.
+cleanup_init
 cleanup() {
-  for id in "${cleanup_ids[@]:-}"; do
+  while read -r id; do
     [ -n "$id" ] || continue
     curl -sf -X DELETE "$ENDPOINT/v2/instance/$id" >/dev/null 2>&1 || true
-  done
+  done < <(cleanup_list)
+  cleanup_done
   sweep_runtime || return
   if ! "$FEINT_BIN" clean --vm "${FEINT_VM:-incus}" 2>&1 | grep -q "nothing was left behind"; then
     echo "FAIL: the runtime is still not clean after the sweep" >&2
@@ -122,7 +131,7 @@ boot() { # name -> instance id
     || fail "instance $name was not created"
   id="$(exo -O json compute instance list | jq -r --arg n "$name" '.[] | select(.name == $n) | .id')"
   [ -n "$id" ] || fail "instance $name is not in the list after create"
-  cleanup_ids+=("$id")
+  cleanup_add "$id"
   echo "$id"
 }
 
@@ -211,6 +220,11 @@ sleep 2
 # isolation it is hard: a declared capability that does not deliver is worse
 # than an absent one. On any other it is a skip that names the mode, never a
 # silent pass — docs/limits.md records why bridges cannot deliver it.
+# The positive control, before the negative verdict: see the Scaleway suite and
+# #219. A listener that never started refuses a connection exactly as isolation
+# does, so it is proved live on its own loopback first.
+assert_listening "$(machine "$far_id")" 80 "the instance of the other private network"
+
 if incus exec "$(machine "$probe_id")" -- timeout 3 nc -z -w 2 "$far_ip" 80 >/dev/null 2>&1; then
   if [ "$ISOLATION" = "true" ]; then
     fail "$far_ip is reachable from another private network, but $MACHINES declares isolation"

--- a/tools/conformance/outscale/network.sh
+++ b/tools/conformance/outscale/network.sh
@@ -39,6 +39,8 @@ skip() { echo "  SKIP: $*" >&2; }
 # comparison is not written three times.
 # shellcheck source=/dev/null
 . "$(dirname "$0")/../shared/addresses.sh"
+# shellcheck source=/dev/null
+. "$(dirname "$0")/../shared/verdicts.sh"
 
 echo "conformance: outscale network against $ENDPOINT"
 
@@ -175,13 +177,13 @@ esac
 # container gets its address a few seconds after it starts.
 carried=""
 for _ in 1 2 3 4 5 6 7 8 9 10; do
-  if incus list -f csv -c n4 2>/dev/null | grep -q "$private_ip"; then
+  if machine_carries "feint-osc-$vm_id" "$private_ip"; then
     carried="yes"
     break
   fi
   sleep 2
 done
-[ -n "$carried" ] || fail "no machine on the host carries $private_ip: the address is a number in a store"
+[ -n "$carried" ] || fail "feint-osc-$vm_id does not carry $private_ip: the address is a number in a store"
 ok "$vm_id carries $private_ip, on $found"
 
 echo "- the machine carries no address the API does not publish"
@@ -252,15 +254,21 @@ ip_b="$(printf '%s' "$vm_b_doc" | jq -r '.Vms[0].PrivateIp // empty')"
 # mean isolation rather than a machine still booting.
 booted=""
 for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
-  if incus list -f csv -c n4 2>/dev/null | grep -q "$ip_b"; then booted="yes"; break; fi
+  if machine_carries "feint-osc-$vm_b" "$ip_b"; then booted="yes"; break; fi
   sleep 2
 done
-[ -n "$booted" ] || fail "no machine carries $ip_b; cannot measure reachability"
+[ -n "$booted" ] || fail "feint-osc-$vm_b does not carry $ip_b; cannot measure reachability"
 sleep 2
 
 # reach: from the machine in Net A towards the address in Net B. The names are
 # the binding's, prefix feint-osc-.
 reach() { incus exec "feint-osc-$vm_a" -- ping -c 2 -W 2 "$ip_b" >/dev/null 2>&1; }
+
+# The positive control, before four negative verdicts in a row: the target answers
+# on its own address. A machine whose stack never came up refuses a ping exactly
+# as an unpeered Net does, and this suite draws its strongest conclusion from that
+# refusal (#219).
+assert_answers_itself "feint-osc-$vm_b" "$ip_b" "the Vm of the second Net"
 
 echo "- before any peering, the Nets do not reach each other"
 if reach; then
@@ -303,7 +311,7 @@ else
   same_vm="$(printf '%s' "$same_doc" | jq -r '.Vms[0].VmId')"
   same_ip="$(printf '%s' "$same_doc" | jq -r '.Vms[0].PrivateIp // empty')"
   for _ in $(seq 1 30); do
-    incus list -f csv -c n4 2>/dev/null | grep -q "$same_ip" && break
+    machine_carries "feint-osc-$same_vm" "$same_ip" && break
     sleep 2
   done
   sleep 3

--- a/tools/conformance/scaleway/network.sh
+++ b/tools/conformance/scaleway/network.sh
@@ -44,6 +44,8 @@ skip() { echo "  SKIP: $*" >&2; }
 # comparison is not written three times.
 # shellcheck source=/dev/null
 . "$(dirname "$0")/../shared/addresses.sh"
+# shellcheck source=/dev/null
+. "$(dirname "$0")/../shared/verdicts.sh"
 
 api() { curl -sf -H 'Content-Type: application/json' "$@"; }
 
@@ -77,7 +79,13 @@ fi
 # not, and it fails honestly when a mode claims something it stops delivering.
 ISOLATION="$(printf '%s' "$health" | jq -r '.capabilities.isolation')"
 
-cleanup_ids=()
+# The list lives in a file rather than in an array, and that is the fix for a
+# sweep that swept nothing (#219): boot() ends with `echo "$id"` and every caller
+# writes `id="$(boot …)"`, which is a subshell — so `cleanup_ids+=("$id")` inside
+# it updated a copy that died with the subshell, and the trap ran on an empty
+# list. Every machine the suite created stayed on the operator's host, and the
+# suite reported a clean exit.
+cleanup_init
 
 # The emulator removes its own leftovers: it labels everything it creates, so the
 # sweep is exact where matching names would be a guess. Running it before as well
@@ -99,11 +107,12 @@ sweep_runtime() {
 }
 
 cleanup() {
-  for id in "${cleanup_ids[@]:-}"; do
+  while read -r id; do
     [ -n "$id" ] || continue
     curl -sf -X POST "$ENDPOINT/instance/v1/zones/$ZONE/servers/$id/action" \
       -H 'Content-Type: application/json' -d '{"action":"terminate"}' >/dev/null 2>&1 || true
-  done
+  done < <(cleanup_list)
+  cleanup_done
   sweep_runtime || return
   # A sweep that ran and still left work behind is the same problem as one that
   # never ran, so the end state is asserted rather than assumed.
@@ -145,7 +154,7 @@ boot() { # name [security-group-id] -> "id ip"
   body="$body}"
   id="$(api -X POST "$ENDPOINT/instance/v1/zones/$ZONE/servers" -d "$body" | jq -r '.server.id')"
   [ -n "$id" ] && [ "$id" != null ] || fail "server $1 was not created"
-  cleanup_ids+=("$id")
+  cleanup_add "$id"
   api -X POST "$ENDPOINT/instance/v1/zones/$ZONE/servers/$id/action" -d '{"action":"poweron"}' >/dev/null
   # The address is resolved the way a client resolves it: instance/v1.PrivateNIC
   # carries no address, only ipam_ip_ids, and ipam/v1 holds the addresses. A
@@ -175,8 +184,7 @@ esac
 # control plane is not a witness for itself.
 machine() { echo "feint-scw-$1"; }
 if ! command -v incus >/dev/null 2>&1; then
-  skip "incus client not available; cannot verify what the machines carry"
-  exit 0
+  stop_here "$LINENO" "incus client not available; cannot verify what the machines carry"
 fi
 sleep 3
 
@@ -224,8 +232,7 @@ sleep 2
 reach() { incus exec "$(machine "$probe_id")" -- timeout 3 nc -z -w 2 "$guard_ip" 80 >/dev/null 2>&1; }
 
 if reach; then
-  skip "port 80 is open although the group drops by default; the runtime enforces nothing (Incus < 6.0.4?)"
-  exit 0
+  stop_here "$LINENO" "port 80 is open although the group drops by default; the runtime enforces nothing (Incus < 6.0.4?)"
 fi
 ok "port 80 refused"
 
@@ -317,7 +324,7 @@ far_pn="$(api -X POST "$ENDPOINT/vpc/v2/regions/$REGION/private-networks" \
 
 far_id="$(api -X POST "$ENDPOINT/instance/v1/zones/$ZONE/servers" \
            -d '{"name":"conformance-far","commercial_type":"DEV1-S","image":"alpine"}' | jq -r '.server.id')"
-cleanup_ids+=("$far_id")
+cleanup_add "$far_id"
 far_nic="$(api -X POST "$ENDPOINT/instance/v1/zones/$ZONE/servers/$far_id/private_nics" \
             -d "{\"private_network_id\":\"$far_pn\"}")"
 far_ipam="$(echo "$far_nic" | jq -r '.private_nic.ipam_ip_ids[0] // empty')"
@@ -335,6 +342,13 @@ sleep 2
 # not silence: two managed bridges of one host are routed together, the
 # emulator tries to separate them, and the separation does not hold once the
 # NICs carry a security group. docs/limits.md records both.
+# The positive control, before the negative verdict: the listener on the far
+# machine answers on its own loopback. Without it a machine that never booted and
+# a machine correctly isolated are the same observation, and the suite read the
+# first as a pass — on the assertion that carries the product's strongest claim
+# (#219).
+assert_listening "$(machine "$far_id")" 80 "the server of the other VPC"
+
 if incus exec "$(machine "$probe_id")" -- timeout 3 nc -z -w 2 "$far_ip" 80 >/dev/null 2>&1; then
   # A runtime that declares isolation and does not deliver it is a hard failure:
   # that claim is the product's strongest, and an unproven claim is worse than
@@ -352,7 +366,7 @@ near_pn="$(api -X POST "$ENDPOINT/vpc/v2/regions/$REGION/private-networks" \
             -d '{"name":"near","subnets":["10.184.0.0/24"]}' | jq -r '.id')"
 near_id="$(api -X POST "$ENDPOINT/instance/v1/zones/$ZONE/servers" \
             -d '{"name":"conformance-near","commercial_type":"DEV1-S","image":"alpine"}' | jq -r '.server.id')"
-cleanup_ids+=("$near_id")
+cleanup_add "$near_id"
 near_nic="$(api -X POST "$ENDPOINT/instance/v1/zones/$ZONE/servers/$near_id/private_nics" \
              -d "{\"private_network_id\":\"$near_pn\"}")"
 near_ipam="$(echo "$near_nic" | jq -r '.private_nic.ipam_ip_ids[0] // empty')"

--- a/tools/conformance/shared/demo-219.sh
+++ b/tools/conformance/shared/demo-219.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# The demonstration #219 asks for: each of the four old forms passes where its
+# replacement fails.
+#
+# A fix to a control is worth nothing until the control is shown to have been
+# blind, and these four are shell rather than Go, so tools/falsify cannot reach
+# them. This does the same job by hand: it builds the situation the old form
+# could not see, runs both forms against it, and requires the old to pass and the
+# new to refuse.
+#
+# It needs no runtime. Where a check reads Incus, the reading is stubbed with the
+# output Incus would have produced, which is the point — what is under test is
+# the judgement, not the runtime.
+#
+#   bash --noprofile --norc tools/conformance/shared/demo-219.sh
+#
+# Exit 0 when all four are demonstrated, 1 otherwise.
+set -uo pipefail
+
+failures=0
+demo() { printf '\n== %s\n' "$1"; }
+verdict() { # old new label
+  if [ "$1" = "pass" ] && [ "$2" = "fail" ]; then
+    printf '   ok   the old form passed and the new one refuses: %s\n' "$3"
+  else
+    printf '   FAIL the demonstration did not hold (old=%s new=%s): %s\n' "$1" "$2" "$3"
+    failures=$((failures + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+demo "1. an address carried by somebody else's machine"
+
+# What `incus list -f csv -c n4` would print with a leftover machine from another
+# run, and none of our own carrying the address.
+host_listing() {
+  printf 'feint-osc-i-other,10.196.1.4 (eth0)\n'
+  printf 'feint-osc-i-ours,10.196.1.44 (eth0)\n'
+}
+# The address our API published, for our machine.
+want_ip=10.196.1.4
+
+old_form() { host_listing | grep -q "$want_ip" && echo pass || echo fail; }
+
+# The new form asks the named machine what it carries, and compares whole values.
+addresses_carried() { # machine
+  case "$1" in
+  feint-osc-i-ours) echo "10.196.1.44" ;;
+  feint-osc-i-other) echo "10.196.1.4" ;;
+  esac
+}
+machine_carries() {
+  local address
+  for address in $(addresses_carried "$1"); do
+    [ "$address" = "$2" ] && return 0
+  done
+  return 1
+}
+new_form() { machine_carries feint-osc-i-ours "$want_ip" && echo pass || echo fail; }
+
+verdict "$(old_form)" "$(new_form)" \
+  "another run's machine, and a substring match, both satisfied the old grep"
+
+# ---------------------------------------------------------------------------
+demo "2. isolation concluded from a machine that never booted"
+
+# The far machine is dead: every connection to it is refused, whatever the
+# network says.
+connect_to_far() { return 1; }
+listener_on_far() { return 1; } # nothing is listening, because nothing booted
+
+old_isolation() { if connect_to_far; then echo fail; else echo pass; fi; }
+new_isolation() {
+  # The positive control first: if the target answers nothing at all, the
+  # negative verdict measures a dead machine.
+  if ! listener_on_far; then echo fail; return; fi
+  if connect_to_far; then echo fail; else echo pass; fi
+}
+
+verdict "$(old_isolation)" "$(new_isolation)" \
+  "a dead machine and a correctly isolated one were the same observation"
+
+# ---------------------------------------------------------------------------
+demo "3. a suite that stops and reports a clean exit"
+
+suite_body() {
+  printf 'echo "- one"\necho "- two"\necho "- three"\necho "- four"\n'
+}
+# The old form: skip, exit 0. A reader sees two results and a zero exit.
+old_stop() {
+  local out
+  out="$(printf '  SKIP: cannot continue\n')"
+  case "$out" in
+  *STOPPED*) echo fail ;;
+  *) echo pass ;;
+  esac
+}
+# The new form names what was not run, so the run cannot be read as complete.
+new_stop() {
+  local total remaining out
+  total="$(suite_body | grep -c '^echo "- ')"
+  remaining="$(suite_body | awk 'NR > 2 && /^echo "- /' | wc -l)"
+  out="$(printf '  SKIP: cannot continue\n  STOPPED: %s of this suite'"'"'s %s check(s) were not run\n' \
+         "$remaining" "$total")"
+  case "$out" in
+  *STOPPED*) echo fail ;;
+  *) echo pass ;;
+  esac
+}
+
+verdict "$(old_stop)" "$(new_stop)" \
+  "everything after the skip was neither passed nor skipped, and the exit was zero"
+
+# ---------------------------------------------------------------------------
+demo "4. a cleanup list that dies with its subshell"
+
+old_swept() (
+  cleanup_ids=()
+  boot_old() { cleanup_ids+=("machine-$1"); echo "machine-$1"; }
+  # The call every suite makes: command substitution, hence a subshell.
+  id="$(boot_old 1)"
+  [ -n "$id" ] || true
+  # The trap would sweep this list.
+  if [ "${#cleanup_ids[@]}" -eq 0 ]; then echo pass; else echo fail; fi
+)
+
+new_swept() (
+  CLEANUP_FILE="$(mktemp)"
+  cleanup_add() { printf '%s\n' "$1" >>"$CLEANUP_FILE"; }
+  cleanup_list() { cat "$CLEANUP_FILE"; }
+  boot_new() { cleanup_add "machine-$1"; echo "machine-$1"; }
+  id="$(boot_new 1)"
+  [ -n "$id" ] || true
+  swept="$(cleanup_list | wc -l)"
+  rm -f "$CLEANUP_FILE"
+  if [ "$swept" -eq 0 ]; then echo pass; else echo fail; fi
+)
+
+verdict "$(old_swept)" "$(new_swept)" \
+  "the trap ran on an empty list and every machine stayed on the host"
+
+# ---------------------------------------------------------------------------
+printf '\n'
+if [ "$failures" -eq 0 ]; then
+  echo "all four weaknesses demonstrated: the old form passes, the new one refuses"
+  exit 0
+fi
+echo "$failures demonstration(s) did not hold" >&2
+exit 1

--- a/tools/conformance/shared/verdicts.sh
+++ b/tools/conformance/shared/verdicts.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Shared conformance verdicts: the four ways these suites measured less than they
+# claimed (#219).
+#
+# The suites are what this project's claim rests on, so a weak control here is
+# the most expensive defect in the repository — worse than a bug, because it
+# reports green. Each function below replaces a form that passed where it should
+# have failed, and tools/conformance/shared/demo-219.sh shows the old and the new
+# side by side on a synthetic case.
+#
+# Sourced after shared/addresses.sh, whose addresses_carried it uses. Every
+# function expects `ok`, `fail` and `skip` to be defined by the caller.
+
+# machine_carries answers whether *this* machine carries *exactly* this address.
+#
+# It replaces `incus list -f csv -c n4 | grep -q "$ip"`, which was wrong twice
+# over: it searched every instance on the host, so a leftover machine from
+# another run satisfied it, and it matched a substring, so 10.1.1.4 was found
+# inside 10.1.1.44. A verdict that another run can satisfy is not a verdict.
+machine_carries() { # machine address
+  local address
+  for address in $(addresses_carried "$1"); do
+    [ "$address" = "$2" ] && return 0
+  done
+  return 1
+}
+
+# assert_listening is the positive control every negative verdict needs.
+#
+# The isolation checks conclude "unreachable" from a connection that did not
+# open. A machine that never booted, or whose listener never started, produces
+# exactly that — so a broken run and a correctly isolated one were the same
+# observation, and the suite read the first as a pass. That verdict is the
+# product's strongest claim, which makes it the worst one to leave unguarded.
+#
+# Asked on the target itself, because the point is precisely that nothing else
+# can reach it: if the listener answers on its own loopback, then a refusal seen
+# from elsewhere is isolation rather than absence.
+assert_listening() { # machine port what
+  local machine=$1 port=$2 what=$3
+  if ! incus exec "$machine" -- timeout 3 nc -z -w 2 127.0.0.1 "$port" >/dev/null 2>&1; then
+    fail "$what is not listening on port $port, so 'unreachable' would measure a dead machine rather than isolation"
+  fi
+}
+
+# assert_answers_itself is assert_listening for a suite that measures reach with
+# ping rather than with a port.
+#
+# Same argument: a machine whose stack is not up refuses a ping exactly as
+# isolation does. Asked of the machine about its own address, which proves the
+# address is live on it without needing anything else to reach it.
+assert_answers_itself() { # machine address what
+  if ! incus exec "$1" -- ping -c 1 -W 2 "$2" >/dev/null 2>&1; then
+    fail "$3 does not answer on $2 from itself, so 'unreachable' would measure a dead stack rather than isolation"
+  fi
+}
+
+# stop_here ends a suite that cannot continue, and says so as a result rather
+# than as silence.
+#
+# `skip … ; exit 0` mid-suite left everything after it neither passed nor
+# skipped, and a reader saw a clean exit. The count is the difference: a run that
+# stops after two of eleven checks reports that it did.
+# Called as `stop_here "$LINENO" "why"`. The count is read from the script rather
+# than written into the call, because a number typed here goes stale the first
+# time somebody adds a check below it — which would make this fix the very thing
+# it is fixing.
+stop_here() { # LINENO why
+  skip "$2"
+  local total remaining
+  total="$(grep -c '^echo "- ' "$0" 2>/dev/null || echo 0)"
+  remaining="$(awk -v start="$1" 'NR > start && /^echo "- /' "$0" 2>/dev/null | wc -l)"
+  echo "  STOPPED: $remaining of this suite's $total check(s) were not run" >&2
+  exit 0
+}
+
+# The cleanup list, kept in a file because the suites fill it from inside command
+# substitutions.
+#
+# `boot()` ends with `echo "$id"` and every caller writes `id="$(boot …)"`, which
+# is a subshell: `cleanup_ids+=("$id")` inside it updated a copy that died with
+# the subshell, so the trap swept an empty list and every machine the suite
+# created stayed on the operator's host. A file survives the subshell; an array
+# does not.
+cleanup_init() {
+  CLEANUP_FILE="$(mktemp)"
+  export CLEANUP_FILE
+}
+
+cleanup_add() { # id
+  [ -n "${CLEANUP_FILE:-}" ] && printf '%s\n' "$1" >>"$CLEANUP_FILE"
+}
+
+cleanup_list() {
+  [ -n "${CLEANUP_FILE:-}" ] && [ -f "$CLEANUP_FILE" ] && cat "$CLEANUP_FILE"
+}
+
+cleanup_done() {
+  [ -n "${CLEANUP_FILE:-}" ] && rm -f "$CLEANUP_FILE"
+}


### PR DESCRIPTION
Closes #219.

The suites are what this project's claim rests on, so a weak control here is the
most expensive defect in the repository: **it reports green**. All four were
verified in the scripts before being changed, and each has a demonstration that
the old form passes where the new one refuses.

## 1. The address was looked for on the wrong machines

```sh
incus list -f csv -c n4 | grep -q "$ip"
```

Searched **every instance on the host**, so a leftover machine from another run
satisfied it — and matched a **substring**, so `10.196.1.4` was found inside
`10.196.1.44`. Two ways for a verdict to be satisfied by something that is not
the subject.

It asks the named machine now, through `addresses_carried` — which the shared
file already offered and this suite was not using.

## 2. A dead machine read as a correctly isolated one

The isolation checks conclude *unreachable* from a connection that did not open.
A machine that never booted, or whose listener never started, produces **exactly
that observation** — and the suite read it as a pass.

That is the verdict carrying the product's strongest claim, and the audit notes
it has been read as proof three times this week.

Every negative verdict now has a positive control first: the target answers on
its own loopback, or answers a ping on its own address, *before* it is required
not to answer from elsewhere.

## 3. A suite that stopped and reported a clean exit

`skip … ; exit 0` mid-suite left everything after it neither passed nor skipped.
Measured: **twelve of the Scaleway suite's sixteen checks** were dropped at the
first of them, **eight** at the second.

`stop_here` names the count — and reads it out of the script rather than from a
constant. A number typed into the call would go stale the first time somebody
adds a check below it, which would make this fix the very thing it is fixing.

## 4. A sweep that swept nothing

`boot()` ends with `echo "$id"` and every caller writes `id="$(boot …)"`, which is
a subshell: `cleanup_ids+=("$id")` inside it updated a copy that died with it, so
the trap ran on an **empty list**. Every machine those suites created stayed on
the operator's host, and the run reported a clean exit.

The list is a file now, because a file survives a subshell and an array does not.

## The demonstration

`tools/falsify` runs `go test`, so it cannot reach shell. The four are
demonstrated by hand instead: `shared/demo-219.sh` builds the situation each old
form could not see, runs both forms against it, and requires **old=pass,
new=fail**. It needs no runtime — what is under test is the judgement, not Incus.

```
== 1. an address carried by somebody else's machine
   ok   the old form passed and the new one refuses: …
== 2. isolation concluded from a machine that never booted
   ok   the old form passed and the new one refuses: …
== 3. a suite that stops and reports a clean exit
   ok   the old form passed and the new one refuses: …
== 4. a cleanup list that dies with its subshell
   ok   the old form passed and the new one refuses: …
```

## Measured

| | |
|---|---|
| `mise run prepush` (shellcheck included) | green |
| `mise run conformance` | **exit 0**, 74 checks, 0 FAIL |
| `FEINT_VM=incus-ovn mise run conformance` | **exit 0**, 111 checks, 0 FAIL, **no STOPPED line** |
| `shared/demo-219.sh` | exit 0, all four demonstrated |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
