### PR TITLE
docs(changelog): 0.9.0 says what it served and what it was proved against

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -78,6 +78,181 @@ tag, vérification des réponses qui cherche aussi ce qui *manque*, et quinze st
 Terraform tierces appliquées contre l'émulateur. Exoscale gagne le stockage bloc
 et les instance pools.
 
+> **Cette section a été complétée le 2026-08-19, après le tag** (#326, #325).
+> Rien de ce qui était déjà écrit plus bas n'a été modifié, et ni le tag, ni les
+> binaires, ni l'image n'ont bougé : seul ce que cette version dit d'elle-même a
+> changé. Un consommateur aval qui fait tourner la 0.9.0 comme gate de CI sans
+> aucun credential a dû sonder les binaires v0.8.0 et v0.9.0 côte à côte pour
+> apprendre que cette version sert `instance/v2alpha1` : la chaîne n'apparaît
+> nulle part dans la section d'origine, et `2.81.0` non plus, la version du
+> provider sur laquelle la suite Scaleway a été épinglée précisément pour
+> l'exercer. Les trois blocs qui suivent sont cette moitié manquante. Ils sont
+> dérivés de `coverage/*-coverage.json` aux deux tags plutôt que rédigés de
+> mémoire, ce qui est la seule raison pour laquelle on peut s'y fier à cette
+> distance.
+
+### Ce que cette version sert et que la 0.8.0 ne servait pas *(consigné le 2026-08-19)*
+
+Dérivé de `coverage/<provider>-coverage.json` tel que versionné à `v0.8.0` et à
+`v0.9.0` : une opération compte comme nouvellement servie quand son statut passe
+à `implemented`, depuis `declined` ou depuis la colonne non triée. Les totaux
+concordent avec le bloc de couverture généré dans le README de chaque tag (220
+routes montées, puis 285).
+
+| Provider | Servies en 0.8.0 | Servies en 0.9.0 | Nouvellement servies | Non triées en 0.8.0 |
+|---|---|---|---|---|
+| Scaleway | 102 / 315 | 107 / 315 | 5 | 0 |
+| Outscale | 72 / 263 | 85 / 263 | 13 | 18 |
+| Exoscale | 46 / 374 | 93 / 374 | 47 | 75 |
+| **Total** | **220** | **285** | **65** | **93** |
+
+Une partie de ces opérations est décrite en prose plus bas : #12 pour le stockage
+bloc Exoscale, #232 pour les instance pools, #161 pour les réseaux privés, #172
+pour la moitié en place d'Outscale et les DHCP options. **Aucune n'était nommée
+en tant qu'opération**, et le nom d'opération dans le dialecte du provider est
+exactement la chaîne qu'un consommateur cherche au grep le jour où son provider
+change sous lui. D'où les listes.
+
+- **Scaleway, 5 opérations, et le seul changement de statut de cette surface
+  entre les deux tags : les interfaces de réseau privé `instance/v2alpha1`**
+  (#257, #260). `CreatePrivateNetworkInterface`,
+  `DeletePrivateNetworkInterface`, `GetPrivateNetworkInterface`,
+  `ListPrivateNetworkInterfaces`, `UpdatePrivateNetworkInterface`, déclinées en
+  0.8.0, servies ici.
+
+  Ce que cela vaut pour un consommateur : `scaleway/scaleway` 2.81.0, publié le
+  2026-08-17, *crée* toujours une NIC privée par `instance/v1` mais la lit, la
+  crée et la supprime par `instance/v2alpha1/private-network-interfaces`, où
+  l'interface est une ressource de premier niveau portant `server_id` au lieu
+  d'être une sous-ressource du serveur. Contre la 0.8.0, cet apply se termine
+  sur un 501. Une lane épinglée à 2.80.0 ou en dessous pour rester verte contre
+  la 0.8.0 peut passer à 2.81.0 contre cette version, et
+  `tools/conformance/scaleway/terraform/main.tf` épingle exactement 2.81.0,
+  pour que la suite exerce ces cinq opérations plutôt qu'une version qui ne les
+  appelle jamais.
+
+- **Outscale, 13 opérations**, toutes les treize sorties de la colonne non
+  triée (#172, #177, #198) : `AcceptNetPeering`, `CreateDhcpOptions`,
+  `CreateNetPeering`, `DeleteDhcpOptions`, `DeleteNetPeering`,
+  `LinkPrivateIps`, `ReadNetPeerings`, `RejectNetPeering`, `UnlinkPrivateIps`,
+  `UpdateNet`, `UpdateNic`, `UpdateRouteTableLink`, `UpdateSubnet`. Les cinq
+  restantes ont quitté cette colonne par l'autre porte, déclinées nommément :
+  `CheckAuthentication`, et les quatre opérations `NetAccessPoint`.
+
+- **Exoscale, 47 opérations**, toutes les quarante-sept sorties de la colonne
+  non triée (#12, #161, #173, #232) : la famille du stockage bloc
+  (`create-block-storage-volume`, `get-block-storage-volume`,
+  `list-block-storage-volumes`, `update-block-storage-volume`,
+  `resize-block-storage-volume`, `delete-block-storage-volume`,
+  `attach-block-storage-volume-to-instance`, `detach-block-storage-volume`,
+  `create-block-storage-snapshot`, `get-block-storage-snapshot`,
+  `list-block-storage-snapshots`, `update-block-storage-snapshot`,
+  `delete-block-storage-snapshot`), les instance pools
+  (`create-instance-pool`, `get-instance-pool`, `list-instance-pools`,
+  `update-instance-pool`, `scale-instance-pool`, `evict-instance-pool-members`,
+  `reset-instance-pool-field`, `delete-instance-pool`), les réseaux privés
+  (`create-private-network`, `get-private-network`, `list-private-networks`,
+  `update-private-network`, `reset-private-network-field`,
+  `delete-private-network`, `attach-instance-to-private-network`,
+  `detach-instance-from-private-network`,
+  `update-private-network-instance-ip`), les snapshots et les templates
+  (`create-snapshot`, `get-snapshot`, `list-snapshots`, `delete-snapshot`,
+  `revert-instance-to-snapshot`, `promote-snapshot-to-template`,
+  `copy-template`, `register-template`, `update-template`, `delete-template`),
+  et `add-external-source-to-security-group`,
+  `remove-external-source-from-security-group`, `enable-tpm`, `list-events`,
+  `get-organization`, `reset-elastic-ip-field`, `reset-instance-field`.
+
+  Vingt-huit autres ont quitté la colonne non triée déclinées nommément (#173,
+  #300) : les onze opérations NLB, les seize opérations VPC marquées `[BETA]`,
+  et `export-snapshot`.
+
+**Rien de ce que cette version a cessé de servir.** Aucune opération n'est
+passée de `implemented` à `declined` entre les deux tags, et aucune opération
+n'a quitté la surface amont d'aucun provider. C'est la direction la plus
+dangereuse, et elle est énoncée ici plutôt que laissée à déduire d'un silence.
+
+### Trois refus qu'un consommateur tenait pour acquis : deux avaient déjà disparu *(consigné le 2026-08-19)*
+
+Le même rapport aval listait trois refus qu'il approuvait et dont il ne demandait
+pas la levée. Mesuré contre les artefacts, **deux des trois avaient été levés
+avant la sortie de la 0.9.0, et le troisième tient toujours dans cette version**.
+Un refus retiré porte autant qu'une route ajoutée : le consommateur continue de
+construire autour d'une absence qui n'existe plus, et rien nulle part ne devient
+rouge. Ce projet ne publiait aucune des deux directions.
+
+- **Un volume racine Scaleway de type `sbs_volume` est honoré**, depuis #8, qui
+  est sorti en **0.8.0** et non ici. `tools/conformance/scaleway/terraform/main.tf`
+  déclare le bloc, et l'apply, le second plan vide et le destroy passent tous.
+  Ce qui reste surchargé, ce sont les types *locaux* (`l_ssd`, `scratch`), pour
+  la raison que `docs/limits.md` donne à ce tag : le catalogue émulé déclare
+  `volumes_constraint.min_size` à 0 et le CLI somme les volumes locaux contre
+  cette valeur, donc en attacher un ferait refuser au CLI la création qu'il
+  vient lui-même de demander. `b_ssd` ne planifie pas non plus, et c'est la
+  décision du provider depuis la 2.79, pas celle de cet émulateur.
+
+- **`ipam/v1/API.BookIP` est servie**, et avec elle `ReleaseIP`, `ReleaseIPSet`,
+  `UpdateIP`, `AttachIP`, `DetachIP` et `MoveIP`.
+  `coverage/scaleway-coverage.json` porte `BookIP` en `declined` à `v0.7.0` et
+  en `implemented` à partir de `v0.8.0` : elle a été levée par SW-4, la première
+  moitié de #11, et la 0.9.0 en a hérité. Un plan portant un `scaleway_ipam_ip`
+  fonctionne, et une adresse réservée sort du subnet du Private Network
+  lui-même au lieu d'être inventée.
+
+- **`osc/Client.CreateLoadBalancer` est toujours déclinée en 0.9.0**, et sur ce
+  point le rapport avait raison. `internal/providers/outscale/declined.go` la
+  porte à ce tag avec le reste de la famille LBU, sur la raison énoncée qu'*un
+  load balancer est un plan de données qui accepte de vraies connexions, et que
+  l'émulateur n'en a aucun*. `ReadLoadBalancers` est l'exception délibérée et
+  répond une liste vide, parce que décliner une lecture dont la réponse honnête
+  est « aucun » a cassé un `terraform destroy` mesuré. La famille est servie sur
+  `main` depuis #281, qui a atterri après ce tag ; la 0.9.0 ne la sert pas.
+
+### Les versions de clients contre lesquelles la 0.9.0 a été prouvée *(consigné le 2026-08-19)*
+
+Toute affirmation de cette note est vraie de ces clients et d'aucun autre. Ce
+sont les versions que le workflow de conformance installe et lance, lues au tag
+plutôt que de mémoire ; les chemins et numéros de ligne sont ceux de `v0.9.0`.
+
+| Client | Version | Où le nombre est écrit, à `v0.9.0` |
+|---|---|---|
+| `scw` | 2.56.3 | `.github/workflows/conformance.yml:27` (`SCW_VERSION`) |
+| Terraform | 1.13.3 | `.github/workflows/conformance.yml:28` (`TERRAFORM_VERSION`) |
+| OpenTofu | 1.12.5 | `.github/workflows/conformance.yml:356` (`TOFU_VERSION`) |
+| `oapi-cli` | 0.15.0 | `.github/workflows/conformance.yml:273` (`OAPI_VERSION`) |
+| `exo` | 1.95.6 | `.github/workflows/conformance.yml:310` (`EXO_VERSION`) |
+| provider `scaleway/scaleway` | **2.81.0, exact** | `tools/conformance/scaleway/terraform/main.tf:31`, et `examples/stacks/scaleway/main.tf:24` épingle la même |
+| provider `outscale/outscale` | `~> 1.7`, une contrainte | `tools/conformance/outscale/terraform/main.tf:19`, et `examples/stacks/outscale/main.tf:27` |
+| chaîne Go | 1.26.6 | `mise.toml:4` et `.github/workflows/conformance.yml:57` |
+
+Terraform et OpenTofu pilotent chacun les deux contraintes de provider
+ci-dessus. C'est la table que le README générait déjà à ce tag sous
+`<!-- clients:start -->`, augmentée de ses sources ; elle n'avait simplement
+jamais été portée dans le corps de la release, là où un consommateur qui choisit
+un pin la rencontrerait.
+
+Deux choses que cette table ne peut pas dire, et qu'elle ne dit pas :
+
+- **La version du provider Outscale réellement exécutée n'est pas récupérable
+  depuis ce dépôt.** La fixture énonce `~> 1.7`, aucun fichier de lock n'est
+  versionné à côté, et la résolution a eu lieu sur le runner. La contrainte est
+  un plancher documenté plutôt qu'un oubli, la génération 1.7+ lisant son
+  chemin d'endpoint depuis la valeur là où la 1.1.x l'ajoute elle-même, et
+  pointer l'émulateur sur la mauvaise génération coûte six minutes de timeout
+  plutôt qu'une erreur. Mais ce qu'un consommateur reçoit de nous ici est un
+  intervalle, pas un nombre.
+- **Aucune version du provider Terraform Exoscale n'est revendiquée, parce
+  qu'aucune n'a été prouvée.** `examples/stacks/exoscale/main.tf` n'en déclare
+  aucune, et aucun job de CI ne le fait tourner : le provider Exoscale publié
+  compile `.exoscale.com` dans l'un de ses deux clients et ne peut pas être
+  pointé sur un émulateur local (exoscale/terraform-provider-exoscale#573),
+  donc un apply se scinde entre l'émulateur et un compte payant. La preuve par
+  client du pack Exoscale dans cette version, c'est le CLI `exo` à la version
+  ci-dessus, et rien d'autre.
+
+`mise.toml` épingle la chaîne d'outils et aucun client : ce n'est donc pas une
+source pour cette table.
+
 ### Ajouté
 
 - **Une raison de refus modifiée dans un pack atteint désormais l'artefact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,173 @@ check that runs before the tag, response checks that look for what is *missing*
 as well as what is invented, and fifteen third-party Terraform stacks applied
 against the emulator. Exoscale gains block storage and instance pools.
 
+> **This section was completed on 2026-08-19, after the tag** (#326, #325).
+> Nothing already written below was changed, and neither the tag, the binaries
+> nor the image moved: only what this release says about itself did. A
+> downstream consumer running 0.9.0 as a credential-less CI gate had to probe
+> v0.8.0 and v0.9.0 side by side to learn that this release serves
+> `instance/v2alpha1` — the string appears nowhere in the original section, and
+> neither does `2.81.0`, the provider version the Scaleway suite was pinned to
+> in order to exercise it. The three blocks that follow are that missing half.
+> They are derived from `coverage/*-coverage.json` at the two tags rather than
+> remembered, which is the only reason they can be trusted at this distance.
+
+### What this release serves that 0.8.0 did not *(recorded 2026-08-19)*
+
+Derived from `coverage/<provider>-coverage.json` as committed at `v0.8.0` and at
+`v0.9.0`: an operation counts as newly served when its status moves to
+`implemented`, from `declined` or from untriaged. The totals agree with the
+generated coverage block in each tag's own README (220 routes mounted, then 285).
+
+| Provider | Served at 0.8.0 | Served at 0.9.0 | Newly served | Untriaged at 0.8.0 |
+|---|---|---|---|---|
+| Scaleway | 102 / 315 | 107 / 315 | 5 | 0 |
+| Outscale | 72 / 263 | 85 / 263 | 13 | 18 |
+| Exoscale | 46 / 374 | 93 / 374 | 47 | 75 |
+| **Total** | **220** | **285** | **65** | **93** |
+
+Some of these operations are described in prose further down — #12 for Exoscale
+block storage, #232 for instance pools, #161 for private networks, #172 for the
+Outscale in-place half and the DHCP options. **None of them was named as an
+operation**, and the operation name in the provider's own dialect is the string a
+consumer greps for when their provider changes under them. Hence the lists.
+
+- **Scaleway, 5 operations, and the only status change on that surface between
+  the two tags: `instance/v2alpha1` private network interfaces** (#257, #260).
+  `CreatePrivateNetworkInterface`, `DeletePrivateNetworkInterface`,
+  `GetPrivateNetworkInterface`, `ListPrivateNetworkInterfaces`,
+  `UpdatePrivateNetworkInterface` — declined in 0.8.0, served here.
+
+  What that is worth to a consumer: `scaleway/scaleway` 2.81.0, published
+  2026-08-17, still *creates* a private NIC through `instance/v1` and reads,
+  creates and deletes it through
+  `instance/v2alpha1/private-network-interfaces`, where the interface is a
+  top-level resource carrying `server_id` rather than a sub-resource of the
+  server. Against 0.8.0 that apply ends on a 501. A lane pinned at or below
+  2.80.0 to stay green against 0.8.0 can be moved to 2.81.0 against this
+  release — and `tools/conformance/scaleway/terraform/main.tf` pins exactly
+  2.81.0, so the suite exercises those five operations rather than a version
+  that never calls them.
+
+- **Outscale, 13 operations**, all thirteen out of the untriaged column (#172,
+  #177, #198): `AcceptNetPeering`, `CreateDhcpOptions`, `CreateNetPeering`,
+  `DeleteDhcpOptions`, `DeleteNetPeering`, `LinkPrivateIps`, `ReadNetPeerings`,
+  `RejectNetPeering`, `UnlinkPrivateIps`, `UpdateNet`, `UpdateNic`,
+  `UpdateRouteTableLink`, `UpdateSubnet`. The remaining five left that column
+  the other way, declined by name: `CheckAuthentication`, and the four
+  `NetAccessPoint` operations.
+
+- **Exoscale, 47 operations**, all forty-seven out of the untriaged column (#12,
+  #161, #173, #232): the block-storage family
+  (`create-block-storage-volume`, `get-block-storage-volume`,
+  `list-block-storage-volumes`, `update-block-storage-volume`,
+  `resize-block-storage-volume`, `delete-block-storage-volume`,
+  `attach-block-storage-volume-to-instance`, `detach-block-storage-volume`,
+  `create-block-storage-snapshot`, `get-block-storage-snapshot`,
+  `list-block-storage-snapshots`, `update-block-storage-snapshot`,
+  `delete-block-storage-snapshot`), the instance pools
+  (`create-instance-pool`, `get-instance-pool`, `list-instance-pools`,
+  `update-instance-pool`, `scale-instance-pool`, `evict-instance-pool-members`,
+  `reset-instance-pool-field`, `delete-instance-pool`), the private networks
+  (`create-private-network`, `get-private-network`, `list-private-networks`,
+  `update-private-network`, `reset-private-network-field`,
+  `delete-private-network`, `attach-instance-to-private-network`,
+  `detach-instance-from-private-network`,
+  `update-private-network-instance-ip`), the snapshots and templates
+  (`create-snapshot`, `get-snapshot`, `list-snapshots`, `delete-snapshot`,
+  `revert-instance-to-snapshot`, `promote-snapshot-to-template`,
+  `copy-template`, `register-template`, `update-template`, `delete-template`),
+  and `add-external-source-to-security-group`,
+  `remove-external-source-from-security-group`, `enable-tpm`, `list-events`,
+  `get-organization`, `reset-elastic-ip-field`, `reset-instance-field`.
+
+  Twenty-eight more left the untriaged column declined by name (#173, #300):
+  the eleven NLB operations, the sixteen `[BETA]` VPC ones, and
+  `export-snapshot`.
+
+**Nothing this release stopped serving.** No operation moved from `implemented`
+to `declined` between the two tags, and no operation left any provider's
+upstream surface. That direction is the more dangerous one and it is stated here
+rather than left to be inferred from silence.
+
+### Three declines a consumer took as settled: two had already gone *(recorded 2026-08-19)*
+
+The same downstream report listed three refusals it agreed with and was not
+asking us to change. Measured against the artefacts, **two of the three had been
+lifted before 0.9.0 shipped, and the third still stands in it**. A withdrawn
+decline is as load-bearing as an added route — a consumer keeps building around
+an absence that is no longer there, and nothing anywhere turns red — and this
+project published neither direction.
+
+- **A Scaleway root volume of type `sbs_volume` is honoured** — since #8, which
+  shipped in **0.8.0**, not here. `tools/conformance/scaleway/terraform/main.tf`
+  declares the block, and the apply, the empty second plan and the destroy all
+  pass. What stays overridden is the *local* types (`l_ssd`, `scratch`), for the
+  reason `docs/limits.md` gives at this tag: the emulated catalogue declares
+  `volumes_constraint.min_size` at 0 and the CLI sums local volumes against it,
+  so attaching one would make the CLI refuse the very creation it just asked
+  for. `b_ssd` will not plan either, and that is the provider's decision from
+  2.79 on, not this emulator's.
+
+- **`ipam/v1/API.BookIP` is served**, and with it `ReleaseIP`, `ReleaseIPSet`,
+  `UpdateIP`, `AttachIP`, `DetachIP` and `MoveIP`.
+  `coverage/scaleway-coverage.json` carries `BookIP` as `declined` at `v0.7.0`
+  and as `implemented` from `v0.8.0` on: it was lifted by SW-4, the first half
+  of #11, and 0.9.0 inherited it. A plan carrying a `scaleway_ipam_ip` works,
+  and a booked address comes out of the Private Network's own subnet rather
+  than being invented.
+
+- **`osc/Client.CreateLoadBalancer` is still declined in 0.9.0**, and this one
+  the report had right. `internal/providers/outscale/declined.go` carries it at
+  this tag with the rest of the LBU family, on the stated reason that *a load
+  balancer is a data plane accepting real connections, and the emulator has
+  none*. `ReadLoadBalancers` is the deliberate exception and answers an empty
+  list, because declining a read whose honest answer is "none" broke a measured
+  `terraform destroy`. The family is served on `main` since #281, which landed
+  after this tag; 0.9.0 does not serve it.
+
+### The client versions 0.9.0 was proved against *(recorded 2026-08-19)*
+
+Every claim in this note is true of these clients and of no others. They are the
+versions the conformance workflow installs and runs, read from the tag rather
+than remembered; the paths and line numbers are those of `v0.9.0`.
+
+| Client | Version | Where the number is written, at `v0.9.0` |
+|---|---|---|
+| `scw` | 2.56.3 | `.github/workflows/conformance.yml:27` (`SCW_VERSION`) |
+| Terraform | 1.13.3 | `.github/workflows/conformance.yml:28` (`TERRAFORM_VERSION`) |
+| OpenTofu | 1.12.5 | `.github/workflows/conformance.yml:356` (`TOFU_VERSION`) |
+| `oapi-cli` | 0.15.0 | `.github/workflows/conformance.yml:273` (`OAPI_VERSION`) |
+| `exo` | 1.95.6 | `.github/workflows/conformance.yml:310` (`EXO_VERSION`) |
+| `scaleway/scaleway` provider | **2.81.0, exact** | `tools/conformance/scaleway/terraform/main.tf:31`, and `examples/stacks/scaleway/main.tf:24` pins the same |
+| `outscale/outscale` provider | `~> 1.7`, a constraint | `tools/conformance/outscale/terraform/main.tf:19`, and `examples/stacks/outscale/main.tf:27` |
+| Go toolchain | 1.26.6 | `mise.toml:4` and `.github/workflows/conformance.yml:57` |
+
+Terraform and OpenTofu each drive both provider constraints. This is the table
+the README already generated at this tag under `<!-- clients:start -->`, plus the
+sources; it was simply never carried into the release body, where a consumer
+choosing a pin would meet it.
+
+Two things the table cannot say, and does not:
+
+- **The Outscale provider version that actually ran is not recoverable from this
+  repository.** The fixture states `~> 1.7`, no lock file is committed beside
+  it, and the resolution happened on the runner. The constraint is a documented
+  floor rather than an oversight — the 1.7+ generation reads its endpoint path
+  from the value where 1.1.x appends it, and pointing the emulator at the wrong
+  generation is a six-minute timeout rather than an error — but what a consumer
+  gets from us here is a range, not a number.
+- **No Exoscale Terraform provider version is claimed, because none was
+  proved.** `examples/stacks/exoscale/main.tf` declares none, and no CI job runs
+  it: the published Exoscale provider compiles `.exoscale.com` into one of its
+  two clients and cannot be pointed at a local emulator
+  (exoscale/terraform-provider-exoscale#573), so an apply splits between the
+  emulator and a paying account. The Exoscale pack's client proof in this
+  release is the `exo` CLI at the version above, and nothing else.
+
+`mise.toml` pins the toolchain and no client, so it is not a source for this
+table.
+
 ### Added
 
 - **A Go test can ask for a cloud, and so can a CI job** (#247, #245, #244,


### PR DESCRIPTION
Completes the `## [0.9.0]` section of both changelogs, after the tag, without
moving the tag, the binaries or the image. Only what that release says about
itself changes.

## Why

A downstream consumer (OpenAether, OpenTofu + Talos, running feint as a
**credential-less required CI gate**) went red on 2026-08-18 when Scaleway
provider 2.81.0 moved private NICs to `instance/v2alpha1`. 0.9.0 serves that
family. Its release note never says so — `v2alpha1` appears nowhere in it, and
neither does `2.81.0`, the provider version our own Scaleway suite is pinned to
in order to exercise it. So they probed v0.8.0 and v0.9.0 side by side to
recover a fact we already had, after pinning their lane to `~> 2.80.0` — which,
in their words, "stopped emulating the provider our clusters actually run".

## What the three new blocks say

All three are **derived from `coverage/*-coverage.json` at the two tags**, not
remembered — which is the only reason they can be trusted three days and
seventy-six commits later.

1. **What 0.9.0 serves that 0.8.0 did not**: 65 operations (Scaleway 5,
   Outscale 13, Exoscale 47), each named in its provider's own dialect, because
   the operation name is the string a consumer greps for when their provider
   changes under them. Several were already described in prose; **none was
   named as an operation**. Plus the direction usually left to silence:
   *nothing* stopped being served between the tags.
2. **Three declines a consumer took as settled**: two had already been lifted
   before 0.9.0 shipped (`sbs_volume` and IPAM `BookIP`, both in 0.8.0), and
   the third still stands in it (`osc/Client.CreateLoadBalancer`, lifted after
   the tag by #281). A withdrawn refusal is as load-bearing as an added route —
   a consumer keeps building around an absence that is no longer there, and
   **nothing anywhere turns red**.
3. **The client versions 0.9.0 was proved against**, each with the file and
   line it was read from at the tag: `scw` 2.56.3, Terraform 1.13.3, OpenTofu
   1.12.5, `oapi-cli` 0.15.0, `exo` 1.95.6, `scaleway/scaleway` pinned exactly
   at 2.81.0. What could not be measured is stated as such rather than guessed:
   the Outscale provider is a `~> 1.7` constraint with no committed lock file,
   so the version a runner resolved is not knowable from this repository.

## Two premises this work corrected

Both were mine, in the issues, and both **narrow** the fix:

- The v2alpha1 family did **not** arrive under a commit about other things.
  `git log --diff-filter=A` names `992bf42`, *"instance/v2alpha1 serves the
  interfaces v1 creates"*. I had used `git log -1 -- <file>`, which returns the
  last commit touching a file, not the one that added it. **The commits were
  fine; the changelog was not** — so a gate aimed at commit titles would find
  nothing.
- One of the three "stale" declines was not stale in 0.9.0. Measured against
  `main` it looked stale; measured against the tag it stands. A gate whose
  verdict is read from the working tree instead of from a tag would have
  produced the wrong answer in the direction that flatters us.

## Scope

Documentation only: no Go, no `coverage/` artefact, no workflow. The prose
already in the section is untouched; a dated header says what was added and
why. The corrected GitHub release note is regenerated from this changelog by
the release workflow's own extractor, so this PR is the single source.

## Related

Half of #326 and half of #325 — the retroactive half. The mechanisms that make
both automatic and gated are the other half, in flight for 0.10.0.
