### PR TITLE
fix(exoscale): a declared query parameter is served or refused, never dropped (#271)

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -28,7 +28,7 @@
 >
 > **Prouvé** : 264 des 285 opérations montées sont pilotées par un vrai client, à chaque pull request. `scw`, `oapi-cli`, `exo`, Terraform et OpenTofu tournent contre l'émulateur en CI, et les machines démarrent réellement : connexion ssh sur le compte par défaut de chaque provider, subnets isolés, pare-feu qui filtre. La chaîne complète est décrite dans [docs/conformance.md](docs/conformance.md).
 >
-> **Pas prouvé** : quotas, prix, capacité réelle, validation des identifiants, authentification, cohérence à terme. Les 31 sections de [docs/limits.md](docs/limits.md) disent chacune ce qu'elle coûte. Un émulateur avec un seul compte implicite et aucune grille tarifaire devrait inventer ces chiffres, et quelqu'un agirait dessus.
+> **Pas prouvé** : quotas, prix, capacité réelle, validation des identifiants, authentification, cohérence à terme. Les 32 sections de [docs/limits.md](docs/limits.md) disent chacune ce qu'elle coûte. Un émulateur avec un seul compte implicite et aucune grille tarifaire devrait inventer ces chiffres, et quelqu'un agirait dessus.
 >
 > **Inconnu** : 21 opérations sont montées et n'ont jamais été pilotées par un client. Chacune dit pourquoi aucun client officiel ne l'atteint, à la route et dans [docs/routes.md](docs/routes.md). Elles sont comptées plutôt qu'escamotées, une par une, dans [coverage/evidence.json](coverage/evidence.json).
 >

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 >
 > **Proven**: 264 of the 285 mounted operations are driven by a real client, on every pull request. `scw`, `oapi-cli`, `exo`, Terraform and OpenTofu run against the emulator in CI, and machines really boot: an ssh login on each provider's own default account, isolated subnets, a firewall that filters. The whole chain is described in [docs/conformance.md](docs/conformance.md).
 >
-> **Not proven**: quotas, prices, real capacity, identifier validation, authentication, eventual consistency. The 31 sections of [docs/limits.md](docs/limits.md) each say what one costs. An emulator with a single implicit account and no price list would have to invent those figures, and somebody would act on them.
+> **Not proven**: quotas, prices, real capacity, identifier validation, authentication, eventual consistency. The 32 sections of [docs/limits.md](docs/limits.md) each say what one costs. An emulator with a single implicit account and no price list would have to invent those figures, and somebody would act on them.
 >
 > **Unknown**: 21 operations are mounted and have never been driven by a client. Every one of them states why no official client reaches it, at the route and in [docs/routes.md](docs/routes.md). They are counted rather than glossed, one by one, in [coverage/evidence.json](coverage/evidence.json).
 >

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -1221,6 +1221,36 @@ The consequence, stated rather than hidden: a client asking for `ch-gva-2` gets
 difference. The alternative — one endpoint pretending to be eight zones — is a
 silent, wrong one.
 
+## A declared query parameter is served or refused, never dropped — and `labels` is the refused one
+
+`GET /v2/template?visibility=private` used to answer the public catalogue,
+each entry declaring `"visibility": "public"` inside a response filtered to
+`private` (#271). The cause was a handler that discarded its request, so no
+query parameter could have an effect — and the same signature sat on four more
+Exoscale operations whose contract declares filters. All five now read what
+their operation declares: `visibility` and `family` on list-templates,
+`visibility` on list-security-groups, `manager-id`, `manager-type` and
+`ip-address` on list-instances, `instance-id` on list-block-storage-volumes,
+and list-events validates its `from`/`to` window (over an audit trail that is
+empty by design, see above). A gate holds the rule from here on:
+`TestDeclaredQueryParametersAreRead` fails any route whose contract declares
+query parameters while its handler never reads the query.
+
+Two answers differ from the real cloud, and both are the honest half of a
+choice rather than an accident:
+
+- **`labels` on list-instances is refused with a 400**, not implemented. Their
+  document types it as a bare string with no format and no description,
+  egoscale v3 exposes no option that sends it, so any wire encoding this
+  emulator picked would be an invented format — the thing rule 4 exists to
+  forbid. A client that sends it learns so at the moment it happens;
+  the real cloud would filter. `TestInstanceListRefusesTheLabelsFilter` holds
+  the refusal.
+- **`?visibility=public` on list-security-groups answers an empty list.** The
+  real cloud publishes public security groups of its own; this emulator
+  publishes none, and listing the private groups under a public label would be
+  the same lie #271 names, pointed the other way.
+
 ## ReadTags does not list an internet service, because upstream names no type for one
 
 Outscale's `Tag` carries a `ResourceType`, and their OpenAPI declares it as a

--- a/internal/core/emulator/queryparams_test.go
+++ b/internal/core/emulator/queryparams_test.go
@@ -1,0 +1,273 @@
+package emulator_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/contract"
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/providers/exoscale"
+	"github.com/stephrobert/feint/internal/providers/outscale"
+	"github.com/stephrobert/feint/internal/providers/scaleway"
+)
+
+// A parameter the contract declares and a handler never reads is invisible to
+// every other gate this project has: the route mounts, the response validates,
+// the drift report joins on the operation name, and the client does not always
+// crash. What the client gets is an answer that ignores its request —
+// `?visibility=private` returning the public catalogue was #271, and the same
+// discarded-request signature sat on four more operations with declared
+// filters when it was first measured (five of the twelve Exoscale operations
+// that declare query parameters, none of Scaleway's fifty-four read nothing,
+// two read only the path).
+//
+// So the gate is structural: for every mounted route whose contract operation
+// declares query parameters, the handler must read the request's query —
+// itself, or through a same-package function it hands the request to. Reading
+// the query is necessary for any parameter to have an effect, so a handler
+// that provably never looks cannot be honouring anything. What this cannot
+// see is a handler that reads the query and drops one declared parameter of
+// several; that depth needs value-level analysis, and the behavioural tests
+// in each pack carry it for the operations fixed under #271.
+//
+// The handler is attributed from the pack's own route table in source, not
+// from the mounted function pointer: packs wrap their handlers (Exoscale's
+// guardSplitClients, Outscale's dryRunnable), and every wrapped pointer
+// resolves to the same closure.
+func TestDeclaredQueryParametersAreRead(t *testing.T) {
+	env := emulator.DefaultEnv()
+	packs := map[string]emulator.Pack{
+		scaleway.Name: scaleway.New(env),
+		outscale.Name: outscale.New(env),
+		exoscale.Name: exoscale.New(env),
+	}
+
+	for provider, pack := range packs {
+		doc, err := contract.Load(filepath.Join("..", "..", "..", "contracts", provider+".json"))
+		if err != nil {
+			t.Fatalf("%s: load contract: %v", provider, err)
+		}
+		files, err := packSources(filepath.Join("..", "..", "providers", provider))
+		if err != nil {
+			t.Fatalf("%s: parse pack sources: %v", provider, err)
+		}
+		readers := queryReaders(files)
+		handlerOf := map[string]string{}
+		for rawOperation, handler := range routeHandlers(files) {
+			if _, name, ok := doc.OperationFor(rawOperation); ok {
+				handlerOf[name] = handler
+			}
+		}
+
+		for _, route := range pack.Routes() {
+			op, name, known := doc.OperationFor(route.Operation)
+			if !known || len(op.Query) == 0 {
+				continue
+			}
+			params := make([]string, 0, len(op.Query))
+			for param := range op.Query {
+				params = append(params, param)
+			}
+			sort.Strings(params)
+
+			handler := handlerOf[name]
+			if handler == "" {
+				t.Errorf("%s: %s declares query parameters (%s) and the gate cannot attribute its handler from the route table; declare the route with Handler: p.<method> or teach the gate the builder",
+					provider, route.Operation, strings.Join(params, ", "))
+				continue
+			}
+			if !readers[handler] {
+				t.Errorf("%s: %s declares query parameters (%s) and its handler %s never reads the request's query — implement them or refuse them, never drop them (#271)",
+					provider, route.Operation, strings.Join(params, ", "), handler)
+			}
+		}
+	}
+}
+
+// packSources parses every non-test file of one pack package.
+func packSources(dir string) ([]*ast.File, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	fset := token.NewFileSet()
+	var files []*ast.File
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, filepath.Join(dir, name), nil, 0)
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, file)
+	}
+	return files, nil
+}
+
+// routeHandlers reads the pack's route table: every composite literal carrying
+// an Operation and a Handler key yields the operation's declared name and the
+// method that serves it. The operation is a string literal (Scaleway) or a
+// one-argument helper call like operation("list-templates") (Exoscale); the
+// handler is the p.<method> the literal names, before any wrapping.
+func routeHandlers(files []*ast.File) map[string]string {
+	out := map[string]string{}
+	for _, file := range files {
+		ast.Inspect(file, func(n ast.Node) bool {
+			lit, ok := n.(*ast.CompositeLit)
+			if !ok {
+				return true
+			}
+			var operation, handler string
+			for _, elt := range lit.Elts {
+				kv, ok := elt.(*ast.KeyValueExpr)
+				if !ok {
+					continue
+				}
+				key, ok := kv.Key.(*ast.Ident)
+				if !ok {
+					continue
+				}
+				switch key.Name {
+				case "Operation":
+					operation = operationLiteral(kv.Value)
+				case "Handler":
+					if sel, ok := kv.Value.(*ast.SelectorExpr); ok {
+						handler = sel.Sel.Name
+					}
+				}
+			}
+			if operation != "" && handler != "" {
+				out[operation] = handler
+			}
+			return true
+		})
+	}
+	return out
+}
+
+// operationLiteral unwraps the two spellings a route table uses for its
+// operation name.
+func operationLiteral(expr ast.Expr) string {
+	switch v := expr.(type) {
+	case *ast.BasicLit:
+		return strings.Trim(v.Value, `"`)
+	case *ast.CallExpr:
+		if len(v.Args) == 1 {
+			if arg, ok := v.Args[0].(*ast.BasicLit); ok {
+				return strings.Trim(arg.Value, `"`)
+			}
+		}
+	}
+	return ""
+}
+
+// queryReaders reports, for every function of one pack package, whether it
+// reads its *http.Request parameter's query — directly (r.URL, r.Form,
+// r.FormValue, r.PostForm) or by handing the request to a same-package
+// function that does.
+func queryReaders(files []*ast.File) map[string]bool {
+	direct := map[string]bool{}
+	handsTo := map[string][]string{}
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			request := requestParamName(fn)
+			if request == "" || request == "_" {
+				continue
+			}
+			reads, callees := requestUse(fn.Body, request)
+			direct[fn.Name.Name] = reads
+			handsTo[fn.Name.Name] = callees
+		}
+	}
+
+	// Propagate through the calls that carry the request, to a fixed point:
+	// listServerTypes reads nothing itself and hands the request to parsePage,
+	// which does.
+	for changed := true; changed; {
+		changed = false
+		for name, callees := range handsTo {
+			if direct[name] {
+				continue
+			}
+			for _, callee := range callees {
+				if direct[callee] {
+					direct[name] = true
+					changed = true
+					break
+				}
+			}
+		}
+	}
+	return direct
+}
+
+// requestParamName names the *http.Request parameter, or "" when there is none.
+func requestParamName(fn *ast.FuncDecl) string {
+	for _, field := range fn.Type.Params.List {
+		star, ok := field.Type.(*ast.StarExpr)
+		if !ok {
+			continue
+		}
+		sel, ok := star.X.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Request" {
+			continue
+		}
+		for _, name := range field.Names {
+			return name.Name
+		}
+	}
+	return ""
+}
+
+// requestUse walks one body: does it touch the request's query surface, and
+// which functions does it pass the request to.
+func requestUse(body *ast.BlockStmt, request string) (reads bool, callees []string) {
+	ast.Inspect(body, func(n ast.Node) bool {
+		if sel, ok := n.(*ast.SelectorExpr); ok {
+			if base, ok := sel.X.(*ast.Ident); ok && base.Name == request {
+				switch sel.Sel.Name {
+				case "URL", "Form", "PostForm", "FormValue", "PostFormValue":
+					reads = true
+				}
+			}
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		for _, arg := range call.Args {
+			if id, ok := arg.(*ast.Ident); ok && id.Name == request {
+				callees = append(callees, calleeName(call.Fun))
+			}
+		}
+		return true
+	})
+	return reads, callees
+}
+
+// calleeName is the bare name a call resolves to inside one package:
+// parsePage for parsePage(r), serverOf for p.serverOf(w, r). Package-qualified
+// calls resolve to their bare selector too, which can only cause a false
+// "reads" if an external helper shares its name with a query-reading local
+// one — accepted, since the gate errs loudly in the other direction.
+func calleeName(fun ast.Expr) string {
+	switch v := fun.(type) {
+	case *ast.Ident:
+		return v.Name
+	case *ast.SelectorExpr:
+		return v.Sel.Name
+	}
+	return ""
+}

--- a/internal/providers/exoscale/account.go
+++ b/internal/providers/exoscale/account.go
@@ -2,6 +2,7 @@ package exoscale
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/stephrobert/feint/internal/core/emulator"
 	"github.com/stephrobert/feint/internal/core/resource"
@@ -45,7 +46,26 @@ const emulatedOrganizationID = "88888888-8888-4888-8888-888888888888"
 //
 // Inventing entries would be worse than either — a client would read a history
 // that never happened.
-func (p *Pack) listEvents(w http.ResponseWriter, _ *http.Request) {
+//
+// The from/to window their document declares on this operation
+// (.upstream/exoscale-openapi.yaml:12234-12246, both format date-time) is read
+// and checked rather than dropped: any window over an empty trail is the empty
+// trail, so honouring the filter costs nothing, and a malformed timestamp is
+// refused the way the real API refuses a value outside its declared format —
+// not swallowed by a handler that never looked (#271 names the class).
+//
+// TestEventWindowIsValidated fails without the check.
+func (p *Pack) listEvents(w http.ResponseWriter, r *http.Request) {
+	for _, key := range []string{"from", "to"} {
+		value := r.URL.Query().Get(key)
+		if value == "" {
+			continue
+		}
+		if _, err := time.Parse(time.RFC3339, value); err != nil {
+			writeError(w, http.StatusBadRequest, key+" must be a date-time")
+			return
+		}
+	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{"events": []any{}})
 }
 

--- a/internal/providers/exoscale/block.go
+++ b/internal/providers/exoscale/block.go
@@ -265,11 +265,25 @@ func labelsOrEmpty(labels map[string]string) map[string]string {
 	return labels
 }
 
-func (p *Pack) listBlockVolumes(w http.ResponseWriter, _ *http.Request) {
+// listBlockVolumes answers the volumes, narrowed to one instance's when the
+// client asks: their document declares an instance-id filter on this operation
+// (.upstream/exoscale-openapi.yaml:24620-24626), and the handler used to
+// discard the request, so a client reading one machine's disks read the whole
+// account's (#271 names the class).
+//
+// TestBlockVolumeInstanceFilterIsHonoured fails without the filter.
+func (p *Pack) listBlockVolumes(w http.ResponseWriter, r *http.Request) {
+	instanceID := r.URL.Query().Get("instance-id")
 	list := p.env.Store.List(kindBlockVolume, resource.Tenant{Provider: Name})
 	sort.Slice(list, func(i, j int) bool { return list[i].ID < list[j].ID })
 	out := make([]map[string]any, 0, len(list))
 	for _, res := range list {
+		if instanceID != "" {
+			attached, _ := res.Attrs["instance"].(map[string]any)
+			if attached["id"] != instanceID {
+				continue
+			}
+		}
 		out = append(out, p.blockVolumeView(res))
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{"block-storage-volumes": out})

--- a/internal/providers/exoscale/catalog.go
+++ b/internal/providers/exoscale/catalog.go
@@ -126,18 +126,53 @@ var instanceTypes = []map[string]any{
 // listTemplates serves the same table the machine driver boots from, so what a
 // client can choose and what the emulator can start cannot drift apart. Holding
 // two lists is how a client ends up picking a template that boots nothing.
-// listTemplates answers the fixed catalogue and whatever the tenant registered or
-// promoted, in one list (#173).
 //
-// One list because a client resolving a template by name has no idea which of the
-// two it is asking for. Serving them apart would be an emulator detail surfacing
-// in an API the client reads as a single inventory — and `exo compute instance
-// create --template <name>` walks exactly this list.
-func (p *Pack) listTemplates(w http.ResponseWriter, _ *http.Request) {
+// The two worlds are NOT one list. Their document declares a visibility filter
+// on this operation — enum private|public, with a family filter beside it
+// (.upstream/exoscale-openapi.yaml:21648-21662) — and the split is the point:
+// public is Exoscale's catalogue, private is what the organisation registered
+// or promoted. The first version discarded the request (`_ *http.Request`), so
+// `?visibility=private` on a fresh store answered the public catalogue, every
+// entry contradicting the filter it was inside (#271). No client escaped the
+// parameter either: `exo compute instance-template list` always sends
+// visibility (its default is public), and sends family beside it when asked —
+// measured through a recording proxy on exo 1.95.1.
+//
+// Absent, visibility defaults to public. That is the one case no real client
+// exercises — the CLI and egoscale always name one — and the catalogue is what
+// keeps a paramless read (the probe, a curl, the cross-pack catalogue guard)
+// meaning "what can I boot here".
+//
+// TestTemplateVisibilityIsHonoured fails without the filter, and
+// TestTemplateFamilyIsHonoured without family.
+func (p *Pack) listTemplates(w http.ResponseWriter, r *http.Request) {
+	visibility := r.URL.Query().Get("visibility")
+	family := r.URL.Query().Get("family")
+
+	matches := func(view map[string]any) bool {
+		return family == "" || view["family"] == family
+	}
+
 	out := make([]map[string]any, 0, len(templates))
-	out = append(out, templates...)
-	for _, res := range p.storedTemplates() {
-		out = append(out, p.templateView(res))
+	switch visibility {
+	case "", "public":
+		for _, t := range templates {
+			if matches(t) {
+				out = append(out, t)
+			}
+		}
+	case "private":
+		for _, res := range p.storedTemplates() {
+			if view := p.templateView(res); matches(view) {
+				out = append(out, view)
+			}
+		}
+	default:
+		// The enum is closed in their document; a value outside it is a request
+		// this emulator cannot answer honestly, so it refuses rather than picking
+		// a visibility the client never asked for.
+		writeError(w, http.StatusBadRequest, "visibility must be private or public")
+		return
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{"templates": out})
 }

--- a/internal/providers/exoscale/pack.go
+++ b/internal/providers/exoscale/pack.go
@@ -767,7 +767,56 @@ func (r createInstanceRequest) keyNames() []string {
 	return names
 }
 
+// instanceListFilter is what list-instances may narrow the answer by. Their
+// document declares four query parameters on the operation — manager-id,
+// manager-type (enum instance-pool), ip-address and labels
+// (.upstream/exoscale-openapi.yaml:24156-24178) — and the handler read none of
+// them, which is the list-templates defect (#271) on another operation: an
+// instance pool asking for its own members received every instance the store
+// holds.
+//
+// labels is the one refused rather than served: their document types it as a
+// bare string with no format and no description, egoscale v3 exposes no option
+// for it, so any wire encoding this emulator picked would be an invented format
+// — the thing rule 4 of CLAUDE.md forbids. A client that sends it gets a 400
+// naming the parameter, never a silently unfiltered list. docs/limits.md
+// carries the decision.
+//
+// TestInstanceListFiltersAreHonoured fails if a filter stops narrowing, and
+// TestInstanceListRefusesTheLabelsFilter if the refusal goes quiet.
+type instanceListFilter struct {
+	managerID, managerType, ipAddress string
+}
+
+func (f instanceListFilter) matches(view map[string]any) bool {
+	if f.managerID != "" || f.managerType != "" {
+		manager, _ := view["manager"].(map[string]any)
+		if f.managerID != "" && manager["id"] != f.managerID {
+			return false
+		}
+		if f.managerType != "" && manager["type"] != f.managerType {
+			return false
+		}
+	}
+	return f.ipAddress == "" || view["public-ip"] == f.ipAddress
+}
+
 func (p *Pack) listInstances(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query()
+	if query.Get("labels") != "" {
+		writeError(w, http.StatusBadRequest, "the labels filter is not served by this emulator")
+		return
+	}
+	if t := query.Get("manager-type"); t != "" && t != "instance-pool" {
+		writeError(w, http.StatusBadRequest, "manager-type must be instance-pool")
+		return
+	}
+	filter := instanceListFilter{
+		managerID:   query.Get("manager-id"),
+		managerType: query.Get("manager-type"),
+		ipAddress:   query.Get("ip-address"),
+	}
+
 	list := p.env.Store.List(kindInstance, resource.Tenant{Provider: Name})
 	instances := make([]map[string]any, 0, len(list))
 	for _, res := range list {
@@ -786,7 +835,12 @@ func (p *Pack) listInstances(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			continue
 		}
-		instances = append(instances, p.view(fresh))
+		// Filtered on the view rather than on the stored attributes, because
+		// public-ip is a fact the view computes and the filter must see the
+		// same value the client would read back.
+		if view := p.view(fresh); filter.matches(view) {
+			instances = append(instances, view)
+		}
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{"instances": instances})
 }

--- a/internal/providers/exoscale/queryfilters_test.go
+++ b/internal/providers/exoscale/queryfilters_test.go
@@ -1,0 +1,289 @@
+package exoscale_test
+
+import (
+	"net/http"
+	"testing"
+)
+
+// The query filters #271 turned up.
+//
+// GET /v2/template?visibility=private answered the public catalogue, each entry
+// declaring "visibility": "public" inside a response filtered to private — the
+// reply refuting its own request. The cause was structural, not a wrong branch:
+// the handler discarded its *http.Request, so no query parameter could ever
+// matter. Four more handlers in this pack had the same signature while their
+// operations declared filters, and every test here holds one of them to the
+// contract's word. The fresh-store private list is the case that lied, so it
+// is asserted first.
+
+func templatesOf(t *testing.T, h http.Handler, query string) []map[string]any {
+	t.Helper()
+	status, list := callRaw(h, "GET", "/v2/template"+query, "")
+	if status != http.StatusOK {
+		t.Fatalf("list templates %q: status %d (%v)", query, status, list)
+	}
+	raw, ok := list["templates"].([]any)
+	if !ok {
+		t.Fatalf("list templates %q answered no templates array: %v", query, list)
+	}
+	out := make([]map[string]any, 0, len(raw))
+	for _, entry := range raw {
+		view, _ := entry.(map[string]any)
+		out = append(out, view)
+	}
+	return out
+}
+
+func aRegisteredTemplate(t *testing.T, h http.Handler, name string) string {
+	t.Helper()
+	status, out := callRaw(h, "POST", "/v2/template", `{
+		"name": "`+name+`",
+		"url": "https://example.invalid/`+name+`.qcow2",
+		"checksum": "0123456789abcdef0123456789abcdef",
+		"default-user": "debian"
+	}`)
+	if status != http.StatusOK {
+		t.Fatalf("register %s: status %d (%v)", name, status, out)
+	}
+	ref, _ := out["reference"].(map[string]any)
+	id, _ := ref["id"].(string)
+	if id == "" {
+		t.Fatalf("register %s: the operation names no resource (%v)", name, out)
+	}
+	return id
+}
+
+func TestTemplateVisibilityIsHonoured(t *testing.T) {
+	h, _ := newExoscaleBarrageServer(t)
+
+	// On a fresh store the honest answer to "my templates" is none — this is
+	// the exact read that answered the public catalogue (#271).
+	if got := templatesOf(t, h, "?visibility=private"); len(got) != 0 {
+		t.Fatalf("a fresh store answered %d private template(s): %v", len(got), got)
+	}
+
+	registered := aRegisteredTemplate(t, h, "registered-private")
+
+	private := templatesOf(t, h, "?visibility=private")
+	if len(private) != 1 {
+		t.Fatalf("after one register the private list holds %d template(s): %v", len(private), private)
+	}
+	if id, _ := private[0]["id"].(string); id != registered {
+		t.Errorf("the private list answers %q, want the registered %q", id, registered)
+	}
+	if v, _ := private[0]["visibility"].(string); v != "private" {
+		t.Errorf("a private-filtered entry declares visibility %q", v)
+	}
+
+	// The public list is Exoscale's catalogue and never the tenant's: mixing
+	// them is how a client counting an organisation's templates counts the
+	// provider's.
+	for _, view := range templatesOf(t, h, "?visibility=public") {
+		if v, _ := view["visibility"].(string); v != "public" {
+			t.Errorf("a public-filtered entry declares visibility %q: %v", v, view)
+		}
+		if id, _ := view["id"].(string); id == registered {
+			t.Errorf("the registered template leaked into the public list")
+		}
+	}
+	if got := templatesOf(t, h, "?visibility=public"); len(got) == 0 {
+		t.Errorf("the public catalogue is empty; the create path dies on it")
+	}
+
+	// Outside the enum their document closes, the emulator refuses rather than
+	// picking a visibility the client never asked for.
+	if status, _ := callRaw(h, "GET", "/v2/template?visibility=confidential", ""); status != http.StatusBadRequest {
+		t.Errorf("visibility=confidential answered %d, want 400", status)
+	}
+}
+
+func TestTemplateFamilyIsHonoured(t *testing.T) {
+	h, _ := newExoscaleBarrageServer(t)
+
+	for _, view := range templatesOf(t, h, "?visibility=public&family=debian") {
+		if f, _ := view["family"].(string); f != "debian" {
+			t.Errorf("a debian-filtered entry declares family %q: %v", f, view)
+		}
+	}
+	if got := templatesOf(t, h, "?visibility=public&family=debian"); len(got) == 0 {
+		t.Errorf("the catalogue's own debian family filters to nothing")
+	}
+	// A family nothing carries is an empty list, not the whole catalogue.
+	if got := templatesOf(t, h, "?visibility=public&family=plan9"); len(got) != 0 {
+		t.Errorf("an unknown family answered %d template(s)", len(got))
+	}
+
+	// A registered template files under the family its view declares, in the
+	// private world only.
+	registered := aRegisteredTemplate(t, h, "filed-by-family")
+	private := templatesOf(t, h, "?visibility=private&family=linux")
+	if len(private) != 1 {
+		t.Fatalf("the private linux family holds %d template(s): %v", len(private), private)
+	}
+	if id, _ := private[0]["id"].(string); id != registered {
+		t.Errorf("the private linux family answers %q, want %q", id, registered)
+	}
+}
+
+func TestSecurityGroupVisibilityIsHonoured(t *testing.T) {
+	h, _ := newExoscaleBarrageServer(t)
+
+	groupsOf := func(query string) []any {
+		t.Helper()
+		status, list := callRaw(h, "GET", "/v2/security-group"+query, "")
+		if status != http.StatusOK {
+			t.Fatalf("list security groups %q: status %d (%v)", query, status, list)
+		}
+		raw, _ := list["security-groups"].([]any)
+		return raw
+	}
+
+	// No parameter is the CLI's own spelling of private — measured, it sends
+	// nothing for its default — so both must answer the organisation's groups.
+	if got := groupsOf(""); len(got) == 0 {
+		t.Errorf("the paramless list lost the default security group")
+	}
+	if got := groupsOf("?visibility=private"); len(got) == 0 {
+		t.Errorf("the private list lost the default security group")
+	}
+	// This emulator publishes no public group, and saying so beats answering
+	// the private ones under a public label.
+	if got := groupsOf("?visibility=public"); len(got) != 0 {
+		t.Errorf("the public list answered %d group(s) this emulator never published", len(got))
+	}
+	if status, _ := callRaw(h, "GET", "/v2/security-group?visibility=shared", ""); status != http.StatusBadRequest {
+		t.Errorf("visibility=shared answered %d, want 400", status)
+	}
+}
+
+func instancesOf(t *testing.T, h http.Handler, query string) []map[string]any {
+	t.Helper()
+	status, list := callRaw(h, "GET", "/v2/instance"+query, "")
+	if status != http.StatusOK {
+		t.Fatalf("list instances %q: status %d (%v)", query, status, list)
+	}
+	raw, _ := list["instances"].([]any)
+	out := make([]map[string]any, 0, len(raw))
+	for _, entry := range raw {
+		view, _ := entry.(map[string]any)
+		out = append(out, view)
+	}
+	return out
+}
+
+func TestInstanceListFiltersAreHonoured(t *testing.T) {
+	h, _ := newExoscaleBarrageServer(t)
+
+	pool := aPool(t, h, "managed", 2)
+	lone := anInstance(t, h, "lone")
+
+	// manager-id is how an instance pool counts its own members; unfiltered it
+	// counted everything the store holds.
+	managed := instancesOf(t, h, "?manager-id="+pool)
+	if len(managed) != 2 {
+		t.Fatalf("the pool's manager-id filter answers %d instance(s), want its 2 members", len(managed))
+	}
+	for _, view := range managed {
+		manager, _ := view["manager"].(map[string]any)
+		if manager["id"] != pool {
+			t.Errorf("a manager-filtered instance carries manager %v", view["manager"])
+		}
+	}
+	if got := instancesOf(t, h, "?manager-id="+pool+"&manager-type=instance-pool"); len(got) != 2 {
+		t.Errorf("adding manager-type=instance-pool changed the answer to %d instance(s)", len(got))
+	}
+
+	// The standalone instance is reachable by the address the API published on
+	// it, and only it comes back.
+	status, view := callRaw(h, "GET", "/v2/instance/"+lone, "")
+	if status != http.StatusOK {
+		t.Fatalf("get instance: status %d", status)
+	}
+	address, _ := view["public-ip"].(string)
+	if address == "" {
+		t.Fatalf("the instance publishes no public-ip; the create contract changed under this test")
+	}
+	byAddress := instancesOf(t, h, "?ip-address="+address)
+	if len(byAddress) != 1 {
+		t.Fatalf("the ip-address filter answers %d instance(s), want 1", len(byAddress))
+	}
+	if id, _ := byAddress[0]["id"].(string); id != lone {
+		t.Errorf("the ip-address filter answers %q, want %q", id, lone)
+	}
+}
+
+// labels is declared by their document as a bare untyped string, egoscale v3
+// exposes no option for it, and any wire format this emulator picked would be
+// invented. Refused out loud, never silently unfiltered — the decision is in
+// docs/limits.md.
+func TestInstanceListRefusesTheLabelsFilter(t *testing.T) {
+	h, _ := newExoscaleBarrageServer(t)
+	if status, _ := callRaw(h, "GET", "/v2/instance?labels=env", ""); status != http.StatusBadRequest {
+		t.Errorf("the labels filter answered %d, want an explicit 400", status)
+	}
+	// manager-type is a closed enum in their document; a value outside it is a
+	// request nothing upstream defines.
+	if status, _ := callRaw(h, "GET", "/v2/instance?manager-type=elastic", ""); status != http.StatusBadRequest {
+		t.Errorf("manager-type=elastic answered %d, want 400", status)
+	}
+}
+
+func TestEventWindowIsValidated(t *testing.T) {
+	h, _ := newExoscaleBarrageServer(t)
+
+	status, list := callRaw(h, "GET", "/v2/event?from=2026-08-01T00:00:00Z&to=2026-08-02T00:00:00Z", "")
+	if status != http.StatusOK {
+		t.Fatalf("a well-formed window answered %d (%v)", status, list)
+	}
+	if events, ok := list["events"].([]any); !ok || len(events) != 0 {
+		t.Errorf("the emulated audit trail answered %v, want an empty list", list["events"])
+	}
+	// Their document declares both bounds as date-time; a value outside the
+	// format is refused, not dropped by a handler that never looked.
+	if status, _ := callRaw(h, "GET", "/v2/event?from=yesterday", ""); status != http.StatusBadRequest {
+		t.Errorf("a malformed from answered %d, want 400", status)
+	}
+	if status, _ := callRaw(h, "GET", "/v2/event?to=2026-13-45", ""); status != http.StatusBadRequest {
+		t.Errorf("a malformed to answered %d, want 400", status)
+	}
+}
+
+func TestBlockVolumeInstanceFilterIsHonoured(t *testing.T) {
+	h, _ := newExoscaleBarrageServer(t)
+	instance := anInstance(t, h, "with-disk")
+
+	volume := func(name string) string {
+		status, out := callRaw(h, "POST", "/v2/block-storage", `{"name": "`+name+`", "size": 10}`)
+		if status != http.StatusOK {
+			t.Fatalf("create volume %s: status %d (%v)", name, status, out)
+		}
+		ref, _ := out["reference"].(map[string]any)
+		id, _ := ref["id"].(string)
+		return id
+	}
+	attached := volume("attached")
+	volume("floating")
+	if status, _ := callRaw(h, "PUT", "/v2/block-storage/"+attached+":attach",
+		`{"instance": {"id": "`+instance+`"}}`); status != http.StatusOK {
+		t.Fatalf("attach: status %d", status)
+	}
+
+	status, list := callRaw(h, "GET", "/v2/block-storage?instance-id="+instance, "")
+	if status != http.StatusOK {
+		t.Fatalf("filtered list: status %d", status)
+	}
+	volumes, _ := list["block-storage-volumes"].([]any)
+	if len(volumes) != 1 {
+		t.Fatalf("the instance-id filter answers %d volume(s), want the 1 attached", len(volumes))
+	}
+	view, _ := volumes[0].(map[string]any)
+	if id, _ := view["id"].(string); id != attached {
+		t.Errorf("the instance-id filter answers %q, want %q", id, attached)
+	}
+
+	// Both still exist unfiltered: the filter narrows, it does not lose.
+	_, all := callRaw(h, "GET", "/v2/block-storage", "")
+	if volumes, _ := all["block-storage-volumes"].([]any); len(volumes) != 2 {
+		t.Errorf("the unfiltered list answers %d volume(s), want 2", len(volumes))
+	}
+}

--- a/internal/providers/exoscale/securitygroups.go
+++ b/internal/providers/exoscale/securitygroups.go
@@ -82,13 +82,36 @@ func (p *Pack) createSecurityGroup(w http.ResponseWriter, r *http.Request) {
 	p.writeOperation(w, p.operationReferring(nounSecurityGroup, res.ID))
 }
 
-func (p *Pack) listSecurityGroups(w http.ResponseWriter, _ *http.Request) {
-	p.ensureDefaultSecurityGroup()
-	list := p.env.Store.List(kindSecurityGroup, resource.Tenant{Provider: Name})
-	sort.Slice(list, func(i, j int) bool { return list[i].Created.Before(list[j].Created) })
-	groups := make([]map[string]any, 0, len(list))
-	for _, res := range list {
-		groups = append(groups, securityGroupView(res))
+// listSecurityGroups answers the organisation's own groups, which their document
+// calls the private ones: it declares a visibility filter on this operation,
+// enum private|public (.upstream/exoscale-openapi.yaml:12540-12547), and the
+// handler used to discard the request, so the filter had no effect — the same
+// defect as list-templates' (#271).
+//
+// The default is private, and that is measured rather than chosen: `exo compute
+// security-group list` documents private as its default and sends **no**
+// parameter for it (exo 1.95.1 through a recording proxy), so the paramless
+// answer must be the private one. public names the groups Exoscale itself
+// publishes, and this emulator publishes none — the empty list is the honest
+// answer, the way listDeployTargets already answers for a resource an emulated
+// account does not hold.
+//
+// TestSecurityGroupVisibilityIsHonoured fails without the filter.
+func (p *Pack) listSecurityGroups(w http.ResponseWriter, r *http.Request) {
+	groups := make([]map[string]any, 0)
+	switch r.URL.Query().Get("visibility") {
+	case "", "private":
+		p.ensureDefaultSecurityGroup()
+		list := p.env.Store.List(kindSecurityGroup, resource.Tenant{Provider: Name})
+		sort.Slice(list, func(i, j int) bool { return list[i].Created.Before(list[j].Created) })
+		for _, res := range list {
+			groups = append(groups, securityGroupView(res))
+		}
+	case "public":
+		// None to list: see above.
+	default:
+		writeError(w, http.StatusBadRequest, "visibility must be private or public")
+		return
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{"security-groups": groups})
 }

--- a/internal/providers/exoscale/snapshots_test.go
+++ b/internal/providers/exoscale/snapshots_test.go
@@ -163,9 +163,10 @@ func TestASnapshotIsPromotedIntoATemplate(t *testing.T) {
 	ref, _ := out["reference"].(map[string]any)
 	id, _ := ref["id"].(string)
 
-	// It joins the list a client resolves a template out of, beside the fixed
-	// catalogue, because a client asking by name cannot tell the two apart.
-	status, list := callRaw(h, "GET", "/v2/template", "")
+	// It joins the organisation's own list, the one a client reaches with
+	// visibility=private — never the public catalogue, which is Exoscale's
+	// alone: the two worlds are split by the filter #271 restored.
+	status, list := callRaw(h, "GET", "/v2/template?visibility=private", "")
 	if status != http.StatusOK {
 		t.Fatalf("list templates: status %d", status)
 	}

--- a/internal/providers/scaleway/block.go
+++ b/internal/providers/scaleway/block.go
@@ -596,18 +596,26 @@ func (p *Pack) listBlockVolumeTypes(w http.ResponseWriter, r *http.Request) {
 			"nanos":         0,
 		}
 	}
+	// One type, and still paged: the SDK declares page and page_size on
+	// ListVolumeTypes, and a handler that drops a declared parameter is the
+	// class #271 names — page=2 answered the same type again, which is a list
+	// that never ends to the SDK's own pagination loop.
+	//
+	// TestBlockVolumeTypesArePaged fails without it.
+	types := []map[string]any{{
+		"type":             blockStorageClass,
+		"pricing":          price(),
+		"snapshot_pricing": price(),
+		"specs": map[string]any{
+			"class":     blockStorageClass,
+			"perf_iops": blockDefaultIOPS,
+		},
+		"zone": zone,
+	}}
+	start, end := parsePage(r).slice(len(types))
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"volume_types": []map[string]any{{
-			"type":             blockStorageClass,
-			"pricing":          price(),
-			"snapshot_pricing": price(),
-			"specs": map[string]any{
-				"class":     blockStorageClass,
-				"perf_iops": blockDefaultIOPS,
-			},
-			"zone": zone,
-		}},
-		"total_count": 1,
+		"volume_types": types[start:end],
+		"total_count":  len(types),
 	})
 }
 

--- a/internal/providers/scaleway/catalog.go
+++ b/internal/providers/scaleway/catalog.go
@@ -2,6 +2,7 @@ package scaleway
 
 import (
 	"net/http"
+	"sort"
 
 	"github.com/stephrobert/feint/internal/core/emulator"
 	"github.com/stephrobert/feint/internal/core/machine"
@@ -169,12 +170,30 @@ var labelByID = func() map[string]string {
 	return out
 }()
 
+// listServerTypes pages like every other list here: the SDK declares page and
+// per_page on ListServersTypes, and the handler used to ignore both — the whole
+// catalogue fits under any client's default page size, so no real client saw
+// it, but a parameter the contract declares and a handler drops is the class
+// #271 names. The response's `servers` is an object keyed by type name in
+// their SDK, so the page is a window over the sorted names.
+//
+// TestServerTypesArePaged fails without it.
 func (p *Pack) listServerTypes(w http.ResponseWriter, r *http.Request) {
 	if _, ok := zoneOf(w, r); !ok {
 		return
 	}
+	names := make([]string, 0, len(catalogue))
+	for name := range catalogue {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	start, end := parsePage(r).slice(len(names))
+	page := make(map[string]*serverType, end-start)
+	for _, name := range names[start:end] {
+		page[name] = catalogue[name]
+	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"servers":     catalogue,
+		"servers":     page,
 		"total_count": len(catalogue),
 	})
 }

--- a/internal/providers/scaleway/catalog_paging_test.go
+++ b/internal/providers/scaleway/catalog_paging_test.go
@@ -1,0 +1,82 @@
+package scaleway_test
+
+import (
+	"net/http"
+	"testing"
+)
+
+// The two catalogue endpoints used to ignore the pagination their contract
+// declares — page/per_page on ListServersTypes, page/page_size on
+// ListVolumeTypes. No real client saw it, because both catalogues fit under
+// every default page size; the contract still promised a parameter the handler
+// dropped, which is the class #271 names. These tests page below the catalogue
+// size, which is the request the defect answered wrong.
+
+func TestServerTypesArePaged(t *testing.T) {
+	ts := newTestServer(t)
+	const url = "/instance/v1/zones/fr-par-1/products/servers"
+
+	status, all := do(t, ts, "GET", url, "")
+	if status != http.StatusOK {
+		t.Fatalf("unpaged: expected 200, got %d (%v)", status, all)
+	}
+	types, _ := all["servers"].(map[string]any)
+	total := int(all["total_count"].(float64))
+	if len(types) != total || total < 2 {
+		t.Fatalf("the unpaged catalogue answers %d of %d types", len(types), total)
+	}
+
+	// A window smaller than the catalogue really is a window, and total_count
+	// still names the whole stock so the SDK's pagination loop terminates.
+	status, page := do(t, ts, "GET", url+"?page=1&per_page=2", "")
+	if status != http.StatusOK {
+		t.Fatalf("paged: expected 200, got %d", status)
+	}
+	first, _ := page["servers"].(map[string]any)
+	if len(first) != 2 {
+		t.Errorf("per_page=2 answered %d types", len(first))
+	}
+	if got := int(page["total_count"].(float64)); got != total {
+		t.Errorf("the page reports total_count %d, want %d", got, total)
+	}
+
+	// The second page is different stock, not the first again: a page that
+	// repeats itself is a list that never ends to a client walking it.
+	_, second := do(t, ts, "GET", url+"?page=2&per_page=2", "")
+	for name := range second["servers"].(map[string]any) {
+		if _, dup := first[name]; dup {
+			t.Errorf("type %q appears on page 1 and page 2", name)
+		}
+	}
+
+	// Past the stock the window is empty, which is how the SDK loop stops.
+	_, past := do(t, ts, "GET", url+"?page=99&per_page=2", "")
+	if got, _ := past["servers"].(map[string]any); len(got) != 0 {
+		t.Errorf("page 99 still answers %d types", len(got))
+	}
+}
+
+func TestBlockVolumeTypesArePaged(t *testing.T) {
+	ts := newTestServer(t)
+	const url = "/block/v1/zones/fr-par-1/volume-types"
+
+	status, all := do(t, ts, "GET", url, "")
+	if status != http.StatusOK {
+		t.Fatalf("unpaged: expected 200, got %d (%v)", status, all)
+	}
+	if types, _ := all["volume_types"].([]any); len(types) != 1 {
+		t.Fatalf("the catalogue answers %d volume types, want 1", len(types))
+	}
+
+	// One entry, so page 2 must be empty — it answered the same entry again.
+	status, past := do(t, ts, "GET", url+"?page=2&page_size=1", "")
+	if status != http.StatusOK {
+		t.Fatalf("paged: expected 200, got %d", status)
+	}
+	if types, _ := past["volume_types"].([]any); len(types) != 0 {
+		t.Errorf("page 2 of a one-entry catalogue answers %d entries", len(types))
+	}
+	if got := int(past["total_count"].(float64)); got != 1 {
+		t.Errorf("the page reports total_count %d, want 1", got)
+	}
+}

--- a/tools/conformance/exoscale/exo-cli.sh
+++ b/tools/conformance/exoscale/exo-cli.sh
@@ -391,25 +391,43 @@ ok "snapshotted, reverted, removed, TPM enabled and reset while stopped"
 # catalogue this emulator publishes is fixed, and registering one is what a
 # client does when it builds its own image. Neither call had been driven — the
 # suite only ever listed the catalogue.
-echo "- a template is registered and removed"
+#
+# The listing goes through --visibility, because that is what the CLI sends on
+# every template list (its default is public) and what #271 proved the emulator
+# ignored: ?visibility=private answered the public catalogue, each entry
+# contradicting the filter it sat inside. The earlier form of this block listed
+# `--family custom` and found the registered template there — through two
+# filters the emulator dropped, so the assertion measured the defect and called
+# it conformance. A registered template is private; private is where it must
+# be, and the public list is where it must never appear.
+echo "- a template is registered, private, and removed"
 span_tmpl="$(prove_begin behaviour)"
+# Before anything is registered, the organisation owns no template, and the
+# honest answer is an empty list — this is the fresh-store case that lied.
+exoc -O json compute instance-template list --visibility private \
+  | jq -e 'length == 0' >/dev/null \
+  || fail "a fresh account already answers private templates"
 exoc -Q compute instance-template register conformance-tmpl \
   https://example.invalid/conformance.qcow2 \
   0000000000000000000000000000000000000000000000000000000000000000 \
   --description 'conformance' --disable-password --disable-ssh-key --username conformance \
   >/dev/null || fail "instance-template register rejected"
-# Registered means listed: the CLI resolves a template by name against the
-# catalogue, so a registration nothing lists is a registration no client can use.
-exoc -O json compute instance-template list --family custom \
+# Registered means listed where the organisation's templates live: private.
+exoc -O json compute instance-template list --visibility private \
   | jq -e 'any(.[]; .name == "conformance-tmpl")' >/dev/null \
-  || fail "the registered template is not in the custom list"
+  || fail "the registered template is not in the private list"
+# And never in the public catalogue, which is Exoscale's alone: a client
+# counting the provider's offer must not count the organisation's.
+exoc -O json compute instance-template list \
+  | jq -e 'all(.[]; .name != "conformance-tmpl")' >/dev/null \
+  || fail "the registered template leaked into the public catalogue"
 exoc -Q compute instance-template delete conformance-tmpl --force >/dev/null \
   || fail "instance-template delete rejected"
-exoc -O json compute instance-template list --family custom \
-  | jq -e 'all(.[]; .name != "conformance-tmpl")' >/dev/null \
+exoc -O json compute instance-template list --visibility private \
+  | jq -e 'length == 0' >/dev/null \
   || fail "the template survived its delete"
 prove_end "$span_tmpl"
-ok "registered, listed, removed"
+ok "registered, listed private and only private, removed"
 
 # Block Storage (EXO-4, #12), driven by `exo compute block-storage`.
 #

--- a/tools/falsify/specs/query-filters.json
+++ b/tools/falsify/specs/query-filters.json
@@ -1,0 +1,54 @@
+{
+  "package": "./internal/providers/exoscale/",
+  "mutations": [
+    {
+      "label": "the template visibility filter reads a key nobody sends, which is #271 verbatim: ?visibility=private answers the public catalogue again",
+      "file": "internal/providers/exoscale/catalog.go",
+      "find": "\tvisibility := r.URL.Query().Get(\"visibility\")",
+      "replace": "\tvisibility := r.URL.Query().Get(\"visibility-never\")",
+      "test": "TestTemplateVisibilityIsHonoured"
+    },
+    {
+      "label": "the template family filter goes inert and an unknown family answers the whole catalogue",
+      "file": "internal/providers/exoscale/catalog.go",
+      "find": "\tfamily := r.URL.Query().Get(\"family\")",
+      "replace": "\tfamily := r.URL.Query().Get(\"family-never\")",
+      "test": "TestTemplateFamilyIsHonoured"
+    },
+    {
+      "label": "the security-group visibility filter goes inert and ?visibility=public answers the private groups",
+      "file": "internal/providers/exoscale/securitygroups.go",
+      "find": "\tswitch r.URL.Query().Get(\"visibility\") {",
+      "replace": "\tswitch r.URL.Query().Get(\"visibility-never\") {",
+      "test": "TestSecurityGroupVisibilityIsHonoured"
+    },
+    {
+      "label": "the manager-id filter goes inert and a pool counting its members counts the whole account",
+      "file": "internal/providers/exoscale/pack.go",
+      "find": "\t\tmanagerID:   query.Get(\"manager-id\"),",
+      "replace": "\t\tmanagerID:   query.Get(\"manager-id-never\"),",
+      "test": "TestInstanceListFiltersAreHonoured"
+    },
+    {
+      "label": "the labels refusal goes quiet, which is the silent drop the whole class is about",
+      "file": "internal/providers/exoscale/pack.go",
+      "find": "\tif query.Get(\"labels\") != \"\" {",
+      "replace": "\tif query.Get(\"labels\") != \"\" && false {",
+      "test": "TestInstanceListRefusesTheLabelsFilter"
+    },
+    {
+      "label": "the event window stops validating and a malformed timestamp is swallowed",
+      "file": "internal/providers/exoscale/account.go",
+      "find": "\t\tif _, err := time.Parse(time.RFC3339, value); err != nil {",
+      "replace": "\t\tif _, err := time.Parse(time.RFC3339, value); err != nil && false {",
+      "test": "TestEventWindowIsValidated"
+    },
+    {
+      "label": "the block-volume instance filter goes inert and one machine's disks are the whole account's",
+      "file": "internal/providers/exoscale/block.go",
+      "find": "\tinstanceID := r.URL.Query().Get(\"instance-id\")",
+      "replace": "\tinstanceID := r.URL.Query().Get(\"instance-id-never\")",
+      "test": "TestBlockVolumeInstanceFilterIsHonoured"
+    }
+  ]
+}


### PR DESCRIPTION
# Summary

`GET /v2/template?visibility=private` answered the public catalogue, each entry declaring `"visibility": "public"` inside a response filtered to `private` (#271). The handler discarded its `*http.Request`, so no query parameter could ever matter, while the OpenAPI document declares `visibility` (enum private|public) and `family` on the operation (`.upstream/exoscale-openapi.yaml:21648-21662`).

The class was **measured before it was fixed**, by crossing the query parameters each contract declares against what every mounted handler reads:

| pack | operations declaring query params | reading none of them |
|---|---|---|
| Exoscale | 12 | **5** — list-templates, list-security-groups, list-instances, list-events, list-block-storage-volumes |
| Scaleway | 54 | **2**, pagination only — ListServersTypes, block ListVolumeTypes |
| Outscale | 0 (its document puts everything in the body) | 0 |

All seven are fixed:

- **list-templates**: `visibility=public` is the fixed catalogue, `visibility=private` is what the organisation registered or promoted — an empty list on a fresh store, the case that lied. `family` filters both worlds. Default is public: the CLI always names a visibility (measured through a recording proxy on exo 1.95.1 — a bare `instance-template list` sends `visibility=public`), so the paramless read only serves the probe and curl, and the catalogue keeps it meaning "what can I boot here".
- **list-security-groups**: `visibility` honoured; default is private because the CLI documents private as its default and sends **no** parameter for it (measured), so the paramless answer must be the private one. `public` answers an empty list — this emulator publishes no public group, and docs/limits.md says so.
- **list-instances**: `manager-id`, `manager-type`, `ip-address` served (an instance pool asking for its members no longer receives the whole account); `labels` **refused with a 400** — their document types it as a bare string with no format, egoscale v3 never sends it, and any encoding picked here would be an invented format. Decision recorded in docs/limits.md.
- **list-events**: the `from`/`to` window is validated as the `date-time` their document declares; any window over the (by-design empty) audit trail is the empty trail.
- **list-block-storage-volumes**: `instance-id` narrows to one machine's volumes.
- **Scaleway ListServersTypes / block ListVolumeTypes**: page through the pack's own `parsePage` — no real client could see the defect (both catalogues fit under every default page size), but the contract promised a parameter the handler dropped.

**The gate** that keeps the class shut: `TestDeclaredQueryParametersAreRead` (internal/core/emulator) fails any route whose contract operation declares query parameters while its handler never reads the request's query — directly or through a same-package helper it hands the request to. Handlers are attributed from the route table in source, because the mounted pointers are wrapped (`guardSplitClients`, `dryRunnable`) and all resolve to the same closure. Verified to bite against the pre-fix `listSecurityGroups`. Its stated limit: it cannot see a handler that reads some declared parameters and drops others; the behavioural tests carry that depth for the operations fixed here.

**The conformance suite was itself resting on the defect**: its template block listed `--family custom` and found the registered template there — through two filters the emulator dropped (the CLI sends `family=custom&visibility=public`; a registered template is private with family linux). The block now asserts the private list empty before register, the registered template present under `--visibility private`, absent from the public catalogue, and gone after delete.

**Falsified**: `tools/falsify/specs/query-filters.json`, seven mutations, one per restored filter or refusal — every one compiles, every test bites, restoration green. `mise run falsify:lint` green (112 mutations across 34 specs).

## Type of change

- [ ] A route added or changed
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes (gofmt, vet, golangci-lint, `go test -race`)
- [x] No new external Go dependency, or the pull request justifies it. The
      standard library covers routing, JSON and Go parsing; `go.mod` has three
      lines and a pre-commit hook keeps it that way
- [x] `internal/core` still knows no provider. If a change seemed to require it,
      the pack changed instead — the gate lives in `emulator_test` (external test
      package) and names packs only as test subjects, like the route/contract
      tests beside it
- [x] Nothing in the diff could be written identically for another provider.
      The filters are each pack's own vocabulary (visibility/family are
      Exoscale's, page/per_page Scaleway's); the shared rule — declared means
      read or refused — lives in the shared gate

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] I ran the conformance legs myself — exo-cli, scw-cli, terraform,
      oapi-cli and probe all pass locally (`mise run conformance:leg -- <leg>`)
- [x] Every field name in the diff comes from the provider's OpenAPI document
      (`.upstream/exoscale-openapi.yaml`, lines cited at each handler) or a
      measured run of the real client (exo 1.95.1 through a recording proxy,
      transcript quoted in the handler comments)

### When a route is added or changed — otherwise N/A

- [x] No route added, no Method/Path/Operation changed — handlers only.
      `Route.Operation` untouched; `mise run drift:check` green (in prepush)
- [x] Conformance run for the providers touched: exo-cli, scw-cli, terraform,
      oapi-cli, probe legs all pass
- [x] Responses validated against the providers' own API descriptions — the
      legs run with `--contracts contracts`, and the probe leg passes
- [x] What the client sends is read, or refused: that is this PR's whole
      subject. `labels` is the refused one, with a 400 naming it
- [x] `mise run drift:update` — N/A: the upstream surface did not move, no
      operation was added or retired; `drift:check` green

### When behaviour a client can observe changes — otherwise N/A

- [x] `docs/limits.md` updated: new section "A declared query parameter is
      served or refused, never dropped — and `labels` is the refused one"
- [x] Generated tables regenerated (`feint docs`; README section count 31→32)

### When `.github/workflows/` is touched — otherwise N/A

- [x] N/A — no workflow touched

### When a machine runtime is involved — otherwise N/A

- [x] N/A — no machine runtime involved; control-plane filters only

## Related issues

Closes #271
