### PR TITLE
fix(compat): retire the 0.8 exemptions the v0.9.0 tag made stale (#310)

### DIFF
--- a/tools/compat/accepted.json
+++ b/tools/compat/accepted.json
@@ -3,22 +3,23 @@
     "Silently-wrong findings the project records rather than fixes, each with the",
     "reason. Recorded and still printed, never hidden (#170).",
     "",
-    "The 0.8 boundary is made of these and it is the one boundary that cannot be",
-    "fixed retroactively: schema_version arrived with #132, after 0.8 shipped, so",
-    "no consumer of that release could have keyed on a signal that did not exist.",
-    "The policy protects from 0.9 onward, and RELEASING.md says so.",
-    "",
     "An entry that matches nothing fails the gate: a stale exemption is a gate",
-    "that quietly stopped covering what it names."
+    "that quietly stopped covering what it names.",
+    "",
+    "That rule fired for the first time on 2026-08-19, the day after v0.9.0 was",
+    "tagged, and it is worth writing down because the next person to add an entry",
+    "will meet it. This list held two exemptions for the 0.8 boundary: `probed`",
+    "was a boolean in 0.8 and became one of response/refusal/none (#156), before",
+    "`schema_version` existed (#132), so no consumer of 0.8 could have keyed on a",
+    "signal that was not there. While v0.8.0 was the latest tag those two",
+    "expressions really were silently wrong and the exemptions really did cover",
+    "them. The moment v0.9.0 became the comparison's old side, both sides agreed,",
+    "the findings disappeared, and the exemptions covered nothing.",
+    "",
+    "So an exemption written for a boundary dies when that boundary is behind the",
+    "latest tag. Retiring it is the triage the gate is asking for, not a workaround",
+    "for a red gate: the gate refusing the next tag is exactly what made anybody",
+    "look."
   ],
-  "accepted": [
-    {
-      "name": "probed operations, compared to true",
-      "reason": "the 0.8 boundary, and it cannot be fixed retroactively: probed was a boolean and is now one of response/refusal/none (#156), and 0.8 shipped before schema_version existed (#132), so no consumer of that release could have keyed on a signal that was not there. Recorded here and still printed. The policy protects from 0.9 onward."
-    },
-    {
-      "name": "probed operations, read as truthy",
-      "reason": "same boundary, and the worse half: every operation now reads as probed, including refusals and the never-probed, which is the exact overstatement #156 existed to remove, reappearing in somebody else's pipeline. Named in the release notes rather than hidden behind a green gate."
-    }
-  ]
+  "accepted": []
 }


### PR DESCRIPTION
Closes #310.

`mise run compat:check` has exited 1 on a pristine `main` since the moment `v0.9.0` was tagged. `release:check` runs it, so **the next tag was already refused** — including the 0.9.1 currently being prepared.

## It is not a consumer break

Against `v0.9.0` the verdict is **10 compatible, 0 explicitly broken, 0 silently wrong**, measured on `main` and on the #309 branch with byte-identical output. Nothing in 0.9.0 broke a consumer.

## It is the gate asking for its own triage

`tools/compat/accepted.json` held two exemptions written for the **0.8 boundary**: `probed` was a boolean in 0.8 and became one of `response`/`refusal`/`none` (#156), before `schema_version` existed (#132) — so no consumer of 0.8 could have keyed on a signal that was not there.

While `v0.8.0` was the latest tag, those expressions really *were* silently wrong and the exemptions really did cover them. That is why `release:check` was green when 0.9.0 was tagged.

The moment `v0.9.0` became the comparison's old side, both sides agreed on `probed`, the findings disappeared, and the entries covered nothing. The file's own rule then fired:

> an entry that matches nothing fails the gate, because a stale exemption is a gate that quietly stopped covering what it names.

## The fix, and what it records

The entries go — which the header anticipated in as many words: *"the policy protects from 0.9 onward"*.

The header now also records what happened, because the next person to add an exemption will meet the same rule: **an exemption written for a boundary dies when that boundary falls behind the latest tag**, and retiring it is the triage being asked for, not a workaround for a red gate.

Worth stating plainly: the gate refusing the next tag is precisely what made anybody look. It behaved correctly from beginning to end.

`mise run compat:check` now answers *no unaccepted silently-wrong expression: this release may be tagged*; `mise run prepush` green.