### PR TITLE
fix: a frozen surface that asks the binary, and an ssh suite that asks for its images first

### DIFF
--- a/.github/workflows/runtime-proof.yml
+++ b/.github/workflows/runtime-proof.yml
@@ -200,6 +200,26 @@ jobs:
           go build -o feint ./cmd/feint
           sudo ./feint doctor --vm "${MODE}"
 
+      # The images the machines boot, built before anything needs them (#335).
+      #
+      # This is not a convenience. Without them the driver falls back to an
+      # upstream image, which carries no ssh daemon; and since #202 a machine
+      # holds exactly the address its provider publishes, on a routed NIC with
+      # no NAT, so cloud-init cannot install one either. The workflow was red
+      # on the "Scaleway ssh suite" step for five consecutive scheduled nights
+      # (2026-08-16 to 2026-08-20) for that reason alone, with `fix="feint
+      # images"` printed in its own log every night and nothing reading it.
+      #
+      # The step is half the fix. The other half is in
+      # tools/conformance/guard.sh: the ssh suites now refuse to start when the
+      # images are missing, so deleting this step fails at the doorstep with the
+      # command to run, instead of ninety seconds later on an ssh timeout that
+      # blames the network.
+      - name: Build the machine images the suites boot
+        env:
+          MODE: ${{ matrix.mode }}
+        run: sudo ./feint images --vm "${MODE}"
+
       # The same verified installs as conformance.yml, because the ssh and
       # network suites drive the official clients, not curl.
       - name: Install the Scaleway CLI

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -210,6 +210,55 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Corrigé
 
+- **La surface CLI gelée est lue depuis les jeux de drapeaux que le binaire
+  enregistre, plus depuis l'aide qu'il imprime** (#334). `feint proxy
+  --intercept` est parti en v0.9.0 : le binaire l'acceptait, `feint proxy
+  --help` l'affichait, et `internal/cli/testdata/frozen/cli.json` ne le listait
+  pas, six jours durant. Cette fixture est la surface que #132 a gelée pour
+  qu'un pipeline extérieur à ce dépôt puisse s'y fier. La cause tenait à
+  l'observation elle-même : elle parsait l'aide rendue par `feint --help`, donc
+  elle consignait ce que l'aide *prétendait*. Le drapeau manquant n'était que la
+  moitié la moins chère. Un drapeau **retiré** d'un jeu alors que sa ligne
+  d'aide survit aurait laissé le même gate au vert, et c'est la direction qui
+  casse un consommateur.
+
+  La surface vient désormais de `flag.FlagSet.VisitAll`, par une couture unique
+  où chaque verbe construit ses drapeaux (`internal/cli/flagset.go`). L'aide
+  garde une promesse, mais sous la forme d'un contrôle qui a son propre sujet :
+  `TestTheHelpNamesEveryFlagTheBinaryAccepts` compare les deux listes dans les
+  deux sens, de sorte qu'un drapeau accepté par le binaire et nommé par aucun
+  bloc d'aide échoue, et qu'un bloc d'aide nommant un drapeau qu'aucun jeu
+  n'enregistre échoue aussi. Falsifié dans les deux sens par
+  `tools/falsify/specs/frozen-cli-surface.json`, sept mutations, chacune rejouée
+  contre le test qui doit mordre.
+
+- **La surface CLI passe en version 5, et 24 drapeaux que le binaire a toujours
+  acceptés y sont visibles pour la première fois** (#334). C'est l'observation
+  qui a bougé, pas le binaire : `--intercept` et `--expose-to-network` sur
+  `proxy`, `--shapes` et `--expose-to-network` sur `serve`, `--check` sur
+  `version`, les six drapeaux de `serve` que `start` accepte réellement, trois
+  sur `evidence` et dix sur `docs`. Trois entrées sont parties, et les trois
+  appartenaient au parseur : `--version` et `-v` sous `version`, qui sont des
+  alias du verbe et non ses drapeaux (un lecteur qui tapait `feint version
+  --version` s'entendait répondre `flag provided but not defined`), et
+  `--state` sous `snapshot`, qui venait d'une phrase parlant de `serve`.
+  `snapshot` est désormais indexé par jeu de drapeaux (`snapshot save`,
+  `snapshot load`, `snapshot list`), ce qui est la façon de dire que `--force`
+  appartient à `save` seul.
+
+  `feint --help` a gagné tous les drapeaux qu'il cachait, dont les deux
+  `--expose-to-network`, ceux qu'un lecteur a le plus besoin de rencontrer avant
+  de les poser.
+
+- **`docs/proxy.md` a cessé de refuser un outil que ce dépôt livre** (#334). La
+  page annonçait au lecteur que l'interception « est #76 et délibérément pas cet
+  outil », pendant que `docs/limits.md` envoyait ce même lecteur s'en servir.
+  `feint proxy --intercept` existe depuis la v0.9.0 ; la page le documente
+  désormais : ce qu'il forge, ce qu'il imprime, et la seule chose qu'il ne fera
+  pas, à savoir installer quoi que ce soit dans le magasin de confiance du
+  système ou modifier le `/etc/hosts` de l'opérateur. #76 et #92 sont closes,
+  livrées.
+
 - **Une stack appliquée à chaque pull request épingle le provider qui a
   répondu, et une stack que la CI n'applique pas dit pourquoi** (la table de
   #325, premier jour). La page générée des clients a révélé deux choses que

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -210,6 +210,47 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Corrigé
 
+- **Une suite de conformité ssh refuse de démarrer quand l'émulateur ne détient
+  aucune des images qu'elle démarre, et la preuve runtime les construit**
+  (#335). `runtime-proof.yml` échouait sur son étape *Scaleway ssh suite* cinq
+  nuits planifiées d'affilée, du 2026-08-16 au 2026-08-20, sur les deux jambes.
+  Le correctif était imprimé dans son propre journal chacune de ces nuits :
+  `WARN no image of ours for this system, booting the upstream one … fix="feint
+  images"`, et rien ne l'exécutait. La sous-commande n'apparaît dans aucune
+  étape de ce workflow ni dans aucune ligne de `mise run conformance:ssh`.
+
+  Reproduit avant d'être corrigé, sur une station qui détenait les images, en
+  supprimant les cinq alias `feint/*` puis en les remettant : la même suite est
+  passée en 21 secondes avec eux et a échoué en 93 sans, sur la phrase même que
+  la CI imprimait. Le workflow lance désormais `feint images` avant de démarrer
+  l'émulateur, et `tools/conformance/guard.sh` a gagné `guard_images`, que les
+  trois suites ssh appellent avant d'enregistrer une clé : il lit `.machines`
+  sur `/_feint/health`, interroge `feint images --check` sur ce runtime, et
+  refuse en un vingtième de seconde en nommant la commande, au lieu d'échouer
+  quatre-vingt-dix secondes plus tard sur « no ssh daemon answered », qui
+  accuse l'adresse. La garde vit dans le fichier partagé, pas dans chaque
+  suite, pour la raison que donne CLAUDE.md : un contrôle recopié trois fois
+  est un contrôle que la quatrième oublie. Falsifié par
+  `tools/falsify/specs/ssh-suite-needs-its-images.json`, cinq mutations, dont
+  celle où une suite garde la garde et cesse de l'appeler.
+
+  **Pourquoi le repli avait cessé d'en être un**, et c'est la partie qui mérite
+  d'être retenue. #203 a choisi de démarrer l'image amont quand l'émulateur ne
+  détient aucune des siennes, délibérément, pour qu'un premier contact
+  fonctionne. #202 a ensuite donné à une machine exactement la seule adresse que
+  publie son fournisseur, sur une NIC routée sans NAT. Les deux vont bien
+  séparément et pas ensemble : mesuré le 2026-08-20, le cloud-init d'une image
+  amont meurt sur `Temporary failure resolving 'archive.ubuntu.com'`,
+  `openssh-server` ne s'installe jamais, et rien n'écoute sur le port 22.
+  L'avertissement de l'émulateur disait « la machine installe un démon ssh au
+  premier démarrage et a besoin du réseau sortant pour cela », ce qui était vrai
+  à l'écriture et était devenu la description d'un événement impossible. Il dit
+  maintenant ce qui se produit vraiment.
+
+  Cela débloque aussi le compteur de #125 : son critère de promotion est une
+  série de nuits planifiées vertes consécutives, donc tant que ceci restait
+  cassé ce nombre était bloqué à zéro par construction, et rien ne le disait.
+
 - **La surface CLI gelée est lue depuis les jeux de drapeaux que le binaire
   enregistre, plus depuis l'aide qu'il imprime** (#334). `feint proxy
   --intercept` est parti en v0.9.0 : le binaire l'acceptait, `feint proxy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,45 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Fixed
 
+- **An ssh conformance suite refuses to start when the emulator holds none of
+  the images it boots, and the runtime proof builds them** (#335).
+  `runtime-proof.yml` failed on its *Scaleway ssh suite* step on five
+  consecutive scheduled nights, 2026-08-16 to 2026-08-20, on both legs. The fix
+  was printed in its own log every one of those nights — `WARN no image of ours
+  for this system, booting the upstream one … fix="feint images"` — and nothing
+  ran it: the subcommand appears in no step of that workflow and in no line of
+  `mise run conformance:ssh`.
+
+  Reproduced before being fixed, on a station that held the images, by deleting
+  the five `feint/*` aliases and putting them back afterwards: the same suite
+  passed in 21 seconds with them and failed in 93 without, on the same sentence
+  CI had been printing. The workflow now runs `feint images` before it starts
+  the emulator, and `tools/conformance/guard.sh` gained `guard_images`, which
+  the three ssh suites call before they register a key: it reads `.machines`
+  from `/_feint/health`, asks `feint images --check` about that runtime, and
+  refuses in a twentieth of a second naming the command, instead of failing
+  ninety seconds later on "no ssh daemon answered", which blames the address.
+  The guard is in the shared file, not in each suite, for the reason CLAUDE.md
+  gives: a control copied three times is one the fourth forgets. Falsified by
+  `tools/falsify/specs/ssh-suite-needs-its-images.json`, five mutations,
+  including the one where a suite keeps the guard and stops calling it.
+
+  **Why the fallback stopped being a fallback**, which is the part worth
+  keeping. #203 chose to boot the upstream image when the emulator holds none of
+  its own, deliberately, so a first contact still works. #202 then gave a
+  machine exactly the one address its provider publishes, on a routed NIC with
+  no NAT. The two are fine apart and not together: measured on 2026-08-20, an
+  upstream image's cloud-init dies on `Temporary failure resolving
+  'archive.ubuntu.com'`, `openssh-server` never installs, and nothing ever
+  listens on port 22. The emulator's warning said "the machine installs an ssh
+  daemon at first boot and needs outbound network to do it", which was true when
+  it was written and had quietly become a description of something that cannot
+  happen. It now says what does happen.
+
+  This also unblocks the counter of #125: its promotion criterion is a run of
+  consecutive green scheduled nights, so while this stayed broken that number
+  was pinned at zero by construction and nothing said so.
+
 - **The frozen CLI surface is read from the flag sets the binary registers, not
   from the help it prints** (#334). `feint proxy --intercept` shipped in v0.9.0:
   the binary accepted it, `feint proxy --help` rendered it, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,50 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Fixed
 
+- **The frozen CLI surface is read from the flag sets the binary registers, not
+  from the help it prints** (#334). `feint proxy --intercept` shipped in v0.9.0:
+  the binary accepted it, `feint proxy --help` rendered it, and
+  `internal/cli/testdata/frozen/cli.json` did not list it, for six days. That
+  fixture is the surface #132 froze so a pipeline outside this repository can
+  key on it. The cause was the observation itself: it parsed the rendered `feint
+  --help`, so it recorded what the help *claimed*. The missing flag was the
+  cheap half. A flag **deleted** from a flag set while its help line survived
+  would have kept the same gate green, and that is the direction that breaks a
+  consumer.
+
+  The surface now comes from `flag.FlagSet.VisitAll`, through one seam every
+  verb builds its flags with (`internal/cli/flagset.go`). The help keeps a
+  promise, but as an assertion with a subject of its own:
+  `TestTheHelpNamesEveryFlagTheBinaryAccepts` compares the two lists in both
+  directions, so a flag the binary accepts and no help block names fails, and a
+  help block naming a flag no flag set registers fails too. Falsified in both
+  directions by `tools/falsify/specs/frozen-cli-surface.json`, seven mutations,
+  each replayed against the test that has to bite.
+
+- **The CLI surface is version 5, and 24 flags the binary always accepted are
+  visible in it for the first time** (#334). What moved is the observation, not
+  the binary: `--intercept` and `--expose-to-network` on `proxy`, `--shapes` and
+  `--expose-to-network` on `serve`, `--check` on `version`, the six `serve`
+  flags `start` really takes, three on `evidence` and ten on `docs`. Three
+  entries left, and all three were the parser's: `--version` and `-v` under
+  `version`, which are aliases of the verb rather than flags of it (a reader who
+  typed `feint version --version` was answered `flag provided but not defined`),
+  and `--state` under `snapshot`, which came from a sentence about `serve`.
+  `snapshot` is now keyed per flag set — `snapshot save`, `snapshot load`,
+  `snapshot list` — which is what says `--force` belongs to `save` alone.
+
+  `feint --help` gained every flag it was hiding, including the two
+  `--expose-to-network` switches, which are the ones a reader most needs to meet
+  before setting them.
+
+- **`docs/proxy.md` stopped refusing a tool this repository ships** (#334).
+  The page told the reader that interception "is #76 and deliberately not this
+  tool" while `docs/limits.md` sent that same reader there to use it. `feint
+  proxy --intercept` has existed since v0.9.0; the page now documents it, with
+  what it mints, what it prints, and the one thing it will not do: it installs
+  nothing in the system trust store and never edits the operator's
+  `/etc/hosts`. #76 and #92 are closed as delivered.
+
 - **A stack applied on every pull request pins the provider that answered, and
   a stack CI does not apply says why** (#325's table, first day). The generated
   client page exposed two things nothing had said before:

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -37,6 +37,9 @@ Two properties matter and are enforced, not documented:
   proxy carries a live credential belonging to whoever started it, and an open
   port would relay it.
 
+A client the cloud walks away from by republishing its own address needs one more
+flag, `--intercept`; it has its own section below.
+
 ## Read
 
 `feint transcript` answers the three questions, in order of value.
@@ -149,14 +152,62 @@ Two properties matter as much as the detection, and each has its own test:
   a scan over the raw bytes would find nothing in any of them and report
   nothing found, which reads exactly like nothing being there.
 
+### Keeping a client the cloud walked away: `--intercept`
+
+A plain proxy holds a client only for as long as the client keeps addressing it.
+The handoff above is the case where it stops: the cloud answers with its own real
+name, the client believes it, and everything after that is somebody else's
+conversation.
+
+`--intercept` is the answer, and it changes one thing only — the client reaches
+this proxy **by the cloud's name** instead of by `127.0.0.1`:
+
+```bash
+feint proxy --provider exoscale \
+  --upstream https://api-ch-gva-2.exoscale.com \
+  --intercept api-ch-gva-2.exoscale.com,api-ch-dk-2.exoscale.com \
+  --record real.jsonl
+```
+
+The listener then serves HTTPS with a short-lived, non-CA leaf covering exactly
+those names, minted by `internal/proxy/intercept.go` from the standard library
+alone — no dependency, no `openssl`. The command prints the two lines a client
+needs and removes the CA when it exits:
+
+```text
+  intercepting HTTPS for api-ch-gva-2.exoscale.com, api-ch-dk-2.exoscale.com
+  CA written to /tmp/feint-intercept-ca-1234.pem (a temporary file, removed on exit)
+  point a client at this proxy by name, in a namespace of its own, e.g.:
+    export SSL_CERT_FILE=/tmp/feint-intercept-ca-1234.pem
+    # resolve api-ch-gva-2.exoscale.com to this proxy (a container's own /etc/hosts, never yours):
+    #   podman run --add-host=api-ch-gva-2.exoscale.com:host-gateway ... , proxy reachable on :4600
+```
+
+**The certificate is the cheap half; the name is the half that has to be
+scoped.** This command installs nothing into the system trust store and never
+edits your `/etc/hosts`, because it has no code that could: `SSL_CERT_FILE` is
+process-scoped, and the redirect is yours to make inside a namespace the client
+owns — a rootless container, feint's own user namespace under
+`tools/install/apparmor/feint`, or an Incus container. A redirect left behind in
+a machine-wide hosts file sends your next *real* `terraform apply` to a local
+port, which is the exact failure this project exists to avoid.
+[limits.md](limits.md), *The cost of DNS/TLS interception*, measures each place
+the redirect is permitted and what it costs the machine.
+
+What it bought, measured: an Exoscale session worth about ninety exchanges
+recorded **eight** without it (#92). `TestInterceptionRecordsThePostHandoffExchanges`
+drives the same session twice against one recorder — the republished name
+resolving to the proxy, then away — and keeps the whole session one way, only the
+pre-handoff exchange the other.
+
 ### What this deliberately does not do
 
 **It does not rewrite the address.** A recorder that edits the answer it is
 recording is not a recorder, and the scratchpad rewriter used to capture the
-Exoscale shapes was honest about shapes and lying about one field. If following
-the endpoint is ever wanted, it belongs behind an explicit flag that records the
-answer **as received** and marks that it rewrote what the client saw — which is
-the open half of #92, deliberately not decided by this change.
+Exoscale shapes was honest about shapes and lying about one field. That refusal
+still stands, and #92 was closed without lifting it: `--intercept` keeps the
+client by making the republished name resolve here, so the body reaches the
+transcript exactly as the cloud wrote it.
 
 **The other route is already there and needs no proxy.** `internal/upstream`
 signs the real host and talks to it directly, so it has neither problem: it is
@@ -192,14 +243,18 @@ Two things follow, and the first one matters most:
   today; only "what does the real cloud answer *to this client*" is not.
 
 Lifting it needs DNS and TLS interception so the client can be pointed at the
-real hostname and still land here, which is #76 and deliberately not this tool.
-That cost is now measured — [limits.md](limits.md), *The cost of DNS/TLS
-interception* — and the finding transfers: the TLS half is cheap and every Go
-client accepts a locally minted CA through `SSL_CERT_FILE`, but redirecting the
-name to loopback has no client-scoped, unprivileged mechanism for a static
-pure-Go client, which is what makes this more than a flag. Until then, a
-real-cloud recording is made with a client whose signed host can be set — which
-is how the transcripts behind this page's examples were produced.
+real hostname and still land here, and **that is `--intercept`, above**: the
+client addresses `api.eu-west-2.outscale.com`, signs that name, and the name is
+what reaches the cloud. The ceremony is the price — the client has to run in a
+namespace that resolves the name to the proxy — so a recording made without it
+is still made with a client whose signed host can be set independently, which is
+how the transcripts behind this page's examples were produced.
+
+Until 2026-08-20 this paragraph said the opposite: *"which is #76 and
+deliberately not this tool"*. The flag shipped in v0.9.0, `docs/limits.md` sent
+readers here to use it, and this page went on refusing it — the same defect as
+[#334](https://github.com/stephrobert/feint/issues/334), one document further
+out. #76 and #92 are closed as delivered.
 
 ### The one caveat of the diff
 

--- a/internal/cli/clean.go
+++ b/internal/cli/clean.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -21,7 +20,7 @@ import (
 // without doing anything wrong, a killed process being enough, and because the
 // conformance suite needs the same sweep and should not reimplement it in shell.
 func clean(args []string, stdout io.Writer) error {
-	fs := flag.NewFlagSet("clean", flag.ContinueOnError)
+	fs := newFlagSet("clean")
 	vm := fs.String("vm", "incus", "machine runtime to sweep: incus, incus-vm, incus-ovn")
 	if err := fs.Parse(args); err != nil {
 		return err

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -7,7 +7,6 @@ package cli
 import (
 	"context"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"log/slog"
@@ -83,16 +82,25 @@ const (
 )
 
 // cliSurfaceVersion names the version of the CLI surface a CI is allowed to
-// depend on: the verbs, the flags the help declares for each, and the exit
-// codes above. It moves when any of those move — additions included, because
-// the number means "the surface changed", not "the surface broke"; the
+// depend on: the verbs, the flags each verb's flag.FlagSet registers, and the
+// exit codes above. It moves when any of those move — additions included,
+// because the number means "the surface changed", not "the surface broke"; the
 // CHANGELOG says which of the two it was.
+//
+// Version 5 is where the observation stopped being a parse of the rendered help
+// and became a read of the FlagSets themselves (#334). What moved is the
+// observation, not the binary: --intercept and --expose-to-network were already
+// accepted by proxy, --shapes by serve, --check by version, and the six serve
+// flags by start, while --version and -v were never flags of the version verb
+// at all. The entries are keyed by flag set, so snapshot now appears as
+// `snapshot save`, `snapshot load` and `snapshot list`, which is what says that
+// --force belongs to save alone.
 //
 // The surface itself is frozen in testdata/frozen/cli.json, compared by
 // TestTheFrozenSurfacesStillMatchTheirFixture, and a fixture regenerated
 // without bumping this constant fails TestASurfaceChangeDemandsItsVersionBump.
 // The procedure for a deliberate change is in RELEASING.md ("Frozen surfaces").
-const cliSurfaceVersion = 4
+const cliSurfaceVersion = 5
 
 // Run executes one command and returns the process exit code.
 func Run(args []string, stdout, stderr io.Writer) int {
@@ -181,14 +189,25 @@ func usage(w io.Writer) {
 
 Usage:
   feint serve      [--addr 127.0.0.1:4599] [--state <file>] [--vm off|incus|incus-vm|incus-ovn|auto]
-                    [--cleanup] [--contracts <dir>] [--coverage <dir>] [--log-level info|debug]
+                    [--cleanup] [--contracts <dir>] [--coverage <dir>] [--shapes <dir>]
+                    [--log-level info|debug] [--expose-to-network]
                     Serve the three emulated clouds on one port, in the
-                    foreground.
+                    foreground. --expose-to-network is the only way off
+                    loopback, and it disarms the anti-rebinding guard: this
+                    emulator accepts every credential and, under --vm, starts
+                    containers with your privileges. Read SECURITY.md first.
 
-  feint start      [every serve flag] [--timeout 30s] [--detach] [--foreground]
+  feint start      [--addr :4599] [--state <file>] [--vm off|incus|incus-vm|incus-ovn|auto]
+                    [--cleanup] [--contracts <dir>] [--log-level info|debug]
+                    [--timeout 30s] [--detach] [--foreground]
                     Same, detached: records the instance, waits until it
                     answers, prints where the log is. Refuses to adopt an
-                    instance already running on that address.
+                    instance already running on that address. The serve flags
+                    repeated here are exactly the ones a restart replays: the
+                    coverage, shapes and expose-to-network flags are serve's
+                    alone, and this verb refuses them. A dashed name in a block
+                    is a flag of that block's verb, which is what lets the help
+                    be held against the binary.
 
   feint stop       [--addr :4599] [--timeout 15s]
                     SIGTERM, then SIGKILL if it has to, and say which. Never
@@ -239,9 +258,9 @@ Usage:
                    list [--format text|json]
                    rm <name>
                     Name the state of a running emulator and come back to it.
-                    Same bytes as serve --state, taken mid-run rather than at
-                    exit. Loading replaces the store: a fixture must not depend
-                    on what the session did before it.
+                    Same bytes the serve state file holds, taken mid-run rather
+                    than at exit. Loading replaces the store: a fixture must not
+                    depend on what the session did before it.
 
   feint coverage   (--sdk <dir> | --contract <file>) [--provider scaleway|outscale|exoscale]
                     [--products <a,b,c>] [--format text|json|triage|list]
@@ -263,11 +282,16 @@ Usage:
 
   feint proxy      --upstream <url> --record <file.jsonl> [--addr 127.0.0.1:4600]
                     [--provider <name>] [--max-body <bytes>] [--queue <n>]
+                    [--intercept <host,host>] [--expose-to-network]
                     Sit between a real client and a real cloud and write down
                     every exchange, as JSON Lines, one object per call, with the
                     upstream operation named. Credentials are redacted before
                     anything is written. Point the client at --addr and drive it
-                    as usual.
+                    as usual. --intercept serves HTTPS with a locally-minted
+                    certificate for those hostnames, so a client redirected here
+                    by name trusts the proxy and lands on it; docs/proxy.md says
+                    what it costs, as does --expose-to-network, which puts this
+                    port and the account behind it on the network.
 
   feint transcript <recording.jsonl> [--shape OP [--against emu.jsonl]] [--format text|json]
                     Read a proxy recording and answer what to serve next. With no
@@ -286,14 +310,29 @@ Usage:
                     exits 2 on a field the cloud returns and it omits.
 
   feint evidence   [--endpoint http://127.0.0.1:4599] [--shapes shapes]
+                   [--contracts contracts] [--suites tools/conformance]
                    [--out coverage/evidence.json] [--join <other.json>]
+                   [--allow-narrowing]
                     Write the per-operation evidence record from a running
                     emulator's /_feint/conformance: which independent proofs
                     each operation has earned, side by side, never summed.
-                    --join merges the other leg of the same regeneration.
+                    --contracts and --suites are digested into the record's
+                    provenance. --join merges the other leg of the same
+                    regeneration, and --allow-narrowing is what a run reaching
+                    fewer runtimes than the record it replaces has to say out
+                    loud before it may overwrite it.
 
-  feint docs       [--file README.md] [--coverage <dir>] [--check]
-                    Regenerate the coverage tables in a Markdown file.
+  feint docs       [--file README.md] [--coverage <dir>] [--contracts <dir>] [--check]
+                    [--limits <file>] [--routes <file>] [--confidence <file>]
+                    [--install <file>] [--proved <file>] [--workflow <file>]
+                    [--client-pins <file>] [--screenshots <file>]
+                    [--ui-manifest <file>]
+                    Regenerate the coverage tables in a Markdown file. Each of
+                    the page flags names the document holding one generated
+                    block and takes an empty value to skip it; --check writes
+                    nothing and exits 2 when a block is out of date.
+                    --ui-manifest only records the page's digest beside the
+                    screenshots, and regenerates nothing.
 
   feint catalog    [--format json]
                     Print the emulated inventory a client reads before creating.
@@ -302,7 +341,13 @@ Usage:
                     Remove every machine, network and rule set the emulator
                     created. Labelled resources only; nothing else is touched.
 
-  feint version    Print the version. --version and -v do the same.
+  feint version    [--check]
+                    Print the version. --check asks GitHub whether a newer
+                    release exists; nothing here reaches the network unless
+                    that flag is typed.
+
+Typing feint with the version flag, in either spelling, is an alias for the
+version verb rather than a flag of it.
 
 The lifecycle verbs are Unix only: detaching uses setsid, which Windows has no
 equivalent for, and the released binaries are linux and darwin.
@@ -573,7 +618,7 @@ func checkAddrUnclaimed(addr string) error {
 }
 
 func serve(args []string, stdout io.Writer) error {
-	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
+	fs := newFlagSet("serve")
 	addr := fs.String("addr", DefaultAddr, "listen address")
 	state := fs.String("state", "", "load and persist the store to this JSON file")
 	vm := fs.String("vm", "off", "back powered-on servers with real machines: off, incus, incus-vm, incus-ovn, auto")
@@ -768,7 +813,7 @@ func serve(args []string, stdout io.Writer) error {
 // coverage compares the upstream SDK surface with what the packs serve. This is
 // the anti-drift gate: run it in CI after every SDK bump.
 func coverage(args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("coverage", flag.ContinueOnError)
+	fs := newFlagSet("coverage")
 	sdk := fs.String("sdk", "", "path to a checkout of the provider Go SDK")
 	contractPath := fs.String("contract", "", "read the upstream surface from a contract artefact instead of an SDK checkout")
 	provider := fs.String("provider", scaleway.Name, "provider to report on")
@@ -985,7 +1030,7 @@ func coverage(args []string, stdout, stderr io.Writer) int {
 // catalog emits what the emulator serves. The documentation site builds its
 // pages from this, so the docs cannot drift from the code.
 func catalog(args []string, stdout io.Writer) error {
-	fs := flag.NewFlagSet("catalog", flag.ContinueOnError)
+	fs := newFlagSet("catalog")
 	format := fs.String("format", "json", "output format: json")
 	if err := fs.Parse(args); err != nil {
 		return err

--- a/internal/cli/docs.go
+++ b/internal/cli/docs.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -66,7 +65,7 @@ const (
 
 // docs regenerates the generated sections of a Markdown file.
 func docs(args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("docs", flag.ContinueOnError)
+	fs := newFlagSet("docs")
 	target := fs.String("file", "README.md", "the Markdown file holding the generated section")
 	dir := fs.String("coverage", "coverage", "directory holding the versioned coverage artefacts")
 	contractsDir := fs.String("contracts", "contracts", "directory holding the API description artefacts")

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"bufio"
 	"context"
-	"flag"
 	"fmt"
 	"io"
 	"net"
@@ -45,7 +44,7 @@ type check struct {
 }
 
 func doctor(args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
+	fs := newFlagSet("doctor")
 	addr := fs.String("addr", DefaultAddr, "the address serve would listen on")
 	vm := fs.String("vm", "auto", "the machine runtime to diagnose: off, incus, incus-vm, incus-ovn, auto")
 	if err := fs.Parse(args); err != nil {

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -31,7 +30,7 @@ import (
 // another provider? Every line here can.
 
 func envCommand(args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("env", flag.ContinueOnError)
+	fs := newFlagSet("env")
 	shell := fs.String("shell", "bash", "shell syntax: bash, fish or powershell")
 	endpoint := fs.String("endpoint", "", "the emulator's address (default: http://<the --addr default>)")
 	unset := fs.Bool("unset", false, "print the removals instead of the exports")

--- a/internal/cli/evidence.go
+++ b/internal/cli/evidence.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"encoding/json"
-	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -97,7 +96,7 @@ func runtimesLost(path string, next *evidenceArtefact) ([]string, error) {
 }
 
 func evidence(args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("evidence", flag.ContinueOnError)
+	fs := newFlagSet("evidence")
 	endpoint := fs.String("endpoint", "http://"+DefaultAddr, "the running emulator to read /_feint/conformance from")
 	shapesDir := fs.String("shapes", "shapes", "directory of observed real-cloud shapes; the shape axis is resolved from it (empty to leave the run's answer)")
 	out := fs.String("out", filepath.Join("coverage", "evidence.json"), "where to write the artefact")

--- a/internal/cli/flagset.go
+++ b/internal/cli/flagset.go
@@ -1,0 +1,47 @@
+package cli
+
+import "flag"
+
+// Every verb builds its flags here rather than calling flag.NewFlagSet itself,
+// and the reason is a gate that could not see what it was freezing (#334).
+//
+// The frozen CLI surface (#132) is what a pipeline outside this repository is
+// allowed to key on. Until this seam existed, the test that freezes it built its
+// observation by parsing the rendered `feint --help` — so the surface recorded
+// what the help *claimed*, not what the binary *accepted*. `feint proxy
+// --intercept` shipped in v0.9.0 accepted by the binary, named by
+// `feint proxy --help`, and absent from the frozen surface, for six days,
+// because no line of the general help mentioned it.
+//
+// The missing flag was the cheap half. The expensive half is the other
+// direction: a flag deleted from a FlagSet while its line in the help survived
+// would have kept the gate green, and that is the direction that breaks a
+// consumer. A surface frozen against a rendered document freezes the document.
+//
+// So the observation is taken from the FlagSet itself, by flag.FlagSet.VisitAll,
+// which means the test needs a way to reach the FlagSet a verb builds. That is
+// all this file is: one constructor, and one seam the test arms.
+//
+// The tests that fail without it: TestTheFrozenSurfacesStillMatchTheirFixture
+// on the "cli" surface (which now compares FlagSets against the fixture, and so
+// goes red on a flag added *or removed*), and
+// TestTheHelpNamesEveryFlagTheBinaryAccepts (which is the help's own,
+// separate assertion, with a subject of its own).
+func newFlagSet(name string) *flag.FlagSet {
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	if observeFlagSet != nil {
+		observeFlagSet(name, fs)
+	}
+	return fs
+}
+
+// observeFlagSet is nil in every running binary: nothing in Run ever sets it,
+// so the production path is one nil check.
+//
+// The frozen-surface test sets it, drives every dispatched verb as far as its
+// flag parsing, and reads the FlagSets it collected. It is handed the set before
+// the verb registers anything on it, which is deliberate — the pointer is what
+// matters, and it is read after the verb has returned, by which time every
+// fs.String/Bool/Int/Duration call has landed on it. There is no second copy to
+// keep in step, which is the whole point.
+var observeFlagSet func(name string, fs *flag.FlagSet)

--- a/internal/cli/frozen_test.go
+++ b/internal/cli/frozen_test.go
@@ -31,6 +31,7 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io"
 	"net/http"
@@ -38,7 +39,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -317,21 +317,22 @@ func observeShape(t *testing.T, path string, dataKeyed []string) json.RawMessage
 	return content
 }
 
-// cliSurfaceContent is the canonical CLI surface: every verb the help renders
-// with the flags its entry declares, and the exit codes. Read from the rendered
-// help rather than from a list kept beside it, for the reason
-// TestEveryDispatchedCommandIsInTheHelp reads the dispatch from the source: a
-// second copy is the thing that drifts.
+// cliSurfaceContent is the canonical CLI surface: every flag set the binary
+// builds, the flags registered on it, and the exit codes.
+//
+// It is read from the flag.FlagSet each verb builds, never from the rendered
+// help (#334). The help is prose: a flag can be added to a FlagSet and never
+// written down — `feint proxy --intercept` shipped in v0.9.0 exactly that way —
+// and, worse, a flag can be deleted from a FlagSet while its help line survives,
+// which is the direction that breaks the consumer #132 froze this surface for.
+// A surface observed through a document freezes the document.
+//
+// The help keeps a promise here, but as its own assertion with its own subject:
+// TestTheHelpNamesEveryFlagTheBinaryAccepts.
 func cliSurfaceContent(t *testing.T) json.RawMessage {
 	t.Helper()
-	verbs := verbsWithFlags(t)
-	// Guard of the guard: a parse that comes back near-empty is a broken
-	// harness, and a fixture regenerated from it would freeze nothing.
-	if len(verbs) < 15 {
-		t.Fatalf("only %d verbs parsed from the help: the parser is broken, not the surface", len(verbs))
-	}
 	content, err := json.Marshal(map[string]any{
-		"verbs":      verbs,
+		"verbs":      flagsTheBinaryAccepts(t),
 		"exit_codes": map[string]int{"ok": exitOK, "error": exitError, "drift": exitDrift},
 	})
 	if err != nil {
@@ -340,50 +341,93 @@ func cliSurfaceContent(t *testing.T) json.RawMessage {
 	return content
 }
 
-// verbsWithFlags parses the rendered help: a line "  feint <verb> " opens a
-// verb, its indented continuation lines belong to it, a line at column zero
-// closes it. Flags are every "-x" / "--xyz" token in the verb's block.
-func verbsWithFlags(t *testing.T) map[string][]string {
+// flagsTheBinaryAccepts drives every dispatched verb as far as its flag parsing
+// and reads back the flags of the FlagSet it built, through newFlagSet's seam.
+//
+// `-h` is what stops each verb there: flag.ContinueOnError makes Parse answer
+// flag.ErrHelp, every command returns on that error, and not one of them does
+// anything before building its set. So this observes the registration and
+// nothing else — no listener opened, no file written, no host touched.
+//
+// The result is keyed by the flag set's own name, which is the verb everywhere
+// but `snapshot`: that one dispatches a second time, and "snapshot save"
+// registers --force where "snapshot list" does not. Keying by the set says so,
+// where a union under `snapshot` would claim all three take all three flags.
+func flagsTheBinaryAccepts(t *testing.T) map[string][]string {
 	t.Helper()
-	var rendered strings.Builder
-	usage(&rendered)
 
-	verbLine := regexp.MustCompile(`^  feint ([a-z][a-z-]*) `)
-	// A flag token starts after a space, bracket, parenthesis or quote — never
-	// in the middle of a word, so "read-only" and "incus-vm" stay words.
-	flagToken := regexp.MustCompile(`(?:^|[\s\[("])(-{1,2}[a-zA-Z][a-zA-Z0-9-]*)`)
+	sets := map[string]*flag.FlagSet{}
+	builtBy := map[string]string{}
+	driving := ""
+	observeFlagSet = func(name string, fs *flag.FlagSet) {
+		// A verb stopped with -h renders its set's defaults; the render is
+		// discarded, because the flags are read from the set itself below.
+		fs.SetOutput(io.Discard)
+		sets[name] = fs
+		builtBy[name] = driving
+	}
+	t.Cleanup(func() { observeFlagSet = nil })
 
-	verbs := map[string][]string{}
-	current := ""
-	seen := map[string]map[string]bool{}
-	for _, line := range strings.Split(rendered.String(), "\n") {
-		if m := verbLine.FindStringSubmatch(line); m != nil {
-			current = m[1]
-			if verbs[current] == nil {
-				verbs[current] = []string{}
-				seen[current] = map[string]bool{}
-			}
-		} else if !strings.HasPrefix(line, " ") {
-			// Prose at column zero: the preamble, the exit-code paragraph.
-			// Whatever dashes it carries belong to no verb.
-			current = ""
-			continue
+	var discard strings.Builder
+	drive := func(verb string, args ...string) {
+		driving = verb
+		Run(append([]string{"feint", verb}, args...), &discard, &discard)
+	}
+
+	dispatched := topLevelCommands(t)
+	if len(dispatched) < 15 {
+		t.Fatalf("only %d verbs found in the dispatch: the scan is broken, not the surface", len(dispatched))
+	}
+	for _, verb := range dispatched {
+		drive(verb, "-h")
+	}
+	// `snapshot` dispatches again before building anything, so its subcommands
+	// are driven by name. save, load and rm read the snapshot's name off the
+	// command line ahead of the flags, hence the placeholder. rm registers no
+	// flag at all and so contributes no entry, which is the truth about it and
+	// the reason the coverage assertion below is per verb and not per set.
+	drive("snapshot", "save", "a-name", "-h")
+	drive("snapshot", "load", "a-name", "-h")
+	drive("snapshot", "list", "-h")
+	drive("snapshot", "rm", "a-name", "-h")
+
+	// Assert the subject rather than skip on its absence. A verb whose set was
+	// never observed would otherwise leave the fixture quietly smaller, and a
+	// frozen surface that shrinks in silence is the defect being fixed here.
+	covered := map[string]bool{}
+	for name, verb := range builtBy {
+		if name != verb && !strings.HasPrefix(name, verb+" ") {
+			t.Errorf("`feint %s` built a flag set named %q: the surface is keyed by that name, "+
+				"so it has to be the verb itself or one of its subcommands", verb, name)
 		}
-		if current == "" {
-			continue
-		}
-		for _, m := range flagToken.FindAllStringSubmatch(line, -1) {
-			flag := m[1]
-			if !seen[current][flag] {
-				seen[current][flag] = true
-				verbs[current] = append(verbs[current], flag)
-			}
+		covered[verb] = true
+	}
+	for _, verb := range dispatched {
+		if !covered[verb] {
+			t.Errorf("`feint %s -h` built no flag set, so this observation cannot see the verb's "+
+				"flags and the frozen surface would freeze nothing for it", verb)
 		}
 	}
-	for _, flags := range verbs {
+
+	verbs := make(map[string][]string, len(sets))
+	for name, fs := range sets {
+		flags := []string{}
+		fs.VisitAll(func(f *flag.Flag) { flags = append(flags, dashed(f.Name)) })
 		sort.Strings(flags)
+		verbs[name] = flags
 	}
 	return verbs
+}
+
+// dashed spells a flag the way the help and every user does: one dash for a
+// single letter, two for a word. Go's flag package accepts either spelling for
+// either, so this is a rendering choice, and it is made once — here — for the
+// frozen surface and the help assertion alike.
+func dashed(name string) string {
+	if len(name) == 1 {
+		return "-" + name
+	}
+	return "--" + name
 }
 
 // loadFrozen reads a surface's fixture, and fails loudly on a missing or empty

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -6,6 +6,8 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -160,4 +162,134 @@ func topLevelCommands(t *testing.T) []string {
 		t.Fatal("the dispatch switch on args[1] was not found in cli.go")
 	}
 	return out
+}
+
+// The help names every flag the binary accepts, and no flag it refuses.
+//
+// This is the assertion the frozen CLI surface used to stand in for, and could
+// not (#334). That surface was built by parsing this very help, so the two
+// agreed by construction and measured nothing: `feint proxy --intercept`
+// shipped in v0.9.0 accepted by the binary, named by `feint proxy --help`,
+// absent from `feint --help`, and therefore absent from the frozen surface for
+// six days. The surface now comes from the FlagSets, which leaves the help
+// needing a check of its own — with a subject on each side, rather than one
+// parser standing in for both.
+//
+// Both directions are asserted, and the second is the one that was missing:
+//
+//   - a flag on a FlagSet that no help block names: a reader of `feint --help`
+//     cannot discover it, which is exactly how --intercept shipped mute;
+//   - a flag a help block names that no FlagSet registers: a reader types it
+//     and the binary answers "flag provided but not defined". `feint version`
+//     was in that state — its block named --version and -v, which are aliases
+//     of the verb and not flags of it — and so was `feint snapshot`, whose
+//     block mentioned `serve --state` in a sentence about file formats.
+//
+// Both are compared per verb, on the help's own granularity: `feint --help`
+// gives `snapshot` one block, so that block is measured against the flags of
+// "snapshot save", "snapshot load" and "snapshot list" together.
+func TestTheHelpNamesEveryFlagTheBinaryAccepts(t *testing.T) {
+	named := flagsTheHelpNames(t)
+	if len(named) < 15 {
+		t.Fatalf("only %d verbs parsed out of the help: the parser is broken, not the help, "+
+			"and would otherwise pass while measuring nothing", len(named))
+	}
+
+	accepted := map[string]map[string]bool{}
+	for set, flags := range flagsTheBinaryAccepts(t) {
+		verb, _, _ := strings.Cut(set, " ")
+		if accepted[verb] == nil {
+			accepted[verb] = map[string]bool{}
+		}
+		for _, name := range flags {
+			accepted[verb][name] = true
+		}
+	}
+	if len(accepted) < 15 {
+		t.Fatalf("only %d verbs built a flag set: the observation is broken, not the help", len(accepted))
+	}
+
+	for verb, flags := range accepted {
+		block, described := named[verb]
+		if !described {
+			t.Errorf("the binary dispatches `feint %s` and `feint --help` renders no block for it, "+
+				"so none of its flags can be named there", verb)
+			continue
+		}
+		shown := map[string]bool{}
+		for _, name := range block {
+			shown[name] = true
+		}
+		for name := range flags {
+			if !shown[name] {
+				t.Errorf("the binary accepts `feint %s %s` and `feint --help` never names it: "+
+					"a flag only the source and `feint %s --help` know about is a flag that shipped mute",
+					verb, name, verb)
+			}
+		}
+		for name := range shown {
+			if !flags[name] {
+				t.Errorf("`feint --help` names `feint %s %s` and no flag set registers it: "+
+					"a reader who types it is answered \"flag provided but not defined\"", verb, name)
+			}
+		}
+	}
+
+	for verb := range named {
+		if _, dispatches := accepted[verb]; !dispatches {
+			t.Errorf("`feint --help` renders a block for `feint %s` and no such verb builds a flag set", verb)
+		}
+	}
+}
+
+// flagsTheHelpNames parses the rendered help: a line "  feint <verb> " opens a
+// verb, its indented continuation lines belong to it, a line at column zero
+// closes it. Flags are every "-x" / "--xyz" token in the verb's block.
+//
+// Parsing is the right tool here and the wrong one for the frozen surface, and
+// the difference is the subject: this reads the document *in order to check it*
+// against the FlagSets, where the surface used to read the document and call
+// the result the binary's behaviour.
+func flagsTheHelpNames(t *testing.T) map[string][]string {
+	t.Helper()
+	var rendered strings.Builder
+	usage(&rendered)
+
+	verbLine := regexp.MustCompile(`^  feint ([a-z][a-z-]*) `)
+	// A flag token starts after a space, bracket, parenthesis or quote — never
+	// in the middle of a word, so "read-only" and "incus-vm" stay words.
+	flagToken := regexp.MustCompile(`(?:^|[\s\[("])(-{1,2}[a-zA-Z][a-zA-Z0-9-]*)`)
+
+	verbs := map[string][]string{}
+	current := ""
+	seen := map[string]map[string]bool{}
+	for _, line := range strings.Split(rendered.String(), "\n") {
+		if m := verbLine.FindStringSubmatch(line); m != nil {
+			current = m[1]
+			if verbs[current] == nil {
+				verbs[current] = []string{}
+				seen[current] = map[string]bool{}
+			}
+		} else if !strings.HasPrefix(line, " ") {
+			// Prose at column zero: the preamble, the exit-code paragraph, the
+			// note on the version aliases. Whatever dashes they carry belong to
+			// no verb.
+			current = ""
+			continue
+		}
+		if current == "" {
+			continue
+		}
+		for _, m := range flagToken.FindAllStringSubmatch(line, -1) {
+			name := m[1]
+			if !seen[current][name] {
+				seen[current][name] = true
+				verbs[current] = append(verbs[current], name)
+			}
+		}
+	}
+	for _, flags := range verbs {
+		sort.Strings(flags)
+	}
+	return verbs
 }

--- a/internal/cli/images.go
+++ b/internal/cli/images.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"io"
 
@@ -27,7 +26,7 @@ import (
 // launches a container and takes minutes, which is a side effect on the
 // operator's station, and this project asks before those rather than after.
 func images(args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("images", flag.ContinueOnError)
+	fs := newFlagSet("images")
 	fs.SetOutput(stderr)
 	vm := fs.String("vm", "auto", "machine runtime to build with: auto, incus, incus-vm, incus-ovn")
 	only := fs.String("only", "", "build just this one, e.g. ubuntu/24.04")

--- a/internal/cli/lifecycle.go
+++ b/internal/cli/lifecycle.go
@@ -65,7 +65,7 @@ func bindServeFlags(fs *flag.FlagSet) *serveFlags {
 
 // start detaches a serve, records it, and waits for it to answer.
 func start(args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("start", flag.ContinueOnError)
+	fs := newFlagSet("start")
 	flags := bindServeFlags(fs)
 	timeout := fs.Duration("timeout", 30*time.Second, "how long to wait for the emulator to answer")
 	detach := fs.Bool("detach", false, "return as soon as the child is spawned, without waiting for health")
@@ -264,7 +264,7 @@ func tail(path string, n int) string {
 
 // stop signals the recorded instance and waits for it to go.
 func stop(args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("stop", flag.ContinueOnError)
+	fs := newFlagSet("stop")
 	addr := fs.String("addr", DefaultAddr, "listen address of the instance to stop")
 	timeout := fs.Duration("timeout", 15*time.Second, "how long to wait after SIGTERM before SIGKILL")
 	if err := fs.Parse(args); err != nil {
@@ -343,7 +343,7 @@ func removeOrFail(inst *Instance, stderr io.Writer) int {
 // in a container, by another tool, in the foreground of another terminal — is
 // still something a script needs to wait for.
 func waitCommand(args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("wait", flag.ContinueOnError)
+	fs := newFlagSet("wait")
 	addr := fs.String("addr", DefaultAddr, "listen address to wait for")
 	timeout := fs.Duration("timeout", 30*time.Second, "how long to wait")
 	if err := fs.Parse(args); err != nil {
@@ -369,7 +369,7 @@ func waitCommand(args []string, stdout, stderr io.Writer) int {
 // restart stops the recorded instance and starts it again with the flags it was
 // started with, which is the reason those flags are recorded at all.
 func restart(args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("restart", flag.ContinueOnError)
+	fs := newFlagSet("restart")
 	addr := fs.String("addr", DefaultAddr, "listen address of the instance to restart")
 	timeout := fs.Duration("timeout", 30*time.Second, "how long to wait for it to answer again")
 	if err := fs.Parse(args); err != nil {
@@ -396,7 +396,7 @@ func restart(args []string, stdout, stderr io.Writer) int {
 
 // logs prints the detached run's log.
 func logs(args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("logs", flag.ContinueOnError)
+	fs := newFlagSet("logs")
 	addr := fs.String("addr", DefaultAddr, "listen address of the instance")
 	follow := fs.Bool("f", false, "follow the log as it grows")
 	lines := fs.Int("n", 50, "how many trailing lines to print (0 for all)")

--- a/internal/cli/probe.go
+++ b/internal/cli/probe.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"io"
 	"net/http"
@@ -24,7 +23,7 @@ import (
 // What it reports never moves the conformance score. A probed route stays on the
 // list of routes nobody has proven until a real client drives it.
 func probeCommand(args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("probe", flag.ContinueOnError)
+	fs := newFlagSet("probe")
 	endpoint := fs.String("endpoint", "http://"+DefaultAddr, "the running emulator")
 	contracts := fs.String("contracts", "contracts", "directory of API contracts")
 	provider := fs.String("provider", "", "probe only this provider")

--- a/internal/cli/proxy.go
+++ b/internal/cli/proxy.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"log/slog"
@@ -32,7 +31,7 @@ const DefaultProxyAddr = "127.0.0.1:4600"
 
 // proxyCommand records what a real client and a real cloud say to each other.
 func proxyCommand(args []string, _ io.Writer, stderr io.Writer) int {
-	fs := flag.NewFlagSet("proxy", flag.ContinueOnError)
+	fs := newFlagSet("proxy")
 	upstream := fs.String("upstream", "", "the cloud (or emulator) to forward to, e.g. https://api.scaleway.com")
 	addr := fs.String("addr", DefaultProxyAddr, "listen address")
 	record := fs.String("record", "", "write the transcript here as JSON Lines; - for stdout")

--- a/internal/cli/shapes.go
+++ b/internal/cli/shapes.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -30,7 +29,7 @@ import (
 //
 // Read-only towards the network: it opens a file and writes a file.
 func shapesCommand(args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("shapes", flag.ContinueOnError)
+	fs := newFlagSet("shapes")
 	provider := fs.String("provider", "", "which provider this recording is of: scaleway, outscale, exoscale")
 	dir := fs.String("dir", "shapes", "directory holding the versioned catalogues")
 	dryRun := fs.Bool("dry-run", false, "report what would be learned without writing")

--- a/internal/cli/snapshot.go
+++ b/internal/cli/snapshot.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"io"
 	"net/http"
@@ -122,7 +121,7 @@ func snapshotSave(args []string, stdout, stderr io.Writer) int {
 	if !ok {
 		return exitError
 	}
-	fs := flag.NewFlagSet("snapshot save", flag.ContinueOnError)
+	fs := newFlagSet("snapshot save")
 	addr := fs.String("addr", DefaultAddr, "address of the running emulator")
 	force := fs.Bool("force", false, "overwrite an existing snapshot of that name")
 	if err := fs.Parse(rest); err != nil {
@@ -166,7 +165,7 @@ func snapshotLoad(args []string, stdout, stderr io.Writer) int {
 	if !ok {
 		return exitError
 	}
-	fs := flag.NewFlagSet("snapshot load", flag.ContinueOnError)
+	fs := newFlagSet("snapshot load")
 	addr := fs.String("addr", DefaultAddr, "address of the running emulator")
 	if err := fs.Parse(rest); err != nil {
 		return exitError
@@ -201,7 +200,7 @@ func snapshotLoad(args []string, stdout, stderr io.Writer) int {
 }
 
 func snapshotList(args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("snapshot list", flag.ContinueOnError)
+	fs := newFlagSet("snapshot list")
 	format := fs.String("format", "text", "output format: text or json")
 	if err := fs.Parse(args); err != nil {
 		return exitError

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"encoding/json"
-	"flag"
 	"fmt"
 	"io"
 	"sort"
@@ -86,7 +85,7 @@ type productStatus struct {
 }
 
 func status(args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("status", flag.ContinueOnError)
+	fs := newFlagSet("status")
 	addr := fs.String("addr", DefaultAddr, "listen address to report on")
 	coverageDir := fs.String("coverage", "coverage", "directory holding the versioned coverage artefacts")
 	format := fs.String("format", "text", "output format: text or json")

--- a/internal/cli/testdata/frozen/cli.json
+++ b/internal/cli/testdata/frozen/cli.json
@@ -513,6 +513,163 @@
           ]
         }
       }
+    },
+    {
+      "schema_version": 5,
+      "content": {
+        "exit_codes": {
+          "drift": 2,
+          "error": 1,
+          "ok": 0
+        },
+        "verbs": {
+          "catalog": [
+            "--format"
+          ],
+          "clean": [
+            "--vm"
+          ],
+          "coverage": [
+            "--artefact",
+            "--baseline",
+            "--contract",
+            "--fail-on-unknown",
+            "--format",
+            "--products",
+            "--provider",
+            "--sdk",
+            "--write-baseline"
+          ],
+          "docs": [
+            "--check",
+            "--client-pins",
+            "--confidence",
+            "--contracts",
+            "--coverage",
+            "--file",
+            "--install",
+            "--limits",
+            "--proved",
+            "--routes",
+            "--screenshots",
+            "--ui-manifest",
+            "--workflow"
+          ],
+          "doctor": [
+            "--addr",
+            "--vm"
+          ],
+          "env": [
+            "--client",
+            "--endpoint",
+            "--shell",
+            "--unset"
+          ],
+          "evidence": [
+            "--allow-narrowing",
+            "--contracts",
+            "--endpoint",
+            "--join",
+            "--out",
+            "--shapes",
+            "--suites"
+          ],
+          "images": [
+            "--check",
+            "--only",
+            "--vm"
+          ],
+          "logs": [
+            "--addr",
+            "-f",
+            "-n"
+          ],
+          "probe": [
+            "--contracts",
+            "--endpoint",
+            "--provider"
+          ],
+          "proxy": [
+            "--addr",
+            "--expose-to-network",
+            "--intercept",
+            "--max-body",
+            "--provider",
+            "--queue",
+            "--record",
+            "--upstream"
+          ],
+          "restart": [
+            "--addr",
+            "--timeout"
+          ],
+          "serve": [
+            "--addr",
+            "--cleanup",
+            "--contracts",
+            "--coverage",
+            "--expose-to-network",
+            "--log-level",
+            "--shapes",
+            "--state",
+            "--vm"
+          ],
+          "shapes": [
+            "--check",
+            "--dir",
+            "--dry-run",
+            "--profile",
+            "--provider",
+            "--record"
+          ],
+          "snapshot list": [
+            "--format"
+          ],
+          "snapshot load": [
+            "--addr"
+          ],
+          "snapshot save": [
+            "--addr",
+            "--force"
+          ],
+          "start": [
+            "--addr",
+            "--cleanup",
+            "--contracts",
+            "--detach",
+            "--foreground",
+            "--log-level",
+            "--state",
+            "--timeout",
+            "--vm"
+          ],
+          "status": [
+            "--addr",
+            "--coverage",
+            "--format"
+          ],
+          "stop": [
+            "--addr",
+            "--timeout"
+          ],
+          "transcript": [
+            "--against",
+            "--format",
+            "--shape"
+          ],
+          "ui": [
+            "--addr",
+            "--print"
+          ],
+          "version": [
+            "--check"
+          ],
+          "wait": [
+            "--addr",
+            "--timeout"
+          ]
+        }
+      }
     }
   ]
 }

--- a/internal/cli/transcript.go
+++ b/internal/cli/transcript.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -25,7 +24,7 @@ import (
 //
 // Read-only and offline: it opens files and talks to nothing.
 func transcriptCommand(args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("transcript", flag.ContinueOnError)
+	fs := newFlagSet("transcript")
 	shape := fs.String("shape", "", "print the response shape of this operation (e.g. ReadNics) instead of the work queue")
 	against := fs.String("against", "", "a second transcript, recorded against the emulator: with --shape, diff the two")
 	format := fs.String("format", "text", "output format: text or json")

--- a/internal/cli/ui.go
+++ b/internal/cli/ui.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -119,7 +118,7 @@ func newestArtefact(dir string) string {
 // decided whether the page was mounted at all — one function, so the command and
 // the server can never disagree about what loopback means.
 func uiCommand(args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("ui", flag.ContinueOnError)
+	fs := newFlagSet("ui")
 	addr := fs.String("addr", DefaultAddr, "the address the emulator is serving on")
 	print := fs.Bool("print", false, "print the URL instead of opening a browser")
 	if err := fs.Parse(args); err != nil {

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"net/http"
@@ -55,7 +54,7 @@ type githubRelease struct {
 
 // versionCheck is `feint version --check`.
 func versionCheck(args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("version", flag.ContinueOnError)
+	fs := newFlagSet("version")
 	fs.SetOutput(stderr)
 	check := fs.Bool("check", false, "ask GitHub whether a newer release exists")
 	if err := fs.Parse(args); err != nil {

--- a/internal/core/machine/incus.go
+++ b/internal/core/machine/incus.go
@@ -183,9 +183,25 @@ func (d *Incus) imageRef(image string) string {
 //
 // The fallback is deliberate and it is announced, never silent. Refusing to boot
 // because `feint images` has not been run would turn a first contact into a
-// failure; falling back without a word would reintroduce the boot-time install
-// and hide the reason a machine suddenly needs the network. So it degrades, and
-// says which and why.
+// failure; falling back without a word would hide the reason a machine suddenly
+// cannot answer. So it degrades, and says which and why.
+//
+// What the warning says changed on 2026-08-20 (#335), because what it described
+// had stopped being true. It promised that "the machine installs an ssh daemon
+// at first boot and needs outbound network to do it" — accurate when #203 wrote
+// it, and false since #202 gave a machine exactly the one address its provider
+// publishes, on a routed NIC with no NAT. Measured that day by hiding the five
+// feint/* aliases on a host that held them: cloud-init's `apt-get install
+// openssh-server` died on "Temporary failure resolving 'archive.ubuntu.com'",
+// nothing listened on port 22, and the Scaleway ssh suite failed after 93
+// seconds where it passes in 21 with the images. So the fallback is not a
+// degradation for anything that logs in: it is a machine that will never
+// answer, and the line now says that.
+//
+// The line is still only a line. The control is in tools/conformance/guard.sh,
+// which refuses an ssh suite whose images are missing; runtime-proof.yml was red
+// for five consecutive nights with this exact warning in its log and nothing
+// reading it.
 //
 // TestTheBuiltImageIsPreferredWhenTheHostHoldsIt fails without this.
 func (d *Incus) resolveImage(ctx context.Context, image string) string {
@@ -210,7 +226,7 @@ func (d *Incus) resolveImage(ctx context.Context, image string) string {
 	}
 	slog.Default().Warn("no image of ours for this system, booting the upstream one",
 		"image", image, "wanted", alias, "using", upstream,
-		"consequence", "the machine installs an ssh daemon at first boot and needs outbound network to do it",
+		"consequence", "no upstream image carries an ssh daemon, and this machine has no route to a package repository, so nothing will answer on port 22",
 		"fix", "feint images")
 	return upstream
 }

--- a/tools/conformance/README.md
+++ b/tools/conformance/README.md
@@ -18,10 +18,23 @@ silence, so you find out at once — but the list is worth having up front:
 | `oapi-cli` | `outscale/oapi-cli.sh` | [oapi-cli releases](https://github.com/outscale/oapi-cli/releases) (AppImage) |
 | `exo` | `exoscale/exo-cli.sh` | [exoscale/cli releases](https://github.com/exoscale/cli/releases) |
 | `incus` | the `network.sh` suites and `ssh.sh` | [Zabbly packages](https://github.com/zabbly/incus), 6.0.4 or later |
+| the machine images | the `ssh.sh` suites | `feint images --vm incus`, once, minutes |
 
 `mise run conformance` runs everything that needs no machine runtime, which is
 what CI does. The suites that need one skip themselves at exit 0 when `--vm` is
 off, so a partial toolbox never turns into a false pass.
+
+**The images are a prerequisite and not a convenience** (#335). No upstream
+image carries an ssh daemon, and since #202 a machine holds exactly the one
+address its provider publishes, on a routed NIC with no NAT — so an emulator
+that has to fall back to an upstream image boots a machine that has no route to
+a package repository and can never install one. `runtime-proof.yml` spent five
+consecutive nights failing on that, with the fix in its own log. The `ssh.sh`
+suites now ask `guard_images` before they register a key: they refuse in a
+twentieth of a second, naming `feint images`, rather than timing out on an ssh
+error that blames the address. Building is never automatic here — it launches a
+container on your host and takes minutes, which this project asks for rather
+than assumes; CI runs the command as a step of its own.
 
 Two client quirks are worth knowing before you debug one:
 

--- a/tools/conformance/exoscale/ssh.sh
+++ b/tools/conformance/exoscale/ssh.sh
@@ -29,6 +29,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
 . "$SCRIPT_DIR/../guard.sh"
 guard_local "$ENDPOINT"
+# The images this suite boots have to exist before it registers a key and
+# promises an address; without them nothing answers on port 22 (#335).
+guard_images "$ENDPOINT"
 
 command -v exo >/dev/null 2>&1 || { echo "FAIL: exo is not installed" >&2; exit 1; }
 command -v jq >/dev/null 2>&1 || { echo "FAIL: jq is not installed" >&2; exit 1; }

--- a/tools/conformance/guard.sh
+++ b/tools/conformance/guard.sh
@@ -19,9 +19,14 @@
 #   . "$(dirname "${BASH_SOURCE[0]}")/guard.sh"
 #   guard_local "$ENDPOINT"
 #   guard_no_real_profile SCW_API_URL scw
+#   guard_images "$ENDPOINT"          # suites that log into a machine
 #
-# Usage of the two functions is deliberately separate: the first checks where the
-# script intends to go, the second checks that the client cannot go anywhere else.
+# Usage of the functions is deliberately separate: the first checks where the
+# script intends to go, the second checks that the client cannot go anywhere
+# else, and the third checks that the emulator can keep the promise the suite is
+# about to make. All three live here rather than in each suite for the reason
+# CLAUDE.md gives about the shared layer: a control copied into three scripts is
+# a control the fourth forgets.
 
 # guard_local refuses an endpoint that is not on this machine.
 #
@@ -67,4 +72,84 @@ EOF
       echo "FAIL: $var is ${!var}, which is not local; refusing to run $client" >&2
       exit 1 ;;
   esac
+}
+
+# guard_images refuses a suite whose machines cannot answer, and names the one
+# command that fixes it (#335).
+#
+# The emulator boots its own images because no upstream image carries an ssh
+# daemon (#203). When it holds none, it falls back to the upstream one and says
+# so in its log, once per boot:
+#
+#   WARN no image of ours for this system, booting the upstream one ...
+#        fix="feint images"
+#
+# That fallback used to be a degradation. Since #202 gave a machine exactly the
+# one address its provider's API publishes, on a routed NIC with no NAT, it is
+# not: the machine has no route to a package repository, cloud-init's
+# `apt-get install openssh-server` dies on DNS, and nothing ever listens on
+# port 22. Measured on 2026-08-20 by hiding the five feint/* aliases on a host
+# that had them: the same suite passed in 21s with the images and failed in 93s
+# without, on the emulator's own message, "no ssh daemon answered ... the
+# published address is a promise nobody keeps".
+#
+# runtime-proof.yml had been red on that line for five consecutive scheduled
+# nights, with the fix printed in its own log the whole time and nothing reading
+# it (#335, blocking the streak #125 counts). So this reads it: the suite either
+# has its images or refuses here, naming them, rather than starting and failing
+# thirty lines later on an ssh error that blames the network.
+#
+# TestTheImageGuardRefusesASuiteWhoseMachinesCannotAnswer fails without it, and
+# tools/falsify/specs/ssh-suite-needs-its-images.json replays that.
+guard_images() {
+  local endpoint="${1:-}"
+  local health machines binary
+
+  health="$(curl -sf "$endpoint/_feint/health" || true)"
+  if [ -z "$health" ]; then
+    echo "FAIL: $endpoint answered no health payload, so nothing here knows what its machines are" >&2
+    exit 1
+  fi
+  machines="$(printf '%s' "$health" | jq -r '.machines // "none"')"
+
+  # With no runtime the login step is skipped by design, and there is nothing to
+  # boot an image from. Said out loud rather than returned in silence: a
+  # precondition that passes quietly on the very case it exists for is how a
+  # check gets read as green when it never ran.
+  if [ "$machines" = "none" ] || [ "$machines" = "null" ] || [ -z "$machines" ]; then
+    echo "  images: not needed, $endpoint runs no machine runtime" >&2
+    return 0
+  fi
+
+  binary="${FEINT_BIN:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/feint}"
+  if [ ! -x "$binary" ]; then
+    cat >&2 <<EOF
+FAIL: no feint binary at $binary.
+
+This suite needs it to ask what images the $machines runtime holds. Build it
+(mise run build, or go build -o feint ./cmd/feint), or point FEINT_BIN at one.
+Skipping the question instead would let the suite start without its images,
+which is the failure this check exists to name.
+EOF
+    exit 1
+  fi
+
+  if ! "$binary" images --check --vm "$machines" >&2; then
+    cat >&2 <<EOF
+
+FAIL: the $machines runtime holds none of the images this suite boots.
+
+Without them the emulator falls back to an upstream image, which carries no ssh
+daemon and cannot install one: since #202 a machine holds exactly the address
+its provider publishes, on a routed NIC with no NAT, so cloud-init has no route
+to a package repository. The machine will run, the API will publish its address,
+and nothing will ever answer on port 22.
+
+Run:  $binary images --vm $machines
+
+It builds them once, takes minutes, and leaves them on the host.
+EOF
+    exit 1
+  fi
+  echo "  images: the $machines runtime holds every image this suite boots" >&2
 }

--- a/tools/conformance/guard_test.go
+++ b/tools/conformance/guard_test.go
@@ -1,0 +1,213 @@
+// Package conformance holds the tests of the shell the conformance suites
+// share. The suites themselves need real clients, a real emulator and, for the
+// ssh ones, a real machine runtime; their preconditions do not, and those are
+// exactly the part that has to hold on a host where nothing is set up yet.
+package conformance
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The ssh suites ask whether the emulator can keep the promise they are about
+// to make, before they make it (#335).
+//
+// runtime-proof.yml failed on the "Scaleway ssh suite" step on five consecutive
+// scheduled nights, 2026-08-16 to 2026-08-20. The cause was in its own log every
+// night:
+//
+//	WARN no image of ours for this system, booting the upstream one …
+//	     fix="feint images"
+//
+// Nothing ran it. The suite started anyway, registered a key, booted a server,
+// waited for an address, and failed ninety seconds later on "no ssh daemon
+// answered … the published address is a promise nobody keeps" — a message that
+// blames the address, the network or the daemon, and names none of the three
+// correctly. Reproduced on 2026-08-20 by hiding the five feint/* aliases on a
+// host that held them: 21s green with them, 93s red without, same message as CI.
+//
+// #125 promotes this workflow to pull_request after a run of consecutive green
+// scheduled nights, so while this stayed broken that counter was pinned at zero
+// by construction.
+//
+// The guard is shell because the suites are shell, and this is the test that
+// makes it a control rather than a paragraph: it drives guard_images itself,
+// against a stub emulator and a stub binary, and asserts what it does in each of
+// the four situations it can meet. tools/falsify/specs/ssh-suite-needs-its-images.json
+// replays it with the guard neutralised.
+func TestTheImageGuardRefusesASuiteWhoseMachinesCannotAnswer(t *testing.T) {
+	// A runtime is on and the binary reports missing images: refuse, and name
+	// the command. This is the CI case, and the one that cost five nights.
+	code, output := runGuard(t, `{"machines":"incus"}`, 2)
+	if code == 0 {
+		t.Errorf("the guard passed while the runtime holds no image:\n%s", output)
+	}
+	for _, want := range []string{"feint images", "incus", "port 22"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("the refusal never says %q, so it does not name what is missing:\n%s", want, output)
+		}
+	}
+}
+
+// The other three situations, each asserted rather than assumed. A precondition
+// that only knows how to fail is as useless as one that only knows how to pass.
+func TestTheImageGuardLetsAPreparedRunThrough(t *testing.T) {
+	code, output := runGuard(t, `{"machines":"incus"}`, 0)
+	if code != 0 {
+		t.Errorf("the guard refused a host that holds every image (exit %d):\n%s", code, output)
+	}
+}
+
+// With no runtime the suites skip their login step by design, and there is no
+// image to hold. The guard must not ask the binary at all: the stub here exits 2
+// on any call, so a guard that asked would fail this.
+func TestTheImageGuardAsksNothingWhenNoRuntimeIsOn(t *testing.T) {
+	code, output := runGuard(t, `{"machines":"none"}`, 2)
+	if code != 0 {
+		t.Errorf("the guard refused a --vm off emulator (exit %d):\n%s", code, output)
+	}
+	if !strings.Contains(output, "not needed") {
+		t.Errorf("the guard passed in silence; a precondition that says nothing on the case "+
+			"it exists for reads as green when it never ran:\n%s", output)
+	}
+}
+
+// An endpoint that answers nothing is not an endpoint with no runtime, and the
+// difference is the whole point: the first is a broken harness, the second a
+// deliberate mode. Answering "fine" to the first is how a suite proves nothing
+// and says it passed.
+func TestTheImageGuardRefusesAnEndpointThatAnswersNothing(t *testing.T) {
+	code, output := runGuard(t, "", 0)
+	if code == 0 {
+		t.Errorf("the guard passed against an emulator that answered no health payload:\n%s", output)
+	}
+}
+
+// The binary is the subject of the question, so its absence is an error and
+// never a reason to skip. A guard that shrugs when it cannot look is the defect
+// this repository keeps naming.
+func TestTheImageGuardRefusesWhenItCannotAsk(t *testing.T) {
+	health := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"machines":"incus"}`)
+	}))
+	defer health.Close()
+
+	code, output := bashGuard(t, health.URL, filepath.Join(t.TempDir(), "no-such-feint"))
+	if code == 0 {
+		t.Errorf("the guard passed with no binary to ask:\n%s", output)
+	}
+	if !strings.Contains(output, "no feint binary") {
+		t.Errorf("the refusal does not say the binary is what is missing:\n%s", output)
+	}
+}
+
+// The call sites, because a shared guard nobody calls guards nothing.
+//
+// Structural on purpose, and it is the weaker half of the pair: it reads the
+// three scripts rather than running them, which is a document check. What makes
+// it worth having is that the behavioural half above cannot see a deleted call,
+// and a deleted call is exactly how the suites were before #335.
+func TestEverySuiteThatLogsInAsksForItsImages(t *testing.T) {
+	suites := []string{
+		filepath.Join("scaleway", "ssh.sh"),
+		filepath.Join("outscale", "ssh.sh"),
+		filepath.Join("exoscale", "ssh.sh"),
+	}
+	for _, suite := range suites {
+		body, err := os.ReadFile(suite) //nolint:gosec // a fixed path in this directory
+		if err != nil {
+			t.Fatalf("read %s: %v", suite, err)
+		}
+		// A line of its own, so the call is a statement rather than a mention.
+		// The first version of this test matched the name anywhere in the file,
+		// and the falsification caught it at once: `true || guard_images
+		// "$ENDPOINT"` still contains the name and calls nothing.
+		called := false
+		for _, line := range strings.Split(string(body), "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), `guard_images "`) {
+				called = true
+				break
+			}
+		}
+		if !called {
+			t.Errorf("%s logs into a machine and never calls guard_images on a line of its own: "+
+				"it will start without its images and fail on an ssh timeout that names nothing", suite)
+		}
+	}
+}
+
+// runGuard drives guard_images against a stub emulator and a stub binary.
+//
+// The stub binary is what makes this run anywhere: `feint images --check` needs
+// an Incus daemon, and the guard's own behaviour is what is under test, not the
+// inventory's. Its exit code is the one thing the guard reads.
+func runGuard(t *testing.T, healthBody string, binaryExit int) (int, string) {
+	t.Helper()
+
+	health := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if healthBody == "" {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, healthBody)
+	}))
+	defer health.Close()
+
+	stub := filepath.Join(t.TempDir(), "feint")
+	script := fmt.Sprintf("#!/bin/sh\necho \"stub feint: $*\" >&2\nexit %d\n", binaryExit)
+	if err := os.WriteFile(stub, []byte(script), 0o700); err != nil { //nolint:gosec // a stub in a test temp dir
+		t.Fatalf("write the stub binary: %v", err)
+	}
+	return bashGuard(t, health.URL, stub)
+}
+
+// bashGuard sources the real guard.sh and calls guard_images in a subshell, so
+// what is measured is the shell the suites source and not a copy of it.
+func bashGuard(t *testing.T, endpoint, binary string) (int, string) {
+	t.Helper()
+	requireTool(t, "bash")
+	requireTool(t, "curl")
+	requireTool(t, "jq")
+
+	guard, err := filepath.Abs("guard.sh")
+	if err != nil {
+		t.Fatalf("locate guard.sh: %v", err)
+	}
+	if _, err := os.Stat(guard); err != nil {
+		t.Fatalf("guard.sh is not where this test looks (%s): %v", guard, err)
+	}
+
+	cmd := exec.Command("bash", "-c", `. "$1"; guard_images "$2"`, "bash", guard, endpoint) //nolint:gosec // fixed script, test-controlled arguments
+	cmd.Env = append(os.Environ(), "FEINT_BIN="+binary)
+	out, err := cmd.CombinedOutput()
+	code := 0
+	if err != nil {
+		var exit *exec.ExitError
+		if !errors.As(err, &exit) {
+			t.Fatalf("run the guard: %v\n%s", err, out)
+		}
+		code = exit.ExitCode()
+	}
+	return code, string(out)
+}
+
+// requireTool fails rather than skips. The suites this guard belongs to cannot
+// run without curl and jq either, so a host without them is a host where the
+// question "does the guard bite" has no answer — and a skip would report that
+// as one.
+func requireTool(t *testing.T, name string) {
+	t.Helper()
+	if _, err := exec.LookPath(name); err != nil {
+		t.Fatalf("%s is not on PATH: the conformance suites need it, so this test cannot "+
+			"be skipped into looking green", name)
+	}
+}

--- a/tools/conformance/outscale/ssh.sh
+++ b/tools/conformance/outscale/ssh.sh
@@ -28,6 +28,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
 . "$SCRIPT_DIR/../guard.sh"
 guard_local "$ENDPOINT"
+# The images this suite boots have to exist before it registers a key and
+# promises an address; without them nothing answers on port 22 (#335).
+guard_images "$ENDPOINT"
 
 command -v oapi-cli >/dev/null 2>&1 || { echo "FAIL: oapi-cli is not installed" >&2; exit 1; }
 command -v jq >/dev/null 2>&1 || { echo "FAIL: jq is not installed" >&2; exit 1; }

--- a/tools/conformance/scaleway/ssh.sh
+++ b/tools/conformance/scaleway/ssh.sh
@@ -22,6 +22,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
 . "$SCRIPT_DIR/../guard.sh"
 guard_local "$ENDPOINT"
+# The images this suite boots have to exist before it registers a key and
+# promises an address; without them nothing answers on port 22 (#335).
+guard_images "$ENDPOINT"
 
 set -a
 # shellcheck source=/dev/null

--- a/tools/falsify/specs/frozen-cli-surface.json
+++ b/tools/falsify/specs/frozen-cli-surface.json
@@ -1,0 +1,55 @@
+{
+  "package": "./internal/cli/",
+  "mutations": [
+    {
+      "label": "the surface is observed from the rendered help again, which is the defect itself: it freezes the document rather than the binary",
+      "file": "internal/cli/frozen_test.go",
+      "find": "\t\t\"verbs\":      flagsTheBinaryAccepts(t),",
+      "replace": "\t\t\"verbs\":      func() map[string][]string { _ = flagsTheBinaryAccepts(t); return flagsTheHelpNames(t) }(),",
+      "test": "TestTheFrozenSurfacesStillMatchTheirFixture"
+    },
+    {
+      "label": "a flag stops being registered while its help line survives, and the frozen surface has to notice: this is the direction that breaks a consumer",
+      "file": "internal/cli/proxy.go",
+      "find": "\tintercept := fs.String(\"intercept\", \"\"",
+      "replace": "\tintercept := fs.String(\"intercept-withdrawn\", \"\"",
+      "test": "TestTheFrozenSurfacesStillMatchTheirFixture"
+    },
+    {
+      "label": "the same withdrawal seen from the help's side: the block keeps naming a flag no flag set registers, so a reader who types it is answered that it does not exist",
+      "file": "internal/cli/proxy.go",
+      "find": "\tintercept := fs.String(\"intercept\", \"\"",
+      "replace": "\tintercept := fs.String(\"intercept-withdrawn\", \"\"",
+      "test": "TestTheHelpNamesEveryFlagTheBinaryAccepts"
+    },
+    {
+      "label": "a flag is added to a flag set and to no help block, which is exactly how --intercept shipped mute in v0.9.0",
+      "file": "internal/cli/proxy.go",
+      "find": "\tif err := fs.Parse(args); err != nil {\n\t\treturn exitError\n\t}\n\n\tif *upstream == \"\" {",
+      "replace": "\t_ = fs.String(\"intercept-and-unnamed\", \"\", \"a flag no help block names\")\n\tif err := fs.Parse(args); err != nil {\n\t\treturn exitError\n\t}\n\n\tif *upstream == \"\" {",
+      "test": "TestTheHelpNamesEveryFlagTheBinaryAccepts"
+    },
+    {
+      "label": "the same arrival seen from the fixture's side: a flag the binary gained and the committed surface never recorded",
+      "file": "internal/cli/proxy.go",
+      "find": "\tif err := fs.Parse(args); err != nil {\n\t\treturn exitError\n\t}\n\n\tif *upstream == \"\" {",
+      "replace": "\t_ = fs.String(\"intercept-and-unnamed\", \"\", \"a flag no help block names\")\n\tif err := fs.Parse(args); err != nil {\n\t\treturn exitError\n\t}\n\n\tif *upstream == \"\" {",
+      "test": "TestTheFrozenSurfacesStillMatchTheirFixture"
+    },
+    {
+      "label": "the help names a flag the binary never registers, the state `feint version` was in with its --version and -v",
+      "file": "internal/cli/cli.go",
+      "find": "  feint catalog    [--format json]",
+      "replace": "  feint catalog    [--format json] [--no-such-flag]",
+      "test": "TestTheHelpNamesEveryFlagTheBinaryAccepts"
+    },
+    {
+      "label": "the seam stops publishing the flag sets, so the observation collects nothing and would freeze an empty surface in silence",
+      "file": "internal/cli/flagset.go",
+      "find": "\tif observeFlagSet != nil {\n\t\tobserveFlagSet(name, fs)\n\t}",
+      "replace": "\tif observeFlagSet != nil && false {\n\t\tobserveFlagSet(name, fs)\n\t}",
+      "test": "TestTheFrozenSurfacesStillMatchTheirFixture"
+    }
+  ],
+  "note": "The subject is #334. `feint proxy --intercept` shipped in v0.9.0: the binary accepted it, `feint proxy --help` rendered it, and the frozen CLI surface (#132) — the thing a pipeline outside this repository is allowed to key on — did not list it, for six days. The cause was that the surface was observed by parsing the rendered `feint --help`, so it recorded what the help claimed. The missing flag was the cheap half; the expensive half is mutation 2, the removal, which that observation could never have seen and which is the direction that breaks a consumer. Mutations 2 and 4 are the two directions the issue asks for, each replayed twice because the fix has two teeth now: the frozen surface reads the FlagSets, and the help carries its own assertion instead of being both the observation and the thing observed. Mutation 7 is the reason the observation asserts its subject rather than skipping on absence: a seam that stopped publishing would otherwise regenerate a fixture that freezes nothing."
+}

--- a/tools/falsify/specs/ssh-suite-needs-its-images.json
+++ b/tools/falsify/specs/ssh-suite-needs-its-images.json
@@ -1,0 +1,41 @@
+{
+  "package": "./tools/conformance/",
+  "mutations": [
+    {
+      "label": "the refusal never fires, so a suite starts against a runtime that holds none of its images — the state runtime-proof was in for five nights",
+      "file": "tools/conformance/guard.sh",
+      "find": "  if ! \"$binary\" images --check --vm \"$machines\" >&2; then",
+      "replace": "  if ! \"$binary\" images --check --vm \"$machines\" >&2 && false; then",
+      "test": "TestTheImageGuardRefusesASuiteWhoseMachinesCannotAnswer"
+    },
+    {
+      "label": "an emulator that answered nothing reads as an emulator with no runtime, so the guard reports fine about a host it never reached",
+      "file": "tools/conformance/guard.sh",
+      "find": "  if [ -z \"$health\" ]; then",
+      "replace": "  if [ -z \"$health\" ] && false; then",
+      "test": "TestTheImageGuardRefusesAnEndpointThatAnswersNothing"
+    },
+    {
+      "label": "the missing binary stops being named, so the one refusal a first-contact host meets says nothing useful",
+      "file": "tools/conformance/guard.sh",
+      "find": "  if [ ! -x \"$binary\" ]; then",
+      "replace": "  if [ ! -x \"$binary\" ] && false; then",
+      "test": "TestTheImageGuardRefusesWhenItCannotAsk"
+    },
+    {
+      "label": "the guard fires on a --vm off emulator, which turns the documented degraded mode into a failure and gets the check disarmed",
+      "file": "tools/conformance/guard.sh",
+      "find": "  if [ \"$machines\" = \"none\" ] || [ \"$machines\" = \"null\" ] || [ -z \"$machines\" ]; then",
+      "replace": "  if ([ \"$machines\" = \"none\" ] || [ \"$machines\" = \"null\" ] || [ -z \"$machines\" ]) && false; then",
+      "test": "TestTheImageGuardAsksNothingWhenNoRuntimeIsOn"
+    },
+    {
+      "label": "the Scaleway ssh suite stops asking, which is exactly the shape of the defect: a shared guard nobody calls",
+      "file": "tools/conformance/scaleway/ssh.sh",
+      "find": "guard_images \"$ENDPOINT\"",
+      "replace": "true || guard_images \"$ENDPOINT\"",
+      "test": "TestEverySuiteThatLogsInAsksForItsImages"
+    }
+  ],
+  "note": "The subject is #335. runtime-proof.yml — the workflow whose consecutive green nights are the promotion criterion of #125 — failed on the Scaleway ssh suite for five scheduled nights running, 2026-08-16 to 2026-08-20, and the emulator printed the fix in its own log every one of them: fix=\"feint images\". Nothing read it. Reproduced on 2026-08-20 on the author's station by deleting the five feint/* image aliases (the images themselves left alone, so the reproduction is reversible): the same suite passed in 21s with them and failed in 93s without, on the same sentence CI had been printing. The cause is not the fallback existing — #203 chose it deliberately so a first contact still boots — but that #202 later gave a machine exactly the one address its provider publishes, on a routed NIC with no NAT, which leaves an upstream image with no route to a package repository and therefore no way to install the ssh daemon it does not carry. Mutation 5 is the one worth reading twice: the guard is in the shared file so three suites and a fourth get it at once, and a shared guard nobody calls is the same defect one layer up."
+}


### PR DESCRIPTION
Two defects found while triaging the open issues before tagging 0.10.0. Both
are guards that had stopped measuring, in the two ways this repository names in
`CLAUDE.md`.

## #334 — the frozen surface asked the help, not the binary

`feint proxy --intercept` shipped in v0.9.0 and appeared in no changelog, no
general help, and therefore not in the frozen CLI surface. The guard that
should have caught it, `verbsWithFlags`, **parsed the rendered help** — its own
comment said so — and so recorded what the help *claimed* rather than what the
binary *accepts*.

The dangerous half was never the missing flag. The same test would have stayed
green while a documented flag was **deleted from the FlagSet**, provided its
help line survived — the direction that breaks a consumer, and the reason #132
froze this surface at all.

**Now**: every verb builds its flags through one seam (`newFlagSet`), the test
drives each dispatched verb to `-h` and reads the `flag.FlagSet` back with
`VisitAll`. No prose is parsed. The observation asserts its subject: a verb
that builds no flag set is an error, not a smaller fixture.

The help keeps its promise as a **separate assertion with its own subject** —
`TestTheHelpNamesEveryFlagTheBinaryAccepts`, both directions. It found **27
gaps on its first run**, and `feint --help` was rewritten to close them.

Surface **version 5**: 24 flags entered, 3 left. All three departures were the
old parser's inventions — `version --version` and `-v` are aliases of the verb,
and typing them returns `flag provided but not defined`; `snapshot --state`
came from a sentence about `serve`.

| verb | gained |
|---|---|
| `proxy` | `--intercept`, `--expose-to-network` |
| `serve` | `--shapes`, `--expose-to-network` |
| `start` | the six serve flags it really takes |
| `docs` | 10 · `evidence` 3 · `version` `--check` |

Beyond the issue's own grievance: `feint start` advertised "every serve flag"
and rejects three of them. The help now says which.

**Falsified in both directions** — `tools/falsify/specs/frozen-cli-surface.json`,
7 mutations, 7 bite. Including one that puts the observation back on the help,
which replays #334 itself.

## #335 — reproduced before it was fixed, and the premise was half wrong

`runtime-proof` had been red for five scheduled nights, pinning #125's counter
of consecutive greens **at zero by construction**.

**Reproduced locally first**, which is what changed the diagnosis. With the
station's five `feint/*` images present the Scaleway ssh suite passes in 21 s;
deleting only the *aliases* (reversible, images untouched) reproduces the
runner's state exactly — the same suite fails in 93 s on the identical CI
sentence, `Temporary failure resolving 'archive.ubuntu.com'`, `openssh-server`
never installed, nothing on port 22.

**The issue blamed #203's image fallback. That alone was harmless**: before it,
machines also booted upstream images and installed sshd at boot, and that was
green. What made it fatal is **#202/#205, landed the same day and after that
day's green run** — a machine now carries exactly its provider's published
address on a `routed` NIC with **no NAT**, so an upstream image has no route to
a package repository. The emulator's `consequence` field promised an install
that can no longer happen; it now says what does.

**Two halves, because a workflow line alone would be a comment**:
`runtime-proof.yml` builds the images before starting the emulator, and
`tools/conformance/guard.sh` gains `guard_images`, called by the three ssh
suites, refusing in 0.055 s while naming `feint images --vm incus`. Delete the
workflow step and the suites now stop at the doorstep instead of timing out on
a message that blames the address.

**Falsified** — `tools/falsify/specs/ssh-suite-needs-its-images.json`, 5
mutations, all bite, against a test that drives the real `guard.sh`. The
harness caught the first call-site test being too weak (`true || guard_images`
kept it green); it now requires the call on a line of its own.

## The ACL error: independent, and filed

Not the runner's Incus version — the last *green* night ran 7.3.0 too. Isolated
on this station's 7.2: a `routed` NIC rejects `security.acls` **and**
`security.acls.default.ingress.action` individually, while the same keys on a
managed network's NIC are accepted. Different builds name a different member of
the same invalid set, which is why the station log said one and CI the other.
Filed as **#337** with a second symptom of the same root: `interfaceFor`
selects on `network != ""`, so a routed NIC is invisible and every address
routed after launch never reaches the machine.

## A prediction, stated rather than left to surprise

`runtime-proof` will probably still be red, **one step later**: with every image
present, the Exoscale ssh suite fails on this station — the API says the elastic
IP is attached and the emulator logs `could not route the elastic IP to the
machine … has no network interface`. That is #337, which the workflow never
reached because it died on the Scaleway suite first. #125's counter is unblocked
from *this* cause but not yet free, and its comment says so rather than letting
the next red read as a new mystery. This is a local measurement, not a CI
observation.

## Related

Closes #334
Closes #335
Files #337.
