### PR TITLE
fix(scaleway): a Private Network publishes its IPv6 /64, dual-stack like upstream

### DIFF
--- a/internal/core/network/ula.go
+++ b/internal/core/network/ula.go
@@ -1,0 +1,28 @@
+package network
+
+import (
+	"crypto/sha256"
+	"net/netip"
+)
+
+// ULA64 derives a unique-local IPv6 /64 from a seed, deterministically.
+//
+// The layout is RFC 4193's: the fd00::/8 prefix, a 40-bit global ID, a 16-bit
+// subnet ID, and 64 zeroed host bits. The RFC wants the global ID picked at
+// random; here it is the first seven bytes of SHA-256(seed) instead, because an
+// emulator's blocks must be reproducible: a prefix that changed between two
+// reads of the same resource would be a permanent Terraform diff, and one that
+// changed across a snapshot round-trip would break every stored reference to
+// it. The seed is the caller's resource identity, so two resources get two
+// blocks and one resource always gets the same.
+//
+// The collision odds of a 56-bit hash are the caller's to close: check the
+// result against the blocks already held, and re-derive with a salted seed on
+// the (astronomically unlikely) clash.
+func ULA64(seed string) netip.Prefix {
+	sum := sha256.Sum256([]byte(seed))
+	var addr [16]byte
+	addr[0] = 0xfd
+	copy(addr[1:8], sum[:7])
+	return netip.PrefixFrom(netip.AddrFrom16(addr), 64)
+}

--- a/internal/core/network/ula_test.go
+++ b/internal/core/network/ula_test.go
@@ -1,0 +1,30 @@
+package network
+
+import (
+	"net/netip"
+	"testing"
+)
+
+func TestULA64IsDeterministicAndWellFormed(t *testing.T) {
+	ula := netip.MustParsePrefix("fd00::/8")
+
+	first := ULA64("11111111-2222-4333-8444-555555555555")
+	second := ULA64("11111111-2222-4333-8444-555555555555")
+	if first != second {
+		t.Fatalf("two derivations of one seed differ: %s vs %s", first, second)
+	}
+	if first.Bits() != 64 {
+		t.Errorf("expected a /64, got %s", first)
+	}
+	if !ula.Contains(first.Addr()) {
+		t.Errorf("expected a unique-local block under fd00::/8, got %s", first)
+	}
+	if first.Masked() != first {
+		t.Errorf("host bits set: %s", first)
+	}
+
+	other := ULA64("another-seed")
+	if other == first {
+		t.Errorf("two seeds derived the same block %s; the seed is not reaching the hash", first)
+	}
+}

--- a/internal/providers/scaleway/ipam.go
+++ b/internal/providers/scaleway/ipam.go
@@ -208,10 +208,14 @@ func (p *Pack) bookIP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if req.IsIPv6 {
+		// The Private Network publishes an IPv6 subnet (#270), but the machine
+		// runtime and the allocator behind it are IPv4: booking from the IPv6
+		// block would hand out an address no emulated machine ever carries,
+		// which is the exact lie this project exists to avoid.
 		writeInvalidArguments(w, ArgumentError{
 			ArgumentName: "is_ipv6",
 			Reason:       "constraint",
-			HelpMessage:  "the emulated networks are IPv4; there is no IPv6 subnet to book from",
+			HelpMessage:  "the emulated machines carry IPv4 only; the IPv6 subnet is published but no address can be booked from it",
 		})
 		return
 	}

--- a/internal/providers/scaleway/ipam_lifecycle_test.go
+++ b/internal/providers/scaleway/ipam_lifecycle_test.go
@@ -27,12 +27,28 @@ func createPN(t *testing.T, ts *httptest.Server, subnet string) (id string, subn
 	}
 	id, _ = body["id"].(string)
 	subnets, _ := body["subnets"].([]any)
-	if len(subnets) != 1 {
-		t.Fatalf("private network carries %d subnets, want 1", len(subnets))
+	// Dual-stack, like upstream (#270): one IPv4 record, one IPv6. IPAM joins
+	// on the IPv4 one, so that is the id handed back.
+	if len(subnets) != 2 {
+		t.Fatalf("private network carries %d subnets, want 2", len(subnets))
 	}
-	first, _ := subnets[0].(map[string]any)
-	subnetID, _ = first["id"].(string)
+	subnetID, _ = ipv4SubnetOf(t, subnets)["id"].(string)
 	return id, subnetID
+}
+
+// ipv4SubnetOf picks the IPv4 record out of a subnets list: a Private Network
+// carries one record per family, and most consumers here want the IPv4 half.
+func ipv4SubnetOf(t *testing.T, subnets []any) map[string]any {
+	t.Helper()
+	for _, raw := range subnets {
+		s, _ := raw.(map[string]any)
+		block, _ := s["subnet"].(string)
+		if p, err := netip.ParsePrefix(block); err == nil && p.Addr().Is4() {
+			return s
+		}
+	}
+	t.Fatalf("no IPv4 subnet in %v", subnets)
+	return nil
 }
 
 func bookIP(t *testing.T, ts *httptest.Server, body string) map[string]any {

--- a/internal/providers/scaleway/routes_test.go
+++ b/internal/providers/scaleway/routes_test.go
@@ -34,10 +34,12 @@ func TestListSubnetsServesTheSameSubnetAsTheNetwork(t *testing.T) {
 		t.Fatalf("list subnets: status %d", status)
 	}
 	subnets, _ := body["subnets"].([]any)
-	if len(subnets) != 1 {
-		t.Fatalf("%d subnets, want 1", len(subnets))
+	// One record per family: the flat door serves the same dual-stack pair the
+	// network embeds (#270).
+	if len(subnets) != 2 {
+		t.Fatalf("%d subnets, want 2", len(subnets))
 	}
-	subnet, _ := subnets[0].(map[string]any)
+	subnet := ipv4SubnetOf(t, subnets)
 	// Two doors, one record: the flat listing and the network's own embed must
 	// agree on the id, because the Terraform provider joins on it.
 	if subnet["id"] != subnetID || subnet["private_network_id"] != pnID {

--- a/internal/providers/scaleway/vpc.go
+++ b/internal/providers/scaleway/vpc.go
@@ -49,6 +49,24 @@ var knownRegions = map[string]bool{
 // the same shape so an address computed here looks like one from up there.
 const privateNetworkMask = 22
 
+// privateNetworkV6Mask is the size of a Private Network's IPv6 subnet.
+//
+// Upstream, every Private Network is dual-stack: creation allocates the IPv4
+// block and an IPv6 /64 without being asked, and the SDK carries both in the
+// one subnets list (vpc_sdk.go: PrivateNetwork.Subnets, []*Subnet — there is no
+// separate ipv6 field on the wire; the Terraform provider splits ipv4_subnet
+// from ipv6_subnets by address family, client-side). An emulator serving only
+// the IPv4 half made `one(pn.ipv6_subnets).subnet` die on null, apply and
+// destroy both (#270).
+//
+// Honest caveat: the /64 size and the fd00::/8 unique-local range are derived
+// from the SDK and the provider's documentation, not observed — the shapes
+// catalogue holds no populated private-network read from the real cloud yet.
+// #270 stays open until `feint shapes --record --provider scaleway` runs
+// against an account holding one Private Network and the recording lands in
+// shapes/scaleway.json to arbitrate this.
+const privateNetworkV6Mask = 64
+
 // reservedPerSubnet is what the runtime keeps at the bottom of a Private Network
 // block: the network address, and the gateway the managed bridge answers on.
 const reservedPerSubnet = 2
@@ -275,8 +293,31 @@ func (p *Pack) createPrivateNetwork(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The IPv6 half, allocated whether or not the client asked: upstream every
+	// Private Network is dual-stack (see privateNetworkV6Mask). The id is drawn
+	// first because it seeds the derivation, so the block is a function of the
+	// resource and nothing else.
+	id := p.env.NewID()
+	prefix6, err := p.resolveSubnetV6(req.Subnets, id)
+	if err != nil {
+		writeInvalidArguments(w, ArgumentError{
+			ArgumentName: "subnets",
+			Reason:       "constraint",
+			HelpMessage:  err.Error(),
+		})
+		return
+	}
+	if other, clash := network.FirstOverlap(prefix6, p.usedPrefixes(region)); clash {
+		writeInvalidArguments(w, ArgumentError{
+			ArgumentName: "subnets",
+			Reason:       "constraint",
+			HelpMessage:  "subnet " + prefix6.String() + " overlaps " + other.String(),
+		})
+		return
+	}
+
 	now := p.env.Now()
-	res := resource.New(p.env.NewID(), kindPrivateNetwork, resource.Tenant{Provider: Name, Project: project, Zone: region}, "available", now)
+	res := resource.New(id, kindPrivateNetwork, resource.Tenant{Provider: Name, Project: project, Zone: region}, "available", now)
 	res.Attrs = map[string]any{
 		"name":                              orDefault(req.Name, "pn-"+prefix.Addr().String()),
 		"project_id":                        project,
@@ -286,6 +327,9 @@ func (p *Pack) createPrivateNetwork(w http.ResponseWriter, r *http.Request) {
 		"dhcp_enabled":                      true,
 		"default_route_propagation_enabled": deref(req.DefaultRoutePropagationEnabled, false),
 		"subnet":                            prefix.String(),
+		// Stored, not recomputed at read time: what a client was told once is
+		// what every later read and every restored snapshot must repeat.
+		"subnet_ipv6": prefix6.String(),
 	}
 	// The backing network is created before the resource is stored, and a
 	// failure is fatal to the request rather than logged.
@@ -392,8 +436,8 @@ func (p *Pack) deletePrivateNetwork(w http.ResponseWriter, r *http.Request) {
 // ---- Subnets ----------------------------------------------------------------
 
 // listSubnets answers the region's subnets as first-class objects. They are the
-// same records ListPrivateNetworks already carries on each network — one block
-// per network here — served flat because the SDK offers this second door and
+// same records ListPrivateNetworks already carries on each network — one per
+// address family — served flat because the SDK offers this second door and
 // the Terraform provider matches a booked address's subnet_id against it.
 func (p *Pack) listSubnets(w http.ResponseWriter, r *http.Request) {
 	region, ok := regionOf(w, r)
@@ -408,35 +452,57 @@ func (p *Pack) listSubnets(w http.ResponseWriter, r *http.Request) {
 			return res.Attrs["vpc_id"] == vpcID
 		})
 	}
+
+	// Flattened before filtering and paging: a Private Network carries two
+	// subnets now, and this door serves subnets, not networks — a page size or
+	// a subnet_ids filter counts records of the thing being listed.
+	subnets := make([]map[string]any, 0, 2*len(networks))
+	for _, pn := range networks {
+		subnets = append(subnets, subnetViews(pn)...)
+	}
 	if ids := q["subnet_ids"]; len(ids) > 0 {
 		wanted := make(map[string]bool, len(ids))
 		for _, id := range ids {
 			wanted[id] = true
 		}
-		networks = filterResources(networks, func(res *resource.Resource) bool {
-			return wanted[subnetIDOf(res.ID)]
-		})
+		filtered := subnets[:0]
+		for _, s := range subnets {
+			if id, _ := s["id"].(string); wanted[id] {
+				filtered = append(filtered, s)
+			}
+		}
+		subnets = filtered
 	}
 
 	page := parsePage(r)
-	start, end := page.slice(len(networks))
-	subnets := make([]map[string]any, 0, end-start)
-	for _, pn := range networks[start:end] {
-		subnets = append(subnets, subnetView(pn))
-	}
+	start, end := page.slice(len(subnets))
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"subnets":     subnets,
-		"total_count": len(networks),
+		"subnets":     subnets[start:end],
+		"total_count": len(subnets),
 	})
 }
 
-// subnetView is the wire shape of a Private Network's one subnet, and the same
-// object privateNetworkView embeds: two doors, one record.
-func subnetView(pn *resource.Resource) map[string]any {
+// subnetViews is the wire shape of a Private Network's subnets, one record per
+// family, and the same objects privateNetworkView embeds: two doors, one
+// builder. The SDK has no ipv6 field here — both families ride the one
+// subnets list (vpc_sdk.go: PrivateNetwork.Subnets), and a client tells them
+// apart by address family.
+func subnetViews(pn *resource.Resource) []map[string]any {
 	subnet, _ := pn.Attrs["subnet"].(string)
+	out := []map[string]any{subnetRecord(pn, subnetIDOf(pn.ID), subnet)}
+	// Absent on a resource restored from a snapshot taken before the emulator
+	// allocated IPv6: serve what the store holds rather than invent a block at
+	// read time that no create path ever validated.
+	if subnet6, _ := pn.Attrs["subnet_ipv6"].(string); subnet6 != "" {
+		out = append(out, subnetRecord(pn, subnetV6IDOf(pn.ID), subnet6))
+	}
+	return out
+}
+
+func subnetRecord(pn *resource.Resource, id, block string) map[string]any {
 	return map[string]any{
-		"id":                 subnetIDOf(pn.ID),
-		"subnet":             subnet,
+		"id":                 id,
+		"subnet":             block,
 		"project_id":         pn.Attrs["project_id"],
 		"private_network_id": pn.ID,
 		"vpc_id":             pn.Attrs["vpc_id"],
@@ -598,9 +664,9 @@ func (p *Pack) resolveSubnet(requested []string) (netip.Prefix, error) {
 	if len(requested) == 0 {
 		return p.freePrefix(), nil
 	}
-	// One IPv4 block per Private Network here. Scaleway also carries an IPv6
-	// one, which the allocator does not handle and which no emulated machine
-	// would use.
+	// This resolves the IPv4 block only; the IPv6 one goes through
+	// resolveSubnetV6. Requesting IPv6 alone stays an error, as upstream
+	// requires the IPv4 half.
 	for _, raw := range requested {
 		prefix, err := network.ParseCIDR(raw)
 		if err != nil {
@@ -615,6 +681,42 @@ func (p *Pack) resolveSubnet(requested []string) (netip.Prefix, error) {
 		return prefix, nil
 	}
 	return netip.Prefix{}, fmt.Errorf("no IPv4 subnet in the request")
+}
+
+// resolveSubnetV6 validates the IPv6 block a client asked for, or derives one.
+//
+// A client that named an fd…/64 expects it back unchanged, exactly like the
+// IPv4 path. A client that named none still gets one, because upstream
+// allocates it unasked — that is the whole of #270. The derived block is a
+// unique-local /64 seeded by the resource id: deterministic between two reads,
+// and stored anyway, so it also survives a snapshot into another instance.
+func (p *Pack) resolveSubnetV6(requested []string, id string) (netip.Prefix, error) {
+	for _, raw := range requested {
+		prefix, err := network.ParseCIDR(raw)
+		if err != nil {
+			return netip.Prefix{}, err
+		}
+		if prefix.Addr().Is4() {
+			continue
+		}
+		if err := network.CheckMask(prefix, privateNetworkV6Mask, privateNetworkV6Mask); err != nil {
+			return netip.Prefix{}, err
+		}
+		return prefix, nil
+	}
+	// Nothing requested: derive, and dodge the blocks already held. A clash is
+	// a 2^-56 hash collision or a client that requested this exact block for
+	// another network; salting the seed keeps the loop deterministic given the
+	// same store, and the result is stored, so later reads do not re-run it.
+	taken := p.usedPrefixes("")
+	seed := id
+	for {
+		candidate := network.ULA64(seed)
+		if _, clash := network.FirstOverlap(candidate, taken); !clash {
+			return candidate, nil
+		}
+		seed += "+"
+	}
 }
 
 // freePrefix picks a block from the private range that no Private Network holds.
@@ -651,6 +753,13 @@ func (p *Pack) usedPrefixes(region string) []netip.Prefix {
 		}
 		if prefix, err := prefixOf(res); err == nil {
 			out = append(out, prefix)
+		}
+		// The IPv6 blocks too, so a requested fd…/64 cannot land on a sibling's.
+		// Harmless to the IPv4 callers: Overlaps is false across families.
+		if raw, _ := res.Attrs["subnet_ipv6"].(string); raw != "" {
+			if prefix6, err := network.ParseCIDR(raw); err == nil {
+				out = append(out, prefix6)
+			}
 		}
 	}
 	return out
@@ -838,15 +947,15 @@ func privateNetworkView(res *resource.Resource) map[string]any {
 		"updated_at": res.Updated.Format(time.RFC3339),
 	}
 	for k, v := range res.Attrs {
-		if k == "subnet" {
+		if k == "subnet" || k == "subnet_ipv6" {
 			continue
 		}
 		out[k] = v
 	}
-	// The wire shape carries a list of subnet objects, not the bare block the
-	// store keeps: a client decodes them into vpc.Subnet. The same object
+	// The wire shape carries a list of subnet objects, not the bare blocks the
+	// store keeps: a client decodes them into vpc.Subnet. The same objects
 	// ListSubnets serves flat — one builder, so the two doors cannot disagree.
-	out["subnets"] = []any{subnetView(res)}
+	out["subnets"] = subnetViews(res)
 	return out
 }
 
@@ -858,6 +967,13 @@ func privateNetworkView(res *resource.Resource) map[string]any {
 // looking at.
 func subnetIDOf(privateNetworkID string) string {
 	return derivedID("subnet:" + privateNetworkID)
+}
+
+// subnetV6IDOf is the IPv6 subnet's identifier, distinct from the IPv4 one for
+// the same reason the IPv4 one is distinct from the network's: two records,
+// two ids, or a client holding both cannot tell which it stored.
+func subnetV6IDOf(privateNetworkID string) string {
+	return derivedID("subnet-v6:" + privateNetworkID)
 }
 
 // derivedID builds a UUID-shaped identifier from a seed, deterministically.

--- a/internal/providers/scaleway/vpc_ipv6_test.go
+++ b/internal/providers/scaleway/vpc_ipv6_test.go
@@ -1,0 +1,186 @@
+package scaleway_test
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"testing"
+)
+
+// The IPv6 half of a Private Network (#270). Upstream every Private Network is
+// dual-stack: creation allocates an IPv4 block and an IPv6 /64 without being
+// asked, and both ride the one subnets list (vpc/v2 SDK, PrivateNetwork.Subnets).
+// An emulator serving only the IPv4 half made the ordinary consumer expression,
+// one(pn.ipv6_subnets).subnet, die on null — on apply and on destroy both.
+//
+// The fd00::/8 range and the /64 size are derived from the SDK and the
+// provider's documentation, not yet observed from the real cloud; the issue
+// stays open until a real recording lands in shapes/scaleway.json.
+
+// ipv6SubnetOf picks the IPv6 record out of a subnets list, the counterpart of
+// ipv4SubnetOf.
+func ipv6SubnetOf(t *testing.T, subnets []any) map[string]any {
+	t.Helper()
+	for _, raw := range subnets {
+		s, _ := raw.(map[string]any)
+		block, _ := s["subnet"].(string)
+		if p, err := netip.ParsePrefix(block); err == nil && p.Addr().Is6() && !p.Addr().Is4In6() {
+			return s
+		}
+	}
+	t.Fatalf("no IPv6 subnet in %v", subnets)
+	return nil
+}
+
+func TestPrivateNetworkPublishesAnIPv6Subnet(t *testing.T) {
+	ts := newTestServer(t)
+	ula := netip.MustParsePrefix("fd00::/8")
+
+	id, created := privateNetwork(t, ts, `{"name":"dual"}`)
+	subnets, _ := created["subnets"].([]any)
+	if len(subnets) != 2 {
+		t.Fatalf("expected an IPv4 and an IPv6 subnet, got %v", created["subnets"])
+	}
+	v6 := ipv6SubnetOf(t, subnets)
+
+	block, _ := v6["subnet"].(string)
+	prefix, err := netip.ParsePrefix(block)
+	if err != nil {
+		t.Fatalf("the IPv6 subnet %q does not parse: %v", block, err)
+	}
+	if prefix.Bits() != 64 {
+		t.Errorf("expected a /64, got %s", prefix)
+	}
+	if !ula.Contains(prefix.Addr()) {
+		t.Errorf("expected a unique-local fd… block, got %s", prefix)
+	}
+
+	// Two records, two identities: a client stores both ids.
+	v4 := ipv4SubnetOf(t, subnets)
+	if v6["id"] == v4["id"] || v6["id"] == id || v6["id"] == "" {
+		t.Errorf("the IPv6 subnet has no identity of its own: v6 %v vs v4 %v", v6["id"], v4["id"])
+	}
+	if v6["private_network_id"] != id {
+		t.Errorf("the IPv6 subnet does not name its network: %v", v6)
+	}
+	if v6["vpc_id"] == nil || v6["project_id"] == nil || v6["region"] != "fr-par" {
+		t.Errorf("the IPv6 subnet is missing its scope: %v", v6)
+	}
+
+	// Identical between two reads: anything Terraform stores must be
+	// deterministic, or the computed ipv6_subnets attribute is a permanent diff.
+	for range 2 {
+		status, got := do(t, ts, "GET", regionURL+"/private-networks/"+id, "")
+		if status != http.StatusOK {
+			t.Fatalf("read back: status %d", status)
+		}
+		reread := ipv6SubnetOf(t, got["subnets"].([]any))
+		if reread["subnet"] != block || reread["id"] != v6["id"] {
+			t.Fatalf("the IPv6 subnet changed between reads: %v vs %v", reread, v6)
+		}
+	}
+
+	// The flat door serves the same record: the two doors cannot disagree.
+	status, listed := do(t, ts, "GET", regionURL+"/subnets", "")
+	if status != http.StatusOK {
+		t.Fatalf("list subnets: status %d", status)
+	}
+	flat := ipv6SubnetOf(t, listed["subnets"].([]any))
+	if flat["id"] != v6["id"] || flat["subnet"] != block {
+		t.Errorf("the flat IPv6 subnet disagrees with the network's: %v vs %v", flat, v6)
+	}
+}
+
+func TestTwoNetworksGetTwoIPv6Blocks(t *testing.T) {
+	ts := newTestServer(t)
+
+	_, first := privateNetwork(t, ts, `{"name":"one"}`)
+	_, second := privateNetwork(t, ts, `{"name":"two"}`)
+	a, _ := ipv6SubnetOf(t, first["subnets"].([]any))["subnet"].(string)
+	b, _ := ipv6SubnetOf(t, second["subnets"].([]any))["subnet"].(string)
+	if a == b {
+		t.Fatalf("two networks share the IPv6 block %s", a)
+	}
+}
+
+func TestARequestedIPv6SubnetComesBackVerbatim(t *testing.T) {
+	ts := newTestServer(t)
+
+	_, created := privateNetwork(t, ts,
+		`{"name":"chosen","subnets":["10.44.0.0/24","fd0c:1111:2222:3333::/64"]}`)
+	v6 := ipv6SubnetOf(t, created["subnets"].([]any))
+	if v6["subnet"] != "fd0c:1111:2222:3333::/64" {
+		t.Fatalf("the requested IPv6 block came back as %v", v6["subnet"])
+	}
+
+	// The same block again overlaps a sibling's, exactly like the IPv4 path.
+	status, body := do(t, ts, "POST", regionURL+"/private-networks",
+		`{"name":"clash","subnets":["10.45.0.0/24","fd0c:1111:2222:3333::/64"]}`)
+	if status != http.StatusBadRequest {
+		t.Fatalf("an overlapping IPv6 block was accepted: status %d (%v)", status, body)
+	}
+
+	// A mask that is not /64 is refused: the blocks upstream hands out are /64,
+	// and a stored block the allocator cannot reason about is worse than a 400.
+	status, body = do(t, ts, "POST", regionURL+"/private-networks",
+		`{"name":"wide","subnets":["10.46.0.0/24","fd0d::/48"]}`)
+	if status != http.StatusBadRequest {
+		t.Fatalf("a /48 IPv6 block was accepted: status %d (%v)", status, body)
+	}
+}
+
+// A snapshot is designed to be loaded into another instance, and the computed
+// ipv6_subnets attribute Terraform stored must survive the trip: a block that
+// changed across a restore would be a permanent diff in a configuration that
+// did nothing.
+func TestTheIPv6SubnetSurvivesASnapshotRoundTrip(t *testing.T) {
+	first := newTestServer(t)
+
+	id, created := privateNetwork(t, first, `{"name":"persistent"}`)
+	before := ipv6SubnetOf(t, created["subnets"].([]any))
+
+	snapshot := rawGet(t, first, "/_feint/state")
+
+	// A fresh instance, the way an operator restores: through the served route.
+	second := newTestServer(t)
+	req, err := http.NewRequest(http.MethodPut, second.URL+"/_feint/state", bytes.NewReader(snapshot))
+	if err != nil {
+		t.Fatalf("build the restore: %v", err)
+	}
+	res, err := second.Client().Do(req)
+	if err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	_ = res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("restore answered %d, so this test measured nothing", res.StatusCode)
+	}
+
+	status, got := do(t, second, "GET", regionURL+"/private-networks/"+id, "")
+	if status != http.StatusOK {
+		t.Fatalf("read after restore: status %d", status)
+	}
+	after := ipv6SubnetOf(t, got["subnets"].([]any))
+	if after["subnet"] != before["subnet"] || after["id"] != before["id"] {
+		t.Fatalf("the IPv6 subnet did not survive the snapshot: %v vs %v", after, before)
+	}
+}
+
+func rawGet(t *testing.T, ts *httptest.Server, path string) []byte {
+	t.Helper()
+	res, err := ts.Client().Get(ts.URL + path)
+	if err != nil {
+		t.Fatalf("GET %s: %v", path, err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s: status %d", path, res.StatusCode)
+	}
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("GET %s: read: %v", path, err)
+	}
+	return body
+}

--- a/internal/providers/scaleway/vpc_test.go
+++ b/internal/providers/scaleway/vpc_test.go
@@ -56,10 +56,12 @@ func TestPrivateNetworkRoundTripsItsBlock(t *testing.T) {
 
 	_, created := privateNetwork(t, ts, `{"name":"app","subnets":["10.20.0.0/24"]}`)
 	subnets, _ := created["subnets"].([]any)
-	if len(subnets) != 1 {
-		t.Fatalf("expected one subnet, got %v", created["subnets"])
+	// Two records, one per family: the IPv4 block the client chose, and the
+	// IPv6 /64 upstream allocates unasked (#270).
+	if len(subnets) != 2 {
+		t.Fatalf("expected two subnets, got %v", created["subnets"])
 	}
-	subnet, _ := subnets[0].(map[string]any)
+	subnet := ipv4SubnetOf(t, subnets)
 	if subnet["subnet"] != "10.20.0.0/24" {
 		t.Errorf("block came back as %v, want 10.20.0.0/24", subnet["subnet"])
 	}

--- a/tools/conformance/scaleway/terraform.sh
+++ b/tools/conformance/scaleway/terraform.sh
@@ -112,6 +112,18 @@ printf '%s' "$ipam_body" | jq -e '.resource.type == "instance_private_nic" and (
   || fail "the booked address does not name the NIC carrying it: $ipam_body"
 ok "10.182.0.10 booked and carried by a NIC"
 
+# The IPv6 half of the Private Network (#270). The fixture's ipv6_subnet output
+# is one(pn.ipv6_subnets).subnet — the expression that died on null while this
+# emulator served IPv4 only, on apply and then again on destroy — so reaching
+# this line at all means the provider found exactly one IPv6 subnet. What is
+# asserted on top is its advertised form: a unique-local /64.
+echo "- the private network publishes one IPv6 /64"
+ipv6_subnet="$("$TF" output -raw ipv6_subnet)"
+case "$ipv6_subnet" in
+  fd*/64) ok "ipv6_subnets carries $ipv6_subnet" ;;
+  *) fail "expected a unique-local /64 in ipv6_subnets, got '$ipv6_subnet'" ;;
+esac
+
 route_id="$("$TF" output -raw route_id)"
 route_uuid="${route_id##*/}"
 code="$(curl -s -o /dev/null -w '%{http_code}' "$ENDPOINT/vpc/v2/regions/fr-par/routes/$route_uuid")"

--- a/tools/conformance/scaleway/terraform/main.tf
+++ b/tools/conformance/scaleway/terraform/main.tf
@@ -238,6 +238,15 @@ resource "scaleway_instance_private_nic" "conformance" {
   zone               = "fr-par-1"
 }
 
+# The exact expression that killed the talos stack (#270): upstream always
+# allocates exactly one IPv6 /64 per Private Network, so one() is the ordinary
+# way to consume it — and against an emulator publishing no IPv6 subnet, one()
+# yields null, this output dies on apply, and a stack already applied cannot
+# even destroy. Keeping the expression here makes that a permanent regression.
+output "ipv6_subnet" {
+  value = one(scaleway_vpc_private_network.conformance.ipv6_subnets).subnet
+}
+
 output "server_id" {
   value = scaleway_instance_server.conformance.id
 }

--- a/tools/falsify/specs/private-network-ipv6.json
+++ b/tools/falsify/specs/private-network-ipv6.json
@@ -1,0 +1,19 @@
+{
+  "package": "./internal/providers/scaleway/",
+  "mutations": [
+    {
+      "label": "the IPv6 block is stored under a key nothing reads, so the network publishes IPv4 only",
+      "file": "internal/providers/scaleway/vpc.go",
+      "find": "\t\t\"subnet_ipv6\": prefix6.String(),",
+      "replace": "\t\t\"subnet_ipv6\" + \"-unread\": prefix6.String(),",
+      "test": "TestPrivateNetworkPublishesAnIPv6Subnet"
+    },
+    {
+      "label": "the stored IPv6 block never reaches the subnets list",
+      "file": "internal/providers/scaleway/vpc.go",
+      "find": "\tif subnet6, _ := pn.Attrs[\"subnet_ipv6\"].(string); subnet6 != \"\" {",
+      "replace": "\tif subnet6, _ := pn.Attrs[\"subnet_ipv6\"].(string); subnet6 != \"\" && false {",
+      "test": "TestPrivateNetworkPublishesAnIPv6Subnet"
+    }
+  ]
+}


### PR DESCRIPTION
# Summary

Upstream, every VPC Private Network is dual-stack: creation allocates the IPv4
block **and** an IPv6 `/64` without being asked. This emulator allocated only
the IPv4 half, so the Terraform provider's computed `ipv6_subnets` was an empty
set and the ordinary way of consuming it — `one(pn.ipv6_subnets).subnet`, the
exact expression the talos scaleway stack templates — died on null, on apply
and then again on destroy (#270).

A Private Network now stores and publishes one subnet per family.

**The measured shape.** The SDK has no `ipv6` field on the wire: both families
ride the one `subnets` list —
`.upstream/scaleway-sdk-go/api/vpc/v2/vpc_sdk.go:634` (`PrivateNetwork.Subnets
[]*Subnet`), `vpc_sdk.go:546-573` (`Subnet`: `id`, `created_at`, `updated_at`,
`subnet` as `scw.IPNet`, `project_id`, `private_network_id`, `vpc_id`,
`region`), confirmed by `.upstream/scaleway-openapi/vpc-v2.yml`
(`scaleway.vpc.v2.Subnet`, lines 685-740; `PrivateNetwork.subnets`, line 536).
The Terraform provider splits `ipv4_subnet` from `ipv6_subnets` client-side, by
address family. `contracts/scaleway.json` already models `subnets` as a list of
`Subnet`, so the contract gate needed no change.

**What the allocation produces.** An RFC 4193 unique-local `/64`
(`fd…::/64`), derived from SHA-256 of the resource id
(`internal/core/network/ula.go`, provider-neutral, no provider name in the
core). Derived once at create, validated against every block the region holds
(same `FirstOverlap` path as IPv4), then **stored** on the resource — so it is
identical between two reads, survives a snapshot into another instance, and a
client that requested its own `fd…/64` gets it back verbatim. The IPv4
allocator, IPAM and the machine runtime stay IPv4; `BookIP` with `is_ipv6`
still refuses, now with a message that says the subnet exists but carries no
bookable address.

**Honest caveat, and why this does not close #270.** The `/64` size and the
`fd00::/8` range are derived from the SDK and the provider's documentation,
**not observed**: `shapes/scaleway.json` still holds no populated
private-network read from the real cloud. The code says so
(`privateNetworkV6Mask` in `internal/providers/scaleway/vpc.go`). The issue
stays open until the recording lands — see the procedure below.

## Real-cloud recording, for whoever holds an account

`internal/upstream/reads.go` already asks
`GET /vpc/v2/regions/fr-par/private-networks`; it has only ever been recorded
against an empty account. The listing embeds the same `PrivateNetwork` struct
as the by-id read, so a populated listing arbitrates the same `subnets` field
tree. Three commands:

```bash
scw vpc private-network create name=feint-shape-270 region=fr-par
feint shapes --record --provider scaleway     # announces each call; the raw
                                              # subnets values print here
scw vpc private-network delete <id> region=fr-par
```

Then `git diff shapes/scaleway.json` should show the `subnets` field tree under
`GET /vpc/v2/regions/fr-par/private-networks`; commit it. Note the catalogue
records field paths and JSON types, not values — the `fd…/64` value itself is
visible in the command's own output, and pasting the (id-sanitised) `subnets`
array into #270 would settle the range question for good.

## Evidence

- Unit: `TestPrivateNetworkPublishesAnIPv6Subnet` (fd…/64, own id, stable
  across reads, both doors agree), `TestTwoNetworksGetTwoIPv6Blocks`,
  `TestARequestedIPv6SubnetComesBackVerbatim` (verbatim round-trip, overlap
  and mask refusals), `TestTheIPv6SubnetSurvivesASnapshotRoundTrip` (through
  `GET`/`PUT /_feint/state`, into a fresh instance),
  `TestULA64IsDeterministicAndWellFormed`.
- Conformance: the fixture now carries
  `output "ipv6_subnet" { value = one(pn.ipv6_subnets).subnet }` — the exact
  expression that exploded — and `terraform.sh` asserts it is a `fd*/64`. The
  suite's existing second `plan -detailed-exitcode` (must be 0) and full
  destroy bracket it, which is the regression #270 demands: apply, empty plan,
  destroy, all through the real provider.
- Falsification: `tools/falsify/specs/private-network-ipv6.json` — removing
  the allocation, or the publication, turns
  `TestPrivateNetworkPublishesAnIPv6Subnet` red ("the test bit", twice);
  `mise run falsify:lint` green.
- `mise run check` and `mise run conformance` run locally (FEINT_VM off).

## Type of change

- [x] A route added or changed (response shape of existing VPC routes)
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes (gofmt, vet, golangci-lint, `go test -race`)
- [x] No new external Go dependency, or the pull request justifies it. The
      standard library covers routing, JSON and Go parsing; `go.mod` has three
      lines and a pre-commit hook keeps it that way
- [x] `internal/core` still knows no provider. If a change seemed to require it,
      the pack changed instead — `network.ULA64` takes a seed string and knows
      nothing about who calls it
- [x] Nothing in the diff could be written identically for another provider. If
      it could, it belongs in the core — the derivation went to
      `internal/core/network`; what stays in the pack is Scaleway's own facts
      (dual-stack-always, /64, the one shared `subnets` list)

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] I ran `mise run conformance` myself — not "it should pass"
- [x] Every field name in the diff comes from the provider's SDK, their OpenAPI
      document, or a run of the real client, and I can say which: every subnet
      field is `vpc_sdk.go:546-573`; the `fd00::/8` `/64` is the one derived
      value, flagged as derived-not-observed in the code and above

### When a route is added or changed — otherwise N/A

- [x] The route declares its upstream operation at the SDK's exact name — no
      route added; the touched handlers keep their existing operations
- [x] `mise run conformance` passes — at minimum the suite of the provider
      touched
- [x] The response was validated against the provider's own API description
      (`--contracts contracts`), not against what looked right
- [x] What the client sends is read, or refused — the IPv6 entry of `subnets`
      was previously parsed and dropped; it is now honoured or refused
- [x] `mise run drift:update` run, and `coverage/` committed with the change —
      run: no operation was added or removed, so `coverage/` is unchanged and
      there is nothing to commit

### When behaviour a client can observe changes — otherwise N/A

- [x] `docs/limits.md` updated if the change moves a documented limit — checked:
      no documented limit names the Private Network subnet count; IPv6 booking
      stays refused and the refusal message now says why
- [x] The README's generated tables regenerated (`mise run docs:coverage`) — no
      coverage change; `feint docs --check` green

### When `.github/workflows/` is touched — otherwise N/A

N/A — no workflow touched.

### When a machine runtime is involved — otherwise N/A

N/A — the machine runtime is untouched and stays IPv4; the IPv6 subnet is
control-plane only, which the code comments state.

## Related issues

Refs #270 — **deliberately not `Closes`**: the issue requires a real-cloud
recording in `shapes/scaleway.json` before it closes, and this pull request
ships the derived shape plus the recording procedure, not the recording.
