### PR TITLE
feat(release): the doorstep gets a formula it derives, and a third party's stack gets a contract

### DIFF
--- a/.github/workflows/tap.yml
+++ b/.github/workflows/tap.yml
@@ -1,0 +1,75 @@
+name: Homebrew tap
+
+# `brew install stephrobert/feint/feint` must install the bytes the release
+# signed, and it will not do that on its own (#321).
+#
+# The decision this job carries. A binary formula needs a URL and a SHA-256 per
+# platform, and both only exist once a release is published — so either the
+# release workflow pushes them into the tap, or somebody copies them and a gate
+# refuses a stale copy. This repository has already refused the first shape
+# twice, in writing:
+#
+#   - workflow-security.yml, on the Marketplace mirror: "a push step in
+#     release.yml would need a cross-repository token this repository does not
+#     hold, and a gate wired to a secret that does not exist is the drift.yml
+#     defect all over again";
+#   - internal/cli/docs_release.go, on the generated pages: "a gate that refuses
+#     is safe; a gate that repairs the repository is a second way in".
+#
+# So the tap is filled by `mise run release:formula`, whose output is derived
+# from the release's own cosign-signed checksums.txt, and this job derives it
+# again and exits 2 on any difference. No secret beyond the default token, which
+# only reads a public repository.
+#
+# ## Why this is not on the pull-request path
+#
+# Its red is clearable only by whoever can push to the tap. A gate a contributor
+# cannot clear teaches everybody to skip it, which is the argument CLAUDE.md
+# makes for keeping `conformance` out of the pre-commit hook. Daily, so a tap
+# left behind by a release is named within a day, and on demand for whoever is
+# cutting one.
+
+on:
+  schedule:
+    - cron: '41 7 * * *'   # daily 07:41 UTC
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  tap:
+    name: The tap serves the formula this release derives
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.26.6'
+          # No go.sum to key a cache on: the zero-dependency rule keeps this
+          # module dependency-free.
+          cache: false
+
+      # Exit 2 on drift, the code every drift gate of this repository uses; 1
+      # when it could not measure, because a release that cannot be fetched is
+      # not a tap that is fine.
+      - name: The tap is not a release behind
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash --noprofile --norc tools/release/tap.sh check

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -112,7 +112,65 @@ change ni l'un ni l'autre a sa place dans `git log`.
   avec le catalogue de la version précédente, et rien dans la réponse ne
   pouvait le dire.
 
+- **`brew install stephrobert/feint/feint`, avec des empreintes dérivées de la
+  release et non recopiées** (#321). La release publiait déjà des binaires
+  macOS signés, et un lecteur macOS devait quand même trouver la page de
+  release, choisir une architecture et vérifier une somme à la main. La
+  décision que portait l'issue était *qui écrit la formule à chaque release*,
+  et la réponse n'est ni l'une ni l'autre des deux moitiés évidentes :
+  `mise run release:formula` récupère le `checksums.txt` signé par cosign de la
+  release et en **dérive** toute la formule, donc remplir le tap coûte une
+  copie et jamais une transcription ; `mise run release:tap` la dérive à
+  nouveau et sort en 2 tant que le tap sert autre chose, chaque jour
+  (`.github/workflows/tap.yml`). Une poussée depuis `release.yml` a été refusée
+  pour la raison que ce dépôt a déjà écrite deux fois : elle demanderait un
+  jeton inter-dépôt qui n'existe pas, et *un gate qui répare le dépôt est une
+  seconde porte d'entrée*. La formule installe les octets publiés et ne
+  recompile jamais : ce que Homebrew vérifie est donc ce que la release a
+  signé. Les refus sont dans `internal/release/formula.go`, falsifiés par
+  `tools/falsify/specs/homebrew-formula.json` : la liste de sommes est
+  récupérée par le réseau, donc une entrée pour laquelle la formule n'a pas de
+  plateforme l'arrête au lieu d'être ignorée, une empreinte qui n'est pas un
+  SHA-256 n'atteint jamais le fichier, et aucun nom venu de cette liste ne
+  devient une URL ou un littéral Ruby sans contrôle. Prouvé avec le vrai client
+  et non par un rendu : le 2026-08-20, contre Homebrew 5.1.15, la formule
+  dérivée placée dans un tap a installé le binaire v0.9.0 publié,
+  `feint version` a répondu `v0.9.0`, `brew test` est passé, `brew audit` n'a
+  rien signalé, et un octet retourné dans une empreinte a fait échouer la même
+  installation sur *Formula reports different checksum*. **Le tap n'existe pas
+  encore** : `mise run release:tap` sort en 2 et nomme la commande qui le
+  remplit.
+
+- **Le contrat qu'on demande à la stack d'un tiers** (#327). Un consommateur
+  aval a proposé la lane qui a trouvé la rupture Scaleway 2.81.0 comme seizième
+  stack observée, et a demandé quel contrat nous voulions qu'elle respecte. Il
+  est écrit dans `examples/stacks/README.md`, avec la décision qu'il a forcée :
+  une telle stack est **recensée et rejouée à la demande, jamais câblée dans la
+  CI de ce dépôt**. Le dépôt d'un tiers change sans notre décision, donc un gate
+  obligatoire posé dessus peut virer au rouge pour une raison que personne ici
+  n'a choisie — et un rouge que personne ne peut traiter est ce qui apprend aux
+  gens à sauter un gate. `examples/stacks/surveyed.md` consigne l'offre avec
+  ses chiffres attribués comme les leurs, et chaque case que nous ne pouvons
+  pas remplir nommée comme non mesurée.
+
 ### Corrigé
+
+- **Une stack appliquée à chaque pull request épingle le provider qui a
+  répondu, et une stack que la CI n'applique pas dit pourquoi** (la table de
+  #325, premier jour). La page générée des clients a révélé deux choses que
+  rien n'avait dites : `examples/stacks/outscale/modules/net` était appliqué à
+  chaque pull request sans déclarer la moindre contrainte de provider —
+  `terraform init -upgrade` le résolvait depuis tout le registre à chaque
+  exécution, donc l'apply prouvait que l'émulateur avait répondu à ce qui était
+  le plus récent ce matin-là, et rien de rejouable — et
+  `examples/stacks/exoscale` n'est appliqué par rien, ce qui est une bonne
+  décision écrite en prose seulement, dans trois fichiers, en trois
+  formulations, vérifiée par rien. Le module porte désormais le même plancher
+  `~> 1.7` que sa racine, et `feint docs --check` sort en 2 sur une stack
+  appliquée sans contrainte, sur une stack non appliquée que rien ne déclare,
+  et sur une déclaration visant une stack disparue ou que la CI s'est mise à
+  appliquer. La raison est imprimée sur `docs/clients.md` depuis la liste même
+  que lit le refus. Falsifié par `tools/falsify/specs/stack-proof.json`.
 
 - **`server.public_ips` répond dans l'ordre que la création a nommé** (#320).
   `Server.public_ips` chez Scaleway est une liste et Terraform la stocke comme

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,60 @@ what this project is judged on: **a response shape a client can observe**, and
   emulator on a shared port answered a probe with the previous build's
   catalogue, and nothing in the answer could say so.
 
+- **`brew install stephrobert/feint/feint`, with the digests derived from the
+  release rather than typed** (#321). The release already published signed
+  macOS binaries and a macOS reader still had to find the release page, pick an
+  architecture and verify a checksum by hand. The decision inside the issue was
+  *who writes the formula on release*, and it is answered by neither of the two
+  obvious halves: `mise run release:formula` fetches the release's own
+  cosign-signed `checksums.txt` and **derives** the whole formula from it, so
+  filling the tap costs a copy and never a transcription; `mise run release:tap`
+  derives it again and exits 2 while the tap serves anything else, daily
+  (`.github/workflows/tap.yml`). A push from `release.yml` was refused for the
+  reason this repository has already written down twice — it would need a
+  cross-repository token that does not exist, and *a gate that repairs the
+  repository is a second way in*. The formula installs the published bytes and
+  never rebuilds them, so what Homebrew verifies is what the release signed.
+  The refusals are in `internal/release/formula.go`, falsified by
+  `tools/falsify/specs/homebrew-formula.json`: a checksums list is fetched over
+  the network, so an entry the formula has no platform for stops it rather than
+  being dropped, a digest that is not a SHA-256 never reaches the file, and no
+  name from that list becomes a URL or a Ruby literal unchecked. Proved with
+  the real client rather than by rendering: on 2026-08-20 against Homebrew
+  5.1.15, the derived formula in a tap installed the published v0.9.0 binary,
+  `feint version` answered `v0.9.0`, `brew test` passed, `brew audit` reported
+  nothing, and one flipped byte in a digest made the install fail with *Formula
+  reports different checksum*. **The tap does not exist yet**: `mise run
+  release:tap` exits 2 and names the one command that fills it.
+
+- **The contract a third party's stack is asked to meet** (#327). A downstream
+  consumer offered the lane that found the Scaleway 2.81.0 break as a sixteenth
+  surveyed stack and asked what contract we wanted it to meet. It is written in
+  `examples/stacks/README.md`, with the decision it forced: such a stack is
+  **recorded and replayed on demand, never wired into this repository's CI**.
+  A third party's repository changes without our decision, so a required gate
+  over it can go red for a reason nobody here chose — and a red nobody can act
+  on is what teaches people to skip a gate. `examples/stacks/surveyed.md`
+  records the offer with its reported figures attributed as theirs and every
+  cell we cannot fill named as unmeasured.
+
 ### Fixed
+
+- **A stack applied on every pull request pins the provider that answered, and
+  a stack CI does not apply says why** (#325's table, first day). The generated
+  client page exposed two things nothing had said before:
+  `examples/stacks/outscale/modules/net` was applied on every pull request
+  while declaring no provider constraint at all — `terraform init -upgrade`
+  resolved it from the whole registry on every run, so the apply proved the
+  emulator answered whatever was newest that morning and nothing replayable —
+  and `examples/stacks/exoscale` is applied by nothing, which is a good
+  decision written only in prose, in three files, in three wordings, checked by
+  nothing. The module now carries the same `~> 1.7` floor its root does, and
+  `feint docs --check` exits 2 on a stack CI applies without a constraint, on a
+  stack CI does not apply that nothing declares, and on a declaration for a
+  stack that has disappeared or that CI has started applying. The reason is
+  printed on `docs/clients.md` from the same list the refusal reads.
+  Falsified by `tools/falsify/specs/stack-proof.json`.
 
 - **`server.public_ips` answers in the order the create named** (#320).
   Scaleway's `Server.public_ips` is a list and Terraform stores it as one: the

--- a/CONTRIBUTING.fr.md
+++ b/CONTRIBUTING.fr.md
@@ -170,6 +170,21 @@ Le tout, en quatre points :
 4. Les tests : aller-retour de cycle de vie, pagination, cloisonnement, un par
    forme d'erreur. Fuzzer tout nouveau décodeur de requête.
 
+## Proposer une stack que vous faites déjà tourner
+
+La contribution la plus utile ici n'est pas toujours du code. Une racine
+Terraform ou OpenTofu que vous faites tourner en gate obligatoire sur votre
+propre infrastructure est une preuve que nous ne pouvons pas fabriquer : elle
+change à votre rythme, contre des providers que vous résolvez à neuf, et c'est
+comme cela que la rupture du provider Scaleway 2.81.0 nous est parvenue (#325).
+
+Ce que nous demandons d'une telle stack, ce que nous en faisons, et ce que nous
+n'en faisons délibérément **pas** — non, nous ne clonerons pas votre dépôt dans
+notre CI — est écrit dans
+[`examples/stacks/README.md`](examples/stacks/README.md#offering-your-stack-what-we-ask-and-what-we-do-with-it).
+Le registre de celles déjà rejouées est
+[`examples/stacks/surveyed.md`](examples/stacks/surveyed.md).
+
 ## L'upstream a bougé
 
 Le workflow hebdomadaire ouvre une pull request quand l'API du provider change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,6 +160,19 @@ The whole of it, in four points:
 4. Tests: lifecycle round-trip, pagination, scoping, one per error shape. Fuzz any
    new request decoder.
 
+## Offering a stack you already run
+
+The most useful contribution here is not always code. A Terraform or OpenTofu
+root that you run as a required gate on your own infrastructure is evidence we
+cannot manufacture: it changes on your schedule, against providers you resolve
+fresh, and that is how the break in Scaleway provider 2.81.0 reached us (#325).
+
+What we ask of one, what we do with it, and what we deliberately do **not** do
+with it — no, we will not clone your repository in our CI — is written out in
+[`examples/stacks/README.md`](examples/stacks/README.md#offering-your-stack-what-we-ask-and-what-we-do-with-it).
+The register of the ones already replayed is
+[`examples/stacks/surveyed.md`](examples/stacks/surveyed.md).
+
 ## Upstream moved
 
 The weekly workflow opens a pull request when the provider API changes. Triaging

--- a/README.fr.md
+++ b/README.fr.md
@@ -208,6 +208,20 @@ télécharger, et ne vérifie donc rien de ce qui précède :
 go install github.com/stephrobert/feint/cmd/feint@latest
 ```
 
+### Avec Homebrew
+
+```bash
+brew install stephrobert/feint/feint
+```
+
+La formule installe le **binaire publié**, jamais une recompilation locale : la
+somme SHA-256 que Homebrew vérifie avant d'installer est donc celle que la
+release a signée. Aucune version n'est nommée ici, volontairement : `brew`
+résout la formule courante du tap. Ce que cela coûte par rapport aux commandes
+vérifiées ci-dessus est dit dans
+[`docs/install.md`](docs/install.md#with-homebrew) — Homebrew contrôle
+l'empreinte, pas la signature qui couvre la liste d'empreintes.
+
 ### Depuis les sources
 
 La version de Go des prérequis, et rien d'autre. Le module n'a **aucune

--- a/README.md
+++ b/README.md
@@ -272,6 +272,19 @@ downloads, and therefore verifies none of the above:
 go install github.com/stephrobert/feint/cmd/feint@latest
 ```
 
+### With Homebrew
+
+```bash
+brew install stephrobert/feint/feint
+```
+
+The formula installs the **published binary**, never a local rebuild, so the
+SHA-256 Homebrew verifies before installing is the one the release signed. No
+version is named here on purpose: `brew` resolves the tap's current formula, and
+[`docs/install.md`](docs/install.md#with-homebrew) says what that costs compared
+with the verified commands above — Homebrew checks the digest, not the signature
+over the digest list.
+
 ### From source
 
 The Go version in the [prerequisites](#prerequisites) table, and nothing else.

--- a/RELEASING.fr.md
+++ b/RELEASING.fr.md
@@ -122,6 +122,38 @@ enregistrée via l'API GitHub : c'est le fichier que cherche le contrôle
 plus récentes**, donc le maximum n'est atteint qu'une fois que cinq releases
 consécutives le portent.
 
+## Après le tag : le tap Homebrew
+
+Une étape que le workflow ne prend délibérément pas. Une formule binaire a
+besoin de l'URL et de la somme SHA-256 de chaque artefact publié, et ces deux
+faits n'existent qu'une fois la release en ligne : soit le workflow les pousse
+dans `stephrobert/homebrew-feint`, ce qui demande un jeton inter-dépôt que ce
+dépôt ne détient pas, soit quelqu'un les copie et un gate refuse une copie
+périmée. Ce projet a déjà refusé la première forme deux fois par écrit (le
+miroir Marketplace dans `.github/workflows/workflow-security.yml`, les pages
+générées dans `internal/cli/docs_release.go` : *un gate qui refuse est sûr ; un
+gate qui répare le dépôt est une seconde porte d'entrée*). C'est donc la
+seconde :
+
+```bash
+mise run release:formula > Formula/feint.rb   # dans le clone du tap
+```
+
+Rien n'y est tapé. `release:formula` récupère le `checksums.txt` signé par
+cosign de la release et en dérive le fichier, donc les empreintes du tap sont
+celles de la release et non leur recopie. Commiter, pousser, puis
+
+```bash
+mise run release:tap
+```
+
+répond 0. Il sort en 2 tant que le tap sert autre chose, et
+`.github/workflows/tap.yml` le lance chaque jour : un tap laissé derrière par
+une release est nommé dans la journée plutôt que deux versions plus tard. Il
+n'est pas sur le chemin des pull requests : seul celui qui peut pousser sur le
+tap peut en éteindre le rouge, et un gate dont un contributeur ne peut rien
+faire est un gate que tout le monde apprend à sauter.
+
 ## Vérifier une release
 
 N'importe qui peut vérifier qu'un binaire vient bien du workflow de ce dépôt, et

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -114,6 +114,36 @@ recorded through GitHub's API: it is the file OpenSSF Scorecard's
 *Signed-Releases* control looks for. That control scores the **five most recent**
 releases, so the maximum is only reached once five consecutive releases carry it.
 
+## After the tag: the Homebrew tap
+
+One step the workflow deliberately does not take. A binary formula needs the URL
+and the SHA-256 of each published asset, and those exist only once the release
+is up — so either the workflow pushes them into `stephrobert/homebrew-feint`,
+which needs a cross-repository token this repository does not hold, or somebody
+copies them and a gate refuses a stale copy. This project already refused the
+first shape twice in writing (the Marketplace mirror in
+`.github/workflows/workflow-security.yml`, the generated pages in
+`internal/cli/docs_release.go`: *a gate that refuses is safe; a gate that repairs
+the repository is a second way in*), so it is the second:
+
+```bash
+mise run release:formula > Formula/feint.rb   # in the tap's checkout
+```
+
+Nothing there is typed. `release:formula` fetches the release's own
+cosign-signed `checksums.txt` and derives the file from it, so the digests in
+the tap are the release's rather than a transcription of them. Commit, push, and
+
+```bash
+mise run release:tap
+```
+
+answers 0. It exits 2 while the tap serves anything else, and
+`.github/workflows/tap.yml` runs it daily so a tap left behind by a release is
+named within a day rather than two versions later. It is not on the
+pull-request path: only whoever can push to the tap can clear its red, and a
+gate a contributor cannot clear is one everybody learns to skip.
+
 ## Verifying a release
 
 Anyone can check that a binary really came from this repository's workflow, and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,8 +28,9 @@ internal/trace/             the record of one HTTP exchange, for /_feint/trace a
 internal/transcript/        turns a proxy recording into what to serve next
 internal/upstream/          talks to the real clouds, so that nothing else has to
 internal/compat/            classifies a consumer's expression across two releases (compat:check)
-internal/release/           diffs two releases' coverage artefacts and asks whether the note
-                            names what changed hands (release:surface)
+internal/release/           what a release owes its consumers: whether the note names what
+                            changed hands (release:surface), and the Homebrew formula
+                            derived from the checksums it signed (release:formula)
 internal/providers/<name>/  one pack per emulated cloud
 tools/conformance/<name>/   that provider's real clients: CLI, Terraform, OpenTofu
 coverage/, contracts/       versioned artefacts the gates read

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -36,6 +36,16 @@ The last column is derived from the conformance workflow and from
 `tools/conformance/stacks.sh`, so a fixture nothing applies cannot pass for a
 proof by sitting in the directory.
 
+Two things this table said the day it landed, which nothing had said before, and
+which are now checked rather than read. A stack CI applies must carry a provider
+constraint — an unconstrained one is resolved from the whole registry on every
+run, so the apply proves the emulator answered *something* and nothing anybody
+can replay. And a stack CI does **not** apply must be declared, with its reason,
+in `stacksRunByHand` (`internal/cli/docs_stacks.go`); `feint docs --check` exits
+2 on a stack that is neither applied nor declared, and on a declaration for a
+stack that no longer exists or that CI has started applying. The list below the
+table is that declaration, printed from the same source the refusal reads.
+
 ## The versions
 
 <!-- proved:start -->
@@ -63,7 +73,7 @@ Each row is one `required_providers` entry, read where it is written.
 | `tools/conformance/scaleway/terraform` | `scaleway/scaleway` | `2.81.0` | exact: the version that answered | yes |
 | `examples/stacks/exoscale` | `exoscale/exoscale` | — | not pinned: whatever the registry served that day | no |
 | `examples/stacks/outscale` | `outscale/outscale` | `~> 1.7` | constraint: resolved fresh on each run, so the version that answered is not knowable here | yes |
-| `examples/stacks/outscale/modules/net` | `outscale/outscale` | — | not pinned: whatever the registry served that day | yes |
+| `examples/stacks/outscale/modules/net` | `outscale/outscale` | `~> 1.7` | constraint: resolved fresh on each run, so the version that answered is not knowable here | yes |
 | `examples/stacks/scaleway` | `scaleway/scaleway` | `2.81.0` | exact: the version that answered | yes |
 
 Read the third column narrowly, because it is the one a consumer pins against.
@@ -72,6 +82,18 @@ resolved by `terraform init -upgrade` on the runner, every run, so the version
 that answered is not knowable from this repository — it is a floor, not a
 proof. **Not pinned** is not pinned: nothing here says which version ran, and
 no number is invented to fill the cell.
+
+The stacks the last column says CI does not apply are declared rather than
+merely absent, so a `no` is a decision somebody wrote down and not a stack
+nobody wired up:
+
+- `examples/stacks/exoscale` — the published Exoscale provider builds two
+  clients and only one honours `EXOSCALE_API_ENDPOINT`, so an apply splits
+  between the emulator and a paying account (docs/limits.md, upstream
+  exoscale/terraform-provider-exoscale#573). Running it needs the patched
+  fork, and no gate here clones a third-party repository — that would put
+  somebody else's availability in this pipeline. Applied by hand on
+  2026-08-18: 13 resources, empty second plan, clean destroy.
 <!-- proved:end -->
 
 ## Where else this appears

--- a/docs/install.md
+++ b/docs/install.md
@@ -105,6 +105,46 @@ That gives you the control plane — every API answers, `scw`, `oapi-cli`, `exo`
 and Terraform drive it, and nothing runs. It is what CI uses and it needs no
 prerequisite at all.
 
+## With Homebrew
+
+```bash
+brew install stephrobert/feint/feint
+```
+
+For the reader who installs everything with `brew` and does not go looking for a
+tarball. It is a **binary** formula: it downloads the published
+`feint-darwin-arm64` or `feint-darwin-amd64` — or their Linux counterparts on
+Linuxbrew — and installs those bytes. Nothing is rebuilt locally, so what
+Homebrew verifies is what the release signed, which is the same reasoning the
+container image follows.
+
+**What it checks, and what it does not.** Homebrew compares the SHA-256 of the
+file it downloaded against the digest in the formula before installing, and
+refuses on a mismatch. That is one of the two guarantees the commands above
+give: the missing one is `cosign verify-blob`, which proves *who* produced the
+digest list. So the honest ranking is that `brew` is the fastest correct
+install, and the block at the top of this page is the strongest one. A reader
+who needs the provenance runs the `gh attestation verify` command above on the
+installed binary.
+
+**The digests are derived, never typed.** The tap's formula is the output of
+`mise run release:formula`, which reads the release's own cosign-signed
+`checksums.txt` and renders the file. `.github/workflows/tap.yml` derives it
+again every day and exits 2 while the tap serves anything else — so a tap left
+behind by a release is named within a day rather than two versions later. The
+refusals that keep a fetched checksums list from becoming an arbitrary URL live
+in `internal/release/formula.go`, with the tests that fail without them.
+
+**Older versions.** The tap carries the current release only. An older one is
+still installed by the commands at the top of this page, which name their tag.
+
+**Measured, not assumed.** On 2026-08-20, Homebrew 5.1.15: the derived formula
+was put in a tap and `brew install stephrobert/feint/feint` fetched the
+published v0.9.0 binary, `feint version` answered `v0.9.0`, `brew test` passed
+and `brew audit` reported nothing. One flipped byte in a digest made the same
+install fail with *Formula reports different checksum* instead of installing —
+which is the guarantee this section claims, seen refusing.
+
 ## The container image
 
 For the CI that consumes an image rather than a binary. What it can and cannot

--- a/examples/stacks/README.md
+++ b/examples/stacks/README.md
@@ -155,6 +155,86 @@ it could not count towards conformance in any case. It was last applied by
 hand on 2026-08-18: apply, an empty second plan, destroy — 13 resources, zero
 contract violations.
 
+## Offering your stack: what we ask, and what we do with it
+
+The fifteen in [`surveyed.md`](surveyed.md) are the strongest instrument this
+project has, and their weakness is that **we chose the fifteen**. A stack whose
+authors run it as a required gate on their own infrastructure is different
+evidence: it changes without asking us, on their schedule, against providers
+they resolve fresh. One such offer arrived on 2026-08-19 ([#327]) and asked the
+right question — *tell us the contract you want it to meet* — so here it is,
+before the next one asks.
+
+### The contract
+
+1. **A public repository, a commit, and a licence that lets us replay it.**
+   "We ran your stack" names nothing without the commit it was at. Every entry
+   in the register carries repository, commit and licence for exactly this
+   reason: a reader has to be able to redo it without asking anybody.
+2. **A root somebody actually applies.** Terraform or OpenTofu, either; the
+   engine is not the point. What is the point is that the configuration exists
+   for its own sake and moves when its authors need it to. A stack written to
+   please this emulator measures this emulator against itself.
+3. **Every provider constrained, in the root and in every module.** Not
+   necessarily exact — a floor is worth having and is often *why* a lane is
+   useful, since a `~> 2.68` is what walked into Scaleway 2.81.0 and told us
+   about it. What matters is that the constraint is declared and readable, so
+   that a red lane can name which version answered. This is the one point the
+   original four did not have, and it is the one our own directory failed on:
+   `examples/stacks/outscale/modules/net` was applied on every pull request
+   while declaring no constraint at all, and nothing said so until the
+   generated table of [#325] existed. It is checked here now
+   ([`docs/clients.md`](../../docs/clients.md)), which is the least we can do
+   before asking it of somebody else.
+4. **apply → empty second plan → destroy, and the destroy on the failure path
+   too.** The middle one does the finding, and the last one is not pedantry:
+   this repository's own runner hung its cleanup on a `RETURN` trap that never
+   fired where it mattered, and every rerun after a failure then died on its own
+   leftovers instead of the defect.
+5. **No credentials at all, and no fallback to any.** Every official client in
+   these three ecosystems falls back to the operator's stored credentials when
+   an endpoint is missing, so a lane that merely *lacks* credentials is not the
+   same thing as a lane that *fails* without them. Ours reaches for the second
+   ([#280]); the offer above arrived having reached the same rule
+   independently, which is the strongest evidence either of us has that it is
+   the right one.
+6. **feint installed at a named version, verified against its checksum.** Not
+   `latest`: a mutable reference installs a binary neither of us can name
+   afterwards, which makes a red lane unattributable to anything.
+7. **A stated wall.** What the stack asks for that this emulator declines, named
+   in advance. Without it, a red that is a declined product reads as a defect,
+   and both sides spend a day finding that out.
+
+Two things the first draft of this list had and that do not survive contact:
+the **number of providers** (one is fine; two proves nothing extra) and
+**OpenTofu specifically** (point 2 covers it).
+
+### What we do with it, and what we will not
+
+**We record it and replay it on demand. We do not put it in our CI.** The
+argument is not about trust, and it is worth stating plainly because the offer
+was generous:
+
+- A third party's repository changes without our decision. A required gate that
+  can go red for a reason nobody here chose is a gate whose red we cannot act
+  on, and a gate whose red cannot be acted on is one everybody learns to skip —
+  the same reasoning that keeps `conformance` out of this repository's
+  pre-commit hook.
+- **No gate here clones a third-party repository.** That would put somebody
+  else's availability inside this project's pipeline. The rule predates this
+  offer: it is why the Exoscale stack above is run by hand.
+
+What we do instead, and it is what actually paid: **their report is evidence,
+and it is credited as theirs.** The break in Scaleway provider 2.81.0 was found
+by a downstream lane and reported to us, which is how [#325] and [#326] exist.
+A stack we had vendored ourselves would have found it whenever somebody thought
+to re-record it. So the exchange we ask for is a report when a lane goes red,
+with the transcript — not a webhook.
+
+And what we owe back: the stack named in the register with what it exercises,
+the findings credited to whoever found them, and a break we caused treated as
+ours to fix.
+
 ## What they do not prove
 
 Nothing here boots a machine, filters a packet or isolates a subnet: that
@@ -170,3 +250,7 @@ on a mode name.
 [#269]: https://github.com/stephrobert/feint/issues/269
 [#270]: https://github.com/stephrobert/feint/issues/270
 [#271]: https://github.com/stephrobert/feint/issues/271
+[#280]: https://github.com/stephrobert/feint/issues/280
+[#325]: https://github.com/stephrobert/feint/issues/325
+[#326]: https://github.com/stephrobert/feint/issues/326
+[#327]: https://github.com/stephrobert/feint/issues/327

--- a/examples/stacks/outscale/modules/net/main.tf
+++ b/examples/stacks/outscale/modules/net/main.tf
@@ -15,6 +15,16 @@ terraform {
     # died exactly there (surveyed.md, annex).
     outscale = {
       source = "outscale/outscale"
+      # The same floor the root declares, and it is not decoration. This module
+      # is applied on every pull request, and docs/clients.md read it as the one
+      # row in the table that CI applies while pinning nothing — a stack applied
+      # under whatever the registry served that morning proves nothing anybody
+      # can reproduce. Terraform intersects a child's constraint with the root's,
+      # so declaring it here is what makes the module carry its own floor when it
+      # is instantiated from somewhere else. 1.7 is the measured boundary: the
+      # 1.7+ generation reads its endpoint path from OSC_ENDPOINT_API, where
+      # 1.1.x appends the path itself (examples/stacks/surveyed.md).
+      version = "~> 1.7"
     }
   }
 }

--- a/examples/stacks/surveyed.md
+++ b/examples/stacks/surveyed.md
@@ -647,6 +647,59 @@ platform entry.
 of the three — and the least of it lands on feint's served surface: the
 public Scaleway ecosystem lives in Kapsule, RDB, LB and Object Storage.
 
+## The sixteenth, offered rather than surveyed (2026-08-19)
+
+A downstream consumer — **OpenAether**, OpenTofu plus Talos on Scaleway and
+Outscale — offered their lane as a sixteenth entry ([#327]). It is not one, and
+the distinction is the point of this register rather than a formality: **every
+entry above was replayed here**, and this one has not been. What follows is
+their report, attributed, plus the decision it forced.
+
+**Reported by them, not replayed here.** Their figures, verbatim from the report
+of 2026-08-19: Scaleway **8 applied → empty re-plan → 8 destroyed**, Outscale
+**27 applied → empty re-plan → 27 destroyed**, with feint installed pinned and
+checksum-verified and **no credentials at all, deliberately** — "if anything in
+it ever needs one, the lane must fail rather than quietly reach a real account",
+which is [#280]'s escape-path rule arrived at independently, downstream. No
+number in this paragraph is a measurement of this repository, and none is
+reconciled against one: the two lanes were run on their infrastructure, at a
+commit we do not hold.
+
+**What it has already paid for.** It is the lane that caught Scaleway provider
+2.81.0 moving private NICs onto `instance/v2alpha1` — the break that produced
+[#325] and [#326]. That is the argument for the whole category: their providers
+resolve fresh on their schedule, so the ecosystem moved under them a day before
+anybody here would have re-recorded anything.
+
+**What it exercises, as reported**: two providers in one project, a Talos
+cluster's shape on each, and the full apply → empty re-plan → destroy cycle on
+both. Which resources, in what versions, with which constraints, is not stated
+in the offer and is not guessed here.
+
+**The wall it stands at**: unknown. The report names no product feint declined
+to serve them, and an absence of complaint is not a measurement of coverage.
+
+**What is not measured**, and it is most of what an entry above carries: the
+repository URL, the commit, the licence, the provider constraints, the client
+versions, the harness, and every resource count as observed from this side. A
+row that filled those cells from the paragraph above would be the exact failure
+this register exists to avoid.
+
+**The decision (#327): recorded here, replayed on demand, and not wired into
+this repository's CI.** Two reasons, neither about trust. A third party's
+repository changes without our decision, so a required gate over it can go red
+for a reason nobody here chose — and a red nobody can act on is what teaches
+people to skip a gate. And no gate here clones a third-party repository, which
+would put somebody else's availability inside this pipeline; that rule predates
+the offer and is why the Exoscale stack is run by hand. The contract we asked
+them to meet, written for whoever offers the next one, is in
+[`README.md`](README.md#offering-your-stack-what-we-ask-and-what-we-do-with-it).
+
+[#280]: https://github.com/stephrobert/feint/issues/280
+[#325]: https://github.com/stephrobert/feint/issues/325
+[#326]: https://github.com/stephrobert/feint/issues/326
+[#327]: https://github.com/stephrobert/feint/issues/327
+
 ## The declined products these fifteen reached for, counted
 
 | provider | product/behaviour | stacks that asked | note |

--- a/internal/cli/docs.go
+++ b/internal/cli/docs.go
@@ -298,6 +298,11 @@ func docs(args []string, stdout, stderr io.Writer) int {
 	// repaired by regenerating, both need a decision.
 	problems := clientPinMismatches(*workflow, *ansible)
 	problems = append(problems, documentedAssetMismatches(releaseWorkflow, *target, *installDoc)...)
+	// And the two the generated client table exposed the day after it landed:
+	// a stack CI applies without pinning the provider that answered, and a
+	// stack CI applies with nothing, declared nowhere. Neither is repaired by
+	// regenerating, which is why they belong here rather than in the render.
+	problems = append(problems, stackProofProblems(*workflow, conformanceRoot, stacksRoot, stacksScript)...)
 	if len(problems) > 0 {
 		for _, line := range problems {
 			fmt.Fprintf(stderr, "feint: %s\n", line)

--- a/internal/cli/docs_proved.go
+++ b/internal/cli/docs_proved.go
@@ -418,13 +418,29 @@ func renderProved(workflow, root, stacks, script string) (string, error) {
 				"nothing installs", workflow, strings.Join(unused, ", "))
 	}
 
-	appliedStacks, err := stacksAppliedInCI(script, workflow)
+	pins, err := providerPinsOfRepository(workflow, root, stacks, script)
 	if err != nil {
 		return "", err
 	}
+	return renderProvedTables(versions, proofs, pins), nil
+}
+
+// providerPinsOfRepository reads every provider constraint the fixtures and the
+// stacks declare, each marked with whether a suite the conformance workflow
+// runs applies it.
+//
+// Its own function because two readers want it: the table below, and the
+// refusal in docs_stacks.go that will not let a directory be applied in CI
+// without saying which provider versions it accepts. Computing it twice would
+// be two chances for the page and the refusal to disagree about the same row.
+func providerPinsOfRepository(workflow, root, stacks, script string) ([]providerPin, error) {
+	appliedStacks, err := stacksAppliedInCI(script, workflow)
+	if err != nil {
+		return nil, err
+	}
 	appliedFixtures, err := fixturesAppliedInCI(root, workflow)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	driven := func(dir string) bool {
 		if appliedFixtures[dir] {
@@ -446,13 +462,17 @@ func renderProved(workflow, root, stacks, script string) (string, error) {
 
 	fixturePins, err := providerPins(root, driven)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	stackPins, err := providerPins(stacks, driven)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
+	return append(fixturePins, stackPins...), nil
+}
 
+// renderProved builds the page, continued.
+func renderProvedTables(versions map[string]string, proofs map[string][]clientProof, pins []providerPin) string {
 	var b strings.Builder
 	b.WriteString(docsGenerated)
 	b.WriteString("\n\n### The clients\n\n")
@@ -483,7 +503,7 @@ func renderProved(workflow, root, stacks, script string) (string, error) {
 	b.WriteString("The client above is the engine; what answers this emulator is the provider.\n")
 	b.WriteString("Each row is one `required_providers` entry, read where it is written.\n\n")
 	b.WriteString("| Fixture or stack | Provider | Constraint | What that is worth | Applied in CI |\n|---|---|---|---|---|\n")
-	for _, pin := range append(append([]providerPin{}, fixturePins...), stackPins...) {
+	for _, pin := range pins {
 		kind, meaning := pinKind(pin.Constraint)
 		constraint := "—"
 		if strings.TrimSpace(pin.Constraint) != "" {
@@ -503,7 +523,8 @@ func renderProved(workflow, root, stacks, script string) (string, error) {
 	b.WriteString("that answered is not knowable from this repository — it is a floor, not a\n")
 	b.WriteString("proof. **Not pinned** is not pinned: nothing here says which version ran, and\n")
 	b.WriteString("no number is invented to fill the cell.\n")
-	return b.String(), nil
+	b.WriteString(renderStackExceptions())
+	return b.String()
 }
 
 // spliceProved reports whether the page is out of date, and leaves it alone.

--- a/internal/cli/docs_release.go
+++ b/internal/cli/docs_release.go
@@ -6,6 +6,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/stephrobert/feint/internal/release"
 )
 
 // The install commands name assets, and a release is where that goes wrong.
@@ -34,11 +36,6 @@ const (
 	installStartMarker = "<!-- install:start -->"
 	installEndMarker   = "<!-- install:end -->"
 )
-
-// modulePath reads the module line, which is where the repository's own name
-// lives. The install commands need it, and typing it into the generator would
-// put a third copy of it in the repository.
-var modulePath = regexp.MustCompile(`(?m)^module\s+github\.com/([^/\s]+/[^/\s]+)`)
 
 // changelogVersion finds the newest released section, which is this repository's
 // record of what the latest published version is.
@@ -74,15 +71,18 @@ func latestReleased(changelog string) string {
 	return ""
 }
 
+// repositorySlug reads the repository this module is published from.
+//
+// The reader itself lives in internal/release, because the Homebrew formula
+// interpolates the same slug into the same kind of download URL (#321). Two
+// readers of one line in go.mod is two chances for the install page and the
+// tap to name different repositories.
 func repositorySlug(goMod string) string {
 	body, err := os.ReadFile(goMod) //nolint:gosec // a path this repository owns
 	if err != nil {
 		return ""
 	}
-	if m := modulePath.FindStringSubmatch(string(body)); m != nil {
-		return m[1]
-	}
-	return ""
+	return release.SlugFromModule(string(body))
 }
 
 // renderInstall writes the download commands, and it writes them verified.

--- a/internal/cli/docs_stacks.go
+++ b/internal/cli/docs_stacks.go
@@ -1,0 +1,262 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+// A stack in this repository is applied on every pull request, or it says why
+// not — and a stack that is applied pins the provider that answered.
+//
+// Both halves came out of the generated table of #325 within a day of it
+// landing, and neither was visible before it existed:
+//
+//  1. `examples/stacks/outscale/modules/net` declared no `version` at all and
+//     was applied on every pull request. A stack applied under whatever the
+//     registry served that morning proves that the emulator answered
+//     *something*, and nothing anybody can reproduce — which is precisely the
+//     complaint #325 was filed for, turned inward.
+//  2. `examples/stacks/exoscale` is applied by nothing. That one is a decision,
+//     and a good one (the published provider splits between the emulator and a
+//     paying account), but it was written only in prose: three files say it in
+//     three wordings and no check reads any of them. A comment is not a
+//     control, so the fourth stack somebody adds and forgets to wire into
+//     tools/conformance/stacks.sh would have printed `no` in the table and read
+//     as a decision.
+//
+// So the exception is declared, with its reason and its date, the way CLAUDE.md
+// rule 3 has declined operations declared — and the declaration is checked in
+// both directions: a stack CI does not apply and nobody declared is refused,
+// and a declaration for a stack that does not exist, or that CI does in fact
+// apply, is refused as stale. One direction alone is the check that stops
+// measuring the day its subject moves.
+//
+// TestAStackCIDoesNotApplyIsDeclaredWithAReason,
+// TestADeclarationThatExcusesNothingIsStale and
+// TestAStackAppliedInCIPinsTheProviderThatAnswered fail without them.
+//
+// One accommodation, and it is the shape this repository has just removed five
+// of, so it is worth being exact about why this one is not that. `feint docs`
+// regenerates the README of somebody who installed the binary and has no
+// examples/stacks directory at all, so stackProofProblems answers "nothing to
+// report" there rather than failing a user's regeneration over a directory that
+// is not theirs. What stops that from becoming a check that skips itself here
+// is TestTheStackChecksHaveASubjectToMeasure, which asserts in this repository
+// that the population is non-empty and that both halves of the judgement run.
+// The runtime tolerance is for the other repository; the assertion is for this
+// one.
+
+// stackException is one example stack the conformance suite does not apply, and
+// why.
+type stackException struct {
+	// Stack is the directory name directly under examples/stacks.
+	Stack string
+	// Reason says what stops CI applying it, and what is done instead. Empty is
+	// refused: "not run" and "not run because X, applied by hand on D" are
+	// different facts, and only the second is a decision.
+	Reason string
+}
+
+// stacksRunByHand is the whole list, and it is deliberately short.
+//
+// An entry here costs a reader something: it is a stack whose green nobody sees
+// on a pull request. The bar is that CI *cannot* apply it, not that applying it
+// would be inconvenient.
+var stacksRunByHand = []stackException{
+	{
+		Stack: "exoscale",
+		Reason: "the published Exoscale provider builds two clients and only one honours " +
+			"`EXOSCALE_API_ENDPOINT`, so an apply splits between the emulator and a paying " +
+			"account (docs/limits.md, upstream exoscale/terraform-provider-exoscale#573). " +
+			"Running it needs the patched fork, and no gate here clones a third-party " +
+			"repository — that would put somebody else's availability in this pipeline. " +
+			"Applied by hand on 2026-08-18: 13 resources, empty second plan, clean destroy",
+	},
+}
+
+// stackDirs lists the example stacks that exist, which is the population both
+// checks below judge.
+//
+// An empty result is an error rather than an empty answer. A walk that finds
+// nothing passes every check written over it while measuring none of them.
+func stackDirs(root string) ([]string, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, err
+	}
+	var out []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			out = append(out, entry.Name())
+		}
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no stack directory under %s: the listing is broken, not the stacks", root)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// stackProofProblems is what `feint docs` reports in both modes: the things a
+// regeneration will not repair.
+//
+// It answers nothing when this repository's own directories are not there,
+// because `feint docs` also regenerates a README outside it — see the note at
+// the top of this file, and TestTheStackChecksHaveASubjectToMeasure, which is
+// what keeps that from becoming a check nobody runs.
+func stackProofProblems(workflow, root, stacks, script string) []string {
+	if _, err := os.Stat(stacks); os.IsNotExist(err) {
+		return nil
+	}
+	problems := undeclaredStacks(stacks, script, workflow)
+	pins, err := providerPinsOfRepository(workflow, root, stacks, script)
+	if err != nil {
+		return append(problems, fmt.Sprintf(
+			"cannot read the provider constraints under %s and %s: %v", root, stacks, err))
+	}
+	return append(problems, unconstrainedAppliedPins(pins)...)
+}
+
+// undeclaredStacks names every disagreement between the stacks that exist, the
+// stacks CI applies, and the exceptions declared above.
+//
+// Three refusals, and the second and third are what keep the first from
+// becoming decoration:
+//
+//   - a stack CI does not apply and nobody declared;
+//   - a declaration naming a stack that does not exist;
+//   - a declaration for a stack CI does apply, or with no reason given.
+func undeclaredStacks(root, script, workflow string) []string {
+	stacks, err := stackDirs(root)
+	if err != nil {
+		return []string{err.Error()}
+	}
+	applied, err := stacksAppliedInCI(script, workflow)
+	if err != nil {
+		return []string{fmt.Sprintf("cannot read which stacks CI applies: %v", err)}
+	}
+
+	declared := map[string]string{}
+	var problems []string
+	for _, e := range stacksRunByHand {
+		if strings.TrimSpace(e.Reason) == "" {
+			problems = append(problems, fmt.Sprintf(
+				"%s/%s is declared as run by hand with no reason: \"not applied\" and \"not applied "+
+					"because X\" are different facts, and only the second is a decision",
+				root, e.Stack))
+		}
+		declared[e.Stack] = e.Reason
+	}
+
+	existing := map[string]bool{}
+	for _, stack := range stacks {
+		existing[stack] = true
+		if applied[stack] {
+			continue
+		}
+		if _, ok := declared[stack]; !ok {
+			problems = append(problems, fmt.Sprintf(
+				"%s/%s is applied by no `run_stack` line in %s and stacksRunByHand in "+
+					"internal/cli/docs_stacks.go does not declare why: a stack nobody applies is not a "+
+					"proof, and the table would print `no` for it as if that were a decision",
+				root, stack, script))
+		}
+	}
+
+	for _, e := range stacksRunByHand {
+		if !existing[e.Stack] {
+			problems = append(problems, fmt.Sprintf(
+				"stacksRunByHand declares %s/%s and no such stack exists: a declaration that "+
+					"excuses nothing is a reason nobody re-reads", root, e.Stack))
+			continue
+		}
+		if applied[e.Stack] {
+			problems = append(problems, fmt.Sprintf(
+				"stacksRunByHand says %s/%s is run by hand and %s applies it: the reason is stale, "+
+					"and it is the kind that survives for months because it reads like evidence",
+				root, e.Stack, script))
+		}
+	}
+	sort.Strings(problems)
+	return problems
+}
+
+// unconstrainedAppliedPins names every provider a suite applies without saying
+// which versions it accepts.
+//
+// The narrow claim, and it is the one #325 was filed over: an unconstrained
+// provider is resolved by `terraform init -upgrade` from the whole registry on
+// every run, so the run proves the emulator answered whatever was newest that
+// morning and nothing that can be replayed. A constraint does not have to be
+// exact — the page is explicit about what a floor is worth — it has to exist.
+//
+// Written over the pins the page itself reads, so a row that reads "not pinned"
+// and "applied in CI" in the table cannot exist without this firing.
+func unconstrainedAppliedPins(pins []providerPin) []string {
+	var problems []string
+	for _, pin := range pins {
+		if !pin.Driven || strings.TrimSpace(pin.Constraint) != "" {
+			continue
+		}
+		problems = append(problems, fmt.Sprintf(
+			"%s declares %s with no version constraint and CI applies it: `terraform init "+
+				"-upgrade` resolves it fresh on every run, so nothing here records which provider "+
+				"answered — the complaint of #325, turned inward",
+			pin.Dir, pin.Source))
+	}
+	sort.Strings(problems)
+	return problems
+}
+
+// renderStackExceptions is the paragraph under the table, written from the same
+// list the refusals above read.
+//
+// Both states are printed. An empty list says so rather than printing nothing,
+// because a section that disappears when it has nothing to report is a section
+// a reader cannot tell from one nobody generated.
+func renderStackExceptions() string {
+	if len(stacksRunByHand) == 0 {
+		return "\nEvery stack under `examples/stacks/` is applied on every pull request.\n"
+	}
+	var b strings.Builder
+	b.WriteString("\nThe stacks the last column says CI does not apply are declared rather than\n")
+	b.WriteString("merely absent, so a `no` is a decision somebody wrote down and not a stack\n")
+	b.WriteString("nobody wired up:\n\n")
+	ordered := append([]stackException{}, stacksRunByHand...)
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].Stack < ordered[j].Stack })
+	for _, e := range ordered {
+		b.WriteString(wrapBullet(fmt.Sprintf("`%s/%s` — %s.", stacksRoot, e.Stack, e.Reason)))
+	}
+	return b.String()
+}
+
+// wrapBullet renders one list item wrapped the way the prose around it is, so a
+// declared reason does not land as a single 500-character line in a file every
+// other paragraph of which stops at the same column.
+func wrapBullet(text string) string {
+	const width = 76
+	var b strings.Builder
+	column := 0
+	prefix := "- "
+	for _, word := range strings.Fields(text) {
+		switch {
+		case column == 0:
+			b.WriteString(prefix)
+			b.WriteString(word)
+			column = len(prefix) + len(word)
+			prefix = "  "
+		case column+1+len(word) > width:
+			b.WriteString("\n  ")
+			b.WriteString(word)
+			column = 2 + len(word)
+		default:
+			b.WriteString(" ")
+			b.WriteString(word)
+			column += 1 + len(word)
+		}
+	}
+	b.WriteString("\n")
+	return b.String()
+}

--- a/internal/cli/docs_stacks_test.go
+++ b/internal/cli/docs_stacks_test.go
@@ -1,0 +1,211 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// stackPaths gives the four paths the stack checks read, rooted in the
+// repository.
+func stackPaths(t *testing.T) (workflow, root, stacks, script string) {
+	t.Helper()
+	repo := repoRoot(t)
+	return filepath.Join(repo, conformanceWorkflow),
+		filepath.Join(repo, conformanceRoot),
+		filepath.Join(repo, stacksRoot),
+		filepath.Join(repo, stacksScript)
+}
+
+// The population both checks judge is not empty, and both halves of the
+// judgement run here.
+//
+// stackProofProblems answers nothing when examples/stacks is absent, because
+// `feint docs` also regenerates the README of somebody who installed the binary
+// and has no such directory. That tolerance is exactly the shape of a check that
+// stops measuring when its subject moves, so the subject is asserted here rather
+// than assumed: this repository has stacks, CI applies some of them, and the
+// list of exceptions is smaller than the list of stacks.
+func TestTheStackChecksHaveASubjectToMeasure(t *testing.T) {
+	workflow, _, stacks, script := stackPaths(t)
+
+	dirs, err := stackDirs(stacks)
+	if err != nil {
+		t.Fatalf("list the stacks: %v", err)
+	}
+	if len(dirs) < 3 {
+		t.Fatalf("only %d stack(s) under %s: the listing is broken, not the stacks", len(dirs), stacksRoot)
+	}
+
+	applied, err := stacksAppliedInCI(script, workflow)
+	if err != nil {
+		t.Fatalf("read which stacks CI applies: %v", err)
+	}
+	if len(applied) == 0 {
+		t.Fatal("no `run_stack` line is read from tools/conformance/stacks.sh: every stack would " +
+			"need a declaration, which is a check measuring its own reader")
+	}
+	if len(stacksRunByHand) >= len(dirs) {
+		t.Fatalf("%d of %d stacks are declared as run by hand: an exception list as long as the "+
+			"population is not an exception list", len(stacksRunByHand), len(dirs))
+	}
+}
+
+// A stack CI does not apply is declared, with a reason.
+//
+// The accepting half is the repository as it stands; the refusing half removes
+// the invocation of a stack CI does apply, which is the shape of the mistake
+// this exists for — somebody adds a fourth stack and forgets to wire it into
+// tools/conformance/stacks.sh, and the generated table prints `no` for it as if
+// that were a decision.
+func TestAStackCIDoesNotApplyIsDeclaredWithAReason(t *testing.T) {
+	workflow, _, stacks, script := stackPaths(t)
+
+	if problems := undeclaredStacks(stacks, script, workflow); len(problems) != 0 {
+		t.Fatalf("the repository does not satisfy its own rule:\n  %s", strings.Join(problems, "\n  "))
+	}
+
+	body, err := os.ReadFile(script)
+	if err != nil {
+		t.Fatal(err)
+	}
+	trimmed := strings.Replace(string(body), "run_stack outscale", "true # run_stack outscale", 1)
+	if trimmed == string(body) {
+		t.Fatal("tools/conformance/stacks.sh no longer applies the outscale stack: either it was " +
+			"removed and a declaration must have appeared, or this test is measuring a file it " +
+			"does not understand")
+	}
+	copied := filepath.Join(t.TempDir(), "stacks.sh")
+	if err := os.WriteFile(copied, []byte(trimmed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	problems := undeclaredStacks(stacks, copied, workflow)
+	if len(problems) == 0 {
+		t.Fatal("a stack no `run_stack` line applies and nothing declares passed: the table " +
+			"would print `no` for it and read as a decision")
+	}
+	if !strings.Contains(strings.Join(problems, "\n"), "outscale") {
+		t.Errorf("the refusal does not name the stack, which is the one thing needed to fix it:\n  %s",
+			strings.Join(problems, "\n  "))
+	}
+
+	// And a declaration with no reason is refused too: "not applied" and "not
+	// applied because X" are different facts.
+	restore := stacksRunByHand
+	t.Cleanup(func() { stacksRunByHand = restore })
+	stacksRunByHand = []stackException{{Stack: "exoscale", Reason: "   "}}
+	problems = undeclaredStacks(stacks, script, workflow)
+	if len(problems) == 0 {
+		t.Fatal("a declaration with an empty reason excused a stack anyway")
+	}
+}
+
+// A declaration that excuses nothing is stale, in both the ways it can be.
+//
+// This is the half that keeps the list from becoming a place reasons go to be
+// forgotten: a name that no longer exists, and a name CI has started applying.
+// Without it the first entry somebody writes outlives the situation it
+// describes, which is the defect CLAUDE.md names as the most expensive one
+// measured on this repository.
+func TestADeclarationThatExcusesNothingIsStale(t *testing.T) {
+	workflow, _, stacks, script := stackPaths(t)
+	restore := stacksRunByHand
+	t.Cleanup(func() { stacksRunByHand = restore })
+
+	stacksRunByHand = append(append([]stackException{}, restore...),
+		stackException{Stack: "kubernetes", Reason: "a stack that was never here"})
+	problems := undeclaredStacks(stacks, script, workflow)
+	if len(problems) == 0 || !strings.Contains(strings.Join(problems, "\n"), "kubernetes") {
+		t.Errorf("a declaration for a stack that does not exist was accepted:\n  %s",
+			strings.Join(problems, "\n  "))
+	}
+
+	// The other direction, and the one that reads like evidence while being
+	// false: the stack is applied on every pull request and the list still says
+	// it is run by hand.
+	stacksRunByHand = []stackException{{Stack: "scaleway", Reason: "stale: CI applies it"}}
+	problems = undeclaredStacks(stacks, script, workflow)
+	if len(problems) == 0 || !strings.Contains(strings.Join(problems, "\n"), "scaleway") {
+		t.Errorf("a declaration survived CI starting to apply the stack it excuses:\n  %s",
+			strings.Join(problems, "\n  "))
+	}
+}
+
+// A stack CI applies names the provider versions it accepts.
+//
+// `examples/stacks/outscale/modules/net` declared no constraint at all and was
+// applied on every pull request, which the generated table of #325 exposed on
+// its first day: `terraform init -upgrade` resolves an unconstrained provider
+// from the whole registry on every run, so the apply proves the emulator
+// answered whatever was newest that morning and nothing that can be replayed.
+// The constraint does not have to be exact — the page says plainly what a floor
+// is worth — it has to exist.
+func TestAStackAppliedInCIPinsTheProviderThatAnswered(t *testing.T) {
+	workflow, root, stacks, script := stackPaths(t)
+
+	pins, err := providerPinsOfRepository(workflow, root, stacks, script)
+	if err != nil {
+		t.Fatalf("read the provider constraints: %v", err)
+	}
+	// The subject: rows that are applied at all, and rows that are not. A run
+	// where every row were undriven would satisfy the check while measuring
+	// nothing.
+	var driven, undriven int
+	for _, pin := range pins {
+		if pin.Driven {
+			driven++
+			continue
+		}
+		undriven++
+	}
+	if driven == 0 || undriven == 0 {
+		t.Fatalf("%d applied and %d unapplied provider entries: the reader is broken, not the stacks",
+			driven, undriven)
+	}
+	if problems := unconstrainedAppliedPins(pins); len(problems) != 0 {
+		t.Fatalf("a stack CI applies pins nothing:\n  %s", strings.Join(problems, "\n  "))
+	}
+
+	// The refusing half, on the entry that really was like this until the
+	// table of #325 named it: the module's constraint removed, nothing else.
+	loosened := make([]providerPin, len(pins))
+	copy(loosened, pins)
+	found := false
+	for i := range loosened {
+		if strings.HasSuffix(loosened[i].Dir, "/outscale/modules/net") {
+			loosened[i].Constraint = ""
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("no row for %s/outscale/modules/net: this test is measuring a tree it does not "+
+			"understand", stacksRoot)
+	}
+	problems := unconstrainedAppliedPins(loosened)
+	if len(problems) == 0 {
+		t.Fatal("a module applied on every pull request with no version constraint passed")
+	}
+	if !strings.Contains(strings.Join(problems, "\n"), "modules/net") {
+		t.Errorf("the refusal does not name the directory to fix:\n  %s", strings.Join(problems, "\n  "))
+	}
+}
+
+// The generated page prints the declaration it is checked against, so a reader
+// meets the reason rather than a bare `no`.
+func TestThePageCarriesTheReasonAStackIsNotApplied(t *testing.T) {
+	rendered := provedPage(t)
+	for _, e := range stacksRunByHand {
+		if !strings.Contains(rendered, "`"+stacksRoot+"/"+e.Stack+"` —") {
+			t.Errorf("the page prints no reason for %s/%s:\n%s", stacksRoot, e.Stack, rendered)
+		}
+	}
+	// And the reason is the declared one rather than a second wording of it.
+	if len(stacksRunByHand) > 0 {
+		first := strings.Fields(stacksRunByHand[0].Reason)[0]
+		if !strings.Contains(rendered, first) {
+			t.Errorf("the page's reason is not the declared one, which is two claims to keep in step")
+		}
+	}
+}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -45,10 +45,10 @@ const (
 	updateTimeout = 5 * time.Second
 )
 
-// release is the sliver of the API answer this needs. Everything else is
+// githubRelease is the sliver of the API answer this needs. Everything else is
 // deliberately not decoded: a reader of a format that takes less of it is a
 // reader that keeps working when the writer grows a field.
-type release struct {
+type githubRelease struct {
 	TagName string `json:"tag_name"`
 	HTMLURL string `json:"html_url"`
 }
@@ -88,17 +88,17 @@ func versionCheck(args []string, stdout, stderr io.Writer) int {
 }
 
 // latestRelease asks for the newest published release.
-func latestRelease(ctx context.Context, client *http.Client, url string) (release, error) {
+func latestRelease(ctx context.Context, client *http.Client, url string) (githubRelease, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return release{}, err
+		return githubRelease{}, err
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("User-Agent", "feint/"+Version)
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return release{}, err
+		return githubRelease{}, err
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -106,23 +106,23 @@ func latestRelease(ctx context.Context, client *http.Client, url string) (releas
 		// 404 is the ordinary answer for a repository with no release yet, and
 		// 403 is the rate limit an unauthenticated caller meets. Both are worth
 		// telling apart from a parse failure.
-		return release{}, fmt.Errorf("the releases API answered %s", resp.Status)
+		return githubRelease{}, fmt.Errorf("the releases API answered %s", resp.Status)
 	}
 	// Bounded like every other body this project reads: an answer that is not a
 	// release document must not be able to fill memory.
-	var out release
+	var out githubRelease
 	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&out); err != nil {
-		return release{}, fmt.Errorf("the releases API answered something that is not a release: %w", err)
+		return githubRelease{}, fmt.Errorf("the releases API answered something that is not a release: %w", err)
 	}
 	if out.TagName == "" {
-		return release{}, errors.New("the releases API answered a release with no tag")
+		return githubRelease{}, errors.New("the releases API answered a release with no tag")
 	}
 	return out, nil
 }
 
 // updateMessage is what the user reads. Separated from the fetch so the wording
 // is testable without a network.
-func updateMessage(current string, latest release) string {
+func updateMessage(current string, latest githubRelease) string {
 	newer, comparable := isNewer(current, latest.TagName)
 	switch {
 	case !comparable:

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -36,7 +36,7 @@ func TestIsNewerComparesVersionsRatherThanStrings(t *testing.T) {
 // The message is what a user acts on, so its three shapes are asserted rather
 // than assumed.
 func TestUpdateMessageSaysWhatToDo(t *testing.T) {
-	latest := release{TagName: "v0.2.0", HTMLURL: "https://example.invalid/releases/v0.2.0"}
+	latest := githubRelease{TagName: "v0.2.0", HTMLURL: "https://example.invalid/releases/v0.2.0"}
 
 	out := updateMessage("0.1.0", latest)
 	for _, want := range []string{"a newer release is available: v0.2.0", "releases/download/v0.2.0", "sha256sum -c"} {

--- a/internal/release/formula.go
+++ b/internal/release/formula.go
@@ -1,0 +1,361 @@
+package release
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// The Homebrew formula a release is installed by, derived rather than written.
+//
+// `brew install stephrobert/feint/feint` needs a formula, a formula needs a
+// URL and a SHA-256 per platform, and those two facts only exist once a release
+// is published. Whoever produces them is the decision inside #321, and this
+// file is one half of the answer.
+//
+// The other half is what it is not: nothing here writes to another repository.
+// A release workflow that pushes the formula to the tap would need a
+// cross-repository token this repository does not hold, and the two precedents
+// are already written down — .github/workflows/workflow-security.yml refused it
+// for the Marketplace mirror ("a gate wired to a secret that does not exist is
+// the drift.yml defect all over again"), and docs_release.go refused it for the
+// generated pages ("a gate that refuses is safe; a gate that repairs the
+// repository is a second way in"). So the tap is updated by hand, and
+// tools/release/tap.sh re-derives the formula and exits 2 while the two differ.
+//
+// What makes the hand-update safe is that the hand never writes the bytes. The
+// input is the release's own `checksums.txt` — the file cosign signs, and the
+// only file whose digests are the release's rather than somebody's transcription
+// of them. Feed it here and the formula falls out; feed it anywhere else and the
+// digests are a claim.
+//
+// Every refusal below exists because the checksums list is fetched over the
+// network at gate time, which makes it an input and not a fact: "un état
+// restauré est une entrée non fiable" applies to a file pulled from a release
+// exactly as it applies to a snapshot. A crafted list must not be able to make
+// this write a URL that points elsewhere or a Ruby literal that closes early.
+//
+// Measured end to end on 2026-08-20, Homebrew 5.1.15, against the published
+// v0.9.0 — because a formula that renders is not a formula that installs, and
+// this repository's whole argument is that the real client is the only proof.
+// The output of this file was put in a local tap: `brew install
+// stephrobert/feint/feint` fetched the published binary, `feint version`
+// answered `v0.9.0`, `brew test` passed, `brew audit` reported nothing, and one
+// flipped byte in the digest made the install fail with "Formula reports
+// different checksum" rather than installing anything.
+//
+// TestAFormulaCoversEveryBinaryTheChecksumsListPublishes,
+// TestAnEntryTheFormulaHasNoPlatformForIsRefused,
+// TestAChecksumsLineThatIsNotTwoFieldsIsRefused,
+// TestADigestThatIsNotOneIsRefused and
+// TestTwoDigestsForOneAssetAreRefused fail without them.
+
+// Spec is everything the formula needs, and the three fields that are not the
+// checksums list are all facts this repository already holds.
+type Spec struct {
+	// Slug is the repository the release lives in, `stephrobert/feint`. It is
+	// read from go.mod rather than typed, so the formula cannot point at a
+	// repository this binary was not built from.
+	Slug string
+	// Version is the released version without its leading `v`, `0.9.0`.
+	Version string
+	// License is the SPDX identifier, read from the LICENSE file.
+	License string
+	// Checksums is the release's `checksums.txt`, verbatim. Not a digest map:
+	// taking the parsed form would let a caller assemble one by hand, which is
+	// the transcription this whole file exists to make impossible.
+	Checksums string
+}
+
+var (
+	// A release asset name, as strictly as it can be spelled, with the two
+	// segments that decide where Homebrew installs it. The URL and the Ruby
+	// string literal are both built by concatenating this name, so anything a
+	// quote, a backslash, a space or a path segment could do to either is
+	// refused here rather than escaped later — the order of preference
+	// CLAUDE.md sets out, refusal at the entrance ahead of escaping at the
+	// render.
+	assetName = regexp.MustCompile(`^feint-([a-z0-9]+)-([a-z0-9]+)$`)
+	// A SHA-256, and nothing that merely looks like one. Homebrew compares the
+	// digest it computes against this string, so a truncated one does not fail
+	// open — but a formula carrying 63 characters is a formula somebody edited.
+	sha256Digest = regexp.MustCompile(`^[0-9a-f]{64}$`)
+	// The released version, as the CHANGELOG spells it.
+	semverOnly = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+	// owner/repo, with the character set GitHub allows and nothing else. A slug
+	// is the first thing interpolated into the download URL.
+	slugShape = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$`)
+)
+
+// homebrewOS and homebrewArch translate a Go platform into the block Homebrew
+// selects on. Two tables rather than one of pairs, so a new GOOS and a new
+// GOARCH are separate facts — and an entry missing from either is a refusal
+// below, never a platform quietly left out of the formula.
+var (
+	homebrewOS   = map[string]string{"darwin": "macos", "linux": "linux"}
+	homebrewArch = map[string]string{"amd64": "intel", "arm64": "arm"}
+)
+
+// binary is one published binary and where Homebrew installs it from.
+type binary struct {
+	asset  string
+	os     string // macos or linux, as `on_<os>` spells it
+	arch   string // intel or arm, as `on_<arch>` spells it
+	digest string
+}
+
+// checksumEntry is one line of a sha256sum listing.
+type checksumEntry struct {
+	name   string
+	digest string
+}
+
+// parseChecksums reads the release's list, refusing everything it does not
+// fully understand.
+//
+// Every line, not the lines it recognises. A parser that skips what it cannot
+// read publishes a formula short by a platform and says nothing, which is the
+// silent-skip shape this repository has just finished removing five of. If a
+// future release adds an artefact to `checksums.txt`, this refuses and somebody
+// decides what the formula does about it — which is the correct amount of
+// thinking for a change to the signed list of what a release is.
+func parseChecksums(text string) ([]checksumEntry, error) {
+	var out []checksumEntry
+	for n, line := range strings.Split(text, "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			return nil, fmt.Errorf("checksums.txt line %d is not `<digest>  <name>`: %q", n+1, line)
+		}
+		// sha256sum writes `*name` in binary mode. Accepted because the tool
+		// writes it, stripped because it is not part of the name.
+		out = append(out, checksumEntry{name: strings.TrimPrefix(fields[1], "*"), digest: fields[0]})
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("checksums.txt is empty: a formula built from it would install nothing, " +
+			"which is not the same fact as a release that published no binary")
+	}
+	return out, nil
+}
+
+// platformOf answers where Homebrew installs one asset, and whether it can.
+//
+// Total and closed: the name has to be spelled `feint-<os>-<arch>` and both
+// segments have to be in the tables above, so every string that reaches the
+// renderer has already been matched against a fixed set. Nothing here indexes
+// past what the pattern captured, which is what keeps the refusal below a
+// refusal rather than a crash.
+func platformOf(name string) (os, arch string, ok bool) {
+	m := assetName.FindStringSubmatch(name)
+	if m == nil {
+		return "", "", false
+	}
+	os, knownOS := homebrewOS[m[1]]
+	arch, knownArch := homebrewArch[m[2]]
+	return os, arch, knownOS && knownArch
+}
+
+// binaries turns the parsed list into the platforms the formula serves.
+func binaries(entries []checksumEntry) ([]binary, error) {
+	seen := map[string]string{}
+	var out []binary
+	for _, entry := range entries {
+		os, arch, known := platformOf(entry.name)
+		// Every entry, not the ones it recognises. An entry the formula has no
+		// platform for is either a binary a `brew install` would fail on with
+		// no mention of why, or a name that was never a binary at all — and
+		// this name is about to be concatenated into a download URL and a Ruby
+		// string literal. Skipping it publishes a formula short by a platform
+		// and says nothing.
+		if !known {
+			return nil, fmt.Errorf("checksums.txt lists %q and the formula has no platform for it: "+
+				"either the release published a binary Homebrew cannot select, or the list carries "+
+				"an artefact that is not one — say which, rather than leaving it out of the formula",
+				entry.name)
+		}
+		if !sha256Digest.MatchString(entry.digest) {
+			return nil, fmt.Errorf("the digest of %s is %q, which is not a SHA-256: Homebrew would "+
+				"compare the bytes against a string nothing produced", entry.name, entry.digest)
+		}
+		if previous, ok := seen[entry.name]; ok && previous != entry.digest {
+			return nil, fmt.Errorf("checksums.txt gives %s two different digests (%s and %s): "+
+				"the list is not one release's", entry.name, previous, entry.digest)
+		}
+		if _, ok := seen[entry.name]; ok {
+			continue
+		}
+		seen[entry.name] = entry.digest
+		out = append(out, binary{asset: entry.name, os: os, arch: arch, digest: entry.digest})
+	}
+	// macos before linux, intel before arm: a stable order, so a formula
+	// re-derived from the same release is byte-identical to the published one
+	// and tools/release/tap.sh can diff them.
+	rank := map[string]int{"macos": 0, "linux": 1, "intel": 0, "arm": 1}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].os != out[j].os {
+			return rank[out[i].os] < rank[out[j].os]
+		}
+		return rank[out[i].arch] < rank[out[j].arch]
+	})
+	return out, nil
+}
+
+// className is the Ruby class Homebrew requires a formula named `feint` to
+// declare. Derived from the repository name, because a second spelling of it in
+// this file would be a second thing to disagree with go.mod.
+func className(repo string) string {
+	var b strings.Builder
+	for _, word := range strings.Split(repo, "-") {
+		if word == "" {
+			continue
+		}
+		b.WriteString(strings.ToUpper(word[:1]) + word[1:])
+	}
+	return b.String()
+}
+
+// formulaDesc is what `brew info` prints. Not derived: no file in this
+// repository holds a Homebrew-shaped description (under 80 characters, no
+// leading article, not starting with the formula's own name), and pretending
+// to derive one from the README's first line would produce a worse sentence
+// that still needed hand-checking.
+const formulaDesc = "Local emulator of the Scaleway, Outscale and Exoscale clouds"
+
+// Formula renders the tap's `Formula/feint.rb` for one release.
+func Formula(spec Spec) (string, error) {
+	if !slugShape.MatchString(spec.Slug) {
+		return "", fmt.Errorf("%q is not an owner/repo slug: it is the first thing this writes into "+
+			"a download URL", spec.Slug)
+	}
+	if !semverOnly.MatchString(spec.Version) {
+		return "", fmt.Errorf("%q is not a released version as `X.Y.Z`: the tag it names is what "+
+			"every URL below points at", spec.Version)
+	}
+	if strings.TrimSpace(spec.License) == "" {
+		return "", fmt.Errorf("no SPDX licence: `brew audit` refuses a formula without one, and " +
+			"guessing it here would put a licence claim in a file nothing checks")
+	}
+	entries, err := parseChecksums(spec.Checksums)
+	if err != nil {
+		return "", err
+	}
+	bins, err := binaries(entries)
+	if err != nil {
+		return "", err
+	}
+
+	_, repo, _ := strings.Cut(spec.Slug, "/")
+	base := fmt.Sprintf("https://github.com/%s/releases/download/v%s", spec.Slug, spec.Version)
+
+	var b strings.Builder
+	b.WriteString("# Generated by `mise run release:formula` from the checksums.txt this release\n")
+	b.WriteString("# published and cosign signed. Do not edit by hand: tools/release/tap.sh derives\n")
+	b.WriteString("# this file again from the release and exits 2 while the tap differs.\n")
+	b.WriteString("#\n")
+	b.WriteString("# It installs the published bytes and never rebuilds them, so the SHA-256 brew\n")
+	b.WriteString("# checks is the one the release signed — the same reasoning the container image\n")
+	b.WriteString("# follows.\n")
+	fmt.Fprintf(&b, "class %s < Formula\n", className(repo))
+	fmt.Fprintf(&b, "  desc %q\n", formulaDesc)
+	fmt.Fprintf(&b, "  homepage \"https://github.com/%s\"\n", spec.Slug)
+	fmt.Fprintf(&b, "  version %q\n", spec.Version)
+	fmt.Fprintf(&b, "  license %q\n", spec.License)
+
+	for _, group := range groupByOS(bins) {
+		fmt.Fprintf(&b, "\n  on_%s do\n", group.os)
+		for j, bin := range group.bins {
+			if j > 0 {
+				b.WriteString("\n")
+			}
+			fmt.Fprintf(&b, "    on_%s do\n", bin.arch)
+			fmt.Fprintf(&b, "      url \"%s/%s\"\n", base, bin.asset)
+			fmt.Fprintf(&b, "      sha256 %q\n", bin.digest)
+			b.WriteString("    end\n")
+		}
+		b.WriteString("  end\n")
+	}
+
+	// One install, outside the platform blocks. A `def install` inside each of
+	// them is what goreleaser emits and what the first version of this rendered,
+	// and `brew audit` reports four problems for it — "Do not define methods in
+	// blocks". Measured on 2026-08-20 against Homebrew 5.1.15, before and after.
+	//
+	// Exactly one file is staged, because exactly one `url` is selected, and
+	// the count is asserted rather than assumed: `Dir[...].first` on an empty
+	// match installs nil, and on two matches installs whichever came first.
+	b.WriteString("\n  def install\n")
+	b.WriteString("    published = Dir[\"" + repo + "-*\"]\n")
+	fmt.Fprintf(&b, "    odie \"expected one published %s binary in the download, found "+
+		"#{published.length}\" if published.length != 1\n", repo)
+	fmt.Fprintf(&b, "    bin.install published.first => %q\n", repo)
+	b.WriteString("  end\n")
+
+	// The one assertion a formula can make that is worth making: the binary it
+	// installed says it is the version the formula claims. Measured rather than
+	// assumed — the release builds with
+	// `-ldflags "-X ...cli.Version=${GITHUB_REF_NAME}"`, and GITHUB_REF_NAME is
+	// the tag, so `feint version` prints `v0.9.0` with the `v`. Asserting
+	// `version` alone would pass on a binary printing anything containing
+	// `0.9.0`.
+	b.WriteString("\n  test do\n")
+	fmt.Fprintf(&b, "    assert_match \"v#{version}\", shell_output(\"#{bin}/%s version\")\n", repo)
+	b.WriteString("  end\n")
+	b.WriteString("end\n")
+	return b.String(), nil
+}
+
+// osGroup is the binaries one `on_<os>` block holds.
+type osGroup struct {
+	os   string
+	bins []binary
+}
+
+// groupByOS keeps the order binaries already put them in.
+func groupByOS(bins []binary) []osGroup {
+	var out []osGroup
+	for _, bin := range bins {
+		if len(out) == 0 || out[len(out)-1].os != bin.os {
+			out = append(out, osGroup{os: bin.os})
+		}
+		out[len(out)-1].bins = append(out[len(out)-1].bins, bin)
+	}
+	return out
+}
+
+// modulePath reads the repository slug out of a go.mod module line.
+var modulePath = regexp.MustCompile(`(?m)^module\s+github\.com/([^/\s]+/[^/\s]+)`)
+
+// SlugFromModule reads the repository a module is published from.
+//
+// One reader, used by the formula and by the install commands in
+// internal/cli/docs_release.go: the slug appears in a download URL on the
+// install page and in a download URL in the formula, and two readers of one
+// line in go.mod is two chances for the two pages to name different
+// repositories.
+func SlugFromModule(goMod string) string {
+	if m := modulePath.FindStringSubmatch(goMod); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// LicenseID names the licence a LICENSE file carries, for the one field
+// Homebrew wants as an SPDX identifier.
+//
+// A table of two, and a refusal for anything else. Deriving a licence by
+// guessing is how a formula ends up publishing a licence claim nobody made;
+// this repository is Apache-2.0 and the day that changes, this refuses until
+// somebody says what it changed to.
+func LicenseID(license string) (string, error) {
+	switch {
+	case strings.Contains(license, "Apache License") && strings.Contains(license, "Version 2.0"):
+		return "Apache-2.0", nil
+	case strings.Contains(license, "MIT License"):
+		return "MIT", nil
+	}
+	return "", fmt.Errorf("the LICENSE file matches no SPDX identifier this knows: " +
+		"the formula must not guess one")
+}

--- a/internal/release/formula_test.go
+++ b/internal/release/formula_test.go
@@ -1,0 +1,258 @@
+package release
+
+import (
+	"strings"
+	"testing"
+)
+
+// The real v0.9.0 list, fetched from the release on 2026-08-20 and pasted here
+// as the fixture every case below starts from. A synthetic one would let the
+// renderer be right about a shape no release has.
+const publishedChecksums = `c1ac05141df079d142a43b9f8d212a84e9c52661af98cb92753860c05aeaace8  feint-darwin-amd64
+af8446dfaff8b657637bfbf295fe8ea58bcecb7fe3ab4fea33fa2d3790ed053b  feint-darwin-arm64
+fa7b9c099239a5e66fadba7312722f84e5ba34ff606540101516a7170965e28a  feint-linux-amd64
+de1d7c093b7755afbfbf053cb5dadf832f3b713d67c00316c39d2023732c34cd  feint-linux-arm64
+`
+
+func spec() Spec {
+	return Spec{
+		Slug:      "stephrobert/feint",
+		Version:   "0.9.0",
+		License:   "Apache-2.0",
+		Checksums: publishedChecksums,
+	}
+}
+
+// Every binary the release published is installable through the formula, and
+// with the digest the release signed.
+//
+// The failure this refuses is the quiet one: a formula that omits a platform is
+// a `brew install` that fails on that machine with a message about the formula
+// rather than about the omission, and nothing in the tap says a platform is
+// missing. So the assertion is over the checksums list, not over a list written
+// here — a fifth binary added to a release makes this fail until the formula
+// carries it.
+func TestAFormulaCoversEveryBinaryTheChecksumsListPublishes(t *testing.T) {
+	out, err := Formula(spec())
+	if err != nil {
+		t.Fatalf("the published checksums must render: %v", err)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(publishedChecksums), "\n") {
+		fields := strings.Fields(line)
+		asset, digest := fields[1], fields[0]
+		if !strings.Contains(out, "/v0.9.0/"+asset+"\"") {
+			t.Errorf("the formula never downloads %s: brew install fails on that platform "+
+				"and says nothing about why", asset)
+		}
+		if !strings.Contains(out, "sha256 \""+digest+"\"") {
+			t.Errorf("the formula does not carry the released digest of %s, so what brew "+
+				"verifies is not what the release signed", asset)
+		}
+	}
+	// A formula that rebuilds locally verifies nothing the release signed.
+	if strings.Contains(out, "system \"go\"") || strings.Contains(out, "depends_on \"go\"") {
+		t.Error("the formula builds from source: the bytes brew installs would then be " +
+			"outside the checksums and the provenance")
+	}
+}
+
+// Every entry of the list is a platform the formula installs, or the formula is
+// refused.
+//
+// Two failures share this one guard, which is why it is written as a closed set
+// rather than as a filter. checksums.txt is pulled over the network by
+// tools/release/tap.sh, so a name in it is an input and not a fact: `"` and a
+// newline close the Ruby literal, and `../` points the download at another
+// release. And an entry that is simply not a binary — an SBOM added to the
+// signed list one day — must stop the formula rather than be dropped from it,
+// because dropping is how a formula ends up short by a platform with nothing
+// saying so.
+func TestAnEntryTheFormulaHasNoPlatformForIsRefused(t *testing.T) {
+	for _, name := range []string{
+		`feint-darwin-arm64"` + "\n" + `  system "id`,
+		"feint-../../../other/feint-linux-amd64",
+		"feint-darwin-arm64;id",
+		"feint-darwin-arm64.bak",
+		"feint-freebsd-amd64", // published, and Homebrew has no block for it
+		"sbom.cdx.json",       // an artefact the list could legitimately gain
+		"feint-darwin",
+	} {
+		s := spec()
+		s.Checksums = strings.Replace(publishedChecksums, "feint-darwin-arm64", name, 1)
+		if out, err := Formula(s); err == nil {
+			t.Errorf("%q was accepted into the formula:\n%s", name, out)
+		}
+	}
+}
+
+// A line that is not `<digest>  <name>` is refused rather than read for the two
+// fields it happens to start with.
+//
+// The case is a line with a trailing third field: everything before it is a
+// perfectly good entry, so a parser that takes fields[0] and fields[1] accepts
+// it and silently ignores whatever the rest was.
+func TestAChecksumsLineThatIsNotTwoFieldsIsRefused(t *testing.T) {
+	s := spec()
+	s.Checksums = strings.Replace(publishedChecksums,
+		"  feint-darwin-arm64", "  feint-darwin-arm64  (recomputed)", 1)
+	if out, err := Formula(s); err == nil {
+		t.Errorf("a three-field checksums line was read as an entry anyway:\n%s", out)
+	}
+}
+
+// A digest that is not a SHA-256 is refused rather than written into the
+// formula, in both directions: too short, and not hexadecimal.
+func TestADigestThatIsNotOneIsRefused(t *testing.T) {
+	for _, digest := range []string{
+		"af8446dfaff8b657637bfbf295fe8ea58bcecb7fe3ab4fea33fa2d3790ed053",  // 63
+		"AF8446DFAFF8B657637BFBF295FE8EA58BCECB7FE3AB4FEA33FA2D3790ED053B", // brew wants lowercase
+		"not-a-digest",
+		"",
+	} {
+		s := spec()
+		s.Checksums = strings.Replace(publishedChecksums,
+			"af8446dfaff8b657637bfbf295fe8ea58bcecb7fe3ab4fea33fa2d3790ed053b", digest, 1)
+		if _, err := Formula(s); err == nil {
+			t.Errorf("digest %q was written into the formula", digest)
+		}
+	}
+}
+
+// Two digests for one asset is a list that is not one release's, and picking
+// either would be picking one at random.
+func TestTwoDigestsForOneAssetAreRefused(t *testing.T) {
+	s := spec()
+	s.Checksums = publishedChecksums +
+		"0000000000000000000000000000000000000000000000000000000000000000  feint-darwin-arm64\n"
+	if _, err := Formula(s); err == nil {
+		t.Fatal("a contradictory checksums list rendered a formula")
+	}
+
+	// The same line twice is not a contradiction, and must not be treated as
+	// one: sha256sum can legitimately be run twice into the same file.
+	s.Checksums = publishedChecksums +
+		"af8446dfaff8b657637bfbf295fe8ea58bcecb7fe3ab4fea33fa2d3790ed053b  feint-darwin-arm64\n"
+	out, err := Formula(s)
+	if err != nil {
+		t.Fatalf("a repeated identical line is not a contradiction: %v", err)
+	}
+	if strings.Count(out, "/feint-darwin-arm64\"") != 1 {
+		t.Errorf("the repeated asset was rendered twice:\n%s", out)
+	}
+}
+
+// An empty list is a measurement that did not happen, and it must not render an
+// empty formula.
+func TestAnEmptyChecksumsListIsRefused(t *testing.T) {
+	s := spec()
+	s.Checksums = "\n  \n"
+	if _, err := Formula(s); err == nil {
+		t.Fatal("an empty checksums list rendered a formula")
+	}
+}
+
+// The slug and the version are the two things interpolated into every URL, and
+// neither is taken on trust.
+func TestTheSlugAndTheVersionAreCheckedBeforeTheyBecomeAURL(t *testing.T) {
+	for _, slug := range []string{"", "feint", "stephrobert/feint/extra", "steph robert/feint", "../feint"} {
+		s := spec()
+		s.Slug = slug
+		if _, err := Formula(s); err == nil {
+			t.Errorf("slug %q became a download URL", slug)
+		}
+	}
+	for _, version := range []string{"", "v0.9.0", "0.9", "latest", "0.9.0-rc1"} {
+		s := spec()
+		s.Version = version
+		if _, err := Formula(s); err == nil {
+			t.Errorf("version %q became a download URL", version)
+		}
+	}
+}
+
+// Homebrew requires a licence and refuses to audit a formula without one;
+// guessing it here would publish a licence claim nothing checks.
+func TestAFormulaWithoutALicenceIsRefused(t *testing.T) {
+	s := spec()
+	s.License = "  "
+	if _, err := Formula(s); err == nil {
+		t.Fatal("a formula rendered with no licence")
+	}
+}
+
+// The class name Homebrew requires is derived from the repository, and the
+// formula it installs is named after it too.
+func TestTheFormulaIsNamedAfterTheRepository(t *testing.T) {
+	out, err := Formula(spec())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "class Feint < Formula") {
+		t.Errorf("brew requires the class of Formula/feint.rb to be Feint:\n%s", out)
+	}
+	if !strings.Contains(out, `bin.install published.first => "feint"`) {
+		t.Errorf("the installed command is not called feint:\n%s", out)
+	}
+	// One `def install`, outside the platform blocks: `brew audit` reports four
+	// problems for a formula that defines a method inside each of them.
+	if n := strings.Count(out, "def install"); n != 1 {
+		t.Errorf("the formula defines install %d times; brew audit refuses more than one at "+
+			"top level:\n%s", n, out)
+	}
+	if got := className("setup-feint"); got != "SetupFeint" {
+		t.Errorf("className(setup-feint) = %q, want SetupFeint", got)
+	}
+}
+
+// The formula asserts the version the binary reports, not a substring of it.
+//
+// Measured on 2026-08-20 against the published v0.9.0 linux binary: `feint
+// version` prints `v0.9.0`, because the release builds with
+// `-X ...cli.Version=${GITHUB_REF_NAME}` and GITHUB_REF_NAME is the tag.
+func TestTheFormulaTestAssertsTheTagTheBinaryPrints(t *testing.T) {
+	out, err := Formula(spec())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, `assert_match "v#{version}"`) {
+		t.Errorf("the formula's test does not assert the `v` the binary prints:\n%s", out)
+	}
+}
+
+// Rendering the same release twice gives the same bytes, which is what lets
+// tools/release/tap.sh diff the tap against a fresh derivation.
+func TestTheSameReleaseRendersTheSameBytes(t *testing.T) {
+	first, err := Formula(spec())
+	if err != nil {
+		t.Fatal(err)
+	}
+	shuffled := spec()
+	lines := strings.Split(strings.TrimSpace(publishedChecksums), "\n")
+	shuffled.Checksums = strings.Join([]string{lines[3], lines[1], lines[0], lines[2]}, "\n") + "\n"
+	second, err := Formula(shuffled)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Errorf("the order of checksums.txt changed the formula:\n%s\n---\n%s", first, second)
+	}
+}
+
+func TestTheSlugComesFromTheModuleLine(t *testing.T) {
+	if got := SlugFromModule("module github.com/stephrobert/feint\n\ngo 1.26\n"); got != "stephrobert/feint" {
+		t.Errorf("SlugFromModule = %q", got)
+	}
+	if got := SlugFromModule("module example.test/feint\n"); got != "" {
+		t.Errorf("a module outside GitHub named a slug: %q", got)
+	}
+}
+
+func TestTheLicenceIsReadRatherThanGuessed(t *testing.T) {
+	id, err := LicenseID("                                 Apache License\n   Version 2.0, January 2004\n")
+	if err != nil || id != "Apache-2.0" {
+		t.Errorf("LicenseID = %q, %v", id, err)
+	}
+	if _, err := LicenseID("All rights reserved.\n"); err == nil {
+		t.Error("an unrecognised licence was given an SPDX identifier anyway")
+	}
+}

--- a/internal/release/surface.go
+++ b/internal/release/surface.go
@@ -1,5 +1,12 @@
-// Package release answers one question about a release: what changed in the
-// surface it serves, and does the release say so.
+// Package release answers what a release owes the people who consume it.
+//
+// Two questions so far, and they share a shape: both are about a fact the
+// release already holds and publishes badly. surface.go asks whether the note
+// names what changed hands; formula.go derives the Homebrew formula from the
+// checksums the release signed, so that installing through `brew` installs the
+// bytes the provenance covers.
+//
+// The first question, and the incident behind it:
 //
 // The question is not rhetorical. 0.9.0 mounted `instance/v2alpha1` private
 // network interfaces and its CHANGELOG contains neither `v2alpha1` nor

--- a/mise.toml
+++ b/mise.toml
@@ -235,6 +235,31 @@ description = "Everything that must be true before a tag exists: mise run releas
 depends = ["build"]
 run = "tools/release/preflight.sh"
 
+[tasks."release:formula"]
+description = "Print the Homebrew formula this release derives, to be copied into the tap"
+# The whole of the "who writes the formula" decision of #321, on one line. The
+# digests come from the release's own checksums.txt — the file cosign signs —
+# so updating the tap by hand costs a copy and never a transcription. Redirect
+# it into the tap's Formula/feint.rb and commit; release:tap then refuses any
+# difference.
+run = "bash --noprofile --norc tools/release/tap.sh print"
+
+[tasks."release:tap"]
+description = "Fail (exit 2) when the Homebrew tap does not serve the formula this release derives"
+# The comparison half, in the shape #245 settled on for the Marketplace mirror:
+# a public artefact read with no secret, rather than a push that would need a
+# cross-repository token this repository does not hold.
+#
+# Deliberately not in prepush and not on the pull-request path. Its red is
+# clearable only by whoever can push to the tap, and a gate a contributor
+# cannot clear is the gate everybody learns to skip — the argument CLAUDE.md
+# makes for keeping `conformance` out of the hook. It runs on a schedule and on
+# demand (.github/workflows/tap.yml).
+#
+# Seen red on 2026-08-20, before the tap existed: exit 2, naming the tap and
+# the one command that fills it.
+run = "bash --noprofile --norc tools/release/tap.sh check"
+
 [tasks."docs:coverage"]
 description = "Regenerate every generated section: coverage tables, client matrix, route reference"
 depends = ["build"]

--- a/tools/falsify/specs/homebrew-formula.json
+++ b/tools/falsify/specs/homebrew-formula.json
@@ -1,0 +1,69 @@
+{
+  "package": "./internal/release/",
+  "mutations": [
+    {
+      "label": "an entry the formula has no platform for is dropped instead of refused, which is how a formula ends up short by a platform with nothing saying so",
+      "file": "internal/release/formula.go",
+      "find": "\t\tif !known {",
+      "replace": "\t\tif !known && false {",
+      "test": "TestAnEntryTheFormulaHasNoPlatformForIsRefused"
+    },
+    {
+      "label": "a checksums line is read for the two fields it happens to start with, so a third field is ignored rather than reported",
+      "file": "internal/release/formula.go",
+      "find": "\t\tif len(fields) != 2 {",
+      "replace": "\t\tif len(fields) != 2 && false {",
+      "test": "TestAChecksumsLineThatIsNotTwoFieldsIsRefused"
+    },
+    {
+      "label": "a digest that is not a SHA-256 is written into the formula, so what brew compares the bytes against is a string nothing produced",
+      "file": "internal/release/formula.go",
+      "find": "\t\tif !sha256Digest.MatchString(entry.digest) {",
+      "replace": "\t\tif !sha256Digest.MatchString(entry.digest) && false {",
+      "test": "TestADigestThatIsNotOneIsRefused"
+    },
+    {
+      "label": "two digests for one asset stop being a contradiction, so the formula publishes whichever line came first",
+      "file": "internal/release/formula.go",
+      "find": "\t\tif previous, ok := seen[entry.name]; ok && previous != entry.digest {",
+      "replace": "\t\tif previous, ok := seen[entry.name]; ok && previous != entry.digest && false {",
+      "test": "TestTwoDigestsForOneAssetAreRefused"
+    },
+    {
+      "label": "an empty checksums list renders a formula that installs nothing, instead of reporting that the measurement did not happen",
+      "file": "internal/release/formula.go",
+      "find": "\tif len(out) == 0 {\n\t\treturn nil, fmt.Errorf(\"checksums.txt is empty",
+      "replace": "\tif len(out) == 0 && false {\n\t\treturn nil, fmt.Errorf(\"checksums.txt is empty",
+      "test": "TestAnEmptyChecksumsListIsRefused"
+    },
+    {
+      "label": "the slug is interpolated into every download URL without being checked, so a module line that is not owner/repo points brew somewhere else",
+      "file": "internal/release/formula.go",
+      "find": "\tif !slugShape.MatchString(spec.Slug) {",
+      "replace": "\tif !slugShape.MatchString(spec.Slug) && false {",
+      "test": "TestTheSlugAndTheVersionAreCheckedBeforeTheyBecomeAURL"
+    },
+    {
+      "label": "the version is interpolated into every download URL without being checked, so `latest` or a range becomes a tag",
+      "file": "internal/release/formula.go",
+      "find": "\tif !semverOnly.MatchString(spec.Version) {",
+      "replace": "\tif !semverOnly.MatchString(spec.Version) && false {",
+      "test": "TestTheSlugAndTheVersionAreCheckedBeforeTheyBecomeAURL"
+    },
+    {
+      "label": "a formula is published with no licence, which brew audit refuses and which nothing here would have noticed",
+      "file": "internal/release/formula.go",
+      "find": "\tif strings.TrimSpace(spec.License) == \"\" {",
+      "replace": "\tif strings.TrimSpace(spec.License) == \"\" && false {",
+      "test": "TestAFormulaWithoutALicenceIsRefused"
+    },
+    {
+      "label": "a LICENSE the table does not recognise is given an SPDX identifier anyway",
+      "file": "internal/release/formula.go",
+      "find": "\treturn \"\", fmt.Errorf(\"the LICENSE file matches no SPDX identifier this knows: \" +\n\t\t\"the formula must not guess one\")",
+      "replace": "\t_ = fmt.Errorf(\"the LICENSE file matches no SPDX identifier this knows: \" +\n\t\t\"the formula must not guess one\")\n\treturn \"Apache-2.0\", nil",
+      "test": "TestTheLicenceIsReadRatherThanGuessed"
+    }
+  ],
+  "note": "The subject is #321: `brew install` has to install the bytes the release signed, and the only file carrying those digests is the release's own cosign-signed checksums.txt. tools/release/tap.sh fetches it over the network, which makes every name and every digest in it an input rather than a fact — the same reasoning that made a restored snapshot untrusted here. The first mutation is the one that matters most and it is the least obvious: dropping an entry the formula has no platform for reads as tolerance and publishes a formula that fails on one architecture with no mention of why."
+}

--- a/tools/falsify/specs/stack-proof.json
+++ b/tools/falsify/specs/stack-proof.json
@@ -1,0 +1,41 @@
+{
+  "package": "./internal/cli/",
+  "mutations": [
+    {
+      "label": "a stack CI applies with no version constraint passes, so an apply resolved from the whole registry that morning reads as a proof",
+      "file": "internal/cli/docs_stacks.go",
+      "find": "\t\tif !pin.Driven || strings.TrimSpace(pin.Constraint) != \"\" {",
+      "replace": "\t\tif !pin.Driven || strings.TrimSpace(pin.Constraint) != \"\" || true {",
+      "test": "TestAStackAppliedInCIPinsTheProviderThatAnswered"
+    },
+    {
+      "label": "a stack no run_stack line applies stops needing a declaration, so the table prints `no` for it as if that were a decision",
+      "file": "internal/cli/docs_stacks.go",
+      "find": "\t\tif _, ok := declared[stack]; !ok {",
+      "replace": "\t\tif _, ok := declared[stack]; !ok && false {",
+      "test": "TestAStackCIDoesNotApplyIsDeclaredWithAReason"
+    },
+    {
+      "label": "a declaration with no reason excuses a stack anyway, and \"not applied\" starts passing for \"not applied because X\"",
+      "file": "internal/cli/docs_stacks.go",
+      "find": "\t\tif strings.TrimSpace(e.Reason) == \"\" {",
+      "replace": "\t\tif strings.TrimSpace(e.Reason) == \"\" && false {",
+      "test": "TestAStackCIDoesNotApplyIsDeclaredWithAReason"
+    },
+    {
+      "label": "a declaration for a stack that no longer exists stops being stale, so the list keeps reasons nothing checks",
+      "file": "internal/cli/docs_stacks.go",
+      "find": "\t\tif !existing[e.Stack] {",
+      "replace": "\t\tif !existing[e.Stack] && false {",
+      "test": "TestADeclarationThatExcusesNothingIsStale"
+    },
+    {
+      "label": "a declaration survives CI starting to apply the stack it excuses, which is the direction that reads like evidence while being false",
+      "file": "internal/cli/docs_stacks.go",
+      "find": "\t\tif applied[e.Stack] {",
+      "replace": "\t\tif applied[e.Stack] && false {",
+      "test": "TestADeclarationThatExcusesNothingIsStale"
+    }
+  ],
+  "note": "The subject is what the generated table of #325 exposed on its first day, and neither half was visible before it existed: examples/stacks/outscale/modules/net was applied on every pull request while declaring no provider constraint at all, and examples/stacks/exoscale is applied by nothing — a good decision, written only in prose, in three files, in three wordings, checked by nothing. The last two mutations are the ones that matter most in the long run: a list of excuses that is never re-read against its subject is how a reason outlives the situation it describes, which CLAUDE.md names as the most expensive defect measured on this repository."
+}

--- a/tools/release/formula/main.go
+++ b/tools/release/formula/main.go
@@ -1,0 +1,86 @@
+// Command formula prints the Homebrew formula a release is installed by.
+//
+// It is a thin front for internal/release, which holds the refusals and their
+// tests. Everything it does itself is reading three files this repository owns:
+//
+//	go run ./tools/release/formula --version 0.9.0 --checksums checksums.txt
+//
+// `--checksums -` reads the list on stdin, which is how tools/release/tap.sh
+// feeds it the file it just fetched from the release.
+//
+// Exit: 0 the formula is on stdout, 1 it could not be produced. There is no
+// exit 2 here: this renders, it does not judge. The verdict is tap.sh's.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/stephrobert/feint/internal/release"
+)
+
+const (
+	exitOK    = 0
+	exitError = 1
+)
+
+func main() { os.Exit(run(os.Args[1:], os.Stdout, os.Stderr)) }
+
+func run(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("formula", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	version := fs.String("version", "", "the released version, without its leading v")
+	checksums := fs.String("checksums", "", "the release's checksums.txt, or - for stdin")
+	goMod := fs.String("go-mod", "go.mod", "the module file the repository slug is read from")
+	license := fs.String("license", "LICENSE", "the licence file the SPDX identifier is read from")
+	if err := fs.Parse(args); err != nil {
+		return exitError
+	}
+	if *version == "" || *checksums == "" {
+		fmt.Fprintln(stderr, "formula: --version and --checksums are required; tools/release/tap.sh fills both in")
+		return exitError
+	}
+
+	list, err := read(*checksums)
+	if err != nil {
+		fmt.Fprintf(stderr, "formula: %v\n", err)
+		return exitError
+	}
+	mod, err := os.ReadFile(*goMod)
+	if err != nil {
+		fmt.Fprintf(stderr, "formula: %v\n", err)
+		return exitError
+	}
+	licence, err := os.ReadFile(*license)
+	if err != nil {
+		fmt.Fprintf(stderr, "formula: %v\n", err)
+		return exitError
+	}
+	spdx, err := release.LicenseID(string(licence))
+	if err != nil {
+		fmt.Fprintf(stderr, "formula: %v\n", err)
+		return exitError
+	}
+
+	out, err := release.Formula(release.Spec{
+		Slug:      release.SlugFromModule(string(mod)),
+		Version:   *version,
+		License:   spdx,
+		Checksums: string(list),
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "formula: %v\n", err)
+		return exitError
+	}
+	fmt.Fprint(stdout, out)
+	return exitOK
+}
+
+func read(path string) ([]byte, error) {
+	if path == "-" {
+		return io.ReadAll(os.Stdin)
+	}
+	return os.ReadFile(path)
+}

--- a/tools/release/tap.sh
+++ b/tools/release/tap.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# The Homebrew tap serves the formula this release derives, or this exits 2.
+#
+#   bash --noprofile --norc tools/release/tap.sh [check|print] [version]
+#
+# version defaults to the CHANGELOG's newest released heading — the same reader
+# `feint docs` uses for every install command it generates, so the tap is judged
+# against the version this repository says is released and never against
+# `latest`.
+#
+# ## Why a comparison and not a push (#321)
+#
+# The decision inside #321 is who writes the formula on release. This is the
+# answer, and it is the shape #245 already settled on one repository over:
+#
+#   - `print` derives the formula from the release's own checksums.txt, the file
+#     cosign signs. Its output is what goes into the tap. Nobody types a digest,
+#     so "hand-updated" costs a copy rather than an authorship, and the failure
+#     mode #321 names — a formula transcribed and then stale — has no door left.
+#   - `check` derives it again and refuses any difference. The tap is public and
+#     the default GITHUB_TOKEN reads it, so this needs no secret. A push step in
+#     release.yml would need a cross-repository token this repository does not
+#     hold, and .github/workflows/workflow-security.yml already refuses exactly
+#     that: "a gate wired to a secret that does not exist is the drift.yml
+#     defect all over again".
+#
+# ## Why it is not on the pull-request path
+#
+# The only person who can clear this red is whoever can push to the tap. A gate
+# a contributor cannot clear is the gate everybody learns to skip, which is the
+# argument CLAUDE.md makes for keeping `conformance` out of the pre-commit hook.
+# So it runs on a schedule and on demand (.github/workflows/tap.yml), where its
+# red lands on the person holding the tap.
+#
+# ## Which ref of the tap
+#
+# The tap's default branch, because that is what `brew update` fetches and
+# therefore what every `brew install` resolves. The Marketplace gate reads a tag
+# for the same reason in the other direction: read what consumers read.
+#
+# Exit: 0 the tap serves this formula, 1 the comparison could not be made,
+# 2 the tap is stale, absent, or serves something else.
+set -uo pipefail
+
+cd "$(dirname "$0")/../.." || exit 1
+
+MODE="${1:-check}"
+VERSION="${2:-}"
+
+if [ -z "$VERSION" ]; then
+  # The newest released heading, the same one internal/cli/docs_release.go
+  # reads. `head -1` on the whole file rather than a range: the Unreleased
+  # section carries no version, so the first match is the released one.
+  VERSION="$(grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | tr -d '#[] ')"
+fi
+if [ -z "$VERSION" ]; then
+  echo "FAIL: no released version in CHANGELOG.md; the reader is broken, not the tap" >&2
+  exit 1
+fi
+
+SLUG="$(sed -n 's|^module github.com/\(.*\)$|\1|p' go.mod)"
+if [ -z "$SLUG" ]; then
+  echo "FAIL: no module path in go.mod to name the repository with" >&2
+  exit 1
+fi
+OWNER="${SLUG%%/*}"
+NAME="${SLUG##*/}"
+# `brew install stephrobert/feint/feint` resolves to github.com/<owner>/homebrew-<name>.
+# Derived, never typed: the day the repository is renamed, the tap this checks
+# is renamed with it instead of staying right about the old one.
+TAP="${OWNER}/homebrew-${NAME}"
+FORMULA_PATH="Formula/${NAME}.rb"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# The release's own list. Fetched rather than rebuilt: the digests in the
+# formula must be the ones the release published and cosign signed, and this is
+# the only file that carries them.
+if ! curl --retry 3 --retry-connrefused -fsSL \
+  -o "$WORK/checksums.txt" \
+  "https://github.com/${SLUG}/releases/download/v${VERSION}/checksums.txt"; then
+  {
+    echo "FAIL: no checksums.txt on the v${VERSION} release of ${SLUG}."
+    echo "Either the network is down, or CHANGELOG.md names a version that was never tagged."
+    echo "Not knowing is not the same answer as the tap being fine."
+  } >&2
+  exit 1
+fi
+
+if ! go run ./tools/release/formula \
+  --version "$VERSION" --checksums "$WORK/checksums.txt" >"$WORK/derived.rb"; then
+  echo "FAIL: the formula could not be derived from the published checksums" >&2
+  exit 1
+fi
+
+if [ "$MODE" = "print" ]; then
+  cat "$WORK/derived.rb"
+  exit 0
+fi
+if [ "$MODE" != "check" ]; then
+  echo "usage: tools/release/tap.sh [check|print] [version]" >&2
+  exit 1
+fi
+
+# The tap as a `brew install` sees it. A 404 here is not a skip: the tap not
+# existing is precisely the state this gate is meant to report, and treating it
+# as "nothing to compare" would make the check pass loudest on the day it has
+# the most to say.
+if ! gh api -H "Accept: application/vnd.github.raw" \
+  "repos/${TAP}/contents/${FORMULA_PATH}" >"$WORK/published.rb" 2>"$WORK/gh.err"; then
+  {
+    echo "DRIFT: ${TAP} does not serve ${FORMULA_PATH}."
+    sed 's/^/  gh: /' "$WORK/gh.err"
+    echo
+    echo "\`brew install ${OWNER}/${NAME}/${NAME}\` installs nothing while this is true."
+    echo "Create the tap, then:"
+    echo "  mise run release:formula > ${FORMULA_PATH}"
+  } >&2
+  exit 2
+fi
+
+if ! diff -u "$WORK/published.rb" "$WORK/derived.rb"; then
+  {
+    echo
+    echo "DRIFT: ${TAP} serves a formula this release does not derive."
+    echo "The left side is what brew installs today; the right side is what v${VERSION} published."
+    echo "Replace it:"
+    echo "  mise run release:formula > ${FORMULA_PATH}"
+  } >&2
+  exit 2
+fi
+
+echo "ok: ${TAP} serves the formula v${VERSION} derives, digests included"


### PR DESCRIPTION
Two doorstep issues of the 0.10.0 milestone, plus the two findings
`docs/clients.md` surfaced the day it was generated.

## #321 — `brew install` exists, and the hand never writes the bytes

**Decision: the gate, not the push — but the formula is derived, never
written.** A push from `release.yml` needs a cross-repository token this
repository does not hold, and it has refused that shape twice in writing
already (`workflow-security.yml` on the Marketplace mirror; `docs_release.go`:
*a gate that repairs the repository is a second way in*).

What kills the other option's failure mode — *hand-written, stale two versions
later* — is that nothing is transcribed: `mise run release:formula` fetches the
release's cosign-signed `checksums.txt` and renders the whole file, so filling
the tap costs a copy. `mise run release:tap` derives it again and exits 2 while
the tap differs.

**Proved with the real client, not by rendering** (Homebrew 5.1.15,
2026-08-20): derived formula → local tap → `brew install
stephrobert/feint/feint` fetched the published v0.9.0 binary, `feint version`
answered `v0.9.0`, `brew test` passed, `brew audit` reported nothing — and
**one flipped byte in a digest failed the install** with `Formula reports
different checksum`. `brew audit` also rejected four `def install`-in-a-block
problems in the first render, which is why the formula carries a single
top-level install.

The digest in the rendered formula is the one the release signed, checked
against the published artefact:
`c1ac0514…aeaace8  feint-darwin-amd64`.

**Falsified** — `tools/falsify/specs/homebrew-formula.json`, 9 mutations, 9
bite. Among them: a platform the formula has no entry for being dropped instead
of refused; a digest that is not a SHA-256 being written anyway; the slug and
the version interpolated into every download URL without being checked.

**Manual actions left, and no secret among them**: create
`stephrobert/homebrew-feint`, run `mise run release:formula > Formula/feint.rb`
in it, commit. The gate reads a public repository with the default
`GITHUB_TOKEN`. Until the tap exists `tap.yml` is red daily, by design — and it
is deliberately **off the PR path**, so no contributor meets a red only the tap
owner can clear.

## #327 — recorded, replayed on demand, never in our CI

**Their repository changes without our decision**, so a required gate over it
can go red for a reason nobody here chose — and a gate whose red we cannot act
on is how a gate teaches people to skip it. This repository already refuses to
clone a third-party repository inside a gate; that rule predates the offer and
is why the Exoscale stack is run by hand.

The contract lives in `examples/stacks/README.md`, where a third party
proposing a stack will find it, with pointers from `CONTRIBUTING.md`. Of the
four points sketched in the issue, **two were dropped** (the provider count
proves nothing extra; "OpenTofu" is subsumed by "a root somebody actually
applies") and **three added**: a commit and a licence, a declared constraint on
every provider in every root *and module*, and a stated wall.

Their figures — 8→0→8 and 27→0→27 — appear in `surveyed.md` attributed,
**"reported by them, not replayed here"**, reconciled against nothing. The
entry is recorded as *"The sixteenth, offered rather than surveyed"* precisely
because #327 carries no repository URL, no commit and no licence, and every
other entry in the register has all three.

## The two findings, now behaviour rather than prose

1. **`examples/stacks/outscale/modules/net`** declared no provider constraint
   and CI applies it. Fixed: it carries the same `~> 1.7` floor as its root,
   with the measured reason (the 1.7+ generation reads its endpoint from
   `OSC_ENDPOINT_API`; 1.1.x appends the path itself). Re-proved with the real
   client through `tools/conformance/stacks.sh`.
2. **`examples/stacks/exoscale`** is pinned by nothing and applied by no CI —
   and **none of pin / apply / remove is right**: a `version` is inert under the
   `dev_overrides` the patched fork requires, applying it would need a
   third-party clone in CI, and removing it deletes the only Terraform reader of
   the Exoscale pack. What was wrong is that the decision existed **only as
   prose**. It is now declared with a reason and a date in `stacksRunByHand`,
   and `docs/clients.md` prints it from the same list the refusal reads.

`feint docs --check` now exits 2 on a stack CI applies without a constraint, on
an unapplied stack nothing declares, on a declaration whose stack disappeared,
and on one that CI has started applying. Measured, not asserted: removing the
constraint from the module gives

```
examples/stacks/outscale/modules/net declares outscale/outscale with no version
constraint and CI applies it: `terraform init -upgrade` resolves it fresh on
every run, so nothing here records which provider answered — the complaint of
#325, turned inward
```

**Falsified** — `tools/falsify/specs/stack-proof.json`, 5 mutations, all bite,
including the direction that reads like evidence while being false: a
declaration surviving CI starting to apply the stack it excuses.

## Premises this work overturned

- **"`examples/stacks/exoscale` is applied by nothing" is false.**
  `examples/stacks/README.md` already records it applied by hand on 2026-08-18 —
  13 resources, empty second plan, clean destroy. What was missing was a *check*
  on that decision, not the application. (My premise, in the brief.)
- **Following the brief would have created a trap.** A committed formula naming
  version N cannot exist before N is published — its digests do not exist yet —
  so it would red `TestEveryExampleNamesTheReleasedVersion` for the whole window
  between moving the changelog heading and publishing. Nothing committed here
  names a version, and the test needed no extension.
- **#321's own dichotomy is incomplete.** "Written by the workflow" versus
  "written by hand" both assume somebody *writes* it. Deriving it from the
  signed checksums removes the authorship from both sides.

## Not measured, and stated as such

`brew install` on **macOS** — only Linuxbrew was available. The darwin URLs and
digests come from the same signed `checksums.txt` and are asserted by tests, but
no Apple machine ran it. `tap.yml` has never run in CI (actionlint and zizmor
clean, zizmor offline). The OpenAether stack itself was never fetched or
replayed, and no figure of theirs is verified here.

## Related

Closes #321
Closes #327
