### PR TITLE
feat: a real account arbitrates the Private Network, and a load balancer distributes packets

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -19,6 +19,61 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Ajouté
 
+- **Un équilibreur de charge Outscale distribue de vrais paquets, à
+  l'intérieur de son propre réseau** (#315). Sous `--vm incus-ovn`, la
+  `PrivateIp` d'un balanceur, une adresse du Subnet où il siège, est remise à
+  l'équilibreur OVN du runtime : les connexions venues de ce réseau se
+  répartissent sur les Vms enregistrées, une Vm déliée cesse d'en recevoir, et
+  la suppression du balanceur le retire de l'hôte. Mesuré le 2026-08-20 avec
+  deux backends et un client sur un même réseau : 6/6 réponses à t0, 6/6 une
+  minute plus tard, sur les deux machines à chaque fois, et 6/6 vers la
+  survivante après un délien. `tools/conformance/outscale/balancer.sh` rejoue
+  la mesure.
+
+  La capacité est déclarée et vérifiée, jamais déduite d'un nom de mode :
+  `/_feint/health` porte désormais `capabilities.balancing` (schéma de santé
+  en version 4), seul le mode OVN la pose, la vérification au démarrage la
+  retire sur un hôte sans OVN, et un binaire qui ignore la clé ne répond rien,
+  ce qui vaut absence. C'est là-dessus qu'un contrôle se branche.
+
+  **Ce qui n'a pas bougé, et pourquoi.** L'adresse publique d'un balanceur
+  exposé sur internet ne route toujours nulle part : une VIP hors du réseau a
+  répondu 6/6 à t0, 6/6 à t+60 s puis 0/6 à partir de t+180 s, définitivement,
+  parce que le runtime n'annonce une telle adresse qu'une fois, à la création.
+  Le pilote **refuse** désormais une adresse d'écoute hors du bloc du réseau
+  plutôt que d'en configurer une qui s'éteindrait quelques minutes après le
+  test qui l'a prouvée. `ReadVmsHealth` reste également décliné : `incus
+  network load-balancer info` répond « No load-balancer health information
+  available », donc rien ne sonde un backend, même ici. La famille `lb/v1` de
+  Scaleway n'est pas touchée : le mécanisme est partagé, le câblage est propre
+  à chaque pack, et ce pack ne demande rien au runtime. `docs/limits.md` porte
+  les chiffres à côté de chaque refus.
+
+- **Un enregistrement du vrai cloud arbitre la forme d'un Private Network**
+  (#270). `feint shapes --record --provider scaleway`, lancé le 2026-08-20
+  contre un vrai compte fr-par portant un Private Network, a appris 76 chemins
+  de champs, dont 62 pour les objets `PrivateNetwork`, `Subnet` et `VPC`, dont
+  aucun n'avait jamais été observé peuplé : l'enregistrement précédent avait été
+  pris sur un compte qui n'en portait aucun, si bien que les deux formes
+  d'élément étaient vides. Les 14 autres sont ceux d'un snapshot block, observés
+  pour la même raison, le compte en portant un.
+
+  Ce qu'il tranche, et que la 0.9.0 disait dans un encadré ne pas pouvoir
+  trancher : la création alloue un `/64` IPv6 sans qu'on le demande, la plage
+  est unique-local (`fdb2:1bb5:120a:9b::/64` sur ce compte), et deux réseaux
+  d'un même projet partagent leur `/48` et ne diffèrent que par l'identifiant
+  de sous-réseau, ce qui est la structure décrite par la RFC 4193. L'émulateur
+  la suit maintenant, au lieu de tirer un `/48` indépendant par réseau. Le
+  `Subnet` que porte une vraie lecture est exactement les huit champs déjà
+  servis.
+
+  La liste de lectures sait désormais décrire une opération qui prend un
+  identifiant : une entrée finissant par `{id}` est remplie depuis la
+  collection qui la précède, dans la même exécution, et le catalogue conserve
+  le chemin gabarit. `GET /vpc/v2/regions/fr-par/private-networks/{id}`, la
+  lecture avec laquelle le provider Terraform rafraîchit, et celle que rien
+  ici ne pouvait arbitrer, est la première.
+
 - **Les équilibreurs de charge Scaleway, cadrés par ce que les stacks
   observées appellent** (#282). `lb/v1` sert 35 opérations sur sa porte zonale :
   `ZonedAPI.CreateLB`, `ZonedAPI.GetLB`, `ZonedAPI.ListLBs`,
@@ -171,6 +226,38 @@ change ni l'un ni l'autre a sa place dans `git log`.
   et sur une déclaration visant une stack disparue ou que la CI s'est mise à
   appliquer. La raison est imprimée sur `docs/clients.md` depuis la liste même
   que lit le refus. Falsifié par `tools/falsify/specs/stack-proof.json`.
+
+- **Un Private Network et un VPC servent le drapeau Object Storage que le vrai
+  cloud porte** (#270). `has_s3_integration` et `s3_integration_enabled`
+  étaient déclarés par le contrat, renvoyés par chaque réponse réelle, et
+  absents ici. Les deux sont invisibles à travers `scw`, qui les laisse tomber
+  en chemin vers sa propre sortie : seul un enregistrement pouvait les
+  trouver, et seulement un enregistrement pris pendant que les objets
+  existaient.
+
+- **Les deux créations `vpc/v2` répondent 200, ce que portait le fil** (#270).
+  `CreateVPC` et `CreatePrivateNetwork` répondaient 201, le statut qu'écrit
+  toute autre création du pack ; les deux ont été mesurées à 200 sur un vrai
+  compte, lues dans une transcription `feint proxy` plutôt que sur un CLI qui
+  n'en montre aucun. Aucun autre produit n'a été mesuré, donc aucun autre n'a
+  bougé. Cela ne change rien pour un client qui teste 2xx, et cela change ce
+  que cet émulateur a le droit d'affirmer.
+
+- **Un identifiant n'atteint jamais un catalogue de formes versionné** (#270).
+  L'enregistrement d'une ressource porte le chemin de cette ressource, et ce
+  chemin partait verbatim dans la clé d'opération et dans `Operation.Path` :
+  la première entrée de liste de lectures visant un objet unique aurait donc
+  commité l'UUID du compte de quelqu'un dans `shapes/*.json`. Les chemins sont
+  désormais anonymisés à la frontière où un enregistrement devient un
+  artefact, quel qu'en soit l'auteur, et un test lit les fichiers versionnés
+  eux-mêmes au lieu de faire confiance à la règle.
+
+- **`feint shapes --check` nomme ce qu'il n'a pas pu comparer** (#270). Onze
+  opérations enregistrées sortaient de son arithmétique sans un mot :
+  l'émulateur répond un refus hors ligne et la comparaison était sautée en
+  silence. La ligne de couverture les liste maintenant comme non contrôlées,
+  ce qui est la différence entre « rien ne va mal » et « rien n'a été
+  regardé ».
 
 - **`server.public_ips` répond dans l'ordre que la création a nommé** (#320).
   `Server.public_ips` chez Scaleway est une liste et Terraform la stocke comme

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,57 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Added
 
+- **An Outscale load balancer distributes real packets, inside its own
+  network** (#315). Under `--vm incus-ovn`, a balancer's `PrivateIp` — an
+  address of the Subnet it sits in — is handed to the runtime's own OVN load
+  balancer: connections from inside that network are spread over the registered
+  Vms, an unlinked Vm stops receiving them, and deleting the balancer takes it
+  off the host. Measured on 2026-08-20 with two backends and one client on one
+  network: 6/6 answered at t0, 6/6 a minute later, over both machines each
+  time, and 6/6 to the survivor after an unlink.
+  `tools/conformance/outscale/balancer.sh` replays it.
+
+  The claim is declared and verified, never deduced from a mode name:
+  `/_feint/health` gained `capabilities.balancing` (health schema version 4),
+  the OVN mode alone sets it, startup verification clears it on a host with no
+  OVN wiring, and a build that does not know the key answers nothing — which
+  reads as absent. Gate on it.
+
+  **What did not move, and why.** The public address of an internet-facing
+  balancer still routes nowhere: a VIP outside the network answered 6/6 at t0,
+  6/6 at t+60s and 0/6 from t+180s onwards, permanently, because the runtime
+  announces such an address once at creation and never again. The driver now
+  **refuses** a listen address outside the network's own block rather than
+  configuring one that would go dark minutes after the test that proved it.
+  `ReadVmsHealth` also stays declined: `incus network load-balancer info`
+  answers "No load-balancer health information available", so nothing probes a
+  backend even here. The Scaleway `lb/v1` family is untouched — the mechanism is
+  shared, the wiring is per pack, and this pack asks the runtime for nothing.
+  `docs/limits.md` carries the figures beside each refusal.
+
+- **A real-cloud recording arbitrates a Private Network's shape** (#270).
+  `feint shapes --record --provider scaleway`, run on 2026-08-20 against a real
+  fr-par account holding one Private Network, learned 76 field paths, 62 of
+  them the `PrivateNetwork`, `Subnet` and `VPC` objects — none of which had ever
+  been observed populated, because the previous recording was taken on an
+  account holding neither, so both element shapes were empty. The other 14 are a
+  block snapshot's, observed for the same reason: the account had one.
+
+  What it settles, and what 0.9.0 said in a callout it could not: creation
+  allocates an IPv6 `/64` without being asked, the range is unique-local
+  (`fdb2:1bb5:120a:9b::/64` on that account), and two networks of one project
+  share their `/48` and differ only in the subnet ID — RFC 4193's own layout,
+  which this emulator now follows instead of drawing an independent `/48` per
+  network. The `Subnet` a real read carries is exactly the eight fields already
+  served.
+
+  The read list can now describe an operation that takes an identifier: an entry
+  ending in `{id}` is filled in from the collection above it, in the same run,
+  and the catalogue stores the templated path. `GET
+  /vpc/v2/regions/fr-par/private-networks/{id}` — the read the Terraform
+  provider refreshes with, and the one nothing here could arbitrate — is the
+  first of them.
+
 - **Scaleway load balancers, scoped by what the surveyed stacks call** (#282).
   `lb/v1` serves 35 operations on its zoned door: `ZonedAPI.CreateLB`,
   `ZonedAPI.GetLB`, `ZonedAPI.ListLBs`, `ZonedAPI.UpdateLB`,
@@ -160,6 +211,35 @@ what this project is judged on: **a response shape a client can observe**, and
   stack that has disappeared or that CI has started applying. The reason is
   printed on `docs/clients.md` from the same list the refusal reads.
   Falsified by `tools/falsify/specs/stack-proof.json`.
+
+- **A Private Network and a VPC serve the Object Storage flag the real cloud
+  carries** (#270). `has_s3_integration` and `s3_integration_enabled` were
+  declared by the contract, returned by every real answer, and absent here. Both
+  are invisible through `scw`, which drops them on the way to its own output, so
+  only a recording could find them — and only one taken while the objects
+  existed.
+
+- **The two `vpc/v2` creates answer 200, which is what the wire carried**
+  (#270). `CreateVPC` and `CreatePrivateNetwork` answered 201, the status every
+  other create in the pack writes; both were measured at 200 on a real account,
+  read off a `feint proxy` transcript rather than off a CLI that shows neither.
+  No other product was measured, so no other product moved. It changes nothing
+  for a client that tests 2xx, and it changes what this emulator is allowed to
+  claim.
+
+- **An identifier never reaches a committed shape catalogue** (#270). A
+  recording of one resource carries that resource's path, and the path went into
+  the operation key and into `Operation.Path` verbatim — so the first read-list
+  entry addressing a single object would have committed somebody's account UUID
+  to `shapes/*.json`. Paths are now anonymised at the boundary where a recording
+  becomes an artefact, whatever wrote it, and a test reads the committed files
+  themselves rather than trusting the rule.
+
+- **`feint shapes --check` names what it could not compare** (#270). Eleven
+  recorded operations were dropping out of its arithmetic without a word: the
+  emulator answers a refusal offline and the comparison was skipped in silence.
+  The coverage line now lists them as unchecked, which is the difference between
+  "nothing is wrong" and "nothing was looked at".
 
 - **`server.public_ips` answers in the order the create named** (#320).
   Scaleway's `Server.public_ips` is a list and Terraform stores it as one: the

--- a/README.md
+++ b/README.md
@@ -575,12 +575,17 @@ There are three runtimes and they do not deliver the same thing. The table is
 what `tools/conformance/scaleway/network.sh` actually returns, run in each mode
 on 2026-07-29:
 
-| `--vm` | Machines | Addresses | Firewall | **Isolation** | Own kernel | Needs |
-|---|:--:|:--:|:--:|:--:|:--:|---|
-| `off` *(default)* | — | — | — | — | — | nothing |
-| `incus` | yes | yes | yes | **no** | no | Incus 6.0.4+ |
-| `incus-vm` | yes | yes | yes | **no** | yes | Incus + KVM |
-| `incus-ovn` | yes | yes | yes | **yes** | no | Incus + `ovn-central`, `ovn-host`, Open vSwitch |
+| `--vm` | Machines | Addresses | Firewall | **Isolation** | **Balancing** | Own kernel | Needs |
+|---|:--:|:--:|:--:|:--:|:--:|:--:|---|
+| `off` *(default)* | — | — | — | — | — | — | nothing |
+| `incus` | yes | yes | yes | **no** | **no** | no | Incus 6.0.4+ |
+| `incus-vm` | yes | yes | yes | **no** | **no** | yes | Incus + KVM |
+| `incus-ovn` | yes | yes | yes | **yes** | **yes** | no | Incus + `ovn-central`, `ovn-host`, Open vSwitch |
+
+Balancing is the second claim only OVN carries (#315): an Outscale load
+balancer's own private address distributes real connections to clients inside
+its network. Its public face routes nowhere in every mode, and the measurement
+behind that refusal is in `docs/limits.md`.
 
 **Exactly one assertion in the whole network suite changes verdict with the
 mode**, and it is the one carrying the project's strongest claim: two private

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -1706,7 +1706,7 @@ So: a plan that builds a routable topology applies, reads back and destroys
 correctly. A machine inside it still cannot reach the internet. Use the emulator
 to test the shape of your infrastructure, never its connectivity.
 
-## An Outscale load balancer records its configuration; nothing distributes packets
+## An Outscale load balancer distributes packets inside its network, and nowhere else
 
 The LBU family is served as far as the surveyed stacks exercise it (#281):
 create, read, update (health check, security groups, secured cookies),
@@ -1720,25 +1720,49 @@ What a `200` from `CreateLoadBalancer` means here, stated rather than implied:
   health-check settings, tags, the security groups and the subnet come back
   field for field, and the delete guards hold the same algebra as the rest of
   the pack: a subnet or a security group under a balancer refuses to go.
-- **No traffic is distributed, in any current mode.** The `DnsName` follows
-  the measured format (`<name>-<digits>.<region>.lbu.outscale.com`,
-  `internal-` prefix included) and resolves nowhere; the public address of an
-  internet-facing balancer comes from `203.0.113.0/24` — TEST-NET-3,
-  RFC 5737, routed nowhere on purpose, and deliberately not the block
-  ReadPublicIps allocates from, because the real service associates an
-  address the account does not own. The OVN path was measured rather than
-  waved at (#315): `incus network load-balancer` on an emulator-owned
-  network genuinely balanced connections across two backends, kept doing so
-  indefinitely for **in-network** clients, and its host-side VIP went dark
-  within three minutes — the same announcement defect the routed-address
-  path exists to avoid. The internal-LBU dataplane is therefore buildable
-  and is #315's; the internet-facing one waits on the VIP holding.
+- **Its own private address distributes, under `--vm incus-ovn` and there
+  only.** A balancer's `PrivateIp` is an address of the Subnet it sits in, and
+  it is handed to `incus network load-balancer` on the Subnet's own network:
+  connections from inside that network are spread over the registered Vms, an
+  unlinked Vm stops receiving them, and deleting the balancer takes it off the
+  host. Measured on 2026-08-20 with three machines on one OVN network — two
+  backends answering their own name on `:80`, one client — 6/6 answered at t0
+  and 6/6 again a minute later, over both backends each time, and 6/6 to the
+  survivor after an unlink. `tools/conformance/outscale/balancer.sh` is that
+  measurement, replayed on demand.
+
+  The claim is declared, never deduced: `/_feint/health` answers
+  `capabilities.balancing`, the OVN mode alone sets it, startup verification
+  clears it on a host with no OVN wiring, and a build that does not know the
+  key answers nothing — which reads as absent. A suite must gate on it and
+  never on a mode name.
+- **The public face distributes nothing, and that is a measurement too.** The
+  `DnsName` follows the measured format
+  (`<name>-<digits>.<region>.lbu.outscale.com`, `internal-` prefix included)
+  and resolves nowhere; the public address of an internet-facing balancer comes
+  from `203.0.113.0/24` — TEST-NET-3, RFC 5737, routed nowhere on purpose, and
+  deliberately not the block ReadPublicIps allocates from, because the real
+  service associates an address the account does not own.
+
+  The reason it stays that way is on the record (#315, measured 2026-08-19). A
+  VIP *outside* the network, delegated through the uplink's `ipv4.routes`,
+  answered 6/6 probes at t0, 6/6 at t+60s, and **0/6 from t+180s onwards**,
+  permanently, `ip neigh flush` included: the runtime announces such an address
+  with a burst of gratuitous ARPs at creation time and never again — the same
+  defect `internal/core/machine/incus_ovn.go` records for network forwards. The
+  driver's `ipv4.routes.external` path holds indefinitely and is strictly
+  one-machine, so it cannot carry a multi-backend VIP either.
+
+  So `EnsureBalancer` **refuses** a listen address outside the network's own
+  block rather than configuring one. A balancer that passes a test and fails
+  three minutes later is worse than a balancer that was never claimed.
 - **No backend health exists, and none is invented.** `ReadVmsHealth` stays
-  declined: under every current runtime mode nothing probes a backend, and a
-  backend reported `UP` that nothing checked is the exact answer this project
-  exists to refuse. The health-check *settings* round-trip because Terraform
-  plans on them; the health *states* do not exist until something measures
-  them.
+  declined, and it stays declined *after* the dataplane landed: `incus network
+  load-balancer info` answers "No load-balancer health information available",
+  so nothing probes a backend even under OVN, and a backend reported `UP` that
+  nothing checked is the exact answer this project exists to refuse. The
+  health-check *settings* round-trip because Terraform plans on them; the
+  health *states* do not exist until something measures them.
 - **The stored health-check defaults are the vendor's own** (interval 30,
   timeout 5, unhealthy 2, healthy 10, TCP on the first listener's backend
   port — the defaults Outscale's user guide documents), so a stack that never
@@ -1756,9 +1780,12 @@ a silent 200.
 
 The lb/v1 ZonedAPI and vpc-gw/v2 families are served as far as the measured
 clients exercise them (#282): the surveyed kubic and terraform-talos stacks,
-Scaleway's own LB and VPC modules, `scw lb` and `scw vpc-gw`. The decision is
-the one #315 measured for the Outscale LBU, and the Scaleway case does not
-differ — the same runtime would carry the packets that nothing carries.
+Scaleway's own LB and VPC modules, `scw lb` and `scw vpc-gw`. The dataplane
+#315 built for the Outscale LBU has not been wired here: the mechanism is the
+same and the pack is not, so the honest statement is that a Scaleway balancer
+still records its configuration and forwards nothing. `capabilities.balancing`
+says what the *runtime* can do, never what a given pack asked it for, and this
+pack asks for nothing.
 
 What a `200` means here, stated rather than implied:
 

--- a/internal/cli/shapes.go
+++ b/internal/cli/shapes.go
@@ -197,13 +197,46 @@ func recordUpstream(p upstream.Provider, profile string, stdout io.Writer) ([]tr
 		return nil, err
 	}
 	fmt.Fprintf(stdout, "reading %s at %s, %d call(s)\n", p, client.Endpoint, len(calls))
+	return readEach(context.Background(), p, calls, client.Read, stdout)
+}
 
-	ctx := context.Background()
+// readEach walks a read list, filling in the templated entries from what the
+// run itself has already read.
+//
+// Separate from recordUpstream because recordUpstream cannot be run without a
+// real account: it loads credentials at its first line. The two properties that
+// matter here — a templated entry refuses to run before its collection, and an
+// account with nothing to read says so instead of asking for an identifier it
+// does not have — are properties of this loop, and this is where a test can
+// hold them.
+func readEach(ctx context.Context, p upstream.Provider, calls []string, read func(context.Context, string) (trace.Exchange, error), stdout io.Writer) ([]trace.Exchange, error) {
 	out := make([]trace.Exchange, 0, len(calls))
-	answered := 0
+	// What each collection answered, so a templated entry can be filled in from
+	// the run's own reading rather than from an identifier written down
+	// somewhere. See the note beside upstream.TemplateOf.
+	answers := map[string]any{}
+	answered, unresolved := 0, 0
 	for _, call := range calls {
+		target := call
+		if collection, templated := upstream.TemplateOf(call); templated {
+			body, read := answers[collection]
+			if !read {
+				// A list ordered so an element read comes before its
+				// collection is a mistake in this file, not a fact about the
+				// account, and it is refused rather than skipped: skipped, it
+				// would read as "this account has none".
+				return nil, fmt.Errorf("%s reads one element of %s, which no earlier entry of Reads[%s] asks for", call, collection, p)
+			}
+			id, found := upstream.FirstID(body)
+			if !found {
+				fmt.Fprintf(stdout, "  %-46s no element to read: %s answered none\n", call, collection)
+				unresolved++
+				continue
+			}
+			target = collection + "/" + id
+		}
 		fmt.Fprintf(stdout, "  %-46s ", call)
-		ex, err := client.Read(ctx, call)
+		ex, err := read(ctx, target)
 		if err != nil {
 			fmt.Fprintf(stdout, "error: %v\n", err)
 			continue
@@ -211,6 +244,9 @@ func recordUpstream(p upstream.Provider, profile string, stdout io.Writer) ([]tr
 		if ex.Status >= 200 && ex.Status < 300 {
 			answered++
 			fmt.Fprintln(stdout, "ok")
+			if ex.Res != nil {
+				answers[call] = ex.Res.Body
+			}
 		} else {
 			fmt.Fprintf(stdout, "HTTP %d\n", ex.Status)
 		}
@@ -220,5 +256,11 @@ func recordUpstream(p upstream.Provider, profile string, stdout io.Writer) ([]tr
 	// read as a complete one: a gate built on it would then report a missing
 	// field where nothing was ever observed.
 	fmt.Fprintf(stdout, "%d of %d answered\n", answered, len(calls))
+	if unresolved > 0 {
+		// Counted separately from a refusal: nothing was asked at all, because
+		// the account holds no such resource. Silence here would let a run made
+		// on an empty account read like a run that observed an empty shape.
+		fmt.Fprintf(stdout, "%d not asked: no resource of that kind on this account to read one of\n", unresolved)
+	}
 	return out, nil
 }

--- a/internal/cli/shapes_check.go
+++ b/internal/cli/shapes_check.go
@@ -98,6 +98,7 @@ func checkShapes(dir string, providers []string, stdout, stderr io.Writer) int {
 	defer ts.Close()
 
 	total, missing, excused, stale := 0, 0, 0, 0
+	var unanswered []string
 	for _, name := range providers {
 		p := upstream.Provider(name)
 		cat, err := readCatalogue(filepath.Join(dir, name+".json"), name)
@@ -113,10 +114,17 @@ func checkShapes(dir string, providers []string, stdout, stderr io.Writer) int {
 			continue
 		}
 
-		checked, gaps, excusedHere, unused := checkProvider(p, cat, declines[name], ts, stdout)
+		checked, gaps, excusedHere, unused, silent := checkProvider(p, cat, declines[name], ts, stdout)
 		total += checked
 		missing += gaps
 		excused += excusedHere
+		// Printed, not counted against anything. An operation the emulator
+		// answers with a refusal is compared against nothing, and it used to
+		// leave no trace at all: the coverage line said "50 compared" and eleven
+		// recorded operations had quietly dropped out of the arithmetic. A
+		// number that shrinks without saying so is the failure this file's own
+		// coverage line exists to prevent.
+		unanswered = append(unanswered, silent...)
 		// A decline that excused no gap is stale: the field is served now, or
 		// was never observed missing. Failing on it is what keeps the declined
 		// list a set of live decisions instead of an archive — the analogue of
@@ -133,6 +141,18 @@ func checkShapes(dir string, providers []string, stdout, stderr io.Writer) int {
 	// "nothing was checked" — the same reason `feint status` prints how many
 	// routes no client has driven.
 	fmt.Fprintf(stdout, "\n%d operation(s) compared, %d field(s) the real cloud returns and this emulator does not\n", total, missing)
+	if len(unanswered) > 0 {
+		// Named, so the gap between "recorded" and "compared" is legible
+		// instead of being a subtraction nobody performs. Two things land
+		// here and they are both worth seeing: an operation this emulator does
+		// not serve at all, and one that needs an object the offline store does
+		// not hold — every element read is in the second class by construction.
+		sort.Strings(unanswered)
+		fmt.Fprintf(stdout, "%d recorded operation(s) this emulator did not answer offline, so nothing was compared:\n", len(unanswered))
+		for _, u := range unanswered {
+			fmt.Fprintf(stdout, "  unchecked %s\n", u)
+		}
+	}
 	if excused > 0 {
 		// Counted out loud so a growing declined list stays visible instead of
 		// silently hollowing the gate.
@@ -151,9 +171,11 @@ func checkShapes(dir string, providers []string, stdout, stderr io.Writer) int {
 // checkProvider drives one provider's read list against the emulator.
 //
 // Besides the counts, it returns the declines that excused nothing, for the
-// caller to refuse: whether a decline is stale is only known once every
-// operation of its provider has been compared.
-func checkProvider(p upstream.Provider, cat *shape.Catalogue, declines []emulator.FieldDecline, ts *httptest.Server, stdout io.Writer) (checked, missing, excused int, unused []emulator.FieldDecline) {
+// caller to refuse — whether a decline is stale is only known once every
+// operation of its provider has been compared — and the recorded operations the
+// emulator did not answer, which are compared against nothing and used to
+// vanish from the arithmetic without a word.
+func checkProvider(p upstream.Provider, cat *shape.Catalogue, declines []emulator.FieldDecline, ts *httptest.Server, stdout io.Writer) (checked, missing, excused int, unused []emulator.FieldDecline, unanswered []string) {
 	// Two gates read DeclinedFields(), each joining on its own spelling: this
 	// one on the catalogue key ("GET /path", or the operation name where the
 	// recording carried one), the live field gate on the mounted operation
@@ -198,6 +220,7 @@ func checkProvider(p upstream.Provider, cat *shape.Catalogue, declines []emulato
 
 		got, ok := emulatorShape(ts, method, path)
 		if !ok {
+			unanswered = append(unanswered, string(p)+" "+key)
 			continue
 		}
 		checked++
@@ -250,7 +273,7 @@ func checkProvider(p upstream.Provider, cat *shape.Catalogue, declines []emulato
 		}
 		unused = append(unused, declines[i])
 	}
-	return checked, missing, excused, unused
+	return checked, missing, excused, unused, unanswered
 }
 
 // matchingDecline is the first decline covering this field, or -1. First match

--- a/internal/cli/shapes_record_test.go
+++ b/internal/cli/shapes_record_test.go
@@ -1,0 +1,146 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/shape"
+	"github.com/stephrobert/feint/internal/trace"
+	"github.com/stephrobert/feint/internal/upstream"
+)
+
+// answering builds a reader that hands back one body per call, and records the
+// order the calls were made in.
+func answering(bodies map[string]any, asked *[]string) func(context.Context, string) (trace.Exchange, error) {
+	return func(_ context.Context, call string) (trace.Exchange, error) {
+		*asked = append(*asked, call)
+		body, known := bodies[call]
+		if !known {
+			return trace.Exchange{Method: "GET", Path: call, Status: 404}, nil
+		}
+		return trace.Exchange{
+			Method: "GET", Path: call, Status: 200,
+			Res: &trace.Message{Body: body},
+		}, nil
+	}
+}
+
+// A templated entry is filled in from the collection's own answer, and the call
+// that goes out carries the identifier the account actually holds.
+//
+// The recording that comes back names the concrete object; the catalogue does
+// not, and that split is the whole reason this can be committed at all
+// (internal/shape.AnonymisePath).
+func TestATemplatedReadResolvesFromTheCollectionItFollows(t *testing.T) {
+	const id = "3f2a91c4-77b0-4d19-9c2e-51ab8e0d64f7"
+	collection := "/vpc/v2/regions/fr-par/private-networks"
+	var asked []string
+	var out strings.Builder
+
+	exs, err := readEach(context.Background(), upstream.Scaleway,
+		[]string{collection, collection + "/" + shape.Placeholder},
+		answering(map[string]any{
+			collection: map[string]any{
+				"private_networks": []any{map[string]any{"id": id, "name": "feint-shape-270"}},
+				"total_count":      1,
+			},
+			collection + "/" + id: map[string]any{"id": id, "has_s3_integration": false},
+		}, &asked),
+		&out)
+	if err != nil {
+		t.Fatalf("readEach: %v", err)
+	}
+	if len(asked) != 2 || asked[1] != collection+"/"+id {
+		t.Fatalf("the element read went to %v, want the collection then %s", asked, collection+"/"+id)
+	}
+	if len(exs) != 2 {
+		t.Fatalf("recorded %d exchange(s), want 2", len(exs))
+	}
+
+	cat := shape.New("scaleway")
+	cat.Merge(exs)
+	wanted := "GET " + collection + "/" + shape.Placeholder
+	if _, known := cat.Operations[wanted]; !known {
+		t.Errorf("the element read is not keyed %q; the gate looks it up under exactly the read-list entry", wanted)
+	}
+}
+
+// An account holding none of the resource asks for nothing, and says so.
+//
+// The alternative failure is the one worth naming: reading the collection,
+// finding it empty and calling `<collection>/` or `<collection>/{id}` anyway
+// would record a 404 as this operation's shape, and a 404 body is a different
+// schema entirely.
+func TestATemplatedReadAsksNothingWhenTheAccountHasNone(t *testing.T) {
+	collection := "/vpc/v2/regions/fr-par/private-networks"
+	var asked []string
+	var out strings.Builder
+
+	exs, err := readEach(context.Background(), upstream.Scaleway,
+		[]string{collection, collection + "/" + shape.Placeholder},
+		answering(map[string]any{
+			collection: map[string]any{"private_networks": []any{}, "total_count": 0},
+		}, &asked),
+		&out)
+	if err != nil {
+		t.Fatalf("readEach: %v", err)
+	}
+	if len(asked) != 1 {
+		t.Fatalf("calls made: %v, want the collection alone", asked)
+	}
+	if len(exs) != 1 {
+		t.Fatalf("recorded %d exchange(s), want 1", len(exs))
+	}
+	if !strings.Contains(out.String(), "no element to read") {
+		t.Errorf("the run went quiet about an unresolved entry:\n%s", out.String())
+	}
+}
+
+// A templated entry placed before its collection is refused, not skipped.
+//
+// Skipped, it would be indistinguishable from an account holding none of the
+// resource — a mistake in the read list would read as a fact about somebody's
+// cloud, and the catalogue would quietly stop covering an operation nobody
+// noticed had dropped out.
+func TestATemplatedReadBeforeItsCollectionIsRefused(t *testing.T) {
+	collection := "/vpc/v2/regions/fr-par/private-networks"
+	var asked []string
+	var out strings.Builder
+
+	_, err := readEach(context.Background(), upstream.Scaleway,
+		[]string{collection + "/" + shape.Placeholder, collection},
+		answering(nil, &asked), &out)
+	if err == nil {
+		t.Fatalf("an element read before its collection was accepted; calls made: %v", asked)
+	}
+	if !strings.Contains(err.Error(), collection) {
+		t.Errorf("the refusal does not name the collection that is missing: %v", err)
+	}
+}
+
+// Every templated entry of every read list is preceded by its collection.
+//
+// The refusal above only bites when somebody runs the recorder, which needs an
+// account; this holds the same rule against the list as committed, offline, on
+// every pull request.
+func TestEveryTemplatedReadFollowsItsCollection(t *testing.T) {
+	templated := 0
+	for p, calls := range upstream.Reads {
+		seen := map[string]bool{}
+		for _, call := range calls {
+			if collection, ok := upstream.TemplateOf(call); ok {
+				templated++
+				if !seen[collection] {
+					t.Errorf("%s: %s reads one element of %s, which no earlier entry asks for", p, call, collection)
+				}
+			}
+			seen[call] = true
+		}
+	}
+	// Asserted rather than assumed: with no templated entry anywhere this test
+	// would pass while measuring nothing.
+	if templated == 0 {
+		t.Fatalf("no templated entry in any read list, so this check proves nothing")
+	}
+}

--- a/internal/cli/testdata/frozen/health.json
+++ b/internal/cli/testdata/frozen/health.json
@@ -212,6 +212,93 @@
           }
         ]
       }
+    },
+    {
+      "schema_version": 4,
+      "content": {
+        "fields": [
+          {
+            "path": "capabilities",
+            "type": "object"
+          },
+          {
+            "path": "capabilities.addresses",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.balancing",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.firewall",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.isolation",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.machines",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.own_kernel",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.private_from_host",
+            "type": "bool"
+          },
+          {
+            "path": "enforced",
+            "type": "object"
+          },
+          {
+            "path": "enforced.firewall",
+            "type": "array"
+          },
+          {
+            "path": "enforced.firewall[]",
+            "type": "string"
+          },
+          {
+            "path": "instance",
+            "type": "object"
+          },
+          {
+            "path": "instance.pid",
+            "type": "number"
+          },
+          {
+            "path": "instance.started_at",
+            "type": "string"
+          },
+          {
+            "path": "machines",
+            "type": "string"
+          },
+          {
+            "path": "providers",
+            "type": "array"
+          },
+          {
+            "path": "providers[]",
+            "type": "string"
+          },
+          {
+            "path": "resources",
+            "type": "number"
+          },
+          {
+            "path": "schema_version",
+            "type": "number"
+          },
+          {
+            "path": "status",
+            "type": "string"
+          }
+        ]
+      }
     }
   ]
 }

--- a/internal/core/emulator/schema.go
+++ b/internal/core/emulator/schema.go
@@ -38,7 +38,14 @@ const (
 	// so. `feint start` now compares `instance.pid` against the process it
 	// spawned and refuses a stranger; any harness that starts an emulator can
 	// do the same.
-	HealthSchemaVersion = 3
+	//
+	// 4 since #315: `capabilities` gained `balancing` — an emulated load
+	// balancer distributes real connections, for clients inside the network it
+	// sits in. Additive, and a claim rather than a detail, which is why it
+	// moves the version: a suite that wants to prove a balancer balances must
+	// key on this and never on a mode name, and a build that cannot answer the
+	// question at all is exactly what a version is for.
+	HealthSchemaVersion = 4
 	// RoutesSchemaVersion is the shape of GET /_feint/routes.
 	//
 	// This one is not on the wire: the endpoint answers a bare JSON array — the

--- a/internal/core/machine/balancer.go
+++ b/internal/core/machine/balancer.go
@@ -1,0 +1,92 @@
+package machine
+
+import "context"
+
+// A load balancer that distributes packets, within the one bound that was
+// measured (#315).
+//
+// The LBU and lb/v1 families are served as configuration everywhere: created,
+// read back, destroyed in the right order. Nothing distributed a packet, and the
+// documentation said so. This is the half that can now be more than a record,
+// and the half that cannot, told apart by measurement rather than by hope.
+//
+// What holds. On 2026-08-20, on an OVN network of this emulator's own making,
+// an `incus network load-balancer` whose listen address is an address of the
+// network's own block distributed real connections across two backends and kept
+// doing so: 6/6 answered at t0, at t+60s and at t+180s, spread over both
+// machines every time. That is a balancer an emulated *internal* load balancer
+// can be, because an internal balancer's address is exactly that — one address
+// of the subnet it sits in.
+//
+// What does not. #315 measured the other address on 2026-08-19: a VIP outside
+// the network, delegated through the uplink's routes, answered 6/6 at t0 and
+// t+60s and then 0/6 for ever from t+180s. The runtime announces such an address
+// with a burst of gratuitous ARPs at creation time and never again, which is the
+// same defect incus_ovn.go records for network forwards. An internet-facing
+// balancer's public address is that kind of address, so it stays what
+// docs/limits.md describes: a TEST-NET-3 address routed nowhere on purpose.
+//
+// The two are not the same mechanism, and reading the second measurement as a
+// verdict on the first is the mistake this comment exists to prevent: an
+// in-block address needs no announcement at all. The emulator already delegates
+// every emulated subnet to the uplink (delegateRoute), so the uplink routes the
+// whole block to the OVN router, and the router answers for the VIP as it does
+// for any other address of its own switch.
+//
+// Hence Capabilities.Balancing, declared by the OVN mode alone, and hence
+// EnsureBalancer refusing a listen address outside the network's own block
+// rather than configuring one that would go dark in minutes.
+
+// BalancerListener is one port a balancer answers on, and the port it hands the
+// connection to on each backend.
+type BalancerListener struct {
+	// Protocol is "tcp" or "udp". A runtime that distributes neither is not a
+	// Balancer.
+	Protocol string
+	// Listen is the port the balancer's address answers on.
+	Listen int
+	// Backend is the port each machine is given the connection on.
+	Backend int
+}
+
+// BalancerSpec is a named balancer on one network, described whole.
+//
+// Whole, and not patched member by member, for the reason EnsureFirewall states
+// for a rule set: replacing is what makes a backend removed upstream actually
+// stop receiving connections. A register followed by an unregister has to leave
+// the runtime holding exactly what the API says it holds.
+type BalancerSpec struct {
+	// Name identifies the emulated balancer, for the description the runtime
+	// stores and an ownership check reads back.
+	Name string
+	// Network is the runtime network the balancer lives on. It must be one the
+	// emulator created: a balancer written onto an operator's own network would
+	// survive every sweep.
+	Network string
+	// Listen is the address the balancer answers on. It must belong to
+	// Network's own block — see the package comment: an address outside it is
+	// announced once and goes dark.
+	Listen string
+	// Listeners are the ports, at least one.
+	Listeners []BalancerListener
+	// Targets are the addresses of the machines behind it. An empty list is
+	// valid and means exactly what it says: a balancer with no backend, which
+	// is what a stack has between creating one and registering its first
+	// machine.
+	Targets []string
+}
+
+// Balancer is the optional half of a Driver that can distribute packets.
+//
+// Optional for the same reason Firewaller is: absence has to be a compile-time
+// fact and a declared capability, never a silent no-op. A pack whose driver is
+// not a Balancer serves the load-balancer family exactly as before — the
+// configuration round-trips, nothing forwards — and says so.
+type Balancer interface {
+	// EnsureBalancer creates or replaces the balancer as a whole. It must
+	// succeed when called again with the same specification.
+	EnsureBalancer(ctx context.Context, spec BalancerSpec) error
+	// RemoveBalancer deletes it. It must succeed when nothing is there, and it
+	// must refuse a balancer the emulator did not create.
+	RemoveBalancer(ctx context.Context, network, listen string) error
+}

--- a/internal/core/machine/capabilities.go
+++ b/internal/core/machine/capabilities.go
@@ -37,6 +37,19 @@ type Capabilities struct {
 	// OwnKernel: the machine boots its own kernel, so a test touching sysctl,
 	// kernel modules or the boot path measures something.
 	OwnKernel bool `json:"own_kernel"`
+	// Balancing: a load balancer distributes real connections across its
+	// backends, for clients inside the network it sits in.
+	//
+	// The bound is in the name of the thing measured and it is not a hedge
+	// (#315, internal/core/machine/balancer.go). An address of the network's
+	// own block — which is what an *internal* load balancer's address is —
+	// balanced 6/6 connections across two machines at t0, t+60s and t+180s. An
+	// address outside it, delegated through the uplink, answered for two
+	// minutes and went dark for ever, because the runtime announces such an
+	// address once at creation and never again. So this claim covers the
+	// internal form and says nothing about the internet-facing one, whose
+	// public address stays a TEST-NET address routed nowhere on purpose.
+	Balancing bool `json:"balancing"`
 	// PrivateFromHost: an address inside an emulated subnet answers from the
 	// host that runs the emulator, not only from the other machines.
 	//
@@ -110,6 +123,10 @@ func (Noop) Capabilities() Capabilities { return Capabilities{} }
 // PrivateFromHost is isolation's trade, not an accident: the same router that
 // separates two VPC's subnets by construction NATs the host away from their
 // insides, so the two claims cannot both be true of one Incus mode.
+//
+// Balancing follows OVN too, and for a plainer reason than isolation's: a
+// managed bridge has no load balancer primitive at all, so there is nothing to
+// measure there rather than something that half works.
 func (d *Incus) Capabilities() Capabilities {
 	// What the host answered wins over what the flag promised (#181). Verify
 	// narrows this set once at startup; before that, and in a test that builds a
@@ -122,6 +139,7 @@ func (d *Incus) Capabilities() Capabilities {
 		Addresses:       true,
 		Firewall:        true,
 		Isolation:       d.OVN,
+		Balancing:       d.OVN,
 		OwnKernel:       d.VM,
 		PrivateFromHost: !d.OVN,
 	}

--- a/internal/core/machine/incus_balancer.go
+++ b/internal/core/machine/incus_balancer.go
@@ -1,0 +1,306 @@
+package machine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/netip"
+	"strconv"
+	"strings"
+)
+
+// An Incus OVN network load balancer is what an emulated internal load balancer
+// becomes. The shapes below are the runtime's own, read off the wire on
+// 2026-08-20 rather than taken from a document:
+//
+//	GET  /1.0/networks/{net}/load-balancers/{listen}
+//	  {"listen_address":"10.61.1.240","description":"...","config":{},
+//	   "backends":[{"name":"b1","description":"","target_address":"10.61.1.10",
+//	                "target_port":"80"}],
+//	   "ports":[{"description":"","protocol":"tcp","listen_port":"80",
+//	             "target_backend":["b1"]}]}
+//
+// Both port fields are strings, which is why they are strings here: sending them
+// as numbers is the kind of guess this repository has paid for before.
+//
+// A whole-object PUT replaces backends and ports at once, and that is what
+// EnsureBalancer uses — the same reason EnsureFirewall replaces a rule set
+// rather than patching it. An unregistered machine must actually stop receiving
+// connections.
+
+// balancerDescription marks a balancer as the emulator's own. A load balancer
+// carries no user config that a sweep could key on, so the description is what
+// ownership is read from — exactly as aclDescription is for a rule set.
+const balancerDescription = "feint load balancer"
+
+type lbBackend struct {
+	Name          string `json:"name"`
+	Description   string `json:"description"`
+	TargetAddress string `json:"target_address"`
+	TargetPort    string `json:"target_port"`
+}
+
+type lbPort struct {
+	Description   string   `json:"description"`
+	Protocol      string   `json:"protocol"`
+	ListenPort    string   `json:"listen_port"`
+	TargetBackend []string `json:"target_backend"`
+}
+
+type lbBody struct {
+	ListenAddress string            `json:"listen_address,omitempty"`
+	Description   string            `json:"description"`
+	Config        map[string]string `json:"config"`
+	Backends      []lbBackend       `json:"backends"`
+	Ports         []lbPort          `json:"ports"`
+}
+
+// balancerProtocols is what OVN distributes.
+//
+// Anything else is refused, and refused rather than skipped on purpose. An
+// emulated LBU listener speaks HTTP, HTTPS, TCP or SSL; all four ride TCP, none
+// of them is terminated here, and translating them is the pack's business
+// because only the pack knows its own vocabulary. A driver that quietly dropped
+// a listener it did not recognise would serve half of what the API describes
+// and say nothing — the silent-skip shape this repository keeps paying for.
+//
+// TestAnUndistributableProtocolIsRefused fails without the refusal.
+var balancerProtocols = map[string]bool{"tcp": true, "udp": true}
+
+// EnsureBalancer implements Balancer.
+//
+// Three refusals before anything is written, each of them a measured line rather
+// than caution:
+//
+//   - not OVN. A managed bridge has no load balancer primitive at all; the
+//     capability is declared by the OVN mode alone and this is the same
+//     statement at the point of use.
+//   - a network the emulator does not own. The balancer would survive every
+//     sweep on somebody else's network, and this is the rule every destructive
+//     and reconfiguring path here follows (mustOwn).
+//   - a listen address outside the network's own block. This is the one that is
+//     not obvious: the runtime accepts such an address, announces it with a
+//     burst of gratuitous ARPs at creation time and never again, so the
+//     balancer answers for a minute or two and then goes dark for ever
+//     (#315, measured 2026-08-19). Refusing beats configuring a balancer whose
+//     failure arrives three minutes after the test that proved it worked.
+//
+// TestABalancerOutsideTheNetworksBlockIsRefused fails without the third.
+func (d *Incus) EnsureBalancer(ctx context.Context, spec BalancerSpec) error {
+	if !d.OVN {
+		return fmt.Errorf("balancing %s needs the OVN mode: a managed bridge has no load balancer", spec.Name)
+	}
+	if !safeName.MatchString(spec.Network) {
+		return fmt.Errorf("invalid network name %q", spec.Network)
+	}
+	listen, err := netip.ParseAddr(spec.Listen)
+	if err != nil {
+		return fmt.Errorf("balancer %s: parse the listen address %q: %w", spec.Name, spec.Listen, err)
+	}
+	if err := d.mustOwn(ctx, spec.Network); err != nil {
+		return err
+	}
+	block, err := d.networkGateway(ctx, spec.Network)
+	if err != nil {
+		return err
+	}
+	if !block.Contains(listen) {
+		return fmt.Errorf("balancer %s listens on %s, which is outside %s's own block %s: "+
+			"an address the runtime has to announce goes dark within minutes (#315)",
+			spec.Name, spec.Listen, spec.Network, block.Masked())
+	}
+
+	for _, target := range spec.Targets {
+		if _, err := netip.ParseAddr(target); err != nil {
+			return fmt.Errorf("balancer %s: parse the backend address %q: %w", spec.Name, target, err)
+		}
+	}
+	for _, listener := range spec.Listeners {
+		if !balancerProtocols[strings.ToLower(listener.Protocol)] {
+			return fmt.Errorf("balancer %s: %q is not a protocol this runtime distributes; "+
+				"translate it to tcp or udp where the provider's vocabulary is known",
+				spec.Name, listener.Protocol)
+		}
+	}
+
+	body := lbBody{
+		Description: balancerDescription + " " + spec.Name,
+		Config:      map[string]string{},
+		Backends:    expandBackends(spec),
+		Ports:       []lbPort{},
+	}
+	// Every listener, with no skip: the loop above already refused anything
+	// this runtime cannot distribute, so a `continue` here would be a second
+	// filter with nothing left to filter and one more place for a listener to
+	// disappear quietly.
+	for _, listener := range spec.Listeners {
+		port := lbPort{
+			Protocol:      strings.ToLower(listener.Protocol),
+			ListenPort:    strconv.Itoa(listener.Listen),
+			TargetBackend: []string{},
+		}
+		for i := range spec.Targets {
+			port.TargetBackend = append(port.TargetBackend, backendName(i, listener))
+		}
+		body.Ports = append(body.Ports, port)
+	}
+	if len(body.Ports) == 0 {
+		return fmt.Errorf("balancer %s carries no listener the runtime can distribute", spec.Name)
+	}
+
+	path := "/1.0/networks/" + spec.Network + "/load-balancers"
+	exists, err := d.balancerExists(ctx, spec.Network, spec.Listen)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		body.ListenAddress = spec.Listen
+	}
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("encode balancer %s: %w", spec.Name, err)
+	}
+	if exists {
+		if _, err := d.run(ctx, "query", "-X", "PUT", "--data", string(encoded), path+"/"+spec.Listen); err != nil {
+			return fmt.Errorf("write balancer %s: %w", spec.Name, err)
+		}
+		return nil
+	}
+	if _, err := d.run(ctx, "query", "-X", "POST", "--data", string(encoded), path); err != nil {
+		return fmt.Errorf("create balancer %s: %w", spec.Name, err)
+	}
+	return nil
+}
+
+// balancerExists asks the collection rather than reading a refusal.
+//
+// The alternative was to PUT and treat the failure as "create it instead", and
+// that alternative shipped broken for exactly the reason isNotFound documents
+// about itself: matching prose is a last resort. The daemon says "Network load
+// balancer not found", which is in no phrase list here, so every first write
+// failed, was reported as a hard error, and the balancer was never created —
+// the emulated load balancer answered on an address nothing was listening on.
+//
+// The collection endpoint answers a list of URLs and succeeds whether or not
+// anything is in it, so the question is structural and no wording can change
+// under it. TestABalancerIsCreatedWhenTheCollectionDoesNotHoldIt fails without
+// this.
+// balancerGone reads the daemon's own wording for a balancer that is not there.
+//
+// Prose, and a last resort, exactly as isNotFound says of itself — which is why
+// it is used on one line only, the DELETE, where the alternative is a race
+// nobody can close structurally. The wording is the daemon's, measured on Incus
+// 7.2 on 2026-08-20: "Error: Network load balancer not found".
+func balancerGone(err error) bool {
+	return strings.Contains(strings.ToLower(err.Error()), "load balancer not found")
+}
+
+func (d *Incus) balancerExists(ctx context.Context, network, listen string) (bool, error) {
+	out, err := d.run(ctx, "query", "/1.0/networks/"+network+"/load-balancers")
+	if err != nil {
+		return false, fmt.Errorf("list the balancers of %s: %w", network, err)
+	}
+	var urls []string
+	if err := json.Unmarshal(out, &urls); err != nil {
+		return false, fmt.Errorf("read the balancers of %s: %w", network, err)
+	}
+	for _, url := range urls {
+		if strings.HasSuffix(url, "/"+listen) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// expandBackends builds one runtime backend per (machine, backend port).
+//
+// The runtime puts the target port on the backend and not on the listener, so a
+// balancer whose listeners hand connections to two different ports needs two
+// records per machine. Written once here rather than inline, because the names
+// have to agree with the ones the ports reference and a second copy of that
+// naming is how they stop agreeing.
+func expandBackends(spec BalancerSpec) []lbBackend {
+	seen := map[string]bool{}
+	out := []lbBackend{}
+	for _, listener := range spec.Listeners {
+		for i, target := range spec.Targets {
+			name := backendName(i, listener)
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
+			out = append(out, lbBackend{
+				Name:          name,
+				TargetAddress: target,
+				TargetPort:    strconv.Itoa(backendPort(listener)),
+			})
+		}
+	}
+	return out
+}
+
+// backendName and backendPort are the two halves of one decision, and they are
+// written once because a port that disagrees with the name referencing it
+// produces a balancer the runtime accepts and that reaches nothing.
+func backendName(i int, listener BalancerListener) string {
+	return fmt.Sprintf("b%d-%d", i, backendPort(listener))
+}
+
+// backendPort is where the connection lands on the machine. A listener that
+// names no backend port hands it to the port it answered on, which is what
+// every one of these APIs means by leaving it out.
+func backendPort(listener BalancerListener) int {
+	if listener.Backend != 0 {
+		return listener.Backend
+	}
+	return listener.Listen
+}
+
+// RemoveBalancer implements Balancer.
+//
+// A balancer that is already gone is not an error: the caller is undoing
+// something, and "nothing left to undo" is success. A balancer that exists and
+// is not the emulator's is refused, because a delete is a destructive path and
+// those are the ones that destroy — the rule mustOwnACL states for a rule set,
+// applied to the object this file creates.
+//
+// TestRemovingAForeignBalancerIsRefused fails without the ownership check.
+func (d *Incus) RemoveBalancer(ctx context.Context, network, listen string) error {
+	if !d.OVN {
+		return nil
+	}
+	if !safeName.MatchString(network) {
+		return fmt.Errorf("invalid network name %q", network)
+	}
+	if _, err := netip.ParseAddr(listen); err != nil {
+		return fmt.Errorf("parse the listen address %q: %w", listen, err)
+	}
+	// Asked of the collection, for the reason balancerExists carries: "gone" and
+	// "the daemon phrased its refusal differently" must not be the same answer
+	// on a path whose whole job is to be idempotent.
+	exists, err := d.balancerExists(ctx, network, listen)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+	path := "/1.0/networks/" + network + "/load-balancers/" + listen
+	out, err := d.run(ctx, "query", path)
+	if err != nil {
+		return fmt.Errorf("inspect balancer %s on %s: %w", listen, network, err)
+	}
+	var existing lbBody
+	if err := json.Unmarshal(out, &existing); err != nil {
+		return fmt.Errorf("read the description of balancer %s: %w", listen, err)
+	}
+	if !strings.HasPrefix(existing.Description, balancerDescription) {
+		return fmt.Errorf("the balancer %s on %s was not created by the emulator; refusing to delete it", listen, network)
+	}
+	// A balancer that vanished between the check above and here is somebody
+	// else's delete winning a race, and "gone" is what this call wanted.
+	if _, err := d.run(ctx, "query", "-X", "DELETE", path); err != nil && !balancerGone(err) {
+		return fmt.Errorf("delete balancer %s on %s: %w", listen, network, err)
+	}
+	return nil
+}

--- a/internal/core/machine/incus_balancer_test.go
+++ b/internal/core/machine/incus_balancer_test.go
@@ -1,0 +1,333 @@
+package machine
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// The balancer path, held to the three refusals and the one shape (#315).
+//
+// Every assertion here is about an argument the driver emits or refuses to
+// emit, which is the only level at which "it will not go dark" and "it will not
+// touch somebody else's network" can be checked without a runtime.
+
+func ovnDriver(f *fakeRuntime) *Incus {
+	d := newFakeDriver(f)
+	d.OVN = true
+	return d
+}
+
+// answerExactly answers a call by its whole argument line, which the map-based
+// fixture cannot do here: the collection path is a prefix of the item path, so
+// a substring match would answer one for the other depending on map order.
+func answerExactly(answers map[string]string) func(int, []string) ([]byte, error, bool) {
+	return func(_ int, args []string) ([]byte, error, bool) {
+		if answer, known := answers[strings.Join(args, " ")]; known {
+			return []byte(answer), nil, true
+		}
+		return nil, nil, false
+	}
+}
+
+// emptyCollection is what a network with no balancer answers: a list, and a
+// success. Every EnsureBalancer asks it first (balancerExists).
+const emptyCollection = "query /1.0/networks/fnt-a/load-balancers"
+
+// A balancer whose address is not inside the network's own block is refused.
+//
+// This is the measurement, turned into a guard. #315 delegated a VIP through
+// the uplink's routes and watched it answer 6/6 at t0, 6/6 at t+60s and 0/6
+// from t+180s onwards: the runtime announces such an address with a burst of
+// gratuitous ARPs at creation and never again. Configuring one would hand a
+// user a balancer that passes their test and fails three minutes later, which
+// is worse than refusing.
+//
+// The emitted commands are asserted too, not just the error: a refusal that has
+// already written the object is not a refusal.
+func TestABalancerOutsideTheNetworksBlockIsRefused(t *testing.T) {
+	f := &fakeRuntime{answers: map[string]string{
+		"network get fnt-a ipv4.address": "10.61.1.1/24\n",
+		"network get fnt-a user.":        "outscale\n",
+	}, hook: answerExactly(map[string]string{emptyCollection: "[]"})}
+	d := ovnDriver(f)
+
+	err := d.EnsureBalancer(context.Background(), BalancerSpec{
+		Name:      "lbu-x",
+		Network:   "fnt-a",
+		Listen:    "198.51.100.240",
+		Listeners: []BalancerListener{{Protocol: "tcp", Listen: 80, Backend: 8080}},
+		Targets:   []string{"10.61.1.10"},
+	})
+	if err == nil {
+		t.Fatalf("a VIP outside the network's block was accepted; commands: %v", f.commands())
+	}
+	if !strings.Contains(err.Error(), "10.61.1.0/24") {
+		t.Errorf("the refusal must name the block the address had to be in, got %v", err)
+	}
+	if wrote := f.matching("load-balancers"); len(wrote) != 0 {
+		t.Errorf("the refusal still wrote to the runtime: %v", wrote)
+	}
+}
+
+// A network the emulator did not create is never written to.
+//
+// The rule every destructive and reconfiguring path here follows: a balancer
+// left on an operator's own network survives every sweep, and the sweep is what
+// makes this emulator safe to run on a working station.
+func TestABalancerOnAForeignNetworkIsRefused(t *testing.T) {
+	f := &fakeRuntime{answers: map[string]string{
+		"network get fnt-a ipv4.address": "10.61.1.1/24\n",
+		"network get fnt-a user.":        "\n",
+	}}
+	d := ovnDriver(f)
+
+	err := d.EnsureBalancer(context.Background(), BalancerSpec{
+		Name:      "lbu-x",
+		Network:   "fnt-a",
+		Listen:    "10.61.1.240",
+		Listeners: []BalancerListener{{Protocol: "tcp", Listen: 80}},
+	})
+	if err == nil {
+		t.Fatalf("a foreign network was written to; commands: %v", f.commands())
+	}
+	if wrote := f.matching("load-balancers"); len(wrote) != 0 {
+		t.Errorf("the refusal still wrote to the runtime: %v", wrote)
+	}
+}
+
+// Deleting a balancer somebody else created is refused.
+//
+// The create paths are guarded by habit; the destroy paths are the ones that
+// destroy. An operator's own OVN load balancer sharing a listen address with an
+// emulated one is not a hypothesis worth taking: the ownership marker is the
+// description this driver writes, and it is read back before the DELETE.
+func TestRemovingAForeignBalancerIsRefused(t *testing.T) {
+	f := &fakeRuntime{hook: answerExactly(map[string]string{
+		emptyCollection: `["/1.0/networks/fnt-a/load-balancers/10.61.1.240"]`,
+		"query /1.0/networks/fnt-a/load-balancers/10.61.1.240": `{"description":"the operator's own","listen_address":"10.61.1.240"}`,
+	})}
+	d := ovnDriver(f)
+
+	err := d.RemoveBalancer(context.Background(), "fnt-a", "10.61.1.240")
+	if err == nil {
+		t.Fatalf("a foreign balancer was deleted; commands: %v", f.commands())
+	}
+	if deleted := f.matching("-X DELETE"); len(deleted) != 0 {
+		t.Errorf("the refusal still issued a delete: %v", deleted)
+	}
+}
+
+// The body sent is the runtime's own shape, and the ports are strings.
+//
+// Read off the wire on 2026-08-20 rather than taken from a document:
+// listen_port and target_port are strings there, and a number would be refused.
+// The backend names the ports reference must be the names the backends carry,
+// which is why one function mints both.
+func TestTheBalancerBodyCarriesTheRuntimesOwnShape(t *testing.T) {
+	f := &fakeRuntime{answers: map[string]string{
+		"network get fnt-a ipv4.address": "10.61.1.1/24\n",
+		"network get fnt-a user.":        "outscale\n",
+	}, hook: answerExactly(map[string]string{emptyCollection: "[]"})}
+	d := ovnDriver(f)
+
+	err := d.EnsureBalancer(context.Background(), BalancerSpec{
+		Name:    "lbu-x",
+		Network: "fnt-a",
+		Listen:  "10.61.1.240",
+		Listeners: []BalancerListener{
+			{Protocol: "tcp", Listen: 80, Backend: 8080},
+			{Protocol: "tcp", Listen: 443, Backend: 8443},
+		},
+		Targets: []string{"10.61.1.10", "10.61.1.11"},
+	})
+	if err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+
+	written := f.matching("load-balancers")
+	if len(written) == 0 {
+		t.Fatalf("nothing was written; commands: %v", f.commands())
+	}
+	var body lbBody
+	if err := json.Unmarshal([]byte(payloadOf(t, f, "load-balancers")), &body); err != nil {
+		t.Fatalf("decode the payload: %v", err)
+	}
+
+	// Both listeners, because a balancer serving half of what the API describes
+	// is the failure this shape has to make impossible.
+	if len(body.Ports) != 2 {
+		t.Fatalf("expected one port per listener, got %d: %+v", len(body.Ports), body.Ports)
+	}
+	for _, port := range body.Ports {
+		if port.Protocol != "tcp" {
+			t.Errorf("the runtime distributes tcp and udp; got protocol %q", port.Protocol)
+		}
+		if port.ListenPort == "" {
+			t.Errorf("listen_port must be a string the runtime accepts, got %q", port.ListenPort)
+		}
+	}
+	// Two machines, two backend ports: four records, and every name a port
+	// references must exist.
+	if len(body.Backends) != 4 {
+		t.Fatalf("expected one backend per machine per backend port, got %d: %+v", len(body.Backends), body.Backends)
+	}
+	names := map[string]bool{}
+	for _, backend := range body.Backends {
+		names[backend.Name] = true
+		if backend.TargetPort == "" {
+			t.Errorf("target_port must be a string the runtime accepts, got %q", backend.TargetPort)
+		}
+	}
+	for _, port := range body.Ports {
+		for _, referenced := range port.TargetBackend {
+			if !names[referenced] {
+				t.Errorf("port %s references the backend %q, which the body does not carry: %+v",
+					port.ListenPort, referenced, body.Backends)
+			}
+		}
+	}
+	if body.Description != balancerDescription+" lbu-x" {
+		t.Errorf("the balancer carries no ownership marker, so nothing can tell it from an operator's: %q", body.Description)
+	}
+}
+
+// A bridge-backed run refuses rather than writing something that cannot work.
+//
+// The declared capability already keeps a pack from calling this, and the
+// refusal is the same statement at the point of use: a managed bridge has no
+// load balancer primitive at all.
+func TestABridgeBackedRunHasNoBalancer(t *testing.T) {
+	f := &fakeRuntime{}
+	d := newFakeDriver(f) // not OVN
+
+	if err := d.EnsureBalancer(context.Background(), BalancerSpec{
+		Name: "lbu-x", Network: "fnt-a", Listen: "10.61.1.240",
+		Listeners: []BalancerListener{{Protocol: "tcp", Listen: 80}},
+	}); err == nil {
+		t.Fatalf("a bridge-backed driver accepted a balancer; commands: %v", f.commands())
+	}
+	if len(f.commands()) != 0 {
+		t.Errorf("a refusal on the mode still called the runtime: %v", f.commands())
+	}
+	if CapabilitiesOf(d).Balancing {
+		t.Error("a bridge-backed driver declares balancing, and a suite keying on it would assert what it cannot deliver")
+	}
+}
+
+// A protocol the runtime cannot distribute is refused, never dropped.
+//
+// The pack translates HTTP, HTTPS, TCP and SSL to the transport they all ride,
+// because only the pack knows its provider's vocabulary. If one ever reaches
+// here untranslated, the balancer must not come up serving the listeners it did
+// recognise and silently missing the rest: that is a working balancer with a
+// hole in it, and nothing in the response would say so.
+func TestAnUndistributableProtocolIsRefused(t *testing.T) {
+	f := &fakeRuntime{answers: map[string]string{
+		"network get fnt-a ipv4.address": "10.61.1.1/24\n",
+		"network get fnt-a user.":        "outscale\n",
+	}, hook: answerExactly(map[string]string{emptyCollection: "[]"})}
+	d := ovnDriver(f)
+
+	err := d.EnsureBalancer(context.Background(), BalancerSpec{
+		Name: "lbu-x", Network: "fnt-a", Listen: "10.61.1.240",
+		Listeners: []BalancerListener{
+			{Protocol: "tcp", Listen: 80, Backend: 8080},
+			{Protocol: "https", Listen: 443, Backend: 8443},
+		},
+		Targets: []string{"10.61.1.10"},
+	})
+	if err == nil {
+		t.Fatalf("an untranslated protocol was accepted; commands: %v", f.commands())
+	}
+	if !strings.Contains(err.Error(), "https") {
+		t.Errorf("the refusal must name the protocol it could not distribute, got %v", err)
+	}
+	if wrote := f.matching("load-balancers"); len(wrote) != 0 {
+		t.Errorf("the refusal still wrote to the runtime: %v", wrote)
+	}
+}
+
+// A balancer the collection does not hold is created, not updated.
+//
+// This shipped broken once and the failure is worth keeping named: the first
+// version wrote a PUT and read the refusal to decide whether to POST instead.
+// The daemon answers "Network load balancer not found", which no phrase list
+// here matches, so every first write failed hard and the balancer was never
+// created — the emulated load balancer answered on an address nothing was
+// listening on, and the conformance suite that found it reported six timeouts
+// out of six.
+//
+// The verb is asserted, not the outcome: a POST to the collection carrying the
+// listen address, and no PUT.
+func TestABalancerIsCreatedWhenTheCollectionDoesNotHoldIt(t *testing.T) {
+	f := &fakeRuntime{answers: map[string]string{
+		"network get fnt-a ipv4.address": "10.61.1.1/24\n",
+		"network get fnt-a user.":        "outscale\n",
+	}, hook: answerExactly(map[string]string{emptyCollection: "[]"})}
+	d := ovnDriver(f)
+
+	if err := d.EnsureBalancer(context.Background(), BalancerSpec{
+		Name: "lbu-x", Network: "fnt-a", Listen: "10.61.1.240",
+		Listeners: []BalancerListener{{Protocol: "tcp", Listen: 80}},
+		Targets:   []string{"10.61.1.10"},
+	}); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	if posted := f.matching("-X POST"); len(posted) != 1 {
+		t.Fatalf("expected one POST to the collection, got %v", f.commands())
+	}
+	if put := f.matching("-X PUT"); len(put) != 0 {
+		t.Errorf("a balancer that does not exist was updated: %v", put)
+	}
+	var body lbBody
+	if err := json.Unmarshal([]byte(payloadOf(t, f, "-X POST")), &body); err != nil {
+		t.Fatalf("decode the payload: %v", err)
+	}
+	if body.ListenAddress != "10.61.1.240" {
+		t.Errorf("a create must name the address it listens on, got %q", body.ListenAddress)
+	}
+}
+
+// And one the collection does hold is replaced whole, never created twice.
+func TestAnExistingBalancerIsReplacedWhole(t *testing.T) {
+	f := &fakeRuntime{answers: map[string]string{
+		"network get fnt-a ipv4.address": "10.61.1.1/24\n",
+		"network get fnt-a user.":        "outscale\n",
+	}, hook: answerExactly(map[string]string{
+		emptyCollection: `["/1.0/networks/fnt-a/load-balancers/10.61.1.240"]`,
+	})}
+	d := ovnDriver(f)
+
+	if err := d.EnsureBalancer(context.Background(), BalancerSpec{
+		Name: "lbu-x", Network: "fnt-a", Listen: "10.61.1.240",
+		Listeners: []BalancerListener{{Protocol: "tcp", Listen: 80}},
+		Targets:   []string{"10.61.1.10"},
+	}); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	if put := f.matching("-X PUT"); len(put) != 1 {
+		t.Fatalf("expected one PUT, got %v", f.commands())
+	}
+	if posted := f.matching("-X POST"); len(posted) != 0 {
+		t.Errorf("an existing balancer was created a second time: %v", posted)
+	}
+}
+
+// payloadOf returns the --data argument of the first call matching substr.
+func payloadOf(t *testing.T, f *fakeRuntime, substr string) string {
+	t.Helper()
+	for _, call := range f.calls {
+		if !strings.Contains(strings.Join(call, " "), substr) {
+			continue
+		}
+		for i, arg := range call {
+			if arg == "--data" && i+1 < len(call) {
+				return call[i+1]
+			}
+		}
+	}
+	t.Fatalf("no call matching %q carried a payload: %v", substr, f.commands())
+	return ""
+}

--- a/internal/core/machine/verify.go
+++ b/internal/core/machine/verify.go
@@ -84,10 +84,23 @@ func (d *Incus) Verify(ctx context.Context) (Capabilities, []string) {
 	verified := declared
 	var unmet []string
 
-	if declared.Isolation {
-		if wired, why := d.ovnWired(ctx); !wired {
-			verified.Isolation = false
-			unmet = append(unmet, "isolation: "+why)
+	if declared.Isolation || declared.Balancing {
+		// One probe, two claims: both are OVN's, and both are false on a host
+		// with no northbound connection. Asking twice would double the startup
+		// cost of every run to learn the same fact, and — worse — could report
+		// one of them true and the other false on a host that answered
+		// differently between the two calls.
+		// TestVerifyNarrowsBalancingWithIsolation fails without this.
+		wired, why := d.ovnWired(ctx)
+		if !wired {
+			if declared.Isolation {
+				verified.Isolation = false
+				unmet = append(unmet, "isolation: "+why)
+			}
+			if declared.Balancing {
+				verified.Balancing = false
+				unmet = append(unmet, "balancing: "+why)
+			}
 		}
 	}
 

--- a/internal/core/machine/verify_test.go
+++ b/internal/core/machine/verify_test.go
@@ -76,8 +76,16 @@ func TestVerifyNarrowsWhatTheHostCannotDeliver(t *testing.T) {
 		t.Error("isolation survived a host with no northbound connection: this is " +
 			"the capability a suite keying on it would assert and the host cannot deliver")
 	}
-	if len(unmet) != 1 || !strings.Contains(unmet[0], ovnNorthbound) {
-		t.Errorf("the narrowing must name what was checked and what answered, got %v", unmet)
+	// Two lines now, one per OVN-borne capability, and each must name what was
+	// checked: a narrowing that says "isolation: unavailable" sends the reader
+	// nowhere.
+	if len(unmet) != 2 {
+		t.Errorf("a host with no OVN must narrow both OVN capabilities, got %v", unmet)
+	}
+	for _, line := range unmet {
+		if !strings.Contains(line, ovnNorthbound) {
+			t.Errorf("the narrowing must name what was checked and what answered, got %q", line)
+		}
 	}
 	// And what the host does deliver is kept: a probe that refused everything
 	// would pass this test's first half and break the product.
@@ -120,8 +128,13 @@ func TestAnUnsetNorthboundIsTheDefaultAndNotAnAbsence(t *testing.T) {
 	if caps.Isolation {
 		t.Error("isolation survived a host with no northbound socket at all")
 	}
-	if len(unmet) != 1 || !strings.Contains(unmet[0], ovnDefaultNorthbound) {
-		t.Errorf("the refusal must name the socket it looked for, got %v", unmet)
+	if len(unmet) != 2 {
+		t.Errorf("a host with no northbound socket must narrow both OVN capabilities, got %v", unmet)
+	}
+	for _, line := range unmet {
+		if !strings.Contains(line, ovnDefaultNorthbound) {
+			t.Errorf("the refusal must name the socket it looked for, got %q", line)
+		}
 	}
 
 	// A remote northbound this process cannot reach: unknown is not a refusal,
@@ -186,6 +199,42 @@ func TestAnUnreadableVersionDoesNotCostTheCapability(t *testing.T) {
 	}
 	if len(unmet) != 0 {
 		t.Errorf("nothing was disproven, so nothing must be narrowed, got %v", unmet)
+	}
+}
+
+// Balancing is narrowed with isolation, and by the same probe.
+//
+// Both are OVN's, and both are false on a host with no northbound connection.
+// The reason to assert it rather than trust the shape: a capability added later
+// gets its declaration and forgets its verification, and the result is exactly
+// what #181 measured for isolation — /_feint/health publishing a claim the host
+// cannot deliver, to a suite this project tells to key on capabilities rather
+// than on a mode name.
+//
+// The accepting half is here too, because a probe that removed balancing from
+// every host would satisfy the first half and take the feature away.
+func TestVerifyNarrowsBalancingWithIsolation(t *testing.T) {
+	// No OVN at all: nothing configured, no socket.
+	caps, unmet := mustVerifyBoth(t, hostSayingWithSocket("", "7.2", false))
+	if caps.Balancing {
+		t.Error("balancing survived a host with no northbound connection")
+	}
+	if caps.Isolation {
+		t.Error("isolation survived a host with no northbound connection")
+	}
+	named := false
+	for _, line := range unmet {
+		if strings.HasPrefix(line, "balancing:") {
+			named = true
+		}
+	}
+	if !named {
+		t.Errorf("the narrowing never mentions balancing, so nothing tells the operator it went: %v", unmet)
+	}
+
+	// A wired host keeps it.
+	if caps, unmet := mustVerifyBoth(t, hostSaying("tcp:10.0.0.1:6641", "7.2")); !caps.Balancing {
+		t.Errorf("a wired host lost balancing: %v", unmet)
 	}
 }
 

--- a/internal/core/network/ula.go
+++ b/internal/core/network/ula.go
@@ -5,24 +5,43 @@ import (
 	"net/netip"
 )
 
-// ULA64 derives a unique-local IPv6 /64 from a seed, deterministically.
+// ULA64Within derives a unique-local IPv6 /64, deterministically, inside the
+// /48 that belongs to a space.
 //
 // The layout is RFC 4193's: the fd00::/8 prefix, a 40-bit global ID, a 16-bit
 // subnet ID, and 64 zeroed host bits. The RFC wants the global ID picked at
-// random; here it is the first seven bytes of SHA-256(seed) instead, because an
-// emulator's blocks must be reproducible: a prefix that changed between two
-// reads of the same resource would be a permanent Terraform diff, and one that
-// changed across a snapshot round-trip would break every stored reference to
-// it. The seed is the caller's resource identity, so two resources get two
-// blocks and one resource always gets the same.
+// random; here it is derived from the space instead, and the subnet ID from the
+// seed, because an emulator's blocks must be reproducible — a prefix that
+// changed between two reads of one resource is a permanent Terraform diff, and
+// one that changed across a snapshot round-trip breaks every stored reference
+// to it.
 //
-// The collision odds of a 56-bit hash are the caller's to close: check the
-// result against the blocks already held, and re-derive with a salted seed on
-// the (astronomically unlikely) clash.
-func ULA64(seed string) netip.Prefix {
-	sum := sha256.Sum256([]byte(seed))
+// Two seeds rather than one, and that split is a measurement. On 2026-08-20 two
+// Private Networks created in one Scaleway project answered
+// fdb2:1bb5:120a:9b::/64 and fdb2:1bb5:120a:6cad::/64 — the same global ID, two
+// subnet IDs, which is RFC 4193 applied the way the RFC describes it. Derived
+// from the resource alone, as this was first written, sibling networks landed
+// in unrelated /48s and nothing in one tenancy looked related to anything else
+// in it.
+//
+// The caller supplies both: the space is whatever owns the /48 — a project, a
+// tenancy, an account — and the seed is the resource's own identity. What
+// neither can be is a provider's name: the honest bound of that measurement is
+// that this account's project and organization identifiers are the same value,
+// so which of the two Scaleway keys the /48 to is not distinguishable from
+// here.
+//
+// The collision odds of a 16-bit subnet ID are the caller's to close — real,
+// not astronomical, at a few hundred networks in one space: check the result
+// against the blocks already held, and re-derive with a salted seed on a clash.
+// Salting the seed keeps the space's /48 and moves only the subnet ID, which is
+// what makes that loop terminate inside the right prefix.
+func ULA64Within(space, seed string) netip.Prefix {
+	global := sha256.Sum256([]byte(space))
+	subnet := sha256.Sum256([]byte(seed))
 	var addr [16]byte
 	addr[0] = 0xfd
-	copy(addr[1:8], sum[:7])
+	copy(addr[1:6], global[:5])
+	copy(addr[6:8], subnet[:2])
 	return netip.PrefixFrom(netip.AddrFrom16(addr), 64)
 }

--- a/internal/core/network/ula_test.go
+++ b/internal/core/network/ula_test.go
@@ -8,8 +8,8 @@ import (
 func TestULA64IsDeterministicAndWellFormed(t *testing.T) {
 	ula := netip.MustParsePrefix("fd00::/8")
 
-	first := ULA64("11111111-2222-4333-8444-555555555555")
-	second := ULA64("11111111-2222-4333-8444-555555555555")
+	first := ULA64Within("space", "11111111-2222-4333-8444-555555555555")
+	second := ULA64Within("space", "11111111-2222-4333-8444-555555555555")
 	if first != second {
 		t.Fatalf("two derivations of one seed differ: %s vs %s", first, second)
 	}
@@ -23,8 +23,38 @@ func TestULA64IsDeterministicAndWellFormed(t *testing.T) {
 		t.Errorf("host bits set: %s", first)
 	}
 
-	other := ULA64("another-seed")
+	other := ULA64Within("space", "another-seed")
 	if other == first {
 		t.Errorf("two seeds derived the same block %s; the seed is not reaching the hash", first)
+	}
+}
+
+// Two blocks of one space are siblings under one /48; two spaces are not.
+//
+// This is the measured half (see ULA64Within): two Private Networks created in
+// one real Scaleway project on 2026-08-20 shared fdb2:1bb5:120a::/48 and
+// differed only in the subnet ID. Derived from the resource alone, which is how
+// this function was first written, they would have landed in unrelated /48s.
+//
+// The negative half matters as much: if the space stopped reaching the hash,
+// every space would share one /48 and the first assertion alone would still
+// pass.
+func TestOneSpacesBlocksAreSiblingsAndTwoSpacesAreNot(t *testing.T) {
+	within := func(p netip.Prefix) netip.Prefix {
+		return netip.PrefixFrom(p.Addr(), 48).Masked()
+	}
+
+	a := ULA64Within("project-a", "network-1")
+	b := ULA64Within("project-a", "network-2")
+	if a == b {
+		t.Fatalf("two networks of one space got the same /64: %s", a)
+	}
+	if within(a) != within(b) {
+		t.Errorf("two networks of one space landed in %s and %s, which share no /48", a, b)
+	}
+
+	elsewhere := ULA64Within("project-b", "network-1")
+	if within(elsewhere) == within(a) {
+		t.Errorf("two spaces share the /48 %s; the space is not reaching the hash", within(a))
 	}
 }

--- a/internal/providers/outscale/loadbalancer_dataplane.go
+++ b/internal/providers/outscale/loadbalancer_dataplane.go
@@ -1,0 +1,162 @@
+package outscale
+
+import (
+	"context"
+
+	"github.com/stephrobert/feint/internal/core/machine"
+	"github.com/stephrobert/feint/internal/core/resource"
+)
+
+// Where a load balancer stops being a record (#315).
+//
+// The LBU family has always round-tripped its configuration and forwarded
+// nothing, and docs/limits.md said so plainly. One half of that can now be
+// true: a balancer's own private address — the one the API publishes as
+// PrivateIp, an address of the Subnet it sits in — is handed to the runtime,
+// which distributes real connections across the registered machines. Measured
+// on 2026-08-20: 6/6 connections answered from inside the network at t0, t+60s
+// and t+180s, spread over both backends every time.
+//
+// The other half stays a record, and that is a measurement too, not modesty. An
+// internet-facing balancer's public address is a TEST-NET-3 address the runtime
+// would have to announce outside the network, and #315 measured what happens
+// then: it answers for two minutes and goes dark for ever. So the public face is
+// unchanged, and the reason is in internal/core/machine/balancer.go beside the
+// figures.
+//
+// Nothing here is conditional on a mode name. The driver declares
+// Capabilities.Balancing, the OVN mode alone sets it, `Verify` clears it on a
+// host with no OVN, and a driver that says nothing is read as not balancing —
+// which is what makes the degraded path the default rather than the exception.
+
+// balancer returns the runtime's balancing half, or nil when it has none.
+//
+// Two questions, both asked: does the driver implement the interface, and does
+// it *declare* the capability. The second is not redundant — the Incus driver
+// implements Balancer in every mode and can only deliver it under OVN, and
+// `Verify` clears the claim on a host whose daemon has no northbound
+// connection. Asking only the first would drive a bridge-backed run into a
+// refusal on every register.
+func (p *Pack) balancer() machine.Balancer {
+	if p.env.Machines == nil || !machine.CapabilitiesOf(p.env.Machines).Balancing {
+		return nil
+	}
+	b, _ := p.env.Machines.(machine.Balancer)
+	return b
+}
+
+// syncBalancer hands one balancer's current backend set to the runtime.
+//
+// Called after every change to the set — the create, a register, an unlink —
+// because the runtime must hold what the API says it holds, and a stale backend
+// keeps receiving connections the API has already stopped listing.
+//
+// A failure is logged and never fails the request. That is this repository's
+// rule for every runtime effect: an emulator whose control plane breaks when a
+// container does is worse than one that records the truth and says what it
+// could not do.
+func (p *Pack) syncBalancer(ctx context.Context, name string) {
+	b := p.balancer()
+	if b == nil {
+		return
+	}
+	res, found := p.env.Store.Get(Name, kindLoadBalancer, name)
+	if !found {
+		return
+	}
+	spec, ok := p.balancerSpecOf(res)
+	if !ok {
+		return
+	}
+	if err := b.EnsureBalancer(ctx, spec); err != nil {
+		p.logger().Error("could not hand the load balancer to the runtime",
+			"load_balancer", res.ID, "listen", spec.Listen, "error", err)
+	}
+}
+
+// removeBalancer undoes it, on the way out.
+func (p *Pack) removeBalancer(ctx context.Context, res *resource.Resource) {
+	b := p.balancer()
+	if b == nil {
+		return
+	}
+	network, listen := p.balancerPlacement(res)
+	if network == "" || listen == "" {
+		return
+	}
+	if err := b.RemoveBalancer(ctx, network, listen); err != nil {
+		p.logger().Error("could not remove the load balancer from the runtime",
+			"load_balancer", res.ID, "listen", listen, "error", err)
+	}
+}
+
+// balancerPlacement is the runtime network a balancer sits on and the address
+// it answers on. Both empty when the balancer has no subnet behind it, which is
+// the metadata-only case and not a defect.
+func (p *Pack) balancerPlacement(res *resource.Resource) (network, listen string) {
+	subnets := stringsOf(res.Attrs["Subnets"])
+	if len(subnets) == 0 {
+		return "", ""
+	}
+	subnet, found := p.env.Store.Get(Name, kindSubnet, subnets[0])
+	if !found {
+		return "", ""
+	}
+	return subnet.Runtime[runtimeNetworkKey], stringOf(res.Attrs["PrivateIp"])
+}
+
+// balancerSpecOf turns a stored balancer into what the runtime is asked for.
+//
+// Two translations, and both are the pack's business rather than the driver's:
+//
+//   - the listener protocol. An LBU listener speaks HTTP, HTTPS, TCP or SSL;
+//     all four ride TCP and none of them is terminated here — nothing decrypts,
+//     nothing parses a request — so the honest thing to hand a packet
+//     distributor is the transport. A balancer that claimed to terminate TLS
+//     because its listener said HTTPS would be exactly the invention this
+//     emulator exists to refuse.
+//   - the backend address. The private one, never the public: this distributes
+//     to machines inside the network, and a public address here is either
+//     absent or the fictional block that routes nowhere.
+func (p *Pack) balancerSpecOf(res *resource.Resource) (machine.BalancerSpec, bool) {
+	network, listen := p.balancerPlacement(res)
+	if network == "" || listen == "" {
+		return machine.BalancerSpec{}, false
+	}
+
+	spec := machine.BalancerSpec{
+		Name:    res.ID,
+		Network: network,
+		Listen:  listen,
+	}
+	listeners, _ := res.Attrs["Listeners"].([]any)
+	for _, raw := range listeners {
+		listener, _ := raw.(map[string]any)
+		// numOf, because a listener that has crossed a snapshot carries
+		// json.Number where the handler stored an int — the same reason
+		// stringsOf exists beside it.
+		front := int(numOf(listener["LoadBalancerPort"]))
+		back := int(numOf(listener["BackendPort"]))
+		if front == 0 {
+			continue
+		}
+		spec.Listeners = append(spec.Listeners, machine.BalancerListener{
+			Protocol: "tcp",
+			Listen:   front,
+			Backend:  back,
+		})
+	}
+	if len(spec.Listeners) == 0 {
+		return machine.BalancerSpec{}, false
+	}
+	for _, id := range stringsOf(res.Attrs["BackendVmIds"]) {
+		vm, found := p.env.Store.Get(Name, kindVM, id)
+		if !found {
+			continue
+		}
+		if address := stringOf(vm.Attrs["PrivateIp"]); address != "" {
+			spec.Targets = append(spec.Targets, address)
+		}
+	}
+	return spec, true
+}

--- a/internal/providers/outscale/loadbalancer_dataplane_test.go
+++ b/internal/providers/outscale/loadbalancer_dataplane_test.go
@@ -1,0 +1,202 @@
+package outscale_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/machine"
+)
+
+// The pack half of the load-balancer dataplane (#315).
+//
+// The driver's own guards are held in internal/core/machine; what belongs here
+// is the wiring: which balancer specification the pack builds out of what it
+// stored, and — the half that decides whether anything is claimed at all —
+// whether it asks the runtime when the runtime has not declared it can.
+
+// recordingBalancer is a driver that can balance, and says whether it was
+// allowed to. `declares` is the capability, deliberately separate from the
+// interface: the two questions are different and conflating them is the defect
+// this file's first test exists for.
+type recordingBalancer struct {
+	*blockingRuntime
+	declares bool
+
+	mu      sync.Mutex
+	ensured []machine.BalancerSpec
+	removed []string
+}
+
+func newRecordingBalancer(declares bool) *recordingBalancer {
+	return &recordingBalancer{blockingRuntime: newBlockingRuntime(), declares: declares}
+}
+
+func (r *recordingBalancer) Capabilities() machine.Capabilities {
+	return machine.Capabilities{Machines: true, Addresses: true, Balancing: r.declares}
+}
+
+func (r *recordingBalancer) EnsureBalancer(_ context.Context, spec machine.BalancerSpec) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.ensured = append(r.ensured, spec)
+	return nil
+}
+
+func (r *recordingBalancer) RemoveBalancer(_ context.Context, network, listen string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.removed = append(r.removed, network+" "+listen)
+	return nil
+}
+
+func (r *recordingBalancer) specs() []machine.BalancerSpec {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]machine.BalancerSpec(nil), r.ensured...)
+}
+
+func (r *recordingBalancer) removals() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.removed...)
+}
+
+// aBalancedStack creates a Net, a Subnet, two Vms and an internal balancer
+// holding both, and returns the balancer's listen address.
+func aBalancedStack(t *testing.T, ts *httptest.Server) (vmA, vmB, vip string) {
+	t.Helper()
+	contractDoc := contractDoc(t)
+	doc := call(t, ts, contractDoc, "CreateNet", `{"IpRange":"10.188.0.0/16"}`)
+	netID, _ := doc["Net"].(map[string]any)["NetId"].(string)
+	doc = call(t, ts, contractDoc, "CreateSubnet", `{"NetId":"`+netID+`","IpRange":"10.188.3.0/24"}`)
+	subnet, _ := doc["Subnet"].(map[string]any)["SubnetId"].(string)
+
+	launch := func() string {
+		t.Helper()
+		out := call(t, ts, contractDoc, "CreateVms",
+			`{"ImageId":"ami-00000003","VmType":"tinav6.c1r1p2","SubnetId":"`+subnet+`"}`)
+		vms, _ := out["Vms"].([]any)
+		if len(vms) == 0 {
+			t.Fatalf("CreateVms answered no machine: %v", out)
+		}
+		id, _ := vms[0].(map[string]any)["VmId"].(string)
+		return id
+	}
+	vmA, vmB = launch(), launch()
+
+	doc = call(t, ts, contractDoc, "CreateLoadBalancer",
+		`{"LoadBalancerName":"lbu-data","LoadBalancerType":"internal","Subnets":["`+subnet+`"],`+
+			`"Listeners":[{"LoadBalancerPort":80,"LoadBalancerProtocol":"TCP","BackendPort":8080,"BackendProtocol":"TCP"}]}`)
+	lb, _ := doc["LoadBalancer"].(map[string]any)
+	vip, _ = lb["PrivateIp"].(string)
+	if vip == "" {
+		t.Fatalf("the balancer came back with no PrivateIp: %v", doc)
+	}
+	call(t, ts, contractDoc, "RegisterVmsInLoadBalancer",
+		`{"LoadBalancerName":"lbu-data","BackendVmIds":["`+vmA+`","`+vmB+`"]}`)
+	return vmA, vmB, vip
+}
+
+// A runtime that has not declared balancing is never asked to balance.
+//
+// The interface and the capability are two questions, and the Incus driver is
+// exactly why: it implements Balancer in every mode and can only deliver it
+// under OVN, and startup verification clears the claim on a host with no OVN
+// wiring. A pack that asked the first question only would drive every
+// bridge-backed run into a refusal on every register, and the operator would
+// read a stack of errors about a feature they never asked for.
+//
+// An undeclared capability reads as absent: that rule has to hold at the point
+// of use, not only in the health payload.
+func TestAnUndeclaredBalancingCapabilityIsNeverUsed(t *testing.T) {
+	runtime := newRecordingBalancer(false)
+	close(runtime.release)
+	ts := newRuntimeServer(t, runtime)
+
+	aBalancedStack(t, ts)
+
+	if specs := runtime.specs(); len(specs) != 0 {
+		t.Fatalf("the pack handed %d balancer(s) to a runtime that declares none: %+v", len(specs), specs)
+	}
+}
+
+// What the pack asks for is what it stored, translated once.
+//
+// Three things are asserted because each was a decision: the listen address is
+// the balancer's own PrivateIp on the Subnet's network, the backends are the
+// machines' private addresses (never the public ones, which route nowhere), and
+// the listener protocol reaching the runtime is the transport — an LBU listener
+// speaks HTTP, HTTPS, TCP or SSL, all four ride TCP, and none is terminated
+// here.
+func TestTheBalancerSpecIsWhatTheApiDescribes(t *testing.T) {
+	runtime := newRecordingBalancer(true)
+	close(runtime.release)
+	ts := newRuntimeServer(t, runtime)
+
+	_, _, vip := aBalancedStack(t, ts)
+
+	specs := runtime.specs()
+	if len(specs) == 0 {
+		t.Fatalf("nothing was handed to a runtime that declares balancing")
+	}
+	last := specs[len(specs)-1]
+	if last.Listen != vip {
+		t.Errorf("the balancer listens on %q, and the API publishes %q", last.Listen, vip)
+	}
+	if last.Network == "" {
+		t.Error("the balancer names no network, so the runtime would not know where to put it")
+	}
+	if len(last.Listeners) != 1 || last.Listeners[0].Protocol != "tcp" ||
+		last.Listeners[0].Listen != 80 || last.Listeners[0].Backend != 8080 {
+		t.Errorf("the listener reached the runtime as %+v, want tcp 80 -> 8080", last.Listeners)
+	}
+	if len(last.Targets) != 2 {
+		t.Fatalf("expected both machines as backends, got %v", last.Targets)
+	}
+	for _, target := range last.Targets {
+		if len(target) < 7 || target[:7] != "10.188." {
+			t.Errorf("the backend %q is not an address of the Subnet; a balancer inside a network "+
+				"distributes to private addresses", target)
+		}
+	}
+}
+
+// An unlinked machine stops being a backend, and a deleted balancer goes.
+//
+// The replace-not-patch rule, at the level a unit test can hold it: the pack
+// must replay the whole set after an unlink, or the runtime keeps sending
+// connections to a machine the API has already stopped listing.
+func TestUnlinkingAndDeletingReachTheRuntime(t *testing.T) {
+	runtime := newRecordingBalancer(true)
+	close(runtime.release)
+	ts := newRuntimeServer(t, runtime)
+
+	vmA, _, vip := aBalancedStack(t, ts)
+
+	call(t, ts, contractDoc(t), "UnlinkLoadBalancerBackendMachines",
+		`{"LoadBalancerName":"lbu-data","BackendVmIds":["`+vmA+`"]}`)
+	specs := runtime.specs()
+	after := specs[len(specs)-1]
+	if len(after.Targets) != 1 {
+		t.Fatalf("after an unlink the runtime still holds %v", after.Targets)
+	}
+
+	if status, _ := post(t, ts, "DeleteLoadBalancer", `{"LoadBalancerName":"lbu-data"}`); status != http.StatusOK {
+		t.Fatalf("DeleteLoadBalancer answered %d", status)
+	}
+	removals := runtime.removals()
+	if len(removals) == 0 {
+		t.Fatal("the balancer was deleted and nothing was removed from the runtime; " +
+			"it would hold an address the next create could reuse")
+	}
+	if last := removals[len(removals)-1]; !containsAddress(last, vip) {
+		t.Errorf("the removal names %q, and the balancer answered on %q", last, vip)
+	}
+}
+
+func containsAddress(line, address string) bool {
+	return len(line) >= len(address) && line[len(line)-len(address):] == address
+}

--- a/internal/providers/outscale/loadbalancers.go
+++ b/internal/providers/outscale/loadbalancers.go
@@ -281,6 +281,12 @@ func (p *Pack) createLoadBalancer(w http.ResponseWriter, r *http.Request) {
 	p.env.Store.Put(res)
 	unlock()
 
+	// Outside the lock, because handing a balancer to the runtime is a call to
+	// another process and the store's lock is measured in microseconds: the
+	// rule the whole repository works under, and the one a slow effect inside
+	// the lock breaks first.
+	p.syncBalancer(r.Context(), res.ID)
+
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
 		"LoadBalancer":    p.loadBalancerView(res),
 		"ResponseContext": p.context(),
@@ -566,6 +572,7 @@ func (p *Pack) registerVmsInLoadBalancer(w http.ResponseWriter, r *http.Request)
 		p.notFound(w, "load balancer", req.LoadBalancerName)
 		return
 	}
+	p.syncBalancer(r.Context(), req.LoadBalancerName)
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{"ResponseContext": p.context()})
 }
 
@@ -611,6 +618,10 @@ func (p *Pack) unlinkLoadBalancerBackendMachines(w http.ResponseWriter, r *http.
 		p.notFound(w, "load balancer", req.LoadBalancerName)
 		return
 	}
+	// The unlink half of the same rule: a backend the API has stopped listing
+	// must stop receiving connections, and only a replay of the whole set makes
+	// that true — the reason EnsureBalancer replaces rather than patches.
+	p.syncBalancer(r.Context(), req.LoadBalancerName)
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{"ResponseContext": p.context()})
 }
 
@@ -623,10 +634,16 @@ func (p *Pack) deleteLoadBalancer(w http.ResponseWriter, r *http.Request) {
 		p.badRequest(w, err.Error())
 		return
 	}
-	if _, found := p.env.Store.Get(Name, kindLoadBalancer, req.LoadBalancerName); !found {
+	res, found := p.env.Store.Get(Name, kindLoadBalancer, req.LoadBalancerName)
+	if !found {
 		p.notFound(w, "load balancer", req.LoadBalancerName)
 		return
 	}
+	// Before the store forgets where it was: balancerPlacement reads the
+	// subnet's runtime network off the resource, and a deleted resource names
+	// nothing. A balancer left behind holds an address of a network the next
+	// create would reuse.
+	p.removeBalancer(r.Context(), res)
 	p.env.Store.Delete(Name, kindLoadBalancer, req.LoadBalancerName)
 	// The provider polls ReadLoadBalancers until the name is gone; deleting
 	// immediately means the first poll already answers "none".

--- a/internal/providers/scaleway/barrage_test.go
+++ b/internal/providers/scaleway/barrage_test.go
@@ -278,7 +278,7 @@ func barrageCycle(ts *httptest.Server, tag string, problems chan<- string) {
 	status, pn := doRaw(ts, "POST", regionURL+"/private-networks",
 		`{"name":"barrage-`+tag+`","subnets":["10.`+subnetOctet(tag)+`.0.0/24"]}`)
 	pnID := ""
-	if status == http.StatusCreated {
+	if status == http.StatusOK {
 		pnID, _ = pn["id"].(string)
 	}
 	if pnID != "" {
@@ -450,7 +450,7 @@ func TestASharedNetworkUnderBarrageNeverHandsOutOneAddressTwice(t *testing.T) {
 	// is not what this measures.
 	status, pn := doRaw(ts, "POST", regionURL+"/private-networks",
 		`{"name":"contended","subnets":["10.199.0.0/24"]}`)
-	if status != http.StatusCreated {
+	if status != http.StatusOK {
 		t.Fatalf("create the shared network: %d (%v)", status, pn)
 	}
 	pnID, _ := pn["id"].(string)

--- a/internal/providers/scaleway/ipam_lifecycle_test.go
+++ b/internal/providers/scaleway/ipam_lifecycle_test.go
@@ -22,7 +22,7 @@ func createPN(t *testing.T, ts *httptest.Server, subnet string) (id string, subn
 	t.Helper()
 	status, body := do(t, ts, "POST", vpcRegion+"/private-networks",
 		fmt.Sprintf(`{"name":"pn-test","subnets":[%q]}`, subnet))
-	if status != http.StatusCreated {
+	if status != http.StatusOK {
 		t.Fatalf("create private network: status %d (%v)", status, body)
 	}
 	id, _ = body["id"].(string)

--- a/internal/providers/scaleway/ipam_lock_internal_test.go
+++ b/internal/providers/scaleway/ipam_lock_internal_test.go
@@ -46,7 +46,7 @@ func TestAReleasedAddressCannotBeTakenWhileItIsBeingAttached(t *testing.T) {
 	// A network, then an address booked from it.
 	status, network := postJSON(t, ts, "/vpc/v2/regions/fr-par/private-networks",
 		`{"name":"locked","subnets":["10.201.0.0/24"]}`)
-	if status != http.StatusCreated {
+	if status != http.StatusOK {
 		t.Fatalf("create the network: %d (%v)", status, network)
 	}
 	pnID, _ := network["id"].(string)
@@ -129,7 +129,7 @@ func TestCommitDoesNotResurrectAReleasedAddress(t *testing.T) {
 
 	status, network := postJSON(t, ts, "/vpc/v2/regions/fr-par/private-networks",
 		`{"name":"resurrect","subnets":["10.202.0.0/24"]}`)
-	if status != http.StatusCreated {
+	if status != http.StatusOK {
 		t.Fatalf("create the network: %d (%v)", status, network)
 	}
 	pnID, _ := network["id"].(string)

--- a/internal/providers/scaleway/listquery_test.go
+++ b/internal/providers/scaleway/listquery_test.go
@@ -146,7 +146,7 @@ func TestServersFilterByLinks(t *testing.T) {
 
 	// A Private Network and a NIC on the bare server.
 	status, out = do(t, ts, "POST", region+"/private-networks", `{"name":"pn"}`)
-	if status != http.StatusCreated {
+	if status != http.StatusOK {
 		t.Fatalf("create pn: status %d (%v)", status, out)
 	}
 	pnID, _ := out["id"].(string)
@@ -267,15 +267,15 @@ func TestVPCListsHonourTheDeclaredFilters(t *testing.T) {
 	const region = "/vpc/v2/regions/fr-par"
 
 	status, out := do(t, ts, "POST", region+"/vpcs", `{"name":"team"}`)
-	if status != http.StatusCreated {
+	if status != http.StatusOK {
 		t.Fatalf("create vpc: status %d (%v)", status, out)
 	}
 	status, out = do(t, ts, "POST", region+"/private-networks", `{"name":"pn-a","tags":["blue"]}`)
-	if status != http.StatusCreated {
+	if status != http.StatusOK {
 		t.Fatalf("create pn-a: status %d (%v)", status, out)
 	}
 	pnA, _ := out["id"].(string)
-	if status, _ = do(t, ts, "POST", region+"/private-networks", `{"name":"pn-b"}`); status != http.StatusCreated {
+	if status, _ = do(t, ts, "POST", region+"/private-networks", `{"name":"pn-b"}`); status != http.StatusOK {
 		t.Fatalf("create pn-b: status %d", status)
 	}
 
@@ -360,7 +360,7 @@ func TestIPAMListHonoursOrderAndResourceFilters(t *testing.T) {
 	const zone = "/instance/v1/zones/fr-par-1"
 
 	status, out := do(t, ts, "POST", "/vpc/v2/regions/fr-par/private-networks", `{"name":"pn"}`)
-	if status != http.StatusCreated {
+	if status != http.StatusOK {
 		t.Fatalf("create pn: status %d (%v)", status, out)
 	}
 	pnID, _ := out["id"].(string)

--- a/internal/providers/scaleway/lostupdate_test.go
+++ b/internal/providers/scaleway/lostupdate_test.go
@@ -141,7 +141,7 @@ func TestAttachingANICDoesNotResurrectADeletedServer(t *testing.T) {
 	for i := range attachers {
 		status, out := do(t, ts, "POST", region+"/private-networks",
 			fmt.Sprintf(`{"name":"barrage-%d","subnets":["10.%d.0.0/24"]}`, i, 60+i))
-		if status != http.StatusOK && status != http.StatusCreated {
+		if status != http.StatusOK {
 			t.Fatalf("private network %d: status %d (%v)", i, status, out)
 		}
 		pnID, _ := out["id"].(string)
@@ -231,7 +231,7 @@ func TestDeletingAServerReleasesItsPrivateNICs(t *testing.T) {
 
 	status, out := do(t, ts, "POST", region+"/private-networks",
 		`{"name":"one","subnets":["10.77.0.0/24"]}`)
-	if status != http.StatusOK && status != http.StatusCreated {
+	if status != http.StatusOK {
 		t.Fatalf("private network: status %d", status)
 	}
 	pnID, _ := out["id"].(string)

--- a/internal/providers/scaleway/routes_test.go
+++ b/internal/providers/scaleway/routes_test.go
@@ -19,7 +19,7 @@ import (
 func createVPC(t *testing.T, ts *httptest.Server, body string) map[string]any {
 	t.Helper()
 	status, out := do(t, ts, "POST", vpcRegion+"/vpcs", body)
-	if status != http.StatusCreated {
+	if status != http.StatusOK {
 		t.Fatalf("create vpc: status %d (%v)", status, out)
 	}
 	return out
@@ -111,7 +111,7 @@ func TestEnableRoutingReconcilesThePeering(t *testing.T) {
 	for i, block := range []string{"10.81.0.0/24", "10.81.1.0/24"} {
 		status, pn := do(t, ts, "POST", vpcRegion+"/private-networks",
 			fmt.Sprintf(`{"name":"member-%d","vpc_id":%q,"subnets":[%q]}`, i, vpcID, block))
-		if status != http.StatusCreated {
+		if status != http.StatusOK {
 			t.Fatalf("create pn %d: status %d (%v)", i, status, pn)
 		}
 		id, _ := pn["id"].(string)
@@ -153,7 +153,7 @@ func TestARouteRoundTripsThroughItsLifecycle(t *testing.T) {
 	vpcID, _ := vpc["id"].(string)
 	status, pn := do(t, ts, "POST", vpcRegion+"/private-networks",
 		fmt.Sprintf(`{"name":"nexthop-net","vpc_id":%q,"subnets":["10.82.0.0/24"]}`, vpcID))
-	if status != http.StatusCreated {
+	if status != http.StatusOK {
 		t.Fatalf("create pn: status %d", status)
 	}
 	pnID, _ := pn["id"].(string)

--- a/internal/providers/scaleway/vpc.go
+++ b/internal/providers/scaleway/vpc.go
@@ -59,17 +59,34 @@ const privateNetworkMask = 22
 // the IPv4 half made `one(pn.ipv6_subnets).subnet` die on null, apply and
 // destroy both (#270).
 //
-// Honest caveat: the /64 size and the fd00::/8 unique-local range are derived
-// from the SDK and the provider's documentation, not observed — the shapes
-// catalogue holds no populated private-network read from the real cloud yet.
-// #270 stays open until `feint shapes --record --provider scaleway` runs
-// against an account holding one Private Network and the recording lands in
-// shapes/scaleway.json to arbitrate this.
+// Measured, no longer inferred. On 2026-08-20 a Private Network was created on
+// a real fr-par account with `subnets: null` — nothing asked for a block — and
+// the answer carried two: 172.16.4.0/22 and fdb2:1bb5:120a:9b::/64. So the
+// unasked allocation, the unique-local fd00::/8 range and the /64 size are all
+// observed, and the read that follows carries the same pair unchanged. The
+// field tree of that read is in shapes/scaleway.json under
+// `GET /vpc/v2/regions/fr-par/private-networks/{id}`; the catalogue keeps paths
+// and types, so this comment is where the observed prefix itself lives.
 const privateNetworkV6Mask = 64
 
 // reservedPerSubnet is what the runtime keeps at the bottom of a Private Network
 // block: the network address, and the gateway the managed bridge answers on.
 const reservedPerSubnet = 2
+
+// vpcCreateStatus is what a successful vpc/v2 create answers with.
+//
+// 200, not the 201 every other create in this pack writes. Measured on the wire
+// on 2026-08-20: both of vpc/v2's creates — CreateVPC and CreatePrivateNetwork
+// — answered 200 on a real fr-par account, read off a `feint proxy` transcript
+// rather than off the CLI's exit code, which shows neither. No other product
+// was measured, so no other product is touched: what is claimed here is what
+// was seen and nothing beyond it.
+//
+// It changes nothing for a client that tests 2xx, which is what the SDK and the
+// Terraform provider do. It changes the rule this repository works under, which
+// is that a status is part of the answer and an invented one is an invented
+// format. TestTheVpcCreatesAnswerWhatTheRealCloudAnswers fails without it.
+const vpcCreateStatus = http.StatusOK
 
 type createVPCRequest struct {
 	Name          string   `json:"name"`
@@ -186,7 +203,7 @@ func (p *Pack) createVPC(w http.ResponseWriter, r *http.Request) {
 	res.Attrs["transitivity_enabled"] = req.EnableTransitivity
 	p.env.Store.Put(res)
 
-	emulator.WriteJSON(w, http.StatusCreated, p.vpcView(res))
+	emulator.WriteJSON(w, vpcCreateStatus, p.vpcView(res))
 }
 
 func (p *Pack) getVPC(w http.ResponseWriter, r *http.Request) {
@@ -366,7 +383,7 @@ func (p *Pack) createPrivateNetwork(w http.ResponseWriter, r *http.Request) {
 	// first because it seeds the derivation, so the block is a function of the
 	// resource and nothing else.
 	id := p.env.NewID()
-	prefix6, err := p.resolveSubnetV6(req.Subnets, id)
+	prefix6, err := p.resolveSubnetV6(req.Subnets, project, id)
 	if err != nil {
 		writeInvalidArguments(w, ArgumentError{
 			ArgumentName: "subnets",
@@ -425,7 +442,7 @@ func (p *Pack) createPrivateNetwork(w http.ResponseWriter, r *http.Request) {
 	p.env.Store.Put(res)
 	p.isolateNetworks(r.Context())
 
-	emulator.WriteJSON(w, http.StatusCreated, privateNetworkView(res))
+	emulator.WriteJSON(w, vpcCreateStatus, privateNetworkView(res))
 }
 
 func (p *Pack) getPrivateNetwork(w http.ResponseWriter, r *http.Request) {
@@ -794,9 +811,10 @@ func (p *Pack) resolveSubnet(requested []string) (netip.Prefix, error) {
 // A client that named an fd…/64 expects it back unchanged, exactly like the
 // IPv4 path. A client that named none still gets one, because upstream
 // allocates it unasked — that is the whole of #270. The derived block is a
-// unique-local /64 seeded by the resource id: deterministic between two reads,
-// and stored anyway, so it also survives a snapshot into another instance.
-func (p *Pack) resolveSubnetV6(requested []string, id string) (netip.Prefix, error) {
+// unique-local /64 seeded by the resource id, inside the /48 the project's
+// networks share: deterministic between two reads, and stored anyway, so it
+// also survives a snapshot into another instance.
+func (p *Pack) resolveSubnetV6(requested []string, project, id string) (netip.Prefix, error) {
 	for _, raw := range requested {
 		prefix, err := network.ParseCIDR(raw)
 		if err != nil {
@@ -810,14 +828,18 @@ func (p *Pack) resolveSubnetV6(requested []string, id string) (netip.Prefix, err
 		}
 		return prefix, nil
 	}
-	// Nothing requested: derive, and dodge the blocks already held. A clash is
-	// a 2^-56 hash collision or a client that requested this exact block for
-	// another network; salting the seed keeps the loop deterministic given the
-	// same store, and the result is stored, so later reads do not re-run it.
+	// Nothing requested: derive inside the project's own /48, and dodge the
+	// blocks already held. The project is the space because that is what the
+	// real cloud was measured to group by — two networks of one project came
+	// back under one fd…/48 (see network.ULA64Within) — and a clash is then a
+	// 16-bit subnet collision rather than an astronomical one, so the loop
+	// earns its keep. Salting the seed moves the subnet ID and keeps the /48,
+	// which is what makes it terminate in the right prefix; the result is
+	// stored, so later reads do not re-run it.
 	taken := p.usedPrefixes("")
 	seed := id
 	for {
-		candidate := network.ULA64(seed)
+		candidate := network.ULA64Within(project, seed)
 		if _, clash := network.FirstOverlap(candidate, taken); !clash {
 			return candidate, nil
 		}
@@ -1038,6 +1060,16 @@ func (p *Pack) vpcView(res *resource.Resource) map[string]any {
 		"created_at":            res.Created.Format(time.RFC3339),
 		"updated_at":            res.Updated.Format(time.RFC3339),
 		"private_network_count": len(p.privateNetworksOf(res.ID)),
+		// Measured on 2026-08-20: the earlier recording of ListVPCs was taken
+		// on an account holding no VPC, so its element shape was never
+		// observed and this omission was invisible. It is served for the same
+		// reason its private-network counterpart is — the five operations that
+		// could attach an Object Storage endpoint are declined in pack.go —
+		// and listVPCs already answers `s3_integration_enabled=true` with an
+		// empty list, so the flag and the filter now say the same thing.
+		//
+		// TestTheObjectStorageFlagsAreServedOnEveryDoor fails without it.
+		"s3_integration_enabled": false,
 	}
 	for k, v := range res.Attrs {
 		out[k] = v
@@ -1051,6 +1083,20 @@ func privateNetworkView(res *resource.Resource) map[string]any {
 		"region":     res.Tenant.Zone,
 		"created_at": res.Created.Format(time.RFC3339),
 		"updated_at": res.Updated.Format(time.RFC3339),
+		// Carried on the wire by every real answer, and dropped by `scw` on the
+		// way to its own output — which is why reading the CLI rather than the
+		// recording would have missed it. Measured on 2026-08-20 against a real
+		// fr-par account (shapes/scaleway.json, GET
+		// /vpc/v2/regions/fr-par/private-networks/{id}); the emulator omitted
+		// it, and the contract has always declared it.
+		//
+		// Computed here rather than stored, and always false: it says an Object
+		// Storage endpoint is attached, and the five operations that could
+		// attach one are declined in pack.go with their reason. A stored flag
+		// would be a value nothing can ever change.
+		//
+		// TestTheObjectStorageFlagsAreServedOnEveryDoor fails without it.
+		"has_s3_integration": false,
 	}
 	for k, v := range res.Attrs {
 		if k == "subnet" || k == "subnet_ipv6" {

--- a/internal/providers/scaleway/vpc_ipv6_test.go
+++ b/internal/providers/scaleway/vpc_ipv6_test.go
@@ -15,9 +15,11 @@ import (
 // An emulator serving only the IPv4 half made the ordinary consumer expression,
 // one(pn.ipv6_subnets).subnet, die on null — on apply and on destroy both.
 //
-// The fd00::/8 range and the /64 size are derived from the SDK and the
-// provider's documentation, not yet observed from the real cloud; the issue
-// stays open until a real recording lands in shapes/scaleway.json.
+// The fd00::/8 range and the /64 size are measured, not derived: a Private
+// Network created on a real fr-par account on 2026-08-20, with nothing asked
+// for, answered 172.16.4.0/22 and fdb2:1bb5:120a:9b::/64. The field tree of
+// that read is committed in shapes/scaleway.json under
+// `GET /vpc/v2/regions/fr-par/private-networks/{id}`.
 
 // ipv6SubnetOf picks the IPv6 record out of a subnets list, the counterpart of
 // ipv4SubnetOf.
@@ -93,7 +95,15 @@ func TestPrivateNetworkPublishesAnIPv6Subnet(t *testing.T) {
 	}
 }
 
-func TestTwoNetworksGetTwoIPv6Blocks(t *testing.T) {
+// Two networks of one project get two /64s out of one /48.
+//
+// Both halves are measured. On 2026-08-20 two Private Networks created in one
+// real fr-par project answered fdb2:1bb5:120a:9b::/64 and
+// fdb2:1bb5:120a:6cad::/64: distinct blocks, one global ID, which is RFC 4193's
+// own layout. Seeded from the resource alone, as this pack first did, sibling
+// networks landed in unrelated /48s — nothing wrong on the wire, and nothing in
+// one tenancy that looked related to anything else in it.
+func TestTwoNetworksGetTwoIPv6BlocksUnderOnePrefix(t *testing.T) {
 	ts := newTestServer(t)
 
 	_, first := privateNetwork(t, ts, `{"name":"one"}`)
@@ -102,6 +112,18 @@ func TestTwoNetworksGetTwoIPv6Blocks(t *testing.T) {
 	b, _ := ipv6SubnetOf(t, second["subnets"].([]any))["subnet"].(string)
 	if a == b {
 		t.Fatalf("two networks share the IPv6 block %s", a)
+	}
+
+	within48 := func(block string) netip.Prefix {
+		p, err := netip.ParsePrefix(block)
+		if err != nil {
+			t.Fatalf("the IPv6 subnet %q does not parse: %v", block, err)
+		}
+		return netip.PrefixFrom(p.Addr(), 48).Masked()
+	}
+	if within48(a) != within48(b) {
+		t.Errorf("two networks of one project landed in %s and %s, which share no /48; "+
+			"the real cloud gives a project one global ID and varies the subnet ID", a, b)
 	}
 }
 

--- a/internal/providers/scaleway/vpc_measured_test.go
+++ b/internal/providers/scaleway/vpc_measured_test.go
@@ -1,0 +1,102 @@
+package scaleway_test
+
+import (
+	"net/http"
+	"testing"
+)
+
+// What a real fr-par account answered on 2026-08-20, held against this pack.
+//
+// The recording behind these assertions is in shapes/scaleway.json (paths and
+// types) and in the comments beside the code they hold (the values, which a
+// shape catalogue deliberately does not keep). Each one replaced something this
+// emulator had inferred: the create status was 201 because every other create
+// in the pack is, and the two Object Storage flags were absent because the
+// recording that would have arbitrated them was taken on an account with no VPC
+// and no Private Network, so neither object's fields were ever observed.
+
+// Both vpc/v2 creates answer 200, which is what the wire carried.
+//
+// Not 201. The two were read off a `feint proxy` transcript of a real account,
+// because neither `scw` nor the Terraform provider shows a status: both accept
+// any 2xx, which is exactly why this could sit wrong indefinitely.
+//
+// Only these two operations are asserted. CreateRoute is vpc/v2 as well and was
+// not measured — nothing was created on that account beyond the two free
+// objects — so it keeps the pack's 201 rather than inheriting a claim from its
+// neighbours.
+func TestTheVpcCreatesAnswerWhatTheRealCloudAnswers(t *testing.T) {
+	ts := newTestServer(t)
+
+	status, vpc := do(t, ts, "POST", vpcRegion+"/vpcs", `{"name":"measured"}`)
+	if status != http.StatusOK {
+		t.Errorf("CreateVPC answered %d, and the real cloud answered 200 (%v)", status, vpc)
+	}
+	status, pn := do(t, ts, "POST", vpcRegion+"/private-networks", `{"name":"measured-pn"}`)
+	if status != http.StatusOK {
+		t.Errorf("CreatePrivateNetwork answered %d, and the real cloud answered 200 (%v)", status, pn)
+	}
+}
+
+// The two Object Storage flags are served, on every door.
+//
+// They are false and can only be false here: the five operations that attach a
+// private network to Object Storage are declined in pack.go with their reason.
+// That is not an argument for omitting them — a client reading
+// `has_s3_integration` off a decoded object gets the zero value either way, and
+// a client comparing field sets does not. The contract has always declared
+// both; nothing observed them until a Private Network and a VPC existed at the
+// moment of a recording.
+//
+// Every door, because the emulator has more than one: a create, a read, and a
+// list, and the list is the one a previous omission survived in.
+func TestTheObjectStorageFlagsAreServedOnEveryDoor(t *testing.T) {
+	ts := newTestServer(t)
+
+	_, createdVPC := do(t, ts, "POST", vpcRegion+"/vpcs", `{"name":"flagged"}`)
+	vpcID, _ := createdVPC["id"].(string)
+	if vpcID == "" {
+		t.Fatalf("no vpc: %v", createdVPC)
+	}
+	pnID, createdPN := privateNetwork(t, ts, `{"name":"flagged-pn","vpc_id":"`+vpcID+`"}`)
+
+	present := func(what string, body map[string]any, field string) {
+		t.Helper()
+		value, carried := body[field]
+		if !carried {
+			t.Errorf("%s carries no %s, and the real cloud carries it on every answer", what, field)
+			return
+		}
+		if value != false {
+			t.Errorf("%s answers %s=%v; nothing here can attach an Object Storage endpoint", what, field, value)
+		}
+	}
+
+	present("CreateVPC", createdVPC, "s3_integration_enabled")
+	present("CreatePrivateNetwork", createdPN, "has_s3_integration")
+
+	_, readVPC := do(t, ts, "GET", vpcRegion+"/vpcs/"+vpcID, "")
+	present("GetVPC", readVPC, "s3_integration_enabled")
+	_, readPN := do(t, ts, "GET", vpcRegion+"/private-networks/"+pnID, "")
+	present("GetPrivateNetwork", readPN, "has_s3_integration")
+
+	_, listedVPCs := do(t, ts, "GET", vpcRegion+"/vpcs", "")
+	vpcs, _ := listedVPCs["vpcs"].([]any)
+	if len(vpcs) == 0 {
+		t.Fatalf("ListVPCs answered none: %v", listedVPCs)
+	}
+	for _, raw := range vpcs {
+		entry, _ := raw.(map[string]any)
+		present("ListVPCs", entry, "s3_integration_enabled")
+	}
+
+	_, listedPNs := do(t, ts, "GET", vpcRegion+"/private-networks", "")
+	networks, _ := listedPNs["private_networks"].([]any)
+	if len(networks) == 0 {
+		t.Fatalf("ListPrivateNetworks answered none: %v", listedPNs)
+	}
+	for _, raw := range networks {
+		entry, _ := raw.(map[string]any)
+		present("ListPrivateNetworks", entry, "has_s3_integration")
+	}
+}

--- a/internal/providers/scaleway/vpc_test.go
+++ b/internal/providers/scaleway/vpc_test.go
@@ -36,11 +36,15 @@ func nicAddress(t *testing.T, ts *httptest.Server, nic map[string]any) string {
 }
 
 // privateNetwork creates one and returns its id and body.
+//
+// 200, not 201: vpc/v2's creates were measured on the wire against a real
+// account (see vpcCreateStatus). This helper is the only place the pack's
+// private-network creates are asserted, so it is where the change bites.
 func privateNetwork(t *testing.T, ts *httptest.Server, body string) (string, map[string]any) {
 	t.Helper()
 	status, created := do(t, ts, "POST", regionURL+"/private-networks", body)
-	if status != http.StatusCreated {
-		t.Fatalf("create private network: expected 201, got %d (%v)", status, created)
+	if status != http.StatusOK {
+		t.Fatalf("create private network: expected 200, got %d (%v)", status, created)
 	}
 	id, _ := created["id"].(string)
 	if id == "" {

--- a/internal/shape/anonymise_test.go
+++ b/internal/shape/anonymise_test.go
@@ -1,0 +1,106 @@
+package shape
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/trace"
+)
+
+// A recording of one resource must not carry that resource into the catalogue.
+//
+// The catalogue is committed and the recording is not, and the whole of that
+// difference is the package's claim: paths and types, no values, no
+// identifiers. A path broke the claim the day a read list grew a call that
+// addresses one object — the identifier lands in Operation.Path and, when the
+// recording could not name the operation, in the key as well.
+//
+// Both are asserted, because they are two writes: an early version normalised
+// the stored path and keyed off the raw one, which put the account's UUID in
+// the file anyway, under a name no gate would ever look up.
+func TestARecordedIdentifierNeverReachesTheCatalogue(t *testing.T) {
+	const id = "3f2a91c4-77b0-4d19-9c2e-51ab8e0d64f7"
+	cat := New("scaleway")
+	cat.Merge([]trace.Exchange{{
+		Method: "GET",
+		Path:   "/vpc/v2/regions/fr-par/private-networks/" + id,
+		Status: 200,
+		Res:    &trace.Message{Body: map[string]any{"id": id, "name": "feint-shape-270"}},
+	}})
+
+	wanted := "GET /vpc/v2/regions/fr-par/private-networks/" + Placeholder
+	op, known := cat.Operations[wanted]
+	if !known {
+		t.Fatalf("the operation was keyed %v, want %q", keys(cat), wanted)
+	}
+	if strings.Contains(op.Path, id) {
+		t.Errorf("Operation.Path carries the account's identifier: %s", op.Path)
+	}
+	if got := render(t, cat); strings.Contains(got, id) {
+		t.Errorf("the saved catalogue carries the account's identifier:\n%s", got)
+	}
+}
+
+// Only an identifier is replaced. A region, a zone and a product name are the
+// call, not somebody's account, and a rule that swallowed them would make two
+// different operations share one key — which is worse than a leak, because it
+// silently merges two field trees.
+func TestAnonymisingAPathTouchesNothingButIdentifiers(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"/instance/v1/zones/fr-par-1/servers", "/instance/v1/zones/fr-par-1/servers"},
+		{"/instance/v1/zones/fr-par-1/products/servers", "/instance/v1/zones/fr-par-1/products/servers"},
+		{"/v2/instance/6d4c02be-9a15-4f83-8b7d-2e91c40fa5d8", "/v2/instance/" + Placeholder},
+		{"/api/v1/ReadVms", "/api/v1/ReadVms"},
+		// Uppercase is the same identifier, and a segment one character short
+		// of a UUID is not one.
+		{"/x/6D4C02BE-9A15-4F83-8B7D-2E91C40FA5D8", "/x/" + Placeholder},
+		{"/x/6d4c02be-9a15-4f83-8b7d-2e91c40fa5d", "/x/6d4c02be-9a15-4f83-8b7d-2e91c40fa5d"},
+	} {
+		if got := AnonymisePath(tc.in); got != tc.want {
+			t.Errorf("AnonymisePath(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// identifier is the shape of a UUID anywhere in a file, not only in a path
+// segment: the scan below is deliberately wider than AnonymisePath, because its
+// job is to disbelieve AnonymisePath.
+var identifier = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
+
+// The committed catalogues carry no identifier, read from disk.
+//
+// AnonymisePath is a rule about the paths this repository knows how to
+// recognise; this asserts the property those files must actually have, on the
+// bytes a commit would publish. The two are not the same claim, and a provider
+// that adopted an identifier spelling AnonymisePath does not know would satisfy
+// the first and fail this one — which is the order things should fail in.
+func TestNoCommittedCatalogueCarriesAnIdentifier(t *testing.T) {
+	dir := filepath.Join("..", "..", "shapes")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+	scanned := 0
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join(dir, e.Name())) //nolint:gosec // a committed artefact of this repository
+		if err != nil {
+			t.Fatalf("read %s: %v", e.Name(), err)
+		}
+		scanned++
+		if found := identifier.FindString(string(body)); found != "" {
+			t.Errorf("%s carries %q, which belongs to whoever recorded it", e.Name(), found)
+		}
+	}
+	// Asserted rather than assumed: a scan that found no file would pass while
+	// measuring nothing, which is the failure mode this repository has already
+	// paid for elsewhere.
+	if scanned == 0 {
+		t.Fatalf("no catalogue found in %s: the scan is broken, not the files", dir)
+	}
+}

--- a/internal/shape/shape.go
+++ b/internal/shape/shape.go
@@ -86,7 +86,11 @@ func (c *Catalogue) Merge(exs []trace.Exchange) Changes {
 		if x.Res == nil {
 			continue
 		}
-		key := keyFor(x)
+		// The path is anonymised before it is used for anything: it becomes the
+		// operation key when the recording could not name the operation, and it
+		// is stored on the operation either way.
+		path := AnonymisePath(x.Path)
+		key := keyFor(x, path)
 		op, known := c.Operations[key]
 		if !known {
 			// Fields starts as an empty slice rather than nil so the file
@@ -95,7 +99,7 @@ func (c *Catalogue) Merge(exs []trace.Exchange) Changes {
 			// and the difference between those two is the whole reason
 			// Statuses is recorded. Measured on a real Exoscale reading where
 			// one 404 wrote a null and the distinction vanished.
-			op = &Operation{Method: x.Method, Path: x.Path, Fields: []transcript.Field{}}
+			op = &Operation{Method: x.Method, Path: path, Fields: []transcript.Field{}}
 			c.Operations[key] = op
 			ch.Added = append(ch.Added, key)
 		}
@@ -194,12 +198,77 @@ func mergeType(a, b string) string {
 
 // keyFor names an operation. The upstream name when the recording carries one,
 // the route otherwise — an operation nothing claims is precisely what a shape
-// catalogue should hold, so it is never dropped for lack of a name.
-func keyFor(x *trace.Exchange) string {
+// catalogue should hold, so it is never dropped for lack of a name. The path it
+// is handed is the anonymised one, never the recorded one.
+func keyFor(x *trace.Exchange, path string) string {
 	if x.Operation != "" {
 		return x.Operation
 	}
-	return x.Method + " " + x.Path
+	return x.Method + " " + path
+}
+
+// AnonymisePath replaces every identifier segment of a request path with
+// "{id}".
+//
+// The catalogue is committed and a recording is not, and what makes that
+// difference safe is the package's own claim: paths and types, "no values, no
+// identifiers". A path stopped honouring it the moment a read list carried a
+// call that addresses one resource — `GET
+// /vpc/v2/regions/fr-par/private-networks/3f2a91c4-…` names an object of
+// somebody's account, and it would be written twice, into Operation.Path and
+// into the operation key. Nothing caught it because until #270 no read list
+// held such a call.
+//
+// The control sits at this boundary rather than in the recorder, because the
+// recorder is not the only writer: `feint shapes <recording.jsonl>` folds a
+// `feint proxy` transcript, which carries whatever a real client asked for. The
+// place that must hold is where a recording becomes a committed artefact.
+//
+// An identifier is a UUID, which is the form these providers put in a path:
+// Scaleway and Exoscale address resources that way, Outscale addresses
+// everything by POST /api/v1/<Action> and puts none there at all. A provider
+// that adopted another spelling would slip through, which is why
+// TestNoCommittedCatalogueCarriesAnIdentifier reads the files on disk instead of
+// trusting this function.
+//
+// TestARecordedIdentifierNeverReachesTheCatalogue fails without this.
+func AnonymisePath(path string) string {
+	segments := strings.Split(path, "/")
+	for i, seg := range segments {
+		if isUUID(seg) {
+			segments[i] = Placeholder
+		}
+	}
+	return strings.Join(segments, "/")
+}
+
+// Placeholder is what an identifier is written as, in a catalogue path and in
+// the read list that produced it. The two must be the same string or the shapes
+// gate would look an operation up under a name the recorder never wrote.
+const Placeholder = "{id}"
+
+// isUUID reports whether a path segment is a UUID, in the canonical
+// 8-4-4-4-12 hexadecimal spelling. The version and variant nibbles are not
+// checked: what is being recognised is an identifier, not a conforming one, and
+// a cloud that hands out an off-version UUID still hands out an identifier.
+func isUUID(seg string) bool {
+	if len(seg) != 36 {
+		return false
+	}
+	for i := 0; i < len(seg); i++ {
+		c := seg[i]
+		if i == 8 || i == 13 || i == 18 || i == 23 {
+			if c != '-' {
+				return false
+			}
+			continue
+		}
+		hex := (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
+		if !hex {
+			return false
+		}
+	}
+	return true
 }
 
 // Changes is what a merge did, so a caller can report it instead of asking the

--- a/internal/upstream/reads.go
+++ b/internal/upstream/reads.go
@@ -1,5 +1,12 @@
 package upstream
 
+import (
+	"sort"
+	"strings"
+
+	"github.com/stephrobert/feint/internal/shape"
+)
+
 // Reads is what to ask each provider in order to learn its shapes.
 //
 // A list rather than a derivation, and the reason is worth stating: what an
@@ -47,6 +54,11 @@ var Reads = map[Provider][]string{
 		"/instance/v1/zones/fr-par-1/products/servers",
 		"/vpc/v2/regions/fr-par/vpcs",
 		"/vpc/v2/regions/fr-par/private-networks",
+		// The read one Terraform refreshes a private network with, and the one
+		// nothing in this repository could arbitrate: a list read on an account
+		// with no network answers an empty array, so it carries no field of the
+		// object itself. See the templated-entry note below.
+		"/vpc/v2/regions/fr-par/private-networks/" + shape.Placeholder,
 		"/ipam/v1/regions/fr-par/ips",
 		"/iam/v1alpha1/ssh-keys",
 		"/marketplace/v2/local-images",
@@ -74,4 +86,71 @@ var Reads = map[Provider][]string{
 		"/v2/load-balancer",
 		"/v2/zone",
 	},
+}
+
+// A read-list entry ending in [shape.Placeholder] reads *one* element of the
+// collection above it, and the identifier is filled in from that collection's
+// own answer earlier in the same run.
+//
+// It exists because the shape of a "read one" was unobservable here. Only a
+// collection can be asked for blind: an item read needs an identifier, an
+// identifier belongs to an account, and so it can be neither written in this
+// list nor committed in a catalogue. #270 sat on that for weeks — the
+// private-network read is what the Terraform provider refreshes with, and not
+// one field of it was arbitrated by anything in this repository.
+//
+// Two properties make what comes back committable:
+//
+//   - the catalogue stores the anonymised path ([shape.AnonymisePath]), so an
+//     entry as written above is exactly the key its recording lands under, and
+//     no account identifier reaches the file;
+//   - the collection is read first, so a run against an account holding none of
+//     the resource resolves nothing and says so, instead of inventing an
+//     identifier or reading somebody else's.
+
+// TemplateOf returns the collection a templated entry reads one element of, and
+// whether the entry is templated at all.
+func TemplateOf(call string) (collection string, templated bool) {
+	trimmed := strings.TrimSuffix(call, "/"+shape.Placeholder)
+	if trimmed == call {
+		return "", false
+	}
+	return trimmed, true
+}
+
+// FirstID picks one identifier out of a collection's answer.
+//
+// These APIs answer a collection as an object holding one array of records —
+// {"private_networks": [...], "total_count": 1} — so the array is found rather
+// than named: a table of "which key holds the records" per provider per
+// resource would be one more thing to maintain, and every line of it a chance
+// to name the wrong key.
+//
+// Keys are visited in sorted order, so one body always yields the same
+// identifier however Go happened to hash the map that day. A recording that
+// moved with map iteration is exactly the volatility internal/shape refuses.
+func FirstID(body any) (string, bool) {
+	obj, ok := body.(map[string]any)
+	if !ok {
+		return "", false
+	}
+	names := make([]string, 0, len(obj))
+	for name := range obj {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		items, ok := obj[name].([]any)
+		if !ok || len(items) == 0 {
+			continue
+		}
+		first, ok := items[0].(map[string]any)
+		if !ok {
+			continue
+		}
+		if id, ok := first["id"].(string); ok && id != "" {
+			return id, true
+		}
+	}
+	return "", false
 }

--- a/mise.toml
+++ b/mise.toml
@@ -171,6 +171,10 @@ run = [
   "tools/conformance/scaleway/network.sh http://$FEINT_ADDR",
   "tools/conformance/outscale/network.sh http://$FEINT_ADDR",
   "tools/conformance/exoscale/network.sh http://$FEINT_ADDR",
+  # The dataplane of a load balancer (#315). It gates on
+  # capabilities.balancing, which only the OVN mode declares, so it skips
+  # itself under --vm incus and --vm incus-vm rather than failing there.
+  "tools/conformance/outscale/balancer.sh http://$FEINT_ADDR",
 ]
 
 [tasks."conformance:ssh"]
@@ -376,6 +380,10 @@ if [ "${FEINT_VM:-off}" = "off" ]; then ./feint probe --endpoint "http://$FEINT_
 tools/conformance/scaleway/network.sh "http://$FEINT_ADDR"
 tools/conformance/outscale/network.sh "http://$FEINT_ADDR"
 tools/conformance/exoscale/network.sh "http://$FEINT_ADDR"
+# Skips itself unless the runtime declares balancing, which is the OVN mode
+# alone: elsewhere a load balancer records its configuration and forwards
+# nothing, and asserting otherwise would assert a defect (#315).
+tools/conformance/outscale/balancer.sh "http://$FEINT_ADDR"
 # The evidence artefact (#123), written only when a caller asks for it: a
 # partial or ad-hoc run must not overwrite the recorded proofs by accident.
 # `mise run evidence:update` is the caller, and sets the two variables.

--- a/shapes/scaleway.json
+++ b/shapes/scaleway.json
@@ -10,6 +10,62 @@
           "type": "array"
         },
         {
+          "path": "snapshots[]",
+          "type": "object"
+        },
+        {
+          "path": "snapshots[].class",
+          "type": "string"
+        },
+        {
+          "path": "snapshots[].created_at",
+          "type": "string"
+        },
+        {
+          "path": "snapshots[].id",
+          "type": "string"
+        },
+        {
+          "path": "snapshots[].name",
+          "type": "string"
+        },
+        {
+          "path": "snapshots[].parent_volume",
+          "type": "null"
+        },
+        {
+          "path": "snapshots[].project_id",
+          "type": "string"
+        },
+        {
+          "path": "snapshots[].public",
+          "type": "bool"
+        },
+        {
+          "path": "snapshots[].references",
+          "type": "array"
+        },
+        {
+          "path": "snapshots[].size",
+          "type": "number"
+        },
+        {
+          "path": "snapshots[].status",
+          "type": "string"
+        },
+        {
+          "path": "snapshots[].tags",
+          "type": "array"
+        },
+        {
+          "path": "snapshots[].updated_at",
+          "type": "string"
+        },
+        {
+          "path": "snapshots[].zone",
+          "type": "string"
+        },
+        {
           "path": "total_count",
           "type": "number"
         }
@@ -8450,8 +8506,197 @@
           "type": "array"
         },
         {
+          "path": "private_networks[]",
+          "type": "object"
+        },
+        {
+          "path": "private_networks[].created_at",
+          "type": "string"
+        },
+        {
+          "path": "private_networks[].default_route_propagation_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "private_networks[].dhcp_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "private_networks[].has_s3_integration",
+          "type": "bool"
+        },
+        {
+          "path": "private_networks[].id",
+          "type": "string"
+        },
+        {
+          "path": "private_networks[].name",
+          "type": "string"
+        },
+        {
+          "path": "private_networks[].organization_id",
+          "type": "string"
+        },
+        {
+          "path": "private_networks[].project_id",
+          "type": "string"
+        },
+        {
+          "path": "private_networks[].region",
+          "type": "string"
+        },
+        {
+          "path": "private_networks[].subnets",
+          "type": "array"
+        },
+        {
+          "path": "private_networks[].subnets[]",
+          "type": "object"
+        },
+        {
+          "path": "private_networks[].subnets[].created_at",
+          "type": "string"
+        },
+        {
+          "path": "private_networks[].subnets[].id",
+          "type": "string"
+        },
+        {
+          "path": "private_networks[].subnets[].private_network_id",
+          "type": "string"
+        },
+        {
+          "path": "private_networks[].subnets[].project_id",
+          "type": "string"
+        },
+        {
+          "path": "private_networks[].subnets[].region",
+          "type": "string"
+        },
+        {
+          "path": "private_networks[].subnets[].subnet",
+          "type": "string"
+        },
+        {
+          "path": "private_networks[].subnets[].updated_at",
+          "type": "string"
+        },
+        {
+          "path": "private_networks[].subnets[].vpc_id",
+          "type": "string"
+        },
+        {
+          "path": "private_networks[].tags",
+          "type": "array"
+        },
+        {
+          "path": "private_networks[].updated_at",
+          "type": "string"
+        },
+        {
+          "path": "private_networks[].vpc_id",
+          "type": "string"
+        },
+        {
           "path": "total_count",
           "type": "number"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "GET /vpc/v2/regions/fr-par/private-networks/{id}": {
+      "method": "GET",
+      "path": "/vpc/v2/regions/fr-par/private-networks/{id}",
+      "fields": [
+        {
+          "path": "created_at",
+          "type": "string"
+        },
+        {
+          "path": "default_route_propagation_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "dhcp_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "has_s3_integration",
+          "type": "bool"
+        },
+        {
+          "path": "id",
+          "type": "string"
+        },
+        {
+          "path": "name",
+          "type": "string"
+        },
+        {
+          "path": "organization_id",
+          "type": "string"
+        },
+        {
+          "path": "project_id",
+          "type": "string"
+        },
+        {
+          "path": "region",
+          "type": "string"
+        },
+        {
+          "path": "subnets",
+          "type": "array"
+        },
+        {
+          "path": "subnets[]",
+          "type": "object"
+        },
+        {
+          "path": "subnets[].created_at",
+          "type": "string"
+        },
+        {
+          "path": "subnets[].id",
+          "type": "string"
+        },
+        {
+          "path": "subnets[].private_network_id",
+          "type": "string"
+        },
+        {
+          "path": "subnets[].project_id",
+          "type": "string"
+        },
+        {
+          "path": "subnets[].region",
+          "type": "string"
+        },
+        {
+          "path": "subnets[].subnet",
+          "type": "string"
+        },
+        {
+          "path": "subnets[].updated_at",
+          "type": "string"
+        },
+        {
+          "path": "subnets[].vpc_id",
+          "type": "string"
+        },
+        {
+          "path": "tags",
+          "type": "array"
+        },
+        {
+          "path": "updated_at",
+          "type": "string"
+        },
+        {
+          "path": "vpc_id",
+          "type": "string"
         }
       ],
       "statuses": [
@@ -8469,6 +8714,70 @@
         {
           "path": "vpcs",
           "type": "array"
+        },
+        {
+          "path": "vpcs[]",
+          "type": "object"
+        },
+        {
+          "path": "vpcs[].created_at",
+          "type": "string"
+        },
+        {
+          "path": "vpcs[].custom_routes_propagation_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "vpcs[].id",
+          "type": "string"
+        },
+        {
+          "path": "vpcs[].is_default",
+          "type": "bool"
+        },
+        {
+          "path": "vpcs[].name",
+          "type": "string"
+        },
+        {
+          "path": "vpcs[].organization_id",
+          "type": "string"
+        },
+        {
+          "path": "vpcs[].private_network_count",
+          "type": "number"
+        },
+        {
+          "path": "vpcs[].project_id",
+          "type": "string"
+        },
+        {
+          "path": "vpcs[].region",
+          "type": "string"
+        },
+        {
+          "path": "vpcs[].routing_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "vpcs[].s3_integration_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "vpcs[].tags",
+          "type": "array"
+        },
+        {
+          "path": "vpcs[].tags[]",
+          "type": "string"
+        },
+        {
+          "path": "vpcs[].transitivity_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "vpcs[].updated_at",
+          "type": "string"
         }
       ],
       "statuses": [

--- a/tools/conformance/outscale/balancer.sh
+++ b/tools/conformance/outscale/balancer.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# Conformance check: an Outscale load balancer distributes real packets (#315).
+#
+# oapi-cli.sh proves the configuration — listeners, backends, health-check
+# settings, the delete guards — and every bit of that is true of a server that
+# stores JSON and forwards nothing, which is exactly what this emulator did
+# until now and what docs/limits.md said. This suite measures the other half,
+# and only the half that was measured to hold: a balancer's own private address,
+# probed from inside the network it sits in, answers and spreads connections
+# over its registered machines.
+#
+# What it deliberately does not measure: the public face of an internet-facing
+# balancer. #315 measured that address going dark within three minutes, so the
+# emulator refuses to configure it and docs/limits.md carries the figures. A
+# suite asserting it would be asserting a defect.
+#
+# The gate is the runtime's *declared* capability, never a mode name: a suite
+# that compares mode strings has to be edited every time a driver gains one, and
+# it lies the day a mode stops delivering it. An undeclared capability reads as
+# absent and the suite skips.
+#
+# Requires a machine runtime with balancing: `feint serve --vm incus-ovn`.
+#
+# Usage: tools/conformance/outscale/balancer.sh [endpoint]
+set -euo pipefail
+
+ENDPOINT="${1:-http://127.0.0.1:4599}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/../guard.sh"
+guard_local "$ENDPOINT"
+
+command -v oapi-cli >/dev/null 2>&1 || { echo "FAIL: oapi-cli is not installed" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "FAIL: jq is not installed" >&2; exit 1; }
+command -v incus >/dev/null 2>&1 || { echo "FAIL: the incus client is not on PATH" >&2; exit 1; }
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ok()   { echo "  ok: $*"; }
+skip() { echo "  SKIP: $*" >&2; }
+
+echo "conformance: outscale load balancer dataplane against $ENDPOINT"
+
+health="$(curl -sf "$ENDPOINT/_feint/health")" || fail "the emulator does not answer /_feint/health"
+if [ "$(printf '%s' "$health" | jq -r '.machines')" = "none" ]; then
+  skip "no machine runtime (start with FEINT_VM=incus-ovn); nothing to measure"
+  exit 0
+fi
+# `// empty` on purpose: a build older than this capability answers no key at
+# all, and reading that as "false" is right, while reading it as an error would
+# make the suite fail on a binary that never claimed anything.
+BALANCING="$(printf '%s' "$health" | jq -r '.capabilities.balancing // empty')"
+if [ "$BALANCING" != "true" ]; then
+  skip "this runtime does not declare balancing; a load balancer here records its configuration and forwards nothing (docs/limits.md)"
+  exit 0
+fi
+
+BLOCK="${FEINT_TEST_LB_BLOCK:-10.186.0.0/16}"
+SUBBLOCK="${FEINT_TEST_LB_SUBNET_BLOCK:-10.186.7.0/24}"
+
+WORK="$(mktemp -d)"
+chmod 700 "$WORK"
+
+set -a
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/fake-credentials.env"
+# shellcheck disable=SC2034 # read by oapi-cli from the environment
+OSC_ENDPOINT_API="$ENDPOINT"
+set +a
+cat >"$WORK/config.json" <<JSON
+{"default": {"access_key": "$OSC_ACCESS_KEY", "secret_key": "$OSC_SECRET_KEY",
+ "protocol": "http", "region": "eu-west-2", "endpoints": {"api": "$ENDPOINT"}}}
+JSON
+osc() { oapi-cli --config "$WORK/config.json" "$@"; }
+
+lb_name="feint-lbu-data"
+net_id=""; sub_id=""; vm_a=""; vm_b=""; vm_c=""; lb_made=""
+
+cleanup() {
+  [ -n "$lb_made" ] && osc DeleteLoadBalancer --LoadBalancerName "$lb_name" >/dev/null 2>&1
+  for vm in "$vm_a" "$vm_b" "$vm_c"; do
+    [ -n "$vm" ] && osc DeleteVms '--VmIds[]' "$vm" >/dev/null 2>&1
+  done
+  sleep 2
+  [ -n "$sub_id" ] && osc DeleteSubnet --SubnetId "$sub_id" >/dev/null 2>&1
+  [ -n "$net_id" ] && osc DeleteNet --NetId "$net_id" >/dev/null 2>&1
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+echo "- a Net, a Subnet and three machines"
+net_id="$(osc CreateNet --IpRange "$BLOCK" | jq -r '.Net.NetId')"
+[ -n "$net_id" ] || fail "CreateNet answered no id"
+sub_id="$(osc CreateSubnet --NetId "$net_id" --IpRange "$SUBBLOCK" | jq -r '.Subnet.SubnetId')"
+[ -n "$sub_id" ] || fail "CreateSubnet answered no id"
+
+launch() {
+  local doc
+  doc="$(osc CreateVms --ImageId ami-00000003 --VmType tinav6.c1r1p2 --SubnetId "$sub_id")" \
+    || { echo "CreateVms rejected: $doc" >&2; return 1; }
+  printf '%s' "$doc" | jq -r '.Vms[0].VmId + " " + .Vms[0].PrivateIp'
+}
+read -r vm_a ip_a <<<"$(launch)" || fail "the first backend was not created"
+read -r vm_b ip_b <<<"$(launch)" || fail "the second backend was not created"
+read -r vm_c ip_c <<<"$(launch)" || fail "the client machine was not created"
+[ -n "$ip_a" ] && [ -n "$ip_b" ] && [ -n "$ip_c" ] || fail "a machine came back with no PrivateIp"
+ok "$vm_a=$ip_a $vm_b=$ip_b, client $vm_c=$ip_c"
+
+# Each backend answers its own name, so a reply identifies which machine served
+# it. Without that, "the VIP answers" cannot be told from "one machine answers
+# and the balancer sends everything to it", which is the whole assertion.
+echo "- each backend answers its own name on :80"
+serve() {
+  incus exec "feint-osc-$1" -- sh -c \
+    "nohup sh -c 'while true; do printf \"HTTP/1.1 200 OK\r\nContent-Length: ${#1}\r\n\r\n$1\" | nc -l -p 80; done' >/dev/null 2>&1 &" \
+    >/dev/null 2>&1
+}
+booted=""
+for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
+  if incus exec "feint-osc-$vm_a" -- true >/dev/null 2>&1 &&
+     incus exec "feint-osc-$vm_b" -- true >/dev/null 2>&1 &&
+     incus exec "feint-osc-$vm_c" -- true >/dev/null 2>&1; then booted="yes"; break; fi
+  sleep 2
+done
+[ -n "$booted" ] || fail "the machines never came up; nothing can be measured"
+serve "$vm_a"
+serve "$vm_b"
+sleep 3
+
+# The positive control, before any verdict is drawn from silence: each backend
+# answers on its own address. A machine whose responder never started refuses a
+# connection exactly as a balancer that forwards nothing does (#219).
+from_client() { incus exec "feint-osc-$vm_c" -- wget -q -T 4 -O - "http://$1/" 2>/dev/null; }
+[ "$(from_client "$ip_a")" = "$vm_a" ] || fail "the first backend does not answer on its own address"
+[ "$(from_client "$ip_b")" = "$vm_b" ] || fail "the second backend does not answer on its own address"
+ok "both backends answer directly"
+
+echo "- an internal load balancer, its two machines registered"
+lb="$(osc CreateLoadBalancer --LoadBalancerName "$lb_name" --LoadBalancerType internal \
+      '--Subnets[]' "$sub_id" \
+      --Listeners "[{\"LoadBalancerPort\": 80, \"LoadBalancerProtocol\": \"TCP\", \"BackendPort\": 80, \"BackendProtocol\": \"TCP\"}]")" \
+  || fail "CreateLoadBalancer rejected: $lb"
+lb_made="yes"
+vip="$(printf '%s' "$lb" | jq -r '.LoadBalancer.PrivateIp // empty')"
+[ -n "$vip" ] || fail "the load balancer came back with no PrivateIp: $lb"
+case "$vip" in
+  "${SUBBLOCK%.*}."*) ;;
+  *) fail "the balancer's PrivateIp $vip is outside its own Subnet $SUBBLOCK" ;;
+esac
+osc RegisterVmsInLoadBalancer --LoadBalancerName "$lb_name" '--BackendVmIds[]' "$vm_a" >/dev/null \
+  || fail "RegisterVmsInLoadBalancer rejected the first machine"
+osc RegisterVmsInLoadBalancer --LoadBalancerName "$lb_name" '--BackendVmIds[]' "$vm_b" >/dev/null \
+  || fail "RegisterVmsInLoadBalancer rejected the second machine"
+sleep 2
+ok "$lb_name answers on $vip"
+
+# probe: N connections from the client machine, printed as the names that
+# answered. TIMEOUT is kept in the output rather than dropped, so a partial
+# failure reads as one instead of looking like a lopsided split.
+probe() {
+  local n="$1" out=""
+  for _ in $(seq 1 "$n"); do
+    out="$out $(from_client "$vip" || echo TIMEOUT)"
+  done
+  printf '%s' "$out"
+}
+
+echo "- the balancer distributes to both machines"
+hits="$(probe 6)"
+case "$hits" in
+  *TIMEOUT*) fail "the balancer did not answer every probe: $hits" ;;
+esac
+case "$hits" in *"$vm_a"*) ;; *) fail "no connection reached $vm_a: $hits" ;; esac
+case "$hits" in *"$vm_b"*) ;; *) fail "no connection reached $vm_b: $hits" ;; esac
+ok "6/6 answered, over both machines:$hits"
+
+# The measurement #315 turned on. An address the runtime has to announce outside
+# the network answers for two minutes and goes dark; an address of the network's
+# own block does not, and that is the difference this whole capability rests on.
+# Sixty seconds is short of the three minutes at which the other one died, and
+# it is what a conformance run can afford; the full curve is in docs/limits.md.
+echo "- and it is still there a minute later"
+sleep 60
+hits="$(probe 6)"
+case "$hits" in
+  *TIMEOUT*) fail "the balancer went dark within a minute: $hits" ;;
+esac
+ok "6/6 answered again:$hits"
+
+# The replace-not-patch rule, measured rather than asserted in a unit test: a
+# machine the API has stopped listing must stop receiving connections.
+echo "- an unlinked machine stops receiving connections"
+osc UnlinkLoadBalancerBackendMachines --LoadBalancerName "$lb_name" '--BackendVmIds[]' "$vm_a" >/dev/null \
+  || fail "UnlinkLoadBalancerBackendMachines rejected"
+sleep 2
+hits="$(probe 6)"
+case "$hits" in
+  *TIMEOUT*) fail "the balancer stopped answering after an unlink: $hits" ;;
+  *"$vm_a"*) fail "$vm_a still receives connections after being unlinked: $hits" ;;
+esac
+case "$hits" in *"$vm_b"*) ;; *) fail "the remaining machine receives nothing: $hits" ;; esac
+ok "everything goes to $vm_b:$hits"
+
+echo "- deleting the balancer takes it off the host"
+network="$(incus network list -f csv 2>/dev/null | grep '^fnt-' | cut -d, -f1 | while read -r name; do
+  addr="$(incus network get "$name" ipv4.address 2>/dev/null || true)"
+  case "$addr" in "${SUBBLOCK%.*}."*) echo "$name"; break ;; esac
+done)"
+[ -n "$network" ] || fail "no host network carries $SUBBLOCK; the delete cannot be verified"
+incus network load-balancer list "$network" -f csv 2>/dev/null | grep -q "$vip" \
+  || fail "the runtime holds no balancer on $vip, so the probes above measured something else"
+osc DeleteLoadBalancer --LoadBalancerName "$lb_name" >/dev/null || fail "DeleteLoadBalancer rejected"
+lb_made=""
+sleep 2
+if incus network load-balancer list "$network" -f csv 2>/dev/null | grep -q "$vip"; then
+  fail "the balancer on $vip outlived the load balancer it belongs to"
+fi
+ok "the host holds no balancer on $vip"
+
+echo "conformance: outscale load balancer dataplane passed"

--- a/tools/falsify/specs/balancer-dataplane.json
+++ b/tools/falsify/specs/balancer-dataplane.json
@@ -1,0 +1,78 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "a listen address outside the network's block is configured, and goes dark three minutes later",
+      "file": "internal/core/machine/incus_balancer.go",
+      "find": "\tif !block.Contains(listen) {",
+      "replace": "\tif !block.Contains(listen) && false {",
+      "test": "TestABalancerOutsideTheNetworksBlockIsRefused"
+    },
+    {
+      "label": "a balancer is written onto a network the emulator does not own",
+      "file": "internal/core/machine/incus_balancer.go",
+      "find": "\tif err := d.mustOwn(ctx, spec.Network); err != nil {\n\t\treturn err\n\t}\n\tblock, err := d.networkGateway(ctx, spec.Network)",
+      "replace": "\tif err := d.mustOwn(ctx, spec.Network); err != nil && false {\n\t\treturn err\n\t}\n\tblock, err := d.networkGateway(ctx, spec.Network)",
+      "test": "TestABalancerOnAForeignNetworkIsRefused"
+    },
+    {
+      "label": "the delete stops reading the ownership marker, so an operator's own balancer goes",
+      "file": "internal/core/machine/incus_balancer.go",
+      "find": "\tif !strings.HasPrefix(existing.Description, balancerDescription) {",
+      "replace": "\tif !strings.HasPrefix(existing.Description, balancerDescription) && false {",
+      "test": "TestRemovingAForeignBalancerIsRefused"
+    },
+    {
+      "label": "an untranslated protocol is dropped instead of refused, and the balancer serves half its listeners",
+      "file": "internal/core/machine/incus_balancer.go",
+      "find": "\t\tif !balancerProtocols[strings.ToLower(listener.Protocol)] {\n\t\t\treturn fmt.Errorf(\"balancer %s: %q is not a protocol this runtime distributes; \"+",
+      "replace": "\t\tif !balancerProtocols[strings.ToLower(listener.Protocol)] && false {\n\t\t\treturn fmt.Errorf(\"balancer %s: %q is not a protocol this runtime distributes; \"+",
+      "test": "TestAnUndistributableProtocolIsRefused"
+    },
+    {
+      "label": "a balancer that does not exist is updated rather than created, which is how it shipped and answered nothing",
+      "file": "internal/core/machine/incus_balancer.go",
+      "find": "\tif exists {\n\t\tif _, err := d.run(ctx, \"query\", \"-X\", \"PUT\", \"--data\", string(encoded), path+\"/\"+spec.Listen); err != nil {",
+      "replace": "\tif exists || true {\n\t\tif _, err := d.run(ctx, \"query\", \"-X\", \"PUT\", \"--data\", string(encoded), path+\"/\"+spec.Listen); err != nil {",
+      "test": "TestABalancerIsCreatedWhenTheCollectionDoesNotHoldIt"
+    },
+    {
+      "label": "every mode declares balancing, including the one with no load balancer primitive",
+      "file": "internal/core/machine/capabilities.go",
+      "find": "\t\tBalancing:       d.OVN,",
+      "replace": "\t\tBalancing:       d.OVN || true,",
+      "test": "TestABridgeBackedRunHasNoBalancer"
+    },
+    {
+      "label": "balancing survives a host with no OVN wiring, which is the capability a suite would assert",
+      "file": "internal/core/machine/verify.go",
+      "find": "\t\t\tif declared.Balancing {\n\t\t\t\tverified.Balancing = false",
+      "replace": "\t\t\tif declared.Balancing && false {\n\t\t\t\tverified.Balancing = false",
+      "test": "TestVerifyNarrowsBalancingWithIsolation"
+    },
+    {
+      "label": "the pack asks a runtime that never declared balancing, so every bridge-backed run meets a refusal",
+      "file": "internal/providers/outscale/loadbalancer_dataplane.go",
+      "find": "\tif p.env.Machines == nil || !machine.CapabilitiesOf(p.env.Machines).Balancing {",
+      "replace": "\tif p.env.Machines == nil || !machine.CapabilitiesOf(p.env.Machines).Balancing && false {",
+      "test": "TestAnUndeclaredBalancingCapabilityIsNeverUsed",
+      "package": "./internal/providers/outscale/"
+    },
+    {
+      "label": "an unlink never reaches the runtime, so a machine the API stopped listing keeps receiving connections",
+      "file": "internal/providers/outscale/loadbalancers.go",
+      "find": "\tp.syncBalancer(r.Context(), req.LoadBalancerName)\n\temulator.WriteJSON(w, http.StatusOK, map[string]any{\"ResponseContext\": p.context()})\n}\n\nfunc (p *Pack) deleteLoadBalancer(w http.ResponseWriter, r *http.Request) {",
+      "replace": "\tif false {\n\t\tp.syncBalancer(r.Context(), req.LoadBalancerName)\n\t}\n\temulator.WriteJSON(w, http.StatusOK, map[string]any{\"ResponseContext\": p.context()})\n}\n\nfunc (p *Pack) deleteLoadBalancer(w http.ResponseWriter, r *http.Request) {",
+      "test": "TestUnlinkingAndDeletingReachTheRuntime",
+      "package": "./internal/providers/outscale/"
+    },
+    {
+      "label": "a deleted balancer is left on the host, holding an address the next create could reuse",
+      "file": "internal/providers/outscale/loadbalancers.go",
+      "find": "\tp.removeBalancer(r.Context(), res)",
+      "replace": "\tif false {\n\t\tp.removeBalancer(r.Context(), res)\n\t}",
+      "test": "TestUnlinkingAndDeletingReachTheRuntime",
+      "package": "./internal/providers/outscale/"
+    }
+  ]
+}

--- a/tools/falsify/specs/private-network-ipv6.json
+++ b/tools/falsify/specs/private-network-ipv6.json
@@ -14,6 +14,42 @@
       "find": "\tif subnet6, _ := pn.Attrs[\"subnet_ipv6\"].(string); subnet6 != \"\" {",
       "replace": "\tif subnet6, _ := pn.Attrs[\"subnet_ipv6\"].(string); subnet6 != \"\" && false {",
       "test": "TestPrivateNetworkPublishesAnIPv6Subnet"
+    },
+    {
+      "label": "each network derives its own /48, so two networks of one project stop being siblings",
+      "file": "internal/providers/scaleway/vpc.go",
+      "find": "\t\tcandidate := network.ULA64Within(project, seed)",
+      "replace": "\t\tcandidate := network.ULA64Within(project+seed, seed)",
+      "test": "TestTwoNetworksGetTwoIPv6BlocksUnderOnePrefix"
+    },
+    {
+      "label": "the space stops reaching the global ID, so every tenancy shares one /48",
+      "file": "internal/core/network/ula.go",
+      "find": "\tcopy(addr[1:6], global[:5])",
+      "replace": "\tcopy(addr[1:6], global[:0])",
+      "test": "TestOneSpacesBlocksAreSiblingsAndTwoSpacesAreNot",
+      "package": "./internal/core/network/"
+    },
+    {
+      "label": "the private network stops publishing the Object Storage flag the real cloud carries",
+      "file": "internal/providers/scaleway/vpc.go",
+      "find": "\t\t\"has_s3_integration\": false,",
+      "replace": "\t\t\"has_s3_integration\" + \"-unserved\": false,",
+      "test": "TestTheObjectStorageFlagsAreServedOnEveryDoor"
+    },
+    {
+      "label": "the VPC stops publishing the Object Storage flag the real cloud carries",
+      "file": "internal/providers/scaleway/vpc.go",
+      "find": "\t\t\"s3_integration_enabled\": false,",
+      "replace": "\t\t\"s3_integration_enabled\" + \"-unserved\": false,",
+      "test": "TestTheObjectStorageFlagsAreServedOnEveryDoor"
+    },
+    {
+      "label": "the vpc/v2 creates go back to the 201 nobody measured",
+      "file": "internal/providers/scaleway/vpc.go",
+      "find": "const vpcCreateStatus = http.StatusOK",
+      "replace": "const vpcCreateStatus = http.StatusCreated",
+      "test": "TestTheVpcCreatesAnswerWhatTheRealCloudAnswers"
     }
   ]
 }

--- a/tools/falsify/specs/recorded-identifiers.json
+++ b/tools/falsify/specs/recorded-identifiers.json
@@ -1,0 +1,35 @@
+{
+  "package": "./internal/shape/",
+  "mutations": [
+    {
+      "label": "an identifier segment is no longer recognised, so the account's UUID reaches the committed catalogue",
+      "file": "internal/shape/shape.go",
+      "find": "\t\tif isUUID(seg) {\n\t\t\tsegments[i] = Placeholder\n\t\t}",
+      "replace": "\t\tif isUUID(seg) && false {\n\t\t\tsegments[i] = Placeholder\n\t\t}",
+      "test": "TestARecordedIdentifierNeverReachesTheCatalogue"
+    },
+    {
+      "label": "the anonymised path is stored but the raw one is keyed, which is the half a first version got wrong",
+      "file": "internal/shape/shape.go",
+      "find": "\t\tkey := keyFor(x, path)",
+      "replace": "\t\tkey := keyFor(x, x.Path+path[:0])",
+      "test": "TestARecordedIdentifierNeverReachesTheCatalogue"
+    },
+    {
+      "label": "an element read placed before its collection is skipped instead of refused, and reads as an empty account",
+      "file": "internal/cli/shapes.go",
+      "find": "\t\t\tif !read {",
+      "replace": "\t\t\tif !read && false {",
+      "test": "TestATemplatedReadBeforeItsCollectionIsRefused",
+      "package": "./internal/cli/"
+    },
+    {
+      "label": "an account holding none of the resource is asked for one anyway, and a 404 becomes the operation's shape",
+      "file": "internal/cli/shapes.go",
+      "find": "\t\t\tif !found {",
+      "replace": "\t\t\tif !found && false {",
+      "test": "TestATemplatedReadAsksNothingWhenTheAccountHasNone",
+      "package": "./internal/cli/"
+    }
+  ]
+}


### PR DESCRIPTION
Two issues that had been waiting on something nobody had: a real account for
one, a re-measurement for the other.

## #270 — a real Private Network arbitrates the field

The issue had blocked itself, honestly and correctly: *"no recording in this
repository arbitrates the field yet — `feint shapes --record` against a real
account is one command away from settling it, and this issue should not close
without that recording."*

**It was not one command away**, and that is the first premise the work denied.
The recorder walked collections only, so it could not read one object; and
`internal/shape` would have committed the account's own UUID as the operation
key. Both had to be built before a recording could be committed at all. The
read list can now describe an item read (`…/{id}`, resolved from the collection
above it in the same run), and identifier segments are anonymised **at the
boundary where a recording becomes a versioned artefact** — the key is
`GET /vpc/v2/regions/fr-par/private-networks/{id}`, with no UUID anywhere.

**What the real cloud answered.** Creating a Private Network with
`subnets: null` allocates **two**: `172.16.4.0/22` and
`fdb2:1bb5:120a:9b::/64`. The unasked allocation, the ULA range and the `/64`
size are confirmed. 76 new field paths are recorded.

**Three things the recording denied, none of them in the issue:**

1. `has_s3_integration` (private network) and `s3_integration_enabled` (VPC)
   are on every real answer and were **absent** from the emulator. `scw` drops
   both, so no CLI-driven test could ever have seen them — only a recording.
2. `POST …/private-networks` and `POST …/vpcs` answer **200**, not the `201`
   the emulator wrote. `CreateRoute` is left at 201 and **not** claimed:
   creating a route was outside the resources this work was authorised to
   create, so it stays unmeasured rather than assumed.
3. Two networks of one project **share their `/48`** (`fdb2:1bb5:120a::/48`,
   subnet ids `009b` and `6cad`). The emulator drew an independent `/48` per
   network. `network.ULA64Within(space, seed)` now derives the global id from
   the project and the subnet id from the resource — and its doc states the
   bound of the measurement: on this account `default_project_id` and
   `default_organization_id` are the same UUID, so project-versus-organization
   is undecidable here.

The issue's minimal reproduction is the conformance fixture: `terraform.sh`
asserts `one(...ipv6_subnets).subnet` matches `fd*/64`. `mise run conformance`
exits 0 — apply, empty re-plan, destroy.

## #315 — the internal half delivered, the public half refused

**The issue's own conclusion 2 does not apply to the design it proposes**, and
taking it as a verdict would have refused a capability that works. The spike
measured a VIP *outside* the network, delegated through the uplink, and watched
it go dark. An internal LBU needs a VIP *inside* the subnet — the balancer's
`PrivateIp` — which needs no gratuitous-ARP announcement at all, because the
uplink already routes the whole subnet to the OVN router. Different mechanism,
different answer.

Re-measured on 2026-08-20, three containers on one OVN network: **t0, t+60s and
t+180s all answered 6/6 across both backends**, with no dark period, and the
host reached it too — which the external VIP never could.

So `Capabilities.Balancing`, declared by the OVN mode alone, cleared at startup
by `Verify` on a host with no northbound connection, published on
`/_feint/health` (schema 4). `EnsureBalancer` **refuses** a listen address
outside the network's own block, naming #315: the public face of an
internet-facing balancer stays a TEST-NET-3 address routing nowhere.
`ReadVmsHealth` stays declined — `incus network load-balancer` reports no
backend health, which confirms the issue rather than working around it. The
Scaleway `lb/v1` family is deliberately untouched, and `docs/limits.md` says so
rather than letting a shared mechanism read as a shared claim.

`tools/conformance/outscale/balancer.sh` ran green for real under
`FEINT_VM=incus-ovn`: distribution over both backends, still alive a minute
later, an unlinked Vm stops receiving, delete removes the balancer from the
host. It gates on `capabilities.balancing` and skips under `--vm off`, so CI
stays runtime-free.

## The account, and what it looks like now

Only VPCs and Private Networks were created — both free — and every object was
destroyed under a `trap … EXIT`, with destruction proved by a read returning
404 or an empty list. Verified independently after the fact: **0 private
networks, 1 VPC (the default), 0 instances, 0 flexible IPs, 0 block volumes**,
identical to the starting inventory.

No account identifier reached the diff: 0 hits for the organisation id, 0 for
any real resource UUID, 0 for the secret. Two real UUIDs used as test fixtures
were replaced with invented ones, following `shape_test.go`'s own rule that a
fixture must not borrow a real account.

## Falsified — 21 mutations, every one bites

`recorded-identifiers.json` (4), `private-network-ipv6.json` (7),
`balancer-dataplane.json` (10), all `compiled=yes / the test bit`, tree green
after restoration. Among them: a per-network `/48` instead of siblings under
one prefix; both S3 flags unserved; creates back to 201; a VIP outside the
block; a foreign balancer deleted; every mode declaring balancing; `Verify` not
narrowing it.

**A defect the conformance suite caught, worth recording**: the first
`EnsureBalancer` decided create-versus-update by matching the daemon's refusal
prose. Every first write failed and the balancer answered nothing — 6 timeouts
out of 6. It now asks the collection, which is structural. That is
*vérifier n'est pas parser* biting in the same session the rule was quoted.

## Related

Closes #270
Closes #315
