### PR TITLE
fix(drift): a decline reason edited in a pack reaches the artefact, or the gate exits 2 (#298)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -19,6 +19,19 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Ajouté
 
+- **Une raison de refus modifiée dans un pack atteint désormais l'artefact
+  versionné, ou le gate le dit** (#298). `feint coverage --artefact` compare
+  `coverage/<provider>-coverage.json` avec ce que le pack déclare aujourd'hui,
+  statuts et raisons de refus, et sort en 2 au moindre écart ; `mise run
+  drift:check` le passe pour les trois providers, et
+  `TestTheCommittedArtefactCarriesWhatThePacksDeclare` échoue sur le même
+  écart dans `mise run check`. Cas mesuré : la raison réécrite par #260 est
+  restée périmée dans l'artefact pendant quatre jours, 67 occurrences, pendant
+  que `drift:check` comparait noms et statuts et que `docs:check` régénérait
+  le README depuis le même fichier périmé : deux gates d'accord entre eux et
+  en désaccord avec le code. Surface CLI v3 : un drapeau ajouté, rien de
+  déplacé ni retiré.
+
 - **Le stockage bloc Exoscale** (#12). Treize opérations — volumes, snapshots,
   le redimensionnement et la chaîne d'attachement — pilotées par le CLI `exo`
   dans la suite de conformance. Chaque nombre qu'un volume publie dit que le

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Added
 
+- **A decline reason edited in a pack now reaches the committed artefact, or
+  the gate says so** (#298). `feint coverage --artefact` compares
+  `coverage/<provider>-coverage.json` with what the pack declares today —
+  statuses and decline reasons — and exits 2 on any skew; `mise run
+  drift:check` passes it for all three providers, and
+  `TestTheCommittedArtefactCarriesWhatThePacksDeclare` fails on the same skew
+  in `mise run check`. Measured case: the reason #260 rewrote sat stale in the
+  artefact for four days, 67 occurrences, while `drift:check` compared names
+  and statuses and `docs:check` regenerated the README from the same stale
+  file — two gates agreeing with each other while both disagreed with the
+  code. CLI surface v3: one flag added, nothing moved or removed.
+
 - **Exoscale block storage** (#12). Thirteen operations — volumes, snapshots,
   the resize and the attach chain — driven by the `exo` CLI in the conformance
   suite. Every number a volume publishes says the storage holds no bytes, and

--- a/coverage/scaleway-coverage.json
+++ b/coverage/scaleway-coverage.json
@@ -1413,49 +1413,49 @@
     {
       "operation": "instance/v2alpha1/API.AddSecurityGroupRules",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.AttachServerFileSystem",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.AttachServerIP",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.AttachServerPrivateNetworkInterface",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.AttachServerVolume",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.CheckTemplate",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.CreatePlacementGroup",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
@@ -1468,35 +1468,35 @@
     {
       "operation": "instance/v2alpha1/API.CreateSecurityGroup",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.CreateServer",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.CreateServerFromTemplate",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.CreateTemplate",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.DeletePlacementGroup",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
@@ -1509,77 +1509,77 @@
     {
       "operation": "instance/v2alpha1/API.DeleteSecurityGroup",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.DeleteSecurityGroupRules",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.DeleteServer",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.DeleteTemplate",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.DeleteTemplateUserData",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.DeleteUserData",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.DetachServerFileSystem",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.DetachServerIP",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.DetachServerPrivateNetworkInterface",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.DetachServerVolume",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.GetPlacementGroup",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
@@ -1592,63 +1592,63 @@
     {
       "operation": "instance/v2alpha1/API.GetResourceCounts",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.GetSecurityGroup",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.GetServer",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.GetServerCloudInit",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.GetTemplate",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.GetTemplateCloudInit",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.GetTemplateUserData",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.GetUserData",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.ListPlacementGroups",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
@@ -1661,126 +1661,126 @@
     {
       "operation": "instance/v2alpha1/API.ListSecurityGroups",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.ListServerTypes",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.ListServers",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.ListTemplateUserDataKeys",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.ListTemplates",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.ListUserDataKeys",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.PauseServer",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.RebootServer",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.SetSecurityGroupRules",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.SetServerCloudInit",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.SetServerDefaultIP",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.SetTemplateCloudInit",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.SetTemplateUserData",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.SetUserData",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.StartServer",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.StopAndDeleteServer",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.StopServer",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.UpdatePlacementGroup",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
@@ -1793,119 +1793,119 @@
     {
       "operation": "instance/v2alpha1/API.UpdateSecurityGroup",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.UpdateSecurityGroupRule",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.UpdateServer",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/API.UpdateTemplate",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/VolumeAPI.CreateSnapshot",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/VolumeAPI.CreateVolume",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/VolumeAPI.DeleteSnapshot",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/VolumeAPI.DeleteVolume",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/VolumeAPI.ExportSnapshotToObjectStorage",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/VolumeAPI.GetSnapshot",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/VolumeAPI.GetVolume",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/VolumeAPI.ImportSnapshotFromObjectStorage",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/VolumeAPI.ListSnapshots",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/VolumeAPI.ListVolumeTypes",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/VolumeAPI.ListVolumes",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/VolumeAPI.UpdateSnapshot",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },
     {
       "operation": "instance/v2alpha1/VolumeAPI.UpdateVolume",
       "product": "instance",
-      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1",
+      "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not",
       "version": "v2alpha1",
       "status": "declined"
     },

--- a/internal/cli/artefact_test.go
+++ b/internal/cli/artefact_test.go
@@ -1,0 +1,127 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/drift"
+	"github.com/stephrobert/feint/internal/providers/exoscale"
+)
+
+// The committed coverage artefact repeats what the packs declare, and #298
+// measured the cost of comparing the copy with nothing: the decline reason #260
+// rewrote in internal/providers/scaleway/pack.go took four days to reach
+// coverage/scaleway-coverage.json, so the versioned verdict for 24 operations
+// stayed a sentence the code had already corrected — while drift:check passed,
+// because the baseline compares operation names, and docs:check passed, because
+// the README regenerates from the same stale artefact. Two gates agreeing with
+// each other, both disagreeing with the code.
+//
+// This test is the comparison that was missing, on the source of record: every
+// mounted pack, judged against its own committed artefact — reasons, statuses,
+// and declines the artefact never recorded. It runs in `mise run check`, so a
+// reason edited without `mise run drift:update` fails the prepush hook rather
+// than surfacing as collateral in somebody else's regeneration.
+//
+// It iterates the packs rather than naming them: the defect is structural — any
+// pack that edits a reason — and a control that names Scaleway is a control the
+// fourth pack ships without. Which is also why a pack with no committed
+// artefact fails rather than being skipped: skipping is how the fourth pack
+// would never join the comparison.
+//
+// tools/falsify/specs/artefact-reasons.json proves it bites, by re-editing the
+// very sentence #260 rewrote.
+func TestTheCommittedArtefactCarriesWhatThePacksDeclare(t *testing.T) {
+	env := emulator.DefaultEnv()
+	packs, err := packsFor(env)
+	if err != nil {
+		t.Fatalf("build the packs: %v", err)
+	}
+	if len(packs) == 0 {
+		t.Fatal("no pack mounted, so this test would pass while measuring nothing")
+	}
+
+	for _, p := range packs {
+		path := filepath.Join("..", "..", "coverage", p.Name()+"-coverage.json")
+		f, err := os.Open(path)
+		if err != nil {
+			t.Errorf("pack %q has no committed coverage artefact at %s; write it with `mise run drift:update` and put it under tools/drift/gate.sh", p.Name(), path)
+			continue
+		}
+		committed, err := drift.LoadCoverage(f)
+		_ = f.Close()
+		if err != nil {
+			t.Errorf("read %s: %v", path, err)
+			continue
+		}
+		if len(committed.Entries) == 0 {
+			t.Errorf("%s carries no entries, so comparing it proves nothing", path)
+			continue
+		}
+
+		var served []string
+		for _, r := range p.Routes() {
+			served = append(served, r.Operation)
+		}
+		declined := map[string]string{}
+		for _, d := range p.Declined() {
+			declined[d.Operation] = d.Reason
+		}
+		for _, line := range drift.ArtefactSkew(committed, served, declined) {
+			t.Errorf("%s: %s (the artefact follows the code; regenerate it: mise run drift:update)", p.Name(), line)
+		}
+	}
+}
+
+// reasonEdited is a real pack with one decline reason rewritten — the exact
+// move #260 made, replayed against the committed artefact.
+type reasonEdited struct{ emulator.Pack }
+
+func (p reasonEdited) Declined() []emulator.Decline {
+	declines := p.Pack.Declined()
+	out := make([]emulator.Decline, len(declines))
+	copy(out, declines)
+	out[0].Reason = "an edited sentence the committed artefact does not carry yet, which is the #298 defect replayed on purpose"
+	return out
+}
+
+// coverage() must exit 2 when the committed artefact lags the pack, and this
+// proves the call site rather than the comparison: ArtefactSkew has its own
+// tests, and this repository has already watched an audit delete a guard's call
+// site in coverage() while the guard's own test stayed green. packsFor is the
+// seam, exactly as in TestCoverageRefusesAPackWithUnusableRefusals; the Exoscale
+// pack is the subject because its upstream surface is a committed contract, so
+// the test needs no SDK checkout and cannot skip.
+func TestCoverageExitsTwoWhenTheArtefactLagsThePack(t *testing.T) {
+	original := packsFor
+	t.Cleanup(func() { packsFor = original })
+
+	contractPath := filepath.Join("..", "..", "contracts", "exoscale.json")
+	artefactPath := filepath.Join("..", "..", "coverage", "exoscale-coverage.json")
+	args := []string{"--provider", "exoscale", "--contract", contractPath, "--artefact", artefactPath}
+
+	packsFor = func(env *emulator.Env) ([]emulator.Pack, error) {
+		return []emulator.Pack{reasonEdited{Pack: exoscale.New(env)}}, nil
+	}
+	var out, errOut strings.Builder
+	if rc := coverage(args, &out, &errOut); rc != exitDrift {
+		t.Fatalf("coverage exited %d on an artefact lagging its pack, want %d\nstderr: %s", rc, exitDrift, errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "disagrees with what the pack declares") {
+		t.Fatalf("the skew was not named: %q", errOut.String())
+	}
+
+	// And the accepting half: the untouched pack against the same artefact is
+	// agreement, or the flag would only ever be a way to fail.
+	packsFor = func(env *emulator.Env) ([]emulator.Pack, error) {
+		return []emulator.Pack{exoscale.New(env)}, nil
+	}
+	out.Reset()
+	errOut.Reset()
+	if rc := coverage(args, &out, &errOut); rc != exitOK {
+		t.Fatalf("coverage exited %d on a fresh artefact, want %d\nstderr: %s", rc, exitOK, errOut.String())
+	}
+}

--- a/internal/cli/baseline.go
+++ b/internal/cli/baseline.go
@@ -64,6 +64,28 @@ func applyBaseline(path string, write bool, rep drift.Report, products string, s
 	return exitOK, nil
 }
 
+// artefactSkew loads the committed coverage artefact and reports every verdict
+// in it that the pack no longer states. The comparison itself lives in
+// internal/drift (ArtefactSkew), where the test that reads the real repository
+// artefacts shares it — one comparison, two callers, so the gate and the test
+// cannot drift apart the way the two halves of the old drift gate did.
+func artefactSkew(path string, served []string, declined map[string]string) ([]string, error) {
+	f, err := os.Open(path) //nolint:gosec // a committed, non-secret artefact
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("coverage artefact %s does not exist; write it with drift:update", path)
+		}
+		return nil, fmt.Errorf("open coverage artefact: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	committed, err := drift.LoadCoverage(f)
+	if err != nil {
+		return nil, fmt.Errorf("read coverage artefact %s: %w", path, err)
+	}
+	return drift.ArtefactSkew(committed, served, declined), nil
+}
+
 func splitProducts(products string) []string {
 	if products == "" {
 		return nil

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -92,7 +92,7 @@ const (
 // TestTheFrozenSurfacesStillMatchTheirFixture, and a fixture regenerated
 // without bumping this constant fails TestASurfaceChangeDemandsItsVersionBump.
 // The procedure for a deliberate change is in RELEASING.md ("Frozen surfaces").
-const cliSurfaceVersion = 2
+const cliSurfaceVersion = 3
 
 // Run executes one command and returns the process exit code.
 func Run(args []string, stdout, stderr io.Writer) int {
@@ -242,7 +242,12 @@ Usage:
   feint coverage   (--sdk <dir> | --contract <file>) [--provider scaleway|outscale|exoscale]
                     [--products <a,b,c>] [--format text|json|triage|list]
                     [--baseline <file> [--write-baseline]] [--fail-on-unknown]
+                    [--artefact <file>]
                     Compare the upstream API surface with what the packs serve.
+                    --artefact compares the committed coverage artefact against
+                    what the pack declares today — statuses and decline reasons —
+                    and exits 2 on any skew, so an edited reason cannot outlive
+                    itself in the versioned copy.
                     Scaleway and Outscale are read from an SDK checkout; Exoscale
                     publishes an OpenAPI document, so it is read with --contract.
                     Given both, the SDK lists the operations and the contract adds
@@ -729,6 +734,7 @@ func coverage(args []string, stdout, stderr io.Writer) int {
 	failOnUnknown := fs.Bool("fail-on-unknown", false, "exit 2 when an upstream operation is neither served nor declined")
 	baseline := fs.String("baseline", "", "compare the unknown operations against this baseline file and exit 2 on new ones")
 	writeBaseline := fs.Bool("write-baseline", false, "rewrite the baseline file from the current upstream surface")
+	artefact := fs.String("artefact", "", "compare this committed coverage artefact against what the pack declares and exit 2 on any skew")
 	if err := fs.Parse(args); err != nil {
 		return exitError
 	}
@@ -859,6 +865,30 @@ func coverage(args []string, stdout, stderr io.Writer) int {
 		}
 		if code != exitOK {
 			return code
+		}
+	}
+
+	// The committed artefact against the pack's current declarations. The
+	// baseline above watches the upstream side; this watches the copy: #298
+	// measured a decline reason rewritten in a pack that took four days to reach
+	// coverage/scaleway-coverage.json, because the baseline compares operation
+	// names and docs --check regenerates the README from the same stale artefact
+	// — two gates agreeing with each other while both disagreed with the code.
+	// TestTheCommittedArtefactCarriesWhatThePacksDeclare fails on the same skew;
+	// this flag is what makes tools/drift/gate.sh check exit 2 on it.
+	if *artefact != "" {
+		skew, err := artefactSkew(*artefact, served, declined)
+		if err != nil {
+			fmt.Fprintf(stderr, "feint: %v\n", err)
+			return exitError
+		}
+		if len(skew) > 0 {
+			fmt.Fprintf(stderr, "feint: %s disagrees with what the pack declares, %d operation(s):\n", *artefact, len(skew))
+			for _, line := range skew {
+				fmt.Fprintf(stderr, "  %s\n", line)
+			}
+			fmt.Fprintln(stderr, "feint: the artefact follows the code; regenerate it: mise run drift:update")
+			return exitDrift
 		}
 	}
 

--- a/internal/cli/testdata/frozen/cli.json
+++ b/internal/cli/testdata/frozen/cli.json
@@ -252,6 +252,136 @@
           ]
         }
       }
+    },
+    {
+      "schema_version": 3,
+      "content": {
+        "exit_codes": {
+          "drift": 2,
+          "error": 1,
+          "ok": 0
+        },
+        "verbs": {
+          "catalog": [
+            "--format"
+          ],
+          "clean": [
+            "--vm"
+          ],
+          "coverage": [
+            "--artefact",
+            "--baseline",
+            "--contract",
+            "--fail-on-unknown",
+            "--format",
+            "--products",
+            "--provider",
+            "--sdk",
+            "--write-baseline"
+          ],
+          "docs": [
+            "--check",
+            "--coverage",
+            "--file"
+          ],
+          "doctor": [
+            "--addr",
+            "--vm"
+          ],
+          "env": [
+            "--endpoint",
+            "--shell",
+            "--unset"
+          ],
+          "evidence": [
+            "--endpoint",
+            "--join",
+            "--out",
+            "--shapes"
+          ],
+          "images": [
+            "--check",
+            "--only",
+            "--vm"
+          ],
+          "logs": [
+            "--addr",
+            "-f",
+            "-n"
+          ],
+          "probe": [
+            "--contracts",
+            "--endpoint",
+            "--provider"
+          ],
+          "proxy": [
+            "--addr",
+            "--max-body",
+            "--provider",
+            "--queue",
+            "--record",
+            "--upstream"
+          ],
+          "restart": [
+            "--addr",
+            "--timeout"
+          ],
+          "serve": [
+            "--addr",
+            "--cleanup",
+            "--contracts",
+            "--coverage",
+            "--log-level",
+            "--state",
+            "--vm"
+          ],
+          "shapes": [
+            "--check",
+            "--dir",
+            "--dry-run",
+            "--profile",
+            "--provider",
+            "--record"
+          ],
+          "snapshot": [
+            "--addr",
+            "--force",
+            "--format",
+            "--state"
+          ],
+          "start": [
+            "--detach",
+            "--foreground",
+            "--timeout"
+          ],
+          "status": [
+            "--addr",
+            "--coverage",
+            "--format"
+          ],
+          "stop": [
+            "--addr",
+            "--timeout"
+          ],
+          "transcript": [
+            "--against",
+            "--format",
+            "--shape"
+          ],
+          "ui": [
+            "--addr",
+            "--print"
+          ],
+          "version": [
+            "--version",
+            "-v"
+          ],
+          "wait": [
+            "--addr",
+            "--timeout"
+          ]
+        }
+      }
     }
   ]
 }

--- a/internal/drift/artefact_skew.go
+++ b/internal/drift/artefact_skew.go
@@ -1,0 +1,89 @@
+package drift
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+)
+
+// The committed artefact repeats what the packs declare, and #298 measured what
+// happens when nothing compares the copy with its source: a decline reason
+// rewritten by #260 took four days to reach coverage/scaleway-coverage.json,
+// during which the versioned verdict for 24 operations was a sentence the code
+// had already corrected. Both gates passed over it — the baseline compares
+// operation names, and docs --check regenerates the README from the same stale
+// artefact, so the two agreed with each other while both disagreed with the
+// code.
+//
+// ArtefactSkew is the missing comparison. It takes the committed artefact and
+// the pack's declarations — the operations its routes serve, the operations it
+// declines and why — and reports every entry whose verdict the pack no longer
+// states: a reason that changed, a status that flipped, a decline the artefact
+// never recorded. The caller treats any line as drift (exit 2), because the
+// artefact follows the code and never the other way round.
+//
+// Both sides are scoped to the products the artefact itself carries, so a pack
+// declaration outside the scan's --products list is not reported as missing: the
+// artefact is the record of a scoped scan, and this function judges the copy
+// against its source on the surface the copy claims to cover. What it leaves
+// alone is the upstream side — entries appearing or disappearing because the SDK
+// moved is the baseline's verdict, not this one's.
+//
+// TestTheCommittedArtefactCarriesWhatThePacksDeclare (internal/cli) fails
+// without this comparison, and tools/falsify/specs/artefact-reasons.json proves
+// it bites: re-editing the pack sentence #260 rewrote turns the test red.
+func ArtefactSkew(committed CoverageFile, served []string, declined map[string]string) []string {
+	products := make([]string, 0, len(committed.Products))
+	for _, p := range committed.Products {
+		products = append(products, p.Product)
+	}
+
+	servedSet := toSet(OnlyProductNames(served, products))
+	scoped := make(map[string]string, len(declined))
+	for op, reason := range declined {
+		if product, _, found := strings.Cut(op, "/"); len(products) == 0 || (found && slices.Contains(products, product)) {
+			scoped[op] = reason
+		}
+	}
+
+	var skew []string
+	listed := make(map[string]bool, len(committed.Entries))
+	for _, e := range committed.Entries {
+		listed[e.Operation] = true
+		reason, isDeclined := scoped[e.Operation]
+		// Same precedence as Compare: a served operation is implemented even if
+		// a stale decline also names it. Diverging here would report a skew
+		// that regenerating the artefact cannot remove.
+		switch {
+		case servedSet[e.Operation]:
+			if e.Status != StatusImplemented {
+				skew = append(skew, fmt.Sprintf("%s: the artefact says %q, the pack serves it", e.Operation, e.Status))
+			}
+		case isDeclined:
+			if e.Status != StatusDeclined {
+				skew = append(skew, fmt.Sprintf("%s: the artefact says %q, the pack declines it", e.Operation, e.Status))
+			} else if e.Reason != reason {
+				skew = append(skew, fmt.Sprintf("%s: the artefact carries a reason the pack no longer states (artefact: %q; pack: %q)", e.Operation, e.Reason, reason))
+			}
+		default:
+			if e.Status != StatusUnknown {
+				skew = append(skew, fmt.Sprintf("%s: the artefact says %q, the pack neither serves nor declines it", e.Operation, e.Status))
+			}
+		}
+	}
+
+	// A decline the artefact never recorded is the same defect before its first
+	// regeneration: the pack made a decision and the committed record still
+	// calls the operation untriaged — or worse, does not mention it. Served
+	// operations get no such check, because a route absent from the entries is
+	// either an orphan (Compare's verdict) or outside the scanned surface.
+	for op := range scoped {
+		if !listed[op] {
+			skew = append(skew, fmt.Sprintf("%s: the pack declines it and the artefact has no entry", op))
+		}
+	}
+
+	sort.Strings(skew)
+	return skew
+}

--- a/internal/drift/artefact_skew_test.go
+++ b/internal/drift/artefact_skew_test.go
@@ -1,0 +1,107 @@
+package drift
+
+import (
+	"strings"
+	"testing"
+)
+
+// The fixture is the #298 shape in miniature: one product, one served
+// operation, one declined operation, one untriaged one.
+func freshArtefact() CoverageFile {
+	return CoverageFile{
+		Provider: "example",
+		Products: []ProductView{{Product: "compute"}},
+		Entries: []Entry{
+			{Operation: "compute/v1/API.CreateThing", Product: "compute", Status: StatusImplemented},
+			{Operation: "compute/v1/API.DeleteThing", Product: "compute", Status: StatusDeclined, Reason: "the current sentence"},
+			{Operation: "compute/v1/API.PatchThing", Product: "compute", Status: StatusUnknown},
+		},
+	}
+}
+
+func packDeclarations() (served []string, declined map[string]string) {
+	return []string{"compute/v1/API.CreateThing"},
+		map[string]string{"compute/v1/API.DeleteThing": "the current sentence"}
+}
+
+func TestAnArtefactThatMatchesItsPackReportsNoSkew(t *testing.T) {
+	served, declined := packDeclarations()
+	if skew := ArtefactSkew(freshArtefact(), served, declined); len(skew) != 0 {
+		t.Fatalf("agreement reported as skew: %v", skew)
+	}
+}
+
+// The measured defect: the pack rewrote its reason, the artefact keeps printing
+// the old sentence. tools/falsify/specs/artefact-reasons.json neutralises the
+// reason comparison and requires this test to fail.
+func TestAStaleReasonIsSkew(t *testing.T) {
+	served, declined := packDeclarations()
+	declined["compute/v1/API.DeleteThing"] = "the corrected sentence"
+	skew := ArtefactSkew(freshArtefact(), served, declined)
+	if len(skew) != 1 {
+		t.Fatalf("one stale reason, %d line(s): %v", len(skew), skew)
+	}
+	for _, want := range []string{"compute/v1/API.DeleteThing", "the current sentence", "the corrected sentence"} {
+		if !strings.Contains(skew[0], want) {
+			t.Errorf("the line does not carry %q: %s", want, skew[0])
+		}
+	}
+}
+
+func TestAFlippedStatusIsSkew(t *testing.T) {
+	served, declined := packDeclarations()
+	// The pack now serves what the artefact still records as declined.
+	served = append(served, "compute/v1/API.DeleteThing")
+	if skew := ArtefactSkew(freshArtefact(), served, declined); len(skew) != 1 || !strings.Contains(skew[0], "the pack serves it") {
+		t.Fatalf("declined->implemented flip not reported as one line: %v", skew)
+	}
+}
+
+func TestATriagedUnknownIsSkew(t *testing.T) {
+	served, declined := packDeclarations()
+	// Somebody triaged the untriaged operation and regenerated nothing.
+	declined["compute/v1/API.PatchThing"] = "a decision the artefact never recorded"
+	if skew := ArtefactSkew(freshArtefact(), served, declined); len(skew) != 1 || !strings.Contains(skew[0], "the pack declines it") {
+		t.Fatalf("unknown->declined flip not reported as one line: %v", skew)
+	}
+}
+
+func TestAWithdrawnDeclarationIsSkew(t *testing.T) {
+	served, declined := packDeclarations()
+	// The pack neither serves nor declines what the artefact calls declined.
+	delete(declined, "compute/v1/API.DeleteThing")
+	if skew := ArtefactSkew(freshArtefact(), served, declined); len(skew) != 1 || !strings.Contains(skew[0], "neither serves nor declines") {
+		t.Fatalf("withdrawn decline not reported as one line: %v", skew)
+	}
+}
+
+func TestADeclineTheArtefactNeverListedIsSkew(t *testing.T) {
+	served, declined := packDeclarations()
+	declined["compute/v1/API.RotateThing"] = "a decision on an operation the artefact has never seen"
+	if skew := ArtefactSkew(freshArtefact(), served, declined); len(skew) != 1 || !strings.Contains(skew[0], "the artefact has no entry") {
+		t.Fatalf("unrecorded decline not reported as one line: %v", skew)
+	}
+}
+
+// The artefact is the record of a scoped scan (--products), so a pack
+// declaration outside that scope is not the artefact's to carry, and reporting
+// it would make the gate fail on something drift:update cannot repair.
+func TestADeclarationOutsideTheArtefactsProductsIsNotSkew(t *testing.T) {
+	served, declined := packDeclarations()
+	served = append(served, "storage/v1/API.CreateBucket")
+	declined["storage/v1/API.DeleteBucket"] = "a decision on a product the scan does not cover"
+	if skew := ArtefactSkew(freshArtefact(), served, declined); len(skew) != 0 {
+		t.Fatalf("out-of-scope declarations reported as skew: %v", skew)
+	}
+}
+
+// A served operation also named by a stale decline is implemented, exactly as
+// Compare ranks it: judging it declined here would report a skew that
+// regenerating the artefact could never remove.
+func TestPrecedenceFollowsCompare(t *testing.T) {
+	served, declined := packDeclarations()
+	declined["compute/v1/API.CreateThing"] = "a stale decline on a served operation"
+	if skew := ArtefactSkew(freshArtefact(), served, declined); len(skew) != 0 {
+		t.Fatalf("served-and-declined reported as skew where Compare says implemented: %v", skew)
+	}
+}

--- a/tools/drift/gate.sh
+++ b/tools/drift/gate.sh
@@ -37,17 +37,30 @@ case "$MODE" in
     # Every provider runs even when an earlier one drifts, so one report carries
     # everything that moved rather than one provider at a time. The exit code is
     # the worst of them.
+    #
+    # --artefact on every call, because the baseline only watches the upstream
+    # side. #298 measured the other side: a decline reason rewritten in a pack
+    # took four days to reach coverage/scaleway-coverage.json, while this gate
+    # passed (names and statuses, never reasons) and docs:check passed (the
+    # README regenerates from the same stale artefact) — two gates agreeing
+    # with each other while both disagreed with the code. The flag compares the
+    # committed artefact with what the pack declares today and exits 2 on any
+    # skew; TestTheCommittedArtefactCarriesWhatThePacksDeclare fails on the
+    # same skew, and tools/falsify/specs/artefact-reasons.json proves it bites.
     status=0
     "$FEINT" coverage --sdk "$SCALEWAY_SDK" --products "$SCALEWAY_PRODUCTS" \
-      --baseline coverage/scaleway-baseline.json || status=$?
+      --baseline coverage/scaleway-baseline.json \
+      --artefact coverage/scaleway-coverage.json || status=$?
     # --contract on top of --sdk: the SDK lists the operations, the contract
     # carries the tags their document files them under, which oapi-codegen
     # flattens away. Without it every artefact row collapses back into `osc`.
     "$FEINT" coverage --provider outscale --sdk "$OUTSCALE_SDK" \
       --contract contracts/outscale.json \
-      --baseline coverage/outscale-baseline.json || status=$?
+      --baseline coverage/outscale-baseline.json \
+      --artefact coverage/outscale-coverage.json || status=$?
     "$FEINT" coverage --provider exoscale --contract contracts/exoscale.json \
-      --baseline coverage/exoscale-baseline.json || status=$?
+      --baseline coverage/exoscale-baseline.json \
+      --artefact coverage/exoscale-coverage.json || status=$?
     exit $status
     ;;
   update)

--- a/tools/falsify/specs/artefact-reasons.json
+++ b/tools/falsify/specs/artefact-reasons.json
@@ -1,0 +1,28 @@
+{
+  "package": "./internal/cli/",
+  "mutations": [
+    {
+      "label": "a pack edits a decline reason and the committed artefact keeps printing the old sentence (#298, replayed with #260's own edit)",
+      "file": "internal/providers/scaleway/pack.go",
+      "find": "\t\temulator.Because(\"instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces onto it, which is why those five are served and these are not\",",
+      "replace": "\t\temulator.Because(\"instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for it: every instance request the conformance suite makes lands on v1\",",
+      "test": "TestTheCommittedArtefactCarriesWhatThePacksDeclare"
+    },
+    {
+      "label": "the comparison stops reading the reason, and a stale sentence passes as agreement",
+      "file": "internal/drift/artefact_skew.go",
+      "find": "\t\t\t} else if e.Reason != reason {",
+      "replace": "\t\t\t} else if e.Reason != reason && false {",
+      "test": "TestAStaleReasonIsSkew",
+      "package": "./internal/drift/"
+    },
+    {
+      "label": "coverage() stops consuming the skew, so the gate prints nothing and exits 0",
+      "file": "internal/cli/cli.go",
+      "find": "\t\tif len(skew) > 0 {",
+      "replace": "\t\tif len(skew) > 0 && false {",
+      "test": "TestCoverageExitsTwoWhenTheArtefactLagsThePack"
+    }
+  ],
+  "note": "The first mutation is not invented: it puts back the exact pre-#260 sentence that coverage/scaleway-coverage.json carried 67 times for four days while drift:check compared names and statuses and docs:check regenerated the README from the same stale artefact — two gates passing by comparing a stale artefact with itself. The three mutations fail differently on purpose: without the first, an edited reason outlives itself in the versioned copy; without the second, the comparison exists but is blind to the one field #298 is about; without the third, the comparison sees the skew and the gate exits 0 anyway, which is the deleted-call-site failure coverage() has already lived through once."
+}


### PR DESCRIPTION
# Summary

A decline reason edited in a pack never reached `coverage/<provider>-coverage.json`, and no gate compared the copy with its source. Measured on `main@7c40b84`: the artefact carried the pre-#260 sentence **67 times** for four days — while `drift:check` passed (it compares operation names and statuses, never reasons) and `docs:check` passed (the README regenerates from the same stale artefact). Two gates agreeing with each other, both disagreeing with the code.

This change is one comparison, delivered through two doors, plus the repair:

- **`drift.ArtefactSkew`** (`internal/drift/artefact_skew.go`) compares a committed coverage artefact with what the pack declares today: a reason that changed, a status that flipped, a decline the artefact never recorded. Both sides are scoped to the products the artefact itself carries; entries appearing or disappearing because upstream moved stays the baseline's verdict.
- **`feint coverage --artefact <file>`** runs it and exits **2** on any skew — the exit code this repository reserves for drift. `tools/drift/gate.sh check` passes it for all three providers, so the skew now fails `mise run drift:check` in prepush, and the weekly workflow's check leg alike. A one-word edit in a reason exits 2 and names every affected operation (measured on a tampered copy: 18 operations named).
- **`TestTheCommittedArtefactCarriesWhatThePacksDeclare`** (`internal/cli/artefact_test.go`) runs the same comparison over every mounted pack's committed artefact in `mise run check`. It iterates the packs rather than naming them — the defect is structural, and a control that names Scaleway is a control a fourth pack ships without — and a pack with **no** artefact fails rather than being skipped, for the same reason. `TestCoverageExitsTwoWhenTheArtefactLagsThePack` proves the call site, on the seam `packsFor`, with the committed Exoscale contract so it cannot skip for want of an SDK checkout.
- **The artefact is regenerated to follow the code**: 134 lines, the 67 reasons and nothing else — the exact diff #298 documented as collateral in another PR. Baselines, the Outscale and Exoscale artefacts and the README did not move.

**The control bites**, per `tools/falsify/specs/artefact-reasons.json`, three mutations, three different failures:

1. putting back the exact pre-#260 sentence in `pack.go` → the repo-level test goes red;
2. neutralising the reason comparison (`&& false`) → `TestAStaleReasonIsSkew` goes red;
3. disconnecting the consumption in `coverage()` → the exit-code test goes red.

All three reported `the test bit`; `mise run falsify:lint` stays green (138 mutations across 41 specs).

Also in the diff: the `--artefact` flag moved the frozen CLI surface, so the fixture gained its v3 entry and `cliSurfaceVersion` follows, with the CHANGELOG line the bump owes (both languages).

**Other families of the same shape, surveyed:** `Route.Undriven` reasons reach `docs/routes.md`, but `feint docs --check` regenerates that page from the live routes — tampering one reason exits 2 (measured). `DeclinedFields()` reasons are consumed live by `shapes:check` and the omissions gate and are copied into no versioned artefact. `coverage/evidence.json` carries booleans, no pack strings, and has its own freshness gate. Decline reasons in `coverage/` were the one copied-and-never-compared family.

## Type of change

- [ ] A route added or changed
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes (gofmt, vet, golangci-lint, `go test -race`)
- [x] No new external Go dependency, or the pull request justifies it. The
      standard library covers routing, JSON and Go parsing; `go.mod` has three
      lines and a pre-commit hook keeps it that way
- [x] `internal/core` still knows no provider. If a change seemed to require it,
      the pack changed instead — the comparison lives in `internal/drift`, and
      the test that names the three packs lives in `internal/cli`, beside the
      command that mounts them
- [x] Nothing in the diff could be written identically for another provider. If
      it could, it belongs in the core — `ArtefactSkew` is written once and both
      callers iterate whatever packs are mounted

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] I ran `mise run conformance` myself — not "it should pass". The station's
      port 4599 was held by a parallel agent's emulator, so the task's exact
      command sequence ran on 127.0.0.1:4699: scw, both Terraform providers,
      oapi-cli, exo, the stacks and the probe, all green, `--vm off`
- [x] Every field name in the diff comes from the provider's SDK, their OpenAPI
      document, or a run of the real client, and I can say which — no wire field
      was touched; the only new names are in the coverage artefact format
      (`internal/drift.CoverageFile`), which this repository owns

### When a route is added or changed — otherwise N/A

N/A — no route, no response shape, no error shape. The `coverage/` diff is
carried per the drift:update rule, regenerated so the artefact follows #260's
code.

### When behaviour a client can observe changes — otherwise N/A

N/A — `feint coverage` is an offline command; no emulated response changed.
The README's generated tables did not move (`feint docs`: already up to date).

### When `.github/workflows/` is touched — otherwise N/A

N/A — the workflows are untouched; the weekly job inherits the new comparison
through `tools/drift/gate.sh check`, which both callers already run. The
exit-code contract holds: 0 ok, 1 error, 2 skew.

### When a machine runtime is involved — otherwise N/A

N/A — no machine runtime; conformance ran with `--vm off`.

## Related issues

Closes #298
