### PR TITLE
docs: the CI recording is on the page it was made for (#252)

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -75,6 +75,8 @@ The image is control-plane only and carries no `latest` tag; [docs/install.md](d
 Apply complete! Resources: 5 added, 0 changed, 0 destroyed.
 ```
 
+![Un job GitHub Actions qui tire l'image, y pointe le CLI Scaleway officiel et applique du Terraform — sans compte cloud et sans secret](docs/assets/ci.gif)
+
 Des pipelines à copier tels quels, sans rien à configurer ni aucun secret à
 ajouter : [**examples/**](examples/) — GitHub Actions, GitLab CI, et une action
 `setup-feint` qui vérifie l'empreinte du binaire avant de l'exécuter.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ The image is control-plane only and carries no `latest` tag; [docs/install.md](d
 Apply complete! Resources: 5 added, 0 changed, 0 destroyed.
 ```
 
+![A GitHub Actions job pulling the image, pointing the official Scaleway CLI at it, and applying Terraform — no cloud account and no secret](docs/assets/ci.gif)
+
 Copy-paste pipelines for both, with nothing to configure and no secret to add:
 [**examples/**](examples/) — GitHub Actions, GitLab CI, and a `setup-feint`
 action that verifies the binary before it runs it.


### PR DESCRIPTION
Part of #252.

The recording was made, checked frame by frame, and committed — and the README never showed it. The issue asks for it above the fold, and says why: the OCI path is the door a CI reader needs, and a reader who has to go looking for a demo has already decided.

It sits under the pipeline snippet it illustrates rather than at the very top, because the quickstart GIF already holds that spot and shows the *other* door — the binary on a laptop. Two doors, two recordings, each beside the snippet it belongs to.

Both languages. This repository has forgotten the second one once before.

**What #252 still asks for after this**, and why it stays open: the release note has to link the recording. That happens when a release is cut, not here.