### PR TITLE
fix(cli): a measurement knows who answered it, and start refuses a stranger (#309)

### DIFF
--- a/.github/workflows/workflow-security.yml
+++ b/.github/workflows/workflow-security.yml
@@ -75,7 +75,7 @@ jobs:
           set -euo pipefail
           workdir="$(mktemp -d)"
           asset="zizmor-x86_64-unknown-linux-gnu.tar.gz"
-          curl -fsSL -o "${workdir}/${asset}" \
+          curl --retry 3 --retry-connrefused -fsSL -o "${workdir}/${asset}" \
             "https://github.com/zizmorcore/zizmor/releases/download/v${ZIZMOR_VERSION}/${asset}"
           gh attestation verify "${workdir}/${asset}" --repo zizmorcore/zizmor
           tar -xzf "${workdir}/${asset}" -C "${workdir}" zizmor
@@ -129,8 +129,8 @@ jobs:
           workdir="$(mktemp -d)"
           base="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}"
           asset="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
-          curl -fsSL -o "${workdir}/${asset}" "${base}/${asset}"
-          curl -fsSL -o "${workdir}/checksums.txt" "${base}/actionlint_${ACTIONLINT_VERSION}_checksums.txt"
+          curl --retry 3 --retry-connrefused -fsSL -o "${workdir}/${asset}" "${base}/${asset}"
+          curl --retry 3 --retry-connrefused -fsSL -o "${workdir}/checksums.txt" "${base}/actionlint_${ACTIONLINT_VERSION}_checksums.txt"
           (cd "${workdir}" && grep " ${asset}$" checksums.txt | sha256sum -c -)
           tar -xzf "${workdir}/${asset}" -C "${workdir}" actionlint
           sudo install -m 0755 "${workdir}/actionlint" /usr/local/bin/actionlint
@@ -167,8 +167,8 @@ jobs:
           workdir="$(mktemp -d)"
           base="https://github.com/boostsecurityio/poutine/releases/download/v${POUTINE_VERSION}"
           asset="poutine_Linux_x86_64.tar.gz"
-          curl -fsSL -o "${workdir}/${asset}" "${base}/${asset}"
-          curl -fsSL -o "${workdir}/checksums.txt" "${base}/poutine_${POUTINE_VERSION}_checksums.txt"
+          curl --retry 3 --retry-connrefused -fsSL -o "${workdir}/${asset}" "${base}/${asset}"
+          curl --retry 3 --retry-connrefused -fsSL -o "${workdir}/checksums.txt" "${base}/poutine_${POUTINE_VERSION}_checksums.txt"
           (cd "${workdir}" && grep " ${asset}$" checksums.txt | sha256sum -c -)
           tar -xzf "${workdir}/${asset}" -C "${workdir}" poutine
           sudo install -m 0755 "${workdir}/poutine" /usr/local/bin/poutine

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -15,6 +15,40 @@ parce que c'est là-dessus que ce projet est jugé : **une forme de réponse qu'
 client peut observer**, et **une limite qui a bougé**. Une refactorisation qui ne
 change ni l'un ni l'autre a sa place dans `git log`.
 
+## [Unreleased]
+
+### Ajouté
+
+- **Une mesure sait désormais qui lui a répondu** (#309). `GET /_feint/health`
+  gagne `instance` (le pid et l'heure de démarrage du processus qui répond) et
+  son `schema_version` passe à 3 (additif : chaque champ de la version 2 est
+  inchangé). Le champ existe parce que son absence a été mesurée : le
+  2026-08-19, un émulateur résiduel sur un port partagé a répondu à une sonde
+  avec le catalogue de la version précédente, et rien dans la réponse ne
+  pouvait le dire.
+
+### Corrigé
+
+- **`feint start` refuse une réponse venant d'un processus qu'il n'a pas
+  lancé** (#309). Avant, quand quelque chose tenait déjà l'adresse, l'enfant
+  lancé mourait sur l'erreur de bind pendant que `start` prenait la réponse de
+  santé de l'occupant pour celle de l'enfant : il affichait « listening
+  (pid N) » à propos d'un pid déjà mort, `feint wait` disait prêt, et chaque
+  suite mesurait alors ce que servait l'occupant ; reproduit contre une
+  version résiduelle avant le correctif. `start` compare désormais
+  `instance.pid` avec l'enfant qu'il a lancé et sort en 1 en nommant
+  l'occupant (pid, heure de démarrage) ; `feint serve` refuse d'emblée une
+  adresse où un émulateur répond déjà, au lieu de laisser le fait dans une
+  erreur de bind qu'un wrapper avale. Une seconde exécution après un arrêt
+  propre n'est pas touchée : le garde compare des identités, il ne compte pas
+  les exécutions.
+- **`FEINT_ADDR` est de nouveau honoré** (#309). Il était déclaré en littéral
+  dans le `[env]` de `mise.toml`, qui l'emporte sur une variable exportée :
+  `FEINT_ADDR=127.0.0.1:4699 mise run conformance` utilisait silencieusement
+  4599, donc toutes les exécutions parallèles convergeaient sur le port qu'un
+  émulateur résiduel avait le plus de chances de tenir. La déclaration lit
+  désormais l'environnement d'abord et ne garde 4599 que comme défaut.
+
 ## [0.9.0]
 
 La version du contrat. Feint se consomme désormais directement depuis un test Go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,37 @@ Two kinds of change deserve their own line whatever their size, because they are
 what this project is judged on: **a response shape a client can observe**, and
 **a limit that moved**. A refactor that changes neither belongs in `git log`.
 
+## [Unreleased]
+
+### Added
+
+- **A measurement can now tell who answered it** (#309). `GET /_feint/health`
+  gains `instance` — the pid and start time of the process answering — and its
+  `schema_version` moves to 3 (additive; every field of version 2 is unchanged).
+  The field exists because its absence was measured: on 2026-08-19 a stale
+  emulator on a shared port answered a probe with the previous build's
+  catalogue, and nothing in the answer could say so.
+
+### Fixed
+
+- **`feint start` refuses an answer from a process it did not spawn** (#309).
+  Before, when something already held the address, the spawned child died on
+  the bind error while `start` took the incumbent's health answer as the
+  child's: it printed "listening (pid N)" about a dead pid, `feint wait` said
+  ready, and every suite then measured whatever the incumbent served —
+  reproduced against a stale build before the fix. `start` now compares
+  `instance.pid` against the child it spawned and exits 1 naming the incumbent
+  (pid, start time); `feint serve` refuses up front an address where an
+  emulator already answers, instead of leaving the fact in a bind error a
+  wrapper reads past. A second run after a clean stop is unaffected: the guard
+  compares identities, it does not count runs.
+- **`FEINT_ADDR` is honoured again** (#309). It was declared as a literal in
+  `mise.toml`'s `[env]`, which beats an exported variable:
+  `FEINT_ADDR=127.0.0.1:4699 mise run conformance` silently used 4599, so every
+  parallel run converged on the port a stale emulator was most likely to hold.
+  The declaration now reads the environment first and keeps 4599 only as the
+  default.
+
 ## [0.9.0]
 
 The contract release. Feint can be consumed directly from a Go test or a CI job

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -532,6 +532,27 @@ func checkListenAddr(addr string, expose bool) error {
 		"Pass --expose-to-network if that is what you want", addr)
 }
 
+// checkAddrUnclaimed refuses to serve on an address where an emulator already
+// answers, naming the process instead of losing the fact in a bind error.
+//
+// The bind error alone was the failure mode #309 measured: a wrapper that
+// spawns `serve` and then polls health takes the incumbent's answer as its
+// child's, and the bind error dies with the child, unread in a log. Refusing
+// here puts the incumbent's pid and start time where the operator is looking,
+// and does so identically for `serve` in a terminal and for the detached child
+// of `start`. Same shape as checkListenAddr, and for the reason that function
+// documents: the decision is separated from the act, and only the decision is
+// tested. TestServeRefusesAnAddressAnotherEmulatorClaims fails without it.
+func checkAddrUnclaimed(addr string) error {
+	id, ok := probeIdentity(addr, 500*time.Millisecond)
+	if !ok {
+		return nil
+	}
+	return fmt.Errorf("refusing to serve on %s: it is already served by %s. "+
+		"Stop it first (feint stop --addr %s, or kill it), or pick another address",
+		addr, describeForeign(id), addr)
+}
+
 func serve(args []string, stdout io.Writer) error {
 	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
 	addr := fs.String("addr", DefaultAddr, "listen address")
@@ -548,6 +569,9 @@ func serve(args []string, stdout io.Writer) error {
 	}
 
 	if err := checkListenAddr(*addr, *expose); err != nil {
+		return err
+	}
+	if err := checkAddrUnclaimed(*addr); err != nil {
 		return err
 	}
 

--- a/internal/cli/identity_test.go
+++ b/internal/cli/identity_test.go
@@ -1,0 +1,137 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// foreignEmulator serves a health payload that identifies as somebody else's
+// process. This is the wire shape of the incident #309 reproduced: a stale
+// `feint serve` from a previous run, healthy and articulate, on the address a
+// fresh run believes it just claimed.
+func foreignEmulator(t *testing.T, pid int, started string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /_feint/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		payload := map[string]any{
+			"status":    "ok",
+			"providers": []string{"scaleway"},
+		}
+		if pid != 0 {
+			payload["instance"] = map[string]any{"pid": pid, "started_at": started}
+		}
+		if err := json.NewEncoder(w).Encode(payload); err != nil {
+			t.Errorf("encode health: %v", err)
+		}
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// selfInstance builds an Instance whose pid is this test process, so that
+// alive() reports Alive and awaitHealthy keeps polling instead of declaring
+// the child dead.
+func selfInstance(t *testing.T, addr string) *Instance {
+	t.Helper()
+	comm, err := os.ReadFile("/proc/self/comm")
+	if err != nil {
+		t.Skipf("no /proc on this host: %v", err)
+	}
+	return &Instance{
+		PID:    os.Getpid(),
+		Addr:   addr,
+		Binary: "/x/" + strings.TrimSpace(string(comm)),
+		Log:    "/dev/null",
+	}
+}
+
+// TestStartRefusesAForeignAnswerOnItsAddress is the guard #309 exists for.
+//
+// Reproduced before the fix, 2026-08-19: a stale emulator held 127.0.0.1:4620,
+// a second checkout's `feint start` spawned a child that died on the bind
+// error, and awaitHealthy took the stale process's health answer as the
+// child's — `start` printed "listening (pid N)" about a dead pid, `wait` said
+// ready, and the suites measured the previous build's catalogue. The answer
+// must be matched against the process this command spawned, and a mismatch
+// must be a refusal, not a success.
+func TestStartRefusesAForeignAnswerOnItsAddress(t *testing.T) {
+	inst := selfInstance(t, "")
+	foreignPID := inst.PID + 1
+	ts := foreignEmulator(t, foreignPID, "2026-08-19T08:00:00Z")
+	inst.Addr = strings.TrimPrefix(ts.URL, "http://")
+
+	err := awaitHealthy(inst, 3*time.Second)
+	if err == nil {
+		t.Fatal("a foreign emulator answered on the address and awaitHealthy accepted it as the child it was waiting for")
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("pid %d", foreignPID)) {
+		t.Fatalf("the refusal does not name the process that answered: %v", err)
+	}
+}
+
+// TestStartRefusesAnAnswerThatCarriesNoIdentity covers the other stale shape:
+// an emulator built before schema_version 3 answers health without `instance`.
+// Whatever it serves, it is not the binary this checkout just built, and
+// accepting it would be the same wrong measurement with an older accomplice.
+func TestStartRefusesAnAnswerThatCarriesNoIdentity(t *testing.T) {
+	inst := selfInstance(t, "")
+	ts := foreignEmulator(t, 0, "")
+	inst.Addr = strings.TrimPrefix(ts.URL, "http://")
+
+	err := awaitHealthy(inst, 3*time.Second)
+	if err == nil {
+		t.Fatal("an identity-less health answer was accepted as the child this command started")
+	}
+	if !strings.Contains(err.Error(), "predates identity") {
+		t.Fatalf("the refusal does not say what answered: %v", err)
+	}
+}
+
+// TestStartAcceptsTheEmulatorItStarted is the half that keeps the guard from
+// being noise: when the answering process is the one this command spawned, the
+// wait succeeds. A guard that fires on a legitimate run teaches people to
+// disarm it, which is worse than no guard — tools/falsify/falsify.py carries
+// that reasoning for the same repository.
+func TestStartAcceptsTheEmulatorItStarted(t *testing.T) {
+	inst := selfInstance(t, "")
+	ts := foreignEmulator(t, inst.PID, "2026-08-19T08:00:00Z")
+	inst.Addr = strings.TrimPrefix(ts.URL, "http://")
+
+	if err := awaitHealthy(inst, 3*time.Second); err != nil {
+		t.Fatalf("awaitHealthy refused the very emulator it was waiting for: %v", err)
+	}
+}
+
+// TestServeRefusesAnAddressAnotherEmulatorClaims holds the second door: a
+// foreground `serve` (or the detached child of `start`) must refuse an address
+// where an emulator already answers, naming the incumbent, rather than dying
+// on a bind error a wrapper reads past. Only the decision is tested, for the
+// reason checkListenAddr documents: with the refusal removed, serve serves,
+// and a test driving it would hang instead of failing.
+func TestServeRefusesAnAddressAnotherEmulatorClaims(t *testing.T) {
+	ts := foreignEmulator(t, 4242, "2026-08-19T08:00:00Z")
+	addr := strings.TrimPrefix(ts.URL, "http://")
+
+	err := checkAddrUnclaimed(addr)
+	if err == nil {
+		t.Fatal("an address already served by an emulator was declared free")
+	}
+	if !strings.Contains(err.Error(), "pid 4242") {
+		t.Fatalf("the refusal does not name the incumbent: %v", err)
+	}
+
+	// The other half: an address nobody answers on stays usable, or every
+	// legitimate serve is refused and the guard is disarmed within the week.
+	ts.Close()
+	if err := checkAddrUnclaimed(addr); err != nil {
+		t.Fatalf("a free address was refused: %v", err)
+	}
+}

--- a/internal/cli/identity_test.go
+++ b/internal/cli/identity_test.go
@@ -38,17 +38,20 @@ func foreignEmulator(t *testing.T, pid int, started string) *httptest.Server {
 
 // selfInstance builds an Instance whose pid is this test process, so that
 // alive() reports Alive and awaitHealthy keeps polling instead of declaring
-// the child dead.
+// the child dead. In practice the fake emulator answers the first probe, so
+// awaitHealthy returns before consulting alive() at all — the Binary is only
+// there for the losing side of that race. Without /proc (macOS is in the CI
+// matrix) alive()'s own fallback is the health probe, which the fake answers.
 func selfInstance(t *testing.T, addr string) *Instance {
 	t.Helper()
-	comm, err := os.ReadFile("/proc/self/comm")
-	if err != nil {
-		t.Skipf("no /proc on this host: %v", err)
+	name := "feint"
+	if comm, err := os.ReadFile("/proc/self/comm"); err == nil {
+		name = strings.TrimSpace(string(comm))
 	}
 	return &Instance{
 		PID:    os.Getpid(),
 		Addr:   addr,
-		Binary: "/x/" + strings.TrimSpace(string(comm)),
+		Binary: "/x/" + name,
 		Log:    "/dev/null",
 	}
 }

--- a/internal/cli/instance.go
+++ b/internal/cli/instance.go
@@ -286,40 +286,64 @@ func (i *Instance) alive() Liveness {
 		return Foreign
 	}
 
-	// No /proc: ask the address whether this emulator answers on it. A stranger
-	// holding the pid will not.
-	if healthy(i.Addr, 500*time.Millisecond) {
+	// No /proc: ask the address whether this emulator answers on it, and
+	// require the answer to name this pid. Any emulator answering was enough
+	// here once, and it is exactly what #309 measured the cost of: a stranger
+	// on the port reads as "alive" and everything downstream drives it.
+	if id, ok := probeIdentity(i.Addr, 500*time.Millisecond); ok && id != nil && id.PID == i.PID {
 		return Alive
 	}
 	return Foreign
 }
 
-// healthy probes the emulator's own health endpoint.
+// identity is what /_feint/health names about the process answering, under
+// `instance` since schema_version 3 (#309).
+type identity struct {
+	PID     int    `json:"pid"`
+	Started string `json:"started_at"`
+}
+
+// probeIdentity probes the emulator's own health endpoint and reports who
+// answered. ok says an emulator answered at all; the identity is nil when the
+// answer named none, which an emulator older than schema_version 3 does.
 //
-// It is the only check that proves the thing listening is this emulator rather
-// than anything else that happened to bind the port, which matters for `wait`:
-// waiting for a port to open would return as soon as an unrelated server bound
-// it, and the caller would then drive a stranger.
-func healthy(addr string, timeout time.Duration) bool {
+// The health check is the only probe that proves the thing listening is a feint
+// emulator rather than anything else that happened to bind the port. The
+// identity is the other half: *which* emulator, because a measurement that
+// cannot say who answered is how a stale build's catalogue got measured as this
+// build's on 2026-08-19 (#309).
+func probeIdentity(addr string, timeout time.Duration) (*identity, bool) {
 	client := &http.Client{Timeout: timeout}
 	resp, err := client.Get(healthURL(addr)) //nolint:noctx // the timeout is the client's
 	if err != nil {
-		return false
+		return nil, false
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return false
+		return nil, false
 	}
 	var body struct {
-		Status    string   `json:"status"`
-		Providers []string `json:"providers"`
+		Status    string    `json:"status"`
+		Providers []string  `json:"providers"`
+		Instance  *identity `json:"instance"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
-		return false
+		return nil, false
 	}
 	// Both fields, because a bare 200 with "ok" in it could come from anything.
-	return body.Status == "ok" && len(body.Providers) > 0
+	if body.Status != "ok" || len(body.Providers) == 0 {
+		return nil, false
+	}
+	return body.Instance, true
+}
+
+// healthy reports whether an emulator — any emulator — answers on the address.
+// `wait` and `doctor` want exactly that; a caller that spawned the process it
+// is waiting for wants probeIdentity, so it can refuse a stranger.
+func healthy(addr string, timeout time.Duration) bool {
+	_, ok := probeIdentity(addr, timeout)
+	return ok
 }
 
 // healthURL builds the health address from a listen address, filling in the

--- a/internal/cli/lifecycle.go
+++ b/internal/cli/lifecycle.go
@@ -195,18 +195,30 @@ func spawn(flags serveFlags) (*Instance, error) {
 	return inst, nil
 }
 
-// awaitHealthy polls until the emulator answers, and gives up early when the
-// child is already gone.
+// awaitHealthy polls until the emulator answers, gives up early when the
+// child is already gone, and refuses an answer that names another process.
 //
 // Detecting the child's death is the difference between a useful error and a
 // useless one. A port already bound, a missing contracts directory or an Incus
 // daemon refusing all produce an immediate exit, and polling health for thirty
 // seconds before printing "timed out" hides the actual message. So the loop
 // checks liveness too, and prints the tail of the log when the process is gone.
+//
+// The identity check is the point of the loop, not a nicety. Measured on
+// 2026-08-19 (#309): with a stale emulator holding the port, the spawned child
+// died on the bind error, this loop took the stale process's health answer as
+// the child's, and `start` printed "listening (pid N)" about a pid that was
+// already dead — after which every suite measured the previous build.
+// TestStartRefusesAForeignAnswerOnItsAddress fails without the refusal.
 func awaitHealthy(inst *Instance, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for {
-		if healthy(inst.Addr, time.Second) {
+		if id, ok := probeIdentity(inst.Addr, time.Second); ok {
+			if id == nil || id.PID != inst.PID {
+				return fmt.Errorf("%s is already served by %s — not the emulator this command just started (pid %d), "+
+					"whose log is %s.\nStop the other one first (feint stop --addr %s, or kill it), or pick another address",
+					inst.Addr, describeForeign(id), inst.PID, inst.Log, inst.Addr)
+			}
 			return nil
 		}
 		if inst.alive() != Alive {
@@ -219,6 +231,17 @@ func awaitHealthy(inst *Instance, timeout time.Duration) error {
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
+}
+
+// describeForeign names the process a health answer said it came from, for a
+// refusal message. A nil identity is an emulator too old to carry one
+// (schema_version < 3), which is still a stranger: whatever it serves, it is
+// not what this checkout just built.
+func describeForeign(id *identity) string {
+	if id == nil {
+		return "another emulator that predates identity (health schema_version < 3)"
+	}
+	return fmt.Sprintf("another emulator (pid %d, started %s)", id.PID, id.Started)
 }
 
 // tail returns the last n lines of a file, for an error message. A file that

--- a/internal/cli/reap_test.go
+++ b/internal/cli/reap_test.go
@@ -192,8 +192,14 @@ func writeInstance(t *testing.T, addr string, pid int) string {
 	return dir
 }
 
-// healthOnly serves what healthy() demands and nothing more: status and
-// providers, both checked, because a bare 200 could come from anything.
+// healthOnly serves what alive()'s health fallback demands and nothing more:
+// status and providers, both checked because a bare 200 could come from
+// anything, and since #309 the identity of the answering process — a real live
+// emulator publishes its own pid, so the stand-in for one must too, or on the
+// platforms without /proc it reads as a stranger on the port and is reaped.
+// That is not hypothetical: this fixture broke exactly that way on the macOS
+// leg when the identity check landed, the second time this comment's history
+// repeats itself (see TestCleanReapsOnlyDeadInstances).
 //
 // A real emulator would do, and is not used on purpose — building one drags the
 // packs into a test about directory collection, and a fixture that needs the
@@ -207,6 +213,10 @@ func healthOnly(t *testing.T) http.Handler {
 		if err := json.NewEncoder(w).Encode(map[string]any{
 			"status":    "ok",
 			"providers": []string{"scaleway"},
+			"instance": map[string]any{
+				"pid":        os.Getpid(),
+				"started_at": "2026-08-19T08:00:00Z",
+			},
 		}); err != nil {
 			t.Errorf("encode health: %v", err)
 		}

--- a/internal/cli/testdata/frozen/health.json
+++ b/internal/cli/testdata/frozen/health.json
@@ -129,6 +129,89 @@
           }
         ]
       }
+    },
+    {
+      "schema_version": 3,
+      "content": {
+        "fields": [
+          {
+            "path": "capabilities",
+            "type": "object"
+          },
+          {
+            "path": "capabilities.addresses",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.firewall",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.isolation",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.machines",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.own_kernel",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.private_from_host",
+            "type": "bool"
+          },
+          {
+            "path": "enforced",
+            "type": "object"
+          },
+          {
+            "path": "enforced.firewall",
+            "type": "array"
+          },
+          {
+            "path": "enforced.firewall[]",
+            "type": "string"
+          },
+          {
+            "path": "instance",
+            "type": "object"
+          },
+          {
+            "path": "instance.pid",
+            "type": "number"
+          },
+          {
+            "path": "instance.started_at",
+            "type": "string"
+          },
+          {
+            "path": "machines",
+            "type": "string"
+          },
+          {
+            "path": "providers",
+            "type": "array"
+          },
+          {
+            "path": "providers[]",
+            "type": "string"
+          },
+          {
+            "path": "resources",
+            "type": "number"
+          },
+          {
+            "path": "schema_version",
+            "type": "number"
+          },
+          {
+            "path": "status",
+            "type": "string"
+          }
+        ]
+      }
     }
   ]
 }

--- a/internal/core/emulator/emulator.go
+++ b/internal/core/emulator/emulator.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -194,6 +195,11 @@ type Server struct {
 	// live. It is the corroboration the omission check fails on (omissions.go);
 	// nil narrows that check to nothing rather than inventing a proof.
 	observedFields map[string]map[string]bool
+	// started is when this server was built, published under `instance` on
+	// /_feint/health. Identity, not uptime: on 2026-08-19 a stale emulator on a
+	// shared port answered a probe with the previous build's catalogue, and
+	// nothing in the answer could say which process produced it (#309).
+	started time.Time
 }
 
 // NewServer mounts the packs. It fails when two packs claim the same route,
@@ -206,6 +212,12 @@ func NewServer(env *Env, packs ...Pack) (*Server, error) {
 		mux:      http.NewServeMux(),
 		stream:   events,
 		observer: newObserver(env.Contracts, events),
+		started:  time.Now().UTC(),
+	}
+	// The injected clock wins when there is one, so golden tests stay stable;
+	// the wall clock is only the fallback for an Env built literally.
+	if env.Now != nil {
+		s.started = env.Now()
 	}
 
 	// The table both indexes the routes and rejects a pattern two packs claim.
@@ -471,6 +483,12 @@ func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
 	// first told a user the firewall was delivered for three packs when one
 	// delivered it. The honest check is both: capabilities.firewall says the
 	// runtime can, enforced.firewall says who asks it to.
+	// `instance` is identity, and it exists because its absence was measured
+	// (#309): a stale emulator on a shared port answered a probe with the
+	// previous build's catalogue, and nothing in the answer said which process
+	// produced it. The pid is what a caller that spawned this process can
+	// compare against something it already knows; started_at is for the human
+	// reading the refusal. TestHealthNamesItsOwnProcess fails if either lies.
 	writeJSON(w, http.StatusOK, map[string]any{
 		"schema_version": HealthSchemaVersion,
 		"status":         "ok",
@@ -479,6 +497,10 @@ func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
 		"machines":       driver,
 		"capabilities":   capabilities,
 		"enforced":       enforcement(s.packs),
+		"instance": map[string]any{
+			"pid":        os.Getpid(),
+			"started_at": s.started.Format(time.RFC3339),
+		},
 	})
 }
 

--- a/internal/core/emulator/identity_test.go
+++ b/internal/core/emulator/identity_test.go
@@ -1,0 +1,58 @@
+package emulator_test
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+)
+
+// TestHealthNamesItsOwnProcess holds /_feint/health to the identity it serves
+// under `instance` (#309): the pid must be this process's, the start time must
+// parse and must not lie about the future. The field exists because a stale
+// emulator on a shared port once answered a probe with the previous build's
+// catalogue, and nothing in the answer could say which process produced it —
+// this test is what keeps the identity from becoming decoration.
+func TestHealthNamesItsOwnProcess(t *testing.T) {
+	env := emulator.DefaultEnv()
+	srv, err := emulator.NewServer(env, stubPack{name: "stub"})
+	if err != nil {
+		t.Fatalf("build emulator: %v", err)
+	}
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	resp, err := ts.Client().Get(ts.URL + "/_feint/health")
+	if err != nil {
+		t.Fatalf("health: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var health struct {
+		Instance *struct {
+			PID     int    `json:"pid"`
+			Started string `json:"started_at"`
+		} `json:"instance"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&health); err != nil {
+		t.Fatalf("health: decode: %v", err)
+	}
+	if health.Instance == nil {
+		t.Fatal("health carries no instance: nothing can tell this emulator from a stale one on the same port")
+	}
+	if health.Instance.PID != os.Getpid() {
+		t.Fatalf("health names pid %d, but this process is %d: a caller comparing pids would refuse its own emulator",
+			health.Instance.PID, os.Getpid())
+	}
+	started, err := time.Parse(time.RFC3339, health.Instance.Started)
+	if err != nil {
+		t.Fatalf("started_at %q is not RFC3339: %v", health.Instance.Started, err)
+	}
+	if started.After(time.Now().Add(time.Minute)) {
+		t.Fatalf("started_at %s is in the future", health.Instance.Started)
+	}
+}

--- a/internal/core/emulator/schema.go
+++ b/internal/core/emulator/schema.go
@@ -30,7 +30,15 @@ const (
 	// enforced". One pack of three handed a rule over. The honest check is both
 	// keys, so a consumer that branches on the version can tell whether it is
 	// talking to a build that can answer the second question at all.
-	HealthSchemaVersion = 2
+	//
+	// 3 since #309: the payload gained `instance`, the identity of the process
+	// answering — its pid and start time. Additive, and it exists because its
+	// absence was measured: a stale emulator on a shared port answered a probe
+	// with the previous build's catalogue, and nothing in the answer could say
+	// so. `feint start` now compares `instance.pid` against the process it
+	// spawned and refuses a stranger; any harness that starts an emulator can
+	// do the same.
+	HealthSchemaVersion = 3
 	// RoutesSchemaVersion is the shape of GET /_feint/routes.
 	//
 	// This one is not on the wire: the endpoint answers a bare JSON array — the

--- a/mise.toml
+++ b/mise.toml
@@ -9,7 +9,14 @@ uv = "0.11.26"           # brings the extraction its one dependency without a ve
 ruff = "0.14.9"          # Python lint + format, mirrors .pre-commit-config.yaml
 
 [env]
-FEINT_ADDR = "127.0.0.1:4599"
+# get_env, not a literal: a value declared here beats an exported variable, so
+# `FEINT_ADDR=127.0.0.1:4699 mise run conformance` silently used 4599 — a knob
+# that read as configurable and was not (#309). Measured on 2026-08-19: with the
+# literal, `mise env` answers 4599 under that export; with get_env it answers
+# 4699, and stays 4599 when nothing is exported. Every parallel run converging
+# on one port is the precondition for a stale emulator answering somebody
+# else's measurement, which is the incident the rest of #309 guards against.
+FEINT_ADDR = "{{ get_env(name='FEINT_ADDR', default='127.0.0.1:4599') }}"
 # Where the upstream SDK checkouts live. The drift scan reads them as source; it never imports them.
 FEINT_SDK_SCALEWAY = "{{config_root}}/.upstream/scaleway-sdk-go"
 FEINT_SDK_OUTSCALE = "{{config_root}}/.upstream/osc-sdk-go"

--- a/tools/falsify/specs/who-answered.json
+++ b/tools/falsify/specs/who-answered.json
@@ -1,0 +1,34 @@
+{
+  "package": "./internal/cli/",
+  "mutations": [
+    {
+      "label": "start takes any healthy answer as the child it spawned, which is the #309 incident verbatim",
+      "file": "internal/cli/lifecycle.go",
+      "find": "\t\t\tif id == nil || id.PID != inst.PID {",
+      "replace": "\t\t\tif (id == nil || id.PID != inst.PID) && false {",
+      "test": "TestStartRefusesAForeignAnswerOnItsAddress"
+    },
+    {
+      "label": "an identity-less answer from an older build is adopted as the spawned child",
+      "file": "internal/cli/lifecycle.go",
+      "find": "\t\t\tif id == nil || id.PID != inst.PID {",
+      "replace": "\t\t\tif (id == nil && false) || id.PID != inst.PID {",
+      "test": "TestStartRefusesAnAnswerThatCarriesNoIdentity"
+    },
+    {
+      "label": "serve treats an address an emulator already answers on as free",
+      "file": "internal/cli/cli.go",
+      "find": "\tid, ok := probeIdentity(addr, 500*time.Millisecond)\n\tif !ok {\n\t\treturn nil\n\t}",
+      "replace": "\tid, ok := probeIdentity(addr, 500*time.Millisecond)\n\tif !ok || id != nil || id == nil {\n\t\treturn nil\n\t}",
+      "test": "TestServeRefusesAnAddressAnotherEmulatorClaims"
+    },
+    {
+      "label": "health names a pid that is not this process, so every caller compares against a fiction",
+      "package": "./internal/core/emulator/",
+      "file": "internal/core/emulator/emulator.go",
+      "find": "\t\t\t\"pid\":        os.Getpid(),",
+      "replace": "\t\t\t\"pid\":        os.Getpid() + 1,",
+      "test": "TestHealthNamesItsOwnProcess"
+    }
+  ]
+}


### PR DESCRIPTION
# Summary

A measurement taken against the wrong process looks exactly like a good one, and #309 measured that the tooling produces them: two mechanisms compound, and this change closes both — after reproducing each.

**Reproduced first, before any code moved (2026-08-19).** A stale `feint serve` (built from main) was left holding `127.0.0.1:4620`. A second checkout added a marker server type (`REPRO309-S`) to its catalogue, built, and started on the same address. What the tooling said:

```
$ ./feint-b start --addr 127.0.0.1:4620 --timeout 10s
feint listening on 127.0.0.1:4620 (pid 3450756)        # exit 0
$ ./feint-b wait --addr 127.0.0.1:4620
127.0.0.1:4620 is ready                                 # exit 0
$ kill -0 3450756
kill: no such process                                   # the pid start named was already dead
$ curl -s :4620/.../products/servers | grep REPRO309-S
(absent — the answer is the stale build's catalogue)
```

The spawned child died on the bind error; `awaitHealthy` took the incumbent's health answer as the child's. Every suite pointed at that endpoint would have measured the previous build, reproducibly, with nothing red.

**The second mechanism, also measured:** `FEINT_ADDR` was a literal in `mise.toml`'s `[env]`, which beats an exported variable. `FEINT_ADDR=127.0.0.1:4699 mise env` answered `4599`. A run could not choose its port, so every parallel run converged on the address a stale process was most likely to hold.

## What changed

1. **Identity on `/_feint/health`** — the payload gains `instance: {pid, started_at}`; `schema_version` moves to 3 (additive). Frozen-surface procedure followed: fixture appended by `mise run frozen:update`, constant bumped with the reason, CHANGELOG line in both languages. `TestHealthNamesItsOwnProcess` holds the pid to the serving process, so the field cannot become decoration. Pid rather than a nonce because it is the one identifier the spawning caller already knows without any new plumbing, and one host cannot have two processes with it at once.
2. **`feint start` refuses an answer that names another process** — `awaitHealthy` compares `instance.pid` with the child it spawned; a mismatch (or an identity-less answer from an older build) is exit 1 naming the incumbent's pid and start time. Re-run against the same stale emulator, the exact command that printed "listening" now prints the refusal.
3. **`feint serve` refuses an address an emulator already answers on** — up front, naming the incumbent, instead of leaving the fact in a bind error a wrapper reads past. Same decision/act separation as `checkListenAddr`, only the decision is tested.
4. **`FEINT_ADDR` is honoured** — declared via `get_env(name='FEINT_ADDR', default='127.0.0.1:4599')`. Measured after the change: unset gives 4599, exported gives 4699, and `mise run probe` under the export dials 4699.

**Proof the guard bites:** `tools/falsify/specs/who-answered.json`, four mutations, `mise run falsify` says "the test bit" for all four; `falsify:lint` green (150 mutations across 44 specs).

**Proof it does not cry wolf:** two consecutive `start`/`stop` cycles on one address, both green; `mise run conformance` (which runs `feint start` + every suite + `feint stop` on the default port) green with the guard in.

**`compat:check`, measured because this PR bumps a frozen surface:** it exits 1 — and the failure is not this change. Same pinned ref (`compat.sh v0.9.0`), binaries rebuilt in each run: pristine `origin/main` (42188fa) and this branch (ecd3135) produce **byte-identical** output (`diff` exit 0), both `10 compatible, 0 explicitly broken, 0 silently wrong`, both failing only on the two 0.8-boundary exemptions in `accepted.json` now matching nothing; with `compat.sh v0.8.0` the same tree is green, which dates the red to the moment the `v0.9.0` tag landed. The two health expressions ("the emulator is up", "providers mounted") are `compatible` with `instance` served and `schema_version` 3. Evidence and the triage decision: #310.

**Out of scope, recorded:** the shared per-session scratchpad (last-writer-wins between parallel agents) belongs to the harness that invokes agents on this repository, not to the repository — nothing here can fix it without modifying tooling this change does not own. Worth carrying to that tooling: one subdirectory per agent.

## Type of change

- [ ] A route added or changed
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes (gofmt, vet, golangci-lint, `go test -race`)
- [x] No new external Go dependency, or the pull request justifies it. The
      standard library covers routing, JSON and Go parsing; `go.mod` has three
      lines and a pre-commit hook keeps it that way
- [x] `internal/core` still knows no provider. If a change seemed to require it,
      the pack changed instead — the identity is a pid and a clock reading,
      provider-free by construction
- [x] Nothing in the diff could be written identically for another provider. If
      it could, it belongs in the core — the whole change lives in the core and
      the CLI; no pack moved

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] I ran `mise run conformance` myself — not "it should pass"
- [x] Every field name in the diff comes from the provider's SDK, their OpenAPI
      document, or a run of the real client, and I can say which — no provider
      field is touched; `instance.pid` / `instance.started_at` are feint's own
      frozen surface, versioned and fixtured under #132's procedure

### When a route is added or changed — otherwise N/A

- N/A — `/_feint/health` is a self surface, not a provider route; no
  `Route.Operation`, no coverage entry, no drift baseline moved

### When behaviour a client can observe changes — otherwise N/A

- [x] `docs/limits.md` updated if the change moves a documented limit — no limit
      moved; the observable change is the health payload, and its contract lives
      in the frozen fixture + CHANGELOG (both languages), per RELEASING.md
- [x] The README's generated tables regenerated (`mise run docs:coverage`) —
      `feint docs --check` green; no generated section depends on the health
      shape

### When `.github/workflows/` is touched — otherwise N/A

One commit touches `workflow-security.yml`, because this PR's own actionlint leg died on `curl: (35) Recv failure: Connection reset by peer` — the transient whose documented fix in this repository is retry flags on the download, not a re-run (already applied in `secrets.yml` and `conformance.yml`). The five bare `curl -fsSL` downloads there now carry `--retry 3 --retry-connrefused`. Nothing else moved.

- [x] Every action pinned to a full 40-character commit SHA with a `# vX.Y.Z`
      comment — never `@v4`, never `@main` — no pin touched
- [x] `step-security/harden-runner` is the job's first step — unchanged
- [x] `permissions:` is least-privilege on every job — unchanged
- [x] No job renamed, or the required status checks updated — no job renamed
- [x] The exit-code contract still holds: `0` ok, `1` error, `2` drift — no
      gate's exit path changed; `set -euo pipefail` still guards each step

### When a machine runtime is involved — otherwise N/A

- N/A — `--vm off` throughout; the station's Incus runtime is shared and was
  deliberately not driven

## Related issues

Closes #309
