### PR TITLE
feat(proxy): a terminated host says where it lands, and the S3 client's answer is measured

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -19,6 +19,86 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Ajouté
 
+- **`--forward` peut dire où atterrit vraiment un hôte terminé** (#357). Une
+  entrée de `feint proxy --forward` peut désormais nommer sa cible — `--forward
+  'api.scaleway.com=http://127.0.0.1:4599'` — de sorte qu'un client dont
+  l'endpoint est compilé en dur est terminé, enregistré, puis réémis vers
+  **l'émulateur** au lieu du vrai cloud. Un hôte écrit sans cible continue
+  d'aller au vrai, donc rien ne change pour un appelant existant, et les deux
+  formes se mélangent dans une même passe.
+
+  C'est la combinaison qui ne s'exprimait pas : `--forward` enregistrait un
+  client qu'on ne peut pas rediriger mais l'envoyait au vrai cloud, et
+  `--upstream` envoyait tout à un hôte choisi mais exigeait un client
+  redirigeable. Enregistrer contre l'émulateur un client à endpoint compilé
+  demandait un espace de noms utilisateur + montage + réseau, un `/etc/hosts`
+  remplacé dedans, un écouteur sur le port 443 dans cette pile privée et un
+  second étage de proxy — 89 lignes de shell. Il faut maintenant deux variables
+  d'environnement et un `=`. Prouvé avec un vrai client le 2026-08-21 :
+  `terraform apply` d'un `scaleway_object_bucket`, dont l'endpoint S3 est
+  compilé dans le provider, enregistré contre un émulateur feint sans espace de
+  noms, sans édition de `/etc/hosts` et sans port privilégié.
+  `tools/conformance/forward.sh` rejoue le mécanisme à la demande avec `scw` et
+  sans compte : il pointe le CLI sur `https://api.scaleway.test`, un TLD réservé
+  qui ne résout jamais, de sorte qu'une passe où le proxy n'est *pas* ce qui
+  porte le trafic échoue sur `no such host` au lieu d'atteindre un cloud.
+
+  **Ce n'est pas `--upstream` déguisé, et la différence est l'enregistrement.**
+  `--upstream` envoie chaque requête au même endroit quoi qu'ait demandé le
+  client, ce qui perd l'information même pour laquelle on enregistre. Ici l'hôte
+  demandé est conservé dans le transcript, seule la socket bouge. L'en-tête
+  `Host` sortant est la seule chose qu'une entrée mappée déplace, et il le faut :
+  la garde anti-DNS-rebinding de feint répond 403 à un `Host` qu'elle ne
+  reconnaît pas, si bien que transmettre `api.scaleway.com` tel quel à
+  l'émulateur produisait un transcript de refus — mesuré avant le correctif, sur
+  l'apply ci-dessus. Une entrée nue reste intacte, donc une signature SigV4 qui
+  couvre `Host` se vérifie toujours face au vrai hôte.
+
+  **Les quatre exigences de sécurité de #336 tiennent sans changement, et chacune
+  est falsifiée de nouveau à cette porte** (`tools/falsify/specs/forward-proxy.json`,
+  21 mutations désormais) : la redaction survit à un tunnel mappé,
+  `--expose-to-network` reste refusé avec `--forward`, l'autorité reste éphémère
+  et jamais installée, et `--forward '*=<cible>'` est refusé exactement comme
+  `--forward '*'` — le joker est cherché dans l'hôte *après* découpe du `=`,
+  c'est-à-dire là où un mappage aurait pu faire du recorder un mouchard sans que
+  personne le voie. Une cible nomme une socket et rien d'autre : un chemin, une
+  requête ou des identifiants sont refusés, sinon le proxy réécrirait chaque
+  requête d'une façon que son propre transcript ne montre pas. Aucun drapeau
+  nouveau : la surface CLI gelée (version 9) ne bouge pas.
+
+  Un hôte intercepté mais non nommé est désormais diagnostiqué comme l'entrée
+  manquante qu'il est, dans la forme que prend le drapeau, plutôt que comme un
+  échec de connexion nu — le cas qui coûte une après-midi, puisqu'une famille
+  d'API peut vivre sur un autre hôte que le principal (l'API Kubernetes managée
+  d'Outscale le fait).
+
+- **Mesuré : le client S3 de Terraform pour Scaleway honore `HTTPS_PROXY`**
+  (#346). Cette entrée n'implémente rien ; elle répond à la seule question sur
+  laquelle reposait le refus de l'object storage. Il l'honore. Mesuré sous Linux
+  le 2026-08-21 — terraform 1.15.4, `scaleway/scaleway 2.81.0` — un apply de
+  `scaleway_object_bucket` a émis `CONNECT
+  feint-346-measurement.s3.fr-par.scw.cloud:443` et son `CreateBucket` a atterri
+  sur un émulateur feint, User-Agent `aws-sdk-go-v2/1.43.4 … api/s3#1.107.0
+  terraform-provider-scaleway/2.81.0`. Aucun compte, aucun endpoint réel, les
+  identifiants factices publics.
+
+  **Les deux négatifs sont distingués, parce qu'un seul ferme la porte.** Une
+  passe témoin contre un proxy qui ne nomme *pas* l'hôte S3 a enregistré zéro
+  échange, terminé zéro tunnel et refusé douze connexions vers cet hôte,
+  terraform rapportant `request send failed … Forbidden` : c'est « arrivé, puis
+  refusé ». L'autre négatif — « n'a pas honoré le proxy » — n'aurait montré
+  aucun `CONNECT` et une plainte de certificat, ce que produit macOS, et c'est
+  pourquoi la mesure a été faite sous Linux.
+
+  La conséquence est écrite là où vit la décision, `docs/limits.md` (numéro 7),
+  avec le transcript : la redirection DNS/TLS que #76 appelait la moitié
+  difficile coûte désormais deux variables d'environnement portées par le
+  processus, **sur le client même qui la bloquait**. L'object storage reste
+  refusé, et le refus tient désormais par son seul argument de couverture — un
+  produit sur un client, et une surface S3 que personne n'a chiffrée — et non
+  par une quelconque difficulté de la redirection. Le rouvrir est une issue en
+  soi, avec ses propres chiffres.
+
 - **Exoscale sert le Network Load Balancer, et aucun backend ne porte de
   verdict de santé** (#345, successeur de #14). Toute la famille est montée :
   `exoscale/v2.create-load-balancer`, `exoscale/v2.list-load-balancers`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,83 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Added
 
+- **`--forward` can say where a terminated host actually goes** (#357). An entry
+  of `feint proxy --forward` may now name its target — `--forward
+  'api.scaleway.com=http://127.0.0.1:4599'` — so a client whose endpoint is
+  compiled in is terminated, recorded, and re-originated to **the emulator**
+  instead of to the real cloud. A host written without a target keeps sending it
+  to the real one, so nothing changes for an existing caller, and the two forms
+  mix in one run.
+
+  This is the combination that could not be expressed before: `--forward`
+  recorded a client nobody can redirect but sent it to the real cloud, and
+  `--upstream` sent everything to one host but needed a redirectable client.
+  Recording a compiled-in-endpoint client *against the emulator* took a user +
+  mount + network namespace, a replaced `/etc/hosts` inside it, a listener on
+  port 443 in that private stack and a second proxy stage — 89 lines of shell.
+  It now takes two environment variables and one `=`. Proven with a real client
+  on 2026-08-21: `terraform apply` of a `scaleway_object_bucket`, whose S3
+  endpoint is compiled into the provider, recorded against a feint emulator with
+  no namespace, no `/etc/hosts` edit and no privileged port.
+  `tools/conformance/forward.sh` replays the mechanism on demand with `scw` and
+  without an account — it points the CLI at `https://api.scaleway.test`, a
+  reserved TLD that never resolves, so a run in which the proxy is *not* what
+  carries the traffic fails with `no such host` instead of reaching a cloud.
+
+  **This is not `--upstream` in disguise, and the difference is the record.**
+  `--upstream` sends every request to one place regardless of what the client
+  asked, which loses the very information a recording is for. Here the requested
+  host is preserved in the transcript and only the socket moves. The outbound
+  `Host` header is the one thing a mapped entry does move, and it has to: feint's
+  own DNS-rebinding guard answers 403 to a `Host` it does not recognise, so
+  forwarding `api.scaleway.com` verbatim to the emulator recorded a transcript of
+  refusals — measured before the fix, on the very apply above. A bare entry is
+  untouched, so a SigV4 signature over `Host` still verifies against the real
+  host.
+
+  **#336's four security requirements hold unchanged, and each is falsified again
+  at this door** (`tools/falsify/specs/forward-proxy.json`, now 21 mutations):
+  the redaction survives a mapped tunnel, `--expose-to-network` is still refused
+  with `--forward`, the authority is still ephemeral and never installed, and
+  `--forward '*=<target>'` is refused exactly as `--forward '*'` is — the
+  wildcard is looked for in the host *after* the `=` is cut out, which is how a
+  mapping could have turned the recorder into a wiretap without anybody noticing.
+  A target names a socket and nothing else: a path, a query or user info is
+  refused, because the proxy would then rewrite every request in a way its own
+  transcript does not show. No new flag, so the frozen CLI surface (version 9)
+  does not move.
+
+  A host that is intercepted but not named is now diagnosed as the missing entry
+  it is, in the form the flag takes, rather than as a bare connection failure —
+  the case that costs an afternoon, since an API family can live on a different
+  host than the main one (Outscale's managed-Kubernetes API does).
+
+- **Measured: the Terraform Scaleway S3 client honours `HTTPS_PROXY`** (#346).
+  This implements nothing; it answers the one question the object-storage
+  refusal had been resting on. It does honour it. Measured on Linux on
+  2026-08-21 — terraform 1.15.4, `scaleway/scaleway 2.81.0` — a
+  `scaleway_object_bucket` apply emitted `CONNECT
+  feint-346-measurement.s3.fr-par.scw.cloud:443` and its `CreateBucket` landed
+  on a feint emulator, User-Agent `aws-sdk-go-v2/1.43.4 … api/s3#1.107.0
+  terraform-provider-scaleway/2.81.0`. No account, no real endpoint, the public
+  fake credentials.
+
+  **The two negatives are told apart, because only one closes the door.** A
+  control run against a proxy that does *not* name the S3 host recorded zero
+  exchanges, terminated zero tunnels and refused twelve connections to that
+  host, with terraform reporting `request send failed … Forbidden`: that is
+  "arrived, and was refused". The other negative — "did not honour the proxy" —
+  would have shown no `CONNECT` at all and a certificate complaint, which is
+  what macOS produces and why this was measured on Linux.
+
+  The consequence is written where the decision lives, `docs/limits.md`
+  (number 7), with the transcript: the DNS/TLS redirect that #76 called the hard
+  half now costs two process-scoped environment variables **on the exact client
+  that blocked it**. Object storage stays refused, and the refusal now stands on
+  its coverage argument alone — one product on one client, and an S3 surface
+  nobody has costed — rather than on any part of the redirect being hard.
+  Reopening it is its own issue, with its own numbers.
+
 - **Exoscale serves the Network Load Balancer, and no backend carries a health
   verdict** (#345, successor to #14). The whole family is mounted:
   `exoscale/v2.create-load-balancer`, `exoscale/v2.list-load-balancers`,

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -233,6 +233,76 @@ republished name resolving to the proxy, then away — and records the whole thi
 one way, only the pre-handoff exchange the other. Eight-of-ninety, and the fix, on
 one run.
 
+### 7. The Terraform S3 client honours `HTTPS_PROXY` — measured (#346)
+
+Everything above rests on the redirect being the hard half. `feint proxy
+--forward` (#336) changed one term of that: a Go client that installs no
+`Transport` inherits `http.DefaultTransport`, which honours `HTTPS_PROXY`, so a
+compiled-in name can be intercepted with **no DNS trick and no `/etc/hosts`**.
+Whether the Scaleway Terraform provider's **S3** client is such a client was
+unknown, and #336 said so rather than predicting.
+
+It is. Measured on Linux on **2026-08-21**, terraform 1.15.4 with
+`scaleway/scaleway 2.81.0`, against this repository's own emulator — no account,
+no real endpoint, the public fake credentials of
+`tools/conformance/scaleway/fake-credentials.env`. The recipe is the two
+variables and nothing else, plus the mapping #357 added so the terminated host
+lands on the emulator instead of the real cloud:
+
+```bash
+feint serve --addr 127.0.0.1:4760 &
+feint proxy --record s3.jsonl --addr 127.0.0.1:4761 \
+  --forward 's3.fr-par.scw.cloud=http://127.0.0.1:4760,*.s3.fr-par.scw.cloud=http://127.0.0.1:4760'
+# then, on a scaleway_object_bucket:
+export HTTPS_PROXY=http://127.0.0.1:4761 SSL_CERT_FILE=/tmp/feint-intercept-ca-….pem
+terraform apply -auto-approve
+```
+
+One tunnel terminated, one exchange recorded, and the User-Agent names the
+client beyond argument:
+
+```json
+{"seq":1,"method":"PUT","path":"/","host":"feint-346-measurement.s3.fr-par.scw.cloud",
+ "status":404,"mounted":false,
+ "req":{"headers":{"Authorization":"REDACTED","X-Amz-Content-Sha256":"REDACTED",
+   "User-Agent":"aws-sdk-go-v2/1.43.4 … api/s3#1.107.0 terraform-provider-scaleway/2.81.0"}}}
+```
+
+The `PUT /` is `CreateBucket`, virtual-host style, and the `404` is **this
+emulator** answering: feint serves no object storage, so no pack claims that
+route (`"mounted": false`). Nothing left the machine.
+
+**Read the two failures apart, because only one of them closes the door.** A
+negative result would have to say *which* negative it was, and the control run
+shows exactly what the other one looks like. Driven again with the same
+environment against a proxy that does **not** name the S3 host:
+
+```text
+recorded 0 exchange(s)
+0 tunnel(s) terminated
+12 connection(s) were refused because --forward does not name their host:
+  feint-346-measurement.s3.fr-par.scw.cloud
+```
+
+```text
+Error: operation error S3: CreateBucket, exceeded maximum number of attempts, 3,
+request send failed, Put "https://feint-346-measurement.s3.fr-par.scw.cloud/": Forbidden
+```
+
+The client emitted `CONNECT` for the compiled-in name twelve times and the proxy
+turned each one down. That is *"arrived, and was refused"* — the door opened. The
+other negative, *"did not honour the proxy"*, would have left the proxy with **no
+CONNECT at all** and the client complaining about a certificate, which is what
+macOS produces (number 2's warning in [proxy.md](proxy.md)) and why this was
+measured on Linux.
+
+So the hard half of #76 has a third door, and this one costs an operator
+nothing: no namespace, no `/etc/hosts`, no privileged port, no AppArmor profile.
+**It does not by itself retain object storage** — what it removes is the
+redirect from the cost, not the S3 surface from the work — but the arbitration in
+the verdict below now rests on the coverage argument alone, since the ceremony it
+weighed has gone to zero. Reopening it is its own issue, with its own numbers.
+
 ### The verdict
 
 **Refused, now with numbers behind it — and the refusal changes shape twice.**
@@ -242,20 +312,22 @@ written. The certificate was never the project it was called: it is `feint proxy
 including the Terraform plugin through one process-scoped environment variable. And
 the name redirect, first read as undeliverable without touching the machine, is
 deliverable after all — in a namespace the client owns (number 6): a rootless
-container, or feint's own namespace under one named profile. What is left is not a
-feasibility wall but an operator ceremony — the client must run inside that
-namespace — and whether the S3-through-Terraform corner is worth that ceremony is a
-product call, the only thing still holding the refusal.
+container, or feint's own namespace under one named profile. And since #346
+(number 7) it is not even that: the one blocked client honours `HTTPS_PROXY`, so
+the redirect costs two environment variables. What is left is not a feasibility
+wall and no longer an operator ceremony either — it is the coverage argument
+alone: whether the S3-through-Terraform corner is worth emulating an S3 surface,
+which is a product call and the only thing still holding the refusal.
 
 The blocker is one product on one client, so the MinIO + `SCW_S3_ENDPOINT` page
 remains the right answer for the S3 workflow, and the refusal caps coverage by
 exactly one corner rather than quietly bounding the whole project. If
 Object-Storage-through-Terraform is ever wanted, it is a roadmap item with a
-named owner and a shape already measured: `SSL_CERT_FILE` (safe) plus an
-explicit, disposable name redirect the operator opts into (a devcontainer or a
-temporary hosts entry) — never a system trust-store install, never a hosts file
-this binary edits itself. Whether that corner is worth the operator ceremony is a
-product call; it is no longer an unmeasured one.
+named owner and a shape already measured, and number 7 shortened it again:
+`SSL_CERT_FILE` and `HTTPS_PROXY`, both process-scoped, both proven on that exact
+client — never a system trust-store install, never a hosts file this binary edits
+itself, and now not even a namespace. What is left to cost is the S3 surface
+itself; that is a product call, and it is no longer an unmeasured one.
 
 ## A run presented as local can still reach the real cloud (#280)
 

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -56,7 +56,9 @@ the run, records the exchange, and re-originates to the real host.
 
 ```bash
 feint proxy --forward api.scaleway.com,'*.exoscale.com' --record real.jsonl
-#   forwarding for api.scaleway.com, *.exoscale.com
+#   forwarding for:
+#     api.scaleway.com -> the host the client asked for
+#     *.exoscale.com -> the host the client asked for
 #   CA written to /tmp/feint-intercept-ca-1655051664.pem (a temporary file, removed on exit)
 #   drive a client whose endpoint is compiled in with:
 #     export HTTPS_PROXY=http://127.0.0.1:4600
@@ -100,7 +102,7 @@ nothing on the wire — and the file holds none of them.
 
 Four properties, each of them a requirement rather than a precaution, and each
 with a test that fails without it (`tools/falsify/specs/forward-proxy.json`
-replays all thirteen, the redaction's own five included):
+replays all twenty-one, the redaction's own five and #357's mapped door included):
 
 - **The redaction survives the interception.** The tunnel records through the
   same `capture` as everything else, so there is no second path to the writer to
@@ -128,6 +130,82 @@ replays all thirteen, the redaction's own five included):
 together; neither are `--forward` and `--intercept`, which are two ways to reach
 the same interception (`--intercept` serves TLS on the listener itself, for a
 client redirected by name — see [limits.md](limits.md)).
+
+### Say where a terminated host actually goes
+
+The command above re-originates to the real cloud, because that is the host the
+client asked for. So the two useful things could not be combined: **record a
+client that cannot be redirected, and have it land on the emulator.** Getting
+there took a user + mount + network namespace, a replaced `/etc/hosts` inside
+it, a listener on port 443 in that private stack and a second proxy stage — 89
+lines of shell before one request was recorded.
+
+An entry may now name where its terminated traffic goes (#357):
+
+```bash
+feint proxy --record run.jsonl \
+  --forward 'api.scaleway.com=http://127.0.0.1:4599,api-ch-gva-2.exoscale.com=http://127.0.0.1:4599'
+#   forwarding for:
+#     api.scaleway.com -> http://127.0.0.1:4599
+#     api-ch-gva-2.exoscale.com -> http://127.0.0.1:4599
+```
+
+A host written **without** a target keeps today's behaviour and goes to the real
+one, so nothing changes for an existing caller — and the two forms mix in one
+run. This is not `--upstream` in disguise: `--upstream` sends *every* request to
+one place regardless of what the client asked, which loses the very information a
+recording is for. Here the requested host is preserved in the transcript, and it
+is only the socket that moves.
+
+Two consequences worth knowing before you read a transcript:
+
+- **The transcript names the host the client asked for**, not the target. That
+  is the `host` field, and `feint replay` reissues against whatever `--endpoint`
+  you give it, so a recording made this way stays a recording *of the client*.
+- **The outbound `Host` header names the target.** It is the one thing a mapped
+  entry does move, and it has to: feint's own DNS-rebinding guard answers 403 to
+  a `Host` it does not recognise, so a run that forwarded `api.scaleway.com`
+  verbatim to the emulator would record a transcript of refusals. A bare entry
+  is untouched — the real host is still addressed by its own name, which is what
+  keeps a SigV4 signature over `Host` verifying.
+
+A target names a socket and nothing else: a path, a query or user info is
+refused, because the proxy would then be rewriting every request in a way its own
+transcript does not show.
+
+And a host that is intercepted but not named is diagnosed as the missing entry it
+is, rather than as a connection failure — the case that costs an afternoon, since
+an API family can live on a different host than the main one (Outscale's
+managed-Kubernetes API does):
+
+```text
+feint proxy: --forward does not name api.eu-west-2.outscale.com, so this connection
+was not terminated and nothing about it is in the transcript.
+Add the missing entry: --forward ...,api.eu-west-2.outscale.com to reach the real
+host, or --forward ...,api.eu-west-2.outscale.com=http://127.0.0.1:4599 to send it
+to the emulator.
+```
+
+**The four requirements above are unchanged by the mapping, and each one is
+falsified again at this door** (`tools/falsify/specs/forward-proxy.json`): the
+redaction survives a mapped tunnel, `--expose-to-network` is still refused with
+`--forward`, the authority is still ephemeral, and `--forward '*=<target>'` is
+refused exactly as `--forward '*'` is — the wildcard is looked for in the host
+*after* the `=` is cut out, which is the way a mapping could have widened the
+allowlist without anybody noticing.
+
+Measured with a real client on 2026-08-21: `terraform apply` of a
+`scaleway_object_bucket`, whose S3 endpoint is compiled into the provider,
+recorded against a feint emulator with **no namespace, no `/etc/hosts` edit and
+no privileged port** — two environment variables and one mapped entry. The
+transcript is in [limits.md](limits.md) number 7.
+
+`tools/conformance/forward.sh` replays that mechanism whenever you want it, with
+`scw` and without an account: it points the CLI at `https://api.scaleway.test` —
+a reserved TLD that never resolves, so nothing can leave the machine if the
+proxy is not what carries it — and asserts that the transcript names
+`api.scaleway.test`, that every operation it recorded was also counted inside the
+emulator, and that the token is redacted.
 
 ## Read
 

--- a/docs/roadmap.fr.md
+++ b/docs/roadmap.fr.md
@@ -484,12 +484,20 @@ et jamais un fichier hosts que le binaire éditerait lui-même.
 redirection de nom : un client qui honore `HTTPS_PROXY` remet le nom d'hôte au
 proxy lui-même. La moitié qu'on appelait le blocage a donc une seconde porte
 pour **tout client qui lit cette variable** — mesuré sur un client Go qui
-n'installe pas de `Transport`, c'est-à-dire le cas ordinaire. Ce qui reste non
-mesuré est justement ce qui rouvrirait l'arbitrage : le client S3 du provider
-Terraform Scaleway honore-t-il `HTTPS_PROXY` pour son
-`https://s3.<region>.scw.cloud` codé en dur ? Tant que personne ne l'a mesuré,
-le refus tient par son argument de couverture — un produit sur un client — et
-non par l'impossibilité de la redirection.
+n'installe pas de `Transport`, c'est-à-dire le cas ordinaire.
+
+**Et #346 a tranché la seule question qui restait.** Le client S3 du provider
+Terraform Scaleway honore bien `HTTPS_PROXY` pour son
+`https://s3.<region>.scw.cloud` codé en dur : mesuré sous Linux le 2026-08-21,
+provider 2.81.0, un `CreateBucket` arrivé sur cet émulateur à travers un
+`CONNECT`, avec `aws-sdk-go-v2 … terraform-provider-scaleway/2.81.0` dans le
+User-Agent, et une passe témoin qui montre les douze `CONNECT` refusés que le
+même apply produit quand le proxy ne nomme pas l'hôte. Le transcript et les deux
+lectures sont dans [limits.md](limits.md) numéro 7. La redirection coûte donc
+deux variables d'environnement portées par le processus, sur le client même qui
+la bloquait, et le refus tient désormais par son seul argument de couverture —
+un produit sur un client, et une surface S3 que personne n'a chiffrée — et non
+par une quelconque difficulté de la redirection.
 
 ### Considéré dans la même passe, et non mis en file
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -443,11 +443,19 @@ never a hosts file the binary edits itself.
 client that honours `HTTPS_PROXY` hands the proxy the hostname itself. So the
 half that was called the blocker has a second door for **any client that reads
 that variable** — measured on a Go client which installs no `Transport`, which is
-the ordinary case. What stays unmeasured is the one that would reopen the
-arbitration: whether the Scaleway Terraform provider's S3 client honours
-`HTTPS_PROXY` for its built-in `https://s3.<region>.scw.cloud`. Until somebody
-runs that, the decline stands on its coverage argument — one product on one
-client — and not on the redirect being impossible.
+the ordinary case.
+
+**And #346 closed the one question that was left.** The Scaleway Terraform
+provider's S3 client *does* honour `HTTPS_PROXY` for its built-in
+`https://s3.<region>.scw.cloud`: measured on Linux on 2026-08-21, provider
+2.81.0, `CreateBucket` arriving on this emulator through a `CONNECT` with
+`aws-sdk-go-v2 … terraform-provider-scaleway/2.81.0` in the User-Agent, and a
+control run showing the twelve refused CONNECTs the same apply produces when the
+proxy does not name the host. The transcript and both readings are in
+[limits.md](limits.md) number 7. The redirect therefore costs two process-scoped
+environment variables on the exact client that blocked it, and the decline now
+stands on its coverage argument alone — one product on one client, and an S3
+surface nobody has costed — rather than on any part of the redirect being hard.
 
 ### Considered in the same pass, and not queued
 

--- a/internal/cli/proxy.go
+++ b/internal/cli/proxy.go
@@ -40,7 +40,7 @@ func proxyCommand(args []string, _ io.Writer, stderr io.Writer) int {
 	queue := fs.Int("queue", proxy.DefaultQueue, "how many exchanges may wait to be written before one is dropped")
 	expose := fs.Bool("expose-to-network", false, "listen off loopback, which offers this proxy's transcript and this cloud account to the network")
 	intercept := fs.String("intercept", "", "serve HTTPS with a locally-minted certificate for these comma-separated hostnames, so a client redirected to this proxy by name (a container's own /etc/hosts) trusts it and lands here; see docs/limits.md #76")
-	forward := fs.String("forward", "", "be a forward proxy for these comma-separated hostnames: accept CONNECT, terminate the TLS with a locally-minted certificate and record it, so a client whose endpoint is compiled in is recorded through HTTPS_PROXY alone; see docs/proxy.md")
+	forward := fs.String("forward", "", "be a forward proxy for these comma-separated hostnames: accept CONNECT, terminate the TLS with a locally-minted certificate and record it, so a client whose endpoint is compiled in is recorded through HTTPS_PROXY alone. An entry may name where its traffic then goes, host=target (api.scaleway.com=http://127.0.0.1:4599); written bare it goes to the real host. See docs/proxy.md")
 	if err := fs.Parse(args); err != nil {
 		return exitError
 	}
@@ -117,7 +117,7 @@ func proxyCommand(args []string, _ io.Writer, stderr io.Writer) int {
 			return exitError
 		}
 		rec = forwarder
-		printForwardRecipe(stderr, splitHosts(*forward), *addr, caPath)
+		printForwardRecipe(stderr, forwarder.Destinations(), *addr, caPath)
 	} else {
 		p, err := proxy.New(proxy.Options{
 			Upstream: target,
@@ -215,8 +215,9 @@ func proxyCommand(args []string, _ io.Writer, stderr io.Writer) int {
 			// host" by reading which.
 			fmt.Fprintf(stderr,
 				"%d connection(s) were refused because --forward does not name their host: %s\n"+
-					"  the client's own calls to them failed, and none of them is in this transcript.\n",
-				refused, strings.Join(sortedHosts(hosts), ", "))
+					"  the client's own calls to them failed, and none of them is in this transcript.\n"+
+					"  add the missing entries: --forward ...,%s\n",
+				refused, strings.Join(sortedHosts(hosts), ", "), strings.Join(sortedHosts(hosts), ","))
 		}
 	}
 	if unnamed := rec.Unnamed(); unnamed > 0 {
@@ -414,8 +415,16 @@ func publishCA(ic *proxy.Interceptor) (string, func(), error) {
 // change in the client — which is what makes this door the cheap one. The
 // warning is part of the recipe: what this records is decrypted, so it is said
 // where the operator is about to run the command rather than only in the docs.
-func printForwardRecipe(stderr io.Writer, names []string, addr, caPath string) {
-	fmt.Fprintf(stderr, "  forwarding for %s\n", strings.Join(names, ", "))
+//
+// destinations is one line per entry, each naming where that host's traffic is
+// re-originated. Printed rather than summarised, because "the real cloud" and
+// "the emulator" are the two answers an operator must never confuse, and #357
+// made them differ per host.
+func printForwardRecipe(stderr io.Writer, destinations []string, addr, caPath string) {
+	fmt.Fprintln(stderr, "  forwarding for:")
+	for _, d := range destinations {
+		fmt.Fprintf(stderr, "    %s\n", d)
+	}
 	fmt.Fprintf(stderr, "  CA written to %s (a temporary file, removed on exit)\n", caPath)
 	fmt.Fprintln(stderr, "  drive a client whose endpoint is compiled in with:")
 	fmt.Fprintf(stderr, "    export HTTPS_PROXY=http://%s\n", addr)

--- a/internal/cli/proxy_test.go
+++ b/internal/cli/proxy_test.go
@@ -154,6 +154,23 @@ func TestProxyRefusesAnUnusableInvocation(t *testing.T) {
 		"forward for everything": {[]string{
 			"--forward", "*", "--record", "-", "--addr", "127.0.0.1:0",
 		}, "every host"},
+		// The mapped form of #357 gets no bypass either, and this is the case
+		// that could have been lost silently: `*=<target>` is the same wiretap
+		// as `*`, and it only stays refused because the name is cut out of the
+		// entry before the wildcard is looked for.
+		"forward for everything, mapped": {[]string{
+			"--forward", "*=http://127.0.0.1:4599", "--record", "-", "--addr", "127.0.0.1:0",
+		}, "every host"},
+		"forward exposed on purpose, mapped": {[]string{
+			"--forward", "api.scaleway.com=http://127.0.0.1:4599", "--record", "-",
+			"--addr", "0.0.0.0:4600", "--expose-to-network",
+		}, "loopback"},
+		"forward to a target that is a path": {[]string{
+			"--forward", "api.scaleway.com=http://127.0.0.1:4599/v2", "--record", "-", "--addr", "127.0.0.1:0",
+		}, "names a socket"},
+		"forward to no target at all": {[]string{
+			"--forward", "api.scaleway.com=", "--record", "-", "--addr", "127.0.0.1:0",
+		}, "names no target"},
 	} {
 		t.Run(name, func(t *testing.T) {
 			var stdout, stderr bytes.Buffer

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -30,6 +30,14 @@ package proxy
 // named and refuses every other CONNECT out loud, because the alternative — a
 // tunnel relayed blind — writes a transcript that silently misses exchanges,
 // which is the exact defect handoff.go exists to report.
+//
+// Where the terminated traffic goes is the entry's own business (#357). Written
+// bare, a host is re-originated to itself — the real cloud, which is what 0.10.0
+// shipped. Written `host=target`, it is re-originated to that socket instead,
+// which is how a client with a compiled-in endpoint is recorded *against the
+// emulator*: two environment variables, no namespace, no /etc/hosts, no
+// privileged port. The requested host stays in the transcript either way; only
+// the socket moves.
 
 import (
 	"crypto/tls"
@@ -61,6 +69,12 @@ type ForwardOptions struct {
 	// which is what a per-zone endpoint needs. Required: a forward proxy that
 	// intercepts whatever it is handed decrypts more of the operator's traffic
 	// than the measurement asked for.
+	//
+	// An entry may also name where its terminated traffic goes, as
+	// `host=target` (#357): `api.scaleway.com=http://127.0.0.1:4599` is
+	// terminated, recorded, and re-originated to the emulator rather than to
+	// the real cloud. An entry written without a target keeps sending it to the
+	// host the client asked for, which is what --forward has always done.
 	Hosts []string
 	// Writer receives every exchange. Required, for [New]'s reason.
 	Writer *Writer
@@ -95,7 +109,7 @@ type ForwardOptions struct {
 type Forward struct {
 	rec       *Proxy
 	authority *Interceptor
-	hosts     []string
+	routes    []forwardRoute
 	log       *slog.Logger
 
 	tunnels atomic.Int64
@@ -108,7 +122,7 @@ type Forward struct {
 
 // NewForward validates the options and builds the forward proxy.
 func NewForward(o ForwardOptions) (*Forward, error) {
-	hosts, err := hostPatterns(o.Hosts)
+	routes, err := forwardRoutes(o.Hosts)
 	if err != nil {
 		return nil, err
 	}
@@ -131,32 +145,105 @@ func NewForward(o ForwardOptions) (*Forward, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Forward{rec: rec, authority: authority, hosts: hosts, log: o.Log}, nil
+	return &Forward{rec: rec, authority: authority, routes: routes, log: o.Log}, nil
 }
 
-// hostPatterns trims the names a forward proxy may intercept, and refuses a set
-// that would intercept nothing or everything.
+// forwardRoute is one entry of --forward: a host pattern this proxy may
+// terminate, and the socket what it terminates is re-originated to.
+//
+// A nil target is the shape --forward shipped with in 0.10.0 and still has for
+// an entry written without an `=`: the traffic goes to the host the client
+// asked for, which is the real cloud. A target sends it elsewhere while leaving
+// the requested host in the transcript — that separation is the whole point of
+// #357, and it is what makes this not [Options.Upstream] in disguise: --upstream
+// sends *every* request to one place regardless of what the client asked, which
+// loses the very information a recording is for.
+// TestAMappedTunnelRecordsTheHostTheClientAsked fails if the two are conflated.
+type forwardRoute struct {
+	pattern string
+	target  *url.URL
+}
+
+// String is what the recipe and the diagnostics print, one line per entry.
+func (r forwardRoute) String() string {
+	if r.target == nil {
+		return r.pattern + " -> the host the client asked for"
+	}
+	return r.pattern + " -> " + r.target.String()
+}
+
+// forwardRoutes reads the entries a forward proxy may intercept, and refuses a
+// set that would intercept nothing or everything.
 //
 // `*` alone is refused rather than read as "all": the flag would then be one
 // character away from decrypting every TLS connection the client makes, which is
 // the difference between a recorder and a wiretap.
-// TestAForwardProxyRefusesAnUnusableHostSet fails without this.
-func hostPatterns(hosts []string) ([]string, error) {
-	var out []string
-	for _, h := range hosts {
-		h = strings.TrimSpace(h)
-		if h == "" {
+//
+// The cut on `=` happens *before* that check and never after, which is the part
+// #357 could have broken silently: `*=http://127.0.0.1:4599` is the same wiretap
+// as `*`, and a guard still reading the whole entry would wave it through
+// because the string no longer equals "*".
+// TestAForwardProxyRefusesAnUnusableHostSet fails without either half — it
+// drives `*`, `*.*` and `*=<target>` through this function.
+func forwardRoutes(entries []string) ([]forwardRoute, error) {
+	var out []forwardRoute
+	for _, entry := range entries {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
 			continue
 		}
-		if h == "*" || strings.HasPrefix(h, "*.*") {
-			return nil, fmt.Errorf("--forward %q would intercept every host a client reaches: name the hosts to record", h)
+		name, rawTarget, mapped := strings.Cut(entry, "=")
+		name = strings.TrimSpace(name)
+		if name == "" {
+			return nil, fmt.Errorf("--forward %q names no host: write host=target, or the host alone", entry)
 		}
-		out = append(out, h)
+		if name == "*" || strings.HasPrefix(name, "*.*") {
+			return nil, fmt.Errorf("--forward %q would intercept every host a client reaches: name the hosts to record", entry)
+		}
+		route := forwardRoute{pattern: name}
+		if mapped {
+			target, err := forwardTarget(name, rawTarget)
+			if err != nil {
+				return nil, err
+			}
+			route.target = target
+		}
+		out = append(out, route)
 	}
 	if len(out) == 0 {
 		return nil, fmt.Errorf("no host to forward for: a forward proxy that intercepts nothing records nothing")
 	}
 	return out, nil
+}
+
+// forwardTarget reads where one entry's terminated traffic is sent.
+//
+// A socket and nothing more: no path, no query, no user info. The client's own
+// request line supplies the path, and a target carrying one would silently
+// prepend it to every request — a rewrite the transcript would not show, in a
+// tool whose only job is to show what was exchanged. TestAForwardTargetMustNameASocket
+// fails without this.
+func forwardTarget(name, raw string) (*url.URL, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, fmt.Errorf("--forward %s= names no target: write %s alone to keep sending it to "+
+			"the real host, or %s=http://127.0.0.1:4599 to send it to the emulator", name, name, name)
+	}
+	target, err := url.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("--forward %s=%q: %w", name, raw, err)
+	}
+	if target.Scheme != "http" && target.Scheme != "https" {
+		return nil, fmt.Errorf("--forward %s=%q: a target's scheme must be http or https", name, raw)
+	}
+	if target.Host == "" {
+		return nil, fmt.Errorf("--forward %s=%q: the target names no host", name, raw)
+	}
+	if target.User != nil || strings.Trim(target.Path, "/") != "" || target.RawQuery != "" || target.Fragment != "" {
+		return nil, fmt.Errorf("--forward %s=%q: a target names a socket, not a path — the client's "+
+			"own request line supplies the path", name, raw)
+	}
+	return &url.URL{Scheme: target.Scheme, Host: target.Host}, nil
 }
 
 // ServeHTTP answers the three shapes a forward proxy is addressed in.
@@ -170,9 +257,18 @@ func (f *Forward) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// names its destination and there is nothing to decrypt. Recorded by the
 		// same path as everything else, and refused for a host nobody named for
 		// the same reason a tunnel is.
-		if !f.intercepts(r.URL.Hostname()) {
+		route, ok := f.route(r.URL.Hostname())
+		if !ok {
 			f.refuse(w, r.URL.Hostname())
 			return
+		}
+		if route.target != nil {
+			// r.Host was read off the original request line before this, so the
+			// host the client asked for survives into the transcript whatever
+			// happens to the socket and to the outbound authority.
+			r.URL.Scheme = route.target.Scheme
+			r.URL.Host = route.target.Host
+			r = reoriginate(r)
 		}
 		f.rec.ServeHTTP(w, r)
 		return
@@ -187,7 +283,8 @@ func (f *Forward) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // tunnel terminates one CONNECT and records what it carries.
 func (f *Forward) tunnel(w http.ResponseWriter, r *http.Request) {
 	host, port := splitTarget(r.Host)
-	if !f.intercepts(host) {
+	route, ok := f.route(host)
+	if !ok {
 		f.refuse(w, host)
 		return
 	}
@@ -218,21 +315,32 @@ func (f *Forward) tunnel(w http.ResponseWriter, r *http.Request) {
 	}
 	f.tunnels.Add(1)
 
+	// Where the terminated traffic is re-originated: the host the client asked
+	// for, unless this entry named a target (#357). What the client *asked for*
+	// is passed alongside rather than derived from the destination, because once
+	// they differ every diagnostic and every recorded field must keep naming the
+	// first — the destination is a socket the client never heard of.
+	dest, moved := route.target, route.target != nil
+	if dest == nil {
+		dest = &url.URL{Scheme: "https", Host: net.JoinHostPort(host, port)}
+	}
+
 	// Whatever the client pipelined behind its CONNECT is already in the
 	// buffer, and a client that sends its ClientHello without waiting for the
 	// 200 is within its rights. Dropping those bytes would fail the handshake
 	// with an error naming the certificate, which is the wrong cause.
-	f.serve(&prefixed{Conn: conn, first: buffered}, cfg, &url.URL{
-		Scheme: "https",
-		Host:   net.JoinHostPort(host, port),
-	})
+	f.serve(&prefixed{Conn: conn, first: buffered}, cfg, host, dest, moved)
 }
 
 // serve terminates the TLS of one tunnel and records the requests inside it.
-func (f *Forward) serve(conn net.Conn, cfg *tls.Config, dest *url.URL) {
+//
+// requested is the host the client named in its CONNECT; dest is where the
+// decrypted requests are sent, which is the same thing only when the entry
+// carried no target, and moved says which of the two this is.
+func (f *Forward) serve(conn net.Conn, cfg *tls.Config, requested string, dest *url.URL, moved bool) {
 	tlsConn := tls.Server(conn, cfg)
 	if err := tlsConn.SetDeadline(time.Now().Add(tunnelHandshakeTimeout)); err != nil {
-		f.log.Error("bound the handshake", "host", dest.Host, "error", err)
+		f.log.Error("bound the handshake", "host", requested, "error", err)
 		_ = tlsConn.Close()
 		return
 	}
@@ -241,13 +349,13 @@ func (f *Forward) serve(conn net.Conn, cfg *tls.Config, dest *url.URL) {
 		// it is worth a line: from the client's side it reads as the cloud
 		// presenting a bad certificate, with nothing pointing here.
 		f.log.Error("the client did not complete the tunnel handshake",
-			"host", dest.Host, "error", err,
+			"host", requested, "error", err,
 			"hint", "point the client's SSL_CERT_FILE at this run's CA")
 		_ = tlsConn.Close()
 		return
 	}
 	if err := tlsConn.SetDeadline(time.Time{}); err != nil {
-		f.log.Error("release the handshake deadline", "host", dest.Host, "error", err)
+		f.log.Error("release the handshake deadline", "host", requested, "error", err)
 		_ = tlsConn.Close()
 		return
 	}
@@ -258,10 +366,19 @@ func (f *Forward) serve(conn net.Conn, cfg *tls.Config, dest *url.URL) {
 			// Promoted to the absolute form the recorder forwards on. The Host
 			// header the client sent is left alone: it is part of the exchange
 			// being measured, and a proxy that rewrote it would be recording its
-			// own edit. What the request is *sent* to stays the address the
-			// CONNECT named and this proxy admitted.
+			// own edit. That is what keeps a mapped entry from being --upstream
+			// in disguise — the socket moves, the record does not — and adding
+			// `r.Host = dest.Host` here turns the transcript into one of a
+			// session against 127.0.0.1.
+			// TestAMappedTunnelRecordsTheHostTheClientAsked fails on that line.
+			//
+			// The *outbound* authority is another question, and a mapped entry
+			// answers it differently: see reoriginate.
 			r.URL.Scheme = dest.Scheme
 			r.URL.Host = dest.Host
+			if moved {
+				r = reoriginate(r)
+			}
 			f.rec.ServeHTTP(w, r)
 		}),
 		// The tunnel's own bound, for the reason the command sets one on the
@@ -272,32 +389,58 @@ func (f *Forward) serve(conn net.Conn, cfg *tls.Config, dest *url.URL) {
 	_ = srv.Serve(listener)
 }
 
-// intercepts reports whether this proxy may terminate a tunnel to host.
+// route finds the entry that admits host, and reports whether one did.
 //
 // Case-insensitive and trailing-dot-insensitive, because a client is free to
 // send either; a single-level wildcard matches one label, exactly as a
 // certificate's does, so `*.exoscale.com` covers `api-ch-gva-2.exoscale.com` and
-// never `a.b.exoscale.com`.
-func (f *Forward) intercepts(host string) bool {
+// never `a.b.exoscale.com`. The first entry that matches wins, so a mapped name
+// written before a wildcard is how one host of a family goes somewhere else.
+func (f *Forward) route(host string) (forwardRoute, bool) {
 	want := strings.ToLower(strings.TrimSuffix(host, "."))
 	if want == "" {
+		return forwardRoute{}, false
+	}
+	for _, r := range f.routes {
+		if admits(r.pattern, want) {
+			return r, true
+		}
+	}
+	return forwardRoute{}, false
+}
+
+// admits reports whether one --forward pattern covers one requested host.
+func admits(pattern, want string) bool {
+	p := strings.ToLower(pattern)
+	if p == want {
+		return true
+	}
+	suffix, isWildcard := strings.CutPrefix(p, "*")
+	if !isWildcard || !strings.HasPrefix(suffix, ".") {
 		return false
 	}
-	for _, pattern := range f.hosts {
-		p := strings.ToLower(pattern)
-		if p == want {
-			return true
-		}
-		suffix, isWildcard := strings.CutPrefix(p, "*")
-		if !isWildcard || !strings.HasPrefix(suffix, ".") {
-			continue
-		}
-		label, found := strings.CutSuffix(want, suffix)
-		if found && label != "" && !strings.Contains(label, ".") {
-			return true
-		}
+	label, found := strings.CutSuffix(want, suffix)
+	return found && label != "" && !strings.Contains(label, ".")
+}
+
+// Destinations names each entry and where what it terminates is sent, for the
+// recipe the command prints before a client starts.
+func (f *Forward) Destinations() []string {
+	out := make([]string, 0, len(f.routes))
+	for _, r := range f.routes {
+		out = append(out, r.String())
 	}
-	return false
+	return out
+}
+
+// patterns is the allowlist as the operator wrote it, without the targets: what
+// a refusal compares against is the set of names, not where they go.
+func (f *Forward) patterns() []string {
+	out := make([]string, 0, len(f.routes))
+	for _, r := range f.routes {
+		out = append(out, r.pattern)
+	}
+	return out
 }
 
 // refuse answers a CONNECT for a host nobody named.
@@ -306,11 +449,32 @@ func (f *Forward) intercepts(host string) bool {
 // client finish its session while the transcript quietly missed every exchange
 // in it — the failure handoff.go was written to report, reintroduced at another
 // door. TestAHostNobodyNamedIsNotIntercepted fails without this.
+//
+// It names the host, which is the difference #357 asks for: an API family can
+// live on a different host than the main one (Outscale's managed-Kubernetes API
+// does), and a missing entry then reads to the operator as the client failing to
+// connect. The entry that is missing is written out, in the form the flag takes.
+// TestARefusalNamesTheEntryThatIsMissing fails without it.
 func (f *Forward) refuse(w http.ResponseWriter, host string) {
 	f.refused.note(host)
 	f.log.Warn("refused to intercept a host --forward does not name",
-		"host", host, "forwarding", strings.Join(f.hosts, ", "))
-	http.Error(w, "feint proxy: this proxy intercepts only the hosts --forward names\n", http.StatusForbidden)
+		"host", host, "forwarding", strings.Join(f.patterns(), ", "),
+		"add", host+" (to the real host), or "+host+"=<target> to send it somewhere you choose")
+	http.Error(w, missingEntry(host), http.StatusForbidden)
+}
+
+// missingEntry is what a client is told when it asked for a host nobody named.
+//
+// It writes the entry out in the form the flag takes. Without the host in it a
+// missing entry reads to the operator as the client failing to connect, which is
+// the case #357 names: an API family can live on a different host than the main
+// one, and the first symptom is a refused connection nobody can attribute.
+// TestARefusalNamesTheEntryThatIsMissing fails without this.
+func missingEntry(host string) string {
+	return fmt.Sprintf("feint proxy: --forward does not name %[1]s, so this connection was not "+
+		"terminated and nothing about it is in the transcript.\n"+
+		"Add the missing entry: --forward ...,%[1]s to reach the real host, or "+
+		"--forward ...,%[1]s=http://127.0.0.1:4599 to send it to the emulator.\n", host)
 }
 
 // Unnamed is how many exchanges walked a route no pack claims.

--- a/internal/proxy/forward_mapped_test.go
+++ b/internal/proxy/forward_mapped_test.go
@@ -1,0 +1,385 @@
+package proxy_test
+
+// Where a terminated host's traffic actually goes (#357).
+//
+// --forward could send it to one place only: the host the client asked for,
+// which is the real cloud. So the two useful things could not be combined —
+// record a client that cannot be redirected, and have it land on the emulator —
+// and getting there took a user + mount + network namespace, a replaced
+// /etc/hosts inside it, a listener on port 443 in that private stack and a
+// second proxy stage. These tests hold the combination that replaces all of it,
+// and they hold it without leaving loopback.
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/proxy"
+)
+
+// landed is what a mapped entry's target received.
+//
+// It is asserted rather than assumed, because half of what #357 promises lives
+// here: the requested host survives into the Host header the target reads, and
+// only the socket moved.
+type landed struct {
+	host  string
+	token string
+	body  string
+	query string
+}
+
+// emulatorStandIn starts a plain-HTTP listener on loopback — the shape `feint
+// serve` has — and returns it with the channel it reports on.
+func emulatorStandIn(t *testing.T) (*httptest.Server, <-chan landed) {
+	t.Helper()
+	seen := make(chan landed, 8)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		seen <- landed{host: r.Host, token: r.Header.Get("X-Auth-Token"), body: string(raw), query: r.URL.RawQuery}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"servers":[{"id":"11111111-1111-1111-1111-111111111111"}]}`)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, seen
+}
+
+// loopbackOnly is the transport a mapped entry is re-originated over.
+//
+// It refuses any address off loopback, which is this test's own guard rail: a
+// mapping that stopped applying would otherwise resolve a real cloud name on the
+// operator's network, and the assertions below would still pass.
+func loopbackOnly(t *testing.T) *http.Transport {
+	t.Helper()
+	return &http.Transport{
+		Proxy: nil,
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			host, _, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, err
+			}
+			if ip := net.ParseIP(host); ip == nil || !ip.IsLoopback() {
+				return nil, fmt.Errorf("this test reaches loopback and nothing else, refusing %s", addr)
+			}
+			return (&net.Dialer{}).DialContext(ctx, network, addr)
+		},
+	}
+}
+
+// TestAMappedTunnelRecordsTheHostTheClientAsked is #357's whole point, and its
+// two halves have to hold together.
+//
+// A client whose endpoint is a constant reaches an emulator on loopback — no
+// namespace, no /etc/hosts edit, no privileged port, two environment variables —
+// and what the transcript names is still the host that client asked for.
+// Recording the target instead would be --upstream in disguise: a transcript of
+// a session against 127.0.0.1, which loses the one fact a recording exists to
+// carry.
+//
+// The redaction is asserted at the same door, because it is the first of #336's
+// four requirements and this is a path that did not exist when it was written:
+// the markers reach the target verbatim and the transcript holds none of them.
+func TestAMappedTunnelRecordsTheHostTheClientAsked(t *testing.T) {
+	emu, seen := emulatorStandIn(t)
+
+	addr, authority, finish := recording(t, loopbackOnly(t), quietLog(), compiledInHost+"="+emu.URL)
+	client := through(t, addr, authority)
+
+	req, err := http.NewRequest(http.MethodPost,
+		compiledInEndpoint+"/instance/v1/servers?x-amz-signature="+queryMarker,
+		strings.NewReader(`{"name":"web","secret_key":"`+bodyMarker+`"}`))
+	if err != nil {
+		t.Fatalf("build the request: %v", err)
+	}
+	req.Header.Set("X-Auth-Token", tokenMarker)
+	req.Header.Set("Content-Type", "application/json")
+	res, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("the mapped call failed: %v", err)
+	}
+	body, _ := io.ReadAll(res.Body)
+	_ = res.Body.Close()
+	if res.StatusCode != http.StatusOK || !bytes.Contains(body, []byte(`"servers"`)) {
+		t.Fatalf("the emulator's answer did not come back: %d %s", res.StatusCode, body)
+	}
+
+	// What the target received: the request the client made, at the socket the
+	// operator chose, addressed to that socket by its own name.
+	//
+	// The authority is the one thing a mapped entry does move, and it has to:
+	// feint's own rebinding guard answers 403 to a Host it does not recognise,
+	// so a run that forwarded `api.scaleway.com` verbatim to the emulator would
+	// record a transcript of refusals and satisfy "reaches the emulator" on a
+	// technicality. Measured on 2026-08-21 before this line existed: `terraform
+	// apply` of a scaleway_object_bucket landed on the emulator and every
+	// request came back 403 from that guard.
+	emuHost := strings.TrimPrefix(emu.URL, "http://")
+	select {
+	case got := <-seen:
+		if got.host != emuHost {
+			t.Errorf("the target was addressed as %q, want its own authority %q", got.host, emuHost)
+		}
+		if got.token != tokenMarker {
+			t.Errorf("the target received the token %q, want it verbatim: the recorder alters "+
+				"nothing on the wire", got.token)
+		}
+		if !strings.Contains(got.body, bodyMarker) || !strings.Contains(got.query, queryMarker) {
+			t.Errorf("the target received body %q query %q, want both markers verbatim", got.body, got.query)
+		}
+	default:
+		t.Fatal("the target received nothing: the mapped entry did not land")
+	}
+
+	recorded := finish()
+	if len(recorded) != 1 {
+		t.Fatalf("recorded %d exchange(s), want one", len(recorded))
+	}
+	x := recorded[0]
+	if x.Host != compiledInHost {
+		t.Errorf("the transcript names host %q, want %q: only the socket moves, never the record",
+			x.Host, compiledInHost)
+	}
+	if x.Path != "/instance/v1/servers" || x.Status != http.StatusOK {
+		t.Errorf("recorded %s %s -> %d, want POST /instance/v1/servers -> 200", x.Method, x.Path, x.Status)
+	}
+	if value := x.Req.Headers["X-Auth-Token"]; value != proxy.Placeholder {
+		t.Errorf("the credential reads %q in the transcript, want %q: the redaction has to survive "+
+			"this door too", value, proxy.Placeholder)
+	}
+	for _, marker := range []string{tokenMarker, bodyMarker, queryMarker} {
+		if strings.Contains(fmt.Sprintf("%+v", x), marker) {
+			t.Errorf("the marker %q survived into the transcript: %+v", marker, x)
+		}
+	}
+}
+
+// TestABareEntryStillReachesTheRealHostBesideAMappedOne is #357's compatibility
+// half, and it is asserted in one run rather than in two.
+//
+// A host written without a target keeps going to the host the client asked for.
+// Two separate runs would prove that a proxy built with no mapping behaves as
+// before, which nobody doubted; one run carrying both proves the thing that
+// could actually break — that a mapping applies to its own entry and to no
+// other.
+func TestABareEntryStillReachesTheRealHostBesideAMappedOne(t *testing.T) {
+	c := stubCloud(t, compiledInHost, func(w http.ResponseWriter, r *http.Request) {
+		// The bare entry's own promise, asserted here because this is the run
+		// where a mapped entry sits beside it: the real host is still addressed
+		// by the name the client used, so a SigV4 signature over Host still
+		// verifies. Only a mapped entry moves the authority.
+		if r.Host != compiledInHost {
+			w.WriteHeader(http.StatusTeapot)
+			_, _ = fmt.Fprintf(w, "the real host was addressed as %q, want %q", r.Host, compiledInHost)
+			return
+		}
+		_, _ = io.WriteString(w, `{"from":"the real host"}`)
+	})
+	emu, seen := emulatorStandIn(t)
+
+	// One transport for both destinations: the stand-in cloud under its name,
+	// loopback for the mapped target, nothing else.
+	both := &http.Transport{
+		Proxy: nil,
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			if addr == net.JoinHostPort(compiledInHost, "443") {
+				return (&net.Dialer{}).DialContext(ctx, network, c.server.Listener.Addr().String())
+			}
+			host, _, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, err
+			}
+			if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+				return (&net.Dialer{}).DialContext(ctx, network, addr)
+			}
+			return nil, fmt.Errorf("this test reaches %s and loopback, refusing %s", compiledInHost, addr)
+		},
+		TLSClientConfig: &tls.Config{RootCAs: c.transport.TLSClientConfig.RootCAs, MinVersion: tls.VersionTLS12},
+	}
+
+	addr, authority, finish := recording(t, both, quietLog(),
+		compiledInHost, "sos.scaleway.test="+emu.URL)
+	client := through(t, addr, authority)
+
+	bare, err := client.Get(compiledInEndpoint + "/instance/v1/servers")
+	if err != nil {
+		t.Fatalf("the bare entry did not reach the host the client asked for: %v", err)
+	}
+	bareBody, _ := io.ReadAll(bare.Body)
+	_ = bare.Body.Close()
+	if !bytes.Contains(bareBody, []byte("the real host")) {
+		t.Errorf("the bare entry answered %s, want the stand-in cloud's own body", bareBody)
+	}
+
+	mapped, err := client.Get("https://sos.scaleway.test/bucket")
+	if err != nil {
+		t.Fatalf("the mapped entry did not reach its target: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, mapped.Body)
+	_ = mapped.Body.Close()
+
+	select {
+	case got := <-seen:
+		if want := strings.TrimPrefix(emu.URL, "http://"); got.host != want {
+			t.Errorf("the target was addressed as %q, want its own authority %q", got.host, want)
+		}
+	default:
+		t.Fatal("the mapped entry did not land on its target")
+	}
+
+	recorded := finish()
+	if len(recorded) != 2 {
+		t.Fatalf("recorded %d exchange(s), want the two the client made", len(recorded))
+	}
+	hosts := map[string]bool{}
+	for _, x := range recorded {
+		hosts[x.Host] = true
+	}
+	if !hosts[compiledInHost] || !hosts["sos.scaleway.test"] {
+		t.Errorf("the transcript names %v, want both hosts the client asked for", hosts)
+	}
+}
+
+// TestAMappedRouteDoesNotWidenTheAllowlist is the fourth of #336's requirements,
+// re-asserted at the door #357 opened.
+//
+// Naming a target must not turn the allowlist into a wildcard: a host nobody
+// wrote down is still refused, and still absent from the transcript. Without
+// this, "only the hosts you name are intercepted" would be a property of the
+// version before the mapping existed.
+func TestAMappedRouteDoesNotWidenTheAllowlist(t *testing.T) {
+	emu, _ := emulatorStandIn(t)
+
+	addr, authority, finish := recording(t, loopbackOnly(t), quietLog(), compiledInHost+"="+emu.URL)
+	client := through(t, addr, authority)
+
+	res, err := client.Get(compiledInEndpoint + "/instance/v1/servers")
+	if err != nil {
+		t.Fatalf("the mapped host was not reachable: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, res.Body)
+	_ = res.Body.Close()
+
+	for _, elsewhere := range []string{
+		"https://telemetry.example.test/collect",
+		"https://a.b.scaleway.test/collect",
+	} {
+		answered, err := client.Get(elsewhere)
+		if err == nil {
+			_ = answered.Body.Close()
+			t.Errorf("a CONNECT to %s, which --forward does not name, was accepted", elsewhere)
+			continue
+		}
+		if !strings.Contains(err.Error(), "Forbidden") {
+			t.Errorf("the refusal of %s did not reach the client as a refusal: %v", elsewhere, err)
+		}
+	}
+
+	recorded := finish()
+	if len(recorded) != 1 || recorded[0].Host != compiledInHost {
+		t.Fatalf("recorded %d exchange(s), want only the named host's: %+v", len(recorded), recorded)
+	}
+}
+
+// TestARefusalNamesTheEntryThatIsMissing is #357's last acceptance criterion.
+//
+// An API family can live on a different host than the main one — Outscale's
+// managed-Kubernetes API does — and the proxy rightly refuses a host it was not
+// told about. What it must not do is leave the operator reading that as a
+// network fault: the answer names the host and writes out the entry to add, in
+// the form the flag takes.
+//
+// Driven in the absolute form, because that is where the body reaches the
+// caller: through a CONNECT the client's transport reports the status line
+// alone, and the same text also goes to the log and to the exit summary.
+func TestARefusalNamesTheEntryThatIsMissing(t *testing.T) {
+	writer := proxy.NewWriter(io.Discard, 0)
+	defer func() { _ = writer.Close() }()
+
+	f, err := proxy.NewForward(proxy.ForwardOptions{
+		Hosts:  []string{"api.scaleway.test=http://127.0.0.1:4599"},
+		Writer: writer,
+		Log:    quietLog(),
+	})
+	if err != nil {
+		t.Fatalf("build the forward proxy: %v", err)
+	}
+	front := httptest.NewServer(f)
+	defer front.Close()
+
+	target, err := url.Parse(front.URL)
+	if err != nil {
+		t.Fatalf("parse the proxy URL: %v", err)
+	}
+	client := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(target)}}
+
+	res, err := client.Get("http://api.eu-west-2.outscale.test/api/v1/ReadVms")
+	if err != nil {
+		t.Fatalf("the refusal did not come back as an answer: %v", err)
+	}
+	body, _ := io.ReadAll(res.Body)
+	_ = res.Body.Close()
+	if res.StatusCode != http.StatusForbidden {
+		t.Fatalf("a host --forward does not name answered %d, want 403", res.StatusCode)
+	}
+	for _, want := range []string{"api.eu-west-2.outscale.test", "--forward"} {
+		if !strings.Contains(string(body), want) {
+			t.Errorf("the refusal does not name %q, so a missing entry reads as a connection "+
+				"failure: %s", want, body)
+		}
+	}
+}
+
+// TestAForwardTargetMustNameASocket refuses a mapping that would rewrite more
+// than the socket.
+//
+// A target carrying a path would silently prepend it to every request the client
+// makes, and the transcript — which records the client's own request line —
+// would not show it. A recorder whose own rewrite is invisible in its output is
+// the one thing this package must never be. User info is refused for its own
+// reason: it is a credential written on a command line.
+func TestAForwardTargetMustNameASocket(t *testing.T) {
+	writer := proxy.NewWriter(io.Discard, 0)
+	defer func() { _ = writer.Close() }()
+
+	for name, entry := range map[string]string{
+		"no target":     "api.scaleway.test=",
+		"blank target":  "api.scaleway.test=   ",
+		"no scheme":     "api.scaleway.test=127.0.0.1:4599",
+		"wrong scheme":  "api.scaleway.test=tcp://127.0.0.1:4599",
+		"no host":       "api.scaleway.test=http://",
+		"carries path":  "api.scaleway.test=http://127.0.0.1:4599/v2",
+		"carries query": "api.scaleway.test=http://127.0.0.1:4599?zone=fr-par",
+		"carries user":  "api.scaleway.test=http://someone@127.0.0.1:4599",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := proxy.NewForward(proxy.ForwardOptions{Hosts: []string{entry}, Writer: writer}); err == nil {
+				t.Errorf("--forward %q was accepted", entry)
+			}
+		})
+	}
+
+	// The accepting half, so a guard that refused every target would fail here:
+	// a bare socket, the trailing slash a shell completion adds, a TLS target,
+	// and the wildcard a per-zone endpoint needs.
+	for name, entry := range map[string]string{
+		"plain":          "api.scaleway.test=http://127.0.0.1:4599",
+		"trailing slash": "api.scaleway.test=http://127.0.0.1:4599/",
+		"tls target":     "api.scaleway.test=https://127.0.0.1:4599",
+		"wildcard":       "*.exoscale.test=http://127.0.0.1:4599",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := proxy.NewForward(proxy.ForwardOptions{Hosts: []string{entry}, Writer: writer}); err != nil {
+				t.Errorf("--forward %q was refused: %v", entry, err)
+			}
+		})
+	}
+}

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -105,6 +105,14 @@ func stubCloud(t *testing.T, host string, handler http.HandlerFunc) *cloud {
 // transcript back.
 func forwarding(t *testing.T, c *cloud, hosts ...string) (addr string, authority *proxy.Interceptor, finish func() []trace.Exchange) {
 	t.Helper()
+	return recording(t, c.transport, nil, hosts...)
+}
+
+// recording is forwarding over any transport, which is what a mapped entry
+// (#357) needs: its traffic goes to a socket on loopback rather than to the
+// stand-in cloud, so the transport that reaches the one cannot reach the other.
+func recording(t *testing.T, tr http.RoundTripper, log *slog.Logger, hosts ...string) (addr string, authority *proxy.Interceptor, finish func() []trace.Exchange) {
+	t.Helper()
 
 	authority, err := proxy.MintAuthority()
 	if err != nil {
@@ -121,7 +129,8 @@ func forwarding(t *testing.T, c *cloud, hosts ...string) (addr string, authority
 		Hosts:     hosts,
 		Writer:    writer,
 		Authority: authority,
-		Transport: c.transport,
+		Transport: tr,
+		Log:       log,
 	})
 	if err != nil {
 		t.Fatalf("build the forward proxy: %v", err)
@@ -650,15 +659,26 @@ func TestTheForwardProxyMintsUnderOneEphemeralAuthority(t *testing.T) {
 // Empty intercepts nothing and records nothing; `*` intercepts everything, which
 // is the difference between a recorder and a wiretap and is one character away
 // on the command line.
+//
+// The mapped forms are here for the reason #357 could have broken this without
+// anybody noticing: `*=http://127.0.0.1:4599` is the same wiretap as `*`, and a
+// guard still reading the whole entry rather than the name it cuts out would
+// accept it, because the string no longer equals "*". The wiretap would then be
+// one that files everything it decrypts into a transcript on the operator's own
+// disk.
 func TestAForwardProxyRefusesAnUnusableHostSet(t *testing.T) {
 	writer := proxy.NewWriter(io.Discard, 0)
 	defer func() { _ = writer.Close() }()
 
 	for name, hosts := range map[string][]string{
-		"none":             nil,
-		"blank":            {"  ", ""},
-		"everything":       {"*"},
-		"everything twice": {"api.scaleway.test", "*.*"},
+		"none":                       nil,
+		"blank":                      {"  ", ""},
+		"everything":                 {"*"},
+		"everything twice":           {"api.scaleway.test", "*.*"},
+		"everything, mapped":         {"*=http://127.0.0.1:4599"},
+		"everything, mapped, spaced": {" * = http://127.0.0.1:4599 "},
+		"everything twice, mapped":   {"api.scaleway.test", "*.*=http://127.0.0.1:4599"},
+		"a target and no host":       {"=http://127.0.0.1:4599"},
 	} {
 		t.Run(name, func(t *testing.T) {
 			if _, err := proxy.NewForward(proxy.ForwardOptions{Hosts: hosts, Writer: writer}); err == nil {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -34,6 +34,7 @@
 package proxy
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
@@ -155,6 +156,22 @@ func newProxy(o Options, forward bool) (*Proxy, error) {
 				// to a fixed upstream is precisely what a forward proxy must not
 				// do, and honouring it in the other mode would turn --upstream
 				// into an open relay for anything that reaches the port.
+				if reoriginated(pr.In) {
+					// Except for the authority, when --forward sent this host
+					// somewhere it never asked for (#357). Clearing Out.Host is
+					// what SetURL does in the other mode, and it makes net/http
+					// address the target by its own name — which the target
+					// generally requires: feint's own rebinding guard answers
+					// 403 to a Host it does not recognise, so every request of a
+					// mapped run would be a refusal.
+					//
+					// The record is untouched by this: capture reads the
+					// inbound request, and ReverseProxy clones before rewriting.
+					// TestAMappedTunnelRecordsTheHostTheClientAsked asserts both
+					// halves — the target addressed as itself, the transcript
+					// naming the host the client asked for.
+					pr.Out.Host = ""
+				}
 				return
 			}
 			// SetURL and nothing else. SetXForwarded is what a reverse proxy in
@@ -167,6 +184,25 @@ func newProxy(o Options, forward bool) (*Proxy, error) {
 		ErrorHandler: p.upstreamFailed,
 	}
 	return p, nil
+}
+
+// reoriginatedKey marks a request a --forward entry sent to a target the client
+// never named.
+//
+// A context value rather than a field, because it is a property of the one
+// request and not of the recorder: the same [Proxy] serves a bare entry and a
+// mapped one in the same run, and only the second may move the authority.
+type reoriginatedKey struct{}
+
+// reoriginate marks r as bound for a target of the operator's choosing.
+func reoriginate(r *http.Request) *http.Request {
+	return r.WithContext(context.WithValue(r.Context(), reoriginatedKey{}, true))
+}
+
+// reoriginated reports whether r was so marked.
+func reoriginated(r *http.Request) bool {
+	value, _ := r.Context().Value(reoriginatedKey{}).(bool)
+	return value
 }
 
 // upstreamFailed answers a request the upstream did not.

--- a/tools/conformance/README.md
+++ b/tools/conformance/README.md
@@ -107,3 +107,23 @@ calls, so this emulator refuses it. See
 
 Credentials are fake, well-formed and deliberately public: the SDKs validate
 their shape even though the emulator ignores their value.
+
+## The recorder, watched by the real clients
+
+Two scripts here have the proxy as their subject rather than a pack. Neither is
+part of `mise run conformance`: recording is a human's job, and the thing worth
+recording — a real cloud — needs an account that will never exist in a runner.
+
+| Script | What it proves |
+|---|---|
+| `proxy.sh` | two observers of one `scw` run agree: what `feint proxy --upstream` wrote down and what `/_feint/conformance` counted inside the emulator are the same set of operations |
+| `forward.sh` | a real client reaching its endpoint **by name** is terminated by `feint proxy --forward`, recorded, and served by the emulator — no namespace, no `/etc/hosts` edit, no privileged port (#357) |
+
+`forward.sh` points `scw` at `https://api.scaleway.test`, and that choice is the
+suite's safety rather than a detail. `.test` is a reserved TLD (RFC 6761): no
+resolver answers for it, so if the proxy is not what carries the traffic — it
+died, the mapping is missing, the client ignored `HTTPS_PROXY` — the run fails
+with `no such host` and nothing leaves the machine. Pointing it at the real
+`api.scaleway.com` would prove the same mechanism while making the proxy the only
+thing between a broken suite and the internet, which is the shape `guard.sh`
+exists to refuse.

--- a/tools/conformance/forward.sh
+++ b/tools/conformance/forward.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# The real client, through a CONNECT, landing on the emulator (#357).
+#
+# `proxy.sh` proves the reverse half: a client pointed at the proxy, forwarded to
+# one upstream. This proves the other one — the half that could not be expressed
+# before #357: a client that reaches its endpoint by *name*, terminated by the
+# forward proxy, recorded, and re-originated to the emulator instead of to the
+# real cloud. No namespace, no /etc/hosts edit, no privileged port: two
+# environment variables and one `=`.
+#
+# **Why the endpoint is a name that cannot resolve.** api.scaleway.test is under
+# a reserved TLD (RFC 6761): no resolver anywhere answers for it. So if the proxy
+# is not what carries this traffic — it died, the mapping is missing, the client
+# ignored HTTPS_PROXY — the run fails with a DNS error and **nothing leaves the
+# machine**. Pointing this at the real api.scaleway.com would prove the same
+# mechanism and would make the proxy the only thing standing between a broken
+# suite and the internet, which is the shape guard.sh exists to refuse.
+#
+# It is not part of `mise run conformance`, for proxy.sh's reasons: recording is
+# a human's job, and this suite's subject is the recorder rather than the pack.
+#
+# Usage: tools/conformance/forward.sh [emulator addr] [proxy addr]
+set -euo pipefail
+
+EMU_ADDR="${1:-127.0.0.1:4701}"
+PROXY_ADDR="${2:-127.0.0.1:4702}"
+ENDPOINT="http://$EMU_ADDR"
+
+# The name the client believes it is talking to. Reserved, unresolvable, and
+# asserted below rather than trusted.
+FAKE_CLOUD="api.scaleway.test"
+
+# shellcheck source=/dev/null
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/guard.sh"
+guard_local "$ENDPOINT"
+
+# The endpoint the client is given is the one thing this suite's safety rests on,
+# so it is asserted rather than assumed. A name outside .test would resolve, and
+# the run would then depend on the proxy to stay offline.
+case "$FAKE_CLOUD" in
+  *.test) ;;
+  *) echo "FAIL: $FAKE_CLOUD is not under the reserved .test TLD, so it may resolve" >&2; exit 1 ;;
+esac
+
+command -v jq >/dev/null 2>&1 || { echo "jq is not installed" >&2; exit 1; }
+command -v scw >/dev/null 2>&1 || { echo "scw is not installed" >&2; exit 1; }
+[ -x ./feint ] || { echo "./feint is not built: run mise run build" >&2; exit 1; }
+
+work="$(mktemp -d)"
+transcript="$work/run.jsonl"
+proxy_pid=""
+cleanup() {
+  [ -n "$proxy_pid" ] && kill "$proxy_pid" 2>/dev/null
+  ./feint stop --addr "$EMU_ADDR" >/dev/null 2>&1
+  rm -rf "$work"
+  return 0
+}
+trap cleanup EXIT
+
+echo "conformance: a real client reaches $FAKE_CLOUD and lands on the emulator"
+echo "- a fresh emulator on $EMU_ADDR"
+./feint start --addr "$EMU_ADDR" --vm off --timeout 60s >"$work/emulator.log" 2>&1 \
+  || { echo "FAIL: the emulator did not start"; cat "$work/emulator.log"; exit 1; }
+
+echo "- forward proxy $PROXY_ADDR, $FAKE_CLOUD -> $ENDPOINT"
+./feint proxy --forward "$FAKE_CLOUD=$ENDPOINT" --addr "$PROXY_ADDR" --record "$transcript" \
+  >"$work/proxy.log" 2>&1 &
+proxy_pid=$!
+
+# The listener is opened, not requested: proxy.sh's reason, and one more here —
+# an HTTP probe of a forward proxy is answered with a 400 telling the caller to
+# set HTTPS_PROXY, which is correct and would still put nothing useful anywhere.
+ready=""
+for _ in $(seq 1 100); do
+  if (exec 3<>"/dev/tcp/${PROXY_ADDR%%:*}/${PROXY_ADDR##*:}") 2>/dev/null; then ready=yes; break; fi
+  sleep 0.1
+done
+[ -n "$ready" ] || { echo "FAIL: the proxy never listened"; cat "$work/proxy.log"; exit 1; }
+
+ca="$(grep -o '/tmp/feint-intercept-ca-[^ ]*\.pem' "$work/proxy.log" | head -1)"
+[ -n "$ca" ] || { echo "FAIL: the proxy named no CA file"; cat "$work/proxy.log"; exit 1; }
+[ -s "$ca" ] || { echo "FAIL: the CA at $ca is empty"; exit 1; }
+
+# Fake but well-formed, the same public values every suite here uses: the SDK
+# validates the shape of a credential even though the emulator ignores its value.
+export SCW_ACCESS_KEY="SCWXXXXXXXXXXXXXXXXX"
+export SCW_SECRET_KEY="11111111-1111-1111-1111-111111111111"
+export SCW_DEFAULT_PROJECT_ID="11111111-1111-1111-1111-111111111111"
+export SCW_DEFAULT_ORGANIZATION_ID="11111111-1111-1111-1111-111111111111"
+export SCW_DEFAULT_ZONE="fr-par-1"
+# The whole point: the client is given a *name*, not this emulator's address, and
+# two environment variables carry it here.
+export SCW_API_URL="https://$FAKE_CLOUD"
+export SSL_CERT_FILE="$ca"
+export HTTPS_PROXY="http://$PROXY_ADDR"
+export https_proxy="http://$PROXY_ADDR"
+export NO_PROXY=""
+export no_proxy=""
+
+echo "- driving scw at https://$FAKE_CLOUD through HTTPS_PROXY"
+created="$(scw instance server create name=forward-1 type=DEV1-S zone=fr-par-1 -o json 2>&1)" \
+  || { echo "FAIL: the CLI did not reach the emulator through the tunnel: $created"; cat "$work/proxy.log"; exit 1; }
+id="$(printf '%s' "$created" | jq -r '.id // empty')"
+[ -n "$id" ] || { echo "FAIL: no id in the create response: $created"; exit 1; }
+scw instance server list zone=fr-par-1 -o json >/dev/null || { echo "FAIL: list rejected"; exit 1; }
+
+# What the emulator itself counted, read before anything is stopped and from
+# outside the tunnel: a transcript alone could be produced by a proxy talking to
+# itself, and this is the second observer that says it was not.
+emu_seen="$(curl -fsS "$ENDPOINT/_feint/conformance" | jq -r '.calls | keys[]' | sort)"
+
+# Stopped before the transcript is read: the writer drains on shutdown, and
+# reading the file while it is still being written is how a comparison becomes a
+# race.
+kill "$proxy_pid"; wait "$proxy_pid" 2>/dev/null || true
+proxy_pid=""
+
+lines="$(wc -l <"$transcript")"
+[ "$lines" -gt 0 ] || { echo "FAIL: nothing was recorded, so nothing below measured anything"; exit 1; }
+echo "  transcript: $lines exchange(s)"
+
+# 1. The transcript names the host the client asked for, never the socket it was
+#    sent to. This is what separates a mapped --forward from --upstream, which
+#    would have recorded 127.0.0.1 and lost the one fact a recording is for.
+hosts="$(jq -r '.host' "$transcript" | sort -u)"
+[ "$hosts" = "$FAKE_CLOUD" ] \
+  || { echo "FAIL: the transcript names host(s) [$hosts], want $FAKE_CLOUD alone" >&2; exit 1; }
+
+# 2. The route table still names operations through the mapped door.
+named="$(jq -r 'select(.operation != null and .operation != "") | .operation' "$transcript" | sort -u)"
+[ -n "$named" ] || { echo "FAIL: no exchange was named, so the table did not reach this door" >&2; exit 1; }
+while IFS= read -r op; do
+  printf '%s\n' "$emu_seen" | grep -qx "$op" \
+    || { echo "FAIL: the proxy recorded $op and the emulator never counted it" >&2; exit 1; }
+done <<<"$named"
+
+# 3. The redaction survives the mapped tunnel. has() first, then the assertion,
+#    so a transcript carrying no such header fails as "measured nothing" rather
+#    than passing by comparing null against the placeholder (proxy.sh's lesson).
+jq -e 'select(.req.headers["X-Auth-Token"] == "REDACTED")' "$transcript" >/dev/null 2>&1 \
+  || { echo "FAIL: no redacted X-Auth-Token anywhere, so the check below measured nothing" >&2; exit 1; }
+if jq -e 'select(.req.headers | has("X-Auth-Token")) | select(.req.headers["X-Auth-Token"] != "REDACTED")' \
+     "$transcript" >/dev/null 2>&1; then
+  echo "FAIL: an X-Auth-Token reached the transcript unredacted" >&2
+  exit 1
+fi
+
+# 4. Nothing in this run went anywhere the operator did not name. A refusal here
+#    would mean the client reached for a host the mapping does not cover, and
+#    that call is absent from the transcript above — the silent gap the whole
+#    allowlist exists to make loud.
+if grep -q "does not name" "$work/proxy.log"; then
+  echo "FAIL: a host was refused in this run, so the transcript is missing calls:" >&2
+  grep "does not name" "$work/proxy.log" >&2
+  exit 1
+fi
+
+echo "conformance: $(printf '%s' "$named" | grep -c .) operation(s) recorded through a CONNECT to $FAKE_CLOUD, served by $ENDPOINT"

--- a/tools/falsify/specs/forward-proxy.json
+++ b/tools/falsify/specs/forward-proxy.json
@@ -11,15 +11,15 @@
     {
       "label": "a CONNECT to a host nobody named is intercepted anyway, and the proxy decrypts whatever else the measured process does",
       "file": "internal/proxy/forward.go",
-      "find": "\thost, port := splitTarget(r.Host)\n\tif !f.intercepts(host) {",
-      "replace": "\thost, port := splitTarget(r.Host)\n\tif !f.intercepts(host) && false {",
+      "find": "\thost, port := splitTarget(r.Host)\n\troute, ok := f.route(host)\n\tif !ok {",
+      "replace": "\thost, port := splitTarget(r.Host)\n\troute, ok := f.route(host)\n\tif !ok && false {",
       "test": "TestAHostNobodyNamedIsNotIntercepted"
     },
     {
       "label": "--forward * is accepted, and the recorder becomes a wiretap on every TLS connection the client makes",
       "file": "internal/proxy/forward.go",
-      "find": "\t\tif h == \"*\" || strings.HasPrefix(h, \"*.*\") {",
-      "replace": "\t\tif (h == \"*\" || strings.HasPrefix(h, \"*.*\")) && false {",
+      "find": "\t\tif name == \"*\" || strings.HasPrefix(name, \"*.*\") {",
+      "replace": "\t\tif (name == \"*\" || strings.HasPrefix(name, \"*.*\")) && false {",
       "test": "TestAForwardProxyRefusesAnUnusableHostSet"
     },
     {
@@ -94,6 +94,63 @@
       "find": "\t\t\tif sensitive(k) && nested != nil && !publishable(nested) {",
       "replace": "\t\t\tif _, container := nested.(map[string]any); container {\n\t\t\t\tvalue[k] = redactValue(nested)\n\t\t\t\tcontinue\n\t\t\t}\n\t\t\tif sensitive(k) && nested != nil && !publishable(nested) {",
       "test": "TestASensitiveContainerIsStillReplacedWholesale"
+    },
+    {
+      "label": "THE MAPPED DOOR: the wildcard guard goes back to reading the whole entry, so `*=http://127.0.0.1:4599` is accepted and the recorder is a wiretap that files everything it decrypts",
+      "file": "internal/proxy/forward.go",
+      "find": "\t\tif name == \"*\" || strings.HasPrefix(name, \"*.*\") {",
+      "replace": "\t\tif (name == \"*\" || strings.HasPrefix(name, \"*.*\")) && name == entry {",
+      "test": "TestAForwardProxyRefusesAnUnusableHostSet"
+    },
+    {
+      "label": "THE MAPPED DOOR: a host nobody named is terminated anyway once an entry carries a target, so naming one target widens the allowlist to everything",
+      "file": "internal/proxy/forward.go",
+      "find": "\thost, port := splitTarget(r.Host)\n\troute, ok := f.route(host)\n\tif !ok {",
+      "replace": "\thost, port := splitTarget(r.Host)\n\troute, ok := f.route(host)\n\tif !ok && false {",
+      "test": "TestAMappedRouteDoesNotWidenTheAllowlist"
+    },
+    {
+      "label": "THE MAPPED DOOR: the recording stops redacting on the path that lands on the emulator, and a live tenant key is written into the transcript there instead",
+      "file": "internal/proxy/record.go",
+      "find": "\tredactExchange(&x)\n\treturn Redacted{x: x}",
+      "replace": "\tif false {\n\t\tredactExchange(&x)\n\t}\n\treturn Redacted{x: x}",
+      "test": "TestAMappedTunnelRecordsTheHostTheClientAsked"
+    },
+    {
+      "label": "the transcript names the socket the traffic was sent to instead of the host the client asked for, which is --upstream in disguise: a recording of a session against 127.0.0.1",
+      "file": "internal/proxy/forward.go",
+      "find": "\t\t\tr.URL.Scheme = dest.Scheme\n\t\t\tr.URL.Host = dest.Host",
+      "replace": "\t\t\tr.URL.Scheme = dest.Scheme\n\t\t\tr.URL.Host = dest.Host\n\t\t\tr.Host = dest.Host",
+      "test": "TestAMappedTunnelRecordsTheHostTheClientAsked"
+    },
+    {
+      "label": "a refused connection stops naming the host that is missing from --forward, and an API family living on another host reads as the client failing to connect",
+      "file": "internal/proxy/forward.go",
+      "find": "func missingEntry(host string) string {\n\treturn fmt.Sprintf(",
+      "replace": "func missingEntry(host string) string {\n\tif host != \"\\x00never\" {\n\t\treturn \"feint proxy: this proxy intercepts only the hosts --forward names\\n\"\n\t}\n\treturn fmt.Sprintf(",
+      "test": "TestARefusalNamesTheEntryThatIsMissing"
+    },
+    {
+      "label": "a target may carry a path, which the proxy then prepends to every request while the transcript records the client's own request line: a rewrite invisible in the recorder's own output",
+      "file": "internal/proxy/forward.go",
+      "find": "\tif target.User != nil || strings.Trim(target.Path, \"/\") != \"\" || target.RawQuery != \"\" || target.Fragment != \"\" {",
+      "replace": "\tif (target.User != nil || strings.Trim(target.Path, \"/\") != \"\" || target.RawQuery != \"\" || target.Fragment != \"\") && false {",
+      "test": "TestAForwardTargetMustNameASocket"
+    },
+    {
+      "label": "THE MAPPED DOOR: --expose-to-network lifts the refusal for a mapped forward proxy, which offers its own authority and its transcript to the network",
+      "file": "internal/cli/proxy.go",
+      "find": "\tif forward && expose {",
+      "replace": "\tif forward && expose && false {",
+      "test": "TestProxyRefusesAnUnusableInvocation",
+      "package": "./internal/cli/"
+    },
+    {
+      "label": "THE MAPPED DOOR: the outbound authority is left as the host the client asked for, so every request of a mapped run is refused by the emulator's own rebinding guard and the recording is a transcript of 403s",
+      "file": "internal/proxy/proxy.go",
+      "find": "\t\t\t\tif reoriginated(pr.In) {",
+      "replace": "\t\t\t\tif reoriginated(pr.In) && false {",
+      "test": "TestAMappedTunnelRecordsTheHostTheClientAsked"
     }
   ]
 }


### PR DESCRIPTION
## #346 — the answer is **yes**, and it moves a door that was closed on an assumption

**Terraform's Scaleway S3 client honours `HTTPS_PROXY`.** Measured on Linux,
terraform 1.15.4 with `scaleway/scaleway 2.81.0`, a `scaleway_object_bucket`
apply against this repository's own emulator. No real endpoint, no account.

```json
{"seq":1,"method":"PUT","path":"/",
 "host":"feint-346-measurement.s3.fr-par.scw.cloud","status":404,"mounted":false,
 "req":{"headers":{"User-Agent":"aws-sdk-go-v2/… api/s3#1.107.0 terraform-provider-scaleway/2.81.0"}}}
```

`PUT /` is `CreateBucket` in virtual-host style, and the `404` is **feint**
answering — no pack claims that route — not a cloud.

**The distinction the issue demanded, with the control that proves it.** Same
apply, against a proxy that does *not* name the S3 host:

```
recorded 0 exchange(s) / 0 tunnel(s) terminated
12 connection(s) were refused because --forward does not name their host
```

Twelve `CONNECT`s **arrived and were turned down** — that is *"arrived, then
refused"*. *"Did not honour the proxy"* would have left the proxy with no
`CONNECT` at all and the client complaining about a certificate, which is what
macOS produces, and why this was measured on Linux.

Consequence, written into `docs/limits.md`: **the object-storage refusal now
stands on its coverage argument alone** — one product, one client, an S3 surface
nobody has costed — and no longer on any part of the redirect being hard. The
roadmap paragraph calling this unmeasured is retired. Reopening the product
stays a separate decision.

## #357 — the two useful things now combine

`--forward api.scaleway.com=http://127.0.0.1:4599` terminates, records, and
re-originates **to the emulator**. A bare entry still goes to the real host, and
both forms mix in one run.

Proved with real clients:

- **terraform**, whose S3 endpoint is compiled into the provider, recorded
  against the emulator with **no namespace, no `/etc/hosts` edit, no privileged
  port** — the #346 run above;
- **`scw`**, through the new `tools/conformance/forward.sh`: 7 operations
  recorded through a `CONNECT` to `api.scaleway.test`, each also counted by
  `/_feint/conformance`, token redacted. That name **cannot resolve** — verified
  `no such host` without the proxy — so a broken run fails offline instead of
  reaching a cloud, which is `guard.sh`'s doctrine rather than trusting the
  proxy to stay up.

## A premise that did not survive contact with the emulator

The issue assumed *"only the socket goes elsewhere"*. The first run landed on
feint and got **403 on every request** from `rebinding.go`, which refuses a
`Host` it does not recognise.

So a mapped entry must move the **outbound** `Host` to the target's authority —
while the transcript still records the client's, because `capture` reads the
inbound request and `ReverseProxy` clones before rewriting. A bare entry is
untouched, so a SigV4 signature over `Host` still verifies against the real
host.

Without that, the acceptance criterion *"reaches the emulator and is recorded"*
would have been satisfied on a technicality: a transcript of refusals.

## The four security requirements, each falsified again at the new door

`tools/falsify/specs/forward-proxy.json` is now **21 mutations**, all compiling,
all turning their named test red.

1. **Redaction survives interception** — neutered → its named test red.
2. **Loopback only**, `--expose-to-network` still **refused** with `--forward` —
   and that test now carries a *mapped* invocation.
3. **Ephemeral authority**, never installed — unchanged, still red.
4. **Bounded interception** — two new: the wildcard guard reading the whole
   entry again, so `*=http://…` would slip through; and a mapped route widening
   the allowlist.

**No new path to any of the four.** The `=` is cut out *before* the wildcard is
looked for — the one ordering this feature could have broken silently, and it
has its own mutation. Three more guard #357's own claims: a transcript naming
the socket instead of the requested host (`--upstream` in disguise), a target
carrying a path (an invisible rewrite), and a refusal that stops naming the
missing entry.

## A deviation from the brief, argued

**`cliSurfaceVersion` stays at 9.** #357 adds no subcommand and no flag — only a
value grammar on the existing `--forward` — and the frozen surface records flag
*names*, not usage strings. Both surface tests are green unchanged. Bumping it
would have been a version claim with nothing behind it.

## Not measured

macOS (no Darwin host; `SSL_CERT_FILE` stays documented as Linux-only for this
recipe), Pépin's own collectors (not on this station — terraform's S3 client is
the harder case anyway), and the real cloud: both runs targeted loopback, and
the negative case was contained by a target that cannot resolve.

## Related

Closes #346
Closes #357