### PR TITLE
fix(outscale): the subregion is a datum the reads restitute, not a constant (#268, #269)

### DIFF
--- a/internal/providers/outscale/audit_test.go
+++ b/internal/providers/outscale/audit_test.go
@@ -865,7 +865,10 @@ func TestAnUnsupportedFilterIsRefused(t *testing.T) {
 		// on it — and TestReadNetsFiltersOnTheDhcpOptionsSet now holds the
 		// accepting half.
 		{"ReadNets", `{"Filters":{"Tags":["a=b"]}}`},
-		{"ReadSubnets", `{"Filters":{"SubregionNames":["eu-west-2a"]}}`},
+		// SubregionNames was the probe here until it became a served filter
+		// (#269); AvailableIpsCounts is declared by FiltersSubnet upstream and
+		// still not applied, so it keeps the refusal measured.
+		{"ReadSubnets", `{"Filters":{"AvailableIpsCounts":[251]}}`},
 		{"ReadKeypairs", `{"Filters":{"TagKeys":["env"]}}`},
 	} {
 		status, out := post(t, ts, probe.action, probe.body)

--- a/internal/providers/outscale/catalog.go
+++ b/internal/providers/outscale/catalog.go
@@ -23,9 +23,43 @@ import (
 // Region is where the emulated account lives. One region, because a second one
 // would need its own store scoping and buys nothing until something tests it.
 const (
-	regionName    = "eu-west-2"
-	subregionName = "eu-west-2a"
+	regionName = "eu-west-2"
+	// defaultSubregionName is where anything lands when the client names no
+	// subregion — the API's own behaviour for a create outside a Net.
+	defaultSubregionName = "eu-west-2a"
 )
+
+// subregions is the catalogue of the region's own subregions: both of them,
+// because Outscale's published reference ("Regions, Endpoints, and Subregions
+// Reference", docs.outscale.com) lists exactly two for eu-west-2, mapped to
+// the physical zones PAR1 and PAR2. One region was a justified constant (store
+// scoping); one *subregion* never was, and #269 measured what the gap breaks:
+// a stack that asks ReadSubregions where it may put things — the recommended
+// pattern, `data "outscale_subregions"` indexed at [1] — died on "list of
+// object with 1 element" while a stack hardcoding its zone sailed through.
+//
+// This table is also the authority the write paths check against
+// (knownSubregion): CreateSubnet used to accept `cloudgouv-eu-west-1a`
+// verbatim while this catalogue claimed one AZ existed, so what a create
+// accepted and what the catalogue declared contradicted each other. Whichever
+// side a client believed, the other one lied to it.
+var subregions = []map[string]any{
+	{"SubregionName": "eu-west-2a", "RegionName": regionName, "LocationCode": "PAR1", "State": "available"},
+	{"SubregionName": "eu-west-2b", "RegionName": regionName, "LocationCode": "PAR2", "State": "available"},
+}
+
+// knownSubregion reports whether the catalogue declares the subregion. Every
+// write path that takes a SubregionName asks this before storing, so the
+// catalogue and the creates cannot disagree about which zones exist —
+// TestWhatACreateAcceptsTheCatalogueDeclares fails without it.
+func knownSubregion(name string) bool {
+	for _, subregion := range subregions {
+		if subregion["SubregionName"] == name {
+			return true
+		}
+	}
+	return false
+}
 
 // vmTypes is the emulated catalogue. Three sizes of the same family: enough for
 // a client to pick one, few enough that nobody mistakes it for Outscale's real
@@ -240,16 +274,35 @@ func (p *Pack) readRegions(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func (p *Pack) readSubregions(w http.ResponseWriter, _ *http.Request) {
+// readSubregions serves the region's subregions and applies the three filters
+// FiltersSubregion declares (osc-sdk-go, pkg/osc/client.gen.go:5071). It used
+// to ignore the body entirely and answer a single fixed zone; the body matters
+// because the Terraform datasource is exactly the client that reads this
+// before deciding where to place everything else (#269).
+func (p *Pack) readSubregions(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Filters        filterSet `json:"Filters"`
+		ResultsPerPage int       `json:"ResultsPerPage"`
+		DryRun         *bool     `json:"DryRun"`
+	}
+	if err := emulator.DecodeJSON(r, &req); err != nil {
+		p.badRequest(w, err.Error())
+		return
+	}
+	if p.refuseUnsupported(w, req.Filters, "SubregionNames", "RegionNames", "States") {
+		return
+	}
+	out := make([]map[string]any, 0, len(subregions))
+	for _, subregion := range subregions {
+		if !matchesStrings(req.Filters, "SubregionNames", stringOf(subregion["SubregionName"])) ||
+			!matchesStrings(req.Filters, "RegionNames", stringOf(subregion["RegionName"])) ||
+			!matchesStrings(req.Filters, "States", stringOf(subregion["State"])) {
+			continue
+		}
+		out = append(out, subregion)
+	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"Subregions": []map[string]any{
-			{
-				"SubregionName": subregionName,
-				"RegionName":    regionName,
-				"LocationCode":  "PAR1",
-				"State":         "available",
-			},
-		},
+		"Subregions":      page(out, req.ResultsPerPage),
 		"ResponseContext": p.context(),
 	})
 }

--- a/internal/providers/outscale/nets.go
+++ b/internal/providers/outscale/nets.go
@@ -84,8 +84,11 @@ type readNetsRequest struct {
 // keyword. Refusing the filter fails every `terraform destroy` of an
 // outscale_dhcp_option.
 var (
-	netFilters    = []string{"NetIds", "IpRanges", "States", "DhcpOptionsSetIds"}
-	subnetFilters = []string{"SubnetIds", "NetIds", "IpRanges", "States"}
+	netFilters = []string{"NetIds", "IpRanges", "States", "DhcpOptionsSetIds"}
+	// SubregionNames is served since the subregion became a stored fact
+	// (#269): FiltersSubnet declares it (osc-sdk-go, client.gen.go:5058), and
+	// it is how a stack that spreads subnets across zones reads its own back.
+	subnetFilters = []string{"SubnetIds", "NetIds", "IpRanges", "States", "SubregionNames"}
 )
 
 type readSubnetsRequest struct {
@@ -268,6 +271,14 @@ func (p *Pack) createSubnet(w http.ResponseWriter, r *http.Request) {
 		p.notFound(w, "Net", req.NetID)
 		return
 	}
+	// A zone the catalogue does not declare is refused, not echoed. This
+	// create used to store `cloudgouv-eu-west-1a` verbatim while
+	// ReadSubregions declared one zone in another region: the two halves of
+	// the same API contradicting each other, measured in #269.
+	if req.SubregionName != "" && !knownSubregion(req.SubregionName) {
+		p.badRequest(w, "the Subregion "+req.SubregionName+" does not exist in "+regionName)
+		return
+	}
 	prefix, err := network.ParseCIDR(req.IPRange)
 	if err != nil {
 		p.badRequest(w, "IpRange: "+err.Error())
@@ -315,7 +326,7 @@ func (p *Pack) createSubnet(w http.ResponseWriter, r *http.Request) {
 	res.Attrs = map[string]any{
 		"IpRange":             prefix.String(),
 		"NetId":               req.NetID,
-		"SubregionName":       orDefault(req.SubregionName, subregionName),
+		"SubregionName":       orDefault(req.SubregionName, defaultSubregionName),
 		"MapPublicIpOnLaunch": false,
 		"Tags":                []any{},
 	}
@@ -378,7 +389,8 @@ func (p *Pack) readSubnets(w http.ResponseWriter, r *http.Request) {
 		if !matchesStrings(req.Filters, "SubnetIds", res.ID) ||
 			!matchesStrings(req.Filters, "NetIds", netID) ||
 			!matchesStrings(req.Filters, "IpRanges", ipRange) ||
-			!matchesStrings(req.Filters, "States", res.State) {
+			!matchesStrings(req.Filters, "States", res.State) ||
+			!matchesStrings(req.Filters, "SubregionNames", p.subnetSubregion(res.ID)) {
 			continue
 		}
 		subnets = append(subnets, p.subnetView(res))
@@ -540,6 +552,18 @@ func (p *Pack) subnetsOf(netID string) []*resource.Resource {
 		}
 	}
 	return out
+}
+
+// subnetSubregion is the zone a Subnet was created in, and the default when
+// the Subnet is unknown or predates the stored field (a restored snapshot from
+// an older emulator). NICs derive their own SubregionName through this — an
+// interface sits where its Subnet sits, so publishing a constant there was the
+// same defect as #268 one resource over, merely not client-writable.
+func (p *Pack) subnetSubregion(subnetID string) string {
+	if subnet, found := p.env.Store.Get(Name, kindSubnet, subnetID); found {
+		return orDefault(stringOf(subnet.Attrs["SubregionName"]), defaultSubregionName)
+	}
+	return defaultSubregionName
 }
 
 // runtimeNetworkKey is the runtime network backing a subnet, kept out of Attrs.

--- a/internal/providers/outscale/nics.go
+++ b/internal/providers/outscale/nics.go
@@ -140,7 +140,7 @@ func (p *Pack) nicView(vm *resource.Resource, nicID, subnetID, netID string) map
 		"MacAddress":          macOf(nicID),
 		"NetId":               netID,
 		"SubnetId":            subnetID,
-		"SubregionName":       subregionName,
+		"SubregionName":       p.subnetSubregion(subnetID),
 		"State":               "in-use",
 		"PrivateDnsName":      dns,
 		"PrivateIps": []any{map[string]any{
@@ -205,7 +205,7 @@ func (p *Pack) storedNicView(nic *resource.Resource) map[string]any {
 		"MacAddress":          macOf(nic.ID),
 		"NetId":               netID,
 		"SubnetId":            stringOf(nic.Attrs["SubnetId"]),
-		"SubregionName":       subregionName,
+		"SubregionName":       p.subnetSubregion(stringOf(nic.Attrs["SubnetId"])),
 		"State":               stringOf(nic.Attrs["State"]),
 		"PrivateDnsName":      dns,
 		// The primary entry, plus every secondary address linked since

--- a/internal/providers/outscale/placement.go
+++ b/internal/providers/outscale/placement.go
@@ -31,6 +31,10 @@ type placement struct {
 	NetID     string
 	Address   netip.Addr
 	PrefixLen int
+	// SubregionName is the zone the Subnet was created in — a stored fact
+	// since #269, and what a Vm created without a Placement of its own
+	// inherits (#268): its machine can only sit where its Subnet sits.
+	SubregionName string
 	// Network is the runtime network backing the Subnet, empty when no runtime
 	// is configured. Recorded for the caller that wants to know without asking
 	// the store again; the boot rebuilds it from the stored Subnet instead, so
@@ -75,11 +79,12 @@ func (p *Pack) placeInSubnet(subnetID string) (placement, error) {
 	}
 	netID := stringOf(subnet.Attrs["NetId"])
 	return placement{
-		SubnetID:  subnetID,
-		NetID:     netID,
-		Address:   address,
-		PrefixLen: prefix.Bits(),
-		Network:   subnet.Runtime[runtimeNetworkKey],
+		SubnetID:      subnetID,
+		NetID:         netID,
+		Address:       address,
+		PrefixLen:     prefix.Bits(),
+		SubregionName: orDefault(stringOf(subnet.Attrs["SubregionName"]), defaultSubregionName),
+		Network:       subnet.Runtime[runtimeNetworkKey],
 	}, nil
 }
 

--- a/internal/providers/outscale/subregions_test.go
+++ b/internal/providers/outscale/subregions_test.go
@@ -1,0 +1,240 @@
+package outscale_test
+
+import (
+	"net/http"
+	"testing"
+)
+
+// The subregion is a datum, not a constant. #268 and #269 were one weakness
+// seen through two doors: CreateVms accepted Placement.SubregionName and every
+// read answered the pack's constant, while ReadSubregions declared one zone
+// and the write paths accepted any string. Every test here uses a NON-default
+// zone on purpose — the whole family shipped because the suite only ever
+// created resources in the default one, so the constant and the datum were
+// indistinguishable.
+
+// placementOf digs the Placement out of a Vms answer.
+func placementOf(t *testing.T, out map[string]any) map[string]any {
+	t.Helper()
+	vms, _ := out["Vms"].([]any)
+	if len(vms) == 0 {
+		t.Fatalf("no Vms in the answer: %v", out)
+	}
+	vm, _ := vms[0].(map[string]any)
+	placement, ok := vm["Placement"].(map[string]any)
+	if !ok {
+		t.Fatalf("the Vm carries no Placement: %v", vm)
+	}
+	return placement
+}
+
+func assertPlacement(t *testing.T, out map[string]any, subregion, tenancy, when string) {
+	t.Helper()
+	placement := placementOf(t, out)
+	if got, _ := placement["SubregionName"].(string); got != subregion {
+		t.Errorf("%s: SubregionName = %q, want %q", when, got, subregion)
+	}
+	if got, _ := placement["Tenancy"].(string); got != tenancy {
+		t.Errorf("%s: Tenancy = %q, want %q", when, got, tenancy)
+	}
+}
+
+// A Vm created with a Placement reads back that Placement, on every door that
+// publishes it: the create's own answer, ReadVms, ReadVmsState, and the
+// SubregionNames filters. Issue #268 measured the lie this replaces — the
+// client asked eu-west-2b, the 200 answered eu-west-2a, and a multi-AZ
+// Terraform stack re-planned the same change for ever. Both values are
+// non-default, Tenancy included, because #268 called out that Tenancy was the
+// same constant and would have lied identically for `dedicated`.
+func TestAVmCreatedInANamedSubregionReadsBackInIt(t *testing.T) {
+	ts := newServer(t)
+	doc := contractDoc(t)
+
+	created := call(t, ts, doc, "CreateVms",
+		`{"ImageId":"ami-00000001","BootOnCreation":false,`+
+			`"Placement":{"SubregionName":"eu-west-2b","Tenancy":"dedicated"}}`)
+	assertPlacement(t, created, "eu-west-2b", "dedicated", "the create's own answer")
+	id := firstVMID(t, created)
+
+	read := call(t, ts, doc, "ReadVms", `{"Filters":{"VmIds":["`+id+`"]}}`)
+	assertPlacement(t, read, "eu-west-2b", "dedicated", "ReadVms")
+
+	// The state view was a second copy of the same constant (readVmsState).
+	states := call(t, ts, doc, "ReadVmsState", `{"AllVms":true,"Filters":{"VmIds":["`+id+`"]}}`)
+	rows, _ := states["VmStates"].([]any)
+	if len(rows) != 1 {
+		t.Fatalf("ReadVmsState answered %d rows for one Vm: %v", len(rows), states)
+	}
+	row, _ := rows[0].(map[string]any)
+	if got, _ := row["SubregionName"].(string); got != "eu-west-2b" {
+		t.Errorf("ReadVmsState: SubregionName = %q, want eu-west-2b", got)
+	}
+
+	// The filters answer from the same stored fact. Both directions, because a
+	// filter that always matches and one that never matches are equally useless.
+	matched := call(t, ts, doc, "ReadVms", `{"Filters":{"SubregionNames":["eu-west-2b"]}}`)
+	if vms, _ := matched["Vms"].([]any); len(vms) != 1 {
+		t.Errorf("filtering ReadVms on the Vm's own zone answered %d Vms", len(vms))
+	}
+	other := call(t, ts, doc, "ReadVms", `{"Filters":{"SubregionNames":["eu-west-2a"]}}`)
+	if vms, _ := other["Vms"].([]any); len(vms) != 0 {
+		t.Errorf("filtering ReadVms on the other zone answered %d Vms, want 0", len(vms))
+	}
+	stateRows := call(t, ts, doc, "ReadVmsState", `{"AllVms":true,"Filters":{"SubregionNames":["eu-west-2a"]}}`)
+	if rows, _ := stateRows["VmStates"].([]any); len(rows) != 0 {
+		// SubregionNames was declared to ReadVmsState's refusal list and
+		// applied nowhere — the declared-and-unread blind spot, again.
+		t.Errorf("ReadVmsState filtered on the other zone answered %d rows, want 0", len(rows))
+	}
+}
+
+// A Vm created in a Subnet without a Placement of its own inherits the
+// Subnet's zone — request → store → response holds for the Subnet's half of
+// the fact too. And an interface sits where its Subnet sits: the NIC's
+// SubregionName was the same constant one resource over, merely not
+// client-writable.
+func TestAVmInheritsItsSubnetsSubregion(t *testing.T) {
+	ts := newServer(t)
+	doc := contractDoc(t)
+
+	_, out := post(t, ts, "CreateNet", `{"IpRange":"10.63.0.0/16"}`)
+	n, _ := out["Net"].(map[string]any)
+	netID, _ := n["NetId"].(string)
+	created := call(t, ts, doc, "CreateSubnet",
+		`{"NetId":"`+netID+`","IpRange":"10.63.1.0/24","SubregionName":"eu-west-2b"}`)
+	subnet, _ := created["Subnet"].(map[string]any)
+	subnetID, _ := subnet["SubnetId"].(string)
+	if got, _ := subnet["SubregionName"].(string); got != "eu-west-2b" {
+		t.Fatalf("the created Subnet reads back in %q, want eu-west-2b", got)
+	}
+
+	vm := call(t, ts, doc, "CreateVms",
+		`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+	assertPlacement(t, vm, "eu-west-2b", "default", "a Vm placed by its Subnet alone")
+
+	// The Subnet answers the zone filter from the stored fact.
+	subnets := call(t, ts, doc, "ReadSubnets", `{"Filters":{"SubregionNames":["eu-west-2b"]}}`)
+	if rows, _ := subnets["Subnets"].([]any); len(rows) != 1 {
+		t.Errorf("filtering ReadSubnets on eu-west-2b answered %d Subnets, want 1", len(rows))
+	}
+
+	// A NIC created on that Subnet sits in the Subnet's zone.
+	nicOut := call(t, ts, doc, "CreateNic", `{"SubnetId":"`+subnetID+`"}`)
+	nic, _ := nicOut["Nic"].(map[string]any)
+	if got, _ := nic["SubregionName"].(string); got != "eu-west-2b" {
+		t.Errorf("the created NIC reads back in %q, want eu-west-2b", got)
+	}
+}
+
+// A Vm created with nothing said still reads back the default — the one half
+// of the old behaviour that was honest, kept honest.
+func TestAVmWithoutAPlacementReadsBackTheDefault(t *testing.T) {
+	ts := newServer(t)
+	doc := contractDoc(t)
+
+	created := call(t, ts, doc, "CreateVms", `{"ImageId":"ami-00000001","BootOnCreation":false}`)
+	assertPlacement(t, created, "eu-west-2a", "default", "a Vm with no Placement")
+}
+
+// ReadSubregions declares the zones eu-west-2 really has — both of them, per
+// Outscale's own published reference. The index [1] is asserted directly
+// because it is the exact expression #269 measured failing: a stack that asks
+// the API where it may put things (`data "outscale_subregions"`, then
+// `subregions[1].subregion_name`) died on "list of object with 1 element"
+// while a stack hardcoding its zone sailed through.
+func TestReadSubregionsDeclaresTheRegionsSubregions(t *testing.T) {
+	ts := newServer(t)
+	doc := contractDoc(t)
+
+	out := call(t, ts, doc, "ReadSubregions", `{}`)
+	rows, _ := out["Subregions"].([]any)
+	if len(rows) != 2 {
+		t.Fatalf("ReadSubregions declares %d Subregions, want 2: %v", len(rows), out)
+	}
+	second, _ := rows[1].(map[string]any)
+	if got, _ := second["SubregionName"].(string); got != "eu-west-2b" {
+		t.Errorf("Subregions[1].SubregionName = %q, want eu-west-2b", got)
+	}
+	if got, _ := second["RegionName"].(string); got != "eu-west-2" {
+		t.Errorf("Subregions[1].RegionName = %q, want eu-west-2", got)
+	}
+
+	// The filters FiltersSubregion declares are applied, not ignored.
+	filtered := call(t, ts, doc, "ReadSubregions", `{"Filters":{"SubregionNames":["eu-west-2b"]}}`)
+	rows, _ = filtered["Subregions"].([]any)
+	if len(rows) != 1 {
+		t.Fatalf("filtering on one zone answered %d, want 1: %v", len(rows), filtered)
+	}
+	only, _ := rows[0].(map[string]any)
+	if got, _ := only["SubregionName"].(string); got != "eu-west-2b" {
+		t.Errorf("the filtered answer is %q, want eu-west-2b", got)
+	}
+	none := call(t, ts, doc, "ReadSubregions", `{"Filters":{"RegionNames":["cloudgouv-eu-west-1"]}}`)
+	if rows, _ := none["Subregions"].([]any); len(rows) != 0 {
+		t.Errorf("a region this emulator does not run answered %d Subregions", len(rows))
+	}
+}
+
+// What a create accepts and what the catalogue declares agree, in both
+// directions: every declared zone is accepted by every write path that takes
+// one, and an undeclared zone is refused by all of them. #269 measured the
+// contradiction this closes — CreateSubnet stored `cloudgouv-eu-west-1a`
+// verbatim while ReadSubregions declared a single zone.
+func TestWhatACreateAcceptsTheCatalogueDeclares(t *testing.T) {
+	ts := newServer(t)
+	doc := contractDoc(t)
+
+	declared := call(t, ts, doc, "ReadSubregions", `{}`)
+	rows, _ := declared["Subregions"].([]any)
+	if len(rows) == 0 {
+		t.Fatal("the catalogue declares no Subregion, so this test measures nothing")
+	}
+
+	_, out := post(t, ts, "CreateNet", `{"IpRange":"10.64.0.0/16"}`)
+	n, _ := out["Net"].(map[string]any)
+	netID, _ := n["NetId"].(string)
+
+	for i, raw := range rows {
+		row, _ := raw.(map[string]any)
+		zone, _ := row["SubregionName"].(string)
+		status, created := post(t, ts, "CreateSubnet",
+			`{"NetId":"`+netID+`","IpRange":"10.64.`+string(rune('1'+i))+`.0/24","SubregionName":"`+zone+`"}`)
+		if status != http.StatusOK {
+			t.Errorf("CreateSubnet refuses %s, a zone the catalogue declares: %v", zone, created)
+		}
+	}
+
+	// An undeclared zone is refused by every door that takes one, with the
+	// refusal naming the zone so the caller can act on it.
+	for _, probe := range []struct{ action, body string }{
+		{"CreateSubnet", `{"NetId":"` + netID + `","IpRange":"10.64.9.0/24","SubregionName":"cloudgouv-eu-west-1a"}`},
+		{"CreateVolume", `{"SubregionName":"cloudgouv-eu-west-1a","Size":10}`},
+		{"CreateVms", `{"ImageId":"ami-00000001","BootOnCreation":false,"Placement":{"SubregionName":"cloudgouv-eu-west-1a"}}`},
+	} {
+		status, refused := post(t, ts, probe.action, probe.body)
+		if status != http.StatusBadRequest {
+			t.Errorf("%s answered %d for a zone the catalogue never declared: %v",
+				probe.action, status, refused)
+		}
+	}
+}
+
+// A Placement naming a zone its own Subnet does not sit in is refused, and the
+// refusal leaves nothing behind: answering 200 while storing one of two
+// contradicting facts is the lie either read would then tell.
+func TestAPlacementContradictingTheSubnetIsRefused(t *testing.T) {
+	ts := newServer(t)
+	_, subnetID := netAndSubnet(t, ts, "10.65.0.0/16", "10.65.1.0/24") // default zone
+
+	status, out := post(t, ts, "CreateVms",
+		`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false,`+
+			`"Placement":{"SubregionName":"eu-west-2b"}}`)
+	if status != http.StatusBadRequest {
+		t.Fatalf("a Placement contradicting the Subnet answered %d: %v", status, out)
+	}
+
+	_, read := post(t, ts, "ReadVms", `{}`)
+	if vms, _ := read["Vms"].([]any); len(vms) != 0 {
+		t.Errorf("the refused create left %d Vms behind", len(vms))
+	}
+}

--- a/internal/providers/outscale/vms.go
+++ b/internal/providers/outscale/vms.go
@@ -2,6 +2,7 @@ package outscale
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -52,12 +53,29 @@ type readVmsRequest struct {
 var vmFilters = []string{
 	"VmIds", "VmStates", "ImageIds", "VmTypes", "KeypairNames",
 	"SubnetIds", "NetIds", "PrivateIps",
+	// The zone filter FiltersVm declares (osc-sdk-go, client.gen.go:5304),
+	// served since the subregion became a stored fact rather than a constant
+	// (#268): a constant made this filter either a tautology or a void.
+	"SubregionNames",
 	// The group filters are what `terraform destroy` asks before removing a
 	// security group: which machines still wear it. Without them the destroy
 	// fails on the group, after the apply succeeded — so the whole fixture is
 	// left standing by a filter nobody had declared.
 	"SecurityGroupIds", "SecurityGroupNames",
 }
+
+// vmPlacement is CreateVmsRequest's Placement (osc-sdk-go,
+// pkg/osc/client.gen.go:6804): the subregion the machine goes to, and its
+// tenancy — `default`, `dedicated`, or a dedicated group ID, per the SDK's own
+// description, which is why Tenancy is stored verbatim rather than checked
+// against a closed list.
+type vmPlacement struct {
+	SubregionName string `json:"SubregionName"`
+	Tenancy       string `json:"Tenancy"`
+}
+
+// defaultTenancy is what a machine placed with nothing said runs under.
+const defaultTenancy = "default"
 
 // createVmsRequest is the subset of CreateVmsRequest this pack honours. The
 // count fields are MinVmsCount and MaxVmsCount: there is no VmCount, and reading
@@ -77,6 +95,12 @@ type createVmsRequest struct {
 	SubnetID             string   `json:"SubnetId"`
 	SecurityGroupIDs     []string `json:"SecurityGroupIds"`
 	BootOnCreation       *bool    `json:"BootOnCreation"`
+	// Placement was the field of #268: accepted with a 200, never read, and
+	// every read then answered the pack's constant. A machine created in
+	// eu-west-2b read back in eu-west-2a, and a multi-AZ Terraform plan
+	// re-planned the same in-place change for ever. The chain is
+	// request → store → response now; vmPlacementView renders what this stored.
+	Placement *vmPlacement `json:"Placement"`
 }
 
 type vmIDsRequest struct {
@@ -188,6 +212,7 @@ func (p *Pack) vmMatches(res *resource.Resource, f filterSet) bool {
 		matchesStrings(f, "SubnetIds", attr("SubnetId")) &&
 		matchesStrings(f, "NetIds", attr("NetId")) &&
 		matchesStrings(f, "PrivateIps", p.addressOf(res)) &&
+		matchesStrings(f, "SubregionNames", vmSubregion(res)) &&
 		matchesAny(f, "SecurityGroupIds", groupIDs...) &&
 		matchesAny(f, "SecurityGroupNames", groupNames...)
 }
@@ -203,6 +228,13 @@ func (p *Pack) createVms(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !p.validVmFields(w, req.KeypairName, req.UserData) {
+		return
+	}
+	// A subregion the catalogue does not declare is refused here, not stored:
+	// accepting it would recreate the contradiction #269 measured, where the
+	// write path took any zone and ReadSubregions denied its existence.
+	if req.Placement != nil && req.Placement.SubregionName != "" && !knownSubregion(req.Placement.SubregionName) {
+		p.badRequest(w, "the Subregion "+req.Placement.SubregionName+" does not exist in "+regionName)
 		return
 	}
 
@@ -263,6 +295,10 @@ func (p *Pack) createVms(w http.ResponseWriter, r *http.Request) {
 		}
 		if errors.Is(err, errUnknownSubnet) {
 			p.notFound(w, "Subnet", req.SubnetID)
+			return
+		}
+		if errors.Is(err, errPlacementMismatch) {
+			p.badRequest(w, err.Error())
 			return
 		}
 		p.conflict(w, "cannot place a Vm in "+req.SubnetID+": "+err.Error())
@@ -335,13 +371,29 @@ func (p *Pack) allocateVms(req createVmsRequest, count int, now time.Time) ([]*r
 		// under the lock, is also what makes deleteSubnet's guard hold: the two
 		// cannot interleave, so a Subnet either still exists for this batch or
 		// is already gone for it.
+		subnetSubregion := ""
 		if req.SubnetID != "" {
 			place, err := p.placeInSubnet(req.SubnetID)
 			if err != nil {
 				return created, err
 			}
+			// A Vm lives where its Subnet lives. A Placement naming another
+			// zone is refused rather than stored: answering 200 while keeping
+			// one of two contradicting facts is the lie either read would then
+			// tell. (The exact upstream error shape for this is unmeasured; the
+			// refusal itself is what must not be traded away.)
+			if req.Placement != nil && req.Placement.SubregionName != "" &&
+				req.Placement.SubregionName != place.SubregionName {
+				return created, fmt.Errorf("%w: the Subnet %s sits in %s, not in %s",
+					errPlacementMismatch, req.SubnetID, place.SubregionName, req.Placement.SubregionName)
+			}
 			place.apply(res)
+			subnetSubregion = place.SubregionName
 		}
+		// The placement the reads will answer, resolved once and stored — the
+		// chain #268 demands is request → store → response, never
+		// request → constant → response.
+		res.Attrs["Placement"] = resolvedPlacement(req.Placement, subnetSubregion)
 		if req.KeypairName != "" {
 			res.Attrs["KeypairName"] = req.KeypairName
 		}
@@ -735,6 +787,50 @@ func Gone(res *resource.Resource) bool {
 	return res.Kind == kindVM && res.State == stateTerminated
 }
 
+// errPlacementMismatch is what a create gets for a Placement naming a zone its
+// own Subnet does not sit in.
+var errPlacementMismatch = errors.New("the Placement contradicts the Subnet")
+
+// resolvedPlacement is the placement a create stores: what the client asked,
+// else the Subnet's own zone, else the default — in that order, because the
+// first two are facts the client can read back and the third is the emulator's
+// only honest answer when nobody said anything.
+//
+// TestAVmCreatedInANamedSubregionReadsBackInIt fails when the request's half
+// stops being read; TestAVmInheritsItsSubnetsSubregion when the Subnet's half
+// does.
+func resolvedPlacement(requested *vmPlacement, subnetSubregion string) map[string]any {
+	subregion := orDefault(subnetSubregion, defaultSubregionName)
+	tenancy := defaultTenancy
+	if requested != nil {
+		subregion = orDefault(requested.SubregionName, subregion)
+		tenancy = orDefault(requested.Tenancy, tenancy)
+	}
+	return map[string]any{
+		"SubregionName": subregion,
+		"Tenancy":       tenancy,
+	}
+}
+
+// vmPlacementView renders a Vm's Placement from what its create stored. The
+// fallback exists for records that predate the stored field — a restored
+// snapshot from an older emulator — because the Vm schema declares Placement
+// on every machine (osc-sdk-go, client.gen.go:10576) and a client reads it
+// unconditionally.
+func vmPlacementView(res *resource.Resource) map[string]any {
+	if placement, ok := res.Attrs["Placement"].(map[string]any); ok {
+		return placement
+	}
+	return resolvedPlacement(nil, "")
+}
+
+// vmSubregion is the zone a Vm's own reads answer, shared by every door that
+// publishes it — the view, the state view (readVmsState) and the filters — so
+// two doors cannot disagree about where a machine sits.
+func vmSubregion(res *resource.Resource) string {
+	return stringOf(vmPlacementView(res)["SubregionName"])
+}
+
 // vmView renders a Vm. Only fields the pack actually knows are emitted: a
 // PrivateIp of "" would tell a client the machine has no address, where an
 // absent field tells it the emulator does not model one.
@@ -800,10 +896,12 @@ func (p *Pack) vmView(res *resource.Resource) map[string]any {
 	out["VmInitiatedShutdownBehavior"] = "stop"
 	out["StateReason"] = ""
 	out["ActionsOnNextBoot"] = map[string]any{"SecureBoot": "none"}
-	out["Placement"] = map[string]any{
-		"SubregionName": subregionName,
-		"Tenancy":       "default",
-	}
+	// What the create stored, never a constant. The constant here was #268: a
+	// machine created in eu-west-2b read back in eu-west-2a, stable and wrong —
+	// #250 had already named the pattern, "a constant in a view is a claim
+	// nobody checks". TestAVmCreatedInANamedSubregionReadsBackInIt fails
+	// without this.
+	out["Placement"] = vmPlacementView(res)
 	// Derived from the machine's own id so it cannot move between two reads:
 	// anything Terraform stores has to be stable or it plans a change for ever.
 	out["ReservationId"] = "r-" + hexOf(strings.TrimPrefix(res.ID, "i-")+res.ID, idLen)

--- a/internal/providers/outscale/volumes.go
+++ b/internal/providers/outscale/volumes.go
@@ -51,6 +51,13 @@ func (p *Pack) createVolume(w http.ResponseWriter, r *http.Request) {
 		p.badRequest(w, "SubregionName is required")
 		return
 	}
+	// Required is not enough: a zone the catalogue does not declare is refused
+	// rather than stored, so the write path and ReadSubregions cannot
+	// contradict each other (#269).
+	if !knownSubregion(req.SubregionName) {
+		p.badRequest(w, "the Subregion "+req.SubregionName+" does not exist in "+regionName)
+		return
+	}
 	size := req.Size
 	if req.SnapshotID != "" {
 		// A volume may come from a snapshot the emulator knows — a control-plane
@@ -376,14 +383,21 @@ func (p *Pack) readVmsState(w http.ResponseWriter, r *http.Request) {
 		if !all && res.State != stateRunning {
 			continue
 		}
+		// SubregionNames was declared to refuseUnsupported above and applied
+		// nowhere — the exact blind spot placement.go documents, one call
+		// over: a declared-and-unread field is invisible to the unread-field
+		// report, and a client filtering by zone got every zone back.
 		if !matchesStrings(req.Filters, "VmIds", res.ID) ||
-			!matchesStrings(req.Filters, "VmStates", res.State) {
+			!matchesStrings(req.Filters, "VmStates", res.State) ||
+			!matchesStrings(req.Filters, "SubregionNames", vmSubregion(res)) {
 			continue
 		}
 		out = append(out, map[string]any{
-			"VmId":              res.ID,
-			"VmState":           res.State,
-			"SubregionName":     subregionName,
+			"VmId":    res.ID,
+			"VmState": res.State,
+			// The machine's own zone, through the same door every other read
+			// answers from (#268) — this was the pack's constant too.
+			"SubregionName":     vmSubregion(res),
 			"MaintenanceEvents": []any{},
 		})
 	}

--- a/tools/conformance/outscale/terraform.sh
+++ b/tools/conformance/outscale/terraform.sh
@@ -120,6 +120,23 @@ printf '%s' "$vms" | jq -e 'any(.Vms[0].Tags[]?; .Key == "name" and .Value == "f
   || fail "the tag the provider created is not on the Vm: $vms"
 ok "served, and carrying its tag"
 
+# The multi-AZ half (#268, #269): the second Vm was placed through the zone the
+# data source handed out — subregions[1], the exact index that could not even
+# plan against a one-zone catalogue — and the emulator must read it back in
+# that zone. Asked of the emulator, not of the state file: the state agreeing
+# with itself is precisely how #268 stayed invisible until a second plan ran.
+echo "- the Vm placed in the data-sourced subregion reads back in it"
+azb_vm_id="$("$TF" output -raw azb_vm_id)"
+azb_zone="$("$TF" output -raw azb_subregion)"
+[ -n "$azb_zone" ] || fail "the data source handed out no second subregion"
+[ "$azb_zone" != "eu-west-2a" ] || fail "subregions[1] is the default zone, so this proves nothing"
+azb_vms="$(curl -sf -X POST "$ENDPOINT/api/v1/ReadVms" -H 'Content-Type: application/json' \
+            -d "{\"Filters\":{\"VmIds\":[\"$azb_vm_id\"]}}")" || fail "ReadVms rejected"
+printf '%s' "$azb_vms" | jq -e --arg z "$azb_zone" \
+  '.Vms[0].Placement.SubregionName == $z and .Vms[0].Placement.Tenancy == "default"' >/dev/null \
+  || fail "the Vm asked for $azb_zone and reads back elsewhere — #268 is back: $azb_vms"
+ok "Vm $azb_vm_id placed and read back in $azb_zone"
+
 # The routing family, which the apply proves the provider accepted and this
 # proves the emulator actually holds. Each of these was a 400 on a filter the
 # provider sends and the pack had not declared — found here, by this fixture,

--- a/tools/conformance/outscale/terraform/multi_az.tf
+++ b/tools/conformance/outscale/terraform/multi_az.tf
@@ -1,0 +1,49 @@
+# Multi-AZ, the way real stacks do it — the permanent regression for #268 and
+# #269, found by applying third-party stacks rather than by any test here.
+#
+# Two shapes, both reduced from published stacks:
+#
+#   - davmartini/ocp_outscale asks the API where it may put things:
+#     `data "outscale_subregions"` then `subregions[1].subregion_name`. Against
+#     the one-zone catalogue that index was "Invalid index: list of object
+#     with 1 element", zero resources created — the stack that did it right
+#     was the one that could not even plan (#269).
+#
+#   - michaelcourcy/kasten-on-outscale places a worker explicitly:
+#     `placement_subregion_name = "eu-west-2b"` beside its subnet. CreateVms
+#     answered 200 and every read answered the pack's constant eu-west-2a, so
+#     the second plan re-planned the same in-place change for ever (#268).
+#
+# The fixture keeps both: the subnet's zone comes from the data source at
+# index [1] (the ocp pattern), and the Vm names the same zone explicitly (the
+# kasten pattern). The existing `outscale_vm.conformance` lives in the default
+# zone, so the suite now spreads machines across two subregions — and the
+# suite's own "second plan is empty" gate is what bites if any read answers a
+# constant again.
+
+data "outscale_subregions" "all" {}
+
+resource "outscale_subnet" "azb" {
+  net_id         = outscale_net.conformance.net_id
+  ip_range       = "10.70.2.0/24"
+  subregion_name = data.outscale_subregions.all.subregions[1].subregion_name
+}
+
+resource "outscale_vm" "azb" {
+  image_id  = "ami-00000003"
+  vm_type   = "tinav6.c1r1p2"
+  subnet_id = outscale_subnet.azb.subnet_id
+
+  placement_subregion_name = data.outscale_subregions.all.subregions[1].subregion_name
+  placement_tenancy        = "default"
+}
+
+output "azb_vm_id" {
+  value = outscale_vm.azb.vm_id
+}
+
+# The zone the data source handed out, so the suite can assert the emulator
+# reads the Vm back in the very zone the API told the stack to use.
+output "azb_subregion" {
+  value = data.outscale_subregions.all.subregions[1].subregion_name
+}

--- a/tools/falsify/specs/outscale-subregions.json
+++ b/tools/falsify/specs/outscale-subregions.json
@@ -1,0 +1,26 @@
+{
+  "package": "./internal/providers/outscale/",
+  "mutations": [
+    {
+      "label": "the view answers the pack's constant again, and a Vm created in eu-west-2b reads back in eu-west-2a (#268)",
+      "file": "internal/providers/outscale/vms.go",
+      "find": "\tif placement, ok := res.Attrs[\"Placement\"].(map[string]any); ok {",
+      "replace": "\tif placement, ok := res.Attrs[\"Placement\"].(map[string]any); ok && false {",
+      "test": "TestAVmCreatedInANamedSubregionReadsBackInIt"
+    },
+    {
+      "label": "the create stops reading the request's Placement, which is the exact defect: accepted with a 200, stored as the default (#268)",
+      "file": "internal/providers/outscale/vms.go",
+      "find": "\t\tsubregion = orDefault(requested.SubregionName, subregion)",
+      "replace": "\t\tsubregion = orDefault(requested.SubregionName[:0], subregion)",
+      "test": "TestAVmCreatedInANamedSubregionReadsBackInIt"
+    },
+    {
+      "label": "the catalogue declares one subregion again, and subregions[1] — the index the ocp stack reads — names nothing (#269)",
+      "file": "internal/providers/outscale/catalog.go",
+      "find": "\tout := make([]map[string]any, 0, len(subregions))\n\tfor _, subregion := range subregions {",
+      "replace": "\tout := make([]map[string]any, 0, len(subregions))\n\tfor _, subregion := range subregions[:1] {",
+      "test": "TestReadSubregionsDeclaresTheRegionsSubregions"
+    }
+  ]
+}


### PR DESCRIPTION
# Summary

`#268` and `#269` are one weakness seen through two doors: part of the Outscale topology was coded as a constant while the API exposes the subregion as data. `CreateVms` accepted `Placement.SubregionName` with a 200 and every read answered the pack's `eu-west-2a`, so a machine created in `eu-west-2b` read back elsewhere and a multi-AZ stack re-planned the same in-place change for ever. Meanwhile `ReadSubregions` declared a single zone while `CreateSubnet` stored `cloudgouv-eu-west-1a` verbatim — the stack that asked the API where to put things (`data "outscale_subregions"`, `subregions[1]`) could not even plan, while a stack hardcoding its zone sailed through.

One model replaces both rustines:

- **The catalogue declares the two subregions `eu-west-2` really has** (Outscale's published reference: `eu-west-2a`/PAR1, `eu-west-2b`/PAR2), and `ReadSubregions` applies the three filters `FiltersSubregion` declares instead of ignoring its body.
- **Every write path that takes a `SubregionName`** (`CreateVms` via `Placement`, `CreateSubnet`, `CreateVolume`) **checks it against that same table**, so what a create accepts and what the catalogue declares can no longer contradict each other — whichever side a client believed, neither lies now.
- **A Vm's Placement is `request → store → response`**: what the client asked, else its Subnet's own zone, else the default. Tenancy included — it was the same constant and would have lied identically for `dedicated`. A Placement contradicting the Subnet is refused rather than stored: answering 200 while keeping one of two contradicting facts is the lie either read would then tell.
- **Every other door publishing the constant now follows the stored fact**: `ReadVmsState` (whose `SubregionNames` filter was declared to the refusal list and *applied nowhere* — the declared-and-unread blind spot `placement.go` documents), the NIC views (an interface sits where its Subnet sits), and the `SubregionNames` filters on `ReadVms` and `ReadSubnets`.

## Proof

- **Unit tests use non-default zones throughout** (`subregions_test.go`) — the family shipped precisely because the suite only ever created resources in the default zone, where a constant and a datum are indistinguishable. `Subregions[1].SubregionName` is asserted directly because it is the exact expression #269 measured failing.
- **The conformance fixture spreads Vms across two subregions** (`tools/conformance/outscale/terraform/multi_az.tf`) through the exact expressions the two source stacks used: the ocp pattern (`data "outscale_subregions"` indexed at `[1]`) and the kasten pattern (`placement_subregion_name` beside a subnet). `terraform.sh` reads the Vm back from the emulator — not from the state file — and the existing empty-second-plan gate now holds the #268 idempotence permanently. Run for real: `outscale tofu apply/destroy passed`, second plan empty, in-place change held, destroy clean; `oapi-cli` leg, probe (99 probed, 0 failed) and the example stacks green on the same emulator.
- **Falsification**: `tools/falsify/specs/outscale-subregions.json` puts the constant back three ways — the view answers the constant again, the create stops reading the request's Placement, the catalogue declares one zone. All three: `the test bit`. `falsify:lint` green (108 mutations across 34 specs still apply).

## What was found beyond the two issues, and deliberately left

`CreateVmsRequest` also declares `BootMode`, `Performance` and `VmInitiatedShutdownBehavior` (osc-sdk-go `client.gen.go:3024`, `:3061`, `:3088`), and `vmView` publishes fixed `"uefi"`, `"high"`, `"stop"` for all three — the same accepted-then-constant pattern, but per-machine scalars rather than topology, each with its own validation questions (enum values, defaults per type). They are not silently absorbed into this diff; now #276, with the measurement.

## Type of change

- [x] A route added or changed
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes (gofmt, vet, golangci-lint, `go test -race`)
- [x] No new external Go dependency, or the pull request justifies it
- [x] `internal/core` still knows no provider. Everything here lives in `internal/providers/outscale/` and `tools/`
- [x] Nothing in the diff could be written identically for another provider: the zone table, the placement chain and the filters are Outscale's own vocabulary; the Scaleway and Exoscale packs model zones through their own catalogues already

### When a model wrote a substantive part of this

- [x] An `Assisted-by:` trailer names the tool and the model version (`Assisted-by: Claude Code (claude-opus-5)`)
- [x] I ran `mise run conformance` myself — the Outscale legs (oapi-cli, Terraform/OpenTofu, probe, stacks) were driven by hand against a dedicated emulator on `127.0.0.1:4620` (port 4599 was held by another session); the network leg self-skips without a runtime, which other sessions were using
- [x] Every field name in the diff comes from osc-sdk-go `pkg/osc/client.gen.go`, cited with line numbers in the comments and the commit body (`Placement` :6804, `Subregion` :9416, `FiltersSubregion` :5071, `FiltersVm` :5304, `FiltersVmsState` :5457, `FiltersSubnet` :5058); the two-zone list and the PAR1/PAR2 mapping come from Outscale's "Regions, Endpoints, and Subregions Reference"

### When a route is added or changed

- [x] No route added; the changed handlers keep their declared operations (`osc/Client.ReadSubregions` et al.), enforced by `TestEveryRouteNamesItsSDKOperation`
- [x] `mise run conformance` — Outscale legs run for real, see above
- [x] Responses validated against `contracts/outscale.json` (`--contracts contracts` on the conformance emulator, and every unit test goes through the contract-checking `call` helper)
- [x] What the client sends is read, or refused: `Placement` is now declared *and* read; `ReadVmsState`'s declared-and-unread `SubregionNames` filter is now applied; unknown zones are refused with a 400 naming the zone
- [x] `mise run drift:check` green — no operation added or removed, `coverage/` unchanged

### When behaviour a client can observe changes

- [x] `docs/limits.md` — N/A: no documented limit moves; the one-zone claim was never documented as a limit, which was part of the problem
- [x] README generated tables — N/A: route counts unchanged (`feint docs --check` green in prepush)

### When `.github/workflows/` is touched

- N/A — no workflow touched

### When a machine runtime is involved

- N/A — control-plane only; the subregion is emulator fiction in every `--vm` mode, and the network leg self-skips without a runtime

## Related issues

Closes #268
Closes #269
