### PR TITLE
fix(scaleway): public_ips answers in the order the create named (#320)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -29,6 +29,23 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Corrigé
 
+- **`server.public_ips` répond dans l'ordre que la création a nommé** (#320).
+  `Server.public_ips` chez Scaleway est une liste et Terraform la stocke comme
+  telle : le provider reconstruit `ip_ids` index par index depuis elle, et son
+  chemin d'application est une suite d'appels `UpdateIP` par ensembles,
+  incapable de réordonner. Un émulateur répondant les adresses attachées dans
+  l'ordre du store faisait donc replanifier sans fin la même permutation à
+  tout `ip_ids = [a, b]` dont l'ordre du store était `[b, a]` ; mesuré sur
+  `sergelogvinov/terraform-talos` au moment où ses serveurs se sont appliqués
+  pour la première fois. Chaque attachement enregistre désormais la position
+  que le client lui a donnée : à la création (`public_ips`/`public_ip`), sur
+  `UpdateServer.public_ips` (déclaré par le SDK et lu par personne ici : un
+  PATCH le nommant répondait 200 sans rien changer), et sur un attachement nu
+  par `PATCH /ips`, qui rejoint la fin de la liste. Les identifiants
+  eux-mêmes étaient déjà les UUID nus de l'API ; la moitié `id → fr-par-1/id`
+  du diff observé est le provider qui normalise son propre état, et elle part
+  avec la permutation.
+
 - **`feint start` refuse une réponse venant d'un processus qu'il n'a pas
   lancé** (#309). Avant, quand quelque chose tenait déjà l'adresse, l'enfant
   lancé mourait sur l'erreur de bind pendant que `start` prenait la réponse de

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,21 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Fixed
 
+- **`server.public_ips` answers in the order the create named** (#320).
+  Scaleway's `Server.public_ips` is a list and Terraform stores it as one: the
+  provider rebuilds `ip_ids` from it index by index, and its apply path is
+  set-based `UpdateIP` calls that cannot reorder — so an emulator answering
+  the attached addresses in store order made every `ip_ids = [a, b]` whose
+  store order was `[b, a]` re-plan the same two-way swap for ever, measured on
+  `sergelogvinov/terraform-talos` the moment its servers first applied. Each
+  attach now records the position the client gave it, on create
+  (`public_ips`/`public_ip`), on `UpdateServer.public_ips` — which was
+  declared by the SDK and read by nobody here, a PATCH naming it answered 200
+  and changed nothing — and on a bare `PATCH /ips` attach, which joins the end
+  of the list. The identifiers themselves were already the API's own bare
+  UUIDs; the `id → fr-par-1/id` half of the observed diff is the provider
+  normalising its own state, and goes with the swap.
+
 - **`feint start` refuses an answer from a process it did not spawn** (#309).
   Before, when something already held the address, the spawned child died on
   the bind error while `start` took the incumbent's health answer as the

--- a/examples/stacks/surveyed.md
+++ b/examples/stacks/surveyed.md
@@ -461,6 +461,23 @@ platform entry.
   (21 to add) and the apply stops at the same two declined walls —
   placement groups and vpc-gw — before any server names its type. Both
   seeded talos images resolve, the arm64 one included.
+- **Replayed 2026-08-19, `fix/320-address-order-and-shape`**: the fourth
+  wall, revealed the moment #285's replay let the servers apply — the
+  stack's `ip_ids = [v4.id, v6.id]` re-planned the same two-way swap for
+  ever (#320) — no longer stands. Measured through `feint proxy --record`
+  at the stack's own pin (`~> 2.43.0`) on the reduced witness of
+  instances-controlplane.tf (two reserved IPs, one server naming them
+  against their creation order): the create sends `public_ips` in the
+  config's order, the answer now carries that same order, and the witness
+  applies, plans empty and destroys. The cause was order alone:
+  `Server.public_ips` answered in store order, the provider rebuilds
+  `ip_ids` from it index by index (2.43.0 `flattenServerIPIDs`,
+  types.go:99) and its apply path is set-based `UpdateIP` calls that
+  cannot reorder. The `id → fr-par-1/id` half of the diff travels with
+  the swap: `dsf.Locality` (locality.go:10) suppresses a bare-vs-zoned
+  pair at the same index, and the bare id is what the real API serves
+  (`ServerIP.ID`, instance_sdk.go:1476). The full stack's servers still
+  wait on the placement-group wall (#285, in flight).
 
 ### 2. ioandev/scaleway-flatcar-k3s — applied in part
 

--- a/internal/providers/scaleway/ip_order_test.go
+++ b/internal/providers/scaleway/ip_order_test.go
@@ -1,0 +1,173 @@
+package scaleway_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// #320: Server.public_ips is a list, and Terraform stores it as one — the
+// provider rebuilds ip_ids index by index from it (flattenServerIPIDs,
+// provider 2.43.0 types.go:99). The emulator answered the attached addresses
+// in store order, so a create that named [b, a] read back [a, b] and the
+// talos stack re-planned the same two-way swap for ever: the apply path is
+// set-based UpdateIP calls (provider server.go:1288) and cannot reorder, so
+// the diff never converged. The order is the client's, not the store's.
+
+const ipOrderZone = "/instance/v1/zones/fr-par-1"
+
+// createFlexibleIP books one address and returns its id.
+func createFlexibleIP(t *testing.T, ts *httptest.Server) string {
+	t.Helper()
+	status, out := do(t, ts, "POST", ipOrderZone+"/ips", `{}`)
+	if status != http.StatusCreated {
+		t.Fatalf("create ip: %d %v", status, out)
+	}
+	ip, _ := out["ip"].(map[string]any)
+	id, _ := ip["id"].(string)
+	if id == "" {
+		t.Fatalf("no ip id in %v", out)
+	}
+	return id
+}
+
+// publicIPIDs reads the id of every entry the server's public_ips carries, in
+// the order the emulator serves them.
+func publicIPIDs(t *testing.T, srv map[string]any) []string {
+	t.Helper()
+	entries, _ := srv["public_ips"].([]any)
+	out := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		ip, _ := entry.(map[string]any)
+		id, _ := ip["id"].(string)
+		out = append(out, id)
+	}
+	return out
+}
+
+func wantIPOrder(t *testing.T, got, want []string, when string) {
+	t.Helper()
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("%s: public_ips order is %v, the client named %v", when, got, want)
+	}
+}
+
+// A server created with public_ips [c, a] answers [c, a] on the create
+// response and on every later GET — and [a, c] answers [a, c]: whichever
+// order the client names is the one served, so at least one of the two
+// subtests disagrees with any fixed store order.
+func TestPublicIPsKeepTheOrderTheCreateNamed(t *testing.T) {
+	ts := newTestServer(t)
+	a := createFlexibleIP(t, ts)
+	createFlexibleIP(t, ts) // b, attached to nothing: order must not lean on the full list
+	c := createFlexibleIP(t, ts)
+
+	for _, named := range [][]string{{c, a}, {a, c}} {
+		body := `{"name":"ordered","commercial_type":"DEV1-S","image":"ubuntu_jammy",` +
+			`"public_ips":["` + named[0] + `","` + named[1] + `"]}`
+		status, out := do(t, ts, "POST", ipOrderZone+"/servers", body)
+		if status != http.StatusCreated {
+			t.Fatalf("create server: %d %v", status, out)
+		}
+		srv, _ := out["server"].(map[string]any)
+		id, _ := srv["id"].(string)
+		wantIPOrder(t, publicIPIDs(t, srv), named, "create response")
+
+		// The deprecated singular is the SDK's own "first address", so it
+		// follows the named order too.
+		first, _ := srv["public_ip"].(map[string]any)
+		if firstID, _ := first["id"].(string); firstID != named[0] {
+			t.Errorf("public_ip is %s, the first named address is %s", firstID, named[0])
+		}
+
+		_, out = do(t, ts, "GET", ipOrderZone+"/servers/"+id, "")
+		srv, _ = out["server"].(map[string]any)
+		wantIPOrder(t, publicIPIDs(t, srv), named, "read after create")
+
+		// Release the pair for the next round.
+		do(t, ts, "POST", ipOrderZone+"/servers/"+id+"/action", `{"action":"terminate"}`)
+	}
+}
+
+// An address attached on its own — PATCH /ips naming the server — joins the
+// end of the list instead of shuffling what the create ordered.
+func TestALaterAttachJoinsTheEndOfTheList(t *testing.T) {
+	ts := newTestServer(t)
+	a := createFlexibleIP(t, ts)
+	b := createFlexibleIP(t, ts)
+	c := createFlexibleIP(t, ts)
+
+	_, out := do(t, ts, "POST", ipOrderZone+"/servers",
+		`{"name":"grows","commercial_type":"DEV1-S","image":"ubuntu_jammy","public_ips":["`+b+`","`+a+`"]}`)
+	srv, _ := out["server"].(map[string]any)
+	id, _ := srv["id"].(string)
+
+	if status, out := do(t, ts, "PATCH", ipOrderZone+"/ips/"+c, `{"server":"`+id+`"}`); status != http.StatusOK {
+		t.Fatalf("attach: %d %v", status, out)
+	}
+
+	_, out = do(t, ts, "GET", ipOrderZone+"/servers/"+id, "")
+	srv, _ = out["server"].(map[string]any)
+	wantIPOrder(t, publicIPIDs(t, srv), []string{b, a, c}, "read after a later attach")
+}
+
+// UpdateServer.public_ips is the SDK's "list of reserved IP IDs to attach to
+// the Instance" (instance_sdk.go:3961). It was declared upstream and read by
+// nobody here, so a PATCH naming it answered 200 and changed nothing. It now
+// makes the attachments be exactly the list, in the list's order: dropped
+// addresses detach and survive, and the response reads back the new order.
+func TestUpdateServerPublicIPsReconcilesAttachmentsInOrder(t *testing.T) {
+	ts := newTestServer(t)
+	a := createFlexibleIP(t, ts)
+	b := createFlexibleIP(t, ts)
+	c := createFlexibleIP(t, ts)
+
+	_, out := do(t, ts, "POST", ipOrderZone+"/servers",
+		`{"name":"reconciled","commercial_type":"DEV1-S","image":"ubuntu_jammy","public_ips":["`+a+`","`+b+`"]}`)
+	srv, _ := out["server"].(map[string]any)
+	id, _ := srv["id"].(string)
+
+	status, out := do(t, ts, "PATCH", ipOrderZone+"/servers/"+id, `{"public_ips":["`+c+`","`+a+`"]}`)
+	if status != http.StatusOK {
+		t.Fatalf("update: %d %v", status, out)
+	}
+	srv, _ = out["server"].(map[string]any)
+	wantIPOrder(t, publicIPIDs(t, srv), []string{c, a}, "update response")
+
+	_, out = do(t, ts, "GET", ipOrderZone+"/servers/"+id, "")
+	srv, _ = out["server"].(map[string]any)
+	wantIPOrder(t, publicIPIDs(t, srv), []string{c, a}, "read after update")
+
+	// The dropped address detached; it was not deleted, because a reserved
+	// address outlives its attachment.
+	_, out = do(t, ts, "GET", ipOrderZone+"/ips/"+b, "")
+	ip, _ := out["ip"].(map[string]any)
+	if ip["server"] != nil || ip["state"] != "detached" {
+		t.Errorf("the dropped address still carries server=%v state=%v", ip["server"], ip["state"])
+	}
+}
+
+// An unknown id in UpdateServer.public_ips is refused before anything moves:
+// a 404 that had already detached half the list would leave the server in a
+// state neither the request nor the previous one described.
+func TestUpdateServerRefusesAnUnknownPublicIPUntouched(t *testing.T) {
+	ts := newTestServer(t)
+	a := createFlexibleIP(t, ts)
+	b := createFlexibleIP(t, ts)
+
+	_, out := do(t, ts, "POST", ipOrderZone+"/servers",
+		`{"name":"kept","commercial_type":"DEV1-S","image":"ubuntu_jammy","public_ips":["`+b+`","`+a+`"]}`)
+	srv, _ := out["server"].(map[string]any)
+	id, _ := srv["id"].(string)
+
+	status, _ := do(t, ts, "PATCH", ipOrderZone+"/servers/"+id,
+		`{"public_ips":["`+a+`","00000000-dead-4000-8000-000000000000"]}`)
+	if status != http.StatusNotFound {
+		t.Fatalf("an unknown ip id answered %d, want 404", status)
+	}
+
+	_, out = do(t, ts, "GET", ipOrderZone+"/servers/"+id, "")
+	srv, _ = out["server"].(map[string]any)
+	wantIPOrder(t, publicIPIDs(t, srv), []string{b, a}, "read after the refused update")
+}

--- a/internal/providers/scaleway/ips.go
+++ b/internal/providers/scaleway/ips.go
@@ -3,8 +3,11 @@ package scaleway
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"net/http"
 	"net/netip"
+	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/stephrobert/feint/internal/core/emulator"
@@ -170,10 +173,62 @@ func emulatedAddress(address string) bool {
 	return prefix.Contains(addr)
 }
 
+// runtimeAttachSeqKey holds the position the client gave this address in the
+// list that attached it — CreateServer.public_ips, UpdateServer.public_ips, or
+// the end of the line for a PATCH /ips attach. Runtime rather than Attrs: the
+// position shapes public_ips but is not itself a field the API serves.
+//
+// It exists because Server.public_ips is a list and Terraform stores it as
+// one: the provider rebuilds ip_ids index by index from it (flattenServerIPIDs,
+// provider 2.43.0 types.go:99), so answering the same set in store order made
+// every ip_ids = [a, b] whose store order was [b, a] re-plan the same swap for
+// ever — and the apply path could not fix it, being set-based UpdateIP calls
+// that never reorder (#320).
+const runtimeAttachSeqKey = "attach-seq"
+
+// recordAttachOrder stamps the address with its position in the client-named
+// list. Every path that writes ip.Attrs["server"] writes this beside it.
+func recordAttachOrder(ip *resource.Resource, seq int) {
+	if ip.Runtime == nil {
+		ip.Runtime = map[string]string{}
+	}
+	ip.Runtime[runtimeAttachSeqKey] = strconv.Itoa(seq)
+}
+
+// attachOrderOf reads the stamped position back. An address without one — a
+// snapshot from before the stamp existed, or a hand-edited state — sorts after
+// every stamped address, in store order: deterministic, never refused, because
+// the value can only reorder a list the server already owns.
+func attachOrderOf(ip *resource.Resource) int {
+	seq, err := strconv.Atoi(ip.Runtime[runtimeAttachSeqKey])
+	if err != nil || seq < 0 {
+		return math.MaxInt
+	}
+	return seq
+}
+
+// nextAttachOrder is the position after every address the server already
+// carries: an address attached on its own joins the end of the list rather
+// than shuffling what the client already ordered.
+func (p *Pack) nextAttachOrder(serverID, zone string) int {
+	next := 0
+	for _, ip := range p.attachedIPsOf(serverID, zone) {
+		if seq := attachOrderOf(ip); seq != math.MaxInt && seq >= next {
+			next = seq + 1
+		}
+	}
+	return next
+}
+
 // attachedIPsOf lists the flexible IPs attached to a server. One walk for the
 // view, the release path, the boot and the replay — four callers, one loop,
 // because the copies had already started to disagree once (an audit found the
 // create path and updateIP setting different halves of the same link).
+//
+// The order is the client's, not the store's: the position each attach stamped
+// (recordAttachOrder), which is what makes public_ips answer in the order the
+// create named and a Terraform ip_ids list converge.
+// TestPublicIPsKeepTheOrderTheCreateNamed fails without the sort.
 func (p *Pack) attachedIPsOf(serverID, zone string) []*resource.Resource {
 	out := make([]*resource.Resource, 0, 1)
 	for _, ip := range p.env.Store.List(kindIP, resource.Tenant{Provider: Name, Zone: zone}) {
@@ -182,6 +237,9 @@ func (p *Pack) attachedIPsOf(serverID, zone string) []*resource.Resource {
 			out = append(out, ip)
 		}
 	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return attachOrderOf(out[i]) < attachOrderOf(out[j])
+	})
 	return out
 }
 
@@ -311,6 +369,7 @@ func (p *Pack) updateIP(w http.ResponseWriter, r *http.Request) {
 			p.detachAddress(r.Context(), res)
 			res.Attrs["server"] = nil
 			res.State = "detached"
+			delete(res.Runtime, runtimeAttachSeqKey)
 		} else {
 			server, ok := p.env.Store.Get(Name, kindServer, serverID)
 			if !ok || server.Tenant.Zone != zone {
@@ -321,10 +380,18 @@ func (p *Pack) updateIP(w http.ResponseWriter, r *http.Request) {
 			// the previous machine's device, and attaching elsewhere without
 			// unrouting leaves two machines claiming the same /32, the old one
 			// winning or losing by ARP order.
+			previousHolder := ""
 			if summary, _ := res.Attrs["server"].(map[string]any); summary != nil {
-				if previous, _ := summary["id"].(string); previous != "" && previous != server.ID {
+				previousHolder, _ = summary["id"].(string)
+				if previousHolder != "" && previousHolder != server.ID {
 					p.detachAddress(r.Context(), res)
 				}
+			}
+			// An address attached on its own joins the end of the server's
+			// list; one re-attached to the same server keeps its place, so a
+			// replayed PATCH cannot shuffle what the client ordered.
+			if previousHolder != server.ID || res.Runtime[runtimeAttachSeqKey] == "" {
+				recordAttachOrder(res, p.nextAttachOrder(server.ID, zone))
 			}
 			name, _ := server.Attrs["name"].(string)
 			res.Attrs["server"] = map[string]any{"id": server.ID, "name": name}
@@ -489,6 +556,7 @@ func (p *Pack) releaseAddressesOf(ctx context.Context, serverID, zone string) {
 		_ = p.env.Store.Update(Name, kindIP, ip.ID, func(stored *resource.Resource) error {
 			stored.Attrs["server"] = nil
 			stored.State = "detached"
+			delete(stored.Runtime, runtimeAttachSeqKey)
 			stored.Updated = p.env.Now()
 			return nil
 		})

--- a/internal/providers/scaleway/servers.go
+++ b/internal/providers/scaleway/servers.go
@@ -111,6 +111,12 @@ type updateServerRequest struct {
 	// run, and nothing turned that into a failure.
 	CommercialType *string                    `json:"commercial_type"`
 	Volumes        *map[string]volumeTemplate `json:"volumes"`
+	// PublicIPs is "a list of reserved IP IDs to attach to the Instance"
+	// (UpdateServerRequest.PublicIPs, instance_sdk.go:3961) — the same field
+	// the create reads, on the update door. It was declared upstream and read
+	// by nobody here, the commercial_type defect one field over: a PATCH
+	// naming it answered 200 and changed nothing (#320).
+	PublicIPs *[]string `json:"public_ips"`
 }
 
 type serverActionRequest struct {
@@ -365,32 +371,8 @@ func (p *Pack) createServer(w http.ResponseWriter, r *http.Request) {
 
 	p.env.Store.Put(rootVol)
 	p.env.Store.Put(res)
-	for _, ip := range attach {
-		// Taken from whoever held it, the way updateIP does: it unroutes the
-		// previous machine before it routes the new one. This loop set the new
-		// owner and left the old machine carrying the address, so under a
-		// runtime two machines claimed the same /32 — and the first server lost
-		// its address with no error anywhere.
-		//
-		// TestCreatingAServerDoesNotStealALiveAddress fails without this.
-		// detachAddress reads the previous holder out of the record itself, so
-		// it has to run before the record is rewritten — the first version
-		// passed it the new server, which type-checks and reads no address at
-		// all, and the falsification caught it because the test kept passing
-		// with the call removed.
-		if previous, _ := ip.Attrs["server"].(map[string]any); previous != nil {
-			if id, _ := previous["id"].(string); id != "" && id != res.ID {
-				p.detachAddress(r.Context(), ip)
-			}
-		}
-		ip.Attrs["server"] = map[string]any{"id": res.ID, "name": req.Name}
-		// The state moves with the attachment. This path used to set the server
-		// and leave the state at "detached", so every address attached at create
-		// described itself as free while carrying a machine — updateIP has always
-		// set both, and an audit found the two paths disagreeing.
-		ip.State = "attached"
-		p.env.Store.Put(ip)
-		p.attachAddress(r.Context(), ip, res)
+	for i, ip := range attach {
+		p.attachIPToServer(r.Context(), ip, res, i)
 	}
 
 	emulator.WriteJSON(w, http.StatusCreated, map[string]any{"server": p.view(res)})
@@ -485,6 +467,17 @@ func (p *Pack) updateServer(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		volumesView, _ = res.Attrs["volumes"].(map[string]any)
+	}
+
+	// Like the volume moves above: the attachments live on the IP resources
+	// and the reconciliation talks to the runtime, so it cannot run inside the
+	// store lock. The order of the list is part of what is being written —
+	// public_ips answers in this order from now on (#320).
+	if req.PublicIPs != nil {
+		if badID, ok := p.setServerIPs(r.Context(), res, *req.PublicIPs); !ok {
+			writeNotFound(w, "ip", badID)
+			return
+		}
 	}
 
 	// Inside the store lock: the clone-mutate-Commit shape this replaces
@@ -966,6 +959,80 @@ func (p *Pack) publicIPsOf(server *resource.Resource) []any {
 		out = append(out, serverIPView(server.Runtime[runtimeDynamicIPIDKey], address, true))
 	}
 	return out
+}
+
+// attachIPToServer gives the server one flexible IP, at position seq in its
+// public_ips list. One body for the create loop and the update reconciliation,
+// because the attach mechanics had already diverged between two paths once
+// (create left State at "detached" while updateIP set it).
+//
+// Taken from whoever held it, the way updateIP does: it unroutes the previous
+// machine before it routes the new one. Setting the new owner without that
+// left the old machine carrying the address, so under a runtime two machines
+// claimed the same /32 — and the first server lost its address with no error
+// anywhere.
+//
+// TestCreatingAServerDoesNotStealALiveAddress fails without this.
+// detachAddress reads the previous holder out of the record itself, so it has
+// to run before the record is rewritten — the first version passed it the new
+// server, which type-checks and reads no address at all, and the falsification
+// caught it because the test kept passing with the call removed.
+func (p *Pack) attachIPToServer(ctx context.Context, ip, server *resource.Resource, seq int) {
+	if previous, _ := ip.Attrs["server"].(map[string]any); previous != nil {
+		if id, _ := previous["id"].(string); id != "" && id != server.ID {
+			p.detachAddress(ctx, ip)
+		}
+	}
+	name, _ := server.Attrs["name"].(string)
+	ip.Attrs["server"] = map[string]any{"id": server.ID, "name": name}
+	// The state moves with the attachment. The create path used to set the
+	// server and leave the state at "detached", so every address attached at
+	// create described itself as free while carrying a machine — updateIP has
+	// always set both, and an audit found the two paths disagreeing.
+	ip.State = "attached"
+	// The position travels with the attachment too: public_ips answers in the
+	// order the client named, not the order the store holds (#320).
+	recordAttachOrder(ip, seq)
+	p.env.Store.Put(ip)
+	p.attachAddress(ctx, ip, server)
+}
+
+// setServerIPs makes the server's attached flexible IPs be exactly the given
+// list, in the given order — which is what the field means upstream: "A list
+// of reserved IP IDs to attach to the Instance" (UpdateServerRequest.PublicIPs,
+// instance_sdk.go:3961). An address dropped from the list detaches; it is not
+// deleted, because on Scaleway a reserved address outlives its attachment.
+//
+// An unknown id is refused before anything is written, so a 404 cannot leave
+// the reconciliation half-done.
+func (p *Pack) setServerIPs(ctx context.Context, server *resource.Resource, ids []string) (badID string, ok bool) {
+	attach := make([]*resource.Resource, 0, len(ids))
+	wanted := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		ip, found := p.env.Store.Get(Name, kindIP, id)
+		if !found || ip.Tenant.Zone != server.Tenant.Zone {
+			return id, false
+		}
+		attach = append(attach, ip)
+		wanted[ip.ID] = true
+	}
+	for _, ip := range p.attachedIPsOf(server.ID, server.Tenant.Zone) {
+		if wanted[ip.ID] {
+			continue
+		}
+		p.detachAddress(ctx, ip)
+		_ = p.env.Store.Update(Name, kindIP, ip.ID, func(stored *resource.Resource) error {
+			stored.Attrs["server"] = nil
+			stored.State = "detached"
+			delete(stored.Runtime, runtimeAttachSeqKey)
+			stored.Updated = p.env.Now()
+			return nil
+		})
+	}
+	for i, ip := range attach {
+		p.attachIPToServer(ctx, ip, server, i)
+	}
+	return "", true
 }
 
 // serverIPView is one ServerIP entry. routed_ip_enabled is this emulator's

--- a/tools/conformance/scaleway/terraform.sh
+++ b/tools/conformance/scaleway/terraform.sh
@@ -124,6 +124,17 @@ case "$ipv6_subnet" in
   *) fail "expected a unique-local /64 in ipv6_subnets, got '$ipv6_subnet'" ;;
 esac
 
+# public_ips answers in the order the create named, asked of the emulator
+# directly (#320): the fixture reserves two addresses and names them in the
+# opposite of their creation order, so an emulator that serves store order
+# fails here — and re-plans the same ip_ids swap for ever in any stack that
+# orders a list, which is how sergelogvinov/terraform-talos found it.
+echo "- public_ips keeps the order the create named"
+named="$("$TF" output -json ordered_ip_ids | jq -r '[.[] | split("/") | last] | join(",")')"
+served="$(curl -s "$ENDPOINT/instance/v1/zones/$ZONE/servers/$server_uuid" | jq -r '[.server.public_ips[].id] | join(",")')"
+[ "$served" = "$named" ] || fail "the create named [$named], the emulator serves [$served]"
+ok "served in the client's order: $served"
+
 route_id="$("$TF" output -raw route_id)"
 route_uuid="${route_id##*/}"
 code="$(curl -s -o /dev/null -w '%{http_code}' "$ENDPOINT/vpc/v2/regions/fr-par/routes/$route_uuid")"

--- a/tools/conformance/scaleway/terraform/main.tf
+++ b/tools/conformance/scaleway/terraform/main.tf
@@ -191,10 +191,30 @@ data "scaleway_block_snapshot" "by_name" {
   zone = "fr-par-1"
 }
 
+# Two reserved addresses the server below names in the opposite of their
+# creation order — the sergelogvinov/terraform-talos ip_ids pattern (#320).
+# Server.public_ips is a list the provider stores index by index, so an
+# emulator answering it in store order made every such stack re-plan the same
+# two-way swap for ever; the apply path is set-based UpdateIP calls and cannot
+# reorder, so the diff never converged. The depends_on forces the creation
+# order, so a regression is a deterministic second-plan diff rather than a
+# coin-flip on two same-second timestamps.
+resource "scaleway_instance_ip" "ordered_first" {
+  zone = "fr-par-1"
+}
+
+resource "scaleway_instance_ip" "ordered_second" {
+  zone       = "fr-par-1"
+  depends_on = [scaleway_instance_ip.ordered_first]
+}
+
 resource "scaleway_instance_server" "conformance" {
   name = "conformance-tf"
   type = "DEV1-S"
   zone = "fr-par-1"
+
+  # Named against the store: the second-created address first (#320).
+  ip_ids = [scaleway_instance_ip.ordered_second.id, scaleway_instance_ip.ordered_first.id]
 
   # The path both defects lived on: the provider attaches it at create and
   # detaches it at destroy, through terminate rather than delete.
@@ -265,6 +285,13 @@ output "volume_id" {
 
 output "ipam_ip_id" {
   value = scaleway_ipam_ip.conformance.id
+}
+
+# The two reserved addresses in the order the server named them, so the suite
+# can ask the emulator — not the state file — whether public_ips serves the
+# client's order (#320).
+output "ordered_ip_ids" {
+  value = [scaleway_instance_ip.ordered_second.id, scaleway_instance_ip.ordered_first.id]
 }
 
 output "route_id" {

--- a/tools/falsify/specs/scaleway-ip-order.json
+++ b/tools/falsify/specs/scaleway-ip-order.json
@@ -1,0 +1,33 @@
+{
+  "package": "./internal/providers/scaleway/",
+  "mutations": [
+    {
+      "label": "attachedIPsOf serves store order again, and a create that named [c, a] reads back [a, c] — the talos two-way swap that never converges (#320)",
+      "file": "internal/providers/scaleway/ips.go",
+      "find": "\t\treturn attachOrderOf(out[i]) < attachOrderOf(out[j])",
+      "replace": "\t\treturn attachOrderOf(out[i]) < attachOrderOf(out[j]) && false",
+      "test": "TestPublicIPsKeepTheOrderTheCreateNamed"
+    },
+    {
+      "label": "the attach stops stamping the client's position, so every address ties at zero and the stable sort falls back to store order (#320)",
+      "file": "internal/providers/scaleway/servers.go",
+      "find": "\trecordAttachOrder(ip, seq)",
+      "replace": "\trecordAttachOrder(ip, seq*0)",
+      "test": "TestPublicIPsKeepTheOrderTheCreateNamed"
+    },
+    {
+      "label": "a later PATCH /ips attach lands at position zero instead of the end, shuffling what the create ordered (#320)",
+      "file": "internal/providers/scaleway/ips.go",
+      "find": "\treturn next",
+      "replace": "\treturn next * 0",
+      "test": "TestALaterAttachJoinsTheEndOfTheList"
+    },
+    {
+      "label": "UpdateServer.public_ips is declared and read by nobody again: the PATCH answers 200 and changes nothing, which is the lying half of #320",
+      "file": "internal/providers/scaleway/servers.go",
+      "find": "\tif req.PublicIPs != nil {\n\t\tif badID, ok := p.setServerIPs(r.Context(), res, *req.PublicIPs); !ok {",
+      "replace": "\tif req.PublicIPs != nil && false {\n\t\tif badID, ok := p.setServerIPs(r.Context(), res, *req.PublicIPs); !ok {",
+      "test": "TestUpdateServerPublicIPsReconcilesAttachmentsInOrder"
+    }
+  ]
+}


### PR DESCRIPTION
# Summary

`server.public_ips` forgot the order the create named, and every Terraform
stack ordering `ip_ids` re-planned the same two-way swap for ever (#320) —
revealed by the #285 replay of `sergelogvinov/terraform-talos`, the first in
which its servers actually applied.

**Measured, not assumed.** `feint proxy --record` between the real provider
(at the stack's own pin, `~> 2.43.0`) and the emulator, on the reduced witness
of `instances-controlplane.tf`: the create sent `public_ips` in the config's
order, the answer came back in store order. The two flexible IPs are created
in parallel, their timestamps tie, and `Store.List` breaks the tie by ID — a
coin flip per apply.

**Which of the two suspected causes was real: the order, alone.** The
provider's own source closes the case:

- the read rebuilds `ip_ids` index by index from `Server.public_ips`
  (`flattenServerIPIDs`, provider 2.43.0 `internal/services/instance/types.go:99`);
- the apply path is set-based `UpdateIP` calls (`server.go:1288`) that cannot
  reorder — with the same set attached it issues no call at all, so applying
  the "fix" changed nothing and the next plan asked again;
- the `id → fr-par-1/id` half of the diff goes with the swap: every `ip_ids`
  element carries `DiffSuppressFunc: dsf.Locality` (`server.go:198-207`,
  `internal/dsf/locality.go:10`), which equates a bare and a zoned id at the
  same index. The bare form is what the real API serves — `ServerIP.ID` is
  "unique ID of the IP address" (`.upstream/scaleway-sdk-go/api/instance/v1/instance_sdk.go:1474-1476`)
  — so the identifier's shape was never the defect.

**The fix is the #268/#276 model applied to a list: request → store →
response.** Each attach records the position the client gave it (in the IP's
`Runtime`, beside the attachment it orders), and `attachedIPsOf` serves that
order:

- `CreateServer.public_ips` / the deprecated singular stamp 0..n-1;
- `UpdateServer.public_ips` (`instance_sdk.go:3961-3962`) is read at last —
  declared upstream, read by nobody here, a PATCH naming it answered 200 and
  changed nothing. It now makes the attachments be exactly the list, in the
  list's order; an unknown id is a 404 before anything moves;
- a bare `PATCH /ips` attach joins the end of the list; a re-attach to the
  same server keeps its place;
- an unstamped address (pre-#320 snapshot) sorts last, in store order —
  deterministic, never refused.

**Proof.** The witness converges: applied, second plan empty (exit 0),
destroyed, through the recording proxy. Unit tests name both orders, the
later attach, the update reconciliation, and the untouched-on-404 refusal
(`ip_order_test.go`). The conformance fixture reserves two addresses, forces
their creation order with `depends_on`, names them reversed, and
`terraform.sh` asks the emulator — not the state file — for the served order.
`mise run conformance` passes end to end (no `FEINT_VM`). Falsified:
`tools/falsify/specs/scaleway-ip-order.json`, four mutations, all four bit
("the test bit" ×4, restoration green, `falsify:lint` green).

**Sweep for siblings (the #276 rule).** `ipam_ip_ids` on a private NIC is the
only other client-ordered list rebuilt from a store walk, and the provider
never sets it on read (2.81.0 `private_nic.go`), so it cannot diff today.
Every other identifier this pack serves is already the API's bare UUID.

**Coordination.** The full talos stack still waits on the placement-group
wall (#285, in flight); `examples/stacks/surveyed.md` records both facts. No
file overlap expected beyond `servers.go` if #285 touches the same view —
flagged to the coordinator.

## Type of change

- [ ] A route added or changed
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes (gofmt, vet, golangci-lint, `go test -race`)
- [x] No new external Go dependency, or the pull request justifies it. The
      standard library covers routing, JSON and Go parsing; `go.mod` has three
      lines and a pre-commit hook keeps it that way
- [x] `internal/core` still knows no provider. If a change seemed to require it,
      the pack changed instead — the order stamp lives in the Scaleway pack, on
      the IP's `Runtime`
- [x] Nothing in the diff could be written identically for another provider. If
      it could, it belongs in the core — the stamp is keyed to Scaleway's
      attach doors (`public_ips`, `PATCH /ips`); Outscale and Exoscale publish
      addresses through different fields

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] I ran `mise run conformance` myself — not "it should pass" (224s, exit 0,
      on a private port; 4599 is held by another agent's runtime)
- [x] Every field name in the diff comes from the provider's SDK, their OpenAPI
      document, or a run of the real client, and I can say which:
      `public_ips` on create and update from `instance_sdk.go:2477-2478` and
      `:3961-3962`, the `ServerIP` entries from `:1472-1509`, and the wire
      order from a `feint proxy --record` transcript of provider 2.43.0

### When a route is added or changed — otherwise N/A

- [x] No route added; two existing handlers changed behaviour.
      `Route.Operation` untouched, so coverage does not move
- [x] `mise run conformance` passes — the Scaleway Terraform leg carries the
      new ordered-`ip_ids` fixture and an emulator-side order assertion
- [x] The response was validated against the provider's own API description
      (`--contracts contracts`) — the suite runs with contracts on
- [x] What the client sends is read, or refused: `UpdateServer.public_ips` was
      the declared-and-unread field, and reading it is half of this fix;
      the probe reports 0 refused-unread
- [x] `mise run drift:update` N/A — no operation added or removed;
      `mise run drift:check` green in prepush

### When behaviour a client can observe changes — otherwise N/A

- [x] `docs/limits.md` unchanged — no limit moved; the observable change is
      recorded in both changelogs
- [x] README's generated tables untouched by this change (`docs:check` green
      in prepush)

### When `.github/workflows/` is touched — otherwise N/A

N/A — no workflow touched.

### When a machine runtime is involved — otherwise N/A

N/A — control-plane ordering only; the runtime calls ride the existing
attach/detach paths unchanged, and the shared runtime on this station was
deliberately left alone.

## Related issues

Closes #320
