### PR TITLE
ci: the Marketplace mirror gate is required, not merely present (#245)

### DIFF
--- a/.github/actions/setup-feint/action.yml
+++ b/.github/actions/setup-feint/action.yml
@@ -17,9 +17,13 @@
 # shell is the supply-chain shape this project spends a workflow proving it does
 # not have.
 name: Set up Feint
+# 125 characters is the Marketplace's hard limit, and it refuses the release
+# rather than truncating: the first version of this line was 153 and the publish
+# form rejected it. OpenTofu and "no credentials" are what came out — the README
+# carries both, and this line has to survive a listing page.
 description: >-
-  Run Terraform, OpenTofu or the official Scaleway, Outscale and Exoscale CLIs
-  against a local emulator — no cloud account, no credentials, nothing billed.
+  Run Terraform and the official Scaleway, Outscale and Exoscale CLIs
+  against a local emulator. No account, no bill.
 author: stephrobert
 
 branding:

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -67,6 +67,9 @@
             "context": "Review dependency changes"
           },
           {
+            "context": "The published action matches the source"
+          },
+          {
             "context": "TruffleHog"
           },
           {


### PR DESCRIPTION
Last piece of #245 that a script can do.

#259 added **The published action matches the source** — it reads the `action.yml` that `stephrobert/setup-feint` serves at the `v1` tag and exits 2 when it differs from this repository's. `v1` rather than `main`, because `v1` is what consumers resolve. No secret: the read is public, so it works from a fork.

A job that can be skipped is a job that will be, so the ruleset now requires it.

**Declared here and applied with `tools/governance/ruleset.sh`, in that order and not the other.** The file is never the claim — the script is, and the already-required "Branch protection matches the declaration" runs its `check` on every pull request. A context declared and not applied fails exactly the way an applied one nobody declared does. `check` now answers *every rule declared in .github/rulesets/main.json is in force*.

Safe to require, verified rather than assumed: `workflow-security.yml` triggers on every `pull_request` with no `paths` filter, and the job carries no `if:` — so it runs on every pull request rather than only on those touching workflows. A required context that some pull requests never produce blocks them forever, which is the failure this check was worth reading the workflow to avoid.

**What stays manual**, and the only thing left on #245: the "Publish this Action to the Marketplace" checkbox, which GitHub exposes on a release form and nowhere in its API.