### PR TITLE
feat(corpus): the committed recordings are replayed on every pull request

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -118,6 +118,22 @@ jobs:
           go build -o feint ./cmd/feint
           ./feint shapes --check
 
+      # And it answers what a real cloud answered. shapes/*.json above holds the
+      # field trees a cloud returns; corpus/ holds whole exchanges of a real
+      # account — the status, the order and the sequence too (#351, #352, #353).
+      # Replaying it is the only control here that compares an answer with the
+      # cloud's: `conformance` proves a real client *accepts* what this emulator
+      # says, which is a weaker question, and it cannot be more because the
+      # cloud is not there.
+      #
+      # On every pull request, forks included, because every input is a
+      # versioned file: no credential, no network, no `scw`, no Terraform, and
+      # thirty milliseconds. Exit 2 is a divergence the acceptance list does not
+      # carry; exit 1 is a corpus that could not be read or that compared
+      # nothing — a corpus replaying nothing is a failure, never a pass.
+      - name: The emulator answers what a real cloud answered
+        run: ./feint corpus --check
+
       # Fuzz the one input feint does not control: the JSON body a client posts. A panic in a
       # handler takes down every provider sharing the process, so a crasher must surface in CI
       # rather than in someone's terminal. Crashers land in testdata/fuzz/ and become permanent

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -88,6 +88,73 @@ change ni l'un ni l'autre a sa place dans `git log`.
   asynchrone émulée vit dans le cycle de vie d'un pack, pas devant un handler, et
   n'est pas replié ici.
 
+- **Le corpus committé est rejoué à chaque pull request** (#353). `feint corpus
+  --check`, `mise run corpus:check`, dans `prepush` et dans
+  `.github/workflows/go.yml`. Il rejoue chaque fichier de `corpus/` contre un
+  émulateur qui lui est propre et échoue sur une divergence avec ce que le vrai
+  cloud a répondu. Trente millisecondes, hors ligne, sans credential ni binaire
+  client, parce que toutes ses entrées sont des fichiers versionnés : c'est
+  précisément ce qui lui permet d'être un gate là où `conformance` ne peut pas
+  l'être, un crochet qui échoue sur un binaire absent enseignant `--no-verify`,
+  qui désarme tous les autres d'un coup.
+
+  **C'est le premier contrôle d'ici qui compare une réponse à celle du cloud.**
+  `mise run conformance` prouve qu'un vrai client **accepte** ce que l'émulateur
+  répond, et ne peut pas prouver que cette réponse est celle que le cloud aurait
+  donnée, puisque le cloud n'est pas là. `shapes --check` compare des arbres de
+  champs ; un corpus porte aussi le statut, l'ordre et la séquence.
+
+  **Trois verdicts, jamais confondus.** Une divergence que la liste
+  d'acceptation ne porte pas vaut 2. Une opération qu'aucune route ne sert est
+  rapportée et jamais comptée : le jour où elle fait échouer un build est le
+  jour où quelqu'un arrête d'enregistrer. Un corpus illisible, ou qui n'a rien
+  comparé, vaut 1 : un fichier vide, un répertoire vide et un fichier dont
+  chaque échange est non servi sont rouges, chacun avec son propre message. **Un
+  corpus qui ne rejoue rien est un échec, jamais un succès** : ce dépôt a livré
+  l'autre forme deux fois, dans la suite réseau et dans cinq contrôles de
+  `tools/ui/check-page.py`.
+
+  **`corpus/accepted.json`**, sur le modèle de `tools/compat/accepted.json`,
+  porte les huit divergences du premier passage avec leur raison et l'issue qui
+  les retire (#355), ainsi que la date d'enregistrement de chaque fichier. Les
+  deux moitiés sont tenues : une entrée qui n'excuse rien fait échouer le gate,
+  donc un correctif ne peut pas laisser son exemption derrière lui, et un
+  fichier de corpus que personne n'a daté le fait échouer aussi.
+
+  **Comment un corpus vieillit : il avertit, il n'échoue jamais.** Un gate qui
+  échoue parce que le **cloud** a bougé est un gate qu'on désactive, et
+  celui-ci ne tient qu'un côté de la comparaison : il peut dire que l'émulateur
+  et l'enregistrement divergent, jamais lequel des deux a changé. Échouer sur
+  l'âge affirmerait exactement ce qu'il ne mesure pas ; #359 est la moitié qui
+  peut trancher. L'horizon vaut 180 jours, dans un fichier committé, et
+  l'avertissement nomme le fichier, son âge et la procédure de réenregistrement.
+
+- **`feint replay` lie un identifiant enregistré sous le nom de champ où il a
+  été vu** (#353). Le corpus a fait apparaître un enregistrement que la liaison
+  précédente ne savait pas représenter : sur un compte Scaleway à un seul
+  projet, `project_id` et `organization_id` sont la **même chaîne**, donc une
+  valeur enregistrée avait deux réponses candidates et une table de valeur à
+  valeur n'en gardait qu'une. Le vainqueur était décidé par le parcours de map
+  aléatoire de Go : six rejeux de `corpus/scaleway/scw-cli.jsonl` contre six
+  émulateurs neufs ont classé `vpc/v2/API.ListPrivateNetworks` divergente trois
+  fois et conforme trois fois, et quand l'organisation gagnait, la création
+  déposait son réseau dans un projet que la liste non filtrée ne couvre pas.
+  Une divergence que le rejeu fabriquait lui-même.
+
+  Les liaisons sont désormais portées par le nom de champ où elles ont été
+  observées, donc `project_id` se résout vers le projet que cet émulateur a
+  frappé et `organization_id` vers l'organisation, et le parcours qui les
+  apprend est trié, de sorte qu'une valeur sans champ pour la porter, un segment
+  de chemin, se résout de la même façon à chaque exécution. La table non portée
+  reste le recours, et c'est elle qui garde un chemin relié. Une exécution
+  rapporte maintenant combien de valeurs enregistrées deux champs ont liées
+  différemment, au lieu de les arbitrer en silence. Le verdict sur le corpus
+  committé est passé de « 8 ou 9 » à 8 sur huit exécutions.
+
+- **La surface CLI gelée passe en version 9** (#353) : le verbe `corpus`, avec
+  `--check`, `--dir` et `--accepted`. Un ajout, rien n'a été retiré, aucun code
+  de sortie n'a bougé, et un pipeline calé sur la version 8 continue de marcher.
+
 - **`feint replay` rejoue un enregistrement ici et dit ce qui diverge** (#73).
   `feint replay run.jsonl --endpoint http://127.0.0.1:4599` reprend chaque
   requête enregistrée, l'envoie à un émulateur qui tourne, et rapporte opération

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,69 @@ what this project is judged on: **a response shape a client can observe**, and
   transition takes lives in a pack's lifecycle, not in front of a handler, and
   is not folded in.
 
+- **The committed corpus is replayed on every pull request** (#353). `feint
+  corpus --check`, `mise run corpus:check`, in `prepush` and in
+  `.github/workflows/go.yml`. It replays every file of `corpus/` against an
+  emulator of its own and fails on a divergence from what the real cloud
+  answered. Thirty milliseconds, offline, no credential and no client binary,
+  because every input is a versioned file — which is exactly why it can be a
+  gate where `conformance` cannot: a hook that fails on an absent binary teaches
+  `--no-verify`, and that disarms every other hook at once.
+
+  **This is the first control here that compares an answer with the cloud's.**
+  `mise run conformance` proves a real client *accepts* what this emulator says,
+  and cannot prove the answer is the one the cloud would have given, because the
+  cloud is not there. `shapes --check` compares field trees; a corpus carries the
+  status, the order and the sequence as well.
+
+  **Three verdicts, never blurred.** A divergence the acceptance list does not
+  carry is exit 2. An operation no route serves is printed and never counted —
+  the day it fails a build is the day somebody stops recording. A corpus that
+  could not be read, or that compared nothing, is exit 1: an empty file, an
+  empty directory and a file whose every exchange is unserved are each red with
+  their own message. **A corpus that replays nothing is a failure, never a
+  pass** — this repository has shipped the other shape twice, in the network
+  conformance suite and in five checks of `tools/ui/check-page.py`.
+
+  **`corpus/accepted.json`**, on the model of `tools/compat/accepted.json`,
+  carries the eight divergences of the first run with their reason and the issue
+  that retires them (#355), plus the date each file was recorded. Both halves are
+  held: an entry that excuses nothing fails the gate, so a fix cannot leave its
+  exemption behind, and a corpus file nobody dated fails it too.
+
+  **How a corpus ages: it warns, and never fails.** A gate that fails because the
+  *cloud* moved is a gate somebody disables, and this one holds only one side of
+  the comparison — it can say the emulator and the recording disagree, never
+  which of the two changed. Failing on age would assert exactly what it cannot
+  measure; #359 is the half that can arbitrate. The horizon is 180 days, in a
+  committed file, and the warning names the file, its age and the re-recording
+  procedure.
+
+- **`feint replay` binds a recorded identifier under the field name it was seen
+  at** (#353). The corpus surfaced a recording the previous binding could not
+  represent: on a Scaleway account with one project, `project_id` and
+  `organization_id` are the *same string*, so one recorded value had two
+  candidate answers and a map from value to value could hold only one. Which one
+  was decided by Go's randomised map iteration — six replays of
+  `corpus/scaleway/scw-cli.jsonl` against six fresh emulators graded
+  `vpc/v2/API.ListPrivateNetworks` divergent three times and matched three
+  times, and when the organisation won, the create filed its network under a
+  project the unfiltered list does not cover. A divergence the replay had
+  manufactured itself.
+
+  Bindings are now scoped to the field name they were observed under, so
+  `project_id` resolves to the project this emulator minted and
+  `organization_id` to the organisation, and the walk that learns them is
+  sorted, so a value with no field to scope it — a path segment — resolves the
+  same way on every run. The unscoped map remains as the fallback, which is what
+  keeps a path rebound at all. A run now reports how many recorded values two
+  fields bound differently, rather than resolving them in silence. The verdict on
+  the committed corpus went from "8 or 9" to 8 on every run of eight.
+
+- **The frozen CLI surface moves to version 9** (#353): the verb `corpus`, with
+  `--check`, `--dir` and `--accepted`. An addition — nothing was removed, no exit
+  code moved, and a pipeline keyed on version 8 keeps working.
+
 - **`feint replay` reissues a recording here and says what diverged** (#73).
   `feint replay run.jsonl --endpoint http://127.0.0.1:4599` takes every recorded
   request, sends it to a running emulator, and reports operation by operation.

--- a/CONTRIBUTING.fr.md
+++ b/CONTRIBUTING.fr.md
@@ -38,7 +38,8 @@ Elle installe trois types de hooks, et les deux derniers se ratent facilement :
 ### Avant de pousser
 
 Le hook `pre-push` lance `mise run prepush` : `check`, `docs:check`,
-`drift:check`, `shapes:check`, `falsify:selftest` et `falsify:lint`.
+`drift:check`, `shapes:check`, `corpus:check`, `falsify:selftest` et
+`falsify:lint`.
 Déterministe, hors ligne, quelques secondes.
 C'est ce qu'une pull request refusera, sans jamais dépendre de la météo d'un
 runner.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,8 @@ It installs three hook types, and the last two are easy to miss: `pre-commit`,
 ### Before you push
 
 The `pre-push` hook runs `mise run prepush`: `check`, `docs:check`,
-`drift:check`, `shapes:check`, `falsify:selftest` and `falsify:lint`.
+`drift:check`, `shapes:check`, `corpus:check`, `falsify:selftest` and
+`falsify:lint`.
 Deterministic, offline, seconds. It is what a pull request will refuse without
 ever depending on a runner's weather.
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -471,6 +471,7 @@ c'est arrivé à dix d'entre eux avant qu'un test compare les deux listes.
 | `feint proxy` | enregistre ce qu'un vrai client et un vrai cloud se disent, identifiants masqués |
 | `feint transcript` | lit un enregistrement : quoi servir ensuite, quelle forme, ce que l'émulateur omet |
 | `feint replay` | rejoue un enregistrement contre un émulateur qui tourne et rapporte, opération par opération, ce qui diverge |
+| `feint corpus` | rejoue les corpus committés contre un émulateur neuf et échoue sur une divergence avec ce que le vrai cloud a répondu |
 | `feint probe` | pilote chaque route montée depuis sa description d'API et contrôle les réponses |
 | `feint shapes` | ce qu'un vrai cloud renvoie, et ce que l'émulateur en omet |
 | `feint evidence` | écrit le registre de preuves qu'une exécution de conformance a gagnées, opération par opération |
@@ -492,6 +493,18 @@ fois où un vrai client l'a appelé quand même, c'est-à-dire la demande qu'une
 raison écrite ne porte pas. Ni l'un ni l'autre n'imprime une valeur lue : un
 enregistrement est l'inventaire d'un compte, et un constat nomme un chemin, un
 type et une position.
+
+`feint corpus --check` est ce qui fait de cette boucle un gate. `corpus/` porte
+les enregistrements d'un vrai compte Scaleway, assainis pour que ce dépôt puisse
+les committer (#351, #352), et ce verbe les rejoue tous contre un émulateur neuf
+à chaque pull request. C'est le seul contrôle d'ici qui compare une réponse à
+celle du **cloud** : `mise run conformance` prouve qu'un vrai client accepte ce
+que l'émulateur répond, ce qui est une autre question, et une plus faible.
+Toutes ses entrées sont des fichiers versionnés, donc il ne lui faut ni compte,
+ni réseau, ni binaire client, et c'est précisément ce qui lui permet d'être un
+gate là où `conformance` ne peut pas l'être. Sortie 2 sur une divergence que la
+liste d'acceptation ne porte pas, sortie 1 sur un corpus illisible ou qui n'a
+rien comparé : **un corpus qui ne rejoue rien est un échec, jamais un succès.**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -859,6 +859,7 @@ rather than assumed.
 | `feint proxy` | sit between a real client and a real cloud and record every exchange, credentials redacted |
 | `feint transcript` | read a recording: what to serve next, what a response must look like, what the emulator omits |
 | `feint replay` | reissue a recording at a running emulator and report, operation by operation, what diverged |
+| `feint corpus` | replay every committed corpus against a fresh emulator and fail on a divergence from what the real cloud answered |
 | `feint probe` | drive every mounted route from its API description and check the answers |
 | `feint shapes` | the field trees a real cloud returns, versioned — and what this emulator omits from them |
 | `feint evidence` | write the per-operation evidence record a conformance run earned |
@@ -886,6 +887,18 @@ them comparable. The second ranks what the packs *decline* by how often a real
 client called it anyway, which is the demand a written reason cannot carry.
 Neither prints a value it read: a recording is an account's inventory, and a
 finding names a path, a type and a position.
+
+`feint corpus --check` is what makes that loop a gate. `corpus/` holds the
+recordings of a real Scaleway account, sanitised so this repository may commit
+them (#351, #352), and this verb replays every one of them against a fresh
+emulator on every pull request. It is the only control here that compares an
+answer with the *cloud's*: `mise run conformance` proves a real client accepts
+what the emulator says, which is a different question and a weaker one. Every
+input is a versioned file, so it needs no account, no network and no client
+binary — which is exactly why it can be a gate where `conformance` cannot. Exit
+2 on a divergence the acceptance list does not carry, and exit 1 on a corpus
+that could not be read or that compared nothing: **a corpus replaying nothing is
+a failure, never a pass.**
 
 ---
 

--- a/corpus/README.md
+++ b/corpus/README.md
@@ -13,14 +13,66 @@ none of the identifiers, addresses, names and free text the account carried.
 `docs/proxy.md`, *A transcript you can commit*, states the format and what it
 guarantees.
 
+## The gate
+
+Nothing here is worth anything unless something replays it, so something does,
+on every pull request:
+
+```bash
+mise run corpus:check      # or: feint corpus --check
+```
+
+It starts an emulator of its own per file, replays every exchange, and compares.
+Thirty milliseconds, offline, no credential and no client binary — which is
+exactly why it can be a gate where `mise run conformance` cannot: a hook that
+fails on an absent binary teaches `--no-verify`, and that disarms every other
+hook at once. It runs in `mise run prepush` and in `.github/workflows/go.yml`.
+
+Three verdicts, never blurred:
+
+| | |
+|---|---|
+| a **divergence** the acceptance list does not carry | exit 2 |
+| an operation **no route serves** | printed, #74's queue, never counted |
+| a corpus that **could not be read**, or compared nothing | exit 1 |
+
+The third is the one that gets forgotten, and it is asserted rather than hoped
+for: an empty file, an empty directory, and a file whose every exchange is
+unserved are each red, each with their own message
+(`TestACorpusThatComparesNothingIsRed`). **A corpus that replays nothing is a
+failure, never a pass.**
+
+`corpus/accepted.json` carries the divergences this repository records rather
+than fixes, each with its reason and the issue that retires it, and an entry
+excusing nothing fails the gate — so the day a defect is fixed, the gate demands
+that its exemption go. The same file dates each recording, and an undated corpus
+is red.
+
+One file at a time, against a **fresh** emulator each time: a corpus is a causal
+sequence that creates what it later reads, so replaying two into one store makes
+a list answer objects the recording never created. The same reason
+`feint serve --state …` is the wrong thing to replay against by hand:
+
 ```bash
 feint serve &
 feint replay corpus/scaleway/terraform.jsonl --endpoint http://127.0.0.1:4599
 ```
 
-Exit 2 means the emulator and a real cloud disagree, and that is the point of
-the file. **Replay against a fresh emulator**: `feint serve --state …` restores
-a snapshot, and a list operation then answers objects this corpus never created.
+## How this corpus ages
+
+A cloud changes. A recording made today describes the cloud of today, and a gate
+that fails because the *cloud* moved is a gate somebody disables — taking all of
+its coverage with it. So `warn_after_days` in `corpus/accepted.json` **warns and
+never fails**, and the reason is a limit of the measurement rather than a
+preference: this gate holds one side of the comparison. A red run says the
+emulator and the recording disagree, and nothing in the process knows which of
+the two moved. Failing on age would be asserting exactly what it cannot measure.
+
+The half that can arbitrate is #359, which replays this corpus against the
+**cloud**. Until it exists, the warning names the file, its age and the
+procedure below, and 180 days is a chosen horizon rather than a measured one:
+about two releases, and short enough that a surface which gained 453 SDK methods
+in twelve months has not silently outrun the file.
 
 ## What is here
 
@@ -98,32 +150,45 @@ Several Outscale profiles on the maintainer's station also name third-party
 organisations, two of them in a sovereign region. That is #354, with its own
 guard rails.
 
-## What the first run found
+## What the runs found
 
 Replaying these two files against the emulator of 2026-08-21: `terraform.jsonl`
-matched on all 16 exchanges, `scw-cli.jsonl` on 33 of 58 with 16 unserved and
-8 or 9 divergent, in three families.
+matched on all 16 exchanges, `scw-cli.jsonl` on 34 of 58 with 16 unserved and 8
+divergent, in three families. All eight are listed in `corpus/accepted.json`
+with their reason and are fixed by #355; the gate is green because it carries
+them, and it goes red the moment one is fixed and its entry is not deleted.
 
-- **The catalogue is a fixed subset.** `fr-par-1` publishes 136 commercial
-  types over three pages; the emulator serves 18, on purpose
+- **The catalogue is a fixed subset.** `fr-par-1` publishes 136 commercial types
+  over three pages; the emulator serves 18, on purpose
   (`internal/providers/scaleway/catalog.go`). The pack declines that shape, but
   the decline is keyed `GET /instance/v1/zones/fr-par-1/products/servers`, which
   is the shapes catalogue's spelling — the replay joins on the mounted operation
-  name, so it never sees it and reports every missing type.
+  name, so it never sees it and reports every missing type. 136 findings.
 - **The default VPC carries no tags.** Scaleway's own default VPC answers
-  `tags: ["default"]`; a fresh emulator answers `[]`.
+  `tags: ["default"]`; a fresh emulator answers `[]`. A defect of the emulator,
+  and the first this corpus surfaced.
 - **The IAM SSH-key lifecycle cannot be replayed at all**, and that is the
   instrument rather than the emulator: the proxy redacts the value under any
   JSON key whose *name* contains "key", so `public_key` reaches the transcript
   as `REDACTED`, `sshkey.Parse` refuses it, and the create answers 400 — taking
   the read and the delete that follow it with it.
 
-**"8 or 9" is not a rounding.** Six runs of the same file against six fresh
-emulators graded `vpc/v2/API.ListPrivateNetworks` divergent three times and
-matched three times. The cause is in the replay's rebinding, not here: this
-account's `project_id` and `organization_id` are the same string, so one
-recorded value has two candidate bindings whose emulator counterparts differ,
-and `bindings.learn` walks a Go map — whichever field it visits first wins.
-When the organisation wins, the create files its network under a project the
-unfiltered list does not cover. A gate built on this corpus (#353) has to settle
-that before it can call a red run a defect.
+**It used to be "8 or 9", and that was not a rounding.** Six runs of the same
+file against six fresh emulators graded `vpc/v2/API.ListPrivateNetworks`
+divergent three times and matched three times. The cause was in the replay's
+rebinding rather than here: this account's `project_id` and `organization_id`
+are the same string, so one recorded value had two candidate bindings whose
+emulator counterparts differ, and `bindings.learn` walked a Go map — whichever
+field it visited first won. When the organisation won, the create filed its
+network under a project the unfiltered list does not cover, and the replay
+reported a divergence it had manufactured itself.
+
+#353 settled it before the gate went in, because a non-deterministic gate is a
+gate that gets disarmed the first time it seems to lie. A binding is now scoped
+to the field name it was observed under — `project_id` resolves to the project
+this emulator minted and `organization_id` to the organisation — and the walk
+that learns them is sorted, so a value with no field to scope it resolves the
+same way on every run. `TestOneRecordedValueUnderTwoFieldsBindsByFieldName` and
+`TestTheSameRecordingBindsTheSameWayOnEveryRun` hold both halves, and
+`TestTheCommittedCorpusPassesItsOwnGateAndSaysTheSameThingTwice` holds the
+whole run.

--- a/corpus/accepted.json
+++ b/corpus/accepted.json
@@ -1,0 +1,112 @@
+{
+  "comment": [
+    "What `feint corpus --check` knows about the committed corpora: when each was",
+    "recorded, and which divergences from the real cloud this repository records",
+    "rather than fails on. Modelled on tools/compat/accepted.json, including the",
+    "rule that gives that file its teeth: an entry that excuses nothing fails the",
+    "gate, because a stale exemption is a gate that quietly stopped covering what",
+    "it names. Every accepted divergence is still printed, with its reason, on",
+    "every run.",
+    "",
+    "WHY THIS FILE EXISTS AT ALL, AND NOT A RED BUILD. The gate went in with the",
+    "corpus already carrying eight divergences, classified by #352 and fixed by",
+    "#355. Merging it red would put every unrelated pull request on a red main,",
+    "and CLAUDE.md's own argument for keeping `conformance` out of the hook",
+    "applies unchanged: a gate people learn to skip is worse than no gate. So the",
+    "eight are listed here, each with the issue that deletes its entry, and the",
+    "staleness rule makes that deletion compulsory: the day #355 serves the",
+    "default VPC's tags, this gate goes red until the entry below is removed.",
+    "",
+    "HOW A CORPUS AGES. `warn_after_days` warns and never fails. This gate holds",
+    "one side of the comparison — it can say the emulator and the recording",
+    "disagree, and nothing in it knows which of the two moved. Failing on age",
+    "would be asserting exactly what it cannot measure, and a gate that fails",
+    "because the cloud changed is a gate somebody disables. #359 is the half that",
+    "can arbitrate: it replays the corpus against the cloud. Until then the",
+    "warning names the file, its age and the re-recording procedure",
+    "(corpus/README.md), and 180 days is a chosen horizon rather than a measured",
+    "one: about two releases, and short enough that a Scaleway surface which",
+    "gained 453 SDK methods in twelve months has not silently outrun the file."
+  ],
+  "warn_after_days": 180,
+  "recorded": [
+    {
+      "file": "scaleway/scw-cli.jsonl",
+      "at": "2026-08-21",
+      "client": "scw 2.56.3",
+      "cloud": "Scaleway fr-par"
+    },
+    {
+      "file": "scaleway/terraform.jsonl",
+      "at": "2026-08-21",
+      "client": "terraform-provider-scaleway 2.81.0",
+      "cloud": "Scaleway fr-par"
+    }
+  ],
+  "accepted": [
+    {
+      "file": "scaleway/scw-cli.jsonl",
+      "operation": "instance/v1/API.ListServersTypes",
+      "kind": "absent",
+      "path": "servers.*",
+      "reason": "fr-par-1 publishes 136 commercial types over three pages and this catalogue serves 18 on purpose, because an emulator has no inventory and must still answer one the CLI accepts; the pack already argues that refusal in DeclinedFields, keyed on the shapes catalogue's spelling GET /instance/v1/zones/fr-par-1/products/servers, which the replay never meets because it joins on the mounted operation name",
+      "issue": "#355"
+    },
+    {
+      "file": "scaleway/scw-cli.jsonl",
+      "operation": "instance/v1/API.ListServersTypes",
+      "kind": "absent",
+      "path": "servers.*.per_volume_constraint.l_ssd",
+      "reason": "a bound for local volumes this catalogue never attaches, which would enter the client's size arithmetic with nothing behind it; the same decision the pack states for the shapes gate, unreachable from here for the same spelling mismatch as the entry above",
+      "issue": "#355"
+    },
+    {
+      "file": "scaleway/scw-cli.jsonl",
+      "operation": "vpc/v2/API.ListVPCs",
+      "kind": "absent",
+      "path": "vpcs[].tags[]",
+      "reason": "Scaleway's own default VPC answers tags: [\"default\"] and a fresh emulator answers an empty list, so the recording sees an element where this one has none; a defect of the emulator, the first this corpus surfaced, and the smallest of the three families",
+      "issue": "#355"
+    },
+    {
+      "file": "scaleway/scw-cli.jsonl",
+      "operation": "iam/v1alpha1/API.CreateSSHKey",
+      "kind": "status",
+      "path": "",
+      "reason": "a defect of the instrument rather than of the emulator: the proxy redacts the value under any JSON key whose name contains \"key\", so public_key reaches the transcript as REDACTED, sshkey.Parse refuses it and the create answers 400 where the cloud answered 200",
+      "issue": "#355"
+    },
+    {
+      "file": "scaleway/scw-cli.jsonl",
+      "operation": "iam/v1alpha1/API.CreateSSHKey",
+      "kind": "absent",
+      "path": "*",
+      "reason": "every field of the answer, because there is no answer: the request the recorder wrote could not be reissued (see the status entry above), so the whole body is missing for one reason and not nine",
+      "issue": "#355"
+    },
+    {
+      "file": "scaleway/scw-cli.jsonl",
+      "operation": "iam/v1alpha1/API.GetSSHKey",
+      "kind": "status",
+      "path": "",
+      "reason": "the read of a key the create could not make, so it answers 404 where the cloud answered 200; it goes when the redaction stops destroying public_key and the create succeeds again",
+      "issue": "#355"
+    },
+    {
+      "file": "scaleway/scw-cli.jsonl",
+      "operation": "iam/v1alpha1/API.GetSSHKey",
+      "kind": "absent",
+      "path": "*",
+      "reason": "every field of a body that was never served, for the same single reason as the status above rather than for nine separate ones",
+      "issue": "#355"
+    },
+    {
+      "file": "scaleway/scw-cli.jsonl",
+      "operation": "iam/v1alpha1/API.DeleteSSHKey",
+      "kind": "status",
+      "path": "",
+      "reason": "the delete of a key the create could not make, answering 404 where the cloud answered 204; the third and last exchange the redaction of public_key takes with it",
+      "issue": "#355"
+    }
+  ]
+}

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -588,6 +588,23 @@ and `feint shapes` read it unchanged — with every value replaced.
 | the word that named the client in the User-Agent | the rest of the User-Agent |
 | what a pack vouches for (`emulator.Vocabulary`) and what the contract enumerates | everything else |
 
+### And something replays it, on every pull request
+
+A corpus nothing replays is a museum piece, so `feint corpus --check` replays
+every file of `corpus/` against a fresh emulator, in `mise run prepush` and in
+`.github/workflows/go.yml` (#353). It is the only control in this repository
+that compares an answer with the **cloud's**: `mise run conformance` proves a
+real client *accepts* what the emulator says, and cannot prove more, because the
+cloud is not there.
+
+It is a gate where `conformance` cannot be one for exactly the reason the
+sanitisation exists: every input is a committed file, so it needs no account, no
+network and no client binary, and it takes thirty milliseconds. Exit 2 on a
+divergence `corpus/accepted.json` does not carry, and exit 1 on a corpus that
+could not be read or that compared nothing — a corpus replaying nothing is a
+failure, never a pass. `corpus/README.md` carries the verdicts, the acceptance
+list and how a corpus ages.
+
 ### Why it still replays
 
 Because the replay already rebinds (above). A transcript whose identifiers are

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -108,11 +108,18 @@ const (
 // own output. Both are additions to one existing verb, nothing was removed and
 // no exit code moved.
 //
+// Version 9 adds the verb `corpus`, with --check, --dir and --accepted (#353):
+// the committed corpora replayed against a fresh emulator on every pull
+// request, offline. An addition, and it reuses the exit codes rule 9 already
+// fixes — 2 for a divergence from the recorded cloud, 1 for a corpus that could
+// not be read or that compared nothing. A pipeline keyed on version 8 keeps
+// working.
+//
 // The surface itself is frozen in testdata/frozen/cli.json, compared by
 // TestTheFrozenSurfacesStillMatchTheirFixture, and a fixture regenerated
 // without bumping this constant fails TestASurfaceChangeDemandsItsVersionBump.
 // The procedure for a deliberate change is in RELEASING.md ("Frozen surfaces").
-const cliSurfaceVersion = 8
+const cliSurfaceVersion = 9
 
 // Run executes one command and returns the process exit code.
 func Run(args []string, stdout, stderr io.Writer) int {
@@ -143,6 +150,8 @@ func Run(args []string, stdout, stderr io.Writer) int {
 		return transcriptCommand(args[2:], stdout, stderr)
 	case "replay":
 		return replayCommand(args[2:], stdout, stderr)
+	case "corpus":
+		return corpusCommand(args[2:], stdout, stderr)
 	case "shapes":
 		return shapesCommand(args[2:], stdout, stderr)
 	case "evidence":
@@ -348,6 +357,18 @@ Usage:
                     is printed: a finding names a path, a type and a position.
                     Exit 2 on a divergence; an operation no route serves is
                     reported and never counted against the verdict.
+
+  feint corpus     --check [--dir corpus] [--accepted corpus/accepted.json]
+                    Replay every committed corpus against a fresh emulator and
+                    fail on a divergence from what the real cloud answered. The
+                    gate conformance cannot be: every input is a versioned
+                    file, so it needs no account, no network and no client
+                    binary. Exit 2 on a divergence the acceptance list does not
+                    carry, 1 on a corpus that could not be read or that compared
+                    nothing — a corpus replaying nothing is a failure, never a
+                    pass. An ageing recording warns and never fails: this gate
+                    holds one side of the comparison and cannot tell a cloud
+                    that moved from an emulator that broke.
 
   feint shapes     <recording.jsonl> --provider <name> [--dir shapes] [--dry-run]
                    [--record [--profile <name>]] [--check]

--- a/internal/cli/corpus.go
+++ b/internal/cli/corpus.go
@@ -1,0 +1,522 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/replay"
+)
+
+// The default locations, so the gate is one word to type and the paths are not
+// spread across a mise task, a workflow and a hook.
+const (
+	defaultCorpusDir      = "corpus"
+	defaultCorpusAccepted = "corpus/accepted.json"
+)
+
+// corpusCommand replays every committed corpus against a fresh emulator and
+// says whether this emulator still answers what a real cloud answered.
+//
+//	feint corpus --check [--dir corpus] [--accepted corpus/accepted.json]
+//
+// # Why this is a gate where `conformance` cannot be one
+//
+// The conformance suite proves a real client *accepts* what this emulator
+// answers. It cannot prove the answer is the one the cloud would have given,
+// because the cloud is not there. corpus/ is the only artefact in this
+// repository that says what a real cloud actually returned (#351, #352), and
+// replaying it is the only control that compares the two.
+//
+// Every input is a committed file: the corpus, this binary, the acceptance
+// list. No credential, no network, no `scw`, no Terraform. That is exactly what
+// keeps it out of the trap CLAUDE.md records twice — `conformance` is
+// deliberately outside the pre-commit hook because it needs four binaries
+// installed and would fail on an absent one rather than on the code, teaching
+// `--no-verify`, which disarms every other hook at once. This one needs none of
+// them, so it belongs where compat:check and release:surface live: on every
+// pull request, in seconds.
+//
+// It is also not the class of control that cost #88 two red pull requests. That
+// rule — a verdict about "this run" must be tried on the poorest run that will
+// trigger it — applies to a gate whose population is whatever a CI leg happened
+// to drive. This one's population is a directory of versioned files, identical
+// on every runner and in every leg. Two tests hold that claim rather than a
+// sentence: TestTheGateReadsOnlyTheFilesItIsPointedAt, which requires the same
+// verdict from a copy of the directory elsewhere, and
+// TestTheGatesVerdictDoesNotDependOnTheEnvironment, which covers the one seam
+// through which it could stop being true — packsFor reads FEINT_OUTSCALE_REGION
+// and FEINT_EXOSCALE_ZONE, and those decide which routes are mounted and
+// therefore which exchanges count as unserved.
+//
+// # The three verdicts it must never blur
+//
+//	a divergence          the emulator answers differently from the cloud   exit 2
+//	an unserved operation a route nobody mounted — #74's queue, never counted
+//	a corpus not read     empty, unreadable, or replayed against nothing    exit 1
+//
+// The third is the one that gets forgotten, and this repository has shipped its
+// shape before: the network conformance suite returned SKIP in CI from the day
+// it was written, and five more controls in tools/ui/check-page.py were found
+// measuring nothing in August 2026. **A corpus that replays nothing is red.**
+func corpusCommand(args []string, stdout, stderr io.Writer) int {
+	flags := newFlagSet("corpus")
+	check := flags.Bool("check", false, "replay every committed corpus and fail on a divergence the acceptance list does not carry")
+	dir := flags.String("dir", defaultCorpusDir, "directory of committed corpora, one subdirectory per provider")
+	accepted := flags.String("accepted", defaultCorpusAccepted, "the divergences this repository records rather than fixes, each with its reason")
+	flags.Usage = func() {
+		fmt.Fprint(stderr, "usage: feint corpus --check [--dir corpus] [--accepted corpus/accepted.json]\n")
+		flags.PrintDefaults()
+	}
+	if err := flags.Parse(args); err != nil {
+		return exitError
+	}
+	if flags.NArg() != 0 {
+		fmt.Fprintf(stderr, "feint: unexpected argument %q; corpus takes flags only\n", flags.Arg(0))
+		return exitError
+	}
+	if !*check {
+		fmt.Fprintln(stderr, "feint: corpus has one mode today: --check (see --help)")
+		return exitError
+	}
+	return checkCorpus(*dir, *accepted, time.Now(), stdout, stderr)
+}
+
+// corpusAcceptance is the committed judgement on a corpus: when each file was
+// recorded, and which divergences this repository records rather than fixes.
+//
+// One file rather than two, because the two questions are asked of the same
+// subject and separating them is how one of them stops being maintained.
+type corpusAcceptance struct {
+	// Comment is prose for whoever opens the file. Read and ignored here.
+	Comment []string `json:"comment"`
+	// WarnAfterDays is how old a recording may be before every run says so. A
+	// warning, never a failure: see [agedCorpora].
+	WarnAfterDays int `json:"warn_after_days"`
+	// Recorded is one entry per corpus file, and it is mandatory: a file with no
+	// entry fails the gate rather than being replayed anonymously, because the
+	// age of a recording is the one thing the file itself cannot carry — the
+	// sanitiser normalises every timestamp in it.
+	Recorded []corpusRecording `json:"recorded"`
+	// Accepted is the exemption list, on the model of tools/compat/accepted.json:
+	// recorded and still printed, never hidden, and an entry that excuses
+	// nothing fails the gate.
+	Accepted []corpusException `json:"accepted"`
+}
+
+// corpusRecording is what a corpus file cannot say about itself.
+type corpusRecording struct {
+	File string `json:"file"`
+	// At is the day the recording was made against the real cloud, YYYY-MM-DD.
+	At string `json:"at"`
+	// Client and Cloud are for the reader: which client drove it, and which
+	// cloud answered. A re-recording that changes either is a different
+	// measurement, and the entry is where that is legible.
+	Client string `json:"client"`
+	Cloud  string `json:"cloud"`
+}
+
+// corpusException is one divergence this repository knows about and has decided
+// not to fail on yet.
+//
+// Keyed the way a finding is named — file, operation, kind, field path — rather
+// than by operation alone, so an exemption for a missing tag cannot also excuse
+// a status that starts differing on the same operation tomorrow. Path takes the
+// same "*" segment as emulator.FieldDecline, and matches through the same
+// implementation, because the gate that excuses a field and the replay that
+// compares one must not disagree about which field they are naming.
+type corpusException struct {
+	File      string `json:"file"`
+	Operation string `json:"operation"`
+	Kind      string `json:"kind"`
+	Path      string `json:"path"`
+	Reason    string `json:"reason"`
+	// Issue names what retires this entry. Required: an exemption with a reason
+	// and no way out is a decision to live with a defect forever, written as if
+	// it were temporary.
+	Issue string `json:"issue"`
+}
+
+// key is what this entry is addressed to, for a message that names it.
+func (e corpusException) key() string {
+	return e.File + " " + e.Operation + " " + e.Kind + " " + e.Path
+}
+
+// matches reports whether this entry excuses that finding of that file.
+func (e corpusException) matches(file, operation string, f replay.Finding) bool {
+	if e.File != file || e.Kind != string(f.Kind) {
+		return false
+	}
+	d := emulator.FieldDecline{Operation: e.Operation, Path: e.Path}
+	return d.Matches(operation, f.Path)
+}
+
+// checkCorpus is the gate. now is a parameter so the ageing warning is testable
+// without waiting for a calendar.
+func checkCorpus(dir, acceptedPath string, now time.Time, stdout, stderr io.Writer) int {
+	acc, err := readCorpusAcceptance(acceptedPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "feint: %v\n", err)
+		return exitError
+	}
+	if bad := unusableCorpusExceptions(acc.Accepted); len(bad) > 0 {
+		// The same guard a pack's own declines face (emulator.carriesNoDecision,
+		// through UnexplainedFieldDeclines): an exemption whose reason carries no
+		// decision is a comment, and CLAUDE.md's most expensive defect is a
+		// comment standing in for a control.
+		// TestAnExemptionWithoutAUsableReasonFailsTheGate fails without this.
+		for _, b := range bad {
+			fmt.Fprintf(stderr, "feint: the accepted divergence %s %s\n", b.key, b.why)
+		}
+		return exitError
+	}
+
+	files, err := corpusFiles(dir)
+	if err != nil {
+		fmt.Fprintf(stderr, "feint: %v\n", err)
+		return exitError
+	}
+	// Asserted, not assumed. A gate that reads an empty directory and reports
+	// success is the SKIP this repository has already shipped once.
+	// TestACorpusThatComparesNothingIsRed fails without this.
+	if len(files) == 0 {
+		fmt.Fprintf(stderr, "feint: %s holds no .jsonl corpus, so this compared nothing against a real cloud\n", dir)
+		return exitError
+	}
+	if code := checkCorpusRecordings(files, acc.Recorded, dir, stderr); code != exitOK {
+		return code
+	}
+
+	env := emulator.DefaultEnv()
+	packs, err := packsFor(env)
+	if err != nil {
+		fmt.Fprintf(stderr, "feint: build the emulator: %v\n", err)
+		return exitError
+	}
+	declined, invariants, code := replayDeclarations(packs, stderr)
+	if code != exitOK {
+		return code
+	}
+
+	used := make([]int, len(acc.Accepted))
+	compared, divergent, unserved, excused := 0, 0, 0, 0
+	for _, f := range files {
+		rep, err := replayCorpusFile(dir, f, env, packs, declined, invariants)
+		if err != nil {
+			// Unreadable, or the emulator refused to answer. An error, never a
+			// pass: "I could not measure" and "nothing is wrong" are different
+			// answers, and only one of them may be green.
+			fmt.Fprintf(stderr, "feint: %s: %v\n", f, err)
+			return exitError
+		}
+		// A file that produced no comparison at all — every exchange unserved,
+		// or the transcript empty. Named per file rather than in a total, so a
+		// second corpus cannot cover for the first having stopped replaying.
+		// TestACorpusThatComparesNothingIsRed fails without this.
+		if rep.Matched+rep.Divergent == 0 {
+			fmt.Fprintf(stderr, "feint: %s replayed against nothing: %d exchange(s), none of them compared\n",
+				f, len(rep.Results))
+			return exitError
+		}
+		compared += rep.Matched + rep.Divergent
+		unserved += rep.Unserved
+		divergent += reportCorpusFile(f, rep, acc.Accepted, used, &excused, stdout, stderr)
+	}
+
+	// Coverage, printed whatever the verdict, for the reason `feint shapes
+	// --check` prints its own: a run that says "no divergence" without saying
+	// how much it compared reads as "nothing is wrong" when it may mean
+	// "nothing was checked".
+	fmt.Fprintf(stdout, "\n%d corpus file(s), %d exchange(s) compared against a real cloud's answer\n", len(files), compared)
+	fmt.Fprintf(stdout, "%d divergent finding(s) nothing accepts, which is what this gate fails on\n", divergent)
+	fmt.Fprintf(stdout, "%d exchange(s) no route serves, which is #74's work queue and not a failure\n", unserved)
+	fmt.Fprintf(stdout, "%d divergent finding(s) knowingly accepted, each printed above with its reason\n", excused)
+
+	// An exemption that excused nothing. The rule tools/compat/accepted.json
+	// states and this one inherits: a stale exemption is a gate that quietly
+	// stopped covering what it names, and the day the defect is fixed is the day
+	// the entry has to go.
+	// TestAnExemptionThatExcusesNothingFailsTheGate fails without this.
+	stale := 0
+	for i, e := range acc.Accepted {
+		if used[i] == 0 {
+			fmt.Fprintf(stderr, "feint: the accepted divergence %s excused nothing this run: either it is fixed and the entry goes, or the corpus no longer carries it\n", e.key())
+			stale++
+		}
+	}
+	if stale > 0 {
+		return exitError
+	}
+
+	warnAgedCorpora(acc, now, stdout)
+
+	if divergent > 0 {
+		fmt.Fprintf(stderr, "feint: %d divergence(s) between this emulator and the recorded cloud, none of them accepted in %s\n", divergent, acceptedPath)
+		return exitDrift
+	}
+	return exitOK
+}
+
+// checkCorpusRecordings holds the corpus and its manifest to each other, in both
+// directions.
+//
+// Both directions, because each one alone rots: a file with no entry replays
+// with nobody knowing how old it is, and an entry with no file is a claim about
+// a recording that left. TestTheCorpusAndItsRecordingDatesAreHeldToEachOther
+// fails without this, in one subtest per direction.
+func checkCorpusRecordings(files []string, recorded []corpusRecording, dir string, stderr io.Writer) int {
+	known := map[string]bool{}
+	for _, r := range recorded {
+		known[r.File] = true
+	}
+	bad := 0
+	for _, f := range files {
+		if !known[f] {
+			fmt.Fprintf(stderr, "feint: %s is committed and no entry says when it was recorded: add it to the acceptance file's \"recorded\" list\n", f)
+			bad++
+		}
+	}
+	present := map[string]bool{}
+	for _, f := range files {
+		present[f] = true
+	}
+	for _, r := range recorded {
+		if !present[r.File] {
+			fmt.Fprintf(stderr, "feint: the recording entry for %s names no file under %s\n", r.File, dir)
+			bad++
+		}
+		if _, err := time.Parse(time.DateOnly, r.At); err != nil {
+			fmt.Fprintf(stderr, "feint: the recording entry for %s carries no readable date (%q, want YYYY-MM-DD)\n", r.File, r.At)
+			bad++
+		}
+	}
+	if bad > 0 {
+		return exitError
+	}
+	return exitOK
+}
+
+// reportCorpusFile prints one file's result and returns how many divergent
+// findings nothing accepted.
+//
+// The unit is the finding rather than the exchange, deliberately: an exchange
+// with one accepted absence and one unexpected status must not read as
+// accepted because the exemption matched half of it.
+func reportCorpusFile(file string, rep replay.Report, accepted []corpusException, used []int, excused *int, stdout, stderr io.Writer) int {
+	unaccepted := 0
+	// Collapsed per exemption rather than per finding: the catalogue exemption
+	// covers 127 commercial types, and printing them one by one buries the
+	// findings a reader has to act on. The count stays, so what the gate
+	// subtracts is still a number and not a shrug.
+	hits := map[int]int{}
+	for _, r := range rep.Results {
+		if r.Verdict != replay.Divergent {
+			continue
+		}
+		for _, f := range r.Findings {
+			if f.Kind == replay.KindExcused || f.Kind == replay.KindRedacted {
+				continue
+			}
+			if i, ok := acceptedBy(accepted, file, r.Operation, f); ok {
+				used[i]++
+				hits[i]++
+				*excused++
+				continue
+			}
+			if unaccepted == 0 {
+				fmt.Fprintf(stderr, "%s: this emulator answers differently from the recorded cloud\n", file)
+			}
+			fmt.Fprintf(stderr, "  %-44s %s\n", r.Operation, describeFinding(f))
+			unaccepted++
+		}
+	}
+	keys := make([]int, 0, len(hits))
+	for i := range hits {
+		keys = append(keys, i)
+	}
+	sort.Ints(keys)
+	for _, i := range keys {
+		fmt.Fprintf(stdout, "accepted %s: %d finding(s) — %s (%s)\n",
+			accepted[i].key(), hits[i], accepted[i].Reason, accepted[i].Issue)
+	}
+	return unaccepted
+}
+
+// acceptedBy returns the index of the entry that excuses this finding.
+func acceptedBy(accepted []corpusException, file, operation string, f replay.Finding) (int, bool) {
+	for i, e := range accepted {
+		if e.matches(file, operation, f) {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+// replayCorpusFile replays one corpus against an emulator of its own.
+//
+// Of its own, not a shared one, and corpus/README.md says why: a corpus is a
+// causal sequence that creates what it later reads, so a second file replayed
+// into the same store meets objects its own recording never created, and an
+// unfiltered list then answers more than the cloud did.
+func replayCorpusFile(dir, file string, env *emulator.Env, packs []emulator.Pack, declined []emulator.FieldDecline, invariants []emulator.Invariant) (replay.Report, error) {
+	exs, err := loadTranscript(filepath.Join(dir, filepath.FromSlash(file)))
+	if err != nil {
+		return replay.Report{}, err
+	}
+	// A transcript that parsed to nothing. Refused here rather than replayed,
+	// so the caller never has to tell "read and empty" from "not read".
+	// TestACorpusThatComparesNothingIsRed fails without this.
+	if len(exs) == 0 {
+		return replay.Report{}, fmt.Errorf("holds no exchange, so there was nothing to compare")
+	}
+	srv, err := emulator.NewServer(env, packs...)
+	if err != nil {
+		return replay.Report{}, fmt.Errorf("build the emulator: %w", err)
+	}
+	table, err := emulator.NewTable(packs...)
+	if err != nil {
+		return replay.Report{}, fmt.Errorf("build the route table: %w", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	return replay.Run(context.Background(), exs, replay.Options{
+		Endpoint:   ts.URL,
+		Client:     &http.Client{Timeout: 30 * time.Second},
+		Table:      table,
+		Declined:   declined,
+		Invariants: invariants,
+	})
+}
+
+// corpusFiles lists every committed corpus under dir, as slash-separated paths
+// relative to it, sorted so two runs report the same order.
+func corpusFiles(dir string) ([]string, error) {
+	var out []string
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(d.Name(), ".jsonl") {
+			return nil
+		}
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		out = append(out, filepath.ToSlash(rel))
+		return nil
+	})
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("no corpus directory at %s: the committed recordings are what this gate compares against", dir)
+		}
+		return nil, err
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func readCorpusAcceptance(path string) (corpusAcceptance, error) {
+	var acc corpusAcceptance
+	raw, err := os.ReadFile(path) //nolint:gosec // operator-supplied path, read-only
+	if err != nil {
+		return acc, fmt.Errorf("read the acceptance file %s: %w", path, err)
+	}
+	if err := json.Unmarshal(raw, &acc); err != nil {
+		return acc, fmt.Errorf("read the acceptance file %s: %w", path, err)
+	}
+	return acc, nil
+}
+
+// unusableCorpusExceptions names the entries that excuse without arguing.
+//
+// The reason faces emulator's own guard rather than a second one written here:
+// one implementation, so an exemption in this file and a decline in a pack are
+// held to the same sentence. The issue is required on top, because a reason
+// says why the divergence is tolerable today and only an issue says when it
+// stops being.
+func unusableCorpusExceptions(accepted []corpusException) []unusableException {
+	var out []unusableException
+	for _, e := range accepted {
+		switch {
+		case len(emulator.UnexplainedFieldDeclines([]emulator.FieldDecline{{Reason: e.Reason}})) > 0:
+			out = append(out, unusableException{e.key(), "carries no usable reason"})
+		case strings.TrimSpace(e.Issue) == "":
+			out = append(out, unusableException{e.key(), "names no issue that retires it"})
+		case strings.TrimSpace(e.Kind) == "":
+			out = append(out, unusableException{e.key(), "names no finding kind, so it would excuse every kind at that path"})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].key < out[j].key })
+	return out
+}
+
+// unusableException is one refused entry and the sentence that says why. The
+// three causes are printed apart rather than as one sentence listing them,
+// because a message that names every possible cause names none of them.
+type unusableException struct{ key, why string }
+
+// warnAgedCorpora says which recordings have outlived the horizon, and changes
+// no exit code.
+//
+// # How a corpus ages, and why the answer is a warning
+//
+// A cloud changes. A corpus recorded today describes the cloud of today, and a
+// gate that fails because the *cloud* moved is a gate that gets disabled — with
+// the whole of its coverage. Three options were on the table (#353): an expiry
+// that fails, a periodic re-record like upstream:sync, and an acceptance file.
+// This gate carries the second and third, and the expiry only warns, for a
+// reason that is a limit of the measurement rather than a preference:
+//
+// **This gate cannot tell "the cloud moved" from "the emulator broke."** It has
+// one side of the comparison. A red run says the two disagree, and nothing in
+// this process knows which of them changed. Failing on age would be this gate
+// asserting the very thing it cannot measure. The half that can is #359, which
+// replays the corpus against the *cloud*; until it exists, the honest form is a
+// warning that names the file, its age and the procedure to re-record it.
+//
+// So the warning is loud, it is on every run, and its date lives in a committed
+// file — moving it is a diff somebody signs, not a flag somebody passes.
+// TestAnAgedCorpusWarnsAndDoesNotFailTheGate fails without this, in both
+// directions: the warning must appear, and the exit code must not move.
+func warnAgedCorpora(acc corpusAcceptance, now time.Time, stdout io.Writer) {
+	for _, name := range agedCorpora(acc.Recorded, now, acc.WarnAfterDays) {
+		fmt.Fprintf(stdout, "warning: %s, and a cloud changes: re-record it (corpus/README.md, \"Recording another one\"), or wait for #359 to say whether it is the cloud that moved\n", name)
+	}
+}
+
+// agedCorpora names the recordings older than the horizon, with their age.
+// A horizon of zero disables the warning and is refused by the caller's own
+// fixture rather than here, so that a repository which genuinely wants no
+// horizon writes the zero rather than inheriting it.
+func agedCorpora(recorded []corpusRecording, now time.Time, days int) []string {
+	if days <= 0 {
+		return nil
+	}
+	var out []string
+	for _, r := range recorded {
+		at, err := time.Parse(time.DateOnly, r.At)
+		if err != nil {
+			// Already refused by checkCorpusRecordings, which runs first and
+			// exits. Nothing to report twice.
+			continue
+		}
+		age := int(now.Sub(at).Hours() / 24)
+		if age > days {
+			out = append(out, fmt.Sprintf("%s was recorded %d days ago against %s, past the %d-day horizon",
+				r.File, age, r.Cloud, days))
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/cli/corpus_test.go
+++ b/internal/cli/corpus_test.go
@@ -1,0 +1,462 @@
+package cli
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The date every fixture is judged against, so a test's verdict never depends
+// on the day it runs — the failure mode a support-window test in this package
+// already carries a paragraph about.
+var corpusNow = time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+
+// The committed corpus passes its own gate, and says the same thing twice.
+//
+// Both halves matter and the second is the one #353 asks for. A gate whose
+// verdict flaps is a gate that gets disarmed the first time it seems to lie,
+// and this one flapped before the bindings were scoped by field name: six
+// replays of corpus/scaleway/scw-cli.jsonl against six fresh emulators graded
+// vpc/v2/API.ListPrivateNetworks divergent three times and matched three times
+// (corpus/README.md). Comparing two whole runs byte for byte covers the counts,
+// the order of the accepted list and every finding printed.
+func TestTheCommittedCorpusPassesItsOwnGateAndSaysTheSameThingTwice(t *testing.T) {
+	first, firstErr, code := runCorpusGate(t, "../../corpus", "../../corpus/accepted.json")
+	if code != exitOK {
+		t.Fatalf("the committed corpus exited %d, want 0.\nstdout:\n%s\nstderr:\n%s", code, first, firstErr)
+	}
+	second, secondErr, again := runCorpusGate(t, "../../corpus", "../../corpus/accepted.json")
+	if again != code || second != first || secondErr != firstErr {
+		t.Fatalf("two runs of the same corpus disagree.\nfirst (exit %d):\n%s%s\nsecond (exit %d):\n%s%s",
+			code, first, firstErr, again, second, secondErr)
+	}
+	// The subject is asserted rather than assumed: a run that compared nothing
+	// would also print no divergence, and this whole gate exists because that
+	// reads identically to a run that found nothing wrong.
+	if !strings.Contains(first, "exchange(s) compared against a real cloud's answer") ||
+		strings.Contains(first, "\n0 exchange(s) compared") {
+		t.Fatalf("the gate does not say how many exchanges it compared, or compared none:\n%s", first)
+	}
+}
+
+// The verdict is a function of the two paths it is given and of nothing else in
+// the tree. That is what makes this gate exempt from the rule that cost #88 two
+// red pull requests: its population is not "whatever this run happened to
+// drive", it is a directory of versioned files, identical on every runner and
+// in every CI leg.
+//
+// Proved by copying that directory somewhere else and requiring the same
+// output, rather than by asserting it in a comment.
+func TestTheGateReadsOnlyTheFilesItIsPointedAt(t *testing.T) {
+	committed, _, code := runCorpusGate(t, "../../corpus", "../../corpus/accepted.json")
+	if code != exitOK {
+		t.Fatalf("the committed corpus exited %d, want 0", code)
+	}
+	elsewhere := filepath.Join(t.TempDir(), "corpus")
+	copyTree(t, "../../corpus", elsewhere)
+	copied, _, copiedCode := runCorpusGate(t, elsewhere, filepath.Join(elsewhere, "accepted.json"))
+	if copiedCode != code || copied != committed {
+		t.Fatalf("the same corpus read from %s gives a different verdict (%d vs %d):\n%s\nvs\n%s",
+			elsewhere, copiedCode, code, copied, committed)
+	}
+}
+
+// The two environment variables that can change which routes are mounted, and
+// therefore which exchanges count as unserved: FEINT_OUTSCALE_REGION and
+// FEINT_EXOSCALE_ZONE, read by packsFor.
+//
+// They are the one seam through which this gate's population is not purely a
+// set of committed files, and the claim in corpusCommand's doc comment is only
+// true while they make no difference. Today they make none, because the corpus
+// is Scaleway's alone — but the day somebody records Outscale (#354) this test
+// goes red, and whoever does gets to decide rather than discover. Measured
+// rather than reasoned about: mounting from packsFor is deliberate, since a
+// hardcoded pack list is what made a fourth pack invisible to `shapes --check`
+// instead of reported.
+func TestTheGatesVerdictDoesNotDependOnTheEnvironment(t *testing.T) {
+	plain, plainErr, code := runCorpusGate(t, "../../corpus", "../../corpus/accepted.json")
+	if code != exitOK {
+		t.Fatalf("the committed corpus exited %d, want 0", code)
+	}
+	t.Setenv("FEINT_OUTSCALE_REGION", "eu-west-2")
+	t.Setenv("FEINT_EXOSCALE_ZONE", "de-fra-1")
+	altered, alteredErr, alteredCode := runCorpusGate(t, "../../corpus", "../../corpus/accepted.json")
+	if alteredCode != code || altered != plain || alteredErr != plainErr {
+		t.Fatalf("an environment variable moved the verdict (%d vs %d): the population is no longer "+
+			"the committed files alone, and this gate's claim to be exempt from the partial-run rule "+
+			"has to be re-argued.\nplain:\n%s%s\naltered:\n%s%s",
+			alteredCode, code, plain, plainErr, altered, alteredErr)
+	}
+}
+
+// #353's falsification, and the one it names first: mutate one recorded status
+// and the gate goes red naming it.
+//
+// The fixture is a recording of this emulator by this emulator, so the clean
+// run needs no exemption at all — the only difference between green and red is
+// the mutation.
+func TestAMutatedRecordedStatusTurnsTheGateRedAndNamesIt(t *testing.T) {
+	dir, accepted := corpusFixture(t, recordAgainstAFreshEmulator(t))
+	out, errs, code := runCorpusGate(t, dir, accepted)
+	if code != exitOK {
+		t.Fatalf("a recording of this emulator failed its own gate (%d).\nstdout:\n%s\nstderr:\n%s", code, out, errs)
+	}
+
+	operation := mutateStatus(t, filepath.Join(dir, "self/self.jsonl"), 201, 418)
+	out, errs, code = runCorpusGate(t, dir, accepted)
+	if code != exitDrift {
+		t.Fatalf("a mutated recorded status exited %d, want %d (drift).\nstdout:\n%s\nstderr:\n%s",
+			code, exitDrift, out, errs)
+	}
+	if !strings.Contains(errs, operation) {
+		t.Fatalf("the gate does not name the operation whose status was mutated (%s):\n%s", operation, errs)
+	}
+	if !strings.Contains(errs, "expected 418") {
+		t.Fatalf("the gate does not name the status it expected:\n%s", errs)
+	}
+}
+
+// A corpus that replays nothing is red. The rule this repository refuses to
+// break a second time: the network conformance suite returned SKIP in CI from
+// the day it was written, and five controls in tools/ui/check-page.py were
+// found measuring nothing in August 2026.
+//
+// Three shapes of "nothing", each asserted, because each one arrives by its own
+// route: a file that parses to no exchange, a directory holding no file, and a
+// file whose every exchange addresses a route no pack mounts.
+func TestACorpusThatComparesNothingIsRed(t *testing.T) {
+	t.Run("an empty file", func(t *testing.T) {
+		dir, accepted := corpusFixture(t, writeLines(t, ""))
+		out, errs, code := runCorpusGate(t, dir, accepted)
+		if code != exitError {
+			t.Fatalf("an empty corpus exited %d, want %d (error).\nstdout:\n%s\nstderr:\n%s", code, exitError, out, errs)
+		}
+		if !strings.Contains(errs, "nothing to compare") {
+			t.Fatalf("the gate does not say the corpus held nothing:\n%s", errs)
+		}
+	})
+
+	t.Run("no file at all", func(t *testing.T) {
+		dir := t.TempDir()
+		accepted := writeAccepted(t, corpusAcceptance{WarnAfterDays: 180})
+		out, errs, code := runCorpusGate(t, dir, accepted)
+		if code != exitError {
+			t.Fatalf("an empty corpus directory exited %d, want %d (error).\nstdout:\n%s\nstderr:\n%s", code, exitError, out, errs)
+		}
+		if !strings.Contains(errs, "compared nothing against a real cloud") {
+			t.Fatalf("the gate does not say it compared nothing:\n%s", errs)
+		}
+	})
+
+	t.Run("every exchange unserved", func(t *testing.T) {
+		// A product no pack mounts. Unserved is a work item and never a
+		// divergence — but a whole corpus of them compared nothing, and that is
+		// an error, not a pass.
+		line := `{"seq":1,"method":"GET","path":"/nowhere/v1/things","status":200,` +
+			`"req":{"headers":{}},"res":{"headers":{},"body":{"things":[]}}}`
+		dir, accepted := corpusFixture(t, writeLines(t, line))
+		out, errs, code := runCorpusGate(t, dir, accepted)
+		if code != exitError {
+			t.Fatalf("a corpus of unserved operations exited %d, want %d (error).\nstdout:\n%s\nstderr:\n%s",
+				code, exitError, out, errs)
+		}
+		if !strings.Contains(errs, "replayed against nothing") {
+			t.Fatalf("the gate does not say the file compared nothing:\n%s", errs)
+		}
+	})
+}
+
+// A corpus file nobody dated, and a date naming no file. Both directions,
+// because each alone rots: an undated file replays with nobody able to say how
+// old the cloud it describes is, and a date with no file is a claim about a
+// recording that left.
+func TestTheCorpusAndItsRecordingDatesAreHeldToEachOther(t *testing.T) {
+	t.Run("a file with no recording entry", func(t *testing.T) {
+		dir, _ := corpusFixture(t, recordAgainstAFreshEmulator(t))
+		bare := writeAccepted(t, corpusAcceptance{WarnAfterDays: 180})
+		_, errs, code := runCorpusGate(t, dir, bare)
+		if code != exitError {
+			t.Fatalf("an undated corpus exited %d, want %d (error):\n%s", code, exitError, errs)
+		}
+		if !strings.Contains(errs, "no entry says when it was recorded") {
+			t.Fatalf("the gate does not name what is missing:\n%s", errs)
+		}
+	})
+
+	t.Run("a recording entry naming no file", func(t *testing.T) {
+		dir, _ := corpusFixture(t, recordAgainstAFreshEmulator(t))
+		accepted := writeAccepted(t, corpusAcceptance{
+			WarnAfterDays: 180,
+			Recorded: []corpusRecording{
+				{File: "self/self.jsonl", At: "2026-08-21", Client: "feint", Cloud: "this emulator"},
+				{File: "self/gone.jsonl", At: "2026-08-21", Client: "feint", Cloud: "this emulator"},
+			},
+		})
+		_, errs, code := runCorpusGate(t, dir, accepted)
+		if code != exitError {
+			t.Fatalf("a date naming no file exited %d, want %d (error):\n%s", code, exitError, errs)
+		}
+		if !strings.Contains(errs, "names no file") {
+			t.Fatalf("the gate does not name the stale entry:\n%s", errs)
+		}
+	})
+}
+
+// An exemption that excuses nothing fails the gate — the rule
+// tools/compat/accepted.json states and this file inherits. It is what makes
+// the list self-retiring: the day #355 serves the default VPC's tags, this gate
+// goes red until the entry is deleted, so nobody has to remember.
+func TestAnExemptionThatExcusesNothingFailsTheGate(t *testing.T) {
+	dir, _ := corpusFixture(t, recordAgainstAFreshEmulator(t))
+	accepted := writeAccepted(t, corpusAcceptance{
+		WarnAfterDays: 180,
+		Recorded:      []corpusRecording{{File: "self/self.jsonl", At: "2026-08-21", Client: "feint", Cloud: "this emulator"}},
+		Accepted: []corpusException{{
+			File: "self/self.jsonl", Operation: "instance/v1/API.CreateServer", Kind: "absent", Path: "server.nothing",
+			Reason: "a field this recording does not carry and this emulator does not omit, so the entry covers no finding at all",
+			Issue:  "#353",
+		}},
+	})
+	_, errs, code := runCorpusGate(t, dir, accepted)
+	if code != exitError {
+		t.Fatalf("a stale exemption exited %d, want %d (error):\n%s", code, exitError, errs)
+	}
+	if !strings.Contains(errs, "excused nothing this run") {
+		t.Fatalf("the gate does not say the exemption is stale:\n%s", errs)
+	}
+}
+
+// An exemption whose reason carries no decision, and one that names no issue.
+// The same guard a pack's own declines face, through the same implementation:
+// an exemption is a decision, and a decision that argues nothing is a comment.
+func TestAnExemptionWithoutAUsableReasonFailsTheGate(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		entry  corpusException
+		expect string
+	}{
+		{
+			name: "a placeholder reason",
+			entry: corpusException{
+				File: "self/self.jsonl", Operation: "instance/v1/API.CreateServer", Kind: "status", Path: "",
+				Reason: "TODO", Issue: "#353",
+			},
+			expect: "no usable reason",
+		},
+		{
+			name: "no issue to retire it",
+			entry: corpusException{
+				File: "self/self.jsonl", Operation: "instance/v1/API.CreateServer", Kind: "status", Path: "",
+				Reason: "a status this emulator answers differently for a reason somebody wrote down at length",
+				Issue:  "",
+			},
+			expect: "names no issue",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir, _ := corpusFixture(t, recordAgainstAFreshEmulator(t))
+			accepted := writeAccepted(t, corpusAcceptance{
+				WarnAfterDays: 180,
+				Recorded:      []corpusRecording{{File: "self/self.jsonl", At: "2026-08-21", Client: "feint", Cloud: "this emulator"}},
+				Accepted:      []corpusException{tc.entry},
+			})
+			_, errs, code := runCorpusGate(t, dir, accepted)
+			if code != exitError {
+				t.Fatalf("an unusable exemption exited %d, want %d (error):\n%s", code, exitError, errs)
+			}
+			if !strings.Contains(errs, tc.expect) {
+				t.Fatalf("the gate does not say %q:\n%s", tc.expect, errs)
+			}
+		})
+	}
+}
+
+// How a corpus ages: it warns, and it never fails.
+//
+// Both directions are asserted and the second carries the decision. A gate that
+// failed on age would be asserting what it cannot measure — it holds one side of
+// the comparison and cannot tell a cloud that moved from an emulator that broke
+// (#359 is the half that can) — and a gate that fails because the cloud changed
+// is a gate somebody disables, taking all of its coverage with it. A warning
+// that could quietly stop appearing would be the other failure, so the first
+// half is asserted too.
+func TestAnAgedCorpusWarnsAndDoesNotFailTheGate(t *testing.T) {
+	dir, _ := corpusFixture(t, recordAgainstAFreshEmulator(t))
+	accepted := writeAccepted(t, corpusAcceptance{
+		WarnAfterDays: 180,
+		Recorded:      []corpusRecording{{File: "self/self.jsonl", At: "2025-01-01", Client: "feint", Cloud: "this emulator"}},
+	})
+	out, errs, code := runCorpusGate(t, dir, accepted)
+	if code != exitOK {
+		t.Fatalf("an aged corpus exited %d, want 0: age must never fail this gate.\nstdout:\n%s\nstderr:\n%s",
+			code, out, errs)
+	}
+	if !strings.Contains(out, "warning:") || !strings.Contains(out, "past the 180-day horizon") {
+		t.Fatalf("an aged corpus produced no warning:\n%s", out)
+	}
+	if !strings.Contains(out, "self/self.jsonl") {
+		t.Fatalf("the warning does not name the file that aged:\n%s", out)
+	}
+
+	// And a fresh one says nothing, so the warning is a measurement and not a
+	// line printed on every run.
+	fresh := writeAccepted(t, corpusAcceptance{
+		WarnAfterDays: 180,
+		Recorded:      []corpusRecording{{File: "self/self.jsonl", At: "2026-08-01", Client: "feint", Cloud: "this emulator"}},
+	})
+	out, _, code = runCorpusGate(t, dir, fresh)
+	if code != exitOK || strings.Contains(out, "warning:") {
+		t.Fatalf("a recording of three weeks ago warned (exit %d):\n%s", code, out)
+	}
+}
+
+// An unserved operation is reported and never counted against the verdict — the
+// second of the three verdicts this gate must not blur. The day it fails the
+// build is the day somebody stops recording, which would make #74's queue
+// unfeedable.
+func TestAnUnservedOperationDoesNotFailTheCorpusGate(t *testing.T) {
+	recording := recordAgainstAFreshEmulator(t)
+	raw, err := os.ReadFile(recording) //nolint:gosec // a file this test just wrote
+	if err != nil {
+		t.Fatal(err)
+	}
+	unserved := `{"seq":99,"method":"GET","path":"/nowhere/v1/things","status":200,` +
+		`"req":{"headers":{}},"res":{"headers":{},"body":{"things":[]}}}` + "\n"
+	dir, accepted := corpusFixture(t, writeLines(t, string(raw)+unserved))
+	out, errs, code := runCorpusGate(t, dir, accepted)
+	if code != exitOK {
+		t.Fatalf("an unserved operation failed the gate (%d).\nstdout:\n%s\nstderr:\n%s", code, out, errs)
+	}
+	if !strings.Contains(out, "1 exchange(s) no route serves") {
+		t.Fatalf("the gate does not report the unserved operation:\n%s", out)
+	}
+}
+
+// --- helpers ---------------------------------------------------------------
+
+func runCorpusGate(t *testing.T, dir, accepted string) (string, string, int) {
+	t.Helper()
+	var out, errb bytes.Buffer
+	code := checkCorpus(dir, accepted, corpusNow, &out, &errb)
+	return out.String(), errb.String(), code
+}
+
+// corpusFixture lays a recording out as a corpus directory with its acceptance
+// file, and returns both paths.
+func corpusFixture(t *testing.T, recording string) (dir, accepted string) {
+	t.Helper()
+	dir = filepath.Join(t.TempDir(), "corpus")
+	if err := os.MkdirAll(filepath.Join(dir, "self"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(recording) //nolint:gosec // a file this test just wrote
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "self", "self.jsonl"), raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	accepted = writeAccepted(t, corpusAcceptance{
+		WarnAfterDays: 180,
+		Recorded: []corpusRecording{
+			{File: "self/self.jsonl", At: "2026-08-21", Client: "feint", Cloud: "this emulator"},
+		},
+	})
+	return dir, accepted
+}
+
+func writeAccepted(t *testing.T, acc corpusAcceptance) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "accepted.json")
+	raw, err := json.MarshalIndent(acc, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func writeLines(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "written.jsonl")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// mutateStatus changes the first recorded status equal to from, and returns the
+// operation the mutated exchange names — so the assertion is about the exchange
+// that moved rather than about a string the test hardcoded.
+func mutateStatus(t *testing.T, path string, from, to int) string {
+	t.Helper()
+	file, err := os.Open(path) //nolint:gosec // a file this test just wrote
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = file.Close() }()
+
+	var out bytes.Buffer
+	operation := ""
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 1<<20), 1<<20)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		var x map[string]any
+		if operation == "" && json.Unmarshal(line, &x) == nil {
+			if status, ok := x["status"].(float64); ok && int(status) == from {
+				x["status"] = to
+				operation, _ = x["operation"].(string)
+				raw, err := json.Marshal(x)
+				if err != nil {
+					t.Fatal(err)
+				}
+				line = raw
+			}
+		}
+		out.Write(line)
+		out.WriteByte('\n')
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if operation == "" {
+		t.Fatalf("the recording carries no exchange answering %d, so the fixture no longer exercises one", from)
+	}
+	if err := os.WriteFile(path, out.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return operation
+}
+
+func copyTree(t *testing.T, src, dst string) {
+	t.Helper()
+	if err := os.MkdirAll(dst, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		from, to := filepath.Join(src, e.Name()), filepath.Join(dst, e.Name())
+		if e.IsDir() {
+			copyTree(t, from, to)
+			continue
+		}
+		raw, err := os.ReadFile(from) //nolint:gosec // a path this test built
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(to, raw, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/internal/cli/replay.go
+++ b/internal/cli/replay.go
@@ -174,6 +174,13 @@ func writeReplayText(w io.Writer, rep replay.Report) {
 	fmt.Fprintf(w, "%d field(s) knowingly not served, each printed above with its reason\n", rep.Excused)
 	fmt.Fprintf(w, "%d field(s) the recorder redacted, whose type could not be compared\n", rep.Redacted)
 	fmt.Fprintf(w, "%d recorded identifier(s) rebound to the one this emulator minted\n", rep.Rebound)
+	if rep.Ambiguous > 0 {
+		// Printed only when there are any, unlike the counts above: those three
+		// answer "how much was compared" and have to be legible at zero, while
+		// this one answers "did anything need arbitrating" and a zero would add
+		// a line to every run to say nothing happened.
+		fmt.Fprintf(w, "%d recorded value(s) two fields bound differently, resolved by field name\n", rep.Ambiguous)
+	}
 	if rep.Unserved > 0 {
 		fmt.Fprintln(w, "not served is a work item, not a failure: rank it with `feint coverage --observed <recording>`")
 	}

--- a/internal/cli/testdata/frozen/cli.json
+++ b/internal/cli/testdata/frozen/cli.json
@@ -1133,6 +1133,177 @@
           ]
         }
       }
+    },
+    {
+      "schema_version": 9,
+      "content": {
+        "exit_codes": {
+          "drift": 2,
+          "error": 1,
+          "ok": 0
+        },
+        "verbs": {
+          "catalog": [
+            "--format"
+          ],
+          "clean": [
+            "--vm"
+          ],
+          "corpus": [
+            "--accepted",
+            "--check",
+            "--dir"
+          ],
+          "coverage": [
+            "--artefact",
+            "--baseline",
+            "--contract",
+            "--fail-on-unknown",
+            "--format",
+            "--observed",
+            "--products",
+            "--provider",
+            "--sdk",
+            "--write-baseline"
+          ],
+          "docs": [
+            "--check",
+            "--client-pins",
+            "--confidence",
+            "--contracts",
+            "--coverage",
+            "--file",
+            "--install",
+            "--limits",
+            "--proved",
+            "--routes",
+            "--screenshots",
+            "--ui-manifest",
+            "--workflow"
+          ],
+          "doctor": [
+            "--addr",
+            "--vm"
+          ],
+          "env": [
+            "--client",
+            "--endpoint",
+            "--shell",
+            "--unset"
+          ],
+          "evidence": [
+            "--allow-narrowing",
+            "--contracts",
+            "--endpoint",
+            "--join",
+            "--out",
+            "--shapes",
+            "--suites"
+          ],
+          "images": [
+            "--check",
+            "--only",
+            "--vm"
+          ],
+          "logs": [
+            "--addr",
+            "-f",
+            "-n"
+          ],
+          "probe": [
+            "--contracts",
+            "--endpoint",
+            "--provider"
+          ],
+          "proxy": [
+            "--addr",
+            "--expose-to-network",
+            "--forward",
+            "--intercept",
+            "--max-body",
+            "--provider",
+            "--queue",
+            "--record",
+            "--upstream"
+          ],
+          "replay": [
+            "--endpoint",
+            "--format",
+            "--timeout"
+          ],
+          "restart": [
+            "--addr",
+            "--timeout"
+          ],
+          "serve": [
+            "--addr",
+            "--cleanup",
+            "--contracts",
+            "--coverage",
+            "--expose-to-network",
+            "--log-level",
+            "--shapes",
+            "--state",
+            "--vm"
+          ],
+          "shapes": [
+            "--check",
+            "--dir",
+            "--dry-run",
+            "--profile",
+            "--provider",
+            "--record"
+          ],
+          "snapshot list": [
+            "--format"
+          ],
+          "snapshot load": [
+            "--addr"
+          ],
+          "snapshot save": [
+            "--addr",
+            "--force"
+          ],
+          "start": [
+            "--addr",
+            "--cleanup",
+            "--contracts",
+            "--detach",
+            "--foreground",
+            "--log-level",
+            "--state",
+            "--timeout",
+            "--vm"
+          ],
+          "status": [
+            "--addr",
+            "--coverage",
+            "--format"
+          ],
+          "stop": [
+            "--addr",
+            "--timeout"
+          ],
+          "transcript": [
+            "--against",
+            "--contract",
+            "--format",
+            "--sanitise",
+            "--shape"
+          ],
+          "ui": [
+            "--addr",
+            "--print"
+          ],
+          "version": [
+            "--check"
+          ],
+          "wait": [
+            "--addr",
+            "--timeout"
+          ]
+        }
+      }
     }
   ]
 }

--- a/internal/replay/bindings_test.go
+++ b/internal/replay/bindings_test.go
@@ -1,0 +1,121 @@
+package replay
+
+import (
+	"reflect"
+	"testing"
+)
+
+// The three values the fixtures below turn on. The recorded side spells
+// organization_id and project_id the same, which is not a contrivance: it is
+// what a Scaleway account with a single project answers, and it is what #352
+// recorded (corpus/scaleway/*.jsonl).
+const (
+	recordedID   = "11111111-1111-4111-8111-111111111111"
+	recordedBoth = "22222222-2222-4222-8222-222222222222"
+
+	mintedID           = "33333333-3333-4333-8333-333333333333"
+	mintedOrganisation = "44444444-4444-4444-8444-444444444444"
+	mintedProject      = "55555555-5555-4555-8555-555555555555"
+)
+
+func recordedAnswer() (want, got map[string]any) {
+	return map[string]any{
+			"id":              recordedID,
+			"organization_id": recordedBoth,
+			"project_id":      recordedBoth,
+		}, map[string]any{
+			"id":              mintedID,
+			"organization_id": mintedOrganisation,
+			"project_id":      mintedProject,
+		}
+}
+
+// One recorded value, two field names, two answers — and the field name is what
+// decides which one a later request carries.
+//
+// Without this the replay had a map from value to value, so the two candidates
+// fought over one slot and whichever field the walk reached first won. The cost
+// was not theoretical: when the organisation won, the create that followed filed
+// its private network under a project the unfiltered list does not cover, and
+// vpc/v2/API.ListPrivateNetworks came back divergent — a divergence the replay
+// had manufactured itself.
+func TestOneRecordedValueUnderTwoFieldsBindsByFieldName(t *testing.T) {
+	b := newBindings()
+	want, got := recordedAnswer()
+	b.learn("", want, got)
+
+	for field, expect := range map[string]string{
+		"project_id":      mintedProject,
+		"organization_id": mintedOrganisation,
+	} {
+		if to := b.applyValue(field, recordedBoth); to != expect {
+			t.Errorf("a request body's %s carried %v, want the one this emulator minted for that field (%s)", field, to, expect)
+		}
+		if to := b.applyQuery(field + "=" + recordedBoth); to != field+"="+expect {
+			t.Errorf("a query filter on %s became %q, want %q", field, to, field+"="+expect)
+		}
+	}
+
+	// The ambiguity is counted rather than silently resolved: a reader is
+	// entitled to know the recording said less than the replay needed.
+	if n := b.ambiguities(); n != 1 {
+		t.Errorf("ambiguities() = %d, want 1: one recorded value had two candidate bindings", n)
+	}
+	// And a value with only one candidate still resolves with no field name at
+	// all, which is what a path segment has.
+	if to, bound := b.resolve("", recordedID); !bound || to != mintedID {
+		t.Errorf("an unambiguous identifier resolved to %q (%v) with no field to scope it, want %s", to, bound, mintedID)
+	}
+}
+
+// The same recording binds the same way on every run.
+//
+// Go randomises map iteration, and the first version of [bindings.learn] ranged
+// over the recorded object: the sibling that reached the map first claimed a
+// value both carried. Six replays of corpus/scaleway/scw-cli.jsonl against six
+// fresh emulators graded the same operation divergent three times and matched
+// three times (corpus/README.md). A gate whose verdict flaps is a gate that gets
+// disarmed the first time it seems to lie, so this asserts the whole map, many
+// times: an unsorted walk survives one comparison with probability one half.
+func TestTheSameRecordingBindsTheSameWayOnEveryRun(t *testing.T) {
+	want, got := recordedAnswer()
+	// Sibling keys spread across the alphabet, so no single ordering is
+	// accidentally the sorted one.
+	want["zone_project"] = recordedBoth
+	got["zone_project"] = "66666666-6666-4666-8666-666666666666"
+	want["account_project"] = recordedBoth
+	got["account_project"] = "77777777-7777-4777-8777-777777777777"
+
+	first := newBindings()
+	first.learn("", want, got)
+	for i := range 200 {
+		again := newBindings()
+		again.learn("", want, got)
+		if !reflect.DeepEqual(again.to, first.to) {
+			t.Fatalf("run %d bound the unscoped map differently: %v, first run had %v", i, again.to, first.to)
+		}
+		if !reflect.DeepEqual(again.byField, first.byField) {
+			t.Fatalf("run %d bound the field-scoped map differently", i)
+		}
+	}
+}
+
+// A field name that never appeared falls back to what the value bound
+// elsewhere, rather than to nothing.
+//
+// The second direction, and it is the one that keeps the scoping from breaking
+// what already worked: a create answers `id` and the read that follows puts that
+// identifier in its *path*, where there is no field name at all. Scoping without
+// this fallback would leave every path unrebound and every read answering 404.
+func TestAValueWithNoFieldOfItsOwnStillResolves(t *testing.T) {
+	b := newBindings()
+	want, got := recordedAnswer()
+	b.learn("", want, got)
+
+	if path := b.applyPath("/vpc/v2/regions/fr-par/vpcs/" + recordedID); path != "/vpc/v2/regions/fr-par/vpcs/"+mintedID {
+		t.Errorf("applyPath left the recorded identifier in place: %s", path)
+	}
+	if to := b.applyValue("vpc_id", recordedID); to != mintedID {
+		t.Errorf("a body field nothing was learned under resolved to %v, want the unscoped binding %s", to, mintedID)
+	}
+}

--- a/internal/replay/replay.go
+++ b/internal/replay/replay.go
@@ -180,6 +180,13 @@ type Report struct {
 	// nothing on a transcript full of creates has not followed the causality
 	// it claims to.
 	Rebound int `json:"rebound"`
+	// Ambiguous is how many recorded values two different field names bound to
+	// two different answers — project_id and organization_id spelled the same
+	// on the account #352 recorded. Reported rather than silently resolved: it
+	// is the count of places where the field name, and not the value, decided
+	// what the request carried, and a reader is entitled to know the recording
+	// said less than the replay needed.
+	Ambiguous int `json:"ambiguous"`
 }
 
 // Options is what a run needs.
@@ -243,7 +250,19 @@ func Run(ctx context.Context, exs []trace.Exchange, opt Options) (Report, error)
 		rep.Results = append(rep.Results, res)
 	}
 	rep.Rebound = b.count()
+	rep.Ambiguous = b.ambiguities()
 	return rep, nil
+}
+
+// leafField is the JSON key an invariant's path ends at, which is the field
+// name its values were learned under. "server.public_ips[].id" is a sequence of
+// values the recording carried at "id", so that is the scope to resolve them
+// in — the same reasoning applyQuery uses for a parameter name.
+func leafField(path string) string {
+	if i := strings.LastIndex(path, "."); i >= 0 {
+		path = path[i+1:]
+	}
+	return strings.TrimSuffix(path, "[]")
 }
 
 // checked counts the declared comparisons one exchange actually ran, per kind.
@@ -278,7 +297,7 @@ func replayOne(ctx context.Context, x *trace.Exchange, seq int, b *bindings, opt
 	res.Provider = mounted.Provider
 
 	if x.Req != nil && x.Req.Body != nil {
-		body, err := encodeBody(b.applyValue(x.Req.Body))
+		body, err := encodeBody(b.applyValue("", x.Req.Body))
 		if err != nil {
 			return res, checked{}, fmt.Errorf("line %d: encode the recorded request body: %w", seq, err)
 		}
@@ -315,7 +334,7 @@ func replayOne(ctx context.Context, x *trace.Exchange, seq int, b *bindings, opt
 	// one answer, and that case has no fixture here.
 	findings, evaluated := compare(x, resp.StatusCode, got, mounted.Route.Operation, b, opt)
 	res.Findings = findings
-	b.learn(x.Res.Body, got)
+	b.learn("", x.Res.Body, got)
 	res.Verdict = Matched
 	for _, f := range res.Findings {
 		if f.Kind != KindExcused && f.Kind != KindRedacted {
@@ -533,7 +552,7 @@ func compareInvariants(want, got any, operation string, b *bindings, opt Options
 			// unevaluated rather than passed: see reorder.
 			mapped := make([]any, len(wantSeq))
 			for i, v := range wantSeq {
-				mapped[i] = b.applyValue(v)
+				mapped[i] = b.applyValue(leafField(inv.Path), v)
 			}
 			positions, ran := reorder(mapped, gotSeq)
 			if ran {
@@ -702,30 +721,96 @@ func jsonType(v any) string {
 
 // bindings maps a value the recording carries to the one this emulator minted
 // in its place.
-type bindings struct{ to map[string]string }
+//
+// # One recorded value can mean two things, and the field name is what says which
+//
+// A recording is not a set of globally unique identifiers. On the account #352
+// recorded, project_id and organization_id are the *same string* — a Scaleway
+// account with one project spells both the same way — while this emulator mints
+// two different ones. So one recorded value has two candidate bindings, and a
+// map from value to value cannot hold both.
+//
+// The first version held only [bindings.to] and walked a Go map to fill it,
+// which decided the question by iteration order: six replays of
+// corpus/scaleway/scw-cli.jsonl against six fresh emulators graded
+// vpc/v2/API.ListPrivateNetworks divergent three times and matched three times
+// (corpus/README.md records the run). When the organisation won, the create
+// filed its network under a project the unfiltered list does not cover.
+//
+// Two changes, and they answer two different questions:
+//
+//   - [bindings.byField] scopes a binding to the field name it was observed
+//     under, so a recorded value substituted into project_id gets the project
+//     this emulator minted and the same value substituted into organization_id
+//     gets the organisation. This is reading the recording's own labelling
+//     rather than guessing, and it is what makes a red run a defect.
+//   - the map walk in [bindings.learn] is sorted, so a value with no field to
+//     scope it — a path segment, a query parameter whose name never appeared as
+//     a body field — resolves the same way on every run. Determinism first,
+//     because a gate that answers differently on two identical inputs is a gate
+//     that gets disarmed the first time it seems to lie.
+//
+// TestOneRecordedValueUnderTwoFieldsBindsByFieldName and
+// TestTheSameRecordingBindsTheSameWayOnEveryRun fail without them.
+type bindings struct {
+	// to maps a recorded value to the one this emulator minted, ignoring where
+	// it was seen. It is the fallback for the places that carry no field name —
+	// a path segment, and a query parameter no body field ever named.
+	to map[string]string
+	// byField is the same map, scoped to the field name the pair was observed
+	// under: byField["project_id"]["<recorded>"] is what this emulator answered
+	// for project_id.
+	byField map[string]map[string]string
+	// ambiguous holds the recorded values that two field names bound
+	// differently. Counted and reported rather than hidden: it is the honest
+	// name for "this recording says less than the replay needs", and a run that
+	// resolved one by field name should be able to say so.
+	ambiguous map[string]struct{}
+}
 
-func newBindings() *bindings { return &bindings{to: map[string]string{}} }
+func newBindings() *bindings {
+	return &bindings{
+		to:        map[string]string{},
+		byField:   map[string]map[string]string{},
+		ambiguous: map[string]struct{}{},
+	}
+}
 
 func (b *bindings) count() int { return len(b.to) }
 
+func (b *bindings) ambiguities() int { return len(b.ambiguous) }
+
 // learn walks the recorded answer and this emulator's beside it, and remembers
-// every identifier that moved.
+// every identifier that moved, under the field name it moved at.
 //
 // Only a differing pair binds, and only when the recorded side looks like an
 // identifier. Both halves matter: a value the emulator answers identically
 // needs no rebinding, and a state name or a status message that differs is not
 // something a later request refers back to — substituting one would corrupt the
 // request rather than repair it.
-func (b *bindings) learn(want, got any) {
+//
+// field is the name of the JSON key this value sits under, "" at the root. A
+// list passes its own field down to each element, because the elements of
+// public_ips are still public_ips.
+func (b *bindings) learn(field string, want, got any) {
 	switch w := want.(type) {
 	case map[string]any:
 		g, ok := got.(map[string]any)
 		if !ok {
 			return
 		}
-		for k, nested := range w {
+		// Sorted rather than ranged, and this line is the determinism. Go
+		// randomises map iteration on purpose, so the unsorted form let the
+		// order of two sibling keys decide which of them claimed a value both
+		// carried — the "8 or 9 divergences" of corpus/README.md.
+		keys := make([]string, 0, len(w))
+		for k := range w {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			if peer, present := g[k]; present {
-				b.learn(nested, peer)
+				b.learn(k, w[k], peer)
 			}
 		}
 	case []any:
@@ -735,7 +820,7 @@ func (b *bindings) learn(want, got any) {
 		}
 		for i := range w {
 			if i < len(g) {
-				b.learn(w[i], g[i])
+				b.learn(field, w[i], g[i])
 			}
 		}
 	case string:
@@ -743,10 +828,34 @@ func (b *bindings) learn(want, got any) {
 		if !ok || g == w || !looksMinted(w) {
 			return
 		}
-		if _, bound := b.to[w]; !bound {
+		scoped := b.byField[field]
+		if scoped == nil {
+			scoped = map[string]string{}
+			b.byField[field] = scoped
+		}
+		if _, bound := scoped[w]; !bound {
+			scoped[w] = g
+		}
+		if previous, bound := b.to[w]; !bound {
 			b.to[w] = g
+		} else if previous != g {
+			b.ambiguous[w] = struct{}{}
 		}
 	}
+}
+
+// resolve answers what this emulator minted for a recorded value, preferring
+// what it minted for that value *under that field name*.
+//
+// The fallback is not a second guess, it is the case where there is no field to
+// ask about: a path segment, or a query parameter whose name no body field
+// carried.
+func (b *bindings) resolve(field, value string) (string, bool) {
+	if to, bound := b.byField[field][value]; bound {
+		return to, true
+	}
+	to, bound := b.to[value]
+	return to, bound
 }
 
 // applyPath substitutes bound identifiers segment by segment. Whole segments
@@ -758,14 +867,14 @@ func (b *bindings) applyPath(path string) string {
 	}
 	segments := strings.Split(path, "/")
 	for i, seg := range segments {
-		if to, bound := b.to[seg]; bound {
+		if to, bound := b.resolve("", seg); bound {
 			segments[i] = to
 			continue
 		}
 		// Exoscale writes the verb in the identifier's own segment
 		// ("{id}:start"), so the identifier is the part before the colon.
 		if id, action, found := strings.Cut(seg, ":"); found {
-			if to, bound := b.to[id]; bound {
+			if to, bound := b.resolve("", id); bound {
 				segments[i] = to + ":" + action
 			}
 		}
@@ -777,6 +886,11 @@ func (b *bindings) applyPath(path string) string {
 // string byte-identical when none is bound — the same reason the proxy's
 // redaction does: re-encoding through url.Values sorts and re-escapes, and the
 // request that goes out would then not be the one that was recorded.
+//
+// The parameter name is the field name: `?project_id=<recorded>` asks the same
+// question a body field project_id asks, and Scaleway's own list filters are
+// spelled exactly like the body fields they filter on. Resolving them globally
+// is what sent one list to the organisation and made the verdict flap.
 func (b *bindings) applyQuery(raw string) string {
 	if raw == "" || len(b.to) == 0 {
 		return raw
@@ -788,7 +902,7 @@ func (b *bindings) applyQuery(raw string) string {
 		if !hasValue {
 			continue
 		}
-		if to, bound := b.to[value]; bound {
+		if to, bound := b.resolve(name, value); bound {
 			pairs[i] = name + "=" + to
 			changed = true
 		}
@@ -799,9 +913,10 @@ func (b *bindings) applyQuery(raw string) string {
 	return strings.Join(pairs, "&")
 }
 
-// applyValue substitutes bound identifiers in a decoded request body. Whole
-// string values only, for the reason applyPath keeps to whole segments.
-func (b *bindings) applyValue(v any) any {
+// applyValue substitutes bound identifiers in a decoded request body, under the
+// field name each value sits at. Whole string values only, for the reason
+// applyPath keeps to whole segments.
+func (b *bindings) applyValue(field string, v any) any {
 	if len(b.to) == 0 {
 		return v
 	}
@@ -809,17 +924,17 @@ func (b *bindings) applyValue(v any) any {
 	case map[string]any:
 		out := make(map[string]any, len(value))
 		for k, nested := range value {
-			out[k] = b.applyValue(nested)
+			out[k] = b.applyValue(k, nested)
 		}
 		return out
 	case []any:
 		out := make([]any, len(value))
 		for i, item := range value {
-			out[i] = b.applyValue(item)
+			out[i] = b.applyValue(field, item)
 		}
 		return out
 	case string:
-		if to, bound := b.to[value]; bound {
+		if to, bound := b.resolve(field, value); bound {
 			return to
 		}
 		return value

--- a/mise.toml
+++ b/mise.toml
@@ -84,6 +84,24 @@ depends = ["build"]
 # with the field list and the exit-code contract (0 ok, 1 error, 2 drift).
 run = "./feint shapes --check"
 
+[tasks."corpus:check"]
+description = "Replay every committed corpus and fail (exit 2) where this emulator answers differently from the real cloud"
+depends = ["build"]
+# The only control in this repository that compares an answer with the *cloud's*.
+# `conformance` proves a real client accepts what the emulator says, which is a
+# different and weaker question, and it cannot be more than that because the
+# cloud is not there. corpus/ is (#351, #352), and this replays it.
+#
+# Offline, no credential, no client binary, thirty milliseconds: every input is a
+# versioned file. That is what lets it be a gate where `conformance` deliberately
+# is not — a hook that fails on an absent binary teaches `--no-verify`, which
+# disarms every other hook at once.
+#
+# Exit 2 is a divergence the acceptance list does not carry; exit 1 is a corpus
+# that could not be read, or that compared nothing. The second is the one that
+# gets forgotten: a corpus replaying nothing is a failure, never a pass.
+run = "./feint corpus --check"
+
 # ---- Upstream tracking (the anti-drift loop) --------------------------------------------------
 [tasks."upstream:sync"]
 description = "Fetch the upstream SDKs and API descriptions the scan and the contracts read"
@@ -424,7 +442,7 @@ run = "python3 tools/falsify/falsify.py"
 
 [tasks.prepush]
 description = "Everything a pull request will fail on that costs seconds and needs no client"
-depends = ["check", "docs:check", "drift:check", "shapes:check", "falsify:selftest", "falsify:lint", "release:surface"]
+depends = ["check", "docs:check", "drift:check", "shapes:check", "corpus:check", "falsify:selftest", "falsify:lint", "release:surface"]
 # What this is, and what it deliberately is not.
 #
 # Each of these is deterministic, offline, and takes seconds: they can be a hook

--- a/tools/falsify/specs/corpus-gate.json
+++ b/tools/falsify/specs/corpus-gate.json
@@ -1,0 +1,107 @@
+{
+  "package": "./internal/cli/",
+  "mutations": [
+    {
+      "label": "a divergence from the recorded cloud stops failing the build, which is the whole gate: mutate one recorded status and the run goes green",
+      "file": "internal/cli/corpus.go",
+      "find": "\tif divergent > 0 {",
+      "replace": "\tif divergent > 0 && false {",
+      "test": "TestAMutatedRecordedStatusTurnsTheGateRedAndNamesIt"
+    },
+    {
+      "label": "a corpus directory holding no file reads as a pass, which is the SKIP this repository has already shipped once",
+      "file": "internal/cli/corpus.go",
+      "find": "\tif len(files) == 0 {",
+      "replace": "\tif len(files) == 0 && false {",
+      "test": "TestACorpusThatComparesNothingIsRed"
+    },
+    {
+      "label": "a corpus every exchange of which is unserved reads as a pass: the file was read, nothing was compared, and the verdict says nothing is wrong",
+      "file": "internal/cli/corpus.go",
+      "find": "\t\tif rep.Matched+rep.Divergent == 0 {",
+      "replace": "\t\tif rep.Matched+rep.Divergent == 0 && false {",
+      "test": "TestACorpusThatComparesNothingIsRed"
+    },
+    {
+      "label": "an empty transcript is replayed instead of refused, so the run reports on a file it never read",
+      "file": "internal/cli/corpus.go",
+      "find": "\tif len(exs) == 0 {",
+      "replace": "\tif len(exs) == 0 && false {",
+      "test": "TestACorpusThatComparesNothingIsRed"
+    },
+    {
+      "label": "an exemption that excuses nothing survives, so the list rots into an archive and the day #355 lands nobody is told to delete the entry",
+      "file": "internal/cli/corpus.go",
+      "find": "\t\tif used[i] == 0 {",
+      "replace": "\t\tif used[i] == 0 && false {",
+      "test": "TestAnExemptionThatExcusesNothingFailsTheGate"
+    },
+    {
+      "label": "an exemption whose reason carries no decision is accepted, and a comment starts standing in for a control",
+      "file": "internal/cli/corpus.go",
+      "find": "\tif bad := unusableCorpusExceptions(acc.Accepted); len(bad) > 0 {",
+      "replace": "\tif bad := unusableCorpusExceptions(acc.Accepted); len(bad) > 0 && false {",
+      "test": "TestAnExemptionWithoutAUsableReasonFailsTheGate"
+    },
+    {
+      "label": "a committed corpus nobody dated replays anonymously, so no run can say how old the cloud it describes is",
+      "file": "internal/cli/corpus.go",
+      "find": "\t\tif !known[f] {",
+      "replace": "\t\tif !known[f] && false {",
+      "test": "TestTheCorpusAndItsRecordingDatesAreHeldToEachOther"
+    },
+    {
+      "label": "a recording entry naming no file survives, which is a claim about a corpus that left",
+      "file": "internal/cli/corpus.go",
+      "find": "\t\tif !present[r.File] {",
+      "replace": "\t\tif !present[r.File] && false {",
+      "test": "TestTheCorpusAndItsRecordingDatesAreHeldToEachOther"
+    },
+    {
+      "label": "THE SECOND DIRECTION: an operation no route serves is counted against the verdict, and the day it fails the build is the day somebody stops recording",
+      "file": "internal/cli/corpus.go",
+      "find": "\t\tunserved += rep.Unserved",
+      "replace": "\t\tunserved += rep.Unserved\n\t\tdivergent += rep.Unserved",
+      "test": "TestAnUnservedOperationDoesNotFailTheCorpusGate"
+    },
+    {
+      "label": "THE SECOND DIRECTION: an aged recording fails instead of warning, so the gate asserts what it cannot measure — it holds one side of the comparison and cannot tell a cloud that moved from an emulator that broke",
+      "file": "internal/cli/corpus.go",
+      "find": "\twarnAgedCorpora(acc, now, stdout)",
+      "replace": "\twarnAgedCorpora(acc, now, stdout)\n\tif len(agedCorpora(acc.Recorded, now, acc.WarnAfterDays)) > 0 {\n\t\treturn exitDrift\n\t}",
+      "test": "TestAnAgedCorpusWarnsAndDoesNotFailTheGate"
+    },
+    {
+      "label": "the recorded value's field name stops scoping its binding, so project_id and organization_id fight over one slot again and the verdict flaps between 8 and 9 divergences",
+      "file": "internal/replay/replay.go",
+      "find": "\t\t\t\tb.learn(k, w[k], peer)",
+      "replace": "\t\t\t\tb.learn(\"\\x00never\", w[k], peer)",
+      "test": "TestOneRecordedValueUnderTwoFieldsBindsByFieldName",
+      "package": "./internal/replay/"
+    },
+    {
+      "label": "the field-scoped lookup is skipped, so every value resolves through the unscoped map the ambiguity broke",
+      "file": "internal/replay/replay.go",
+      "find": "\tif to, bound := b.byField[field][value]; bound {",
+      "replace": "\tif to, bound := b.byField[field][value]; bound && false {",
+      "test": "TestOneRecordedValueUnderTwoFieldsBindsByFieldName",
+      "package": "./internal/replay/"
+    },
+    {
+      "label": "the walk over the recorded answer stops being sorted, and Go's randomised map iteration decides which sibling claims a shared value",
+      "file": "internal/replay/replay.go",
+      "find": "\t\tsort.Strings(keys)\n\t\tfor _, k := range keys {",
+      "replace": "\t\tsort.Strings(keys[:0])\n\t\tfor _, k := range keys {",
+      "test": "TestTheSameRecordingBindsTheSameWayOnEveryRun",
+      "package": "./internal/replay/"
+    },
+    {
+      "label": "THE SECOND DIRECTION: the unscoped fallback is removed, so an identifier that only ever appeared in a path is never rebound and every read of a fresh emulator answers 404",
+      "file": "internal/replay/replay.go",
+      "find": "\tto, bound := b.to[value]\n\treturn to, bound",
+      "replace": "\tto, bound := b.to[value]\n\treturn to, bound && false",
+      "test": "TestAValueWithNoFieldOfItsOwnStillResolves",
+      "package": "./internal/replay/"
+    }
+  ]
+}

--- a/tools/falsify/specs/replay-compares.json
+++ b/tools/falsify/specs/replay-compares.json
@@ -46,8 +46,8 @@
     {
       "label": "a recorded identifier is no longer rebound, so every read of a fresh emulator addresses an object that does not exist and the identity case is unreachable",
       "file": "internal/replay/replay.go",
-      "find": "\t\tif to, bound := b.to[seg]; bound {",
-      "replace": "\t\tif to, bound := b.to[seg]; bound && false {",
+      "find": "\t\tif to, bound := b.resolve(\"\", seg); bound {",
+      "replace": "\t\tif to, bound := b.resolve(\"\", seg); bound && false {",
       "test": "TestARecordedIdentifierIsReboundBeforeTheRequestGoesOut"
     },
     {


### PR DESCRIPTION
A corpus nothing replays is a museum piece. This makes the recordings of #351
and #352 a gate — and the difference it makes is the difference between this
project's claim and its proof.

The conformance suite proves a real client **accepts** what the emulator
answers. It cannot prove that answer is what the **cloud** would have said,
because the cloud is not there. A replayed corpus can.

## Where it lives, and why it can be a gate where conformance cannot

`feint corpus --check` — `mise run corpus:check`. It walks `corpus/`, builds a
**fresh in-process emulator per file**, replays every exchange and grades.
**30 ms, offline, no credential, no client binary** — measured.

Every input is a committed file, which is exactly what lets it sit in `prepush`
and on every pull request, beside `shapes --check`. `conformance` cannot: it
needs four binaries installed and would teach `--no-verify`, which disarms every
other hook at once.

## The binding ambiguity had to be settled first

`bindings.learn` held one map from recorded value to emulator value and filled
it by ranging a Go map. On the recording account `project_id == organization_id`,
so two candidates fought over one slot and iteration order picked the winner.

Bindings are now **scoped to the field name they were observed under**, the walk
that learns them is **sorted**, and `Report.Ambiguous` counts values two fields
bound differently instead of resolving them in silence.

Measured at gate level on the committed corpus:

| | distinct outputs / 30 runs | exit codes |
|---|---|---|
| pre-fix binding, restored outside the repo | **2** | **0 seventeen times, 2 thirteen times** |
| as committed | **1** | **0** |

**Before the fix the gate was a coin toss.** A gate that lies once is a gate
somebody disarms.

And the ambiguity was not only noise: the `ListPrivateNetworks` divergence
`corpus/README.md` recorded was **manufactured by the replay itself**, not an
emulator defect.

## Ageing: it warns, and never fails

`warn_after_days: 180`, in a committed file so moving it is a diff somebody
signs. The argument is a limit of the measurement rather than a preference:
**this gate holds one side of the comparison.** A red run says the emulator and
the recording disagree, and nothing here knows which of the two moved. Failing
on age would assert exactly what it cannot measure — #359 is the half that can
arbitrate, and this decision is deliberately compatible with it.

## First pass: green, with eight exemptions

The exemption file was chosen over a red merge, on CLAUDE.md's own argument:
merging red puts every unrelated pull request on a red `main`, and a gate people
learn to skip is worse than no gate.

`corpus/accepted.json` carries the eight, each with a reason held to the
repository's own `carriesNoDecision` guard and a required `issue: #355`.
Everything excused is printed and counted. **An entry that excuses nothing fails
the gate**, so #355 cannot land and leave its exemption behind.

The `*`-segment matching reuses `emulator.FieldDecline.Matches` — one
implementation, so the gate that excuses and the replay that compares cannot
disagree about which field they name. And no pack was touched: the server-type
catalogue's unreachable refusal is exempted with its reason rather than fixed by
adding a decline spelling, so no pack behaviour rides in on a gate PR.

## Three verdicts, never blurred

A **divergence** the acceptance list does not carry is exit 2. An operation **no
route serves** is printed and never counted against the verdict. A corpus that
**could not be read, or that compared nothing**, is exit 1 — and the three routes
into "nothing" (an empty file, an empty directory, a file whose every exchange
is unserved) are each asserted separately with their own message.

That third verdict is the one this repository has shipped wrong before: the
network suite returned SKIP in CI from the day it was written, and five more
were found in the page harness last week.

## Falsified — 14 mutations, all bite

`tools/falsify/specs/corpus-gate.json`. The two the issue demanded, plus twelve:
a stale exemption, an unusable reason, both recording-date directions, unserved
counted against the verdict, age made to fail, and four on the bindings
themselves.

The status mutation's fixture is a self-recording that replays clean with
**zero** exemptions, so the mutation is the only difference between green and
red.

## A premise the measurement contradicted

**`cliSurfaceVersion` was 8, not 7** — #351 had already bumped it. Now **9**.

And the "poorest run" question was worth verifying rather than believing:
`packsFor` reads `FEINT_OUTSCALE_REGION` and `FEINT_EXOSCALE_ZONE`, which decide
which routes are mounted and therefore which exchanges count as unserved. Today
they make no difference — measured, byte-identical output with both set — but
that is only true while the corpus is Scaleway-only, so it is now a test that
goes red the day an Outscale corpus lands (#354).

## Related

Closes #353