### PR TITLE
feat(outscale): the doorway serves each client family its measured endpoint shape (#286)

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -231,6 +231,11 @@ jobs:
         run: |
           go build -o /tmp/feint ./cmd/feint
           /tmp/feint start --addr 127.0.0.1:4599 --contracts contracts --timeout 60s
+          # The doorway step of the Outscale Terraform suite evals the real
+          # output of `feint env` rather than restating it, so the script needs
+          # the binary this job just built — the repo-root default it falls
+          # back to only exists where `mise run build` ran (#286).
+          echo "FEINT_BIN=/tmp/feint" >> "$GITHUB_ENV"
 
       # Every client below is verified before it runs, and the reason is what
       # this repository is: a conformance suite is a machine that downloads four

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,36 @@ Two kinds of change deserve their own line whatever their size, because they are
 what this project is judged on: **a response shape a client can observe**, and
 **a limit that moved**. A refactor that changes neither belongs in `git log`.
 
+## [Unreleased]
+
+### Fixed
+
+- **`feint env outscale` now opens the door its own documentation points at**
+  (#286). The printed `OSC_ENDPOINT_API` carries `/api/v1` — the shape the
+  current Terraform provider line (>= 1.7) reads, measured on 1.8.0, which
+  died on a 404 given the bare host the command used to print. The clients
+  that append the path themselves get `--client oapi-cli` (alias
+  `terraform-1.1`): measured on oapi-cli 0.13.0 and provider 1.1.3, which
+  URL-escapes a path'd value into `invalid port ":4599%2Fapi%2Fv1"`
+  client-side. Either mispairing now fails in seconds with the remedy named;
+  the conformance suite drives provider 1.8.0 to a plan from a shell holding
+  nothing but the command's exports. CLI surface v4: one flag added
+  (`env --client`), nothing moved or removed — but the flagless
+  `feint env outscale` value changed shape, which is the point.
+
+- **The escape a shell can carry is named before the apply, not after**
+  (#286; the cheapest instance of #280). With `OSC_PROFILE` set, the Outscale
+  Terraform provider 1.1.x reads `~/.osc/config.json` and ignores
+  `OSC_ENDPOINT_API` entirely — reproduced on 1.1.3: the plan left for
+  `https://api.<region>.outscale.com` while the emulator received nothing.
+  `feint env outscale` and `feint doctor` now warn when the shell carries it,
+  on stderr, where an `eval` cannot swallow the warning. The legacy credential
+  names (`OUTSCALE_ACCESSKEYID`/`OUTSCALE_SECRETKEYID`) are warned about too,
+  with exactly what was measured: they do **not** override the endpoint on
+  1.1.3 or 1.8.0 — four combinations, all reaching the emulator, refuting the
+  survey register's earlier reading — but they are real-cloud credentials one
+  lost export away from being signed with.
+
 ## [0.9.0]
 
 The contract release. Feint can be consumed directly from a Go test or a CI job

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -23,6 +23,34 @@ Nothing to install beyond one binary, no account, no credentials, nothing
 billed. If your configuration applies, re-plans empty and destroys, say so — that
 is a data point too, and it is the one this project cannot generate for itself.
 
+### Pointing an Outscale stack here, per provider generation
+
+The fifteen-stack survey ([the register](../examples/stacks/surveyed.md))
+measured four Outscale provider generations and three endpoint mechanisms.
+This table is that knowledge, moved to the page that invites the pointing;
+every row was re-measured against the emulator on 2026-08-19 ([#286]):
+
+| your provider | the recipe | given the other shape |
+|---|---|---|
+| `outscale/outscale` >= 1.7 (current; 1.8.0 measured) | `eval "$(feint env outscale)"` — the printed `OSC_ENDPOINT_API` carries `/api/v1`, which this generation wants in the value | a fast 404 naming the missing prefix (a six-minute retry backoff before the emulator learned to say so) |
+| `outscale/outscale` 1.1.x (1.1.3 measured), or oapi-cli | `eval "$(feint env outscale --client oapi-cli)"` — the bare host; these clients append `/api/v1` themselves | 1.1.x dies client-side in seconds: `invalid port ":4599%2Fapi%2Fv1"`; oapi-cli gets a 404 saying the endpoint carries `/api/v1` twice |
+| `outscale-dev/*` 0.x | none exists: these read no endpoint variable at all. 0.5.3 honours only an `endpoints { api = … }` block and needs TLS interception; 0.7.0 crashes in its own error path. Measured once in the survey register, not replayed since | — |
+
+Two values in one shell cannot both win, which is why the flag exists rather
+than a second variable. And one escape is worth knowing before the apply,
+because it ignores every value feint prints: **with `OSC_PROFILE` set, the
+1.1.x provider reads `~/.osc/config.json` and never reads
+`OSC_ENDPOINT_API`** — a run that looks local reaches
+`https://api.<region>.outscale.com` with that profile's credentials
+(measured on 1.1.3; 1.8.0 honours the endpoint despite the profile).
+`feint env outscale` and `feint doctor` now warn when the shell carries it.
+The legacy credential names (`OUTSCALE_ACCESSKEYID`/`OUTSCALE_SECRETKEYID`)
+were measured too: they do **not** override the endpoint on 1.1.3 or 1.8.0
+while the exports stand, but they are real-cloud credentials one lost export
+away from being used, and the same warning names them.
+
+[#286]: https://github.com/stephrobert/feint/issues/286
+
 **The goal for 1.0: ten real configurations that apply, re-plan empty and destroy
 with no cloud account.**
 

--- a/examples/stacks/surveyed.md
+++ b/examples/stacks/surveyed.md
@@ -70,6 +70,22 @@ Also set `OUTSCALE_ACCESSKEYID`/`OUTSCALE_SECRETKEYID` **unset** for the 1.x
 providers: with the legacy names present, 1.1.3 takes a config path that
 ignores `OSC_ENDPOINT_API` and talks to the real API.
 
+**Correction, 2026-08-19 (#286).** Re-measured in isolation, the trigger above
+is wrong. Four combinations of the legacy credential names against 1.1.3 —
+alone, beside the `OSC_*` pair, with credentials in the provider block, with
+and without `OSC_REGION` — all reached the emulator while `OSC_ENDPOINT_API`
+was set, and 1.8.0 behaves the same. What ignores `OSC_ENDPOINT_API` is the
+**old-profile path**: with `OSC_PROFILE` set (or `profile` in the provider
+block), 1.1.3's `providerConfigureClient` calls `setProviderDefaultEnv` — the
+only reader of `OSC_ENDPOINT_API` — only when `IsOldProfileSet` says no
+profile is in force. Reproduced: `OSC_PROFILE=default` plus a profile without
+an `endpoints` key sent the plan to `https://api.<region>.outscale.com` while
+the emulator received nothing. The harness that produced the line above
+carried `~/.osc/config.json` in a disposable `HOME` (ztiac), which is how the
+two triggers were conflated. `feint env outscale` and `feint doctor` now warn
+on both: the profile variables as the measured escape, the legacy names as
+real-cloud credentials one lost export away from being signed with.
+
 Scores are `/10` and answer one question — *does the repository as published
 let a reader run this infrastructure?* — from observable facts (pins,
 backend, secrets, docs, maintenance). They are independent of whether feint

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -92,7 +92,7 @@ const (
 // TestTheFrozenSurfacesStillMatchTheirFixture, and a fixture regenerated
 // without bumping this constant fails TestASurfaceChangeDemandsItsVersionBump.
 // The procedure for a deliberate change is in RELEASING.md ("Frozen surfaces").
-const cliSurfaceVersion = 3
+const cliSurfaceVersion = 4
 
 // Run executes one command and returns the process exit code.
 func Run(args []string, stdout, stderr io.Writer) int {
@@ -226,9 +226,13 @@ Usage:
                     what is missing and exits 2, building nothing.
 
   feint env <provider> [--shell bash|fish|powershell] [--endpoint <url>] [--unset]
+                       [--client <family>]
                     The environment a real client of that provider needs.
                     Exports on stdout, everything else on stderr, so
-                    eval "$(feint env scaleway)" is safe.
+                    eval "$(feint env scaleway)" is safe. --client selects a
+                    family when a provider's clients disagree about a value:
+                    outscale serves terraform (>= 1.7, the default) and
+                    oapi-cli / terraform-1.1, which want the bare host.
 
   feint snapshot   save <name> [--addr :4599] [--force]
                    load <name> [--addr :4599]

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -59,6 +59,7 @@ func doctor(args []string, stdout, stderr io.Writer) int {
 	}
 	checks = append(checks, checkRuntime(ctx, *vm)...)
 	checks = append(checks, checkClients()...)
+	checks = append(checks, checkEnvHazards()...)
 	checks = append(checks, checkSSHConfig())
 
 	failed := 0
@@ -331,6 +332,43 @@ func checkClients() []check {
 		}
 		version := firstLine(runQuiet(c.binary, c.args))
 		out = append(out, check{title: c.binary + " " + version, state: verdictOK, detail: path})
+	}
+	return out
+}
+
+// checkEnvHazards asks each mounted pack whether the operator's shell carries
+// a value that would send that provider's clients to the real cloud no matter
+// what `feint env` prints — OSC_PROFILE is the measured case (#286): with it
+// set, the Outscale Terraform provider 1.1.x ignores OSC_ENDPOINT_API and a
+// run that looks local reaches api.<region>.outscale.com. The variable names
+// are provider knowledge and live in each pack; doctor only relays.
+//
+// Warnings, never failures: the shell may be configured that way on purpose,
+// and a diagnostic that fails builds is a diagnostic people stop running.
+func checkEnvHazards() []check {
+	srv, _, err := newServer(nil)
+	if err != nil {
+		// Some other check owns reporting a server that cannot be built.
+		return nil
+	}
+	var out []check
+	for _, p := range srv.Packs() {
+		hazards, ok := p.(packEnvHazards)
+		if !ok {
+			continue
+		}
+		warnings := hazards.EnvHazards(os.LookupEnv)
+		if len(warnings) == 0 {
+			out = append(out, check{title: "nothing in this shell reroutes " + p.Name() + " clients", state: verdictOK})
+			continue
+		}
+		for _, warning := range warnings {
+			out = append(out, check{
+				title: "this shell can reroute " + p.Name() + " clients to the real cloud",
+				state: verdictWarn,
+				fix:   warning,
+			})
+		}
 	}
 	return out
 }

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"os"
 	"sort"
 	"strings"
 
@@ -34,6 +35,7 @@ func envCommand(args []string, stdout, stderr io.Writer) int {
 	shell := fs.String("shell", "bash", "shell syntax: bash, fish or powershell")
 	endpoint := fs.String("endpoint", "", "the emulator's address (default: http://<the --addr default>)")
 	unset := fs.Bool("unset", false, "print the removals instead of the exports")
+	client := fs.String("client", "", "client family the exports target, for a provider whose clients disagree about a value")
 
 	// The provider comes first and is taken before parsing, because the standard
 	// flag package stops at the first non-flag argument: with `env scaleway
@@ -88,6 +90,22 @@ func envCommand(args []string, stdout, stderr io.Writer) int {
 		target = defaultEndpoint()
 	}
 	env := pack.Env(target)
+	if *client != "" {
+		// A client family only means something to a pack whose clients
+		// disagree; anywhere else the flag would silently print the same thing
+		// and teach that it does something. Refusing names both facts.
+		chooser, ok := pack.(packEnvClients)
+		if !ok {
+			fmt.Fprintf(stderr, "feint: the %s pack serves every client the same environment; drop --client\n", wanted)
+			return exitError
+		}
+		env, ok = chooser.EnvFor(target, *client)
+		if !ok {
+			fmt.Fprintf(stderr, "feint: the %s pack knows no client %q; it serves %s\n",
+				wanted, *client, strings.Join(chooser.EnvClients(), ", "))
+			return exitError
+		}
+	}
 
 	render, ok := renderers[*shell]
 	if !ok {
@@ -128,6 +146,23 @@ func envCommand(args []string, stdout, stderr io.Writer) int {
 	if !*unset && env.Note != "" {
 		fmt.Fprintf(stderr, "note: %s\n", env.Note)
 	}
+
+	// The shell itself can carry a value that sends this provider's clients to
+	// the real cloud no matter what was just printed — a profile variable the
+	// client honours before it reads any of these exports. Only the pack knows
+	// which names those are; only this command is present at the moment the
+	// user can still act on them. Skipped with --unset, which is the deliberate
+	// way back to the real cloud.
+	//
+	// TestEnvHazardWarningsReachStderrNeverStdout fails if a warning ever
+	// reaches stdout, where eval would execute it.
+	if !*unset {
+		if hazards, ok := pack.(packEnvHazards); ok {
+			for _, warning := range hazards.EnvHazards(os.LookupEnv) {
+				fmt.Fprintf(stderr, "warning: %s\n", warning)
+			}
+		}
+	}
 	return exitOK
 }
 
@@ -137,6 +172,30 @@ func envCommand(args []string, stdout, stderr io.Writer) int {
 type packEnv interface {
 	Name() string
 	Env(endpoint string) emulator.Environment
+}
+
+// packEnvClients is the optional half of a pack whose clients disagree about a
+// value, so that one printed environment cannot serve them all. Outscale is
+// the measured case (#286): OSC_ENDPOINT_API carries the /api/v1 path for the
+// Terraform provider >= 1.7 and must not for oapi-cli and the 1.1.x provider.
+//
+// Optional and declared here rather than on emulator.Pack: the core has no
+// business knowing that a provider's clients quarrel, and a pack whose clients
+// agree (Scaleway) should not have to implement a method to say so.
+type packEnvClients interface {
+	// EnvFor answers the environment for one named client family, ok=false
+	// when the family is unknown.
+	EnvFor(endpoint, client string) (emulator.Environment, bool)
+	// EnvClients names the families EnvFor accepts, for the refusal message.
+	EnvClients() []string
+}
+
+// packEnvHazards is the optional half of a pack that can recognise, in the
+// caller's environment, a value that reroutes its clients to the real cloud
+// regardless of what env prints. The variable names are provider knowledge and
+// live in the pack; this command only carries their warnings to stderr.
+type packEnvHazards interface {
+	EnvHazards(lookup func(string) (string, bool)) []string
 }
 
 // shellRenderer writes an assignment and its removal in one shell's syntax.

--- a/internal/cli/env_test.go
+++ b/internal/cli/env_test.go
@@ -136,3 +136,72 @@ func TestEnvNamesTheProvidersItServes(t *testing.T) {
 		}
 	}
 }
+
+// The Outscale doorway (#286). One variable, two measured shapes: the default
+// serves the current Terraform provider line (the /api/v1 path in the value,
+// or provider 1.8.0 dies on a 404 at the root), and --client selects the
+// families that append the path themselves. What must never happen is the
+// third option: one value printed for everybody with nothing saying whom it
+// fails.
+func TestEnvOutscaleServesTheClientFamilyItWasAskedFor(t *testing.T) {
+	code, printed, errOut := run("env", "outscale", "--endpoint", "http://127.0.0.1:4599")
+	if code != 0 {
+		t.Fatalf("exited %d: %s", code, errOut)
+	}
+	if !strings.Contains(printed, "export OSC_ENDPOINT_API='http://127.0.0.1:4599/api/v1'") {
+		t.Fatalf("the default does not carry the /api/v1 path the current provider reads:\n%s", printed)
+	}
+
+	code, printed, errOut = run("env", "outscale", "--client", "oapi-cli", "--endpoint", "http://127.0.0.1:4599")
+	if code != 0 {
+		t.Fatalf("--client oapi-cli exited %d: %s", code, errOut)
+	}
+	if !strings.Contains(printed, "export OSC_ENDPOINT_API='http://127.0.0.1:4599'\n") {
+		t.Fatalf("--client oapi-cli does not print the bare host it appends /api/v1 to:\n%s", printed)
+	}
+
+	// An unknown family is refused by name, with the known ones listed —
+	// printing a guessed shape is exactly the wall this flag removes.
+	code, printed, errOut = run("env", "outscale", "--client", "osc-cli")
+	if code == 0 {
+		t.Fatalf("an unknown client family was served:\n%s", printed)
+	}
+	if !strings.Contains(errOut, "oapi-cli") || !strings.Contains(errOut, "terraform") {
+		t.Fatalf("the refusal does not name the families that exist: %q", errOut)
+	}
+
+	// A pack whose clients all read the same environment refuses the flag
+	// rather than teaching that it selects something.
+	if code, _, _ := run("env", "scaleway", "--client", "terraform"); code == 0 {
+		t.Fatal("--client was accepted by a pack that serves every client the same environment")
+	}
+}
+
+// The escape warning fires where the user can still act: on the same stderr
+// the eval cannot swallow, before any terraform run. With OSC_PROFILE set the
+// Outscale 1.1.x provider ignores OSC_ENDPOINT_API and reaches the real cloud
+// (measured, #286) — and a warning that leaked to stdout would be executed by
+// the eval instead of read.
+func TestEnvHazardWarningsReachStderrNeverStdout(t *testing.T) {
+	t.Setenv("OSC_PROFILE", "default")
+
+	code, printed, errOut := run("env", "outscale")
+	if code != 0 {
+		t.Fatalf("exited %d: %s", code, errOut)
+	}
+	if !strings.Contains(errOut, "warning:") || !strings.Contains(errOut, "OSC_PROFILE") {
+		t.Fatalf("OSC_PROFILE is set and stderr carries no warning about it: %q", errOut)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(printed), "\n") {
+		if !strings.HasPrefix(line, "export ") {
+			t.Fatalf("a warning leaked onto stdout, where eval would execute it: %q", line)
+		}
+	}
+
+	// --unset is the deliberate way back to the real cloud; warning on the way
+	// out would teach people to ignore the warning on the way in.
+	_, _, errOut = run("env", "outscale", "--unset")
+	if strings.Contains(errOut, "OSC_PROFILE") {
+		t.Fatalf("--unset still warns about the shell it is restoring: %q", errOut)
+	}
+}

--- a/internal/cli/testdata/frozen/cli.json
+++ b/internal/cli/testdata/frozen/cli.json
@@ -382,6 +382,137 @@
           ]
         }
       }
+    },
+    {
+      "schema_version": 4,
+      "content": {
+        "exit_codes": {
+          "drift": 2,
+          "error": 1,
+          "ok": 0
+        },
+        "verbs": {
+          "catalog": [
+            "--format"
+          ],
+          "clean": [
+            "--vm"
+          ],
+          "coverage": [
+            "--artefact",
+            "--baseline",
+            "--contract",
+            "--fail-on-unknown",
+            "--format",
+            "--products",
+            "--provider",
+            "--sdk",
+            "--write-baseline"
+          ],
+          "docs": [
+            "--check",
+            "--coverage",
+            "--file"
+          ],
+          "doctor": [
+            "--addr",
+            "--vm"
+          ],
+          "env": [
+            "--client",
+            "--endpoint",
+            "--shell",
+            "--unset"
+          ],
+          "evidence": [
+            "--endpoint",
+            "--join",
+            "--out",
+            "--shapes"
+          ],
+          "images": [
+            "--check",
+            "--only",
+            "--vm"
+          ],
+          "logs": [
+            "--addr",
+            "-f",
+            "-n"
+          ],
+          "probe": [
+            "--contracts",
+            "--endpoint",
+            "--provider"
+          ],
+          "proxy": [
+            "--addr",
+            "--max-body",
+            "--provider",
+            "--queue",
+            "--record",
+            "--upstream"
+          ],
+          "restart": [
+            "--addr",
+            "--timeout"
+          ],
+          "serve": [
+            "--addr",
+            "--cleanup",
+            "--contracts",
+            "--coverage",
+            "--log-level",
+            "--state",
+            "--vm"
+          ],
+          "shapes": [
+            "--check",
+            "--dir",
+            "--dry-run",
+            "--profile",
+            "--provider",
+            "--record"
+          ],
+          "snapshot": [
+            "--addr",
+            "--force",
+            "--format",
+            "--state"
+          ],
+          "start": [
+            "--detach",
+            "--foreground",
+            "--timeout"
+          ],
+          "status": [
+            "--addr",
+            "--coverage",
+            "--format"
+          ],
+          "stop": [
+            "--addr",
+            "--timeout"
+          ],
+          "transcript": [
+            "--against",
+            "--format",
+            "--shape"
+          ],
+          "ui": [
+            "--addr",
+            "--print"
+          ],
+          "version": [
+            "--version",
+            "-v"
+          ],
+          "wait": [
+            "--addr",
+            "--timeout"
+          ]
+        }
+      }
     }
   ]
 }

--- a/internal/providers/outscale/env_test.go
+++ b/internal/providers/outscale/env_test.go
@@ -1,0 +1,101 @@
+package outscale_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/providers/outscale"
+)
+
+// The doorway measurements behind every assertion here are in #286, each cell
+// produced by running the real client against this emulator on 2026-08-19:
+// provider 1.8.0 needs the /api/v1 path inside OSC_ENDPOINT_API and dies on a
+// 404 without it; provider 1.1.3 and oapi-cli append the path themselves and
+// die on `invalid port ":4599%2Fapi%2Fv1"` with it.
+
+// The default environment serves the current Terraform provider line, because
+// that is what docs/adoption.md tells a stranger to run first. Printing the
+// bare host here is not a style choice: it is the measured wall of #286.
+func TestEnvServesTheCurrentTerraformProviderLine(t *testing.T) {
+	pack := outscale.New(emulator.DefaultEnv())
+	env := pack.Env("http://127.0.0.1:4599")
+	got := env.Vars["OSC_ENDPOINT_API"]
+	if got != "http://127.0.0.1:4599/api/v1" {
+		t.Fatalf("the default OSC_ENDPOINT_API is %q; provider >= 1.7 needs the /api/v1 path in the value", got)
+	}
+	if !strings.Contains(env.Note, "oapi-cli") || !strings.Contains(env.Note, "--client") {
+		t.Fatalf("the note does not teach the other client families their flag: %q", env.Note)
+	}
+}
+
+// The families that append /api/v1 themselves get the bare host, and a family
+// nobody measured gets a refusal rather than a guess.
+func TestEnvForServesEachMeasuredClientFamily(t *testing.T) {
+	pack := outscale.New(emulator.DefaultEnv())
+	for _, client := range []string{"oapi-cli", "terraform-1.1"} {
+		env, ok := pack.EnvFor("http://127.0.0.1:4599", client)
+		if !ok {
+			t.Fatalf("EnvFor refused the measured family %q", client)
+		}
+		if got := env.Vars["OSC_ENDPOINT_API"]; got != "http://127.0.0.1:4599" {
+			t.Errorf("EnvFor(%q) printed %q; this family appends /api/v1 itself and wants the bare host", client, got)
+		}
+	}
+	if _, ok := pack.EnvFor("http://127.0.0.1:4599", "osc-cli"); ok {
+		t.Fatal("an unmeasured client family was served a guessed environment")
+	}
+	for _, known := range pack.EnvClients() {
+		if _, ok := pack.EnvFor("http://127.0.0.1:4599", known); !ok {
+			t.Errorf("EnvClients names %q but EnvFor refuses it", known)
+		}
+	}
+}
+
+// The escape that reaches the real cloud: with OSC_PROFILE set, provider 1.1.3
+// reads ~/.osc/config.json and never reads OSC_ENDPOINT_API — reproduced in
+// #286 by watching the plan leave for api.<region>.outscale.com while the
+// emulator received nothing. The warning must exist before the apply does.
+func TestEnvHazardsNameTheProfileEscape(t *testing.T) {
+	pack := outscale.New(emulator.DefaultEnv())
+
+	clean := func(string) (string, bool) { return "", false }
+	if warnings := pack.EnvHazards(clean); len(warnings) != 0 {
+		t.Fatalf("a clean shell was warned about: %v", warnings)
+	}
+
+	profile := func(name string) (string, bool) {
+		if name == "OSC_PROFILE" {
+			return "default", true
+		}
+		return "", false
+	}
+	warnings := pack.EnvHazards(profile)
+	if len(warnings) == 0 {
+		t.Fatal("OSC_PROFILE is set and nothing warned; that shell's terraform run reaches the real cloud")
+	}
+	if !strings.Contains(warnings[0], "OSC_PROFILE") || !strings.Contains(warnings[0], "OSC_ENDPOINT_API") {
+		t.Fatalf("the warning names neither the trigger nor what it disables: %q", warnings[0])
+	}
+}
+
+// The legacy credential names do not redirect anything by themselves — four
+// measured combinations against 1.1.3 all reached the emulator while
+// OSC_ENDPOINT_API was set — but they are real-cloud credentials one lost
+// export away from being used, and the warning says exactly that.
+func TestEnvHazardsNameLegacyCredentials(t *testing.T) {
+	pack := outscale.New(emulator.DefaultEnv())
+	legacy := func(name string) (string, bool) {
+		if name == "OUTSCALE_ACCESSKEYID" || name == "OUTSCALE_SECRETKEYID" {
+			return "x", true
+		}
+		return "", false
+	}
+	warnings := pack.EnvHazards(legacy)
+	if len(warnings) != 1 {
+		t.Fatalf("expected one warning for the legacy credential pair, got %v", warnings)
+	}
+	if !strings.Contains(warnings[0], "OUTSCALE_ACCESSKEYID") {
+		t.Fatalf("the warning does not name the variables it is about: %q", warnings[0])
+	}
+}

--- a/internal/providers/outscale/mispointed_test.go
+++ b/internal/providers/outscale/mispointed_test.go
@@ -30,9 +30,13 @@ func TestAMispointedOutscaleClientIsToldWhichSideIsWrong(t *testing.T) {
 		refuses string
 	}{
 		{
-			name:  "the endpoint carries the prefix and the client appended it again",
-			path:  "/api/v1/api/v1/CreateVms",
-			wants: []string{"twice", "bare host", "feint env outscale"},
+			name: "the endpoint carries the prefix and the client appended it again",
+			path: "/api/v1/api/v1/CreateVms",
+			// The remedy must name the flag: since #286 the flagless default
+			// prints the path'd shape for the Terraform provider >= 1.7, so
+			// pointing this client at it would recreate the very request
+			// this error is answering.
+			wants: []string{"twice", "bare host", "feint env outscale --client oapi-cli"},
 			// The confident, wrong answer: it must not name the operation as
 			// unserved, because it is served.
 			refuses: "does not serve",

--- a/internal/providers/outscale/pack.go
+++ b/internal/providers/outscale/pack.go
@@ -364,7 +364,8 @@ func (p *Pack) NotFound(w http.ResponseWriter, r *http.Request) {
 		p.writeError(w, http.StatusNotFound, "", "OperationNotEmulated",
 			"the endpoint carries "+strings.TrimSuffix(pathPrefix, "/")+" twice: point the "+
 				"client at the bare host, oapi-cli appends "+strings.TrimSuffix(pathPrefix, "/")+
-				"/<Call> itself. `feint env outscale` prints the endpoint to use")
+				"/<Call> itself. `feint env outscale --client oapi-cli` prints the endpoint to "+
+				"use — the flagless default carries the path, for the Terraform provider >= 1.7")
 		return
 	}
 
@@ -428,6 +429,35 @@ func orDefault(v, fallback string) string {
 	return v
 }
 
+// The client families this pack can point at the emulator, and the one fact
+// that forces the split: they read the same variable, OSC_ENDPOINT_API, and
+// disagree about its shape. Measured on 2026-08-19, each cell by running the
+// real client against this emulator (#286):
+//
+//   - Terraform provider 1.8.0 (the current line, >= 1.7) wants the /api/v1
+//     path IN the value; given the bare host it posts /<Action> at the root
+//     and dies on a 404 that used to be a six-minute retry backoff before
+//     the mispointed hint (#185) made it fast.
+//   - Terraform provider 1.1.3 and oapi-cli append /api/v1 themselves; given
+//     the path, 1.1.3 URL-escapes it and dies client-side on
+//     `invalid port ":4599%2Fapi%2Fv1"`.
+//
+// One variable, two shapes: no single printed value serves both families, so
+// the choice is a client parameter rather than a Note a reader has to reverse-
+// engineer. The default is the family a stranger meets first — the current
+// Terraform provider line, which is what docs/adoption.md invites them to run.
+const (
+	clientTerraform   = "terraform"     // provider >= 1.7: the path belongs in the value
+	clientOAPICLI     = "oapi-cli"      // bare host: the CLI appends /api/v1 itself
+	clientTerraform11 = "terraform-1.1" // bare host: the 1.1.x provider appends it too
+)
+
+// apiPath is what the modern Terraform provider expects to find inside
+// OSC_ENDPOINT_API, and what the other two clients insist on appending
+// themselves. It is pathPrefix without the trailing slash, kept as one
+// declaration so the URL space and the environment cannot drift apart.
+var apiPath = strings.TrimSuffix(pathPrefix, "/")
+
 // Env implements emulator.Pack.
 //
 // The values come from tools/conformance/outscale/fake-credentials.env, so the
@@ -435,20 +465,100 @@ func orDefault(v, fallback string) string {
 // nothing: the emulator accepts any signature without checking it, but the
 // client still refuses to sign a request whose credentials are not well-formed.
 //
-// OSC_ENDPOINT_API takes the bare host. The CLI appends /api/v1/<Call> itself,
-// so an endpoint carrying that prefix produces a request for
-// /api/v1/api/v1/<Call> — a 404 that reads exactly like a missing route, and an
-// afternoon to diagnose the first time.
+// The default serves the current Terraform provider line (>= 1.7), because the
+// documented first contact is `eval "$(feint env outscale)"` then `terraform
+// plan` — and until #286 that exact recipe printed the bare host, which the
+// modern provider cannot use. The other families are one --client away, and
+// the Note names them; a client that gets the wrong shape fails fast and named
+// on both sides (the pack's doubled-prefix 404 for oapi-cli, the provider's
+// own parse error for 1.1.x), never with a silent stall.
 func (p *Pack) Env(endpoint string) emulator.Environment {
-	return emulator.Environment{
-		Vars: map[string]string{
+	env, _ := p.EnvFor(endpoint, clientTerraform)
+	return env
+}
+
+// EnvClients names the client families EnvFor accepts, sorted, for the CLI to
+// print when a caller asks for one it does not know.
+func (p *Pack) EnvClients() []string {
+	return []string{clientOAPICLI, clientTerraform, clientTerraform11}
+}
+
+// EnvFor answers the environment one client family needs, or ok=false for a
+// family this pack has never measured — refusing beats guessing, because a
+// guessed shape is exactly the wall #286 is about.
+func (p *Pack) EnvFor(endpoint, client string) (emulator.Environment, bool) {
+	bare := strings.TrimRight(endpoint, "/")
+	vars := func(endpointAPI string) map[string]string {
+		return map[string]string{
 			"OSC_ACCESS_KEY":   "AAAAAAAAAAAAAAAAAAAA",
 			"OSC_SECRET_KEY":   "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
 			"OSC_REGION":       p.region,
 			"OSC_PROTOCOL":     "http",
-			"OSC_ENDPOINT_API": endpoint,
-		},
-		Note: "oapi-cli reads a JSON profile rather than the environment: --config, with endpoints.api set to " +
-			endpoint + " (the bare host; it appends /api/v1 itself).",
+			"OSC_ENDPOINT_API": endpointAPI,
+		}
 	}
+	switch client {
+	case clientTerraform:
+		return emulator.Environment{
+			Vars: vars(bare + apiPath),
+			Note: "this endpoint carries " + apiPath + ": the shape the Terraform provider >= 1.7 reads. " +
+				"oapi-cli and the Terraform provider 1.1.x append " + apiPath + " themselves and want the " +
+				"bare host instead: eval \"$(feint env outscale --client oapi-cli)\". " +
+				"The 0.x providers (outscale-dev/*) read no endpoint variable at all " +
+				"(examples/stacks/surveyed.md).",
+		}, true
+	case clientOAPICLI, clientTerraform11:
+		return emulator.Environment{
+			Vars: vars(bare),
+			Note: "the bare host: oapi-cli and the Terraform provider 1.1.x append " + apiPath + " themselves. " +
+				"The Terraform provider >= 1.7 wants the path in the value: drop --client for that one. " +
+				"With --config, oapi-cli wants endpoints.api set to " + bare + ".",
+		}, true
+	}
+	return emulator.Environment{}, false
+}
+
+// EnvHazards names what, in the caller's own shell, would send this provider's
+// clients to the real cloud no matter which values feint prints. The lookup is
+// injected so the check is testable; the CLI passes os.LookupEnv.
+//
+// Both hazards were measured rather than assumed, on 2026-08-19 (#286):
+//
+//   - OSC_PROFILE set: provider 1.1.3 reads ~/.osc/config.json and skips the
+//     environment entirely — its providerConfigureClient calls
+//     setProviderDefaultEnv, the only reader of OSC_ENDPOINT_API, only when
+//     IsOldProfileSet says no profile is in force. Reproduced: with
+//     OSC_PROFILE=default and OSC_ENDPOINT_API pointing at this emulator, the
+//     plan left for https://api.<region>.outscale.com and the emulator
+//     received nothing. Provider 1.8.0 honours the endpoint despite the
+//     profile, so the escape selects exactly the users on the legacy line.
+//   - The legacy credential names alone do NOT redirect — four combinations
+//     of OUTSCALE_ACCESSKEYID/OUTSCALE_SECRETKEYID against 1.1.3 all reached
+//     the emulator while OSC_ENDPOINT_API was set, refuting the survey
+//     register's earlier reading — but they are real-cloud credentials
+//     sitting in the shell, and every Outscale client falls back to them the
+//     moment the endpoint export is lost (a new terminal, an eval that
+//     printed nothing). The warning says which of the two situations this is.
+//
+// TestEnvHazardsNameTheProfileEscape fails without the first check, and
+// TestEnvHazardsNameLegacyCredentials without the second.
+func (p *Pack) EnvHazards(lookup func(string) (string, bool)) []string {
+	var warnings []string
+	if _, ok := lookup("OSC_PROFILE"); ok {
+		warnings = append(warnings,
+			"OSC_PROFILE is set: the Outscale Terraform provider 1.1.x then reads ~/.osc/config.json and "+
+				"ignores OSC_ENDPOINT_API entirely, so a run that looks local reaches "+
+				"https://api.<region>.outscale.com with that profile's credentials (measured on 1.1.3). "+
+				"unset OSC_PROFILE before running terraform against this emulator")
+	}
+	_, hasLegacyAccess := lookup("OUTSCALE_ACCESSKEYID")
+	_, hasLegacySecret := lookup("OUTSCALE_SECRETKEYID")
+	if hasLegacyAccess || hasLegacySecret {
+		warnings = append(warnings,
+			"OUTSCALE_ACCESSKEYID/OUTSCALE_SECRETKEYID are set: real-cloud credentials every Outscale "+
+				"client falls back to when the endpoint export is missing. They lose to the values printed "+
+				"here as long as this shell keeps them (measured on providers 1.1.3 and 1.8.0); a new "+
+				"terminal or a failed eval does not. unset them for emulator work")
+	}
+	return warnings
 }

--- a/tools/conformance/outscale/terraform-doorway/main.tf
+++ b/tools/conformance/outscale/terraform-doorway/main.tf
@@ -1,0 +1,33 @@
+# The doorway fixture (#286): the provider block is deliberately EMPTY.
+#
+# Everything — credentials, region, endpoint — must come from the environment,
+# because what this fixture proves is the documented first contact: a stranger
+# runs `eval "$(feint env outscale)"` and then `terraform plan`, with no hand
+# edit. A provider block carrying an endpoint would prove the main fixture's
+# point a second time and this one's not at all.
+#
+# The pin is the current provider line, the one the printed endpoint shape is
+# for. Measured on 2026-08-19: provider 1.8.0 wants the /api/v1 path inside
+# OSC_ENDPOINT_API; given the bare host it posts /<Action> at the root and the
+# plan dies on a 404 (a six-minute retry backoff before the #185 hint).
+terraform {
+  required_version = ">= 1.7.0"
+
+  required_providers {
+    outscale = {
+      source  = "outscale/outscale"
+      version = "~> 1.7"
+    }
+  }
+}
+
+provider "outscale" {}
+
+# One data source is one real API call at plan time (ReadSubregions), which is
+# exactly the depth first contact has: nothing created, nothing to destroy,
+# and a wrong endpoint shape cannot hide behind an empty diff.
+data "outscale_subregions" "all" {}
+
+output "subregions" {
+  value = data.outscale_subregions.all.subregions[*].subregion_name
+}

--- a/tools/conformance/outscale/terraform.sh
+++ b/tools/conformance/outscale/terraform.sh
@@ -85,12 +85,57 @@ cleanup() {
 trap cleanup EXIT
 
 cp "$DIR"/*.tf "$WORK/"
-cd "$WORK"
 
 export TF_IN_AUTOMATION=1
 export TF_INPUT=0
 
 echo "conformance: outscale $TF against $ENDPOINT"
+
+# ---- The doorway (#286) ------------------------------------------------------
+# Before any fixture with a hand-written provider block: a shell holding ONLY
+# what `feint env outscale` prints must drive the current provider line to a
+# plan. That is the recipe docs/adoption.md gives a stranger — and it used to
+# print the bare host, which the >= 1.7 provider cannot use: measured, the plan
+# died on a 404 at the root (a six-minute retry backoff before the #185 hint).
+#
+# The exports are parsed from the real command's real output, not restated
+# here, so this step and `feint env` cannot drift apart. `env -i` is the point:
+# nothing from the operator's shell — no stored profile, no leftover
+# OSC_ENDPOINT_API from another port — can make a broken doorway look open.
+echo "- the doorway: a shell holding only the feint env exports reaches a plan"
+FEINT_BIN="${FEINT_BIN:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)/feint}"
+[ -x "$FEINT_BIN" ] || fail "no feint binary at $FEINT_BIN (build it: mise run build); the doorway step evals its real output"
+DOORWAY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/terraform-doorway" && pwd)"
+doorway="$WORK/doorway"
+mkdir -p "$doorway/home"
+cp "$DOORWAY_DIR"/*.tf "$doorway/"
+
+doorway_env=()
+while IFS= read -r line; do
+  line="${line#export }"
+  key="${line%%=*}"
+  value="${line#*=}"
+  value="${value#\'}"
+  value="${value%\'}"
+  doorway_env+=("$key=$value")
+done < <("$FEINT_BIN" env outscale --endpoint "$ENDPOINT" 2>/dev/null)
+[ "${#doorway_env[@]}" -gt 0 ] || fail "feint env outscale printed nothing; an eval of nothing is the accident guard.sh exists for"
+
+(cd "$doorway" && "$TF" init -no-color -upgrade >/dev/null) || fail "doorway init failed"
+# 60 seconds, not six minutes: the failure this step exists to catch used to
+# present as a retry backoff indistinguishable from a dead emulator.
+if ! (cd "$doorway" && timeout 60 env -i HOME="$doorway/home" PATH="$PATH" TF_IN_AUTOMATION=1 TF_INPUT=0 \
+      "${doorway_env[@]}" "$TF" plan -no-color -input=false >doorway-plan.out 2>&1); then
+  cat "$doorway/doorway-plan.out" >&2
+  fail "an env-only shell could not reach a plan: the endpoint shape feint env prints is wrong for the current provider"
+fi
+grep -q "Read complete" "$doorway/doorway-plan.out" \
+  || fail "the doorway plan never read its data source, so nothing proved the emulator was reached"
+doorway_version="$(grep -m1 'version' "$doorway/.terraform.lock.hcl" | tr -d ' "' | cut -d= -f2)"
+[ -n "$doorway_version" ] || doorway_version=">= 1.7"
+ok "provider $doorway_version planned with nothing but the feint env exports"
+
+cd "$WORK"
 
 "$TF" init -no-color -upgrade >/dev/null
 "$TF" validate -no-color >/dev/null

--- a/tools/falsify/specs/outscale-doorway.json
+++ b/tools/falsify/specs/outscale-doorway.json
@@ -1,0 +1,34 @@
+{
+  "package": "./internal/providers/outscale/",
+  "mutations": [
+    {
+      "label": "the default environment goes back to the bare host, which the current Terraform provider cannot use",
+      "file": "internal/providers/outscale/pack.go",
+      "find": "\tenv, _ := p.EnvFor(endpoint, clientTerraform)",
+      "replace": "\tenv, _ := p.EnvFor(endpoint, clientTerraform[:0]+clientOAPICLI)",
+      "test": "TestEnvServesTheCurrentTerraformProviderLine"
+    },
+    {
+      "label": "the OSC_PROFILE escape stops being warned about, and a local-looking run reaches the real cloud in silence",
+      "file": "internal/providers/outscale/pack.go",
+      "find": "\tif _, ok := lookup(\"OSC_PROFILE\"); ok {",
+      "replace": "\tif _, ok := lookup(\"OSC_PROFILE\"); ok && false {",
+      "test": "TestEnvHazardsNameTheProfileEscape"
+    },
+    {
+      "label": "the legacy credential names stop being warned about",
+      "file": "internal/providers/outscale/pack.go",
+      "find": "\tif hasLegacyAccess || hasLegacySecret {",
+      "replace": "\tif (hasLegacyAccess || hasLegacySecret) && false {",
+      "test": "TestEnvHazardsNameLegacyCredentials"
+    },
+    {
+      "label": "the hazard warning moves to stdout, where the eval executes it instead of the reader reading it",
+      "file": "internal/cli/env.go",
+      "find": "\t\t\tfor _, warning := range hazards.EnvHazards(os.LookupEnv) {\n\t\t\t\tfmt.Fprintf(stderr, \"warning: %s\\n\", warning)\n\t\t\t}",
+      "replace": "\t\t\tfor _, warning := range hazards.EnvHazards(os.LookupEnv) {\n\t\t\t\t_ = stderr\n\t\t\t\tfmt.Fprintf(stdout, \"warning: %s\\n\", warning)\n\t\t\t}",
+      "test": "TestEnvHazardWarningsReachStderrNeverStdout",
+      "package": "./internal/cli/"
+    }
+  ]
+}


### PR DESCRIPTION
# Summary

Pointing an Outscale client at this emulator stops being folklore. Three walls, each measured before being touched (#286):

**1. `feint env outscale` now opens the door its own documentation points at.** The flagless default prints `OSC_ENDPOINT_API` with the `/api/v1` path — the shape the current Terraform provider line reads. Measured by driving the real providers against the emulator (2026-08-19):

| client, measured | bare host (the old default) | host + `/api/v1` (the new default) |
|---|---|---|
| provider 1.8.0 | 404 in 0 s (the #185 hint; a six-minute retry backoff before it) — and the hint pointed back at `feint env`, which printed the very value that caused it | **plan OK** |
| provider 1.1.3 | plan OK | `invalid port ":4620%2Fapi%2Fv1"` client-side, in 0 s |
| oapi-cli 0.13.0 | ReadSubregions OK | the pack's doubled-prefix 404, naming the fix |

One variable, two shapes: no single value serves both families, so the choice is now a flag rather than a survey register. `feint env outscale --client oapi-cli` (alias `terraform-1.1`) prints the bare host; an unknown family is refused with the known ones listed; `--client` on a pack whose clients agree (Scaleway) is refused rather than silently ignored. The generation knowledge lives in the pack (`EnvFor`/`EnvClients`) behind optional interfaces declared in `internal/cli` — `internal/core` is untouched. The doubled-prefix error now names `--client oapi-cli`, closing the circular hint in the other direction.

CLI surface v4 (one flag added, fixture appended, CHANGELOG carries the line — the flagless outscale value changed shape, which is the point of the change).

**2. The escape is warned about where the user can still act — and its trigger was re-measured first.** The issue (and the register) blamed `OUTSCALE_ACCESSKEYID`/`OUTSCALE_SECRETKEYID`. Four combinations of those against 1.1.3 — alone, beside the `OSC_*` pair, with credentials in the provider block, with and without `OSC_REGION` — **all reached the emulator** while `OSC_ENDPOINT_API` was set (1.8.0 identically). What actually ignores `OSC_ENDPOINT_API` is the old-profile path: provider 1.1.3 calls `setProviderDefaultEnv` — the only reader of that variable — only when `IsOldProfileSet` says no profile is in force (its `provider.go`). Reproduced: `OSC_PROFILE=default` plus a `~/.osc/config.json` without an `endpoints` key sent the plan to `https://api.<region>.outscale.com/api/v1/ReadSubregions` (bogus region, so only DNS fired) while the emulator on the exported endpoint received nothing. 1.8.0 honours the endpoint despite the profile — the escape selects exactly the legacy-line users.

`feint env outscale` now warns on stderr (which `eval` cannot swallow) when `OSC_PROFILE` is set, and `feint doctor` carries the same check as a `warn`. The legacy names get their own warning with exactly what was measured: they do not override the endpoint, but they are real-cloud credentials one lost export away from being signed with. The register carries a dated correction; this is the cheapest instance of #280's class, which stays open for the general question.

**3. The recipe and the pointing table are on the page that invites the pointing.** `docs/adoption.md`'s `eval "$(feint env outscale)"` recipe is now true for the current provider, and the per-generation table graduated from `examples/stacks/surveyed.md` with the 2026-08-19 measurements beside each row.

**Proof in the suite:** `tools/conformance/outscale/terraform.sh` gained a doorway step — an empty `provider "outscale" {}` block, `env -i`, and nothing but the parsed output of the real `feint env outscale` command drives provider 1.8.0 to a plan, time-bounded at 60 s so a regression to the retry backoff fails fast. Run here: `ok: provider 1.8.0 planned with nothing but the feint env exports`, inside a full green `mise run conformance` (no `FEINT_VM`).

**Falsified** (`tools/falsify/specs/outscale-doorway.json`, four mutations, all "the test bit"): the default back to the bare host; the `OSC_PROFILE` check neutralised; the legacy-names check neutralised; the warning moved to stdout where `eval` would execute it.

**Not verified by execution, said plainly:** the 0.x providers (`outscale-dev/*`) were not replayed — they need the `endpoints{}` block plus TLS interception; the docs cite the register for that row instead of asserting it.

## Type of change

- [ ] A route added or changed
- [x] Bug fix
- [ ] Refactor
- [x] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes (gofmt, vet, golangci-lint, `go test -race`)
- [x] No new external Go dependency, or the pull request justifies it. The
      standard library covers routing, JSON and Go parsing; `go.mod` has three
      lines and a pre-commit hook keeps it that way
- [x] `internal/core` still knows no provider. If a change seemed to require it,
      the pack changed instead — the client families and hazard names live in
      `internal/providers/outscale`, behind optional interfaces declared in
      `internal/cli`
- [x] Nothing in the diff could be written identically for another provider. If
      it could, it belongs in the core — the `--client` plumbing and the hazard
      relay are provider-neutral and live in the CLI; every provider-specific
      string is in the pack

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] I ran `mise run conformance` myself — not "it should pass"
- [x] Every field name in the diff comes from the provider's SDK, their OpenAPI
      document, or a run of the real client, and I can say which: the variable
      names and their per-generation shapes come from runs of providers 1.8.0
      and 1.1.3 and oapi-cli 0.13.0 against this emulator, and from
      `terraform-provider-outscale` v1.1.3's own `provider.go`
      (`IsOldProfileSet` / `setProviderDefaultEnv`)

### When a route is added or changed — otherwise N/A

N/A — no route added or changed; one unrouted-path error message reworded
(same envelope, same status).

### When behaviour a client can observe changes — otherwise N/A

- [x] `docs/limits.md` updated if the change moves a documented limit — no
      limit moved; `docs/adoption.md` carries the new pointing table and
      `feint docs --check` is green
- [x] The README's generated tables regenerated (`mise run docs:coverage`) —
      nothing generated changed; `docs:check` green in prepush

### When `.github/workflows/` is touched — otherwise N/A

One environment line added to an existing `run:` step of `conformance.yml`
(the matrix legs build to `/tmp/feint`; the doorway step needs `FEINT_BIN`
pointed at it — its first run went red on exactly this, and the fix was
verified locally with the same shape).

- [x] Every action pinned to a full 40-character commit SHA with a `# vX.Y.Z`
      comment — never `@v4`, never `@main` — no action touched
- [x] `step-security/harden-runner` is the job's first step — unchanged
- [x] `permissions:` is least-privilege on every job — unchanged
- [x] No job renamed, or the required status checks updated — no job renamed
- [x] The exit-code contract still holds: `0` ok, `1` error, `2` drift — no
      gate piping changed

### When a machine runtime is involved — otherwise N/A

N/A

## Related issues

Closes #286. Cross-references #280 (this is its cheapest, most targeted
instance; the general escape question stays there). The
`OUTSCALE_ACCESSKEYID`/`OUTSCALE_SECRETKEYID` premise in #286 and the register
was re-measured and corrected — the measured trigger is `OSC_PROFILE`
(`examples/stacks/surveyed.md`, dated correction).
