### PR TITLE
feat(cli): the measured escape paths are named before the apply, and the docs say exactly what runs locally (#280)

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -28,7 +28,7 @@
 >
 > **Prouvé** : 270 des 291 opérations montées sont pilotées par un vrai client, à chaque pull request. `scw`, `oapi-cli`, `exo`, Terraform et OpenTofu tournent contre l'émulateur en CI, et les machines démarrent réellement : connexion ssh sur le compte par défaut de chaque provider, subnets isolés, pare-feu qui filtre. La chaîne complète est décrite dans [docs/conformance.md](docs/conformance.md).
 >
-> **Pas prouvé** : quotas, prix, capacité réelle, validation des identifiants, authentification, cohérence à terme. Les 36 sections de [docs/limits.md](docs/limits.md) disent chacune ce qu'elle coûte. Un émulateur avec un seul compte implicite et aucune grille tarifaire devrait inventer ces chiffres, et quelqu'un agirait dessus.
+> **Pas prouvé** : quotas, prix, capacité réelle, validation des identifiants, authentification, cohérence à terme. Les 37 sections de [docs/limits.md](docs/limits.md) disent chacune ce qu'elle coûte. Un émulateur avec un seul compte implicite et aucune grille tarifaire devrait inventer ces chiffres, et quelqu'un agirait dessus.
 >
 > **Inconnu** : 21 opérations sont montées et n'ont jamais été pilotées par un client. Chacune dit pourquoi aucun client officiel ne l'atteint, à la route et dans [docs/routes.md](docs/routes.md). Elles sont comptées plutôt qu'escamotées, une par une, dans [coverage/evidence.json](coverage/evidence.json).
 >
@@ -93,10 +93,16 @@ ajouter : [**examples/**](examples/) — GitHub Actions, GitLab CI, et une actio
 `setup-feint` qui vérifie l'empreinte du binaire avant de l'exécuter.
 
 Pas de compte. Pas d'identifiants. Rien de facturé, et rien qui continue de
-tourner ailleurs que sur votre machine. Le provider qui a produit cette ligne est
-le vrai, celui du registre : tout l'argument de ce dépôt est qu'il ne peut pas
-voir la différence, et [ce que vous pouvez valider](docs/confidence.md) dit où
-cette affirmation s'arrête.
+tourner ailleurs que sur votre machine, **pour chaque API que Feint sert**. Un
+produit hors de ce périmètre (Object Storage est le cas mesuré) est joint par
+son client au vrai endpoint, où que pointe le reste de l'exécution :
+[docs/limits.md](docs/limits.md#a-run-presented-as-local-can-still-reach-the-real-cloud-280)
+nomme ces chemins d'évasion, et `feint doctor`, lancé depuis le répertoire de
+la stack, avertit des cas mesurés avant que l'apply ne le fasse. Le provider
+qui a produit cette ligne est le vrai, celui du registre : tout l'argument de
+ce dépôt est qu'il ne peut pas voir la différence, et
+[ce que vous pouvez valider](docs/confidence.md) dit où cette affirmation
+s'arrête.
 
 ![Démarrage de Feint, le CLI Scaleway officiel pointé dessus, et un terraform apply exécuté contre lui](docs/assets/quickstart.gif)
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 >
 > **Proven**: 270 of the 291 mounted operations are driven by a real client, on every pull request. `scw`, `oapi-cli`, `exo`, Terraform and OpenTofu run against the emulator in CI, and machines really boot: an ssh login on each provider's own default account, isolated subnets, a firewall that filters. The whole chain is described in [docs/conformance.md](docs/conformance.md).
 >
-> **Not proven**: quotas, prices, real capacity, identifier validation, authentication, eventual consistency. The 36 sections of [docs/limits.md](docs/limits.md) each say what one costs. An emulator with a single implicit account and no price list would have to invent those figures, and somebody would act on them.
+> **Not proven**: quotas, prices, real capacity, identifier validation, authentication, eventual consistency. The 37 sections of [docs/limits.md](docs/limits.md) each say what one costs. An emulator with a single implicit account and no price list would have to invent those figures, and somebody would act on them.
 >
 > **Unknown**: 21 operations are mounted and have never been driven by a client. Every one of them states why no official client reaches it, at the route and in [docs/routes.md](docs/routes.md). They are counted rather than glossed, one by one, in [coverage/evidence.json](coverage/evidence.json).
 >
@@ -85,11 +85,16 @@ Copy-paste pipelines for both, with nothing to configure and no secret to add:
 [**examples/**](examples/) — GitHub Actions, GitLab CI, and a `setup-feint`
 action that verifies the binary before it runs it.
 
-No account. No credentials. Nothing billed, and nothing left running anywhere but
-your machine. The provider that produced that line is the real one from the
-registry — this repository's whole argument is that it cannot tell the
-difference, and [what you can validate](docs/confidence.md) says where that
-claim stops.
+No account. No credentials. Nothing billed, and nothing left running anywhere
+but your machine — **for every API Feint serves**. A product outside that scope
+(Object Storage is the measured case) is reached by its client at the real
+endpoint no matter where the rest of the run points:
+[docs/limits.md](docs/limits.md#a-run-presented-as-local-can-still-reach-the-real-cloud-280)
+names those escape paths, and `feint doctor`, run from the stack directory,
+warns about the measured ones before the apply does. The provider that produced
+that line is the real one from the registry — this repository's whole argument
+is that it cannot tell the difference, and
+[what you can validate](docs/confidence.md) says where that claim stops.
 
 ![Starting Feint, pointing the official Scaleway CLI at it, and applying a Terraform configuration against it](docs/assets/quickstart.gif)
 

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -23,6 +23,15 @@ Nothing to install beyond one binary, no account, no credentials, nothing
 billed. If your configuration applies, re-plans empty and destroys, say so — that
 is a data point too, and it is the one this project cannot generate for itself.
 
+One honest sentence before you point anything here: **the APIs Feint serves run
+locally; a product outside that scope is reached by your client at the real
+endpoint**, with whatever credentials your shell holds — Object Storage is the
+measured case, and only fake credentials made the measured escape harmless.
+`feint doctor`, run from the stack directory, warns about the measured escape
+paths before the apply does, and
+[docs/limits.md](limits.md#a-run-presented-as-local-can-still-reach-the-real-cloud-280)
+names them all, with the tested ways to cut egress for the run.
+
 ### Pointing an Outscale stack here, per provider generation
 
 The fifteen-stack survey ([the register](../examples/stacks/surveyed.md))

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -39,7 +39,9 @@ fake credentials. Nothing was created and nothing was billed — but the request
 left the machine. A configuration carrying `scaleway_object_bucket` talks to
 the real endpoint no matter where the rest of it is pointed, and any sentence
 here promising that traffic never leaves your machine has to carve out this
-one product on this one client.
+one product on this one client. The escape-path section below (#280) carries
+the full measured list, what warns before the run, and the egress cuts that
+were tested rather than described.
 
 ## The cost of DNS/TLS interception, measured (#76)
 
@@ -254,6 +256,95 @@ explicit, disposable name redirect the operator opts into (a devcontainer or a
 temporary hosts entry) — never a system trust-store install, never a hosts file
 this binary edits itself. Whether that corner is worth the operator ceremony is a
 product call; it is no longer an unmeasured one.
+
+## A run presented as local can still reach the real cloud (#280)
+
+Every sentence this project writes about locality has to be the one that is
+true: **the APIs Feint serves run locally; a client can compose its own
+endpoint for a product outside that scope, and then its requests go where they
+always went.** From the outside the two runs are indistinguishable — that is
+the whole problem — and the failure that would actually hurt is not the 403
+the survey measured on fake credentials. It is somebody with real credentials
+in their environment — a developer's shell, a CI job that also deploys —
+running a stack they believe is sandboxed.
+
+### The measured escape paths, and what says something today
+
+| path | measured | what warns today |
+|---|---|---|
+| Scaleway Object Storage through Terraform: `scaleway_object_*` hardcodes `https://s3.<region>.scw.cloud` (top of this file) | live on a surveyed stack (#262, flatcar-k3s): `CreateBucket` at the real endpoint, 403 on fake credentials. Reproduced for #280 with egress cut to a dead proxy: **the same apply created its instance IP on this emulator and died on `Put "https://<bucket>.s3.fr-par.scw.cloud/"` — one run, half local, half not** | `feint doctor` and `feint env scaleway`, from the stack directory: the configuration's own text names the resource family |
+| an S3 state backend or an aws provider pointed at real object storage | three surveyed stacks: kubic (state on Object Storage, endpoint in `backend.conf`), eu-data-platform (state on `sos-ch-gva-2.exo.io`, inline), platform (aws provider at `sos-<zone>.exo.io`, 403 at the real endpoint) | the same scan, when the host is written in the `.tf` text — the kubic shape keeps its endpoint in a `backend.conf` the scan does not read, and stays invisible to it |
+| Outscale, `OSC_PROFILE` set: provider 1.1.x reads `~/.osc/config.json` and ignores `OSC_ENDPOINT_API` | #286, on 1.1.3: the plan left for `api.<region>.outscale.com` while the emulator received nothing | `feint doctor` and `feint env outscale`, since #286 — this one lives in the shell, not in the stack |
+| the Exoscale Terraform provider's split client: egoscale v2 built with no endpoint option | #262/#284, section below: an apply splits between this emulator and the real cloud | **the emulator itself refuses that client by user agent** — the one escape that must pass through the front door to do damage, so the front door is where it is stopped |
+
+The scan behind the first two rows reads the Terraform files around `feint
+doctor` and `feint env` (`*.tf`, `*.tf.json`, `*.tofu`, comment-stripped, dot
+directories skipped) and matches the measured signatures each pack declares —
+`internal/providers/*/stackhazards.go`. Warnings, never failures, and three
+silence rules the tests hold: a directory whose own top level carries no
+Terraform file produces nothing — Terraform only runs where root module files
+sit, so a workspace that merely *contains* projects is not a stack
+(`TestADirectoryOfProjectsIsNotAStack`, while a rooted stack's `modules/` are
+scanned); a commented-out resource produces nothing
+(`TestAStackHazardInACommentStaysSilent`) — a warning that fires on dead text
+is a warning people learn to ignore; and this repository's own fixtures scan
+clean. The `ok` row states its own scope ("checks the measured list") because
+that is all it checks.
+
+### What is out of reach, and why no guard here can promise more
+
+Feint controls neither the client's process nor its DNS. `feint proxy` sees
+every request that reaches it and, by construction, none that does not. The
+scan above reads text, so it cannot see a value passed at runtime
+(`-backend-config`, a variable), a module fetched at init, or the next product
+whose client composes its endpoint upstream tomorrow — the weekly drift scan
+reads SDK surfaces, not endpoint construction, so it will not see that one
+either. **In general, the escape is undetectable from inside the emulator, and
+an approximate guard would be worse than none: it would license exactly the
+belief it fails to protect.** What exists is a measured list, said as such,
+plus the one boundary that does not depend on the client cooperating — the
+network the run executes in.
+
+### Cutting egress, measured both ways
+
+The tripwire costs one line and no privilege, and it is how the reproduction
+above was run — the escape became a loud failure naming its destination
+instead of a silent success:
+
+```bash
+HTTPS_PROXY=http://127.0.0.1:9 NO_PROXY=127.0.0.1,localhost terraform apply
+```
+
+```text
+Error: … CreateBucket, … Put "https://feint-escape-repro.s3.fr-par.scw.cloud/":
+proxyconnect tcp: dial tcp 127.0.0.1:9: connect: connection refused
+```
+
+The emulator, on loopback, is reached directly through `NO_PROXY`; everything
+else dies on a proxy that is not listening, and the error names the host that
+was contacted. Scope, honestly: proxy variables are honoured, not enforced —
+measured on Terraform with the Scaleway provider (above) and on the Exoscale
+provider (#284, same technique); a client that ignores them walks straight
+past. A tripwire, not a boundary.
+
+The boundary is a network with no route out. Measured on rootless podman
+(4.9.3, netavark), no privilege and no host trace:
+
+```bash
+podman network create --internal feint-noegress
+# feint on it (feint serve --addr 0.0.0.0:4599 --expose-to-network), the client beside it:
+# GET /_feint/health → HTTP/1.0 200 OK
+# connect s3.fr-par.scw.cloud:443 → "Network is unreachable", immediately
+```
+
+One caveat the measurement exposed: on an `--internal` network the container's
+DNS still *resolves* real names (aardvark-dns forwards to the host's
+resolver), so the cut is at connect, not at lookup — a name leaks as a query,
+a connection goes nowhere. In CI the same property is whatever your runner's
+egress policy provides; a hosted runner with open egress protects nothing, and
+no flag here can change that. That sentence is the honest end of this section:
+where the network permits the escape, Feint can at most name the measured
+paths before the run — which is what `feint doctor` now does.
 
 ## Managed Kubernetes is not emulated, and a CRUD-only version is refused (#283)
 

--- a/examples/stacks/surveyed.md
+++ b/examples/stacks/surveyed.md
@@ -60,7 +60,7 @@ edit **except** where the table below says so:
 
 | provider | environment that reaches the emulator | trap, measured |
 |---|---|---|
-| Scaleway (provider 2.x) | `feint env scaleway`, with `SCW_API_URL` pointing at the proxy | Object Storage still goes to the real `s3.<region>.scw.cloud` (docs/limits.md); measured live on flatcar-k3s, a 403 from the real endpoint |
+| Scaleway (provider 2.x) | `feint env scaleway`, with `SCW_API_URL` pointing at the proxy | Object Storage still goes to the real `s3.<region>.scw.cloud` (docs/limits.md); measured live on flatcar-k3s, a 403 from the real endpoint. Since #280, `feint doctor` and `feint env scaleway` warn from the stack directory when its text carries `scaleway_object_*` or a real `*.scw.cloud` host |
 | Outscale 1.7+ | `OSC_ENDPOINT_API=http://…:4611/api/v1` — the path belongs in the value | without the path: six-minute retry backoff |
 | Outscale 1.1.x | `OSC_ENDPOINT_API=http://…:4611` — **no path**; both its HTTP clients append `/api/v1` themselves | with the path: `invalid port ":4611%2Fapi%2Fv1"` — the legacy client URL-escapes it |
 | Outscale 0.x (`outscale-dev/*`) | none exists. Zero exchanges reached the recorder with `OSC_ENDPOINT_API` and `OUTSCALE_OAPI_URL` both set | 0.5.3 honours only the `endpoints{api=…}` block, prepends `https://` to it, and needs `feint proxy --intercept localhost` + `SSL_CERT_FILE`; 0.7.0 honours nothing found and SIGSEGVs in its own create-retry error path |

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -61,6 +61,7 @@ func doctor(args []string, stdout, stderr io.Writer) int {
 	checks = append(checks, checkLeftoverDHCP())
 	checks = append(checks, checkClients()...)
 	checks = append(checks, checkEnvHazards()...)
+	checks = append(checks, checkStackHazards()...)
 	checks = append(checks, checkSSHConfig())
 
 	failed := 0
@@ -406,6 +407,60 @@ func checkEnvHazards() []check {
 				fix:   warning,
 			})
 		}
+	}
+	return out
+}
+
+// checkStackHazards reads the Terraform configuration around the operator —
+// doctor is documented to run from the stack directory — and asks each pack
+// whether its text names something measured to reach the real cloud no matter
+// where the exports point. scaleway_object_* is the measured case (#262,
+// #280): the provider hardcodes s3.<region>.scw.cloud for Object Storage, so a
+// run that looks local sends those calls out with whatever credentials it
+// holds, and the emulator cannot see a request that never arrives. The
+// signatures are provider knowledge and live in each pack; doctor only walks
+// the files and relays.
+//
+// Silence rules, in order: no Terraform files here means no rows at all — a
+// doctor run from a home directory must not gain noise — and a stack carrying
+// no signature gets one row saying what was checked, worded as the measured
+// list it is rather than as a guarantee nobody can give.
+// TestDoctorNamesTheObjectStorageEscape fails without the warning, and
+// TestDoctorStaysSilentOffAStack without the silence.
+func checkStackHazards() []check {
+	dir, err := os.Getwd()
+	if err != nil {
+		return nil
+	}
+	config, files := stackConfig(dir)
+	if files == 0 {
+		return nil
+	}
+	srv, _, err := newServer(nil)
+	if err != nil {
+		// Some other check owns reporting a server that cannot be built.
+		return nil
+	}
+	var out []check
+	for _, p := range srv.Packs() {
+		hazards, ok := p.(packStackHazards)
+		if !ok {
+			continue
+		}
+		for _, warning := range hazards.StackHazards(config) {
+			out = append(out, check{
+				title: "this Terraform configuration can reach the real " + p.Name() + " cloud",
+				state: verdictWarn,
+				fix:   warning,
+			})
+		}
+	}
+	if len(out) == 0 {
+		out = append(out, check{
+			title:  fmt.Sprintf("no known escape signature in the %d Terraform file(s) here", files),
+			state:  verdictOK,
+			detail: "this checks the measured list (docs/limits.md), not every path a client could compose",
+		})
 	}
 	return out
 }

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -162,6 +162,22 @@ func envCommand(args []string, stdout, stderr io.Writer) int {
 				fmt.Fprintf(stderr, "warning: %s\n", warning)
 			}
 		}
+		// The stack's own text can defeat every export just printed: a
+		// scaleway_object_* resource reaches the real s3.<region>.scw.cloud
+		// no matter what SCW_API_URL says (measured, #262/#280). env is
+		// eval'd from the stack directory, which makes this the last moment
+		// a warning can land before the apply that escapes. Same contract as
+		// above: stderr only, and a directory with no Terraform files stays
+		// silent. TestEnvNamesTheEscapeInTheStackNextToIt fails without it.
+		if hazards, ok := pack.(packStackHazards); ok {
+			if dir, err := os.Getwd(); err == nil {
+				if config, files := stackConfig(dir); files > 0 {
+					for _, warning := range hazards.StackHazards(config) {
+						fmt.Fprintf(stderr, "warning: %s\n", warning)
+					}
+				}
+			}
+		}
 	}
 	return exitOK
 }

--- a/internal/cli/env_test.go
+++ b/internal/cli/env_test.go
@@ -1,6 +1,8 @@
 package cli_test
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -203,5 +205,45 @@ func TestEnvHazardWarningsReachStderrNeverStdout(t *testing.T) {
 	_, _, errOut = run("env", "outscale", "--unset")
 	if strings.Contains(errOut, "OSC_PROFILE") {
 		t.Fatalf("--unset still warns about the shell it is restoring: %q", errOut)
+	}
+}
+
+// The stack's own text can defeat every export env prints: a
+// scaleway_object_* resource reaches the real s3.<region>.scw.cloud no matter
+// what SCW_API_URL says (measured, #262/#280). env is eval'd from the stack
+// directory, so it is the last voice before the apply that escapes — on
+// stderr, where the eval cannot swallow it, and silent when the directory
+// carries no Terraform at all.
+func TestEnvNamesTheEscapeInTheStackNextToIt(t *testing.T) {
+	dir := t.TempDir()
+	stack := `
+resource "scaleway_instance_ip" "local" {}
+resource "scaleway_object_bucket" "escapes" { name = "x" }
+`
+	if err := os.WriteFile(filepath.Join(dir, "main.tf"), []byte(stack), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+
+	code, printed, errOut := run("env", "scaleway")
+	if code != 0 {
+		t.Fatalf("exited %d: %s", code, errOut)
+	}
+	if !strings.Contains(errOut, "warning:") || !strings.Contains(errOut, "scaleway_object") {
+		t.Fatalf("the stack next to this shell escapes and stderr says nothing: %q", errOut)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(printed), "\n") {
+		if !strings.HasPrefix(line, "export ") {
+			t.Fatalf("a warning leaked onto stdout, where eval would execute it: %q", line)
+		}
+	}
+
+	// A directory with no Terraform files stays silent: env runs from plenty
+	// of places that are not stacks, and noise there teaches people to
+	// ignore the warning where it is true.
+	t.Chdir(t.TempDir())
+	_, _, errOut = run("env", "scaleway")
+	if strings.Contains(errOut, "warning:") {
+		t.Fatalf("an empty directory drew a warning: %q", errOut)
 	}
 }

--- a/internal/cli/stack.go
+++ b/internal/cli/stack.go
@@ -1,0 +1,156 @@
+package cli
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// A stack's own text can defeat every value this CLI prints. The measured case
+// (#262, #280): a Terraform configuration pointed here through SCW_API_URL
+// carried one scaleway_object_bucket, and that call left for the real
+// s3.fr-par.scw.cloud — the provider hardcodes the host for Object Storage —
+// while every other resource applied locally. The emulator cannot see a
+// request that never reaches it, so the only moment anything can warn is
+// before the run, from the configuration's own text.
+//
+// The division of labour mirrors packEnvHazards: this file reads the files and
+// strips what a client would not execute; which tokens mean "this reaches the
+// real cloud" is provider knowledge and lives in each pack.
+
+// packStackHazards is the optional half of a pack that can recognise, in the
+// text of a Terraform configuration, something measured to reach the real
+// cloud no matter where the emulator's exports point. The input is the
+// comment-stripped concatenation of the stack's files; the output is one
+// warning per recognised signature, empty for a clean stack.
+type packStackHazards interface {
+	StackHazards(config string) []string
+}
+
+// stackFileCap bounds the walk. A Terraform stack is tens of files; the cap
+// exists so a `feint env` eval'd from somebody's home directory scans a bounded
+// amount and returns, rather than reading a filesystem.
+const stackFileCap = 256
+
+// stackConfig gathers the Terraform files under dir — *.tf, *.tf.json and
+// *.tofu, recursively, skipping dot-directories such as .git and .terraform —
+// into one comment-stripped string. files is how many were read; zero means
+// "no stack here" and callers stay silent, which is what keeps this scan free
+// of noise for everybody not standing in a stack.
+//
+// The gate is the directory's own top level: Terraform only runs where root
+// module files sit, so a directory without one is not a stack, however many
+// projects live somewhere below it. Without this gate, a doctor run from a
+// workspace holding vendored provider sources and old stack copies warned
+// about text nobody was about to apply — measured on this repository's own
+// scratchpad — and a warning that fires on other people's files teaches the
+// operator to ignore it. TestADirectoryOfProjectsIsNotAStack fails without
+// the gate. Once the gate passes, the walk is recursive on purpose: the root
+// module is where the apply happens, and its modules/ subdirectories are part
+// of the same run.
+func stackConfig(dir string) (config string, files int) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", 0
+	}
+	rooted := false
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if name := entry.Name(); strings.HasSuffix(name, ".tf") || strings.HasSuffix(name, ".tf.json") || strings.HasSuffix(name, ".tofu") {
+			rooted = true
+			break
+		}
+	}
+	if !rooted {
+		return "", 0
+	}
+	var parts []string
+	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil //nolint:nilerr // an unreadable entry is skipped, not fatal: this is a diagnostic
+		}
+		if d.IsDir() {
+			// .terraform holds provider binaries and remote module copies;
+			// .git holds history. Neither is the operator's own text, and the
+			// former is where a walk would stop being cheap.
+			if name := d.Name(); strings.HasPrefix(name, ".") && path != dir {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		name := d.Name()
+		if !strings.HasSuffix(name, ".tf") && !strings.HasSuffix(name, ".tf.json") && !strings.HasSuffix(name, ".tofu") {
+			return nil
+		}
+		if files >= stackFileCap {
+			return fs.SkipAll
+		}
+		body, readErr := os.ReadFile(path) //nolint:gosec // the operator's own configuration, read to warn them about it
+		if readErr != nil {
+			return nil //nolint:nilerr // same as above: skip what cannot be read
+		}
+		files++
+		parts = append(parts, stripHCLComments(string(body)))
+		return nil
+	})
+	return strings.Join(parts, "\n"), files
+}
+
+// stripHCLComments removes #, // and /* */ comments so a commented-out
+// resource never triggers a warning — a warning that fires on dead text is a
+// warning people learn to ignore, and teaching that is worse than staying
+// quiet. Quoted strings are honoured: a "#" inside one is data, not a comment.
+// TestAStackHazardInACommentStaysSilent fails without this.
+func stripHCLComments(s string) string {
+	var out strings.Builder
+	out.Grow(len(s))
+	inString, inLineComment, inBlockComment := false, false, false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case inLineComment:
+			if c == '\n' {
+				inLineComment = false
+				out.WriteByte(c)
+			}
+		case inBlockComment:
+			if c == '*' && i+1 < len(s) && s[i+1] == '/' {
+				inBlockComment = false
+				i++
+			} else if c == '\n' {
+				out.WriteByte(c)
+			}
+		case inString:
+			if c == '\\' && i+1 < len(s) {
+				out.WriteByte(c)
+				i++
+				out.WriteByte(s[i])
+				continue
+			}
+			if c == '"' {
+				inString = false
+			}
+			out.WriteByte(c)
+		default:
+			switch {
+			case c == '"':
+				inString = true
+				out.WriteByte(c)
+			case c == '#':
+				inLineComment = true
+			case c == '/' && i+1 < len(s) && s[i+1] == '/':
+				inLineComment = true
+				i++
+			case c == '/' && i+1 < len(s) && s[i+1] == '*':
+				inBlockComment = true
+				i++
+			default:
+				out.WriteByte(c)
+			}
+		}
+	}
+	return out.String()
+}

--- a/internal/cli/stack_test.go
+++ b/internal/cli/stack_test.go
@@ -1,0 +1,178 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The scan exists because of a measured escape (#262, #280): a stack pointed
+// here through SCW_API_URL sent its CreateBucket to the real
+// s3.fr-par.scw.cloud while every other resource applied locally. The emulator
+// cannot see a request that never arrives, so the warning has to come from the
+// stack's own text, before the run — and it has to stay quiet everywhere else,
+// or people learn to ignore it.
+
+func writeStack(t *testing.T, files map[string]string) {
+	t.Helper()
+	dir := t.TempDir()
+	for name, body := range files {
+		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Chdir(dir)
+}
+
+// A stack carrying the measured escape gets a warning row naming the pack and
+// the resource family; the row is a warning, never a failure, because doctor
+// must not fail builds.
+func TestDoctorNamesTheObjectStorageEscape(t *testing.T) {
+	writeStack(t, map[string]string{
+		"main.tf": `
+resource "scaleway_instance_ip" "local" {}
+resource "scaleway_object_bucket" "escapes" { name = "x" }
+`,
+	})
+	checks := checkStackHazards()
+	var warned bool
+	for _, c := range checks {
+		if c.state == verdictFail {
+			t.Fatalf("a stack hazard failed the run instead of warning: %+v", c)
+		}
+		if c.state == verdictWarn && strings.Contains(c.title, "scaleway") && strings.Contains(c.fix, "scaleway_object") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Fatalf("the measured Object Storage escape went unnamed: %+v", checks)
+	}
+}
+
+// No Terraform files here means no rows at all: a doctor run from a home
+// directory must not gain a line about stacks that do not exist.
+func TestDoctorStaysSilentOffAStack(t *testing.T) {
+	writeStack(t, map[string]string{"notes.txt": "not terraform"})
+	if checks := checkStackHazards(); len(checks) != 0 {
+		t.Fatalf("a directory with no Terraform files produced rows: %+v", checks)
+	}
+}
+
+// A clean stack gets exactly one row, and that row states its own scope — the
+// measured list — rather than promising that nothing can escape.
+func TestACleanStackGetsOneHonestRow(t *testing.T) {
+	writeStack(t, map[string]string{
+		"main.tf": `resource "scaleway_instance_ip" "local" {}`,
+	})
+	checks := checkStackHazards()
+	if len(checks) != 1 || checks[0].state != verdictOK {
+		t.Fatalf("a clean stack should get one ok row, got: %+v", checks)
+	}
+	if !strings.Contains(checks[0].detail, "measured list") {
+		t.Fatalf("the ok row does not state its scope, which licenses the belief it cannot back: %+v", checks[0])
+	}
+}
+
+// Dead text must not trigger: a commented-out resource is the ordinary way
+// somebody parks the S3 half of a stack to run the rest here, and warning on
+// it teaches them the warning is noise. All three HCL comment forms count,
+// and a "#" inside a quoted string is data, not a comment.
+func TestAStackHazardInACommentStaysSilent(t *testing.T) {
+	writeStack(t, map[string]string{
+		"main.tf": `
+# resource "scaleway_object_bucket" "parked" {}
+// resource "scaleway_object_bucket" "parked" {}
+/*
+resource "scaleway_object_bucket" "parked" { name = "x" }
+*/
+resource "scaleway_instance_ip" "local" {
+  tags = ["#not-a-comment"]
+}
+`,
+	})
+	checks := checkStackHazards()
+	for _, c := range checks {
+		if c.state == verdictWarn {
+			t.Fatalf("a commented-out resource triggered a warning: %+v", c)
+		}
+	}
+	if len(checks) != 1 {
+		t.Fatalf("expected the one honest ok row, got: %+v", checks)
+	}
+}
+
+// A directory that merely contains projects is not a stack: Terraform only
+// runs where root module files sit. Without the top-level gate, a doctor run
+// from a workspace holding vendored provider sources and old stack copies
+// warned about text nobody was about to apply — measured on this repository's
+// own scratchpad — while a stack whose escaping resource lives in a module
+// below a rooted configuration must still be seen.
+func TestADirectoryOfProjectsIsNotAStack(t *testing.T) {
+	writeStack(t, map[string]string{
+		"vendored-provider/examples/main.tf": `resource "scaleway_object_bucket" "someone_elses" {}`,
+		"notes.md":                           "no terraform at this level",
+	})
+	if checks := checkStackHazards(); len(checks) != 0 {
+		t.Fatalf("a directory of projects was scanned as a stack: %+v", checks)
+	}
+}
+
+// The other half of the gate: once the top level is a root module, its
+// modules are part of the same apply and must be scanned.
+func TestARootedStacksModulesAreScanned(t *testing.T) {
+	writeStack(t, map[string]string{
+		"main.tf":                 `module "storage" { source = "./modules/storage" }`,
+		"modules/storage/main.tf": `resource "scaleway_object_bucket" "escapes" { name = "x" }`,
+	})
+	checks := checkStackHazards()
+	var warned bool
+	for _, c := range checks {
+		if c.state == verdictWarn && strings.Contains(c.fix, "scaleway_object") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Fatalf("an escape in a module of a rooted stack went unnamed: %+v", checks)
+	}
+}
+
+// What lives under .terraform is not the operator's own text: provider
+// source trees and remote module copies mention real hosts constantly, and
+// scanning them would make every initialised stack warn.
+func TestTheScanSkipsDotDirectories(t *testing.T) {
+	writeStack(t, map[string]string{
+		"main.tf":                      `resource "scaleway_instance_ip" "local" {}`,
+		".terraform/modules/x/main.tf": `resource "scaleway_object_bucket" "vendored" {}`,
+	})
+	checks := checkStackHazards()
+	for _, c := range checks {
+		if c.state == verdictWarn {
+			t.Fatalf(".terraform content triggered a warning: %+v", c)
+		}
+	}
+}
+
+// The stripper itself, on the shapes that carried the measured escapes: the
+// stack text survives with its strings intact and without its comments.
+func TestStripHCLCommentsKeepsStringsAndDropsComments(t *testing.T) {
+	in := `a = "https://s3.fr-par.scw.cloud" # trailing
+b = "quoted # not a comment" // gone
+/* block
+gone too */ c = 1`
+	out := stripHCLComments(in)
+	for _, kept := range []string{`"https://s3.fr-par.scw.cloud"`, `"quoted # not a comment"`, "c = 1"} {
+		if !strings.Contains(out, kept) {
+			t.Errorf("stripped too much: %q missing from %q", kept, out)
+		}
+	}
+	for _, dropped := range []string{"trailing", "gone", "block"} {
+		if strings.Contains(out, dropped) {
+			t.Errorf("comment text survived: %q in %q", dropped, out)
+		}
+	}
+}

--- a/internal/providers/exoscale/stackhazards.go
+++ b/internal/providers/exoscale/stackhazards.go
@@ -1,0 +1,41 @@
+package exoscale
+
+import "strings"
+
+// StackHazards names what, in the text of a Terraform configuration, is
+// measured to reach the real cloud no matter what this emulator serves. The
+// CLI hands in the stack's comment-stripped text; the one signature here is a
+// measurement, not a guess (#262, #284):
+//
+//   - a literal *.exo.io host, which is SOS. Both surveyed shapes composed it
+//     client-side and never touched the emulator: mattias-fjellstrom/…-platform
+//     drives SOS buckets through the aws provider pointed at sos-<zone>.exo.io
+//     (its apply reached the real endpoint on fake credentials, 403), and
+//     bitrockteam/eu-data-platform keeps its state on S3-on-SOS, so
+//     `terraform init` talks to the real sos-ch-gva-2.exo.io before any
+//     resource exists. Serving SOS cannot fix either — the #284 triage
+//     declined it for exactly this reason — so naming the contact is the only
+//     answer that serves both.
+//
+// The Terraform provider's own split client (egoscale v2 without an endpoint
+// option) is the other Exoscale escape, and it is not detectable from a
+// stack's text: any exoscale_* resource may ride it. That one is refused at
+// the emulator's door by user agent instead — the barrage in pack.go — which
+// is the stronger position: it sees every request that arrives, where this
+// scan only sees what is written down.
+//
+// TestStackHazardsNameTheSOSEscape fails without the check, and a clean stack
+// must return nil: a warning that fires on a healthy configuration teaches
+// people to ignore the one that matters.
+func (p *Pack) StackHazards(config string) []string {
+	var warnings []string
+	if strings.Contains(config, ".exo.io") {
+		warnings = append(warnings,
+			"this configuration names a real *.exo.io host (SOS, Object Storage): those requests are "+
+				"composed client-side and go there, never to this emulator — measured on two surveyed "+
+				"stacks, an aws provider pointed at sos-<zone>.exo.io and an S3-on-SOS state backend that "+
+				"terraform init contacts before any resource (#262, #284). Keep SOS out of an emulated "+
+				"run, or cut egress first: docs/limits.md, \"A run presented as local\"")
+	}
+	return warnings
+}

--- a/internal/providers/exoscale/stackhazards_test.go
+++ b/internal/providers/exoscale/stackhazards_test.go
@@ -1,0 +1,41 @@
+package exoscale_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/providers/exoscale"
+)
+
+// SOS is composed client-side and never reaches this emulator — both surveyed
+// shapes proved it (#262, #284): an aws provider pointed at sos-<zone>.exo.io
+// (403 on fake credentials, at the real endpoint) and an S3-on-SOS state
+// backend that terraform init contacts before any resource exists. The #284
+// triage declined serving SOS for exactly that reason, so naming the contact
+// in the stack's own text is the only warning that can exist at all.
+func TestStackHazardsNameTheSOSEscape(t *testing.T) {
+	pack := exoscale.New(nil)
+
+	clean := `
+resource "exoscale_compute_instance" "local" {
+  zone = "ch-dk-2"
+  type = "standard.medium"
+}
+`
+	if warnings := pack.StackHazards(clean); len(warnings) != 0 {
+		t.Fatalf("a stack the emulator fully serves was warned about: %v", warnings)
+	}
+
+	for _, escape := range []string{
+		`endpoint = "https://sos-ch-gva-2.exo.io"`,         // the eu-data-platform state backend
+		`endpoints { s3 = "https://sos-de-fra-1.exo.io" }`, // the platform stack's aws provider
+	} {
+		warnings := pack.StackHazards(escape)
+		if len(warnings) == 0 {
+			t.Fatalf("a real *.exo.io host went unnamed; those requests never reach this emulator: %s", escape)
+		}
+		if !strings.Contains(warnings[0], ".exo.io") || !strings.Contains(warnings[0], "SOS") {
+			t.Fatalf("the warning names neither the host family nor the product: %q", warnings[0])
+		}
+	}
+}

--- a/internal/providers/scaleway/stackhazards.go
+++ b/internal/providers/scaleway/stackhazards.go
@@ -1,0 +1,44 @@
+package scaleway
+
+import "strings"
+
+// StackHazards names what, in the text of a Terraform configuration, is
+// measured to reach the real cloud no matter where SCW_API_URL or api_url
+// point. The CLI hands in the stack's comment-stripped text; every signature
+// here is a measurement, not a guess:
+//
+//   - scaleway_object_* resources: the provider hardcodes
+//     https://s3.<region>.scw.cloud in newS3Client (no env var, no attribute —
+//     the docs/limits.md table), so their calls ignore the redirect entirely.
+//     Measured live on a surveyed stack (#262, ioandev/scaleway-flatcar-k3s):
+//     CreateBucket went to the real endpoint and only the fake credentials'
+//     403 made it harmless. Reproduced for #280 with egress cut to a dead
+//     proxy: the same apply created its instance IP on the emulator and died
+//     on `Put "https://<bucket>.s3.fr-par.scw.cloud/"` — one run, half local,
+//     half not, indistinguishable from outside.
+//   - a literal *.scw.cloud host: whatever names it (an S3 state backend as in
+//     CentraleSupelec/kubic, an aws provider block) sends those requests to
+//     that host by construction — an emulator on 127.0.0.1 never sees them.
+//
+// TestStackHazardsNameTheObjectStorageEscape fails without the first check,
+// TestStackHazardsNameARealHost without the second, and a clean stack must
+// return nil: a warning that fires on a healthy configuration teaches people
+// to ignore the one that matters.
+func (p *Pack) StackHazards(config string) []string {
+	var warnings []string
+	if strings.Contains(config, `"scaleway_object`) {
+		warnings = append(warnings,
+			"this configuration carries scaleway_object_* (Object Storage): the Terraform provider "+
+				"hardcodes https://s3.<region>.scw.cloud for that product, so those calls leave for the "+
+				"real cloud with whatever credentials the run holds — measured on a surveyed stack, where "+
+				"only a 403 on fake credentials made it harmless (#262). Keep Object Storage out of an "+
+				"emulated run, or cut egress first: docs/limits.md, \"A run presented as local\"")
+	}
+	if strings.Contains(config, ".scw.cloud") {
+		warnings = append(warnings,
+			"this configuration names a real *.scw.cloud host: requests to it go there, never to this "+
+				"emulator. An S3 state backend is the measured shape. Check the mention is deliberate "+
+				"before treating the run as local (docs/limits.md, \"A run presented as local\")")
+	}
+	return warnings
+}

--- a/internal/providers/scaleway/stackhazards_test.go
+++ b/internal/providers/scaleway/stackhazards_test.go
@@ -1,0 +1,69 @@
+package scaleway_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/providers/scaleway"
+)
+
+// The escape behind every assertion here was measured live (#262): a surveyed
+// stack pointed at this emulator through SCW_API_URL sent its CreateBucket to
+// the real s3.fr-par.scw.cloud, and only the fake credentials' 403 made it
+// harmless. Reproduced for #280 with egress cut to a dead proxy: the same
+// apply created its instance IP locally and died on
+// `Put "https://<bucket>.s3.fr-par.scw.cloud/"`.
+
+// A stack carrying any scaleway_object_* resource reaches the real cloud, so
+// its text must warn — and a stack without one must stay silent, because a
+// warning that fires on a healthy configuration teaches people to ignore the
+// one that matters.
+func TestStackHazardsNameTheObjectStorageEscape(t *testing.T) {
+	pack := scaleway.New(nil)
+
+	clean := `
+resource "scaleway_instance_ip" "local" {}
+resource "scaleway_instance_server" "local" {
+  type  = "DEV1-S"
+  image = "ubuntu_jammy"
+}
+`
+	if warnings := pack.StackHazards(clean); len(warnings) != 0 {
+		t.Fatalf("a stack the emulator fully serves was warned about: %v", warnings)
+	}
+
+	for _, escape := range []string{
+		`resource "scaleway_object_bucket" "state" { name = "x" }`,
+		`resource "scaleway_object_bucket_policy" "p" {}`,
+		`data "scaleway_object_bucket" "existing" { name = "x" }`,
+	} {
+		warnings := pack.StackHazards(escape)
+		if len(warnings) == 0 {
+			t.Fatalf("an Object Storage resource went unnamed; that stack's apply reaches the real cloud: %s", escape)
+		}
+		if !strings.Contains(warnings[0], "scaleway_object") || !strings.Contains(warnings[0], "s3.<region>.scw.cloud") {
+			t.Fatalf("the warning names neither the resource family nor where it goes: %q", warnings[0])
+		}
+	}
+}
+
+// A literal *.scw.cloud host in the text — an S3 state backend is the surveyed
+// shape (CentraleSupelec/kubic) — sends those requests there by construction.
+func TestStackHazardsNameARealHost(t *testing.T) {
+	pack := scaleway.New(nil)
+	config := `
+terraform {
+  backend "s3" {
+    endpoint = "https://s3.fr-par.scw.cloud"
+    bucket   = "tf-state"
+  }
+}
+`
+	warnings := pack.StackHazards(config)
+	if len(warnings) == 0 {
+		t.Fatal("a real *.scw.cloud host went unnamed; terraform init contacts it before any resource")
+	}
+	if !strings.Contains(warnings[0], ".scw.cloud") {
+		t.Fatalf("the warning does not name the host family it found: %q", warnings[0])
+	}
+}

--- a/tools/falsify/specs/escape-signatures.json
+++ b/tools/falsify/specs/escape-signatures.json
@@ -1,0 +1,36 @@
+{
+  "package": "./internal/providers/scaleway/",
+  "mutations": [
+    {
+      "label": "the Object Storage signature never matches: a stack carrying scaleway_object_* gets no warning, and its apply reaches the real s3.<region>.scw.cloud exactly as #262 measured, with nothing said beforehand",
+      "file": "internal/providers/scaleway/stackhazards.go",
+      "find": "\tif strings.Contains(config, `\"scaleway_object`) {",
+      "replace": "\tif strings.Contains(config, `\"scaleway_object_never`) {",
+      "test": "TestStackHazardsNameTheObjectStorageEscape"
+    },
+    {
+      "label": "the *.exo.io signature never matches: an S3-on-SOS state backend or an aws provider pointed at sos-<zone>.exo.io goes unnamed, the two surveyed shapes of #262/#284",
+      "package": "./internal/providers/exoscale/",
+      "file": "internal/providers/exoscale/stackhazards.go",
+      "find": "\tif strings.Contains(config, \".exo.io\") {",
+      "replace": "\tif strings.Contains(config, \".exo.io.never\") {",
+      "test": "TestStackHazardsNameTheSOSEscape"
+    },
+    {
+      "label": "# comments are no longer stripped: a commented-out scaleway_object_bucket triggers the warning, which is the false positive that teaches people to ignore the true one",
+      "package": "./internal/cli/",
+      "file": "internal/cli/stack.go",
+      "find": "\t\t\tcase c == '#':\n\t\t\t\tinLineComment = true",
+      "replace": "\t\t\tcase c == '#' && false:\n\t\t\t\tinLineComment = true",
+      "test": "TestAStackHazardInACommentStaysSilent"
+    },
+    {
+      "label": "env no longer relays the stack hazards: the eval prints its exports and says nothing about the resource next to it that ignores them all",
+      "package": "./internal/cli/",
+      "file": "internal/cli/env.go",
+      "find": "\t\tif hazards, ok := pack.(packStackHazards); ok {",
+      "replace": "\t\tif hazards, ok := pack.(packStackHazards); ok && false {",
+      "test": "TestEnvNamesTheEscapeInTheStackNextToIt"
+    }
+  ]
+}


### PR DESCRIPTION
# Summary

A run presented as local can still reach the real cloud, and until now only a
403 on fake credentials revealed it (#280). This change does the three things
the issue asks for, in its order of value, and every claim in it was measured
before being written.

**The escape, reproduced first.** A minimal stack pointed here through
`SCW_API_URL`, carrying one `scaleway_object_bucket`, with egress routed to a
dead proxy (the #284 technique — the attempt is visible and cannot succeed):
the apply created its instance IP **on the emulator** and sent `CreateBucket`
to the real endpoint:

```text
Error: … CreateBucket, … Put "https://feint-escape-repro.s3.fr-par.scw.cloud/":
proxyconnect tcp: dial tcp 127.0.0.1:9: connect: connection refused
```

One run, half local, half not. From that stack's own directory, `feint doctor`
and `feint env scaleway` said nothing.

**1. Say it plainly, where it is read.** README, README.fr and
docs/adoption.md now carry the sentence that is true — *the APIs Feint serves
run locally; a product outside that scope is reached by its client at the real
endpoint* — with a link to the new limits section that names every measured
path. The safety banner's limits count moved 36 → 37 (`feint docs`).

**2. Detect the escape.** The emulator cannot see a request that never
arrives, so detection reads the stack's own text before the run. Packs declare
measured signatures through `packStackHazards` (the `packEnvHazards` pattern
of #286); `feint doctor` and `feint env`, run from the stack directory, scan
`*.tf` / `*.tf.json` / `*.tofu` (comment-stripped, dot-directories skipped,
bounded) and relay the pack's warning — stderr for env, a warn row (never a
failure) for doctor:

- Scaleway: `scaleway_object_*` (the provider hardcodes
  `s3.<region>.scw.cloud`; measured live in #262) and literal `*.scw.cloud`
  hosts (the kubic state-backend shape);
- Exoscale: literal `*.exo.io` hosts (SOS — the platform aws-provider shape
  and the eu-data S3-on-SOS backend, #262/#284);
- Outscale: nothing config-side — its measured escape (`OSC_PROFILE`) lives in
  the shell and has warned since #286. The Exoscale split-client escape stays
  where it is already stopped: at the emulator's door, by user agent.

**No noise, shown.** A directory without Terraform files produces no output at
all; a commented-out resource stays silent (all three HCL comment forms,
tested); the repository's own 15 fixture files scan clean, including the
conformance fixture whose comments name `s3.<region>.scw.cloud`.

**3. Decide honestly what is out of reach.** Written in docs/limits.md rather
than implied: the scan is a measured list and says so in its own `ok` row; it
cannot see runtime values (`-backend-config`), modules fetched at init, or the
next product that composes its endpoint upstream. In general the escape is
undetectable from inside the emulator, and an approximate guard would license
exactly the belief it fails to protect. The network-level recipes are tested,
not described:

- **tripwire** — `HTTPS_PROXY=http://127.0.0.1:9 NO_PROXY=127.0.0.1,localhost`:
  the escape becomes a loud failure naming its destination (output above);
  honoured, not enforced, and the doc says so;
- **boundary** — rootless `podman network create --internal`: the emulator
  answers `HTTP/1.0 200 OK` on the network while
  `connect s3.fr-par.scw.cloud:443` dies on *Network is unreachable*; measured
  caveat kept: DNS still resolves through the host's resolver, the cut is at
  connect.

**Falsified.** `tools/falsify/specs/escape-signatures.json`, four mutations,
all bite: each pack signature, the comment stripper (a pass-through makes the
commented-out resource warn — the false positive that teaches people to ignore
the true one), and the env relay.

## Type of change

- [ ] A route added or changed
- [ ] Bug fix
- [x] Refactor
- [x] Documentation
- [ ] Chore / tooling
- [x] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes (gofmt, vet, golangci-lint, `go test -race`)
- [x] No new external Go dependency, or the pull request justifies it. The
      standard library covers routing, JSON and Go parsing; `go.mod` has three
      lines and a pre-commit hook keeps it that way
- [x] `internal/core` still knows no provider. The scan mechanics live in
      `internal/cli`, the signatures in each pack; the core is untouched
- [x] Nothing in the diff could be written identically for another provider.
      The walker, the stripper and the relay are shared (`internal/cli/stack.go`);
      what each pack keeps is exactly what only it knows — which of its
      products a client reaches without asking the emulator

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
      (`Assisted-by: Claude Code (claude-fable-5)`)
- [x] I ran `mise run conformance` myself — not "it should pass"
- [x] Every field name in the diff comes from the provider's SDK, their
      OpenAPI document, or a run of the real client, and I can say which: the
      signature strings come from the survey register's measurements (#262:
      flatcar-k3s for `scaleway_object_*`, kubic for the scw.cloud backend,
      platform and eu-data-platform for `*.exo.io`) and from the reproduction
      in this pull request; the hardcoded-endpoint fact comes from the
      provider source already cited in docs/limits.md (`newS3Client`)

### When a route is added or changed — otherwise N/A

N/A — no route, no response shape, no `Route.Operation` touched. `mise run
conformance` was run anyway (above) because doctor and env changed behaviour.

### When behaviour a client can observe changes — otherwise N/A

- [x] `docs/limits.md` updated: new section *"A run presented as local can
      still reach the real cloud (#280)"*, plus a pointer from the Object
      Storage section
- [x] The README's generated tables regenerated (`feint docs` — the safety
      banner's section count follows limits.md)

### When `.github/workflows/` is touched — otherwise N/A

N/A — no workflow touched.

### When a machine runtime is involved — otherwise N/A

N/A — control-plane CLI and docs only; no runtime, nothing started that was
not stopped (the reproduction emulator ran on 127.0.0.1:4642 and was stopped;
the podman network and container were removed).

## Related issues

Closes #280
