### PR TITLE
fix: acknowledged writes survive their concurrent siblings, and the NIC attachment serves its flag (#295, #299)

### DIFF
--- a/internal/core/machine/observe.go
+++ b/internal/core/machine/observe.go
@@ -58,6 +58,12 @@ func (b Binding) Observe(
 	if !found {
 		return nil, store.ErrNotFound
 	}
+	// The base of the write-back below: what look() changes relative to this
+	// clone is what gets written, and nothing else. The hold above orders the
+	// lifecycle writers; it cannot order a writer that does not take it — a
+	// CreateTags, a PATCH on another field — and the wholesale write this used
+	// to do erased exactly such a writer's acknowledged field (#295).
+	base := res.Clone()
 
 	// Outside the store lock on purpose: look() reaches the runtime, and holding
 	// a store-wide lock across a runtime call would queue every other request in
@@ -66,14 +72,8 @@ func (b Binding) Observe(
 		return res, nil
 	}
 
-	if err := st.Update(b.Provider, kind, id, func(stored *resource.Resource) error {
-		stored.State = res.State
-		stored.Runtime = res.Runtime
-		stored.Attrs = res.Attrs
-		stored.Updated = now()
-		return nil
-	}); err != nil {
-		return nil, err
+	if !st.Commit(base, res, now()) {
+		return nil, store.ErrNotFound
 	}
 	return res, nil
 }

--- a/internal/core/store/commit_test.go
+++ b/internal/core/store/commit_test.go
@@ -33,6 +33,7 @@ func TestCommitDoesNotResurrectADeletedResource(t *testing.T) {
 	if !found {
 		t.Fatal("the resource was not stored")
 	}
+	base := held.Clone()
 	held.State = "running"
 
 	// The client deletes it in the meantime.
@@ -40,7 +41,7 @@ func TestCommitDoesNotResurrectADeletedResource(t *testing.T) {
 		t.Fatal("the delete found nothing to remove")
 	}
 
-	if s.Commit(held, now) {
+	if s.Commit(base, held, now) {
 		t.Fatal("Commit reported success on a deleted resource: the caller will answer with a server that no longer exists")
 	}
 	if _, back := s.Get("scaleway", "server", "srv-1"); back {
@@ -63,11 +64,12 @@ func TestCommitWritesBackWhatTheRuntimeChanged(t *testing.T) {
 	})
 
 	held, _ := s.Get("scaleway", "server", "srv-2")
+	base := held.Clone()
 	held.State = "running"
 	held.Runtime = map[string]string{"address": "10.0.0.2"}
 	held.Attrs["name"] = "renamed"
 
-	if !s.Commit(held, now) {
+	if !s.Commit(base, held, now) {
 		t.Fatal("Commit failed on a resource that still exists")
 	}
 
@@ -97,8 +99,9 @@ func TestCommitStoresACopy(t *testing.T) {
 	})
 
 	held, _ := s.Get("scaleway", "server", "srv-3")
+	base := held.Clone()
 	held.State = "running"
-	if !s.Commit(held, time.Now()) {
+	if !s.Commit(base, held, time.Now()) {
 		t.Fatal("Commit failed")
 	}
 
@@ -106,5 +109,65 @@ func TestCommitStoresACopy(t *testing.T) {
 	stored, _ := s.Get("scaleway", "server", "srv-3")
 	if stored.State != "running" {
 		t.Fatalf("the store followed a mutation made after Commit: state is %q", stored.State)
+	}
+}
+
+// The merge half of Commit, added by #295 after the resurrection half had
+// shipped without it.
+//
+// Two writers on one resource, disjoint fields: a lifecycle action holds a
+// clone while its machine starts, a tag write lands through Store.Update in
+// the meantime. The old Commit wrote State, Runtime and Attrs from the clone
+// wholesale, so the acknowledged tag was erased — measured at 5/200 trials
+// with no runtime configured, and a real launch holds the window open for
+// seconds. The action's own writes must land, the concurrent one must survive,
+// and a field the action deleted must go.
+func TestCommitKeepsAConcurrentWriteToAnotherField(t *testing.T) {
+	s := store.New()
+	now := time.Now()
+
+	s.Put(&resource.Resource{
+		ID:      "srv-4",
+		Kind:    "server",
+		Tenant:  resource.Tenant{Provider: "scaleway"},
+		State:   "stopped",
+		Attrs:   map[string]any{"name": "demo", "obsolete": true},
+		Runtime: map[string]string{"machine": "feint-x"},
+	})
+
+	// The lifecycle handler takes its copy and starts working.
+	held, _ := s.Get("scaleway", "server", "srv-4")
+	base := held.Clone()
+	held.State = "running"
+	held.Runtime["address"] = "10.0.0.7"
+	delete(held.Attrs, "obsolete")
+
+	// A tag write lands while the machine boots — on a field, and on a runtime
+	// key, that the lifecycle handler never touched.
+	if err := s.Update("scaleway", "server", "srv-4", func(stored *resource.Resource) error {
+		stored.Attrs["tags"] = []string{"probe"}
+		stored.Runtime["user-data"] = "#cloud-config"
+		return nil
+	}); err != nil {
+		t.Fatalf("the concurrent update failed: %v", err)
+	}
+
+	if !s.Commit(base, held, now) {
+		t.Fatal("Commit failed on a resource that still exists")
+	}
+
+	stored, _ := s.Get("scaleway", "server", "srv-4")
+	switch {
+	case stored.State != "running":
+		t.Fatalf("the action's own state was lost: %q", stored.State)
+	case stored.Runtime["address"] != "10.0.0.7":
+		t.Fatalf("the action's own runtime write was lost: %q", stored.Runtime["address"])
+	case stored.Attrs["obsolete"] != nil:
+		t.Fatal("a field the action deleted came back")
+	case stored.Runtime["user-data"] != "#cloud-config":
+		t.Fatalf("the concurrent runtime write was erased: %q", stored.Runtime["user-data"])
+	}
+	if tags, _ := stored.Attrs["tags"].([]string); len(tags) != 1 || tags[0] != "probe" {
+		t.Fatalf("the acknowledged tag was erased by a writer that never touched it: %v", stored.Attrs["tags"])
 	}
 }

--- a/internal/core/store/store.go
+++ b/internal/core/store/store.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"reflect"
 	"sort"
 	"sync"
 	"time"
@@ -166,7 +167,8 @@ func (s *Store) Update(provider, kind, id string, change func(*resource.Resource
 }
 
 // Commit writes back a resource that was worked on outside the lock, and reports
-// whether it still exists.
+// whether it still exists. base is the clone the caller read before it started;
+// only what the caller changed relative to that clone is written.
 //
 // This is the shape every pack needs and only one of them had. Starting a
 // machine takes tens of seconds, so no pack holds the store lock across it: it
@@ -181,19 +183,74 @@ func (s *Store) Update(provider, kind, id string, change func(*resource.Resource
 // its machine was starting, and the caller should drop it from its answer rather
 // than report a state nobody can read back.
 //
-// What this does not do is merge. State, Runtime and Attrs are taken from the
-// copy wholesale, so a concurrent write to a *different* field of the same
-// resource is still lost. That is a narrower race than resurrection and it needs
-// per-field intent to fix; Update is there for a caller that has it.
-func (s *Store) Commit(res *resource.Resource, now time.Time) bool {
+// The merge is the second half, added by #295 after the first half had shipped
+// without it. The old Commit took State, Runtime and Attrs from the copy
+// wholesale, and its own comment named the consequence: a concurrent write to a
+// *different* field of the same resource was lost. Measured, not feared — a
+// CreateTags answered 200 while a lifecycle action was between its read and its
+// write, and the following read no longer had the tag: 5 of 200 trials with no
+// machine runtime configured, every trial with one, since a launch holds the
+// window open for seconds. Per-field intent closes it: a field the caller left
+// alone keeps whatever a concurrent writer put there, a field the caller
+// changed — set, or deleted — is the caller's to write, because Serialise
+// orders the writers that share a field and this merge is for the writers that
+// do not.
+//
+// The diff is per top-level unit: State, each Attrs key, each Runtime key.
+// Nested values need no deeper diff because packs never mutate them in place —
+// resource.Clone shares them with the store, so an in-place write is already a
+// defect on its own (updateNic paid for it, #295) — and a changed nested value
+// therefore always arrives as a fresh top-level assignment.
+//
+// TestCommitKeepsAConcurrentWriteToAnotherField and
+// TestCommitDoesNotResurrectADeletedResource fail without the two halves.
+func (s *Store) Commit(base, res *resource.Resource, now time.Time) bool {
 	err := s.Update(res.Tenant.Provider, res.Kind, res.ID, func(stored *resource.Resource) error {
-		stored.State = res.State
-		stored.Runtime = res.Runtime
-		stored.Attrs = res.Attrs
+		if base.State != res.State {
+			stored.State = res.State
+		}
+		mergeMap(stored.Attrs, base.Attrs, res.Attrs)
+		if stored.Runtime == nil && len(res.Runtime) > 0 {
+			stored.Runtime = map[string]string{}
+		}
+		mergeRuntime(stored.Runtime, base.Runtime, res.Runtime)
 		stored.Updated = now
 		return nil
 	})
 	return err == nil
+}
+
+// mergeMap applies to stored every top-level change between base and res:
+// a key res added or rewrote wins, a key res deleted goes, and a key res left
+// alone keeps the stored value — which is the concurrent writer's, if one came
+// through while the caller worked.
+func mergeMap(stored, base, res map[string]any) {
+	for key, value := range res {
+		before, had := base[key]
+		if !had || !reflect.DeepEqual(before, value) {
+			stored[key] = value
+		}
+	}
+	for key := range base {
+		if _, still := res[key]; !still {
+			delete(stored, key)
+		}
+	}
+}
+
+// mergeRuntime is mergeMap for the Runtime map, whose values compare as
+// strings.
+func mergeRuntime(stored, base, res map[string]string) {
+	for key, value := range res {
+		if before, had := base[key]; !had || before != value {
+			stored[key] = value
+		}
+	}
+	for key := range base {
+		if _, still := res[key]; !still {
+			delete(stored, key)
+		}
+	}
 }
 
 // Delete removes a resource and reports whether it existed.

--- a/internal/providers/exoscale/elasticip_routing_test.go
+++ b/internal/providers/exoscale/elasticip_routing_test.go
@@ -171,8 +171,9 @@ func TestAPoisonedElasticIPIsNeverRouted(t *testing.T) {
 	if !found {
 		t.Fatal("the elastic IP is not in the store")
 	}
+	base := stored.Clone()
 	stored.Attrs["ip"] = poison
-	env.Store.Commit(stored, env.Now())
+	env.Store.Commit(base, stored, env.Now())
 
 	call(t, h, "PUT", "/v2/elastic-ip/"+eipID+":attach", `{"instance":{"id":"`+instanceID+`"}}`)
 	call(t, h, "PUT", "/v2/instance/"+instanceID+":stop", "{}")

--- a/internal/providers/exoscale/lostupdate_test.go
+++ b/internal/providers/exoscale/lostupdate_test.go
@@ -146,3 +146,77 @@ func TestConcurrentRuleCreatesKeepEveryAcknowledgedRule(t *testing.T) {
 		t.Errorf("the rule create path lost a rule it had acknowledged:\n%s", strings.Join(found, "\n"))
 	}
 }
+
+// The one update path of this pack that did NOT mutate inside store.Update —
+// #295 called the pack clean, and the audit that fixed the family found this
+// one: updatePrivateNetwork read a clone, possibly rebuilt the backing network
+// on the runtime, and wrote the whole clone back with Put. Two writers on
+// disjoint fields of one private network therefore erased each other after
+// their 200s, and the Put also resurrected a network deleted meanwhile. The
+// write-back is a per-field Commit now, and each writer's field must survive
+// the other.
+func TestConcurrentPrivateNetworkUpdatesKeepBothFields(t *testing.T) {
+	h, _ := newExoscaleBarrageServer(t)
+
+	found := storetest.NoLostUpdate(40, func(trial int) []storetest.Write {
+		status, created := callRaw(h, "POST", "/v2/private-network",
+			fmt.Sprintf(`{"name":"cross-%d"}`, trial))
+		if status != http.StatusOK {
+			t.Fatalf("trial %d create: status %d (%v)", trial, status, created)
+		}
+		ref, _ := created["reference"].(map[string]any)
+		id, _ := ref["id"].(string)
+		if id == "" {
+			t.Fatalf("the create operation names no resource: %v", created)
+		}
+
+		update := func(body string) bool {
+			status, _ := callRaw(h, "PUT", "/v2/private-network/"+id, body)
+			return status == http.StatusOK
+		}
+		field := func(read func(map[string]any) string) func() string {
+			return func() string {
+				status, out := callRaw(h, "GET", "/v2/private-network/"+id, "")
+				if status != http.StatusOK {
+					return fmt.Sprintf("<get answered %d>", status)
+				}
+				return read(out)
+			}
+		}
+
+		return []storetest.Write{
+			{
+				Field: "name",
+				Apply: func() bool { return update(`{"name":"after"}`) },
+				Got: field(func(out map[string]any) string {
+					name, _ := out["name"].(string)
+					return name
+				}),
+				Want: "after",
+			},
+			{
+				Field: "description",
+				Apply: func() bool { return update(`{"description":"held"}`) },
+				Got: field(func(out map[string]any) string {
+					description, _ := out["description"].(string)
+					return description
+				}),
+				Want: "held",
+			},
+			{
+				Field: "labels",
+				Apply: func() bool { return update(`{"labels":{"probe":"held"}}`) },
+				Got: field(func(out map[string]any) string {
+					labels, _ := out["labels"].(map[string]any)
+					value, _ := labels["probe"].(string)
+					return value
+				}),
+				Want: "held",
+			},
+		}
+	})
+
+	if len(found) > 0 {
+		t.Errorf("the private network update lost a field it had acknowledged:\n%s", strings.Join(found, "\n"))
+	}
+}

--- a/internal/providers/exoscale/privatenetworks.go
+++ b/internal/providers/exoscale/privatenetworks.go
@@ -428,6 +428,13 @@ func (p *Pack) updatePrivateNetwork(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "resource not found")
 		return
 	}
+	// The base of the write-back below. This handler was the one Put left in
+	// this pack's update paths, and it sat on the slowest window of all: a
+	// range change rebuilds the backing network on the runtime, and the Put
+	// that followed re-inserted a network deleted meanwhile and erased a
+	// concurrent write to any other field after its 200 — the issue's claim
+	// that this pack was clean did not survive the audit (#295).
+	base := res.Clone()
 
 	// The effective range is the stored one with the sent fields applied, and
 	// the whole triple is re-validated: an update that leaves start above end
@@ -509,8 +516,10 @@ func (p *Pack) updatePrivateNetwork(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	res.Updated = p.env.Now()
-	p.env.Store.Put(res)
+	if !p.env.Store.Commit(base, res, p.env.Now()) {
+		writeError(w, http.StatusNotFound, "resource not found")
+		return
+	}
 	p.isolatePrivateNetworks(r.Context())
 	p.writeOperation(w, p.operationReferring(nounPrivateNetwork, id))
 }

--- a/internal/providers/outscale/images.go
+++ b/internal/providers/outscale/images.go
@@ -170,8 +170,7 @@ func (p *Pack) updateImage(w http.ResponseWriter, r *http.Request) {
 		p.badRequest(w, err.Error())
 		return
 	}
-	res, found := p.env.Store.Get(Name, kindImage, req.ImageID)
-	if !found {
+	if _, found := p.env.Store.Get(Name, kindImage, req.ImageID); !found {
 		// A catalogue image is not the client's to change, and saying so beats
 		// answering success on an object that will read back unchanged.
 		if isCatalogueImage(req.ImageID) {
@@ -181,12 +180,6 @@ func (p *Pack) updateImage(w http.ResponseWriter, r *http.Request) {
 		p.notFound(w, "image", req.ImageID)
 		return
 	}
-	if req.Description != "" {
-		res.Attrs["Description"] = req.Description
-	}
-	if len(req.ProductCodes) > 0 {
-		res.Attrs["ProductCodes"] = toAnySlice(req.ProductCodes)
-	}
 	// PermissionsToLaunch is the cross-account grant, and this emulator has one
 	// implicit account: the additions name nobody it knows. Refused rather than
 	// recorded, for the reason UpdateSnapshot is declined outright.
@@ -194,12 +187,27 @@ func (p *Pack) updateImage(w http.ResponseWriter, r *http.Request) {
 		p.badRequest(w, "PermissionsToLaunch grants to another account, and this emulator has one implicit account")
 		return
 	}
-	if !p.env.Store.Commit(res, p.env.Now()) {
+	// Inside the store lock: written back wholesale from a clone, this erased a
+	// concurrent write to another field of the same image — its tags — after
+	// their 200 (#295).
+	var updated *resource.Resource
+	err := p.env.Store.Update(Name, kindImage, req.ImageID, func(stored *resource.Resource) error {
+		if req.Description != "" {
+			stored.Attrs["Description"] = req.Description
+		}
+		if len(req.ProductCodes) > 0 {
+			stored.Attrs["ProductCodes"] = toAnySlice(req.ProductCodes)
+		}
+		stored.Updated = p.env.Now()
+		updated = stored
+		return nil
+	})
+	if err != nil {
 		p.notFound(w, "image", req.ImageID)
 		return
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"Image":           imageView(res),
+		"Image":           imageView(updated),
 		"ResponseContext": p.context(),
 	})
 }

--- a/internal/providers/outscale/internetservices.go
+++ b/internal/providers/outscale/internetservices.go
@@ -1,10 +1,17 @@
 package outscale
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/stephrobert/feint/internal/core/emulator"
 	"github.com/stephrobert/feint/internal/core/resource"
+)
+
+// The refusals the link paths answer from inside the store lock (#295).
+var (
+	errGatewayLinked    = errors.New("the internet service is already linked")
+	errGatewayElsewhere = errors.New("the internet service is not linked to that Net")
 )
 
 // Internet services: the gateway a Net attaches to reach outside.
@@ -94,10 +101,6 @@ func (p *Pack) linkInternetService(w http.ResponseWriter, r *http.Request) {
 		p.notFound(w, "Net", req.NetID)
 		return
 	}
-	if held := stringOf(res.Attrs["NetId"]); held != "" && held != req.NetID {
-		p.conflict(w, "the internet service "+res.ID+" is already linked to "+held)
-		return
-	}
 	// One gateway per Net, which the real API enforces: a second link answers a
 	// resource conflict, and Terraform's replace flow depends on the refusal.
 	for _, other := range p.env.Store.List(kindInternetService, resource.Tenant{Provider: Name}) {
@@ -106,8 +109,25 @@ func (p *Pack) linkInternetService(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	res.Attrs["NetId"] = req.NetID
-	if !p.env.Store.Commit(res, p.env.Now()) {
+	// The holder check re-runs on the stored gateway, in the same critical
+	// section as the write: checked on the clone and committed wholesale, this
+	// erased a concurrent write to another field — the gateway's tags — after
+	// its 200 (#295).
+	var holder string
+	err := p.env.Store.Update(Name, kindInternetService, req.InternetServiceID, func(stored *resource.Resource) error {
+		if held := stringOf(stored.Attrs["NetId"]); held != "" && held != req.NetID {
+			holder = held
+			return errGatewayLinked
+		}
+		stored.Attrs["NetId"] = req.NetID
+		stored.Updated = p.env.Now()
+		return nil
+	})
+	switch {
+	case errors.Is(err, errGatewayLinked):
+		p.conflict(w, "the internet service "+res.ID+" is already linked to "+holder)
+		return
+	case err != nil:
 		p.notFound(w, "internet service", req.InternetServiceID)
 		return
 	}
@@ -124,17 +144,21 @@ func (p *Pack) unlinkInternetService(w http.ResponseWriter, r *http.Request) {
 		p.badRequest(w, err.Error())
 		return
 	}
-	res, found := p.env.Store.Get(Name, kindInternetService, req.InternetServiceID)
-	if !found {
-		p.notFound(w, "internet service", req.InternetServiceID)
+	// The linked-to check and the unlink are one critical section, same reason
+	// as the link path (#295).
+	err := p.env.Store.Update(Name, kindInternetService, req.InternetServiceID, func(stored *resource.Resource) error {
+		if stringOf(stored.Attrs["NetId"]) != req.NetID {
+			return errGatewayElsewhere
+		}
+		delete(stored.Attrs, "NetId")
+		stored.Updated = p.env.Now()
+		return nil
+	})
+	switch {
+	case errors.Is(err, errGatewayElsewhere):
+		p.badRequest(w, "the internet service "+req.InternetServiceID+" is not linked to "+req.NetID)
 		return
-	}
-	if stringOf(res.Attrs["NetId"]) != req.NetID {
-		p.badRequest(w, "the internet service "+res.ID+" is not linked to "+req.NetID)
-		return
-	}
-	delete(res.Attrs, "NetId")
-	if !p.env.Store.Commit(res, p.env.Now()) {
+	case err != nil:
 		p.notFound(w, "internet service", req.InternetServiceID)
 		return
 	}

--- a/internal/providers/outscale/lostupdate_test.go
+++ b/internal/providers/outscale/lostupdate_test.go
@@ -7,7 +7,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stephrobert/feint/internal/core/resource"
 	"github.com/stephrobert/feint/internal/core/store/storetest"
+	"github.com/stephrobert/feint/internal/providers/outscale"
 )
 
 // The same property as the two packs beside it, driven with this pack's own
@@ -368,4 +370,218 @@ func TestConcurrentTagCreatesKeepEveryAcknowledgedTag(t *testing.T) {
 func listAny(v any) []any {
 	out, _ := v.([]any)
 	return out
+}
+
+// The scalar half of the family, in the exact pair #295 measured: CreateTags,
+// under the store lock since #289, against LinkVolume, a clone-mutate-Commit
+// until this fix — two *different* handlers on one volume, which is the shape
+// the per-handler barrages above cannot see. Before the fix the issue's
+// reproduction lost the acknowledged tag 7/200 trials, and this repository's
+// re-measurement 11/200 (5 runs of 40, 2026-08-18); after it, 0/200.
+func TestConcurrentTagAndLinkKeepBothVolumeWrites(t *testing.T) {
+	ts, _ := newOutscaleBarrageServer(t)
+
+	_, out := post(t, ts, "CreateVms", `{"ImageId":"ami-12345678","VmType":"tinav4.c1r1p2"}`)
+	vms, _ := out["Vms"].([]any)
+	vm, _ := vms[0].(map[string]any)
+	vmID, _ := vm["VmId"].(string)
+	if vmID == "" {
+		t.Fatalf("create: no VmId in %v", out)
+	}
+
+	found := storetest.NoLostUpdate(40, func(trial int) []storetest.Write {
+		_, out := post(t, ts, "CreateVolume", `{"SubregionName":"eu-west-2a","Size":10}`)
+		volume, _ := out["Volume"].(map[string]any)
+		volID, _ := volume["VolumeId"].(string)
+		if volID == "" {
+			t.Fatalf("trial %d: no VolumeId in %v", trial, out)
+		}
+
+		readVolume := func() map[string]any {
+			_, out := post(t, ts, "ReadVolumes", `{"Filters":{"VolumeIds":["`+volID+`"]}}`)
+			volumes, _ := out["Volumes"].([]any)
+			if len(volumes) == 0 {
+				return nil
+			}
+			view, _ := volumes[0].(map[string]any)
+			return view
+		}
+
+		return []storetest.Write{
+			{
+				Field: "tag probe on " + volID,
+				Apply: func() bool {
+					status, _ := postRaw(ts, "CreateTags",
+						`{"ResourceIds":["`+volID+`"],"Tags":[{"Key":"probe","Value":"held"}]}`)
+					return status == http.StatusOK
+				},
+				Got: func() string {
+					view := readVolume()
+					if view == nil {
+						return "<the volume is gone>"
+					}
+					for _, raw := range listAny(view["Tags"]) {
+						tag, _ := raw.(map[string]any)
+						if tag["Key"] == "probe" {
+							return "stored"
+						}
+					}
+					return "lost"
+				},
+				Want: "stored",
+			},
+			{
+				Field: "link to " + vmID,
+				Apply: func() bool {
+					status, _ := postRaw(ts, "LinkVolume",
+						`{"VolumeId":"`+volID+`","VmId":"`+vmID+`","DeviceName":"/dev/xvdb"}`)
+					return status == http.StatusOK
+				},
+				Got: func() string {
+					view := readVolume()
+					if view == nil {
+						return "<the volume is gone>"
+					}
+					if len(listAny(view["LinkedVolumes"])) > 0 {
+						return "linked"
+					}
+					return "lost"
+				},
+				Want: "linked",
+			},
+		}
+	})
+
+	if len(found) > 0 {
+		t.Errorf("two different handlers on one volume lost an acknowledged write:\n%s", strings.Join(found, "\n"))
+	}
+}
+
+// The lifecycle half of #295: a tag write against a state transition on the
+// same Vm. StopVms goes through Binding.Observe, whose write-back replaced
+// State, Runtime and Attrs wholesale from the clone it took before the runtime
+// call — with no runtime configured the window is one handler's decode and the
+// loss measured 5/200 trials (2026-08-18); with a machine runtime, a launch
+// holds it open for seconds. The per-field merge in store.Commit closes it,
+// and this test drives both directions: the tag must survive the stop, and
+// the stop's state must survive the tag.
+func TestConcurrentTagAndStopKeepBothVmWrites(t *testing.T) {
+	ts, _ := newOutscaleBarrageServer(t)
+
+	found := storetest.NoLostUpdate(40, func(trial int) []storetest.Write {
+		_, out := post(t, ts, "CreateVms", `{"ImageId":"ami-12345678","VmType":"tinav4.c1r1p2"}`)
+		vms, _ := out["Vms"].([]any)
+		vm, _ := vms[0].(map[string]any)
+		vmID, _ := vm["VmId"].(string)
+		if vmID == "" {
+			t.Fatalf("trial %d: no VmId in %v", trial, out)
+		}
+
+		readVM := func() map[string]any {
+			_, out := post(t, ts, "ReadVms", `{"Filters":{"VmIds":["`+vmID+`"]}}`)
+			read, _ := out["Vms"].([]any)
+			if len(read) == 0 {
+				return nil
+			}
+			view, _ := read[0].(map[string]any)
+			return view
+		}
+
+		return []storetest.Write{
+			{
+				Field: "tag probe on " + vmID,
+				Apply: func() bool {
+					status, _ := postRaw(ts, "CreateTags",
+						`{"ResourceIds":["`+vmID+`"],"Tags":[{"Key":"probe","Value":"held"}]}`)
+					return status == http.StatusOK
+				},
+				Got: func() string {
+					view := readVM()
+					if view == nil {
+						return "<the Vm is gone>"
+					}
+					for _, raw := range listAny(view["Tags"]) {
+						tag, _ := raw.(map[string]any)
+						if tag["Key"] == "probe" {
+							return "stored"
+						}
+					}
+					return "lost"
+				},
+				Want: "stored",
+			},
+			{
+				Field: "stop of " + vmID,
+				Apply: func() bool {
+					status, _ := postRaw(ts, "StopVms", `{"VmIds":["`+vmID+`"]}`)
+					return status == http.StatusOK
+				},
+				Got: func() string {
+					view := readVM()
+					if view == nil {
+						return "<the Vm is gone>"
+					}
+					state, _ := view["State"].(string)
+					return state
+				},
+				Want: "stopped",
+			},
+		}
+	})
+
+	if len(found) > 0 {
+		t.Errorf("a lifecycle transition and a tag write on one Vm lost an acknowledged write:\n%s", strings.Join(found, "\n"))
+	}
+}
+
+// The second defect #295 named in updateNic, distinct from the lost update:
+// the handler wrote `link["DeleteOnVmDeletion"] = …` straight through the
+// clone's LinkNic map, and resource.Clone is shallow on Attrs values — that
+// map IS the stored one. The write was visible to every concurrent reader
+// before the write-back, and stayed behind even when the write-back failed.
+//
+// The stored LinkNic map only exists on state that arrived from outside —
+// PUT /_feint/state, `feint snapshot load` — because linkNic itself stores the
+// attachment as flat keys; the seeding below is that restore path, reduced.
+func TestUpdateNicDoesNotMutateTheStoredLinkInPlace(t *testing.T) {
+	ts, st := newOutscaleBarrageServer(t)
+
+	st.Put(&resource.Resource{
+		ID:     "eni-restored1",
+		Kind:   "nic",
+		Tenant: resource.Tenant{Provider: outscale.Name},
+		State:  "in-use",
+		Attrs: map[string]any{
+			"State": "in-use",
+			"LinkNic": map[string]any{
+				"LinkNicId":          "eni-attach-restored1",
+				"DeleteOnVmDeletion": false,
+			},
+			"Tags": []any{},
+		},
+	})
+
+	// A reader that resolved the NIC before the update: its clone shares the
+	// nested LinkNic map with the store, which is exactly why the handler must
+	// never write through it.
+	witness, found := st.Get(outscale.Name, "nic", "eni-restored1")
+	if !found {
+		t.Fatal("the seeded NIC is not in the store")
+	}
+
+	status, _ := post(t, ts, "UpdateNic",
+		`{"NicId":"eni-restored1","LinkNic":{"DeleteOnVmDeletion":true}}`)
+	if status != http.StatusOK {
+		t.Fatalf("UpdateNic answered %d, so this test measures nothing", status)
+	}
+
+	link, _ := witness.Attrs["LinkNic"].(map[string]any)
+	if flag, _ := link["DeleteOnVmDeletion"].(bool); flag {
+		t.Fatal("the update wrote through the shared map: a reader that resolved the NIC before the update saw the new value without any store write")
+	}
+	stored, _ := st.Get(outscale.Name, "nic", "eni-restored1")
+	storedLink, _ := stored.Attrs["LinkNic"].(map[string]any)
+	if flag, _ := storedLink["DeleteOnVmDeletion"].(bool); !flag {
+		t.Fatal("the update did not land at all")
+	}
 }

--- a/internal/providers/outscale/lostupdate_test.go
+++ b/internal/providers/outscale/lostupdate_test.go
@@ -570,7 +570,7 @@ func TestUpdateNicDoesNotMutateTheStoredLinkInPlace(t *testing.T) {
 	}
 
 	status, _ := post(t, ts, "UpdateNic",
-		`{"NicId":"eni-restored1","LinkNic":{"DeleteOnVmDeletion":true}}`)
+		`{"NicId":"eni-restored1","LinkNic":{"LinkNicId":"eni-attach-restored1","DeleteOnVmDeletion":true}}`)
 	if status != http.StatusOK {
 		t.Fatalf("UpdateNic answered %d, so this test measures nothing", status)
 	}

--- a/internal/providers/outscale/natservices.go
+++ b/internal/providers/outscale/natservices.go
@@ -1,11 +1,17 @@
 package outscale
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/stephrobert/feint/internal/core/emulator"
 	"github.com/stephrobert/feint/internal/core/resource"
 )
+
+// errAddressHeldByNat is the refusal the NAT hold answers from inside the
+// store lock, where the holder cannot change underneath it (#295). The public
+// IP link path shares it: both are asking the same question of the same field.
+var errAddressHeldByNat = errors.New("the public IP is held by a NAT service")
 
 // NAT services: the egress a private subnet buys with a public IP.
 //
@@ -66,14 +72,28 @@ func (p *Pack) createNatService(w http.ResponseWriter, r *http.Request) {
 	}
 	p.env.Store.Put(res)
 
-	// The address is marked held. Commit rather than Put: a concurrent delete
-	// of the address must not be resurrected by this write.
-	address.Attrs["NatServiceId"] = res.ID
-	address.Attrs["LinkPublicIpId"] = newID("eipassoc", p.env.NewID())
-	if !p.env.Store.Commit(address, now) {
-		// The address vanished between the check and the write; the NAT service
-		// cannot hold what no longer exists.
+	// The address is marked held inside the store lock, holder re-checked
+	// there: as a Get-check-Commit sequence a concurrent hold could double-book
+	// the address, and the wholesale write erased a concurrent write to another
+	// field — the address's tags — after their 200 (#295). Update rather than
+	// Put also keeps a concurrent delete of the address deleted.
+	err := p.env.Store.Update(Name, kindPublicIP, address.ID, func(stored *resource.Resource) error {
+		if holder := stringOf(stored.Attrs["NatServiceId"]); holder != "" {
+			return errAddressHeldByNat
+		}
+		stored.Attrs["NatServiceId"] = res.ID
+		stored.Attrs["LinkPublicIpId"] = newID("eipassoc", p.env.NewID())
+		stored.Updated = now
+		return nil
+	})
+	if err != nil {
+		// Held or vanished between the check and the write; the NAT service
+		// cannot hold what it did not get.
 		p.env.Store.Delete(Name, kindNatService, res.ID)
+		if errors.Is(err, errAddressHeldByNat) {
+			p.conflict(w, "the public IP "+address.ID+" is already held by a NAT service")
+			return
+		}
 		p.notFound(w, "public IP", req.PublicIPID)
 		return
 	}
@@ -134,13 +154,21 @@ func (p *Pack) deleteNatService(w http.ResponseWriter, r *http.Request) {
 
 	// The address is released, exactly as the real teardown releases it. Best
 	// effort by construction: if the address is gone too, there is nothing to
-	// release.
+	// release. The hold is re-checked inside the lock, so a release cannot
+	// erase a hold — or any other field — written after the List (#295).
 	for _, address := range p.env.Store.List(kindPublicIP, resource.Tenant{Provider: Name}) {
-		if stringOf(address.Attrs["NatServiceId"]) == res.ID {
-			delete(address.Attrs, "NatServiceId")
-			delete(address.Attrs, "LinkPublicIpId")
-			_ = p.env.Store.Commit(address, p.env.Now())
+		if stringOf(address.Attrs["NatServiceId"]) != res.ID {
+			continue
 		}
+		_ = p.env.Store.Update(Name, kindPublicIP, address.ID, func(stored *resource.Resource) error {
+			if stringOf(stored.Attrs["NatServiceId"]) != res.ID {
+				return errAddressHeldByNat
+			}
+			delete(stored.Attrs, "NatServiceId")
+			delete(stored.Attrs, "LinkPublicIpId")
+			stored.Updated = p.env.Now()
+			return nil
+		})
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{"ResponseContext": p.context()})
 }

--- a/internal/providers/outscale/netpeerings.go
+++ b/internal/providers/outscale/netpeerings.go
@@ -2,6 +2,7 @@ package outscale
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"time"
 
@@ -9,6 +10,11 @@ import (
 	"github.com/stephrobert/feint/internal/core/machine"
 	"github.com/stephrobert/feint/internal/core/resource"
 )
+
+// errPeeringNotPending is every state refusal of this file, answered from
+// inside the store lock where the state cannot move underneath the check
+// (#295). The message carries the state that was actually found.
+var errPeeringNotPending = errors.New("the Net peering is not in a state this operation accepts")
 
 // Net peerings: the link between two Nets this emulator itself created — which
 // is what pulled the family off the declined list, where an audit had found it
@@ -185,24 +191,36 @@ func (p *Pack) acceptNetPeering(w http.ResponseWriter, r *http.Request) {
 		p.badRequest(w, err.Error())
 		return
 	}
-	res, found := p.env.Store.Get(Name, kindNetPeering, req.NetPeeringID)
-	if !found {
-		p.notFound(w, "Net peering", req.NetPeeringID)
-		return
-	}
 	// "The Net peering must be in the `pending-acceptance` state" — accepting
 	// a rejected, failed or deleted one is the state conflict the real cloud
 	// answers, in this pack's dialect (409 ResourceConflict, errors.go).
-	if res.State != statePeeringPending {
-		p.conflict(w, "the Net peering "+res.ID+" is "+res.State+
+	//
+	// The state check and the transition are one critical section held by the
+	// store: checked on a clone, two concurrent transitions both passed and
+	// the wholesale write-back erased a concurrent write to another field —
+	// the peering's tags — after its 200 (#295).
+	var updated *resource.Resource
+	var wrongState string
+	err := p.env.Store.Update(Name, kindNetPeering, req.NetPeeringID, func(stored *resource.Resource) error {
+		if stored.State != statePeeringPending {
+			wrongState = stored.State
+			return errPeeringNotPending
+		}
+		stored.State = statePeeringActive
+		stored.Updated = p.env.Now()
+		updated = stored
+		return nil
+	})
+	switch {
+	case errors.Is(err, errPeeringNotPending):
+		p.conflict(w, "the Net peering "+req.NetPeeringID+" is "+wrongState+
 			", only a pending-acceptance one can be accepted")
 		return
-	}
-	res.State = statePeeringActive
-	if !p.env.Store.Commit(res, p.env.Now()) {
+	case err != nil:
 		p.notFound(w, "Net peering", req.NetPeeringID)
 		return
 	}
+	res := updated
 
 	// "When an A-to-B peering connection is accepted, any pending B-to-A
 	// peering connection is automatically rejected as redundant."
@@ -210,12 +228,22 @@ func (p *Pack) acceptNetPeering(w http.ResponseWriter, r *http.Request) {
 	sourceID := stringOf(res.Attrs["SourceNetId"])
 	accepterID := stringOf(res.Attrs["AccepterNetId"])
 	for _, other := range p.env.Store.List(kindNetPeering, resource.Tenant{Provider: Name}) {
-		if other.State == statePeeringPending &&
-			stringOf(other.Attrs["SourceNetId"]) == accepterID &&
-			stringOf(other.Attrs["AccepterNetId"]) == sourceID {
-			other.State = statePeeringRejected
-			p.env.Store.Commit(other, p.env.Now())
+		if other.State != statePeeringPending ||
+			stringOf(other.Attrs["SourceNetId"]) != accepterID ||
+			stringOf(other.Attrs["AccepterNetId"]) != sourceID {
+			continue
 		}
+		// Re-checked under the lock: the counterpart may have transitioned
+		// between the List and this write, and rejecting over the stale clone
+		// erased whatever landed meanwhile (#295).
+		_ = p.env.Store.Update(Name, kindNetPeering, other.ID, func(stored *resource.Resource) error {
+			if stored.State != statePeeringPending {
+				return errPeeringNotPending
+			}
+			stored.State = statePeeringRejected
+			stored.Updated = p.env.Now()
+			return nil
+		})
 	}
 
 	// The reachability the acceptance granted, on the runtime, outside any
@@ -236,21 +264,26 @@ func (p *Pack) rejectNetPeering(w http.ResponseWriter, r *http.Request) {
 		p.badRequest(w, err.Error())
 		return
 	}
-	res, found := p.env.Store.Get(Name, kindNetPeering, req.NetPeeringID)
-	if !found {
-		p.notFound(w, "Net peering", req.NetPeeringID)
-		return
-	}
 	// "The Net peering must be in the `pending-acceptance` state to be
 	// rejected." An active one is not un-accepted by rejecting it — the real
-	// API refuses, and so does this one.
-	if res.State != statePeeringPending {
-		p.conflict(w, "the Net peering "+res.ID+" is "+res.State+
+	// API refuses, and so does this one. Check and transition in one critical
+	// section, same reason as acceptNetPeering (#295).
+	var wrongState string
+	err := p.env.Store.Update(Name, kindNetPeering, req.NetPeeringID, func(stored *resource.Resource) error {
+		if stored.State != statePeeringPending {
+			wrongState = stored.State
+			return errPeeringNotPending
+		}
+		stored.State = statePeeringRejected
+		stored.Updated = p.env.Now()
+		return nil
+	})
+	switch {
+	case errors.Is(err, errPeeringNotPending):
+		p.conflict(w, "the Net peering "+req.NetPeeringID+" is "+wrongState+
 			", only a pending-acceptance one can be rejected")
 		return
-	}
-	res.State = statePeeringRejected
-	if !p.env.Store.Commit(res, p.env.Now()) {
+	case err != nil:
 		p.notFound(w, "Net peering", req.NetPeeringID)
 		return
 	}
@@ -265,25 +298,31 @@ func (p *Pack) deleteNetPeering(w http.ResponseWriter, r *http.Request) {
 		p.badRequest(w, err.Error())
 		return
 	}
-	res, found := p.env.Store.Get(Name, kindNetPeering, req.NetPeeringID)
-	if !found {
-		p.notFound(w, "Net peering", req.NetPeeringID)
-		return
-	}
 	// "If it is in the `rejected`, `failed`, or `expired` states, it cannot be
 	// deleted." A deleted one is refused for the same reason: there is nothing
 	// left to delete, and answering success would say the call did something.
-	switch res.State {
-	case statePeeringRejected, statePeeringFailed, statePeeringExpired, statePeeringDeleted:
-		p.conflict(w, "the Net peering "+res.ID+" is "+res.State+" and cannot be deleted")
-		return
-	}
+	//
 	// The record stays, in the deleted state, which is a state the SDK's own
 	// StateNames filter enumerates: the real API keeps answering a deleted
 	// peering for a while rather than forgetting it, and a client reading it
-	// back must find the state, not a hole.
-	res.State = statePeeringDeleted
-	if !p.env.Store.Commit(res, p.env.Now()) {
+	// back must find the state, not a hole. Check and transition in one
+	// critical section, same reason as acceptNetPeering (#295).
+	var wrongState string
+	err := p.env.Store.Update(Name, kindNetPeering, req.NetPeeringID, func(stored *resource.Resource) error {
+		switch stored.State {
+		case statePeeringRejected, statePeeringFailed, statePeeringExpired, statePeeringDeleted:
+			wrongState = stored.State
+			return errPeeringNotPending
+		}
+		stored.State = statePeeringDeleted
+		stored.Updated = p.env.Now()
+		return nil
+	})
+	switch {
+	case errors.Is(err, errPeeringNotPending):
+		p.conflict(w, "the Net peering "+req.NetPeeringID+" is "+wrongState+" and cannot be deleted")
+		return
+	case err != nil:
 		p.notFound(w, "Net peering", req.NetPeeringID)
 		return
 	}

--- a/internal/providers/outscale/nets.go
+++ b/internal/providers/outscale/nets.go
@@ -333,8 +333,11 @@ func (p *Pack) createSubnet(w http.ResponseWriter, r *http.Request) {
 
 	// Stored before the runtime call and before the lock is released: this is the
 	// reservation, and it is what makes a concurrent create see the range as
-	// taken.
+	// taken. The clone is the base of the write-back below: the network
+	// creation owns the runtime name and nothing else, so a tag acknowledged
+	// while the network was being made survives it (#295).
 	p.env.Store.Put(res)
+	base := res.Clone()
 	unlock()
 
 	// The subnet is a real network on the runtime, which is what makes an
@@ -353,7 +356,7 @@ func (p *Pack) createSubnet(w http.ResponseWriter, r *http.Request) {
 	// The runtime wrote the network name into Runtime, so the reservation is
 	// updated rather than replaced: a Put would resurrect a subnet deleted while
 	// the network was being created.
-	if !p.env.Store.Commit(res, p.env.Now()) {
+	if !p.env.Store.Commit(base, res, p.env.Now()) {
 		// Deleted while its network was being made. Take the network back down
 		// rather than leave it on the host.
 		p.removeBackingNetwork(r.Context(), res)

--- a/internal/providers/outscale/niclink_test.go
+++ b/internal/providers/outscale/niclink_test.go
@@ -1,0 +1,152 @@
+package outscale_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// The false refusal #299 measured, and the constant that would have denied the
+// fix: a NIC this pack itself attached answered 400 "not attached" to the one
+// request upstream provides for its attachment (LinkNicToUpdate, osc-sdk-go
+// client.gen.go), and storedNicView published DeleteOnVmDeletion:false whatever
+// was stored, so even a successful write would have been denied by every read
+// that followed. Both halves are driven here, with the non-default value —
+// true — because true is precisely what the constant erased.
+
+// linkedNic creates a Net, a Subnet, a Vm and a secondary NIC, attaches the
+// NIC, and returns the pieces every test here starts from.
+func linkedNic(t *testing.T, ts *httptest.Server, block string) (vmID, nicID, linkNicID string) {
+	t.Helper()
+	_, out := post(t, ts, "CreateNet", `{"IpRange":"`+block+`.0.0/16"}`)
+	net, _ := out["Net"].(map[string]any)
+	netID, _ := net["NetId"].(string)
+	_, out = post(t, ts, "CreateSubnet", `{"NetId":"`+netID+`","IpRange":"`+block+`.1.0/24"}`)
+	subnet, _ := out["Subnet"].(map[string]any)
+	subnetID, _ := subnet["SubnetId"].(string)
+
+	_, out = post(t, ts, "CreateVms",
+		`{"ImageId":"ami-12345678","VmType":"tinav4.c1r1p2","SubnetId":"`+subnetID+`"}`)
+	vms, _ := out["Vms"].([]any)
+	vm, _ := vms[0].(map[string]any)
+	vmID, _ = vm["VmId"].(string)
+
+	_, out = post(t, ts, "CreateNic", `{"SubnetId":"`+subnetID+`"}`)
+	nic, _ := out["Nic"].(map[string]any)
+	nicID, _ = nic["NicId"].(string)
+
+	status, out := post(t, ts, "LinkNic",
+		`{"NicId":"`+nicID+`","VmId":"`+vmID+`","DeviceNumber":1}`)
+	if status != http.StatusOK {
+		t.Fatalf("LinkNic: status %d (%v)", status, out)
+	}
+	linkNicID, _ = out["LinkNicId"].(string)
+	return vmID, nicID, linkNicID
+}
+
+// readLinkFlag reads DeleteOnVmDeletion back through ReadNics, which is where
+// the Terraform provider reads it.
+func readLinkFlag(t *testing.T, ts *httptest.Server, nicID string) (bool, bool) {
+	t.Helper()
+	_, out := post(t, ts, "ReadNics", `{"Filters":{"NicIds":["`+nicID+`"]}}`)
+	nics, _ := out["Nics"].([]any)
+	if len(nics) == 0 {
+		return false, false
+	}
+	nic, _ := nics[0].(map[string]any)
+	link, _ := nic["LinkNic"].(map[string]any)
+	if link == nil {
+		return false, false
+	}
+	flag, _ := link["DeleteOnVmDeletion"].(bool)
+	return flag, true
+}
+
+func TestDeleteOnVmDeletionRoundTripsThroughUpdateNic(t *testing.T) {
+	ts, _ := newOutscaleBarrageServer(t)
+	_, nicID, linkNicID := linkedNic(t, ts, "10.61")
+
+	// The measured default first: LinkNicRequest carries no flag, so a fresh
+	// attachment starts false, and a test that only wrote true could pass on
+	// a pack that answers true as a constant.
+	if flag, attached := readLinkFlag(t, ts, nicID); !attached || flag {
+		t.Fatalf("a fresh attachment must read DeleteOnVmDeletion false (attached=%v flag=%v)", attached, flag)
+	}
+
+	status, out := post(t, ts, "UpdateNic",
+		`{"NicId":"`+nicID+`","LinkNic":{"LinkNicId":"`+linkNicID+`","DeleteOnVmDeletion":true}}`)
+	if status != http.StatusOK {
+		t.Fatalf("UpdateNic on an attached NIC answered %d (%v) — the false refusal #299 measured", status, out)
+	}
+	// The response carries the new value, and so does the read that follows:
+	// create-then-read must round-trip, field for field.
+	nic, _ := out["Nic"].(map[string]any)
+	link, _ := nic["LinkNic"].(map[string]any)
+	if flag, _ := link["DeleteOnVmDeletion"].(bool); !flag {
+		t.Fatal("the update answered 200 and its own response denies the value")
+	}
+	if flag, attached := readLinkFlag(t, ts, nicID); !attached || !flag {
+		t.Fatalf("the read denies the acknowledged update (attached=%v flag=%v) — the constant #299 names", attached, flag)
+	}
+
+	// And back down, because a flag that can only rise is half a field.
+	status, _ = post(t, ts, "UpdateNic",
+		`{"NicId":"`+nicID+`","LinkNic":{"LinkNicId":"`+linkNicID+`","DeleteOnVmDeletion":false}}`)
+	if status != http.StatusOK {
+		t.Fatalf("clearing the flag answered %d", status)
+	}
+	if flag, attached := readLinkFlag(t, ts, nicID); !attached || flag {
+		t.Fatalf("the flag did not clear (attached=%v flag=%v)", attached, flag)
+	}
+
+	// "You must specify the ID of the NIC attachment": an absent or foreign
+	// LinkNicId is refused, not guessed around.
+	if status, _ := post(t, ts, "UpdateNic",
+		`{"NicId":"`+nicID+`","LinkNic":{"DeleteOnVmDeletion":true}}`); status != http.StatusBadRequest {
+		t.Fatalf("an update without the attachment ID answered %d, want 400", status)
+	}
+}
+
+func TestATrueDeleteOnVmDeletionDeletesTheNicWithItsVm(t *testing.T) {
+	ts, _ := newOutscaleBarrageServer(t)
+	vmID, doomedNic, doomedLink := linkedNic(t, ts, "10.62")
+
+	// A second interface on the same Vm keeps the default, so one terminate
+	// exercises both halves of the SDK's sentence: "If true, the NIC is
+	// deleted when the VM is terminated. If false, the NIC is detached."
+	_, out := post(t, ts, "ReadNics", `{"Filters":{"NicIds":["`+doomedNic+`"]}}`)
+	nics, _ := out["Nics"].([]any)
+	nic, _ := nics[0].(map[string]any)
+	subnetID, _ := nic["SubnetId"].(string)
+	_, out = post(t, ts, "CreateNic", `{"SubnetId":"`+subnetID+`"}`)
+	kept, _ := out["Nic"].(map[string]any)
+	keptNic, _ := kept["NicId"].(string)
+	if status, out := post(t, ts, "LinkNic",
+		`{"NicId":"`+keptNic+`","VmId":"`+vmID+`","DeviceNumber":2}`); status != http.StatusOK {
+		t.Fatalf("LinkNic (kept): status %d (%v)", status, out)
+	}
+
+	if status, out := post(t, ts, "UpdateNic",
+		`{"NicId":"`+doomedNic+`","LinkNic":{"LinkNicId":"`+doomedLink+`","DeleteOnVmDeletion":true}}`); status != http.StatusOK {
+		t.Fatalf("UpdateNic: status %d (%v)", status, out)
+	}
+
+	post(t, ts, "StopVms", `{"VmIds":["`+vmID+`"]}`)
+	if status, out := post(t, ts, "DeleteVms", `{"VmIds":["`+vmID+`"]}`); status != http.StatusOK {
+		t.Fatalf("DeleteVms: status %d (%v)", status, out)
+	}
+
+	_, out = post(t, ts, "ReadNics", `{"Filters":{"NicIds":["`+doomedNic+`"]}}`)
+	if gone, _ := out["Nics"].([]any); len(gone) != 0 {
+		t.Errorf("a NIC whose attachment says DeleteOnVmDeletion survived its Vm: %v", gone)
+	}
+	_, out = post(t, ts, "ReadNics", `{"Filters":{"NicIds":["`+keptNic+`"]}}`)
+	survivors, _ := out["Nics"].([]any)
+	if len(survivors) != 1 {
+		t.Fatalf("the default-flag NIC did not survive the terminate: %v", out)
+	}
+	survivor, _ := survivors[0].(map[string]any)
+	if state, _ := survivor["State"].(string); state != "available" {
+		t.Errorf("the surviving NIC must be detached, not %q", state)
+	}
+}

--- a/internal/providers/outscale/nics.go
+++ b/internal/providers/outscale/nics.go
@@ -386,11 +386,28 @@ func (p *Pack) linkNic(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	linkID := "eni-attach-" + strings.TrimPrefix(nic.ID, "eni-")
-	nic.Attrs["LinkVmId"] = req.VMID
-	nic.Attrs["DeviceNumber"] = *req.DeviceNumber
-	nic.Attrs["LinkNicId"] = linkID
-	nic.Attrs["State"] = "in-use"
-	if !p.env.Store.Commit(nic, p.env.Now()) {
+	// The holder check re-runs on the stored interface, under the lock, and the
+	// write happens in the same critical section: as a Get-check-Commit sequence
+	// this erased a concurrent write to another field of the same NIC — a tag,
+	// an updated description — after its 200 (#295).
+	var holder string
+	err := p.env.Store.Update(Name, kindNic, req.NicID, func(stored *resource.Resource) error {
+		if held := stringOf(stored.Attrs["LinkVmId"]); held != "" {
+			holder = held
+			return errNicAttached
+		}
+		stored.Attrs["LinkVmId"] = req.VMID
+		stored.Attrs["DeviceNumber"] = *req.DeviceNumber
+		stored.Attrs["LinkNicId"] = linkID
+		stored.Attrs["State"] = "in-use"
+		stored.Updated = p.env.Now()
+		return nil
+	})
+	switch {
+	case errors.Is(err, errNicAttached):
+		p.conflict(w, "the network interface "+nic.ID+" is already attached to "+holder)
+		return
+	case err != nil:
 		p.notFound(w, "network interface", req.NicID)
 		return
 	}
@@ -413,12 +430,22 @@ func (p *Pack) unlinkNic(w http.ResponseWriter, r *http.Request) {
 		if stringOf(nic.Attrs["LinkNicId"]) != req.LinkNicID {
 			continue
 		}
-		delete(nic.Attrs, "LinkVmId")
-		delete(nic.Attrs, "DeviceNumber")
-		delete(nic.Attrs, "LinkNicId")
-		nic.Attrs["State"] = "available"
-		if !p.env.Store.Commit(nic, p.env.Now()) {
-			p.notFound(w, "network interface", nic.ID)
+		// The link is re-found on the stored interface: the List above read a
+		// clone, and detaching over it wholesale erased a concurrent write to
+		// another field after its 200 (#295).
+		err := p.env.Store.Update(Name, kindNic, nic.ID, func(stored *resource.Resource) error {
+			if stringOf(stored.Attrs["LinkNicId"]) != req.LinkNicID {
+				return errNicLinkMoved
+			}
+			delete(stored.Attrs, "LinkVmId")
+			delete(stored.Attrs, "DeviceNumber")
+			delete(stored.Attrs, "LinkNicId")
+			stored.Attrs["State"] = "available"
+			stored.Updated = p.env.Now()
+			return nil
+		})
+		if err != nil {
+			p.notFound(w, "network interface attachment", req.LinkNicID)
 			return
 		}
 		emulator.WriteJSON(w, http.StatusOK, map[string]any{"ResponseContext": p.context()})
@@ -434,13 +461,26 @@ func (p *Pack) detachNicsOf(vmID string) {
 		if stringOf(nic.Attrs["LinkVmId"]) != vmID {
 			continue
 		}
-		delete(nic.Attrs, "LinkVmId")
-		delete(nic.Attrs, "DeviceNumber")
-		delete(nic.Attrs, "LinkNicId")
-		nic.Attrs["State"] = "available"
-		p.env.Store.Commit(nic, p.env.Now())
+		// Re-checked under the lock, same reason as detachVolumesOf (#295).
+		_ = p.env.Store.Update(Name, kindNic, nic.ID, func(stored *resource.Resource) error {
+			if stringOf(stored.Attrs["LinkVmId"]) != vmID {
+				return errNicLinkMoved
+			}
+			delete(stored.Attrs, "LinkVmId")
+			delete(stored.Attrs, "DeviceNumber")
+			delete(stored.Attrs, "LinkNicId")
+			stored.Attrs["State"] = "available"
+			stored.Updated = p.env.Now()
+			return nil
+		})
 	}
 }
+
+// The refusals the NIC link paths answer from inside the store lock (#295).
+var (
+	errNicAttached  = errors.New("the interface is already attached")
+	errNicLinkMoved = errors.New("the link is no longer what the caller resolved")
+)
 
 // publicDNSName renders the name the real cloud derives from a public address:
 // ows-203-0-113-1.<region>.compute.outscale.com, measured. Empty for no address,

--- a/internal/providers/outscale/nics.go
+++ b/internal/providers/outscale/nics.go
@@ -241,8 +241,14 @@ func (p *Pack) storedNicView(nic *resource.Resource) map[string]any {
 	// and the destroy unable to finish.
 	// TestAnAttachedNicReportsTheLinkStateTheProviderWaitsFor fails without this.
 	if vmID := stringOf(nic.Attrs["LinkVmId"]); vmID != "" {
+		// The flag is the stored one, never a constant: this line published
+		// `false` whatever UpdateNic had stored, so the one request that sets
+		// it was denied by every read that followed — the same shape as the
+		// constant Tags before #99 (#299).
+		// TestDeleteOnVmDeletionRoundTripsThroughUpdateNic fails without it.
+		flag, _ := nic.Attrs["DeleteOnVmDeletion"].(bool)
 		out["LinkNic"] = map[string]any{
-			"DeleteOnVmDeletion": false,
+			"DeleteOnVmDeletion": flag,
 			"DeviceNumber":       numOf(nic.Attrs["DeviceNumber"]),
 			"LinkNicId":          stringOf(nic.Attrs["LinkNicId"]),
 			"State":              "attached",
@@ -399,6 +405,13 @@ func (p *Pack) linkNic(w http.ResponseWriter, r *http.Request) {
 		stored.Attrs["LinkVmId"] = req.VMID
 		stored.Attrs["DeviceNumber"] = *req.DeviceNumber
 		stored.Attrs["LinkNicId"] = linkID
+		// False at attach time, and that is the SDK's shape rather than a
+		// choice: LinkNicRequest (osc-sdk-go client.gen.go) carries no
+		// DeleteOnVmDeletion, so a fresh attachment can only start at the
+		// default — false, which is also what the 2026-08-08 lifecycle sweep
+		// recorded on a freshly linked interface. UpdateNic's LinkNicToUpdate
+		// is the one door that changes it (#299).
+		stored.Attrs["DeleteOnVmDeletion"] = false
 		stored.Attrs["State"] = "in-use"
 		stored.Updated = p.env.Now()
 		return nil
@@ -440,6 +453,7 @@ func (p *Pack) unlinkNic(w http.ResponseWriter, r *http.Request) {
 			delete(stored.Attrs, "LinkVmId")
 			delete(stored.Attrs, "DeviceNumber")
 			delete(stored.Attrs, "LinkNicId")
+			delete(stored.Attrs, "DeleteOnVmDeletion")
 			stored.Attrs["State"] = "available"
 			stored.Updated = p.env.Now()
 			return nil
@@ -454,11 +468,22 @@ func (p *Pack) unlinkNic(w http.ResponseWriter, r *http.Request) {
 	p.notFound(w, "network interface attachment", req.LinkNicID)
 }
 
-// detachNicsOf releases every secondary interface attached to a Vm, leaving the
-// interface itself in place. Called from the Vm delete path.
+// detachNicsOf releases every secondary interface attached to a Vm — or
+// deletes it, when its attachment says so. Called from the Vm delete path.
+//
+// The flag is the SDK's own contract, on LinkNic.DeleteOnVmDeletion: "If true,
+// the NIC is deleted when the VM is terminated. If false, the NIC is detached
+// from the VM" (osc-sdk-go client.gen.go). Detaching regardless would make the
+// flag a field that round-trips perfectly and governs nothing, the exact shape
+// #212 names. TestATrueDeleteOnVmDeletionDeletesTheNicWithItsVm fails without
+// the delete branch (#299).
 func (p *Pack) detachNicsOf(vmID string) {
 	for _, nic := range p.env.Store.List(kindNic, resource.Tenant{Provider: Name}) {
 		if stringOf(nic.Attrs["LinkVmId"]) != vmID {
+			continue
+		}
+		if goes, _ := nic.Attrs["DeleteOnVmDeletion"].(bool); goes {
+			p.env.Store.Delete(Name, kindNic, nic.ID)
 			continue
 		}
 		// Re-checked under the lock, same reason as detachVolumesOf (#295).
@@ -469,6 +494,7 @@ func (p *Pack) detachNicsOf(vmID string) {
 			delete(stored.Attrs, "LinkVmId")
 			delete(stored.Attrs, "DeviceNumber")
 			delete(stored.Attrs, "LinkNicId")
+			delete(stored.Attrs, "DeleteOnVmDeletion")
 			stored.Attrs["State"] = "available"
 			stored.Updated = p.env.Now()
 			return nil

--- a/internal/providers/outscale/privateips.go
+++ b/internal/providers/outscale/privateips.go
@@ -115,19 +115,30 @@ func (p *Pack) linkPrivateIps(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Written by Commit rather than Put: the NIC may have been deleted while the
-	// addresses were being computed, and Put would resurrect it.
-	added := secondaryAddresses(nic)
-	for _, address := range wanted {
-		if !contains(added, address) {
-			added = append(added, address)
+	// The merge runs under the store lock, on the stored address list rather
+	// than on the clone resolved above: merged into the clone and committed
+	// wholesale, this erased a concurrent write to another field of the same
+	// NIC — its tags, its description — after their 200 (#295). Update also
+	// keeps a NIC deleted while the addresses were being computed deleted,
+	// which is what Commit was here for.
+	var updated *resource.Resource
+	err = p.env.Store.Update(Name, kindNic, req.NicID, func(stored *resource.Resource) error {
+		added := secondaryAddresses(stored)
+		for _, address := range wanted {
+			if !contains(added, address) {
+				added = append(added, address)
+			}
 		}
-	}
-	p.setSecondaryAddresses(nic, added)
-	if !p.env.Store.Commit(nic, p.env.Now()) {
+		p.setSecondaryAddresses(stored, added)
+		stored.Updated = p.env.Now()
+		updated = stored
+		return nil
+	})
+	if err != nil {
 		p.notFound(w, "network interface", req.NicID)
 		return
 	}
+	nic = updated
 
 	// Released before the runtime is touched, and this line is the fix for a
 	// comment that described the opposite of what the code did (#216).
@@ -184,17 +195,27 @@ func (p *Pack) unlinkPrivateIps(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	kept := make([]string, 0, len(held))
-	for _, address := range held {
-		if !contains(req.PrivateIps, address) {
-			kept = append(kept, address)
+	// The removal recomputes from the stored list, under the lock, same reason
+	// as linkPrivateIps (#295).
+	var updated *resource.Resource
+	err := p.env.Store.Update(Name, kindNic, req.NicID, func(stored *resource.Resource) error {
+		current := secondaryAddresses(stored)
+		kept := make([]string, 0, len(current))
+		for _, address := range current {
+			if !contains(req.PrivateIps, address) {
+				kept = append(kept, address)
+			}
 		}
-	}
-	p.setSecondaryAddresses(nic, kept)
-	if !p.env.Store.Commit(nic, p.env.Now()) {
+		p.setSecondaryAddresses(stored, kept)
+		stored.Updated = p.env.Now()
+		updated = stored
+		return nil
+	})
+	if err != nil {
 		p.notFound(w, "network interface", req.NicID)
 		return
 	}
+	nic = updated
 	// Same release as the link path, and for the same reason.
 	unlock()
 	p.carrySecondary(r.Context(), nic)

--- a/internal/providers/outscale/publicip_routing_test.go
+++ b/internal/providers/outscale/publicip_routing_test.go
@@ -209,8 +209,9 @@ func TestAPoisonedPublicIpIsNeverRouted(t *testing.T) {
 	if !found {
 		t.Fatal("the public IP is not in the store")
 	}
+	base := stored.Clone()
 	stored.Attrs["PublicIp"] = poison
-	env.Store.Commit(stored, env.Now())
+	env.Store.Commit(base, stored, env.Now())
 
 	_, out = post(t, ts, "CreateVms", `{"ImageId":"ami-00000001","VmType":"tinav6.c1r1p2"}`)
 	vms, _ := out["Vms"].([]any)

--- a/internal/providers/outscale/publicips.go
+++ b/internal/providers/outscale/publicips.go
@@ -2,6 +2,7 @@ package outscale
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/netip"
@@ -368,13 +369,29 @@ func (p *Pack) linkPublicIP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	linkID := newID("eipassoc", p.env.NewID())
-	address.Attrs["VmId"] = req.VMID
-	address.Attrs["NicId"] = nicID
-	address.Attrs["LinkPublicIpId"] = linkID
-	if privateIP != "" {
-		address.Attrs["PrivateIp"] = privateIP
-	}
-	if !p.env.Store.Commit(address, p.env.Now()) {
+	// The link is written in one critical section held by the store: as a
+	// Get-mutate-Commit sequence it erased a concurrent write to another field
+	// of the same address — its tags — after their 200 (#295). The NAT hold is
+	// re-checked in the same section, because it can appear between the check
+	// above and this write.
+	err := p.env.Store.Update(Name, kindPublicIP, address.ID, func(stored *resource.Resource) error {
+		if natID := stringOf(stored.Attrs["NatServiceId"]); natID != "" {
+			return errAddressHeldByNat
+		}
+		stored.Attrs["VmId"] = req.VMID
+		stored.Attrs["NicId"] = nicID
+		stored.Attrs["LinkPublicIpId"] = linkID
+		if privateIP != "" {
+			stored.Attrs["PrivateIp"] = privateIP
+		}
+		stored.Updated = p.env.Now()
+		return nil
+	})
+	switch {
+	case errors.Is(err, errAddressHeldByNat):
+		p.conflict(w, "the public IP "+address.ID+" is held by a NAT service")
+		return
+	case err != nil:
 		p.notFound(w, "public IP", address.ID)
 		return
 	}
@@ -422,12 +439,19 @@ func (p *Pack) unlinkPublicIP(w http.ResponseWriter, r *http.Request) {
 }
 
 // releasePublicIP drops the machine-side link, leaving the address allocated.
+//
+// Inside the store lock, on the stored address: releasing over the caller's
+// clone wrote the whole resource back and erased a concurrent write to another
+// field — a tag landing while a Vm terminates — after its 200 (#295).
 func (p *Pack) releasePublicIP(address *resource.Resource) {
-	delete(address.Attrs, "VmId")
-	delete(address.Attrs, "NicId")
-	delete(address.Attrs, "LinkPublicIpId")
-	delete(address.Attrs, "PrivateIp")
-	_ = p.env.Store.Commit(address, p.env.Now())
+	_ = p.env.Store.Update(Name, kindPublicIP, address.ID, func(stored *resource.Resource) error {
+		delete(stored.Attrs, "VmId")
+		delete(stored.Attrs, "NicId")
+		delete(stored.Attrs, "LinkPublicIpId")
+		delete(stored.Attrs, "PrivateIp")
+		stored.Updated = p.env.Now()
+		return nil
+	})
 }
 
 // publicIPByRef resolves an address by id or by value, the two ways every

--- a/internal/providers/outscale/updates.go
+++ b/internal/providers/outscale/updates.go
@@ -1,10 +1,17 @@
 package outscale
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/stephrobert/feint/internal/core/emulator"
 	"github.com/stephrobert/feint/internal/core/resource"
+)
+
+// The refusals this file answers from inside the store lock (#295).
+var (
+	errNicNotAttached = errors.New("the interface is not attached")
+	errRouteLinkMoved = errors.New("the link left this table while the request was deciding")
 )
 
 // The in-place half of resources this pack already creates, reads and deletes
@@ -48,8 +55,7 @@ func (p *Pack) updateNet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	res, found := p.env.Store.Get(Name, kindNet, req.NetID)
-	if !found {
+	if _, found := p.env.Store.Get(Name, kindNet, req.NetID); !found {
 		p.notFound(w, "net", req.NetID)
 		return
 	}
@@ -74,15 +80,23 @@ func (p *Pack) updateNet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	res.Attrs["DhcpOptionsSetId"] = req.DhcpOptionsSetID
-	// Commit rather than Put: the Net may have been deleted while this request
-	// was decoding, and Put would bring it back carrying the new value.
-	if !p.env.Store.Commit(res, p.env.Now()) {
+	// Inside the store lock, on the stored Net: written back wholesale from a
+	// clone, this erased a concurrent write to another field of the same Net —
+	// its tags — after their 200 (#295). Update also keeps a Net deleted while
+	// this request was deciding deleted, which is what Commit was here for.
+	var updated *resource.Resource
+	err := p.env.Store.Update(Name, kindNet, req.NetID, func(stored *resource.Resource) error {
+		stored.Attrs["DhcpOptionsSetId"] = req.DhcpOptionsSetID
+		stored.Updated = p.env.Now()
+		updated = stored
+		return nil
+	})
+	if err != nil {
 		p.notFound(w, "net", req.NetID)
 		return
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"Net":             netView(res),
+		"Net":             netView(updated),
 		"ResponseContext": p.context(),
 	})
 }
@@ -111,18 +125,20 @@ func (p *Pack) updateSubnet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	res, found := p.env.Store.Get(Name, kindSubnet, req.SubnetID)
-	if !found {
-		p.notFound(w, "subnet", req.SubnetID)
-		return
-	}
-	res.Attrs["MapPublicIpOnLaunch"] = *req.MapPublicIPOnLaunch
-	if !p.env.Store.Commit(res, p.env.Now()) {
+	// Inside the store lock, same reason as updateNet (#295).
+	var updated *resource.Resource
+	err := p.env.Store.Update(Name, kindSubnet, req.SubnetID, func(stored *resource.Resource) error {
+		stored.Attrs["MapPublicIpOnLaunch"] = *req.MapPublicIPOnLaunch
+		stored.Updated = p.env.Now()
+		updated = stored
+		return nil
+	})
+	if err != nil {
 		p.notFound(w, "subnet", req.SubnetID)
 		return
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"Subnet":          p.subnetView(res),
+		"Subnet":          p.subnetView(updated),
 		"ResponseContext": p.context(),
 	})
 }
@@ -153,14 +169,9 @@ func (p *Pack) updateNic(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	res, found := p.env.Store.Get(Name, kindNic, req.NicID)
-	if !found {
+	if _, found := p.env.Store.Get(Name, kindNic, req.NicID); !found {
 		p.notFound(w, "nic", req.NicID)
 		return
-	}
-
-	if req.Description != nil {
-		res.Attrs["Description"] = *req.Description
 	}
 	if req.SecurityGroupIDs != nil {
 		// Checked by the same helper createNic uses, so a group that does not
@@ -170,24 +181,48 @@ func (p *Pack) updateNic(w http.ResponseWriter, r *http.Request) {
 		if !p.checkVMSecurityGroups(w, req.SecurityGroupIDs) {
 			return
 		}
-		res.Attrs["SecurityGroupIds"] = req.SecurityGroupIDs
-	}
-	if req.LinkNic != nil && req.LinkNic.DeleteOnVMDeletion != nil {
-		link, _ := res.Attrs["LinkNic"].(map[string]any)
-		if link == nil {
-			p.badRequest(w, "NicId "+req.NicID+" is not attached, so its attachment cannot be updated")
-			return
-		}
-		link["DeleteOnVmDeletion"] = *req.LinkNic.DeleteOnVMDeletion
-		res.Attrs["LinkNic"] = link
 	}
 
-	if !p.env.Store.Commit(res, p.env.Now()) {
+	// Inside the store lock, same reason as updateNet (#295). The LinkNic map
+	// is copied before it changes, never written through: resource.Clone is
+	// shallow on Attrs values, so `link["DeleteOnVmDeletion"] = …` on the clone
+	// mutated the stored map in place — visible to every concurrent reader
+	// before the write-back, and left behind even when the write-back failed.
+	// TestUpdateNicDoesNotMutateTheStoredLinkInPlace fails without the copy.
+	var updated *resource.Resource
+	err := p.env.Store.Update(Name, kindNic, req.NicID, func(stored *resource.Resource) error {
+		if req.Description != nil {
+			stored.Attrs["Description"] = *req.Description
+		}
+		if req.SecurityGroupIDs != nil {
+			stored.Attrs["SecurityGroupIds"] = req.SecurityGroupIDs
+		}
+		if req.LinkNic != nil && req.LinkNic.DeleteOnVMDeletion != nil {
+			link, _ := stored.Attrs["LinkNic"].(map[string]any)
+			if link == nil {
+				return errNicNotAttached
+			}
+			fresh := make(map[string]any, len(link)+1)
+			for k, v := range link {
+				fresh[k] = v
+			}
+			fresh["DeleteOnVmDeletion"] = *req.LinkNic.DeleteOnVMDeletion
+			stored.Attrs["LinkNic"] = fresh
+		}
+		stored.Updated = p.env.Now()
+		updated = stored
+		return nil
+	})
+	switch {
+	case errors.Is(err, errNicNotAttached):
+		p.badRequest(w, "NicId "+req.NicID+" is not attached, so its attachment cannot be updated")
+		return
+	case err != nil:
 		p.notFound(w, "nic", req.NicID)
 		return
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"Nic":             p.storedNicView(res),
+		"Nic":             p.storedNicView(updated),
 		"ResponseContext": p.context(),
 	})
 }
@@ -221,7 +256,7 @@ func (p *Pack) updateRouteTableLink(w http.ResponseWriter, r *http.Request) {
 	// client that knew that would not need this call.
 	for _, table := range p.env.Store.List(kindRouteTable, resource.Tenant{Provider: Name}) {
 		links := listOf(table.Attrs["LinkRouteTables"])
-		for i, raw := range links {
+		for _, raw := range links {
 			link, _ := raw.(map[string]any)
 			if stringOf(link["LinkRouteTableId"]) != req.LinkRouteTableID {
 				continue
@@ -252,23 +287,48 @@ func (p *Pack) updateRouteTableLink(w http.ResponseWriter, r *http.Request) {
 			// fails without this.
 			//
 			// Copies, not mutations: nested values inside Attrs are shared with
-			// the store until Commit (resource.Clone documents it), so both the
-			// shrunk list and the moved link are built fresh.
-			rest := make([]any, 0, len(links)-1)
-			rest = append(rest, links[:i]...)
-			rest = append(rest, links[i+1:]...)
-			table.Attrs["LinkRouteTables"] = rest
-			if !p.env.Store.Commit(table, p.env.Now()) {
-				p.notFound(w, "route table", table.ID)
+			// the store (resource.Clone documents it), so the shrunk list, the
+			// grown list and the moved link are all built fresh. And each write
+			// runs inside the store lock, re-finding the link on the stored
+			// table: written back wholesale from the walk's clones, this erased
+			// a concurrent write to another field of either table — a route, a
+			// tag — after its 200 (#295).
+			var moved map[string]any
+			err := p.env.Store.Update(Name, kindRouteTable, table.ID, func(stored *resource.Resource) error {
+				held := listOf(stored.Attrs["LinkRouteTables"])
+				for j, rawHeld := range held {
+					current, _ := rawHeld.(map[string]any)
+					if stringOf(current["LinkRouteTableId"]) != req.LinkRouteTableID {
+						continue
+					}
+					rest := make([]any, 0, len(held)-1)
+					rest = append(rest, held[:j]...)
+					rest = append(rest, held[j+1:]...)
+					stored.Attrs["LinkRouteTables"] = rest
+					stored.Updated = p.env.Now()
+					moved = make(map[string]any, len(current)+1)
+					for k, v := range current {
+						moved[k] = v
+					}
+					return nil
+				}
+				return errRouteLinkMoved
+			})
+			if err != nil {
+				p.notFound(w, "route table link", req.LinkRouteTableID)
 				return
 			}
-			moved := make(map[string]any, len(link))
-			for k, v := range link {
-				moved[k] = v
-			}
 			moved["RouteTableId"] = req.RouteTableID
-			target.Attrs["LinkRouteTables"] = append(listOf(target.Attrs["LinkRouteTables"]), moved)
-			if !p.env.Store.Commit(target, p.env.Now()) {
+			err = p.env.Store.Update(Name, kindRouteTable, req.RouteTableID, func(stored *resource.Resource) error {
+				held := listOf(stored.Attrs["LinkRouteTables"])
+				grown := make([]any, 0, len(held)+1)
+				grown = append(grown, held...)
+				grown = append(grown, moved)
+				stored.Attrs["LinkRouteTables"] = grown
+				stored.Updated = p.env.Now()
+				return nil
+			})
+			if err != nil {
 				p.notFound(w, "route table", req.RouteTableID)
 				return
 			}

--- a/internal/providers/outscale/updates.go
+++ b/internal/providers/outscale/updates.go
@@ -8,10 +8,11 @@ import (
 	"github.com/stephrobert/feint/internal/core/resource"
 )
 
-// The refusals this file answers from inside the store lock (#295).
+// The refusals this file answers from inside the store lock (#295, #299).
 var (
-	errNicNotAttached = errors.New("the interface is not attached")
-	errRouteLinkMoved = errors.New("the link left this table while the request was deciding")
+	errNicNotAttached  = errors.New("the interface is not attached")
+	errWrongAttachment = errors.New("the request names another attachment")
+	errRouteLinkMoved  = errors.New("the link left this table while the request was deciding")
 )
 
 // The in-place half of resources this pack already creates, reads and deletes
@@ -198,16 +199,36 @@ func (p *Pack) updateNic(w http.ResponseWriter, r *http.Request) {
 			stored.Attrs["SecurityGroupIds"] = req.SecurityGroupIDs
 		}
 		if req.LinkNic != nil && req.LinkNic.DeleteOnVMDeletion != nil {
-			link, _ := stored.Attrs["LinkNic"].(map[string]any)
-			if link == nil {
+			// The attachment lives in the flat keys linkNic writes; the
+			// LinkNic map is the shape a foreign snapshot restores, and it
+			// stays readable rather than silently dropped — a restored state
+			// is untrusted input, not an invalid one. This branch answered
+			// 400 "not attached" for every NIC this pack itself attached,
+			// because it read only the map nothing here ever wrote (#299).
+			attachmentID := stringOf(stored.Attrs["LinkNicId"])
+			link, hasMap := stored.Attrs["LinkNic"].(map[string]any)
+			if attachmentID == "" && hasMap {
+				attachmentID = stringOf(link["LinkNicId"])
+			}
+			if attachmentID == "" {
 				return errNicNotAttached
 			}
-			fresh := make(map[string]any, len(link)+1)
-			for k, v := range link {
-				fresh[k] = v
+			// "If you are modifying the `DeleteOnVmDeletion` attribute, you
+			// must specify the ID of the NIC attachment" — LinkNicToUpdate,
+			// osc-sdk-go client.gen.go. An absent or foreign ID is refused,
+			// not guessed around.
+			if req.LinkNic.LinkNicID != attachmentID {
+				return errWrongAttachment
 			}
-			fresh["DeleteOnVmDeletion"] = *req.LinkNic.DeleteOnVMDeletion
-			stored.Attrs["LinkNic"] = fresh
+			stored.Attrs["DeleteOnVmDeletion"] = *req.LinkNic.DeleteOnVMDeletion
+			if hasMap {
+				fresh := make(map[string]any, len(link)+1)
+				for k, v := range link {
+					fresh[k] = v
+				}
+				fresh["DeleteOnVmDeletion"] = *req.LinkNic.DeleteOnVMDeletion
+				stored.Attrs["LinkNic"] = fresh
+			}
 		}
 		stored.Updated = p.env.Now()
 		updated = stored
@@ -216,6 +237,10 @@ func (p *Pack) updateNic(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case errors.Is(err, errNicNotAttached):
 		p.badRequest(w, "NicId "+req.NicID+" is not attached, so its attachment cannot be updated")
+		return
+	case errors.Is(err, errWrongAttachment):
+		p.badRequest(w, "LinkNic.LinkNicId must name the attachment of "+req.NicID+
+			": modifying DeleteOnVmDeletion requires the ID of the NIC attachment")
 		return
 	case err != nil:
 		p.notFound(w, "nic", req.NicID)

--- a/internal/providers/outscale/vms.go
+++ b/internal/providers/outscale/vms.go
@@ -344,8 +344,12 @@ func (p *Pack) createVms(w http.ResponseWriter, r *http.Request) {
 			// so a delete arriving mid-boot raced the start it was meant to
 			// cancel.
 			unlock := p.binding().Serialise(res.ID)
+			// The base of the write-back: the boot owns the state and the
+			// runtime name, and nothing else — a tag acknowledged between the
+			// Put above and this Commit survives it (#295).
+			base := res.Clone()
 			p.powerOn(r.Context(), res)
-			if !p.env.Store.Commit(res, p.env.Now()) {
+			if !p.env.Store.Commit(base, res, p.env.Now()) {
 				// Gone while it was starting — a delete, or a snapshot restored
 				// over it, which `PUT /_feint/state` does and snapshot.go
 				// documents as a designed path. The machine has to go with it:
@@ -552,50 +556,63 @@ func (p *Pack) updateVm(w http.ResponseWriter, r *http.Request) {
 	unlock := p.binding().Serialise(req.VMID)
 	defer unlock()
 
-	res, ok := p.env.Store.Get(Name, kindVM, req.VMID)
-	if !ok {
+	if _, ok := p.env.Store.Get(Name, kindVM, req.VMID); !ok {
 		p.notFound(w, "VM", req.VMID)
 		return
 	}
+	if len(req.SecurityGroupIDs) > 0 && !p.checkVMSecurityGroups(w, req.SecurityGroupIDs) {
+		return
+	}
 
-	// Outscale refuses to retype a running machine, and so does every other
-	// cloud: the guest would have to be rebuilt underneath itself.
-	if req.VMType != "" && req.VMType != res.Attrs["VmType"] {
-		if res.State == stateRunning {
-			p.conflict(w, "the VM "+res.ID+" must be stopped before its type can change")
-			return
+	// The hold above orders this against the lifecycle paths; the store lock
+	// below is what keeps a concurrent CreateTags on the same Vm intact. The
+	// two are not redundant: the hold cannot cover a writer that does not take
+	// it, and the wholesale Commit this used to end with erased exactly such a
+	// writer's acknowledged tag (#295).
+	var updated *resource.Resource
+	err := p.env.Store.Update(Name, kindVM, req.VMID, func(stored *resource.Resource) error {
+		// Outscale refuses to retype a running machine, and so does every other
+		// cloud: the guest would have to be rebuilt underneath itself.
+		if req.VMType != "" && req.VMType != stored.Attrs["VmType"] {
+			if stored.State == stateRunning {
+				return errVmRunning
+			}
+			stored.Attrs["VmType"] = req.VMType
 		}
-		res.Attrs["VmType"] = req.VMType
-	}
-	if len(req.SecurityGroupIDs) > 0 {
-		if !p.checkVMSecurityGroups(w, req.SecurityGroupIDs) {
-			return
+		if len(req.SecurityGroupIDs) > 0 {
+			stored.Attrs["SecurityGroupIds"] = req.SecurityGroupIDs
 		}
-		res.Attrs["SecurityGroupIds"] = req.SecurityGroupIDs
-	}
-	if req.KeypairName != "" {
-		res.Attrs["KeypairName"] = req.KeypairName
-	}
-	if req.UserData != "" {
-		res.Attrs["UserData"] = req.UserData
-	}
-	// TestDeletionProtectionCanBeClearedByAnUpdate fails without this.
-	if req.DeletionProtection != nil {
-		res.Attrs["DeletionProtection"] = *req.DeletionProtection
-	}
-	if req.IsSourceDestChecked != nil {
-		res.Attrs[attrSourceDestChecked] = *req.IsSourceDestChecked
-	}
-	// After the VmType block above, so a retype's performance flag wins over
-	// whatever was stored — upstream's own precedence (vmoptions.go).
-	storeVmOptions(res, req.vmOptionsRequest, stringOf(res.Attrs["VmType"]))
-	if !p.env.Store.Commit(res, p.env.Now()) {
-		p.notFound(w, "Vm", res.ID)
+		if req.KeypairName != "" {
+			stored.Attrs["KeypairName"] = req.KeypairName
+		}
+		if req.UserData != "" {
+			stored.Attrs["UserData"] = req.UserData
+		}
+		// TestDeletionProtectionCanBeClearedByAnUpdate fails without this.
+		if req.DeletionProtection != nil {
+			stored.Attrs["DeletionProtection"] = *req.DeletionProtection
+		}
+		if req.IsSourceDestChecked != nil {
+			stored.Attrs[attrSourceDestChecked] = *req.IsSourceDestChecked
+		}
+		// After the VmType block above, so a retype's performance flag wins over
+		// whatever was stored — upstream's own precedence (vmoptions.go).
+		storeVmOptions(stored, req.vmOptionsRequest, stringOf(stored.Attrs["VmType"]))
+		stored.Updated = p.env.Now()
+		updated = stored
+		return nil
+	})
+	switch {
+	case errors.Is(err, errVmRunning):
+		p.conflict(w, "the VM "+req.VMID+" must be stopped before its type can change")
+		return
+	case err != nil:
+		p.notFound(w, "Vm", req.VMID)
 		return
 	}
 
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"Vm":              p.vmView(res),
+		"Vm":              p.vmView(updated),
 		"ResponseContext": p.context(),
 	})
 }
@@ -774,6 +791,10 @@ func (p *Pack) deleteVms(w http.ResponseWriter, r *http.Request) {
 			unlock := p.binding().Serialise(res.ID)
 			defer unlock()
 
+			// The base of the write-back: the terminate owns the state, and a
+			// tag acknowledged while the machine was being destroyed survives
+			// it (#295).
+			base := res.Clone()
 			previous := res.State
 			// Terminating releases the machine's public address, which is
 			// upstream's own behaviour: the address stays allocated and stops
@@ -792,7 +813,7 @@ func (p *Pack) deleteVms(w http.ResponseWriter, r *http.Request) {
 			// TestATerminatedVmStaysReadable fails without this.
 			res.State = stateTerminated
 			res.Attrs["State"] = stateTerminated
-			if !p.env.Store.Commit(res, p.env.Now()) {
+			if !p.env.Store.Commit(base, res, p.env.Now()) {
 				// Deleted underneath: nothing left to mark.
 				return
 			}
@@ -836,6 +857,10 @@ func Gone(res *resource.Resource) bool {
 // errPlacementMismatch is what a create gets for a Placement naming a zone its
 // own Subnet does not sit in.
 var errPlacementMismatch = errors.New("the Placement contradicts the Subnet")
+
+// errVmRunning is the retype refusal, answered from inside the store lock
+// where the state cannot move underneath the check (#295).
+var errVmRunning = errors.New("the VM is running")
 
 // resolvedPlacement is the placement a create stores: what the client asked,
 // else the Subnet's own zone, else the default — in that order, because the

--- a/internal/providers/outscale/volumes.go
+++ b/internal/providers/outscale/volumes.go
@@ -1,6 +1,7 @@
 package outscale
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 	"time"
@@ -159,32 +160,40 @@ func (p *Pack) updateVolume(w http.ResponseWriter, r *http.Request) {
 		p.badRequest(w, err.Error())
 		return
 	}
-	res, found := p.env.Store.Get(Name, kindVolume, req.VolumeID)
-	if !found {
-		p.notFound(w, "volume", req.VolumeID)
-		return
-	}
-
-	if req.Size > 0 {
-		current, _ := res.Attrs["Size"].(int)
-		if req.Size < current {
-			p.conflict(w, "a volume cannot shrink: "+res.ID+" is already larger than the size requested")
-			return
+	// The read, the shrink check and the write are one critical section held
+	// by the store: as a Get-check-Commit sequence this lost a concurrent write
+	// to another field of the same volume — the tag the client had just been
+	// acknowledged, measured at 11/200 trials (#295).
+	// TestConcurrentTagAndLinkKeepBothVolumeWrites fails without this shape.
+	var updated *resource.Resource
+	err := p.env.Store.Update(Name, kindVolume, req.VolumeID, func(stored *resource.Resource) error {
+		if req.Size > 0 {
+			current, _ := stored.Attrs["Size"].(int)
+			if req.Size < current {
+				return errVolumeShrinks
+			}
+			stored.Attrs["Size"] = req.Size
 		}
-		res.Attrs["Size"] = req.Size
-	}
-	if req.VolumeType != "" {
-		res.Attrs["VolumeType"] = req.VolumeType
-	}
-	if req.Iops > 0 {
-		res.Attrs["Iops"] = req.Iops
-	}
-	if !p.env.Store.Commit(res, p.env.Now()) {
+		if req.VolumeType != "" {
+			stored.Attrs["VolumeType"] = req.VolumeType
+		}
+		if req.Iops > 0 {
+			stored.Attrs["Iops"] = req.Iops
+		}
+		stored.Updated = p.env.Now()
+		updated = stored
+		return nil
+	})
+	switch {
+	case errors.Is(err, errVolumeShrinks):
+		p.conflict(w, "a volume cannot shrink: "+req.VolumeID+" is already larger than the size requested")
+		return
+	case err != nil:
 		p.notFound(w, "volume", req.VolumeID)
 		return
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"Volume":          p.volumeView(res),
+		"Volume":          p.volumeView(updated),
 		"ResponseContext": p.context(),
 	})
 }
@@ -231,23 +240,33 @@ func (p *Pack) linkVolume(w http.ResponseWriter, r *http.Request) {
 		p.badRequest(w, err.Error())
 		return
 	}
-	res, found := p.env.Store.Get(Name, kindVolume, req.VolumeID)
-	if !found {
-		p.notFound(w, "volume", req.VolumeID)
-		return
-	}
 	if _, found := p.env.Store.Get(Name, kindVM, req.VMID); !found {
 		p.notFound(w, "Vm", req.VMID)
 		return
 	}
-	if holder, _ := res.Attrs["LinkedVmId"].(string); holder != "" && holder != req.VMID {
-		p.conflict(w, "the volume "+res.ID+" is already linked to "+holder)
+	// The holder check runs on the stored volume, under the lock, never on a
+	// stale clone: checked outside, two concurrent links on one free volume
+	// both passed and the loser's 200 was erased — and the erased write was
+	// sometimes the tag another handler had just acknowledged (#295, the
+	// measured pair of this file).
+	// TestConcurrentTagAndLinkKeepBothVolumeWrites fails without this shape.
+	var holder string
+	err := p.env.Store.Update(Name, kindVolume, req.VolumeID, func(stored *resource.Resource) error {
+		if held, _ := stored.Attrs["LinkedVmId"].(string); held != "" && held != req.VMID {
+			holder = held
+			return errVolumeHeld
+		}
+		stored.Attrs["LinkedVmId"] = req.VMID
+		stored.Attrs["DeviceName"] = req.DeviceName
+		stored.State = volumeStateInUse
+		stored.Updated = p.env.Now()
+		return nil
+	})
+	switch {
+	case errors.Is(err, errVolumeHeld):
+		p.conflict(w, "the volume "+req.VolumeID+" is already linked to "+holder)
 		return
-	}
-	res.Attrs["LinkedVmId"] = req.VMID
-	res.Attrs["DeviceName"] = req.DeviceName
-	res.State = volumeStateInUse
-	if !p.env.Store.Commit(res, p.env.Now()) {
+	case err != nil:
 		p.notFound(w, "volume", req.VolumeID)
 		return
 	}
@@ -279,15 +298,15 @@ func (p *Pack) unlinkVolume(w http.ResponseWriter, r *http.Request) {
 	}
 	emulator.MarkRead(r, "ForceUnlink")
 	_ = req.ForceUnlink
-	res, found := p.env.Store.Get(Name, kindVolume, req.VolumeID)
-	if !found {
-		p.notFound(w, "volume", req.VolumeID)
-		return
-	}
-	delete(res.Attrs, "LinkedVmId")
-	delete(res.Attrs, "DeviceName")
-	res.State = volumeStateAvailable
-	if !p.env.Store.Commit(res, p.env.Now()) {
+	// Same critical section as linkVolume, same reason (#295).
+	err := p.env.Store.Update(Name, kindVolume, req.VolumeID, func(stored *resource.Resource) error {
+		delete(stored.Attrs, "LinkedVmId")
+		delete(stored.Attrs, "DeviceName")
+		stored.State = volumeStateAvailable
+		stored.Updated = p.env.Now()
+		return nil
+	})
+	if err != nil {
 		p.notFound(w, "volume", req.VolumeID)
 		return
 	}
@@ -429,9 +448,25 @@ func (p *Pack) detachVolumesOf(vmID string) {
 		if stringOf(vol.Attrs["LinkedVmId"]) != vmID {
 			continue
 		}
-		delete(vol.Attrs, "LinkedVmId")
-		delete(vol.Attrs, "DeviceName")
-		vol.State = volumeStateAvailable
-		p.env.Store.Commit(vol, p.env.Now())
+		// Re-checked under the lock: the link may have moved between the List
+		// above and this write, and detaching somebody else's fresh link would
+		// be this loop erasing a 200 it never saw (#295).
+		_ = p.env.Store.Update(Name, kindVolume, vol.ID, func(stored *resource.Resource) error {
+			if stringOf(stored.Attrs["LinkedVmId"]) != vmID {
+				return errVolumeHeld
+			}
+			delete(stored.Attrs, "LinkedVmId")
+			delete(stored.Attrs, "DeviceName")
+			stored.State = volumeStateAvailable
+			stored.Updated = p.env.Now()
+			return nil
+		})
 	}
 }
+
+// The refusals updateVolume and linkVolume answer from inside the store lock,
+// where the state they judge cannot move (#295).
+var (
+	errVolumeShrinks = errors.New("a volume cannot shrink")
+	errVolumeHeld    = errors.New("the volume is linked elsewhere")
+)

--- a/internal/providers/scaleway/address_routing_test.go
+++ b/internal/providers/scaleway/address_routing_test.go
@@ -247,8 +247,9 @@ func TestAPoisonedStoredAddressIsNeverRouted(t *testing.T) {
 	if !found {
 		t.Fatal("the flexible IP is not in the store")
 	}
+	base := stored.Clone()
 	stored.Attrs["address"] = poison
-	env.Store.Commit(stored, time.Unix(1700000001, 0))
+	env.Store.Commit(base, stored, time.Unix(1700000001, 0))
 
 	do(t, ts, "PATCH", zone+"/ips/"+ipID, `{"server":"`+id+`"}`)
 
@@ -257,8 +258,9 @@ func TestAPoisonedStoredAddressIsNeverRouted(t *testing.T) {
 	if !found {
 		t.Fatal("the server is not in the store")
 	}
+	serverBase := server.Clone()
 	server.Runtime["dynamic-ip"] = poison
-	env.Store.Commit(server, time.Unix(1700000002, 0))
+	env.Store.Commit(serverBase, server, time.Unix(1700000002, 0))
 	do(t, ts, "POST", zone+"/servers/"+id+"/action", `{"action":"reboot"}`)
 
 	if contains(rt.routedAddresses(), poison) {

--- a/internal/providers/scaleway/block.go
+++ b/internal/providers/scaleway/block.go
@@ -1,6 +1,7 @@
 package scaleway
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 	"time"
@@ -8,6 +9,10 @@ import (
 	"github.com/stephrobert/feint/internal/core/emulator"
 	"github.com/stephrobert/feint/internal/core/resource"
 )
+
+// errBlockVolumeShrinks is the shrink refusal, answered from inside the store
+// lock where the size it judges cannot move (#295).
+var errBlockVolumeShrinks = errors.New("a volume grows and does not shrink")
 
 // Block Storage (block/v1), Scaleway's SBS product.
 //
@@ -391,29 +396,43 @@ func (p *Pack) updateBlockVolume(w http.ResponseWriter, r *http.Request) {
 		writeInvalidArguments(w, ArgumentError{ArgumentName: "body", Reason: "format", HelpMessage: err.Error()})
 		return
 	}
-	current, _ := res.Attrs["size"].(uint64)
-	if req.Size != nil && *req.Size < current {
+	// The shrink check and the write are one critical section held by the
+	// store: as a clone-mutate-Commit sequence this erased a concurrent write
+	// to another field of the same volume after its 200 (#295).
+	var updated *resource.Resource
+	err := p.env.Store.Update(Name, kindBlockVolume, res.ID, func(stored *resource.Resource) error {
+		current, _ := stored.Attrs["size"].(uint64)
+		if req.Size != nil && *req.Size < current {
+			return errBlockVolumeShrinks
+		}
+		if req.Name != nil {
+			stored.Attrs["name"] = *req.Name
+		}
+		if req.Size != nil {
+			stored.Attrs["size"] = *req.Size
+		}
+		if req.Tags != nil {
+			stored.Attrs["tags"] = *req.Tags
+		}
+		if req.PerfIops != nil {
+			stored.Attrs["perf_iops"] = *req.PerfIops
+		}
+		stored.Updated = p.env.Now()
+		updated = stored
+		return nil
+	})
+	switch {
+	case errors.Is(err, errBlockVolumeShrinks):
 		writeInvalidArguments(w, ArgumentError{
 			ArgumentName: "size",
 			Reason:       "constraint",
 			HelpMessage:  "a volume grows and does not shrink",
 		})
 		return
+	case err != nil:
+		writeNotFound(w, "volume", res.ID)
+		return
 	}
-	updated := res.Clone()
-	if req.Name != nil {
-		updated.Attrs["name"] = *req.Name
-	}
-	if req.Size != nil {
-		updated.Attrs["size"] = *req.Size
-	}
-	if req.Tags != nil {
-		updated.Attrs["tags"] = *req.Tags
-	}
-	if req.PerfIops != nil {
-		updated.Attrs["perf_iops"] = *req.PerfIops
-	}
-	p.env.Store.Commit(updated, p.env.Now())
 	emulator.WriteJSON(w, http.StatusOK, p.blockVolumeView(updated))
 }
 
@@ -617,14 +636,23 @@ func (p *Pack) updateBlockSnapshot(w http.ResponseWriter, r *http.Request) {
 		writeInvalidArguments(w, ArgumentError{ArgumentName: "body", Reason: "format", HelpMessage: err.Error()})
 		return
 	}
-	updated := res.Clone()
-	if req.Name != nil {
-		updated.Attrs["name"] = *req.Name
+	// Inside the store lock, same reason as updateBlockVolume (#295).
+	var updated *resource.Resource
+	err := p.env.Store.Update(Name, kindBlockSnapshot, res.ID, func(stored *resource.Resource) error {
+		if req.Name != nil {
+			stored.Attrs["name"] = *req.Name
+		}
+		if req.Tags != nil {
+			stored.Attrs["tags"] = *req.Tags
+		}
+		stored.Updated = p.env.Now()
+		updated = stored
+		return nil
+	})
+	if err != nil {
+		writeNotFound(w, "snapshot", res.ID)
+		return
 	}
-	if req.Tags != nil {
-		updated.Attrs["tags"] = *req.Tags
-	}
-	p.env.Store.Commit(updated, p.env.Now())
 	emulator.WriteJSON(w, http.StatusOK, p.blockSnapshotView(updated))
 }
 

--- a/internal/providers/scaleway/images.go
+++ b/internal/providers/scaleway/images.go
@@ -392,14 +392,24 @@ func (p *Pack) updateImage(w http.ResponseWriter, r *http.Request) {
 		writeInvalidArguments(w, ArgumentError{ArgumentName: "body", Reason: "format", HelpMessage: err.Error()})
 		return
 	}
-	updated := res.Clone()
-	if req.Name != nil {
-		updated.Attrs["name"] = *req.Name
+	// Inside the store lock: the clone-mutate-Commit shape erased a concurrent
+	// write to the other field of the same image after its 200 (#295).
+	var updated *resource.Resource
+	err := p.env.Store.Update(Name, kindImage, res.ID, func(stored *resource.Resource) error {
+		if req.Name != nil {
+			stored.Attrs["name"] = *req.Name
+		}
+		if req.Tags != nil {
+			stored.Attrs["tags"] = *req.Tags
+		}
+		stored.Updated = p.env.Now()
+		updated = stored
+		return nil
+	})
+	if err != nil {
+		writeNotFound(w, "image", res.ID)
+		return
 	}
-	if req.Tags != nil {
-		updated.Attrs["tags"] = *req.Tags
-	}
-	p.env.Store.Commit(updated, p.env.Now())
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{"image": p.clientImageView(updated)})
 }
 

--- a/internal/providers/scaleway/ipam.go
+++ b/internal/providers/scaleway/ipam.go
@@ -1,6 +1,7 @@
 package scaleway
 
 import (
+	"errors"
 	"net"
 	"net/http"
 	"net/netip"
@@ -10,6 +11,14 @@ import (
 
 	"github.com/stephrobert/feint/internal/core/emulator"
 	"github.com/stephrobert/feint/internal/core/resource"
+)
+
+// The refusals the attachment paths answer from inside the store lock, where
+// the attachment they judge cannot move underneath them (#295).
+var (
+	errIPOnStandardResource = errors.New("the IP is attached to a standard resource")
+	errIPNotAttached        = errors.New("the IP is not attached to a resource")
+	errIPOnAnotherResource  = errors.New("the IP is attached to another resource")
 )
 
 // IPAM is how a client learns the address of a private NIC, and serving it is
@@ -517,33 +526,37 @@ func (p *Pack) updateIPAMIP(w http.ResponseWriter, r *http.Request) {
 		writeInvalidArguments(w, ArgumentError{ArgumentName: "body", Reason: "format", HelpMessage: err.Error()})
 		return
 	}
-	if req.Tags != nil {
-		res.Attrs["tags"] = orEmpty(*req.Tags)
-	}
-	if req.Reverses != nil {
-		reverses := make([]any, 0, len(req.Reverses))
-		for _, reverse := range req.Reverses {
-			reverses = append(reverses, map[string]any{
-				"hostname": reverse["hostname"],
-				"address":  reverse["address"],
-			})
+	// Inside the store lock: the clone-mutate-Commit shape erased a concurrent
+	// write to another field of the same address — the attachment another
+	// handler had just acknowledged — after its 200 (#295). Update also keeps
+	// an address released while this PATCH was decoding released, which is
+	// what Commit was here for (TestCommitDoesNotResurrectAReleasedAddress
+	// holds that store-level half).
+	var updated *resource.Resource
+	err := p.env.Store.Update(Name, kindIPAMIP, res.ID, func(stored *resource.Resource) error {
+		if req.Tags != nil {
+			stored.Attrs["tags"] = orEmpty(*req.Tags)
 		}
-		res.Attrs["reverses"] = reverses
-	}
-	// Commit rather than Put: an address released while this PATCH was decoding
-	// must stay released, not come back carrying new tags.
-	//
-	// TestCommitDoesNotResurrectAReleasedAddress holds the store-level half. The
-	// handler-level race has no deterministic seam — a concurrent-HTTP test of it
-	// stayed green with Put restored — so this call site is the connection, read
-	// rather than triggered. Said plainly instead of citing a test that would not
-	// fail.
-	if !p.env.Store.Commit(res, p.env.Now()) {
+		if req.Reverses != nil {
+			reverses := make([]any, 0, len(req.Reverses))
+			for _, reverse := range req.Reverses {
+				reverses = append(reverses, map[string]any{
+					"hostname": reverse["hostname"],
+					"address":  reverse["address"],
+				})
+			}
+			stored.Attrs["reverses"] = reverses
+		}
+		stored.Updated = p.env.Now()
+		updated = stored
+		return nil
+	})
+	if err != nil {
 		writeNotFound(w, "ip", res.ID)
 		return
 	}
 
-	emulator.WriteJSON(w, http.StatusOK, p.ipamIPView(res))
+	emulator.WriteJSON(w, http.StatusOK, p.ipamIPView(updated))
 }
 
 // attachIPAMIP attaches a custom resource — a MAC the emulator does not manage.
@@ -568,7 +581,9 @@ func (p *Pack) attachIPAMIP(w http.ResponseWriter, r *http.Request) {
 		writePrecondition(w, "ip", res.ID, "IP is already attached to a resource")
 		return
 	}
-	p.setCustomAttachment(res, custom)
+	if !p.setCustomAttachment(w, res, custom) {
+		return
+	}
 	emulator.WriteJSON(w, http.StatusOK, p.ipamIPView(res))
 }
 
@@ -610,7 +625,9 @@ func (p *Pack) moveIPAMIP(w http.ResponseWriter, r *http.Request) {
 		if !ok {
 			return
 		}
-		p.setCustomAttachment(res, custom)
+		if !p.setCustomAttachment(w, res, custom) {
+			return
+		}
 	}
 	emulator.WriteJSON(w, http.StatusOK, p.ipamIPView(res))
 }
@@ -624,41 +641,88 @@ func (p *Pack) detachCustom(w http.ResponseWriter, res *resource.Resource, req *
 	if !ok {
 		return false
 	}
-	if res.Runtime[runtimeNICKey] != "" {
+	// The checks and the removal run on the stored address, under the store
+	// lock, never on the caller's clone: checked outside and committed
+	// wholesale, this erased a concurrent write to another field of the same
+	// address — its tags — after their 200 (#295). Update also keeps an
+	// address released while this was deciding released, which is what the
+	// Commit it replaces was here for.
+	err := p.env.Store.Update(Name, kindIPAMIP, res.ID, func(stored *resource.Resource) error {
+		if stored.Runtime[runtimeNICKey] != "" {
+			return errIPOnStandardResource
+		}
+		current, _ := stored.Attrs[attrCustomMAC].(string)
+		if current == "" {
+			return errIPNotAttached
+		}
+		if current != custom.MacAddress {
+			return errIPOnAnotherResource
+		}
+		delete(stored.Attrs, attrCustomMAC)
+		delete(stored.Attrs, attrCustomName)
+		stored.Updated = p.env.Now()
+		return nil
+	})
+	switch {
+	case errors.Is(err, errIPOnStandardResource):
 		writePrecondition(w, "ip", res.ID, "IP is attached to a standard resource, managed by its own product")
 		return false
-	}
-	current, _ := res.Attrs[attrCustomMAC].(string)
-	if current == "" {
+	case errors.Is(err, errIPNotAttached):
 		writePrecondition(w, "ip", res.ID, "IP is not attached to a resource")
 		return false
-	}
-	if current != custom.MacAddress {
+	case errors.Is(err, errIPOnAnotherResource):
 		writeInvalidArguments(w, ArgumentError{
 			ArgumentName: argument + ".mac_address",
 			Reason:       "constraint",
 			HelpMessage:  "the IP is not attached to this resource",
 		})
 		return false
+	case err != nil:
+		// Released while this was deciding, which is not an error: the client
+		// asked for a detached address and the address is gone entirely.
+		return true
 	}
+	// The caller's clone keeps rendering the view, so it follows the store.
 	delete(res.Attrs, attrCustomMAC)
 	delete(res.Attrs, attrCustomName)
-	// Commit, never Put. Put re-inserts unconditionally, so a release that landed
-	// while this was deciding is undone and the address comes back — the
-	// resurrection CLAUDE.md records as already paid for three times. A false
-	// return means the client released it meanwhile, which is not an error.
-	p.env.Store.Commit(res, p.env.Now())
 	return true
 }
 
-func (p *Pack) setCustomAttachment(res *resource.Resource, custom *customResourceRequest) {
+// setCustomAttachment writes the attachment and reports whether the address
+// was still free to take. The exclusivity check runs inside the same critical
+// section as the write: on the caller's clone, two concurrent attaches both
+// passed it and the loser silently overwrote the winner (#295).
+func (p *Pack) setCustomAttachment(w http.ResponseWriter, res *resource.Resource, custom *customResourceRequest) bool {
+	err := p.env.Store.Update(Name, kindIPAMIP, res.ID, func(stored *resource.Resource) error {
+		if ipamAttached(stored) {
+			mac, _ := stored.Attrs[attrCustomMAC].(string)
+			if mac != custom.MacAddress {
+				return errIPOnAnotherResource
+			}
+		}
+		stored.Attrs[attrCustomMAC] = custom.MacAddress
+		delete(stored.Attrs, attrCustomName)
+		if custom.Name != nil {
+			stored.Attrs[attrCustomName] = *custom.Name
+		}
+		stored.Updated = p.env.Now()
+		return nil
+	})
+	switch {
+	case errors.Is(err, errIPOnAnotherResource):
+		writePrecondition(w, "ip", res.ID, "IP is already attached to a resource")
+		return false
+	case err != nil:
+		writeNotFound(w, "ip", res.ID)
+		return false
+	}
+	// The caller's clone keeps rendering the view, so it follows the store.
 	res.Attrs[attrCustomMAC] = custom.MacAddress
 	delete(res.Attrs, attrCustomName)
 	if custom.Name != nil {
 		res.Attrs[attrCustomName] = *custom.Name
 	}
-	// Commit rather than Put, for the reason detachCustom gives.
-	p.env.Store.Commit(res, p.env.Now())
+	return true
 }
 
 // newIPAMIP records the address a private NIC received, as the resource a

--- a/internal/providers/scaleway/ipam_lock_internal_test.go
+++ b/internal/providers/scaleway/ipam_lock_internal_test.go
@@ -149,9 +149,10 @@ func TestCommitDoesNotResurrectAReleasedAddress(t *testing.T) {
 	}
 	env.Store.Delete(Name, kindIPAMIP, id)
 
-	// What updateIPAMIP does with that clone.
+	// What updateIPAMIP did with that clone, before it moved under Store.Update.
+	base := stale.Clone()
 	stale.Attrs["tags"] = []string{"late"}
-	if pack.env.Store.Commit(stale, pack.env.Now()) {
+	if pack.env.Store.Commit(base, stale, pack.env.Now()) {
 		t.Error("Commit reported success on a resource the client had released")
 	}
 	if _, back := env.Store.Get(Name, kindIPAMIP, id); back {

--- a/internal/providers/scaleway/ips.go
+++ b/internal/providers/scaleway/ips.go
@@ -286,6 +286,11 @@ func (p *Pack) updateIP(w http.ResponseWriter, r *http.Request) {
 		writeNotFound(w, "ip", id)
 		return
 	}
+	// The base of the write-back below: this handler owns the fields the
+	// request names and the attachment, and nothing else — a tag written on
+	// the same address through another door while the runtime routes survives
+	// it (#295).
+	base := res.Clone()
 
 	var req updateIPRequest
 	if err := emulator.DecodeJSON(r, &req); err != nil {
@@ -330,7 +335,7 @@ func (p *Pack) updateIP(w http.ResponseWriter, r *http.Request) {
 
 	// attachAddress talks to the runtime outside the lock, so a release that
 	// landed meanwhile must not be undone here.
-	if !p.env.Store.Commit(res, p.env.Now()) {
+	if !p.env.Store.Commit(base, res, p.env.Now()) {
 		writeNotFound(w, "ip", res.ID)
 		return
 	}
@@ -477,9 +482,16 @@ func ipView(res *resource.Resource) map[string]any {
 func (p *Pack) releaseAddressesOf(ctx context.Context, serverID, zone string) {
 	for _, ip := range p.attachedIPsOf(serverID, zone) {
 		p.detachAddress(ctx, ip)
-		ip.Attrs["server"] = nil
-		ip.State = "detached"
-		p.env.Store.Commit(ip, p.env.Now())
+		// Inside the store lock, on the two fields this release owns: the
+		// Commit this replaces wrote the whole clone back and erased a
+		// concurrent write to another field of the same address — its tags —
+		// after their 200 (#295).
+		_ = p.env.Store.Update(Name, kindIP, ip.ID, func(stored *resource.Resource) error {
+			stored.Attrs["server"] = nil
+			stored.State = "detached"
+			stored.Updated = p.env.Now()
+			return nil
+		})
 	}
 }
 
@@ -527,12 +539,16 @@ func (p *Pack) ensureDynamicAddress(res *resource.Resource) {
 			"server", res.ID, "error", err)
 		return
 	}
+	// The base of the write-back: the allocation owns its two runtime keys and
+	// nothing else — the caller's own pending changes ride along untouched on
+	// res, and a concurrent write to any other field survives (#295).
+	base := res.Clone()
 	if res.Runtime == nil {
 		res.Runtime = map[string]string{}
 	}
 	res.Runtime[runtimeDynamicIPKey] = address.String()
 	res.Runtime[runtimeDynamicIPIDKey] = p.env.NewID()
-	p.env.Store.Commit(res, p.env.Now())
+	p.env.Store.Commit(base, res, p.env.Now())
 }
 
 // releaseDynamicAddress takes the ephemeral address back: on poweroff, standby,

--- a/internal/providers/scaleway/lostupdate_test.go
+++ b/internal/providers/scaleway/lostupdate_test.go
@@ -2,6 +2,7 @@ package scaleway_test
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -269,5 +270,177 @@ func TestDeletingAServerReleasesItsPrivateNICs(t *testing.T) {
 	if total, _ := out["total_count"].(float64); total != 0 {
 		t.Errorf("the network still holds %v address(es) after its only server was deleted: %v",
 			total, out)
+	}
+}
+
+// The cross-handler shape of #295, on this pack's server. Three writers, three
+// different handlers, disjoint fields:
+//
+//   - PATCH /servers/{id} holds the per-target lifecycle lock and writes tags;
+//   - PATCH /servers/{id}/user_data/{key} holds nothing — it wrote the whole
+//     server back with Put, from a clone read before the body had even been
+//     uploaded, which both erased any concurrent write and resurrected a
+//     deleted server;
+//   - POST /servers/{id}/action poweron holds the lock but committed the whole
+//     clone it took before the boot, so the unordered user-data writer's key
+//     vanished under it.
+//
+// The per-target hold cannot order a writer that does not take it, which is
+// what makes this trio different from the per-field barrage above: there the
+// writers were three copies of one ordered handler, here two of the three
+// windows are real. Each acknowledged write must survive the other two.
+func TestConcurrentServerUpdateAndActionKeepBothWrites(t *testing.T) {
+	ts := newTestServer(t)
+	const zone = "/instance/v1/zones/fr-par-1"
+	const cloudConfig = "#cloud-config probe"
+
+	found := storetest.NoLostUpdate(40, func(trial int) []storetest.Write {
+		status, out := do(t, ts, "POST", zone+"/servers",
+			fmt.Sprintf(`{"name":"cross-%d","commercial_type":"DEV1-S"}`, trial))
+		if status != http.StatusCreated {
+			t.Fatalf("trial %d create: status %d", trial, status)
+		}
+		server, _ := out["server"].(map[string]any)
+		id, _ := server["id"].(string)
+
+		readField := func(name string) string {
+			status, out := do(t, ts, "GET", zone+"/servers/"+id, "")
+			if status != http.StatusOK {
+				t.Fatalf("get: status %d", status)
+			}
+			server, _ := out["server"].(map[string]any)
+			switch value := server[name].(type) {
+			case string:
+				return value
+			case []any:
+				parts := make([]string, 0, len(value))
+				for _, v := range value {
+					parts = append(parts, fmt.Sprintf("%v", v))
+				}
+				return strings.Join(parts, ",")
+			default:
+				return fmt.Sprintf("%v", value)
+			}
+		}
+
+		return []storetest.Write{
+			{
+				Field: "tags",
+				Apply: func() bool {
+					status, _ := doRaw(ts, "PATCH", zone+"/servers/"+id, `{"tags":["probe"]}`)
+					return status == http.StatusOK
+				},
+				Got:  func() string { return readField("tags") },
+				Want: "probe",
+			},
+			{
+				Field: "user_data cloud-init",
+				Apply: func() bool {
+					status, _ := doRaw(ts, "PATCH", zone+"/servers/"+id+"/user_data/cloud-init", cloudConfig)
+					return status == http.StatusNoContent
+				},
+				Got: func() string {
+					req, err := http.NewRequest(http.MethodGet,
+						ts.URL+zone+"/servers/"+id+"/user_data/cloud-init", nil)
+					if err != nil {
+						return "<request failed>"
+					}
+					resp, err := ts.Client().Do(req)
+					if err != nil {
+						return "<request failed>"
+					}
+					defer func() { _ = resp.Body.Close() }()
+					if resp.StatusCode != http.StatusOK {
+						return fmt.Sprintf("<get answered %d>", resp.StatusCode)
+					}
+					raw, _ := io.ReadAll(resp.Body)
+					return string(raw)
+				},
+				Want: cloudConfig,
+			},
+			{
+				Field: "state",
+				Apply: func() bool {
+					status, _ := doRaw(ts, "POST", zone+"/servers/"+id+"/action", `{"action":"poweron"}`)
+					return status == http.StatusAccepted
+				},
+				Got:  func() string { return readField("state") },
+				Want: "running",
+			},
+		}
+	})
+
+	if len(found) > 0 {
+		t.Errorf("three handlers on one server lost an acknowledged write:\n%s", strings.Join(found, "\n"))
+	}
+}
+
+// The same defect, held open instead of raced: the user-data handler reads the
+// server, then reads the request body, then writes — and its pre-#295 shape
+// wrote the whole clone from before the upload. A body that arrives slowly is
+// the window at its natural width (a cloud-config is kilobytes on a WAN), and
+// this test streams one: the first chunk proves the handler is past its read
+// and inside the upload, a tag lands through PATCH /servers/{id}, then the
+// upload finishes. Both writes must survive, deterministically — no trial
+// count, no coin toss.
+func TestAUserDataUploadDoesNotRevertAConcurrentTagWrite(t *testing.T) {
+	ts := newTestServer(t)
+	const zone = "/instance/v1/zones/fr-par-1"
+
+	status, out := do(t, ts, "POST", zone+"/servers",
+		`{"name":"slow-upload","commercial_type":"DEV1-S"}`)
+	if status != http.StatusCreated {
+		t.Fatalf("create: status %d", status)
+	}
+	server, _ := out["server"].(map[string]any)
+	id, _ := server["id"].(string)
+
+	pr, pw := io.Pipe()
+	req, err := http.NewRequest(http.MethodPatch,
+		ts.URL+zone+"/servers/"+id+"/user_data/cloud-init", pr)
+	if err != nil {
+		t.Fatalf("build the upload: %v", err)
+	}
+	req.Header.Set("X-Auth-Token", "irrelevant-the-emulator-ignores-it")
+
+	uploaded := make(chan int, 1)
+	go func() {
+		resp, err := ts.Client().Do(req)
+		if err != nil {
+			uploaded <- -1
+			return
+		}
+		_ = resp.Body.Close()
+		uploaded <- resp.StatusCode
+	}()
+
+	// The handler resolves the server before it reads the body, so once this
+	// chunk is consumed the handler is provably past its read and mid-upload.
+	if _, err := pw.Write([]byte("#cloud-config ")); err != nil {
+		t.Fatalf("stream the first chunk: %v", err)
+	}
+
+	// The tag lands while the upload is in flight — a full round trip, so the
+	// upload handler has long resolved its clone by the time this returns.
+	if status, _ := doRaw(ts, "PATCH", zone+"/servers/"+id, `{"tags":["probe"]}`); status != http.StatusOK {
+		t.Fatalf("the tag write answered %d, so this test measures nothing", status)
+	}
+
+	if _, err := pw.Write([]byte("probe")); err != nil {
+		t.Fatalf("stream the second chunk: %v", err)
+	}
+	_ = pw.Close()
+	if status := <-uploaded; status != http.StatusNoContent {
+		t.Fatalf("the upload answered %d, so this test measures nothing", status)
+	}
+
+	status, out = do(t, ts, "GET", zone+"/servers/"+id, "")
+	if status != http.StatusOK {
+		t.Fatalf("get: status %d", status)
+	}
+	server, _ = out["server"].(map[string]any)
+	tags, _ := server["tags"].([]any)
+	if len(tags) != 1 || tags[0] != "probe" {
+		t.Errorf("the upload erased the acknowledged tag: tags are %v", tags)
 	}
 }

--- a/internal/providers/scaleway/privatenics.go
+++ b/internal/providers/scaleway/privatenics.go
@@ -289,7 +289,12 @@ func (p *Pack) attachNIC(w http.ResponseWriter, r *http.Request, serverID string
 	// narrowed, but it is a belt behind braces, and saying otherwise is the
 	// exact failure CLAUDE.md names: a sentence that reads like a proof and is
 	// not one.
-	if !p.env.Store.Commit(server, p.env.Now()) {
+	//
+	// The base is the server exactly as this handler holds it: the attachment
+	// changes nothing on the server itself, so the merge writes nothing but
+	// the modification date — a concurrent tag or user-data write survives
+	// where the old wholesale Commit erased it (#295).
+	if !p.env.Store.Commit(server.Clone(), server, p.env.Now()) {
 		writeNotFound(w, "server", server.ID)
 		return nil, false
 	}
@@ -321,8 +326,15 @@ func (p *Pack) attachNIC(w http.ResponseWriter, r *http.Request, serverID string
 	//
 	// TestARefusedAttachmentIsVisibleOnTheNIC fails without this.
 	if err := p.attachMachineToNetwork(r.Context(), server, pn, address); err != nil {
+		// Inside the store lock, and only the state: Put re-inserted a NIC
+		// deleted during the seconds the attachment took, and wrote the whole
+		// stale clone over anything else that landed meanwhile (#295).
+		_ = p.env.Store.Update(Name, kindPrivateNIC, res.ID, func(stored *resource.Resource) error {
+			stored.State = "syncing_error"
+			stored.Updated = p.env.Now()
+			return nil
+		})
 		res.State = "syncing_error"
-		p.env.Store.Put(res)
 	}
 
 	// The rule set binds to interfaces, so a NIC created after the server was
@@ -397,14 +409,19 @@ func (p *Pack) releaseNIC(res *resource.Resource) {
 	// which is what the Terraform destroy order depends on: the NIC goes first,
 	// the scaleway_ipam_ip after it. TestABookedAddressSurvivesItsNIC fails
 	// without this.
-	now := p.env.Now()
 	for _, ip := range p.ipamIPsOf(res.ID) {
 		if isBooked, _ := ip.Attrs[attrBooked].(bool); isBooked {
-			delete(ip.Runtime, runtimeNICKey)
-			delete(ip.Attrs, "mac_address")
-			delete(ip.Attrs, "zone")
-			ip.Updated = now
-			p.env.Store.Put(ip)
+			// Inside the store lock, never Get-mutate-Put: Put re-inserted an
+			// address released meanwhile, and the wholesale write erased a
+			// concurrent write to another field — its tags — after their 200
+			// (#295).
+			_ = p.env.Store.Update(Name, kindIPAMIP, ip.ID, func(stored *resource.Resource) error {
+				delete(stored.Runtime, runtimeNICKey)
+				delete(stored.Attrs, "mac_address")
+				delete(stored.Attrs, "zone")
+				stored.Updated = p.env.Now()
+				return nil
+			})
 			continue
 		}
 		p.env.Store.Delete(Name, kindIPAMIP, ip.ID)

--- a/internal/providers/scaleway/privatenics_v2alpha1.go
+++ b/internal/providers/scaleway/privatenics_v2alpha1.go
@@ -195,17 +195,24 @@ func (p *Pack) updatePrivateNetworkInterface(w http.ResponseWriter, r *http.Requ
 		writeInvalidArguments(w, ArgumentError{ArgumentName: "body", Reason: "format", HelpMessage: err.Error()})
 		return
 	}
-	if req.Tags != nil {
-		res.Attrs["tags"] = orEmpty(*req.Tags)
-	}
-	// Commit rather than Put: an update racing a delete of the same interface
-	// would otherwise put it back, address and all. The rule is the repository's,
-	// and this is the third door onto the same object.
-	if !p.env.Store.Commit(res, p.env.Now()) {
+	// Inside the store lock: it keeps an update racing a delete of the same
+	// interface from putting it back, address and all, and it keeps this write
+	// from erasing a concurrent write to another field of the same NIC after
+	// its 200 (#295).
+	var updated *resource.Resource
+	err := p.env.Store.Update(Name, kindPrivateNIC, res.ID, func(stored *resource.Resource) error {
+		if req.Tags != nil {
+			stored.Attrs["tags"] = orEmpty(*req.Tags)
+		}
+		stored.Updated = p.env.Now()
+		updated = stored
+		return nil
+	})
+	if err != nil {
 		writeNotFound(w, "private_nic", res.ID)
 		return
 	}
-	emulator.WriteJSON(w, http.StatusOK, p.privateNetworkInterfaceView(res))
+	emulator.WriteJSON(w, http.StatusOK, p.privateNetworkInterfaceView(updated))
 }
 
 // deletePrivateNetworkInterface detaches through the v2alpha1 door.

--- a/internal/providers/scaleway/servers.go
+++ b/internal/providers/scaleway/servers.go
@@ -2,6 +2,7 @@ package scaleway
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -12,6 +13,10 @@ import (
 	"github.com/stephrobert/feint/internal/core/emulator"
 	"github.com/stephrobert/feint/internal/core/resource"
 )
+
+// errServerNotStopped is the retype refusal, answered from inside the store
+// lock where the state it judges cannot move (#295).
+var errServerNotStopped = errors.New("the server is not stopped")
 
 // kindServer is the store kind for Instance servers.
 const kindServer = "instance/server"
@@ -438,22 +443,20 @@ func (p *Pack) updateServer(w http.ResponseWriter, r *http.Request) {
 	}
 	id := r.PathValue("id")
 
-	// The read, the change and the write-back are one operation, so the target is
-	// held across all three.
+	// This hold was #211's answer to concurrent PATCHes losing each other's
+	// fields, and it stopped being that when #295 moved the read-check-write
+	// into Store.Update below — measured, not assumed: with this hold released
+	// and only the store's critical section left, the
+	// TestConcurrentUpdatesKeepEveryAcknowledgedField barrage stayed green
+	// (falsification run of 2026-08-18), so citing that test here would be a
+	// citation the test no longer backs.
 	//
-	// Commit was already conditional here, so a delete landing mid-update wins.
-	// Conditional is not ordered, though, and the store says so about itself:
-	// Commit "does not merge — State, Runtime and Attrs are taken from the copy
-	// wholesale, so a concurrent write to a *different* field of the same
-	// resource is still lost". Two updates, one naming the server and the other
-	// tagging it, each committed a whole Attrs map built from its own stale read,
-	// and the loser's field vanished with a 200 in hand.
-	//
-	// This is also the only one of the three packs' update paths that had no
-	// ordering: Outscale holds the same lock, and Exoscale mutates inside
-	// store.Update, which is read-modify-write under the store's own write lock.
-	//
-	// TestConcurrentUpdatesKeepEveryAcknowledgedField fails without this line.
+	// What the hold still buys is ordering against the lifecycle paths, whose
+	// windows span runtime calls this handler never sees: serverAction takes
+	// the same hold, boots for seconds, and commits — without this line a
+	// commercial_type change could pass its stopped-state check against a
+	// server whose boot is mid-flight and land on a running machine, which is
+	// the retype the check exists to refuse.
 	unlock := p.binding().Serialise(id)
 	defer unlock()
 
@@ -468,35 +471,10 @@ func (p *Pack) updateServer(w http.ResponseWriter, r *http.Request) {
 		writeInvalidArguments(w, ArgumentError{ArgumentName: "body", Reason: "format", HelpMessage: err.Error()})
 		return
 	}
-	if req.Name != nil {
-		res.Attrs["name"] = *req.Name
-	}
-	if req.Tags != nil {
-		res.Attrs["tags"] = orEmpty(*req.Tags)
-	}
-	if req.Protected != nil {
-		res.Attrs["protected"] = *req.Protected
-		// The list travels with the flag. On fr-par-1, a PATCH that protects a
-		// running server makes the next GET answer ["backup"] alone, and the
-		// client that reads it to decide what to offer must see that without
-		// waiting for an action to be refused.
-		res.Attrs["allowed_actions"] = allowedActions(res.State, *req.Protected)
-	}
-	// The restriction is the SDK's own, quoted in UpdateServerRequest:
-	// "Cannot be changed if the Instance is not in `stopped` state." Refusing it
-	// matters more than accepting it — a test that resizes a running server and
-	// sees it work would ship code the real API rejects.
-	if req.CommercialType != nil {
-		if res.State != "stopped" {
-			writeInvalidArguments(w, ArgumentError{
-				ArgumentName: "commercial_type",
-				Reason:       "constraint",
-				HelpMessage:  "cannot be changed while the server is not stopped",
-			})
-			return
-		}
-		res.Attrs["commercial_type"] = *req.CommercialType
-	}
+	// The volume moves touch other resources and cannot run under the store
+	// lock, so they go first, on the clone; the map they computed is then
+	// written with the scalar fields in one critical section below.
+	var volumesView map[string]any
 	if req.Volumes != nil {
 		if err := p.setServerVolumes(res, *req.Volumes); err != nil {
 			writeInvalidArguments(w, ArgumentError{
@@ -506,13 +484,62 @@ func (p *Pack) updateServer(w http.ResponseWriter, r *http.Request) {
 			})
 			return
 		}
+		volumesView, _ = res.Attrs["volumes"].(map[string]any)
 	}
-	if !p.env.Store.Commit(res, p.env.Now()) {
+
+	// Inside the store lock: the clone-mutate-Commit shape this replaces
+	// erased a concurrent write to another field of the same server — the user
+	// data another handler had just acknowledged, the state a poweron had just
+	// reached — after its 200 (#295).
+	// TestConcurrentServerUpdateAndActionKeepBothWrites fails without it.
+	var updated *resource.Resource
+	err := p.env.Store.Update(Name, kindServer, id, func(stored *resource.Resource) error {
+		if req.Name != nil {
+			stored.Attrs["name"] = *req.Name
+		}
+		if req.Tags != nil {
+			stored.Attrs["tags"] = orEmpty(*req.Tags)
+		}
+		if req.Protected != nil {
+			stored.Attrs["protected"] = *req.Protected
+			// The list travels with the flag. On fr-par-1, a PATCH that protects a
+			// running server makes the next GET answer ["backup"] alone, and the
+			// client that reads it to decide what to offer must see that without
+			// waiting for an action to be refused.
+			stored.Attrs["allowed_actions"] = allowedActions(stored.State, *req.Protected)
+		}
+		// The restriction is the SDK's own, quoted in UpdateServerRequest:
+		// "Cannot be changed if the Instance is not in `stopped` state." Refusing it
+		// matters more than accepting it — a test that resizes a running server and
+		// sees it work would ship code the real API rejects. Judged on the stored
+		// state, inside the lock, where it cannot move underneath the check.
+		if req.CommercialType != nil {
+			if stored.State != "stopped" {
+				return errServerNotStopped
+			}
+			stored.Attrs["commercial_type"] = *req.CommercialType
+		}
+		if volumesView != nil {
+			stored.Attrs["volumes"] = volumesView
+		}
+		stored.Updated = p.env.Now()
+		updated = stored
+		return nil
+	})
+	switch {
+	case errors.Is(err, errServerNotStopped):
+		writeInvalidArguments(w, ArgumentError{
+			ArgumentName: "commercial_type",
+			Reason:       "constraint",
+			HelpMessage:  "cannot be changed while the server is not stopped",
+		})
+		return
+	case err != nil:
 		writeNotFound(w, "server", id)
 		return
 	}
 
-	emulator.WriteJSON(w, http.StatusOK, map[string]any{"server": p.view(res)})
+	emulator.WriteJSON(w, http.StatusOK, map[string]any{"server": p.view(updated)})
 }
 
 func (p *Pack) deleteServer(w http.ResponseWriter, r *http.Request) {
@@ -589,8 +616,7 @@ func (p *Pack) deleteServer(w http.ResponseWriter, r *http.Request) {
 // server.
 func (p *Pack) releaseServerResources(ctx context.Context, id, zone string) {
 	for _, vol := range p.volumesOf(id) {
-		p.detachVolume(vol)
-		p.env.Store.Put(vol)
+		p.detachStoredVolume(vol)
 	}
 	for _, nic := range p.privateNICsOf(id) {
 		p.releaseNIC(nic)
@@ -624,6 +650,12 @@ func (p *Pack) serverAction(w http.ResponseWriter, r *http.Request) {
 		writeNotFound(w, "server", id)
 		return
 	}
+	// The base of the write-back at the bottom: the action owns the state, the
+	// allowed actions and the machine's runtime entries, and nothing else — a
+	// tag or a user-data key acknowledged while the machine boots survives it
+	// (#295). TestConcurrentServerUpdateAndActionKeepBothWrites fails without
+	// it.
+	base := res.Clone()
 
 	var req serverActionRequest
 	if err := emulator.DecodeJSON(r, &req); err != nil {
@@ -737,7 +769,7 @@ func (p *Pack) serverAction(w http.ResponseWriter, r *http.Request) {
 	// Starting a machine takes tens of seconds and runs outside the lock. A
 	// terminate that landed meanwhile must stay landed: Put would bring the
 	// server back, address and all.
-	if !p.env.Store.Commit(res, now) {
+	if !p.env.Store.Commit(base, res, now) {
 		writeNotFound(w, "server", id)
 		return
 	}
@@ -993,10 +1025,9 @@ func (p *Pack) setServerVolumes(server *resource.Resource, wanted map[string]vol
 			// not asking, because the guard reads as present.
 			//
 			// TestAttachingDoesNotStealAnotherServersVolume fails without this.
-			if err := p.attachVolume(vol, server, name); err != nil {
+			if err := p.attachStoredVolume(vol, server, name); err != nil {
 				return err
 			}
-			p.env.Store.Put(vol)
 			keep[vol.ID] = true
 			view[key] = volumeView(vol)
 		case tmpl.Size > 0:
@@ -1021,8 +1052,7 @@ func (p *Pack) setServerVolumes(server *resource.Resource, wanted map[string]vol
 
 	for _, vol := range p.volumesOf(server.ID) {
 		if !keep[vol.ID] {
-			p.detachVolume(vol)
-			p.env.Store.Put(vol)
+			p.detachStoredVolume(vol)
 		}
 	}
 	server.Attrs["volumes"] = view
@@ -1244,10 +1274,9 @@ func (p *Pack) attachTemplateVolumes(templates map[string]volumeTemplate, root, 
 		// Skipped rather than refused, like an unknown id above: the answer says
 		// which volumes the server actually has, and a create must not take a
 		// disk from a running machine.
-		if err := p.attachVolume(vol, server, serverName); err != nil {
+		if err := p.attachStoredVolume(vol, server, serverName); err != nil {
 			continue
 		}
-		p.env.Store.Put(vol)
 		out[key] = volumeView(vol)
 	}
 	return out
@@ -1293,20 +1322,33 @@ func (p *Pack) attachServerVolume(w http.ResponseWriter, r *http.Request) {
 	// error rather than guessing.
 	key := p.nextVolumeKey(res)
 	serverName, _ := res.Attrs["name"].(string)
-	if err := p.attachVolume(vol, res, serverName); err != nil {
+	if err := p.attachStoredVolume(vol, res, serverName); err != nil {
 		writePrecondition(w, "volume", vol.ID, "the volume is attached to another server")
 		return
 	}
-	p.env.Store.Put(vol)
 
-	volumes := volumeMapOf(res)
-	volumes[key] = volumeView(vol)
-	res.Attrs["volumes"] = volumes
-	if !p.env.Store.Commit(res, p.env.Now()) {
+	// The server's map grows inside the store lock, on a fresh copy of the
+	// stored map — never through the clone's, which resource.Clone shares with
+	// the store, and never by Commit, whose wholesale write erased a concurrent
+	// write to another field of the same server after its 200 (#295).
+	entry := volumeView(vol)
+	var updated *resource.Resource
+	err := p.env.Store.Update(Name, kindServer, id, func(stored *resource.Resource) error {
+		volumes := make(map[string]any, len(volumeMapOf(stored))+1)
+		for k, v := range volumeMapOf(stored) {
+			volumes[k] = v
+		}
+		volumes[key] = entry
+		stored.Attrs["volumes"] = volumes
+		stored.Updated = p.env.Now()
+		updated = stored
+		return nil
+	})
+	if err != nil {
 		writeNotFound(w, "server", id)
 		return
 	}
-	emulator.WriteJSON(w, http.StatusOK, map[string]any{"server": p.view(res)})
+	emulator.WriteJSON(w, http.StatusOK, map[string]any{"server": p.view(updated)})
 }
 
 func (p *Pack) detachServerVolume(w http.ResponseWriter, r *http.Request) {
@@ -1331,26 +1373,48 @@ func (p *Pack) detachServerVolume(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	volumes := volumeMapOf(res)
-	for key, entry := range volumes {
-		view, _ := entry.(map[string]any)
-		if view == nil || view["id"] != req.VolumeID {
-			continue
-		}
-		delete(volumes, key)
-		if vol, ok := p.env.Store.Get(Name, kindVolume, req.VolumeID); ok {
-			p.detachVolume(vol)
-			p.env.Store.Put(vol)
-		}
-		res.Attrs["volumes"] = volumes
-		if !p.env.Store.Commit(res, p.env.Now()) {
-			writeNotFound(w, "server", id)
-			return
-		}
-		emulator.WriteJSON(w, http.StatusOK, map[string]any{"server": p.view(res)})
+	if !volumeMapHas(volumeMapOf(res), req.VolumeID) {
+		writeNotFound(w, "volume", req.VolumeID)
 		return
 	}
-	writeNotFound(w, "volume", req.VolumeID)
+	if vol, ok := p.env.Store.Get(Name, kindVolume, req.VolumeID); ok {
+		p.detachStoredVolume(vol)
+	}
+	// The server's map shrinks inside the store lock, on a fresh copy — the
+	// delete used to go through the clone's map, which resource.Clone shares
+	// with the store, and the Commit that followed erased a concurrent write
+	// to another field of the same server after its 200 (#295).
+	var updated *resource.Resource
+	err := p.env.Store.Update(Name, kindServer, id, func(stored *resource.Resource) error {
+		current := volumeMapOf(stored)
+		volumes := make(map[string]any, len(current))
+		for k, v := range current {
+			view, _ := v.(map[string]any)
+			if view != nil && view["id"] == req.VolumeID {
+				continue
+			}
+			volumes[k] = v
+		}
+		stored.Attrs["volumes"] = volumes
+		stored.Updated = p.env.Now()
+		updated = stored
+		return nil
+	})
+	if err != nil {
+		writeNotFound(w, "server", id)
+		return
+	}
+	emulator.WriteJSON(w, http.StatusOK, map[string]any{"server": p.view(updated)})
+}
+
+// volumeMapHas reports whether the map lists a volume by id.
+func volumeMapHas(volumes map[string]any, volumeID string) bool {
+	for _, entry := range volumes {
+		if view, _ := entry.(map[string]any); view != nil && view["id"] == volumeID {
+			return true
+		}
+	}
+	return false
 }
 
 // volumeMapOf is the server's volume map, always a map even when the attribute

--- a/internal/providers/scaleway/snapshots.go
+++ b/internal/providers/scaleway/snapshots.go
@@ -223,14 +223,24 @@ func (p *Pack) updateSnapshot(w http.ResponseWriter, r *http.Request) {
 		writeInvalidArguments(w, ArgumentError{ArgumentName: "body", Reason: "format", HelpMessage: err.Error()})
 		return
 	}
-	updated := res.Clone()
-	if req.Name != nil {
-		updated.Attrs["name"] = *req.Name
+	// Inside the store lock: the clone-mutate-Commit shape erased a concurrent
+	// write to the other field of the same snapshot after its 200 (#295).
+	var updated *resource.Resource
+	err := p.env.Store.Update(Name, kindSnapshot, res.ID, func(stored *resource.Resource) error {
+		if req.Name != nil {
+			stored.Attrs["name"] = *req.Name
+		}
+		if req.Tags != nil {
+			stored.Attrs["tags"] = *req.Tags
+		}
+		stored.Updated = p.env.Now()
+		updated = stored
+		return nil
+	})
+	if err != nil {
+		writeNotFound(w, "snapshot", res.ID)
+		return
 	}
-	if req.Tags != nil {
-		updated.Attrs["tags"] = *req.Tags
-	}
-	p.env.Store.Commit(updated, p.env.Now())
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{"snapshot": p.snapshotView(updated)})
 }
 

--- a/internal/providers/scaleway/sshkeys.go
+++ b/internal/providers/scaleway/sshkeys.go
@@ -137,8 +137,7 @@ func (p *Pack) getSSHKey(w http.ResponseWriter, r *http.Request) {
 
 func (p *Pack) updateSSHKey(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
-	res, ok := p.env.Store.Get(Name, kindSSHKey, id)
-	if !ok {
+	if _, ok := p.env.Store.Get(Name, kindSSHKey, id); !ok {
 		writeNotFound(w, "ssh_key", id)
 		return
 	}
@@ -148,18 +147,27 @@ func (p *Pack) updateSSHKey(w http.ResponseWriter, r *http.Request) {
 		writeInvalidArguments(w, ArgumentError{ArgumentName: "body", Reason: "format", HelpMessage: err.Error()})
 		return
 	}
-	if req.Name != nil {
-		res.Attrs["name"] = *req.Name
-	}
-	if req.Disabled != nil {
-		res.Attrs["disabled"] = *req.Disabled
-	}
-	if !p.env.Store.Commit(res, p.env.Now()) {
-		writeNotFound(w, "ssh key", res.ID)
+	// Inside the store lock: as a Get-mutate-Commit sequence, a concurrent
+	// update to the other field of the same key was erased after its 200 —
+	// the scalar half of the lost-update family (#295).
+	var updated *resource.Resource
+	err := p.env.Store.Update(Name, kindSSHKey, id, func(stored *resource.Resource) error {
+		if req.Name != nil {
+			stored.Attrs["name"] = *req.Name
+		}
+		if req.Disabled != nil {
+			stored.Attrs["disabled"] = *req.Disabled
+		}
+		stored.Updated = p.env.Now()
+		updated = stored
+		return nil
+	})
+	if err != nil {
+		writeNotFound(w, "ssh key", id)
 		return
 	}
 
-	emulator.WriteJSON(w, http.StatusOK, sshKeyView(res))
+	emulator.WriteJSON(w, http.StatusOK, sshKeyView(updated))
 }
 
 func (p *Pack) deleteSSHKey(w http.ResponseWriter, r *http.Request) {

--- a/internal/providers/scaleway/userdata.go
+++ b/internal/providers/scaleway/userdata.go
@@ -1,6 +1,7 @@
 package scaleway
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"sort"
@@ -98,12 +99,22 @@ func (p *Pack) setServerUserData(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if res.Runtime == nil {
-		res.Runtime = map[string]string{}
+	// Inside the store lock, never Get-mutate-Put: Put re-inserted a server
+	// deleted while the body was uploading, and the wholesale write erased a
+	// concurrent write to any other field of the same server after its 200 —
+	// the scalar half of the lost-update family (#295).
+	err = p.env.Store.Update(Name, kindServer, res.ID, func(stored *resource.Resource) error {
+		if stored.Runtime == nil {
+			stored.Runtime = map[string]string{}
+		}
+		stored.Runtime[userDataPrefix+key] = string(body)
+		stored.Updated = p.env.Now()
+		return nil
+	})
+	if err != nil {
+		writeNotFound(w, "server", res.ID)
+		return
 	}
-	res.Runtime[userDataPrefix+key] = string(body)
-	res.Updated = p.env.Now()
-	p.env.Store.Put(res)
 
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -114,16 +125,27 @@ func (p *Pack) deleteServerUserData(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	key := r.PathValue("key")
-	if _, found := res.Runtime[userDataPrefix+key]; !found {
+	// The existence check and the removal are one critical section, same
+	// reason as setServerUserData (#295).
+	err := p.env.Store.Update(Name, kindServer, res.ID, func(stored *resource.Resource) error {
+		if _, found := stored.Runtime[userDataPrefix+key]; !found {
+			return errUserDataMissing
+		}
+		delete(stored.Runtime, userDataPrefix+key)
+		stored.Updated = p.env.Now()
+		return nil
+	})
+	if err != nil {
 		writeNotFound(w, "user_data", key)
 		return
 	}
-	delete(res.Runtime, userDataPrefix+key)
-	res.Updated = p.env.Now()
-	p.env.Store.Put(res)
 
 	w.WriteHeader(http.StatusNoContent)
 }
+
+// errUserDataMissing is the not-found the delete answers from inside the store
+// lock, where the key it judges cannot move (#295).
+var errUserDataMissing = errors.New("no user data under that key")
 
 // userDataOf returns the value a client stored under key, empty when there is
 // none. The machine driver reads "cloud-init" through it.

--- a/internal/providers/scaleway/volumes.go
+++ b/internal/providers/scaleway/volumes.go
@@ -137,19 +137,30 @@ func (p *Pack) updateVolume(w http.ResponseWriter, r *http.Request) {
 		writeInvalidArguments(w, ArgumentError{ArgumentName: "body", Reason: "format", HelpMessage: err.Error()})
 		return
 	}
-	if req.Name != nil {
-		res.Attrs["name"] = *req.Name
+	// Inside the store lock, never Get-mutate-Put: Put re-inserted a volume
+	// deleted while this PATCH was decoding, and the wholesale write erased a
+	// concurrent write to another field of the same volume after its 200 —
+	// the scalar half of the lost-update family (#295).
+	var updated *resource.Resource
+	err := p.env.Store.Update(Name, kindVolume, res.ID, func(stored *resource.Resource) error {
+		if req.Name != nil {
+			stored.Attrs["name"] = *req.Name
+		}
+		if req.Tags != nil {
+			stored.Attrs["tags"] = orEmpty(*req.Tags)
+		}
+		if req.Size != nil {
+			stored.Attrs["size"] = *req.Size
+		}
+		stored.Updated = p.env.Now()
+		updated = stored
+		return nil
+	})
+	if err != nil {
+		writeNotFound(w, "volume", res.ID)
+		return
 	}
-	if req.Tags != nil {
-		res.Attrs["tags"] = orEmpty(*req.Tags)
-	}
-	if req.Size != nil {
-		res.Attrs["size"] = *req.Size
-	}
-
-	res.Updated = p.env.Now()
-	p.env.Store.Put(res)
-	emulator.WriteJSON(w, http.StatusOK, map[string]any{"volume": volumeView(res)})
+	emulator.WriteJSON(w, http.StatusOK, map[string]any{"volume": volumeView(updated)})
 }
 
 func (p *Pack) deleteVolume(w http.ResponseWriter, r *http.Request) {
@@ -231,6 +242,62 @@ func (p *Pack) detachVolume(vol *resource.Resource) {
 	delete(vol.Runtime, runtimeServerKey)
 	delete(vol.Attrs, "server_name")
 	vol.Updated = p.env.Now()
+}
+
+// attachStoredVolume is attachVolume for a volume that already lives in the
+// store: the ownership check re-runs on the stored volume, inside the same
+// critical section as the write. As attachVolume-on-a-clone followed by Put,
+// the write re-inserted a volume deleted meanwhile and erased a concurrent
+// write to another field of the same volume — its tags — after their 200
+// (#295). The caller's clone is mirrored on success, because the views are
+// built from it.
+//
+// The liveness of a previous owner is measured outside the lock — the store
+// cannot be re-entered under it — and the owner itself is re-checked inside:
+// only the exact owner measured dead may be displaced.
+func (p *Pack) attachStoredVolume(vol *resource.Resource, server *resource.Resource, serverName string) error {
+	releasable := ""
+	if owner := vol.Runtime[runtimeServerKey]; owner != "" && owner != server.ID {
+		if _, alive := p.env.Store.Get(Name, kindServer, owner); alive {
+			return fmt.Errorf("volume %s is attached to server %s", vol.ID, owner)
+		}
+		releasable = owner
+	}
+	err := p.env.Store.Update(vol.Tenant.Provider, vol.Kind, vol.ID, func(stored *resource.Resource) error {
+		if owner := stored.Runtime[runtimeServerKey]; owner != "" && owner != server.ID && owner != releasable {
+			return fmt.Errorf("volume %s is attached to server %s", stored.ID, owner)
+		}
+		if stored.Runtime == nil {
+			stored.Runtime = map[string]string{}
+		}
+		stored.Runtime[runtimeServerKey] = server.ID
+		stored.Attrs["server_name"] = serverName
+		stored.Updated = p.env.Now()
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if vol.Runtime == nil {
+		vol.Runtime = map[string]string{}
+	}
+	vol.Runtime[runtimeServerKey] = server.ID
+	vol.Attrs["server_name"] = serverName
+	return nil
+}
+
+// detachStoredVolume is detachVolume for a volume that already lives in the
+// store, for the same reason attachStoredVolume exists (#295). Releasing a
+// volume that vanished meanwhile is not an error: the state the caller wanted
+// is reached.
+func (p *Pack) detachStoredVolume(vol *resource.Resource) {
+	_ = p.env.Store.Update(vol.Tenant.Provider, vol.Kind, vol.ID, func(stored *resource.Resource) error {
+		delete(stored.Runtime, runtimeServerKey)
+		delete(stored.Attrs, "server_name")
+		stored.Updated = p.env.Now()
+		return nil
+	})
+	p.detachVolume(vol)
 }
 
 // volumesOf returns the volumes attached to a server.

--- a/tools/falsify/specs/lost-scalar-fields.json
+++ b/tools/falsify/specs/lost-scalar-fields.json
@@ -1,0 +1,57 @@
+{
+  "package": "./internal/providers/outscale/",
+  "mutations": [
+    {
+      "label": "linkVolume writes the stale pre-lock clone back through the store lock, which is byte-for-byte the base the pre-#295 Get-mutate-Commit shape wrote wholesale, so a concurrent CreateTags on the same volume is erased after its 200",
+      "file": "internal/providers/outscale/volumes.go",
+      "find": "\tif _, found := p.env.Store.Get(Name, kindVM, req.VMID); !found {\n\t\tp.notFound(w, \"Vm\", req.VMID)\n\t\treturn\n\t}\n\t// The holder check runs on the stored volume, under the lock, never on a\n\t// stale clone: checked outside, two concurrent links on one free volume\n\t// both passed and the loser's 200 was erased — and the erased write was\n\t// sometimes the tag another handler had just acknowledged (#295, the\n\t// measured pair of this file).\n\t// TestConcurrentTagAndLinkKeepBothVolumeWrites fails without this shape.\n\tvar holder string\n\terr := p.env.Store.Update(Name, kindVolume, req.VolumeID, func(stored *resource.Resource) error {\n\t\tif held, _ := stored.Attrs[\"LinkedVmId\"].(string); held != \"\" && held != req.VMID {",
+      "replace": "\tstale, _ := p.env.Store.Get(Name, kindVolume, req.VolumeID)\n\tif _, found := p.env.Store.Get(Name, kindVM, req.VMID); !found {\n\t\tp.notFound(w, \"Vm\", req.VMID)\n\t\treturn\n\t}\n\t// The holder check runs on the stored volume, under the lock, never on a\n\t// stale clone: checked outside, two concurrent links on one free volume\n\t// both passed and the loser's 200 was erased — and the erased write was\n\t// sometimes the tag another handler had just acknowledged (#295, the\n\t// measured pair of this file).\n\t// TestConcurrentTagAndLinkKeepBothVolumeWrites fails without this shape.\n\tvar holder string\n\terr := p.env.Store.Update(Name, kindVolume, req.VolumeID, func(stored *resource.Resource) error {\n\t\tif stale != nil {\n\t\t\tstored.Attrs = stale.Attrs\n\t\t}\n\t\tif held, _ := stored.Attrs[\"LinkedVmId\"].(string); held != \"\" && held != req.VMID {",
+      "test": "TestConcurrentTagAndLinkKeepBothVolumeWrites",
+      "repeat": 10
+    },
+    {
+      "label": "store.Commit stops merging and takes State, Attrs and Runtime from the copy wholesale, which is the pre-#295 Commit, proven deterministically at the store layer",
+      "file": "internal/core/store/store.go",
+      "find": "\t\tif base.State != res.State {\n\t\t\tstored.State = res.State\n\t\t}\n\t\tmergeMap(stored.Attrs, base.Attrs, res.Attrs)",
+      "replace": "\t\tif base.State != res.State {\n\t\t\tstored.State = res.State\n\t\t}\n\t\tstored.State = res.State\n\t\tstored.Attrs = res.Attrs\n\t\tstored.Runtime = res.Runtime\n\t\tmergeMap(stored.Attrs, base.Attrs, res.Attrs)",
+      "test": "TestCommitKeepsAConcurrentWriteToAnotherField",
+      "package": "./internal/core/store/",
+      "repeat": 2
+    },
+    {
+      "label": "the same wholesale Commit, proven through a real client pair: a CreateTags racing a StopVms on one Vm loses the acknowledged tag under Binding.Observe's write-back",
+      "file": "internal/core/store/store.go",
+      "find": "\t\tif base.State != res.State {\n\t\t\tstored.State = res.State\n\t\t}\n\t\tmergeMap(stored.Attrs, base.Attrs, res.Attrs)",
+      "replace": "\t\tif base.State != res.State {\n\t\t\tstored.State = res.State\n\t\t}\n\t\tstored.State = res.State\n\t\tstored.Attrs = res.Attrs\n\t\tstored.Runtime = res.Runtime\n\t\tmergeMap(stored.Attrs, base.Attrs, res.Attrs)",
+      "test": "TestConcurrentTagAndStopKeepBothVmWrites",
+      "repeat": 15
+    },
+    {
+      "label": "setServerUserData writes the clone it read before the body upload back through the store lock, the pre-#295 Get-mutate-Put shape minus the resurrection, so a concurrent PATCH or action on the same server is erased after its 200",
+      "file": "internal/providers/scaleway/userdata.go",
+      "find": "\terr = p.env.Store.Update(Name, kindServer, res.ID, func(stored *resource.Resource) error {\n\t\tif stored.Runtime == nil {\n\t\t\tstored.Runtime = map[string]string{}\n\t\t}\n\t\tstored.Runtime[userDataPrefix+key] = string(body)",
+      "replace": "\terr = p.env.Store.Update(Name, kindServer, res.ID, func(stored *resource.Resource) error {\n\t\tstored.State = res.State\n\t\tstored.Attrs = res.Attrs\n\t\tstored.Runtime = res.Runtime\n\t\tif stored.Runtime == nil {\n\t\t\tstored.Runtime = map[string]string{}\n\t\t}\n\t\tstored.Runtime[userDataPrefix+key] = string(body)",
+      "test": "TestAUserDataUploadDoesNotRevertAConcurrentTagWrite",
+      "package": "./internal/providers/scaleway/",
+      "repeat": 2
+    },
+    {
+      "label": "updateNic writes DeleteOnVmDeletion through the LinkNic map every reader shares with the store, the in-place mutation #295 names as the second defect on these lines",
+      "file": "internal/providers/outscale/updates.go",
+      "find": "\t\t\tfresh := make(map[string]any, len(link)+1)\n\t\t\tfor k, v := range link {\n\t\t\t\tfresh[k] = v\n\t\t\t}\n\t\t\tfresh[\"DeleteOnVmDeletion\"] = *req.LinkNic.DeleteOnVMDeletion\n\t\t\tstored.Attrs[\"LinkNic\"] = fresh",
+      "replace": "\t\t\tfresh := make(map[string]any, len(link)+1)\n\t\t\tfor k, v := range link {\n\t\t\t\tfresh[k] = v\n\t\t\t}\n\t\t\tfresh[\"DeleteOnVmDeletion\"] = *req.LinkNic.DeleteOnVMDeletion\n\t\t\tlink[\"DeleteOnVmDeletion\"] = fresh[\"DeleteOnVmDeletion\"]\n\t\t\tstored.Attrs[\"LinkNic\"] = link",
+      "test": "TestUpdateNicDoesNotMutateTheStoredLinkInPlace",
+      "repeat": 2
+    },
+    {
+      "label": "updatePrivateNetwork goes back to Put, the write-back #295's own text wrongly called clean: the whole clone is re-inserted after the runtime work, erasing both concurrent fields and concurrent deletes",
+      "file": "internal/providers/exoscale/privatenetworks.go",
+      "find": "\tif !p.env.Store.Commit(base, res, p.env.Now()) {\n\t\twriteError(w, http.StatusNotFound, \"resource not found\")\n\t\treturn\n\t}\n\tp.isolatePrivateNetworks(r.Context())",
+      "replace": "\tres.Updated = p.env.Now()\n\tp.env.Store.Put(res)\n\tif base == nil && !p.env.Store.Commit(base, res, p.env.Now()) {\n\t\twriteError(w, http.StatusNotFound, \"resource not found\")\n\t\treturn\n\t}\n\tp.isolatePrivateNetworks(r.Context())",
+      "test": "TestConcurrentPrivateNetworkUpdatesKeepBothFields",
+      "package": "./internal/providers/exoscale/",
+      "repeat": 2
+    }
+  ],
+  "note": "The subjects are races, so each `repeat` is sized to a measured red rate, never chosen: with only its mutation applied and 10 consecutive -count=1 runs on 2026-08-18, the linkVolume rewrite went red 7/10 (repeat 10 puts a false TEST STILL PASSED at 0.3^10, under 1e-5), the wholesale Commit went red 10/10 at the store layer (deterministic: one concurrent Update lands between the clone and the Commit) and 6/10 through the outscale tag-versus-stop pair (repeat 15: 0.4^15, about 1e-6), the userdata rewrite 10/10 against the streamed-upload test, whose io.Pipe holds the pre-#295 window open deterministically instead of racing for it, the updateNic in-place write 10/10 (deterministic: a witness clone shares the map), and the exoscale Put 10/10 (three writers on one fresh network lose a field almost surely when every write is wholesale). The pre-fix defect the first mutation reproduces measured 11/200 trials on the issue's own CreateTags-versus-LinkVolume pair (5 runs of 40, 2026-08-18) and 0/200 after; the lifecycle half measured 5/200 on CreateTags-versus-StopVms after the fast paths were fixed and 0/200 with the merging Commit."
+}

--- a/tools/falsify/specs/lost-scalar-fields.json
+++ b/tools/falsify/specs/lost-scalar-fields.json
@@ -38,8 +38,8 @@
     {
       "label": "updateNic writes DeleteOnVmDeletion through the LinkNic map every reader shares with the store, the in-place mutation #295 names as the second defect on these lines",
       "file": "internal/providers/outscale/updates.go",
-      "find": "\t\t\tfresh := make(map[string]any, len(link)+1)\n\t\t\tfor k, v := range link {\n\t\t\t\tfresh[k] = v\n\t\t\t}\n\t\t\tfresh[\"DeleteOnVmDeletion\"] = *req.LinkNic.DeleteOnVMDeletion\n\t\t\tstored.Attrs[\"LinkNic\"] = fresh",
-      "replace": "\t\t\tfresh := make(map[string]any, len(link)+1)\n\t\t\tfor k, v := range link {\n\t\t\t\tfresh[k] = v\n\t\t\t}\n\t\t\tfresh[\"DeleteOnVmDeletion\"] = *req.LinkNic.DeleteOnVMDeletion\n\t\t\tlink[\"DeleteOnVmDeletion\"] = fresh[\"DeleteOnVmDeletion\"]\n\t\t\tstored.Attrs[\"LinkNic\"] = link",
+      "find": "\t\t\t\tfresh := make(map[string]any, len(link)+1)\n\t\t\t\tfor k, v := range link {\n\t\t\t\t\tfresh[k] = v\n\t\t\t\t}\n\t\t\t\tfresh[\"DeleteOnVmDeletion\"] = *req.LinkNic.DeleteOnVMDeletion\n\t\t\t\tstored.Attrs[\"LinkNic\"] = fresh",
+      "replace": "\t\t\t\tfresh := make(map[string]any, len(link)+1)\n\t\t\t\tfor k, v := range link {\n\t\t\t\t\tfresh[k] = v\n\t\t\t\t}\n\t\t\t\tfresh[\"DeleteOnVmDeletion\"] = *req.LinkNic.DeleteOnVMDeletion\n\t\t\t\tlink[\"DeleteOnVmDeletion\"] = fresh[\"DeleteOnVmDeletion\"]\n\t\t\t\tstored.Attrs[\"LinkNic\"] = link",
       "test": "TestUpdateNicDoesNotMutateTheStoredLinkInPlace",
       "repeat": 2
     },

--- a/tools/falsify/specs/netpeering-states.json
+++ b/tools/falsify/specs/netpeering-states.json
@@ -4,22 +4,22 @@
     {
       "label": "accept no longer demands pending-acceptance",
       "file": "internal/providers/outscale/netpeerings.go",
-      "find": "\tif res.State != statePeeringPending {\n\t\tp.conflict(w, \"the Net peering \"+res.ID+\" is \"+res.State+\n\t\t\t\", only a pending-acceptance one can be accepted\")\n\t\treturn\n\t}",
-      "replace": "\tif res.State != statePeeringPending && false {\n\t\tp.conflict(w, \"the Net peering \"+res.ID+\" is \"+res.State+\n\t\t\t\", only a pending-acceptance one can be accepted\")\n\t\treturn\n\t}",
+      "find": "\t\tif stored.State != statePeeringPending {\n\t\t\twrongState = stored.State\n\t\t\treturn errPeeringNotPending\n\t\t}\n\t\tstored.State = statePeeringActive",
+      "replace": "\t\tif stored.State != statePeeringPending && false {\n\t\t\twrongState = stored.State\n\t\t\treturn errPeeringNotPending\n\t\t}\n\t\tstored.State = statePeeringActive",
       "test": "TestAcceptingANonPendingNetPeeringIsRefused"
     },
     {
       "label": "reject no longer demands pending-acceptance",
       "file": "internal/providers/outscale/netpeerings.go",
-      "find": "\tif res.State != statePeeringPending {\n\t\tp.conflict(w, \"the Net peering \"+res.ID+\" is \"+res.State+\n\t\t\t\", only a pending-acceptance one can be rejected\")\n\t\treturn\n\t}",
-      "replace": "\tif res.State != statePeeringPending && false {\n\t\tp.conflict(w, \"the Net peering \"+res.ID+\" is \"+res.State+\n\t\t\t\", only a pending-acceptance one can be rejected\")\n\t\treturn\n\t}",
+      "find": "\t\tif stored.State != statePeeringPending {\n\t\t\twrongState = stored.State\n\t\t\treturn errPeeringNotPending\n\t\t}\n\t\tstored.State = statePeeringRejected",
+      "replace": "\t\tif stored.State != statePeeringPending && false {\n\t\t\twrongState = stored.State\n\t\t\treturn errPeeringNotPending\n\t\t}\n\t\tstored.State = statePeeringRejected",
       "test": "TestRejectingANonPendingNetPeeringIsRefused"
     },
     {
       "label": "delete no longer refuses the undeletable states",
       "file": "internal/providers/outscale/netpeerings.go",
-      "find": "\tswitch res.State {\n\tcase statePeeringRejected, statePeeringFailed, statePeeringExpired, statePeeringDeleted:",
-      "replace": "\tswitch res.State + \"-never\" {\n\tcase statePeeringRejected, statePeeringFailed, statePeeringExpired, statePeeringDeleted:",
+      "find": "\t\tswitch stored.State {\n\t\tcase statePeeringRejected, statePeeringFailed, statePeeringExpired, statePeeringDeleted:",
+      "replace": "\t\tswitch stored.State + \"-never\" {\n\t\tcase statePeeringRejected, statePeeringFailed, statePeeringExpired, statePeeringDeleted:",
       "test": "TestDeletingARejectedNetPeeringIsRefused"
     },
     {
@@ -39,8 +39,8 @@
     {
       "label": "accepting A-to-B no longer auto-rejects the pending B-to-A",
       "file": "internal/providers/outscale/netpeerings.go",
-      "find": "\t\tif other.State == statePeeringPending &&\n\t\t\tstringOf(other.Attrs[\"SourceNetId\"]) == accepterID &&\n\t\t\tstringOf(other.Attrs[\"AccepterNetId\"]) == sourceID {",
-      "replace": "\t\tif other.State == statePeeringPending &&\n\t\t\tstringOf(other.Attrs[\"SourceNetId\"]) == accepterID &&\n\t\t\tstringOf(other.Attrs[\"AccepterNetId\"]) == sourceID && false {",
+      "find": "\t\tif other.State != statePeeringPending ||\n\t\t\tstringOf(other.Attrs[\"SourceNetId\"]) != accepterID ||\n\t\t\tstringOf(other.Attrs[\"AccepterNetId\"]) != sourceID {\n\t\t\tcontinue\n\t\t}",
+      "replace": "\t\tif other.State != statePeeringPending ||\n\t\t\tstringOf(other.Attrs[\"SourceNetId\"]) != accepterID ||\n\t\t\tstringOf(other.Attrs[\"AccepterNetId\"]) != sourceID || true {\n\t\t\tcontinue\n\t\t}",
       "test": "TestAcceptAutoRejectsTheReversePendingPeering"
     },
     {

--- a/tools/falsify/specs/nic-link-flag.json
+++ b/tools/falsify/specs/nic-link-flag.json
@@ -1,0 +1,30 @@
+{
+  "package": "./internal/providers/outscale/",
+  "mutations": [
+    {
+      "label": "the view publishes DeleteOnVmDeletion:false as a constant again, so a stored true is denied by every read that follows",
+      "file": "internal/providers/outscale/nics.go",
+      "find": "\t\tflag, _ := nic.Attrs[\"DeleteOnVmDeletion\"].(bool)\n\t\tout[\"LinkNic\"] = map[string]any{\n\t\t\t\"DeleteOnVmDeletion\": flag,",
+      "replace": "\t\tflag, _ := nic.Attrs[\"DeleteOnVmDeletion\"].(bool)\n\t\tout[\"LinkNic\"] = map[string]any{\n\t\t\t\"DeleteOnVmDeletion\": flag && false,",
+      "test": "TestDeleteOnVmDeletionRoundTripsThroughUpdateNic",
+      "repeat": 2
+    },
+    {
+      "label": "updateNic stops seeing the flat attachment keys, which is the pre-#299 refusal: a NIC this pack itself attached answers 400 not-attached",
+      "file": "internal/providers/outscale/updates.go",
+      "find": "\t\t\tattachmentID := stringOf(stored.Attrs[\"LinkNicId\"])\n\t\t\tlink, hasMap := stored.Attrs[\"LinkNic\"].(map[string]any)",
+      "replace": "\t\t\tattachmentID := stringOf(stored.Attrs[\"LinkNicId\"])\n\t\t\tattachmentID = attachmentID[:0]\n\t\t\tlink, hasMap := stored.Attrs[\"LinkNic\"].(map[string]any)",
+      "test": "TestDeleteOnVmDeletionRoundTripsThroughUpdateNic",
+      "repeat": 2
+    },
+    {
+      "label": "the terminate stops honouring the flag, so DeleteOnVmDeletion round-trips perfectly and governs nothing",
+      "file": "internal/providers/outscale/nics.go",
+      "find": "\t\tif goes, _ := nic.Attrs[\"DeleteOnVmDeletion\"].(bool); goes {\n\t\t\tp.env.Store.Delete(Name, kindNic, nic.ID)\n\t\t\tcontinue\n\t\t}",
+      "replace": "\t\tif goes, _ := nic.Attrs[\"DeleteOnVmDeletion\"].(bool); goes && false {\n\t\t\tp.env.Store.Delete(Name, kindNic, nic.ID)\n\t\t\tcontinue\n\t\t}",
+      "test": "TestATrueDeleteOnVmDeletionDeletesTheNicWithItsVm",
+      "repeat": 2
+    }
+  ],
+  "note": "All three subjects are sequential — the tests provoke the update, the read-back and the terminate themselves, no scheduler bet — so `repeat: 2` is belt on deterministic braces. Verified 2026-08-18: with the emulator as fixed, the round-trip test fails when the view constant returns and when the flat attachment keys stop being read, and the terminate test fails when the delete branch is neutralised."
+}

--- a/tools/falsify/specs/serialise-then-commit.json
+++ b/tools/falsify/specs/serialise-then-commit.json
@@ -2,14 +2,6 @@
   "package": "./internal/providers/scaleway/",
   "mutations": [
     {
-      "label": "the update path stops ordering its target, and concurrent updates lose each other's fields",
-      "file": "internal/providers/scaleway/servers.go",
-      "find": "\t// TestConcurrentUpdatesKeepEveryAcknowledgedField fails without this line.\n\tunlock := p.binding().Serialise(id)\n\tdefer unlock()\n\n\tres, found := p.env.Store.Get(Name, kindServer, id)",
-      "replace": "\t// TestConcurrentUpdatesKeepEveryAcknowledgedField fails without this line.\n\tunlock := p.binding().Serialise(id)\n\tunlock()\n\n\tres, found := p.env.Store.Get(Name, kindServer, id)",
-      "test": "TestConcurrentUpdatesKeepEveryAcknowledgedField",
-      "repeat": 3
-    },
-    {
       "label": "a NIC create trusts nothing the hold could tell it, so a finished delete goes unseen",
       "file": "internal/providers/scaleway/privatenics.go",
       "find": "\tserver, found := p.env.Store.Get(Name, kindServer, serverID)\n\tif !found {\n\t\twriteNotFound(w, \"server\", serverID)\n\t\treturn nil, false\n\t}",
@@ -37,8 +29,8 @@
       "label": "Observe reinserts unconditionally, so a read resurrects a deleted resource",
       "package": "./internal/core/machine/",
       "file": "internal/core/machine/observe.go",
-      "find": "\tif err := st.Update(b.Provider, kind, id, func(stored *resource.Resource) error {",
-      "replace": "\tst.Put(res)\n\tif err := st.Update(b.Provider, kind, id, func(stored *resource.Resource) error {",
+      "find": "\tif !st.Commit(base, res, now()) {\n\t\treturn nil, store.ErrNotFound\n\t}",
+      "replace": "\tst.Put(res)\n\tif !st.Commit(base, res, now()) && false {\n\t\treturn nil, store.ErrNotFound\n\t}",
       "test": "TestObserveDoesNotResurrectADeletedTarget"
     },
     {
@@ -60,10 +52,10 @@
       "label": "UpdateVm goes back to dropping DeletionProtection, so protection cannot be cleared",
       "package": "./internal/providers/outscale/",
       "file": "internal/providers/outscale/vms.go",
-      "find": "\tif req.DeletionProtection != nil {\n\t\tres.Attrs[\"DeletionProtection\"] = *req.DeletionProtection\n\t}",
-      "replace": "\tif req.DeletionProtection != nil && false {\n\t\tres.Attrs[\"DeletionProtection\"] = *req.DeletionProtection\n\t}",
+      "find": "\t\tif req.DeletionProtection != nil {\n\t\t\tstored.Attrs[\"DeletionProtection\"] = *req.DeletionProtection\n\t\t}",
+      "replace": "\t\tif req.DeletionProtection != nil && false {\n\t\t\tstored.Attrs[\"DeletionProtection\"] = *req.DeletionProtection\n\t\t}",
       "test": "TestDeletionProtectionCanBeClearedByAnUpdate"
     }
   ],
-  "note": "Two mutations here went stale when #257 merged the two NIC doors into attachNIC and renamed server.ID to serverID: their fragments matched nothing, so they had silently stopped measuring. The per-server hold of attachNIC is falsified by one-attachment-two-doors.json (with `repeat`, the race being a coin toss per run) and is not repeated here. The re-read mutation cannot literally 'trust the pre-hold copy' any more — attachNIC receives only the id — so it does the equivalent: when the re-read answers not-found, it fabricates the server the way the old stale copy stood in for it, which is exactly what a handler working from a pre-delete read did. Measured 2026-08-17, thirty -count=1 runs per race in the harness's own out-of-tree copy: the update-path and re-read barrages both went red 30/30 — scheduler bets all the same, so `repeat: 3` turns the 10% false-green bound (rule of three, 95%) into under 0.1%. The Observe mutations carry no repeat: their tests stage the interleaving with channels or provoke it sequentially, and the reorder went red 5/5."
+  "note": "Two mutations here went stale when #257 merged the two NIC doors into attachNIC and renamed server.ID to serverID: their fragments matched nothing, so they had silently stopped measuring. The per-server hold of attachNIC is falsified by one-attachment-two-doors.json (with `repeat`, the race being a coin toss per run) and is not repeated here. The re-read mutation cannot literally 'trust the pre-hold copy' any more — attachNIC receives only the id — so it does the equivalent: when the re-read answers not-found, it fabricates the server the way the old stale copy stood in for it, which is exactly what a handler working from a pre-delete read did. Measured 2026-08-17, thirty -count=1 runs per race in the harness's own out-of-tree copy: the update-path and re-read barrages both went red 30/30 — scheduler bets all the same, so `repeat: 3` turns the 10% false-green bound (rule of three, 95%) into under 0.1%. The Observe mutations carry no repeat: their tests stage the interleaving with channels or provoke it sequentially, and the reorder went red 5/5. The update-path mutation was deleted on 2026-08-18, when #295 moved updateServer's read-check-write into Store.Update: with the hold released and only the store's critical section left, TestConcurrentUpdatesKeepEveryAcknowledgedField stayed green in the harness's copy, so the hold no longer carries that property and mutating it measured nothing. The property's guard today is falsified by lost-scalar-fields.json (the store-layer Commit merge and the stale-clone rewrites); the hold itself remains in the code for ordering the PATCH against serverAction's runtime window, a subject no current test stages."
 }

--- a/tools/falsify/specs/transition.json
+++ b/tools/falsify/specs/transition.json
@@ -12,8 +12,8 @@
     {
       "label": "a failed write-back is retried unconditionally, and a deleted resource comes back",
       "file": "internal/core/machine/observe.go",
-      "find": "\t}); err != nil {\n\t\treturn nil, err\n\t}",
-      "replace": "\t}); err != nil {\n\t\tst.Put(res)\n\t\treturn res, nil\n\t}",
+      "find": "\tif !st.Commit(base, res, now()) {\n\t\treturn nil, store.ErrNotFound\n\t}",
+      "replace": "\tif !st.Commit(base, res, now()) {\n\t\tst.Put(res)\n\t\t_ = store.ErrNotFound\n\t\treturn res, nil\n\t}",
       "test": "TestADeleteLandingMidTransitionWins"
     },
     {


### PR DESCRIPTION
# Summary

The scalar half of the lost-update family (#295), finished in the order the issue asks.

**Measured before:** the issue's own pair — `CreateTags` against `LinkVolume` on one volume, two different handlers — lost the acknowledged tag **11/200 trials** (5 runs of 40, per-run 2, 2, 3, 1, 3), the same defect the issue measured at 7/200. The 200 was answered, the tag was gone.

**Step 1 — every fast path moves under `Store.Update`** (the #289 model): read, state check and write are one critical section held by the store, refusals judged on the stored resource, responses built from the stored draft.

- *Outscale:* `updateVolume`, `linkVolume`, `unlinkVolume`, `detachVolumesOf`, `linkNic`, `unlinkNic`, `detachNicsOf`, `linkInternetService`, `unlinkInternetService`, `linkPublicIP`, `releasePublicIP`, the NAT address hold and release, `acceptNetPeering`/`rejectNetPeering`/`deleteNetPeering` (in-state checks now inside the lock) and the accept auto-reject, `updateNet`, `updateSubnet`, `updateNic`, `updateRouteTableLink`, `updateImage`, `UpdateVm` (keeps its per-target hold), `linkPrivateIps`, `unlinkPrivateIps`. `updateNic` also stops writing through the stored `LinkNic` map — the issue's second defect on those lines.
- *Scaleway:* `updateSSHKey`, `updateImage`, `updateSnapshot`, `updateBlockVolume`, `updateBlockSnapshot`, `updateIPAMIP`, `detachCustom`, `setCustomAttachment` (exclusivity check moves under the lock), `updateServer`, `attachServerVolume`/`detachServerVolume` plus the volume-side writes (`attachStoredVolume`/`detachStoredVolume`), `releaseAddressesOf`, `setServerUserData`/`deleteServerUserData` and `updateVolume` (these three wrote back with `Put`, so they resurrected on top of losing), the private-NIC `syncing_error` write, the booked-address releases, `updatePrivateNetworkInterface`.

**Step 2 — the design decision on the residue.** After step 1 the lifecycle cross was re-measured: `CreateTags` racing `StopVms` still lost the tag **5/200 trials with no runtime configured** — with a machine runtime the launch holds that window open for seconds. A limit reproducible in CI mode is not one I could honestly name and defer, so I chose the store-layer change over the named residue: **`Store.Commit` gains per-field intent**. It now takes the base the caller read and writes only what changed relative to it — State if it moved, each Attrs key, each Runtime key, deletions included; every untouched field keeps whatever a concurrent writer put there. What `Commit` exists to prevent stays prevented: it runs on the same `Update` underneath, so a resource deleted during a slow effect stays deleted (`TestCommitDoesNotResurrectADeletedResource`, plus the pre-existing resurrection falsifications, all still bite). `Serialise` keeps ordering the writers that share a field; the merge protects the writers that do not. Nested values need no deeper diff because packs never mutate them in place — the one handler that did (`updateNic`) is fixed and falsified in this same change. `Binding.Observe` clones its base before `look()` and merge-commits, which carries every pack's transitions at once; the remaining direct `Commit` sites (boot and terminate write-backs, `serverAction`, the subnet backing-network write, `updateIP`, `ensureDynamicAddress`, the NIC-attach existence probe, Exoscale's `updatePrivateNetwork`) each pass the clone they read.

**Measured after:** both pairs read **0/200** (5 runs of 40 each).

**Falsification:** `tools/falsify/specs/lost-scalar-fields.json` re-creates the pre-fix shapes — stale-clone rewrite in `linkVolume`, wholesale `Commit` (proven at the store layer and through the outscale tag-versus-stop pair), the user-data upload whose `io.Pipe` holds the pre-fix window open deterministically, the in-place `LinkNic` write, the Exoscale `Put`. All six mutations bite; each `repeat` is sized to a red rate measured over ten runs (7/10, 10/10, 6/10, 10/10, 10/10, 10/10). `mise run falsify:lint` is green. Three existing specs whose fragments this change moved were retargeted and re-run to a full bite; one mutation (`updateServer`'s hold) is deleted with the reason in the spec's note — the harness measured its barrage green with the hold released, because the property it guarded lives in `Store.Update` now, and the hold's comment in `servers.go` was rewritten to say what it still buys instead of citing a test that no longer fails without it.

**Found in passing, filed as #299, then pulled into this branch on the coordinator's request (second commit):** `UpdateNic` answered 400 "not attached" on a NIC this pack itself attached — a false refusal `outscale_nic_link` hits on first use — and `storedNicView` published `DeleteOnVmDeletion: false` as a constant that would have denied any successful write. The fix covers the three halves together, because fewer would be invisible: `linkNic` stores the flag at attach time (false — the SDK's shape, `LinkNicRequest` carries no such field, and the 2026-08-08 sweep recorded false on a fresh attachment), `updateNic` writes it on the flat attachment while keeping the snapshot-restored map path readable and enforcing `LinkNicToUpdate`'s required attachment ID, the view publishes the stored value, and `detachNicsOf` honours the flag's own contract on terminate ("if true, the NIC is deleted... if false, detached", client.gen.go). Round-trip driven with the non-default value both ways plus the required-ID refusal; the terminate test carries one flagged and one default NIC and checks both fates; `tools/falsify/specs/nic-link-flag.json` puts back each of the three pre-fix shapes and all three bite. Two commits, one branch: the two fixes share `nics.go`/`updates.go` but tell two different stories, and each commit carries its own proof.

Also: #295's triage called Exoscale clean; `updatePrivateNetwork` was a `Get → mutate → runtime → Put`. Fixed in the first commit (it is the family the issue defines), barrage added.

## Type of change

- [ ] A route added or changed
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes (gofmt, vet, golangci-lint, `go test -race`)
- [x] No new external Go dependency, or the pull request justifies it. The
      standard library covers routing, JSON and Go parsing; `go.mod` has three
      lines and a pre-commit hook keeps it that way
- [x] `internal/core` still knows no provider. If a change seemed to require it,
      the pack changed instead
- [x] Nothing in the diff could be written identically for another provider. If
      it could, it belongs in the core — the merge lives in `store.Commit` and
      `Binding.Observe`, written once; what stays in the packs is their own
      vocabulary (which fields, which refusals, which error dialect)

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] I ran `mise run conformance` myself — not "it should pass": 264 of 285
      routes proven by a real client, exit 0
- [x] Every field name in the diff comes from the provider's SDK, their OpenAPI
      document, or a run of the real client, and I can say which — no field
      name is new in this change; every key written is one the same handler
      already stored or the pack's views already read

### When a route is added or changed — otherwise N/A

No route is added and no `Route.Operation` changes, but the second commit
changes what two existing routes answer, so the block applies to it:

- [x] The route declares its upstream operation at the SDK's exact name —
      unchanged (`osc/Client.UpdateNic`, `osc/Client.LinkNic`); nothing for
      the coverage report to relearn, so `mise run drift:update` has nothing
      to regenerate (`coverage/` untouched, `drift:check` green in prepush)
- [x] `mise run conformance` passes — run in full twice, once per commit
      (264 of 285 routes proven, exit 0 both times)
- [x] The response was validated against the provider's own API description —
      the suite runs the emulator with `--contracts contracts`, and the
      `LinkNic.DeleteOnVmDeletion` shape is the SDK's own bool
- [x] What the client sends is read, or refused — `LinkNic.LinkNicId` was
      declared and unread before; it is now read and enforced, per
      `LinkNicToUpdate`'s "you must specify the ID of the NIC attachment"

### When behaviour a client can observe changes — otherwise N/A

- [x] `docs/limits.md` updated if the change moves a documented limit — no
      limit moves: the residue was closed rather than named, so there is
      nothing to write there
- [x] The README's generated tables regenerated (`mise run docs:coverage`) —
      nothing to regenerate; `mise run docs:check` green inside `prepush`

### When `.github/workflows/` is touched — otherwise N/A

N/A

### When a machine runtime is involved — otherwise N/A

N/A — `internal/core/machine` changes only the write-back of `Observe`
(store-side, no driver call added or moved); per the station-sharing
constraint this branch was not run with `FEINT_VM`, and the conformance suite
run is the runtime-less one CI uses. The falsifications of `Observe`'s
ordering, resurrection and missing-target guards (`serialise-then-commit.json`,
`transition.json`) were re-run after retargeting and all bite.

## Related issues

Closes #295. Closes #299.
