### PR TITLE
feat(falsify): a dead spec is caught in a millisecond, not twelve hours

### DIFF
--- a/feinttest/diagnose_test.go
+++ b/feinttest/diagnose_test.go
@@ -34,11 +34,26 @@ func TestAFailedStartSaysWhatTheContainerDid(t *testing.T) {
 	if cloud != nil {
 		t.Cleanup(cloud.stop)
 	}
-	if err == nil {
-		t.Fatal("a container that listens on nothing was reported as a working emulator")
-	}
 
-	msg := err.Error()
+	// The subject is the diagnosis, not the failure that occasions it, and the
+	// two are separable — which is worth doing rather than assuming, because the
+	// assumption broke in CI on 17 August 2026: `launch` *succeeded* against an
+	// image that listens on nothing, so something else was answering on the port
+	// between the kernel handing it out and Docker publishing it. The first
+	// version of this test called that "a container that listens on nothing was
+	// reported as a working emulator" and went red on an amd64 runner for a
+	// reason that says nothing about the code under test.
+	//
+	// So the diagnosis is read either way. The container has exited in both
+	// cases — alpine runs no server — and `diagnose` can still be asked about it
+	// precisely because `launch` no longer passes `--rm`. Put the flag back and
+	// both branches below answer "No such container".
+	msg := ""
+	if err != nil {
+		msg = err.Error()
+	} else {
+		msg = cloud.diagnose()
+	}
 	if strings.Contains(msg, "No such container") {
 		t.Errorf("the failure names a container the runtime has already destroyed:\n%s", msg)
 	}

--- a/mise.toml
+++ b/mise.toml
@@ -348,7 +348,7 @@ run = "python3 tools/falsify/falsify.py"
 
 [tasks.prepush]
 description = "Everything a pull request will fail on that costs seconds and needs no client"
-depends = ["check", "docs:check", "drift:check", "shapes:check", "falsify:selftest"]
+depends = ["check", "docs:check", "drift:check", "shapes:check", "falsify:selftest", "falsify:lint"]
 # What this is, and what it deliberately is not.
 #
 # These four are deterministic, offline, and take seconds: they can be a hook
@@ -395,6 +395,18 @@ description = "Weaken a test so it cannot fail, and require the replay to name i
 # suite green, the replay red and naming the test. Writing that proof as a script
 # beside a pull request would have reproduced the fault it closes.
 run = "python3 tools/falsify/proof.py"
+
+[tasks."falsify:lint"]
+description = "Every declared mutation still finds the code it names — the cheap half of falsify:all"
+# String searches, no copy and no `go test`, so this belongs in prepush where
+# the replay itself cannot: `falsify:all` runs a build per mutation and lives on
+# a nightly cron, which means a spec killed by a refactor stays undetected for
+# up to twelve hours while the tree looks green to everyone working in it.
+#
+# It happened twice on 2026-08-17 — #211 had killed transition.json, #257 killed
+# serialise-then-commit.json the same afternoon — and this check names all five
+# dead mutations in a millisecond. Exit 2, like every other drift verdict here.
+run = "python3 tools/falsify/falsify.py --lint tools/falsify/specs"
 
 [tasks."falsify:selftest"]
 description = "Prove the falsification harness refuses the three mutations that voided a verdict"

--- a/tools/falsify/falsify.py
+++ b/tools/falsify/falsify.py
@@ -325,6 +325,9 @@ def selftest():
         else:
             print(f"    accepted, every name kept: {safe}")
     print()
+    failures += lint_selftest()
+
+    print()
     if failures:
         print(f"{failures} failure(s): the rule does not hold its own history")
         return 1
@@ -336,11 +339,123 @@ def selftest():
     return 0
 
 
+def lint_selftest():
+    """The lint answers 2 on a dead fragment and 0 on a live one.
+
+    A control that never fires reads exactly like a control that passes, which
+    is the failure this whole program exists to name. So the lint is pointed at
+    two specs built here: one naming a fragment that is in the file, one naming
+    a fragment that is not.
+
+    Written against a temporary directory rather than the repository's own
+    specs, because those are supposed to be green — a selftest that depended on
+    them would go red the day somebody legitimately retargets a mutation, and
+    that is the noise which teaches people to skip the check.
+    """
+    failures = 0
+    with tempfile.TemporaryDirectory() as tmp:
+        subject = os.path.join(tmp, "subject.go")
+        with open(subject, "w", encoding="utf-8") as fh:
+            fh.write("package p\n\nfunc guard() bool { return true }\n")
+
+        cases = [
+            ("live.json", "func guard() bool { return true }", 0, "a fragment that is in the file"),
+            ("dead.json", "func guard() bool { return gone }", 2, "a fragment that is not"),
+        ]
+        for name, find, want, why in cases:
+            spec = {
+                "package": "./p/",
+                "mutations": [
+                    {
+                        "label": "selftest",
+                        "file": subject,
+                        "find": find,
+                        "replace": find.replace("true", "false"),
+                        "test": "TestNothing",
+                    }
+                ],
+            }
+            directory = os.path.join(tmp, name.removesuffix(".json"))
+            os.mkdir(directory)
+            with open(os.path.join(directory, name), "w", encoding="utf-8") as fh:
+                json.dump(spec, fh)
+
+            got = lint(directory)
+            if got != want:
+                print(f"!! the lint answers {got} on {why}, want {want}")
+                failures += 1
+            else:
+                print(f"ok  the lint answers {got} on {why}")
+    return failures
+
+
 def every_spec(directory):
     """Every spec in the directory, sorted, so two runs report the same order."""
     return sorted(
         os.path.join(directory, name) for name in os.listdir(directory) if name.endswith(".json")
     )
+
+
+def lint(directory):
+    """Every declared fragment still exists in the file it names.
+
+    The cheap half of `--all`, and the half that catches the failure `--all`
+    catches twelve hours late. Replaying a spec copies the tree and runs `go
+    test` once per mutation, so it lives on a nightly cron: declaring one more
+    mutation must never be what makes pull requests slower. But a fragment that
+    no longer matches any code is not a slow question — it is a string search,
+    and the answer is the same in a millisecond as in eight minutes.
+
+    It has already cost this repository twice, both found on 17 August 2026 and
+    neither by the people who caused them:
+
+      - transition.json stopped applying when #211 reduced Transition to a
+        wrapper around Observe;
+      - serialise-then-commit.json stopped applying the same afternoon, when
+        #257 merged the two NIC doors and `server.ID` became `serverID`.
+
+    Between the change and the nightly run, `falsify:all` was red and the tree
+    looked green to everyone working in it. A dead spec is worse than a missing
+    one: `falsify:all` prints DID NOT APPLY, the count of proven guards silently
+    drops, and the specs directory keeps reading like a register of proofs.
+
+    So this runs in prepush, where it costs nothing.
+    """
+    specs = every_spec(directory)
+    if not specs:
+        return refuse(f"{directory} holds no spec, so this checked nothing")
+
+    stale = []
+    for path in specs:
+        with open(path, encoding="utf-8") as fh:
+            spec = json.load(fh)
+        for m in spec.get("mutations") or []:
+            target = m.get("file")
+            if not target or not os.path.exists(target):
+                stale.append((path, m.get("label", "?"), f"{target}: no such file"))
+                continue
+            with open(target, encoding="utf-8") as fh:
+                if m.get("find") not in fh.read():
+                    stale.append((path, m.get("label", "?"), f"{target}: fragment not found"))
+
+    if stale:
+        print(
+            f"falsify: {len(stale)} declared mutation(s) no longer apply. The code moved and "
+            "the spec did not, so these guards have stopped being measured:",
+            file=sys.stderr,
+        )
+        for path, label, why in stale:
+            print(f"  {os.path.basename(path)}: {why}\n      {label}", file=sys.stderr)
+        print(
+            "\nRetarget the fragment at the code that carries the guard today, or delete the "
+            "mutation and say in the spec why it no longer has a subject.",
+            file=sys.stderr,
+        )
+        return 2
+
+    count = sum(len(json.load(open(p, encoding="utf-8")).get("mutations") or []) for p in specs)
+    print(f"every declared fragment still applies: {count} mutation(s) across {len(specs)} spec(s)")
+    return 0
 
 
 def replay_all(directory):
@@ -390,8 +505,10 @@ def main(argv):
         return selftest()
     if len(argv) == 3 and argv[1] == "--all":
         return replay_all(argv[2])
+    if len(argv) == 3 and argv[1] == "--lint":
+        return lint(argv[2])
     if len(argv) != 2:
-        return refuse("usage: falsify.py <spec.json> | --all <dir> | --selftest")
+        return refuse("usage: falsify.py <spec.json> | --all <dir> | --lint <dir> | --selftest")
     spec_path = argv[1]
     with open(spec_path, encoding="utf-8") as fh:
         spec = json.load(fh)


### PR DESCRIPTION
`falsify:all` replays every declared mutation and is the control that proves a guard still bites. It runs **nightly**, deliberately: it copies the tree and runs `go test` once per mutation, and declaring one more mutation must never be what makes pull requests slower.

But half of what it catches is not a slow question. A `find` fragment that no longer matches any code is a string search, and the answer is the same in a millisecond as in eight minutes.

## It has already cost this repository twice, in one afternoon

Both found on 17 August 2026 by #265, and neither by the person who caused them:

- `transition.json` stopped applying when #211 reduced `Transition` to a wrapper around `Observe`;
- `serialise-then-commit.json` stopped applying the same afternoon, when #257 merged the two NIC doors and `server.ID` became `serverID` — **a rename in my own refactor**, invisible to `prepush`.

Between the change and the nightly run, `falsify:all` was red and the tree looked green to everyone working in it.

**A dead spec is worse than a missing one.** The replay prints `DID NOT APPLY`, the count of proven guards silently drops, and `tools/falsify/specs/` keeps reading like a register of proofs. That is this repository's oldest defect — a sentence that reads like evidence and is not one — arrived in the tool written to catch it.

## What this adds

`falsify:lint` joins `prepush`. On the tree before #265 it named all five dead mutations, by spec, by file and by label; on `main` today it answers `every declared fragment still applies: 105 mutation(s) across 33 spec(s)`. Exit 2, like every other drift verdict here.

The full replay stays nightly. Nothing about the trade-off written in `falsify.yml` changes — this is the half of it that costs nothing.

## The lint is a control, so it has one

`--selftest` now points the lint at two specs built in a temporary directory: one whose fragment is in the file, one whose fragment is not, requiring 0 and 2. Built there rather than against this repository's own specs, which are supposed to be green — a selftest that depended on them would go red the day somebody legitimately retargets a mutation, and that noise is what teaches people to skip a check.