### PR TITLE
fix(falsify): every race verdict is measured, and two stale specs bite again

### DIFF
--- a/internal/providers/scaleway/lostupdate_test.go
+++ b/internal/providers/scaleway/lostupdate_test.go
@@ -114,7 +114,9 @@ func TestConcurrentUpdatesKeepEveryAcknowledgedField(t *testing.T) {
 // the lock deleteServer takes, so it orders nothing here.
 //
 // What the barrage measures is the pair working together; each half is falsified
-// on its own by tools/falsify/specs/serialise-then-commit.json.
+// on its own — the hold by tools/falsify/specs/one-attachment-two-doors.json
+// (under `repeat`, one run of this barrage being a coin toss with the hold gone),
+// the re-read by tools/falsify/specs/serialise-then-commit.json.
 //
 // Trials rather than one run: written when a delete released nothing, any
 // completed attach left an orphan and once was enough. Once the delete learned to

--- a/tools/falsify/specs/address-domains.json
+++ b/tools/falsify/specs/address-domains.json
@@ -14,7 +14,8 @@
       "find": "func (p *Pack) lockAddresses() func() { return serialise.Lock(Name + \"/addresses\") }",
       "replace": "func (p *Pack) lockAddresses() func() {\n\tserialise.Lock(Name + \"/addresses\")()\n\treturn func() {}\n}",
       "test": "TestConcurrentCreatesDoNotShareAnAddress",
-      "package": "./internal/providers/outscale/"
+      "package": "./internal/providers/outscale/",
+      "repeat": 3
     },
     {
       "label": "the exoscale addresses domain releases before the transaction, and concurrent allocations share",
@@ -22,7 +23,9 @@
       "find": "func (p *Pack) lockAddresses() func() { return serialise.Lock(Name + \"/addresses\") }",
       "replace": "func (p *Pack) lockAddresses() func() {\n\tserialise.Lock(Name + \"/addresses\")()\n\treturn func() {}\n}",
       "test": "TestConcurrentAllocationsShareNothing",
-      "package": "./internal/providers/exoscale/"
+      "package": "./internal/providers/exoscale/",
+      "repeat": 3
     }
-  ]
+  ],
+  "note": "Measured 2026-08-17, thirty -count=1 runs per mutation in the harness's own out-of-tree copy. The Scaleway test stages its interleaving — it holds the domain itself while a release runs — so its verdict is not a bet: red 5/5, no repeat. The Outscale and Exoscale tests bet on the scheduler (12 and 8+8 concurrent workers over one allocator): both went red 30/30, which still only bounds a false green at 10% per run (rule of three, 95%), and `repeat: 3` brings that worst case under 0.1%."
 }

--- a/tools/falsify/specs/lock-not-held-across-runtime.json
+++ b/tools/falsify/specs/lock-not-held-across-runtime.json
@@ -8,5 +8,6 @@
       "replace": "\tdefer unlock()\n\tp.carrySecondary(r.Context(), nic)\n\n\temulator.WriteJSON(w, http.StatusOK, map[string]any{\"ResponseContext\": p.context()})\n}\n\n// unlinkPrivateIps",
       "test": "TestAnAddressLinkDoesNotHoldTheAddressLockAcrossTheRuntime"
     }
-  ]
+  ],
+  "note": "No repeat: the interleaving is staged, not bet on. The fake runtime parks the link on a channel until the test releases it, so with the lock held across that call the concurrent allocation times out on every run — red 5/5 on 2026-08-17, -count=1 in the harness's own out-of-tree copy."
 }

--- a/tools/falsify/specs/one-attachment-two-doors.json
+++ b/tools/falsify/specs/one-attachment-two-doors.json
@@ -16,5 +16,6 @@
       "replace": "\tstatus := res.State\n\tif status == \"syncing_error\" {\n\t\tstatus = \"available\"\n\t}",
       "test": "TestARefusedAttachmentIsVisibleOnTheV2alpha1View"
     }
-  ]
+  ],
+  "note": "`repeat: 10` is measured, not chosen. With the hold released, one -count=1 run of the barrage is close to a coin toss: red 3 of 5 on 17 August 2026 — the day this spec printed TEST STILL PASSED twice for a guard that bites — and red 7 of 10 when re-measured the same day in the harness's own out-of-tree copy. A false green near one run in three becomes (1/3)^10, about 2e-5, over ten."
 }

--- a/tools/falsify/specs/serialise-then-commit.json
+++ b/tools/falsify/specs/serialise-then-commit.json
@@ -6,21 +6,16 @@
       "file": "internal/providers/scaleway/servers.go",
       "find": "\t// TestConcurrentUpdatesKeepEveryAcknowledgedField fails without this line.\n\tunlock := p.binding().Serialise(id)\n\tdefer unlock()\n\n\tres, found := p.env.Store.Get(Name, kindServer, id)",
       "replace": "\t// TestConcurrentUpdatesKeepEveryAcknowledgedField fails without this line.\n\tunlock := p.binding().Serialise(id)\n\tunlock()\n\n\tres, found := p.env.Store.Get(Name, kindServer, id)",
-      "test": "TestConcurrentUpdatesKeepEveryAcknowledgedField"
+      "test": "TestConcurrentUpdatesKeepEveryAcknowledgedField",
+      "repeat": 3
     },
     {
-      "label": "a NIC create stops holding the server, so a delete lands between its NIC and its write-back",
+      "label": "a NIC create trusts nothing the hold could tell it, so a finished delete goes unseen",
       "file": "internal/providers/scaleway/privatenics.go",
-      "find": "\tunlock := p.binding().Serialise(server.ID)\n\tdefer unlock()",
-      "replace": "\tunlock := p.binding().Serialise(server.ID)\n\tunlock()",
-      "test": "TestAttachingANICDoesNotResurrectADeletedServer"
-    },
-    {
-      "label": "a NIC create trusts the copy it read before the hold, so a finished delete goes unseen",
-      "file": "internal/providers/scaleway/privatenics.go",
-      "find": "\tserver, found := p.env.Store.Get(Name, kindServer, server.ID)\n\tif !found {\n\t\twriteNotFound(w, \"server\", r.PathValue(\"id\"))\n\t\treturn\n\t}",
-      "replace": "\tif fresh, found := p.env.Store.Get(Name, kindServer, server.ID); found {\n\t\tserver = fresh\n\t} else if false {\n\t\twriteNotFound(w, \"server\", r.PathValue(\"id\"))\n\t\treturn\n\t}",
-      "test": "TestAttachingANICDoesNotResurrectADeletedServer"
+      "find": "\tserver, found := p.env.Store.Get(Name, kindServer, serverID)\n\tif !found {\n\t\twriteNotFound(w, \"server\", serverID)\n\t\treturn nil, false\n\t}",
+      "replace": "\tserver, found := p.env.Store.Get(Name, kindServer, serverID)\n\tif !found && false {\n\t\twriteNotFound(w, \"server\", serverID)\n\t\treturn nil, false\n\t}\n\tif !found {\n\t\tserver = resource.New(serverID, kindServer, resource.Tenant{Provider: Name}, \"stopped\", p.env.Now())\n\t}",
+      "test": "TestAttachingANICDoesNotResurrectADeletedServer",
+      "repeat": 3
     },
     {
       "label": "Observe hands the look a copy read before the hold",
@@ -69,5 +64,6 @@
       "replace": "\tif req.DeletionProtection != nil && false {\n\t\tres.Attrs[\"DeletionProtection\"] = *req.DeletionProtection\n\t}",
       "test": "TestDeletionProtectionCanBeClearedByAnUpdate"
     }
-  ]
+  ],
+  "note": "Two mutations here went stale when #257 merged the two NIC doors into attachNIC and renamed server.ID to serverID: their fragments matched nothing, so they had silently stopped measuring. The per-server hold of attachNIC is falsified by one-attachment-two-doors.json (with `repeat`, the race being a coin toss per run) and is not repeated here. The re-read mutation cannot literally 'trust the pre-hold copy' any more — attachNIC receives only the id — so it does the equivalent: when the re-read answers not-found, it fabricates the server the way the old stale copy stood in for it, which is exactly what a handler working from a pre-delete read did. Measured 2026-08-17, thirty -count=1 runs per race in the harness's own out-of-tree copy: the update-path and re-read barrages both went red 30/30 — scheduler bets all the same, so `repeat: 3` turns the 10% false-green bound (rule of three, 95%) into under 0.1%. The Observe mutations carry no repeat: their tests stage the interleaving with channels or provoke it sequentially, and the reorder went red 5/5."
 }

--- a/tools/falsify/specs/serialise.json
+++ b/tools/falsify/specs/serialise.json
@@ -24,5 +24,6 @@
       "test": "TestSerialiseSeparatesProviders",
       "package": "./internal/core/machine/"
     }
-  ]
+  ],
+  "note": "No repeat, and that is measured rather than assumed (2026-08-17, -count=1 in the harness's own out-of-tree copy): the subject is a lock, but none of these verdicts is a bet on the scheduler. The two keyed-locking tests hold one side themselves and wait on a five-second timeout the mutation forces, red 3/3 each; the refcount test is a sequential loop over the map, red every run."
 }

--- a/tools/falsify/specs/transition.json
+++ b/tools/falsify/specs/transition.json
@@ -3,24 +3,26 @@
   "mutations": [
     {
       "label": "the target releases before the change, and two actions run on one machine at once",
-      "file": "internal/core/machine/transition.go",
+      "file": "internal/core/machine/observe.go",
       "find": "\tunlock := b.Serialise(id)\n\tdefer unlock()",
       "replace": "\tunlock := b.Serialise(id)\n\tunlock()",
-      "test": "TestTransitionExcludesASecondActionOnTheTarget"
+      "test": "TestTransitionExcludesASecondActionOnTheTarget",
+      "repeat": 3
     },
     {
       "label": "a failed write-back is retried unconditionally, and a deleted resource comes back",
-      "file": "internal/core/machine/transition.go",
-      "find": "\treturn st.Update(b.Provider, kind, id, func(stored *resource.Resource) error {\n\t\tstored.State = res.State\n\t\tstored.Runtime = res.Runtime\n\t\tstored.Attrs = res.Attrs\n\t\tstored.Updated = now()\n\t\treturn nil\n\t})",
-      "replace": "\terr := st.Update(b.Provider, kind, id, func(stored *resource.Resource) error {\n\t\tstored.State = res.State\n\t\tstored.Runtime = res.Runtime\n\t\tstored.Attrs = res.Attrs\n\t\tstored.Updated = now()\n\t\treturn nil\n\t})\n\tif err != nil {\n\t\tst.Put(res)\n\t}\n\treturn nil",
+      "file": "internal/core/machine/observe.go",
+      "find": "\t}); err != nil {\n\t\treturn nil, err\n\t}",
+      "replace": "\t}); err != nil {\n\t\tst.Put(res)\n\t\treturn res, nil\n\t}",
       "test": "TestADeleteLandingMidTransitionWins"
     },
     {
       "label": "a missing target no longer stops the change, and the runtime works for a resource nobody stores",
-      "file": "internal/core/machine/transition.go",
-      "find": "\tif !found {\n\t\treturn store.ErrNotFound\n\t}",
-      "replace": "\tif !found {\n\t\tres = &resource.Resource{Attrs: map[string]any{}}\n\t\t_ = store.ErrNotFound\n\t}",
+      "file": "internal/core/machine/observe.go",
+      "find": "\tres, found := st.Get(b.Provider, kind, id)\n\tif !found {\n\t\treturn nil, store.ErrNotFound\n\t}",
+      "replace": "\tres, found := st.Get(b.Provider, kind, id)\n\tif !found {\n\t\tres = &resource.Resource{ID: id, Kind: kind, Attrs: map[string]any{}}\n\t\t_ = store.ErrNotFound\n\t}",
       "test": "TestTransitionRefusesAMissingTargetBeforeTheChange"
     }
-  ]
+  ],
+  "note": "Transition became a one-line wrapper over Observe when #211 moved the transactional half into the shared layer, and this spec silently stopped applying: its fragments named code transition.go no longer holds. The guards live in observe.go now, so that is what the mutations remove — while the tests stay at the Transition door, which is what proves the wrapper still delegates to them. The Observe door of the same guards is falsified by serialise-then-commit.json. Measured 2026-08-17: the exclusion barrage (eight goroutines betting on the scheduler) went red 30/30 in -count=1 with the hold released, which bounds a false green at 10% per run (rule of three, 95%); `repeat: 3` brings that worst case under 0.1%. The other two mutations are sequential — the test itself provokes the delete and the missing target — and carry no repeat."
 }


### PR DESCRIPTION
# Summary

On 17 August the falsify harness printed `TEST STILL PASSED` — twice — for a per-server hold that does bite: `TestAttachingANICDoesNotResurrectADeletedServer` measures a race, and one `-count=1` run of it is a draw, not a verdict. The `repeat` mechanism is already in `main`; what was missing is the audit this PR does: classify **all 33 specs** by mechanism (staged interleaving, sequential, or a bet on the scheduler), **measure** the instability of every race before touching a number, and size `repeat` from the measured rate. Every rate is from runs of the mutated test in `-count=1`, in an out-of-tree copy built the way the harness builds it.

**Measured rates, written into the specs beside the values they justify:**

| spec / mutation | rate red | mechanism | repeat |
|---|---|---|---|
| one-attachment-two-doors, per-server hold | 7/10 (plus the incident's 3/5) | scheduler bet | 10 → false green ≈ 2e-5 |
| address-domains, outscale creates | 30/30 | scheduler bet | 3 → < 0.1 % worst case |
| address-domains, exoscale allocations | 30/30 | scheduler bet | 3 |
| serialise-then-commit, update path | 30/30 | scheduler bet | 3 |
| serialise-then-commit, NIC re-read (retargeted) | 30/30 | scheduler bet | 3 |
| transition, exclusion (retargeted) | 30/30 | scheduler bet | 3 |
| address-domains, scaleway release | 5/5 | staged (test holds the lock) | none |
| serialise-then-commit, Observe reorder | 5/5 | staged (channels) | none |
| lock-not-held-across-runtime | 5/5 | staged (runtime parked on a channel) | none |
| serialise, keyed-lock ×2 | 3/3 each | staged (5 s timeout forced) | none |

A 30/30 sweep still only bounds a false green at 10 % per run (rule of three, 95 %), hence `repeat: 3` on the scheduler bets; the staged tests force their interleaving, so a repeat there is noise that slows `falsify:all` without proving anything.

**Two specs had silently stopped measuring** — the population the replay exists to catch. Their fragments were orphaned by refactors that landed after their last replay, so `falsify:all` was failing on `main` before this PR (5 × `DID NOT APPLY`):

- `transition.json` named code #211 removed when `Transition` became a one-line wrapper over `Observe`. Retargeted at `observe.go`; the tests stay at the Transition door, which keeps the wrapper's delegation proven.
- `serialise-then-commit.json` named the pre-#257 `privatenics.go` (`server.ID`, two separate doors). The hold half is falsified by `one-attachment-two-doors.json` under `repeat` and is not duplicated; the re-read half now fabricates the server on a not-found — the observable equivalent of trusting a pre-delete copy — and goes red 30/30.

**No dead guard found**: after the retargets, all 33 specs bite (`mise run falsify:all` green locally). The one comment that cited a spec for the dropped duplicate (`lostupdate_test.go`) now names which spec falsifies which half.

## Type of change

- [ ] A route added or changed
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes (gofmt, vet, golangci-lint, `go test -race`)
- [x] No new external Go dependency, or the pull request justifies it. The
      standard library covers routing, JSON and Go parsing; `go.mod` has three
      lines and a pre-commit hook keeps it that way
- [x] `internal/core` still knows no provider. If a change seemed to require it,
      the pack changed instead
- [x] Nothing in the diff could be written identically for another provider. If
      it could, it belongs in the core — that is the rule that stopped the same
      lifecycle bug being fixed once and surviving twice

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] I ran `mise run conformance` myself — not "it should pass"
- [x] Every field name in the diff comes from the provider's SDK, their OpenAPI
      document, or a run of the real client, and I can say which. "The model
      produced it" is not a source — no wire field is touched here; the only Go
      fragments in the diff quote `observe.go` and `privatenics.go` verbatim

### When a route is added or changed — otherwise N/A

N/A — no route, no response shape, no error shape changes. The only non-spec
edits are mutation `find`/`replace` strings and one test comment.

### When behaviour a client can observe changes — otherwise N/A

N/A — the emulator's behaviour is untouched; only the falsification specs and
their measured justifications move.

### When `.github/workflows/` is touched — otherwise N/A

N/A

### When a machine runtime is involved — otherwise N/A

N/A — no runtime was started; measurements ran against fake runtimes inside
`go test`, per the tests' own design.

## Related issues

Follow-up to #169 (falsifications declared and replayed) and to the
`repeat` mechanism added after the 17 August false verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
