### PR TITLE
feat(exoscale): the zone is a datum, and the catalogue follows it (#278)

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -325,6 +325,15 @@ jobs:
         if: matrix.client == 'exo-cli' || matrix.client == 'fields'
         run: tools/conformance/exoscale/exo-cli.sh http://127.0.0.1:4599
 
+      # The two-zone proof (#278): the same real CLI against a second emulator
+      # this suite starts itself, configured for ch-gva-2 on its own port. Not
+      # on the `fields` leg: the field gate judges the shared emulator's run,
+      # and this suite's traffic goes to its own — adding it there would prove
+      # nothing about that verdict.
+      - name: Run the Exoscale two-zone suite
+        if: matrix.client == 'exo-cli'
+        run: FEINT_BIN=/tmp/feint tools/conformance/exoscale/zones.sh
+
       # The release zip and its checksum, verified before anything runs — not a
       # key piped from a URL into gpg. The apt route asked this job to trust a
       # transport for a key that then authorises every package from that

--- a/README.md
+++ b/README.md
@@ -420,6 +420,22 @@ exo compute instance create demo \
 exo compute instance list
 ```
 
+At Exoscale a zone is a property of the endpoint a client points at
+(`api-<zone>.exoscale.com`), so the emulator's single endpoint serves one zone
+per process — publishing several turns one instance into one row per zone in
+`exo compute instance list`, measured and recorded in `docs/limits.md`. It is
+`ch-dk-2`, the CLI's own default, unless `FEINT_EXOSCALE_ZONE` selects another
+of the zones Exoscale publishes:
+
+```bash
+FEINT_EXOSCALE_ZONE=ch-gva-2 feint serve   # where three of five surveyed stacks live
+```
+
+The zone list, the zones every template and instance type declare, and the
+`EXOSCALE_ZONE` that `feint env exoscale` prints follow the selection
+together. A value Exoscale does not publish refuses to serve, naming what
+would have been accepted.
+
 ### Ask the emulator what it is doing
 
 ```bash

--- a/docs/confidence.md
+++ b/docs/confidence.md
@@ -43,7 +43,7 @@ prints the reason under the pack that owns it.
 | Retry and backoff against 429s, 5xx or a control-plane outage | **no** | nothing injects a fault yet; it is scoped rather than forgotten — [roadmap.md](roadmap.md#3-fault-injection--26) |
 | Object Storage, and anything addressed as `s3.<region>` | **no** | [limits.md](limits.md#object-storage-is-not-emulated) |
 | A Terraform run against Exoscale | **no**, and refused rather than half-served | the provider splits between this emulator and a paying account — [limits.md](limits.md#the-exoscale-terraform-provider-is-refused-and-why) |
-| Multi-zone or multi-region behaviour on Exoscale | **no** | one zone, and the reason is the client — [limits.md](limits.md#exoscale-has-one-zone-and-the-reason-is-the-client) |
+| Multi-zone or multi-region behaviour on Exoscale | **no** | one zone per process, selectable with `FEINT_EXOSCALE_ZONE`, and the reason is the client — [limits.md](limits.md#exoscale-has-one-zone-per-process-and-the-reason-is-the-client) |
 | Traffic actually flowing through a gateway or a NAT | **no** | records move, packets do not — [limits.md](limits.md#outscales-gateways-and-nat-move-records-not-packets) |
 
 ## How to read a verdict

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -1210,27 +1210,42 @@ account for all 1700 upstream operations would fail forever and train everyone t
 ignore it. Widening the scope is a decision to make when a product is started,
 not before.
 
-## Exoscale has one zone, and the reason is the client
+## Exoscale has one zone per process, and the reason is the client
 
-The API description enumerates eight zone names and this emulator publishes one:
-`ch-dk-2`. It is not an oversight and it is not laziness — it is what the
-official CLI forced.
-
-Serving a zone the CLI does not default to makes every unflagged command fail
-before it calls anything: `exo` resolves its zone first and stops on
-`find zone: not found in ListZonesResponse`. So the emulated zone has to be
-`ch-dk-2`, the CLI's own default.
+The API description enumerates eight zone names and this emulator publishes
+one per process. It is not an oversight and it is not laziness — it is what
+the official CLI forced.
 
 Serving all eight was the obvious fix and it was worse. The CLI queries **every**
 zone it is told about and merges the answers, so eight zone entries pointing at
 one emulator turned a single instance into eight identical rows in
 `exo compute instance list`. A resource duplicated per zone is a defect a user
-sees on their first command.
+sees on their first command. At Exoscale a zone is a property of the endpoint
+(`api-<zone>.exoscale.com`), so one endpoint honestly serves one zone.
 
-The consequence, stated rather than hidden: a client asking for `ch-gva-2` gets
-`no such zone`, where the real cloud would serve it. That is a visible, honest
-difference. The alternative — one endpoint pretending to be eight zones — is a
-silent, wrong one.
+*Which* zone is the operator's choice since #278: `FEINT_EXOSCALE_ZONE`
+selects any zone their document publishes, and unset keeps `ch-dk-2`, the
+CLI's own default — serving a zone the CLI does not default to makes every
+unflagged command fail before it calls anything, on
+`find zone: not found in ListZonesResponse`. Three of the five surveyed
+Exoscale stacks target another zone (#262), which is what made the choice
+worth a knob.
+
+Two consequences, stated rather than hidden:
+
+- a client asking for a zone the process does not serve gets `no such zone`,
+  where the real cloud would serve it. That is a visible, honest difference.
+  The alternative — one endpoint pretending to be eight zones — is a silent,
+  wrong one.
+- on any zone but `ch-dk-2`, `exo compute instance-type list` and `show` fail
+  with `find zone: "ch-dk-2" not found`, and that is the client, measured at
+  its source: exo 1.95.1 passes its compiled default to the v3 zone switch
+  (`cmd/compute/instance_type/instance_type_list.go:85`, with
+  `cmd/common.go:15` fixing `DefaultZone = "ch-dk-2"`); no flag, config or
+  env reaches it. Invisible against the real cloud, whose zone list always
+  names `ch-dk-2`. Every other command of the driven flows takes `--zone` or
+  honours the account default; `tools/conformance/exoscale/zones.sh` pins
+  the exact failure so the day exo heals it, the suite says so.
 
 ## A declared query parameter is served or refused, never dropped — and `labels` is the refused one
 

--- a/examples/stacks/surveyed.md
+++ b/examples/stacks/surveyed.md
@@ -241,8 +241,12 @@ answered everything the modern provider sent.
   and the failure surfaces as `find zone "ch-gva-2" not found in
   ListZonesResponse` because the DNS client resolves through the zone list
   (single-zone catalogue, `internal/providers/exoscale/catalog.go` — a
-  measured decision). Its `visibility=private` template reads produced the
-  #271 transcript.
+  measured decision). Since #278, a deployment configured with
+  `FEINT_EXOSCALE_ZONE=ch-gva-2` answers that resolution, and the same
+  branch fails naming its real cause instead — `feint does not serve
+  /v2/dns-domain` (measured on the route, 2026-08-19); on an unconfigured
+  deployment the misleading message stands, which is #284's business. Its
+  `visibility=private` template reads produced the #271 transcript.
 - **Recorded edit** (`security_groups.tf`): `icmp_code = 0` beside
   `icmp_type = 8` — the stack pins provider 0.68.0, only the 0.70-based
   patched fork reaches the emulator, and 0.70 refuses the pair client-side.
@@ -286,6 +290,15 @@ answered everything the modern provider sent.
 - **Replayed 2026-08-18, `main@23f57c1`**: identical — 19 applied, NLB
   refused by name, SOS at the real endpoint on fake credentials, re-plan
   `6 to add / 0 to change`, 19 destroyed.
+- **Replayed 2026-08-19 on the #278 branch, against
+  `FEINT_EXOSCALE_ZONE=de-fra-1`**: the zone pin is gone from the harness.
+  `locals.tf` keeps the example's own `platform_zone = "de-fra-1"` — the
+  default the survey had to overwrite, because the emulator froze `ch-dk-2` —
+  and the operator file's only remaining input is the admin-network pin.
+  Same figures as the reference: **19 applied, re-plan `6 to add / 0 to
+  change`, 19 destroyed**; the six re-adds are the NLB branch (refused, its
+  five services behind it) and the SOS pair at the real
+  `sos-de-muc-1.exo.io` on fake credentials, exactly as on `ch-dk-2`.
 
 ### 3. PhilippeChepy/terraform-exoscale-vault — applied after a recorded edit, fully green
 
@@ -346,7 +359,9 @@ answered everything the modern provider sent.
 **Exoscale mean: 6.0.** The ecosystem splits cleanly in two: compute-shaped
 stacks (instance pools, SGs, EIPs) apply and converge; platform-shaped ones
 live in SKS/DBaaS/SOS and cannot start. Three of five pin or default to a
-zone other than `ch-dk-2`.
+zone other than `ch-dk-2` — the measurement that became
+`FEINT_EXOSCALE_ZONE` (#278), verified above on this register's own
+platform entry.
 
 ## Scaleway — four applied in part, one not applicable
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -478,6 +478,14 @@ func loadContracts(dir string) (map[string]*contract.Doc, error) {
 // does not publish refuses to serve rather than silently answering the
 // default, which would be #268's lie moved to startup.
 // TestAnUnknownOutscaleRegionRefusesToServe fails without the refusal.
+//
+// FEINT_EXOSCALE_ZONE is the same knob for the Exoscale zone (#278): at
+// Exoscale a zone is a property of the endpoint a client points at
+// (api-<zone>.exoscale.com), so the emulator's single endpoint serves one
+// zone per process, chosen here. Unset keeps ch-dk-2, the official CLI's own
+// default; a zone Exoscale does not publish refuses to serve, naming the
+// accepted list. TestAnUnknownExoscaleZoneRefusesToServe fails without the
+// refusal.
 var packsFor = func(env *emulator.Env) ([]emulator.Pack, error) {
 	osc := outscale.New(env)
 	if region := os.Getenv("FEINT_OUTSCALE_REGION"); region != "" {
@@ -486,7 +494,14 @@ var packsFor = func(env *emulator.Env) ([]emulator.Pack, error) {
 			return nil, fmt.Errorf("FEINT_OUTSCALE_REGION: %w", err)
 		}
 	}
-	return []emulator.Pack{scaleway.New(env), osc, exoscale.New(env)}, nil
+	exo := exoscale.New(env)
+	if zone := os.Getenv("FEINT_EXOSCALE_ZONE"); zone != "" {
+		var err error
+		if exo, err = exoscale.NewInZone(env, zone); err != nil {
+			return nil, fmt.Errorf("FEINT_EXOSCALE_ZONE: %w", err)
+		}
+	}
+	return []emulator.Pack{scaleway.New(env), osc, exo}, nil
 }
 
 // newServer builds the emulator with every pack mounted. With contracts, every

--- a/internal/cli/docs_status.go
+++ b/internal/cli/docs_status.go
@@ -46,9 +46,13 @@ var suiteInvocation = regexp.MustCompile(`tools/conformance/([a-z]+)/([a-z-]+)\.
 // name nobody mapped is how a table understates what is proven — the mirror of
 // the defect above, and just as wrong.
 var clientOf = map[string]string{
-	"scw-cli":   "`scw`",
-	"oapi-cli":  "`oapi-cli`",
-	"exo-cli":   "`exo`",
+	"scw-cli":  "`scw`",
+	"oapi-cli": "`oapi-cli`",
+	"exo-cli":  "`exo`",
+	// The two-zone suite (#278) drives the same real CLI, against an emulator
+	// it starts itself on a non-default zone; the client a reader would name
+	// is still `exo`, and both consumers deduplicate.
+	"zones":     "`exo`",
 	"terraform": "Terraform, OpenTofu",
 	// Neither names a client: the probe drives every route from the provider's
 	// own API description, and the network and ssh suites prove the machine

--- a/internal/cli/zone_test.go
+++ b/internal/cli/zone_test.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+)
+
+// FEINT_EXOSCALE_ZONE is #278's knob, the Exoscale twin of
+// FEINT_OUTSCALE_REGION next door: an Exoscale zone is a property of the
+// endpoint a client points at (api-<zone>.exoscale.com), so it rides the
+// environment into the composition root and is fixed for the process. These
+// two tests hold both halves of the contract: the value selects the zone
+// every mounted entry point will serve, and a value Exoscale does not publish
+// refuses to serve instead of silently answering the default.
+
+func TestTheExoscaleZoneRidesTheEnvironment(t *testing.T) {
+	t.Setenv("FEINT_EXOSCALE_ZONE", "de-fra-1")
+
+	env := emulator.DefaultEnv()
+	packs, err := packsFor(env)
+	if err != nil {
+		t.Fatalf("packsFor with a zone Exoscale publishes: %v", err)
+	}
+	srv, err := emulator.NewServer(env, packs...)
+	if err != nil {
+		t.Fatalf("build the emulator: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	res, err := http.Get(ts.URL + "/v2/zone") //nolint:noctx // test client
+	if err != nil {
+		t.Fatalf("GET /v2/zone: %v", err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	body := make([]byte, 4096)
+	n, _ := res.Body.Read(body)
+	if !strings.Contains(string(body[:n]), `"de-fra-1"`) {
+		t.Errorf("the zone list does not name the selected zone: %s", body[:n])
+	}
+}
+
+func TestAnUnknownExoscaleZoneRefusesToServe(t *testing.T) {
+	t.Setenv("FEINT_EXOSCALE_ZONE", "ch-mars-1")
+
+	if _, err := packsFor(emulator.DefaultEnv()); err == nil {
+		t.Fatal("packsFor accepted ch-mars-1, a zone Exoscale does not publish")
+	} else if !strings.Contains(err.Error(), "ch-mars-1") {
+		t.Errorf("the refusal does not name the offending value: %v", err)
+	}
+}

--- a/internal/providers/exoscale/catalog.go
+++ b/internal/providers/exoscale/catalog.go
@@ -3,6 +3,7 @@ package exoscale
 import (
 	"net/http"
 	"sort"
+	"strings"
 
 	"github.com/stephrobert/feint/internal/core/emulator"
 	"github.com/stephrobert/feint/internal/core/resource"
@@ -20,25 +21,64 @@ import (
 // This is the Scaleway catalogue trap in another dialect. An emulator has no
 // inventory, and it must serve one anyway.
 
-// zoneName is the one zone this emulator has, and it is ch-dk-2 because that is
-// the official CLI's own default. Serving any other single zone makes every
-// unflagged command fail with "find zone: not found in ListZonesResponse" before
-// it calls anything.
+// The emulator serves ONE zone per process, and which one is a datum, not a
+// constant (#278). Both halves of that sentence were measured:
 //
-// Publishing all eight names the API description enumerates was the second
-// attempt, and the CLI showed why it is wrong: it queries **every** zone it is
-// told about and merges the answers. Eight zones pointing at one emulator turned
-// one instance into eight identical rows in `exo compute instance list`. A
-// resource duplicated per zone is a defect a user sees immediately.
+// One zone, because publishing all eight names the API description enumerates
+// was tried, and the CLI showed why it is wrong: it queries **every** zone it
+// is told about and merges the answers. Eight zones pointing at one emulator
+// turned one instance into eight identical rows in `exo compute instance
+// list`. A resource duplicated per zone is a defect a user sees immediately.
+// At Exoscale a zone is a property of the endpoint (api-<zone>.exoscale.com),
+// so one endpoint honestly serves one zone — the same reasoning that fixed the
+// Outscale region one pack over (#290).
 //
-// The honest emulation is therefore one zone. Their zone-name enum has eight
-// entries and this account has one of them, which is a difference from the real
-// cloud that docs/limits.md records rather than papers over: a client asking for
-// ch-gva-2 gets a clear "no such zone" instead of a silent duplicate.
-var zoneNames = []string{zoneName}
+// A datum, because freezing that one zone on ch-dk-2 had a measured cost:
+// three of the five surveyed Exoscale stacks target another zone —
+// eu-data-platform hardcodes ch-gva-2, PhilippeChepy/platform defaults to
+// de-fra-1, openshift4-exoscale's DNS client resolves ch-gva-2 (#262, #278).
+// The zone is now Pack.zone, chosen at construction, and everything the
+// catalogue declares follows it. A client asking for a zone this deployment
+// does not serve still gets a clear "not found in ListZonesResponse" instead
+// of a silent duplicate, which docs/limits.md records.
 
-// zoneName is the emulated zone, and the CLI's default.
-const zoneName = "ch-dk-2"
+// defaultZoneName is where the emulated account lives when nobody chooses:
+// ch-dk-2, because that is the official CLI's own default. Serving any other
+// single zone by default makes every unflagged command fail with "find zone:
+// not found in ListZonesResponse" before it calls anything.
+const defaultZoneName = "ch-dk-2"
+
+// publishedZoneNames is every zone Exoscale publishes, in their document's own
+// order. Source: .upstream/exoscale-openapi.yaml, the `zone-name` schema enum,
+// which is also — reordered — the `zone` enum of the server URL the same
+// document declares (`https://api-{zone}.exoscale.com/v2`); fetched from
+// openapi-v2.exoscale.com by `mise run upstream:sync` on 2026-08-18. A
+// selection outside this list is refused at construction (NewInZone), naming
+// these: silently answering the default to an operator who asked for
+// something else would be the #268 lie moved to startup.
+var publishedZoneNames = []string{
+	"ch-dk-2", "de-muc-1", "ch-gva-2", "at-vie-1", "de-fra-1", "bg-sof-1", "at-vie-2", "hr-zag-1",
+}
+
+// publishedZone reports whether Exoscale publishes the zone.
+func publishedZone(name string) bool {
+	for _, zone := range publishedZoneNames {
+		if zone == name {
+			return true
+		}
+	}
+	return false
+}
+
+// zoneList renders what would have been accepted, sorted, for the error a
+// misspelt selection gets: a refusal that does not say what it accepts sends
+// the operator back to the source code.
+func zoneList() string {
+	names := make([]string, len(publishedZoneNames))
+	copy(names, publishedZoneNames)
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}
 
 // apiPrefix is the version segment every Exoscale route sits under, and the
 // suffix a client needs on the address it is handed.
@@ -62,31 +102,29 @@ const apiPrefix = "/v2"
 // upload to a route that does not exist. An empty string is what "not here"
 // looks like; an invented address is a promise the emulator cannot keep.
 func (p *Pack) listZones(w http.ResponseWriter, r *http.Request) {
-	zones := make([]map[string]any, 0, len(zoneNames))
-	for _, name := range zoneNames {
-		// The real answer also carries an id per zone, measured on 2026-08-10
-		// and absent from their published schema, which this emulator's
-		// contract check enforces as closed. The field stays off the wire for
-		// the same reason as security-group's visibility: a response the
-		// emulator would refuse itself is not one it may send.
-		zones = append(zones, map[string]any{
-			"name": name,
-			// No id, and that is measured rather than an oversight. The live API
-			// sends one on every zone — recorded in shapes/exoscale.json — while
-			// their published OpenAPI declares no such field on `zone`. Emitting
-			// it fails this emulator's own contract check, which is the gate that
-			// keeps every other answer honest.
-			//
-			// Same call as start/stop's `resource` envelope in lifecycle.go: the
-			// live API is ahead of its own description in four measured places,
-			// and the rule is to serve what clients decode and what the contract
-			// accepts. Raised as #94 from a shape diff and closed as not-a-defect
-			// on that basis: TestEveryRouteAnswersItsContract in internal/probe fails
-			// the moment the field is added.
-			"api-endpoint": emulator.EndpointOf(r) + apiPrefix,
-			"sos-endpoint": "",
-		})
-	}
+	// One row: the zone this deployment serves (Pack.zone, #278). The real
+	// answer also carries an id per zone, measured on 2026-08-10 and absent
+	// from their published schema, which this emulator's contract check
+	// enforces as closed. The field stays off the wire for the same reason as
+	// security-group's visibility: a response the emulator would refuse itself
+	// is not one it may send.
+	zones := []map[string]any{{
+		"name": p.zone,
+		// No id, and that is measured rather than an oversight. The live API
+		// sends one on every zone — recorded in shapes/exoscale.json — while
+		// their published OpenAPI declares no such field on `zone`. Emitting
+		// it fails this emulator's own contract check, which is the gate that
+		// keeps every other answer honest.
+		//
+		// Same call as start/stop's `resource` envelope in lifecycle.go: the
+		// live API is ahead of its own description in four measured places,
+		// and the rule is to serve what clients decode and what the contract
+		// accepts. Raised as #94 from a shape diff and closed as not-a-defect
+		// on that basis: TestEveryRouteAnswersItsContract in internal/probe fails
+		// the moment the field is added.
+		"api-endpoint": emulator.EndpointOf(r) + apiPrefix,
+		"sos-endpoint": "",
+	}}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{"zones": zones})
 }
 
@@ -110,16 +148,18 @@ func (p *Pack) getDeployTarget(w http.ResponseWriter, _ *http.Request) {
 // family and size are closed enums in the API description, so the values here
 // are theirs. memory is in bytes, which is the unit their own schema uses; a
 // value in mebibytes would display as a machine four thousand times too small.
+//
+// No "zones" key here: which zone an entry is available in follows the pack's
+// datum, stamped at construction (stampedWithZone), so the catalogue cannot
+// declare a zone this deployment does not serve.
 var instanceTypes = []map[string]any{
 	{
 		"id": "21624abb-764e-4def-81d7-9fc54b5957fb", "family": "standard", "size": "tiny",
 		"cpus": 1, "memory": 1073741824, "gpus": 0, "authorized": true,
-		"zones": allZones(),
 	},
 	{
 		"id": "b6cd1ff5-3a2f-4e9d-a4d1-8988c1191fe8", "family": "standard", "size": "small",
 		"cpus": 2, "memory": 2147483648, "gpus": 0, "authorized": true,
-		"zones": allZones(),
 	},
 }
 
@@ -153,10 +193,10 @@ func (p *Pack) listTemplates(w http.ResponseWriter, r *http.Request) {
 		return family == "" || view["family"] == family
 	}
 
-	out := make([]map[string]any, 0, len(templates))
+	out := make([]map[string]any, 0, len(p.templates))
 	switch visibility {
 	case "", "public":
-		for _, t := range templates {
+		for _, t := range p.templates {
 			if matches(t) {
 				out = append(out, t)
 			}
@@ -186,7 +226,7 @@ func (p *Pack) storedTemplates() []*resource.Resource {
 }
 
 func (p *Pack) listInstanceTypes(w http.ResponseWriter, _ *http.Request) {
-	emulator.WriteJSON(w, http.StatusOK, map[string]any{"instance-types": instanceTypes})
+	emulator.WriteJSON(w, http.StatusOK, map[string]any{"instance-types": p.instanceTypes})
 }
 
 // getTemplate and getInstanceType answer the by-id reads a client makes once it
@@ -195,7 +235,7 @@ func (p *Pack) listInstanceTypes(w http.ResponseWriter, _ *http.Request) {
 // client walks before it posts anything.
 func (p *Pack) getTemplate(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
-	for _, t := range templates {
+	for _, t := range p.templates {
 		if t["id"] == id {
 			emulator.WriteJSON(w, http.StatusOK, t)
 			return
@@ -211,7 +251,7 @@ func (p *Pack) getTemplate(w http.ResponseWriter, r *http.Request) {
 }
 
 func (p *Pack) getInstanceType(w http.ResponseWriter, r *http.Request) {
-	for _, t := range instanceTypes {
+	for _, t := range p.instanceTypes {
 		if t["id"] == r.PathValue("id") {
 			emulator.WriteJSON(w, http.StatusOK, t)
 			return
@@ -220,13 +260,23 @@ func (p *Pack) getInstanceType(w http.ResponseWriter, r *http.Request) {
 	writeError(w, http.StatusNotFound, "no instance type "+r.PathValue("id"))
 }
 
-// allZones is what a catalogue entry declares it is available in: everywhere,
-// because the emulator has one store and no zone scoping. A client filtering a
-// template or a type by zone must find it wherever it looks.
-func allZones() []any {
-	out := make([]any, 0, len(zoneNames))
-	for _, name := range zoneNames {
-		out = append(out, name)
+// stampedWithZone renders catalogue rows for the zone in force: each entry
+// declares it is available exactly where this deployment lives, because the
+// emulator has one store and one zone per process. A client filtering a
+// template or a type by zone must find it in the zone it was told about by
+// list-zones, and must not find it anywhere else — a catalogue declaring
+// zones the deployment does not serve is the #269 contradiction, this pack's
+// dialect. Copies, never the base rows: stamping in place would leak one
+// pack's zone into the next pack built from the same tables.
+func stampedWithZone(rows []map[string]any, zone string) []map[string]any {
+	out := make([]map[string]any, 0, len(rows))
+	for _, row := range rows {
+		entry := make(map[string]any, len(row)+1)
+		for key, value := range row {
+			entry[key] = value
+		}
+		entry["zones"] = []any{zone}
+		out = append(out, entry)
 	}
 	return out
 }

--- a/internal/providers/exoscale/machines.go
+++ b/internal/providers/exoscale/machines.go
@@ -61,12 +61,17 @@ const catalogueDate = "2025-01-01T00:00:00Z"
 // application-consistent-snapshot-enabled. The values are the emulator's own
 // claims, like the rest of this catalogue; the size matches the 10 GiB disk
 // floor a create is checked against.
+//
+// No "zones" key here: which zone a template is available in follows the
+// pack's datum (#278), stamped at construction (stampedWithZone, catalog.go).
+// Everything served reads Pack.templates; this base table stays for what is
+// zone-independent — templateFor resolves default-user from it.
 var templates = []map[string]any{
 	{
 		"id": "11111111-1111-4111-8111-111111111111", "name": "Linux Ubuntu 24.04 LTS 64-bit",
 		"family": "ubuntu", "default-user": "ubuntu", "visibility": "public",
 		"boot-mode": "uefi", "ssh-key-enabled": true, "password-enabled": false,
-		"created-at": catalogueDate, "zones": allZones(),
+		"created-at":  catalogueDate,
 		"description": "Linux Ubuntu 24.04 LTS 64-bit", "version": "24.04",
 		"build": "feint", "checksum": "00000000000000000000000000000001",
 		"maintainer": "feint", "size": 10737418240,
@@ -76,7 +81,7 @@ var templates = []map[string]any{
 		"id": "22222222-2222-4222-8222-222222222222", "name": "Linux Debian 12 64-bit",
 		"family": "debian", "default-user": "debian", "visibility": "public",
 		"boot-mode": "uefi", "ssh-key-enabled": true, "password-enabled": false,
-		"created-at": catalogueDate, "zones": allZones(),
+		"created-at":  catalogueDate,
 		"description": "Linux Debian 12 64-bit", "version": "12",
 		"build": "feint", "checksum": "00000000000000000000000000000002",
 		"maintainer": "feint", "size": 10737418240,

--- a/internal/providers/exoscale/pack.go
+++ b/internal/providers/exoscale/pack.go
@@ -20,6 +20,7 @@
 package exoscale
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 	"slices"
@@ -58,6 +59,20 @@ const (
 // Pack implements emulator.Pack for Exoscale.
 type Pack struct {
 	env *emulator.Env
+	// zone is where this deployment claims to live — a datum, not a constant
+	// (#278). Exoscale serves every zone from its own endpoint
+	// (api-<zone>.exoscale.com), so an emulator with a single endpoint
+	// chooses one zone at construction, exactly as the Outscale pack chooses
+	// its region (#290). Fixed for the pack's lifetime, like a real endpoint:
+	// a zone that moved mid-run would strand every stored resource in a zone
+	// the list no longer names.
+	zone string
+	// templates and instanceTypes are the fixed catalogue stamped with the
+	// zone in force (stampedWithZone), so what an entry declares it is
+	// available in and what this deployment serves cannot disagree — the
+	// #269 invariant, this pack's turn.
+	templates     []map[string]any
+	instanceTypes []map[string]any
 }
 
 // lockAddresses serializes elastic IP and lease allocation, which is
@@ -76,8 +91,32 @@ type Pack struct {
 // TestAnExoscaleBarrageLeavesTheStoreCoherent fails without this.
 func (p *Pack) lockAddresses() func() { return serialise.Lock(Name + "/addresses") }
 
-// New returns an Exoscale pack backed by env.
-func New(env *emulator.Env) *Pack { return &Pack{env: env} }
+// New returns an Exoscale pack backed by env, serving the default zone.
+// Nothing configured keeps today's behaviour: ch-dk-2, the official CLI's own
+// default, exactly as before the zone became selectable.
+func New(env *emulator.Env) *Pack { return newInZone(env, defaultZoneName) }
+
+// NewInZone returns a pack serving the named zone, or an error naming the
+// zones Exoscale publishes when it publishes no such zone. Refusing beats
+// defaulting: an emulator that answered ch-dk-2 to an operator who asked for
+// ch-gva-2 would be the exact lie #268 was about, moved to startup.
+func NewInZone(env *emulator.Env, zone string) (*Pack, error) {
+	if !publishedZone(zone) {
+		return nil, fmt.Errorf("exoscale publishes no zone %q (it publishes %s)", zone, zoneList())
+	}
+	return newInZone(env, zone), nil
+}
+
+// newInZone builds the pack with everything the zone decides. Callers
+// guarantee the zone is one Exoscale publishes.
+func newInZone(env *emulator.Env, zone string) *Pack {
+	return &Pack{
+		env:           env,
+		zone:          zone,
+		templates:     stampedWithZone(templates, zone),
+		instanceTypes: stampedWithZone(instanceTypes, zone),
+	}
+}
 
 // Name implements emulator.Pack.
 func (p *Pack) Name() string { return Name }
@@ -1397,7 +1436,7 @@ func (p *Pack) Env(endpoint string) emulator.Environment {
 			"EXOSCALE_API_KEY":      "EXOxxxxxxxxxxxxxxxxxxxx",
 			"EXOSCALE_API_SECRET":   "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			"EXOSCALE_API_ENDPOINT": endpoint + apiPrefix,
-			"EXOSCALE_ZONE":         zoneName,
+			"EXOSCALE_ZONE":         p.zone,
 		},
 		Note: "the exo CLI reads these. The Terraform provider only half does: it honours " +
 			"EXOSCALE_API_ENDPOINT for its egoscale v3 client and not for its v2 one, so an " +

--- a/internal/providers/exoscale/pools.go
+++ b/internal/providers/exoscale/pools.go
@@ -643,7 +643,7 @@ func (p *Pack) templateByID(id string) (map[string]any, bool) {
 	if id == "" {
 		return nil, false
 	}
-	for _, t := range templates {
+	for _, t := range p.templates {
 		if t["id"] == id {
 			return t, true
 		}

--- a/internal/providers/exoscale/zones_test.go
+++ b/internal/providers/exoscale/zones_test.go
@@ -1,0 +1,144 @@
+package exoscale_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/providers/exoscale"
+)
+
+// The zone is a datum, not a constant (#278). At Exoscale every zone is
+// served from its own endpoint (api-<zone>.exoscale.com), so an emulator with
+// a single endpoint chooses its zone at construction instead of hardwiring
+// ch-dk-2 — the same correction the Outscale pack received for its region
+// (#290). Every test here runs in a NON-default zone on purpose; the
+// default-zone suite next door (pack_test.go) is exactly the population that
+// let the constant ship, because a constant and a datum are indistinguishable
+// from ch-dk-2.
+
+// serveInZone mounts the pack in a named zone, the way the CLI does when
+// FEINT_EXOSCALE_ZONE is set.
+func serveInZone(t *testing.T, zone string) http.Handler {
+	t.Helper()
+	env := emulator.DefaultEnv()
+	pack, err := exoscale.NewInZone(env, zone)
+	if err != nil {
+		t.Fatalf("build the pack in %s: %v", zone, err)
+	}
+	srv, err := emulator.NewServer(env, pack)
+	if err != nil {
+		t.Fatalf("build the server: %v", err)
+	}
+	return srv.Handler()
+}
+
+// A pack built for ch-gva-2 — the zone the eu-data-platform stack hardcodes
+// and the one openshift4-exoscale's DNS client resolves (#262, #278) — agrees
+// with itself everywhere: the zone list, what every catalogue entry declares
+// it is available in, and the write paths that resolve through that
+// catalogue. Never ch-dk-2 anywhere, and never a union: a catalogue declaring
+// zones this deployment does not serve is the #269 contradiction in this
+// pack's dialect.
+func TestANonDefaultZoneAgreesWithItself(t *testing.T) {
+	h := serveInZone(t, "ch-gva-2")
+
+	// The zone list, which is where every other call gets its address:
+	// exactly one row, and it names the zone in force.
+	rec, body := call(t, h, "GET", "/v2/zone", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /v2/zone: status %d, want 200", rec.Code)
+	}
+	zones, _ := body["zones"].([]any)
+	if len(zones) != 1 {
+		t.Fatalf("%d zones point at this emulator, want exactly 1: %v", len(zones), body)
+	}
+	row, _ := zones[0].(map[string]any)
+	if name, _ := row["name"].(string); name != "ch-gva-2" {
+		t.Errorf("the zone list names %q, want ch-gva-2", name)
+	}
+	if endpoint, _ := row["api-endpoint"].(string); !strings.HasSuffix(endpoint, "/v2") ||
+		strings.Contains(endpoint, "exoscale.com") {
+		t.Errorf("api-endpoint %q must point back at this emulator, /v2 included", endpoint)
+	}
+
+	// Every catalogue entry declares it is available exactly here. A client
+	// filtering by the zone it was told about must find the entry; one
+	// declaring ch-dk-2 in a ch-gva-2 deployment declares a zone every other
+	// route contradicts.
+	templateID, typeID := "", ""
+	for _, route := range []struct {
+		path, key string
+		id        *string
+	}{
+		{"/v2/template", "templates", &templateID},
+		{"/v2/instance-type", "instance-types", &typeID},
+	} {
+		_, listing := call(t, h, "GET", route.path, "")
+		entries, _ := listing[route.key].([]any)
+		if len(entries) == 0 {
+			t.Fatalf("GET %s answered no entries: %v", route.path, listing)
+		}
+		for _, raw := range entries {
+			entry, _ := raw.(map[string]any)
+			declared, _ := entry["zones"].([]any)
+			if len(declared) != 1 || declared[0] != "ch-gva-2" {
+				t.Errorf("%s entry %v declares zones %v, want [ch-gva-2]", route.path, entry["id"], declared)
+			}
+		}
+		first, _ := entries[0].(map[string]any)
+		*route.id, _ = first["id"].(string)
+	}
+
+	// The write paths accept what the catalogue above declared, and what they
+	// store reads back — a create resolved through this zone's own catalogue,
+	// which is exactly how `exo compute instance create --zone ch-gva-2`
+	// arrives here.
+	rec, created := call(t, h, "POST", "/v2/instance",
+		`{"name":"gva","disk-size":10,"template":{"id":"`+templateID+`"},"instance-type":{"id":"`+typeID+`"}}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST /v2/instance with this zone's own catalogue ids: status %d: %v", rec.Code, created)
+	}
+	// The create answers an operation; the instance's own id rides its
+	// reference, which is where the CLI reads it.
+	reference, _ := created["reference"].(map[string]any)
+	instanceID, _ := reference["id"].(string)
+	if instanceID == "" {
+		t.Fatalf("the create's operation names no instance: %v", created)
+	}
+	rec, read := call(t, h, "GET", "/v2/instance/"+instanceID, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("the created instance does not read back: status %d: %v", rec.Code, read)
+	}
+	if tpl, _ := read["template"].(map[string]any); tpl["id"] != templateID {
+		t.Errorf("the instance reads back template %v, want %s", tpl["id"], templateID)
+	}
+
+	// The pool path validates its template through the same catalogue
+	// (templateByID): refusing here what the list offered would be the two
+	// halves of the pack contradicting each other.
+	rec, pool := call(t, h, "POST", "/v2/instance-pool",
+		`{"name":"gva-pool","size":1,"disk-size":10,"template":{"id":"`+templateID+`"},"instance-type":{"id":"`+typeID+`"}}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST /v2/instance-pool refused this zone's own template: status %d: %v", rec.Code, pool)
+	}
+}
+
+// A zone Exoscale does not publish is refused at construction, naming what
+// would have been accepted. Refusing beats defaulting: an emulator that
+// answered ch-dk-2 to an operator who asked for something else would be
+// #268's lie moved to startup.
+func TestAZoneExoscaleDoesNotPublishIsRefused(t *testing.T) {
+	env := emulator.DefaultEnv()
+	if _, err := exoscale.NewInZone(env, "ch-mars-1"); err == nil {
+		t.Fatal("NewInZone accepted ch-mars-1, a zone Exoscale does not publish")
+	} else {
+		if !strings.Contains(err.Error(), "ch-mars-1") {
+			t.Errorf("the refusal does not name the zone asked for: %v", err)
+		}
+		if !strings.Contains(err.Error(), "ch-gva-2") {
+			t.Errorf("the refusal does not name what would have been accepted: %v", err)
+		}
+	}
+}

--- a/mise.toml
+++ b/mise.toml
@@ -267,6 +267,11 @@ run = "./feint docs --check"
 description = "Drive the running emulator with the real Exoscale CLI"
 run = "tools/conformance/exoscale/exo-cli.sh http://$FEINT_ADDR"
 
+[tasks."conformance:zones"]
+description = "Prove the Exoscale zone is a datum: an emulator of its own on ch-gva-2, driven by exo (#278)"
+depends = ["build"]
+run = "tools/conformance/exoscale/zones.sh"
+
 [tasks.probe]
 description = "Drive every mounted route from its provider's API description and check the answers"
 depends = ["build"]
@@ -308,6 +313,10 @@ tools/conformance/outscale/terraform.sh "http://$FEINT_ADDR"
 # they found two defects every other gate was blind to (#249, #250).
 tools/conformance/stacks.sh "http://$FEINT_ADDR"
 tools/conformance/exoscale/exo-cli.sh "http://$FEINT_ADDR"
+# The Exoscale zone is a datum (#278): a second emulator, on its own port and
+# configured for ch-gva-2, driven by the same real CLI. Two zones, two
+# processes — the way a real client meets a second zone: another endpoint.
+tools/conformance/exoscale/zones.sh
 # Every route driven from its provider's API description. Skipped when a machine
 # runtime is on: a synthetic walk of every Create* would start a container each.
 if [ "${FEINT_VM:-off}" = "off" ]; then ./feint probe --endpoint "http://$FEINT_ADDR" --contracts contracts; fi

--- a/tools/conformance/exoscale/zones.sh
+++ b/tools/conformance/exoscale/zones.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Conformance check: the Exoscale zone is a datum, proven with the real CLI (#278).
+#
+# The emulator serves one zone per process — measured: the CLI queries every
+# zone it is told about and merges the answers, so one emulator publishing
+# eight zones listed one instance eight times. What #278 changed is *which*
+# zone: a constant became a datum, selected by FEINT_EXOSCALE_ZONE. This suite
+# is the second half of the two-zone proof: exo-cli.sh drives the default
+# deployment (ch-dk-2) and this one starts its own emulator on ch-gva-2 — the
+# zone the eu-data-platform stack hardcodes and openshift4-exoscale's DNS
+# client resolves (#262) — the way a real client meets a second zone: another
+# endpoint.
+#
+# It owns its emulator (a zone is fixed at construction, so the shared one
+# cannot be re-pointed mid-run) and therefore starts and stops it with the
+# lifecycle verbs, on its own port.
+#
+# Usage: tools/conformance/exoscale/zones.sh   (port: FEINT_ZONES_PORT, default 4662)
+set -euo pipefail
+
+PORT="${FEINT_ZONES_PORT:-4662}"
+ADDR="127.0.0.1:$PORT"
+ENDPOINT="http://$ADDR"
+ZONE="ch-gva-2"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+# Never let a client reach anything but the local emulator. See guard.sh for
+# the incident that wrote this rule.
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/../guard.sh"
+guard_local "$ENDPOINT"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ok() { echo "  ok: $*"; }
+
+command -v exo >/dev/null 2>&1 || fail "exo is not installed"
+command -v jq >/dev/null 2>&1 || fail "jq is not installed"
+
+FEINT_BIN="${FEINT_BIN:-$REPO_DIR/feint}"
+[ -x "$FEINT_BIN" ] || fail "no feint binary at $FEINT_BIN (build it: mise run build)"
+
+set -a
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/fake-credentials.env"
+set +a
+export EXOSCALE_API_ENDPOINT=${ENDPOINT}/v2
+export EXOSCALE_ZONE="$ZONE"
+
+echo "conformance: exo CLI against $ENDPOINT, zone $ZONE"
+
+echo "- an emulator of its own, because the zone is fixed at construction"
+FEINT_EXOSCALE_ZONE="$ZONE" "$FEINT_BIN" start --addr "$ADDR" \
+  --contracts "$REPO_DIR/contracts" --timeout 60s
+trap '"$FEINT_BIN" stop --addr "$ADDR" >/dev/null 2>&1 || true' EXIT
+
+# The spans of prove.sh, against this suite's own emulator.
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/../prove.sh"
+
+echo "- the zone list names the zone in force, and only it"
+zones="$(exo -O json zone)" || fail "zone rejected: $zones"
+printf '%s' "$zones" | jq -e 'length == 1' >/dev/null \
+  || fail "more than one zone points at this emulator: every resource would be listed once per zone"
+printf '%s' "$zones" | jq -e "any(.[]; .name == \"$ZONE\")" >/dev/null \
+  || fail "the selected zone $ZONE is missing from: $zones"
+# The default must be gone: a list still naming ch-dk-2 would mean the
+# selection changed nothing, which is the constant this suite exists to refuse.
+printf '%s' "$zones" | jq -e 'any(.[]; .name == "ch-dk-2") | not' >/dev/null \
+  || fail "ch-dk-2 is still on offer in a $ZONE deployment: the zone is a constant again"
+ok "one zone, $ZONE, selected by FEINT_EXOSCALE_ZONE"
+
+echo "- the catalogue a create walks, in the zone in force"
+templates="$(exo -O json compute instance-template list --zone "$ZONE")" || fail "template list rejected: $templates"
+template_name="$(printf '%s' "$templates" | jq -r '.[0].name // empty')"
+[ -n "$template_name" ] || fail "no template on offer: $templates"
+# `exo compute instance-type list` is the one command of this flow that CANNOT
+# work off ch-dk-2, and that is the client, measured at the source: exo 1.95.1
+# hardcodes its compiled default for the v3 zone switch
+# (cmd/compute/instance_type/instance_type_list.go:85 passes
+# exocmd.DefaultZone, which cmd/common.go:15 fixes at "ch-dk-2"; no flag,
+# config or env reaches it — instance_type_show.go:76 is the same). Invisible
+# against the real cloud, whose zone list always names ch-dk-2; fatal against
+# any one-zone deployment that is not ch-dk-2, docs/limits.md records it. So
+# the suite demands exactly that failure, naming exactly that zone — and lets
+# a future exo that fixes it pass, so the day it heals is the day this says so.
+if types="$(exo -O json compute instance-type list 2>&1)"; then
+  type_name="$(printf '%s' "$types" | jq -r '"\(.[0].family).\(.[0].name)"')"
+else
+  printf '%s' "$types" | grep -q 'ch-dk-2' \
+    || fail "instance-type list failed for a new reason (not its hardcoded ch-dk-2): $types"
+  # The type name comes from the deployment's own catalogue instead, the same
+  # rows the CLI would have printed.
+  type_name="$(curl -sf "$ENDPOINT/v2/instance-type" | jq -r '.["instance-types"][0] | "\(.family).\(.size)"')"
+fi
+case "$type_name" in
+  *null*|.|"") fail "no instance type on offer: $types" ;;
+esac
+ok "$template_name, $type_name, offered in $ZONE"
+
+echo "- create in $ZONE, from that catalogue, and read it back there"
+span="$(prove_begin behaviour)"
+exo compute instance create conformance-gva \
+  --zone "$ZONE" --template "$template_name" --instance-type "$type_name" \
+  >/dev/null || fail "instance create in $ZONE rejected"
+instances="$(exo -O json compute instance list --zone "$ZONE")" || fail "instance list rejected: $instances"
+id="$(printf '%s' "$instances" | jq -r '.[] | select(.name == "conformance-gva") | .id')"
+[ -n "$id" ] || fail "the instance is not in the $ZONE list after create: $instances"
+exo -Q compute instance delete "$id" --zone "$ZONE" --force >/dev/null \
+  || fail "instance delete rejected"
+prove_end "$span"
+ok "instance $id lived and died in $ZONE"
+
+echo "PASS: the zone is a datum — $ZONE served, ch-dk-2 gone, the real CLI drove it"

--- a/tools/falsify/specs/catalogue-is-served.json
+++ b/tools/falsify/specs/catalogue-is-served.json
@@ -12,8 +12,8 @@
       "label": "the inventory is mounted and empty, which fails a client exactly as a 404 does",
       "package": "./internal/cli/",
       "file": "internal/providers/exoscale/catalog.go",
-      "find": "\temulator.WriteJSON(w, http.StatusOK, map[string]any{\"instance-types\": instanceTypes})",
-      "replace": "\temulator.WriteJSON(w, http.StatusOK, map[string]any{\"instance-types\": instanceTypes[:0]})",
+      "find": "\temulator.WriteJSON(w, http.StatusOK, map[string]any{\"instance-types\": p.instanceTypes})",
+      "replace": "\temulator.WriteJSON(w, http.StatusOK, map[string]any{\"instance-types\": p.instanceTypes[:0]})",
       "test": "TestEveryDeclaredCatalogueAnswersSomething"
     },
     {

--- a/tools/falsify/specs/exoscale-zones.json
+++ b/tools/falsify/specs/exoscale-zones.json
@@ -1,0 +1,19 @@
+{
+  "package": "./internal/providers/exoscale/",
+  "mutations": [
+    {
+      "label": "the zone is a constant again: whatever a caller selects, the pack builds ch-dk-2, which is the #269 defect one level up, this pack's turn (#278)",
+      "file": "internal/providers/exoscale/pack.go",
+      "find": "func newInZone(env *emulator.Env, zone string) *Pack {\n\treturn &Pack{",
+      "replace": "func newInZone(env *emulator.Env, zone string) *Pack {\n\tzone = defaultZoneName + zone[:0]\n\treturn &Pack{",
+      "test": "TestANonDefaultZoneAgreesWithItself"
+    },
+    {
+      "label": "the catalogue declares the default zone whatever the pack serves: list-zones and every entry's zones field contradict the deployment (#278)",
+      "file": "internal/providers/exoscale/catalog.go",
+      "find": "\t\tentry[\"zones\"] = []any{zone}",
+      "replace": "\t\tentry[\"zones\"] = []any{defaultZoneName + zone[:0]}",
+      "test": "TestANonDefaultZoneAgreesWithItself"
+    }
+  ]
+}


### PR DESCRIPTION
# Summary

The Exoscale zone becomes a datum, selected at construction, instead of the constant `ch-dk-2` — the same correction the Outscale region received in #290, one provider over. The emulator still serves **one zone per process** (measured: `exo` queries every zone it is told about and merges the answers, so several published zones duplicate every resource per zone), but *which* zone now rides `FEINT_EXOSCALE_ZONE`, read once in the CLI's composition root beside `FEINT_OUTSCALE_REGION`. Unset keeps `ch-dk-2` exactly as before; a zone Exoscale does not publish refuses to serve, naming the accepted list.

The zone table is Exoscale's own: the `zone-name` enum of `.upstream/exoscale-openapi.yaml` (`ch-dk-2`, `de-muc-1`, `ch-gva-2`, `at-vie-1`, `de-fra-1`, `bg-sof-1`, `at-vie-2`, `hr-zag-1`), fetched from openapi-v2.exoscale.com on 2026-08-18. Everything the zone decides follows the datum: `list-zones`, the `zones` array every template and instance type declares (stamped per pack at construction — the catalogue and the deployment cannot disagree, the #269 invariant), and the `EXOSCALE_ZONE` that `feint env exoscale` prints.

Why now: #262 measured the constant's cost — three of the five surveyed Exoscale stacks target another zone (`eu-data-platform` hardcodes `ch-gva-2`, `PhilippeChepy/platform` defaults to `de-fra-1`, `openshift4-exoscale`'s DNS client resolves `ch-gva-2`).

Proof:

- `TestANonDefaultZoneAgreesWithItself` builds `ch-gva-2` and reads everything back: the zone list, the catalogue's declared zones, an instance and an instance pool created from that catalogue; `NewInZone` refuses `ch-mars-1` naming what it accepts (plus the same pair at the CLI seam, `internal/cli/zone_test.go`).
- `exo` drives **two zones** in the conformance suite: `exo-cli.sh` on the default deployment, the new `tools/conformance/exoscale/zones.sh` on its own emulator at `ch-gva-2`.
- `PhilippeChepy/platform` replayed at the surveyed commit (`84791e3`) against `FEINT_EXOSCALE_ZONE=de-fra-1` — the zone its own `locals.tf.example` declares, zone pin removed from the operator file: **19 applied, re-plan `6 to add / 0 to change`, 19 destroyed**, the register's reference figures on the stack's own zone (`examples/stacks/surveyed.md` updated).
- Falsification bites twice (`tools/falsify/specs/exoscale-zones.json`): the constant restored in `newInZone`, and the stamp forced to the default in `stampedWithZone`, each turns the test red — "the test bit" on both; `falsify:lint` green on all 44 specs.
- Full `mise run conformance` (no `FEINT_VM`) passes.

One client defect surfaced, pinned rather than papered over: exo 1.95.1 hardcodes `ch-dk-2` for `compute instance-type list/show` (`cmd/compute/instance_type/instance_type_list.go:85` passes `exocmd.DefaultZone`, fixed at `ch-dk-2` in `cmd/common.go:15`). Invisible against the real cloud; fatal on any other one-zone deployment. `docs/limits.md` records it and `zones.sh` demands exactly that failure, so a future exo that heals it turns the assertion visible.

Side effect #290's analysis predicted, measured: on a `ch-gva-2` deployment, openshift4's DNS failure stops being `find zone "ch-gva-2" not found in ListZonesResponse` and becomes the honest `feint does not serve /v2/dns-domain`. An unconfigured deployment keeps the old message — clarifying that one remains #284's business, not short-circuited here.

## Type of change

- [ ] A route added or changed
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes (gofmt, vet, golangci-lint, `go test -race`)
- [x] No new external Go dependency, or the pull request justifies it. The
      standard library covers routing, JSON and Go parsing; `go.mod` has three
      lines and a pre-commit hook keeps it that way
- [x] `internal/core` still knows no provider. If a change seemed to require it,
      the pack changed instead — the knob lives in `internal/cli`'s composition
      root, the pack stays constructor-configured
- [x] Nothing in the diff could be written identically for another provider.
      What could be — a datum selected at construction, refused with the
      accepted list — follows the exact pattern #290 set in the Outscale pack;
      the zone table, the stamping of catalogue rows and the exo quirk are
      Exoscale's own

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] I ran `mise run conformance` myself — not "it should pass"
- [x] Every field name in the diff comes from the provider's SDK, their OpenAPI
      document, or a run of the real client, and I can say which: the zone
      names from the `zone-name` enum of `.upstream/exoscale-openapi.yaml`
      (also the server-URL `zone` enum of the same document); no response field
      added or renamed

### When a route is added or changed — otherwise N/A

N/A — no route added, none renamed, no `Route.Operation` touched; the routes'
answers follow the pack's zone datum. `mise run conformance` was still run in
full (no `FEINT_VM`) and passes, `--contracts contracts` on, including the new
two-zone leg.

### When behaviour a client can observe changes — otherwise N/A

- [x] `docs/limits.md` updated — the single-zone section becomes "one zone per
      process", documents `FEINT_EXOSCALE_ZONE` and the exo `instance-type
      list` hardcode (`docs/confidence.md` row follows the renamed anchor)
- [x] The README's generated tables regenerated — N/A in substance: no
      generated block moves; `feint docs --check` passes

### When `.github/workflows/` is touched — otherwise N/A

One step added to `conformance.yml`'s `exo-cli` leg: the two-zone suite, so the #278 proof runs in CI and not only in `mise run conformance`. It reuses the binary the leg already builds (`FEINT_BIN=/tmp/feint`) and starts/stops its own emulator; deliberately not on the `fields` leg, whose verdict is about the shared emulator's run. The `readme-coverage` hook demanded the `clientOf` mapping for the new suite (`internal/cli/docs_status.go`); both generated tables deduplicate and README.md is byte-identical.

- [x] Every action pinned to a full 40-character commit SHA with a `# vX.Y.Z` comment — no action added or moved, the file's pins untouched; `actionlint` green locally
- [x] `step-security/harden-runner` is the job's first step — unchanged
- [x] `permissions:` is least-privilege on every job — unchanged
- [x] No job renamed, or the required status checks updated — a step was added, no job name moved

### When a machine runtime is involved — otherwise N/A

N/A

## Related issues

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)
