### PR TITLE
chore(exoscale): the NLB and VPC families are declined with dated reasons

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,12 +686,12 @@ what this emulator serves, declines on purpose, or has not triaged yet.
 #### Exoscale
 
 93 routes mounted. Of the 374 operations upstream declares: 24% served,
-67% declined on purpose, 7% untriaged.
+75% declined on purpose, 0% untriaged.
 
 | Group | Served | Declined | Untriaged | Upstream |
 |---|--:|--:|--:|--:|
 | `dbaas` | 0 | 146 | 0 | 146 |
-| `compute` | 74 | 10 | 27 | 111 |
+| `compute` | 74 | 37 | 0 | 111 |
 | `sks` | 0 | 25 | 0 | 25 |
 | `ai` | 0 | 22 | 0 | 22 |
 | `iam` | 0 | 18 | 0 | 18 |
@@ -699,7 +699,7 @@ what this emulator serves, declines on purpose, or has not triaged yet.
 | `block-storage` | 13 | 0 | 0 | 13 |
 | `dns` | 0 | 10 | 0 | 10 |
 | *… 6 smaller groups* | 6 | 7 | 0 | 13 |
-| **Total** | **93** | **254** | **27** | **374** |
+| **Total** | **93** | **281** | **0** | **374** |
 
 #### Outscale
 

--- a/coverage/exoscale-baseline.json
+++ b/coverage/exoscale-baseline.json
@@ -1,32 +1,4 @@
 {
   "provider": "exoscale",
-  "unknown": [
-    "exoscale/v2.add-service-to-load-balancer",
-    "exoscale/v2.attach-instance-to-subnet",
-    "exoscale/v2.create-load-balancer",
-    "exoscale/v2.create-route",
-    "exoscale/v2.create-subnet",
-    "exoscale/v2.create-vpc",
-    "exoscale/v2.delete-load-balancer",
-    "exoscale/v2.delete-load-balancer-service",
-    "exoscale/v2.delete-route",
-    "exoscale/v2.delete-subnet",
-    "exoscale/v2.delete-vpc",
-    "exoscale/v2.detach-instance-from-subnet",
-    "exoscale/v2.get-load-balancer",
-    "exoscale/v2.get-load-balancer-service",
-    "exoscale/v2.get-subnet",
-    "exoscale/v2.get-vpc",
-    "exoscale/v2.list-load-balancers",
-    "exoscale/v2.list-routes",
-    "exoscale/v2.list-subnets",
-    "exoscale/v2.list-vpc-routes",
-    "exoscale/v2.list-vpcs",
-    "exoscale/v2.reset-load-balancer-field",
-    "exoscale/v2.reset-load-balancer-service-field",
-    "exoscale/v2.update-load-balancer",
-    "exoscale/v2.update-load-balancer-service",
-    "exoscale/v2.update-subnet",
-    "exoscale/v2.update-vpc"
-  ]
+  "unknown": []
 }

--- a/coverage/exoscale-coverage.json
+++ b/coverage/exoscale-coverage.json
@@ -2,23 +2,23 @@
   "provider": "exoscale",
   "total": 374,
   "implemented": 93,
-  "declined": 254,
-  "unknown": 27,
+  "declined": 281,
+  "unknown": 0,
   "orphans": null,
   "products": [
     {
       "product": "exoscale",
       "total": 374,
       "implemented": 93,
-      "declined": 254,
-      "unknown": 27,
+      "declined": 281,
+      "unknown": 0,
       "versions": [
         {
           "version": "2.0.0",
           "total": 374,
           "implemented": 93,
-          "declined": 254,
-          "unknown": 27
+          "declined": 281,
+          "unknown": 0
         }
       ]
     }
@@ -49,8 +49,8 @@
       "group": "compute",
       "total": 111,
       "implemented": 74,
-      "declined": 10,
-      "unknown": 27
+      "declined": 37,
+      "unknown": 0
     },
     {
       "group": "dbaas",
@@ -148,9 +148,10 @@
     {
       "operation": "exoscale/v2.add-service-to-load-balancer",
       "product": "exoscale",
+      "reason": "a network load balancer's services publish a per-backend healthcheck verdict, success or failure with no third value, and nothing here probes a backend yet, so every verdict would be invented; one surveyed stack in fifteen reaches this refusal (platform, 2026-08), and serving the NLB is #284's decision, scoped as batch EXO-5 (#14)",
       "version": "2.0.0",
       "group": "compute",
-      "status": "unknown"
+      "status": "declined"
     },
     {
       "operation": "exoscale/v2.assume-iam-role",
@@ -199,9 +200,10 @@
     {
       "operation": "exoscale/v2.attach-instance-to-subnet",
       "product": "exoscale",
+      "reason": "upstream marks all sixteen VPC operations beta, and none of the fifteen surveyed stacks asks for the product (2026-08); emulating a surface still allowed to rename its fields means chasing upstream instead of clients, and serving the VPC once it settles belongs to batch EXO-6 (#15)",
       "version": "2.0.0",
       "group": "compute",
-      "status": "unknown"
+      "status": "declined"
     },
     {
       "operation": "exoscale/v2.cancel-kms-key-deletion",
@@ -535,9 +537,10 @@
     {
       "operation": "exoscale/v2.create-load-balancer",
       "product": "exoscale",
+      "reason": "a network load balancer's services publish a per-backend healthcheck verdict, success or failure with no third value, and nothing here probes a backend yet, so every verdict would be invented; one surveyed stack in fifteen reaches this refusal (platform, 2026-08), and serving the NLB is #284's decision, scoped as batch EXO-5 (#14)",
       "version": "2.0.0",
       "group": "compute",
-      "status": "unknown"
+      "status": "declined"
     },
     {
       "operation": "exoscale/v2.create-model",
@@ -557,9 +560,10 @@
     {
       "operation": "exoscale/v2.create-route",
       "product": "exoscale",
+      "reason": "upstream marks all sixteen VPC operations beta, and none of the fifteen surveyed stacks asks for the product (2026-08); emulating a surface still allowed to rename its fields means chasing upstream instead of clients, and serving the VPC once it settles belongs to batch EXO-6 (#15)",
       "version": "2.0.0",
       "group": "compute",
-      "status": "unknown"
+      "status": "declined"
     },
     {
       "operation": "exoscale/v2.create-security-group",
@@ -594,9 +598,10 @@
     {
       "operation": "exoscale/v2.create-subnet",
       "product": "exoscale",
+      "reason": "upstream marks all sixteen VPC operations beta, and none of the fifteen surveyed stacks asks for the product (2026-08); emulating a surface still allowed to rename its fields means chasing upstream instead of clients, and serving the VPC once it settles belongs to batch EXO-6 (#15)",
       "version": "2.0.0",
       "group": "compute",
-      "status": "unknown"
+      "status": "declined"
     },
     {
       "operation": "exoscale/v2.create-user",
@@ -609,9 +614,10 @@
     {
       "operation": "exoscale/v2.create-vpc",
       "product": "exoscale",
+      "reason": "upstream marks all sixteen VPC operations beta, and none of the fifteen surveyed stacks asks for the product (2026-08); emulating a surface still allowed to rename its fields means chasing upstream instead of clients, and serving the VPC once it settles belongs to batch EXO-6 (#15)",
       "version": "2.0.0",
       "group": "compute",
-      "status": "unknown"
+      "status": "declined"
     },
     {
       "operation": "exoscale/v2.decrypt",
@@ -930,16 +936,18 @@
     {
       "operation": "exoscale/v2.delete-load-balancer",
       "product": "exoscale",
+      "reason": "a network load balancer's services publish a per-backend healthcheck verdict, success or failure with no third value, and nothing here probes a backend yet, so every verdict would be invented; one surveyed stack in fifteen reaches this refusal (platform, 2026-08), and serving the NLB is #284's decision, scoped as batch EXO-5 (#14)",
       "version": "2.0.0",
       "group": "compute",
-      "status": "unknown"
+      "status": "declined"
     },
     {
       "operation": "exoscale/v2.delete-load-balancer-service",
       "product": "exoscale",
+      "reason": "a network load balancer's services publish a per-backend healthcheck verdict, success or failure with no third value, and nothing here probes a backend yet, so every verdict would be invented; one surveyed stack in fifteen reaches this refusal (platform, 2026-08), and serving the NLB is #284's decision, scoped as batch EXO-5 (#14)",
       "version": "2.0.0",
       "group": "compute",
-      "status": "unknown"
+      "status": "declined"
     },
     {
       "operation": "exoscale/v2.delete-model",
@@ -975,9 +983,10 @@
     {
       "operation": "exoscale/v2.delete-route",
       "product": "exoscale",
+      "reason": "upstream marks all sixteen VPC operations beta, and none of the fifteen surveyed stacks asks for the product (2026-08); emulating a surface still allowed to rename its fields means chasing upstream instead of clients, and serving the VPC once it settles belongs to batch EXO-6 (#15)",
       "version": "2.0.0",
       "group": "compute",
-      "status": "unknown"
+      "status": "declined"
     },
     {
       "operation": "exoscale/v2.delete-rule-from-security-group",
@@ -1026,9 +1035,10 @@
     {
       "operation": "exoscale/v2.delete-subnet",
       "product": "exoscale",
+      "reason": "upstream marks all sixteen VPC operations beta, and none of the fifteen surveyed stacks asks for the product (2026-08); emulating a surface still allowed to rename its fields means chasing upstream instead of clients, and serving the VPC once it settles belongs to batch EXO-6 (#15)",
       "version": "2.0.0",
       "group": "compute",
-      "status": "unknown"
+      "status": "declined"
     },
     {
       "operation": "exoscale/v2.delete-template",
@@ -1048,9 +1058,10 @@
     {
       "operation": "exoscale/v2.delete-vpc",
       "product": "exoscale",
+      "reason": "upstream marks all sixteen VPC operations beta, and none of the fifteen surveyed stacks asks for the product (2026-08); emulating a surface still allowed to rename its fields means chasing upstream instead of clients, and serving the VPC once it settles belongs to batch EXO-6 (#15)",
       "version": "2.0.0",
       "group": "compute",
-      "status": "unknown"
+      "status": "declined"
     },
     {
       "operation": "exoscale/v2.detach-block-storage-volume",
@@ -1091,9 +1102,10 @@
     {
       "operation": "exoscale/v2.detach-instance-from-subnet",
       "product": "exoscale",
+      "reason": "upstream marks all sixteen VPC operations beta, and none of the fifteen surveyed stacks asks for the product (2026-08); emulating a surface still allowed to rename its fields means chasing upstream instead of clients, and serving the VPC once it settles belongs to batch EXO-6 (#15)",
       "version": "2.0.0",
       "group": "compute",
-      "status": "unknown"
+      "status": "declined"
     },
     {
       "operation": "exoscale/v2.disable-kms-key",
@@ -1662,16 +1674,18 @@
     {
       "operation": "exoscale/v2.get-load-balancer",
       "product": "exoscale",
+      "reason": "a network load balancer's services publish a per-backend healthcheck verdict, success or failure with no third value, and nothing here probes a backend yet, so every verdict would be invented; one surveyed stack in fifteen reaches this refusal (platform, 2026-08), and serving the NLB is #284's decision, scoped as batch EXO-5 (#14)",
       "version": "2.0.0",
       "group": "compute",
-      "status": "unknown"
+      "status": "declined"
     },
     {
       "operation": "exoscale/v2.get-load-balancer-service",
       "product": "exoscale",
+      "reason": "a network load balancer's services publish a per-backend healthcheck verdict, success or failure with no third value, and nothing here probes a backend yet, so every verdict would be invented; one surveyed stack in fifteen reaches this refusal (platform, 2026-08), and serving the NLB is #284's decision, scoped as batch EXO-5 (#14)",
       "version": "2.0.0",
       "group": "compute",
-      "status": "unknown"
+      "status": "declined"
     },
     {
       "operation": "exoscale/v2.get-model",
@@ -1789,9 +1803,10 @@
     {
       "operation": "exoscale/v2.get-subnet",
       "product": "exoscale",
+      "reason": "upstream marks all sixteen VPC operations beta, and none of the fifteen surveyed stacks asks for the product (2026-08); emulating a surface still allowed to rename its fields means chasing upstream instead of clients, and serving the VPC once it settles belongs to batch EXO-6 (#15)",
       "version": "2.0.0",
       "group": "compute",
-      "status": "unknown"
+      "status": "declined"
     },
     {
       "operation": "exoscale/v2.get-template",
@@ -1819,9 +1834,10 @@
     {
       "operation": "exoscale/v2.get-vpc",
       "product": "exoscale",
+      "reason": "upstream marks all sixteen VPC operations beta, and none of the fifteen surveyed stacks asks for the product (2026-08); emulating a surface still allowed to rename its fields means chasing upstream instead of clients, and serving the VPC once it settles belongs to batch EXO-6 (#15)",
       "version": "2.0.0",
       "group": "compute",
-      "status": "unknown"
+      "status": "declined"
     },
     {
       "operation": "exoscale/v2.list-ai-api-keys",
@@ -2041,9 +2057,10 @@
     {
       "operation": "exoscale/v2.list-load-balancers",
       "product": "exoscale",
+      "reason": "a network load balancer's services publish a per-backend healthcheck verdict, success or failure with no third value, and nothing here probes a backend yet, so every verdict would be invented; one surveyed stack in fifteen reaches this refusal (platform, 2026-08), and serving the NLB is #284's decision, scoped as batch EXO-5 (#14)",
       "version": "2.0.0",
       "group": "compute",
-      "status": "unknown"
+      "status": "declined"
     },
     {
       "operation": "exoscale/v2.list-models",
@@ -2070,9 +2087,10 @@
     {
       "operation": "exoscale/v2.list-routes",
       "product": "exoscale",
+      "reason": "upstream marks all sixteen VPC operations beta, and none of the fifteen surveyed stacks asks for the product (2026-08); emulating a surface still allowed to rename its fields means chasing upstream instead of clients, and serving the VPC once it settles belongs to batch EXO-6 (#15)",
       "version": "2.0.0",
       "group": "compute",
-      "status": "unknown"
+      "status": "declined"
     },
     {
       "operation": "exoscale/v2.list-security-groups",
@@ -2130,9 +2148,10 @@
     {
       "operation": "exoscale/v2.list-subnets",
       "product": "exoscale",
+      "reason": "upstream marks all sixteen VPC operations beta, and none of the fifteen surveyed stacks asks for the product (2026-08); emulating a surface still allowed to rename its fields means chasing upstream instead of clients, and serving the VPC once it settles belongs to batch EXO-6 (#15)",
       "version": "2.0.0",
       "group": "compute",
-      "status": "unknown"
+      "status": "declined"
     },
     {
       "operation": "exoscale/v2.list-templates",
@@ -2152,16 +2171,18 @@
     {
       "operation": "exoscale/v2.list-vpc-routes",
       "product": "exoscale",
+      "reason": "upstream marks all sixteen VPC operations beta, and none of the fifteen surveyed stacks asks for the product (2026-08); emulating a surface still allowed to rename its fields means chasing upstream instead of clients, and serving the VPC once it settles belongs to batch EXO-6 (#15)",
       "version": "2.0.0",
       "group": "compute",
-      "status": "unknown"
+      "status": "declined"
     },
     {
       "operation": "exoscale/v2.list-vpcs",
       "product": "exoscale",
+      "reason": "upstream marks all sixteen VPC operations beta, and none of the fifteen surveyed stacks asks for the product (2026-08); emulating a surface still allowed to rename its fields means chasing upstream instead of clients, and serving the VPC once it settles belongs to batch EXO-6 (#15)",
       "version": "2.0.0",
       "group": "compute",
-      "status": "unknown"
+      "status": "declined"
     },
     {
       "operation": "exoscale/v2.list-zones",
@@ -2331,16 +2352,18 @@
     {
       "operation": "exoscale/v2.reset-load-balancer-field",
       "product": "exoscale",
+      "reason": "a network load balancer's services publish a per-backend healthcheck verdict, success or failure with no third value, and nothing here probes a backend yet, so every verdict would be invented; one surveyed stack in fifteen reaches this refusal (platform, 2026-08), and serving the NLB is #284's decision, scoped as batch EXO-5 (#14)",
       "version": "2.0.0",
       "group": "compute",
-      "status": "unknown"
+      "status": "declined"
     },
     {
       "operation": "exoscale/v2.reset-load-balancer-service-field",
       "product": "exoscale",
+      "reason": "a network load balancer's services publish a per-backend healthcheck verdict, success or failure with no third value, and nothing here probes a backend yet, so every verdict would be invented; one surveyed stack in fifteen reaches this refusal (platform, 2026-08), and serving the NLB is #284's decision, scoped as batch EXO-5 (#14)",
       "version": "2.0.0",
       "group": "compute",
-      "status": "unknown"
+      "status": "declined"
     },
     {
       "operation": "exoscale/v2.reset-private-network-field",
@@ -2892,16 +2915,18 @@
     {
       "operation": "exoscale/v2.update-load-balancer",
       "product": "exoscale",
+      "reason": "a network load balancer's services publish a per-backend healthcheck verdict, success or failure with no third value, and nothing here probes a backend yet, so every verdict would be invented; one surveyed stack in fifteen reaches this refusal (platform, 2026-08), and serving the NLB is #284's decision, scoped as batch EXO-5 (#14)",
       "version": "2.0.0",
       "group": "compute",
-      "status": "unknown"
+      "status": "declined"
     },
     {
       "operation": "exoscale/v2.update-load-balancer-service",
       "product": "exoscale",
+      "reason": "a network load balancer's services publish a per-backend healthcheck verdict, success or failure with no third value, and nothing here probes a backend yet, so every verdict would be invented; one surveyed stack in fifteen reaches this refusal (platform, 2026-08), and serving the NLB is #284's decision, scoped as batch EXO-5 (#14)",
       "version": "2.0.0",
       "group": "compute",
-      "status": "unknown"
+      "status": "declined"
     },
     {
       "operation": "exoscale/v2.update-private-network",
@@ -2952,9 +2977,10 @@
     {
       "operation": "exoscale/v2.update-subnet",
       "product": "exoscale",
+      "reason": "upstream marks all sixteen VPC operations beta, and none of the fifteen surveyed stacks asks for the product (2026-08); emulating a surface still allowed to rename its fields means chasing upstream instead of clients, and serving the VPC once it settles belongs to batch EXO-6 (#15)",
       "version": "2.0.0",
       "group": "compute",
-      "status": "unknown"
+      "status": "declined"
     },
     {
       "operation": "exoscale/v2.update-template",
@@ -2974,9 +3000,10 @@
     {
       "operation": "exoscale/v2.update-vpc",
       "product": "exoscale",
+      "reason": "upstream marks all sixteen VPC operations beta, and none of the fifteen surveyed stacks asks for the product (2026-08); emulating a surface still allowed to rename its fields means chasing upstream instead of clients, and serving the VPC once it settles belongs to batch EXO-6 (#15)",
       "version": "2.0.0",
       "group": "compute",
-      "status": "unknown"
+      "status": "declined"
     },
     {
       "operation": "exoscale/v2.upgrade-sks-cluster",

--- a/coverage/scaleway-coverage.json
+++ b/coverage/scaleway-coverage.json
@@ -1413,49 +1413,49 @@
     {
       "operation": "instance/v2alpha1/API.AddSecurityGroupRules",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.AttachServerFileSystem",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.AttachServerIP",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.AttachServerPrivateNetworkInterface",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.AttachServerVolume",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.CheckTemplate",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.CreatePlacementGroup",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
@@ -1468,35 +1468,35 @@
     {
       "operation": "instance/v2alpha1/API.CreateSecurityGroup",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.CreateServer",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.CreateServerFromTemplate",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.CreateTemplate",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.DeletePlacementGroup",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
@@ -1509,77 +1509,77 @@
     {
       "operation": "instance/v2alpha1/API.DeleteSecurityGroup",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.DeleteSecurityGroupRules",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.DeleteServer",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.DeleteTemplate",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.DeleteTemplateUserData",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.DeleteUserData",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.DetachServerFileSystem",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.DetachServerIP",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.DetachServerPrivateNetworkInterface",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.DetachServerVolume",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.GetPlacementGroup",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
@@ -1592,63 +1592,63 @@
     {
       "operation": "instance/v2alpha1/API.GetResourceCounts",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.GetSecurityGroup",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.GetServer",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.GetServerCloudInit",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.GetTemplate",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.GetTemplateCloudInit",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.GetTemplateUserData",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.GetUserData",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.ListPlacementGroups",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
@@ -1661,126 +1661,126 @@
     {
       "operation": "instance/v2alpha1/API.ListSecurityGroups",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.ListServerTypes",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.ListServers",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.ListTemplateUserDataKeys",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.ListTemplates",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.ListUserDataKeys",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.PauseServer",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.RebootServer",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.SetSecurityGroupRules",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.SetServerCloudInit",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.SetServerDefaultIP",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.SetTemplateCloudInit",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.SetTemplateUserData",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.SetUserData",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.StartServer",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.StopAndDeleteServer",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.StopServer",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.UpdatePlacementGroup",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
@@ -1793,119 +1793,119 @@
     {
       "operation": "instance/v2alpha1/API.UpdateSecurityGroup",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.UpdateSecurityGroupRule",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.UpdateServer",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.UpdateTemplate",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/VolumeAPI.CreateSnapshot",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/VolumeAPI.CreateVolume",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/VolumeAPI.DeleteSnapshot",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/VolumeAPI.DeleteVolume",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/VolumeAPI.ExportSnapshotToObjectStorage",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/VolumeAPI.GetSnapshot",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/VolumeAPI.GetVolume",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/VolumeAPI.ImportSnapshotFromObjectStorage",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/VolumeAPI.ListSnapshots",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/VolumeAPI.ListVolumeTypes",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/VolumeAPI.ListVolumes",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/VolumeAPI.UpdateSnapshot",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/VolumeAPI.UpdateVolume",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -659,7 +659,7 @@ reason that outlived its cause.
 - `general` — 1 operation — every operation this pack answers is already terminal, so no client has anything to poll for; it stays served for the client that polls anyway
 - `quotas` — 1 operation — `exo limits` reads the whole quota list and prints it, so the per-name read has no client path even though the SDK declares one
 
-### Declined on purpose (254)
+### Declined on purpose (281)
 
 Operations this pack knowingly does not serve, and why. Declining is a
 decision the drift gate records, which is what separates it from having
@@ -669,6 +669,8 @@ how many it covers, and the reason they share. The per-operation verdicts
 are in `coverage/`, one artefact per provider.
 
 - `ai` — 22 operations — inference needs the accelerators and the model weights Exoscale hosts, neither of which exists on this station
+- `compute` — 16 operations — upstream marks all sixteen VPC operations beta, and none of the fifteen surveyed stacks asks for the product (2026-08); emulating a surface still allowed to rename its fields means chasing upstream instead of clients, and serving the VPC once it settles belongs to batch EXO-6 (#15)
+- `compute` — 11 operations — a network load balancer's services publish a per-backend healthcheck verdict, success or failure with no third value, and nothing here probes a backend yet, so every verdict would be invented; one surveyed stack in fifteen reaches this refusal (platform, 2026-08), and serving the NLB is #284's decision, scoped as batch EXO-5 (#14)
 - `compute` — 6 operations — authoritative DNS is a public service with real resolvers behind it, and nothing here answers a query from the internet
 - `compute` — 3 operations — there is no console to proxy and no password to reveal: machines here are opened by the registered SSH key, and a URL or a password the emulator invented would claim an access nothing answers
 - `compute` — 1 operation — it answers a pre-signed URL into Object Storage, which this project does not emulate, and a URL resolving to nothing is worse than a refusal because a client follows it

--- a/internal/providers/exoscale/pack.go
+++ b/internal/providers/exoscale/pack.go
@@ -306,11 +306,16 @@ func (p *Pack) Declined() []emulator.Decline {
 	// of this file is that additions are seen. The scan reports a new operation
 	// as untriaged even inside a family already refused, and somebody decides.
 	//
-	// What is NOT here is the IaaS surface — instances, block storage, private
-	// networks, elastic IPs, security groups, load balancers, snapshots,
-	// templates, anti-affinity groups, VPCs. Those are the work list this pack is
-	// built to serve, and declining them to flatten the report would be the
-	// widened denominator docs/roadmap.md forbids.
+	// What is NOT here is the served IaaS surface — instances, block storage,
+	// private networks, elastic IPs, security groups, snapshots, templates,
+	// anti-affinity groups. Declining any of those to flatten the report would
+	// be the widened denominator docs/roadmap.md forbids.
+	//
+	// Two IaaS families ARE here, and they are not that: the network load
+	// balancer and the VPC each carry the demand measured by the fifteen-stack
+	// survey (examples/stacks/surveyed.md) and name the roadmap batch that owns
+	// the decision to serve them. Their refusal replaces silence until that
+	// decision is made; it does not make it.
 	return slices.Concat(
 		// Managed databases: PostgreSQL, MySQL, Kafka, OpenSearch, Valkey,
 		// ClickHouse, Grafana, their users, their settings, their integrations
@@ -633,6 +638,65 @@ func (p *Pack) Declined() []emulator.Decline {
 			"exoscale/v2.get-impact-report",
 			"exoscale/v2.get-live-balance",
 			"exoscale/v2.get-usage-report"),
+
+		// The network load balancer, whole: the balancer, its services, and
+		// the two per-field resets.
+		//
+		// Not out of scope — batch EXO-5 (#14) is scoped to serve it, and #284
+		// holds the decision. This entry does not make that decision; it only
+		// ends the silence around it, which is the one state this file exists
+		// to forbid. What blocks a cheap serve today is the schema itself:
+		// `load-balancer-service.healthcheck-status` is a read-only,
+		// per-backend verdict whose enum is `success` or `failure` with no
+		// third value, so an emulator that probes no backend has to invent one
+		// of the two for every server of every pool a service targets. The
+		// survey puts a number on the demand: one stack of the fifteen reaches
+		// this refusal (PhilippeChepy/platform, `exoscale_nlb` plus five
+		// `exoscale_nlb_service`, replayed 2026-08-18), and its apply survives
+		// it — 19 resources, the NLB branch alone refused by name.
+		emulator.Because("a network load balancer's services publish a per-backend healthcheck verdict, success or failure with no third value, and nothing here probes a backend yet, so every verdict would be invented; one surveyed stack in fifteen reaches this refusal (platform, 2026-08), and serving the NLB is #284's decision, scoped as batch EXO-5 (#14)",
+			"exoscale/v2.add-service-to-load-balancer",
+			"exoscale/v2.create-load-balancer",
+			"exoscale/v2.delete-load-balancer",
+			"exoscale/v2.delete-load-balancer-service",
+			"exoscale/v2.get-load-balancer",
+			"exoscale/v2.get-load-balancer-service",
+			"exoscale/v2.list-load-balancers",
+			"exoscale/v2.reset-load-balancer-field",
+			"exoscale/v2.reset-load-balancer-service-field",
+			"exoscale/v2.update-load-balancer",
+			"exoscale/v2.update-load-balancer-service"),
+
+		// The VPC family: VPCs, their subnets, instance attachment and
+		// detachment, and routes at both the VPC and the subnet level. A
+		// different product from the private networks this pack serves —
+		// upstream publishes /private-network and /vpc side by side.
+		//
+		// Every summary of the family reads "[BETA]" in the upstream API
+		// description (source.yaml, synced 2026-08-18), and no stack of the
+		// fifteen surveyed asks for the product at all
+		// (examples/stacks/surveyed.md). Batch EXO-6 (#15) owns serving it —
+		// scoped when the family counted 9 operations; it counts 16 now, which
+		// is exactly the drift this gate exists to surface, and is recorded on
+		// the issue. The beta marker is in the reason on purpose: upstream
+		// removing it is the event that re-opens the question here.
+		emulator.Because("upstream marks all sixteen VPC operations beta, and none of the fifteen surveyed stacks asks for the product (2026-08); emulating a surface still allowed to rename its fields means chasing upstream instead of clients, and serving the VPC once it settles belongs to batch EXO-6 (#15)",
+			"exoscale/v2.attach-instance-to-subnet",
+			"exoscale/v2.create-route",
+			"exoscale/v2.create-subnet",
+			"exoscale/v2.create-vpc",
+			"exoscale/v2.delete-route",
+			"exoscale/v2.delete-subnet",
+			"exoscale/v2.delete-vpc",
+			"exoscale/v2.detach-instance-from-subnet",
+			"exoscale/v2.get-subnet",
+			"exoscale/v2.get-vpc",
+			"exoscale/v2.list-routes",
+			"exoscale/v2.list-subnets",
+			"exoscale/v2.list-vpc-routes",
+			"exoscale/v2.list-vpcs",
+			"exoscale/v2.update-subnet",
+			"exoscale/v2.update-vpc"),
 	)
 }
 


### PR DESCRIPTION
# Summary

The repository's last 27 untriaged operations — all Exoscale, 11 NLB and 16 VPC, the only `unknown` entries left across the three providers — each get a decision and a reason. Per the drift-triage doctrine, here is the state each one landed in and why:

**Declined, reason 1 — the 11 network-load-balancer operations** (`create/get/list/update/delete-load-balancer`, `add-service-to-load-balancer`, `get/update/delete-load-balancer-service`, the two `reset-*-field`): a served NLB must publish `load-balancer-service.healthcheck-status`, a read-only per-backend verdict whose enum is `success` or `failure` with **no third value** (upstream `source.yaml`, synced 2026-08-18) — so an emulator that probes no backend has to invent one of the two for every server of every pool a service targets. Demand is measured, not guessed: one stack of the fifteen surveyed reaches this refusal (`PhilippeChepy/platform`, `exoscale_nlb` + 5 `exoscale_nlb_service`, replayed 2026-08-18) and its apply survives it. **This entry does not decide whether to serve the NLB — that stays with #284, scoped as batch EXO-5 (#14).** It only ends the silence until that decision is made, and the reason stays true after it: serving will mean answering the verdict honestly, which is exactly the work #14 scopes.

**Declined, reason 2 — the 16 VPC operations** (VPCs, subnets, instance attach/detach, routes at both the VPC and subnet level): upstream summarises every one of them `[BETA]`, and none of the fifteen surveyed stacks asks for the product (`examples/stacks/surveyed.md`). Serving it once the surface settles belongs to batch EXO-6 (#15). The beta marker is in the reason on purpose: upstream removing it is the event that re-opens the question. Note recorded on #15: the batch was scoped on 9 operations, the family now counts 16 ([comment](https://github.com/stephrobert/feint/issues/15#issuecomment-5331891350)).

**Implemented: none.** Verified none of the 27 is already served under another name (no `/v2/load-balancer` or `/v2/vpc` route exists; Exoscale private networks are a distinct upstream product served separately), and none is a read cheap enough that refusing it is absurd — a partial serve would fragment the two batches without a client asking for it.

The head comment of `Declined()` is updated: it listed load balancers and VPCs among the families that must never be declined ("the widened denominator"). These two entries are not that — each carries measured demand and names the batch that owns the serve decision.

**Collateral, named:** `coverage/scaleway-coverage.json` moves too. `drift:update` caught it stale since 992bf42 (#260) rewrote the `instance/v2alpha1` decline reason in the pack without the artefact following — no gate compares reason strings, filed as #298.

Result: `mise run drift:check` exits 0 with **0 unknown for all three providers** — Exoscale reads 93 implemented / 281 declined / 0 unknown of 374.

## Type of change

- [ ] A route added or changed
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes (gofmt, vet, golangci-lint, `go test -race`)
- [x] No new external Go dependency, or the pull request justifies it. The
      standard library covers routing, JSON and Go parsing; `go.mod` has three
      lines and a pre-commit hook keeps it that way
- [x] `internal/core` still knows no provider. If a change seemed to require it,
      the pack changed instead — only the Exoscale pack and generated artefacts move
- [x] Nothing in the diff could be written identically for another provider. If
      it could, it belongs in the core — the declined operations, their schema facts
      and their survey figures are Exoscale's own

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] I ran `mise run conformance` myself — not "it should pass" (`FEINT_ADDR=127.0.0.1:4699`, `FEINT_VM` unset so `off`; no route changed, run for the disclosure bar)
- [x] Every field name in the diff comes from the provider's SDK, their OpenAPI
      document, or a run of the real client, and I can say which: the operation names and the `healthcheck-status` enum come from Exoscale's published `source.yaml` (synced 2026-08-18); the demand figures from `examples/stacks/surveyed.md`

### When a route is added or changed — otherwise N/A

N/A — no route added or changed; the declined paths stay unrouted and keep answering the pack's own 404 envelope. `mise run drift:update` was run and `coverage/` is committed with the change.

### When behaviour a client can observe changes — otherwise N/A

N/A — a client calling these paths saw the pack's 404 before and sees it still; only the recorded verdict (untriaged → declined, with the printed reason) changes. README tables regenerated by `drift:update`.

### When `.github/workflows/` is touched — otherwise N/A

N/A

### When a machine runtime is involved — otherwise N/A

N/A — `FEINT_VM` stayed unset (off) throughout, per the shared-Incus constraint on this station.

## Related issues

Progresses #284 (NLB now declined with the survey's figures, as the issue asks; the serve decision remains open there). Does **not** close #14 or #15 — both batches stay open, and the declines point at them. Surfaced #298.
