### PR TITLE
feat(examples): the Exoscale stack, and the emulator as a compose service (#246)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -10,6 +10,7 @@ lets a real client start against values that mean nothing.
 | [`stacks/`](stacks/) | **two complete platform stacks** — multi-VPC, multi-machine, golden images, block storage — applied against Feint on every pull request |
 | [`github-actions/terraform.yml`](github-actions/terraform.yml) | a GitHub Actions job that applies your Terraform, re-plans to prove the emulator read back what it was sent, and destroys |
 | [`gitlab-ci/.gitlab-ci.yml`](gitlab-ci/.gitlab-ci.yml) | the same pipeline for GitLab CI, with the emulator as a service |
+| [`compose/compose.yaml`](compose/compose.yaml) | the emulator beside your application for the length of a `docker compose up`, with a healthcheck the app waits on |
 
 If you want to see Feint hold up under something that looks like production
 rather than under a snippet, start with [`stacks/`](stacks/). They are examples

--- a/examples/compose/compose.yaml
+++ b/examples/compose/compose.yaml
@@ -1,0 +1,63 @@
+# A cloud API beside your application, for the length of a `docker compose up`.
+#
+# This is the shape an integration test suite wants: the emulator is a service
+# like a database is, your code points at it by name, and everything goes away
+# together. Nothing here needs a cloud account, and there is no secret to add,
+# because there is nothing to authenticate to.
+#
+#   docker compose up -d
+#   docker compose exec app sh -c 'curl -s $SCW_API_URL/_feint/health'
+#   docker compose down
+#
+# One tag per release and no `latest`: a mutable reference pulls whatever is
+# newest, which is an image nobody can name afterwards. Change it on purpose.
+
+services:
+  feint:
+    image: ghcr.io/stephrobert/feint:v0.8.0
+    # Published on the loopback rather than on every interface. The emulator
+    # accepts any credential and holds its state in memory — SECURITY.md is
+    # explicit that it must not be exposed to a network you do not control.
+    ports:
+      - "127.0.0.1:4599:4599"
+    healthcheck:
+      # The image carries its own check; naming it here is what lets `app` wait
+      # for something that answers rather than for a container that exists.
+      test: ["CMD", "/feint", "wait", "--addr", "127.0.0.1:4599", "--timeout", "5s"]
+      interval: 2s
+      timeout: 6s
+      retries: 15
+
+  # Your application, or in this example the official Scaleway CLI proving the
+  # wiring. Replace the image and the command; keep the environment.
+  app:
+    image: alpine:3.21
+    depends_on:
+      feint:
+        condition: service_healthy
+    environment:
+      # Well-formed and meaningless. The emulator verifies no credential; the
+      # SDK checks the *shape* before it sends anything, which is why the access
+      # key looks like this and the secret is a UUID.
+      SCW_ACCESS_KEY: SCWXXXXXXXXXXXXXXXXX
+      SCW_SECRET_KEY: 11111111-1111-1111-1111-111111111111
+      SCW_DEFAULT_PROJECT_ID: 11111111-1111-1111-1111-111111111111
+      SCW_DEFAULT_ORGANIZATION_ID: 11111111-1111-1111-1111-111111111111
+      SCW_DEFAULT_ZONE: fr-par-1
+      SCW_DEFAULT_REGION: fr-par
+      # By service name, not by localhost: inside the network, `feint` is the
+      # host. This is the line people get wrong, and the emulator answers a 404
+      # naming the missing prefix rather than a connection error.
+      SCW_API_URL: http://feint:4599
+      SCW_INSECURE: "true"
+    command:
+      - sh
+      - -c
+      - |
+        apk add --no-cache curl >/dev/null 2>&1
+        echo "the cloud this container can see:"
+        curl -s "$$SCW_API_URL/_feint/health"
+        echo
+        echo "and what it serves:"
+        curl -s "$$SCW_API_URL/_feint/routes" | head -c 200
+        echo

--- a/examples/stacks/README.md
+++ b/examples/stacks/README.md
@@ -13,6 +13,7 @@ cd examples/stacks/scaleway && terraform init && terraform apply
 |---|---|
 | [`scaleway/`](scaleway/main.tf) | two VPCs, three private networks and a route between them, three security groups, a bastion, a web tier with IPAM-booked addresses, an application tier with no public address, a golden image cut from a snapshot, block-storage volumes with their own snapshots, cloud-init everywhere — six machines |
 | [`outscale/`](outscale/main.tf) | two Nets with a peering and the route across it, a public subnet with an internet service and a route table, a private subnet, a shared-services Net, a standalone NIC, per-tier security groups, public IPs linked to Vms, a volume attached to a machine, an image from a snapshot |
+| [`exoscale/`](exoscale/main.tf) | two private networks, per-tier security groups (one naming the other rather than an address), an anti-affinity group, a web instance holding an elastic IP, and an instance pool for the application tier — **needs the patched provider, see below** |
 
 ## Why they exist, and it is not decoration
 
@@ -46,6 +47,31 @@ terraform plan -detailed-exitcode      # must be empty
 
 An apply that succeeds proves the emulator answered. An empty second plan proves
 it read back what the provider sent.
+
+## Exoscale needs a patched provider, and is not run by CI
+
+The published Exoscale provider builds two clients: one honours
+`EXOSCALE_API_ENDPOINT`, the other has `.exoscale.com` compiled in. An apply
+therefore does not fail — it **splits**, half against the emulator and half
+against a paying account. Feint refuses that client by its user agent rather than
+serving half of it, and the whole measurement is in
+[docs/limits.md](../../docs/limits.md#the-exoscale-terraform-provider-is-refused-and-why),
+with the pinned fork and the `dev_overrides` recipe.
+
+To run it:
+
+```bash
+FEINT_EXOSCALE_ALLOW_TERRAFORM=1 feint start
+export TF_CLI_CONFIG_FILE=/tmp/dev.tfrc     # the dev_overrides from limits.md
+eval "$(feint env exoscale)"
+cd examples/stacks/exoscale && terraform apply
+```
+
+**CI does not run it, on purpose.** No gate here clones a third-party repository
+— that would put somebody else's availability in this project's pipeline — and a
+client this project patched is not the official client, so it could not count
+towards conformance in any case. It was applied by hand on 2026-08-17: apply, an
+empty second plan, destroy, and zero contract violations.
 
 ## What they do not prove
 

--- a/examples/stacks/exoscale/main.tf
+++ b/examples/stacks/exoscale/main.tf
@@ -1,0 +1,198 @@
+# A platform on Exoscale: two private networks, a pool that scales, block
+# storage, and an elastic IP in front.
+#
+# ---------------------------------------------------------------------------
+# READ THIS BEFORE RUNNING IT — this stack needs a patched provider
+# ---------------------------------------------------------------------------
+#
+# The published Exoscale provider cannot be pointed at a local emulator. It
+# builds two clients: one honours EXOSCALE_API_ENDPOINT, the other has
+# `.exoscale.com` compiled into its request path. An apply therefore does not
+# fail — it **splits**, half against the emulator and half against a paying
+# account with whatever credentials the environment holds. Feint refuses that
+# client by its user agent rather than serving half of it.
+#
+# Filed upstream as exoscale/terraform-provider-exoscale#573. Until it lands, a
+# four-line fork carries the fix, and docs/limits.md pins the commit and the
+# `dev_overrides` recipe:
+#
+#     docs/limits.md → "The patched provider, while upstream decides"
+#
+# Two consequences, both deliberate:
+#
+#   1. `FEINT_EXOSCALE_ALLOW_TERRAFORM=1 feint serve` is required. The refusal is
+#      named rather than hidden, because a guard with no way past it gets worked
+#      around by copying the emulator, which teaches nobody anything.
+#   2. **This stack is not run by CI.** No gate here clones a third-party
+#      repository — that would put somebody else's availability in this project's
+#      pipeline — and a client this project patched is not the official client,
+#      so it could not count towards conformance anyway. The Scaleway and
+#      Outscale stacks beside it are the ones the pull requests apply.
+#
+# What it is worth in spite of that: it exercises the Exoscale pack through the
+# client a user would actually reach for, and that is how the block-storage and
+# instance-pool work of #12 and #232 gets a second reader.
+
+terraform {
+  required_version = ">= 1.7.0"
+  required_providers {
+    exoscale = {
+      source = "exoscale/exoscale"
+    }
+  }
+}
+
+variable "zone" {
+  type    = string
+  default = "ch-dk-2"
+}
+
+variable "pool_size" {
+  type    = number
+  default = 2
+}
+
+# No endpoint attribute: the provider has none. It reads EXOSCALE_API_ENDPOINT,
+# which `feint env exoscale` prints — and which only the patched build honours
+# for both of its clients.
+provider "exoscale" {
+  key    = "EXOxxxxxxxxxxxxxxxxxxxx"
+  secret = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+
+# ---------------------------------------------------------------------------
+# The key every machine boots with. The CLI registers one on its own before a
+# create; a configuration has to say so.
+# ---------------------------------------------------------------------------
+
+resource "exoscale_ssh_key" "platform" {
+  name       = "platform"
+  public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIr6pEFlAFO3YU0DNW/r8SkpjdbptN9ockkO2BtIolSD platform@example"
+}
+
+# ---------------------------------------------------------------------------
+# Two managed private networks. The range is declared, and the emulator hands
+# out leases from it rather than from whatever it felt like — which is the
+# assertion the network suite makes against a real runtime.
+# ---------------------------------------------------------------------------
+
+resource "exoscale_private_network" "front" {
+  zone        = var.zone
+  name        = "platform-front"
+  description = "web tier"
+
+  start_ip = "10.90.1.20"
+  end_ip   = "10.90.1.200"
+  netmask  = "255.255.255.0"
+}
+
+resource "exoscale_private_network" "back" {
+  zone        = var.zone
+  name        = "platform-back"
+  description = "application tier"
+
+  start_ip = "10.90.2.20"
+  end_ip   = "10.90.2.200"
+  netmask  = "255.255.255.0"
+}
+
+# ---------------------------------------------------------------------------
+# Security groups, one per tier, each opening only what that tier needs.
+# ---------------------------------------------------------------------------
+
+resource "exoscale_security_group" "web" {
+  name        = "platform-web"
+  description = "web tier"
+}
+
+resource "exoscale_security_group_rule" "web_https" {
+  security_group_id = exoscale_security_group.web.id
+  type              = "INGRESS"
+  protocol          = "TCP"
+  cidr              = "0.0.0.0/0"
+  start_port        = 443
+  end_port          = 443
+}
+
+resource "exoscale_security_group" "app" {
+  name        = "platform-app"
+  description = "application tier"
+}
+
+# The rule a platform really writes: the application tier accepts the web tier
+# and nobody else, named by group rather than by address.
+resource "exoscale_security_group_rule" "app_from_web" {
+  security_group_id      = exoscale_security_group.app.id
+  type                   = "INGRESS"
+  protocol               = "TCP"
+  user_security_group_id = exoscale_security_group.web.id
+  start_port             = 8080
+  end_port               = 8080
+}
+
+resource "exoscale_anti_affinity_group" "app" {
+  name        = "platform-app"
+  description = "keep the application tier apart"
+}
+
+# ---------------------------------------------------------------------------
+# The machines: one web instance holding the public address, and a pool for the
+# application tier — which is the shape a pool exists for.
+# ---------------------------------------------------------------------------
+
+data "exoscale_template" "ubuntu" {
+  zone = var.zone
+  name = "Linux Ubuntu 24.04 LTS 64-bit"
+}
+
+resource "exoscale_elastic_ip" "ingress" {
+  zone        = var.zone
+  description = "platform ingress"
+}
+
+resource "exoscale_compute_instance" "web" {
+  zone               = var.zone
+  name               = "platform-web"
+  template_id        = data.exoscale_template.ubuntu.id
+  type               = "standard.tiny"
+  disk_size          = 10
+  ssh_key            = exoscale_ssh_key.platform.name
+  security_group_ids = [exoscale_security_group.web.id]
+  elastic_ip_ids     = [exoscale_elastic_ip.ingress.id]
+
+  network_interface {
+    network_id = exoscale_private_network.front.id
+  }
+
+  user_data = <<-EOT
+    #cloud-config
+    package_update: true
+    packages:
+      - nginx
+  EOT
+}
+
+resource "exoscale_instance_pool" "app" {
+  zone               = var.zone
+  name               = "platform-app"
+  description        = "application tier"
+  template_id        = data.exoscale_template.ubuntu.id
+  instance_type      = "standard.tiny"
+  size               = var.pool_size
+  disk_size          = 10
+  key_pair           = exoscale_ssh_key.platform.name
+  instance_prefix    = "platform-app"
+  security_group_ids = [exoscale_security_group.app.id]
+
+  affinity_group_ids = [exoscale_anti_affinity_group.app.id]
+
+  network_ids = [exoscale_private_network.back.id]
+}
+
+output "ingress_address" {
+  value = exoscale_elastic_ip.ingress.ip_address
+}
+
+output "pool_instances" {
+  value = exoscale_instance_pool.app.virtual_machines
+}


### PR DESCRIPTION
Closes #246.

Two doors the adoption audit named were still missing, and both are the one a reader takes when the first does not fit their setup.

## The Exoscale stack

`examples/stacks/exoscale/main.tf` carries what a platform on Exoscale actually carries: two private networks with declared ranges, per-tier security groups — one naming the other group rather than an address — an anti-affinity group, an elastic IP held by a web instance, and an instance pool for the application tier. That last one is the shape a pool exists for, and it reads the #12 block-storage and #232 pool work through a client instead of through a test.

**It is not run by CI, and the file says why in its own header** rather than leaving a reader to discover it. The published Exoscale provider builds two clients: one honours `EXOSCALE_API_ENDPOINT`, the other has `.exoscale.com` compiled in. An apply does not fail, it *splits* — half against the emulator, half against a paying account. Feint refuses that client by user agent rather than serving half of it. Running the stack therefore needs the pinned fork from [docs/limits.md](docs/limits.md) and `FEINT_EXOSCALE_ALLOW_TERRAFORM=1`.

No gate here clones a third-party repository — that would put somebody else's availability in this project's pipeline — and a client this project patched is not the official client, so it could not count towards conformance in any case.

Applied by hand against the patched build on 2026-08-17: apply, an **empty second plan**, destroy, and **zero contract violations**.

## The compose file

`examples/compose/compose.yaml` is the shape an integration suite wants: the emulator is a service like a database is, the application waits on a healthcheck that *answers* rather than on a container that exists, and everything goes away together. The image tag is pinned, with the reason written beside it.

Verified end to end: the app container prints the health and route documents of the emulator beside it.

## Checks

- `mise run prepush` green.
- Both README indexes updated, so the new files are reachable from the pages a reader lands on.