### PR TITLE
fix(outscale): an acknowledged rule, route or tag survives its concurrent sibling (#289)

### DIFF
--- a/internal/core/store/storetest/lostupdate.go
+++ b/internal/core/store/storetest/lostupdate.go
@@ -24,6 +24,18 @@ import (
 // a *different* field of the same resource is still lost". Two handlers reading
 // the same resource, changing one field each and committing whole maps built
 // from their own stale read: the second erases the first, and both answered 200.
+//
+// The lost thing is not always a field. A collection on one resource — the
+// rules of a security group, the routes of a table, the tags of anything — is
+// one Attrs value, and two writers appending one element each to their own
+// stale clone are the same race wearing the same 200s. That shape escaped this
+// control for a whole milestone because every pack's trials drove fields only,
+// and it was a real client that measured it first: replaying a Terraform k3s
+// stack against the Outscale pack acknowledged 8 CreateSecurityGroupRule and
+// stored 5 rules, then destroy died on the phantom (#289). A pack's trials must
+// therefore drive both shapes: one writer per field, and one writer per element
+// of every collection its clients grow concurrently — Terraform's default
+// 10-way parallelism does exactly that to rules, routes and links.
 
 // Write is one concurrent updater in a NoLostUpdate run: how to send its change,
 // and how to read back the field it must have left behind.

--- a/internal/providers/exoscale/lostupdate_test.go
+++ b/internal/providers/exoscale/lostupdate_test.go
@@ -90,3 +90,59 @@ func TestConcurrentUpdatesKeepEveryAcknowledgedField(t *testing.T) {
 		t.Errorf("the update path lost a field it had acknowledged:\n%s", strings.Join(found, "\n"))
 	}
 }
+
+// The same control on the other shape a lost update takes: an acknowledged
+// *element* of one collection (#289). This pack already appends its rules
+// inside store.Update, so this is a regression test for a correct handler —
+// exactly what the Outscale pack lacked when the k3s replay measured 8 rule
+// creates acknowledged and 5 rules stored on the group next door.
+func TestConcurrentRuleCreatesKeepEveryAcknowledgedRule(t *testing.T) {
+	h, _ := newExoscaleBarrageServer(t)
+
+	found := storetest.NoLostUpdate(40, func(trial int) []storetest.Write {
+		status, created := callRaw(h, "POST", "/v2/security-group",
+			fmt.Sprintf(`{"name":"race-%d","description":"membership barrage"}`, trial))
+		if status != http.StatusOK {
+			t.Fatalf("trial %d create: status %d (%v)", trial, status, created)
+		}
+		ref, _ := created["reference"].(map[string]any)
+		id, _ := ref["id"].(string)
+		if id == "" {
+			t.Fatalf("the create operation names no resource: %v", created)
+		}
+
+		writes := make([]storetest.Write, 0, 8)
+		for i := range 8 {
+			port := 1001 + i
+			writes = append(writes, storetest.Write{
+				Field: fmt.Sprintf("ingress tcp %d on %s", port, id),
+				Apply: func() bool {
+					status, _ := callRaw(h, "POST", "/v2/security-group/"+id+"/rules", fmt.Sprintf(
+						`{"flow-direction":"ingress","protocol":"tcp","network":"10.0.0.0/24","start-port":%d,"end-port":%d}`,
+						port, port))
+					return status == http.StatusOK
+				},
+				Got: func() string {
+					status, out := callRaw(h, "GET", "/v2/security-group/"+id, "")
+					if status != http.StatusOK {
+						return fmt.Sprintf("<get answered %d>", status)
+					}
+					rules, _ := out["rules"].([]any)
+					for _, raw := range rules {
+						rule, _ := raw.(map[string]any)
+						if start, _ := rule["start-port"].(float64); int(start) == port {
+							return "stored"
+						}
+					}
+					return "lost"
+				},
+				Want: "stored",
+			})
+		}
+		return writes
+	})
+
+	if len(found) > 0 {
+		t.Errorf("the rule create path lost a rule it had acknowledged:\n%s", strings.Join(found, "\n"))
+	}
+}

--- a/internal/providers/outscale/lostupdate_test.go
+++ b/internal/providers/outscale/lostupdate_test.go
@@ -183,3 +183,189 @@ func TestTerminatingAVmFreesItsVolumes(t *testing.T) {
 		t.Fatalf("the volume is still held by a terminated Vm: status %d (%v)", status, out)
 	}
 }
+
+// The same control, on the other shape a lost update takes: an acknowledged
+// *element* of one collection, not an acknowledged field (#289).
+//
+// Replaying pli01/terraform-outscale-k3s measured it: Terraform creates 15
+// security group rules through its default 10-way parallelism, the group
+// received seven CreateSecurityGroupRule answering 200 each, and only six
+// rules survived — the reduced reproduction acknowledged 8 and stored 5. The
+// handler read a clone, appended to the clone's list and committed the whole
+// resource, which is exactly the non-merge store.Commit documents. Each writer
+// below owns one rule of one group, the way each writer above owns one field
+// of one Vm.
+func TestConcurrentRuleCreatesKeepEveryAcknowledgedRule(t *testing.T) {
+	ts, _ := newOutscaleBarrageServer(t)
+
+	found := storetest.NoLostUpdate(40, func(trial int) []storetest.Write {
+		_, out := post(t, ts, "CreateSecurityGroup", fmt.Sprintf(
+			`{"SecurityGroupName":"race-%d","Description":"membership barrage"}`, trial))
+		sg, _ := out["SecurityGroup"].(map[string]any)
+		id, _ := sg["SecurityGroupId"].(string)
+		if id == "" {
+			t.Fatalf("create: no SecurityGroupId in %v", out)
+		}
+
+		writes := make([]storetest.Write, 0, 8)
+		for i := range 8 {
+			port := 1001 + i
+			writes = append(writes, storetest.Write{
+				Field: fmt.Sprintf("inbound tcp %d on %s", port, id),
+				Apply: func() bool {
+					status, _ := postRaw(ts, "CreateSecurityGroupRule", fmt.Sprintf(
+						`{"Flow":"Inbound","IpProtocol":"tcp","FromPortRange":%d,"ToPortRange":%d,"IpRange":"10.0.0.0/24","SecurityGroupId":%q}`,
+						port, port, id))
+					return status == http.StatusOK
+				},
+				Got: func() string {
+					_, out := post(t, ts, "ReadSecurityGroups",
+						`{"Filters":{"SecurityGroupIds":["`+id+`"]}}`)
+					groups, _ := out["SecurityGroups"].([]any)
+					if len(groups) == 0 {
+						return "<the group is gone>"
+					}
+					group, _ := groups[0].(map[string]any)
+					for _, raw := range listAny(group["InboundRules"]) {
+						rule, _ := raw.(map[string]any)
+						if from, _ := rule["FromPortRange"].(float64); int(from) == port {
+							return "stored"
+						}
+					}
+					return "lost"
+				},
+				Want: "stored",
+			})
+		}
+		return writes
+	})
+
+	if len(found) > 0 {
+		t.Errorf("the rule create path lost a rule it had acknowledged:\n%s", strings.Join(found, "\n"))
+	}
+}
+
+// Routes are the same collection shape on the same stack: a route table takes
+// its routes through Terraform's parallelism exactly as a group takes its
+// rules, and createRoute had the same clone-append-Commit body.
+func TestConcurrentRouteCreatesKeepEveryAcknowledgedRoute(t *testing.T) {
+	ts, _ := newOutscaleBarrageServer(t)
+
+	found := storetest.NoLostUpdate(40, func(trial int) []storetest.Write {
+		// One block per trial: Nets whose ranges overlap are refused, and every
+		// trial must build on a target nothing else has touched anyway.
+		_, out := post(t, ts, "CreateNet", fmt.Sprintf(`{"IpRange":"10.%d.0.0/24"}`, trial))
+		net, _ := out["Net"].(map[string]any)
+		netID, _ := net["NetId"].(string)
+		if netID == "" {
+			t.Fatalf("create: no NetId in %v", out)
+		}
+		_, out = post(t, ts, "CreateRouteTable", `{"NetId":"`+netID+`"}`)
+		table, _ := out["RouteTable"].(map[string]any)
+		tableID, _ := table["RouteTableId"].(string)
+		if tableID == "" {
+			t.Fatalf("create: no RouteTableId in %v", out)
+		}
+		_, out = post(t, ts, "CreateInternetService", `{}`)
+		gateway, _ := out["InternetService"].(map[string]any)
+		gatewayID, _ := gateway["InternetServiceId"].(string)
+		if gatewayID == "" {
+			t.Fatalf("create: no InternetServiceId in %v", out)
+		}
+		post(t, ts, "LinkInternetService",
+			`{"InternetServiceId":"`+gatewayID+`","NetId":"`+netID+`"}`)
+
+		writes := make([]storetest.Write, 0, 8)
+		for i := range 8 {
+			destination := fmt.Sprintf("198.51.%d.0/24", 100+i)
+			writes = append(writes, storetest.Write{
+				Field: "route to " + destination,
+				Apply: func() bool {
+					status, _ := postRaw(ts, "CreateRoute", fmt.Sprintf(
+						`{"RouteTableId":%q,"DestinationIpRange":%q,"GatewayId":%q}`,
+						tableID, destination, gatewayID))
+					return status == http.StatusOK
+				},
+				Got: func() string {
+					_, out := post(t, ts, "ReadRouteTables",
+						`{"Filters":{"RouteTableIds":["`+tableID+`"]}}`)
+					tables, _ := out["RouteTables"].([]any)
+					if len(tables) == 0 {
+						return "<the table is gone>"
+					}
+					table, _ := tables[0].(map[string]any)
+					for _, raw := range listAny(table["Routes"]) {
+						route, _ := raw.(map[string]any)
+						if route["DestinationIpRange"] == destination {
+							return "stored"
+						}
+					}
+					return "lost"
+				},
+				Want: "stored",
+			})
+		}
+		return writes
+	})
+
+	if len(found) > 0 {
+		t.Errorf("the route create path lost a route it had acknowledged:\n%s", strings.Join(found, "\n"))
+	}
+}
+
+// Tags are the third member: CreateTags wrote its merge back with Put, which
+// loses a concurrent key the way Commit does and resurrects a deleted resource
+// on top of it. Each writer owns one key of one Net's tag collection.
+func TestConcurrentTagCreatesKeepEveryAcknowledgedTag(t *testing.T) {
+	ts, _ := newOutscaleBarrageServer(t)
+
+	found := storetest.NoLostUpdate(40, func(trial int) []storetest.Write {
+		// One block per trial, as above: overlapping Nets are refused.
+		_, out := post(t, ts, "CreateNet", fmt.Sprintf(`{"IpRange":"10.%d.1.0/24"}`, trial))
+		net, _ := out["Net"].(map[string]any)
+		netID, _ := net["NetId"].(string)
+		if netID == "" {
+			t.Fatalf("create: no NetId in %v", out)
+		}
+
+		writes := make([]storetest.Write, 0, 8)
+		for i := range 8 {
+			key := fmt.Sprintf("barrage-%d", i)
+			writes = append(writes, storetest.Write{
+				Field: "tag " + key + " on " + netID,
+				Apply: func() bool {
+					status, _ := postRaw(ts, "CreateTags", fmt.Sprintf(
+						`{"ResourceIds":[%q],"Tags":[{"Key":%q,"Value":"held"}]}`, netID, key))
+					return status == http.StatusOK
+				},
+				Got: func() string {
+					_, out := post(t, ts, "ReadNets", `{"Filters":{"NetIds":["`+netID+`"]}}`)
+					nets, _ := out["Nets"].([]any)
+					if len(nets) == 0 {
+						return "<the Net is gone>"
+					}
+					net, _ := nets[0].(map[string]any)
+					for _, raw := range listAny(net["Tags"]) {
+						tag, _ := raw.(map[string]any)
+						if tag["Key"] == key {
+							return "stored"
+						}
+					}
+					return "lost"
+				},
+				Want: "stored",
+			})
+		}
+		return writes
+	})
+
+	if len(found) > 0 {
+		t.Errorf("the tag create path lost a key it had acknowledged:\n%s", strings.Join(found, "\n"))
+	}
+}
+
+// listAny reads a decoded JSON list, nil included.
+func listAny(v any) []any {
+	out, _ := v.([]any)
+	return out
+}

--- a/internal/providers/outscale/routetables.go
+++ b/internal/providers/outscale/routetables.go
@@ -1,6 +1,7 @@
 package outscale
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/stephrobert/feint/internal/core/emulator"
@@ -284,15 +285,38 @@ func (p *Pack) linkRouteTable(w http.ResponseWriter, r *http.Request) {
 	}
 	// The recorded response is {LinkRouteTableId, ResponseContext} alone; the
 	// link itself appears in the table on the next read.
+	//
+	// Appended inside Store.Update, under the lock: Terraform links one table
+	// to its subnets ten at a time, and the clone-append-Commit shape this had
+	// loses an acknowledged link exactly as it lost a security group rule
+	// (#289). The one-link-per-subnet scan re-runs on this table's own links,
+	// because two identical concurrent links both pass the scan above.
 	linkID := newID("rtbassoc", p.env.NewID())
-	res.Attrs["LinkRouteTables"] = append(listOf(res.Attrs["LinkRouteTables"]), map[string]any{
-		"LinkRouteTableId": linkID,
-		"Main":             false,
-		"NetId":            stringOf(res.Attrs["NetId"]),
-		"RouteTableId":     res.ID,
-		"SubnetId":         req.SubnetID,
+	err := p.env.Store.Update(Name, kindRouteTable, res.ID, func(stored *resource.Resource) error {
+		links := listOf(stored.Attrs["LinkRouteTables"])
+		for _, raw := range links {
+			link, _ := raw.(map[string]any)
+			if stringOf(link["SubnetId"]) == req.SubnetID {
+				return errAlreadyLinked
+			}
+		}
+		merged := make([]any, len(links), len(links)+1)
+		copy(merged, links)
+		stored.Attrs["LinkRouteTables"] = append(merged, map[string]any{
+			"LinkRouteTableId": linkID,
+			"Main":             false,
+			"NetId":            stringOf(stored.Attrs["NetId"]),
+			"RouteTableId":     stored.ID,
+			"SubnetId":         req.SubnetID,
+		})
+		stored.Updated = p.env.Now()
+		return nil
 	})
-	if !p.env.Store.Commit(res, p.env.Now()) {
+	switch {
+	case errors.Is(err, errAlreadyLinked):
+		p.conflict(w, "the Subnet "+req.SubnetID+" is already linked to "+res.ID)
+		return
+	case err != nil:
 		p.notFound(w, "route table", req.RouteTableID)
 		return
 	}
@@ -312,27 +336,68 @@ func (p *Pack) unlinkRouteTable(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	for _, res := range p.env.Store.List(kindRouteTable, resource.Tenant{Provider: Name}) {
-		links := listOf(res.Attrs["LinkRouteTables"])
-		for i, raw := range links {
+		holds := false
+		for _, raw := range listOf(res.Attrs["LinkRouteTables"]) {
 			link, _ := raw.(map[string]any)
-			if stringOf(link["LinkRouteTableId"]) != req.LinkRouteTableID {
-				continue
+			if stringOf(link["LinkRouteTableId"]) == req.LinkRouteTableID {
+				holds = true
+				break
 			}
-			if main, _ := link["Main"].(bool); main {
-				p.conflict(w, "the main link of "+res.ID+" cannot be unlinked")
-				return
+		}
+		if !holds {
+			continue
+		}
+		// The link is re-found and removed under the lock: the List clone
+		// above is stale by construction, and committing it wholesale is the
+		// lost-update shape #289 measured on rules.
+		err := p.env.Store.Update(Name, kindRouteTable, res.ID, func(stored *resource.Resource) error {
+			links := listOf(stored.Attrs["LinkRouteTables"])
+			kept := make([]any, 0, len(links))
+			removed := false
+			for _, raw := range links {
+				link, _ := raw.(map[string]any)
+				if stringOf(link["LinkRouteTableId"]) == req.LinkRouteTableID {
+					if main, _ := link["Main"].(bool); main {
+						return errMainLink
+					}
+					removed = true
+					continue
+				}
+				kept = append(kept, raw)
 			}
-			res.Attrs["LinkRouteTables"] = append(links[:i:i], links[i+1:]...)
-			if !p.env.Store.Commit(res, p.env.Now()) {
-				p.notFound(w, "route table", res.ID)
-				return
+			if !removed {
+				return errLinkMissing
 			}
-			emulator.WriteJSON(w, http.StatusOK, map[string]any{"ResponseContext": p.context()})
+			stored.Attrs["LinkRouteTables"] = kept
+			stored.Updated = p.env.Now()
+			return nil
+		})
+		switch {
+		case errors.Is(err, errMainLink):
+			p.conflict(w, "the main link of "+res.ID+" cannot be unlinked")
+			return
+		case err != nil:
+			// Gone between the scan and the lock — deleted table or already
+			// unlinked; either way the link no longer exists.
+			p.notFound(w, "route table link", req.LinkRouteTableID)
 			return
 		}
+		emulator.WriteJSON(w, http.StatusOK, map[string]any{"ResponseContext": p.context()})
+		return
 	}
 	p.notFound(w, "route table link", req.LinkRouteTableID)
 }
+
+// The sentinels that carry a check out of a Store.Update change function, so
+// the handler can answer the HTTP shape the check calls for.
+var (
+	errAlreadyLinked = errors.New("the subnet is already linked")
+	errMainLink      = errors.New("the main link cannot go")
+	errLinkMissing   = errors.New("the link does not exist")
+	errRouteExists   = errors.New("the destination already has a route")
+	errRouteMissing  = errors.New("the destination has no route")
+	errLocalRoute    = errors.New("the local route cannot go")
+)
 
 // routeRequest is CreateRoute, DeleteRoute and UpdateRoute: one shape, three
 // verbs, keyed by the destination inside one table.
@@ -424,31 +489,48 @@ func (p *Pack) createRoute(w http.ResponseWriter, r *http.Request) {
 		p.badRequest(w, "DestinationIpRange: "+err.Error())
 		return
 	}
-	for _, raw := range listOf(res.Attrs["Routes"]) {
-		route, _ := raw.(map[string]any)
-		if stringOf(route["DestinationIpRange"]) == req.DestinationIPRange {
-			p.conflict(w, "the destination "+req.DestinationIPRange+" already has a route in "+res.ID)
-			return
-		}
-	}
 	key, value, ok := p.routeTarget(w, &req, stringOf(res.Attrs["NetId"]))
 	if !ok {
 		return
 	}
-	// The recorded created route: CreationMethod "CreateRoute", State
-	// "active", the target under its own key, nothing else.
-	res.Attrs["Routes"] = append(listOf(res.Attrs["Routes"]), map[string]any{
-		"CreationMethod":     "CreateRoute",
-		"DestinationIpRange": req.DestinationIPRange,
-		key:                  value,
-		"State":              "active",
+	// The duplicate check and the append run under the store lock: ten
+	// concurrent CreateRoute on one table is Terraform's default parallelism,
+	// and the clone-append-Commit shape this had loses acknowledged routes the
+	// way it lost security group rules (#289).
+	// TestConcurrentRouteCreatesKeepEveryAcknowledgedRoute fails without this.
+	var final *resource.Resource
+	err := p.env.Store.Update(Name, kindRouteTable, res.ID, func(stored *resource.Resource) error {
+		routes := listOf(stored.Attrs["Routes"])
+		for _, raw := range routes {
+			route, _ := raw.(map[string]any)
+			if stringOf(route["DestinationIpRange"]) == req.DestinationIPRange {
+				return errRouteExists
+			}
+		}
+		merged := make([]any, len(routes), len(routes)+1)
+		copy(merged, routes)
+		// The recorded created route: CreationMethod "CreateRoute", State
+		// "active", the target under its own key, nothing else.
+		stored.Attrs["Routes"] = append(merged, map[string]any{
+			"CreationMethod":     "CreateRoute",
+			"DestinationIpRange": req.DestinationIPRange,
+			key:                  value,
+			"State":              "active",
+		})
+		stored.Updated = p.env.Now()
+		final = stored
+		return nil
 	})
-	if !p.env.Store.Commit(res, p.env.Now()) {
+	switch {
+	case errors.Is(err, errRouteExists):
+		p.conflict(w, "the destination "+req.DestinationIPRange+" already has a route in "+res.ID)
+		return
+	case err != nil:
 		p.notFound(w, "route table", req.RouteTableID)
 		return
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"RouteTable":      routeTableView(res),
+		"RouteTable":      routeTableView(final),
 		"ResponseContext": p.context(),
 	})
 }
@@ -464,27 +546,43 @@ func (p *Pack) deleteRoute(w http.ResponseWriter, r *http.Request) {
 		p.notFound(w, "route table", req.RouteTableID)
 		return
 	}
-	routes := listOf(res.Attrs["Routes"])
-	for i, raw := range routes {
-		route, _ := raw.(map[string]any)
-		if stringOf(route["DestinationIpRange"]) != req.DestinationIPRange {
-			continue
+	// Found and removed under the lock, same reasoning as createRoute (#289).
+	err := p.env.Store.Update(Name, kindRouteTable, res.ID, func(stored *resource.Resource) error {
+		routes := listOf(stored.Attrs["Routes"])
+		kept := make([]any, 0, len(routes))
+		removed := false
+		for _, raw := range routes {
+			route, _ := raw.(map[string]any)
+			if stringOf(route["DestinationIpRange"]) == req.DestinationIPRange {
+				// The local route is the Net's own and never goes; the real
+				// API refuses, whatever the table.
+				if stringOf(route["GatewayId"]) == "local" {
+					return errLocalRoute
+				}
+				removed = true
+				continue
+			}
+			kept = append(kept, raw)
 		}
-		// The local route is the Net's own and never goes; the real API
-		// refuses, whatever the table.
-		if stringOf(route["GatewayId"]) == "local" {
-			p.conflict(w, "the local route of "+res.ID+" cannot be deleted")
-			return
+		if !removed {
+			return errRouteMissing
 		}
-		res.Attrs["Routes"] = append(routes[:i:i], routes[i+1:]...)
-		if !p.env.Store.Commit(res, p.env.Now()) {
-			p.notFound(w, "route table", req.RouteTableID)
-			return
-		}
-		emulator.WriteJSON(w, http.StatusOK, map[string]any{"ResponseContext": p.context()})
+		stored.Attrs["Routes"] = kept
+		stored.Updated = p.env.Now()
+		return nil
+	})
+	switch {
+	case errors.Is(err, errLocalRoute):
+		p.conflict(w, "the local route of "+res.ID+" cannot be deleted")
+		return
+	case errors.Is(err, errRouteMissing):
+		p.notFound(w, "route to", req.DestinationIPRange)
+		return
+	case err != nil:
+		p.notFound(w, "route table", req.RouteTableID)
 		return
 	}
-	p.notFound(w, "route to", req.DestinationIPRange)
+	emulator.WriteJSON(w, http.StatusOK, map[string]any{"ResponseContext": p.context()})
 }
 
 func (p *Pack) updateRoute(w http.ResponseWriter, r *http.Request) {
@@ -502,36 +600,55 @@ func (p *Pack) updateRoute(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	for i, raw := range listOf(res.Attrs["Routes"]) {
-		route, _ := raw.(map[string]any)
-		if stringOf(route["DestinationIpRange"]) != req.DestinationIPRange {
-			continue
+	// Found and replaced under the lock, and into a fresh slice: writing
+	// routes[i] on the clone mutates the backing array every other reader's
+	// clone shares, which is a torn write even before the Commit lands (#289).
+	var final *resource.Resource
+	err := p.env.Store.Update(Name, kindRouteTable, res.ID, func(stored *resource.Resource) error {
+		routes := listOf(stored.Attrs["Routes"])
+		replaced := false
+		merged := make([]any, 0, len(routes))
+		for _, raw := range routes {
+			route, _ := raw.(map[string]any)
+			if stringOf(route["DestinationIpRange"]) != req.DestinationIPRange {
+				merged = append(merged, raw)
+				continue
+			}
+			if stringOf(route["GatewayId"]) == "local" {
+				return errLocalRoute
+			}
+			// Replaced whole rather than patched: a route is its destination
+			// and its target, and leaving the old target key beside the new
+			// one would answer a route pointing two ways at once.
+			merged = append(merged, map[string]any{
+				"CreationMethod":     stringOf(route["CreationMethod"]),
+				"DestinationIpRange": req.DestinationIPRange,
+				key:                  value,
+				"State":              "active",
+			})
+			replaced = true
 		}
-		if stringOf(route["GatewayId"]) == "local" {
-			p.conflict(w, "the local route of "+res.ID+" cannot be redirected")
-			return
+		if !replaced {
+			return errRouteMissing
 		}
-		// Replaced whole rather than patched: a route is its destination and
-		// its target, and leaving the old target key beside the new one would
-		// answer a route pointing two ways at once.
-		replaced := map[string]any{
-			"CreationMethod":     stringOf(route["CreationMethod"]),
-			"DestinationIpRange": req.DestinationIPRange,
-			key:                  value,
-			"State":              "active",
-		}
-		routes := listOf(res.Attrs["Routes"])
-		routes[i] = replaced
-		res.Attrs["Routes"] = routes
-		if !p.env.Store.Commit(res, p.env.Now()) {
-			p.notFound(w, "route table", req.RouteTableID)
-			return
-		}
-		emulator.WriteJSON(w, http.StatusOK, map[string]any{
-			"RouteTable":      routeTableView(res),
-			"ResponseContext": p.context(),
-		})
+		stored.Attrs["Routes"] = merged
+		stored.Updated = p.env.Now()
+		final = stored
+		return nil
+	})
+	switch {
+	case errors.Is(err, errLocalRoute):
+		p.conflict(w, "the local route of "+res.ID+" cannot be redirected")
+		return
+	case errors.Is(err, errRouteMissing):
+		p.notFound(w, "route to", req.DestinationIPRange)
+		return
+	case err != nil:
+		p.notFound(w, "route table", req.RouteTableID)
 		return
 	}
-	p.notFound(w, "route to", req.DestinationIPRange)
+	emulator.WriteJSON(w, http.StatusOK, map[string]any{
+		"RouteTable":      routeTableView(final),
+		"ResponseContext": p.context(),
+	})
 }

--- a/internal/providers/outscale/securitygroups.go
+++ b/internal/providers/outscale/securitygroups.go
@@ -2,6 +2,7 @@ package outscale
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"sort"
@@ -323,6 +324,13 @@ func (p *Pack) asRules(req *securityGroupRuleRequest, mint bool) ([]map[string]a
 	}
 }
 
+// errRuleExists and errRuleMissing carry a rule check out of a Store.Update
+// change function, so the handler can answer the right HTTP shape.
+var (
+	errRuleExists  = errors.New("the rule already exists")
+	errRuleMissing = errors.New("the rule does not exist")
+)
+
 func (p *Pack) createSecurityGroupRule(w http.ResponseWriter, r *http.Request) {
 	var req securityGroupRuleRequest
 	if err := emulator.DecodeJSON(r, &req); err != nil {
@@ -338,26 +346,47 @@ func (p *Pack) createSecurityGroupRule(w http.ResponseWriter, r *http.Request) {
 		p.notFound(w, "security group", missing)
 		return
 	}
-	existing, _ := res.Attrs[side].([]any)
-	for _, rule := range rules {
-		// A rule that already exists is a conflict, not a second copy: the real
-		// API refuses the duplicate, and a client retrying a create depends on
-		// the refusal to converge.
-		for _, raw := range existing {
-			if sameRule(raw, rule) {
-				p.conflict(w, "the rule already exists on "+res.ID)
-				return
+	// The read, the duplicate check and the append happen inside Store.Update,
+	// under the store lock. As a Get-clone-append-Commit sequence, two
+	// concurrent creates on one group each appended to their own stale copy and
+	// the second Commit erased the first: replaying terraform-outscale-k3s
+	// measured 8 CreateSecurityGroupRule acknowledged with 200 and 5 rules
+	// stored, then destroy died on the phantom (#289).
+	// TestConcurrentRuleCreatesKeepEveryAcknowledgedRule fails without this.
+	var final *resource.Resource
+	err := p.env.Store.Update(Name, kindSecurityGroup, res.ID, func(stored *resource.Resource) error {
+		existing, _ := stored.Attrs[side].([]any)
+		// A fresh slice, never an append into the stored backing array: clones
+		// share the nested values, so in-place growth is a write other readers
+		// can see mid-request.
+		merged := make([]any, len(existing), len(existing)+len(rules))
+		copy(merged, existing)
+		for _, rule := range rules {
+			// A rule that already exists is a conflict, not a second copy: the
+			// real API refuses the duplicate, and a client retrying a create
+			// depends on the refusal to converge.
+			for _, raw := range merged {
+				if sameRule(raw, rule) {
+					return errRuleExists
+				}
 			}
+			merged = append(merged, rule)
 		}
-		existing = append(existing, rule)
-	}
-	res.Attrs[side] = existing
-	if !p.env.Store.Commit(res, p.env.Now()) {
+		stored.Attrs[side] = merged
+		stored.Updated = p.env.Now()
+		final = stored
+		return nil
+	})
+	switch {
+	case errors.Is(err, errRuleExists):
+		p.conflict(w, "the rule already exists on "+res.ID)
+		return
+	case err != nil:
 		p.notFound(w, "security group", res.ID)
 		return
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"SecurityGroup":   securityGroupView(res),
+		"SecurityGroup":   securityGroupView(final),
 		"ResponseContext": p.context(),
 	})
 }
@@ -377,34 +406,46 @@ func (p *Pack) deleteSecurityGroupRule(w http.ResponseWriter, r *http.Request) {
 		p.notFound(w, "security group", missing)
 		return
 	}
-	existing, _ := res.Attrs[side].([]any)
-	kept := make([]any, 0, len(existing))
-	removed := 0
-	for _, raw := range existing {
-		matched := false
-		for _, candidate := range wanted {
-			if sameRule(raw, candidate) {
-				matched = true
-				break
+	// Same ordering as the create: the match and the removal run under the
+	// store lock, or a delete racing a create on the other side of the group
+	// commits a stale copy and one acknowledged change vanishes (#289).
+	var final *resource.Resource
+	err := p.env.Store.Update(Name, kindSecurityGroup, res.ID, func(stored *resource.Resource) error {
+		existing, _ := stored.Attrs[side].([]any)
+		kept := make([]any, 0, len(existing))
+		removed := 0
+		for _, raw := range existing {
+			matched := false
+			for _, candidate := range wanted {
+				if sameRule(raw, candidate) {
+					matched = true
+					break
+				}
 			}
+			if matched {
+				removed++
+				continue
+			}
+			kept = append(kept, raw)
 		}
-		if matched {
-			removed++
-			continue
+		if removed == 0 {
+			return errRuleMissing
 		}
-		kept = append(kept, raw)
-	}
-	if removed == 0 {
+		stored.Attrs[side] = kept
+		stored.Updated = p.env.Now()
+		final = stored
+		return nil
+	})
+	switch {
+	case errors.Is(err, errRuleMissing):
 		p.notFound(w, "security group rule on", res.ID)
 		return
-	}
-	res.Attrs[side] = kept
-	if !p.env.Store.Commit(res, p.env.Now()) {
+	case err != nil:
 		p.notFound(w, "security group", res.ID)
 		return
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"SecurityGroup":   securityGroupView(res),
+		"SecurityGroup":   securityGroupView(final),
 		"ResponseContext": p.context(),
 	})
 }

--- a/internal/providers/outscale/tags.go
+++ b/internal/providers/outscale/tags.go
@@ -133,13 +133,26 @@ func (p *Pack) createTags(w http.ResponseWriter, r *http.Request) {
 		targets = append(targets, res)
 	}
 
+	// The merge runs under the store lock, on the stored tags rather than on
+	// the clone resolved above. As a Get-merge-Put sequence this lost every
+	// concurrent key — two CreateTags on one resource each merged into their
+	// own stale copy — and Put re-inserts unconditionally, so it also
+	// resurrected a resource deleted meanwhile, tags and all (#289).
+	// TestConcurrentTagCreatesKeepEveryAcknowledgedTag fails without this.
 	for _, res := range targets {
-		tags := tagsOf(res)
-		for _, want := range req.Tags {
-			tags[want.Key] = want.Value
+		err := p.env.Store.Update(Name, res.Kind, res.ID, func(stored *resource.Resource) error {
+			tags := tagsOf(stored)
+			for _, want := range req.Tags {
+				tags[want.Key] = want.Value
+			}
+			stored.Attrs["Tags"] = tagsList(tags)
+			stored.Updated = p.env.Now()
+			return nil
+		})
+		if err != nil {
+			p.notFound(w, "resource", res.ID)
+			return
 		}
-		res.Attrs["Tags"] = tagsList(tags)
-		p.env.Store.Put(res)
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{"ResponseContext": p.context()})
 }
@@ -158,18 +171,27 @@ func (p *Pack) deleteTags(w http.ResponseWriter, r *http.Request) {
 			p.notFound(w, "resource", id)
 			return
 		}
-		tags := tagsOf(res)
-		for _, want := range req.Tags {
-			// A value given must match: DeleteTags removes a key only when the
-			// value matches, which is how the API refuses to drop a tag someone
-			// else changed under you.
-			if want.Value != "" && tags[want.Key] != want.Value {
-				continue
+		// Same ordering as createTags: the value check and the removal run on
+		// the stored tags, under the lock, never on the stale clone (#289).
+		err := p.env.Store.Update(Name, res.Kind, res.ID, func(stored *resource.Resource) error {
+			tags := tagsOf(stored)
+			for _, want := range req.Tags {
+				// A value given must match: DeleteTags removes a key only when
+				// the value matches, which is how the API refuses to drop a tag
+				// someone else changed under you.
+				if want.Value != "" && tags[want.Key] != want.Value {
+					continue
+				}
+				delete(tags, want.Key)
 			}
-			delete(tags, want.Key)
+			stored.Attrs["Tags"] = tagsList(tags)
+			stored.Updated = p.env.Now()
+			return nil
+		})
+		if err != nil {
+			p.notFound(w, "resource", id)
+			return
 		}
-		res.Attrs["Tags"] = tagsList(tags)
-		p.env.Store.Put(res)
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{"ResponseContext": p.context()})
 }

--- a/internal/providers/scaleway/routes.go
+++ b/internal/providers/scaleway/routes.go
@@ -124,13 +124,14 @@ func (p *Pack) updateRoute(w http.ResponseWriter, r *http.Request) {
 		writeInvalidArguments(w, ArgumentError{ArgumentName: "body", Reason: "format", HelpMessage: err.Error()})
 		return
 	}
+	destination := ""
 	if req.Destination != nil {
-		destination, err := network.ParseCIDR(*req.Destination)
+		parsed, err := network.ParseCIDR(*req.Destination)
 		if err != nil {
 			writeInvalidArguments(w, ArgumentError{ArgumentName: "destination", Reason: "format", HelpMessage: err.Error()})
 			return
 		}
-		res.Attrs["destination"] = destination.String()
+		destination = parsed.String()
 	}
 	if req.NexthopVpcConnectorID != nil && *req.NexthopVpcConnectorID != "" {
 		writeInvalidArguments(w, ArgumentError{
@@ -140,29 +141,44 @@ func (p *Pack) updateRoute(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	if req.Description != nil {
-		res.Attrs["description"] = *req.Description
-	}
-	if req.Tags != nil {
-		res.Attrs["tags"] = orEmpty(*req.Tags)
-	}
-	if req.NexthopResourceID != nil {
-		setOrDelete(res.Attrs, "nexthop_resource_id", *req.NexthopResourceID)
-	}
-	if req.NexthopPrivateNetworkID != nil {
-		if *req.NexthopPrivateNetworkID != "" {
-			pn, found := p.env.Store.Get(Name, kindPrivateNetwork, *req.NexthopPrivateNetworkID)
-			if !found || pn.Attrs["vpc_id"] != res.Attrs["vpc_id"] {
-				writeNotFound(w, "private_network", *req.NexthopPrivateNetworkID)
-				return
-			}
+	if req.NexthopPrivateNetworkID != nil && *req.NexthopPrivateNetworkID != "" {
+		pn, found := p.env.Store.Get(Name, kindPrivateNetwork, *req.NexthopPrivateNetworkID)
+		if !found || pn.Attrs["vpc_id"] != res.Attrs["vpc_id"] {
+			writeNotFound(w, "private_network", *req.NexthopPrivateNetworkID)
+			return
 		}
-		setOrDelete(res.Attrs, "nexthop_private_network_id", *req.NexthopPrivateNetworkID)
 	}
-	res.Updated = p.env.Now()
-	p.env.Store.Put(res)
 
-	emulator.WriteJSON(w, http.StatusOK, routeView(res))
+	// Inside Store.Update rather than mutate-then-Put: Put resurrects a route
+	// deleted while this PATCH was decoding, and its whole-Attrs write-back
+	// from a stale clone loses a concurrent writer's field (#289).
+	var final *resource.Resource
+	err := p.env.Store.Update(Name, kindVPCRoute, res.ID, func(stored *resource.Resource) error {
+		if req.Destination != nil {
+			stored.Attrs["destination"] = destination
+		}
+		if req.Description != nil {
+			stored.Attrs["description"] = *req.Description
+		}
+		if req.Tags != nil {
+			stored.Attrs["tags"] = orEmpty(*req.Tags)
+		}
+		if req.NexthopResourceID != nil {
+			setOrDelete(stored.Attrs, "nexthop_resource_id", *req.NexthopResourceID)
+		}
+		if req.NexthopPrivateNetworkID != nil {
+			setOrDelete(stored.Attrs, "nexthop_private_network_id", *req.NexthopPrivateNetworkID)
+		}
+		stored.Updated = p.env.Now()
+		final = stored
+		return nil
+	})
+	if err != nil {
+		writeNotFound(w, "route", res.ID)
+		return
+	}
+
+	emulator.WriteJSON(w, http.StatusOK, routeView(final))
 }
 
 func (p *Pack) deleteRoute(w http.ResponseWriter, r *http.Request) {

--- a/internal/providers/scaleway/securitygroups.go
+++ b/internal/providers/scaleway/securitygroups.go
@@ -227,45 +227,63 @@ func (p *Pack) updateSecurityGroup(w http.ResponseWriter, r *http.Request) {
 		writeInvalidArguments(w, ArgumentError{ArgumentName: "body", Reason: "format", HelpMessage: err.Error()})
 		return
 	}
-	if req.InboundDefaultPolicy != "" {
-		if !validPolicies[req.InboundDefaultPolicy] {
-			writePolicyError(w, "inbound_default_policy", req.InboundDefaultPolicy)
-			return
-		}
-		res.Attrs["inbound_default_policy"] = req.InboundDefaultPolicy
+	if req.InboundDefaultPolicy != "" && !validPolicies[req.InboundDefaultPolicy] {
+		writePolicyError(w, "inbound_default_policy", req.InboundDefaultPolicy)
+		return
 	}
-	if req.OutboundDefaultPolicy != "" {
-		if !validPolicies[req.OutboundDefaultPolicy] {
-			writePolicyError(w, "outbound_default_policy", req.OutboundDefaultPolicy)
-			return
-		}
-		res.Attrs["outbound_default_policy"] = req.OutboundDefaultPolicy
+	if req.OutboundDefaultPolicy != "" && !validPolicies[req.OutboundDefaultPolicy] {
+		writePolicyError(w, "outbound_default_policy", req.OutboundDefaultPolicy)
+		return
 	}
-	if req.Name != nil {
-		res.Attrs["name"] = *req.Name
-	}
-	if req.Description != nil {
-		res.Attrs["description"] = *req.Description
-	}
-	if req.Tags != nil {
-		res.Attrs["tags"] = orEmpty(*req.Tags)
-	}
-	if req.Stateful != nil {
-		res.Attrs["stateful"] = *req.Stateful
-	}
-	if req.EnableDefaultSecurity != nil {
-		res.Attrs["enable_default_security"] = *req.EnableDefaultSecurity
-	}
-	if deref(req.ProjectDefault, false) || deref(req.OrganizationDefault, false) {
+	becomesDefault := deref(req.ProjectDefault, false) || deref(req.OrganizationDefault, false)
+	if becomesDefault {
+		// A group asking to become the project default demotes the previous
+		// one first, exactly as on create: two defaults in a project is a
+		// state the API cannot return.
 		p.clearProjectDefault(res.Tenant.Zone, res.Tenant.Project)
-		res.Attrs["project_default"] = true
-		res.Attrs["organization_default"] = true
 	}
 
-	res.Updated = p.env.Now()
-	p.env.Store.Put(res)
-	p.syncSecurityGroup(r.Context(), res)
-	emulator.WriteJSON(w, http.StatusOK, map[string]any{"security_group": p.securityGroupView(res)})
+	// Written inside Store.Update rather than mutate-the-clone-then-Put: Put
+	// re-inserts unconditionally, so it resurrected a group deleted while this
+	// PATCH was decoding, and a concurrent writer of another field — the tags,
+	// say — was erased by the stale whole-Attrs write-back (#289).
+	var final *resource.Resource
+	err := p.env.Store.Update(Name, kindSecurityGroup, res.ID, func(stored *resource.Resource) error {
+		if req.InboundDefaultPolicy != "" {
+			stored.Attrs["inbound_default_policy"] = req.InboundDefaultPolicy
+		}
+		if req.OutboundDefaultPolicy != "" {
+			stored.Attrs["outbound_default_policy"] = req.OutboundDefaultPolicy
+		}
+		if req.Name != nil {
+			stored.Attrs["name"] = *req.Name
+		}
+		if req.Description != nil {
+			stored.Attrs["description"] = *req.Description
+		}
+		if req.Tags != nil {
+			stored.Attrs["tags"] = orEmpty(*req.Tags)
+		}
+		if req.Stateful != nil {
+			stored.Attrs["stateful"] = *req.Stateful
+		}
+		if req.EnableDefaultSecurity != nil {
+			stored.Attrs["enable_default_security"] = *req.EnableDefaultSecurity
+		}
+		if becomesDefault {
+			stored.Attrs["project_default"] = true
+			stored.Attrs["organization_default"] = true
+		}
+		stored.Updated = p.env.Now()
+		final = stored
+		return nil
+	})
+	if err != nil {
+		writeNotFound(w, "security_group", res.ID)
+		return
+	}
+	p.syncSecurityGroup(r.Context(), final)
+	emulator.WriteJSON(w, http.StatusOK, map[string]any{"security_group": p.securityGroupView(final)})
 }
 
 func (p *Pack) deleteSecurityGroup(w http.ResponseWriter, r *http.Request) {
@@ -418,29 +436,21 @@ func (p *Pack) updateSecurityGroupRule(w http.ResponseWriter, r *http.Request) {
 		writeInvalidArguments(w, ArgumentError{ArgumentName: "body", Reason: "format", HelpMessage: err.Error()})
 		return
 	}
-	if req.Protocol != "" {
-		if !validProtocols[req.Protocol] {
-			writeEnumError(w, "protocol", req.Protocol)
-			return
-		}
-		res.Attrs["protocol"] = req.Protocol
+	if req.Protocol != "" && !validProtocols[req.Protocol] {
+		writeEnumError(w, "protocol", req.Protocol)
+		return
 	}
-	if req.Direction != "" {
-		if !validDirections[req.Direction] {
-			writeEnumError(w, "direction", req.Direction)
-			return
-		}
-		res.Attrs["direction"] = req.Direction
+	if req.Direction != "" && !validDirections[req.Direction] {
+		writeEnumError(w, "direction", req.Direction)
+		return
 	}
-	if req.Action != "" {
-		if !validActions[req.Action] {
-			writeEnumError(w, "action", req.Action)
-			return
-		}
-		res.Attrs["action"] = req.Action
+	if req.Action != "" && !validActions[req.Action] {
+		writeEnumError(w, "action", req.Action)
+		return
 	}
+	ipRange := ""
 	if req.IPRange != "" {
-		ipRange, ok := normalizeIPRange(req.IPRange)
+		normalized, ok := normalizeIPRange(req.IPRange)
 		if !ok {
 			writeInvalidArguments(w, ArgumentError{
 				ArgumentName: "ip_range",
@@ -449,26 +459,50 @@ func (p *Pack) updateSecurityGroupRule(w http.ResponseWriter, r *http.Request) {
 			})
 			return
 		}
-		res.Attrs["ip_range"] = ipRange
-	}
-	// A zero port unsets the bound, which the SDK documents on the update
-	// request. Anything else would leave a rule Terraform cannot narrow back.
-	if req.DestPortFrom != nil {
-		res.Attrs["dest_port_from"] = portOrNil(req.DestPortFrom)
-	}
-	if req.DestPortTo != nil {
-		res.Attrs["dest_port_to"] = portOrNil(req.DestPortTo)
-	}
-	if req.Position != nil {
-		res.Attrs["position"] = *req.Position
+		ipRange = normalized
 	}
 
-	res.Updated = p.env.Now()
-	p.env.Store.Put(res)
-	if group, found := p.env.Store.Get(Name, kindSecurityGroup, res.Runtime[runtimeGroupKey]); found {
+	// Written inside Store.Update rather than mutate-the-clone-then-Put: Put
+	// re-inserts unconditionally, so it resurrected a rule deleted while this
+	// PATCH was decoding, and it wrote back a whole Attrs built from a stale
+	// read, which is the lost-update shape #289 measured on the pack next door.
+	var final *resource.Resource
+	err := p.env.Store.Update(Name, kindSecurityGroupRule, res.ID, func(stored *resource.Resource) error {
+		if req.Protocol != "" {
+			stored.Attrs["protocol"] = req.Protocol
+		}
+		if req.Direction != "" {
+			stored.Attrs["direction"] = req.Direction
+		}
+		if req.Action != "" {
+			stored.Attrs["action"] = req.Action
+		}
+		if req.IPRange != "" {
+			stored.Attrs["ip_range"] = ipRange
+		}
+		// A zero port unsets the bound, which the SDK documents on the update
+		// request. Anything else would leave a rule Terraform cannot narrow back.
+		if req.DestPortFrom != nil {
+			stored.Attrs["dest_port_from"] = portOrNil(req.DestPortFrom)
+		}
+		if req.DestPortTo != nil {
+			stored.Attrs["dest_port_to"] = portOrNil(req.DestPortTo)
+		}
+		if req.Position != nil {
+			stored.Attrs["position"] = *req.Position
+		}
+		stored.Updated = p.env.Now()
+		final = stored
+		return nil
+	})
+	if err != nil {
+		writeNotFound(w, "security_group_rule", res.ID)
+		return
+	}
+	if group, found := p.env.Store.Get(Name, kindSecurityGroup, final.Runtime[runtimeGroupKey]); found {
 		p.syncSecurityGroup(r.Context(), group)
 	}
-	emulator.WriteJSON(w, http.StatusOK, map[string]any{"rule": ruleView(res)})
+	emulator.WriteJSON(w, http.StatusOK, map[string]any{"rule": ruleView(final)})
 }
 
 func (p *Pack) deleteSecurityGroupRule(w http.ResponseWriter, r *http.Request) {
@@ -683,9 +717,15 @@ func (p *Pack) serversUsing(group *resource.Resource) []serverSummary {
 func (p *Pack) clearProjectDefault(zone, project string) {
 	for _, res := range p.env.Store.List(kindSecurityGroup, resource.Tenant{Provider: Name, Project: project, Zone: zone}) {
 		if isProjectDefault(res) {
-			res.Attrs["project_default"] = false
-			res.Attrs["organization_default"] = false
-			p.env.Store.Put(res)
+			// Update rather than Put: a Put here resurrected a group deleted
+			// between the List and the write, and erased any field a
+			// concurrent request had just stored on it (#289).
+			_ = p.env.Store.Update(Name, kindSecurityGroup, res.ID, func(stored *resource.Resource) error {
+				stored.Attrs["project_default"] = false
+				stored.Attrs["organization_default"] = false
+				stored.Updated = p.env.Now()
+				return nil
+			})
 		}
 	}
 }

--- a/internal/providers/scaleway/vpc.go
+++ b/internal/providers/scaleway/vpc.go
@@ -379,19 +379,29 @@ func (p *Pack) updatePrivateNetwork(w http.ResponseWriter, r *http.Request) {
 		writeInvalidArguments(w, ArgumentError{ArgumentName: "body", Reason: "format", HelpMessage: err.Error()})
 		return
 	}
-	if req.Name != nil {
-		res.Attrs["name"] = *req.Name
+	// Inside Store.Update rather than mutate-then-Put: Put resurrects a network
+	// deleted while this PATCH was decoding, and its whole-Attrs write-back from
+	// a stale clone loses a concurrent writer's field (#289).
+	var final *resource.Resource
+	err := p.env.Store.Update(Name, kindPrivateNetwork, res.ID, func(stored *resource.Resource) error {
+		if req.Name != nil {
+			stored.Attrs["name"] = *req.Name
+		}
+		if req.Tags != nil {
+			stored.Attrs["tags"] = orEmpty(*req.Tags)
+		}
+		if req.DefaultRoutePropagationEnabled != nil {
+			stored.Attrs["default_route_propagation_enabled"] = *req.DefaultRoutePropagationEnabled
+		}
+		stored.Updated = p.env.Now()
+		final = stored
+		return nil
+	})
+	if err != nil {
+		writeNotFound(w, "private_network", res.ID)
+		return
 	}
-	if req.Tags != nil {
-		res.Attrs["tags"] = orEmpty(*req.Tags)
-	}
-	if req.DefaultRoutePropagationEnabled != nil {
-		res.Attrs["default_route_propagation_enabled"] = *req.DefaultRoutePropagationEnabled
-	}
-
-	res.Updated = p.env.Now()
-	p.env.Store.Put(res)
-	emulator.WriteJSON(w, http.StatusOK, privateNetworkView(res))
+	emulator.WriteJSON(w, http.StatusOK, privateNetworkView(final))
 }
 
 func (p *Pack) deletePrivateNetwork(w http.ResponseWriter, r *http.Request) {
@@ -523,13 +533,23 @@ func (p *Pack) enableRouting(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	res.Attrs["routing_enabled"] = true
-	res.Updated = p.env.Now()
-	p.env.Store.Put(res)
+	// Update rather than Put, like every write to an existing resource: a Put
+	// here resurrected a VPC deleted meanwhile, routing enabled (#289).
+	var final *resource.Resource
+	err := p.env.Store.Update(Name, kindVPC, res.ID, func(stored *resource.Resource) error {
+		stored.Attrs["routing_enabled"] = true
+		stored.Updated = p.env.Now()
+		final = stored
+		return nil
+	})
+	if err != nil {
+		writeNotFound(w, "vpc", res.ID)
+		return
+	}
 	// What was isolated may now be reachable: the rule sets carried by the
 	// backing networks must say what the control plane just said.
 	p.isolateNetworks(r.Context())
-	emulator.WriteJSON(w, http.StatusOK, p.vpcView(res))
+	emulator.WriteJSON(w, http.StatusOK, p.vpcView(final))
 }
 
 // enableDHCP exists for Private Networks created before DHCP was the default.
@@ -541,10 +561,19 @@ func (p *Pack) enableDHCP(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	res.Attrs["dhcp_enabled"] = true
-	res.Updated = p.env.Now()
-	p.env.Store.Put(res)
-	emulator.WriteJSON(w, http.StatusOK, privateNetworkView(res))
+	// Update rather than Put, same reasoning as enableRouting above (#289).
+	var final *resource.Resource
+	err := p.env.Store.Update(Name, kindPrivateNetwork, res.ID, func(stored *resource.Resource) error {
+		stored.Attrs["dhcp_enabled"] = true
+		stored.Updated = p.env.Now()
+		final = stored
+		return nil
+	})
+	if err != nil {
+		writeNotFound(w, "private_network", res.ID)
+		return
+	}
+	emulator.WriteJSON(w, http.StatusOK, privateNetworkView(final))
 }
 
 // ---- Default inventory ------------------------------------------------------

--- a/tools/falsify/specs/lost-collection-elements.json
+++ b/tools/falsify/specs/lost-collection-elements.json
@@ -1,0 +1,30 @@
+{
+  "package": "./internal/providers/outscale/",
+  "mutations": [
+    {
+      "label": "the rule create merges from the stale pre-lock clone, so two concurrent creates on one group each append to their own copy and the last write erases the other's acknowledged rule",
+      "file": "internal/providers/outscale/securitygroups.go",
+      "find": "\t\texisting, _ := stored.Attrs[side].([]any)\n\t\t// A fresh slice, never an append into the stored backing array: clones",
+      "replace": "\t\texisting, _ := stored.Attrs[side].([]any)\n\t\texisting, _ = res.Attrs[side].([]any)\n\t\t// A fresh slice, never an append into the stored backing array: clones",
+      "test": "TestConcurrentRuleCreatesKeepEveryAcknowledgedRule",
+      "repeat": 5
+    },
+    {
+      "label": "the route create merges from the stale pre-lock clone, the same lost-update shape on the table's Routes",
+      "file": "internal/providers/outscale/routetables.go",
+      "find": "\t\troutes := listOf(stored.Attrs[\"Routes\"])\n\t\tfor _, raw := range routes {\n\t\t\troute, _ := raw.(map[string]any)\n\t\t\tif stringOf(route[\"DestinationIpRange\"]) == req.DestinationIPRange {\n\t\t\t\treturn errRouteExists",
+      "replace": "\t\troutes := listOf(stored.Attrs[\"Routes\"])\n\t\troutes = listOf(res.Attrs[\"Routes\"])\n\t\tfor _, raw := range routes {\n\t\t\troute, _ := raw.(map[string]any)\n\t\t\tif stringOf(route[\"DestinationIpRange\"]) == req.DestinationIPRange {\n\t\t\t\treturn errRouteExists",
+      "test": "TestConcurrentRouteCreatesKeepEveryAcknowledgedRoute",
+      "repeat": 5
+    },
+    {
+      "label": "the tag create merges from the stale pre-lock clone, so a concurrent key on the same resource is erased after its 200",
+      "file": "internal/providers/outscale/tags.go",
+      "find": "\t\t\ttags := tagsOf(stored)\n\t\t\tfor _, want := range req.Tags {\n\t\t\t\ttags[want.Key] = want.Value",
+      "replace": "\t\t\ttags := tagsOf(stored)\n\t\t\ttags = tagsOf(res)\n\t\t\tfor _, want := range req.Tags {\n\t\t\t\ttags[want.Key] = want.Value",
+      "test": "TestConcurrentTagCreatesKeepEveryAcknowledgedTag",
+      "repeat": 5
+    }
+  ],
+  "note": "Each mutation re-reads the collection from the clone taken before the lock, which is byte-for-byte the base the pre-#289 Commit shape merged from; the stored read stays on the line above so every name survives, per this harness's own rule. The subject is a race, so `repeat` is declared and the rate behind it is measured, not chosen: without the fix, each of the three tests went red 10 of 10 consecutive -count=1 runs on 2026-08-18 (the 40-trial structure of storetest.NoLostUpdate makes a single run nearly deterministic — the original #289 replay lost 3 rules of 8 in one shot). At a measured red rate of at least 9 in 10, five repeats put a false TEST STILL PASSED below 1e-5."
+}


### PR DESCRIPTION
# Summary

Two concurrent `CreateSecurityGroupRule` on one Outscale group each answered
200 and one rule was never stored (#289): the handler did `Get` → append to the
clone's list → `Commit`, and `store.go` documents on `Commit` itself that it
does not merge — the second writer's whole-Attrs write-back erased the first
writer's acknowledged rule. Replaying `terraform-outscale-k3s` measured 8
creates acknowledged and 5 rules stored; `destroy` then died on the phantom
with `[5063]`.

This moves every such write into `Store.Update`, the model the Exoscale pack
already used: the read, the check and the mutation are one critical section
held by the store. Fixed in the same change, because they are the same race:

- **Outscale rules** (`createSecurityGroupRule`, `deleteSecurityGroupRule`) —
  the issue; the duplicate check now also runs under the lock, so two identical
  concurrent creates cannot both pass it.
- **Outscale route tables** (`linkRouteTable`, `unlinkRouteTable`,
  `createRoute`, `deleteRoute`, `updateRoute`) — the same clone-append-Commit
  body on `Routes`/`LinkRouteTables`; `updateRoute` also stops writing
  `routes[i]` through the backing array a shallow `Clone` shares with every
  concurrent reader.
- **Outscale tags** (`createTags`, `deleteTags`) — wrote back with `Put`, which
  loses concurrent keys *and* resurrects a resource deleted mid-request.
- **Scaleway update paths** (`updateSecurityGroup`, `updateSecurityGroupRule`,
  `clearProjectDefault`, `updatePrivateNetwork`, `enableRouting`, `enableDHCP`,
  VPC `updateRoute`) — the same mutate-then-`Put` shape.
- **Exoscale** was already correct everywhere and is untouched except for a new
  regression trial.

**The shared barrage learns the shape that escaped it.** `storetest.NoLostUpdate`
drove one writer per *field*; a lost *element of a collection* is the same race
and no pack's trials exercised it, which is why #289 was first measured by a
real client. The package doc now names both shapes, and the packs drive
membership: one writer per rule/route/tag key on one target (Outscale, 3 new
tests), one writer per rule on the already-correct pack (Exoscale, 1 new test).

**Measured, not asserted:**

- Without the fix, each new test went red **10 of 10** consecutive `-count=1`
  runs (2026-08-18).
- `tools/falsify/specs/lost-collection-elements.json` re-reads the stale
  pre-lock clone (the exact pre-fix merge base) and all three mutations
  compiled and bit, `repeat: 5` against that measured rate;
  `mise run falsify:lint` green.
- The issue's own curl reproduction (8 concurrent creates on one group) answers
  `stored == acknowledged` on **12 of 12** tries against the fixed binary.
- Full suite ×3 under `-race`: clean.

The scalar half of the family (single-field `Get`→`Commit` across two different
handlers) is real too — measured at **7/200** trials losing an acknowledged tag
to a concurrent `LinkVolume` — and is enumerated with its reproduction in #295
rather than left silent.

## Type of change

- [ ] A route added or changed
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes (gofmt, vet, golangci-lint, `go test -race`)
- [x] No new external Go dependency, or the pull request justifies it. The
      standard library covers routing, JSON and Go parsing; `go.mod` has three
      lines and a pre-commit hook keeps it that way
- [x] `internal/core` still knows no provider. If a change seemed to require it,
      the pack changed instead (the only core change is documentation in
      `storetest`, keyed on nothing but the store's own vocabulary)
- [x] Nothing in the diff could be written identically for another provider. If
      it could, it belongs in the core — the critical section itself is
      `Store.Update`, which already lives there; what each pack keeps is its own
      request shapes, error dialects and collection names

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] I ran `mise run conformance` myself — not "it should pass" (full suite,
      no `FEINT_VM`: scw, oapi-cli, exo, Terraform, OpenTofu, probe; score 264
      of 285 routes proven by a real client, network suites skipped as designed
      without a runtime)
- [x] Every field name in the diff comes from the provider's SDK, their OpenAPI
      document, or a run of the real client, and I can say which: no response
      field changed — every JSON key written (`InboundRules`, `Routes`,
      `LinkRouteTables`, `Tags`, …) is the one the handler already stored, and
      the new tests read keys straight from the emulator's measured responses

### When a route is added or changed — otherwise N/A

N/A — no route added, no response shape changed; the same bytes are stored and
served, minus the lost ones. (`mise run conformance` was run anyway, see above;
`drift:check` green — the surface did not move.)

### When behaviour a client can observe changes — otherwise N/A

- [x] `docs/limits.md` updated if the change moves a documented limit — no
      documented limit moves: the change removes an undocumented lie (a 200
      whose effect vanished), which is the project's baseline, not a limit
- [x] The README's generated tables regenerated (`mise run docs:coverage`) —
      nothing to regenerate; `feint docs --check` green via `mise run prepush`

### When `.github/workflows/` is touched — otherwise N/A

N/A — no workflow touched.

### When a machine runtime is involved — otherwise N/A

N/A — the store is the only side effect on every touched path; no runtime call
moved. (Deliberately not run with `FEINT_VM` in this session: other sessions
hold Incus.)

## Related issues

Closes #289. The scalar remainder of the family is measured and enumerated in
#295.
