### PR TITLE
fix(outscale): a Vm's options are data the reads restitute, not constants (#276)

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -28,7 +28,7 @@
 >
 > **Prouvé** : 264 des 285 opérations montées sont pilotées par un vrai client, à chaque pull request. `scw`, `oapi-cli`, `exo`, Terraform et OpenTofu tournent contre l'émulateur en CI, et les machines démarrent réellement : connexion ssh sur le compte par défaut de chaque provider, subnets isolés, pare-feu qui filtre. La chaîne complète est décrite dans [docs/conformance.md](docs/conformance.md).
 >
-> **Pas prouvé** : quotas, prix, capacité réelle, validation des identifiants, authentification, cohérence à terme. Les 32 sections de [docs/limits.md](docs/limits.md) disent chacune ce qu'elle coûte. Un émulateur avec un seul compte implicite et aucune grille tarifaire devrait inventer ces chiffres, et quelqu'un agirait dessus.
+> **Pas prouvé** : quotas, prix, capacité réelle, validation des identifiants, authentification, cohérence à terme. Les 33 sections de [docs/limits.md](docs/limits.md) disent chacune ce qu'elle coûte. Un émulateur avec un seul compte implicite et aucune grille tarifaire devrait inventer ces chiffres, et quelqu'un agirait dessus.
 >
 > **Inconnu** : 21 opérations sont montées et n'ont jamais été pilotées par un client. Chacune dit pourquoi aucun client officiel ne l'atteint, à la route et dans [docs/routes.md](docs/routes.md). Elles sont comptées plutôt qu'escamotées, une par une, dans [coverage/evidence.json](coverage/evidence.json).
 >

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 >
 > **Proven**: 264 of the 285 mounted operations are driven by a real client, on every pull request. `scw`, `oapi-cli`, `exo`, Terraform and OpenTofu run against the emulator in CI, and machines really boot: an ssh login on each provider's own default account, isolated subnets, a firewall that filters. The whole chain is described in [docs/conformance.md](docs/conformance.md).
 >
-> **Not proven**: quotas, prices, real capacity, identifier validation, authentication, eventual consistency. The 32 sections of [docs/limits.md](docs/limits.md) each say what one costs. An emulator with a single implicit account and no price list would have to invent those figures, and somebody would act on them.
+> **Not proven**: quotas, prices, real capacity, identifier validation, authentication, eventual consistency. The 33 sections of [docs/limits.md](docs/limits.md) each say what one costs. An emulator with a single implicit account and no price list would have to invent those figures, and somebody would act on them.
 >
 > **Unknown**: 21 operations are mounted and have never been driven by a client. Every one of them states why no official client reaches it, at the route and in [docs/routes.md](docs/routes.md). They are counted rather than glossed, one by one, in [coverage/evidence.json](coverage/evidence.json).
 >

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -1313,6 +1313,41 @@ So: a plan that builds a routable topology applies, reads back and destroys
 correctly. A machine inside it still cannot reach the internet. Use the emulator
 to test the shape of your infrastructure, never its connectivity.
 
+## An Outscale Vm's options round-trip as data; their behavioural half has nothing to act on here
+
+`BootMode`, `Performance` and `VmInitiatedShutdownBehavior` used to be
+accepted at create with a 200 while every read answered a constant of the
+pack — the client asked `medium`/`restart`/`legacy`, the same create's answer
+said `high`/`stop`/`uefi`, and a Terraform stack setting any of them
+re-planned the same in-place change for ever (#276, the #268 pattern on
+per-machine scalars). They are stored and restituted now, on the create and
+on UpdateVm where upstream declares them, values validated against their
+enums, and `Performance` honours upstream's own precedence: a performance
+flag inside the `VmType` (`tinavW.cXrYpZ`) wins over the parameter. The same
+sweep covers the neighbours with the same symptom: `TpmEnabled`,
+`ActionsOnNextBoot.SecureBoot`, `ShutdownBehaviorConfiguration` (whose
+defaults are now the SDK's own "By default" lines — GuestAction `stop`,
+HostAction `restart`; the old constant said `stop`/`stop`) and UpdateVm's
+`IsSourceDestChecked`.
+
+What is served is the datum. The behavioural half of these fields has nothing
+to act on in this emulator, and saying so is the difference between an echo
+and a lie:
+
+- `VmInitiatedShutdownBehavior` and `ShutdownBehaviorConfiguration` describe
+  what the platform does when the **guest** shuts itself down. No path here
+  watches a guest-initiated shutdown — `StopVms` stops the machine whatever
+  the field says, which matches upstream, where the API stop is not a
+  VM-initiated one. A `terminate` behaviour will therefore never terminate a
+  machine here, because the event that would trigger it is never observed.
+- `TpmEnabled` and `ActionsOnNextBoot.SecureBoot` round-trip; no vTPM and no
+  secure-boot state is presented to any guest the runtime boots.
+- `IsSourceDestChecked` round-trips; nothing enforces the check on traffic.
+- `BsuOptimized` stays the constant `false` on every read, and that one is
+  upstream's own behaviour, not this pack's shortcut: "This parameter is not
+  available. It is present in our API for the sake of historical
+  compatibility with AWS" (osc-sdk-go client.gen.go:3029).
+
 ## An Outscale Net peering carries traffic under OVN, and only there
 
 The `NetPeering` family is served — create, accept, reject, delete, read, with

--- a/internal/providers/outscale/vmoptions.go
+++ b/internal/providers/outscale/vmoptions.go
@@ -1,0 +1,237 @@
+package outscale
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/stephrobert/feint/internal/core/resource"
+)
+
+// The Vm options a client writes and the reads must restitute (#276).
+//
+// BootMode, Performance and VmInitiatedShutdownBehavior were accepted at
+// create with a 200 while every read answered a constant of the pack — the
+// client asked medium/restart/legacy, the same create's answer said
+// high/stop/uefi. That is #268's accepted-then-constant pattern on per-machine
+// scalars: a Terraform stack setting any of them re-plans the same in-place
+// change for ever. The chain #275 established for Placement applies unchanged:
+// request → store → response, never request → constant → response.
+//
+// The same sweep covers the neighbours with the same symptom:
+// ShutdownBehaviorConfiguration (both actions were the constant "stop" while
+// their own SDK comments state the defaults, GuestAction stop and HostAction
+// restart), TpmEnabled, ActionsOnNextBoot.SecureBoot, and UpdateVm's
+// IsSourceDestChecked.
+//
+// Field sources, osc-sdk-go pkg/osc/client.gen.go: CreateVmsRequest.BootMode
+// :3024, .Performance :3060 ("ignored if you specify a performance flag
+// directly in the VmType parameter"), .VmInitiatedShutdownBehavior :3088
+// (stop|restart|terminate), .ShutdownBehaviorConfiguration :3075,
+// .TpmEnabled :3081, .ActionsOnNextBoot :3018; UpdateVmRequest.Performance
+// :10320, .VmInitiatedShutdownBehavior :10336, .ShutdownBehaviorConfiguration
+// :10326, .IsSourceDestChecked :10310, .ActionsOnNextBoot :10295. Enums:
+// BootMode :79-84 (legacy|uefi), CreateVmsRequestPerformance :225-230
+// (medium|high|highest), ShutdownBehaviorConfigurationGuestAction :769-773
+// (stop|terminate), ShutdownBehaviorConfigurationHostAction :795-799
+// (restart|stop), SecureBootAction (enable|disable|setup-mode|none) via
+// ActionsOnNextBoot :1507-1510.
+//
+// What is served is the datum; what is enacted is stated in docs/limits.md:
+// no guest-initiated shutdown, secure boot or vTPM exists in the runtime, so
+// the behavioural half of these fields has nothing to act on here.
+
+// The defaults a Vm created without options reads back. BootMode and
+// Performance are what a real machine answered in the recorded account (the
+// transcript diff that added the twenty fixed fields); the shutdown defaults
+// are the SDK's own "By default" lines — GuestAction stop, HostAction restart
+// (client.gen.go:9233-9237) — and VmInitiatedShutdownBehavior stop (the
+// documented stop|restart|terminate family's neutral member, matching
+// GuestAction's default).
+const (
+	defaultBootMode           = "uefi"
+	defaultPerformance        = "high"
+	defaultShutdownBehavior   = "stop"
+	defaultGuestAction        = "stop"
+	defaultHostAction         = "restart"
+	defaultSecureBootAction   = "none"
+	attrBootMode              = "BootMode"
+	attrPerformance           = "Performance"
+	attrShutdownBehavior      = "VmInitiatedShutdownBehavior"
+	attrShutdownConfiguration = "ShutdownBehaviorConfiguration"
+	attrTpmEnabled            = "TpmEnabled"
+	attrActionsOnNextBoot     = "ActionsOnNextBoot"
+	attrSourceDestChecked     = "IsSourceDestChecked"
+)
+
+type shutdownBehaviorConfigurationRequest struct {
+	GuestAction *string `json:"GuestAction"`
+	HostAction  *string `json:"HostAction"`
+}
+
+type actionsOnNextBootRequest struct {
+	SecureBoot *string `json:"SecureBoot"`
+}
+
+// vmOptionsRequest is the slice of CreateVms and UpdateVm both carry; BootMode
+// is create-only upstream (UpdateVmRequest declares none) and lives beside the
+// embedding structs.
+type vmOptionsRequest struct {
+	Performance                   *string                               `json:"Performance"`
+	VmInitiatedShutdownBehavior   *string                               `json:"VmInitiatedShutdownBehavior"`
+	ShutdownBehaviorConfiguration *shutdownBehaviorConfigurationRequest `json:"ShutdownBehaviorConfiguration"`
+	ActionsOnNextBoot             *actionsOnNextBootRequest             `json:"ActionsOnNextBoot"`
+}
+
+// validVmOptions checks the enumerated values CreateVms and UpdateVm share,
+// answering the client itself so the two paths cannot drift — the same shape
+// as validVmFields, for the same reason. A value outside its enum is refused,
+// never stored: stored, every later read would either restitute a value the
+// platform does not define or fall back to a default the client did not ask.
+func (p *Pack) validVmOptions(w http.ResponseWriter, opts vmOptionsRequest) bool {
+	if opts.Performance != nil && !oneOf(*opts.Performance, "medium", "high", "highest") {
+		p.badRequest(w, "Performance must be medium, high or highest")
+		return false
+	}
+	if opts.VmInitiatedShutdownBehavior != nil && !oneOf(*opts.VmInitiatedShutdownBehavior, "stop", "restart", "terminate") {
+		p.badRequest(w, "VmInitiatedShutdownBehavior must be stop, restart or terminate")
+		return false
+	}
+	if sbc := opts.ShutdownBehaviorConfiguration; sbc != nil {
+		if sbc.GuestAction != nil && !oneOf(*sbc.GuestAction, "stop", "terminate") {
+			p.badRequest(w, "ShutdownBehaviorConfiguration.GuestAction must be stop or terminate")
+			return false
+		}
+		if sbc.HostAction != nil && !oneOf(*sbc.HostAction, "restart", "stop") {
+			p.badRequest(w, "ShutdownBehaviorConfiguration.HostAction must be restart or stop")
+			return false
+		}
+	}
+	if boot := opts.ActionsOnNextBoot; boot != nil && boot.SecureBoot != nil &&
+		!oneOf(*boot.SecureBoot, "enable", "disable", "setup-mode", "none") {
+		p.badRequest(w, "ActionsOnNextBoot.SecureBoot must be enable, disable, setup-mode or none")
+		return false
+	}
+	return true
+}
+
+func oneOf(value string, allowed ...string) bool {
+	for _, v := range allowed {
+		if value == v {
+			return true
+		}
+	}
+	return false
+}
+
+// storeVmOptions writes what the update carries over what the create resolved,
+// field by field: a request that says nothing about a field leaves the stored
+// datum alone.
+func storeVmOptions(res *resource.Resource, opts vmOptionsRequest, vmType string) {
+	res.Attrs[attrPerformance] = resolvedVmPerformance(vmType, opts.Performance, vmPerformance(res))
+	if opts.VmInitiatedShutdownBehavior != nil {
+		res.Attrs[attrShutdownBehavior] = *opts.VmInitiatedShutdownBehavior
+	}
+	if sbc := opts.ShutdownBehaviorConfiguration; sbc != nil {
+		stored := vmShutdownConfiguration(res)
+		if sbc.GuestAction != nil {
+			stored["GuestAction"] = *sbc.GuestAction
+		}
+		if sbc.HostAction != nil {
+			stored["HostAction"] = *sbc.HostAction
+		}
+		res.Attrs[attrShutdownConfiguration] = stored
+	}
+	if boot := opts.ActionsOnNextBoot; boot != nil && boot.SecureBoot != nil {
+		res.Attrs[attrActionsOnNextBoot] = map[string]any{"SecureBoot": *boot.SecureBoot}
+	}
+}
+
+// resolvedVmPerformance is the performance a Vm's reads will answer.
+//
+// The flag inside the VmType wins, which is upstream's own rule: "this
+// parameter is ignored if you specify a performance flag directly in the
+// VmType parameter" (client.gen.go:3059). Then the client's explicit ask,
+// then what is already stored, then the platform default.
+func resolvedVmPerformance(vmType string, asked *string, current string) string {
+	if flag := performanceFlagOf(vmType); flag != "" {
+		return flag
+	}
+	if asked != nil {
+		return *asked
+	}
+	return orDefault(current, defaultPerformance)
+}
+
+// performanceFlagOf reads the pZ of a tinavW.cXrYpZ type name. The mapping is
+// Outscale's published one (the VM Types page the SDK's own VmType comment
+// points to): p1 highest, p2 high, p3 medium. A type without the flag — the
+// tinavW.cXrY spelling, or an AWS name — carries none.
+func performanceFlagOf(vmType string) string {
+	if !strings.HasPrefix(vmType, "tinav") {
+		return ""
+	}
+	switch {
+	case strings.HasSuffix(vmType, "p1"):
+		return "highest"
+	case strings.HasSuffix(vmType, "p2"):
+		return "high"
+	case strings.HasSuffix(vmType, "p3"):
+		return "medium"
+	}
+	return ""
+}
+
+// The readers every door goes through: the stored datum, else the default a
+// machine created before these fields were stored has always published. One
+// reader per field so no view rebuilds the fallback chain its own way.
+
+func vmBootMode(res *resource.Resource) string {
+	return orDefault(stringOf(res.Attrs[attrBootMode]), defaultBootMode)
+}
+
+func vmPerformance(res *resource.Resource) string {
+	return orDefault(stringOf(res.Attrs[attrPerformance]), defaultPerformance)
+}
+
+func vmShutdownBehavior(res *resource.Resource) string {
+	return orDefault(stringOf(res.Attrs[attrShutdownBehavior]), defaultShutdownBehavior)
+}
+
+// vmShutdownConfiguration always answers both actions: the SDK declares the
+// defaults on the schema itself, and a partial object would read as an
+// omission to a client that decodes pointers.
+func vmShutdownConfiguration(res *resource.Resource) map[string]any {
+	out := map[string]any{
+		"GuestAction": defaultGuestAction,
+		"HostAction":  defaultHostAction,
+	}
+	if stored, ok := res.Attrs[attrShutdownConfiguration].(map[string]any); ok {
+		for k, v := range stored {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+func vmActionsOnNextBoot(res *resource.Resource) map[string]any {
+	if stored, ok := res.Attrs[attrActionsOnNextBoot].(map[string]any); ok {
+		if action := stringOf(stored["SecureBoot"]); action != "" {
+			return map[string]any{"SecureBoot": action}
+		}
+	}
+	return map[string]any{"SecureBoot": defaultSecureBootAction}
+}
+
+func vmTpmEnabled(res *resource.Resource) bool {
+	enabled, _ := res.Attrs[attrTpmEnabled].(bool)
+	return enabled
+}
+
+// vmSourceDestChecked defaults to true, the value the pack has always
+// published and the platform's own default for a Vm in a Net.
+func vmSourceDestChecked(res *resource.Resource) bool {
+	if stored, ok := res.Attrs[attrSourceDestChecked].(bool); ok {
+		return stored
+	}
+	return true
+}

--- a/internal/providers/outscale/vmoptions_test.go
+++ b/internal/providers/outscale/vmoptions_test.go
@@ -1,0 +1,191 @@
+package outscale_test
+
+import (
+	"net/http"
+	"testing"
+)
+
+// Every test here asks with NON-default values, and that is the point, not a
+// detail: #276's fields shipped as constants because the suite only ever
+// created machines with defaults, under which a constant and a datum are
+// indistinguishable — the same lesson #268 taught for Placement one release
+// earlier.
+
+// vmOf digs the first Vm out of a Vms answer.
+func vmOf(t *testing.T, out map[string]any) map[string]any {
+	t.Helper()
+	vms, _ := out["Vms"].([]any)
+	if len(vms) == 0 {
+		t.Fatalf("no Vms in the answer: %v", out)
+	}
+	vm, _ := vms[0].(map[string]any)
+	return vm
+}
+
+func singleVmOf(t *testing.T, out map[string]any) map[string]any {
+	t.Helper()
+	vm, ok := out["Vm"].(map[string]any)
+	if !ok {
+		t.Fatalf("no Vm in the answer: %v", out)
+	}
+	return vm
+}
+
+func assertVmOptions(t *testing.T, vm map[string]any, want map[string]any, when string) {
+	t.Helper()
+	for field, expected := range want {
+		if got := vm[field]; got != expected {
+			t.Errorf("%s: %s = %v, want %v", when, field, got, expected)
+		}
+	}
+}
+
+// TestAVmReadsBackItsOwnOptions is #276 verbatim: the client asks
+// medium/restart/legacy and the 200 — the create's own, and every ReadVms
+// after it — must answer medium/restart/legacy, not high/stop/uefi. The
+// VmType carries no performance flag, so the Performance parameter is the
+// one that decides.
+func TestAVmReadsBackItsOwnOptions(t *testing.T) {
+	ts := newServer(t)
+	doc := contractDoc(t)
+
+	created := call(t, ts, doc, "CreateVms",
+		`{"ImageId":"ami-00000001","VmType":"tinav6.c1r1","BootOnCreation":false,`+
+			`"BootMode":"legacy","Performance":"medium","VmInitiatedShutdownBehavior":"restart",`+
+			`"TpmEnabled":true,`+
+			`"ShutdownBehaviorConfiguration":{"GuestAction":"terminate","HostAction":"stop"},`+
+			`"ActionsOnNextBoot":{"SecureBoot":"enable"}}`)
+	want := map[string]any{
+		"BootMode":                    "legacy",
+		"Performance":                 "medium",
+		"VmInitiatedShutdownBehavior": "restart",
+		"TpmEnabled":                  true,
+	}
+	assertVmOptions(t, vmOf(t, created), want, "the create's own answer")
+	id := firstVMID(t, created)
+
+	read := call(t, ts, doc, "ReadVms", `{"Filters":{"VmIds":["`+id+`"]}}`)
+	vm := vmOf(t, read)
+	assertVmOptions(t, vm, want, "ReadVms")
+
+	sbc, _ := vm["ShutdownBehaviorConfiguration"].(map[string]any)
+	if sbc["GuestAction"] != "terminate" || sbc["HostAction"] != "stop" {
+		t.Errorf("ShutdownBehaviorConfiguration = %v, want terminate/stop", sbc)
+	}
+	boot, _ := vm["ActionsOnNextBoot"].(map[string]any)
+	if boot["SecureBoot"] != "enable" {
+		t.Errorf("ActionsOnNextBoot = %v, want SecureBoot enable", boot)
+	}
+}
+
+// TestAVmCreatedWithDefaultsReadsThePlatformOnes pins the other direction: a
+// bare create answers the platform defaults, HostAction restart among them —
+// the SDK's own "By default" line (client.gen.go:9236), which the old
+// constant contradicted with "stop".
+func TestAVmCreatedWithDefaultsReadsThePlatformOnes(t *testing.T) {
+	ts := newServer(t)
+	doc := contractDoc(t)
+
+	created := call(t, ts, doc, "CreateVms",
+		`{"ImageId":"ami-00000001","VmType":"tinav6.c1r1","BootOnCreation":false}`)
+	vm := vmOf(t, created)
+	assertVmOptions(t, vm, map[string]any{
+		"BootMode":                    "uefi",
+		"Performance":                 "high",
+		"VmInitiatedShutdownBehavior": "stop",
+		"TpmEnabled":                  false,
+		"IsSourceDestChecked":         true,
+	}, "a bare create")
+	sbc, _ := vm["ShutdownBehaviorConfiguration"].(map[string]any)
+	if sbc["GuestAction"] != "stop" || sbc["HostAction"] != "restart" {
+		t.Errorf("ShutdownBehaviorConfiguration = %v, want the SDK defaults stop/restart", sbc)
+	}
+	boot, _ := vm["ActionsOnNextBoot"].(map[string]any)
+	if boot["SecureBoot"] != "none" {
+		t.Errorf("ActionsOnNextBoot = %v, want SecureBoot none", boot)
+	}
+}
+
+// TestTheVmTypePerformanceFlagWins holds upstream's precedence: "this
+// parameter is ignored if you specify a performance flag directly in the
+// VmType parameter" (client.gen.go:3059). p3 spells medium, so a client
+// asking highest beside a p3 type reads medium back.
+func TestTheVmTypePerformanceFlagWins(t *testing.T) {
+	ts := newServer(t)
+	doc := contractDoc(t)
+
+	created := call(t, ts, doc, "CreateVms",
+		`{"ImageId":"ami-00000001","VmType":"tinav6.c1r1p3","BootOnCreation":false,"Performance":"highest"}`)
+	assertVmOptions(t, vmOf(t, created), map[string]any{"Performance": "medium"},
+		"a p3 type beside Performance=highest")
+}
+
+// TestUpdateVmMovesTheOptions covers the update half upstream declares:
+// Performance, VmInitiatedShutdownBehavior, ShutdownBehaviorConfiguration and
+// IsSourceDestChecked on UpdateVmRequest — accepted-and-denied there is the
+// same non-converging plan one call later.
+func TestUpdateVmMovesTheOptions(t *testing.T) {
+	ts := newServer(t)
+	doc := contractDoc(t)
+
+	created := call(t, ts, doc, "CreateVms",
+		`{"ImageId":"ami-00000001","VmType":"tinav6.c1r1","BootOnCreation":false,"Performance":"medium"}`)
+	id := firstVMID(t, created)
+
+	updated := call(t, ts, doc, "UpdateVm",
+		`{"VmId":"`+id+`","Performance":"highest","VmInitiatedShutdownBehavior":"terminate",`+
+			`"IsSourceDestChecked":false,`+
+			`"ShutdownBehaviorConfiguration":{"GuestAction":"terminate"}}`)
+	want := map[string]any{
+		"Performance":                 "highest",
+		"VmInitiatedShutdownBehavior": "terminate",
+		"IsSourceDestChecked":         false,
+	}
+	assertVmOptions(t, singleVmOf(t, updated), want, "the update's own answer")
+
+	read := call(t, ts, doc, "ReadVms", `{"Filters":{"VmIds":["`+id+`"]}}`)
+	vm := vmOf(t, read)
+	assertVmOptions(t, vm, want, "ReadVms after the update")
+	sbc, _ := vm["ShutdownBehaviorConfiguration"].(map[string]any)
+	if sbc["GuestAction"] != "terminate" || sbc["HostAction"] != "restart" {
+		t.Errorf("ShutdownBehaviorConfiguration = %v, want terminate and the untouched default restart", sbc)
+	}
+
+	// A retype onto a flagged VmType re-resolves the performance: the flag
+	// wins over the highest stored just above.
+	retyped := call(t, ts, doc, "UpdateVm", `{"VmId":"`+id+`","VmType":"tinav6.c2r2p2"}`)
+	assertVmOptions(t, singleVmOf(t, retyped), map[string]any{"Performance": "high"},
+		"a retype onto a p2 flag")
+}
+
+// TestVmOptionsOutsideTheirEnumAreRefused: refused, never stored — a stored
+// value outside the platform's enum can only be restituted as a lie or
+// silently replaced by a default the client did not ask.
+func TestVmOptionsOutsideTheirEnumAreRefused(t *testing.T) {
+	ts := newServer(t)
+
+	cases := []struct {
+		label string
+		body  string
+	}{
+		{"BootMode", `{"ImageId":"ami-00000001","BootMode":"bios"}`},
+		{"Performance", `{"ImageId":"ami-00000001","Performance":"turbo"}`},
+		{"VmInitiatedShutdownBehavior", `{"ImageId":"ami-00000001","VmInitiatedShutdownBehavior":"hibernate"}`},
+		{"GuestAction", `{"ImageId":"ami-00000001","ShutdownBehaviorConfiguration":{"GuestAction":"restart"}}`},
+		{"SecureBoot", `{"ImageId":"ami-00000001","ActionsOnNextBoot":{"SecureBoot":"maybe"}}`},
+	}
+	for _, tc := range cases {
+		status, out := post(t, ts, "CreateVms", tc.body)
+		if status != http.StatusBadRequest {
+			t.Errorf("%s outside its enum answered %d, want 400 (%v)", tc.label, status, out)
+		}
+	}
+	// Nothing half-created behind a refusal.
+	status, read := post(t, ts, "ReadVms", `{}`)
+	if status != http.StatusOK {
+		t.Fatalf("ReadVms: status %d", status)
+	}
+	if vms, _ := read["Vms"].([]any); len(vms) != 0 {
+		t.Fatalf("a refused create left %d Vm(s) behind", len(vms))
+	}
+}

--- a/internal/providers/outscale/vms.go
+++ b/internal/providers/outscale/vms.go
@@ -101,6 +101,20 @@ type createVmsRequest struct {
 	// re-planned the same in-place change for ever. The chain is
 	// request → store → response now; vmPlacementView renders what this stored.
 	Placement *vmPlacement `json:"Placement"`
+	// The per-machine scalars of the same family (#276): accepted with a 200
+	// while every read answered a constant — medium/restart/legacy asked,
+	// high/stop/uefi answered. vmoptions.go carries the model and the SDK
+	// citations. BootMode is create-only upstream: UpdateVmRequest declares
+	// no such field.
+	BootMode   *string `json:"BootMode"`
+	TpmEnabled *bool   `json:"TpmEnabled"`
+	// BsuOptimized is read and deliberately not stored: "This parameter is
+	// not available. It is present in our API for the sake of historical
+	// compatibility with AWS" (client.gen.go:3029) — the real cloud ignores
+	// it too, so the constant false every read answers is upstream's own
+	// behaviour, not this pack's invention.
+	BsuOptimized *bool `json:"BsuOptimized"`
+	vmOptionsRequest
 }
 
 type vmIDsRequest struct {
@@ -126,6 +140,10 @@ type updateVMRequest struct {
 	// A pointer because false is the value that matters: a plain bool cannot
 	// tell "clear the protection" from "this request says nothing about it".
 	DeletionProtection *bool `json:"DeletionProtection"`
+	// "(Net only)" upstream; stored and restituted, enacted by nothing —
+	// docs/limits.md carries what the flag does not do here.
+	IsSourceDestChecked *bool `json:"IsSourceDestChecked"`
+	vmOptionsRequest
 }
 
 func (p *Pack) readVms(w http.ResponseWriter, r *http.Request) {
@@ -228,6 +246,16 @@ func (p *Pack) createVms(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !p.validVmFields(w, req.KeypairName, req.UserData) {
+		return
+	}
+	// The option enums, shared with UpdateVm; BootMode is create-only, so its
+	// check lives here. Refused rather than stored: a stored value outside
+	// the platform's enum is a read that can only lie one way or another.
+	if !p.validVmOptions(w, req.vmOptionsRequest) {
+		return
+	}
+	if req.BootMode != nil && !oneOf(*req.BootMode, "legacy", "uefi") {
+		p.badRequest(w, "BootMode must be legacy or uefi")
 		return
 	}
 	// A subregion the catalogue does not declare is refused here, not stored:
@@ -365,7 +393,16 @@ func (p *Pack) allocateVms(req createVmsRequest, count int, now time.Time) ([]*r
 			"VmType":               orDefault(req.VMType, defaultVMType),
 			"DeletionProtection":   boolOr(req.DeletionProtection, false),
 			"NestedVirtualization": boolOr(req.NestedVirtualization, false),
+			// Resolved once and stored, like Placement below: the chain #276
+			// demands is request → store → response, never
+			// request → constant → response.
+			attrBootMode:   defaultBootMode,
+			attrTpmEnabled: boolOr(req.TpmEnabled, false),
 		}
+		if req.BootMode != nil {
+			res.Attrs[attrBootMode] = *req.BootMode
+		}
+		storeVmOptions(res, req.vmOptionsRequest, stringOf(res.Attrs["VmType"]))
 		// The Subnet the client asked for, resolved before anything is stored: a
 		// Vm placed nowhere is not a Vm the client asked for. Reading it here,
 		// under the lock, is also what makes deleteSubnet's guard hold: the two
@@ -500,6 +537,9 @@ func (p *Pack) updateVm(w http.ResponseWriter, r *http.Request) {
 	if !p.validVmFields(w, req.KeypairName, req.UserData) {
 		return
 	}
+	if !p.validVmOptions(w, req.vmOptionsRequest) {
+		return
+	}
 
 	// Serialised on the target, like transitionOne and deleteVms. Without it,
 	// Commit replaces State, Runtime and Attrs wholesale over whatever a
@@ -543,6 +583,12 @@ func (p *Pack) updateVm(w http.ResponseWriter, r *http.Request) {
 	if req.DeletionProtection != nil {
 		res.Attrs["DeletionProtection"] = *req.DeletionProtection
 	}
+	if req.IsSourceDestChecked != nil {
+		res.Attrs[attrSourceDestChecked] = *req.IsSourceDestChecked
+	}
+	// After the VmType block above, so a retype's performance flag wins over
+	// whatever was stored — upstream's own precedence (vmoptions.go).
+	storeVmOptions(res, req.vmOptionsRequest, stringOf(res.Attrs["VmType"]))
 	if !p.env.Store.Commit(res, p.env.Now()) {
 		p.notFound(w, "Vm", res.ID)
 		return
@@ -884,18 +930,31 @@ func (p *Pack) vmView(res *resource.Resource) map[string]any {
 	// whatever Hypervisor says. What matters to a client is that the field is
 	// there, well-formed, and stable between two reads.
 	out["Architecture"] = "x86_64"
-	out["BootMode"] = "uefi"
 	out["Hypervisor"] = "xen"
-	out["IsSourceDestChecked"] = true
 	out["LaunchNumber"] = 0
-	out["Performance"] = "high"
 	out["RootDeviceName"] = "/dev/sda1"
 	out["RootDeviceType"] = "ebs"
+	// Upstream's own constant, not this pack's: "This parameter is not
+	// available. It is present in our API for the sake of historical
+	// compatibility with AWS" (client.gen.go:3029), so false is what the real
+	// cloud answers whatever a create asked.
 	out["BsuOptimized"] = false
-	out["TpmEnabled"] = false
-	out["VmInitiatedShutdownBehavior"] = "stop"
 	out["StateReason"] = ""
-	out["ActionsOnNextBoot"] = map[string]any{"SecureBoot": "none"}
+	// What the create (and UpdateVm, where upstream declares it) stored,
+	// never a constant — BootMode, Performance and
+	// VmInitiatedShutdownBehavior were #276: medium/restart/legacy asked,
+	// high/stop/uefi answered on the same create's 200, and a Terraform
+	// stack setting any of them re-planned for ever. The neighbours carried
+	// the same defect one field over. vmoptions.go holds the readers, the
+	// defaults, and the SDK lines. TestAVmReadsBackItsOwnOptions fails
+	// without this.
+	out["BootMode"] = vmBootMode(res)
+	out["Performance"] = vmPerformance(res)
+	out["VmInitiatedShutdownBehavior"] = vmShutdownBehavior(res)
+	out["ShutdownBehaviorConfiguration"] = vmShutdownConfiguration(res)
+	out["ActionsOnNextBoot"] = vmActionsOnNextBoot(res)
+	out["TpmEnabled"] = vmTpmEnabled(res)
+	out["IsSourceDestChecked"] = vmSourceDestChecked(res)
 	// What the create stored, never a constant. The constant here was #268: a
 	// machine created in eu-west-2b read back in eu-west-2a, stable and wrong —
 	// #250 had already named the pattern, "a constant in a view is a claim
@@ -932,14 +991,6 @@ func (p *Pack) vmView(res *resource.Resource) map[string]any {
 	// this emulator's machines truthfully have (they model no root volume,
 	// docs/limits.md).
 	out["BlockDeviceMappings"] = p.blockDeviceMappingsOf(res.ID)
-	// Declared by Outscale's document since the 1.42 contract refresh — an
-	// earlier note here recorded the opposite, and the note aged while the
-	// document moved. Both actions sit on their platform defaults, matching
-	// VmInitiatedShutdownBehavior above.
-	out["ShutdownBehaviorConfiguration"] = map[string]any{
-		"GuestAction": "stop",
-		"HostAction":  "stop",
-	}
 	return out
 }
 

--- a/tools/conformance/outscale/terraform.sh
+++ b/tools/conformance/outscale/terraform.sh
@@ -137,6 +137,22 @@ printf '%s' "$azb_vms" | jq -e --arg z "$azb_zone" \
   || fail "the Vm asked for $azb_zone and reads back elsewhere — #268 is back: $azb_vms"
 ok "Vm $azb_vm_id placed and read back in $azb_zone"
 
+# The Vm options (#276): boot_mode, performance and
+# vm_initiated_shutdown_behavior, asked with non-default values in
+# vm_options.tf, must read back from the emulator as asked — every one of them
+# used to answer a constant (uefi/high/stop) on a 200. Asked of the emulator,
+# not of the state file, for the same reason as the subregion above; the
+# second-plan gate below holds the provider's own reading.
+echo "- the Vm options read back as asked, not as constants"
+options_vm_id="$("$TF" output -raw options_vm_id)"
+options_vms="$(curl -sf -X POST "$ENDPOINT/api/v1/ReadVms" -H 'Content-Type: application/json' \
+            -d "{\"Filters\":{\"VmIds\":[\"$options_vm_id\"]}}")" || fail "ReadVms rejected"
+printf '%s' "$options_vms" | jq -e \
+  '.Vms[0].BootMode == "legacy" and .Vms[0].Performance == "medium"
+   and .Vms[0].VmInitiatedShutdownBehavior == "restart"' >/dev/null \
+  || fail "the Vm asked legacy/medium/restart and reads back constants — #276 is back: $options_vms"
+ok "Vm $options_vm_id reads back legacy/medium/restart"
+
 # The routing family, which the apply proves the provider accepted and this
 # proves the emulator actually holds. Each of these was a 400 on a filter the
 # provider sends and the pack had not declared — found here, by this fixture,

--- a/tools/conformance/outscale/terraform/vm_options.tf
+++ b/tools/conformance/outscale/terraform/vm_options.tf
@@ -1,0 +1,27 @@
+# The per-machine scalars of #276, asked with NON-default values on purpose:
+# BootMode, Performance and VmInitiatedShutdownBehavior were accepted at
+# create with a 200 while every read answered a constant of the pack
+# (uefi/high/stop) — a stack setting any of them re-planned the same in-place
+# change for ever, exactly #268 one field over. A fixture asking the defaults
+# would prove nothing: a constant and a datum are indistinguishable there.
+#
+# The vm_type deliberately carries NO performance flag (the tinavW.cXrY
+# spelling): upstream ignores the Performance parameter when the type spells
+# one (osc-sdk-go client.gen.go:3059), so a p2 type beside performance=medium
+# would legitimately read back "high" and re-plan for ever against the real
+# cloud too.
+#
+# The suite's own "second plan is empty" gate is what bites if any of the
+# three reads back a constant again.
+resource "outscale_vm" "options" {
+  image_id = "ami-00000002"
+  vm_type  = "tinav6.c1r1"
+
+  boot_mode                      = "legacy"
+  performance                    = "medium"
+  vm_initiated_shutdown_behavior = "restart"
+}
+
+output "options_vm_id" {
+  value = outscale_vm.options.vm_id
+}

--- a/tools/falsify/specs/outscale-vm-options.json
+++ b/tools/falsify/specs/outscale-vm-options.json
@@ -1,0 +1,40 @@
+{
+  "package": "./internal/providers/outscale/",
+  "mutations": [
+    {
+      "label": "BootMode reads a key nobody stores and the constant uefi is back — the client asked legacy, the 200 answers uefi (#276)",
+      "file": "internal/providers/outscale/vmoptions.go",
+      "find": "\treturn orDefault(stringOf(res.Attrs[attrBootMode]), defaultBootMode)",
+      "replace": "\treturn orDefault(stringOf(res.Attrs[attrBootMode+\"-never\"]), defaultBootMode)",
+      "test": "TestAVmReadsBackItsOwnOptions"
+    },
+    {
+      "label": "Performance reads a key nobody stores and the constant high is back",
+      "file": "internal/providers/outscale/vmoptions.go",
+      "find": "\treturn orDefault(stringOf(res.Attrs[attrPerformance]), defaultPerformance)",
+      "replace": "\treturn orDefault(stringOf(res.Attrs[attrPerformance+\"-never\"]), defaultPerformance)",
+      "test": "TestAVmReadsBackItsOwnOptions"
+    },
+    {
+      "label": "VmInitiatedShutdownBehavior reads a key nobody stores and the constant stop is back",
+      "file": "internal/providers/outscale/vmoptions.go",
+      "find": "\treturn orDefault(stringOf(res.Attrs[attrShutdownBehavior]), defaultShutdownBehavior)",
+      "replace": "\treturn orDefault(stringOf(res.Attrs[attrShutdownBehavior+\"-never\"]), defaultShutdownBehavior)",
+      "test": "TestAVmReadsBackItsOwnOptions"
+    },
+    {
+      "label": "the VmType performance flag stops winning, so a p3 type beside Performance=highest reads highest — upstream's documented precedence inverted",
+      "file": "internal/providers/outscale/vmoptions.go",
+      "find": "\tif !strings.HasPrefix(vmType, \"tinav\") {",
+      "replace": "\tif !strings.HasPrefix(vmType, \"tinav-never\") {",
+      "test": "TestTheVmTypePerformanceFlagWins"
+    },
+    {
+      "label": "the enum refusal goes quiet and Performance=turbo is stored with a 200 — accepted-then-denied, the one option off the table",
+      "file": "internal/providers/outscale/vmoptions.go",
+      "find": "\tif opts.Performance != nil && !oneOf(*opts.Performance, \"medium\", \"high\", \"highest\") {",
+      "replace": "\tif opts.Performance != nil && !oneOf(*opts.Performance, \"medium\", \"high\", \"highest\") && false {",
+      "test": "TestVmOptionsOutsideTheirEnumAreRefused"
+    }
+  ]
+}


### PR DESCRIPTION
# Summary

`CreateVms` accepted `BootMode`, `Performance` and
`VmInitiatedShutdownBehavior` with a 200 while every read answered a constant
of the pack — the client asked `medium`/`restart`/`legacy`, the same create's
answer said `high`/`stop`/`uefi` (#276). That is #268's accepted-then-constant
pattern on per-machine scalars, and the same never-converging Terraform plan,
since all three are attributes of `outscale_vm`.

The model is #275's, applied unchanged: **request → store → response**, never
request → constant → response. Each field is read at create and at update
where upstream declares it (BootMode is create-only upstream), validated
against its enum — a value outside it is a 400, never stored — and resolved
through one reader per field that every view shares (`vmoptions.go`, with the
osc-sdk-go line for every field and enum). `Performance` honours upstream's
own precedence: a performance flag inside the `VmType` (`tinavW.cXrYpZ`) wins
over the parameter, at create and on a retype.

The sweep the issue asked for found the same symptom on the neighbours, fixed
the same way: `ShutdownBehaviorConfiguration` (the constant said
`{stop, stop}` while the SDK schema's own "By default" lines say GuestAction
`stop`, HostAction `restart`), `TpmEnabled`, `ActionsOnNextBoot.SecureBoot`,
and UpdateVm's `IsSourceDestChecked`. `BsuOptimized` stays the constant
`false` deliberately — that constant is upstream's own ("This parameter is
not available", client.gen.go:3029), not this pack's shortcut.

What is served is the datum; `docs/limits.md` states what the behavioural
half has nothing to act on here: no guest-initiated shutdown is ever observed
(StopVms stops whatever the field says, which matches upstream, where the API
stop is not a VM-initiated one), no vTPM or secure-boot state reaches a
guest, nothing enforces the source/dest check.

Proof: unit tests ask with non-default values throughout — the suite only
ever creating with defaults is what made a constant indistinguishable from a
datum; the conformance fixture gains a Vm asking `legacy`/`medium`/`restart`
on a flag-less `vm_type` (`vm_options.tf`), read back from the emulator by
`terraform.sh` and held by the existing empty-second-plan gate; the falsify
spec puts the constants back three ways, inverts the flag precedence and
silences the enum refusal — all five mutations bit.

## Type of change

- [ ] A route added or changed
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes (gofmt, vet, golangci-lint, `go test -race`)
- [x] No new external Go dependency
- [x] `internal/core` still knows no provider
- [x] Nothing in the diff could be written identically for another provider:
      the fields, enums, defaults and the VmType flag precedence are
      Outscale's own vocabulary

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] I ran `mise run conformance` myself — full run, exit 0
- [x] Every field name in the diff comes from osc-sdk-go
      `pkg/osc/client.gen.go`, cited file:line per field and enum in
      `vmoptions.go` and the commit message; the p1/p2/p3 mapping comes from
      the VM Types page the SDK's own `VmType` comment points to

### When a route is added or changed — otherwise N/A

- [x] No route added, no `Route.Operation` changed — CreateVms/UpdateVm/ReadVms
      behaviour changed, so:
- [x] `mise run conformance` passes (all suites, one emulator, exit 0), the
      outscale terraform fixture extended with the non-default options and the
      explicit read-back assert
- [x] Responses validated against the provider's own API description — the
      unit helpers validate every answer against `contracts/outscale.json`,
      and the conformance run drives `--contracts contracts`
- [x] What the client sends is read, or refused: the three fields (and the
      neighbours) moved from silently-dropped to stored-or-400;
      `BsuOptimized` is declared and deliberately constant, with upstream's
      own sentence as the reason
- [x] `mise run drift:update` N/A: the upstream surface did not move,
      `mise run drift:check` green; `coverage/` untouched by instruction

### When behaviour a client can observe changes — otherwise N/A

- [x] `docs/limits.md` updated: new section "An Outscale Vm's options
      round-trip as data; their behavioural half has nothing to act on here"
- [x] Generated tables regenerated (`feint docs`; the limits-section count in
      both READMEs follows)

### When `.github/workflows/` is touched — otherwise N/A

N/A — no workflow touched.

### When a machine runtime is involved — otherwise N/A

N/A — control-plane only; the suite ran without `FEINT_VM` by instruction
(other sessions hold Incus).

## Related issues

Closes #276
