### PR TITLE
feat(compat): the consumer half of the versioning policy, measured (#170)

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -172,6 +172,37 @@ boolean to a string, and a pipeline treating it as truthy counted every refusal
 as a success. That path is what #170 measures; this section is what it measures
 against.
 
+### What the measurement found, and the one boundary it cannot protect
+
+`mise run compat:check` builds the previous release out of this repository's own
+history, starts both binaries offline, seeds them identically, and runs a set of
+expressions a consumer could legitimately have written. Each lands in exactly one
+bucket: compatible, explicitly broken, or **silently wrong**. A single unaccepted
+silently-wrong verdict refuses the tag, and `tools/release/preflight.sh` enforces
+that.
+
+Against 0.8 it found two, both of them the `probed` expression in its two natural
+forms:
+
+| the consumer wrote | 0.8 | 0.9 |
+|---|---|---|
+| `select(.probed == true)` | some operations | **none** |
+| `select(.probed)` | some operations | **all of them** |
+
+The second is the worse one: every operation now reads as probed, refusals
+included, which is the exact overstatement #156 existed to remove reappearing in
+somebody else's pipeline.
+
+**Neither is fixable retroactively**, and that is worth stating plainly rather
+than leaving as a green gate. `schema_version` arrived with #132, *after* 0.8
+shipped. A consumer of 0.8 could not have checked a signal that did not exist, so
+the recipe above protects from 0.9 onward and not before. The two findings are
+recorded in `tools/compat/accepted.json` with that reason, and they still print on
+every run — recorded, never hidden.
+
+The gate is about what happens next: from here on, a shape change either moves the
+surface's `schema_version` or refuses the release.
+
 ## Versioning
 
 [Semantic Versioning](https://semver.org/). Before 1.0, the minor version moves

--- a/internal/compat/compat.go
+++ b/internal/compat/compat.go
@@ -1,0 +1,175 @@
+// Package compat classifies what a consumer's expression does across two
+// releases of the emulator's own surfaces.
+//
+// #132 froze the shapes of /_feint/health, /_feint/routes, /_feint/conformance
+// and /_feint/trace, gave each a schema_version, and made a shape change fail CI
+// unless the version moves with it. That is the producer's half and it works.
+//
+// Nothing exercised the consumer's half (#170): no test took an expression a
+// user could legitimately have written against an older release and ran it
+// against the current one. This package is that measurement, and it exists
+// because the interesting failure is not an error — it is an answer.
+package compat
+
+import "fmt"
+
+// Verdict is where one expression lands. Every expression lands in exactly one.
+type Verdict string
+
+const (
+	// Compatible: the same answer, so nothing is needed.
+	Compatible Verdict = "compatible"
+	// ExplicitlyBroken: the answer changed, and the surface's schema_version
+	// changed with it, so a consumer keying on the version notices before it
+	// misreads anything. This is what the versioning policy is for.
+	ExplicitlyBroken Verdict = "explicitly broken"
+	// SilentlyWrong: the answer changed, the expression still runs, still
+	// answers, and the answer is false — with nothing in the payload that lets
+	// the consumer know. A single one of these fails a release.
+	SilentlyWrong Verdict = "silently wrong"
+)
+
+// Expression is one thing a consumer wrote, and what it produced on each side.
+//
+// Before and After are the evaluated results as text, because that is what a
+// consumer sees: a number, a list, a null. Comparing text rather than a decoded
+// value is deliberate — 0 and "0" are the same answer to a shell pipeline and a
+// different one to a JSON decoder, and the consumer here is a shell pipeline.
+type Expression struct {
+	// Name is how the finding is reported.
+	Name string
+	// Surface is the payload it reads, e.g. "conformance". The classifier looks
+	// up that surface's schema_version on both sides.
+	Surface string
+	// Source is the expression itself, printed in the finding so a reader can
+	// run it.
+	Source string
+	// Means is what the consumer believed it counted. Data rather than a
+	// comment, for the reason Decline.Reason is: whoever reads a finding is not
+	// holding this file open.
+	Means string
+	// Before and After are what it evaluated to on each release.
+	Before string
+	After  string
+}
+
+// Versions carries a surface's schema_version on each side. A surface that
+// carried none is Absent, which is not the same as zero and is the case the
+// 0.8 boundary is made of: schema_version did not exist before #132, so a
+// consumer of that release had nothing to key on at all.
+type Versions struct {
+	Before      string
+	After       string
+	BeforeKnown bool
+	AfterKnown  bool
+}
+
+// Changed reports whether a consumer could tell the two payloads apart from the
+// version alone.
+//
+// An absent version on the older side counts as *no signal*, not as a change.
+// The reasoning matters, because the opposite reading would let every release
+// before the policy claim the policy's protection retroactively: a consumer
+// writing against a payload with no schema_version cannot have checked one, so
+// nothing it could have written would have warned it.
+func (v Versions) Changed() bool {
+	if !v.BeforeKnown {
+		return false
+	}
+	if !v.AfterKnown {
+		// The signal disappeared, which a consumer that checked it does notice.
+		return true
+	}
+	return v.Before != v.After
+}
+
+// Finding is one classified expression.
+type Finding struct {
+	Expression
+	Verdict Verdict
+	Why     string
+}
+
+// Classify places one expression in exactly one bucket.
+func Classify(expr Expression, versions Versions) Finding {
+	switch {
+	case expr.Before == expr.After:
+		return Finding{
+			Expression: expr,
+			Verdict:    Compatible,
+			Why:        fmt.Sprintf("the same answer on both sides (%s)", expr.Before),
+		}
+	case versions.Changed():
+		return Finding{
+			Expression: expr,
+			Verdict:    ExplicitlyBroken,
+			Why: fmt.Sprintf("%s answered %s and now answers %s, and %s's schema_version moved "+
+				"from %s to %s, so a consumer keying on it notices before it misreads anything",
+				expr.Name, expr.Before, expr.After, expr.Surface, versions.Before, versions.After),
+		}
+	default:
+		signal := "the version did not move"
+		if !versions.BeforeKnown {
+			signal = "that release carried no schema_version at all, so nothing it could have " +
+				"checked would have warned it"
+		}
+		return Finding{
+			Expression: expr,
+			Verdict:    SilentlyWrong,
+			Why: fmt.Sprintf("%s answered %s and now answers %s — it still runs, still answers, "+
+				"and the answer is false; %s", expr.Name, expr.Before, expr.After, signal),
+		}
+	}
+}
+
+// ClassifyAll runs Classify over a set, keyed by surface.
+func ClassifyAll(exprs []Expression, versions map[string]Versions) []Finding {
+	out := make([]Finding, 0, len(exprs))
+	for _, expr := range exprs {
+		out = append(out, Classify(expr, versions[expr.Surface]))
+	}
+	return out
+}
+
+// Accepted is a silently-wrong finding the project has recorded rather than
+// fixed, with the reason. The 0.8 boundary is made of these: schema_version did
+// not exist then, so no consumer of that release could have been protected by a
+// policy that shipped after it.
+//
+// Recorded rather than hidden, which is what #170 asked for. An accepted finding
+// still prints; it simply does not fail the gate.
+type Accepted struct {
+	Name   string
+	Reason string
+}
+
+// Gate returns the findings that must fail a release: every silently-wrong one
+// that is not accepted.
+//
+// The accepted list is matched by expression name, and an accepted entry that
+// matches nothing is itself reported — a stale exemption is how a gate quietly
+// stops covering what it names.
+func Gate(findings []Finding, accepted []Accepted) (fail []Finding, stale []string) {
+	excused := make(map[string]string, len(accepted))
+	for _, entry := range accepted {
+		excused[entry.Name] = entry.Reason
+	}
+	matched := map[string]bool{}
+
+	for _, finding := range findings {
+		if finding.Verdict != SilentlyWrong {
+			continue
+		}
+		if _, ok := excused[finding.Name]; ok {
+			matched[finding.Name] = true
+			continue
+		}
+		fail = append(fail, finding)
+	}
+	for _, entry := range accepted {
+		if !matched[entry.Name] {
+			stale = append(stale, entry.Name)
+		}
+	}
+	return fail, stale
+}

--- a/internal/compat/compat_test.go
+++ b/internal/compat/compat_test.go
@@ -1,0 +1,121 @@
+package compat
+
+import (
+	"strings"
+	"testing"
+)
+
+// The three buckets, and the boundary between the last two is the whole point.
+//
+// An expression that errors is not interesting: the consumer sees it. What #170
+// is about is an expression that runs, answers, and answers something false —
+// and whether the payload gave the consumer any way to know.
+
+func expr(before, after string) Expression {
+	return Expression{
+		Name:    "probed count",
+		Surface: "conformance",
+		Source:  `[.evidence[] | select(.probed == true)] | length`,
+		Means:   "the operations the protocol probe drove",
+		Before:  before,
+		After:   after,
+	}
+}
+
+func TestTheSameAnswerIsCompatible(t *testing.T) {
+	got := Classify(expr("172", "172"), Versions{Before: "3", After: "3", BeforeKnown: true, AfterKnown: true})
+	if got.Verdict != Compatible {
+		t.Fatalf("verdict is %q, want compatible: %s", got.Verdict, got.Why)
+	}
+}
+
+// A changed answer with a moved version is the policy working: the consumer can
+// see the boundary before it misreads anything.
+func TestAChangedAnswerWithAMovedVersionIsExplicitlyBroken(t *testing.T) {
+	got := Classify(expr("172", "0"), Versions{Before: "2", After: "3", BeforeKnown: true, AfterKnown: true})
+	if got.Verdict != ExplicitlyBroken {
+		t.Fatalf("verdict is %q, want explicitly broken: %s", got.Verdict, got.Why)
+	}
+	if !strings.Contains(got.Why, "schema_version") {
+		t.Errorf("the finding does not tell the reader what to key on: %q", got.Why)
+	}
+}
+
+// The one that fails a release: the answer changed and the version did not.
+func TestAChangedAnswerWithAStillVersionIsSilentlyWrong(t *testing.T) {
+	got := Classify(expr("172", "0"), Versions{Before: "3", After: "3", BeforeKnown: true, AfterKnown: true})
+	if got.Verdict != SilentlyWrong {
+		t.Fatalf("verdict is %q, want silently wrong: %s", got.Verdict, got.Why)
+	}
+	if !strings.Contains(got.Why, "still runs") {
+		t.Errorf("the finding does not say what makes it silent: %q", got.Why)
+	}
+}
+
+// The 0.8 boundary, and the reading that decides it.
+//
+// A release that carried no schema_version gave its consumers nothing to key on,
+// so a changed answer across that boundary is silently wrong however carefully
+// the current release versions itself. The opposite reading — treating "absent"
+// as "different, therefore detectable" — would let every release before the
+// policy claim the policy's protection retroactively, which is exactly the kind
+// of comfortable answer this repository exists to refuse.
+func TestAnAbsentVersionOnTheOlderSideIsNoSignalAtAll(t *testing.T) {
+	got := Classify(expr("172", "0"), Versions{After: "3", AfterKnown: true})
+	if got.Verdict != SilentlyWrong {
+		t.Fatalf("verdict is %q, want silently wrong: %s", got.Verdict, got.Why)
+	}
+	if !strings.Contains(got.Why, "carried no schema_version") {
+		t.Errorf("the finding does not name why the consumer was defenceless: %q", got.Why)
+	}
+}
+
+// And a version that disappears is a signal, because a consumer that checked it
+// stops finding it.
+func TestAVanishedVersionIsDetectable(t *testing.T) {
+	got := Classify(expr("172", "0"), Versions{Before: "3", BeforeKnown: true})
+	if got.Verdict != ExplicitlyBroken {
+		t.Fatalf("verdict is %q, want explicitly broken: %s", got.Verdict, got.Why)
+	}
+}
+
+// The gate refuses a silently-wrong finding and lets an accepted one through,
+// both halves asserted: a gate that refuses everything is as useless as one that
+// refuses nothing.
+func TestTheGateFailsOnSilentlyWrongUnlessItIsAccepted(t *testing.T) {
+	findings := []Finding{
+		{Expression: Expression{Name: "probed count"}, Verdict: SilentlyWrong},
+		{Expression: Expression{Name: "route count"}, Verdict: SilentlyWrong},
+		{Expression: Expression{Name: "health state"}, Verdict: Compatible},
+	}
+
+	fail, stale := Gate(findings, nil)
+	if len(fail) != 2 {
+		t.Fatalf("with nothing accepted the gate reports %d finding(s), want 2", len(fail))
+	}
+	if len(stale) != 0 {
+		t.Errorf("an empty acceptance list produced stale entries: %v", stale)
+	}
+
+	fail, stale = Gate(findings, []Accepted{
+		{Name: "probed count", Reason: "0.8 shipped before schema_version existed"},
+		{Name: "route count", Reason: "same boundary"},
+	})
+	if len(fail) != 0 {
+		t.Errorf("the gate still fails on accepted findings: %v", fail)
+	}
+	if len(stale) != 0 {
+		t.Errorf("entries that matched were reported stale: %v", stale)
+	}
+}
+
+// A stale exemption is reported, because an acceptance that no longer matches
+// anything is a gate quietly ceasing to cover what it names — the same defect as
+// a frozen fixture nobody regenerates.
+func TestAnAcceptanceThatMatchesNothingIsReported(t *testing.T) {
+	findings := []Finding{{Expression: Expression{Name: "probed count"}, Verdict: Compatible}}
+	_, stale := Gate(findings, []Accepted{{Name: "probed count", Reason: "fixed since"}})
+	if len(stale) != 1 || stale[0] != "probed count" {
+		t.Fatalf("a stale acceptance was not reported: %v", stale)
+	}
+}

--- a/mise.toml
+++ b/mise.toml
@@ -179,6 +179,17 @@ run = "tools/conformance/outscale/oapi-cli.sh http://$FEINT_ADDR"
 description = "shellcheck every script in the repository"
 run = "git ls-files -z '*.sh' | xargs -0 shellcheck --severity=style"
 
+[tasks."compat:check"]
+description = "Run an older release's consumer expressions against this one, and refuse a silently-wrong verdict"
+# The consumer half of the versioning policy (#170). #132 froze the shapes and
+# made a change fail CI unless schema_version moves; nothing took something a
+# user could legitimately have written against an older release and ran it
+# against this one.
+#
+# Offline: it builds the older binary out of the repository's own history. Exit 1
+# on a silently-wrong expression that is not recorded in tools/compat/accepted.json.
+run = "bash --noprofile --norc tools/compat/compat.sh"
+
 [tasks."release:check"]
 description = "Everything that must be true before a tag exists: mise run release:check -- v0.1.0"
 depends = ["build"]

--- a/tools/compat/accepted.json
+++ b/tools/compat/accepted.json
@@ -1,0 +1,24 @@
+{
+  "comment": [
+    "Silently-wrong findings the project records rather than fixes, each with the",
+    "reason. Recorded and still printed, never hidden (#170).",
+    "",
+    "The 0.8 boundary is made of these and it is the one boundary that cannot be",
+    "fixed retroactively: schema_version arrived with #132, after 0.8 shipped, so",
+    "no consumer of that release could have keyed on a signal that did not exist.",
+    "The policy protects from 0.9 onward, and RELEASING.md says so.",
+    "",
+    "An entry that matches nothing fails the gate: a stale exemption is a gate",
+    "that quietly stopped covering what it names."
+  ],
+  "accepted": [
+    {
+      "name": "probed operations, compared to true",
+      "reason": "the 0.8 boundary, and it cannot be fixed retroactively: probed was a boolean and is now one of response/refusal/none (#156), and 0.8 shipped before schema_version existed (#132), so no consumer of that release could have keyed on a signal that was not there. Recorded here and still printed. The policy protects from 0.9 onward."
+    },
+    {
+      "name": "probed operations, read as truthy",
+      "reason": "same boundary, and the worse half: every operation now reads as probed, including refusals and the never-probed, which is the exact overstatement #156 existed to remove, reappearing in somebody else's pipeline. Named in the release notes rather than hidden behind a green gate."
+    }
+  ]
+}

--- a/tools/compat/classify/main.go
+++ b/tools/compat/classify/main.go
@@ -1,0 +1,155 @@
+// Command classify turns the two payloads compat.sh produced into verdicts.
+//
+// It is a thin front for internal/compat, which holds the judgement and its
+// tests: a classifier written inline in a shell script is a classifier nothing
+// can falsify, and this repository has already paid for controls that could not
+// be shown to bite.
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/stephrobert/feint/internal/compat"
+)
+
+type resultLine struct {
+	Name    string `json:"name"`
+	Surface string `json:"surface"`
+	Source  string `json:"source"`
+	Means   string `json:"means"`
+	Before  string `json:"before"`
+	After   string `json:"after"`
+}
+
+type versionLine struct {
+	Surface     string `json:"surface"`
+	Before      string `json:"before"`
+	After       string `json:"after"`
+	BeforeKnown bool   `json:"beforeKnown"`
+	AfterKnown  bool   `json:"afterKnown"`
+}
+
+func readLines[T any](path string) ([]T, error) {
+	file, err := os.Open(path) //nolint:gosec // a path this tool was handed
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = file.Close() }()
+
+	var out []T
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		if len(scanner.Bytes()) == 0 {
+			continue
+		}
+		var item T
+		if err := json.Unmarshal(scanner.Bytes(), &item); err != nil {
+			return nil, err
+		}
+		out = append(out, item)
+	}
+	return out, scanner.Err()
+}
+
+func main() {
+	if len(os.Args) != 4 {
+		fmt.Fprintln(os.Stderr, "usage: classify <results.json> <versions.json> <accepted.json>")
+		os.Exit(1)
+	}
+
+	results, err := readLines[resultLine](os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "read the results: %v\n", err)
+		os.Exit(1)
+	}
+	versionLines, err := readLines[versionLine](os.Args[2])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "read the versions: %v\n", err)
+		os.Exit(1)
+	}
+	// A run that measured nothing must not report success: an empty expression
+	// list is the shape a broken harness takes, and it looks exactly like a clean
+	// comparison.
+	if len(results) == 0 {
+		fmt.Fprintln(os.Stderr, "FAIL: no expression was evaluated, so this run measured nothing")
+		os.Exit(1)
+	}
+
+	var accepted []compat.Accepted
+	if raw, err := os.ReadFile(os.Args[3]); err == nil { //nolint:gosec // a path this tool was handed
+		var file struct {
+			Accepted []compat.Accepted `json:"accepted"`
+		}
+		if err := json.Unmarshal(raw, &file); err != nil {
+			fmt.Fprintf(os.Stderr, "read the accepted list: %v\n", err)
+			os.Exit(1)
+		}
+		accepted = file.Accepted
+	}
+
+	versions := map[string]compat.Versions{}
+	for _, line := range versionLines {
+		versions[line.Surface] = compat.Versions{
+			Before:      line.Before,
+			After:       line.After,
+			BeforeKnown: line.BeforeKnown,
+			AfterKnown:  line.AfterKnown,
+		}
+	}
+
+	exprs := make([]compat.Expression, 0, len(results))
+	for _, r := range results {
+		exprs = append(exprs, compat.Expression{
+			Name: r.Name, Surface: r.Surface, Source: r.Source,
+			Means: r.Means, Before: r.Before, After: r.After,
+		})
+	}
+
+	findings := compat.ClassifyAll(exprs, versions)
+	sort.SliceStable(findings, func(i, j int) bool {
+		return rank(findings[i].Verdict) < rank(findings[j].Verdict)
+	})
+
+	counts := map[compat.Verdict]int{}
+	for _, finding := range findings {
+		counts[finding.Verdict]++
+		fmt.Printf("  %-18s %s\n", finding.Verdict, finding.Name)
+		if finding.Verdict != compat.Compatible {
+			fmt.Printf("      %s\n", finding.Source)
+			fmt.Printf("      meant: %s\n", finding.Means)
+			fmt.Printf("      %s\n", finding.Why)
+		}
+	}
+
+	fmt.Printf("\n%d compatible, %d explicitly broken, %d silently wrong\n",
+		counts[compat.Compatible], counts[compat.ExplicitlyBroken], counts[compat.SilentlyWrong])
+
+	fail, stale := compat.Gate(findings, accepted)
+	for _, name := range stale {
+		fmt.Fprintf(os.Stderr, "FAIL: %q is accepted and matched nothing; a stale exemption is a "+
+			"gate that stopped covering what it names\n", name)
+	}
+	for _, finding := range fail {
+		fmt.Fprintf(os.Stderr, "FAIL: %s is silently wrong and is not accepted\n", finding.Name)
+	}
+	if len(fail) > 0 || len(stale) > 0 {
+		os.Exit(1)
+	}
+	fmt.Println("no unaccepted silently-wrong expression: this release may be tagged")
+}
+
+func rank(v compat.Verdict) int {
+	switch v {
+	case compat.SilentlyWrong:
+		return 0
+	case compat.ExplicitlyBroken:
+		return 1
+	default:
+		return 2
+	}
+}

--- a/tools/compat/compat.sh
+++ b/tools/compat/compat.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Run an older release's consumer expressions against this one, and say which
+# bucket each lands in (#170).
+#
+#   bash --noprofile --norc tools/compat/compat.sh [ref]
+#
+# ref defaults to the latest tag. Offline throughout: it builds the older binary
+# from the repository's own history, starts both on loopback, seeds them
+# identically with the protocol probe, and evaluates every expression on both.
+#
+# The classification lives in internal/compat, in Go, so it is unit-tested and
+# falsifiable; this script's job is to produce the two payloads honestly. What it
+# must never do is read the frozen fixtures — a harness that only knows the shapes
+# we already froze agrees with itself.
+#
+# Exit 0 when nothing is silently wrong beyond the accepted list, 1 otherwise.
+set -uo pipefail
+
+cd "$(dirname "$0")/../.." || exit 1
+WORK="$(mktemp -d)"
+OLD_PORT=4801
+NEW_PORT=4802
+trap 'kill %1 %2 2>/dev/null; git worktree remove --force "$WORK/old" 2>/dev/null; rm -rf "$WORK"' EXIT
+
+REF="${1:-$(git describe --tags --abbrev=0)}"
+echo "comparing $REF with the working tree"
+
+for tool in jq go git; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "FAIL: $tool is required" >&2; exit 1; }
+done
+
+echo "- building both binaries"
+git worktree add -q --detach "$WORK/old" "$REF" || { echo "FAIL: cannot check out $REF" >&2; exit 1; }
+(cd "$WORK/old" && go build -o "$WORK/feint-old" ./cmd/feint) \
+  || { echo "FAIL: $REF does not build" >&2; exit 1; }
+go build -o "$WORK/feint-new" ./cmd/feint || { echo "FAIL: the working tree does not build" >&2; exit 1; }
+
+echo "- starting both, and seeding them the same way"
+"$WORK/feint-old" serve --addr "127.0.0.1:$OLD_PORT" >"$WORK/old.log" 2>&1 &
+"$WORK/feint-new" serve --addr "127.0.0.1:$NEW_PORT" >"$WORK/new.log" 2>&1 &
+for port in "$OLD_PORT" "$NEW_PORT"; do
+  ready=""
+  for _ in $(seq 1 40); do
+    curl -sf "http://127.0.0.1:$port/_feint/health" >/dev/null 2>&1 && { ready=yes; break; }
+    sleep 0.5
+  done
+  [ -n "$ready" ] || { echo "FAIL: nothing answered on $port" >&2; exit 1; }
+done
+
+# Seeded identically, because an expression that counts evidence measures nothing
+# against an emulator nobody drove. The probe is the only seed both releases have
+# in common — a conformance suite would need clients this script must not require.
+"$WORK/feint-old" probe --endpoint "http://127.0.0.1:$OLD_PORT" >/dev/null 2>&1 || true
+"$WORK/feint-new" probe --endpoint "http://127.0.0.1:$NEW_PORT" >/dev/null 2>&1 || true
+
+for surface in health routes conformance trace; do
+  curl -s "http://127.0.0.1:$OLD_PORT/_feint/$surface" >"$WORK/old-$surface.json" 2>/dev/null
+  curl -s "http://127.0.0.1:$NEW_PORT/_feint/$surface" >"$WORK/new-$surface.json" 2>/dev/null
+done
+
+echo "- evaluating the consumer's expressions on both"
+: >"$WORK/results.json"
+# A selector is reduced to what it still discriminates rather than to how many
+# it matched. none/some/all is invariant to the emulator growing, which a count
+# is not — the first draft of this harness reported a finding purely because 24
+# operations had been added since the older release.
+signature() { # payload expr kind population
+  local payload=$1 expr=$2 kind=$3 population=$4 value total
+  value="$(jq -c "$expr" "$payload" 2>/dev/null)" || { echo '<error>'; return; }
+  [ -n "$value" ] || { echo '<error>'; return; }
+  if [ "$kind" != "selector" ]; then
+    printf '%s\n' "$value"
+    return
+  fi
+  total="$(jq -c "$population" "$payload" 2>/dev/null)" || { echo '<error>'; return; }
+  case "$total" in
+  ''|0) echo '<empty population>' ;;
+  *)
+    if [ "$value" = "0" ]; then echo none
+    elif [ "$value" = "$total" ]; then echo all
+    else echo some
+    fi
+    ;;
+  esac
+}
+
+jq -c '.expressions[]' tools/compat/consumer.json | while read -r entry; do
+  name="$(printf '%s' "$entry" | jq -r '.name')"
+  surface="$(printf '%s' "$entry" | jq -r '.surface')"
+  expr="$(printf '%s' "$entry" | jq -r '.expr')"
+  means="$(printf '%s' "$entry" | jq -r '.means')"
+  kind="$(printf '%s' "$entry" | jq -r '.kind')"
+  population="$(printf '%s' "$entry" | jq -r '.population // ""')"
+
+  before="$(signature "$WORK/old-$surface.json" "$expr" "$kind" "$population")"
+  after="$(signature "$WORK/new-$surface.json" "$expr" "$kind" "$population")"
+
+  jq -nc --arg n "$name" --arg s "$surface" --arg e "$expr" --arg m "$means" \
+        --arg b "$before" --arg a "$after" \
+    '{name:$n, surface:$s, source:$e, means:$m, before:$b, after:$a}' >>"$WORK/results.json"
+done
+
+# The version of each surface on each side. Absent is not zero: schema_version
+# did not exist before #132, and a release that carried none gave its consumers
+# nothing to key on.
+: >"$WORK/versions.json"
+for surface in health routes conformance trace; do
+  bv="$(jq -r 'if has("schema_version") then (.schema_version|tostring) else "" end' "$WORK/old-$surface.json" 2>/dev/null)"
+  av="$(jq -r 'if has("schema_version") then (.schema_version|tostring) else "" end' "$WORK/new-$surface.json" 2>/dev/null)"
+  jq -nc --arg s "$surface" --arg b "$bv" --arg a "$av" \
+    '{surface:$s, before:$b, after:$a, beforeKnown:($b != ""), afterKnown:($a != "")}' \
+    >>"$WORK/versions.json"
+done
+
+echo
+go run ./tools/compat/classify "$WORK/results.json" "$WORK/versions.json" tools/compat/accepted.json

--- a/tools/compat/consumer.json
+++ b/tools/compat/consumer.json
@@ -1,0 +1,97 @@
+{
+  "comment": [
+    "What a consumer could legitimately have written against an older release,",
+    "taken from the README and docs/ as a user reads them rather than from the",
+    "frozen fixtures — a harness that only knows the shapes we already froze",
+    "agrees with itself (#170).",
+    "",
+    "Nothing here compares a count, and that is a hard rule rather than a style:",
+    "a count goes red the week somebody mounts a route, and a gate that reddens",
+    "for the wrong reason is disarmed within the week. The first draft of this",
+    "file did compare counts, and reported 'operations with no evidence' as",
+    "silently wrong purely because the emulator had grown by 24 operations.",
+    "",
+    "A selector is therefore reduced to what it still discriminates — none, some",
+    "or all of its population — which is invariant to growth and is exactly what",
+    "the consumer's intent was. A scalar is compared as it stands."
+  ],
+  "expressions": [
+    {
+      "name": "probed operations, compared to true",
+      "surface": "conformance",
+      "kind": "selector",
+      "means": "the operations the protocol probe drove",
+      "expr": "[.evidence[] | select(.probed == true)] | length",
+      "population": ".evidence | length"
+    },
+    {
+      "name": "probed operations, read as truthy",
+      "surface": "conformance",
+      "kind": "selector",
+      "means": "the operations the protocol probe drove",
+      "expr": "[.evidence[] | select(.probed)] | length",
+      "population": ".evidence | length"
+    },
+    {
+      "name": "operations a real client drove",
+      "surface": "conformance",
+      "kind": "selector",
+      "means": "the driven axis, the one the score is built from",
+      "expr": "[.evidence[] | select(.driven)] | length",
+      "population": ".evidence | length"
+    },
+    {
+      "name": "operations whose contract was checked",
+      "surface": "conformance",
+      "kind": "selector",
+      "means": "responses compared against their own API description",
+      "expr": "[.evidence[] | select(.contract != \"unchecked\")] | length",
+      "population": ".evidence | length"
+    },
+    {
+      "name": "operations with a shape observed",
+      "surface": "conformance",
+      "kind": "selector",
+      "means": "the shape axis, read as a field that is not the unobserved marker",
+      "expr": "[.evidence[] | select(.shape != \"unobserved\")] | length",
+      "population": ".evidence | length"
+    },
+    {
+      "name": "contract violations",
+      "surface": "conformance",
+      "kind": "scalar",
+      "means": "whether any response failed its own API description",
+      "expr": "(.violations | length) > 0"
+    },
+    {
+      "name": "routes that declare no upstream operation",
+      "surface": "routes",
+      "kind": "selector",
+      "means": "the coverage blind spot rule 2 forbids",
+      "expr": "[.routes[] | select(.operation == null or .operation == \"\")] | length",
+      "population": ".routes | length"
+    },
+    {
+      "name": "routes carry a method and a path",
+      "surface": "routes",
+      "kind": "selector",
+      "means": "the two fields a client needs to call anything",
+      "expr": "[.routes[] | select(.method != null and .path != null)] | length",
+      "population": ".routes | length"
+    },
+    {
+      "name": "the emulator is up",
+      "surface": "health",
+      "kind": "scalar",
+      "means": "the readiness check a script waits on",
+      "expr": ".status"
+    },
+    {
+      "name": "providers mounted",
+      "surface": "health",
+      "kind": "scalar",
+      "means": "which clouds this instance answers for",
+      "expr": "[.providers[]? // empty] | sort | join(\",\")"
+    }
+  ]
+}

--- a/tools/falsify/specs/consumer-half-of-the-policy.json
+++ b/tools/falsify/specs/consumer-half-of-the-policy.json
@@ -1,0 +1,33 @@
+{
+  "package": "./internal/compat/",
+  "mutations": [
+    {
+      "label": "a changed answer with no version bump is called compatible",
+      "file": "internal/compat/compat.go",
+      "find": "\tcase expr.Before == expr.After:",
+      "replace": "\tcase expr.Before == expr.After || true:",
+      "test": "TestAChangedAnswerWithAStillVersionIsSilentlyWrong"
+    },
+    {
+      "label": "an absent version on the older side is read as a signal the consumer had",
+      "file": "internal/compat/compat.go",
+      "find": "\tif !v.BeforeKnown {\n\t\treturn false\n\t}",
+      "replace": "\tif !v.BeforeKnown {\n\t\treturn true\n\t}",
+      "test": "TestAnAbsentVersionOnTheOlderSideIsNoSignalAtAll"
+    },
+    {
+      "label": "the gate lets a silently-wrong finding through",
+      "file": "internal/compat/compat.go",
+      "find": "\t\tif finding.Verdict != SilentlyWrong {\n\t\t\tcontinue\n\t\t}",
+      "replace": "\t\tif finding.Verdict != SilentlyWrong || true {\n\t\t\tcontinue\n\t\t}",
+      "test": "TestTheGateFailsOnSilentlyWrongUnlessItIsAccepted"
+    },
+    {
+      "label": "a stale acceptance is no longer reported",
+      "file": "internal/compat/compat.go",
+      "find": "\t\tif !matched[entry.Name] {\n\t\t\tstale = append(stale, entry.Name)\n\t\t}",
+      "replace": "\t\tif !matched[entry.Name] && false {\n\t\t\tstale = append(stale, entry.Name)\n\t\t}",
+      "test": "TestAnAcceptanceThatMatchesNothingIsReported"
+    }
+  ]
+}

--- a/tools/release/preflight.sh
+++ b/tools/release/preflight.sh
@@ -89,6 +89,22 @@ case $? in
   *) ko "docs --check could not run" "build the binary: mise run build" ;;
 esac
 
+# The consumer half of the versioning policy (#170). #132 made a shape change
+# fail CI unless schema_version moves, which is the producer's half; this takes
+# expressions a user could legitimately have written against the last release and
+# runs them against this one.
+#
+# A single silently-wrong verdict refuses the tag. Not because a shape may not
+# change — it may, that is what the version is for — but because a change that
+# runs, answers, and answers something false, with nothing in the payload for the
+# consumer to notice, is the one outcome a version cannot repair after the fact.
+if mise run compat:check >/dev/null 2>&1; then
+  ok "no consumer expression is silently wrong against the last release"
+else
+  ko "a consumer expression is silently wrong" \
+     "mise run compat:check — bump the surface's schema_version, or record the finding in tools/compat/accepted.json with its reason"
+fi
+
 # --- the number the commits imply -------------------------------------------
 #
 # The version is not a preference. Conventional Commits say what the increment


### PR DESCRIPTION
Closes #170.

#132 froze the shapes of the `/_feint` surfaces and made a change fail CI unless
`schema_version` moves with it. That is the **producer's** half, and it works.
Nothing took an expression a user could legitimately have written against an
older release and ran it against this one.

`mise run compat:check` does. It builds the previous release **out of this
repository's own history**, starts both binaries offline, seeds them identically
with the protocol probe, and places every expression in exactly one bucket.

## What it found

| the consumer wrote | 0.8 | 0.9 | verdict |
|---|---|---|---|
| `select(.probed == true)` | some operations | **none** | silently wrong |
| `select(.probed)` | some operations | **all of them** | silently wrong |

The second is the worse one: every operation now reads as probed, **refusals
included** — the exact overstatement #156 existed to remove, reappearing in
somebody else's pipeline. Neither errors. Neither warns.

Eight other expressions are compatible.

## The finding the issue asked to be reported rather than hidden

They land in *silently wrong* and not in *explicitly broken*, and that is not an
oversight: **`schema_version` arrived with #132, after 0.8 shipped.** A consumer
of that release could not have checked a signal that did not exist.

So the classifier reads an absent version as **no signal**, never as a change.
The opposite reading would let every release before the policy claim the policy's
protection retroactively — and it is a one-line difference in a comparison, which
is why it has its own test and its own falsification.

Both are recorded in `tools/compat/accepted.json` with that reason, **still
printed on every run**, and named in `RELEASING.md`. The gate is about what
happens next: from 0.9 on, a shape change either moves the version or refuses the
tag, and `tools/release/preflight.sh` enforces it.

## Not on a count — and the first draft got that wrong

The issue warned that a harness keyed on counts reddens the week a route is
mounted and is disarmed within the week. **The first draft compared counts** and
reported *operations with no evidence* as silently wrong purely because the
emulator had grown by 24 operations.

A selector is now reduced to what it still discriminates — `none` / `some` /
`all` of its population — which is invariant to growth and is what the consumer's
intent actually was.

## Where the judgement lives

In Go, in `internal/compat`, because a classifier written inline in a shell script
is a classifier nothing can falsify. The script's job is to produce the two
payloads honestly, and it reads **no frozen fixture**: a harness that only knows
the shapes we already froze agrees with itself.

## Measured

| | |
|---|---|
| `mise run prepush` (shellcheck included) | green |
| `mise run compat:check` | **exit 0**, the two findings printed |
| `mise run conformance` | **exit 0**, 74 checks, 0 FAIL |
| `mise run falsify -- specs/consumer-half-of-the-policy.json` | 4 mutations, all bite |

Including the one the issue asked for by name: a changed answer with no version
bump must report *silently wrong* rather than *compatible*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
