### PR TITLE
fix(machine): the uplink race is gone, and doctor asks about networks

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -246,6 +246,18 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Corrigé
 
+- **Attacher une NIC privée ne met plus toutes les machines en file derrière la
+  plus lente** (#348). Six attachements sur la stack d'exemple Scaleway en
+  `--vm incus-ovn` ont pris 26 s, 31 s, 42 s, 52 s, 63 s et 73 s — dix secondes
+  de plus à chaque fois, c'est-à-dire le travail d'une machine repayé par toutes
+  celles qui la suivent. Passé la minute, le client abandonne et rejoue, et son
+  rejeu tombe sur l'interface que sa propre première tentative avait créée :
+  *le serveur est déjà attaché à ce réseau privé*. Le pilote tenait un unique
+  mutex de paquet pendant tous ses appels dans la machine ; il prend désormais
+  le verrou par cible du dépôt, indexé par machine — la portée qu'a toujours eue
+  la collision de noms qu'il protège. Mesuré sur `main` sans cette branche : la
+  même pente, donc la file préexiste et n'était qu'inatteignable derrière
+  #341.
 - **Un passage complet `incus-ovn` ne fait plus supprimer deux fois la même
   chaîne de pare-feu au démon** (#341). L'échec — `Failed deleting nftables
   chain "fwd.feint-uplink": No such file or directory`, qui tuait la suite

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -246,6 +246,36 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Corrigé
 
+- **Un passage complet `incus-ovn` ne fait plus supprimer deux fois la même
+  chaîne de pare-feu au démon** (#341). L'échec — `Failed deleting nftables
+  chain "fwd.feint-uplink": No such file or directory`, qui tuait la suite
+  outscale-tofu — se reproduit **depuis une station vierge** : la lecture « état
+  accumulé entre les passages » n'était vraie qu'à moitié. Mesuré avec `incus
+  monitor` sur un passage entier : `feint clean` en fin de suite oapi-cli
+  supprime l'uplink, puis le parallélisme par défaut d'OpenTofu recrée d'un coup
+  deux subnets et un réseau machine par défaut. Un `PUT` sur l'uplink et un
+  `POST` de réseau OVN qui s'y rattache font tous deux reconstruire le pare-feu
+  nftables de l'uplink, et le `removeChains` d'Incus liste puis supprime sans
+  verrou partagé entre ces deux chemins — la chaîne du perdant est donc
+  supprimée par l'opération concurrente *entre son propre relevé et sa
+  suppression*. `uplinkMu` sérialise désormais toute opération qui fait
+  reconstruire l'uplink, le `network create` compris.
+- **Un réseau OVN supprimé retire son bloc délégué de l'uplink** (#341).
+  `RemoveNetwork` ne le faisait jamais, si bien qu'un seul passage en accumulait
+  neuf — les sept routes signalées par l'issue n'étaient pas le résidu de sept
+  exécutions. Un uplink laissé par une exécution morte est aussi adopté une fois
+  par processus, en retirant les routes des réseaux disparus ; et un uplink tenu
+  par un émulateur **vivant** est refusé plutôt que partagé, le partage entre
+  processus étant la même corruption sans verrou sous un autre nom.
+- **`feint doctor` demande si un service DHCP survit à son réseau, et non à son
+  interface** (#342). Il répondait `ok` pendant qu'un orphelin tenait
+  `10.50.2.1` et faisait échouer la conformance suivante, parce qu'il cherchait
+  un service dont l'interface avait disparu — or l'interface avait survécu *avec*
+  son service. Les deux avaient survécu au réseau, et c'est la question que
+  personne ne posait. Un reste est désormais une ligne rouge qui nomme le bloc
+  et le pid, `feint clean` tue le service et **dit ce qu'il ne touchera pas** —
+  un pont sans étiquette n'est pas démontrablement à nous — et chaque ligne
+  verte de `doctor` a été relue contre ce qu'elle mesure réellement.
 - **Une suite de conformité ssh refuse de démarrer quand l'émulateur ne détient
   aucune des images qu'elle démarre, et la preuve runtime les construit**
   (#335). `runtime-proof.yml` échouait sur son étape *Scaleway ssh suite* cinq

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,6 +230,17 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Fixed
 
+- **Attaching a private NIC no longer queues every machine behind the slowest
+  one** (#348). Six attachments on the Scaleway example stack under
+  `--vm incus-ovn` took 26s, 31s, 42s, 52s, 63s and 73s — a flat ten seconds
+  each, which is one machine's work paid again by every machine behind it. Past
+  the client's minute the apply gives up and retries, and the retry meets the
+  interface its own first attempt created: *the server is already attached to
+  this private network*. The driver held one package-level mutex across every
+  call it makes into the machine; it now takes the repository's own per-target
+  lock, keyed by machine, which is what the name collision it guards against
+  has always been scoped to. Measured on `main` without this branch: the same
+  slope, so the queue predates it and was merely unreachable behind #341.
 - **A full `incus-ovn` conformance pass no longer races the daemon into
   deleting a firewall chain twice** (#341). The failure — `Failed deleting
   nftables chain "fwd.feint-uplink": No such file or directory`, killing the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,6 +230,36 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Fixed
 
+- **A full `incus-ovn` conformance pass no longer races the daemon into
+  deleting a firewall chain twice** (#341). The failure — `Failed deleting
+  nftables chain "fwd.feint-uplink": No such file or directory`, killing the
+  outscale-tofu suite — reproduces from a **clean station**, so the "state
+  accumulated across runs" reading was only half right. Measured with `incus
+  monitor` through a whole pass: `feint clean` at the end of the oapi-cli suite
+  deletes the uplink, then OpenTofu's default parallelism recreates two subnets
+  and a default machine network at once. A network `PUT` on the uplink and an
+  OVN network `POST` attached to it both make the daemon rebuild the uplink's
+  nftables firewall, and Incus' `removeChains` is a snapshot-then-delete with
+  no lock shared between those two paths — so the loser's chain is deleted by
+  the concurrent operation *between its own snapshot and its delete*. `uplinkMu`
+  now serialises every operation that makes the daemon rebuild the uplink, the
+  `network create` included.
+- **A deleted OVN network takes its delegated block off the uplink** (#341).
+  `RemoveNetwork` never withdrew the route, so one pass accumulated nine of
+  them — the seven the issue reported were not the residue of seven runs. An
+  uplink left behind by a dead run is also adopted once per process, dropping
+  the routes of networks that no longer exist, and an uplink held by a **live**
+  emulator is refused rather than shared: sharing it across processes is the
+  same unlocked corruption by another name.
+- **`feint doctor` asks whether a DHCP service outlives its network, not its
+  interface** (#342). It answered `ok` while an orphan held `10.50.2.1` and
+  broke the next run's conformance, because it looked for a service whose
+  interface was gone — and there the interface had survived *alongside* its
+  service. Both had outlived the network, which is the question nobody asked.
+  A leftover is now a red line naming the block and the pid, `feint clean` kills
+  the service and **says what it will not touch** — an unlabelled bridge is not
+  demonstrably ours — and every green line of `doctor` was re-read against what
+  it actually measured.
 - **An ssh conformance suite refuses to start when the emulator holds none of
   the images it boots, and the runtime proof builds them** (#335).
   `runtime-proof.yml` failed on its *Scaleway ssh suite* step on five

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -203,3 +203,43 @@ détruit ses ressources ; l'émulateur est arrêté, aucun processus feint) :
   `FEINT_VM=incus-ovn mise run serve`.
 - Scratchpad : `…/scratchpad/` contient les logs de mesure et
   `incus-src` (clone shallow d'Incus v7.2.0, lecture seule).
+
+
+---
+
+## Suite donnée par le coordinateur (2026-08-20, après épuisement du crédit)
+
+Rebase sur `d735385` (#337) fait, `prepush` vert, entrées de changelog écrites
+dans les deux langues. Puis le critère d'acceptation de #341 a été lancé, et il
+a produit un résultat que ce brief ne pouvait pas prévoir.
+
+**Le correctif de #341 marche, et c'est mesuré des deux côtés :**
+
+| | référence `d735385` | avec ce lot |
+|---|---|---|
+| `Failed deleting nftables chain` | **1** | **0** |
+| suite `outscale-tofu` | morte dessus | passée |
+| stacks d'exemple atteintes | **jamais** (`stacks=0`) | oui |
+
+Vérifié sur tous les logs de passage OVN du scratchpad : `stacks=0` partout.
+**`pass-1.log` est le premier passage `incus-ovn` de ce dépôt à atteindre les
+stacks d'exemple.** Le mur tombé en révèle donc un autre, exactement comme
+#335 avait masqué #341.
+
+**Le mur suivant**, et il n'est pas de notre fait : la stack d'exemple Scaleway
+échoue *immédiatement* sur `init and apply`, sur **les deux** serveurs —
+`scaleway_instance_private_nic.web[0]` et `web[1]` — avec `the server is
+already attached to this private network`. Pas de `Still creating`, donc pas
+un timeout ni un retry lent. `run_stack` copie la stack dans un `mktemp -d`,
+donc pas d'état résiduel. Et la même stack passe en mode `incus` simple (la
+conformance de #337 était entièrement verte). C'est donc un défaut **propre au
+mode OVN**, invisible jusqu'ici faute d'y arriver.
+
+Filé séparément plutôt que traité ici : le corriger demande d'instrumenter un
+passage OVN de plus, et il ne conditionne pas la valeur de ce lot.
+
+**Conséquence sur le critère de #341** : « deux passages complets verts
+d'affilée » n'est pas atteignable tant que ce nouveau mur tient. Ce qui est
+prouvé, et qui était la question de l'issue, c'est que la course nftables ne se
+produit plus — mesurée présente sur la référence, absente ici, dans le même
+passage complet.

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -1,0 +1,205 @@
+# Reprise du lot #341 + #342 (jalon 0.10.0)
+
+> **Note d'intégration, ajoutée par le coordinateur.** L'agent qui a écrit ce
+> document a épuisé son crédit *avant* de committer : il écrivait « commité » au
+> futur. Le commit a été fait à sa place, tel quel, sans rien modifier de son
+> travail — l'arbre compile et `go test -race ./internal/core/machine/
+> ./internal/cli/` passe, vérifié avant le commit. Ce qui suit décrit donc
+> exactement le contenu de ce commit, mais **`mise run prepush` n'a pas été
+> rejoué** et les deux passages OVN consécutifs exigés par #341 n'ont pas eu
+> lieu.
+
+Base : `1df41a1` (main au moment du départ). **`main` a avancé depuis avec #337
+(`d735385`, NIC routée, capacité `firewall_public_only`, schéma santé v5) : il
+faudra rebaser.** Les sujets ne se recouvrent pas (doctor et uplink ici, NIC
+là-bas), le conflit devrait être nul ou trivial.
+
+## Ce qui est FAIT et prouvé
+
+Tout ce qui suit est commité, compile, et passe `go test -race
+./internal/core/machine/ ./internal/cli/`. Les trois specs de falsification
+passent (`compiled=yes / the test bit` sur les 11 mutations) :
+
+```
+python3 tools/falsify/falsify.py tools/falsify/specs/dhcp-leftover-ownership.json
+python3 tools/falsify/falsify.py tools/falsify/specs/uplink-serialisation.json
+python3 tools/falsify/falsify.py tools/falsify/specs/dhcp-doctor-network-question.json
+```
+
+## #341 — LA CAUSE, NOMMÉE ET MESURÉE (ne pas re-payer cette mesure)
+
+Un passage complet `FEINT_VM=incus-ovn mise run conformance` sur cette station
+(2026-08-20, 297 s, exit 1) a reproduit l'échec exact de l'issue **du premier
+coup, depuis une station propre** — la théorie « état accumulé de runs
+précédents » est donc partiellement démentie, voir Prémisses. Artefacts :
+
+- `/tmp/claude-1000/-home-bob-Projets-coucou/642e21ac-a973-45b5-ac8e-3ed5bef14b39/scratchpad/pass-baseline.log` (la suite outscale-tofu meurt sur `delegate 10.70.1.0/24 … Failed deleting nftables chain "fwd.feint-uplink" … No such file or directory`, lignes ~1668)
+- `…/scratchpad/monitor-baseline.log` (`incus monitor --pretty --type=logging --loglevel=debug` pendant tout le passage — **c'est la pièce à conviction**, lignes 5115–5145)
+- `…/scratchpad/watch-baseline.log` (routes de l'uplink + chaînes nftables toutes les 2 s)
+
+La chaîne causale, lisible dans monitor-baseline.log à 20:39:34–35 :
+
+1. `tools/conformance/outscale/oapi-cli.sh:785` lance **`feint clean` en fin de
+   suite** : l'uplink est vidé (`Update … ipv4.routes:` vide, ligne 4979) puis
+   **supprimé**. La suite outscale-tofu, juste derrière, doit donc tout
+   recréer d'un coup.
+2. tofu (parallélisme par défaut) crée en même temps : le subnet 10.70.1.0/24,
+   le subnet azb 10.70.2.0/24, et une VM sans subnet qui déclenche la création
+   du réseau machine par défaut `fnt-default`.
+3. Côté feint, la délégation d'un bloc est un `incus network set feint-uplink
+   ipv4.routes=…` (`delegateRoute`), qui ne prenait **pas** `uplinkMu` (le
+   verrou ne couvrait que `setUplinkRoute`) ; la création `network create
+   --type=ovn network=feint-uplink` n'était pas verrouillée non plus.
+4. Côté Incus 7.2 (source lu dans
+   `…/scratchpad/incus-src`) : un `PUT /1.0/networks/feint-uplink` (bridge
+   `Update → setup → Firewall.NetworkClear`) **et** un `POST /1.0/networks`
+   créant un réseau OVN attaché à l'uplink **reconstruisent tous deux le
+   pare-feu nftables de l'uplink** (mesuré : `Clearing firewall
+   driver=bridge network=feint-uplink` sous les deux requêtes, lignes 5133 et
+   5143). `removeChains` (`internal/server/firewall/drivers/drivers_nftables.go:766`)
+   est un **snapshot-puis-suppression** : il liste le ruleset, puis émet un
+   `nft flush chain … ; delete chain …` par chaîne trouvée. Les deux chemins ne
+   partagent **aucun verrou** dans le démon (`networkPut` n'en prend pas ; le
+   verrou `network.ovn.<uplink>` ne couvre que les opérations de port OVN).
+   Donc : la chaîne est **supprimée par l'autre requête d'abord**, et le
+   perdant meurt sur ENOENT. C'est la réponse à la question de l'issue
+   (« supprimée deux fois / par autre chose d'abord / jamais créée ») :
+   **supprimée par l'opération concurrente entre le snapshot du perdant et sa
+   suppression**.
+5. Pourquoi « seule une jambe complète le produit » : en jambe isolée,
+   `feint-uplink` et `fnt-default` **survivent du run précédent** (restes
+   volontairement gardés) — pas de création concurrente, pas de course. Le
+   passage complet intercale le `feint clean` d'oapi-cli, qui force la
+   recréation simultanée.
+
+Corroboration de la moitié « restes » : dans CE MÊME passage, l'uplink portait
+déjà 9 routes accumulées (10.182–10.186, 172.16.8/9, 10.190.x) avant le clean —
+`RemoveNetwork` ne retirait jamais le bloc délégué. Les « sept routes » de
+l'issue s'accumulent **dans un seul passage**, pas seulement entre passages.
+
+### Le correctif (commité)
+
+`internal/core/machine/incus.go` :
+- `uplinkMu` re-documenté : il sérialise désormais **toute** opération qui fait
+  reconstruire l'uplink par le démon. `EnsureNetwork` (branche OVN) tient le
+  verrou sur ensureUplink + delegateRoute + **le `network create` lui-même**.
+- `RemoveNetwork` : lit le bloc du réseau avant suppression
+  (`networkGateway` → `Masked()`), le **retire des routes de l'uplink après une
+  suppression réussie** (`dropUplinkRouteOVN`), sous le même verrou.
+- `networkCreateError` : nomme aussi un service DHCP **étranger** qui tient une
+  adresse du bloc demandé (seam `holderScan`), sans jamais proposer de le tuer.
+
+`internal/core/machine/incus_ovn.go` :
+- `delegateRoute`/`ensureUplink` : appelant tient `uplinkMu` ;
+  `addUplinkRoute`/`dropUplinkRoute` factorisent l'édition (écriture évitée
+  quand rien ne change — chaque écriture est une reconstruction du pare-feu).
+- `adoptUplink` (nouveau) : à la première réutilisation d'un uplink laissé par
+  un run mort, **les routes des réseaux disparus sont retirées** (on ne garde
+  que les blocs des réseaux OVN étiquetés encore debout), une fois par
+  processus (`uplinkAdopt sync.Once`, brûlé à la création pour ne pas
+  « réconcilier » nos propres /32).
+- `UplinkHolderKey` (`user.feint.holder` = pid) : un uplink tenu par un **autre
+  émulateur vivant** est **refusé** au lieu d'être partagé (le partage
+  inter-processus est la même corruption sans verrou possible). Un pid mort est
+  repris. Seam `holderProbe` pour les tests.
+
+Tests : `internal/core/machine/incus_uplink_test.go` (5 tests, dont la
+sérialisation prouvée par un runner qui détecte deux reconstructions en vol).
+Falsification : `tools/falsify/specs/uplink-serialisation.json` (5 mutations,
+toutes mordent).
+
+## #342 — fait aussi
+
+La question posée passe de l'interface au **réseau**. `classifyDHCP`
+(`internal/core/machine/leftover.go`) : un dnsmasq aux interfaces toutes
+`fnt-` est un reste si chaque interface est disparue **ou** si l'objet réseau
+n'existe plus dans **aucun projet** du runtime (`incus query
+/1.0/networks?recursion=1&all-projects=true`, prédicat conservateur trois fois
+— runtime muet, JSON illisible, nom trouvé quelque part ⇒ pas un reste) **et**
+que le processus tourne sur `/var/lib/incus/networks/<iface>/` (preuve la plus
+forte exigée quand le sujet est vivant). Nouveau champ
+`DHCPLeftover.InterfaceAlive`.
+
+- `feint doctor` (`internal/cli/doctor.go`) : le reste est un **FAIL** (rouge),
+  nomme bloc et pid ; la ligne verte dit « no DHCP service of the emulator's
+  outlives its network » avec le périmètre mesuré en détail.
+- `feint clean` (`internal/cli/clean.go`) : tue le service, et **dit ce qu'il
+  ne touchera pas** — le pont survivant, sans étiquette, n'est pas
+  démontrablement à nous (`sudo ip link delete <pont>` proposé à l'opérateur).
+- Relecture des lignes vertes de doctor (le point 4 de l'issue) — reformulées :
+  images (« le daemon ssh est la promesse de la recette, pas de ce contrôle »),
+  env hazards (« la liste mesurée du pack, pas tout le shell »), ProxyJump
+  (« les deux motifs mesurés, * et 10.* » ; « could not look » devient warn au
+  lieu d'un ok).
+- `DHCPHolders(block)` : la moitié « à nous ou non » de la question, répondue
+  au seul moment où le bloc voulu est connu : l'erreur de création.
+
+## Ce qui RESTE, dans l'ordre
+
+1. **Rejouer `mise run prepush`** (jamais rejoué après les derniers edits ;
+   `golangci-lint cache clean` d'abord si le lint parle de worktrees
+   supprimés — piège rencontré deux fois le 2026-08-20).
+2. **Entrées `## [Unreleased]` dans les DEUX changelogs** (CHANGELOG.md et
+   CHANGELOG.fr.md) — non faites.
+3. **LE CRITÈRE DE #341 : deux passages complets `FEINT_VM=incus-ovn mise run
+   conformance` verts d'affilée sur cette station** (~5 min chacun ici). Non
+   lancés après correctif — c'est la preuve d'acceptation, sans elle le lot
+   n'est pas clos. Utiliser
+   `…/scratchpad/run-pass.sh <label>` qui capture aussi monitor incus +
+   watcher (état avant/après inclus).
+4. Vérifier que la suite ssh/balancer OVN accepte le refus d'uplink partagé
+   (aucun scénario connu ne partage, zones.sh tourne sans --vm, mais le
+   passage complet tranchera).
+5. Rebaser sur main (#337). Commit final au format du dépôt, PR non ouverte
+   (consigne : commits locaux seulement).
+
+## Pièges rencontrés
+
+- **`mise` non « trusted » dans un worktree neuf** : `mise trust` d'abord,
+  sinon tout `mise run` échoue.
+- Les patterns de `fakeRuntime` (answers/fail) matchent par **sous-chaîne** sur
+  la commande jointe : choisir des clés qui ne se recouvrent pas
+  (`ipv4.address` vs `ipv4.routes`).
+- Le harnais falsify **refuse toute mutation qui perd un identifiant** (même un
+  const) : neutraliser par `&& false`, `[:0]`, `* 0`, jamais par suppression.
+- `feint clean` au milieu du passage complet (oapi-cli.sh:785) supprime
+  l'uplink pendant que l'émulateur sert : c'est voulu et ça marche parce que
+  les requêtes sont séquencées à ce moment-là. Ne pas « corriger » ça par un
+  refus de clean : le garde holder ne vise que les émulateurs vivants.
+- Le sandbox de l'agent refuse les heredocs/redirections composées : écrire les
+  scripts via Write puis `bash --noprofile --norc <fichier>`.
+
+## Prémisses démenties par la mesure
+
+- « L'échec dépend de l'état accumulé par des runs antérieurs » : **non** — il
+  se reproduit depuis une station vierge, au premier passage complet. Ce qui le
+  produit est le `feint clean` de fin d'oapi-cli + le parallélisme de tofu.
+  L'accumulation (les 7 routes) est réelle mais c'est un défaut **frère**
+  (restes), pas le déclencheur du crash.
+- « La même jambe isolée passe » s'explique par les restes gardés
+  (fnt-default et l'uplink survivent d'un run à l'autre), pas par une
+  différence d'arbre.
+- L'issue #342 dit « an unmanaged bridge » : exact, et la conséquence non
+  écrite est que **le pont survivant ne porte plus d'étiquette** — c'est
+  pourquoi clean ne peut pas le supprimer (mustOwn n'a plus rien à lire) et se
+  contente de le nommer.
+
+## État de la station à l'instant du handover
+
+Laissé par le passage baseline (le passage a échoué puis la suite tofu a
+détruit ses ressources ; l'émulateur est arrêté, aucun processus feint) :
+
+- `feint-uplink` (bridge, étiqueté feint) avec `ipv4.routes =
+  10.209.84.0/24,10.70.2.0/24` — **10.70.2.0/24 est un reste** (le subnet azb a
+  été détruit par le cleanup tofu, l'arbre commité ne portait pas encore le
+  retrait) ; il illustre exactement le défaut corrigé.
+- `fnt-default` (ovn, étiqueté) — reste volontairement gardé (politique
+  existante).
+- dnsmasq de `feint-uplink` (celui du runtime, normal tant que l'uplink vit).
+- Aucune machine, aucun pont orphelin, pas de dnsmasq orphelin.
+- `feint clean --vm incus-ovn` remettrait tout à zéro ; il a été laissé en
+  l'état **exprès** pour que le successeur puisse voir l'adoption
+  (`adoptUplink`) retirer 10.70.2.0/24 en vrai au premier
+  `FEINT_VM=incus-ovn mise run serve`.
+- Scratchpad : `…/scratchpad/` contient les logs de mesure et
+  `incus-src` (clone shallow d'Incus v7.2.0, lecture seule).

--- a/internal/cli/clean.go
+++ b/internal/cli/clean.go
@@ -98,17 +98,25 @@ var (
 	endLeftoverDHCP  = machine.TerminateLeftover
 )
 
-// sweepLeftoverDHCP ends the DHCP services an interrupted run left holding an
-// address block (#316): dnsmasq processes whose fnt- interface no longer
-// exists. They are invisible to `ip addr` and to the runtime's own listings —
-// only `ss -lnp` shows them — and the block they hold fails the next run
-// minutes in on "Address already in use".
+// sweepLeftoverDHCP ends the DHCP services an earlier run left holding an
+// address block (#316, #342): dnsmasq processes attributable to this emulator
+// whose network is gone — the interface with it, or the network object alone.
+// They are invisible to `ip addr` and to the runtime's own listings — only
+// `ss -lnp` shows them — and the block they hold fails the next run minutes
+// in on "Address already in use".
 //
 // Attribution comes first and lives in internal/core/machine: a process that
 // cannot be attributed to this emulator is never named here, let alone
 // signalled. The common refusal is not foreignness but permission — the
 // runtime's dnsmasq belongs to the incus user, not the operator — and then
 // the sweep reports the exact command instead of failing in silence.
+//
+// When the interface survived its network (#342), the sweep ends the service
+// and says what it will not touch: the bridge left standing carries no label
+// any more, so nothing on the host proves the emulator created it, and a
+// bridge nobody here created is not ours to delete. Saying so beats deleting
+// it and beats silence: the operator gets the exact command and the decision.
+// TestCleanSaysWhatItWillNotTouchWhenTheBridgeSurvived fails without the line.
 func sweepLeftoverDHCP(stdout io.Writer) error {
 	leftovers, err := findLeftoverDHCP()
 	if err != nil {
@@ -122,9 +130,13 @@ func sweepLeftoverDHCP(stdout io.Writer) error {
 		err := endLeftoverDHCP(leftover)
 		switch {
 		case err == nil:
-			fmt.Fprintf(stdout, "ended a DHCP service an interrupted run left behind: %s\n", leftover)
+			fmt.Fprintf(stdout, "ended a DHCP service an earlier run left behind: %s\n", leftover)
+			if leftover.InterfaceAlive {
+				fmt.Fprintf(stdout, "  left untouched: the bridge %s survived its network, and nothing proves this emulator created it — `sudo ip link delete %s` if it is yours\n",
+					leftover.Interface, leftover.Interface)
+			}
 		case errors.Is(err, os.ErrPermission):
-			fmt.Fprintf(stdout, "a DHCP service an interrupted run left behind belongs to another user: %s\n", leftover)
+			fmt.Fprintf(stdout, "a DHCP service an earlier run left behind belongs to another user: %s\n", leftover)
 			fmt.Fprintf(stdout, "  → sudo kill %d\n", leftover.PID)
 			stuck = append(stuck, leftover.String())
 		default:

--- a/internal/cli/dhcp_leftover_test.go
+++ b/internal/cli/dhcp_leftover_test.go
@@ -38,8 +38,11 @@ func TestDoctorNamesTheDHCPServiceThatOutlivedItsInterface(t *testing.T) {
 		func(machine.DHCPLeftover) error { t.Fatal("a diagnostic signalled a process"); return nil })
 
 	c := checkLeftoverDHCP()
-	if c.state != verdictWarn {
-		t.Fatalf("the leftover did not warn: %+v", c)
+	// A fail, not a warning: this state kills the next machines-on run with
+	// certainty, and a doctor that stays green over it is the reassurance
+	// #342 measured the cost of.
+	if c.state != verdictFail {
+		t.Fatalf("the leftover did not fail the diagnosis: %+v", c)
 	}
 	// The line must carry what ss -lnp was the only tool to show: the pid,
 	// the address it holds, and the interface that no longer exists.
@@ -50,6 +53,53 @@ func TestDoctorNamesTheDHCPServiceThatOutlivedItsInterface(t *testing.T) {
 	}
 	if !strings.Contains(c.fix, "feint clean") {
 		t.Errorf("the fix does not name the remedy: %s", c.fix)
+	}
+}
+
+// TestDoctorFailsOnTheDHCPServiceWhoseNetworkIsGone is #342's acceptance: the
+// state that produced it — a bridge and its dnsmasq both surviving the
+// network — goes red, and the line carries the block and the pid, the two
+// facts needed to act.
+func TestDoctorFailsOnTheDHCPServiceWhoseNetworkIsGone(t *testing.T) {
+	survivor := machine.DHCPLeftover{
+		PID:            612421,
+		Interface:      "fnt-99109f524b2",
+		Addresses:      []string{"10.50.2.1"},
+		InterfaceAlive: true,
+	}
+	swapLeftoverSeams(t,
+		func() ([]machine.DHCPLeftover, error) { return []machine.DHCPLeftover{survivor}, nil },
+		func(machine.DHCPLeftover) error { t.Fatal("a diagnostic signalled a process"); return nil })
+
+	c := checkLeftoverDHCP()
+	if c.state != verdictFail {
+		t.Fatalf("the survivor did not fail the diagnosis: %+v", c)
+	}
+	for _, fact := range []string{"612421", "10.50.2.1"} {
+		if !strings.Contains(c.detail, fact) {
+			t.Errorf("the detail does not carry %q: %s", fact, c.detail)
+		}
+	}
+}
+
+// And the green line claims exactly what was measured: the emulator's own
+// services against their networks — not "no DHCP service outlives its
+// interface", the true-but-narrower sentence #342 caught reassuring the
+// operator past a held block.
+func TestDoctorGreenLineClaimsTheNetworkQuestion(t *testing.T) {
+	swapLeftoverSeams(t,
+		func() ([]machine.DHCPLeftover, error) { return nil, nil },
+		func(machine.DHCPLeftover) error { t.Fatal("a diagnostic signalled a process"); return nil })
+
+	c := checkLeftoverDHCP()
+	if c.state != verdictOK {
+		t.Fatalf("a healthy host did not get an ok: %+v", c)
+	}
+	if !strings.Contains(c.title, "network") {
+		t.Fatalf("the green line still speaks of interfaces, not networks: %s", c.title)
+	}
+	if strings.Contains(c.title, "outlives its interface") {
+		t.Fatalf("the green line still carries the narrower claim: %s", c.title)
 	}
 }
 
@@ -101,6 +151,39 @@ func TestCleanReportsTheCommandWhenTheLeftoverBelongsToAnotherUser(t *testing.T)
 	}
 	if !strings.Contains(out.String(), "sudo kill 4071323") {
 		t.Errorf("the report does not carry the exact command:\n%s", out.String())
+	}
+}
+
+// TestCleanSaysWhatItWillNotTouchWhenTheBridgeSurvived holds #342's third
+// half: the sweep ends the service it attributed, and names the bridge it
+// refuses to delete — the surviving interface carries no label, so nothing
+// proves the emulator created it, and a bridge nobody here created is not
+// ours to remove.
+func TestCleanSaysWhatItWillNotTouchWhenTheBridgeSurvived(t *testing.T) {
+	survivor := machine.DHCPLeftover{
+		PID:            612421,
+		Interface:      "fnt-99109f524b2",
+		Addresses:      []string{"10.50.2.1"},
+		InterfaceAlive: true,
+	}
+	var ended []machine.DHCPLeftover
+	swapLeftoverSeams(t,
+		func() ([]machine.DHCPLeftover, error) { return []machine.DHCPLeftover{survivor}, nil },
+		func(l machine.DHCPLeftover) error { ended = append(ended, l); return nil })
+
+	var out bytes.Buffer
+	if err := sweepLeftoverDHCP(&out); err != nil {
+		t.Fatalf("a swept leftover still failed the sweep: %v", err)
+	}
+	if len(ended) != 1 || ended[0].PID != survivor.PID {
+		t.Fatalf("the service was not ended: %v", ended)
+	}
+	report := out.String()
+	if !strings.Contains(report, "left untouched") || !strings.Contains(report, "fnt-99109f524b2") {
+		t.Fatalf("the sweep does not say what it will not touch:\n%s", report)
+	}
+	if !strings.Contains(report, "ip link delete fnt-99109f524b2") {
+		t.Fatalf("the report does not carry the exact command for the operator:\n%s", report)
 	}
 }
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -225,9 +225,12 @@ func checkImages(ctx context.Context, driver machine.Driver) check {
 	missing := machine.MissingImages(inventory)
 	if len(missing) == 0 {
 		return check{
-			title:  fmt.Sprintf("%d machine image(s) present", len(inventory)),
-			state:  verdictOK,
-			detail: "each carries an ssh daemon, so a machine answers on port 22 without reaching a package repository",
+			title: fmt.Sprintf("%d machine image(s) present", len(inventory)),
+			state: verdictOK,
+			// What was measured is presence by name; the ssh daemon is the
+			// build recipe's promise, not this check's, and the wording says
+			// whose it is (#342: a green line claims what it looked at).
+			detail: "built by `feint images`, whose recipe installs an ssh daemon — a machine from them answers on port 22 without reaching a package repository",
 		}
 	}
 	return check{
@@ -306,18 +309,30 @@ func checkIncusVersion(ctx context.Context) check {
 	return check{title: fmt.Sprintf("Incus %d.%d.%d, new enough for NIC ACLs", got[0], got[1], got[2]), state: verdictOK}
 }
 
-// checkLeftoverDHCP reports the DHCP services an interrupted run left holding
-// an address block (#316): dnsmasq processes whose fnt- interface no longer
-// exists. The condition is invisible to `ip addr` and `incus network list`,
-// and knowing that `ss -lnp` is the third place to look cost three ten-minute
-// runs the first time; this check is that knowledge, one line, before the run
-// starts. It reports and never signals — ending the process is `feint clean`'s
-// job, and touching the host is not what a diagnostic is for.
+// checkLeftoverDHCP reports the DHCP services an earlier run left holding an
+// address block (#316, #342): dnsmasq processes attributable to this emulator
+// whose network is gone — the interface with it, or the network object alone,
+// the interface having survived. The condition is invisible to `ip addr` and
+// `incus network list`, and knowing that `ss -lnp` is the third place to look
+// cost three ten-minute runs the first time; this check is that knowledge,
+// one line, before the run starts. It reports and never signals — ending the
+// process is `feint clean`'s job, and touching the host is not what a
+// diagnostic is for.
+//
+// A fail, not a warning, deliberately: unlike the hazards around it, this
+// state makes the next machines-on run die at the bind with certainty, and a
+// green doctor followed by that death is precisely the misplaced reassurance
+// #342 measured. The check once answered `ok: no DHCP service outlives its
+// interface` while pid 612421 held 10.50.2.1 — a true sentence about a
+// narrower question than its reader was asking, because the interface had
+// survived along with its service and only the network had died. The green
+// line now claims exactly what was measured, no more.
 //
 // Independent of --vm on purpose: the leftover is a host fact, and it blocks a
 // future machines-on run whatever mode this invocation asked about.
 //
-// TestDoctorNamesTheDHCPServiceThatOutlivedItsInterface fails without this.
+// TestDoctorNamesTheDHCPServiceThatOutlivedItsInterface and
+// TestDoctorFailsOnTheDHCPServiceWhoseNetworkIsGone fail without this.
 func checkLeftoverDHCP() check {
 	leftovers, err := findLeftoverDHCP()
 	if err != nil {
@@ -328,15 +343,19 @@ func checkLeftoverDHCP() check {
 		}
 	}
 	if len(leftovers) == 0 {
-		return check{title: "no DHCP service outlives its interface", state: verdictOK}
+		return check{
+			title:  "no DHCP service of the emulator's outlives its network",
+			state:  verdictOK,
+			detail: "checked: dnsmasq processes on interfaces this emulator names; a service of another owner is only diagnosable when a create fails on its block, and the create error names it",
+		}
 	}
 	held := make([]string, 0, len(leftovers))
 	for _, leftover := range leftovers {
 		held = append(held, leftover.String())
 	}
 	return check{
-		title:  fmt.Sprintf("%d DHCP service(s) from an interrupted run still hold an address block", len(leftovers)),
-		state:  verdictWarn,
+		title:  fmt.Sprintf("%d DHCP service(s) left by an earlier run still hold an address block this emulator will want", len(leftovers)),
+		state:  verdictFail,
 		detail: strings.Join(held, "; "),
 		fix:    "the next run on such a block dies on 'Address already in use'; feint clean ends them (sudo kill <pid> if they belong to another user)",
 	}
@@ -396,7 +415,13 @@ func checkEnvHazards() []check {
 		}
 		warnings := hazards.EnvHazards(os.LookupEnv)
 		if len(warnings) == 0 {
-			out = append(out, check{title: "nothing in this shell reroutes " + p.Name() + " clients", state: verdictOK})
+			// "nothing in this shell reroutes" claimed the shell; what was
+			// measured is the pack's list of known variables (#342).
+			out = append(out, check{
+				title:  "no variable measured to reroute " + p.Name() + " clients is set in this shell",
+				state:  verdictOK,
+				detail: "this checks the pack's measured list, not every way a shell can redirect a client",
+			})
 			continue
 		}
 		for _, warning := range warnings {
@@ -473,11 +498,16 @@ func checkStackHazards() []check {
 func checkSSHConfig() check {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return check{title: "could not read ~/.ssh/config", state: verdictOK}
+		// "Could not look" was reported as an ok for years; a green mark on an
+		// unasked question is the #342 family, so it warns now.
+		return check{title: "could not look for a ProxyJump in ~/.ssh/config", state: verdictWarn, detail: err.Error()}
 	}
 	file, err := os.Open(filepath.Join(home, ".ssh", "config")) //nolint:gosec // the operator's own file
 	if err != nil {
-		return check{title: "no ~/.ssh/config to get in the way", state: verdictOK}
+		if os.IsNotExist(err) {
+			return check{title: "no ~/.ssh/config to get in the way", state: verdictOK}
+		}
+		return check{title: "could not look for a ProxyJump in ~/.ssh/config", state: verdictWarn, detail: err.Error()}
 	}
 	defer func() { _ = file.Close() }()
 
@@ -507,7 +537,13 @@ func checkSSHConfig() check {
 			}
 		}
 	}
-	return check{title: "no ProxyJump in ~/.ssh/config captures the runtime's range", state: verdictOK}
+	// The claim matches the measurement: two patterns are checked, not every
+	// pattern ssh can compose ("10*" or "?0.*" would slip past) — #342.
+	return check{
+		title:  "no ProxyJump on a Host pattern of * or 10.* in ~/.ssh/config",
+		state:  verdictOK,
+		detail: "this checks the two measured patterns, not every pattern ssh can compose",
+	}
 }
 
 func runQuiet(binary string, args ...string) string {

--- a/internal/core/machine/incus.go
+++ b/internal/core/machine/incus.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/stephrobert/feint/internal/core/serialise"
 )
 
 // Incus backs emulated servers with Incus instances: system containers, or real
@@ -89,11 +91,25 @@ type Incus struct {
 	// the honest answer, because no host was consulted to contradict it.
 	verified *Capabilities
 
-	// attachMu serialises interface allocation. Attach reads the device list and
-	// then adds a device under a name it believes free; two concurrent calls
-	// without the lock pick the same name, and the loser's attachment silently
-	// becomes the winner's.
-	attachMu sync.Mutex
+	// Interface allocation is serialised per machine, by serialise.Lock in
+	// Attach — there is no field here on purpose.
+	//
+	// It used to be a package-level sync.Mutex, and serialise.go described it as
+	// "the same idea one layer down" from its own one-lock-per-target rule. It
+	// was not: it was the global lock that file warns against, and it queued
+	// every attachment in the session behind whichever machine was slowest to
+	// answer, because it is held across waitForAgent.
+	//
+	// Measured on the Scaleway example stack under --vm incus-ovn: six
+	// attachments took 26s, 31s, 42s, 52s, 63s and 73s — a flat +10s per
+	// attachment, which is one machine's wait paid by every machine after it.
+	// Past sixty seconds the client gives up and retries, and the retry meets
+	// the NIC its own first attempt created: "the server is already attached to
+	// this private network" (#348).
+	//
+	// The name collision it exists to prevent is per machine — two calls reading
+	// one machine's device list and both picking eth1 — so the exclusion is per
+	// machine too. TestTwoMachinesAttachWithoutQueueing fails without this.
 	// defaultNetMu serialises the creation of the default machine network: two
 	// concurrent first boots would otherwise both see it absent and the loser's
 	// `network create` would fail the launch it was only preparing.
@@ -568,8 +584,8 @@ func (d *Incus) Attach(ctx context.Context, name string, att Attachment) error {
 		return fmt.Errorf("invalid network name %q", att.Network)
 	}
 
-	d.attachMu.Lock()
-	defer d.attachMu.Unlock()
+	release := serialise.Lock("incus.attach." + name)
+	defer release()
 
 	// A virtual machine is ready for a device once its agent answers, and not
 	// when `incus start` returns. Adding one while the firmware is still

--- a/internal/core/machine/incus.go
+++ b/internal/core/machine/incus.go
@@ -98,9 +98,28 @@ type Incus struct {
 	// concurrent first boots would otherwise both see it absent and the loser's
 	// `network create` would fail the launch it was only preparing.
 	defaultNetMu sync.Mutex
-	// uplinkMu serialises edits of the uplink's ipv4.routes, one value shared
-	// by every routed public address.
+	// uplinkMu serialises every operation that makes the runtime reconfigure
+	// the uplink bridge: its config edits (delegated blocks and routed /32s
+	// share one ipv4.routes value), and the create of any OVN network attached
+	// to it. Not only the edits: Incus clears and rebuilds the uplink's
+	// nftables chains on a bridge config change *and* on an OVN network
+	// create, its clear is snapshot-then-delete, and the two paths share no
+	// lock in the daemon — so of two concurrent rebuilds, the loser dies on
+	// `Failed deleting nftables chain "fwd.feint-uplink" ... No such file or
+	// directory` (#341, measured on Incus 7.2 with the daemon's debug log: a
+	// PUT from delegateRoute interleaved with the POST creating fnt-default).
+	// TestConcurrentSubnetAndMachineNetworkCreatesSerialiseOnTheUplink fails
+	// without this serialisation.
 	uplinkMu sync.Mutex
+	// uplinkAdopt runs once per process, at the first reuse of an uplink a
+	// previous emulator left behind: see adoptUplink.
+	uplinkAdopt sync.Once
+	// holderProbe answers whether a pid recorded on the uplink is a live feint
+	// process. A test seam; nil means reading /proc.
+	holderProbe func(pid int) bool
+	// holderScan lists the DHCP services holding an address inside a block.
+	// A test seam; nil means scanning /proc.
+	holderScan func(block netip.Prefix) []BlockHolder
 }
 
 // NewIncus returns a driver launching system containers.
@@ -965,6 +984,18 @@ func (d *Incus) EnsureNetwork(ctx context.Context, spec NetworkSpec) error {
 
 	args := []string{"network", "create", spec.Name}
 	if d.OVN {
+		// The whole OVN sequence — uplink ensure, block delegation, and the
+		// create itself — holds uplinkMu. The create is under the lock on
+		// purpose: the daemon rebuilds the uplink bridge's firewall while
+		// creating an OVN network attached to it, exactly as it does on a
+		// route edit, and two concurrent rebuilds corrupt each other (#341;
+		// the lock's own comment carries the measurement). This is the
+		// narrow exception to "a slow side effect does not sit inside a
+		// lock": the uplink is the single named target whose reconfigurations
+		// must be exclusive, and a network create costs seconds, not the tens
+		// of seconds of a machine launch.
+		d.uplinkMu.Lock()
+		defer d.uplinkMu.Unlock()
 		// The uplink is what an OVN network draws its router address from;
 		// without one the create is refused outright.
 		if err := d.ensureUplink(ctx); err != nil {
@@ -991,12 +1022,20 @@ func (d *Incus) EnsureNetwork(ctx context.Context, spec NetworkSpec) error {
 	return nil
 }
 
-// networkCreateError wraps a failed network create, and names the leftover
-// DHCP service when one still holds an address inside the requested block
-// (#316). The bare failure reads "Address already in use" while `ip addr` and
-// `incus network list` both show a clean host, and finding the cause cost
-// three ten-minute runs the first time; the process that holds the block is
-// the one fact worth adding, so the error carries it.
+// networkCreateError wraps a failed network create, and names the DHCP service
+// still holding an address inside the requested block (#316). The bare failure
+// reads "Address already in use" while `ip addr` and `incus network list` both
+// show a clean host, and finding the cause cost three ten-minute runs the
+// first time; the process that holds the block is the one fact worth adding,
+// so the error carries it.
+//
+// Two populations, in order of usefulness. A leftover attributable to the
+// emulator comes with its remedy, `feint clean`. A service that cannot be
+// attributed is named too (#342): this is the one moment the block the
+// emulator wants is known exactly, so "of ours or otherwise" is answerable
+// here and nowhere else — named and never touched, because attribution failed.
+// TestANetworkCreateFailureNamesAForeignHolderWithoutClaimingIt fails without
+// the second half.
 func (d *Incus) networkCreateError(name, address, cidr string, err error) error {
 	base := fmt.Errorf("create network %s (%s): %w", name, address, err)
 	block, parseErr := netip.ParsePrefix(cidr)
@@ -1010,6 +1049,11 @@ func (d *Incus) networkCreateError(name, address, cidr string, err error) error 
 		return fmt.Errorf("%w; a DHCP service left by an interrupted run still holds the block: %s"+
 			" — `feint clean` ends it (sudo kill %d if it belongs to another user)",
 			base, leftover, leftover.PID)
+	}
+	for _, holder := range d.blockHolders(block) {
+		return fmt.Errorf("%w; a DHCP service this emulator cannot claim holds an address in the block: %s"+
+			" — it is not the emulator's to end; stop it yourself, or use another block",
+			base, holder)
 	}
 	return base
 }
@@ -1028,6 +1072,14 @@ func (d *Incus) leftovers() []DHCPLeftover {
 		return nil
 	}
 	return found
+}
+
+// blockHolders is the second scan behind networkCreateError, with its seam.
+func (d *Incus) blockHolders(block netip.Prefix) []BlockHolder {
+	if d.holderScan != nil {
+		return d.holderScan(block)
+	}
+	return DHCPHolders(block)
 }
 
 // leftoverHolds reports whether the leftover's listen addresses fall inside
@@ -1058,9 +1110,26 @@ func (d *Incus) RemoveNetwork(ctx context.Context, name string) error {
 	if !safeName.MatchString(name) || !ownedNetwork(name) {
 		return fmt.Errorf("refusing to delete network %q: not one the emulator created", name)
 	}
+	// The delegated block goes with the network it was delegated for. Left
+	// behind, each one is a real route on the host pointed at the uplink for as
+	// long as the uplink lives — seven of them were measured on one station,
+	// every one the block of a network long deleted (#341, the leftover half).
+	// Read before the delete, because afterwards nobody remembers the block;
+	// withdrawn only after a delete that succeeded, because a network still
+	// standing must keep its delegation. The lock spans the whole sequence for
+	// the same measured reason EnsureNetwork's does (see uplinkMu).
+	// TestRemoveNetworkWithdrawsTheDelegatedBlock fails without the withdrawal.
+	block := ""
+	if d.OVN {
+		d.uplinkMu.Lock()
+		defer d.uplinkMu.Unlock()
+		if prefix, err := d.networkGateway(ctx, name); err == nil {
+			block = prefix.Masked().String()
+		}
+	}
 	if _, err := d.run(ctx, "network", "delete", name); err != nil {
 		if isNotFound(err) {
-			return nil
+			return d.dropUplinkRouteOVN(ctx, block)
 		}
 		if d.OVN && strings.Contains(strings.ToLower(err.Error()), "in use") {
 			if peers, peersErr := d.networkPeers(ctx, name); peersErr == nil && len(peers) > 0 {
@@ -1068,13 +1137,23 @@ func (d *Incus) RemoveNetwork(ctx context.Context, name string) error {
 					_, _ = d.run(ctx, "network", "peer", "delete", name, peer.Name)
 				}
 				if _, err := d.run(ctx, "network", "delete", name); err == nil || isNotFound(err) {
-					return nil
+					return d.dropUplinkRouteOVN(ctx, block)
 				}
 			}
 		}
 		return fmt.Errorf("delete network %s: %w", name, err)
 	}
-	return nil
+	return d.dropUplinkRouteOVN(ctx, block)
+}
+
+// dropUplinkRouteOVN withdraws one delegated block after a network delete, and
+// is a no-op outside OVN mode or for an unknown block. The caller holds
+// uplinkMu when d.OVN.
+func (d *Incus) dropUplinkRouteOVN(ctx context.Context, block string) error {
+	if !d.OVN || block == "" {
+		return nil
+	}
+	return d.dropUplinkRoute(ctx, block)
 }
 
 // gatewayAddress renders the gateway in the form Incus expects. An empty

--- a/internal/core/machine/incus_attach_queue_test.go
+++ b/internal/core/machine/incus_attach_queue_test.go
@@ -1,0 +1,73 @@
+package machine
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestTwoMachinesAttachWithoutQueueing holds the bound that #348 was measured
+// against: an attachment waits for its own machine, never for somebody else's.
+//
+// The lock this asserts used to be one package-level mutex, held across
+// waitForAgent — so every attachment in the session queued behind whichever
+// machine answered slowest. Measured on the Scaleway example stack under
+// --vm incus-ovn, six attachments took 26s, 31s, 42s, 52s, 63s and 73s: a flat
+// +10s each, which is one machine's wait paid again by every machine after it.
+// Past the client's minute the apply retries, and the retry meets the NIC its
+// own first attempt created — "the server is already attached to this private
+// network".
+//
+// The test drives two attachments on two *different* machines, each of whose
+// agent takes a beat to answer. Serialised, the pair costs two beats; per
+// machine, it costs one. The assertion is on the total, because that is the
+// property a stack feels: a slow machine must not tax its neighbours.
+func TestTwoMachinesAttachWithoutQueueing(t *testing.T) {
+	const beat = 300 * time.Millisecond
+
+	d := &Incus{
+		agentPoll: 5 * time.Millisecond,
+		runner: func(_ context.Context, args ...string) ([]byte, error) {
+			joined := strings.Join(args, " ")
+			switch {
+			// Adding the device: one of the several calls Attach makes into the
+			// machine while holding the lock. Under --vm incus-ovn the real ones
+			// are the guest address configuration and the private-route install,
+			// and together they are the ten seconds each attachment costs.
+			case strings.Contains(joined, "config device add"):
+				time.Sleep(beat)
+				return []byte("ok"), nil
+			case strings.Contains(joined, "exec"):
+				return []byte("ok"), nil
+			// The device list, read before a free name is chosen.
+			case strings.Contains(joined, "config device") && strings.Contains(joined, "show"):
+				return []byte("{}"), nil
+			case strings.Contains(joined, "list"):
+				return []byte(`[{"name":"m","status":"Running","type":"virtual-machine"}]`), nil
+			}
+			return []byte("{}"), nil
+		},
+	}
+
+	var wg sync.WaitGroup
+	start := time.Now()
+	for _, name := range []string{"feint-scw-one", "feint-scw-two"} {
+		wg.Add(1)
+		go func(machine string) {
+			defer wg.Done()
+			// The error is not the subject: a stub runtime cannot complete an
+			// attachment. What is asserted is how long the pair took.
+			_ = d.Attach(context.Background(), machine, Attachment{Network: "fnt-net"})
+		}(name)
+	}
+	wg.Wait()
+	elapsed := time.Since(start)
+
+	// One beat plus slack. Two beats means the two machines queued.
+	if limit := beat * 3 / 2; elapsed > limit {
+		t.Fatalf("two attachments on two machines took %v, over %v: they queued behind one lock, "+
+			"which is #348 — one machine's wait must not be paid by another", elapsed, limit)
+	}
+}

--- a/internal/core/machine/incus_ovn.go
+++ b/internal/core/machine/incus_ovn.go
@@ -6,6 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/netip"
+	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -40,7 +43,9 @@ const (
 	DefaultUplinkCIDR = "10.209.83.0/24"
 )
 
-// delegateRoute adds one block to the uplink's ipv4.routes.
+// delegateRoute adds one block to the uplink's ipv4.routes. The caller holds
+// uplinkMu — see the field's comment for the measured reason there is no safe
+// unserialised edit of the uplink.
 //
 // An OVN network must sit inside its uplink's routes, and Incus says so in terms
 // that name the network rather than the setting: "Uplink network doesn't contain
@@ -57,26 +62,8 @@ const (
 // Idempotent by construction: a block already delegated is left alone, so
 // creating the same network twice does not grow the list.
 func (d *Incus) delegateRoute(ctx context.Context, block string) error {
-	name := d.uplinkName()
-	out, err := d.run(ctx, "network", "get", name, "ipv4.routes")
-	if err != nil {
-		return fmt.Errorf("read routes on uplink %s: %w", name, err)
-	}
-
-	current := strings.TrimSpace(string(out))
-	routes := []string{}
-	if current != "" {
-		routes = strings.Split(current, ",")
-	}
-	for _, route := range routes {
-		if strings.TrimSpace(route) == block {
-			return nil
-		}
-	}
-	routes = append(routes, block)
-
-	if _, err := d.run(ctx, "network", "set", name, "ipv4.routes="+strings.Join(routes, ",")); err != nil {
-		return fmt.Errorf("delegate %s to uplink %s: %w", block, name, err)
+	if err := d.addUplinkRoute(ctx, block); err != nil {
+		return fmt.Errorf("delegate %s to uplink %s: %w", block, d.uplinkName(), err)
 	}
 	return nil
 }
@@ -96,12 +83,25 @@ func (d *Incus) uplinkCIDR() string {
 	return DefaultUplinkCIDR
 }
 
-// ensureUplink creates the uplink bridge OVN networks attach to, once.
+// UplinkHolderKey is the config key (under user.) naming the emulator process
+// that holds the uplink, as a pid. The uplink is shared host state, and the
+// serialisation that keeps its rebuilds safe (uplinkMu) lives in one process:
+// a second live emulator editing the same uplink is outside any lock, and the
+// measured outcome of two concurrent edits is a corrupted firewall rebuild.
+// So sharing refuses instead of corrupting: an uplink held by another live
+// feint process is not reused.
+const UplinkHolderKey = "feint.holder"
+
+// ensureUplink creates the uplink bridge OVN networks attach to, once. The
+// caller holds uplinkMu.
 //
 // An OVN network refuses to exist without an uplink to allocate its router
 // address from (ipv4.ovn.ranges), so this runs before the first network. An
 // existing network under the name is only reused when it carries the
-// emulator's label: the operator's own bridges are never conscripted.
+// emulator's label: the operator's own bridges are never conscripted. And a
+// labelled uplink is only reused when no other live emulator holds it —
+// TestEnsureUplinkRefusesAnUplinkHeldByALiveEmulator fails without that
+// refusal.
 func (d *Incus) ensureUplink(ctx context.Context) error {
 	name := d.uplinkName()
 	if out, err := d.run(ctx, "query", "/1.0/networks/"+name); err == nil {
@@ -115,7 +115,7 @@ func (d *Incus) ensureUplink(ctx context.Context) error {
 		if existing.Type != "bridge" || existing.Config["user."+LabelKey] == "" {
 			return fmt.Errorf("network %s exists and is not the emulator's uplink; refusing to reuse it", name)
 		}
-		return nil
+		return d.adoptUplink(ctx, existing.Config)
 	} else if !isNotFound(err) {
 		return fmt.Errorf("inspect uplink %s: %w", name, err)
 	}
@@ -139,10 +139,106 @@ func (d *Incus) ensureUplink(ctx context.Context) error {
 		"ipv6.address=none",
 		"ipv4.dhcp.ranges="+dhcp,
 		"ipv4.ovn.ranges="+ovn,
-		"user."+LabelKey+"=feint"); err != nil {
+		"user."+LabelKey+"=feint",
+		"user."+UplinkHolderKey+"="+strconv.Itoa(os.Getpid())); err != nil {
 		return fmt.Errorf("create uplink %s (%s): %w", name, gateway, err)
 	}
+	// A freshly created uplink has nothing to adopt: burn the once so a later
+	// reuse of our own uplink does not "reconcile" away the routed /32s this
+	// process adds between two network creates.
+	d.uplinkAdopt.Do(func() {})
 	return nil
+}
+
+// adoptUplink is the reuse half of ensureUplink: the uplink exists, is
+// labelled ours, and was left by somebody. Two questions, in order.
+//
+// Whose is it now? A pid recorded by a live feint process means a second
+// emulator would be editing shared host state outside any common lock, which
+// is the measured corruption of #341 — so it refuses.
+//
+// What did the previous life leave on it? Every block a dead run delegated is
+// still a real route on the host, captured towards the uplink: seven were
+// measured on one station (#341). Nothing of a dead emulator is adopted
+// anywhere else, so its routes are not either: the adopt keeps exactly the
+// blocks of the labelled OVN networks still standing (the next run reuses
+// those by name), drops the rest, and records this process as holder. Once
+// per process, because staleness is a fact about what predates it.
+// TestAdoptedUplinkDropsADeadRunsRoutes fails without the drop.
+func (d *Incus) adoptUplink(ctx context.Context, config map[string]string) error {
+	holder := config["user."+UplinkHolderKey]
+	self := strconv.Itoa(os.Getpid())
+	if holder != "" && holder != self {
+		if pid, err := strconv.Atoi(holder); err == nil && d.holderIsAlive(pid) {
+			return fmt.Errorf("uplink %s is held by another running emulator (pid %d); "+
+				"two emulators corrupt each other's firewall rebuilds, so sharing is refused — "+
+				"stop the other emulator, or point this one at another uplink", d.uplinkName(), pid)
+		}
+	}
+	var adoptErr error
+	d.uplinkAdopt.Do(func() {
+		kept, err := d.liveDelegations(ctx)
+		if err != nil {
+			adoptErr = err
+			return
+		}
+		args := []string{"network", "set", d.uplinkName(),
+			"user." + UplinkHolderKey + "=" + self}
+		if current := strings.TrimSpace(config["ipv4.routes"]); current != strings.Join(kept, ",") {
+			args = append(args, "ipv4.routes="+strings.Join(kept, ","))
+		} else if holder == self {
+			return // Nothing stale, and already ours: spare the rebuild.
+		}
+		if _, err := d.run(ctx, args...); err != nil {
+			adoptErr = fmt.Errorf("adopt uplink %s: %w", d.uplinkName(), err)
+		}
+	})
+	return adoptErr
+}
+
+// liveDelegations lists the blocks that must stay delegated to the uplink: the
+// block of every labelled OVN network still attached to it.
+func (d *Incus) liveDelegations(ctx context.Context) ([]string, error) {
+	out, err := d.run(ctx, "query", "/1.0/networks?recursion=1")
+	if err != nil {
+		return nil, fmt.Errorf("list networks to adopt uplink %s: %w", d.uplinkName(), err)
+	}
+	var items []struct {
+		Name   string            `json:"name"`
+		Type   string            `json:"type"`
+		Config map[string]string `json:"config"`
+	}
+	if err := json.Unmarshal(out, &items); err != nil {
+		return nil, fmt.Errorf("decode networks to adopt uplink %s: %w", d.uplinkName(), err)
+	}
+	var kept []string
+	for _, item := range items {
+		if item.Type != "ovn" || item.Config["user."+LabelKey] == "" ||
+			item.Config["network"] != d.uplinkName() {
+			continue
+		}
+		prefix, err := netip.ParsePrefix(item.Config["ipv4.address"])
+		if err != nil {
+			continue
+		}
+		kept = append(kept, prefix.Masked().String())
+	}
+	return kept, nil
+}
+
+// holderIsAlive reports that the pid recorded on the uplink still belongs to a
+// live feint process. Conservative in the direction that refuses: only a
+// readable /proc entry whose binary is feint counts as alive, so a recycled
+// pid running something else does not hold the uplink hostage.
+func (d *Incus) holderIsAlive(pid int) bool {
+	if d.holderProbe != nil {
+		return d.holderProbe(pid)
+	}
+	argv, err := procArgv(pid)
+	if err != nil || len(argv) == 0 {
+		return false
+	}
+	return strings.HasPrefix(filepath.Base(argv[0]), "feint")
 }
 
 // uplinkRanges splits an uplink block into the two ranges Incus wants: DHCP
@@ -524,36 +620,61 @@ func removeRoute(routes, route string) string {
 }
 
 // setUplinkRoute adds or removes one /32 from the uplink's ipv4.routes, which
-// is what makes the host route the address towards OVN. The key is shared by
-// every routed address, hence the lock: two attachments editing it without one
-// lose each other's routes.
+// is what makes the host route the address towards OVN. It takes uplinkMu
+// itself: its callers are address attachments, which hold no uplink lock of
+// their own.
 func (d *Incus) setUplinkRoute(ctx context.Context, address string, add bool) error {
 	d.uplinkMu.Lock()
 	defer d.uplinkMu.Unlock()
+	if add {
+		if err := d.addUplinkRoute(ctx, address+"/32"); err != nil {
+			return fmt.Errorf("set routes of uplink %s: %w", d.uplinkName(), err)
+		}
+		return nil
+	}
+	return d.dropUplinkRoute(ctx, address+"/32")
+}
 
+// addUplinkRoute puts one entry on the uplink's ipv4.routes, leaving the rest
+// alone; an entry already present is left as it is, so nothing is rebuilt for
+// nothing. The caller holds uplinkMu.
+func (d *Incus) addUplinkRoute(ctx context.Context, route string) error {
 	name := d.uplinkName()
 	out, err := d.run(ctx, "network", "get", name, "ipv4.routes")
 	if err != nil {
-		// No uplink means nothing routes the address anyway; for a removal
-		// that is the outcome asked for.
-		if !add && isNotFound(err) {
+		return fmt.Errorf("read routes on uplink %s: %w", name, err)
+	}
+	current := strings.TrimSpace(string(out))
+	if routeListContains(current, route) {
+		return nil
+	}
+	if _, err := d.run(ctx, "network", "set", name, "ipv4.routes="+appendRoute(current, route)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// dropUplinkRoute takes one entry off the uplink's ipv4.routes. The caller
+// holds uplinkMu. An uplink already gone, or an entry already absent, is the
+// outcome asked for — and skipping the write in the absent case matters, since
+// every write makes the runtime clear and rebuild the uplink's firewall.
+func (d *Incus) dropUplinkRoute(ctx context.Context, route string) error {
+	if route == "" {
+		return nil
+	}
+	name := d.uplinkName()
+	out, err := d.run(ctx, "network", "get", name, "ipv4.routes")
+	if err != nil {
+		if isNotFound(err) {
 			return nil
 		}
 		return fmt.Errorf("read routes of uplink %s: %w", name, err)
 	}
-
-	route := address + "/32"
-	kept := make([]string, 0, 4)
-	for _, existing := range strings.Split(strings.TrimSpace(string(out)), ",") {
-		existing = strings.TrimSpace(existing)
-		if existing != "" && existing != route {
-			kept = append(kept, existing)
-		}
+	current := strings.TrimSpace(string(out))
+	if !routeListContains(current, route) {
+		return nil
 	}
-	if add {
-		kept = append(kept, route)
-	}
-	if _, err := d.run(ctx, "network", "set", name, "ipv4.routes="+strings.Join(kept, ",")); err != nil {
+	if _, err := d.run(ctx, "network", "set", name, "ipv4.routes="+removeRoute(current, route)); err != nil {
 		return fmt.Errorf("set routes of uplink %s: %w", name, err)
 	}
 	return nil

--- a/internal/core/machine/incus_uplink_test.go
+++ b/internal/core/machine/incus_uplink_test.go
@@ -1,0 +1,238 @@
+package machine
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// The uplink is one bridge shared by every OVN network and every routed
+// address, and the daemon rebuilds its firewall on each reconfiguration —
+// including the create of an OVN network attached to it. Everything in this
+// file is #341: the serialisation of those rebuilds, the withdrawal of a
+// deleted network's delegated block, the adoption that drops a dead run's
+// routes, and the refusal to share the uplink with another live emulator.
+
+// ourUplinkJSON renders the uplink as the runtime reports it, labelled and
+// held by the given pid ("" for an unclaimed one).
+func ourUplinkJSON(holder, routes string) string {
+	cfg := `"user.` + LabelKey + `":"feint","ipv4.routes":"` + routes + `"`
+	if holder != "" {
+		cfg += `,"user.` + UplinkHolderKey + `":"` + holder + `"`
+	}
+	return `{"type":"bridge","config":{` + cfg + `}}`
+}
+
+// TestConcurrentSubnetAndMachineNetworkCreatesSerialiseOnTheUplink holds the
+// serialisation that closes #341's crash. Measured with the daemon's debug
+// log on Incus 7.2: a `network set feint-uplink ipv4.routes=…` (delegating a
+// subnet's block) interleaved with the POST creating fnt-default, both paths
+// cleared the uplink's nftables chains, and the loser died on `Failed
+// deleting nftables chain "fwd.feint-uplink" … No such file or directory`.
+// The two operations here are exactly those two; the runner fails the test if
+// any two uplink-rebuilding commands are ever in flight at once.
+func TestConcurrentSubnetAndMachineNetworkCreatesSerialiseOnTheUplink(t *testing.T) {
+	self := strconv.Itoa(os.Getpid())
+	uplink := ourUplinkJSON(self, "")
+	var inRebuild atomic.Int32
+	var overlapped atomic.Bool
+	runner := func(_ context.Context, args ...string) ([]byte, error) {
+		key := strings.Join(args, " ")
+		// The commands that make the daemon clear and rebuild the uplink's
+		// firewall: a config write on the uplink, and an OVN network create.
+		if strings.HasPrefix(key, "network set feint-uplink") || strings.HasPrefix(key, "network create") {
+			if inRebuild.Add(1) > 1 {
+				overlapped.Store(true)
+			}
+			time.Sleep(10 * time.Millisecond)
+			inRebuild.Add(-1)
+		}
+		switch {
+		case strings.HasPrefix(key, "query /1.0/networks/feint-uplink"):
+			return []byte(uplink), nil
+		case strings.HasPrefix(key, "query /1.0/networks?recursion=1"):
+			return []byte("[]"), nil
+		case strings.HasPrefix(key, "query /1.0/networks/"):
+			return nil, errors.New("Network not found")
+		case strings.HasPrefix(key, "network get feint-uplink ipv4.routes"):
+			return []byte("\n"), nil
+		}
+		return nil, nil
+	}
+	d := NewIncus()
+	d.runner = runner
+	d.OVN = true
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for _, spec := range []NetworkSpec{
+		{Name: "fnt-subnet00001", CIDR: "10.70.1.0/24"},
+		{Name: "fnt-default", CIDR: "10.209.84.0/24"},
+	} {
+		wg.Add(1)
+		go func(s NetworkSpec) {
+			defer wg.Done()
+			<-start
+			if err := d.EnsureNetwork(context.Background(), s); err != nil {
+				t.Errorf("create %s: %v", s.Name, err)
+			}
+		}(spec)
+	}
+	close(start)
+	wg.Wait()
+
+	if overlapped.Load() {
+		t.Fatal("two uplink rebuilds were in flight at once; the loser of that race dies on 'Failed deleting nftables chain' (#341)")
+	}
+}
+
+// TestRemoveNetworkWithdrawsTheDelegatedBlock holds the leftover half of
+// #341: seven blocks of long-deleted networks were measured still delegated
+// to one station's uplink, each a real host route pointed at it.
+func TestRemoveNetworkWithdrawsTheDelegatedBlock(t *testing.T) {
+	f := &fakeRuntime{answers: map[string]string{
+		"network get fnt-abc123 ipv4.address":  "10.70.1.1/24\n",
+		"network get feint-uplink ipv4.routes": "10.209.84.0/24,10.70.1.0/24\n",
+	}}
+	d := newFakeDriver(f)
+	d.OVN = true
+
+	if err := d.RemoveNetwork(context.Background(), "fnt-abc123"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	deletes := f.matching("network delete fnt-abc123")
+	withdraws := f.matching("network set feint-uplink ipv4.routes=10.209.84.0/24")
+	if len(deletes) != 1 || len(withdraws) != 1 {
+		t.Fatalf("expected one delete and one withdrawal, got:\n%s", strings.Join(f.commands(), "\n"))
+	}
+	// Withdrawn after the delete: a network still standing keeps its block.
+	cmds := f.commands()
+	deleteAt, withdrawAt := -1, -1
+	for i, cmd := range cmds {
+		if strings.HasPrefix(cmd, "network delete") {
+			deleteAt = i
+		}
+		if strings.HasPrefix(cmd, "network set feint-uplink") {
+			withdrawAt = i
+		}
+	}
+	if withdrawAt < deleteAt {
+		t.Fatalf("the block was withdrawn before the delete:\n%s", strings.Join(cmds, "\n"))
+	}
+}
+
+// Bridge mode has no uplink, and its RemoveNetwork must not grow one.
+func TestRemoveNetworkLeavesTheUplinkAloneOffOVN(t *testing.T) {
+	f := &fakeRuntime{}
+	d := newFakeDriver(f)
+
+	if err := d.RemoveNetwork(context.Background(), "fnt-abc123"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if touched := f.matching("feint-uplink"); len(touched) != 0 {
+		t.Fatalf("bridge mode touched the uplink:\n%s", strings.Join(touched, "\n"))
+	}
+}
+
+// TestAdoptedUplinkDropsADeadRunsRoutes holds the adoption: nothing else of a
+// dead emulator is adopted, so its delegations are not either. What stays is
+// exactly the blocks of the labelled OVN networks still standing, because the
+// next run reuses those by name.
+func TestAdoptedUplinkDropsADeadRunsRoutes(t *testing.T) {
+	networks := `[
+	  {"name":"fnt-survivor001","type":"ovn","config":{"user.` + LabelKey + `":"feint","network":"feint-uplink","ipv4.address":"10.209.84.1/24"}},
+	  {"name":"incusbr0","type":"bridge","config":{}}
+	]`
+	f := &fakeRuntime{answers: map[string]string{
+		"query /1.0/networks/feint-uplink": ourUplinkJSON("999", "10.182.0.0/24,10.183.0.0/24,10.209.84.0/24"),
+		"query /1.0/networks?recursion=1":  networks,
+	}, fail: map[string]error{
+		"query /1.0/networks/fnt-fresh000001": errors.New("Network not found"),
+	}}
+	d := newFakeDriver(f)
+	d.OVN = true
+	d.holderProbe = func(int) bool { return false } // pid 999 is dead
+
+	if err := d.EnsureNetwork(context.Background(), NetworkSpec{
+		Name: "fnt-fresh000001", CIDR: "10.70.1.0/24",
+	}); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+
+	adopts := f.matching("user." + UplinkHolderKey + "=" + strconv.Itoa(os.Getpid()))
+	if len(adopts) != 1 {
+		t.Fatalf("the uplink was not claimed exactly once:\n%s", strings.Join(f.commands(), "\n"))
+	}
+	if !strings.Contains(adopts[0], "ipv4.routes=10.209.84.0/24") {
+		t.Fatalf("the dead run's routes were not dropped to the survivor's block:\n%s", adopts[0])
+	}
+}
+
+// TestEnsureUplinkRefusesAnUplinkHeldByALiveEmulator holds the refusal that
+// replaces corruption: uplinkMu serialises one process, so a second live
+// emulator on the same uplink would race the first outside any lock — the
+// exact interleaving #341 measured, minus the luck.
+func TestEnsureUplinkRefusesAnUplinkHeldByALiveEmulator(t *testing.T) {
+	f := &fakeRuntime{answers: map[string]string{
+		"query /1.0/networks/feint-uplink": ourUplinkJSON("31337", ""),
+	}, fail: map[string]error{
+		"query /1.0/networks/fnt-fresh000001": errors.New("Network not found"),
+	}}
+	d := newFakeDriver(f)
+	d.OVN = true
+	d.holderProbe = func(int) bool { return true } // pid 31337 is a live feint
+
+	err := d.EnsureNetwork(context.Background(), NetworkSpec{
+		Name: "fnt-fresh000001", CIDR: "10.70.1.0/24",
+	})
+	if err == nil {
+		t.Fatal("an uplink held by a live emulator was shared")
+	}
+	if !strings.Contains(err.Error(), "31337") {
+		t.Fatalf("the refusal does not name the holder: %v", err)
+	}
+	for _, cmd := range f.commands() {
+		if strings.HasPrefix(cmd, "network set feint-uplink") || strings.HasPrefix(cmd, "network create") {
+			t.Fatalf("the refusal still touched the uplink: %s", cmd)
+		}
+	}
+}
+
+// TestANetworkCreateFailureNamesAForeignHolderWithoutClaimingIt is the "of
+// ours or otherwise" half of #342's question, at the one moment the wanted
+// block is known. Named without a remedy that touches it: `feint clean` must
+// not be advertised against a process nobody attributed to the emulator.
+func TestANetworkCreateFailureNamesAForeignHolderWithoutClaimingIt(t *testing.T) {
+	f := &fakeRuntime{fail: map[string]error{
+		"query /1.0/networks/fnt-99109f524b2": errors.New("Network not found"),
+		"network create":                      errors.New("Address already in use"),
+	}}
+	d := newFakeDriver(f)
+	d.leftoverScan = func() []DHCPLeftover { return nil }
+	d.holderScan = func(_ netip.Prefix) []BlockHolder {
+		return []BlockHolder{{PID: 3187, Command: "dnsmasq", Address: "10.76.154.1"}}
+	}
+
+	err := d.EnsureNetwork(context.Background(), NetworkSpec{
+		Name: "fnt-99109f524b2", CIDR: "10.76.154.0/24", Gateway: "10.76.154.1",
+	})
+	if err == nil {
+		t.Fatal("the failed create reported success")
+	}
+	for _, fact := range []string{"3187", "10.76.154.1", "not the emulator's to end"} {
+		if !strings.Contains(err.Error(), fact) {
+			t.Errorf("the error does not carry %q:\n%v", fact, err)
+		}
+	}
+	if strings.Contains(err.Error(), "feint clean") {
+		t.Fatalf("the error offers the sweep against a process it could not attribute:\n%v", err)
+	}
+}

--- a/internal/core/machine/leftover.go
+++ b/internal/core/machine/leftover.go
@@ -1,9 +1,12 @@
 package machine
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/netip"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -19,15 +22,26 @@ import (
 // "dnsmasq: failed to create listening socket: Address already in use" —
 // measured twice, on 2026-08-18 and 2026-08-19.
 //
+// The interface being gone is not the only way a service outlives its network
+// (#342): on 2026-08-18 a dnsmasq (pid 612421) held 10.50.2.1 on a bridge that
+// had survived *with* it — the network object was gone from the runtime, the
+// interface and the service were not. The question the operator needs answered
+// is therefore about the network, not the interface: a service whose network
+// the runtime no longer knows is a leftover whichever half of its plumbing
+// survived. TestLeftoverDHCPFindsTheServiceWhoseNetworkIsGone fails when only
+// the vanished-interface half is asked.
+//
 // The rule of cli.go applies unchanged: well formed is not authorised. A
 // dnsmasq on the operator's host may belong to libvirt, to another Incus
 // project or to the operator's own lab, and none of those is ours to name,
 // let alone to signal. A process is attributable to this emulator only when
-// its --interface carries the prefix NetworkName writes AND that interface no
-// longer exists; one whose interface is alive is not a leftover at all, it is
-// somebody's working service. TestLeftoverDHCPRefusesAProcessItCannotAttribute
-// holds the refusal, and the falsification spec dhcp-leftover-ownership.json
-// proves the test bites.
+// its --interface carries the prefix NetworkName writes AND the network it
+// served is demonstrably gone — the interface no longer exists, or no project
+// of the runtime knows a network under that name while the process runs off
+// the runtime's own state directory. A service whose network is alive is
+// somebody's working arrangement, whatever its name.
+// TestLeftoverDHCPRefusesAProcessItCannotAttribute holds the refusal, and the
+// falsification spec dhcp-leftover-ownership.json proves the tests bite.
 
 // HostProcess is one process on the operator's host, as read from /proc. The
 // command line of a foreign process is data it wrote about itself, not
@@ -40,14 +54,19 @@ type HostProcess struct {
 
 // DHCPLeftover is a DHCP service that outlived the emulator network it served:
 // a dnsmasq whose --interface names a network only this emulator derives, and
-// whose interface no longer exists on the host.
+// whose network is gone — the interface with it, or the network object alone.
 type DHCPLeftover struct {
 	PID int
-	// Interface is the vanished fnt- interface the service was started for.
+	// Interface is the fnt- interface the service was started for.
 	Interface string
 	// Addresses are the listen addresses the service still holds; the gateway
 	// of the block the next run will fail to take.
 	Addresses []string
+	// InterfaceAlive says the interface survived alongside its service (#342):
+	// what died is the network object. The interface is then a bridge the
+	// runtime no longer manages, which the sweep must name and never delete —
+	// nothing left on the host proves the emulator created it.
+	InterfaceAlive bool
 }
 
 // String names the leftover the way clean and doctor report it.
@@ -56,28 +75,33 @@ func (l DHCPLeftover) String() string {
 	if held == "" {
 		held = "an address"
 	}
+	if l.InterfaceAlive {
+		return fmt.Sprintf("dnsmasq pid %d holds %s for %s, an interface that outlived its network", l.PID, held, l.Interface)
+	}
 	return fmt.Sprintf("dnsmasq pid %d holds %s for the vanished interface %s", l.PID, held, l.Interface)
 }
 
 // LeftoverDHCP scans the host's processes for DHCP services that outlived the
-// emulator's networks. Read-only: it opens /proc and stats /sys/class/net,
-// and issues no command and no signal. A host with no /proc has no Incus
-// runtime either, so it reports nothing rather than an error.
+// emulator's networks. Read-only: it opens /proc, stats /sys/class/net, asks
+// the runtime for its network listing, and issues no signal and no mutating
+// command. A host with no /proc has no Incus runtime either, so it reports
+// nothing rather than an error.
 func LeftoverDHCP() ([]DHCPLeftover, error) {
 	procs, err := hostProcesses()
 	if err != nil {
 		return nil, err
 	}
-	return leftoverDHCP(procs, interfaceGone), nil
+	return leftoverDHCP(procs, interfaceGone, networkUnknown()), nil
 }
 
 // leftoverDHCP classifies the given processes. gone answers whether a named
-// interface is absent from the host; it is a parameter so a test can hold the
-// classification without owning the station's interfaces.
-func leftoverDHCP(procs []HostProcess, gone func(string) bool) []DHCPLeftover {
+// interface is absent from the host; unknown answers whether the runtime
+// positively has no network under the name. Both are parameters so a test can
+// hold the classification without owning the station's interfaces.
+func leftoverDHCP(procs []HostProcess, gone, unknown func(string) bool) []DHCPLeftover {
 	var out []DHCPLeftover
 	for _, proc := range procs {
-		if leftover, ok := classifyDHCP(proc, gone); ok {
+		if leftover, ok := classifyDHCP(proc, gone, unknown); ok {
 			out = append(out, leftover)
 		}
 	}
@@ -87,8 +111,14 @@ func leftoverDHCP(procs []HostProcess, gone func(string) bool) []DHCPLeftover {
 // classifyDHCP answers the two questions for one process, in order: is it
 // attributable to this emulator, and is it a leftover. Both attribution
 // criteria are required — the prefix alone would claim a live service, and
-// "interface gone" alone would claim libvirt's or the operator's own dnsmasq.
-func classifyDHCP(proc HostProcess, gone func(string) bool) (DHCPLeftover, bool) {
+// "network gone" alone would claim libvirt's or the operator's own dnsmasq.
+//
+// A vanished interface settles both at once. An interface that survived does
+// not (#342): there the network object must be demonstrably absent from the
+// runtime, and the process must run off the runtime's own state directory —
+// the strongest evidence is demanded exactly when the subject is still alive,
+// because the cost of a wrong claim is a signal to somebody's working service.
+func classifyDHCP(proc HostProcess, gone, unknown func(string) bool) (DHCPLeftover, bool) {
 	if len(proc.Argv) == 0 || filepath.Base(proc.Argv[0]) != "dnsmasq" {
 		return DHCPLeftover{}, false
 	}
@@ -98,20 +128,72 @@ func classifyDHCP(proc HostProcess, gone func(string) bool) (DHCPLeftover, bool)
 		// nothing here says whose it is, so it is not ours to classify.
 		return DHCPLeftover{}, false
 	}
+	alive := false
 	for _, name := range interfaces {
 		// Ours by the prefix NetworkName writes, well formed enough to become
-		// a /sys path, and demonstrably gone. A process serving several
-		// interfaces is attributable only if every one of them passes: a mixed
-		// set is somebody else's arrangement, and it is left alone.
-		if !ownedNetwork(name) || !safeName.MatchString(name) || !gone(name) {
+		// a /sys path, and its network demonstrably gone. A process serving
+		// several interfaces is attributable only if every one of them passes:
+		// a mixed set is somebody else's arrangement, and it is left alone.
+		if !ownedNetwork(name) || !safeName.MatchString(name) {
 			return DHCPLeftover{}, false
 		}
+		if gone(name) {
+			continue
+		}
+		if !unknown(name) || !runtimeServiceOf(proc, name) {
+			return DHCPLeftover{}, false
+		}
+		alive = true
 	}
 	return DHCPLeftover{
-		PID:       proc.PID,
-		Interface: interfaces[0],
-		Addresses: flagValues(proc.Argv, "--listen-address"),
+		PID:            proc.PID,
+		Interface:      interfaces[0],
+		Addresses:      flagValues(proc.Argv, "--listen-address"),
+		InterfaceAlive: alive,
 	}, true
+}
+
+// runtimeServiceOf reports that a process runs off the runtime's own state
+// directory for the named network — the --conf-file and --dhcp-leasefile Incus
+// puts on every dnsmasq it launches. It is the extra evidence the live-interface
+// case demands: an fnt- name on argv is claimable by anybody, a path under the
+// runtime's state directory only by a service the runtime itself started.
+func runtimeServiceOf(proc HostProcess, network string) bool {
+	marker := "/var/lib/incus/networks/" + network + "/"
+	for _, arg := range proc.Argv {
+		if strings.Contains(arg, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// networkUnknown builds the predicate for "the runtime positively has no
+// network under this name", from one listing across every project. Conservative
+// three times over: a runtime that cannot be asked, a listing that cannot be
+// decoded, and a name found in any project all answer false, so the predicate
+// can only ever promote a process on a listed-nowhere name. Without the
+// all-projects listing a live network in a neighbouring project would read as
+// absent, which is the exact wrong-claim classifyDHCP refuses to make.
+func networkUnknown() func(string) bool {
+	out, err := exec.Command("incus", "query", "/1.0/networks?recursion=1&all-projects=true").Output()
+	if err != nil {
+		return func(string) bool { return false }
+	}
+	var items []struct {
+		Name    string `json:"name"`
+		Managed bool   `json:"managed"`
+	}
+	if err := json.Unmarshal(out, &items); err != nil {
+		return func(string) bool { return false }
+	}
+	managed := make(map[string]bool, len(items))
+	for _, item := range items {
+		if item.Managed {
+			managed[item.Name] = true
+		}
+	}
+	return func(name string) bool { return !managed[name] }
 }
 
 // flagValues collects the values of a repeatable flag, in both spellings a
@@ -142,7 +224,7 @@ func flagValues(argv []string, flag string) []string {
 // TestTerminateLeftoverRefusesAPidThatIsNoLongerTheLeftover fails without the
 // re-check.
 func TerminateLeftover(leftover DHCPLeftover) error {
-	return terminateLeftover(leftover, procArgv, interfaceGone, func(pid int) error {
+	return terminateLeftover(leftover, procArgv, interfaceGone, networkUnknown(), func(pid int) error {
 		process, err := os.FindProcess(pid)
 		if err != nil {
 			return err
@@ -151,18 +233,69 @@ func TerminateLeftover(leftover DHCPLeftover) error {
 	})
 }
 
-func terminateLeftover(leftover DHCPLeftover, argvOf func(int) ([]string, error), gone func(string) bool, signal func(int) error) error {
+func terminateLeftover(leftover DHCPLeftover, argvOf func(int) ([]string, error), gone, unknown func(string) bool, signal func(int) error) error {
 	argv, err := argvOf(leftover.PID)
 	if err != nil {
 		// The process is already gone, which is the goal state, not a failure.
 		return nil
 	}
-	current, ok := classifyDHCP(HostProcess{PID: leftover.PID, Argv: argv}, gone)
+	current, ok := classifyDHCP(HostProcess{PID: leftover.PID, Argv: argv}, gone, unknown)
 	if !ok || current.Interface != leftover.Interface {
 		return fmt.Errorf("pid %d is no longer the DHCP service that outlived %s; refusing to signal it",
 			leftover.PID, leftover.Interface)
 	}
 	return signal(leftover.PID)
+}
+
+// A BlockHolder is any DHCP service, whoever owns it, holding an address
+// inside a block the emulator wants (#342). Attribution is deliberately not
+// part of the question: at the moment a network create has just failed, the
+// wanted block is known exactly, and the operator's question is who sits on
+// it, not whose process it is. Data only — a holder that was never attributed
+// to the emulator is never signalled, so the answer names and does not touch.
+type BlockHolder struct {
+	PID int
+	// Command is the process name, as /proc shows it.
+	Command string
+	// Address is the listen address inside the wanted block.
+	Address string
+}
+
+// String names the holder the way the create error reports it.
+func (h BlockHolder) String() string {
+	return fmt.Sprintf("%s pid %d listens on %s", h.Command, h.PID, h.Address)
+}
+
+// DHCPHolders scans the host for DHCP services listening inside the given
+// block, whoever owns them. Read-only, like LeftoverDHCP above.
+func DHCPHolders(block netip.Prefix) []BlockHolder {
+	procs, err := hostProcesses()
+	if err != nil {
+		return nil
+	}
+	return dhcpHolders(procs, block)
+}
+
+func dhcpHolders(procs []HostProcess, block netip.Prefix) []BlockHolder {
+	var out []BlockHolder
+	for _, proc := range procs {
+		if len(proc.Argv) == 0 || filepath.Base(proc.Argv[0]) != "dnsmasq" {
+			continue
+		}
+		for _, listen := range flagValues(proc.Argv, "--listen-address") {
+			addr, err := netip.ParseAddr(listen)
+			if err != nil || !block.Contains(addr) {
+				continue
+			}
+			out = append(out, BlockHolder{
+				PID:     proc.PID,
+				Command: filepath.Base(proc.Argv[0]),
+				Address: listen,
+			})
+			break
+		}
+	}
+	return out
 }
 
 // hostProcesses reads every process the host will show, pid and command line.

--- a/internal/core/machine/leftover_test.go
+++ b/internal/core/machine/leftover_test.go
@@ -2,6 +2,7 @@ package machine
 
 import (
 	"errors"
+	"net/netip"
 	"strings"
 	"testing"
 )
@@ -34,6 +35,16 @@ var libvirtDNSMasq = []string{
 	"--leasefile-ro", "--dhcp-script=/usr/lib/libvirt/libvirt_leaseshelper",
 }
 
+// runtimeKnows is the conservative default for the network question: the
+// runtime was not asked, or answered that it still manages the name. Under it
+// only a vanished interface can make a leftover, which is #316's original
+// classification.
+func runtimeKnows(string) bool { return false }
+
+// runtimeForgot answers that no project of the runtime has a network under
+// the name: the missing half of #342.
+func runtimeForgot(string) bool { return true }
+
 func TestLeftoverDHCPFindsTheServiceThatOutlivedItsInterface(t *testing.T) {
 	// The exact condition measured in #316: the interface is gone, the
 	// process is not, and only the process knows which block it still holds.
@@ -42,7 +53,7 @@ func TestLeftoverDHCPFindsTheServiceThatOutlivedItsInterface(t *testing.T) {
 	}
 	everythingGone := func(string) bool { return true }
 
-	leftovers := leftoverDHCP(procs, everythingGone)
+	leftovers := leftoverDHCP(procs, everythingGone, runtimeKnows)
 	if len(leftovers) != 1 {
 		t.Fatalf("expected one leftover, got %v", leftovers)
 	}
@@ -84,7 +95,7 @@ func TestLeftoverDHCPRefusesAProcessItCannotAttribute(t *testing.T) {
 	}
 	everythingGone := func(string) bool { return true }
 
-	if leftovers := leftoverDHCP(procs, everythingGone); len(leftovers) != 0 {
+	if leftovers := leftoverDHCP(procs, everythingGone, runtimeForgot); len(leftovers) != 0 {
 		t.Fatalf("a foreign process was attributed to the emulator: %v", leftovers)
 	}
 }
@@ -100,7 +111,7 @@ func TestLeftoverDHCPLeavesALiveServiceAlone(t *testing.T) {
 	}
 	alive := func(string) bool { return false }
 
-	if leftovers := leftoverDHCP(procs, alive); len(leftovers) != 0 {
+	if leftovers := leftoverDHCP(procs, alive, runtimeKnows); len(leftovers) != 0 {
 		t.Fatalf("a live service was reported as a leftover: %v", leftovers)
 	}
 }
@@ -112,7 +123,7 @@ func TestLeftoverDHCPRefusesAMixedInterfaceSet(t *testing.T) {
 	argv := append(incusDNSMasq("fnt-99109f524b2", "10.50.2.1"), "--interface=incusbr0")
 	procs := []HostProcess{{PID: 99, Argv: argv}}
 
-	if leftovers := leftoverDHCP(procs, func(string) bool { return true }); len(leftovers) != 0 {
+	if leftovers := leftoverDHCP(procs, func(string) bool { return true }, runtimeKnows); len(leftovers) != 0 {
 		t.Fatalf("a mixed interface set was attributed to the emulator: %v", leftovers)
 	}
 }
@@ -146,6 +157,7 @@ func TestTerminateLeftoverRefusesAPidThatIsNoLongerTheLeftover(t *testing.T) {
 		err := terminateLeftover(leftover,
 			func(int) ([]string, error) { return tc.argv, tc.err },
 			func(string) bool { return tc.gone },
+			runtimeKnows,
 			func(pid int) error { signalled = append(signalled, pid); return nil })
 		if len(signalled) != 0 {
 			t.Errorf("%s: a signal was sent anyway, to %v", name, signalled)
@@ -164,6 +176,7 @@ func TestTerminateLeftoverTreatsAGoneProcessAsDone(t *testing.T) {
 	err := terminateLeftover(DHCPLeftover{PID: 1, Interface: "fnt-x"},
 		func(int) ([]string, error) { return nil, errors.New("no such process") },
 		func(string) bool { return true },
+		runtimeKnows,
 		func(pid int) error { signalled = append(signalled, pid); return nil })
 	if err != nil || len(signalled) != 0 {
 		t.Fatalf("a vanished process was not treated as done: err=%v signals=%v", err, signalled)
@@ -178,6 +191,7 @@ func TestTerminateLeftoverEndsTheLeftoverItWasGiven(t *testing.T) {
 	err := terminateLeftover(leftover,
 		func(int) ([]string, error) { return incusDNSMasq("fnt-99109f524b2", "10.50.2.1"), nil },
 		func(string) bool { return true },
+		runtimeKnows,
 		func(pid int) error { signalled = append(signalled, pid); return nil })
 	if err != nil {
 		t.Fatalf("the leftover was refused: %v", err)
@@ -235,5 +249,82 @@ func TestANetworkCreateFailureStaysQuietAboutAnUnrelatedLeftover(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "7777") || strings.Contains(err.Error(), "fnt-a1b2c3d4e5f") {
 		t.Fatalf("the error names a process that does not hold this block:\n%v", err)
+	}
+}
+
+// TestLeftoverDHCPFindsTheServiceWhoseNetworkIsGone is #342's exact state,
+// measured on 2026-08-18: pid 612421 held 10.50.2.1 on a bridge that had
+// survived alongside its dnsmasq, both outliving the network object — and the
+// interface-only question answered "nothing outlives its interface" while the
+// next conformance run died on the bind. The falsification spec
+// dhcp-leftover-ownership.json proves this test fails when the network half
+// of the question is removed.
+func TestLeftoverDHCPFindsTheServiceWhoseNetworkIsGone(t *testing.T) {
+	procs := []HostProcess{
+		{PID: 612421, Argv: incusDNSMasq("fnt-99109f524b2", "10.50.2.1")},
+	}
+	interfaceStillThere := func(string) bool { return false }
+
+	leftovers := leftoverDHCP(procs, interfaceStillThere, runtimeForgot)
+	if len(leftovers) != 1 {
+		t.Fatalf("a service whose network is gone was not classified: %v", leftovers)
+	}
+	got := leftovers[0]
+	if got.PID != 612421 || got.Interface != "fnt-99109f524b2" || !got.InterfaceAlive {
+		t.Errorf("wrong classification: %+v", got)
+	}
+	// The report carries the two facts needed to act: the block (through its
+	// held address) and the pid.
+	for _, fact := range []string{"612421", "10.50.2.1", "fnt-99109f524b2"} {
+		if !strings.Contains(got.String(), fact) {
+			t.Errorf("the report does not carry %q: %s", fact, got)
+		}
+	}
+}
+
+// A live interface with a live network is nobody's leftover — and so is a
+// dnsmasq that merely borrowed an fnt- name without running off the runtime's
+// state directory. The live-interface case demands the strongest attribution
+// precisely because the wrong claim signals a working service.
+func TestLeftoverDHCPDemandsTheRuntimesOwnPathWhenTheInterfaceSurvives(t *testing.T) {
+	handRolled := []string{
+		"dnsmasq", "--interface=fnt-99109f524b2", "--listen-address=10.50.2.1",
+		"--conf-file=/home/operator/lab/dnsmasq.conf",
+	}
+	procs := []HostProcess{{PID: 4242, Argv: handRolled}}
+	interfaceStillThere := func(string) bool { return false }
+
+	if leftovers := leftoverDHCP(procs, interfaceStillThere, runtimeForgot); len(leftovers) != 0 {
+		t.Fatalf("a service that does not run off the runtime's state directory was claimed: %v", leftovers)
+	}
+}
+
+// DHCPHolders answers the other half of #342's question — "of ours or
+// otherwise" — at the one moment the wanted block is known: a create just
+// failed on it. Attribution is deliberately absent from the question, which is
+// why the answer must only ever name, never touch.
+func TestDHCPHoldersNamesAnyServiceInsideTheBlock(t *testing.T) {
+	procs := []HostProcess{
+		// The operator's own Incus bridge: never a leftover, but it does hold
+		// its block, and a create that collides with it deserves the fact.
+		{PID: 3187, Argv: incusDNSMasq("incusbr0", "10.76.154.1")},
+		// libvirt: no listen address on argv, so nothing places it in a block.
+		{PID: 2308, Argv: libvirtDNSMasq},
+		// Not a dnsmasq: not a DHCP service, whatever it listens on.
+		{PID: 77, Argv: []string{"nginx", "--listen-address=10.76.154.9"}},
+	}
+
+	holders := dhcpHolders(procs, netip.MustParsePrefix("10.76.154.0/24"))
+	if len(holders) != 1 || holders[0].PID != 3187 || holders[0].Address != "10.76.154.1" {
+		t.Fatalf("the holder of the block was not the one named: %v", holders)
+	}
+	for _, fact := range []string{"3187", "10.76.154.1", "dnsmasq"} {
+		if !strings.Contains(holders[0].String(), fact) {
+			t.Errorf("the report does not carry %q: %s", fact, holders[0])
+		}
+	}
+
+	if holders := dhcpHolders(procs, netip.MustParsePrefix("10.50.0.0/16")); len(holders) != 0 {
+		t.Fatalf("a service outside the block was named: %v", holders)
 	}
 }

--- a/internal/core/machine/serialise.go
+++ b/internal/core/machine/serialise.go
@@ -19,8 +19,17 @@ import "github.com/stephrobert/feint/internal/core/serialise"
 //
 // The exclusion is named rather than widened. One lock per target, never one
 // global lock: a global one would queue every server in the session behind a
-// single launch, turning a correctness fix into a throughput bug. attachMu in
-// the Incus driver is the same idea one layer down, for interface allocation.
+// single launch, turning a correctness fix into a throughput bug. Interface
+// allocation in the Incus driver is the same idea one layer down, and takes
+// this same mechanism keyed by machine.
+//
+// Until #348 that last sentence was false, and this is why it is worth reading
+// twice. The driver held one package-level attachMu, and this paragraph
+// described it as an example of the rule it broke. Nothing was wrong with the
+// sentence except that no test held it: six attachments on one stack took 26s,
+// 31s, 42s, 52s, 63s and 73s, a flat ten seconds each, until the client gave up
+// past its minute and its retry met the interface its own first attempt had
+// created. A comment claiming a property is not the property.
 //
 // The mechanism itself lives in core/serialise, because it is not specific to
 // machines: a pack's address allocation needs the same named exclusion, and

--- a/tools/falsify/specs/attach-per-machine.json
+++ b/tools/falsify/specs/attach-per-machine.json
@@ -1,0 +1,13 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "interface allocation goes back to one global lock, so every attachment in the session queues behind whichever machine is slowest",
+      "file": "internal/core/machine/incus.go",
+      "find": "\trelease := serialise.Lock(\"incus.attach.\" + name)",
+      "replace": "\trelease := serialise.Lock(\"incus.attach.\" + name[:0])",
+      "test": "TestTwoMachinesAttachWithoutQueueing"
+    }
+  ],
+  "note": "Measured rather than reasoned. Six attachments on the Scaleway example stack under --vm incus-ovn took 26s, 31s, 42s, 52s, 63s and 73s — a flat +10s each, which is one machine's work paid again by every machine behind it. Past the client's minute the apply retries, and the retry meets the NIC its own first attempt created: \"the server is already attached to this private network\" (#348). The same slope was measured on main without any of this branch's commits, so the queue predates them; it was simply unreachable, because no incus-ovn pass had ever got past the nftables race of #341. internal/core/machine/serialise.go had stated the rule all along — one lock per target, never one global — and named attachMu as an example of it, which it was not: that is a comment describing a property the code did not have."
+}

--- a/tools/falsify/specs/dhcp-doctor-network-question.json
+++ b/tools/falsify/specs/dhcp-doctor-network-question.json
@@ -1,0 +1,19 @@
+{
+  "package": "./internal/cli/",
+  "mutations": [
+    {
+      "label": "the held block goes back to a warning, so a state that kills the next run with certainty leaves doctor green for CI (#342)",
+      "file": "internal/cli/doctor.go",
+      "find": "\t\ttitle:  fmt.Sprintf(\"%d DHCP service(s) left by an earlier run still hold an address block this emulator will want\", len(leftovers)),\n\t\tstate:  verdictFail,",
+      "replace": "\t\ttitle:  fmt.Sprintf(\"%d DHCP service(s) left by an earlier run still hold an address block this emulator will want\", len(leftovers)),\n\t\tstate:  verdictFail * 0,",
+      "test": "TestDoctorFailsOnTheDHCPServiceWhoseNetworkIsGone"
+    },
+    {
+      "label": "the sweep stops saying what it will not touch, so the surviving bridge is left standing in silence (#342)",
+      "file": "internal/cli/clean.go",
+      "find": "\t\t\tif leftover.InterfaceAlive {",
+      "replace": "\t\t\tif leftover.InterfaceAlive && false {",
+      "test": "TestCleanSaysWhatItWillNotTouchWhenTheBridgeSurvived"
+    }
+  ]
+}

--- a/tools/falsify/specs/dhcp-leftover-ownership.json
+++ b/tools/falsify/specs/dhcp-leftover-ownership.json
@@ -4,8 +4,8 @@
     {
       "label": "the ownership question is no longer asked before a DHCP service is attributed to the emulator",
       "file": "internal/core/machine/leftover.go",
-      "find": "\t\tif !ownedNetwork(name) || !safeName.MatchString(name) || !gone(name) {\n\t\t\treturn DHCPLeftover{}, false\n\t\t}",
-      "replace": "\t\tif false && (!ownedNetwork(name) || !safeName.MatchString(name)) || !gone(name) {\n\t\t\treturn DHCPLeftover{}, false\n\t\t}",
+      "find": "\t\tif !ownedNetwork(name) || !safeName.MatchString(name) {\n\t\t\treturn DHCPLeftover{}, false\n\t\t}",
+      "replace": "\t\tif false && (!ownedNetwork(name) || !safeName.MatchString(name)) {\n\t\t\treturn DHCPLeftover{}, false\n\t\t}",
       "test": "TestLeftoverDHCPRefusesAProcessItCannotAttribute"
     },
     {
@@ -14,6 +14,20 @@
       "find": "\tif !ok || current.Interface != leftover.Interface {\n\t\treturn fmt.Errorf(\"pid %d is no longer the DHCP service that outlived %s; refusing to signal it\",\n\t\t\tleftover.PID, leftover.Interface)\n\t}",
       "replace": "\tif (!ok || current.Interface != leftover.Interface) && false {\n\t\treturn fmt.Errorf(\"pid %d is no longer the DHCP service that outlived %s; refusing to signal it\",\n\t\t\tleftover.PID, leftover.Interface)\n\t}",
       "test": "TestTerminateLeftoverRefusesAPidThatIsNoLongerTheLeftover"
+    },
+    {
+      "label": "the classification answers only the interface question again, so a service whose network died under a surviving bridge reads as healthy (#342)",
+      "file": "internal/core/machine/leftover.go",
+      "find": "\t\tif !unknown(name) || !runtimeServiceOf(proc, name) {\n\t\t\treturn DHCPLeftover{}, false\n\t\t}",
+      "replace": "\t\tif true || !unknown(name) || !runtimeServiceOf(proc, name) {\n\t\t\treturn DHCPLeftover{}, false\n\t\t}",
+      "test": "TestLeftoverDHCPFindsTheServiceWhoseNetworkIsGone"
+    },
+    {
+      "label": "the live-interface case stops demanding the runtime's own state directory, so a hand-rolled dnsmasq on a borrowed fnt- name is claimed",
+      "file": "internal/core/machine/leftover.go",
+      "find": "\t\tif !unknown(name) || !runtimeServiceOf(proc, name) {\n\t\t\treturn DHCPLeftover{}, false\n\t\t}",
+      "replace": "\t\tif !unknown(name) || (false && !runtimeServiceOf(proc, name)) {\n\t\t\treturn DHCPLeftover{}, false\n\t\t}",
+      "test": "TestLeftoverDHCPDemandsTheRuntimesOwnPathWhenTheInterfaceSurvives"
     }
   ]
 }

--- a/tools/falsify/specs/uplink-serialisation.json
+++ b/tools/falsify/specs/uplink-serialisation.json
@@ -1,0 +1,40 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "the uplink rebuilds stop being serialised, so a subnet delegation and a machine-network create race in the daemon's firewall clear (#341)",
+      "file": "internal/core/machine/incus.go",
+      "find": "\t\t// of seconds of a machine launch.\n\t\td.uplinkMu.Lock()\n\t\tdefer d.uplinkMu.Unlock()",
+      "replace": "\t\t// of seconds of a machine launch.\n\t\tif false {\n\t\t\td.uplinkMu.Lock()\n\t\t\tdefer d.uplinkMu.Unlock()\n\t\t}",
+      "test": "TestConcurrentSubnetAndMachineNetworkCreatesSerialiseOnTheUplink"
+    },
+    {
+      "label": "a deleted network's block is never withdrawn from the uplink, so delegations accumulate run after run (#341)",
+      "file": "internal/core/machine/incus.go",
+      "find": "\tif !d.OVN || block == \"\" {\n\t\treturn nil\n\t}\n\treturn d.dropUplinkRoute(ctx, block)",
+      "replace": "\tif !d.OVN || block == \"\" {\n\t\treturn nil\n\t}\n\treturn d.dropUplinkRoute(ctx, block[:0])",
+      "test": "TestRemoveNetworkWithdrawsTheDelegatedBlock"
+    },
+    {
+      "label": "an uplink held by a live emulator is shared instead of refused, which is the cross-process shape of the same corruption (#341)",
+      "file": "internal/core/machine/incus_ovn.go",
+      "find": "\t\tif pid, err := strconv.Atoi(holder); err == nil && d.holderIsAlive(pid) {",
+      "replace": "\t\tif pid, err := strconv.Atoi(holder); err == nil && false && d.holderIsAlive(pid) {",
+      "test": "TestEnsureUplinkRefusesAnUplinkHeldByALiveEmulator"
+    },
+    {
+      "label": "the adoption keeps a dead run's routes, so every stale delegated block stays a live host route (#341)",
+      "file": "internal/core/machine/incus_ovn.go",
+      "find": "\t\tif current := strings.TrimSpace(config[\"ipv4.routes\"]); current != strings.Join(kept, \",\") {\n\t\t\targs = append(args, \"ipv4.routes=\"+strings.Join(kept, \",\"))\n\t\t}",
+      "replace": "\t\tif current := strings.TrimSpace(config[\"ipv4.routes\"]); current != strings.Join(kept, \",\") {\n\t\t\targs = append(args, \"ipv4.routes=\"+current)\n\t\t}",
+      "test": "TestAdoptedUplinkDropsADeadRunsRoutes"
+    },
+    {
+      "label": "a foreign DHCP holder of the wanted block goes unnamed in the create error (#342)",
+      "file": "internal/core/machine/incus.go",
+      "find": "\tfor _, holder := range d.blockHolders(block) {",
+      "replace": "\tfor _, holder := range d.blockHolders(block)[:0] {",
+      "test": "TestANetworkCreateFailureNamesAForeignHolderWithoutClaimingIt"
+    }
+  ]
+}


### PR DESCRIPTION
Two defects of one family — what a run leaves behind, and a guard that answered
a narrower question than its sentence claimed.

## #341 — the cause, measured rather than guessed

**The issue's premise was half wrong, and finding that out is what solved it.**
The failure reproduces from a **clean station**, at the first full pass. It is
not accumulated state.

Instrumented with `incus monitor` through a whole pass:

1. `feint clean` at the end of the oapi-cli suite **deletes the uplink**;
2. the outscale-tofu suite, right behind, has OpenTofu recreate two subnets and
   a default machine network **concurrently**;
3. a network `PUT` on the uplink and an OVN network `POST` attached to it
   **both** make the daemon rebuild the uplink's nftables firewall;
4. Incus' `removeChains` is a **snapshot-then-delete**, and the two paths share
   no lock in the daemon.

So the loser's chain is deleted by the concurrent operation **between its own
snapshot and its delete**, and it dies on `ENOENT`. That is the third branch of
the question the issue asked — not deleted twice, not never created: deleted by
the other, mid-sequence.

`uplinkMu` now serialises every operation that makes the daemon rebuild the
uplink, the `network create` included.

Two siblings of the same family, fixed with it:

- **A deleted OVN network takes its delegated block off the uplink.** One pass
  accumulated nine routes; the seven the issue reported were not the residue of
  seven runs. An uplink left by a dead run is adopted once per process, dropping
  the routes of networks that no longer exist.
- **An uplink held by a live emulator is refused rather than shared** — sharing
  it across processes is the same unlocked corruption under another name.

## #342 — the guard now asks the operator's question

`feint doctor` answered `ok: no DHCP service outlives its interface` while an
orphan held `10.50.2.1` and broke the next run. The sentence was true; it was
not the question. It looked for a service whose **interface** was gone, and
there the interface had survived *alongside* its service — both had outlived
the **network**.

Now: a leftover is a red line **naming the block and the pid**, the two facts
needed to act; `feint clean` kills the service and **says what it will not
touch**, because an unlabelled bridge is not demonstrably ours; and every green
line of `doctor` was re-read against what it actually measures.

## What the acceptance run measured, and what it revealed

| | reference `d735385` | with this lot |
|---|---|---|
| `Failed deleting nftables chain` | **1** | **0** |
| `outscale-tofu` suite | dies on it | **passes** |
| example stacks reached | **never** | yes |

Checked across every OVN pass log on this station: `stacks=0` in all of them.
**This is the first `incus-ovn` pass in the repository's history to reach the
example stacks.**

Which means the wall that fell reveals the next one — the same shape as #335
hiding #341. The Scaleway example stack now fails immediately on `init and
apply`, on **both** servers, with *"the server is already attached to this
private network"*. Not a timeout (no `Still creating`), not residual state
(`run_stack` copies into a fresh `mktemp`), and not present under plain `incus`
where the same stack passes. **An OVN-mode defect nobody could see before**,
filed separately.

**Consequence, stated rather than glossed**: #341's written criterion — two
consecutive green full passes — is not reachable while that new wall stands.
What the issue actually asked is answered, and measured on both sides of the
same full pass: the race is named, and it no longer happens. Claiming the
criterion met would be exactly the kind of assertion this repository exists to
refuse.

## Falsified

Three specs, 11 mutations, each turning its named test red:
`dhcp-leftover-ownership.json`, `uplink-serialisation.json`,
`dhcp-doctor-network-question.json` — the last including a runner that detects
two firewall rebuilds in flight.

## Provenance

The measurement and the fix are the work of an agent that reached its model
limit mid-task, before committing. Its work was committed on its behalf,
unaltered, and its `HANDOVER.md` is in the tree: the cause analysis above is
its measurement, and it should not be paid for twice. What followed — rebase,
changelogs, the acceptance run and the reading of it — was done after.

## Related

Closes #341
Closes #342

## The wall behind it, found and fixed in the same session (#348)

The pass above went further than any before it, and hit the next wall
immediately: the Scaleway example stack failed on both servers with *"the
server is already attached to this private network"*. Recorded through
`feint proxy`, the six attachments read:

```
26s -> 201    52s -> 201
31s -> 201    63s -> 502   the client's minute is up
42s -> 201    73s -> 502
                1ms -> 400  "already attached"  (the retry)
```

**A flat ten seconds each is not slowness, it is a queue.** The driver held one
package-level `attachMu` across every call `Attach` makes into the machine.
Past the client's timeout the apply retries, and the retry meets the interface
its own first attempt created — so the `400` is right and the queue is the
defect.

`internal/core/machine/serialise.go` had stated the rule all along — *"one lock
per target, never one global lock: a global one would queue every server in the
session behind a single launch, turning a correctness fix into a throughput
bug"* — **and named `attachMu` as an example of it**. It was the
counter-example. The sentence was never wrong; no test held it.

Now keyed by machine, through the repository's own `serialise.Lock`. Measured
again with the real stack, same conditions:

| | before | after |
|---|---|---|
| six attachments | 26 / 31 / 42 / 52 / **63** / **73** s | 24 / 21 / 21 / 21 / 21 / 21 s |
| `already attached` | 2 | **0** |
| the apply | fails | **completes**, `web_addresses = ["10.30.1.10", "10.30.1.11"]` |

The Scaleway example stack now applies end to end under `incus-ovn`, which no
pass had ever achieved. Falsified by
`tools/falsify/specs/attach-per-machine.json`.

Not this branch's doing, and measured rather than assumed: the same slope was
recorded on `main` without any of these commits. The queue predates them; it
was unreachable behind #341.

Closes #348
