### PR TITLE
fix(outscale): a route reaches a peering, a NIC keeps its tags (#249, #250)

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -354,6 +354,20 @@ jobs:
         if: matrix.client == 'terraform' || matrix.client == 'opentofu' || matrix.client == 'fields'
         run: tools/conformance/outscale/terraform.sh http://127.0.0.1:4599
 
+      # The example stacks, which are examples and tests at once. They are
+      # written the way a platform team writes Terraform rather than the way a
+      # fixture is written, and that difference is measured rather than claimed:
+      # within an hour of the first one being applied, two defects surfaced that
+      # every gate here was blind to — a route that could not point at a Net
+      # peering (#249), and a tagged NIC that read back without its tags (#250).
+      #
+      # They run on the terraform and opentofu legs rather than on `fields`: the
+      # omission gate's verdict is about a whole run, and a stack applying a
+      # thousand resources tells it nothing a suite does not.
+      - name: Apply the example stacks
+        if: matrix.client == 'terraform' || matrix.client == 'opentofu'
+        run: tools/conformance/stacks.sh http://127.0.0.1:4599
+
       # No client at all: every route driven from its provider's own API
       # description, which is the half of conformance that needs nothing
       # installed. It proves the protocol and never touches the score.

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,8 +7,13 @@ lets a real client start against values that mean nothing.
 
 | File | What it gives you |
 |---|---|
+| [`stacks/`](stacks/) | **two complete platform stacks** — multi-VPC, multi-machine, golden images, block storage — applied against Feint on every pull request |
 | [`github-actions/terraform.yml`](github-actions/terraform.yml) | a GitHub Actions job that applies your Terraform, re-plans to prove the emulator read back what it was sent, and destroys |
 | [`gitlab-ci/.gitlab-ci.yml`](gitlab-ci/.gitlab-ci.yml) | the same pipeline for GitLab CI, with the emulator as a service |
+
+If you want to see Feint hold up under something that looks like production
+rather than under a snippet, start with [`stacks/`](stacks/). They are examples
+and tests at once, and they have already found two defects nothing else saw.
 
 There is a third way, for a job that does not already run in containers or one
 that wants real machines behind `--vm` on a host with Incus:

--- a/examples/stacks/README.md
+++ b/examples/stacks/README.md
@@ -1,0 +1,55 @@
+# Two platform stacks, applied on every pull request
+
+These are not snippets. Each one is the shape a platform team ends up with, and
+each runs against Feint in CI — apply, an empty second plan, destroy — with no
+cloud account and nothing billed.
+
+```bash
+feint start
+cd examples/stacks/scaleway && terraform init && terraform apply
+```
+
+| Stack | What it carries |
+|---|---|
+| [`scaleway/`](scaleway/main.tf) | two VPCs, three private networks and a route between them, three security groups, a bastion, a web tier with IPAM-booked addresses, an application tier with no public address, a golden image cut from a snapshot, block-storage volumes with their own snapshots, cloud-init everywhere — six machines |
+| [`outscale/`](outscale/main.tf) | two Nets with a peering and the route across it, a public subnet with an internet service and a route table, a private subnet, a shared-services Net, a standalone NIC, per-tier security groups, public IPs linked to Vms, a volume attached to a machine, an image from a snapshot |
+
+## Why they exist, and it is not decoration
+
+`tools/conformance/*/terraform/` already holds fixtures. They prove what somebody
+thought to assert. These stacks exercise **what somebody actually writes**, and
+the difference was measured rather than argued: within an hour of the first one
+being applied, two defects surfaced that every existing gate was blind to.
+
+- **[#249](https://github.com/stephrobert/feint/issues/249)** — a route could not
+  point at a Net peering, so two peered Nets stayed unreachable. The suite
+  creates peerings and asserts their state machine; it never routes through one.
+- **[#250](https://github.com/stephrobert/feint/issues/250)** — a tagged NIC read
+  back without its tags, so a Terraform plan never converged. The suite tagged
+  Nets, Vms and volumes, and never an interface.
+
+Neither was visible to a schema check. A missing route target answers a clean
+400, and a view publishing a constant empty list has exactly the shape an
+untagged NIC should have: the form was right and the fact was wrong.
+
+## The rule when you change one
+
+**Every defect a stack finds gets its resource added to the stack.** That is what
+keeps them tests rather than demonstrations, and it is the same rule the
+conformance suites obey.
+
+The assertion that does the finding is the middle one:
+
+```bash
+terraform plan -detailed-exitcode      # must be empty
+```
+
+An apply that succeeds proves the emulator answered. An empty second plan proves
+it read back what the provider sent.
+
+## What they do not prove
+
+Nothing here boots a machine, filters a packet or isolates a subnet: that needs
+`--vm` and a host with Incus. [`docs/confidence.md`](../../docs/confidence.md)
+says row by row what changes when you have one, keyed on the capability the
+runtime declares rather than on a mode name.

--- a/examples/stacks/outscale/main.tf
+++ b/examples/stacks/outscale/main.tf
@@ -1,0 +1,293 @@
+# Two peered Nets on Outscale, with a public tier, a private tier and a shared
+# services Net — the shape a platform reaches when one account holds more than
+# one environment.
+#
+# Written as a real project would be, not as a fixture: an internet service and
+# a route table on the public side, a peering between the two Nets with the
+# route that makes it useful, a NIC of its own on the application machine,
+# volumes with snapshots, an image cut from one of them, and tags everywhere
+# because the provider sends them on almost every call.
+
+terraform {
+  required_version = ">= 1.7.0"
+  required_providers {
+    outscale = {
+      source  = "outscale/outscale"
+      version = "~> 1.3"
+    }
+  }
+}
+
+variable "endpoint" {
+  type    = string
+  default = "http://127.0.0.1:4599"
+}
+
+variable "web_count" {
+  type    = number
+  default = 2
+}
+
+# The endpoint carries the whole API path — their documentation gives the shape
+# `https://api.eu-west-2.outscale.com/api/v1` — so the version segment belongs to
+# the value rather than being appended by the provider. Getting it wrong is not a
+# warning: the emulator answers 404 and names the missing prefix, which is how
+# this file came to be written correctly.
+provider "outscale" {
+  access_key_id = "AAAAAAAAAAAAAAAAAAAA"
+  secret_key_id = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+
+  api {
+    endpoint = "${var.endpoint}/api/v1"
+    region   = "eu-west-2"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# The workload Net: a public subnet and a private one.
+# ---------------------------------------------------------------------------
+
+resource "outscale_net" "workload" {
+  ip_range = "10.50.0.0/16"
+
+  tags {
+    key   = "Name"
+    value = "platform-workload"
+  }
+}
+
+resource "outscale_subnet" "public" {
+  net_id   = outscale_net.workload.net_id
+  ip_range = "10.50.1.0/24"
+
+  tags {
+    key   = "Name"
+    value = "platform-public"
+  }
+}
+
+resource "outscale_subnet" "private" {
+  net_id   = outscale_net.workload.net_id
+  ip_range = "10.50.2.0/24"
+
+  tags {
+    key   = "Name"
+    value = "platform-private"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# The shared-services Net, peered with the workload one. Two Nets that must
+# reach each other is the case a single-Net example never exercises.
+# ---------------------------------------------------------------------------
+
+resource "outscale_net" "services" {
+  ip_range = "10.60.0.0/16"
+
+  tags {
+    key   = "Name"
+    value = "platform-services"
+  }
+}
+
+resource "outscale_subnet" "services" {
+  net_id   = outscale_net.services.net_id
+  ip_range = "10.60.1.0/24"
+
+  tags {
+    key   = "Name"
+    value = "platform-services"
+  }
+}
+
+resource "outscale_net_peering" "workload_to_services" {
+  accepter_net_id = outscale_net.services.net_id
+  source_net_id   = outscale_net.workload.net_id
+}
+
+resource "outscale_net_peering_acceptation" "workload_to_services" {
+  net_peering_id = outscale_net_peering.workload_to_services.net_peering_id
+}
+
+# ---------------------------------------------------------------------------
+# The public door: an internet service, a route table, and the default route.
+# ---------------------------------------------------------------------------
+
+resource "outscale_internet_service" "main" {}
+
+resource "outscale_internet_service_link" "main" {
+  internet_service_id = outscale_internet_service.main.internet_service_id
+  net_id              = outscale_net.workload.net_id
+}
+
+resource "outscale_route_table" "public" {
+  net_id = outscale_net.workload.net_id
+
+  tags {
+    key   = "Name"
+    value = "platform-public"
+  }
+}
+
+resource "outscale_route" "default" {
+  route_table_id       = outscale_route_table.public.route_table_id
+  destination_ip_range = "0.0.0.0/0"
+  gateway_id           = outscale_internet_service.main.internet_service_id
+
+  depends_on = [outscale_internet_service_link.main]
+}
+
+# The route that makes the peering useful, which is the half people forget.
+resource "outscale_route" "to_services" {
+  route_table_id       = outscale_route_table.public.route_table_id
+  destination_ip_range = "10.60.0.0/16"
+  net_peering_id       = outscale_net_peering.workload_to_services.net_peering_id
+
+  depends_on = [outscale_net_peering_acceptation.workload_to_services]
+}
+
+resource "outscale_route_table_link" "public" {
+  route_table_id = outscale_route_table.public.route_table_id
+  subnet_id      = outscale_subnet.public.subnet_id
+}
+
+# ---------------------------------------------------------------------------
+# Security groups, one per tier.
+# ---------------------------------------------------------------------------
+
+resource "outscale_security_group" "web" {
+  description         = "platform web tier"
+  security_group_name = "platform-web"
+  net_id              = outscale_net.workload.net_id
+}
+
+resource "outscale_security_group_rule" "web_https" {
+  flow              = "Inbound"
+  security_group_id = outscale_security_group.web.security_group_id
+  from_port_range   = 443
+  to_port_range     = 443
+  ip_protocol       = "tcp"
+  ip_range          = "0.0.0.0/0"
+}
+
+resource "outscale_security_group" "app" {
+  description         = "platform application tier"
+  security_group_name = "platform-app"
+  net_id              = outscale_net.workload.net_id
+}
+
+resource "outscale_security_group_rule" "app_from_web" {
+  flow              = "Inbound"
+  security_group_id = outscale_security_group.app.security_group_id
+  from_port_range   = 8080
+  to_port_range     = 8080
+  ip_protocol       = "tcp"
+  ip_range          = "10.50.1.0/24"
+}
+
+# ---------------------------------------------------------------------------
+# A golden image, from a volume and its snapshot.
+# ---------------------------------------------------------------------------
+
+resource "outscale_volume" "golden" {
+  subregion_name = "eu-west-2a"
+  size           = 10
+}
+
+resource "outscale_snapshot" "golden" {
+  volume_id = outscale_volume.golden.volume_id
+}
+
+resource "outscale_image" "golden" {
+  image_name = "platform-golden"
+
+  block_device_mappings {
+    device_name = "/dev/sda1"
+    bsu {
+      snapshot_id = outscale_snapshot.golden.snapshot_id
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# The machines.
+# ---------------------------------------------------------------------------
+
+data "outscale_images" "ubuntu" {
+  filter {
+    name   = "image_names"
+    values = ["Ubuntu-24.04-2025.01"]
+  }
+}
+
+resource "outscale_vm" "web" {
+  count = var.web_count
+
+  image_id           = data.outscale_images.ubuntu.images[0].image_id
+  vm_type            = "tinav5.c1r1p2"
+  subnet_id          = outscale_subnet.public.subnet_id
+  security_group_ids = [outscale_security_group.web.security_group_id]
+
+  tags {
+    key   = "Name"
+    value = "platform-web-${count.index}"
+  }
+}
+
+resource "outscale_public_ip" "web" {
+  count = var.web_count
+}
+
+resource "outscale_public_ip_link" "web" {
+  count = var.web_count
+
+  vm_id     = outscale_vm.web[count.index].vm_id
+  public_ip = outscale_public_ip.web[count.index].public_ip
+}
+
+resource "outscale_vm" "app" {
+  image_id           = outscale_image.golden.image_id
+  vm_type            = "tinav5.c1r1p2"
+  subnet_id          = outscale_subnet.private.subnet_id
+  security_group_ids = [outscale_security_group.app.security_group_id]
+
+  tags {
+    key   = "Name"
+    value = "platform-app"
+  }
+}
+
+# A NIC of its own on the services Net — the case that needs an interface
+# created separately rather than the one a Vm is born with.
+resource "outscale_nic" "app_services" {
+  subnet_id = outscale_subnet.services.subnet_id
+
+  tags {
+    key   = "Name"
+    value = "platform-app-services"
+  }
+}
+
+resource "outscale_volume" "app_data" {
+  subregion_name = "eu-west-2a"
+  size           = 20
+
+  tags {
+    key   = "Name"
+    value = "platform-app-data"
+  }
+}
+
+resource "outscale_volume_link" "app_data" {
+  device_name = "/dev/xvdb"
+  volume_id   = outscale_volume.app_data.volume_id
+  vm_id       = outscale_vm.app.vm_id
+}
+
+output "web_public_ips" {
+  value = outscale_public_ip.web[*].public_ip
+}
+
+output "machines" {
+  value = var.web_count + 1
+}

--- a/examples/stacks/scaleway/main.tf
+++ b/examples/stacks/scaleway/main.tf
@@ -1,0 +1,303 @@
+# A three-tier platform on Scaleway, with a separate management VPC.
+#
+# Written the way a real project is written rather than the way a test fixture
+# is: two VPCs that do not share a network, a bastion that is the only public
+# door, web and application tiers with their own security groups, data disks,
+# a golden image cut from a snapshot, block-storage volumes with their own
+# snapshots, and addresses booked from IPAM before anything carries them.
+#
+# It exists to be run against Feint with no cloud account. Everything here is
+# ordinary Terraform: if it applies, re-plans empty and destroys, the emulator
+# held up under something that looks like production rather than under a test.
+
+terraform {
+  required_version = ">= 1.7.0"
+  required_providers {
+    scaleway = {
+      source  = "scaleway/scaleway"
+      version = "~> 2.79"
+    }
+  }
+}
+
+variable "endpoint" {
+  type    = string
+  default = "http://127.0.0.1:4599"
+}
+
+variable "web_count" {
+  type    = number
+  default = 2
+}
+
+variable "app_count" {
+  type    = number
+  default = 3
+}
+
+provider "scaleway" {
+  api_url         = var.endpoint
+  access_key      = "SCWXXXXXXXXXXXXXXXXX"
+  secret_key      = "11111111-1111-1111-1111-111111111111"
+  project_id      = "11111111-1111-1111-1111-111111111111"
+  organization_id = "11111111-1111-1111-1111-111111111111"
+  region          = "fr-par"
+  zone            = "fr-par-1"
+}
+
+# ---------------------------------------------------------------------------
+# Two VPCs. The workload one and the management one, which is the shape most
+# platforms end up with and the one that makes isolation a real question.
+# ---------------------------------------------------------------------------
+
+resource "scaleway_vpc" "workload" {
+  name = "platform-workload"
+  tags = ["platform", "workload"]
+}
+
+resource "scaleway_vpc" "management" {
+  name = "platform-management"
+  tags = ["platform", "management"]
+}
+
+resource "scaleway_vpc_private_network" "web" {
+  name   = "platform-web"
+  vpc_id = scaleway_vpc.workload.id
+  ipv4_subnet {
+    subnet = "10.30.1.0/24"
+  }
+}
+
+resource "scaleway_vpc_private_network" "app" {
+  name   = "platform-app"
+  vpc_id = scaleway_vpc.workload.id
+  ipv4_subnet {
+    subnet = "10.30.2.0/24"
+  }
+}
+
+resource "scaleway_vpc_private_network" "admin" {
+  name   = "platform-admin"
+  vpc_id = scaleway_vpc.management.id
+  ipv4_subnet {
+    subnet = "10.40.1.0/24"
+  }
+}
+
+# A route a platform team really writes: reach the management range through the
+# admin network.
+resource "scaleway_vpc_route" "to_management" {
+  vpc_id                     = scaleway_vpc.workload.id
+  description                = "management range"
+  destination                = "10.40.0.0/16"
+  nexthop_private_network_id = scaleway_vpc_private_network.app.id
+}
+
+# ---------------------------------------------------------------------------
+# Security groups, one per tier, each opening only what that tier needs.
+# ---------------------------------------------------------------------------
+
+resource "scaleway_instance_security_group" "bastion" {
+  name                    = "platform-bastion"
+  inbound_default_policy  = "drop"
+  outbound_default_policy = "accept"
+
+  inbound_rule {
+    action = "accept"
+    port   = 22
+  }
+}
+
+resource "scaleway_instance_security_group" "web" {
+  name                    = "platform-web"
+  inbound_default_policy  = "drop"
+  outbound_default_policy = "accept"
+
+  inbound_rule {
+    action = "accept"
+    port   = 443
+  }
+
+  inbound_rule {
+    action   = "accept"
+    port     = 22
+    ip_range = "10.40.1.0/24"
+  }
+}
+
+resource "scaleway_instance_security_group" "app" {
+  name                    = "platform-app"
+  inbound_default_policy  = "drop"
+  outbound_default_policy = "accept"
+
+  inbound_rule {
+    action   = "accept"
+    port     = 8080
+    ip_range = "10.30.1.0/24"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# A golden image: a volume, a snapshot of it, an image cut from the snapshot.
+# This is the sequence a platform builds once and boots from everywhere, and it
+# is where an emulator that stores a snapshot without a parent falls over.
+# ---------------------------------------------------------------------------
+
+resource "scaleway_instance_volume" "golden" {
+  name       = "platform-golden-src"
+  type       = "b_ssd"
+  size_in_gb = 10
+}
+
+resource "scaleway_instance_snapshot" "golden" {
+  name      = "platform-golden-snap"
+  volume_id = scaleway_instance_volume.golden.id
+}
+
+resource "scaleway_instance_image" "golden" {
+  name           = "platform-golden"
+  root_volume_id = scaleway_instance_snapshot.golden.id
+  architecture   = "x86_64"
+}
+
+# ---------------------------------------------------------------------------
+# The bastion: the only machine with a public address.
+# ---------------------------------------------------------------------------
+
+resource "scaleway_instance_ip" "bastion" {}
+
+resource "scaleway_instance_server" "bastion" {
+  name              = "platform-bastion"
+  type              = "DEV1-S"
+  image             = "ubuntu_jammy"
+  ip_id             = scaleway_instance_ip.bastion.id
+  security_group_id = scaleway_instance_security_group.bastion.id
+  tags              = ["platform", "bastion"]
+
+  cloud_init = <<-EOT
+    #cloud-config
+    package_update: true
+    packages:
+      - fail2ban
+  EOT
+}
+
+resource "scaleway_instance_private_nic" "bastion" {
+  server_id          = scaleway_instance_server.bastion.id
+  private_network_id = scaleway_vpc_private_network.admin.id
+}
+
+# ---------------------------------------------------------------------------
+# The web tier: addresses booked from IPAM before the NICs carry them, which is
+# what a platform does when it wants stable addresses rather than whatever the
+# cloud hands out.
+# ---------------------------------------------------------------------------
+
+resource "scaleway_ipam_ip" "web" {
+  count   = var.web_count
+  address = "10.30.1.${10 + count.index}"
+
+  source {
+    private_network_id = scaleway_vpc_private_network.web.id
+  }
+
+  tags = ["platform", "web"]
+}
+
+resource "scaleway_instance_volume" "web_data" {
+  count      = var.web_count
+  name       = "platform-web-data-${count.index}"
+  type       = "b_ssd"
+  size_in_gb = 10
+}
+
+resource "scaleway_instance_ip" "web" {
+  count = var.web_count
+}
+
+resource "scaleway_instance_server" "web" {
+  count = var.web_count
+
+  name                  = "platform-web-${count.index}"
+  type                  = "DEV1-S"
+  image                 = scaleway_instance_image.golden.id
+  ip_id                 = scaleway_instance_ip.web[count.index].id
+  security_group_id     = scaleway_instance_security_group.web.id
+  additional_volume_ids = [scaleway_instance_volume.web_data[count.index].id]
+  tags                  = ["platform", "web"]
+
+  cloud_init = <<-EOT
+    #cloud-config
+    package_update: true
+    packages:
+      - nginx
+  EOT
+}
+
+resource "scaleway_instance_private_nic" "web" {
+  count = var.web_count
+
+  server_id          = scaleway_instance_server.web[count.index].id
+  private_network_id = scaleway_vpc_private_network.web.id
+  ipam_ip_ids        = [scaleway_ipam_ip.web[count.index].id]
+}
+
+# ---------------------------------------------------------------------------
+# The application tier: no public address at all, and block-storage volumes
+# rather than instance ones, which is the other volume product and a different
+# API entirely.
+# ---------------------------------------------------------------------------
+
+resource "scaleway_block_volume" "app_data" {
+  count      = var.app_count
+  name       = "platform-app-data-${count.index}"
+  iops       = 5000
+  size_in_gb = 20
+  tags       = ["platform", "app"]
+}
+
+resource "scaleway_block_snapshot" "app_data" {
+  count     = var.app_count
+  name      = "platform-app-snap-${count.index}"
+  volume_id = scaleway_block_volume.app_data[count.index].id
+  tags      = ["platform", "app"]
+}
+
+resource "scaleway_instance_server" "app" {
+  count = var.app_count
+
+  name              = "platform-app-${count.index}"
+  type              = "DEV1-S"
+  image             = "ubuntu_jammy"
+  security_group_id = scaleway_instance_security_group.app.id
+  tags              = ["platform", "app"]
+
+  # No ip_id at all: this tier is unreachable from outside, which is the point.
+}
+
+resource "scaleway_instance_private_nic" "app" {
+  count = var.app_count
+
+  server_id          = scaleway_instance_server.app[count.index].id
+  private_network_id = scaleway_vpc_private_network.app.id
+}
+
+# ---------------------------------------------------------------------------
+# What a reader would check afterwards.
+# ---------------------------------------------------------------------------
+
+output "bastion_ip" {
+  value = scaleway_instance_ip.bastion.address
+}
+
+output "web_addresses" {
+  value = scaleway_ipam_ip.web[*].address
+}
+
+output "golden_image_id" {
+  value = scaleway_instance_image.golden.id
+}
+
+output "machines" {
+  value = length(scaleway_instance_server.web) + length(scaleway_instance_server.app) + 1
+}

--- a/internal/providers/outscale/nics.go
+++ b/internal/providers/outscale/nics.go
@@ -214,7 +214,13 @@ func (p *Pack) storedNicView(nic *resource.Resource) map[string]any {
 		// nothing changed — a write the API accepted and never showed.
 		"PrivateIps":     privateIPEntries(nic, dns, privateIP),
 		"SecurityGroups": groups,
-		"Tags":           []any{},
+		// The NIC's own tags, not a constant. This published `[]` whatever the
+		// NIC carried, so `CreateTags` on an interface answered 200 and
+		// `ReadNics` denied it — and a Terraform configuration tagging a NIC
+		// planned the same change on every run, for ever. Found by applying a
+		// realistic stack rather than by a test: the conformance suite tags Nets,
+		// Vms and volumes, and never tagged an interface.
+		"Tags": tagsOrEmpty(nic),
 	}
 	// The link appears only when attached, in the measured shape: DeviceNumber
 	// from 1 (0 is the derived primary), VmAccountId the account's own.
@@ -293,6 +299,10 @@ func (p *Pack) createNic(w http.ResponseWriter, r *http.Request) {
 		"PrivateIp":   place.Address.String(),
 		"Description": req.Description,
 		"State":       "available",
+		// Present and empty from the start, like every other taggable resource
+		// here: CreateTags writes this key, and a NIC created without it made
+		// the first tag land on a resource whose view published a constant.
+		"Tags": []any{},
 	}
 	if len(req.SecurityGroupIDs) > 0 {
 		nic.Attrs["SecurityGroupIds"] = req.SecurityGroupIDs

--- a/internal/providers/outscale/routetables.go
+++ b/internal/providers/outscale/routetables.go
@@ -341,9 +341,14 @@ type routeRequest struct {
 	DestinationIPRange string `json:"DestinationIpRange"`
 	GatewayID          string `json:"GatewayId"`
 	NatServiceID       string `json:"NatServiceId"`
-	NicID              string `json:"NicId"`
-	VMID               string `json:"VmId"`
-	DryRun             *bool  `json:"DryRun"`
+	// A route whose next hop is the other side of a peering. Declared by their
+	// SDK's CreateRouteRequest and refused here until a realistic configuration
+	// asked for it: two peered Nets are useless without the route that points at
+	// the peering, and the Terraform provider sends exactly this.
+	NetPeeringID string `json:"NetPeeringId"`
+	NicID        string `json:"NicId"`
+	VMID         string `json:"VmId"`
+	DryRun       *bool  `json:"DryRun"`
 }
 
 // routeTarget validates whichever target the request names and returns the key
@@ -374,6 +379,22 @@ func (p *Pack) routeTarget(w http.ResponseWriter, req *routeRequest, netID strin
 			return "", "", false
 		}
 		return "NatServiceId", req.NatServiceID, true
+	case req.NetPeeringID != "":
+		peering, found := p.env.Store.Get(Name, kindNetPeering, req.NetPeeringID)
+		if !found {
+			p.notFound(w, "Net peering", req.NetPeeringID)
+			return "", "", false
+		}
+		// The table's Net has to be one of the peering's two ends. A route
+		// through somebody else's peering is the mistake this checks for, and
+		// it is the same shape as the gateway check above.
+		source := stringOf(peering.Attrs["SourceNetId"])
+		accepter := stringOf(peering.Attrs["AccepterNetId"])
+		if netID != source && netID != accepter {
+			p.badRequest(w, "the Net peering "+req.NetPeeringID+" does not have "+netID+" at either end")
+			return "", "", false
+		}
+		return "NetPeeringId", req.NetPeeringID, true
 	case req.NicID != "":
 		return "NicId", req.NicID, true
 	case req.VMID != "":
@@ -383,7 +404,7 @@ func (p *Pack) routeTarget(w http.ResponseWriter, req *routeRequest, netID strin
 		}
 		return "VmId", req.VMID, true
 	default:
-		p.badRequest(w, "a route needs a target: GatewayId, NatServiceId, NicId or VmId")
+		p.badRequest(w, "a route needs a target: GatewayId, NatServiceId, NetPeeringId, NicId or VmId")
 		return "", "", false
 	}
 }

--- a/internal/providers/outscale/routetables_lifecycle_test.go
+++ b/internal/providers/outscale/routetables_lifecycle_test.go
@@ -2,6 +2,7 @@ package outscale_test
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -120,4 +121,83 @@ func mainRouteTableID(t *testing.T, payload map[string]any) (string, string) {
 	}
 	t.Fatal("no main route table in the answer")
 	return "", ""
+}
+
+// A route can point at a Net peering, which is the only way two peered Nets
+// reach each other (#249).
+//
+// Their SDK declares it — CreateRouteRequest.NetPeeringId, "The ID of a Net
+// peering" — and the Terraform provider sends it for `outscale_route` with
+// `net_peering_id`. This emulator refused it with "a route needs a target:
+// GatewayId, NatServiceId, NicId or VmId" until a realistic stack asked.
+//
+// Found by writing the Terraform a platform team writes rather than by a test:
+// the suite creates peerings and asserts their state machine, and never routes
+// through one. That is the gap between proving what somebody thought to assert
+// and exercising what somebody actually writes.
+func TestARouteCanPointAtANetPeering(t *testing.T) {
+	ts := newServer(t)
+	doc := contractDoc(t)
+
+	netID, _ := netAndSubnet(t, ts, "10.70.0.0/16", "10.70.1.0/24")
+	other := call(t, ts, doc, "CreateNet", `{"IpRange":"10.71.0.0/16"}`)
+	otherNet, _ := other["Net"].(map[string]any)
+	otherID, _ := otherNet["NetId"].(string)
+
+	peering := call(t, ts, doc, "CreateNetPeering",
+		`{"SourceNetId":"`+netID+`","AccepterNetId":"`+otherID+`"}`)
+	pcx, _ := peering["NetPeering"].(map[string]any)
+	pcxID, _ := pcx["NetPeeringId"].(string)
+	if pcxID == "" {
+		t.Fatalf("no peering to route through: %v", peering)
+	}
+
+	created := call(t, ts, doc, "CreateRouteTable", `{"NetId":"`+netID+`"}`)
+	rtb, _ := created["RouteTable"].(map[string]any)
+	rtbID, _ := rtb["RouteTableId"].(string)
+
+	routed := call(t, ts, doc, "CreateRoute", `{
+		"RouteTableId":"`+rtbID+`",
+		"DestinationIpRange":"10.71.0.0/16",
+		"NetPeeringId":"`+pcxID+`"
+	}`)
+	table, _ := routed["RouteTable"].(map[string]any)
+	routes, _ := table["Routes"].([]any)
+	found := false
+	for _, entry := range routes {
+		route, _ := entry.(map[string]any)
+		if route["DestinationIpRange"] == "10.71.0.0/16" && route["NetPeeringId"] == pcxID {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("the route does not carry the peering it was created with: %v", routes)
+	}
+
+	// And a peering that has neither end in this Net is refused, the way a
+	// gateway attached elsewhere is: a route stored against somebody else's
+	// peering is a plan that would never work on the real cloud.
+	third := call(t, ts, doc, "CreateNet", `{"IpRange":"10.72.0.0/16"}`)
+	thirdNet, _ := third["Net"].(map[string]any)
+	thirdID, _ := thirdNet["NetId"].(string)
+	fourth := call(t, ts, doc, "CreateNet", `{"IpRange":"10.73.0.0/16"}`)
+	fourthNet, _ := fourth["Net"].(map[string]any)
+	fourthID, _ := fourthNet["NetId"].(string)
+	elsewhere := call(t, ts, doc, "CreateNetPeering",
+		`{"SourceNetId":"`+thirdID+`","AccepterNetId":"`+fourthID+`"}`)
+	elsewherePcx, _ := elsewhere["NetPeering"].(map[string]any)
+	elsewhereID, _ := elsewherePcx["NetPeeringId"].(string)
+
+	res, err := http.Post(ts.URL+"/api/v1/CreateRoute", "application/json", strings.NewReader(`{
+		"RouteTableId":"`+rtbID+`",
+		"DestinationIpRange":"10.73.0.0/16",
+		"NetPeeringId":"`+elsewhereID+`"
+	}`)) //nolint:noctx // test client
+	if err != nil {
+		t.Fatalf("CreateRoute: %v", err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode == http.StatusOK {
+		t.Error("a route was stored through a peering neither of whose ends is this Net")
+	}
 }

--- a/internal/providers/outscale/tags.go
+++ b/internal/providers/outscale/tags.go
@@ -258,3 +258,16 @@ func tagsList(tags map[string]string) []any {
 	}
 	return out
 }
+
+// tagsOrEmpty publishes a resource's tags, and an empty list when it has none.
+//
+// A nil slice marshals to `null`, and a client ranging over null is a client
+// that stops. Every taggable view here owes this; the NIC one published a
+// constant `[]` instead, which is the same shape and a different fact.
+func tagsOrEmpty(res *resource.Resource) []any {
+	entries, _ := res.Attrs["Tags"].([]any)
+	if entries == nil {
+		return []any{}
+	}
+	return entries
+}

--- a/internal/providers/outscale/tags_test.go
+++ b/internal/providers/outscale/tags_test.go
@@ -121,3 +121,54 @@ func TestReadTagsOmitsAKindUpstreamDoesNotName(t *testing.T) {
 		}
 	}
 }
+
+// A tagged NIC reads back its tags (#250).
+//
+// `storedNicView` published `"Tags": []` as a constant, so CreateTags on an
+// interface answered 200, stored the tag, and ReadNics denied it. For a client
+// that is worse than a refusal: a Terraform configuration tagging an interface
+// planned the same change on every run, for ever.
+//
+// The shape was right and the fact was wrong, which is why no schema check saw
+// it — an empty list is exactly what an untagged NIC should publish. Found by
+// applying a realistic stack and reading the second plan, and the suite had
+// tagged Nets, Vms and volumes without ever tagging an interface.
+func TestATaggedNicReadsBackItsTags(t *testing.T) {
+	ts := newServer(t)
+	doc := contractDoc(t)
+
+	netID, subnetID := netAndSubnet(t, ts, "10.80.0.0/16", "10.80.1.0/24")
+	_ = netID
+
+	created := call(t, ts, doc, "CreateNic", `{"SubnetId":"`+subnetID+`"}`)
+	nic, _ := created["Nic"].(map[string]any)
+	nicID, _ := nic["NicId"].(string)
+	if nicID == "" {
+		t.Fatalf("no NicId in the create response: %v", created)
+	}
+	// Empty rather than absent on a fresh interface: that is the honest answer,
+	// and a client ranging over null is a client that stops.
+	if tags, ok := nic["Tags"].([]any); !ok || len(tags) != 0 {
+		t.Errorf("a fresh NIC publishes %v for Tags, want an empty list", nic["Tags"])
+	}
+
+	call(t, ts, doc, "CreateTags", `{
+		"ResourceIds":["`+nicID+`"],
+		"Tags":[{"Key":"Name","Value":"platform-app-services"}]
+	}`)
+
+	read := call(t, ts, doc, "ReadNics", `{"Filters":{"NicIds":["`+nicID+`"]}}`)
+	nics, _ := read["Nics"].([]any)
+	if len(nics) != 1 {
+		t.Fatalf("the NIC is not readable after tagging: %v", read)
+	}
+	found, _ := nics[0].(map[string]any)
+	tags, _ := found["Tags"].([]any)
+	if len(tags) != 1 {
+		t.Fatalf("the tagged NIC publishes %d tag(s): the write was accepted and denied", len(tags))
+	}
+	tag, _ := tags[0].(map[string]any)
+	if tag["Key"] != "Name" || tag["Value"] != "platform-app-services" {
+		t.Errorf("the NIC carries %v, not the tag it was given", tags[0])
+	}
+}

--- a/mise.toml
+++ b/mise.toml
@@ -139,6 +139,10 @@ run = [
   "tools/conformance/outscale/terraform.sh http://$FEINT_ADDR",
 ]
 
+[tasks."conformance:stacks"]
+description = "Apply the example stacks — realistic platform configurations, not fixtures"
+run = "tools/conformance/stacks.sh http://$FEINT_ADDR"
+
 [tasks."conformance:terraform:outscale"]
 description = "Run the real Outscale Terraform provider against the running emulator"
 run = "tools/conformance/outscale/terraform.sh http://$FEINT_ADDR"
@@ -274,6 +278,10 @@ tools/conformance/scaleway/scw-cli.sh "http://$FEINT_ADDR"
 tools/conformance/scaleway/terraform.sh "http://$FEINT_ADDR"
 tools/conformance/outscale/oapi-cli.sh "http://$FEINT_ADDR"
 tools/conformance/outscale/terraform.sh "http://$FEINT_ADDR"
+# The example stacks, which are examples and tests at once: written the way a
+# platform team writes Terraform rather than the way a fixture is written, and
+# they found two defects every other gate was blind to (#249, #250).
+tools/conformance/stacks.sh "http://$FEINT_ADDR"
 tools/conformance/exoscale/exo-cli.sh "http://$FEINT_ADDR"
 # Every route driven from its provider's API description. Skipped when a machine
 # runtime is on: a synthetic walk of every Create* would start a container each.

--- a/tools/conformance/stacks.sh
+++ b/tools/conformance/stacks.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# The example stacks, applied against a running emulator.
+#
+# These are not fixtures. `tools/conformance/*/terraform/` holds configurations
+# written to exercise what somebody thought to assert; `examples/stacks/` holds
+# configurations written the way a platform team writes them, and the difference
+# is not cosmetic. Within an hour of the first one being applied, two defects
+# surfaced that every existing gate was blind to:
+#
+#   #249 — a route could not point at a Net peering, so two peered Nets stayed
+#          unreachable. The suite creates peerings and asserts their state
+#          machine; it never routes through one.
+#   #250 — a tagged NIC read back without its tags, so a Terraform plan never
+#          converged. The suite tagged Nets, Vms and volumes, never an interface.
+#
+# So they run here, on every pull request, for the same reason the examples are
+# in this repository rather than in one of their own: an example nobody runs is
+# an example that rots, and this one is also a test.
+#
+# What each stack must do, and the third is the one that finds things:
+#
+#   1. apply
+#   2. destroy cleanly
+#   3. **plan empty in between** — where an emulator that answers 200 and stores
+#      something else shows up
+#
+# Usage: tools/conformance/stacks.sh [endpoint]
+set -euo pipefail
+
+ENDPOINT="${1:-http://127.0.0.1:4599}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Never let a client reach anything but the local emulator. Without this, a
+# missing endpoint does not fail: every official client falls back to the
+# operator's stored credentials, and a test creates billable resources on a real
+# account. That is not hypothetical — it happened, to this repository.
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/guard.sh"
+guard_local "$ENDPOINT"
+
+TF="${FEINT_TF:-}"
+if [ -z "$TF" ]; then
+  if command -v tofu >/dev/null 2>&1; then TF=tofu; else TF=terraform; fi
+fi
+command -v "$TF" >/dev/null 2>&1 || { echo "FAIL: neither tofu nor terraform is installed" >&2; exit 1; }
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ok() { echo "  ok: $*"; }
+
+echo "conformance: the example stacks against $ENDPOINT, with $TF"
+
+run_stack() { # name
+  local name="$1"
+  local src="$ROOT/examples/stacks/$name"
+  [ -d "$src" ] || fail "no stack at $src"
+
+  # A copy, so the working directory of a repository nobody asked to dirty stays
+  # clean: state files and provider caches belong to the run, not to the tree.
+  local work
+  work="$(mktemp -d)"
+  cp "$src"/*.tf "$work/"
+
+  # The destroy has to happen on the error path too. Without it the first broken
+  # run poisons every later one, and the operator sweeps by hand.
+  local destroyed=0
+  cleanup_stack() {
+    if [ "$destroyed" = "0" ] && [ -f "$work/terraform.tfstate" ]; then
+      (cd "$work" && "$TF" destroy -no-color -auto-approve -var "endpoint=$ENDPOINT" >/dev/null 2>&1) \
+        || echo "FAIL: could not destroy $name; resources may be left behind" >&2
+    fi
+    rm -rf "$work"
+  }
+  trap cleanup_stack RETURN
+
+  cd "$work"
+  export TF_IN_AUTOMATION=1 TF_INPUT=0
+
+  echo "- $name: init and apply"
+  "$TF" init -no-color -upgrade >/dev/null || fail "$name: init failed"
+  "$TF" apply -no-color -auto-approve -var "endpoint=$ENDPOINT" >/dev/null \
+    || fail "$name: apply failed"
+  ok "applied"
+
+  # The assertion that separates a test from a demonstration. Both defects this
+  # file's header names were caught here rather than by the apply.
+  echo "- $name: the second plan is empty"
+  local status=0
+  "$TF" plan -no-color -detailed-exitcode -var "endpoint=$ENDPOINT" >/dev/null 2>&1 || status=$?
+  case "$status" in
+    0) ok "no drift between what was sent and what is served" ;;
+    2) "$TF" plan -no-color -var "endpoint=$ENDPOINT" || true
+       fail "$name: the emulator does not read back what the stack sent" ;;
+    *) fail "$name: the second plan errored with status $status" ;;
+  esac
+
+  echo "- $name: destroy"
+  "$TF" destroy -no-color -auto-approve -var "endpoint=$ENDPOINT" >/dev/null \
+    || fail "$name: destroy failed"
+  destroyed=1
+  ok "destroyed"
+}
+
+run_stack scaleway
+run_stack outscale
+
+echo "conformance: the example stacks applied, re-planned empty and destroyed"

--- a/tools/falsify/specs/outscale-route-peering-and-nic-tags.json
+++ b/tools/falsify/specs/outscale-route-peering-and-nic-tags.json
@@ -1,0 +1,27 @@
+{
+  "package": "./internal/providers/outscale/",
+  "mutations": [
+    {
+      "label": "a route can no longer point at a Net peering, so two peered Nets stay unreachable",
+      "file": "internal/providers/outscale/routetables.go",
+      "find": "\tcase req.NetPeeringID != \"\":",
+      "replace": "\tcase req.NetPeeringID != \"\" && false:",
+      "test": "TestARouteCanPointAtANetPeering"
+    },
+    {
+      "label": "the peering's two ends stop being checked, so a route lands on somebody else's peering",
+      "file": "internal/providers/outscale/routetables.go",
+      "find": "\t\tif netID != source && netID != accepter {",
+      "replace": "\t\tif netID != source && netID != accepter && false {",
+      "test": "TestARouteCanPointAtANetPeering"
+    },
+    {
+      "label": "the NIC view publishes a constant again, so a tagged interface denies its own tag",
+      "file": "internal/providers/outscale/nics.go",
+      "find": "\t\t\"Tags\": tagsOrEmpty(nic),",
+      "replace": "\t\t\"Tags\": func() []any { _ = tagsOrEmpty(nic); return []any{} }(),",
+      "test": "TestATaggedNicReadsBackItsTags"
+    }
+  ],
+  "note": "Both defects were found by applying a realistic Terraform stack rather than by a test, and both were invisible to every schema check: a missing route target answers a clean 400, and a view publishing a constant empty list has exactly the shape an untagged NIC should have. The third mutation keeps `tagsOrEmpty(nic)` evaluated — the rule falsify.py enforces — while discarding its answer, which is precisely the defect as it stood."
+}


### PR DESCRIPTION
# Summary

Two realistic platform stacks enter the repository and run in CI — and the two
defects they found in their first hour are fixed.

Closes #249, closes #250, and does the work #251 asked for.

## The defects, and why nothing here saw them

| # | What was wrong | Why no gate caught it |
|---|---|---|
| #249 | An `outscale_route` could not point at a Net peering. Their SDK declares `CreateRouteRequest.NetPeeringId`; the emulator answered `a route needs a target: GatewayId, NatServiceId, NicId or VmId` | The suite creates peerings and asserts their state machine. It never routes through one — and a clean 400 is a valid answer to a schema check |
| #250 | A tagged NIC read back without its tags: `storedNicView` published `"Tags": []` as a **constant** | An empty list is exactly what an untagged NIC should publish. The shape was right and the fact was wrong, which is the one thing a contract check cannot see |

#250 is the more interesting of the two. `CreateTags` answered 200, stored the
tag, and `ReadNics` denied it — so a configuration tagging an interface planned
the same change for ever:

```text
# outscale_nic.app_services will be updated in-place
~ resource "outscale_nic" "app_services" {
    + tags { + key = "Name" + value = "platform-app-services" }
```

Both causes are fixed: the create did not initialise the key, and the view read a
literal instead of the resource.

## The stacks, and why they are in this repository

`examples/stacks/scaleway` — two VPCs, three private networks and a route between
them, three security groups, a bastion, a web tier on IPAM-booked addresses, an
application tier with no public address at all, a golden image cut from a
snapshot of a volume, block-storage volumes with their own snapshots, cloud-init
everywhere. **Six machines.**

`examples/stacks/outscale` — two Nets with a peering and the route across it, a
public subnet with an internet service and a route table, a private subnet, a
shared-services Net, a standalone NIC, per-tier security groups with rules,
public IPs linked to Vms, a volume attached to a machine, an image from a
snapshot.

They run on the `terraform` and `opentofu` legs of the conformance matrix, and
through `mise run conformance`. **An example nobody runs is an example that
rots** — and these are also tests, which is the whole reason they are here rather
than in a repository of their own.

The assertion that does the finding is the middle one:

```bash
terraform apply
terraform plan -detailed-exitcode      # must be empty  ← this caught #250
terraform destroy
```

## Falsified

`tools/falsify/specs/outscale-route-peering-and-nic-tags.json`, three mutations,
all three bite. The third keeps `tagsOrEmpty(nic)` evaluated and discards its
answer — the defect exactly as it stood, and the rule `falsify.py` enforces about
not dropping an identifier the original expression used.

## Type of change

- [x] A route added or changed
- [x] Bug fix
- [ ] Refactor
- [x] Documentation
- [ ] Chore / tooling

## Checklist

### Always

- [x] `mise run check` passes
- [x] No new external Go dependency
- [x] `internal/core` untouched
- [x] Nothing in the diff could be written identically for another provider: the
      route targets and the tag shape are Outscale's own vocabulary

### When a model wrote a substantive part of this

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] I ran `mise run conformance` myself — 259 of 280 driven, and the stacks
      apply, re-plan empty and destroy inside it
- [x] Every field name comes from the upstream SDK (`CreateRouteRequest.NetPeeringId`)
      or from a run of the real provider

### When a route is added or changed

- [x] No new route: an existing one gains a target its SDK declares
- [x] `mise run conformance` passes, all suites against one emulator
- [x] Responses validated against Outscale's own API description — zero violations
- [x] What the client sends is read or refused: `NetPeeringId` was sent and
      dropped, which is what this fixes
- [x] N/A for `drift:update`: no operation changed its triage

### When behaviour a client can observe changes

- [x] N/A for `docs/limits.md`: a route here still moves a record rather than a
      packet, which the gateways-and-NAT section already states
- [x] Generated blocks regenerated

### When `.github/workflows/` is touched

- [x] `conformance.yml` gains one step on two existing legs; no job renamed, so
      the required checks still match
- [x] `actionlint` over the repository returns 0
- [x] No action added or repinned

### When a machine runtime is involved

N/A — the stacks are control-plane only by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
