### PR TITLE
feat(proxy): a client whose endpoint is compiled in is recorded, through CONNECT

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -19,6 +19,42 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Ajouté
 
+- **`feint proxy --forward` enregistre un client dont l'endpoint est codé en
+  dur** (#336). Le proxy accepte `CONNECT hôte:port`, termine le TLS avec un
+  certificat forgé pour la session, enregistre l'échange et le ré-émet vers
+  l'hôte que le client a demandé. Rien ne change chez le client : un client Go
+  qui n'installe pas de `Transport` honore `HTTPS_PROXY` tout seul, et
+  `SSL_CERT_FILE` est ce qui lui fait accepter le tunnel. C'est le cas que
+  `--upstream` ne pouvait pas atteindre : les collecteurs de Pépin portent leurs
+  URL de base dans leur source, et rendre celles-ci configurables a été refusé
+  par leur propre audit de livraison, puisque chaque requête de collecte
+  transporte une clé secrète vivante. Mesuré de bout en bout le 2026-08-20
+  contre un serveur HTTPS local, avec un client dont l'endpoint est une
+  constante : un échange enregistré, nommé `instance/v1/API.CreateServer`, avec
+  `X-Auth-Token`, `X-Consumer`, la signature en query et le `X-Session-Token` de
+  la réponse tous `REDACTED`, alors que le serveur les a reçus intacts.
+
+  **Les exigences de sécurité sont la fonctionnalité, et chacune porte sa
+  falsification** (`tools/falsify/specs/forward-proxy.json`, sept mutations, qui
+  mordent toutes). La redaction survit à l'interception, parce que le tunnel
+  enregistre par le même `capture` : il n'existe pas de seconde porte vers le
+  fichier. Boucle locale uniquement, et `--expose-to-network` est *refusé* avec
+  `--forward` : un proxy détenant une autorité à laquelle un client fait
+  confiance est, hors boucle locale, une machine qui déchiffre et classe tout ce
+  que lui envoie quiconque peut l'atteindre. L'autorité est forgée en mémoire,
+  écrite dans un unique fichier temporaire, retirée à la sortie, jamais
+  installée. Et seuls les hôtes nommés sont interceptés : un `CONNECT` ailleurs
+  est refusé par un 403, compté et rapporté à la fin, jamais relayé en aveugle,
+  et `--forward '*'` est refusé net.
+
+  Le transcript gagne un champ `host`, rempli par le proxy et laissé vide par
+  l'anneau de l'émulateur : un enregistrement de proxy avant contient plusieurs
+  clouds, et `POST /api/v1/ReadVms` n'est pas le même échange selon celui qui a
+  répondu. Surface CLI en version 5. `docs/proxy.md` dit désormais ce que
+  contient un enregistrement, champ par champ, et ce qu'il faut assainir avant
+  de le partager — complètement, parce que l'assainissement partiel est le piège
+  qui a ouvert l'audit de Pépin.
+
 - **Un équilibreur de charge Outscale distribue de vrais paquets, à
   l'intérieur de son propre réseau** (#315). Sous `--vm incus-ovn`, la
   `PrivateIp` d'un balanceur, une adresse du Subnet où il siège, est remise à

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,40 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Added
 
+- **`feint proxy --forward` records a client whose endpoint is compiled in**
+  (#336). The proxy accepts `CONNECT host:port`, terminates the TLS with a
+  certificate minted for the run, records the exchange and re-originates to the
+  host the client asked for. Nothing changes in the client: a Go client that
+  installs no `Transport` honours `HTTPS_PROXY` on its own, and `SSL_CERT_FILE`
+  is what makes it trust the tunnel. That is the case `--upstream` could never
+  reach — Pépin's collectors hold their base URLs in their source, and making
+  them configurable was refused on its own delivery audit, because every
+  collection request carries a live secret key. Measured end to end on
+  2026-08-20 against a local HTTPS server, with a client whose endpoint is a
+  constant: one exchange recorded, named `instance/v1/API.CreateServer`, with
+  `X-Auth-Token`, `X-Consumer`, the query signature and the answer's
+  `X-Session-Token` all `REDACTED` while the server received every one of them
+  in full.
+
+  **The security requirements are the feature, and each has a falsification**
+  (`tools/falsify/specs/forward-proxy.json`, seven mutations, all of which bite).
+  The redaction survives the interception, because the tunnel records through the
+  same `capture` — there is no second path to the writer. Loopback only, and
+  `--expose-to-network` is *refused* with `--forward`: a proxy holding an
+  authority a client trusts is, off loopback, a machine that decrypts and files
+  whatever anyone who can reach it sends. The authority is minted in memory,
+  written to one temporary file, removed at exit, never installed. And only the
+  hosts named are intercepted — a `CONNECT` elsewhere is refused with a 403,
+  counted and reported at exit, never relayed blind, and `--forward '*'` is
+  refused outright.
+
+  The transcript gained a `host` field, filled by the proxy and left empty by the
+  emulator's own ring: one forward-proxy recording holds several clouds, and
+  `POST /api/v1/ReadVms` is a different exchange depending on which one answered.
+  CLI surface version 5. `docs/proxy.md` now states what a recording contains,
+  field by field, and what has to be sanitised before it is shared — completely,
+  because partial sanitisation is the trap that opened Pépin's audit.
+
 - **An Outscale load balancer distributes real packets, inside its own
   network** (#315). Under `--vm incus-ovn`, a balancer's `PrivateIp` — an
   address of the Subnet it sits in — is handed to the runtime's own OVN load

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -40,6 +40,79 @@ Two properties matter and are enforced, not documented:
 A client the cloud walks away from by republishing its own address needs one more
 flag, `--intercept`; it has its own section below.
 
+## Record a client whose endpoint is compiled in
+
+The command above needs a client you can redirect. Some cannot be: Pépin's
+collectors hold `https://api.scaleway.com`, `https://api-{zone}.exoscale.com/v2`
+and `https://api.{region}.{host}/api/v1` in their source, and adding a
+configurable endpoint was **refused** on their own delivery audit — every
+collection request carries a live secret key, so a redirectable endpoint is a way
+to send a tenant's credentials to a host of somebody else's choosing. The
+redirect belongs outside the tool being measured.
+
+`--forward` is that outside. It makes the proxy a **forward** proxy: it accepts
+`CONNECT api.scaleway.com:443`, terminates the TLS with a certificate minted for
+the run, records the exchange, and re-originates to the real host.
+
+```bash
+feint proxy --forward api.scaleway.com,'*.exoscale.com' --record real.jsonl
+#   forwarding for api.scaleway.com, *.exoscale.com
+#   CA written to /tmp/feint-intercept-ca-1655051664.pem (a temporary file, removed on exit)
+#   drive a client whose endpoint is compiled in with:
+#     export HTTPS_PROXY=http://127.0.0.1:4600
+#     export SSL_CERT_FILE=/tmp/feint-intercept-ca-1655051664.pem
+```
+
+Nothing changes in the client. A Go client that installs no `Transport` inherits
+`http.DefaultTransport`, which honours `HTTPS_PROXY` on its own; `SSL_CERT_FILE`
+is what makes it trust the certificate the tunnel presents. Measured end to end
+on 2026-08-20 against a local HTTPS server, with a client whose endpoint is a
+constant:
+
+```json
+{"seq":1,"host":"api.localhost:8443","method":"POST",
+ "path":"/instance/v1/zones/fr-par-1/servers","query":"x-amz-signature=REDACTED",
+ "operation":"instance/v1/API.CreateServer","provider":"scaleway","status":200,
+ "req":{"headers":{"User-Agent":"pepin-shaped-collector/1.0",
+                   "X-Auth-Token":"REDACTED","X-Consumer":"REDACTED"}},
+ "res":{"headers":{"X-Session-Token":"REDACTED"},
+        "body":{"servers":[{"id":"c2f1a7b0-…","public_ip":{"address":"51.15.0.1"}}]}}}
+```
+
+The cloud received every one of those values in full — the recorder alters
+nothing on the wire — and the file holds none of them.
+
+Four properties, each of them a requirement rather than a precaution, and each
+with a test that fails without it (`tools/falsify/specs/forward-proxy.json`
+replays all seven):
+
+- **The redaction survives the interception.** The tunnel records through the
+  same `capture` as everything else, so there is no second path to the writer to
+  forget. `TestASecretHeaderIsStillRedactedThroughCONNECT` drives a real TLS
+  session and asserts both ends of it, including an `X-Consumer` header — the
+  name a denylist wrote out in clear while redacting an `X-Auth-Token` holding
+  the same value.
+- **Loopback only, and `--expose-to-network` does not lift it here.** A forward
+  proxy holds an authority whose certificates a client has been told to trust:
+  off loopback it is not a relay but a machine that decrypts and files whatever
+  anyone who can reach the port sends it.
+- **The authority is ephemeral and never installed.** The CA is generated in
+  memory at startup, written to one temporary file, and removed when the command
+  returns. It never goes near the system trust store, and the leaf it signs
+  cannot itself sign anything.
+- **Only the hosts you name are intercepted.** A `CONNECT` to any other host is
+  refused with a 403, counted, and reported at exit. Refused rather than relayed
+  blind, because a blind relay writes a transcript that silently misses
+  exchanges — the failure the handoff counter below exists to report. A wildcard
+  covers one label (`*.exoscale.com` matches `api-ch-gva-2.exoscale.com` and
+  never `a.b.exoscale.com`), and `--forward '*'` is refused outright: that flag
+  would be a wiretap on everything the measured process does.
+
+`--forward` and `--upstream` are two different proxies and are not passed
+together; neither are `--forward` and `--intercept`, which are two ways to reach
+the same interception (`--intercept` serves TLS on the listener itself, for a
+client redirected by name — see [limits.md](limits.md)).
+
 ## Read
 
 `feint transcript` answers the three questions, in order of value.
@@ -242,13 +315,32 @@ Two things follow, and the first one matters most:
   signature. Every "what does the provider actually call" question is answerable
   today; only "what does the real cloud answer *to this client*" is not.
 
-Lifting it needs DNS and TLS interception so the client can be pointed at the
-real hostname and still land here, and **that is `--intercept`, above**: the
-client addresses `api.eu-west-2.outscale.com`, signs that name, and the name is
-what reaches the cloud. The ceremony is the price — the client has to run in a
-namespace that resolves the name to the proxy — so a recording made without it
-is still made with a client whose signed host can be set independently, which is
-how the transcripts behind this page's examples were produced.
+Lifting it needs the client to address the real hostname and still land here.
+Two doors now do that, and both mint the certificate the same way — the cost is
+measured in [limits.md](limits.md), *The cost of DNS/TLS interception*: the TLS
+half is cheap and every Go client accepts a locally minted CA through
+`SSL_CERT_FILE`.
+
+- `--intercept` redirects by **name**, and that half is the expensive one:
+  pointing a hostname at loopback has no client-scoped, unprivileged mechanism
+  for a static pure-Go client, so it needs a namespace of the client's own (a
+  container's `/etc/hosts`).
+- `--forward` redirects by **proxy**, and needs no name redirect at all: the
+  client asks for `api.eu-west-2.outscale.com` and the proxy re-originates to
+  that same host, with the `Host` header it received.
+
+**What that means for a signed client is reasoning, not a measurement.** The
+signature covers `Host`; through a tunnel the client signs the cloud's own name,
+and the header reaches the cloud unaltered, which
+`TestASecretHeaderIsStillRedactedThroughCONNECT` asserts against a local server.
+Whether a real
+`oapi-cli` against a real Outscale account then answers 200 has **not** been
+measured here, and this project takes no real-account measurement in CI. If you
+have such an account, that is the run worth making, and this page will say what
+it found rather than what it expects.
+
+Until then, a real-cloud recording is made with a client whose signed host can be
+set — which is how the transcripts behind this page's examples were produced.
 
 Until 2026-08-20 this paragraph said the opposite: *"which is #76 and
 deliberately not this tool"*. The flag shipped in v0.9.0, `docs/limits.md` sent
@@ -266,6 +358,52 @@ with a comparable resource before trusting an absence, and read a `(absent)` on 
 field the sampled resource would not carry as "not shown here", not "omitted".
 Type mismatches (a `number` upstream, a `string` in the emulator) do not have
 this caveat: both sides had the field.
+
+## What a recording contains, and what to sanitise before sharing it
+
+A transcript is redacted of credentials and is **not** anonymous. It is the
+inventory of a real account, written down by something whose whole purpose is to
+alter nothing. Read this table before a recording leaves the machine it was made
+on.
+
+| field | what it carries | after redaction |
+|---|---|---|
+| `host` | the authority the client addressed | verbatim — the cloud, the zone, sometimes the region |
+| `path`, `query` | the request line | verbatim, **identifiers included**: `/servers/{a real UUID}`. Only a parameter whose *name* carries a credential becomes `REDACTED` |
+| `operation`, `provider` | what the pack calls this route | invented here, carries nothing of the account |
+| `req.headers` | the request's header names | names in full, values dropped unless the name is on the allowlist (`Accept`, `Content-Type`, `User-Agent`, `Host`, …) |
+| `req.body`, `res.body` | the payloads | **verbatim**, except values under a key naming a credential. This is the measurement, and it is why the file is worth having |
+| `res.headers` | the answer's header names | same rule as the request's |
+
+So the bodies hold what the account holds: resource and project identifiers,
+machine and bucket names, public and private addresses, tags, and whatever a
+colleague put in a description field. The proxy writes the transcript `0600` and
+prints nothing of it, and that is the whole of what the tool can do for you.
+
+**Sanitise before you share, and sanitise completely.** Partial sanitisation is
+the trap, not an improvement: Pépin's delivery audit opened on a real instance
+UUID left in a fixture whose IP address had been scrubbed — the scrubbing is what
+made the file look reviewed. Before a recording, or anything derived from one,
+enters a repository or an issue:
+
+1. Replace every identifier — UUIDs, project and account numbers, resource names
+   — with invented values, in `path` and in the bodies alike.
+2. Replace every address: public IPs, private ranges, DNS names of your own.
+3. Re-read the bodies for free text: descriptions, tags, key names, bucket
+   names, the name of the person who created the resource.
+4. Search the result for the account's own identifiers one last time. `grep` for
+   the project UUID is thirty seconds and it is the step the audit's fixture
+   skipped.
+
+A test fixture is **built from the observed shape with invented values**, and
+says so, rather than being a recording with a few values crossed out. The field
+tree is what carries the knowledge; the values never did.
+
+Two things in this repository already do that for you, and neither is the
+transcript: `feint shapes --record` stores field trees with identifiers folded
+into `{id}` and no values at all, which is why `shapes/*.json` is committed;
+`feint transcript --shape` prints the same tree out of a recording. If what you
+want to share is "what the cloud answers", share one of those.
 
 ## Doing it against a real, billed account
 

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -69,6 +69,22 @@ is what makes it trust the certificate the tunnel presents. Measured end to end
 on 2026-08-20 against a local HTTPS server, with a client whose endpoint is a
 constant:
 
+> **On macOS, `SSL_CERT_FILE` does not do this**, and the sentence above is
+> therefore true of Linux only. Go's `crypto/x509` reads the system keychain on
+> Darwin, and the code path that consults `SSL_CERT_FILE` carries a build
+> constraint excluding it. Measured rather than read: the first CI run of this
+> feature on `macos-15` failed with `x509: certificate signed by unknown
+> authority` while the proxy logged `the client did not complete the tunnel
+> handshake`.
+>
+> The tunnel itself works there — the repository's own test proves it on macOS
+> by handing the child an explicit pool. What does not work is the part that
+> makes this feature worth having: *not touching the client*. On macOS the
+> client must be given the CA some other way (its own `tls.Config`, or the
+> authority added to the keychain), which is a change to the tool you were
+> trying to measure. Plan for a Linux runner, a container, or a VM when the
+> point is to trace something you must not modify.
+
 ```json
 {"seq":1,"host":"api.localhost:8443","method":"POST",
  "path":"/instance/v1/zones/fr-par-1/servers","query":"x-amz-signature=REDACTED",

--- a/docs/roadmap.fr.md
+++ b/docs/roadmap.fr.md
@@ -479,6 +479,18 @@ de nom jetable à la main de l'opérateur (un devcontainer, une entrée hosts
 temporaire), jamais une installation dans le magasin de confiance du système
 et jamais un fichier hosts que le binaire éditerait lui-même.
 
+**Ce que #336 a changé à la moitié bloquante, et ce qu'il n'a pas changé.**
+`feint proxy --forward` (2026-08-20) accepte `CONNECT` et n'a besoin d'aucune
+redirection de nom : un client qui honore `HTTPS_PROXY` remet le nom d'hôte au
+proxy lui-même. La moitié qu'on appelait le blocage a donc une seconde porte
+pour **tout client qui lit cette variable** — mesuré sur un client Go qui
+n'installe pas de `Transport`, c'est-à-dire le cas ordinaire. Ce qui reste non
+mesuré est justement ce qui rouvrirait l'arbitrage : le client S3 du provider
+Terraform Scaleway honore-t-il `HTTPS_PROXY` pour son
+`https://s3.<region>.scw.cloud` codé en dur ? Tant que personne ne l'a mesuré,
+le refus tient par son argument de couverture — un produit sur un client — et
+non par l'impossibilité de la redirection.
+
 ### Considéré dans la même passe, et non mis en file
 
 Nommé plutôt que laissé flotter, la même discipline que `Declined()` :

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -438,6 +438,17 @@ retained, it is an item with a named owner and a measured shape —
 devcontainer, a temporary hosts entry), never a system trust-store install and
 never a hosts file the binary edits itself.
 
+**What #336 changed about the blocking half, and what it did not.** `feint proxy
+--forward` (2026-08-20) accepts `CONNECT` and needs no name redirect at all: a
+client that honours `HTTPS_PROXY` hands the proxy the hostname itself. So the
+half that was called the blocker has a second door for **any client that reads
+that variable** — measured on a Go client which installs no `Transport`, which is
+the ordinary case. What stays unmeasured is the one that would reopen the
+arbitration: whether the Scaleway Terraform provider's S3 client honours
+`HTTPS_PROXY` for its built-in `https://s3.<region>.scw.cloud`. Until somebody
+runs that, the decline stands on its coverage argument — one product on one
+client — and not on the redirect being impossible.
+
 ### Considered in the same pass, and not queued
 
 Named rather than left floating, which is the same discipline as `Declined()`:

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -100,7 +100,7 @@ const (
 // TestTheFrozenSurfacesStillMatchTheirFixture, and a fixture regenerated
 // without bumping this constant fails TestASurfaceChangeDemandsItsVersionBump.
 // The procedure for a deliberate change is in RELEASING.md ("Frozen surfaces").
-const cliSurfaceVersion = 5
+const cliSurfaceVersion = 6
 
 // Run executes one command and returns the process exit code.
 func Run(args []string, stdout, stderr io.Writer) int {
@@ -282,16 +282,23 @@ Usage:
 
   feint proxy      --upstream <url> --record <file.jsonl> [--addr 127.0.0.1:4600]
                     [--provider <name>] [--max-body <bytes>] [--queue <n>]
-                    [--intercept <host,host>] [--expose-to-network]
+                    [--intercept <host,host>] [--forward <host,...>]
+                    [--expose-to-network]
                     Sit between a real client and a real cloud and write down
                     every exchange, as JSON Lines, one object per call, with the
                     upstream operation named. Credentials are redacted before
                     anything is written. Point the client at --addr and drive it
-                    as usual. --intercept serves HTTPS with a locally-minted
+                    as usual. Two ways reach a client you cannot redirect by
+                    configuration. --intercept serves HTTPS with a locally-minted
                     certificate for those hostnames, so a client redirected here
-                    by name trusts the proxy and lands on it; docs/proxy.md says
-                    what it costs, as does --expose-to-network, which puts this
-                    port and the account behind it on the network.
+                    by name trusts the proxy and lands on it. --forward records a
+                    client whose endpoint is compiled in: it accepts CONNECT for
+                    the hosts you name, terminates the TLS with a certificate
+                    minted for the run, and needs nothing of the client but
+                    HTTPS_PROXY and SSL_CERT_FILE. Loopback only, in every mode;
+                    docs/proxy.md says what each costs, as does
+                    --expose-to-network, which puts this port and the account
+                    behind it on the network.
 
   feint transcript <recording.jsonl> [--shape OP [--against emu.jsonl]] [--format text|json]
                     Read a proxy recording and answer what to serve next. With no

--- a/internal/cli/proxy.go
+++ b/internal/cli/proxy.go
@@ -40,22 +40,26 @@ func proxyCommand(args []string, _ io.Writer, stderr io.Writer) int {
 	queue := fs.Int("queue", proxy.DefaultQueue, "how many exchanges may wait to be written before one is dropped")
 	expose := fs.Bool("expose-to-network", false, "listen off loopback, which offers this proxy's transcript and this cloud account to the network")
 	intercept := fs.String("intercept", "", "serve HTTPS with a locally-minted certificate for these comma-separated hostnames, so a client redirected to this proxy by name (a container's own /etc/hosts) trusts it and lands here; see docs/limits.md #76")
+	forward := fs.String("forward", "", "be a forward proxy for these comma-separated hostnames: accept CONNECT, terminate the TLS with a locally-minted certificate and record it, so a client whose endpoint is compiled in is recorded through HTTPS_PROXY alone; see docs/proxy.md")
 	if err := fs.Parse(args); err != nil {
 		return exitError
 	}
 
-	if *upstream == "" {
-		fmt.Fprintln(stderr, "feint: --upstream is required: a proxy with nothing to forward to records nothing")
+	if err := checkProxyMode(*upstream, *forward, *intercept); err != nil {
+		fmt.Fprintf(stderr, "feint: %v\n", err)
 		return exitError
 	}
 	if *record == "" {
 		fmt.Fprintln(stderr, "feint: --record is required: pass a path, or - for stdout")
 		return exitError
 	}
-	if err := checkProxyAddr(*addr, *expose); err != nil {
+	if err := checkProxyAddr(*addr, *expose, *forward != ""); err != nil {
 		fmt.Fprintf(stderr, "feint: %v\n", err)
 		return exitError
 	}
+	// Parsed even in forward mode, where it is empty and unused: url.Parse of ""
+	// is a valid empty URL, and the branch that skipped it would be one more
+	// thing to keep in step for nothing.
 	target, err := url.Parse(*upstream)
 	if err != nil {
 		fmt.Fprintf(stderr, "feint: --upstream %q: %v\n", *upstream, err)
@@ -75,34 +79,78 @@ func proxyCommand(args []string, _ io.Writer, stderr io.Writer) int {
 	}
 
 	writer := proxy.NewWriter(out, *queue)
-	p, err := proxy.New(proxy.Options{
-		Upstream: target,
-		Writer:   writer,
-		Table:    table,
-		MaxBody:  *maxBody,
-		Log:      slog.New(slog.NewTextHandler(stderr, nil)),
-	})
-	if err != nil {
-		_ = writer.Close()
-		_ = closeOut()
-		fmt.Fprintf(stderr, "feint: %v\n", err)
-		return exitError
+	logger := slog.New(slog.NewTextHandler(stderr, nil))
+
+	// rec is what listens. The two modes differ in where a request goes and in
+	// nothing else: both record through this writer, by the same capture, under
+	// the same redaction. A forward proxy that had its own recording path would
+	// be a second door to the transcript, which is what proxy.Redacted exists to
+	// make impossible.
+	var (
+		rec       proxyRecorder
+		forwarder *proxy.Forward
+	)
+	if *forward != "" {
+		authority, caPath, removeCA, err := mintTemporaryAuthority()
+		if err != nil {
+			_ = writer.Close()
+			_ = closeOut()
+			fmt.Fprintf(stderr, "feint: %v\n", err)
+			return exitError
+		}
+		// The CA outlives nothing: it is a temporary file removed when this
+		// command returns, whatever the exit path, and it is never installed
+		// anywhere a process could trust it by accident.
+		defer removeCA()
+		forwarder, err = proxy.NewForward(proxy.ForwardOptions{
+			Hosts:     splitHosts(*forward),
+			Writer:    writer,
+			Table:     table,
+			MaxBody:   *maxBody,
+			Log:       logger,
+			Authority: authority,
+		})
+		if err != nil {
+			_ = writer.Close()
+			_ = closeOut()
+			fmt.Fprintf(stderr, "feint: %v\n", err)
+			return exitError
+		}
+		rec = forwarder
+		printForwardRecipe(stderr, splitHosts(*forward), *addr, caPath)
+	} else {
+		p, err := proxy.New(proxy.Options{
+			Upstream: target,
+			Writer:   writer,
+			Table:    table,
+			MaxBody:  *maxBody,
+			Log:      logger,
+		})
+		if err != nil {
+			_ = writer.Close()
+			_ = closeOut()
+			fmt.Fprintf(stderr, "feint: %v\n", err)
+			return exitError
+		}
+		rec = p
 	}
 
 	// Everything this command says goes to stderr, without exception: --record -
 	// puts the transcript on stdout, and a status line landing in the middle of a
 	// JSON Lines stream would break every reader of it.
 	fmt.Fprintf(stderr, "feint proxy listening on %s\n", *addr)
-	fmt.Fprintf(stderr, "  upstream  %s\n", target)
+	if *forward == "" {
+		fmt.Fprintf(stderr, "  upstream  %s\n", target)
+	}
 	fmt.Fprintf(stderr, "  recording %s\n", *record)
 	fmt.Fprintf(stderr, "  naming    %s\n", namingOf(*provider))
-	if *intercept == "" {
+	if *intercept == "" && *forward == "" {
 		fmt.Fprintf(stderr, "  point a client at http://%s and drive it as usual\n", *addr)
 	}
 
 	srv := &http.Server{
 		Addr:    *addr,
-		Handler: p,
+		Handler: rec,
 		// The only timeout set, and the omissions are deliberate: a real cloud
 		// answering a large list is allowed to take its time, and a proxy that
 		// cut the response would be blamed for the cloud's latency. This one
@@ -158,14 +206,27 @@ func proxyCommand(args []string, _ io.Writer, stderr io.Writer) int {
 
 	written, dropped := writer.Stats()
 	fmt.Fprintf(stderr, "\nrecorded %d exchange(s) to %s\n", written, *record)
-	if unnamed := p.Unnamed(); unnamed > 0 {
+	if forwarder != nil {
+		fmt.Fprintf(stderr, "%d tunnel(s) terminated\n", forwarder.Tunnels())
+		if refused, hosts := forwarder.Refused(); refused > 0 {
+			// Named rather than counted alone: every refusal is a call the
+			// client made and this transcript does not carry, and the operator
+			// can only tell "the client tried something else" from "I forgot a
+			// host" by reading which.
+			fmt.Fprintf(stderr,
+				"%d connection(s) were refused because --forward does not name their host: %s\n"+
+					"  the client's own calls to them failed, and none of them is in this transcript.\n",
+				refused, strings.Join(sortedHosts(hosts), ", "))
+		}
+	}
+	if unnamed := rec.Unnamed(); unnamed > 0 {
 		// The product, printed rather than left in the file for someone to grep
 		// for: an exchange no pack claims is a route a real client walks and this
 		// emulator does not serve. That is the list #74 will rank.
 		fmt.Fprintf(stderr, "%d of them walked a route no pack claims: grep '\"operation\":\"\"' or filter on .mounted == false\n",
 			unnamed)
 	}
-	if handed, hosts := p.HandedElsewhere(); handed > 0 {
+	if handed, hosts := rec.HandedElsewhere(); handed > 0 {
 		// The other half of the product, and the one that would otherwise be
 		// invisible: an answer that gave the client a different address. If the
 		// client followed it, everything after this point left no trace here,
@@ -191,7 +252,50 @@ func proxyCommand(args []string, _ io.Writer, stderr io.Writer) int {
 	return exitOK
 }
 
-// checkProxyAddr refuses to offer the proxy to the network unless asked.
+// proxyRecorder is what `feint proxy` mounts: a handler that also answers what
+// its own transcript does not cover.
+//
+// The interface exists so the summary at the end of a run is written once. Both
+// modes produce the same two findings — an exchange no pack names, an answer
+// that handed the client an address — and a second copy of that reporting is a
+// second place for one of them to be forgotten.
+type proxyRecorder interface {
+	http.Handler
+	Unnamed() int64
+	HandedElsewhere() (int64, map[string]int64)
+}
+
+// checkProxyMode refuses an invocation that names two doors, or none.
+//
+// The two doors do opposite things with the address a client asks for.
+// --upstream sends every request to the one host the operator named, whatever
+// the client asked; --forward sends each request to the host the client asked
+// for, which is what a CONNECT names. An invocation carrying both has not said
+// which, and picking one silently is how an operator ends up with a transcript
+// of the wrong endpoint. --intercept is the third: it serves TLS on the
+// listener itself, for a client redirected by name, and that is the same
+// question answered a different way.
+// TestProxyRefusesTwoDoorsAtOnce fails without this, and TestProxyRefusesAnUnusableInvocation
+// drives the same refusals through the command.
+func checkProxyMode(upstream, forward, intercept string) error {
+	switch {
+	case upstream != "" && forward != "":
+		return fmt.Errorf("--upstream and --forward are two different proxies: --upstream sends every " +
+			"request to one host you chose, --forward sends each one to the host the client asked for. " +
+			"Pass one")
+	case forward != "" && intercept != "":
+		return fmt.Errorf("--forward and --intercept are two ways to reach the same interception: " +
+			"--forward accepts CONNECT from a client honouring HTTPS_PROXY, --intercept serves TLS to " +
+			"a client redirected to this proxy by name. Pass one")
+	case upstream == "" && forward == "":
+		return fmt.Errorf("--upstream is required: a proxy with nothing to forward to records nothing " +
+			"(or --forward, to record whichever host the client asks for)")
+	}
+	return nil
+}
+
+// checkProxyAddr refuses to offer the proxy to the network unless asked, and
+// refuses it outright in forward mode.
 //
 // The reason is not serve's. There is no browser guard here and nothing to
 // rebind: what an open port on this proxy offers is a relay to a real cloud and,
@@ -199,11 +303,23 @@ func proxyCommand(args []string, _ io.Writer, stderr io.Writer) int {
 // file. Loopback by default, and an operator who wants otherwise says so in a
 // flag they can be held to.
 //
+// --forward does not get that flag. A forward proxy holds an authority whose
+// certificates a client has been told to trust, so off loopback it is not a
+// relay but a machine that decrypts and files whatever any reachable client
+// sends it — including credentials belonging to someone who never started it.
+// The reverse proxy at least only ever reaches the one upstream its operator
+// named. TestAForwardProxyIsRefusedOffLoopback fails without this.
+//
 // A function rather than a branch inside proxyCommand, for the reason
 // checkListenAddr is one: with the refusal removed, a test that drove the
 // command would find it listening and never return. TestProxyRefusesANonLoopbackAddress
 // fails without this.
-func checkProxyAddr(addr string, expose bool) error {
+func checkProxyAddr(addr string, expose, forward bool) error {
+	if forward && expose {
+		return fmt.Errorf("refusing --expose-to-network with --forward: this proxy mints certificates " +
+			"a client has been told to trust, so off loopback it decrypts and records whatever anyone " +
+			"who can reach the port sends through it. Record on loopback")
+	}
 	if emulator.LoopbackListen(addr) || expose {
 		return nil
 	}
@@ -231,14 +347,8 @@ func setUpInterception(hosts, addr string, stderr io.Writer) (*tls.Config, func(
 	if err != nil {
 		return nil, nil, fmt.Errorf("mint the interception certificate: %w", err)
 	}
-	caFile, err := os.CreateTemp("", "feint-intercept-ca-*.pem")
+	caPath, cleanup, err := publishCA(ic)
 	if err != nil {
-		return nil, nil, fmt.Errorf("create the CA file: %w", err)
-	}
-	caPath := caFile.Name()
-	_ = caFile.Close()
-	if err := ic.WriteCA(caPath); err != nil {
-		_ = os.Remove(caPath)
 		return nil, nil, err
 	}
 
@@ -254,7 +364,64 @@ func setUpInterception(hosts, addr string, stderr io.Writer) (*tls.Config, func(
 		fmt.Fprintf(stderr, "    # resolve %s to this proxy (a container's own /etc/hosts, never yours):\n", n)
 		fmt.Fprintf(stderr, "    #   podman run --add-host=%s:host-gateway ... , proxy reachable on :%s\n", n, port)
 	}
-	return ic.ServerTLSConfig(), func() { _ = os.Remove(caPath) }, nil
+	return ic.ServerTLSConfig(), cleanup, nil
+}
+
+// mintTemporaryAuthority builds the authority a forward proxy signs with, and
+// publishes its CA where the client can be told to trust it.
+//
+// The names are not known here and cannot be: a forward proxy learns them one
+// CONNECT at a time. What is known before the client starts is the CA, which is
+// exactly what SSL_CERT_FILE needs to point at.
+func mintTemporaryAuthority() (*proxy.Interceptor, string, func(), error) {
+	authority, err := proxy.MintAuthority()
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("mint the interception authority: %w", err)
+	}
+	caPath, cleanup, err := publishCA(authority)
+	if err != nil {
+		return nil, "", nil, err
+	}
+	return authority, caPath, cleanup, nil
+}
+
+// publishCA writes an interception CA to a temporary file, and returns how to
+// remove it.
+//
+// A temporary file and never the system trust store, which is the whole safety
+// argument: the certificates this run mints are trusted by the one process the
+// operator points at this file, for as long as the command runs, and by nothing
+// else afterwards. TestTheInterceptionCAIsTemporaryAndNeverInstalled fails if
+// this writes anywhere durable.
+func publishCA(ic *proxy.Interceptor) (string, func(), error) {
+	caFile, err := os.CreateTemp("", "feint-intercept-ca-*.pem")
+	if err != nil {
+		return "", nil, fmt.Errorf("create the CA file: %w", err)
+	}
+	caPath := caFile.Name()
+	_ = caFile.Close()
+	if err := ic.WriteCA(caPath); err != nil {
+		_ = os.Remove(caPath)
+		return "", nil, err
+	}
+	return caPath, func() { _ = os.Remove(caPath) }, nil
+}
+
+// printForwardRecipe says what to export so a client with a compiled-in endpoint
+// lands here.
+//
+// Two variables and nothing else — no /etc/hosts, no system trust store, no
+// change in the client — which is what makes this door the cheap one. The
+// warning is part of the recipe: what this records is decrypted, so it is said
+// where the operator is about to run the command rather than only in the docs.
+func printForwardRecipe(stderr io.Writer, names []string, addr, caPath string) {
+	fmt.Fprintf(stderr, "  forwarding for %s\n", strings.Join(names, ", "))
+	fmt.Fprintf(stderr, "  CA written to %s (a temporary file, removed on exit)\n", caPath)
+	fmt.Fprintln(stderr, "  drive a client whose endpoint is compiled in with:")
+	fmt.Fprintf(stderr, "    export HTTPS_PROXY=http://%s\n", addr)
+	fmt.Fprintf(stderr, "    export SSL_CERT_FILE=%s\n", caPath)
+	fmt.Fprintln(stderr, "  every exchange with those hosts is decrypted and written to the transcript;")
+	fmt.Fprintln(stderr, "  a CONNECT to any other host is refused, and reported at exit.")
 }
 
 // splitHosts turns the comma list --intercept takes into trimmed, non-empty

--- a/internal/cli/proxy_test.go
+++ b/internal/cli/proxy_test.go
@@ -2,8 +2,12 @@ package cli
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stephrobert/feint/internal/proxy"
 )
 
 // The proxy refuses to listen off loopback unless asked.
@@ -17,7 +21,7 @@ import (
 // that ran the command would find it listening, and never return.
 func TestProxyRefusesANonLoopbackAddress(t *testing.T) {
 	for _, addr := range []string{"0.0.0.0:4600", ":4600", "[::]:4600", "192.168.1.10:4600"} {
-		err := checkProxyAddr(addr, false)
+		err := checkProxyAddr(addr, false, false)
 		if err == nil {
 			t.Errorf("%s was accepted", addr)
 			continue
@@ -31,12 +35,89 @@ func TestProxyRefusesANonLoopbackAddress(t *testing.T) {
 
 	// The accepting half.
 	for _, addr := range []string{"127.0.0.1:4600", "localhost:4600", "[::1]:4600"} {
-		if err := checkProxyAddr(addr, false); err != nil {
+		if err := checkProxyAddr(addr, false, false); err != nil {
 			t.Errorf("the loopback address %s was refused: %v", addr, err)
 		}
 	}
-	if err := checkProxyAddr("0.0.0.0:4600", true); err != nil {
+	if err := checkProxyAddr("0.0.0.0:4600", true, false); err != nil {
 		t.Errorf("--expose-to-network did not lift the refusal: %v", err)
+	}
+}
+
+// A forward proxy is refused off loopback, and --expose-to-network does not lift
+// it.
+//
+// The escape hatch the reverse proxy has cannot be given to this one. A forward
+// proxy holds an authority whose leaves a client has been told to trust, so a
+// port open to the network is a machine that decrypts and files whatever anyone
+// who can reach it sends — a credential-harvesting service, started by a flag.
+// The reverse proxy off loopback is a relay to the one upstream its operator
+// named, which is bad and bounded; this is neither.
+//
+// Both halves are asserted, because a refusal that also refused the legitimate
+// case would pass the first half alone and make the mode unusable.
+func TestAForwardProxyIsRefusedOffLoopback(t *testing.T) {
+	for _, addr := range []string{"0.0.0.0:4600", "192.168.1.10:4600", "127.0.0.1:4600"} {
+		err := checkProxyAddr(addr, true, true)
+		if err == nil {
+			t.Errorf("--forward --expose-to-network on %s was accepted", addr)
+			continue
+		}
+		for _, want := range []string{"--forward", "loopback"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("the refusal for %s does not mention %q: %v", addr, want, err)
+			}
+		}
+	}
+	// Off loopback without the flag is refused too, by the general guard.
+	if err := checkProxyAddr("0.0.0.0:4600", false, true); err == nil {
+		t.Error("a forward proxy on 0.0.0.0 without --expose-to-network was accepted")
+	}
+	// And the mode itself still works where it belongs.
+	if err := checkProxyAddr("127.0.0.1:4600", false, true); err != nil {
+		t.Errorf("a forward proxy on loopback was refused: %v", err)
+	}
+}
+
+// The two doors are not passed together, and one of them is passed.
+//
+// --upstream sends every request to a host the operator chose; --forward sends
+// each one where the client asked. An invocation carrying both has not said
+// which, and a proxy that picked one silently would record the wrong endpoint
+// while looking like it worked.
+func TestProxyRefusesTwoDoorsAtOnce(t *testing.T) {
+	for name, tc := range map[string]struct {
+		upstream, forward, intercept string
+		want                         string
+	}{
+		"upstream and forward":  {"https://api.scaleway.com", "api.scaleway.com", "", "--forward"},
+		"forward and intercept": {"", "api.scaleway.com", "api.scaleway.com", "--intercept"},
+		"neither":               {"", "", "", "--upstream"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := checkProxyMode(tc.upstream, tc.forward, tc.intercept)
+			if err == nil {
+				t.Fatal("accepted")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("the refusal does not mention %q: %v", tc.want, err)
+			}
+		})
+	}
+
+	// The accepting half, one line per door, so a guard that refused everything
+	// would fail here.
+	for name, tc := range map[string]struct{ upstream, forward, intercept string }{
+		"upstream alone":             {"https://api.scaleway.com", "", ""},
+		"forward alone":              {"", "api.scaleway.com", ""},
+		"upstream with intercept":    {"https://api.scaleway.com", "", "api.scaleway.com"},
+		"forward with two hostnames": {"", "api.scaleway.com,*.exoscale.com", ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := checkProxyMode(tc.upstream, tc.forward, tc.intercept); err != nil {
+				t.Errorf("refused: %v", err)
+			}
+		})
 	}
 }
 
@@ -57,6 +138,22 @@ func TestProxyRefusesAnUnusableInvocation(t *testing.T) {
 		"exposed address": {[]string{
 			"--upstream", "https://api.scaleway.com", "--record", "-", "--addr", "0.0.0.0:4600",
 		}, "--expose-to-network"},
+		// The CONNECT door gets no bypass of its own: the same three refusals
+		// apply to it, and the exposure one applies harder.
+		"forward with no record": {[]string{"--forward", "api.scaleway.com"}, "--record"},
+		"forward off loopback": {[]string{
+			"--forward", "api.scaleway.com", "--record", "-", "--addr", "0.0.0.0:4600",
+		}, "--expose-to-network"},
+		"forward exposed on purpose": {[]string{
+			"--forward", "api.scaleway.com", "--record", "-", "--addr", "0.0.0.0:4600", "--expose-to-network",
+		}, "loopback"},
+		"forward and upstream": {[]string{
+			"--forward", "api.scaleway.com", "--upstream", "https://api.scaleway.com", "--record", "-",
+		}, "--forward"},
+		"forward for nothing": {[]string{"--forward", " , ", "--record", "-"}, "no host to forward for"},
+		"forward for everything": {[]string{
+			"--forward", "*", "--record", "-", "--addr", "127.0.0.1:0",
+		}, "every host"},
 	} {
 		t.Run(name, func(t *testing.T) {
 			var stdout, stderr bytes.Buffer
@@ -100,5 +197,58 @@ func TestProxyNamesOperationsFromThePacksThemselves(t *testing.T) {
 		if m.Provider != "scaleway" {
 			t.Errorf("--provider scaleway kept %s, owned by %s", pattern, m.Provider)
 		}
+	}
+}
+
+// The authority a recording run mints lives in a temporary file and nowhere
+// else.
+//
+// This is #336's third security requirement, and the one that would be cheapest
+// to get wrong: an interception CA installed into the system trust store
+// outlives the run, and every process on the station then trusts certificates
+// this proxy can mint for any name it is pointed at. So the file is temporary,
+// it is removed when the command returns, and it is never one of the
+// directories a distribution reads its roots from.
+//
+// The subject is asserted present before anything is asserted about it: a
+// publishCA that wrote nothing at all would satisfy "not in the trust store"
+// trivially, and that is the shape of green this repository has learned to
+// distrust.
+func TestTheInterceptionCAIsTemporaryAndNeverInstalled(t *testing.T) {
+	authority, err := proxy.MintAuthority()
+	if err != nil {
+		t.Fatalf("mint the authority: %v", err)
+	}
+	path, cleanup, err := publishCA(authority)
+	if err != nil {
+		t.Fatalf("publish the CA: %v", err)
+	}
+
+	published, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("the published CA is not readable at %s: %v", path, err)
+	}
+	if !bytes.Contains(published, []byte("BEGIN CERTIFICATE")) {
+		t.Fatalf("%s holds no certificate, so this test would pass on an empty file", path)
+	}
+
+	// Temporary, which is what makes it disposable.
+	if dir := filepath.Dir(path); dir != filepath.Clean(os.TempDir()) {
+		t.Errorf("the CA was written to %s, outside the temporary directory (%s): an interception "+
+			"authority that lands somewhere durable outlives the run that needed it", dir, os.TempDir())
+	}
+	// And never where a distribution reads its roots from.
+	for _, store := range []string{
+		"/etc/ssl/certs", "/usr/local/share/ca-certificates", "/usr/share/ca-certificates",
+		"/etc/pki/ca-trust", "/etc/ca-certificates",
+	} {
+		if strings.HasPrefix(path, store) {
+			t.Errorf("the CA was written into the system trust store at %s", path)
+		}
+	}
+
+	cleanup()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("%s survived the run: the CA must go when the command that minted it returns", path)
 	}
 }

--- a/internal/cli/testdata/frozen/cli.json
+++ b/internal/cli/testdata/frozen/cli.json
@@ -542,18 +542,8 @@
           ],
           "docs": [
             "--check",
-            "--client-pins",
-            "--confidence",
-            "--contracts",
             "--coverage",
-            "--file",
-            "--install",
-            "--limits",
-            "--proved",
-            "--routes",
-            "--screenshots",
-            "--ui-manifest",
-            "--workflow"
+            "--file"
           ],
           "doctor": [
             "--addr",
@@ -566,13 +556,10 @@
             "--unset"
           ],
           "evidence": [
-            "--allow-narrowing",
-            "--contracts",
             "--endpoint",
             "--join",
             "--out",
-            "--shapes",
-            "--suites"
+            "--shapes"
           ],
           "images": [
             "--check",
@@ -591,8 +578,7 @@
           ],
           "proxy": [
             "--addr",
-            "--expose-to-network",
-            "--intercept",
+            "--forward",
             "--max-body",
             "--provider",
             "--queue",
@@ -608,9 +594,7 @@
             "--cleanup",
             "--contracts",
             "--coverage",
-            "--expose-to-network",
             "--log-level",
-            "--shapes",
             "--state",
             "--vm"
           ],
@@ -622,26 +606,16 @@
             "--provider",
             "--record"
           ],
-          "snapshot list": [
-            "--format"
-          ],
-          "snapshot load": [
-            "--addr"
-          ],
-          "snapshot save": [
+          "snapshot": [
             "--addr",
-            "--force"
+            "--force",
+            "--format",
+            "--state"
           ],
           "start": [
-            "--addr",
-            "--cleanup",
-            "--contracts",
             "--detach",
             "--foreground",
-            "--log-level",
-            "--state",
-            "--timeout",
-            "--vm"
+            "--timeout"
           ],
           "status": [
             "--addr",
@@ -662,7 +636,8 @@
             "--print"
           ],
           "version": [
-            "--check"
+            "--version",
+            "-v"
           ],
           "wait": [
             "--addr",

--- a/internal/cli/testdata/frozen/cli.json
+++ b/internal/cli/testdata/frozen/cli.json
@@ -645,6 +645,164 @@
           ]
         }
       }
+    },
+    {
+      "schema_version": 6,
+      "content": {
+        "exit_codes": {
+          "drift": 2,
+          "error": 1,
+          "ok": 0
+        },
+        "verbs": {
+          "catalog": [
+            "--format"
+          ],
+          "clean": [
+            "--vm"
+          ],
+          "coverage": [
+            "--artefact",
+            "--baseline",
+            "--contract",
+            "--fail-on-unknown",
+            "--format",
+            "--products",
+            "--provider",
+            "--sdk",
+            "--write-baseline"
+          ],
+          "docs": [
+            "--check",
+            "--client-pins",
+            "--confidence",
+            "--contracts",
+            "--coverage",
+            "--file",
+            "--install",
+            "--limits",
+            "--proved",
+            "--routes",
+            "--screenshots",
+            "--ui-manifest",
+            "--workflow"
+          ],
+          "doctor": [
+            "--addr",
+            "--vm"
+          ],
+          "env": [
+            "--client",
+            "--endpoint",
+            "--shell",
+            "--unset"
+          ],
+          "evidence": [
+            "--allow-narrowing",
+            "--contracts",
+            "--endpoint",
+            "--join",
+            "--out",
+            "--shapes",
+            "--suites"
+          ],
+          "images": [
+            "--check",
+            "--only",
+            "--vm"
+          ],
+          "logs": [
+            "--addr",
+            "-f",
+            "-n"
+          ],
+          "probe": [
+            "--contracts",
+            "--endpoint",
+            "--provider"
+          ],
+          "proxy": [
+            "--addr",
+            "--expose-to-network",
+            "--forward",
+            "--intercept",
+            "--max-body",
+            "--provider",
+            "--queue",
+            "--record",
+            "--upstream"
+          ],
+          "restart": [
+            "--addr",
+            "--timeout"
+          ],
+          "serve": [
+            "--addr",
+            "--cleanup",
+            "--contracts",
+            "--coverage",
+            "--expose-to-network",
+            "--log-level",
+            "--shapes",
+            "--state",
+            "--vm"
+          ],
+          "shapes": [
+            "--check",
+            "--dir",
+            "--dry-run",
+            "--profile",
+            "--provider",
+            "--record"
+          ],
+          "snapshot list": [
+            "--format"
+          ],
+          "snapshot load": [
+            "--addr"
+          ],
+          "snapshot save": [
+            "--addr",
+            "--force"
+          ],
+          "start": [
+            "--addr",
+            "--cleanup",
+            "--contracts",
+            "--detach",
+            "--foreground",
+            "--log-level",
+            "--state",
+            "--timeout",
+            "--vm"
+          ],
+          "status": [
+            "--addr",
+            "--coverage",
+            "--format"
+          ],
+          "stop": [
+            "--addr",
+            "--timeout"
+          ],
+          "transcript": [
+            "--against",
+            "--format",
+            "--shape"
+          ],
+          "ui": [
+            "--addr",
+            "--print"
+          ],
+          "version": [
+            "--check"
+          ],
+          "wait": [
+            "--addr",
+            "--timeout"
+          ]
+        }
+      }
     }
   ]
 }

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -1,0 +1,427 @@
+package proxy
+
+// The other door into the same recorder (#336).
+//
+// [Proxy] records a client that can be pointed at it: SCW_API_URL, an endpoint
+// in a configuration file, a `--s3-endpoint`. A client whose endpoint is
+// compiled in reads none of those. Pépin's collectors are that client — their
+// base URLs are `https://api.scaleway.com`, `https://api-{zone}.exoscale.com/v2`
+// and `https://api.{region}.{host}/api/v1`, and making them configurable was
+// refused on its own delivery audit: every collection request carries a live
+// secret key, and an endpoint anybody can redirect is a way to send a tenant's
+// credentials to a host of their choosing. The redirect belongs outside the tool
+// being measured, which is here.
+//
+// One property makes it cheap: a Go client that installs no Transport inherits
+// http.DefaultTransport, and http.DefaultTransport honours HTTPS_PROXY. So it
+// already emits
+//
+//	CONNECT api.scaleway.com:443 HTTP/1.1
+//
+// with nothing changed in its code. This file accepts that, terminates the TLS
+// with the run's own authority (see [MintAuthority]), and hands each decrypted
+// request to the same [Proxy] that records everything else — same capture, same
+// [Redacted], same writer. TestASecretHeaderIsStillRedactedThroughCONNECT is
+// what holds that "same": a recorder with its own certificate authority is a
+// credential-harvesting tool the moment a second path to the writer forgets to
+// redact.
+//
+// What it is not: a general-purpose MITM. It intercepts the hosts the operator
+// named and refuses every other CONNECT out loud, because the alternative — a
+// tunnel relayed blind — writes a transcript that silently misses exchanges,
+// which is the exact defect handoff.go exists to report.
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+)
+
+// tunnelHandshakeTimeout bounds the TLS handshake of one accepted tunnel.
+//
+// A connection that opened a tunnel and then says nothing holds a goroutine and
+// a file descriptor for as long as it likes; ten seconds is far more than a
+// local handshake needs and far less than a night.
+const tunnelHandshakeTimeout = 10 * time.Second
+
+// ForwardOptions configures a [Forward].
+type ForwardOptions struct {
+	// Hosts are the names this proxy may intercept, exactly as they appear in a
+	// CONNECT line. A single-level wildcard is accepted (`*.exoscale.com`),
+	// which is what a per-zone endpoint needs. Required: a forward proxy that
+	// intercepts whatever it is handed decrypts more of the operator's traffic
+	// than the measurement asked for.
+	Hosts []string
+	// Writer receives every exchange. Required, for [New]'s reason.
+	Writer *Writer
+	// Table names the operation an exchange addressed. Optional.
+	Table *emulator.Table
+	// MaxBody caps the recorded part of one body. Zero takes DefaultMaxBody.
+	MaxBody int
+	// Log is where a refused tunnel and a failed handshake are reported. Never
+	// nil after NewForward.
+	Log *slog.Logger
+	// Authority mints the leaf each tunnel presents. Optional: nil mints a fresh
+	// one. A caller that has to publish the CA before the proxy starts — the
+	// command does, since the client needs SSL_CERT_FILE in its environment —
+	// mints it first and passes it here.
+	Authority *Interceptor
+	// Transport carries the re-originated request. See [Options.Transport].
+	Transport http.RoundTripper
+}
+
+// Forward records a client that was never told where to connect.
+//
+// It accepts `CONNECT host:port`, terminates the TLS itself, and re-originates
+// to the host the client asked for. Everything it decrypts goes through the
+// recorder it wraps, so a transcript from this door is the same shape, redacted
+// by the same rules, as one from [Proxy].
+//
+// What it does not cover, said here rather than left to be discovered: a tunnel
+// is a hijacked connection, and http.Server.Shutdown neither closes nor waits
+// for one. An exchange still in flight when the operator interrupts the command
+// can therefore reach the writer after it closed, where it is counted as a drop.
+// The honest end of a recording session is the client finishing first.
+type Forward struct {
+	rec       *Proxy
+	authority *Interceptor
+	hosts     []string
+	log       *slog.Logger
+
+	tunnels atomic.Int64
+	// refused counts and names the CONNECTs this proxy would not intercept. It
+	// is reported rather than silently dropped: a client that could not reach a
+	// host is about to fail, and the operator needs to read why here rather than
+	// guess from the client's own error.
+	refused refusals
+}
+
+// NewForward validates the options and builds the forward proxy.
+func NewForward(o ForwardOptions) (*Forward, error) {
+	hosts, err := hostPatterns(o.Hosts)
+	if err != nil {
+		return nil, err
+	}
+	if o.Log == nil {
+		o.Log = slog.Default()
+	}
+	authority := o.Authority
+	if authority == nil {
+		if authority, err = MintAuthority(); err != nil {
+			return nil, err
+		}
+	}
+	rec, err := newProxy(Options{
+		Writer:    o.Writer,
+		Table:     o.Table,
+		MaxBody:   o.MaxBody,
+		Log:       o.Log,
+		Transport: o.Transport,
+	}, true)
+	if err != nil {
+		return nil, err
+	}
+	return &Forward{rec: rec, authority: authority, hosts: hosts, log: o.Log}, nil
+}
+
+// hostPatterns trims the names a forward proxy may intercept, and refuses a set
+// that would intercept nothing or everything.
+//
+// `*` alone is refused rather than read as "all": the flag would then be one
+// character away from decrypting every TLS connection the client makes, which is
+// the difference between a recorder and a wiretap.
+// TestAForwardProxyRefusesAnUnusableHostSet fails without this.
+func hostPatterns(hosts []string) ([]string, error) {
+	var out []string
+	for _, h := range hosts {
+		h = strings.TrimSpace(h)
+		if h == "" {
+			continue
+		}
+		if h == "*" || strings.HasPrefix(h, "*.*") {
+			return nil, fmt.Errorf("--forward %q would intercept every host a client reaches: name the hosts to record", h)
+		}
+		out = append(out, h)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no host to forward for: a forward proxy that intercepts nothing records nothing")
+	}
+	return out, nil
+}
+
+// ServeHTTP answers the three shapes a forward proxy is addressed in.
+func (f *Forward) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodConnect {
+		f.tunnel(w, r)
+		return
+	}
+	if r.URL.IsAbs() {
+		// The plain-HTTP form, which HTTP_PROXY produces: the request already
+		// names its destination and there is nothing to decrypt. Recorded by the
+		// same path as everything else, and refused for a host nobody named for
+		// the same reason a tunnel is.
+		if !f.intercepts(r.URL.Hostname()) {
+			f.refuse(w, r.URL.Hostname())
+			return
+		}
+		f.rec.ServeHTTP(w, r)
+		return
+	}
+	// Origin-form on the forward port: a client that was pointed here as if this
+	// were the cloud itself. Answered rather than forwarded blindly, because the
+	// alternative is a 502 that reads like the cloud being down.
+	http.Error(w, "feint proxy: this is a forward proxy (--forward); set HTTPS_PROXY to it, "+
+		"or use --upstream to point a client at it directly\n", http.StatusBadRequest)
+}
+
+// tunnel terminates one CONNECT and records what it carries.
+func (f *Forward) tunnel(w http.ResponseWriter, r *http.Request) {
+	host, port := splitTarget(r.Host)
+	if !f.intercepts(host) {
+		f.refuse(w, host)
+		return
+	}
+	cfg, err := f.authority.TLSFor(host)
+	if err != nil {
+		f.log.Error("no certificate for the tunnel", "host", host, "error", err)
+		http.Error(w, "feint proxy: could not mint a certificate for this host\n", http.StatusInternalServerError)
+		return
+	}
+
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		// Unreachable through net/http's own server, which always hijacks; a
+		// wrapper that does not is a configuration mistake and says so rather
+		// than hanging.
+		http.Error(w, "feint proxy: this server cannot open a tunnel\n", http.StatusInternalServerError)
+		return
+	}
+	conn, buffered, err := hijacker.Hijack()
+	if err != nil {
+		f.log.Error("hijack the tunnel", "host", host, "error", err)
+		return
+	}
+	if _, err := conn.Write([]byte("HTTP/1.1 200 Connection established\r\n\r\n")); err != nil {
+		f.log.Error("acknowledge the tunnel", "host", host, "error", err)
+		_ = conn.Close()
+		return
+	}
+	f.tunnels.Add(1)
+
+	// Whatever the client pipelined behind its CONNECT is already in the
+	// buffer, and a client that sends its ClientHello without waiting for the
+	// 200 is within its rights. Dropping those bytes would fail the handshake
+	// with an error naming the certificate, which is the wrong cause.
+	f.serve(&prefixed{Conn: conn, first: buffered}, cfg, &url.URL{
+		Scheme: "https",
+		Host:   net.JoinHostPort(host, port),
+	})
+}
+
+// serve terminates the TLS of one tunnel and records the requests inside it.
+func (f *Forward) serve(conn net.Conn, cfg *tls.Config, dest *url.URL) {
+	tlsConn := tls.Server(conn, cfg)
+	if err := tlsConn.SetDeadline(time.Now().Add(tunnelHandshakeTimeout)); err != nil {
+		f.log.Error("bound the handshake", "host", dest.Host, "error", err)
+		_ = tlsConn.Close()
+		return
+	}
+	if err := tlsConn.Handshake(); err != nil {
+		// The ordinary cause is a client that does not trust the run's CA, and
+		// it is worth a line: from the client's side it reads as the cloud
+		// presenting a bad certificate, with nothing pointing here.
+		f.log.Error("the client did not complete the tunnel handshake",
+			"host", dest.Host, "error", err,
+			"hint", "point the client's SSL_CERT_FILE at this run's CA")
+		_ = tlsConn.Close()
+		return
+	}
+	if err := tlsConn.SetDeadline(time.Time{}); err != nil {
+		f.log.Error("release the handshake deadline", "host", dest.Host, "error", err)
+		_ = tlsConn.Close()
+		return
+	}
+
+	listener := &oneConnListener{conn: tlsConn, done: make(chan struct{})}
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Promoted to the absolute form the recorder forwards on. The Host
+			// header the client sent is left alone: it is part of the exchange
+			// being measured, and a proxy that rewrote it would be recording its
+			// own edit. What the request is *sent* to stays the address the
+			// CONNECT named and this proxy admitted.
+			r.URL.Scheme = dest.Scheme
+			r.URL.Host = dest.Host
+			f.rec.ServeHTTP(w, r)
+		}),
+		// The tunnel's own bound, for the reason the command sets one on the
+		// listener: a connection that opens a request and stops holds a
+		// goroutine, and no cloud needs thirty seconds to send its headers.
+		ReadHeaderTimeout: 30 * time.Second,
+	}
+	_ = srv.Serve(listener)
+}
+
+// intercepts reports whether this proxy may terminate a tunnel to host.
+//
+// Case-insensitive and trailing-dot-insensitive, because a client is free to
+// send either; a single-level wildcard matches one label, exactly as a
+// certificate's does, so `*.exoscale.com` covers `api-ch-gva-2.exoscale.com` and
+// never `a.b.exoscale.com`.
+func (f *Forward) intercepts(host string) bool {
+	want := strings.ToLower(strings.TrimSuffix(host, "."))
+	if want == "" {
+		return false
+	}
+	for _, pattern := range f.hosts {
+		p := strings.ToLower(pattern)
+		if p == want {
+			return true
+		}
+		suffix, isWildcard := strings.CutPrefix(p, "*")
+		if !isWildcard || !strings.HasPrefix(suffix, ".") {
+			continue
+		}
+		label, found := strings.CutSuffix(want, suffix)
+		if found && label != "" && !strings.Contains(label, ".") {
+			return true
+		}
+	}
+	return false
+}
+
+// refuse answers a CONNECT for a host nobody named.
+//
+// Loud, and never a blind relay. A tunnel passed through unopened would let the
+// client finish its session while the transcript quietly missed every exchange
+// in it — the failure handoff.go was written to report, reintroduced at another
+// door. TestAHostNobodyNamedIsNotIntercepted fails without this.
+func (f *Forward) refuse(w http.ResponseWriter, host string) {
+	f.refused.note(host)
+	f.log.Warn("refused to intercept a host --forward does not name",
+		"host", host, "forwarding", strings.Join(f.hosts, ", "))
+	http.Error(w, "feint proxy: this proxy intercepts only the hosts --forward names\n", http.StatusForbidden)
+}
+
+// Unnamed is how many exchanges walked a route no pack claims.
+func (f *Forward) Unnamed() int64 { return f.rec.Unnamed() }
+
+// HandedElsewhere is how many responses gave the client an address other than
+// the host it was addressing.
+//
+// It reads better from here than from the reverse proxy: through a tunnel the
+// client addresses the cloud's own name, so a republished endpoint is compared
+// against what the client believes it is talking to.
+func (f *Forward) HandedElsewhere() (int64, map[string]int64) { return f.rec.HandedElsewhere() }
+
+// Tunnels is how many CONNECTs this proxy terminated.
+func (f *Forward) Tunnels() int64 { return f.tunnels.Load() }
+
+// Refused is how many CONNECTs it turned down, and for which hosts. Every one of
+// them is a call the client made and this transcript does not carry.
+func (f *Forward) Refused() (int64, map[string]int64) { return f.refused.seen() }
+
+// splitTarget reads the authority a CONNECT line names.
+//
+// A CONNECT without a port is malformed, but a client sending one means 443 and
+// answering it with a refusal would blame the wrong side.
+func splitTarget(target string) (host, port string) {
+	host, port, err := net.SplitHostPort(target)
+	if err != nil {
+		return strings.Trim(target, "[]"), "443"
+	}
+	return host, port
+}
+
+// refusals counts what was not intercepted, and names the hosts.
+type refusals struct {
+	mu    sync.Mutex
+	count int64
+	hosts map[string]int64
+}
+
+func (r *refusals) note(host string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.count++
+	if r.hosts == nil {
+		r.hosts = map[string]int64{}
+	}
+	r.hosts[host]++
+}
+
+func (r *refusals) seen() (int64, map[string]int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make(map[string]int64, len(r.hosts))
+	for host, n := range r.hosts {
+		out[host] = n
+	}
+	return r.count, out
+}
+
+// prefixed is a hijacked connection that still owes its buffered bytes.
+//
+// net/http hands back whatever it had already read past the CONNECT line, and
+// on a client that does not wait for the 200 those bytes are the first record of
+// the TLS handshake. Reading the socket directly would lose them.
+// The reader is the one net/http returned rather than a MultiReader assembled
+// here: it is a bufio.Reader over this same connection, so it answers what was
+// buffered first and the socket afterwards, in order, with nothing to get wrong.
+type prefixed struct {
+	net.Conn
+	first io.Reader
+}
+
+func (p *prefixed) Read(b []byte) (int, error) { return p.first.Read(b) }
+
+// oneConnListener hands an already-accepted connection to an http.Server, and
+// reports the listener closed once that connection is.
+//
+// The alternative — reading requests off the tunnel by hand with
+// http.ReadRequest — reimplements keep-alive, chunked bodies, 100-continue and
+// the half-dozen other things net/http already knows, on the one code path where
+// being wrong means a transcript that quietly disagrees with the wire.
+type oneConnListener struct {
+	conn net.Conn
+	once sync.Once
+	done chan struct{}
+}
+
+func (l *oneConnListener) Accept() (net.Conn, error) {
+	var handed net.Conn
+	l.once.Do(func() { handed = &closes{Conn: l.conn, done: l.done} })
+	if handed != nil {
+		return handed, nil
+	}
+	// Blocks until the served connection is closed, at which point Serve returns
+	// and the tunnel's goroutine ends. Returning an error straight away would
+	// have the server tear down a connection it is still serving.
+	<-l.done
+	return nil, net.ErrClosed
+}
+
+func (l *oneConnListener) Close() error   { return nil }
+func (l *oneConnListener) Addr() net.Addr { return l.conn.LocalAddr() }
+
+// closes signals the listener when the served connection ends.
+type closes struct {
+	net.Conn
+	once sync.Once
+	done chan struct{}
+}
+
+func (c *closes) Close() error {
+	c.once.Do(func() { close(c.done) })
+	return c.Conn.Close()
+}

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -1,0 +1,645 @@
+package proxy_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/proxy"
+	"github.com/stephrobert/feint/internal/trace"
+)
+
+// compiledInEndpoint stands for Pépin's own `https://api.scaleway.com`: an
+// endpoint a collector carries in its source and no environment can move.
+//
+// A reserved TLD (RFC 6761) rather than the real name, on purpose. The stand-in
+// cloud below is reached by a transport that maps this one address and refuses
+// every other, so a mapping that stopped applying fails here instead of reaching
+// a real, billed account — which is the difference between a test that is
+// offline and a test that is offline as long as nothing breaks.
+const compiledInEndpoint = "https://api.scaleway.test"
+
+const compiledInHost = "api.scaleway.test"
+
+// The markers, one per carrier the recorder can see through a tunnel.
+//
+// consumerMarker is the one that matters most. `X-Consumer` matches none of the
+// eight name patterns in carriers, and a denylist wrote it out in full while
+// redacting an X-Auth-Token holding the very same value (measured 2026-08-10,
+// see redact.go). It is here so that "the redaction survives interception" is
+// answered by the rule that actually holds — the allowlist — and not by a name
+// that happens to look like a secret.
+const (
+	tokenMarker    = "MARKER-connect-x-auth-token"
+	consumerMarker = "MARKER-connect-x-consumer"
+	bodyMarker     = "MARKER-connect-body-secret"
+	queryMarker    = "MARKER-connect-query-signature"
+)
+
+// cloud is a local HTTPS server standing in for a real one, plus the transport
+// that reaches it.
+//
+// The handler is where a test asserts what the cloud received: a recorder that
+// broke the request on its way out would otherwise pass a redaction check by
+// destroying the very exchange it is supposed to be measuring.
+type cloud struct {
+	server    *httptest.Server
+	transport *http.Transport
+}
+
+// quietLog keeps a refused tunnel out of the test output. The refusal itself is
+// asserted through Refused(), which is the counter an operator reads.
+func quietLog() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// stubCloud starts an HTTPS server answering as host, and returns the transport
+// that reaches it under that name.
+//
+// The transport refuses any address but the one it maps. That refusal is the
+// test's own guard rail: without it, a proxy that re-originated to the wrong
+// place would quietly resolve a real hostname on the operator's network.
+func stubCloud(t *testing.T, host string, handler http.HandlerFunc) *cloud {
+	t.Helper()
+
+	cert, err := proxy.MintInterceptor(host)
+	if err != nil {
+		t.Fatalf("mint the stand-in cloud's certificate: %v", err)
+	}
+	c := &cloud{}
+	server := httptest.NewUnstartedServer(handler)
+	server.TLS = cert.ServerTLSConfig()
+	server.StartTLS()
+	t.Cleanup(server.Close)
+
+	c.server = server
+	c.transport = &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			if addr != net.JoinHostPort(host, "443") {
+				return nil, fmt.Errorf("this test reaches %s and nothing else, refusing %s", host, addr)
+			}
+			return (&net.Dialer{}).DialContext(ctx, network, server.Listener.Addr().String())
+		},
+		TLSClientConfig: &tls.Config{RootCAs: cert.CAPool(), MinVersion: tls.VersionTLS12},
+	}
+	return c
+}
+
+// forwarding starts a forward proxy in front of a stand-in cloud, and returns
+// its address, its authority and a function that shuts it down and reads the
+// transcript back.
+func forwarding(t *testing.T, c *cloud, hosts ...string) (addr string, authority *proxy.Interceptor, finish func() []trace.Exchange) {
+	t.Helper()
+
+	authority, err := proxy.MintAuthority()
+	if err != nil {
+		t.Fatalf("mint the authority: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "run.jsonl")
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatalf("open the transcript: %v", err)
+	}
+	writer := proxy.NewWriter(file, 0)
+
+	f, err := proxy.NewForward(proxy.ForwardOptions{
+		Hosts:     hosts,
+		Writer:    writer,
+		Authority: authority,
+		Transport: c.transport,
+	})
+	if err != nil {
+		t.Fatalf("build the forward proxy: %v", err)
+	}
+	front := httptest.NewServer(f)
+
+	return front.Listener.Addr().String(), authority, func() []trace.Exchange {
+		front.Close()
+		if err := writer.Close(); err != nil {
+			t.Fatalf("close the writer: %v", err)
+		}
+		if err := file.Close(); err != nil {
+			t.Fatalf("close the transcript: %v", err)
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read the transcript: %v", err)
+		}
+		return read(t, raw)
+	}
+}
+
+// through builds a client that reaches the cloud only by way of the proxy, and
+// trusts the proxy's authority the way SSL_CERT_FILE makes a separate process
+// trust it.
+func through(t *testing.T, proxyAddr string, authority *proxy.Interceptor) *http.Client {
+	t.Helper()
+	target, err := url.Parse("http://" + proxyAddr)
+	if err != nil {
+		t.Fatalf("parse the proxy address: %v", err)
+	}
+	return &http.Client{Transport: &http.Transport{
+		Proxy:           http.ProxyURL(target),
+		TLSClientConfig: &tls.Config{RootCAs: authority.CAPool(), MinVersion: tls.VersionTLS12},
+	}}
+}
+
+// TestASecretHeaderIsStillRedactedThroughCONNECT is the requirement #336 puts
+// first, and the one a falsification is pointed at.
+//
+// An intercepting proxy holding its own certificate authority is a
+// credential-harvesting tool by construction: it decrypts, and it writes down.
+// The only thing between that and a file full of live tenant keys is that the
+// CONNECT path records through the same [proxy.Redacted] as everything else.
+// This drives a real TLS session through a real tunnel and asserts both ends of
+// it — the cloud received every marker verbatim, the transcript carries none of
+// them, and the header names are all still there to read.
+//
+// Remove the redactExchange call in capture and this goes red. That is the
+// condition for "the redaction survives interception" counting as a control
+// rather than as a sentence in a design note.
+func TestASecretHeaderIsStillRedactedThroughCONNECT(t *testing.T) {
+	c := stubCloud(t, compiledInHost, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		// The Host the client sent reaches the cloud unaltered, which is more
+		// than tidiness: a SigV4 signature covers this header, and a reverse
+		// proxy re-originating under its own name is exactly why a signed client
+		// cannot be recorded that way (see docs/proxy.md). Through a tunnel the
+		// client addresses the cloud's own name and this must still be it.
+		if r.Host != compiledInHost {
+			w.WriteHeader(http.StatusTeapot)
+			_, _ = fmt.Fprintf(w, "the cloud was addressed as %q, want %q", r.Host, compiledInHost)
+			return
+		}
+		// The upstream asserts what it received, so a redactor that mangled the
+		// request on its way out cannot pass by destroying the exchange.
+		for name, want := range map[string]string{
+			"X-Auth-Token": tokenMarker,
+			"X-Consumer":   consumerMarker,
+		} {
+			if got := r.Header.Get(name); got != want {
+				w.WriteHeader(http.StatusTeapot)
+				_, _ = fmt.Fprintf(w, "the cloud received %s = %q, want %q", name, got, want)
+				return
+			}
+		}
+		if !bytes.Contains(body, []byte(bodyMarker)) {
+			w.WriteHeader(http.StatusTeapot)
+			_, _ = io.WriteString(w, "the cloud did not receive the body marker")
+			return
+		}
+		if got := r.URL.Query().Get("x-amz-signature"); got != queryMarker {
+			w.WriteHeader(http.StatusTeapot)
+			_, _ = fmt.Fprintf(w, "the cloud received the query signature %q", got)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Session-Token", tokenMarker)
+		_, _ = io.WriteString(w, `{"servers":[{"id":"11111111-1111-1111-1111-111111111111","secret":"`+bodyMarker+`"}]}`)
+	})
+
+	addr, authority, finish := forwarding(t, c, compiledInHost)
+	client := through(t, addr, authority)
+
+	body := `{"name":"web","volumes":{"0":{"secret_key":"` + bodyMarker + `"}}}`
+	req, err := http.NewRequest(http.MethodPost,
+		compiledInEndpoint+"/instance/v1/zones/fr-par-1/servers?x-amz-signature="+queryMarker,
+		strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("build the request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Auth-Token", tokenMarker)
+	// The header a name check answers "no" about and a tenant's account answers
+	// "yes" about.
+	req.Header.Set("X-Consumer", consumerMarker)
+
+	res, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("the tunnelled request failed: %v", err)
+	}
+	answer, _ := io.ReadAll(res.Body)
+	_ = res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("the stand-in cloud refused the exchange (%d): %s", res.StatusCode, answer)
+	}
+	if !bytes.Contains(answer, []byte(bodyMarker)) {
+		t.Fatalf("the client did not receive the cloud's answer unaltered: %s", answer)
+	}
+
+	recorded := finish()
+	if len(recorded) != 1 {
+		t.Fatalf("the tunnel recorded %d exchange(s), want 1", len(recorded))
+	}
+	x := recorded[0]
+
+	// The subject is asserted present before anything is asserted about it: a
+	// transcript that recorded nothing carries no marker either, and would pass
+	// a leak check that only searched.
+	if x.Host != compiledInHost {
+		t.Errorf("the exchange names host %q, want %q: a tunnelled transcript that cannot say which "+
+			"cloud answered is unreadable the moment two of them are in one file", x.Host, compiledInHost)
+	}
+	if x.Path != "/instance/v1/zones/fr-par-1/servers" || x.Status != http.StatusOK {
+		t.Errorf("the exchange is %s %s -> %d, want the tunnelled POST", x.Method, x.Path, x.Status)
+	}
+	for _, name := range []string{"X-Auth-Token", "X-Consumer"} {
+		value, carried := x.Req.Headers[name]
+		if !carried {
+			t.Errorf("%s is missing from the transcript: the name always stays, only the value goes", name)
+			continue
+		}
+		if value != proxy.Placeholder {
+			t.Errorf("%s reads %q, want %q", name, value, proxy.Placeholder)
+		}
+	}
+	if value := x.Res.Headers["X-Session-Token"]; value != proxy.Placeholder {
+		t.Errorf("the response header X-Session-Token reads %q, want %q", value, proxy.Placeholder)
+	}
+
+	line, err := json.Marshal(x)
+	if err != nil {
+		t.Fatalf("re-encode the exchange: %v", err)
+	}
+	for _, marker := range []string{tokenMarker, consumerMarker, bodyMarker, queryMarker} {
+		if bytes.Contains(line, []byte(marker)) {
+			t.Errorf("the transcript carries %s in clear:\n%s", marker, line)
+		}
+	}
+}
+
+// TestAClientWithACompiledInEndpointIsRecordedEndToEnd is #336's acceptance
+// criterion, run as the issue words it: a Go client with no configurable
+// endpoint, recorded end to end, against a local HTTPS server, with no cloud
+// account anywhere near it.
+//
+// The client is a separate process, and that is the point rather than
+// thoroughness. In this one everything is arranged — the transport, the trust
+// pool, the proxy — and none of that is available in a tool one is trying to
+// measure. The child is given two environment variables and nothing else:
+// HTTPS_PROXY and SSL_CERT_FILE. It calls a constant. It installs no Transport,
+// so it inherits http.DefaultTransport and therefore ProxyFromEnvironment, which
+// is the exact property #336 measured on Pépin's collectors.
+func TestAClientWithACompiledInEndpointIsRecordedEndToEnd(t *testing.T) {
+	c := stubCloud(t, compiledInHost, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Auth-Token"); got != tokenMarker {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"servers":[{"id":"11111111-1111-1111-1111-111111111111","name":"web"}]}`)
+	})
+
+	addr, authority, finish := forwarding(t, c, compiledInHost)
+
+	caPath := filepath.Join(t.TempDir(), "feint-ca.pem")
+	if err := authority.WriteCA(caPath); err != nil {
+		t.Fatalf("publish the CA: %v", err)
+	}
+
+	child := exec.Command(os.Args[0], "-test.run=^TestCompiledInClientHelper$", "-test.v")
+	child.Env = append(os.Environ(),
+		"FEINT_COMPILED_IN_CLIENT=1",
+		"HTTPS_PROXY=http://"+addr,
+		"SSL_CERT_FILE="+caPath,
+		// Emptied rather than inherited: a NO_PROXY on the operator's station
+		// would take the child around the proxy and this test would measure the
+		// station's environment instead of the proxy.
+		"NO_PROXY=",
+		"no_proxy=",
+	)
+	out, err := child.CombinedOutput()
+	if err != nil {
+		t.Fatalf("the client process failed: %v\n%s", err, out)
+	}
+	if !bytes.Contains(out, []byte("CHILD-OK")) {
+		t.Fatalf("the client process did not report a successful call:\n%s", out)
+	}
+
+	recorded := finish()
+	if len(recorded) != 1 {
+		t.Fatalf("recorded %d exchange(s), want the one the child made:\n%s", len(recorded), out)
+	}
+	x := recorded[0]
+	if x.Host != compiledInHost || x.Path != "/instance/v1/servers" || x.Status != http.StatusOK {
+		t.Errorf("recorded %s %s%s -> %d, want GET %s/instance/v1/servers -> 200",
+			x.Method, x.Host, x.Path, x.Status, compiledInHost)
+	}
+	if value := x.Req.Headers["X-Auth-Token"]; value != proxy.Placeholder {
+		t.Errorf("the child's credential reads %q in the transcript, want %q", value, proxy.Placeholder)
+	}
+	servers, ok := x.Res.Body.(map[string]any)
+	if !ok || servers["servers"] == nil {
+		t.Errorf("the recorded body is not the cloud's answer: %#v", x.Res.Body)
+	}
+}
+
+// TestCompiledInClientHelper is the child process of the test above, and is a
+// no-op anywhere else.
+//
+// It is deliberately as dumb as a collector: one constant, one header, one call
+// through http.DefaultClient. Nothing here knows a proxy exists.
+func TestCompiledInClientHelper(t *testing.T) {
+	if os.Getenv("FEINT_COMPILED_IN_CLIENT") == "" {
+		t.Skip("the child half of TestAClientWithACompiledInEndpointIsRecordedEndToEnd")
+	}
+	req, err := http.NewRequest(http.MethodGet, compiledInEndpoint+"/instance/v1/servers", nil)
+	if err != nil {
+		t.Fatalf("build the request: %v", err)
+	}
+	req.Header.Set("X-Auth-Token", tokenMarker)
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("the call failed: %v", err)
+	}
+	body, _ := io.ReadAll(res.Body)
+	_ = res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("the cloud answered %d: %s", res.StatusCode, body)
+	}
+	if !bytes.Contains(body, []byte(`"servers"`)) {
+		t.Fatalf("the answer is not the cloud's: %s", body)
+	}
+	t.Log("CHILD-OK")
+}
+
+// TestAHostNobodyNamedIsNotIntercepted holds the bound on what this door
+// decrypts.
+//
+// A forward proxy that terminated every CONNECT would decrypt whatever else the
+// measured process does — a package index, an identity provider, a telemetry
+// endpoint — and file it beside the measurement. So the hosts are named, and a
+// tunnel to any other is refused rather than relayed blind: a blind relay would
+// let the client finish its session while the transcript silently missed every
+// exchange in it, which is the defect handoff.go exists to report.
+//
+// Both halves are asserted in one run, against one proxy: the named host is
+// recorded, the unnamed one is refused, counted and absent.
+func TestAHostNobodyNamedIsNotIntercepted(t *testing.T) {
+	c := stubCloud(t, compiledInHost, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	})
+
+	authority, err := proxy.MintAuthority()
+	if err != nil {
+		t.Fatalf("mint the authority: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "run.jsonl")
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatalf("open the transcript: %v", err)
+	}
+	writer := proxy.NewWriter(file, 0)
+	// A wildcard, because that is what a per-zone endpoint needs, and because it
+	// is where "named" is easiest to get wrong: it covers one label and never
+	// two, exactly as a certificate's does.
+	f, err := proxy.NewForward(proxy.ForwardOptions{
+		Hosts:     []string{"*.scaleway.test"},
+		Writer:    writer,
+		Authority: authority,
+		Transport: c.transport,
+		Log:       quietLog(),
+	})
+	if err != nil {
+		t.Fatalf("build the forward proxy: %v", err)
+	}
+	front := httptest.NewServer(f)
+	client := through(t, front.Listener.Addr().String(), authority)
+
+	// The named host: recorded.
+	res, err := client.Get(compiledInEndpoint + "/instance/v1/servers")
+	if err != nil {
+		t.Fatalf("the named host was not reachable: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, res.Body)
+	_ = res.Body.Close()
+
+	// The ones nobody named: refused, and the client is told so rather than left
+	// with a tunnel that goes nowhere. The second is the wildcard's own bound —
+	// `*.scaleway.test` must not swallow a deeper name.
+	for _, elsewhere := range []string{
+		"https://telemetry.example.test/collect",
+		"https://a.b.scaleway.test/collect",
+	} {
+		// The transport reports the refused CONNECT by its status text, which is
+		// what the operator will read in the client's own error.
+		answered, err := client.Get(elsewhere)
+		if err == nil {
+			_ = answered.Body.Close()
+			t.Errorf("a CONNECT to %s, which --forward does not name, was accepted", elsewhere)
+			continue
+		}
+		if !strings.Contains(err.Error(), "Forbidden") {
+			t.Errorf("the refusal of %s did not reach the client as a refusal: %v", elsewhere, err)
+		}
+	}
+
+	front.Close()
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close the writer: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close the transcript: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read the transcript: %v", err)
+	}
+
+	recorded := read(t, raw)
+	if len(recorded) != 1 || recorded[0].Host != compiledInHost {
+		t.Fatalf("recorded %d exchange(s), want only the named host's: %s", len(recorded), raw)
+	}
+	if tunnels := f.Tunnels(); tunnels != 1 {
+		t.Errorf("terminated %d tunnel(s), want 1", tunnels)
+	}
+	refused, hosts := f.Refused()
+	if refused != 2 || hosts["telemetry.example.test"] != 1 || hosts["a.b.scaleway.test"] != 1 {
+		t.Errorf("refused %d connection(s) %v, want one each to telemetry.example.test and "+
+			"a.b.scaleway.test: a refusal nobody counts is a call the operator cannot know is missing",
+			refused, hosts)
+	}
+}
+
+// TestAPlainHTTPRequestThroughTheForwardProxyIsRecorded covers the other form a
+// forward proxy is addressed in.
+//
+// HTTP_PROXY produces an absolute-form request rather than a CONNECT, and a
+// proxy that answered it with a 400 would look broken to a client that has
+// nothing wrong with it. The allowlist applies here too: the destination is
+// still a host the operator did or did not name.
+func TestAPlainHTTPRequestThroughTheForwardProxyIsRecorded(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"plain":true}`)
+	}))
+	defer upstream.Close()
+	host := upstream.Listener.Addr().String()
+
+	path := filepath.Join(t.TempDir(), "run.jsonl")
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatalf("open the transcript: %v", err)
+	}
+	writer := proxy.NewWriter(file, 0)
+	f, err := proxy.NewForward(proxy.ForwardOptions{
+		Hosts:  []string{"127.0.0.1"},
+		Writer: writer,
+		Log:    quietLog(),
+	})
+	if err != nil {
+		t.Fatalf("build the forward proxy: %v", err)
+	}
+	front := httptest.NewServer(f)
+	defer front.Close()
+
+	target, err := url.Parse(front.URL)
+	if err != nil {
+		t.Fatalf("parse the proxy URL: %v", err)
+	}
+	client := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(target)}}
+
+	res, err := client.Get("http://" + host + "/v2/instance")
+	if err != nil {
+		t.Fatalf("the plain request failed: %v", err)
+	}
+	body, _ := io.ReadAll(res.Body)
+	_ = res.Body.Close()
+	if !bytes.Contains(body, []byte(`"plain"`)) {
+		t.Fatalf("the upstream's answer did not come back: %s", body)
+	}
+
+	// And a host nobody named is refused in this form too. Here the refusal is
+	// the answer itself rather than a failed tunnel, so it is read as a status.
+	refusal, err := client.Get("http://elsewhere.example.test/v2/instance")
+	if err != nil {
+		t.Fatalf("the refused request did not come back as an answer: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, refusal.Body)
+	_ = refusal.Body.Close()
+	if refusal.StatusCode != http.StatusForbidden {
+		t.Errorf("a plain request to a host --forward does not name answered %d, want 403", refusal.StatusCode)
+	}
+
+	front.Close()
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close the writer: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close the transcript: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read the transcript: %v", err)
+	}
+	recorded := read(t, raw)
+	if len(recorded) != 1 || recorded[0].Path != "/v2/instance" {
+		t.Fatalf("recorded %d exchange(s), want the plain one alone: %s", len(recorded), raw)
+	}
+}
+
+// TestTheForwardProxyMintsUnderOneEphemeralAuthority pins the third security
+// requirement: one authority for the run, generated on the fly, trusted through
+// the file the client was given and nothing else.
+//
+// The property that has teeth is "one". A leaf minted under a second authority
+// would be a certificate nothing has been told to trust, and every call after it
+// would fail with an error naming the wrong cause — so the test asks the
+// authority for two hosts it has never seen and verifies both against the single
+// pool published before either existed.
+func TestTheForwardProxyMintsUnderOneEphemeralAuthority(t *testing.T) {
+	authority, err := proxy.MintAuthority()
+	if err != nil {
+		t.Fatalf("mint the authority: %v", err)
+	}
+	published := authority.CAPool()
+
+	for _, host := range []string{compiledInHost, "api-ch-gva-2.exoscale.test", "127.0.0.1"} {
+		cfg, err := authority.TLSFor(host)
+		if err != nil {
+			t.Fatalf("mint a leaf for %s: %v", host, err)
+		}
+		if len(cfg.Certificates) != 1 {
+			t.Fatalf("the configuration for %s presents %d certificate(s)", host, len(cfg.Certificates))
+		}
+		leaf, err := x509.ParseCertificate(cfg.Certificates[0].Certificate[0])
+		if err != nil {
+			t.Fatalf("parse the leaf for %s: %v", host, err)
+		}
+		if leaf.IsCA {
+			t.Errorf("the leaf for %s is itself a CA: a client trusting it would trust anything it signs", host)
+		}
+		if err := leaf.VerifyHostname(host); err != nil {
+			t.Errorf("the leaf minted for %s does not cover it: %v", host, err)
+		}
+		if _, err := leaf.Verify(x509.VerifyOptions{Roots: published, KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}}); err != nil {
+			t.Errorf("the leaf for %s does not chain to the CA the client was given: %v", host, err)
+		}
+	}
+
+	// The same host twice is the same leaf: a session is hundreds of requests
+	// over a handful of tunnels, and a key generation per connection would sit on
+	// the critical path of every one of them.
+	first, err := authority.TLSFor(compiledInHost)
+	if err != nil {
+		t.Fatalf("mint again: %v", err)
+	}
+	second, err := authority.TLSFor(compiledInHost)
+	if err != nil {
+		t.Fatalf("mint again: %v", err)
+	}
+	if !bytes.Equal(first.Certificates[0].Certificate[0], second.Certificates[0].Certificate[0]) {
+		t.Error("two tunnels to one host were served two different certificates")
+	}
+
+	// And nothing was written anywhere: the CA exists in memory until a caller
+	// asks for it by path.
+	if _, err := authority.TLSFor(""); err == nil {
+		t.Error("a certificate covering no host was minted")
+	}
+}
+
+// TestAForwardProxyRefusesAnUnusableHostSet holds the two ends of the allowlist.
+//
+// Empty intercepts nothing and records nothing; `*` intercepts everything, which
+// is the difference between a recorder and a wiretap and is one character away
+// on the command line.
+func TestAForwardProxyRefusesAnUnusableHostSet(t *testing.T) {
+	writer := proxy.NewWriter(io.Discard, 0)
+	defer func() { _ = writer.Close() }()
+
+	for name, hosts := range map[string][]string{
+		"none":             nil,
+		"blank":            {"  ", ""},
+		"everything":       {"*"},
+		"everything twice": {"api.scaleway.test", "*.*"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := proxy.NewForward(proxy.ForwardOptions{Hosts: hosts, Writer: writer}); err == nil {
+				t.Errorf("--forward %v was accepted", hosts)
+			}
+		})
+	}
+
+	// The accepting half: a name, and the single-level wildcard a per-zone
+	// endpoint needs.
+	if _, err := proxy.NewForward(proxy.ForwardOptions{
+		Hosts:  []string{"api.scaleway.test", "*.exoscale.test"},
+		Writer: writer,
+	}); err != nil {
+		t.Errorf("a usable host set was refused: %v", err)
+	}
+}

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -362,7 +363,39 @@ func TestCompiledInClientHelper(t *testing.T) {
 		t.Fatalf("build the request: %v", err)
 	}
 	req.Header.Set("X-Auth-Token", tokenMarker)
-	res, err := http.DefaultClient.Do(req)
+
+	// On every platform but macOS this is http.DefaultClient untouched, which is
+	// the property #336 is about: two environment variables and not one line of
+	// the traced tool.
+	//
+	// macOS is the exception, and it is a property of Go rather than of this
+	// proxy: crypto/x509 reads the system keychain there, and the code path that
+	// consults SSL_CERT_FILE carries a build constraint excluding darwin. The
+	// child therefore cannot trust this run's authority from the environment,
+	// and the first CI run on macos-15 said so in as many words —
+	// "x509: certificate signed by unknown authority", while the proxy logged
+	// "the client did not complete the tunnel handshake".
+	//
+	// Loading the CA explicitly here keeps macOS proving what this test exists
+	// to prove — that the tunnel records a client whose endpoint is a constant —
+	// while docs/proxy.md and docs/limits.md carry the part it can no longer
+	// prove there: that nothing about the client had to change.
+	client := http.DefaultClient
+	if runtime.GOOS == "darwin" {
+		pem, err := os.ReadFile(os.Getenv("SSL_CERT_FILE"))
+		if err != nil {
+			t.Fatalf("read the authority macOS will not read for us: %v", err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(pem) {
+			t.Fatal("the authority did not parse")
+		}
+		client = &http.Client{Transport: &http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
+			TLSClientConfig: &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12},
+		}}
+	}
+	res, err := client.Do(req)
 	if err != nil {
 		t.Fatalf("the call failed: %v", err)
 	}

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -9,7 +9,9 @@ import (
 	"encoding/pem"
 	"fmt"
 	"math/big"
+	"net"
 	"os"
+	"sync"
 	"time"
 
 	"crypto/tls"
@@ -39,11 +41,35 @@ import (
 // the CA is minted to a caller-supplied path (a namespace's temporary file), the
 // leaf is short-lived and not itself a CA (it cannot be repurposed as a trust
 // anchor), and neither half is ever installed into the operator's system store.
+//
+// # Two ways in, one authority
+//
+// [MintInterceptor] covers a set of names known up front: the operator says
+// which names a client will be redirected to, and one leaf covers all of them.
+// [MintAuthority] covers a set nobody can write down in advance, which is what
+// the forward proxy of #336 meets — it learns the name one `CONNECT
+// host:port` at a time. Both keep the same CA, because the client trusts
+// exactly one file for the whole run: a second CA minted mid-session would be a
+// certificate nothing has been told to trust, and every call after it would
+// fail with an error naming the wrong cause.
 type Interceptor struct {
+	// The authority itself, kept rather than discarded after the first leaf:
+	// [Interceptor.TLSFor] signs one more whenever a tunnel names a host this
+	// run has not seen yet.
+	caKey  *ecdsa.PrivateKey
+	caCert *x509.Certificate
+	caDER  []byte
+
 	tlsConfig *tls.Config
 	caPEM     []byte
 	pool      *x509.CertPool
 	hosts     []string
+
+	// leaves are what has been minted for a name so far. Bounded by the caller:
+	// the forward proxy only ever asks for a host its own allowlist admitted, so
+	// a client CONNECTing to a million names cannot grow this map.
+	mu     sync.Mutex
+	leaves map[string]*tls.Certificate
 }
 
 // leafValidity bounds how long a minted leaf is accepted.
@@ -74,6 +100,34 @@ func MintInterceptor(hosts ...string) (*Interceptor, error) {
 		}
 	}
 
+	i, err := MintAuthority()
+	if err != nil {
+		return nil, err
+	}
+	leaf, err := i.mint(hosts...)
+	if err != nil {
+		return nil, err
+	}
+	// The whole set on one leaf, presented to every connection: the names are
+	// known here, so nothing has to be decided per handshake and a client
+	// connecting by address rather than by name still gets a certificate.
+	i.tlsConfig.Certificates = []tls.Certificate{*leaf}
+	i.hosts = append([]string(nil), hosts...)
+	return i, nil
+}
+
+// MintAuthority builds the CA alone, for names that are not known yet.
+//
+// It is what the forward proxy holds: `CONNECT api.scaleway.com:443` names its
+// host at the moment the tunnel opens, so the leaf cannot be minted before the
+// client speaks. [Interceptor.TLSFor] signs one then, under this CA — the one
+// the client was told to trust through SSL_CERT_FILE before the run started.
+//
+// The CA is the same shape as the one MintInterceptor uses and lives as long as
+// the process: generated in memory, written only where the caller asks, never
+// installed anywhere. TestTheForwardProxyMintsUnderOneEphemeralAuthority fails
+// if a second authority appears mid-run.
+func MintAuthority() (*Interceptor, error) {
 	notBefore := time.Now().Add(-time.Minute)
 	notAfter := time.Now().Add(leafValidity)
 
@@ -99,6 +153,33 @@ func MintInterceptor(hosts ...string) (*Interceptor, error) {
 		return nil, fmt.Errorf("parse the CA back: %w", err)
 	}
 
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caPEM) {
+		return nil, fmt.Errorf("the minted CA does not parse as a trust root")
+	}
+
+	return &Interceptor{
+		caKey:     caKey,
+		caCert:    caCert,
+		caDER:     caDER,
+		tlsConfig: &tls.Config{MinVersion: tls.VersionTLS12},
+		caPEM:     caPEM,
+		pool:      pool,
+		leaves:    map[string]*tls.Certificate{},
+	}, nil
+}
+
+// mint signs one leaf covering hosts, under this authority's CA.
+//
+// An IP literal goes into IPAddresses rather than DNSNames, because a client
+// that dialled an address validates it there and nowhere else: a leaf carrying
+// "127.0.0.1" as a DNS name is rejected by every verifier, and the failure reads
+// as an untrusted CA rather than as a certificate for the wrong subject.
+func (i *Interceptor) mint(hosts ...string) (*tls.Certificate, error) {
+	notBefore := time.Now().Add(-time.Minute)
+	notAfter := time.Now().Add(leafValidity)
+
 	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, fmt.Errorf("generate the leaf key: %w", err)
@@ -110,32 +191,58 @@ func MintInterceptor(hosts ...string) (*Interceptor, error) {
 		NotAfter:     notAfter,
 		KeyUsage:     x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		DNSNames:     append([]string(nil), hosts...),
 	}
-	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, &leafKey.PublicKey, caKey)
+	for _, h := range hosts {
+		if ip := net.ParseIP(h); ip != nil {
+			leafTmpl.IPAddresses = append(leafTmpl.IPAddresses, ip)
+			continue
+		}
+		leafTmpl.DNSNames = append(leafTmpl.DNSNames, h)
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, i.caCert, &leafKey.PublicKey, i.caKey)
 	if err != nil {
 		return nil, fmt.Errorf("sign the leaf: %w", err)
 	}
-
-	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
-	pool := x509.NewCertPool()
-	if !pool.AppendCertsFromPEM(caPEM) {
-		return nil, fmt.Errorf("the minted CA does not parse as a trust root")
-	}
-
-	return &Interceptor{
-		tlsConfig: &tls.Config{
-			MinVersion: tls.VersionTLS12,
-			Certificates: []tls.Certificate{{
-				Certificate: [][]byte{leafDER, caDER},
-				PrivateKey:  leafKey,
-				Leaf:        leafTmpl,
-			}},
-		},
-		caPEM: caPEM,
-		pool:  pool,
-		hosts: append([]string(nil), hosts...),
+	return &tls.Certificate{
+		Certificate: [][]byte{leafDER, i.caDER},
+		PrivateKey:  leafKey,
+		Leaf:        leafTmpl,
 	}, nil
+}
+
+// TLSFor is the server configuration for one intercepted connection to host.
+//
+// The certificate is pinned to the host the caller names, and the SNI the client
+// sends is deliberately not consulted. The tunnel re-originates to the address
+// its `CONNECT` line named, so minting for a different SNI would present a
+// certificate for one host while talking to another — the one dishonesty a
+// recorder must not commit. A client whose SNI disagrees with its own CONNECT
+// gets a certificate it refuses, which is loud and correct.
+//
+// One leaf per host, kept: a session is hundreds of requests over a handful of
+// tunnels, and re-signing per connection would put a key generation on the
+// critical path of every one of them.
+//
+// TestTheForwardProxyMintsUnderOneEphemeralAuthority fails without the refusal
+// of an empty host, and without the single authority every leaf chains to.
+func (i *Interceptor) TLSFor(host string) (*tls.Config, error) {
+	if host == "" {
+		return nil, fmt.Errorf("no host to intercept: a certificate covering nothing terminates nothing")
+	}
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	leaf, known := i.leaves[host]
+	if !known {
+		minted, err := i.mint(host)
+		if err != nil {
+			return nil, err
+		}
+		i.leaves[host] = minted
+		leaf = minted
+	}
+	cfg := i.tlsConfig.Clone()
+	cfg.Certificates = []tls.Certificate{*leaf}
+	return cfg, nil
 }
 
 // serial draws a random 128-bit certificate serial. Two certificates minted in
@@ -155,6 +262,11 @@ func serial() *big.Int {
 
 // ServerTLSConfig is the configuration the proxy's listener serves. It presents
 // the minted leaf for every intercepted name.
+//
+// It belongs to [MintInterceptor], whose names are known before a client
+// connects. An authority from [MintAuthority] carries no leaf yet and answers a
+// configuration with none: what a tunnel serves is [Interceptor.TLSFor], per
+// connection, for the host its own CONNECT line named.
 func (i *Interceptor) ServerTLSConfig() *tls.Config { return i.tlsConfig.Clone() }
 
 // CAPEM is the CA in PEM, the bytes [Interceptor.WriteCA] writes. A caller that

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -9,10 +9,15 @@
 // — "a unit test would never have found them". Three findings, three throwaway
 // proxies, nothing committed. This package is that tool, built.
 //
-// It is a reverse proxy, not a forward one: the client is pointed at it
-// (SCW_API_URL, an endpoint in a configuration file) and it forwards to one
-// upstream. A client whose endpoint is hardcoded needs DNS and TLS interception,
-// which is #76 and not here.
+// [Proxy] is the reverse half: the client is pointed at it (SCW_API_URL, an
+// endpoint in a configuration file) and it forwards to one upstream. A client
+// whose endpoint is compiled in reads none of those, and there are two doors for
+// it, both minting their certificates with [Interceptor]:
+//
+//   - [MintInterceptor] and `--intercept`, which serve TLS on this proxy's own
+//     listener for a client redirected to it by *name* (#92);
+//   - [Forward] and `--forward`, which accept `CONNECT host:port` from a client
+//     that honours HTTPS_PROXY and need no name redirect at all (#336).
 //
 // What it deliberately does not do:
 //
@@ -51,7 +56,8 @@ const DefaultMaxBody = 1 << 20
 
 // Options configures a [Proxy].
 type Options struct {
-	// Upstream is where every request goes. Required.
+	// Upstream is where every request goes. Required by [New]; a forward proxy
+	// ([NewForward]) has none, because the client names its own destination.
 	Upstream *url.URL
 	// Writer receives every exchange. Required: a proxy that records nothing is
 	// a proxy, and this package is not for that.
@@ -65,6 +71,14 @@ type Options struct {
 	MaxBody int
 	// Log is where a failed upstream call is reported. Never nil after New.
 	Log *slog.Logger
+	// Transport carries the re-originated request. Optional: nil takes
+	// http.DefaultTransport, which verifies against the system trust store —
+	// what a real cloud needs and what an interception proxy must keep, since
+	// re-originating without verification would turn a recorder into a
+	// downgrade. A caller whose upstream presents a private authority (a local
+	// HTTPS stand-in for a cloud, as the forward-proxy tests use) supplies one
+	// that trusts it and nothing more.
+	Transport http.RoundTripper
 }
 
 // Proxy forwards requests to one upstream and records what went past.
@@ -98,6 +112,18 @@ func New(o Options) (*Proxy, error) {
 	if o.Upstream.Host == "" {
 		return nil, fmt.Errorf("upstream %q names no host", o.Upstream)
 	}
+	return newProxy(o, false)
+}
+
+// newProxy is the half [New] and [NewForward] share.
+//
+// forward says where the destination comes from, and it is the only difference
+// between the two: a reverse proxy sends every request to the one upstream it
+// was given, a forward proxy sends each one where the client asked. Everything
+// after — the recording, the redaction, the counters — is the same code, which
+// is what makes "the redaction survives interception" a property rather than a
+// second implementation somebody has to keep in step.
+func newProxy(o Options, forward bool) (*Proxy, error) {
 	if o.Writer == nil {
 		return nil, fmt.Errorf("no writer: a proxy that records nothing is a plain reverse proxy")
 	}
@@ -115,9 +141,22 @@ func New(o Options) (*Proxy, error) {
 		log:     o.Log,
 		now:     func() time.Time { return time.Now().UTC() },
 	}
-	upstream := *o.Upstream
+	var upstream url.URL
+	if o.Upstream != nil {
+		upstream = *o.Upstream
+	}
 	p.rp = &httputil.ReverseProxy{
+		Transport: o.Transport,
 		Rewrite: func(pr *httputil.ProxyRequest) {
+			if forward {
+				// The outbound URL is already the destination: a forward proxy
+				// is addressed in absolute form, and a tunnelled request was
+				// promoted to it from the host its CONNECT named. Rewriting it
+				// to a fixed upstream is precisely what a forward proxy must not
+				// do, and honouring it in the other mode would turn --upstream
+				// into an open relay for anything that reaches the port.
+				return
+			}
 			// SetURL and nothing else. SetXForwarded is what a reverse proxy in
 			// front of an application wants and the opposite of what this one
 			// does: it would add three headers the client never sent to a request

--- a/internal/proxy/record.go
+++ b/internal/proxy/record.go
@@ -72,8 +72,13 @@ type seen struct {
 // responsibility, and [Redacted] is what stops a future caller from having one.
 func capture(s seen) Redacted {
 	x := trace.Exchange{
-		At:      s.at,
-		Method:  s.req.Method,
+		At:     s.at,
+		Method: s.req.Method,
+		// The Host header rather than the URL's host: net/http promotes it out of
+		// the header set, so without this line a transcript recorded through a
+		// tunnel names no host at all — the request line inside a CONNECT is
+		// origin-form.
+		Host:    s.req.Host,
 		Path:    s.req.URL.Path,
 		Query:   s.req.URL.RawQuery,
 		Status:  s.status,

--- a/internal/trace/exchange.go
+++ b/internal/trace/exchange.go
@@ -45,6 +45,15 @@ type Exchange struct {
 	// that two calls to the same operation read as the same line.
 	Method string `json:"method"`
 	Path   string `json:"path"`
+	// Host is the authority the client addressed, when a recorder observed one.
+	//
+	// A transcript of one reverse proxy needs it least — every line carries the
+	// same value — and a forward proxy (#336) cannot be read without it: one
+	// file then holds three clouds, and `POST /api/v1/ReadVms` is a different
+	// exchange depending on which host answered it. The emulator's own ring
+	// leaves it empty, because a process observing itself from the inside has
+	// only one.
+	Host string `json:"host,omitempty"`
 	// Query is the raw query string, without the leading "?", empty when there
 	// is none. Separate from Path because a replay has to reissue the request
 	// exactly and a reader wants the line to stay short.

--- a/tools/falsify/specs/forward-proxy.json
+++ b/tools/falsify/specs/forward-proxy.json
@@ -1,0 +1,57 @@
+{
+  "package": "./internal/proxy/",
+  "mutations": [
+    {
+      "label": "the recording stops redacting, and the tunnel writes a live tenant key into the transcript",
+      "file": "internal/proxy/record.go",
+      "find": "\tredactExchange(&x)\n\treturn Redacted{x: x}",
+      "replace": "\tif false {\n\t\tredactExchange(&x)\n\t}\n\treturn Redacted{x: x}",
+      "test": "TestASecretHeaderIsStillRedactedThroughCONNECT"
+    },
+    {
+      "label": "a CONNECT to a host nobody named is intercepted anyway, and the proxy decrypts whatever else the measured process does",
+      "file": "internal/proxy/forward.go",
+      "find": "\thost, port := splitTarget(r.Host)\n\tif !f.intercepts(host) {",
+      "replace": "\thost, port := splitTarget(r.Host)\n\tif !f.intercepts(host) && false {",
+      "test": "TestAHostNobodyNamedIsNotIntercepted"
+    },
+    {
+      "label": "--forward * is accepted, and the recorder becomes a wiretap on every TLS connection the client makes",
+      "file": "internal/proxy/forward.go",
+      "find": "\t\tif h == \"*\" || strings.HasPrefix(h, \"*.*\") {",
+      "replace": "\t\tif (h == \"*\" || strings.HasPrefix(h, \"*.*\")) && false {",
+      "test": "TestAForwardProxyRefusesAnUnusableHostSet"
+    },
+    {
+      "label": "a leaf is minted for no host at all, so a tunnel can present a certificate covering nothing",
+      "file": "internal/proxy/intercept.go",
+      "find": "\tif host == \"\" {\n\t\treturn nil, fmt.Errorf(\"no host to intercept: a certificate covering nothing terminates nothing\")",
+      "replace": "\tif host == \"\\x00never\" {\n\t\treturn nil, fmt.Errorf(\"no host to intercept: a certificate covering nothing terminates nothing\")",
+      "test": "TestTheForwardProxyMintsUnderOneEphemeralAuthority"
+    },
+    {
+      "label": "the proxy listens off loopback without being asked, and relays a real credential to whoever reaches the port",
+      "file": "internal/cli/proxy.go",
+      "find": "\tif emulator.LoopbackListen(addr) || expose {",
+      "replace": "\tif emulator.LoopbackListen(addr) || expose || true {",
+      "test": "TestProxyRefusesANonLoopbackAddress",
+      "package": "./internal/cli/"
+    },
+    {
+      "label": "--expose-to-network lifts the refusal for a forward proxy too, which offers its own authority to the network",
+      "file": "internal/cli/proxy.go",
+      "find": "\tif forward && expose {",
+      "replace": "\tif forward && expose && false {",
+      "test": "TestAForwardProxyIsRefusedOffLoopback",
+      "package": "./internal/cli/"
+    },
+    {
+      "label": "the interception CA is written somewhere durable instead of a temporary file",
+      "file": "internal/cli/proxy.go",
+      "find": "\tcaFile, err := os.CreateTemp(\"\", \"feint-intercept-ca-*.pem\")",
+      "replace": "\tcaFile, err := os.CreateTemp(\".\", \"feint-intercept-ca-*.pem\")",
+      "test": "TestTheInterceptionCAIsTemporaryAndNeverInstalled",
+      "package": "./internal/cli/"
+    }
+  ]
+}

--- a/tools/falsify/specs/frozen-cli-surface.json
+++ b/tools/falsify/specs/frozen-cli-surface.json
@@ -25,15 +25,15 @@
     {
       "label": "a flag is added to a flag set and to no help block, which is exactly how --intercept shipped mute in v0.9.0",
       "file": "internal/cli/proxy.go",
-      "find": "\tif err := fs.Parse(args); err != nil {\n\t\treturn exitError\n\t}\n\n\tif *upstream == \"\" {",
-      "replace": "\t_ = fs.String(\"intercept-and-unnamed\", \"\", \"a flag no help block names\")\n\tif err := fs.Parse(args); err != nil {\n\t\treturn exitError\n\t}\n\n\tif *upstream == \"\" {",
+      "find": "\tif err := fs.Parse(args); err != nil {\n\t\treturn exitError\n\t}\n\n\tif err := checkProxyMode(*upstream, *forward, *intercept); err != nil {",
+      "replace": "\t_ = fs.String(\"intercept-and-unnamed\", \"\", \"a flag no help block names\")\n\tif err := fs.Parse(args); err != nil {\n\t\treturn exitError\n\t}\n\n\tif err := checkProxyMode(*upstream, *forward, *intercept); err != nil {",
       "test": "TestTheHelpNamesEveryFlagTheBinaryAccepts"
     },
     {
       "label": "the same arrival seen from the fixture's side: a flag the binary gained and the committed surface never recorded",
       "file": "internal/cli/proxy.go",
-      "find": "\tif err := fs.Parse(args); err != nil {\n\t\treturn exitError\n\t}\n\n\tif *upstream == \"\" {",
-      "replace": "\t_ = fs.String(\"intercept-and-unnamed\", \"\", \"a flag no help block names\")\n\tif err := fs.Parse(args); err != nil {\n\t\treturn exitError\n\t}\n\n\tif *upstream == \"\" {",
+      "find": "\tif err := fs.Parse(args); err != nil {\n\t\treturn exitError\n\t}\n\n\tif err := checkProxyMode(*upstream, *forward, *intercept); err != nil {",
+      "replace": "\t_ = fs.String(\"intercept-and-unnamed\", \"\", \"a flag no help block names\")\n\tif err := fs.Parse(args); err != nil {\n\t\treturn exitError\n\t}\n\n\tif err := checkProxyMode(*upstream, *forward, *intercept); err != nil {",
       "test": "TestTheFrozenSurfacesStillMatchTheirFixture"
     },
     {
@@ -51,5 +51,5 @@
       "test": "TestTheFrozenSurfacesStillMatchTheirFixture"
     }
   ],
-  "note": "The subject is #334. `feint proxy --intercept` shipped in v0.9.0: the binary accepted it, `feint proxy --help` rendered it, and the frozen CLI surface (#132) — the thing a pipeline outside this repository is allowed to key on — did not list it, for six days. The cause was that the surface was observed by parsing the rendered `feint --help`, so it recorded what the help claimed. The missing flag was the cheap half; the expensive half is mutation 2, the removal, which that observation could never have seen and which is the direction that breaks a consumer. Mutations 2 and 4 are the two directions the issue asks for, each replayed twice because the fix has two teeth now: the frozen surface reads the FlagSets, and the help carries its own assertion instead of being both the observation and the thing observed. Mutation 7 is the reason the observation asserts its subject rather than skipping on absence: a seam that stopped publishing would otherwise regenerate a fixture that freezes nothing."
+  "note": "The subject is #334. `feint proxy --intercept` shipped in v0.9.0: the binary accepted it, `feint proxy --help` rendered it, and the frozen CLI surface (#132) \u2014 the thing a pipeline outside this repository is allowed to key on \u2014 did not list it, for six days. The cause was that the surface was observed by parsing the rendered `feint --help`, so it recorded what the help claimed. The missing flag was the cheap half; the expensive half is mutation 2, the removal, which that observation could never have seen and which is the direction that breaks a consumer. Mutations 2 and 4 are the two directions the issue asks for, each replayed twice because the fix has two teeth now: the frozen surface reads the FlagSets, and the help carries its own assertion instead of being both the observation and the thing observed. Mutation 7 is the reason the observation asserts its subject rather than skipping on absence: a seam that stopped publishing would otherwise regenerate a fixture that freezes nothing."
 }


### PR DESCRIPTION
Records a client whose endpoint is compiled in, which is what Pépin needs to
anchor its resource contracts on measurement rather than on a reading of the
SDK. It also holds for any Go client: no line changes in the traced tool.

## What was reused, and one premise corrected

The `Interceptor` from #92 already mints an ephemeral CA and signs leaves from
the standard library alone. **But it mints one leaf at construction, for a host
set known in advance**, and a forward proxy learns its host at `CONNECT` time.
So the same type was extended — `MintAuthority()` (CA only) and `TLSFor(host)`
(one leaf per host, on demand, cached, under the one CA) — with
`MintInterceptor` delegating to them. The certificate code is shared, not
duplicated.

`Proxy` gained a shared constructor: `New` and `NewForward` differ only in
**where a request goes**. That is why redaction cannot be bypassed on the new
path — there is no new path.

## The end-to-end recording, through the built binary

A client whose endpoint is the constant `https://api.localhost:8443`, using
`http.DefaultClient`, given nothing but `HTTPS_PROXY` and `SSL_CERT_FILE`:

```json
{"seq":1,"host":"api.localhost:8443","method":"POST",
 "path":"/instance/v1/zones/fr-par-1/servers","operation":"instance/v1/API.CreateServer",
 "query":"x-amz-signature=REDACTED","status":200,
 "req":{"headers":{"X-Auth-Token":"REDACTED","X-Consumer":"REDACTED"}}}
```

The stand-in server logged both headers carrying the same fake key in full;
neither value appears anywhere in the recording. `X-Consumer` is deliberate: it
is the header the denylist got wrong when one was tried, and the reason headers
are an allowlist.

This session is also a test that runs the client in a **child process**, so
nothing it relies on is arranged in-process. No real cloud: the endpoint is a
reserved `.test` TLD and the transport refuses any address but the mapped one.

## The four security requirements, each falsified

`tools/falsify/specs/forward-proxy.json` — 7 mutations, 7 bite:

| requirement | the mutation, and what it would allow |
|---|---|
| redaction survives interception | `redactExchange` neutralised → *the tunnel writes a live tenant key into the transcript* |
| loopback only | the check short-circuited → *relays a real credential to whoever reaches the port* |
| loopback only | `--expose-to-network` lifting the refusal for a forward proxy → **refused outright when combined with `--forward`** |
| ephemeral authority | CA written to the working directory instead of a temp file |
| ephemeral authority | empty-host guard neutralised → *a leaf covering nothing* |
| bounded interception | intercept anything → *the proxy decrypts whatever else the measured process does* |
| bounded interception | `--forward '*'` accepted → **the recorder becomes a wiretap on every TLS connection the client makes** |

The last two matter most: an intercepting proxy with its own CA is a
credential-harvesting tool by construction, and what keeps it from being one is
that it intercepts only hosts somebody named.

## What `docs/proxy.md` now says about a recording

A new section — *"What a recording contains, and what to sanitise before
sharing it"* — with a field-by-field table (`host`, `path` and `query` carry
identifiers verbatim; only a *name*-matched query parameter is redacted; bodies
are verbatim except credential-named keys; headers keep names and drop values
off the allowlist), four sanitisation steps, and the statement that a fixture is
built from the observed *shape* with invented values. The partial-sanitisation
trap is named with the case behind it: Pépin's audit opened on a real instance
UUID left in a fixture whose IP address had been scrubbed.

## Merged with #334, which landed first

Both changed the CLI surface. Resolved rather than picked: the help block now
describes **both** doors (`--intercept` redirects by name, `--forward` by
proxy), `docs/proxy.md` keeps #336's fuller two-door explanation *and* #334's
paragraph recording that this page said the opposite until 2026-08-20, and the
frozen fixture was **regenerated from the binary** rather than merged by hand.
`cliSurfaceVersion` is **6**, and `proxy` records its nine real flags.

`mise run falsify:lint` then refused the tree, correctly: two mutations of
`frozen-cli-surface.json` named a fragment `--forward` had displaced. Retargeted
rather than deleted — they cover the exact defect #334 was filed for. All 7 of
that spec's mutations still bite; the lint counts 255 fragments across 63
specs, none stale.

## Not measured, and said as such

- **No real-cloud run.** Whether a SigV4-signed client through `--forward` gets
  a 200 from a real Outscale account is *not* measured. Only the mechanism is
  asserted: the `Host` header reaches the upstream unaltered.
- **Whether Terraform's Scaleway S3 client honours `HTTPS_PROXY`** — unmeasured,
  and it is what would reopen the #76 object-storage arbitration. Noted in the
  roadmap.
- **The issue calls the redaction an allowlist; it is half one.** Headers are;
  bodies and query are a denylist by key name, so a credential in a body field
  named `message` still survives. Unchanged here, and both halves are covered
  through `CONNECT` by the tests.
- `mise run conformance` was not run (no pack route or shape moved);
  `tools/conformance/proxy.sh` was, with the real `scw` CLI: green, two
  observers agreeing on 137 operations.

## Related

Closes #336
