### PR TITLE
feat(examples): the stacks are written the way strangers write them (#262)

### DIFF
--- a/examples/stacks/README.md
+++ b/examples/stacks/README.md
@@ -1,83 +1,141 @@
-# Two platform stacks, applied on every pull request
+# Three platform stacks, two applied on every pull request
 
-These are not snippets. Each one is the shape a platform team ends up with, and
-each runs against Feint in CI — apply, an empty second plan, destroy — with no
-cloud account and nothing billed.
+These are not snippets. Each stack is the shape a platform team ends up with,
+written the way the surveyed third-party stacks are written — modules,
+`for_each` over typed variables, a `terraform.tfvars.example`, zones asked
+from the API rather than hardcoded. The Scaleway and Outscale stacks run
+against Feint in CI on every pull request — apply, an empty second plan,
+destroy — with no cloud account and nothing billed. The Exoscale one is run
+by hand, for a reason [measured below](#the-exoscale-stack-needs-the-patched-provider).
+
+## Running one
 
 ```bash
 feint start
 cd examples/stacks/scaleway && terraform init && terraform apply
 ```
 
-| Stack | What it carries |
-|---|---|
-| [`scaleway/`](scaleway/main.tf) | two VPCs, three private networks and a route between them, three security groups, a bastion, a web tier with IPAM-booked addresses, an application tier with no public address, a golden image cut from a snapshot, block-storage volumes with their own snapshots, cloud-init everywhere — six machines |
-| [`outscale/`](outscale/main.tf) | two Nets with a peering and the route across it, a public subnet with an internet service and a route table, a private subnet, a shared-services Net, a standalone NIC, per-tier security groups, public IPs linked to Vms, a volume attached to a machine, an image from a snapshot |
-| [`exoscale/`](exoscale/main.tf) | two private networks, per-tier security groups (one naming the other rather than an address), an anti-affinity group, a web instance holding an elastic IP, and an instance pool for the application tier — **needs the patched provider, see below** |
+Every variable has a working default; `terraform.tfvars.example` in each
+directory shows what an override looks like.
 
-## Why they exist, and it is not decoration
+## The stacks
 
-`tools/conformance/*/terraform/` already holds fixtures. They prove what somebody
-thought to assert. These stacks exercise **what somebody actually writes**, and
-the difference was measured rather than argued: within an hour of the first one
-being applied, two defects surfaced that every existing gate was blind to.
+Resource counts are measured — the number the apply reports — not estimated.
 
-- **[#249](https://github.com/stephrobert/feint/issues/249)** — a route could not
-  point at a Net peering, so two peered Nets stayed unreachable. The suite
-  creates peerings and asserts their state machine; it never routes through one.
-- **[#250](https://github.com/stephrobert/feint/issues/250)** — a tagged NIC read
-  back without its tags, so a Terraform plan never converged. The suite tagged
-  Nets, Vms and volumes, and never an interface.
+### `scaleway/` — 37 resources, 6 machines
 
-Neither was visible to a schema check. A missing route target answers a clean
-400, and a view publishing a constant empty list has exactly the shape an
-untagged NIC should have: the form was right and the fact was wrong.
+- **Builds**: two VPCs (workload and management), three private networks and
+  a route between them, three per-tier security groups, a bastion as the only
+  public door, a web tier with IPAM-booked addresses and data volumes, an
+  application tier with no public address driven by a typed `for_each` map,
+  block-storage volumes with their own snapshots, a golden image cut from a
+  snapshot, cloud-init everywhere.
+- **Real motifs it reproduces** (sources in [`surveyed.md`](surveyed.md)):
+  IPAM-first addressing and the `one(pn.ipv6_subnets).subnet` read from
+  sergelogvinov/terraform-talos; the named-workers map from the same stack's
+  typed tiers; the `tfvars.example` hygiene from kiwinet-infra-cloud.
+- **Keeps under watch**: [#270] — the IPv6 `/64` a private network must
+  publish; the output consuming it dies on apply against an emulator that
+  omits it, and a stack already applied then cannot even destroy. Also the
+  volume → snapshot → image chain, built and deliberately not booted from
+  ([#83], see the comment in the file).
 
-The same argument was then turned outward: fifteen stacks from GitHub,
-written by people who had never seen this repository, applied against the
-emulator — five per provider. [`surveyed.md`](surveyed.md) is that register
-(#262): repository and commit for each, verdict, every edit recorded with
-its reason, the declined products they reached for, and the four defects
-they surfaced (#268, #269, #270, #271).
+### `outscale/` — 38 resources, 3 machines
 
-## The rule when you change one
+- **Builds**: two Nets from a reusable `modules/net` module, four subnets —
+  the public tier spread over both subregions — a peering and the route
+  through it, an internet service and public route table, a NAT service with
+  its own public IP and the private route table whose default route crosses
+  it, per-tier security groups, a keypair, a standalone NIC, public IPs
+  linked to Vms, a volume attached to a machine, an image from a snapshot.
+- **Real motifs it reproduces**: the Net-plus-subnets module from
+  chimere-eu/ztiac; `data "outscale_subregions"` indexed past `[0]` from
+  davmartini/ocp_outscale; explicit `placement_subregion_name` beside the
+  subnet from michaelcourcy/kasten-on-outscale; NAT-behind-the-public-tier
+  from all four substantial surveyed stacks; the created-in-stack keypair
+  from osc-k8s-rke-cluster.
+- **Keeps under watch**: [#249] — a route pointing at a Net peering; [#250] —
+  a tagged NIC reading back with its tags; [#268] — a Vm's placement must
+  round-trip or the second plan re-plans for ever; [#269] — the subregion
+  catalogue must match the write path, or indexing the data source dies at
+  plan. The route through the NAT service is coverage the conformance
+  fixtures do not have: they create a NAT service and never route through it.
 
-**Every defect a stack finds gets its resource added to the stack.** That is what
-keeps them tests rather than demonstrations, and it is the same rule the
-conformance suites obey.
+### `exoscale/` — 13 resources, 3 machines
 
-The assertion that does the finding is the middle one:
+- **Builds**: two managed private networks with declared lease ranges,
+  per-tier security groups (one rule naming the other group rather than an
+  address), an anti-affinity group, an elastic IP with a healthcheck in front
+  of a web instance, a block-storage volume attached to that instance with
+  its snapshot, and an instance pool for the application tier.
+- **Real motifs it reproduces**: the healthchecked elastic IP from
+  PhilippeChepy/terraform-exoscale-vault — the only surveyed stack that came
+  out entirely green; the group-names-group rule and instance pools from
+  appuio/terraform-openshift4-exoscale; the persistent-data-volume chain from
+  HealsCodes/ephemeral-devbox; the explicit template `visibility` filter
+  whose reads produced the [#271] transcript.
+- **Keeps under watch**: [#271] — a query parameter the API document declares
+  must be served or refused, never dropped; the elastic-ip healthcheck block
+  must read back as sent. It is also the Terraform reader of the
+  block-storage and instance-pool work of #12 and #232, which the exo CLI
+  suite otherwise exercises alone.
+- **Not run by CI** — it needs the patched provider,
+  [measured below](#the-exoscale-stack-needs-the-patched-provider).
+
+## What a run proves, and the rule that makes the stacks grow
+
+Each run asserts three things, and the middle one does the finding:
 
 ```bash
-terraform plan -detailed-exitcode      # must be empty
+terraform apply                        # the emulator answered
+terraform plan -detailed-exitcode      # must exit 0: it read back what was sent
+terraform destroy                      # nothing wedges on a half-truth
 ```
 
-An apply that succeeds proves the emulator answered. An empty second plan proves
-it read back what the provider sent.
+An apply that succeeds proves the emulator answered. An empty second plan
+proves it read back what the provider sent — a 200 with a constant inside it
+fails here and nowhere else.
+
+`tools/conformance/*/terraform/` already holds fixtures. They prove what
+somebody thought to assert; these stacks exercise what somebody actually
+writes, and the difference was measured rather than argued — twice:
+
+- Within an hour of the first stack being applied: [#249] (a route could not
+  point at a Net peering — the suite asserted peering state machines and
+  never routed through one) and [#250] (a tagged NIC read back without its
+  tags — the suite tagged Nets, Vms and volumes, never an interface).
+- Then the same argument turned outward: fifteen stacks from GitHub, five per
+  provider, written by people who had never seen this repository, applied
+  against the emulator. [`surveyed.md`](surveyed.md) is that register (#262),
+  and it produced [#268], [#269], [#270] and [#271].
+
+**The rule: every defect a stack finds gets the resource that found it added
+to a stack**, so the next run keeps checking it. That is what keeps these
+tests rather than demonstrations, and it is why they grow.
 
 ## What CI runs them against, and why not the published tag
 
-Every pull request applies them twice: against the emulator built from the
-branch (the `terraform` and `opentofu` legs — the change under review), and
-against the container image built from the branch with the release's own recipe
-(the `image` job — the packaging a user pulls). Not against the last tag on
-ghcr.io, and that is arithmetic rather than preference: a published image is
-immutable, and the rule above makes the stacks grow every time they find a
-defect, so the two must diverge exactly when the stacks do their job. Measured
-before it was decided — v0.8.0 predates the fixes for [#249] and [#250], both
-stacks exercise those fixes, and a gate on the published tag would have been
-red by construction from its first run. The commit a tag is cut from gets the
-same image run on `main` after the merge, which is what makes the image
-eventually published a proven one.
+Every pull request applies the Scaleway and Outscale stacks twice: against
+the emulator built from the branch (the `terraform` and `opentofu` legs — the
+change under review), and against the container image built from the branch
+with the release's own recipe (the `image` job — the packaging a user pulls).
+Not against the last tag on ghcr.io, and that is arithmetic rather than
+preference: a published image is immutable, and the rule above makes the
+stacks grow every time they find a defect, so the two must diverge exactly
+when the stacks do their job. Measured before it was decided — v0.8.0
+predates the fixes for [#249] and [#250], both stacks exercise those fixes,
+and a gate on the published tag would have been red by construction from its
+first run. The commit a tag is cut from gets the same image run on `main`
+after the merge, which is what makes the image eventually published a proven
+one.
 
-[#249]: https://github.com/stephrobert/feint/issues/249
-[#250]: https://github.com/stephrobert/feint/issues/250
+## The Exoscale stack needs the patched provider
 
 The published Exoscale provider builds two clients: one honours
 `EXOSCALE_API_ENDPOINT`, the other has `.exoscale.com` compiled in. An apply
 therefore does not fail — it **splits**, half against the emulator and half
-against a paying account. Feint refuses that client by its user agent rather than
-serving half of it, and the whole measurement is in
+against a paying account. Feint refuses that client by its user agent rather
+than serving half of it, and the whole measurement is in
 [docs/limits.md](../../docs/limits.md#the-exoscale-terraform-provider-is-refused-and-why),
 with the pinned fork and the `dev_overrides` recipe.
 
@@ -87,18 +145,28 @@ To run it:
 FEINT_EXOSCALE_ALLOW_TERRAFORM=1 feint start
 export TF_CLI_CONFIG_FILE=/tmp/dev.tfrc     # the dev_overrides from limits.md
 eval "$(feint env exoscale)"
-cd examples/stacks/exoscale && terraform apply
+cd examples/stacks/exoscale && terraform apply   # no init: the override resolves the provider
 ```
 
-**CI does not run it, on purpose.** No gate here clones a third-party repository
-— that would put somebody else's availability in this project's pipeline — and a
-client this project patched is not the official client, so it could not count
-towards conformance in any case. It was applied by hand on 2026-08-17: apply, an
-empty second plan, destroy, and zero contract violations.
+**CI does not run it, on purpose.** No gate here clones a third-party
+repository — that would put somebody else's availability in this project's
+pipeline — and a client this project patched is not the official client, so
+it could not count towards conformance in any case. It was last applied by
+hand on 2026-08-18: apply, an empty second plan, destroy — 13 resources, zero
+contract violations.
 
 ## What they do not prove
 
-Nothing here boots a machine, filters a packet or isolates a subnet: that needs
-`--vm` and a host with Incus. [`docs/confidence.md`](../../docs/confidence.md)
-says row by row what changes when you have one, keyed on the capability the
-runtime declares rather than on a mode name.
+Nothing here boots a machine, filters a packet or isolates a subnet: that
+needs `--vm` and a host with Incus.
+[`docs/confidence.md`](../../docs/confidence.md) says row by row what changes
+when you have one, keyed on the capability the runtime declares rather than
+on a mode name.
+
+[#83]: https://github.com/stephrobert/feint/issues/83
+[#249]: https://github.com/stephrobert/feint/issues/249
+[#250]: https://github.com/stephrobert/feint/issues/250
+[#268]: https://github.com/stephrobert/feint/issues/268
+[#269]: https://github.com/stephrobert/feint/issues/269
+[#270]: https://github.com/stephrobert/feint/issues/270
+[#271]: https://github.com/stephrobert/feint/issues/271

--- a/examples/stacks/exoscale/main.tf
+++ b/examples/stacks/exoscale/main.tf
@@ -140,14 +140,66 @@ resource "exoscale_anti_affinity_group" "app" {
 # application tier — which is the shape a pool exists for.
 # ---------------------------------------------------------------------------
 
+# The visibility filter is written out rather than left to its default.
+# appuio/terraform-openshift4-exoscale resolves every template through this
+# parameter, and its reads produced the #271 transcript: a filter the API
+# document declares and the emulator dropped, answering the public catalogue
+# to a private query. The declared parameter on this read keeps the served
+# half of that fix under a real client; the private half — register a
+# template, list it under `--visibility private` — needs a register call the
+# pinned provider fork (0.70-based) has no resource for, so it lives in the
+# exo CLI conformance suite instead.
 data "exoscale_template" "ubuntu" {
-  zone = var.zone
-  name = "Linux Ubuntu 24.04 LTS 64-bit"
+  zone       = var.zone
+  name       = "Linux Ubuntu 24.04 LTS 64-bit"
+  visibility = "public"
 }
 
 resource "exoscale_elastic_ip" "ingress" {
   zone        = var.zone
   description = "platform ingress"
+
+  # A managed EIP rather than a bare one: PhilippeChepy/terraform-exoscale-vault
+  # — the only surveyed third-party stack that came out entirely green — fronts
+  # its cluster with exactly this healthcheck shape. The block must read back
+  # as sent or the second plan never converges.
+  healthcheck {
+    mode         = "tcp"
+    port         = 443
+    interval     = 10
+    timeout      = 5
+    strikes_ok   = 2
+    strikes_fail = 3
+  }
+}
+
+# ---------------------------------------------------------------------------
+# A persistent data volume, attached to the web instance and snapshotted —
+# the block-storage product, which is a different API from the instance disk.
+# HealsCodes/ephemeral-devbox is built around exactly this motif (a machine
+# that comes and goes, a data volume that survives it, a snapshot rotation);
+# it drove the chain on the neighbouring provider, and this is the Terraform
+# reader of the block-storage work of #12 and #232 that the exo CLI suite
+# otherwise exercises alone.
+# ---------------------------------------------------------------------------
+
+resource "exoscale_block_storage_volume" "web_data" {
+  zone = var.zone
+  name = "platform-web-data"
+  size = 20
+
+  labels = {
+    tier = "web"
+  }
+}
+
+resource "exoscale_block_storage_volume_snapshot" "web_data" {
+  zone = var.zone
+  name = "platform-web-snap"
+
+  volume = {
+    id = exoscale_block_storage_volume.web_data.id
+  }
 }
 
 resource "exoscale_compute_instance" "web" {
@@ -159,6 +211,8 @@ resource "exoscale_compute_instance" "web" {
   ssh_key            = exoscale_ssh_key.platform.name
   security_group_ids = [exoscale_security_group.web.id]
   elastic_ip_ids     = [exoscale_elastic_ip.ingress.id]
+
+  block_storage_volume_ids = [exoscale_block_storage_volume.web_data.id]
 
   network_interface {
     network_id = exoscale_private_network.front.id
@@ -195,4 +249,9 @@ output "ingress_address" {
 
 output "pool_instances" {
   value = exoscale_instance_pool.app.virtual_machines
+}
+
+output "template_id" {
+  # Resolved through an explicit visibility filter — the #271 read path.
+  value = data.exoscale_template.ubuntu.id
 }

--- a/examples/stacks/exoscale/terraform.tfvars.example
+++ b/examples/stacks/exoscale/terraform.tfvars.example
@@ -1,0 +1,11 @@
+# Copy to terraform.tfvars and adjust. Every value has a working default, so
+# the file is optional.
+
+# The emulated catalogue serves a single zone, and this is it — a measured
+# decision (internal/providers/exoscale/catalog.go). Three of the five
+# surveyed Exoscale stacks default to another zone and meet that wall; this
+# variable exists so a reader sees where the zone is chosen.
+zone = "ch-dk-2"
+
+# How many machines the application pool holds.
+pool_size = 2

--- a/examples/stacks/outscale/main.tf
+++ b/examples/stacks/outscale/main.tf
@@ -1,12 +1,17 @@
-# Two peered Nets on Outscale, with a public tier, a private tier and a shared
-# services Net — the shape a platform reaches when one account holds more than
-# one environment.
+# Two peered Nets on Outscale, with a public tier spread over two subregions,
+# a private tier behind a NAT service, and a shared-services Net — the shape a
+# platform reaches when one account holds more than one environment.
 #
-# Written as a real project would be, not as a fixture: an internet service and
-# a route table on the public side, a peering between the two Nets with the
-# route that makes it useful, a NIC of its own on the application machine,
-# volumes with snapshots, an image cut from one of them, and tags everywhere
-# because the provider sends them on almost every call.
+# Written as a real project would be, not as a fixture: the Nets come from a
+# module the way ztiac builds its VPCs, the availability zones are asked from
+# the API the way ocp_outscale asks (never hardcoded), the web machines are
+# spread over two subregions the way kasten-on-outscale places its workers, an
+# internet service and a route table serve the public side, a NAT service and
+# its own route table serve the private side, a peering carries the route
+# between the two Nets, and tags ride on almost every call because the
+# provider sends them on almost every call. Each of those motifs is lifted
+# from a stack in examples/stacks/surveyed.md written by someone who never saw
+# this repository.
 
 terraform {
   required_version = ">= 1.7.0"
@@ -23,9 +28,10 @@ variable "endpoint" {
   default = "http://127.0.0.1:4599"
 }
 
-variable "web_count" {
-  type    = number
-  default = 2
+variable "vm_type" {
+  type        = string
+  description = "The Vm type every machine uses. Must exist in the emulated catalogue."
+  default     = "tinav5.c1r1p2"
 }
 
 # The endpoint carries the whole API path — their documentation gives the shape
@@ -44,65 +50,54 @@ provider "outscale" {
 }
 
 # ---------------------------------------------------------------------------
-# The workload Net: a public subnet and a private one.
+# Where machines may go is asked, not assumed. davmartini/ocp_outscale plans
+# its subnets over `data "outscale_subregions"` and indexes past [0]; against
+# the one-zone catalogue that index was "Invalid index", zero resources
+# created (#269). Keeping the same read here keeps the catalogue honest.
 # ---------------------------------------------------------------------------
 
-resource "outscale_net" "workload" {
+data "outscale_subregions" "all" {}
+
+locals {
+  az_a = data.outscale_subregions.all.subregions[0].subregion_name
+  az_b = data.outscale_subregions.all.subregions[1].subregion_name
+}
+
+# ---------------------------------------------------------------------------
+# The workload Net: a public subnet per subregion, and a private one. The
+# services Net beside it. Both come from the same module, which is how ztiac
+# and pli01/terraform-outscale-k3s shape every Net they build.
+# ---------------------------------------------------------------------------
+
+module "workload" {
+  source = "./modules/net"
+
+  name     = "platform-workload"
   ip_range = "10.50.0.0/16"
 
-  tags {
-    key   = "Name"
-    value = "platform-workload"
+  subnets = {
+    public-a = { ip_range = "10.50.1.0/24", subregion_name = local.az_a }
+    public-b = { ip_range = "10.50.3.0/24", subregion_name = local.az_b }
+    private  = { ip_range = "10.50.2.0/24", subregion_name = local.az_a }
   }
 }
 
-resource "outscale_subnet" "public" {
-  net_id   = outscale_net.workload.net_id
-  ip_range = "10.50.1.0/24"
+module "services" {
+  source = "./modules/net"
 
-  tags {
-    key   = "Name"
-    value = "platform-public"
-  }
-}
-
-resource "outscale_subnet" "private" {
-  net_id   = outscale_net.workload.net_id
-  ip_range = "10.50.2.0/24"
-
-  tags {
-    key   = "Name"
-    value = "platform-private"
-  }
-}
-
-# ---------------------------------------------------------------------------
-# The shared-services Net, peered with the workload one. Two Nets that must
-# reach each other is the case a single-Net example never exercises.
-# ---------------------------------------------------------------------------
-
-resource "outscale_net" "services" {
+  name     = "platform-services"
   ip_range = "10.60.0.0/16"
 
-  tags {
-    key   = "Name"
-    value = "platform-services"
-  }
-}
-
-resource "outscale_subnet" "services" {
-  net_id   = outscale_net.services.net_id
-  ip_range = "10.60.1.0/24"
-
-  tags {
-    key   = "Name"
-    value = "platform-services"
+  # No subregion named: this subnet takes the region default, and the read
+  # back of that default is the other half of what #269 measured.
+  subnets = {
+    services = { ip_range = "10.60.1.0/24" }
   }
 }
 
 resource "outscale_net_peering" "workload_to_services" {
-  accepter_net_id = outscale_net.services.net_id
-  source_net_id   = outscale_net.workload.net_id
+  accepter_net_id = module.services.net_id
+  source_net_id   = module.workload.net_id
 }
 
 resource "outscale_net_peering_acceptation" "workload_to_services" {
@@ -117,11 +112,11 @@ resource "outscale_internet_service" "main" {}
 
 resource "outscale_internet_service_link" "main" {
   internet_service_id = outscale_internet_service.main.internet_service_id
-  net_id              = outscale_net.workload.net_id
+  net_id              = module.workload.net_id
 }
 
 resource "outscale_route_table" "public" {
-  net_id = outscale_net.workload.net_id
+  net_id = module.workload.net_id
 
   tags {
     key   = "Name"
@@ -137,7 +132,8 @@ resource "outscale_route" "default" {
   depends_on = [outscale_internet_service_link.main]
 }
 
-# The route that makes the peering useful, which is the half people forget.
+# The route that makes the peering useful, which is the half people forget —
+# and the half the emulator once refused (#249).
 resource "outscale_route" "to_services" {
   route_table_id       = outscale_route_table.public.route_table_id
   destination_ip_range = "10.60.0.0/16"
@@ -147,8 +143,49 @@ resource "outscale_route" "to_services" {
 }
 
 resource "outscale_route_table_link" "public" {
+  for_each = toset(["public-a", "public-b"])
+
   route_table_id = outscale_route_table.public.route_table_id
-  subnet_id      = outscale_subnet.public.subnet_id
+  subnet_id      = module.workload.subnet_ids[each.key]
+}
+
+# ---------------------------------------------------------------------------
+# The private door out: a NAT service with its own public IP, and the private
+# route table whose default route goes through it. Every substantial surveyed
+# stack builds this (ztiac one per AZ, ocp_outscale two, kasten one, pli01
+# one); the conformance fixture creates a NAT service but never routes through
+# it, so this route is the only place a client drives that target.
+# ---------------------------------------------------------------------------
+
+resource "outscale_public_ip" "nat" {}
+
+resource "outscale_nat_service" "main" {
+  subnet_id    = module.workload.subnet_ids["public-a"]
+  public_ip_id = outscale_public_ip.nat.public_ip_id
+
+  # A NAT service belongs in a subnet that already routes to an internet
+  # service — same ordering the conformance fixture states.
+  depends_on = [outscale_route_table_link.public]
+}
+
+resource "outscale_route_table" "private" {
+  net_id = module.workload.net_id
+
+  tags {
+    key   = "Name"
+    value = "platform-private"
+  }
+}
+
+resource "outscale_route" "private_default" {
+  route_table_id       = outscale_route_table.private.route_table_id
+  destination_ip_range = "0.0.0.0/0"
+  nat_service_id       = outscale_nat_service.main.nat_service_id
+}
+
+resource "outscale_route_table_link" "private" {
+  route_table_id = outscale_route_table.private.route_table_id
+  subnet_id      = module.workload.subnet_ids["private"]
 }
 
 # ---------------------------------------------------------------------------
@@ -158,7 +195,7 @@ resource "outscale_route_table_link" "public" {
 resource "outscale_security_group" "web" {
   description         = "platform web tier"
   security_group_name = "platform-web"
-  net_id              = outscale_net.workload.net_id
+  net_id              = module.workload.net_id
 }
 
 resource "outscale_security_group_rule" "web_https" {
@@ -173,7 +210,7 @@ resource "outscale_security_group_rule" "web_https" {
 resource "outscale_security_group" "app" {
   description         = "platform application tier"
   security_group_name = "platform-app"
-  net_id              = outscale_net.workload.net_id
+  net_id              = module.workload.net_id
 }
 
 resource "outscale_security_group_rule" "app_from_web" {
@@ -186,11 +223,23 @@ resource "outscale_security_group_rule" "app_from_web" {
 }
 
 # ---------------------------------------------------------------------------
+# The keypair the machines boot with. Every surveyed stack creates or requires
+# one (osc-k8s-rke-cluster creates three), and a Vm naming a keypair that does
+# not exist is refused with upstream's own 5063 — creating it here is the only
+# order that applies.
+# ---------------------------------------------------------------------------
+
+resource "outscale_keypair" "platform" {
+  keypair_name = "platform"
+  public_key   = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIr6pEFlAFO3YU0DNW/r8SkpjdbptN9ockkO2BtIolSD platform@example"
+}
+
+# ---------------------------------------------------------------------------
 # A golden image, from a volume and its snapshot.
 # ---------------------------------------------------------------------------
 
 resource "outscale_volume" "golden" {
-  subregion_name = "eu-west-2a"
+  subregion_name = local.az_a
   size           = 10
 }
 
@@ -210,7 +259,11 @@ resource "outscale_image" "golden" {
 }
 
 # ---------------------------------------------------------------------------
-# The machines.
+# The machines. The web tier is spread over both subregions, and each Vm names
+# its placement explicitly beside its subnet — the kasten-on-outscale shape
+# that found #268: CreateVms answered 200 and every read answered a constant
+# eu-west-2a, so the second plan re-planned the same change for ever. The
+# "second plan is empty" gate below is what bites if a read does that again.
 # ---------------------------------------------------------------------------
 
 data "outscale_images" "ubuntu" {
@@ -220,29 +273,40 @@ data "outscale_images" "ubuntu" {
   }
 }
 
+locals {
+  web_tier = {
+    a = { subnet = "public-a", subregion = local.az_a }
+    b = { subnet = "public-b", subregion = local.az_b }
+  }
+}
+
 resource "outscale_vm" "web" {
-  count = var.web_count
+  for_each = local.web_tier
 
   image_id           = data.outscale_images.ubuntu.images[0].image_id
-  vm_type            = "tinav5.c1r1p2"
-  subnet_id          = outscale_subnet.public.subnet_id
+  vm_type            = var.vm_type
+  keypair_name       = outscale_keypair.platform.keypair_name
+  subnet_id          = module.workload.subnet_ids[each.value.subnet]
   security_group_ids = [outscale_security_group.web.security_group_id]
+
+  placement_subregion_name = each.value.subregion
+  placement_tenancy        = "default"
 
   tags {
     key   = "Name"
-    value = "platform-web-${count.index}"
+    value = "platform-web-${each.key}"
   }
 }
 
 resource "outscale_public_ip" "web" {
-  count = var.web_count
+  for_each = local.web_tier
 }
 
 resource "outscale_public_ip_link" "web" {
-  count = var.web_count
+  for_each = local.web_tier
 
-  vm_id     = outscale_vm.web[count.index].vm_id
-  public_ip = outscale_public_ip.web[count.index].public_ip
+  vm_id     = outscale_vm.web[each.key].vm_id
+  public_ip = outscale_public_ip.web[each.key].public_ip
 }
 
 resource "outscale_vm" "app" {
@@ -261,8 +325,9 @@ resource "outscale_vm" "app" {
   # The image is still built, and outscale_image.golden below still proves the
   # snapshot → image chain. Only the boot moves.
   image_id           = data.outscale_images.ubuntu.images[0].image_id
-  vm_type            = "tinav5.c1r1p2"
-  subnet_id          = outscale_subnet.private.subnet_id
+  vm_type            = var.vm_type
+  keypair_name       = outscale_keypair.platform.keypair_name
+  subnet_id          = module.workload.subnet_ids["private"]
   security_group_ids = [outscale_security_group.app.security_group_id]
 
   tags {
@@ -272,9 +337,10 @@ resource "outscale_vm" "app" {
 }
 
 # A NIC of its own on the services Net — the case that needs an interface
-# created separately rather than the one a Vm is born with.
+# created separately rather than the one a Vm is born with, and the resource
+# whose tags once vanished on read (#250).
 resource "outscale_nic" "app_services" {
-  subnet_id = outscale_subnet.services.subnet_id
+  subnet_id = module.services.subnet_ids["services"]
 
   tags {
     key   = "Name"
@@ -283,7 +349,7 @@ resource "outscale_nic" "app_services" {
 }
 
 resource "outscale_volume" "app_data" {
-  subregion_name = "eu-west-2a"
+  subregion_name = local.az_a
   size           = 20
 
   tags {
@@ -299,9 +365,18 @@ resource "outscale_volume_link" "app_data" {
 }
 
 output "web_public_ips" {
-  value = outscale_public_ip.web[*].public_ip
+  value = { for name, ip in outscale_public_ip.web : name => ip.public_ip }
+}
+
+output "web_subregions" {
+  # What the API reads back, not what the plan asked — the #268 round-trip.
+  value = { for name, vm in outscale_vm.web : name => vm.placement_subregion_name }
+}
+
+output "nat_public_ip" {
+  value = outscale_public_ip.nat.public_ip
 }
 
 output "machines" {
-  value = var.web_count + 1
+  value = length(outscale_vm.web) + 1
 }

--- a/examples/stacks/outscale/modules/net/main.tf
+++ b/examples/stacks/outscale/modules/net/main.tf
@@ -1,0 +1,67 @@
+# A Net and its subnets, as a reusable module.
+#
+# The shape is chimere-eu/ztiac's (surveyed.md): every substantial third-party
+# Outscale stack the survey applied wraps "a Net plus its subnets spread over
+# subregions" in a module and instantiates it per environment. The house stack
+# used to inline all of it, which meant the module resolution path — a child
+# module with its own required_providers, for_each over typed objects — was
+# never exercised against the emulator.
+
+terraform {
+  required_version = ">= 1.7.0"
+  required_providers {
+    # Without this block Terraform resolves the unqualified "outscale" of a
+    # child module to hashicorp/outscale, which does not exist. kalisio/kaabah
+    # died exactly there (surveyed.md, annex).
+    outscale = {
+      source = "outscale/outscale"
+    }
+  }
+}
+
+variable "name" {
+  type = string
+}
+
+variable "ip_range" {
+  type = string
+}
+
+variable "subnets" {
+  # subregion_name stays optional: a subnet that does not name one takes the
+  # region default, and both paths must read back what was written (#268, #269).
+  type = map(object({
+    ip_range       = string
+    subregion_name = optional(string)
+  }))
+}
+
+resource "outscale_net" "this" {
+  ip_range = var.ip_range
+
+  tags {
+    key   = "Name"
+    value = var.name
+  }
+}
+
+resource "outscale_subnet" "this" {
+  for_each = var.subnets
+
+  net_id         = outscale_net.this.net_id
+  ip_range       = each.value.ip_range
+  subregion_name = each.value.subregion_name
+
+  tags {
+    key   = "Name"
+    value = "${var.name}-${each.key}"
+  }
+}
+
+output "net_id" {
+  value = outscale_net.this.net_id
+}
+
+output "subnet_ids" {
+  value = { for name, subnet in outscale_subnet.this : name => subnet.subnet_id }
+}

--- a/examples/stacks/outscale/terraform.tfvars.example
+++ b/examples/stacks/outscale/terraform.tfvars.example
@@ -1,0 +1,9 @@
+# Copy to terraform.tfvars and adjust. Every value has a working default, so
+# the file is optional — which is exactly how the better surveyed stacks ship
+# theirs (Rookain-Kiwi/kiwinet-infra-cloud, PhilippeChepy/platform).
+
+# Where the emulator answers.
+endpoint = "http://127.0.0.1:4599"
+
+# The Vm type every machine uses.
+vm_type = "tinav5.c1r1p2"

--- a/examples/stacks/scaleway/main.tf
+++ b/examples/stacks/scaleway/main.tf
@@ -14,7 +14,7 @@ terraform {
   required_version = ">= 1.7.0"
   required_providers {
     scaleway = {
-      source  = "scaleway/scaleway"
+      source = "scaleway/scaleway"
       # Exact for the same reason the conformance fixture is exact: a floating
       # constraint turned CI red the hour 2.81.0 was published, with no change
       # on this side (#257). 2.81.0 is the pin rather than the 2.80.0 that made
@@ -36,9 +36,19 @@ variable "web_count" {
   default = 2
 }
 
-variable "app_count" {
-  type    = number
-  default = 3
+# A typed map rather than a count, because that is what the better surveyed
+# stacks do (sergelogvinov/terraform-talos drives every tier from typed maps):
+# each worker is named, and carries its own data-disk size. The default applies
+# as-is; terraform.tfvars.example shows what an override looks like.
+variable "app_servers" {
+  type = map(object({
+    data_gb = optional(number, 20)
+  }))
+  default = {
+    worker-a = {}
+    worker-b = {}
+    worker-c = { data_gb = 30 }
+  }
 }
 
 provider "scaleway" {
@@ -275,24 +285,24 @@ resource "scaleway_instance_private_nic" "web" {
 # ---------------------------------------------------------------------------
 
 resource "scaleway_block_volume" "app_data" {
-  count      = var.app_count
-  name       = "platform-app-data-${count.index}"
+  for_each   = var.app_servers
+  name       = "platform-app-data-${each.key}"
   iops       = 5000
-  size_in_gb = 20
+  size_in_gb = each.value.data_gb
   tags       = ["platform", "app"]
 }
 
 resource "scaleway_block_snapshot" "app_data" {
-  count     = var.app_count
-  name      = "platform-app-snap-${count.index}"
-  volume_id = scaleway_block_volume.app_data[count.index].id
+  for_each  = var.app_servers
+  name      = "platform-app-snap-${each.key}"
+  volume_id = scaleway_block_volume.app_data[each.key].id
   tags      = ["platform", "app"]
 }
 
 resource "scaleway_instance_server" "app" {
-  count = var.app_count
+  for_each = var.app_servers
 
-  name              = "platform-app-${count.index}"
+  name              = "platform-app-${each.key}"
   type              = "DEV1-S"
   image             = "ubuntu_jammy"
   security_group_id = scaleway_instance_security_group.app.id
@@ -302,9 +312,9 @@ resource "scaleway_instance_server" "app" {
 }
 
 resource "scaleway_instance_private_nic" "app" {
-  count = var.app_count
+  for_each = var.app_servers
 
-  server_id          = scaleway_instance_server.app[count.index].id
+  server_id          = scaleway_instance_server.app[each.key].id
   private_network_id = scaleway_vpc_private_network.app.id
 }
 
@@ -322,6 +332,20 @@ output "web_addresses" {
 
 output "golden_image_id" {
   value = scaleway_instance_image.golden.id
+}
+
+# The /64 each private network carries beside its declared IPv4 subnet.
+# sergelogvinov/terraform-talos consumes exactly this expression to build its
+# machine configs, and it is the expression that found #270: against an
+# emulator publishing no IPv6 subnet, one() yields null, this output dies on
+# apply — and a stack already applied cannot even destroy. Keeping it here
+# keeps that a permanent regression.
+output "ipv6_subnets" {
+  value = {
+    web   = one(scaleway_vpc_private_network.web.ipv6_subnets).subnet
+    app   = one(scaleway_vpc_private_network.app.ipv6_subnets).subnet
+    admin = one(scaleway_vpc_private_network.admin.ipv6_subnets).subnet
+  }
 }
 
 output "machines" {

--- a/examples/stacks/scaleway/terraform.tfvars.example
+++ b/examples/stacks/scaleway/terraform.tfvars.example
@@ -1,0 +1,17 @@
+# Copy to terraform.tfvars and adjust. Every value has a working default, so
+# the file is optional — the shape the better surveyed stacks ship
+# (Rookain-Kiwi/kiwinet-infra-cloud carries exactly this file).
+
+# Where the emulator answers.
+endpoint = "http://127.0.0.1:4599"
+
+# How many web machines carry a public address and an IPAM-booked one.
+web_count = 2
+
+# The application tier: one entry per named worker, each with its own
+# block-storage data disk.
+app_servers = {
+  worker-a = {}
+  worker-b = {}
+  worker-c = { data_gb = 30 }
+}

--- a/tools/conformance/stacks.sh
+++ b/tools/conformance/stacks.sh
@@ -89,7 +89,13 @@ run_stack() { # name
   WORK="$(mktemp -d)"
   STACK="$name"
   DESTROYED=0
+  # *.tf and modules/ explicitly, never the whole directory: a reader who ran
+  # a stack in place leaves .terraform/ and terraform.tfstate behind, and
+  # copying those would hand this run somebody else's state.
   cp "$src"/*.tf "$WORK/"
+  if [ -d "$src/modules" ]; then
+    cp -R "$src/modules" "$WORK/"
+  fi
 
   cd "$WORK"
   export TF_IN_AUTOMATION=1 TF_INPUT=0


### PR DESCRIPTION
# Summary

The fifteen-stack survey (`examples/stacks/surveyed.md`, #262) measured what
Terraform stacks written by strangers do that the house example stacks did
not — and found four defects doing it (#268, #269, #270, #271). This change
makes the example stacks carry those motifs, so every pull request keeps
checking the fixes under the shape a platform team actually writes:

- **Scaleway** (37 resources, measured): the application tier moves from
  `count` to a typed `for_each` map (sergelogvinov/terraform-talos drives
  every tier from typed maps), and a new output consumes
  `one(pn.ipv6_subnets).subnet` for all three private networks — the exact
  expression that found #270, where an applied stack could not even destroy.
- **Outscale** (38 resources, measured): the Nets come from a reusable
  `modules/net` module (chimere-eu/ztiac's shape, including the child-module
  `required_providers` block whose absence killed kalisio/kaabah); the
  subregions are asked from `data.outscale_subregions` and indexed past `[0]`
  (davmartini/ocp_outscale, #269); the web tier spreads over both subregions
  with `placement_subregion_name` declared beside its subnet
  (michaelcourcy/kasten-on-outscale, #268 — the run reads back `eu-west-2a`
  and `eu-west-2b`, not a constant); a keypair is created in-stack
  (osc-k8s-rke-cluster); and a NAT service carries the private route table's
  default route — a route target no conformance fixture drives (the fixture
  creates a NAT service and never routes through it).
- **Exoscale** (13 resources, applied by hand with the patched provider on
  2026-08-18: apply, empty second plan, destroy, `violations: {}`): the
  elastic IP gains the healthcheck block from
  PhilippeChepy/terraform-exoscale-vault — the only surveyed stack that came
  out entirely green; a block-storage volume is attached to the web instance
  and snapshotted (HealsCodes/ephemeral-devbox's persistent-volume motif,
  and the Terraform reader the block-storage work of #12/#232 never had);
  and the template read declares its `visibility` filter, the parameter
  whose dropped reads produced the #271 transcript. The
  register-then-read-private half stays with the exo CLI suite: the pinned
  0.70-based fork has no `exoscale_template` resource.

Each stack ships a `terraform.tfvars.example` (the publication hygiene the
survey scored), and `stacks.sh` copies `modules/` beside `*.tf` — explicitly,
never the whole directory, so a reader's leftover state files stay out of
the run.

**Deliberately not added**: LBU (Outscale), SKS/DNS/NLB/DBaaS/SOS (Exoscale),
Kapsule/LB/vpc-gw/placement groups (Scaleway) — the products the surveyed
stacks reached for most are declined or unserved, and the register counts
them as roadmap data, not as stack material.

The README is normalized around how a reader uses it: what the stacks are →
how to run one → a homogeneous section per stack (built, measured count,
motifs with sources, defects kept under watch) → what a run proves and the
growth rule stated once → what CI applies them against and why not the
published tag → the Exoscale fork measurement → what nothing here proves.
The title said "Two platform stacks" while its own table listed three.

## Type of change

- [ ] A route added or changed
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation
- [x] Chore / tooling

## Checklist

### Always

- [x] `mise run check` passes (gofmt, vet, golangci-lint, `go test -race`)
- [x] No new external Go dependency, or the pull request justifies it. The
      standard library covers routing, JSON and Go parsing; `go.mod` has three
      lines and a pre-commit hook keeps it that way
- [x] `internal/core` still knows no provider. If a change seemed to require it,
      the pack changed instead — no Go code is touched at all
- [x] Nothing in the diff could be written identically for another provider. If
      it could, it belongs in the core — the stacks are deliberately
      provider-shaped; the only shared piece (the copy rule) lives in
      `stacks.sh`

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] I ran `mise run conformance` myself — not "it should pass": green,
      264 of 285 routes proven, the reworked stacks applied, re-planned
      empty and destroyed inside it (and once more standalone under tofu)
- [x] Every field name in the diff comes from the provider's SDK, their OpenAPI
      document, or a run of the real client, and I can say which: every
      attribute here was accepted and read back by the pinned providers
      themselves (scaleway 2.81.0, outscale ~> 1.3, the pinned exoscale fork)
      across apply / empty plan / destroy

### When a route is added or changed — otherwise N/A

N/A — no route, no response shape, no Go code.

### When behaviour a client can observe changes — otherwise N/A

N/A — the emulator's behaviour is unchanged; the stacks and their harness
copy step changed. `mise run prepush` (which carries `docs:check`) is green.

### When `.github/workflows/` is touched — otherwise N/A

N/A.

### When a machine runtime is involved — otherwise N/A

N/A — not run: the station's Incus host is shared and a machines-on run was
not cleared by the operator. No stack's machine count changed (6/3/3), and
every boot stays on the catalogue image, which is the #83 rule the in-file
comments keep.

## Related issues

#262, and the watch list the stacks now carry: #268, #269, #270, #271
(their fixes are on `main`; #271's is in the conformance suite pending
merge — the stack exercises the served half of that parameter either way).
