### PR TITLE
feat(scaleway): the server-type table is measured, and carries what the surveyed stacks name (#279)

### DIFF
--- a/docs/confidence.md
+++ b/docs/confidence.md
@@ -37,7 +37,7 @@ prints the reason under the pack that owns it.
 | Reaching a private address from the host that runs the emulator | **depends on the mode** | keys on `capabilities.private_from_host` — [limits.md](limits.md#a-public-address-is-the-providers-value-made-to-answer-on-the-host) |
 | A kernel-level test: sysctl, modules, the boot path | **with a VM runtime** | `FEINT_VM=incus-vm`, keying on `capabilities.own_kernel`: a container shares the host kernel and cannot carry any of it — [limits.md](limits.md#docker-was-removed-it-cannot-back-an-emulated-network) |
 | That a bad image or instance-type id is rejected | **no** | [limits.md](limits.md#identifiers-are-not-checked-against-anything) |
-| Quotas, real capacity, prices | **no** | [limits.md](limits.md#the-catalogue-is-fiction) |
+| Quotas, real capacity, prices | **no** | [limits.md](limits.md#the-catalogue-is-a-whitelist-and-its-values-are-measured) |
 | Authentication, IAM permissions, a signature that must fail | **no** | [limits.md](limits.md#authentication-is-accepted-never-verified) |
 | Waiting behaviour: a resource that stays `provisioning` for a while | **no, today** | transitions are immediate — [limits.md](limits.md#lifecycle-transitions-are-immediate) |
 | Retry and backoff against 429s, 5xx or a control-plane outage | **no** | nothing injects a fault yet; it is scoped rather than forgotten — [roadmap.md](roadmap.md#3-fault-injection--26) |

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -255,15 +255,67 @@ temporary hosts entry) — never a system trust-store install, never a hosts fil
 this binary edits itself. Whether that corner is worth the operator ceremony is a
 product call; it is no longer an unmeasured one.
 
-## The catalogue is fiction
+## The catalogue is a whitelist, and its values are measured
 
-Server types, prices, images and zones are a small fixed table
+Server types, prices and images are a small fixed table
 (`internal/providers/scaleway/catalog.go`). The emulator has no fleet, no
-inventory and no price list, and it will never pretend to reflect the real ones.
+inventory and no price list. It serves a table anyway because the clients read
+it before creating anything: a 404 there makes `scw instance server create`
+fail outright.
 
-It serves them anyway because the clients read them before creating anything: a
-404 there makes `scw instance server create` fail outright. Treat any capacity,
-price or availability answer as decoration.
+The 0.10.0 survey (#279) measured that the table is more than pre-flight
+scenery: **the Terraform provider validates a server's type against
+`/products/servers` before it creates anything, so a type outside the table
+fails a stack at plan** — two of five surveyed stacks died exactly there.
+Three consequences, each a decision this page records:
+
+- **The rows are measured, not invented.** The served types are an excerpt of
+  the real answer to `GET
+  https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers`
+  (public, no authentication), captured 2026-08-19 and embedded verbatim as
+  `catalog_servers.json`: every family the emulator carries, every size of it
+  (PLAY2, DEV1, GP1, PRO2), plus `STARDUST1-S`, which a surveyed stack named.
+  The one deviation is `per_volume_constraint`, served empty and declared to
+  the shapes gate, because a bound for local volumes this emulator never
+  attaches would enter the client's size arithmetic with nothing behind it.
+- **What the emulator will never enforce about a type stays unenforced.** The
+  RAM, CPU count, GPU count, bandwidth and prices of a row are answers, not
+  behaviour: nothing meters a byte or bills a cent, and with a machine runtime
+  every server boots the same class of container whatever its type claims.
+  Treat any capacity, price or availability answer as decoration — it is now
+  *accurate* decoration, which is strictly less misleading, and still
+  decoration.
+- **One table serves every zone, and the real cloud varies by zone.** The real
+  fr-par-1 lists 136 types where fr-par-3 lists 41, and `STARDUST1-S` exists
+  in three zones of nine. A plan naming `STARDUST1-S` in `fr-par-2` passes
+  here and fails against the real region. Zone-accurate inventory would mean
+  carrying nine tables of a moving target; the divergence is accepted and
+  stated instead.
+
+**There is no ARM row, and that is a refusal with a reason, not a gap.** The
+one ARM type a surveyed stack asked for, `COPARM1-2C-8G`, is absent from all
+nine zones of the real catalogue (measured 2026-08-19, every page, while
+genuinely end-of-service families — START1, VC1, X64 — are still listed with
+`end_of_service: true`): Scaleway withdrew the family, and resurrecting it
+here would let a plan pass that production refuses.
+`TestTheRetiredArmFamilyStaysRetired` keeps it out. The current ARM families
+(`BASIC2-A*`, `STANDARD2-A*`) are real and could be carried the day a stack
+asks — but an arm64 row costs more than a paste: the emulated marketplace is
+x86_64 (its `arch` filter truthfully answers arm64 requests with an empty
+list, #277), and a machine runtime boots containers on the **host's**
+architecture, so an arm64 row must arrive with an arm64 image story or its
+servers can never boot. The demand-driven rule above applies, with that bill
+attached.
+
+**An unknown type is still accepted at create.** The section below argues this
+for image identifiers, and the reasoning transfers whole: a configuration that
+names a type this table lacks — including a real one the excerpt has not
+caught up with — must not die on the one thing that has nothing to do with
+what it is testing. The clients that care already refuse client-side against
+`/products/servers` (that refusal is the measured wall of #279, and growing
+the table is its fix); an emulator-side refusal would add a second wall for
+raw SDK users and catch nothing the first does not. The real cloud does
+refuse an unknown type, so this is a divergence, recorded here on purpose.
 
 ## Identifiers are not checked against anything
 

--- a/examples/stacks/surveyed.md
+++ b/examples/stacks/surveyed.md
@@ -383,6 +383,17 @@ zone other than `ch-dk-2`.
   `one(pn.ipv6_subnets).subnet` evaluates, zero null errors, and the
   destroy that wedged completes: 12 of 12. The two declined walls stand as
   designed (placement groups ×2, vpc-gw, each a 501 naming its route).
+- **Replayed 2026-08-19, `feat/279-server-catalogue`**: same harness, same
+  12 of 12 applied and destroyed with the DEV1-L override — and the type
+  table is no longer the reason that override exists. #279 measured that
+  the real catalogue withdrew COPARM1 from all nine zones (end-of-service
+  families are still listed; COPARM1 is not), so the stack's published
+  default fails against production exactly as it fails here, and feint
+  refuses it deliberately rather than by poverty
+  (`TestTheRetiredArmFamilyStaysRetired`). Run with the default anyway,
+  the plan is accepted (21 to add) and the apply stops at the same two
+  declined walls — placement groups and vpc-gw — before any server names
+  its type. Both seeded talos images resolve, the arm64 one included.
 
 ### 2. ioandev/scaleway-flatcar-k3s — applied in part
 
@@ -468,6 +479,11 @@ zone other than `ch-dk-2`.
 - **Replayed 2026-08-18, `main@23f57c1`**: identical — 4 of 5 applied, the
   provider's own pre-check still refuses `STARDUST1-S` against the
   fictional type table, `0 to change`, clean destroy.
+- **Replayed 2026-08-19, `feat/279-server-catalogue`**: **applies whole — 5
+  of 5.** The catalogue now carries `STARDUST1-S` with the values the real
+  fr-par-1 publishes for it, the provider's pre-check passes, the server is
+  created with its `debian_bookworm` image and cloud-init, re-plan says `No
+  changes`, 5 destroyed. The last wall this stack had is gone.
 
 ### Annex — surveyed and set aside
 
@@ -494,7 +510,7 @@ public Scaleway ecosystem lives in Kapsule, RDB, LB and Object Storage.
 | Scaleway | LB | 2 (kubic, talos') | |
 | Scaleway | vpc-gw (public gateway) | 2 (talos, vpc-module*) | |
 | Scaleway | placement groups | 1 (talos) | declined today |
-| Scaleway | instance types outside the table (`STARDUST1-S`, `COPARM1-*`) | 2 (kiwinet, talos) | the provider pre-validates against `/products/servers`, so the fictional table is a hard whitelist |
+| Scaleway | instance types outside the table (`STARDUST1-S`, `COPARM1-*`) | 2 (kiwinet, talos) | the provider pre-validates against `/products/servers`, so the fictional table is a hard whitelist — resolved by #279: `STARDUST1-S` is served from the measured catalogue (kiwinet applies whole), and `COPARM1-*` is refused because the real cloud withdrew the family |
 | Exoscale | SKS | 3 (camptocamp, eu-data, WhizUs*) | dominates that ecosystem |
 | Exoscale | DNS (`exoscale_domain`) | 1 (openshift4) | fails as a zone-lookup error, which misleads |
 | Exoscale | NLB | 1 (platform) | |

--- a/examples/stacks/surveyed.md
+++ b/examples/stacks/surveyed.md
@@ -390,10 +390,11 @@ zone other than `ch-dk-2`.
   families are still listed; COPARM1 is not), so the stack's published
   default fails against production exactly as it fails here, and feint
   refuses it deliberately rather than by poverty
-  (`TestTheRetiredArmFamilyStaysRetired`). Run with the default anyway,
-  the plan is accepted (21 to add) and the apply stops at the same two
-  declined walls — placement groups and vpc-gw — before any server names
-  its type. Both seeded talos images resolve, the arm64 one included.
+  (`TestTheRetiredArmFamilyStaysRetired`). Run with the default type
+  anyway (count 2, type left at `COPARM1-2C-8G`), the plan is accepted
+  (21 to add) and the apply stops at the same two declined walls —
+  placement groups and vpc-gw — before any server names its type. Both
+  seeded talos images resolve, the arm64 one included.
 
 ### 2. ioandev/scaleway-flatcar-k3s — applied in part
 

--- a/internal/providers/scaleway/catalog.go
+++ b/internal/providers/scaleway/catalog.go
@@ -1,6 +1,8 @@
 package scaleway
 
 import (
+	_ "embed"
+	"encoding/json"
 	"net/http"
 	"sort"
 
@@ -13,8 +15,12 @@ import (
 // default image BEFORE it creates anything, and gives up on a 404. Declining
 // these endpoints makes the official CLI unusable, which defeats the purpose.
 //
-// So the catalogue is served from a small, fixed table. It is fiction, and it is
-// labelled as such in the docs, but it is the fiction the clients need.
+// So the catalogue is served from a small, fixed table. Since #279 its rows
+// are an excerpt of what the real cloud publishes rather than invented values,
+// because the table turned out to be a whitelist, not scenery: the Terraform
+// provider validates a server's type against it before creating anything.
+// What stays fiction is everything around the rows — one table for every
+// zone, nothing enforced — and docs/limits.md states it.
 
 // serverType mirrors instance.ServerType. Only the fields the CLI and the
 // Terraform provider actually read are populated.
@@ -72,57 +78,65 @@ type serverType struct {
 	ScratchStorageMaxVolumesCount uint64 `json:"scratch_storage_max_volumes_count"`
 }
 
-func newServerType(cpus uint32, ramGiB uint64, hourly float32) *serverType {
-	st := &serverType{
-		MonthlyPrice: hourly * 24 * 30,
-		HourlyPrice:  hourly,
-		AltNames:     []string{},
-		Ncpus:        cpus,
-		RAM:          ramGiB << 30,
-		Arch:         "x86_64",
-	}
-	st.Network.Interfaces = []any{}
-	st.Network.SumInternalBandwidth = 100_000_000
-	st.Network.SumInternetBandwidth = 100_000_000
-	st.Network.IPv6Support = true
-	// min_size stays at 0: the CLI sums the LOCAL volumes of a create request and
-	// refuses anything below the minimum. Modern Scaleway types boot from block
-	// storage and carry no local volume, so a non-zero minimum here would make
-	// `scw instance server create` fail with "total local volume size must be
-	// between ...". Types that really require local storage are not emulated.
-	st.VolumesConstraint.MinSize = 0
-	st.VolumesConstraint.MaxSize = 200_000_000_000
-	st.Capabilities.BlockStorage = true
-	st.Capabilities.BootTypes = []string{"local", "rescue"}
-	// Placement groups are served by this pack, so the capability says so; a
-	// client that checks it before asking would otherwise never ask.
-	st.Capabilities.PlacementGroups = true
-	st.Capabilities.PrivateNetwork = 8
-	st.Capabilities.MaxFileSystems = 0
-	st.Capabilities.HotSnapshotsLocalVolume = false
-	// Empty rather than populated: no local volume is attached here, so there
-	// is no per-volume bound to state. The key exists because the real answer
-	// has it and a client reads it; its emptiness is the honest content.
-	st.PerVolumeConstraint = map[string]any{}
-	st.BlockBandwidth = 209_715_200
-	st.EndOfService = false
-	st.ScratchStorageMaxSize = 0
-	st.ScratchStorageMaxVolumesCount = 0
-	return st
-}
+// publishedServerTypes is a verbatim excerpt of the table the real cloud
+// publishes: GET https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers
+// (no authentication required), captured 2026-08-19. The values used to be
+// invented by a constructor; #279 measured that the table is not scenery — the
+// Terraform provider validates a server's type against it before creating
+// anything, so every row is a compatibility claim, and an invented row is a
+// claim nothing published. The file is the measurement; the two deviations
+// from it are applied in code below, where they can be read and tested.
+//
+//go:embed catalog_servers.json
+var publishedServerTypes []byte
 
-// catalogue is the fixed set of types the emulator accepts. Names are real
-// Scaleway commercial types so copied documentation and existing Terraform code
-// work unchanged.
-var catalogue = map[string]*serverType{
-	"PLAY2-PICO": newServerType(1, 2, 0.0086),
-	"PLAY2-NANO": newServerType(2, 4, 0.0172),
-	"DEV1-S":     newServerType(2, 2, 0.0084),
-	"DEV1-M":     newServerType(3, 4, 0.0168),
-	"DEV1-L":     newServerType(4, 8, 0.0336),
-	"GP1-XS":     newServerType(4, 16, 0.0771),
-	"PRO2-XXS":   newServerType(2, 8, 0.0301),
-}
+// catalogue is the fixed set of types the emulator accepts, loaded from the
+// published excerpt above.
+//
+// How much of the real table to carry was #279's first question. The answer:
+// every size of every family already carried (PLAY2, DEV1, GP1, PRO2 — a stack
+// that outgrows GP1-XS should not die on GP1-S), plus what the surveyed stacks
+// name (STARDUST1-S, the kiwinet-infra-cloud witness). Not the whole table:
+// the real one is 136 rows in fr-par-1 alone, varies per zone, and includes
+// GPU and local-storage families whose published constraints this emulator
+// would falsify (see the min_size trap below). A family outside the excerpt
+// joins it when a stack asks, values captured from the same endpoint — #279
+// itself is the template for that.
+//
+// COPARM1-* is refused, not missing: the terraform-talos survey witness
+// defaults to COPARM1-2C-8G, and the family is absent from all nine zones of
+// the real catalogue (measured 2026-08-19, same endpoint, every page), while
+// genuinely end-of-service families — START1, VC1, X64 — are still listed
+// with end_of_service:true. Scaleway withdrew it. Serving it here would let a
+// plan pass that production refuses, the #268 class of lie in the more
+// dangerous direction. TestTheRetiredArmFamilyStaysRetired holds the line.
+var catalogue = func() map[string]*serverType {
+	var published struct {
+		Servers map[string]*serverType `json:"servers"`
+	}
+	if err := json.Unmarshal(publishedServerTypes, &published); err != nil {
+		// A compile-time asset: unreachable unless the embedded file is
+		// edited into invalidity, and TestServerTypesArePaged would say so.
+		panic("scaleway: catalog_servers.json: " + err.Error())
+	}
+	for _, st := range published.Servers {
+		// Deviation 1 — per_volume_constraint is served empty, not with the
+		// published l_ssd bounds: this emulator attaches no local volume, so
+		// a bound would enter the client's size arithmetic with nothing
+		// behind it. DeclinedFields() declares this to the shapes gate.
+		st.PerVolumeConstraint = map[string]any{}
+	}
+	// What is deliberately NOT rewritten here: volumes_constraint.min_size.
+	// It must stay 0 — the CLI sums the LOCAL volumes of a create request and
+	// refuses anything below the minimum with "total local volume size must
+	// be between ...", and this catalogue attaches none. Every type in the
+	// excerpt publishes 0 already, so the constraint is carried verbatim, and
+	// TestCatalogueKeepsTheLocalVolumeTrapDisarmed makes pasting a future
+	// type whose real minimum is non-zero fail there, loudly, instead of as a
+	// CLI refusal three tools away. Zeroing it silently here would hide the
+	// exact measurement that test exists to surface.
+	return published.Servers
+}()
 
 // defaultImageLabel is the image the CLI asks for when none is given.
 const defaultImageLabel = "ubuntu_jammy"

--- a/internal/providers/scaleway/catalog_servers.json
+++ b/internal/providers/scaleway/catalog_servers.json
@@ -1,0 +1,850 @@
+{
+  "servers": {
+    "DEV1-L": {
+      "alt_names": [],
+      "arch": "x86_64",
+      "block_bandwidth": 209715200,
+      "capabilities": {
+        "block_storage": true,
+        "boot_types": [
+          "local",
+          "rescue"
+        ],
+        "hot_snapshots_local_volume": true,
+        "max_file_systems": 0,
+        "placement_groups": true,
+        "private_network": 8
+      },
+      "end_of_service": false,
+      "gpu": 0,
+      "gpu_info": null,
+      "hourly_price": 0.04284,
+      "mig_profile": null,
+      "monthly_price": 31.2732,
+      "ncpus": 4,
+      "network": {
+        "interfaces": [
+          {
+            "internal_bandwidth": 400000000,
+            "internet_bandwidth": 400000000
+          }
+        ],
+        "ipv6_support": true,
+        "sum_internal_bandwidth": 400000000,
+        "sum_internet_bandwidth": 400000000
+      },
+      "per_volume_constraint": {
+        "l_ssd": {
+          "max_size": 800000000000,
+          "min_size": 1000000000
+        }
+      },
+      "ram": 8589934592,
+      "scratch_storage_max_size": 0,
+      "scratch_storage_max_volumes_count": 0,
+      "volumes_constraint": {
+        "max_size": 80000000000,
+        "min_size": 0
+      }
+    },
+    "DEV1-M": {
+      "alt_names": [],
+      "arch": "x86_64",
+      "block_bandwidth": 157286400,
+      "capabilities": {
+        "block_storage": true,
+        "boot_types": [
+          "local",
+          "rescue"
+        ],
+        "hot_snapshots_local_volume": true,
+        "max_file_systems": 0,
+        "placement_groups": true,
+        "private_network": 8
+      },
+      "end_of_service": false,
+      "gpu": 0,
+      "gpu_info": null,
+      "hourly_price": 0.020196,
+      "mig_profile": null,
+      "monthly_price": 14.74308,
+      "ncpus": 3,
+      "network": {
+        "interfaces": [
+          {
+            "internal_bandwidth": 300000000,
+            "internet_bandwidth": 300000000
+          }
+        ],
+        "ipv6_support": true,
+        "sum_internal_bandwidth": 300000000,
+        "sum_internet_bandwidth": 300000000
+      },
+      "per_volume_constraint": {
+        "l_ssd": {
+          "max_size": 800000000000,
+          "min_size": 1000000000
+        }
+      },
+      "ram": 4294967296,
+      "scratch_storage_max_size": 0,
+      "scratch_storage_max_volumes_count": 0,
+      "volumes_constraint": {
+        "max_size": 40000000000,
+        "min_size": 0
+      }
+    },
+    "DEV1-S": {
+      "alt_names": [],
+      "arch": "x86_64",
+      "block_bandwidth": 104857600,
+      "capabilities": {
+        "block_storage": true,
+        "boot_types": [
+          "local",
+          "rescue"
+        ],
+        "hot_snapshots_local_volume": true,
+        "max_file_systems": 0,
+        "placement_groups": true,
+        "private_network": 8
+      },
+      "end_of_service": false,
+      "gpu": 0,
+      "gpu_info": null,
+      "hourly_price": 0.008976,
+      "mig_profile": null,
+      "monthly_price": 6.55248,
+      "ncpus": 2,
+      "network": {
+        "interfaces": [
+          {
+            "internal_bandwidth": 200000000,
+            "internet_bandwidth": 200000000
+          }
+        ],
+        "ipv6_support": true,
+        "sum_internal_bandwidth": 200000000,
+        "sum_internet_bandwidth": 200000000
+      },
+      "per_volume_constraint": {
+        "l_ssd": {
+          "max_size": 800000000000,
+          "min_size": 1000000000
+        }
+      },
+      "ram": 2147483648,
+      "scratch_storage_max_size": 0,
+      "scratch_storage_max_volumes_count": 0,
+      "volumes_constraint": {
+        "max_size": 20000000000,
+        "min_size": 0
+      }
+    },
+    "DEV1-XL": {
+      "alt_names": [],
+      "arch": "x86_64",
+      "block_bandwidth": 262144000,
+      "capabilities": {
+        "block_storage": true,
+        "boot_types": [
+          "local",
+          "rescue"
+        ],
+        "hot_snapshots_local_volume": true,
+        "max_file_systems": 0,
+        "placement_groups": true,
+        "private_network": 8
+      },
+      "end_of_service": false,
+      "gpu": 0,
+      "gpu_info": null,
+      "hourly_price": 0.065076,
+      "mig_profile": null,
+      "monthly_price": 47.50548,
+      "ncpus": 4,
+      "network": {
+        "interfaces": [
+          {
+            "internal_bandwidth": 500000000,
+            "internet_bandwidth": 500000000
+          }
+        ],
+        "ipv6_support": true,
+        "sum_internal_bandwidth": 500000000,
+        "sum_internet_bandwidth": 500000000
+      },
+      "per_volume_constraint": {
+        "l_ssd": {
+          "max_size": 800000000000,
+          "min_size": 1000000000
+        }
+      },
+      "ram": 12884901888,
+      "scratch_storage_max_size": 0,
+      "scratch_storage_max_volumes_count": 0,
+      "volumes_constraint": {
+        "max_size": 120000000000,
+        "min_size": 0
+      }
+    },
+    "GP1-L": {
+      "alt_names": [],
+      "arch": "x86_64",
+      "block_bandwidth": 1073741824,
+      "capabilities": {
+        "block_storage": true,
+        "boot_types": [
+          "local",
+          "rescue"
+        ],
+        "hot_snapshots_local_volume": true,
+        "max_file_systems": 0,
+        "placement_groups": true,
+        "private_network": 8
+      },
+      "end_of_service": false,
+      "gpu": 0,
+      "gpu_info": null,
+      "hourly_price": 0.77418,
+      "mig_profile": null,
+      "monthly_price": 565.1514,
+      "ncpus": 32,
+      "network": {
+        "interfaces": [
+          {
+            "internal_bandwidth": 5000000000,
+            "internet_bandwidth": 5000000000
+          }
+        ],
+        "ipv6_support": true,
+        "sum_internal_bandwidth": 5000000000,
+        "sum_internet_bandwidth": 5000000000
+      },
+      "per_volume_constraint": {
+        "l_ssd": {
+          "max_size": 800000000000,
+          "min_size": 1000000000
+        }
+      },
+      "ram": 137438953472,
+      "scratch_storage_max_size": 0,
+      "scratch_storage_max_volumes_count": 0,
+      "volumes_constraint": {
+        "max_size": 600000000000,
+        "min_size": 0
+      }
+    },
+    "GP1-M": {
+      "alt_names": [],
+      "arch": "x86_64",
+      "block_bandwidth": 838860800,
+      "capabilities": {
+        "block_storage": true,
+        "boot_types": [
+          "local",
+          "rescue"
+        ],
+        "hot_snapshots_local_volume": true,
+        "max_file_systems": 0,
+        "placement_groups": true,
+        "private_network": 8
+      },
+      "end_of_service": false,
+      "gpu": 0,
+      "gpu_info": null,
+      "hourly_price": 0.38352,
+      "mig_profile": null,
+      "monthly_price": 279.9696,
+      "ncpus": 16,
+      "network": {
+        "interfaces": [
+          {
+            "internal_bandwidth": 1500000000,
+            "internet_bandwidth": 1500000000
+          }
+        ],
+        "ipv6_support": true,
+        "sum_internal_bandwidth": 1500000000,
+        "sum_internet_bandwidth": 1500000000
+      },
+      "per_volume_constraint": {
+        "l_ssd": {
+          "max_size": 800000000000,
+          "min_size": 1000000000
+        }
+      },
+      "ram": 68719476736,
+      "scratch_storage_max_size": 0,
+      "scratch_storage_max_volumes_count": 0,
+      "volumes_constraint": {
+        "max_size": 600000000000,
+        "min_size": 0
+      }
+    },
+    "GP1-S": {
+      "alt_names": [],
+      "arch": "x86_64",
+      "block_bandwidth": 524288000,
+      "capabilities": {
+        "block_storage": true,
+        "boot_types": [
+          "local",
+          "rescue"
+        ],
+        "hot_snapshots_local_volume": true,
+        "max_file_systems": 0,
+        "placement_groups": true,
+        "private_network": 8
+      },
+      "end_of_service": false,
+      "gpu": 0,
+      "gpu_info": null,
+      "hourly_price": 0.19074,
+      "mig_profile": null,
+      "monthly_price": 139.2402,
+      "ncpus": 8,
+      "network": {
+        "interfaces": [
+          {
+            "internal_bandwidth": 800000000,
+            "internet_bandwidth": 800000000
+          }
+        ],
+        "ipv6_support": true,
+        "sum_internal_bandwidth": 800000000,
+        "sum_internet_bandwidth": 800000000
+      },
+      "per_volume_constraint": {
+        "l_ssd": {
+          "max_size": 800000000000,
+          "min_size": 1000000000
+        }
+      },
+      "ram": 34359738368,
+      "scratch_storage_max_size": 0,
+      "scratch_storage_max_volumes_count": 0,
+      "volumes_constraint": {
+        "max_size": 300000000000,
+        "min_size": 0
+      }
+    },
+    "GP1-XL": {
+      "alt_names": [],
+      "arch": "x86_64",
+      "block_bandwidth": 2147483648,
+      "capabilities": {
+        "block_storage": true,
+        "boot_types": [
+          "local",
+          "rescue"
+        ],
+        "hot_snapshots_local_volume": true,
+        "max_file_systems": 0,
+        "placement_groups": true,
+        "private_network": 8
+      },
+      "end_of_service": false,
+      "gpu": 0,
+      "gpu_info": null,
+      "hourly_price": 1.67382,
+      "mig_profile": null,
+      "monthly_price": 1221.8886,
+      "ncpus": 48,
+      "network": {
+        "interfaces": [
+          {
+            "internal_bandwidth": 10000000000,
+            "internet_bandwidth": 10000000000
+          }
+        ],
+        "ipv6_support": true,
+        "sum_internal_bandwidth": 10000000000,
+        "sum_internet_bandwidth": 10000000000
+      },
+      "per_volume_constraint": {
+        "l_ssd": {
+          "max_size": 800000000000,
+          "min_size": 1000000000
+        }
+      },
+      "ram": 274877906944,
+      "scratch_storage_max_size": 0,
+      "scratch_storage_max_volumes_count": 0,
+      "volumes_constraint": {
+        "max_size": 600000000000,
+        "min_size": 0
+      }
+    },
+    "GP1-XS": {
+      "alt_names": [],
+      "arch": "x86_64",
+      "block_bandwidth": 314572800,
+      "capabilities": {
+        "block_storage": true,
+        "boot_types": [
+          "local",
+          "rescue"
+        ],
+        "hot_snapshots_local_volume": true,
+        "max_file_systems": 0,
+        "placement_groups": true,
+        "private_network": 8
+      },
+      "end_of_service": false,
+      "gpu": 0,
+      "gpu_info": null,
+      "hourly_price": 0.09282,
+      "mig_profile": null,
+      "monthly_price": 67.7586,
+      "ncpus": 4,
+      "network": {
+        "interfaces": [
+          {
+            "internal_bandwidth": 500000000,
+            "internet_bandwidth": 500000000
+          }
+        ],
+        "ipv6_support": true,
+        "sum_internal_bandwidth": 500000000,
+        "sum_internet_bandwidth": 500000000
+      },
+      "per_volume_constraint": {
+        "l_ssd": {
+          "max_size": 800000000000,
+          "min_size": 1000000000
+        }
+      },
+      "ram": 17179869184,
+      "scratch_storage_max_size": 0,
+      "scratch_storage_max_volumes_count": 0,
+      "volumes_constraint": {
+        "max_size": 150000000000,
+        "min_size": 0
+      }
+    },
+    "PLAY2-MICRO": {
+      "alt_names": [],
+      "arch": "x86_64",
+      "block_bandwidth": 167772160,
+      "capabilities": {
+        "block_storage": true,
+        "boot_types": [
+          "local",
+          "rescue"
+        ],
+        "hot_snapshots_local_volume": false,
+        "max_file_systems": 0,
+        "placement_groups": true,
+        "private_network": 8
+      },
+      "end_of_service": false,
+      "gpu": 0,
+      "gpu_info": null,
+      "hourly_price": 0.05508,
+      "mig_profile": null,
+      "monthly_price": 40.2084,
+      "ncpus": 4,
+      "network": {
+        "interfaces": [
+          {
+            "internal_bandwidth": 400000000,
+            "internet_bandwidth": 400000000
+          }
+        ],
+        "ipv6_support": true,
+        "sum_internal_bandwidth": 400000000,
+        "sum_internet_bandwidth": 400000000
+      },
+      "per_volume_constraint": {
+        "l_ssd": {
+          "max_size": 0,
+          "min_size": 0
+        }
+      },
+      "ram": 8589934592,
+      "scratch_storage_max_size": 0,
+      "scratch_storage_max_volumes_count": 0,
+      "volumes_constraint": {
+        "max_size": 0,
+        "min_size": 0
+      }
+    },
+    "PLAY2-NANO": {
+      "alt_names": [],
+      "arch": "x86_64",
+      "block_bandwidth": 83886080,
+      "capabilities": {
+        "block_storage": true,
+        "boot_types": [
+          "local",
+          "rescue"
+        ],
+        "hot_snapshots_local_volume": false,
+        "max_file_systems": 0,
+        "placement_groups": true,
+        "private_network": 8
+      },
+      "end_of_service": false,
+      "gpu": 0,
+      "gpu_info": null,
+      "hourly_price": 0.02754,
+      "mig_profile": null,
+      "monthly_price": 20.1042,
+      "ncpus": 2,
+      "network": {
+        "interfaces": [
+          {
+            "internal_bandwidth": 200000000,
+            "internet_bandwidth": 200000000
+          }
+        ],
+        "ipv6_support": true,
+        "sum_internal_bandwidth": 200000000,
+        "sum_internet_bandwidth": 200000000
+      },
+      "per_volume_constraint": {
+        "l_ssd": {
+          "max_size": 0,
+          "min_size": 0
+        }
+      },
+      "ram": 4294967296,
+      "scratch_storage_max_size": 0,
+      "scratch_storage_max_volumes_count": 0,
+      "volumes_constraint": {
+        "max_size": 0,
+        "min_size": 0
+      }
+    },
+    "PLAY2-PICO": {
+      "alt_names": [],
+      "arch": "x86_64",
+      "block_bandwidth": 41943040,
+      "capabilities": {
+        "block_storage": true,
+        "boot_types": [
+          "local",
+          "rescue"
+        ],
+        "hot_snapshots_local_volume": false,
+        "max_file_systems": 0,
+        "placement_groups": true,
+        "private_network": 8
+      },
+      "end_of_service": false,
+      "gpu": 0,
+      "gpu_info": null,
+      "hourly_price": 0.01428,
+      "mig_profile": null,
+      "monthly_price": 10.4244,
+      "ncpus": 1,
+      "network": {
+        "interfaces": [
+          {
+            "internal_bandwidth": 100000000,
+            "internet_bandwidth": 100000000
+          }
+        ],
+        "ipv6_support": true,
+        "sum_internal_bandwidth": 100000000,
+        "sum_internet_bandwidth": 100000000
+      },
+      "per_volume_constraint": {
+        "l_ssd": {
+          "max_size": 0,
+          "min_size": 0
+        }
+      },
+      "ram": 2147483648,
+      "scratch_storage_max_size": 0,
+      "scratch_storage_max_volumes_count": 0,
+      "volumes_constraint": {
+        "max_size": 0,
+        "min_size": 0
+      }
+    },
+    "PRO2-L": {
+      "alt_names": [],
+      "arch": "x86_64",
+      "block_bandwidth": 2097152000,
+      "capabilities": {
+        "block_storage": true,
+        "boot_types": [
+          "local",
+          "rescue"
+        ],
+        "hot_snapshots_local_volume": false,
+        "max_file_systems": 0,
+        "placement_groups": true,
+        "private_network": 8
+      },
+      "end_of_service": false,
+      "gpu": 0,
+      "gpu_info": null,
+      "hourly_price": 0.89454,
+      "mig_profile": null,
+      "monthly_price": 653.0142,
+      "ncpus": 32,
+      "network": {
+        "interfaces": [
+          {
+            "internal_bandwidth": 6000000000,
+            "internet_bandwidth": 6000000000
+          }
+        ],
+        "ipv6_support": true,
+        "sum_internal_bandwidth": 6000000000,
+        "sum_internet_bandwidth": 6000000000
+      },
+      "per_volume_constraint": {
+        "l_ssd": {
+          "max_size": 0,
+          "min_size": 0
+        }
+      },
+      "ram": 137438953472,
+      "scratch_storage_max_size": 0,
+      "scratch_storage_max_volumes_count": 0,
+      "volumes_constraint": {
+        "max_size": 0,
+        "min_size": 0
+      }
+    },
+    "PRO2-M": {
+      "alt_names": [],
+      "arch": "x86_64",
+      "block_bandwidth": 1048576000,
+      "capabilities": {
+        "block_storage": true,
+        "boot_types": [
+          "local",
+          "rescue"
+        ],
+        "hot_snapshots_local_volume": false,
+        "max_file_systems": 0,
+        "placement_groups": true,
+        "private_network": 8
+      },
+      "end_of_service": false,
+      "gpu": 0,
+      "gpu_info": null,
+      "hourly_price": 0.44676,
+      "mig_profile": null,
+      "monthly_price": 326.1348,
+      "ncpus": 16,
+      "network": {
+        "interfaces": [
+          {
+            "internal_bandwidth": 3000000000,
+            "internet_bandwidth": 3000000000
+          }
+        ],
+        "ipv6_support": true,
+        "sum_internal_bandwidth": 3000000000,
+        "sum_internet_bandwidth": 3000000000
+      },
+      "per_volume_constraint": {
+        "l_ssd": {
+          "max_size": 0,
+          "min_size": 0
+        }
+      },
+      "ram": 68719476736,
+      "scratch_storage_max_size": 0,
+      "scratch_storage_max_volumes_count": 0,
+      "volumes_constraint": {
+        "max_size": 0,
+        "min_size": 0
+      }
+    },
+    "PRO2-S": {
+      "alt_names": [],
+      "arch": "x86_64",
+      "block_bandwidth": 524288000,
+      "capabilities": {
+        "block_storage": true,
+        "boot_types": [
+          "local",
+          "rescue"
+        ],
+        "hot_snapshots_local_volume": false,
+        "max_file_systems": 0,
+        "placement_groups": true,
+        "private_network": 8
+      },
+      "end_of_service": false,
+      "gpu": 0,
+      "gpu_info": null,
+      "hourly_price": 0.22338,
+      "mig_profile": null,
+      "monthly_price": 163.0674,
+      "ncpus": 8,
+      "network": {
+        "interfaces": [
+          {
+            "internal_bandwidth": 1500000000,
+            "internet_bandwidth": 1500000000
+          }
+        ],
+        "ipv6_support": true,
+        "sum_internal_bandwidth": 1500000000,
+        "sum_internet_bandwidth": 1500000000
+      },
+      "per_volume_constraint": {
+        "l_ssd": {
+          "max_size": 0,
+          "min_size": 0
+        }
+      },
+      "ram": 34359738368,
+      "scratch_storage_max_size": 0,
+      "scratch_storage_max_volumes_count": 0,
+      "volumes_constraint": {
+        "max_size": 0,
+        "min_size": 0
+      }
+    },
+    "PRO2-XS": {
+      "alt_names": [],
+      "arch": "x86_64",
+      "block_bandwidth": 262144000,
+      "capabilities": {
+        "block_storage": true,
+        "boot_types": [
+          "local",
+          "rescue"
+        ],
+        "hot_snapshots_local_volume": false,
+        "max_file_systems": 0,
+        "placement_groups": true,
+        "private_network": 8
+      },
+      "end_of_service": false,
+      "gpu": 0,
+      "gpu_info": null,
+      "hourly_price": 0.1122,
+      "mig_profile": null,
+      "monthly_price": 81.906,
+      "ncpus": 4,
+      "network": {
+        "interfaces": [
+          {
+            "internal_bandwidth": 700000000,
+            "internet_bandwidth": 700000000
+          }
+        ],
+        "ipv6_support": true,
+        "sum_internal_bandwidth": 700000000,
+        "sum_internet_bandwidth": 700000000
+      },
+      "per_volume_constraint": {
+        "l_ssd": {
+          "max_size": 0,
+          "min_size": 0
+        }
+      },
+      "ram": 17179869184,
+      "scratch_storage_max_size": 0,
+      "scratch_storage_max_volumes_count": 0,
+      "volumes_constraint": {
+        "max_size": 0,
+        "min_size": 0
+      }
+    },
+    "PRO2-XXS": {
+      "alt_names": [],
+      "arch": "x86_64",
+      "block_bandwidth": 131072000,
+      "capabilities": {
+        "block_storage": true,
+        "boot_types": [
+          "local",
+          "rescue"
+        ],
+        "hot_snapshots_local_volume": false,
+        "max_file_systems": 0,
+        "placement_groups": true,
+        "private_network": 8
+      },
+      "end_of_service": false,
+      "gpu": 0,
+      "gpu_info": null,
+      "hourly_price": 0.0561,
+      "mig_profile": null,
+      "monthly_price": 40.953,
+      "ncpus": 2,
+      "network": {
+        "interfaces": [
+          {
+            "internal_bandwidth": 350000000,
+            "internet_bandwidth": 350000000
+          }
+        ],
+        "ipv6_support": true,
+        "sum_internal_bandwidth": 350000000,
+        "sum_internet_bandwidth": 350000000
+      },
+      "per_volume_constraint": {
+        "l_ssd": {
+          "max_size": 0,
+          "min_size": 0
+        }
+      },
+      "ram": 8589934592,
+      "scratch_storage_max_size": 0,
+      "scratch_storage_max_volumes_count": 0,
+      "volumes_constraint": {
+        "max_size": 0,
+        "min_size": 0
+      }
+    },
+    "STARDUST1-S": {
+      "alt_names": [],
+      "arch": "x86_64",
+      "block_bandwidth": 52428800,
+      "capabilities": {
+        "block_storage": true,
+        "boot_types": [
+          "local",
+          "rescue"
+        ],
+        "hot_snapshots_local_volume": true,
+        "max_file_systems": 0,
+        "placement_groups": true,
+        "private_network": 8
+      },
+      "end_of_service": false,
+      "gpu": 0,
+      "gpu_info": null,
+      "hourly_price": 0.0006,
+      "mig_profile": null,
+      "monthly_price": 0.438,
+      "ncpus": 1,
+      "network": {
+        "interfaces": [
+          {
+            "internal_bandwidth": 100000000,
+            "internet_bandwidth": 100000000
+          }
+        ],
+        "ipv6_support": true,
+        "sum_internal_bandwidth": 100000000,
+        "sum_internet_bandwidth": 100000000
+      },
+      "per_volume_constraint": {
+        "l_ssd": {
+          "max_size": 800000000000,
+          "min_size": 1000000000
+        }
+      },
+      "ram": 1073741824,
+      "scratch_storage_max_size": 0,
+      "scratch_storage_max_volumes_count": 0,
+      "volumes_constraint": {
+        "max_size": 10000000000,
+        "min_size": 0
+      }
+    }
+  }
+}

--- a/internal/providers/scaleway/catalog_test.go
+++ b/internal/providers/scaleway/catalog_test.go
@@ -1,0 +1,114 @@
+package scaleway_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+const serverTypesURL = "/instance/v1/zones/fr-par-1/products/servers"
+
+// The catalogue is a whitelist, not scenery: the Terraform provider validates
+// a server's type against /products/servers before it creates anything, so a
+// missing entry fails a stack at plan (#279, measured on two of the five
+// surveyed Scaleway stacks). These tests hold what the fix decided.
+
+// The type the kiwinet-infra-cloud survey witness names is served, with the
+// values the real cloud publishes for it — captured from
+// GET /instance/v1/zones/fr-par-1/products/servers on 2026-08-19, the excerpt
+// embedded as catalog_servers.json.
+func TestTheSurveyedTypeIsServedWithItsPublishedValues(t *testing.T) {
+	ts := newTestServer(t)
+	status, body := do(t, ts, "GET", serverTypesURL, "")
+	if status != http.StatusOK {
+		t.Fatalf("expected 200, got %d (%v)", status, body)
+	}
+	types, _ := body["servers"].(map[string]any)
+	entry, ok := types["STARDUST1-S"].(map[string]any)
+	if !ok {
+		t.Fatalf("STARDUST1-S is not in the catalogue: %v", sortedKeys(types))
+	}
+	published := map[string]any{
+		"arch":         "x86_64",
+		"ncpus":        float64(1),
+		"ram":          float64(1073741824),
+		"hourly_price": 0.0006,
+		"gpu":          float64(0),
+	}
+	for field, want := range published {
+		if got := entry[field]; got != want {
+			t.Errorf("STARDUST1-S %s = %v, want the published %v", field, got, want)
+		}
+	}
+	vc, _ := entry["volumes_constraint"].(map[string]any)
+	if vc["max_size"] != float64(10_000_000_000) {
+		t.Errorf("volumes_constraint.max_size = %v, want the published 10000000000", vc["max_size"])
+	}
+}
+
+// Two fields of every served type keep `scw instance server create` alive, and
+// both are deviations or near-deviations from the published table, so they are
+// pinned here rather than trusted to a comment:
+//
+//   - volumes_constraint.min_size must be 0. The CLI sums the LOCAL volumes of
+//     a create request against it and refuses anything below the minimum with
+//     "total local volume size must be between ...", and this catalogue
+//     attaches no local volume. Every type in the embedded excerpt publishes 0
+//     today; a future type pasted with a non-zero real minimum fails here,
+//     loudly, instead of as a CLI refusal three tools away.
+//   - per_volume_constraint must be empty. The real table states l_ssd bounds
+//     on several families; served here they would enter the client's size
+//     arithmetic with nothing behind them. DeclinedFields() declares the gap
+//     to the shapes gate; this test proves the load-time strip does it.
+func TestCatalogueKeepsTheLocalVolumeTrapDisarmed(t *testing.T) {
+	ts := newTestServer(t)
+	status, body := do(t, ts, "GET", serverTypesURL, "")
+	if status != http.StatusOK {
+		t.Fatalf("expected 200, got %d", status)
+	}
+	types, _ := body["servers"].(map[string]any)
+	if len(types) == 0 {
+		t.Fatal("the catalogue is empty")
+	}
+	for name, raw := range types {
+		entry, _ := raw.(map[string]any)
+		vc, _ := entry["volumes_constraint"].(map[string]any)
+		if got := vc["min_size"]; got != float64(0) {
+			t.Errorf("%s volumes_constraint.min_size = %v, want 0: the CLI sums local volumes against it and this catalogue attaches none", name, got)
+		}
+		pvc, ok := entry["per_volume_constraint"].(map[string]any)
+		if !ok || len(pvc) != 0 {
+			t.Errorf("%s per_volume_constraint = %v, want an empty object: a bound for local volumes never attached", name, raw)
+		}
+	}
+}
+
+// COPARM1-* is refused, not forgotten. The terraform-talos survey witness
+// defaults to COPARM1-2C-8G, and the family is absent from all nine zones of
+// the real catalogue — measured 2026-08-19 on
+// GET /instance/v1/zones/{zone}/products/servers, every page, while genuinely
+// end-of-service families (START1, VC1, X64) are still listed with
+// end_of_service:true. Scaleway withdrew it. Resurrecting it here would let a
+// plan pass that production refuses — the #268 class of lie, in the direction
+// that hurts: acceptance where the real cloud rejects.
+func TestTheRetiredArmFamilyStaysRetired(t *testing.T) {
+	ts := newTestServer(t)
+	status, body := do(t, ts, "GET", serverTypesURL+"?per_page=100", "")
+	if status != http.StatusOK {
+		t.Fatalf("expected 200, got %d", status)
+	}
+	types, _ := body["servers"].(map[string]any)
+	for name := range types {
+		if strings.HasPrefix(name, "COPARM1-") {
+			t.Errorf("%s is served, but the real cloud withdrew the COPARM1 family; an entry here accepts what production refuses", name)
+		}
+	}
+}
+
+func sortedKeys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/tools/conformance/scaleway/scw-cli.sh
+++ b/tools/conformance/scaleway/scw-cli.sh
@@ -75,6 +75,25 @@ prove_end "$neg"
 prove_end "$span"
 ok "deleted, and gone"
 
+# The catalogue is a whitelist, not scenery (#279): the CLI reads /products/servers before it
+# creates anything and sums local volumes against the type's volumes_constraint, so a type is
+# only proven served when a create names it. STARDUST1-S is the entry the kiwinet-infra-cloud
+# survey stack died on, and the one whose published constraint is tightest (max_size 10 GB) —
+# if the CLI's volume arithmetic ever starts counting the block root volume, this is the type
+# that says so first.
+echo "- create with a surveyed type outside the old table (STARDUST1-S)"
+span="$(prove_begin behaviour)"
+sd="$(scw instance server create name=conformance-stardust type=STARDUST1-S zone="$ZONE" -o json 2>&1)" \
+  || fail "create type=STARDUST1-S rejected by the CLI: $sd"
+sd_id="$(printf '%s' "$sd" | jq -r '.id // empty')"
+[ -n "$sd_id" ] || fail "no id in the create response: $sd"
+printf '%s' "$sd" | jq -e '.commercial_type == "STARDUST1-S"' >/dev/null \
+  || fail "the commercial type did not round-trip: $sd"
+scw instance server stop "$sd_id" zone="$ZONE" >/dev/null || fail "poweroff rejected"
+scw instance server delete "$sd_id" zone="$ZONE" >/dev/null || fail "delete rejected"
+prove_end "$span"
+ok "STARDUST1-S created, typed back, deleted"
+
 # The protection flag, whose behaviour was measured against fr-par-1 rather than assumed (#212):
 # it closes the action endpoint, not the DELETE verb. Both halves are driven here, because the
 # surprising half is the one a future reader will want to "fix".

--- a/tools/falsify/specs/server-type-catalogue.json
+++ b/tools/falsify/specs/server-type-catalogue.json
@@ -1,0 +1,26 @@
+{
+  "package": "./internal/providers/scaleway/",
+  "mutations": [
+    {
+      "label": "the retired COPARM1 family is pasted back into the catalogue, accepting what production refuses (#279)",
+      "file": "internal/providers/scaleway/catalog_servers.json",
+      "find": "    \"STARDUST1-S\": {",
+      "replace": "    \"COPARM1-2C-8G\": {",
+      "test": "TestTheRetiredArmFamilyStaysRetired"
+    },
+    {
+      "label": "a type is pasted with a non-zero local-volume minimum, the value that makes the CLI refuse its own create",
+      "file": "internal/providers/scaleway/catalog_servers.json",
+      "find": "        \"max_size\": 10000000000,\n        \"min_size\": 0",
+      "replace": "        \"max_size\": 10000000000,\n        \"min_size\": 1000000000",
+      "test": "TestCatalogueKeepsTheLocalVolumeTrapDisarmed"
+    },
+    {
+      "label": "the published l_ssd bounds are served instead of stripped, a bound with nothing behind it",
+      "file": "internal/providers/scaleway/catalog.go",
+      "find": "\t\tst.PerVolumeConstraint = map[string]any{}",
+      "replace": "\t\t_ = st",
+      "test": "TestCatalogueKeepsTheLocalVolumeTrapDisarmed"
+    }
+  ]
+}


### PR DESCRIPTION
# Summary

The emulated Scaleway server-type table was written as scenery — a small fixed inventory so `scw instance server create` would not 404 on its pre-flight reads. The #262 survey measured that it is a **whitelist**: the Terraform provider validates a server's type against `/products/servers` before it creates anything, so a missing entry fails a stack at plan. Two of the five surveyed stacks died exactly there (`STARDUST1-S` for kiwinet-infra-cloud, `COPARM1-2C-8G` for terraform-talos).

This change replaces the seven invented rows with **eighteen measured ones**, embedded verbatim as `catalog_servers.json` from `GET https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers` (public, no authentication, captured 2026-08-19). Three decisions, written down rather than made in silence:

1. **How much of the real table to carry.** Every size of every family already carried (PLAY2, DEV1, GP1, PRO2), plus `STARDUST1-S`, which a surveyed stack names — not the whole 136-row table, which varies per zone and includes GPU and local-storage families whose published constraints this emulator would falsify. A family joins when a stack asks; this PR is the template for that. Constraints are read from the published capture, not transcribed: the served map is unmarshalled from the embedded excerpt, and the one deviation (`per_volume_constraint` served empty, already declared to the shapes gate) is applied in code where it can be read and falsified.
2. **ARM.** `COPARM1-2C-8G` is **refused, not missing**: the family is absent from all nine zones of the real catalogue (measured 2026-08-19, every page) while genuinely end-of-service families — START1, VC1, X64 — are still listed with `end_of_service: true`. Scaleway withdrew it, and the surveyed stack's default fails against production for the same reason it fails here. Serving it would accept a plan production refuses — the #268 class of lie in the more dangerous direction. `TestTheRetiredArmFamilyStaysRetired` holds the line, and `docs/limits.md` states what any future arm64 row must bring with it (an arm64 image story: the marketplace is x86_64, and a machine runtime boots the host's architecture).
3. **Unknown types at create stay accepted.** The reasoning `docs/limits.md` gives for image identifiers transfers whole: a configuration naming a type this excerpt has not caught up with must not die on the one thing it is not testing, and the refusal that matters already lives in the client. The divergence from the real cloud is recorded in `docs/limits.md` on purpose.

The `volumes_constraint.min_size` trap is preserved: every published value in the excerpt is 0, the value is carried verbatim, and `TestCatalogueKeepsTheLocalVolumeTrapDisarmed` makes pasting a future non-zero type fail in the suite instead of as a CLI refusal three tools away.

**Witness stacks replayed** (same harness as #262, entries updated in `examples/stacks/surveyed.md`):

- `Rookain-Kiwi/kiwinet-infra-cloud` @ `78c97c9`: **applies whole — 5 of 5** (was 4 of 5), `No changes` on re-plan, 5 destroyed. Its last wall is gone.
- `sergelogvinov/terraform-talos` (scaleway/) @ `1edaa02`: unchanged at 12 of 12 with the two declined walls (placement groups, vpc-gw); both seeded talos images resolve, the arm64 one included; run with its published COPARM1 default, the apply stops at the same declined walls — and that default now fails against production too.

## Type of change

- [x] A route added or changed — no route is added, but the response of `ListServersTypes` changes
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes (gofmt, vet, golangci-lint, `go test -race`)
- [x] No new external Go dependency (`embed` and `encoding/json` are standard library)
- [x] `internal/core` still knows no provider — the diff never leaves the Scaleway pack, its conformance suite and the docs
- [x] Nothing in the diff could be written identically for another provider: the table, its capture and its traps are Scaleway's own (Outscale's and Exoscale's catalogues have their own files and their own shapes)

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version (`Claude Code (claude-fable-5)`)
- [x] I ran `mise run conformance` myself — full suite, green, 264 of 285 routes proven by a real client
- [x] Every field name and value in the diff comes from a run of the real API: `GET /instance/v1/zones/{zone}/products/servers`, captured 2026-08-19, embedded verbatim as `catalog_servers.json`

### When a route is added or changed — otherwise N/A

- [x] `Route.Operation` unchanged (`instance/v1/API.ListServersTypes`) — no route added or moved
- [x] `mise run conformance` passes, and the scw suite now drives a create with `type=STARDUST1-S` (the new block in `scw-cli.sh`)
- [x] The response was validated against the provider's own API description (`--contracts contracts`, part of the conformance run) and the shapes gate (`mise run shapes:check`, which also still excuses `per_volume_constraint` by its declared reason)
- [x] No request field changed — the diff touches what is answered, not what is read
- [x] `mise run drift:update` N/A — no operation appears or disappears; `coverage/` is untouched by a data change and `mise run drift:check` is green

### When behaviour a client can observe changes — otherwise N/A

- [x] `docs/limits.md` updated: "The catalogue is fiction" became "The catalogue is a whitelist, and its values are measured", carrying the three decisions above and what the emulator will never enforce about a type
- [x] Generated tables untouched by this change; `feint docs --check` green (part of `mise run prepush`)

### When `.github/workflows/` is touched — otherwise N/A

N/A — no workflow touched.

### When a machine runtime is involved — otherwise N/A

N/A — the machine layer is untouched; the catalogue change is control-plane only.

**Falsification**: `mise run falsify -- tools/falsify/specs/server-type-catalogue.json` — three mutations (COPARM1 pasted back, a non-zero `min_size` pasted in, the `per_volume_constraint` strip removed), all three answered "the test bit", green after restoration. `falsify:lint` green via `mise run prepush`.

## Related issues

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)
