### PR TITLE
fix(machine): a routed NIC takes its addresses and declines its rule sets

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -336,6 +336,36 @@ change ni l'un ni l'autre a sa place dans `git log`.
   système ou modifier le `/etc/hosts` de l'opérateur. #76 et #92 sont closes,
   livrées.
 
+- **Une adresse attachée après le lancement atteint une machine qui ne joint
+  aucun réseau, et un groupe de sécurité y devient une limite déclarée plutôt
+  qu'un silence** (#337). Depuis #202, une machine qui ne porte qu'une adresse
+  publique la porte sur une NIC `routed`, qui n'a pas de clé `network` ; or les
+  deux chemins d'adresse de `internal/core/machine` sélectionnaient les
+  interfaces par cette clé. Toute adresse routée après le lancement mourait sur
+  « machine has no network interface » : l'IP élastique de la suite ssh
+  Exoscale était annoncée attachée par l'API sans que rien ne la pose sur la
+  machine, et chaque replay de poweron Scaleway journalisait la même erreur
+  au-dessus d'une adresse qui fonctionnait. La NIC routée est désormais
+  reconnue, et le mécanisme est le sien : l'adresse rejoint l'`ipv4.routes` du
+  device (mesuré accepté sur Incus 7.2, à froid comme à chaud), et le
+  rebranchement qu'une édition à chaud provoque (mesuré : l'interface invitée
+  revient éteinte et nue) est réparé depuis la configuration du device
+  lui-même. La suite ssh Exoscale passe de bout en bout.
+
+  La moitié pare-feu ne pouvait pas se corriger de la même façon, parce que la
+  mesure dit non : une NIC routée n'accepte aucune option de sécurité, chaque
+  clé étant une « Invalid device option » sur Incus 7.2 comme 7.3 (table dans
+  `docs/limits.md`). Y appliquer un jeu de règles était une ligne ERROR que le
+  plan de contrôle recouvrait en répondant comme si le groupe était appliqué.
+  Le refus est désormais déclaré plutôt que maquillé : `/_feint/health` gagne
+  `capabilities.firewall_public_only` (schéma de santé en version 5), faux
+  dans tous les modes Incus ; `ApplyFirewall` répond l'erreur typée
+  `machine.ErrFirewallUnenforceable` au lieu d'émettre des clés condamnées,
+  tout en couvrant encore les interfaces qui savent appliquer ; et un groupe
+  qui ne filtre rien (celui par défaut, embarqué par chaque `scw instance
+  server create`) n'attache rien sur aucun runtime, seule traduction fidèle de
+  « ne filtre rien ». Falsifié par `tools/falsify/specs/routed-nic.json`.
+
 - **Une stack appliquée à chaque pull request épingle le provider qui a
   répondu, et une stack que la CI n'applique pas dit pourquoi** (la table de
   #325, premier jour). La page générée des clients a révélé deux choses que

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -313,6 +313,34 @@ what this project is judged on: **a response shape a client can observe**, and
   nothing in the system trust store and never edits the operator's
   `/etc/hosts`. #76 and #92 are closed as delivered.
 
+- **An address attached after launch reaches a machine that joins no network,
+  and a security group there is a declared limit instead of a silent one**
+  (#337). Since #202 a machine with only a public address carries it on a
+  `routed` NIC, which has no `network` key — and both address paths of
+  `internal/core/machine` selected interfaces by that key. Every address routed
+  after the launch died on "machine has no network interface": the Exoscale ssh
+  suite's elastic IP was reported attached by the API while nothing put it on
+  the machine, and every Scaleway poweron replay logged the same error over a
+  working address. The routed NIC is now recognised, and the mechanism is its
+  own: the address lands in the device's `ipv4.routes` — measured accepted on
+  Incus 7.2, cold and live — and the re-plug a live edit causes (measured: the
+  guest interface comes back down and bare) is repaired from the device's own
+  config. The Exoscale ssh suite passes end to end.
+
+  The firewall half could not be fixed the same way, because the measurement
+  says no: a routed NIC accepts no security option at all — every key an
+  `Invalid device option` on Incus 7.2 and 7.3 alike, table in
+  `docs/limits.md` — so applying a rule set there was an ERROR log the control
+  plane answered over as if the group were enforced. The refusal is now
+  declared instead of pretended: `/_feint/health` gained
+  `capabilities.firewall_public_only` (health schema version 5), false in every
+  Incus mode; `ApplyFirewall` answers the typed
+  `machine.ErrFirewallUnenforceable` rather than sending doomed keys, while
+  still covering the interfaces that can enforce; and a group that filters
+  nothing — the default one riding every `scw instance server create` — binds
+  nothing on any runtime, which is the only faithful translation of "filters
+  nothing". Falsified by `tools/falsify/specs/routed-nic.json`.
+
 - **A stack applied on every pull request pins the provider that answered, and
   a stack CI does not apply says why** (#325's table, first day). The generated
   client page exposed two things nothing had said before:

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -783,6 +783,37 @@ The `stateful` flag translates too, onto the runtime's `allow` and
 The bound is that none of this applies to a server with no backing machine,
 which is the default configuration and what CI runs.
 
+**The bound a routed NIC adds (#337).** A server that joins no private network
+gets its public address on a `routed` NIC (#202) — and a routed NIC accepts
+**no security option at all**. Measured on Incus 7.2, cold, one key at a time,
+and the wording of the same refusal on the 7.3 CI runner:
+
+| device | key | Incus answers |
+|---|---|---|
+| `nictype=routed` | `security.acls` | `Invalid device option "security.acls"` |
+| `nictype=routed` | `security.acls.default.ingress.action` | `Invalid device option …` |
+| `nictype=routed` | `security.ipv4_filtering`, `security.mac_filtering` | `Invalid device option …` |
+| `nic network=<managed>` | the same keys, together | `Network ACL "…" does not exist` |
+
+The last row is the contrast that settles it: a NIC of a managed network
+accepts the option names and complains only about the missing ACL; on a routed
+NIC they are not options. There is no other per-NIC filtering mechanism to fall
+back to, so **a security group that restricts traffic is not enforced on a
+server whose only interface is a routed NIC** — a server with a public address
+and no private network. The runtime declares it instead of pretending:
+`capabilities.firewall_public_only` is `false` on `/_feint/health`, a rule set
+bound to such a machine comes back as `machine.ErrFirewallUnenforceable`
+rather than being half-sent, and the pack logs the declared limit as a warning
+naming this section. The default security group — pure accept, filtering
+nothing upstream — binds nothing anywhere, which is the faithful translation
+of "filters nothing" and why an ordinary `scw instance server create` raises
+no alarm at all.
+
+A server *with* a private network keeps the full claim: its NICs are on
+managed networks, the group attaches to every one of them, and a flexible IP —
+routed through the filtered NIC — stays covered, as the paragraph below
+measures.
+
 The group covers a **flexible IP**. The address is routed through the NIC
 device's `ipv4.routes` (`nic_bridged.go` at v7.2.0 lists it among the device's
 own fields and applies it host-side), so host traffic towards it crosses the

--- a/internal/cli/testdata/frozen/health.json
+++ b/internal/cli/testdata/frozen/health.json
@@ -299,6 +299,97 @@
           }
         ]
       }
+    },
+    {
+      "schema_version": 5,
+      "content": {
+        "fields": [
+          {
+            "path": "capabilities",
+            "type": "object"
+          },
+          {
+            "path": "capabilities.addresses",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.balancing",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.firewall",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.firewall_public_only",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.isolation",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.machines",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.own_kernel",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.private_from_host",
+            "type": "bool"
+          },
+          {
+            "path": "enforced",
+            "type": "object"
+          },
+          {
+            "path": "enforced.firewall",
+            "type": "array"
+          },
+          {
+            "path": "enforced.firewall[]",
+            "type": "string"
+          },
+          {
+            "path": "instance",
+            "type": "object"
+          },
+          {
+            "path": "instance.pid",
+            "type": "number"
+          },
+          {
+            "path": "instance.started_at",
+            "type": "string"
+          },
+          {
+            "path": "machines",
+            "type": "string"
+          },
+          {
+            "path": "providers",
+            "type": "array"
+          },
+          {
+            "path": "providers[]",
+            "type": "string"
+          },
+          {
+            "path": "resources",
+            "type": "number"
+          },
+          {
+            "path": "schema_version",
+            "type": "number"
+          },
+          {
+            "path": "status",
+            "type": "string"
+          }
+        ]
+      }
     }
   ]
 }

--- a/internal/core/emulator/schema.go
+++ b/internal/core/emulator/schema.go
@@ -45,7 +45,16 @@ const (
 	// moves the version: a suite that wants to prove a balancer balances must
 	// key on this and never on a mode name, and a build that cannot answer the
 	// question at all is exactly what a version is for.
-	HealthSchemaVersion = 4
+	//
+	// 5 since #337: `capabilities` gained `firewall_public_only` — a security
+	// group is enforced even on a machine that joins no emulated network. The
+	// Incus driver declares it false, measured: a routed NIC, the interface of
+	// a server carrying only its published public addresses, accepts no
+	// security option at all (7.2 and 7.3). Publishing the refusal is the
+	// point. `capabilities.firewall` alone read as "my security groups are
+	// enforced", it was true for a machine on a private network and false for
+	// one with only a public address, and nothing said which.
+	HealthSchemaVersion = 5
 	// RoutesSchemaVersion is the shape of GET /_feint/routes.
 	//
 	// This one is not on the wire: the endpoint answers a bare JSON array — the

--- a/internal/core/machine/capabilities.go
+++ b/internal/core/machine/capabilities.go
@@ -25,6 +25,18 @@ type Capabilities struct {
 	// Firewall: a security group's rules are enforced on the machine's
 	// interface, and a change applies without restarting it.
 	Firewall bool `json:"firewall"`
+	// FirewallPublicOnly: the rules are enforced even on a machine that joins
+	// no emulated network — a server whose only interface is a routed NIC
+	// carrying the public addresses its API publishes (#202).
+	//
+	// Declared apart from Firewall because the two were measured apart (#337).
+	// On Incus, the same group that closes a port for real on a machine with
+	// an emulated network under it — public address included, since a flexible
+	// IP is routed through the filtered NIC — attaches to nothing on a routed
+	// NIC: every security option is an invalid device option there, on 7.2 and
+	// 7.3 alike. A suite probing the ports of a public-only machine gates on
+	// this claim, never on capabilities.firewall.
+	FirewallPublicOnly bool `json:"firewall_public_only"`
 	// Isolation: two networks of two different VPCs cannot reach each other.
 	//
 	// This is the one that separates the modes. Managed bridges on one host are
@@ -135,12 +147,18 @@ func (d *Incus) Capabilities() Capabilities {
 		return *d.verified
 	}
 	return Capabilities{
-		Machines:        true,
-		Addresses:       true,
-		Firewall:        true,
-		Isolation:       d.OVN,
-		Balancing:       d.OVN,
-		OwnKernel:       d.VM,
-		PrivateFromHost: !d.OVN,
+		Machines:  true,
+		Addresses: true,
+		Firewall:  true,
+		// False in every Incus mode, and measured rather than pending: a
+		// routed NIC accepts no security option at all (#337, Incus 7.2 and
+		// 7.3), so ApplyFirewall refuses a rule set on a public-only machine
+		// instead of pretending. The claim goes true the day a mechanism
+		// exists and is measured, not before.
+		FirewallPublicOnly: false,
+		Isolation:          d.OVN,
+		Balancing:          d.OVN,
+		OwnKernel:          d.VM,
+		PrivateFromHost:    !d.OVN,
 	}
 }

--- a/internal/core/machine/firewall.go
+++ b/internal/core/machine/firewall.go
@@ -1,6 +1,22 @@
 package machine
 
-import "context"
+import (
+	"context"
+	"errors"
+)
+
+// ErrFirewallUnenforceable reports an interface the runtime has no mechanism
+// to enforce a rule set on — as opposed to an interface where enforcement was
+// attempted and failed. A routed NIC is the measured case (#337): every
+// security option is an invalid device option there, on Incus 7.2 and 7.3
+// alike, so a rule set bound to such a machine can only be refused.
+//
+// Typed so a pack can tell the two apart: a declared limit is reported against
+// the matching capability (Capabilities.FirewallPublicOnly, false for the
+// Incus driver) and docs/limits.md, where a real failure stays an error. What
+// no caller may do with it is answer as if the rules were enforced — the
+// half-applied ERROR-then-200 is the exact divergence #337 removed.
+var ErrFirewallUnenforceable = errors.New("the runtime has no mechanism to enforce a rule set on this interface")
 
 // Firewalls are what makes an emulated security group more than documentation.
 //

--- a/internal/core/machine/incus_address.go
+++ b/internal/core/machine/incus_address.go
@@ -25,17 +25,31 @@ import (
 // own, the runtime removes it with the device, and it teaches the runtime an
 // address it would otherwise merely transport.
 func (d *Incus) RouteAddress(ctx context.Context, spec AddressSpec) error {
-	// OVN NICs take no live route edits, so the address travels as a network
-	// forward instead; see routeAddressOVN for the measurements behind it.
-	if d.OVN {
-		return d.routeAddressOVN(ctx, spec)
-	}
 	if !safeName.MatchString(spec.Machine) {
 		return fmt.Errorf("invalid machine name %q", spec.Machine)
 	}
 	network, device, err := d.interfaceFor(ctx, spec.Machine, spec.Network)
 	if err != nil {
 		return err
+	}
+	if network == "" {
+		// A routed NIC (#202): the interface of a machine that joins no
+		// emulated network. There is no network whose ownership could vouch for
+		// this call, so the question moves to the object actually reconfigured
+		// — the instance — and its label answers it. The mechanism is the NIC's
+		// own in both driver modes: a routed NIC has no OVN port, so the OVN
+		// forward machinery below has nothing to say about it.
+		// TestRouteAddressRefusesARoutedMachineTheEmulatorDidNotCreate fails
+		// without the ownership half.
+		if err := d.mustOwnInstance(ctx, spec.Machine); err != nil {
+			return err
+		}
+		return d.routeOntoRoutedNIC(ctx, spec.Machine, device, spec.Address)
+	}
+	// OVN NICs take no live route edits, so the address travels as a network
+	// forward instead; see routeAddressOVN for the measurements behind it.
+	if d.OVN {
+		return d.routeAddressOVN(ctx, spec)
 	}
 	// Never route through a network the emulator did not create: an operator's
 	// own bridge is not ours to reconfigure, and a route left on it would
@@ -160,6 +174,17 @@ func (d *Incus) UnrouteAddress(ctx context.Context, machine, address string) err
 		if err := d.setDeviceRoutes(ctx, machine, device, address, false); err != nil {
 			return err
 		}
+		if cfg["nictype"] == "routed" {
+			// The edit re-plugged the device (measured on 7.2: any ipv4.routes
+			// change on a live routed NIC removes and re-adds it), so the
+			// address went with the old interface and there is nothing left to
+			// delete — but everything else the interface carried went too.
+			// TestUnrouteAddressRepairsARoutedNIC fails without the repair.
+			if err := d.repairRoutedInterface(ctx, machine, device); err != nil {
+				return err
+			}
+			continue
+		}
 		// Dropping the address inside the guest is tolerant on purpose: a
 		// stopped machine holds no live address, an image without `ip` never
 		// took it, and "cannot find" means it is already gone. With the route
@@ -167,6 +192,130 @@ func (d *Incus) UnrouteAddress(ctx context.Context, machine, address string) err
 		_, _ = d.run(ctx, "exec", machine, "--", "ip", "address", "del", route, "dev", device)
 	}
 	return nil
+}
+
+// routeOntoRoutedNIC gives one more address to a machine whose interface is a
+// routed NIC (#337).
+//
+// A routed NIC has no `network` key, so until #337 it was invisible to
+// interfaceFor and every address routed after the launch died on "machine has
+// no network interface": the Exoscale ssh suite's elastic IP was reported
+// attached by the API while nothing put it on the machine.
+//
+// The mechanism is the NIC's own. `ipv4.routes` is accepted on a routed NIC —
+// measured on Incus 7.2, cold and live, the same key every security option is
+// refused on — and installs the host route next to the ones the launch's
+// ipv4.address list created. Two more measured facts shape the branches:
+//
+//   - an address already in ipv4.address rode the launch: the guest's netplan
+//     declares it and the host route exists, so the replay is a no-op. This is
+//     what lets poweron replay every published address through here without
+//     re-plugging the interface at each boot.
+//   - a live ipv4.routes edit re-plugs the device: the veth is torn down and
+//     rebuilt, and the guest interface comes back down and bare. The repair is
+//     not optional; without it the machine loses every address it had,
+//     including the one the API published at create.
+//
+// TestRouteAddressReachesARoutedNIC and TestRouteAddressLeavesALaunchAddressAlone
+// fail without this.
+func (d *Incus) routeOntoRoutedNIC(ctx context.Context, machine, device, address string) error {
+	devices, err := d.instanceDevices(ctx, machine)
+	if err != nil {
+		return fmt.Errorf("inspect %s: %w", machine, err)
+	}
+	cfg := devices.own[device]
+	if routeListContains(cfg["ipv4.address"], address) {
+		return nil
+	}
+	route := address + "/32"
+	if !routeListContains(cfg["ipv4.routes"], route) {
+		if _, err := d.run(ctx, "config", "device", "set", machine, device,
+			"ipv4.routes="+appendRoute(cfg["ipv4.routes"], route)); err != nil {
+			return fmt.Errorf("route %s to %s/%s: %w", address, machine, device, err)
+		}
+		if err := d.repairRoutedInterface(ctx, machine, device); err != nil {
+			return err
+		}
+	}
+	// The machine answers on it. A /32 on purpose: the address is a route to
+	// this machine, not a subnet it belongs to. A stopped machine takes no
+	// exec; its device key is set cold, and the poweron replay lands here again
+	// with the machine running.
+	if _, err := d.run(ctx, "exec", machine, "--",
+		"ip", "address", "add", route, "dev", device); err != nil &&
+		!addressAlreadyThere(err) && !isNotRunning(err) {
+		return fmt.Errorf("give %s to %s: %w", address, machine, err)
+	}
+	return nil
+}
+
+// repairRoutedInterface restores what an ipv4.routes edit cost the guest of a
+// routed NIC. Measured on 7.2: the edit removes and re-adds the device, and
+// the new interface comes up down and bare — no address, no default route, and
+// no DHCP client to notice, since a routed NIC never had one.
+//
+// Everything restored is read back from the device itself: the launch
+// addresses from ipv4.address, the extra ones from ipv4.routes, the next hop
+// from ipv4.host_address. The default route is installed in netplan's own
+// on-link shape — a device route to the next hop, then the default through it
+// — as two plain commands rather than the `onlink` keyword, so a busybox `ip`
+// (Alpine) takes them too.
+func (d *Incus) repairRoutedInterface(ctx context.Context, machine, device string) error {
+	devices, err := d.instanceDevices(ctx, machine)
+	if err != nil {
+		return fmt.Errorf("inspect %s after re-plug: %w", machine, err)
+	}
+	cfg := devices.own[device]
+	if _, err := d.run(ctx, "exec", machine, "--", "ip", "link", "set", device, "up"); err != nil {
+		if isNotRunning(err) {
+			// A cold edit re-plugged nothing: the next boot reads its netplan
+			// and the poweron replay hands the guest the routed extras.
+			return nil
+		}
+		return fmt.Errorf("bring %s/%s back up: %w", machine, device, err)
+	}
+	give := func(route string) error {
+		if _, err := d.run(ctx, "exec", machine, "--",
+			"ip", "address", "add", route, "dev", device); err != nil && !addressAlreadyThere(err) {
+			return fmt.Errorf("restore %s on %s/%s: %w", route, machine, device, err)
+		}
+		return nil
+	}
+	for _, address := range splitList(cfg["ipv4.address"]) {
+		if err := give(address + "/32"); err != nil {
+			return err
+		}
+	}
+	for _, route := range splitList(cfg["ipv4.routes"]) {
+		if err := give(route); err != nil {
+			return err
+		}
+	}
+	next := cfg["ipv4.host_address"]
+	if next == "" {
+		next = routedNextHop
+	}
+	for _, hop := range [][]string{
+		{"ip", "route", "add", next, "dev", device},
+		{"ip", "route", "add", "default", "via", next, "dev", device},
+	} {
+		if _, err := d.run(ctx, append([]string{"exec", machine, "--"}, hop...)...); err != nil &&
+			!addressAlreadyThere(err) {
+			return fmt.Errorf("restore the default route of %s: %w", machine, err)
+		}
+	}
+	return nil
+}
+
+// splitList reads a comma-separated device value into its entries.
+func splitList(value string) []string {
+	out := make([]string, 0, 4)
+	for _, entry := range strings.Split(value, ",") {
+		if entry = strings.TrimSpace(entry); entry != "" {
+			out = append(out, entry)
+		}
+	}
+	return out
 }
 
 // routeListContains reports whether a comma-separated ipv4.routes value carries
@@ -208,7 +357,8 @@ func (d *Incus) setDeviceRoutes(ctx context.Context, machine, device, address st
 	return nil
 }
 
-// interfaceFor returns the network to route through and the device on it.
+// interfaceFor returns the network to route through and the device on it. An
+// empty network names a routed NIC, which sits on none.
 //
 // When the caller names a network, that one is used: a public address belongs
 // on the network the server lives on, and only the pack knows which that is.
@@ -222,9 +372,16 @@ func (d *Incus) interfaceFor(ctx context.Context, name, wanted string) (network,
 
 	// Sorted for determinism: a machine with several private NICs must not get
 	// its public address on a different one between two runs.
+	//
+	// A routed NIC counts (#337). It has no `network` key — it is an address
+	// with a host route, no L2 segment underneath — and selecting on the key
+	// alone made the interface of every machine without an emulated network
+	// invisible: "machine has no network interface", on a machine whose one
+	// interface was carrying the published address.
+	// TestRouteAddressReachesARoutedNIC fails without it.
 	names := make([]string, 0, len(devices.own))
 	for candidate, config := range devices.own {
-		if config["type"] == "nic" && config["network"] != "" {
+		if config["type"] == "nic" && (config["network"] != "" || config["nictype"] == "routed") {
 			names = append(names, candidate)
 		}
 	}

--- a/internal/core/machine/incus_address_routed_test.go
+++ b/internal/core/machine/incus_address_routed_test.go
@@ -1,0 +1,183 @@
+package machine
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// A routed NIC is the interface of every machine that joins no emulated
+// network (#202): a Scaleway server with only its public address, every
+// Exoscale instance. Until #337 the address paths could not see it — it has no
+// `network` key — so the API reported an elastic IP attached while nothing put
+// it on the machine, and the poweron replay of a launch address died on
+// "machine has no network interface". These tests hold the recognition, the
+// mechanism, and its two measured costs: the ownership question has no network
+// to be asked of, and a live ipv4.routes edit re-plugs the device.
+
+// routedOnly is the machine the Scaleway and Exoscale ssh suites boot: one
+// routed NIC carrying the published address, no network anywhere.
+const routedOnly = `{
+  "expanded_devices": {
+    "eth0": {"type": "nic", "nictype": "routed",
+             "ipv4.address": "203.0.113.7", "ipv4.host_address": "169.254.0.1"}
+  },
+  "devices": {
+    "eth0": {"type": "nic", "nictype": "routed",
+             "ipv4.address": "203.0.113.7", "ipv4.host_address": "169.254.0.1"}
+  }
+}`
+
+// TestRouteAddressReachesARoutedNIC holds the whole mechanism: the routed NIC
+// is selected although it sits on no network, the address lands in the
+// device's own ipv4.routes — the one route key a routed NIC accepts, measured
+// on Incus 7.2 — the re-plug that edit causes is repaired, and the guest is
+// handed the address.
+func TestRouteAddressReachesARoutedNIC(t *testing.T) {
+	for name, ovn := range map[string]bool{"bridge mode": false, "ovn mode": true} {
+		t.Run(name, func(t *testing.T) {
+			f := &fakeRuntime{answers: map[string]string{
+				"/1.0/instances/vm": routedOnly,
+			}}
+			d := newFakeDriver(f)
+			d.OVN = ovn
+
+			if err := d.RouteAddress(context.Background(), AddressSpec{
+				Machine: "vm", Address: "192.0.2.2",
+			}); err != nil {
+				t.Fatalf("route: %v", err)
+			}
+
+			if got := f.matching("ipv4.routes=192.0.2.2/32"); len(got) != 1 ||
+				!strings.Contains(got[0], "config device set vm eth0") {
+				t.Fatalf("the address must land in the routed NIC's own ipv4.routes, got:\n%s",
+					strings.Join(f.commands(), "\n"))
+			}
+			// The routed mechanism is the same in both modes: a routed NIC has
+			// no OVN port, so nothing external and no uplink route.
+			for _, wrong := range []string{"ipv4.routes.external", "network set"} {
+				if got := f.matching(wrong); len(got) != 0 {
+					t.Errorf("the OVN machinery has nothing to say about a routed NIC, got %v", got)
+				}
+			}
+			// The edit re-plugged the device (measured: the guest interface
+			// comes back down and bare), so the repair must run: link up, the
+			// launch address back, the default route back through the NIC's
+			// own next hop.
+			for _, must := range []string{
+				"exec vm -- ip link set eth0 up",
+				"exec vm -- ip address add 203.0.113.7/32 dev eth0",
+				"exec vm -- ip route add default via 169.254.0.1 dev eth0",
+				"exec vm -- ip address add 192.0.2.2/32 dev eth0",
+			} {
+				if len(f.matching(must)) == 0 {
+					t.Errorf("missing %q in:\n%s", must, strings.Join(f.commands(), "\n"))
+				}
+			}
+		})
+	}
+}
+
+// TestRouteAddressLeavesALaunchAddressAlone holds the no-op half, which is
+// what the poweron replay depends on: an address already in ipv4.address rode
+// the launch — the guest's netplan declares it, the host route exists — and
+// editing the device again would re-plug a working interface at every boot.
+func TestRouteAddressLeavesALaunchAddressAlone(t *testing.T) {
+	f := &fakeRuntime{answers: map[string]string{
+		"/1.0/instances/vm": routedOnly,
+	}}
+	d := newFakeDriver(f)
+
+	if err := d.RouteAddress(context.Background(), AddressSpec{
+		Machine: "vm", Address: "203.0.113.7",
+	}); err != nil {
+		t.Fatalf("replaying the launch address must succeed, got %v", err)
+	}
+	for _, wrong := range []string{"config device set", "ip address add", "ip link"} {
+		if got := f.matching(wrong); len(got) != 0 {
+			t.Errorf("a launch address must not be touched again, got %v", got)
+		}
+	}
+}
+
+// TestRouteAddressRefusesARoutedMachineTheEmulatorDidNotCreate is the
+// ownership half. On a managed network mustOwn vouches for the network; a
+// routed NIC has none, so the question moves to the instance — whose name
+// arrives from Resource.Runtime, restored verbatim by PUT /_feint/state and
+// `feint snapshot load`. Without the check, a crafted snapshot would route an
+// emulated address into any container on the host.
+func TestRouteAddressRefusesARoutedMachineTheEmulatorDidNotCreate(t *testing.T) {
+	const foreign = "production-database"
+	f := &fakeRuntime{answers: map[string]string{
+		// The label is absent: the operator's instance, not ours.
+		"config get " + foreign: "",
+		"/1.0/instances/":       routedOnly,
+	}}
+	d := newFakeDriver(f)
+
+	if err := d.RouteAddress(context.Background(), AddressSpec{
+		Machine: foreign, Address: "192.0.2.2",
+	}); err == nil {
+		t.Fatal("an address was routed into an instance the emulator never created")
+	}
+	for _, command := range f.commands() {
+		if !strings.Contains(command, foreign) {
+			continue
+		}
+		// Inspecting and reading the label are the questions themselves.
+		if strings.HasPrefix(command, "config get ") || strings.HasPrefix(command, "query ") {
+			continue
+		}
+		t.Errorf("a command reached the operator's own instance: %s", command)
+	}
+}
+
+// TestUnrouteAddressRepairsARoutedNIC holds the withdrawal in both driver
+// modes. Removing the entry from ipv4.routes re-plugs the device like adding
+// one does, so the repair must follow — without it the machine loses the
+// address the API still publishes, not only the one being taken back.
+func TestUnrouteAddressRepairsARoutedNIC(t *testing.T) {
+	const carrying = `{
+  "expanded_devices": {
+    "eth0": {"type": "nic", "nictype": "routed", "ipv4.address": "203.0.113.7",
+             "ipv4.host_address": "169.254.0.1", "ipv4.routes": "192.0.2.2/32"}
+  },
+  "devices": {
+    "eth0": {"type": "nic", "nictype": "routed", "ipv4.address": "203.0.113.7",
+             "ipv4.host_address": "169.254.0.1", "ipv4.routes": "192.0.2.2/32"}
+  }
+}`
+	for name, ovn := range map[string]bool{"bridge mode": false, "ovn mode": true} {
+		t.Run(name, func(t *testing.T) {
+			f := &fakeRuntime{answers: map[string]string{
+				"/1.0/instances/vm":                     carrying,
+				"config device get vm eth0 ipv4.routes": "192.0.2.2/32",
+			}}
+			d := newFakeDriver(f)
+			d.OVN = ovn
+
+			if err := d.UnrouteAddress(context.Background(), "vm", "192.0.2.2"); err != nil {
+				t.Fatalf("unroute: %v", err)
+			}
+			cleared := false
+			for _, cmd := range f.matching("config device set vm eth0 ipv4.routes=") {
+				if strings.HasSuffix(cmd, "ipv4.routes=") {
+					cleared = true
+				}
+			}
+			if !cleared {
+				t.Fatalf("the route must be taken off the device, got:\n%s",
+					strings.Join(f.commands(), "\n"))
+			}
+			for _, must := range []string{
+				"exec vm -- ip link set eth0 up",
+				"exec vm -- ip address add 203.0.113.7/32 dev eth0",
+			} {
+				if len(f.matching(must)) == 0 {
+					t.Errorf("the re-plug must be repaired, missing %q in:\n%s",
+						must, strings.Join(f.commands(), "\n"))
+				}
+			}
+		})
+	}
+}

--- a/internal/core/machine/incus_firewall.go
+++ b/internal/core/machine/incus_firewall.go
@@ -162,7 +162,33 @@ func (d *Incus) ApplyFirewall(ctx context.Context, machine string, binding Firew
 
 	joined := strings.Join(binding.Names, ",")
 	networkTypes := map[string]string{}
+	var unenforceable error
 	for _, device := range devices {
+		// A routed NIC takes no rule set at all (#337). Measured on Incus 7.2
+		// and confirmed by the 7.3 wording of the same refusal: every security
+		// option is an invalid device option there — security.acls, its two
+		// default actions, and both filtering flags — so there is no mechanism
+		// to enforce with, only keys to be refused on.
+		//
+		// Detaching skips it: no rule set has ever been attached to a routed
+		// NIC, so an empty binding has nothing to take back. A binding that
+		// names rule sets is refused with the typed error instead of being
+		// half-sent: until #337 the doomed keys were sent, the failure was
+		// logged as an operational ERROR, and the control plane answered as if
+		// the group were enforced — a green light over rules that existed
+		// nowhere. The other interfaces still get their rule sets first; a
+		// machine with a private NIC beside its routed one keeps its private
+		// plane covered.
+		//
+		// TestApplyFirewallRefusesAGroupOnARoutedNIC and
+		// TestApplyFirewallDetachIgnoresARoutedNIC fail without this.
+		if device.routed {
+			if joined != "" && unenforceable == nil {
+				unenforceable = fmt.Errorf("apply firewall to %s/%s: a routed NIC accepts no security option: %w",
+					machine, device.name, ErrFirewallUnenforceable)
+			}
+			continue
+		}
 		// "set" for a device the instance owns, "override" for one it inherits
 		// from a profile. Incus refuses the first on an inherited device, and
 		// the second copies it locally rather than editing the profile every
@@ -193,7 +219,7 @@ func (d *Incus) ApplyFirewall(ctx context.Context, machine string, binding Firew
 			return fmt.Errorf("apply firewall to %s/%s: %w", machine, device.name, err)
 		}
 	}
-	return nil
+	return unenforceable
 }
 
 // isOVNNetwork reports whether a network is OVN-typed, caching the answer for
@@ -265,11 +291,13 @@ func FirewallName(prefix, id string) string {
 }
 
 // nicDevice is one interface of a machine: its name, the network it sits on,
-// and whether it comes from a profile.
+// whether it comes from a profile, and whether it is a routed NIC — the one
+// kind that sits on no network and takes no security option.
 type nicDevice struct {
 	name      string
 	network   string
 	inherited bool
+	routed    bool
 }
 
 // networkDevices lists every NIC of a machine, its own and the ones it inherits.
@@ -299,7 +327,12 @@ func (d *Incus) networkDevices(ctx context.Context, machine string) ([]nicDevice
 			continue
 		}
 		_, own := raw.Devices[name]
-		devices = append(devices, nicDevice{name: name, network: device["network"], inherited: !own})
+		devices = append(devices, nicDevice{
+			name:      name,
+			network:   device["network"],
+			inherited: !own,
+			routed:    device["nictype"] == "routed",
+		})
 	}
 	return devices, nil
 }

--- a/internal/core/machine/incus_firewall_test.go
+++ b/internal/core/machine/incus_firewall_test.go
@@ -409,6 +409,78 @@ func TestApplyFirewallRefusesAnInstanceTheEmulatorDidNotCreate(t *testing.T) {
 	}
 }
 
+// mixedNICs is the terraform conformance server's machine: a routed eth0
+// carrying the public addresses from the launch, and a private NIC attached
+// afterwards on a managed network.
+const mixedNICs = `{
+  "expanded_devices": {
+    "eth0": {"type": "nic", "nictype": "routed", "ipv4.address": "203.0.113.7"},
+    "eth1": {"type": "nic", "network": "scw-abc"}
+  },
+  "devices": {
+    "eth0": {"type": "nic", "nictype": "routed", "ipv4.address": "203.0.113.7"},
+    "eth1": {"type": "nic", "network": "scw-abc"}
+  }
+}`
+
+// TestApplyFirewallRefusesAGroupOnARoutedNIC holds the honest half of #337. A
+// routed NIC accepts no security option — measured on Incus 7.2 and 7.3, every
+// key an invalid device option — so a binding that names rule sets must come
+// back as the typed refusal, with no doomed key ever sent to that interface,
+// while the interfaces that can enforce still get their rule sets. Until #337
+// the keys were sent, the failure was logged as an operational ERROR, and the
+// control plane answered as if the group were enforced.
+func TestApplyFirewallRefusesAGroupOnARoutedNIC(t *testing.T) {
+	f := &fakeRuntime{answers: map[string]string{
+		"/1.0/instances/srv": mixedNICs,
+		"/1.0/networks/":     `{"type": "bridge"}`,
+	}}
+	d := newFakeDriver(f)
+
+	err := d.ApplyFirewall(context.Background(), "srv", FirewallBinding{
+		Names:          []string{"sg-one"},
+		DefaultIngress: "drop",
+		DefaultEgress:  "allow",
+	})
+	if !errors.Is(err, ErrFirewallUnenforceable) {
+		t.Fatalf("a rule set on a routed NIC must be refused with the typed error, got %v", err)
+	}
+	for _, cmd := range f.matching("security.acls") {
+		if strings.Contains(cmd, " eth0 ") {
+			t.Errorf("a security option was sent to the routed NIC: %q", cmd)
+		}
+	}
+	if got := f.matching("config device set srv eth1 security.acls=sg-one"); len(got) != 1 {
+		t.Errorf("the enforceable interface must still get its rule set, got:\n%s",
+			strings.Join(f.commands(), "\n"))
+	}
+}
+
+// TestApplyFirewallDetachIgnoresARoutedNIC holds the other direction: no rule
+// set has ever been attached to a routed NIC, so an empty binding — the
+// detach-all every permissive group now becomes — has nothing to take back
+// there and must not fail over it.
+func TestApplyFirewallDetachIgnoresARoutedNIC(t *testing.T) {
+	f := &fakeRuntime{answers: map[string]string{
+		"/1.0/instances/srv": mixedNICs,
+		"/1.0/networks/":     `{"type": "bridge"}`,
+	}}
+	d := newFakeDriver(f)
+
+	if err := d.ApplyFirewall(context.Background(), "srv", FirewallBinding{}); err != nil {
+		t.Fatalf("detaching must succeed on a machine with a routed NIC, got %v", err)
+	}
+	for _, cmd := range f.matching("security.acls") {
+		if strings.Contains(cmd, " eth0 ") {
+			t.Errorf("the routed NIC has nothing to detach and must not be touched: %q", cmd)
+		}
+	}
+	if got := f.matching("config device set srv eth1 security.acls="); len(got) != 1 {
+		t.Errorf("the managed interface must still be detached, got:\n%s",
+			strings.Join(f.commands(), "\n"))
+	}
+}
+
 // And the accepting half. A guard that refused everything would pass the test
 // above and leave the product unable to attach a security group at all.
 func TestApplyFirewallStillWorksOnOurOwnInstance(t *testing.T) {

--- a/internal/core/machine/incus_ovn.go
+++ b/internal/core/machine/incus_ovn.go
@@ -357,7 +357,26 @@ func (d *Incus) unrouteAddressOVN(ctx context.Context, machine, address string) 
 			return fmt.Errorf("inspect %s: %w", machine, err)
 		}
 		for device, cfg := range devices.own {
-			if cfg["type"] != "nic" || !routeListContains(cfg["ipv4.routes.external"], route) {
+			if cfg["type"] != "nic" {
+				continue
+			}
+			// A routed NIC in OVN mode (#337): a machine that joins no network
+			// has no OVN port, so its extra addresses live in the device's own
+			// ipv4.routes, exactly as in bridge mode — and removing one
+			// re-plugs the device, so the same repair follows.
+			if cfg["nictype"] == "routed" {
+				if !routeListContains(cfg["ipv4.routes"], route) {
+					continue
+				}
+				if err := d.setDeviceRoutes(ctx, machine, device, address, false); err != nil {
+					return err
+				}
+				if err := d.repairRoutedInterface(ctx, machine, device); err != nil {
+					return err
+				}
+				continue
+			}
+			if !routeListContains(cfg["ipv4.routes.external"], route) {
 				continue
 			}
 			kept := removeRoute(cfg["ipv4.routes.external"], route)

--- a/internal/providers/scaleway/firewall.go
+++ b/internal/providers/scaleway/firewall.go
@@ -2,6 +2,7 @@ package scaleway
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/stephrobert/feint/internal/core/machine"
@@ -48,10 +49,28 @@ func (p *Pack) syncSecurityGroup(ctx context.Context, group *resource.Resource) 
 			continue
 		}
 		if err := fw.ApplyFirewall(ctx, name, binding); err != nil {
-			p.logger().Error("could not apply the firewall to a machine",
-				"security_group", group.ID, "server", server.ID, "error", err)
+			p.reportFirewall(err, "security_group", group.ID, "server", server.ID)
 		}
 	}
+}
+
+// reportFirewall logs a failed application at the level it deserves. A rule
+// set the runtime has no mechanism for — a routed NIC, the interface of a
+// server with only a public address (#337) — is a declared limit, not an
+// operational failure: /_feint/health publishes it as
+// capabilities.firewall_public_only=false and docs/limits.md carries the
+// measurement, so the warning names the declaration instead of crying wolf.
+// Anything else stays an error, because nothing declared it.
+// TestAnUnenforceableGroupIsReportedAsTheDeclaredLimit fails without the
+// distinction.
+func (p *Pack) reportFirewall(err error, keyvals ...any) {
+	if errors.Is(err, machine.ErrFirewallUnenforceable) {
+		p.logger().Warn("the security group is not enforced on this machine's public-only interface, "+
+			"which the runtime declares (capabilities.firewall_public_only=false, docs/limits.md)",
+			append(keyvals, "error", err)...)
+		return
+	}
+	p.logger().Error("could not apply the firewall to a machine", append(keyvals, "error", err)...)
 }
 
 // applyServerFirewall binds the group a server carries to its machine. Called
@@ -82,26 +101,37 @@ func (p *Pack) applyServerFirewall(ctx context.Context, server *resource.Resourc
 		return
 	}
 	if err := fw.ApplyFirewall(ctx, name, p.bindingOf(spec)); err != nil {
-		p.logger().Error("could not apply the firewall to a machine",
-			"server", server.ID, "machine", name, "error", err)
+		p.reportFirewall(err, "server", server.ID, "machine", name)
 	}
 }
 
 // bindingOf turns a rule set into what the machine's interfaces enforce.
 //
-// On a natively isolated runtime, a group that enforces nothing attaches
-// nothing. This is not an optimisation. The runtime's OVN pipeline evaluates
-// the sender's egress rules before the receiver's ingress default (the
-// priority constants in acl_ovn.go at v7.2.0: NIC ingress default 100, NIC
-// egress default 111, rule-level allow 300), so any allow carried by the
-// sender's rule set opens a port the receiver's default-deny closes — measured
-// here with the suite's own probe machine. The default security group is pure
-// accept, upstream it filters nothing, and the only faithful translation of
-// "filters nothing" in that pipeline is absence. A group that does restrict
+// A group that enforces nothing attaches nothing, on every runtime. This is
+// not an optimisation, and each runtime family contributed its own measured
+// reason:
+//
+//   - OVN: the pipeline evaluates the sender's egress rules before the
+//     receiver's ingress default (the priority constants in acl_ovn.go at
+//     v7.2.0: NIC ingress default 100, NIC egress default 111, rule-level
+//     allow 300), so any allow carried by the sender's rule set opens a port
+//     the receiver's default-deny closes — measured here with the suite's own
+//     probe machine.
+//   - routed NICs (#337): the default security group — pure accept, filtering
+//     nothing upstream — rides every `scw instance server create`, including
+//     onto a server with no emulated network under it, whose one interface
+//     accepts no rule set at all. Attaching the empty policy there was an
+//     ERROR log the control plane answered over as if the group were
+//     enforced.
+//
+// The default security group filters nothing upstream, and the only faithful
+// translation of "filters nothing" is absence. A group that does restrict
 // something still attaches, and the residual gap between two such groups on
-// one subnet is recorded in docs/limits.md.
+// one OVN subnet is recorded in docs/limits.md.
+// TestAPermissiveGroupBindsNothingOnEveryRuntime fails without the
+// unconditional half.
 func (p *Pack) bindingOf(spec machine.FirewallSpec) machine.FirewallBinding {
-	if p.nativeIsolation() && enforcesNothing(spec) {
+	if enforcesNothing(spec) {
 		return machine.FirewallBinding{}
 	}
 	return machine.FirewallBinding{

--- a/internal/providers/scaleway/firewall_internal_test.go
+++ b/internal/providers/scaleway/firewall_internal_test.go
@@ -1,6 +1,11 @@
 package scaleway
 
 import (
+	"bytes"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/stephrobert/feint/internal/core/emulator"
@@ -50,5 +55,69 @@ func TestFirewallSpecWritesPermissiveDefaultsAsCatchAlls(t *testing.T) {
 	spec = p.firewallSpecOf(group(policyDrop, policyDrop, true))
 	if got := catchAlls(spec); len(got) != 0 {
 		t.Errorf("drop/drop: catch-alls = %v, want none, or the group would open what it closes", got)
+	}
+}
+
+// TestAPermissiveGroupBindsNothingOnEveryRuntime holds the unconditional half
+// of bindingOf (#337). The empty binding used to be OVN's alone, for the
+// pipeline-priority reason its comment keeps; but the default security group —
+// pure accept, filtering nothing upstream — rides every `scw instance server
+// create`, including onto a server whose only interface is a routed NIC that
+// accepts no rule set at all. On the bridge runtime that attach was an ERROR
+// log the control plane answered over as if the group were enforced. The only
+// faithful translation of "filters nothing" is absence, on every runtime.
+func TestAPermissiveGroupBindsNothingOnEveryRuntime(t *testing.T) {
+	p := New(emulator.DefaultEnv())
+	if p.nativeIsolation() {
+		t.Fatal("the default env must not isolate natively, or this test measures the OVN branch")
+	}
+
+	permissive := machine.FirewallSpec{
+		Name:           "sg-permissive",
+		DefaultIngress: "allow",
+		DefaultEgress:  "allow",
+		Rules: []machine.FirewallRule{
+			{Direction: "ingress", Action: "allow"},
+			{Direction: "egress", Action: "allow"},
+		},
+	}
+	if got := p.bindingOf(permissive); len(got.Names) != 0 {
+		t.Fatalf("a group that filters nothing must attach nothing, got %v", got.Names)
+	}
+
+	// The accepting half: a group that restricts something still attaches.
+	restrictive := permissive
+	restrictive.DefaultIngress = "drop"
+	if got := p.bindingOf(restrictive); len(got.Names) != 1 || got.DefaultIngress != "drop" {
+		t.Fatalf("a restricting group must still bind, got %+v", got)
+	}
+}
+
+// TestAnUnenforceableGroupIsReportedAsTheDeclaredLimit separates the two
+// meanings one ERROR line used to conflate (#337). A rule set the runtime has
+// no mechanism for — machine.ErrFirewallUnenforceable, the routed NIC — is a
+// declared limit, published as capabilities.firewall_public_only=false, and is
+// reported as a warning that names the declaration. A failure nothing declared
+// stays an error.
+func TestAnUnenforceableGroupIsReportedAsTheDeclaredLimit(t *testing.T) {
+	var buf bytes.Buffer
+	env := emulator.DefaultEnv()
+	env.Log = slog.New(slog.NewTextHandler(&buf, nil))
+	p := New(env)
+
+	p.reportFirewall(fmt.Errorf("apply firewall to m/eth0: %w", machine.ErrFirewallUnenforceable),
+		"server", "srv-1")
+	declared := buf.String()
+	if !strings.Contains(declared, "level=WARN") {
+		t.Fatalf("a declared limit must be a warning, got %q", declared)
+	}
+	if !strings.Contains(declared, "firewall_public_only") {
+		t.Fatalf("the warning must name the declaring capability, got %q", declared)
+	}
+
+	buf.Reset()
+	p.reportFirewall(errors.New("the daemon went away"), "server", "srv-1")
+	if failure := buf.String(); !strings.Contains(failure, "level=ERROR") {
+		t.Fatalf("an undeclared failure must stay an error, got %q", failure)
 	}
 }

--- a/tools/falsify/specs/balancer-dataplane.json
+++ b/tools/falsify/specs/balancer-dataplane.json
@@ -39,8 +39,8 @@
     {
       "label": "every mode declares balancing, including the one with no load balancer primitive",
       "file": "internal/core/machine/capabilities.go",
-      "find": "\t\tBalancing:       d.OVN,",
-      "replace": "\t\tBalancing:       d.OVN || true,",
+      "find": "\t\tBalancing:          d.OVN,",
+      "replace": "\t\tBalancing:          d.OVN || true,",
       "test": "TestABridgeBackedRunHasNoBalancer"
     },
     {

--- a/tools/falsify/specs/routed-nic.json
+++ b/tools/falsify/specs/routed-nic.json
@@ -1,0 +1,77 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "the routed NIC becomes invisible to interface selection again",
+      "file": "internal/core/machine/incus_address.go",
+      "find": "\t\tif config[\"type\"] == \"nic\" && (config[\"network\"] != \"\" || config[\"nictype\"] == \"routed\") {",
+      "replace": "\t\tif config[\"type\"] == \"nic\" && config[\"network\"] != \"\" {",
+      "test": "TestRouteAddressReachesARoutedNIC"
+    },
+    {
+      "label": "the ownership question is no longer asked before routing into a routed machine",
+      "file": "internal/core/machine/incus_address.go",
+      "find": "\t\tif err := d.mustOwnInstance(ctx, spec.Machine); err != nil {\n\t\t\treturn err\n\t\t}\n\t\treturn d.routeOntoRoutedNIC(ctx, spec.Machine, device, spec.Address)",
+      "replace": "\t\tif err := d.mustOwnInstance(ctx, spec.Machine); err != nil && false {\n\t\t\treturn err\n\t\t}\n\t\treturn d.routeOntoRoutedNIC(ctx, spec.Machine, device, spec.Address)",
+      "test": "TestRouteAddressRefusesARoutedMachineTheEmulatorDidNotCreate"
+    },
+    {
+      "label": "a launch address is re-routed at every replay, re-plugging a working interface",
+      "file": "internal/core/machine/incus_address.go",
+      "find": "\tcfg := devices.own[device]\n\tif routeListContains(cfg[\"ipv4.address\"], address) {\n\t\treturn nil\n\t}",
+      "replace": "\tcfg := devices.own[device]\n\tif routeListContains(cfg[\"ipv4.address\"], address) && false {\n\t\treturn nil\n\t}",
+      "test": "TestRouteAddressLeavesALaunchAddressAlone"
+    },
+    {
+      "label": "the re-plug a route edit causes is no longer repaired, leaving the guest bare",
+      "file": "internal/core/machine/incus_address.go",
+      "find": "\t\t\treturn fmt.Errorf(\"route %s to %s/%s: %w\", address, machine, device, err)\n\t\t}\n\t\tif err := d.repairRoutedInterface(ctx, machine, device); err != nil {\n\t\t\treturn err\n\t\t}",
+      "replace": "\t\t\treturn fmt.Errorf(\"route %s to %s/%s: %w\", address, machine, device, err)\n\t\t}\n\t\tif false {\n\t\t\tif err := d.repairRoutedInterface(ctx, machine, device); err != nil {\n\t\t\t\treturn err\n\t\t\t}\n\t\t}",
+      "test": "TestRouteAddressReachesARoutedNIC"
+    },
+    {
+      "label": "a withdrawal from a routed NIC stops repairing the re-plug it causes",
+      "file": "internal/core/machine/incus_address.go",
+      "find": "\t\tif cfg[\"nictype\"] == \"routed\" {",
+      "replace": "\t\tif cfg[\"nictype\"] == \"routed\" && false {",
+      "test": "TestUnrouteAddressRepairsARoutedNIC"
+    },
+    {
+      "label": "the OVN unroute goes back to seeing only external routes, missing routed NICs",
+      "file": "internal/core/machine/incus_ovn.go",
+      "find": "\t\t\tif cfg[\"nictype\"] == \"routed\" {",
+      "replace": "\t\t\tif cfg[\"nictype\"] == \"routed\" && false {",
+      "test": "TestUnrouteAddressRepairsARoutedNIC"
+    },
+    {
+      "label": "a rule set on a routed NIC is silently skipped instead of refused",
+      "file": "internal/core/machine/incus_firewall.go",
+      "find": "\t\tif device.routed {\n\t\t\tif joined != \"\" && unenforceable == nil {",
+      "replace": "\t\tif device.routed {\n\t\t\tif false && joined != \"\" && unenforceable == nil {",
+      "test": "TestApplyFirewallRefusesAGroupOnARoutedNIC"
+    },
+    {
+      "label": "the routed NIC is handed the doomed security keys again",
+      "file": "internal/core/machine/incus_firewall.go",
+      "find": "\t\tif device.routed {",
+      "replace": "\t\tif device.routed && false {",
+      "test": "TestApplyFirewallDetachIgnoresARoutedNIC"
+    },
+    {
+      "label": "a group that filters nothing goes back to binding on non-OVN runtimes",
+      "package": "./internal/providers/scaleway/",
+      "file": "internal/providers/scaleway/firewall.go",
+      "find": "\tif enforcesNothing(spec) {\n\t\treturn machine.FirewallBinding{}\n\t}",
+      "replace": "\tif p.nativeIsolation() && enforcesNothing(spec) {\n\t\treturn machine.FirewallBinding{}\n\t}",
+      "test": "TestAPermissiveGroupBindsNothingOnEveryRuntime"
+    },
+    {
+      "label": "a declared limit is reported as an operational failure again",
+      "package": "./internal/providers/scaleway/",
+      "file": "internal/providers/scaleway/firewall.go",
+      "find": "\tif errors.Is(err, machine.ErrFirewallUnenforceable) {",
+      "replace": "\tif errors.Is(err, machine.ErrFirewallUnenforceable) && false {",
+      "test": "TestAnUnenforceableGroupIsReportedAsTheDeclaredLimit"
+    }
+  ]
+}


### PR DESCRIPTION
One root, two symptoms. Since #202 a machine that joins no emulated network
carries its published addresses on a **routed** NIC, which has no `network`
key — and two paths of `internal/core/machine` were written for a NIC of a
managed network.

## Symptom 2 — addresses: repaired

Both address paths selected interfaces by `network != ""`, so a routed NIC was
invisible: every address routed *after* launch died on `machine has no network
interface` **while the API answered as if it were attached**.

Measured before the fix, on the base commit: `exoscale/ssh.sh` reports
`ok: elastic IP 192.0.2.2 attached` and then `FAIL: no ssh daemon answered for
debian@192.0.2.2`.

`interfaceFor` now recognises it, and the mechanism is the NIC's own in both
driver modes: the address joins the device's `ipv4.routes`, a launch address
already in `ipv4.address` is left alone, and ownership moves to the instance
label since there is no network to vouch for the call.

**A premise the measurement overturned, and it is the obligatory half of the
fix**: editing `ipv4.routes` on a live device **re-plugs it** — the guest
interface comes back down and bare. The mechanism alone would have killed every
machine it served. `repairRoutedInterface` restores it from the device's own
config.

After: `conformance: exoscale ssh round-trip passed` with a real
`debian@192.0.2.2` login, the Scaleway suite still green, and not one ERROR
line left.

## Symptom 1 — firewall: **declared absent**, not imitated

Measured key by key on a cold container with a routed NIC (Incus 7.2):
`security.acls`, `security.acls.default.ingress.action`,
`security.ipv4_filtering`, `security.mac_filtering` — **all `Invalid device
option`**. The same pair on a managed network's NIC only complains that the ACL
does not exist. **No filtering mechanism exists for a routed NIC**, so "really
applied" is not available.

Until now `ApplyFirewall` sent the doomed keys, the failure was logged as an
operational ERROR, and **the control plane answered as if the group were
enforced** — a 200 worth less than it says, on the very surface somebody would
use to test their firewall rules.

Now:

- `ApplyFirewall` returns the typed `machine.ErrFirewallUnenforceable` for a
  rule set bound to a routed NIC, still covering the interfaces that *can*
  enforce, and skips the NIC on detach where nothing was ever attached;
- `/_feint/health` **declares** `capabilities.firewall_public_only`, false in
  every Incus mode — health schema **v5**, frozen fixture moved with it;
- the Scaleway pack binds nothing for a group that filters nothing (the default
  group riding every `scw instance server create`) on every runtime, and
  reports the typed refusal **as the declared limit it is, not as a failure**.

**Why not an HTTP refusal**, which the issue suggested: the conformance
fixture itself binds a restrictive group (`inbound drop`) to a
public-addresses-only server at create, and the real cloud accepts it. Refusing
the call would break `terraform apply` — the north star. So the loudness is:
typed driver error, capability declared absent, a WARN naming that declaration,
and `docs/limits.md`.

## The OVN failure is pre-existing, and that was measured rather than argued

`FEINT_VM=incus-ovn mise run conformance` dies in the outscale-tofu suite on
`Failed deleting nftables chain "fwd.feint-uplink": No such file or directory`.

**Reproduced identically on `main` without this commit.** The same leg run in
isolation passes on both trees, so it depends on state accumulated by a full
pass. It is invisible in CI because `runtime-proof` never reaches that suite.
Filed separately rather than folded in here.

`FEINT_VM=incus mise run conformance` — the mode that carries this issue's
judge — is **fully green**, 552 s, all suites, 335/357 routes proven.

## Falsified

`tools/falsify/specs/routed-nic.json` — **10 mutations, each compiles, each
turns exactly its named test red**, green after restoration, verified twice
(before and after rebase). Among them: *the routed NIC becomes invisible to
interface selection again*, *the re-plug a route edit causes is no longer
repaired, leaving the guest bare*, *a rule set on a routed NIC is silently
skipped instead of refused*, *a declared limit is reported as an operational
failure again*.

`mise run falsify:lint` also caught a mutation of `balancer-dataplane.json`
that a gofmt realignment had detached; retargeted.

## Station

Before: a pre-existing unmanaged bridge with an **orphan dnsmasq holding
10.50.2.1** — it is what failed this work's first conformance
(`dnsmasq: failed to create listening socket`). After: zero instances, zero
`fnt-*`/`feint-*` networks, orphan and bridge gone, the author's own `acltest`
ACL untouched.

**A diagnostic gap worth naming**: `feint doctor` answered *"no DHCP service
outlives its interface"* while that orphan held the address. The check compares
against interfaces, and there the interface had survived alongside its service —
the case where *both* outlive the network escapes it.

## Related

Closes #337
