### PR TITLE
feat(corpus): a committed recording is reissued at the provider, and what the cloud answers differently now is reported (#359)

### DIFF
--- a/.github/workflows/corpus-cloud.yml
+++ b/.github/workflows/corpus-cloud.yml
@@ -1,0 +1,241 @@
+name: Corpus against the cloud
+
+# The drift no SDK scan can see (#359).
+#
+# .github/workflows/drift.yml reads the providers' generated SDKs every Monday and reports an
+# operation that appeared or disappeared. It sees that a method exists; it sees nothing of what
+# the method answers. A status that moves from 200 to 201, a field that appears or goes, a list
+# that reorders, a refusal that stops being one — the Go signature is identical before and after,
+# the baseline stays green, and this emulator goes on serving what the cloud stopped answering.
+# #270 measured three of those in one read of one private network.
+#
+# So this job reissues a committed corpus at the provider it was recorded from, and opens a pull
+# request when the answers have moved. Same shape as drift.yml, deliberately: one mechanism for
+# "something upstream changed", not two.
+#
+# WHAT MAKES THIS DIFFERENT FROM EVERY OTHER WORKFLOW HERE, AND WHY IT IS NOT ON PULL REQUESTS
+#
+# It authenticates against a real Scaleway account, and it creates real objects. That is three
+# reasons it can never be a gate: it needs a credential, its verdict depends on whose account ran
+# it, and a create is a resource somebody pays for. `mise run conformance` is already outside the
+# pre-commit hook for a weaker version of the same argument, and CLAUDE.md is explicit that a gate
+# people skip by habit is worse than no gate.
+#
+# The account rules live in tools/corpus/cloud.sh and are not restated here — one file, two
+# callers, for the reason tools/drift/gate.sh gives: the same procedure written twice drifts, and
+# the copy that drifts is the one that touches somebody's account.
+
+on:
+  schedule:
+    - cron: '41 6 1 * *'   # the 1st of each month, 06:41 UTC
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  replay:
+    name: Reissue the Scaleway corpus at Scaleway
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      moved: ${{ steps.replay.outputs.moved }}
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.26.6'
+          cache: false
+
+      # Asserted, never skipped. A job that quietly did nothing when the credential was absent
+      # would report success on every run and measure the provider on none of them — the SKIP that
+      # measures nothing, which this repository has shipped once and refuses to ship again.
+      #
+      # So the first scheduled run on a repository without these secrets is RED, and that is the
+      # honest state: this measurement is configured nowhere. Adding SCW_SECRET_KEY,
+      # SCW_DEFAULT_PROJECT_ID and SCW_DEFAULT_ORGANIZATION_ID is a decision the account holder
+      # makes, and a silent green would be this workflow making it for them.
+      - name: The account this run measures must be named
+        env:
+          SECRET: ${{ secrets.SCW_SECRET_KEY }}
+          ACCESS: ${{ secrets.SCW_ACCESS_KEY }}
+          PROJECT: ${{ secrets.SCW_DEFAULT_PROJECT_ID }}
+          ORGANISATION: ${{ secrets.SCW_DEFAULT_ORGANIZATION_ID }}
+        run: |
+          missing=""
+          [ -n "$SECRET" ]       || missing="$missing SCW_SECRET_KEY"
+          [ -n "$ACCESS" ]       || missing="$missing SCW_ACCESS_KEY"
+          [ -n "$PROJECT" ]      || missing="$missing SCW_DEFAULT_PROJECT_ID"
+          [ -n "$ORGANISATION" ] || missing="$missing SCW_DEFAULT_ORGANIZATION_ID"
+          if [ -n "$missing" ]; then
+            echo "This workflow reissues a committed corpus at a real Scaleway account and has no" >&2
+            echo "account to reissue it at. Add these repository secrets, or disable the schedule:" >&2
+            echo "  $missing" >&2
+            echo "Nothing was sent anywhere." >&2
+            exit 1
+          fi
+
+      - name: Install the Scaleway CLI
+        run: |
+          set -euo pipefail
+          version="2.56.3"
+          url="https://github.com/scaleway/scaleway-cli/releases/download/v${version}/scaleway-cli_${version}_linux_amd64"
+          curl --fail --silent --show-error --location "$url" -o "$RUNNER_TEMP/scw"
+          chmod +x "$RUNNER_TEMP/scw"
+          echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
+
+      - name: Build feint
+        run: go build -o "$RUNNER_TEMP/feint" ./cmd/feint
+
+      # One profile, named on every command. The rule corpus/README.md states for Outscale and
+      # that applies everywhere: a config holding exactly one profile means there is no `default`
+      # to fall back to, and no stored profile of anybody's station a code path nobody read can
+      # present instead.
+      - name: Write the one profile this run may use
+        env:
+          SCW_ACCESS_KEY: ${{ secrets.SCW_ACCESS_KEY }}
+          SCW_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}
+          SCW_DEFAULT_PROJECT_ID: ${{ secrets.SCW_DEFAULT_PROJECT_ID }}
+          SCW_DEFAULT_ORGANIZATION_ID: ${{ secrets.SCW_DEFAULT_ORGANIZATION_ID }}
+        run: |
+          set -euo pipefail
+          umask 077
+          mkdir -p "$RUNNER_TEMP/scw"
+          cat > "$RUNNER_TEMP/scw/config.yaml" <<'YAML'
+          profiles:
+            corpus:
+          YAML
+          {
+            printf '    access_key: %s\n' "$SCW_ACCESS_KEY"
+            printf '    secret_key: %s\n' "$SCW_SECRET_KEY"
+            printf '    default_project_id: %s\n' "$SCW_DEFAULT_PROJECT_ID"
+            printf '    default_organization_id: %s\n' "$SCW_DEFAULT_ORGANIZATION_ID"
+            printf '    default_region: fr-par\n'
+            printf '    default_zone: fr-par-1\n'
+          } >> "$RUNNER_TEMP/scw/config.yaml"
+
+      # --mark-stale is what makes the pull request below carry something real. A cloud that moved
+      # changes no source file by itself; what it does change is the standing of a committed
+      # recording, and corpus/accepted.json is where that is written down.
+      - name: Reissue every Scaleway corpus
+        id: replay
+        env:
+          SCW_CONFIG_PATH: ${{ runner.temp }}/scw/config.yaml
+          FEINT_SCW_PROFILE: corpus
+        run: |
+          set -uo pipefail
+          status=0
+          for corpus in corpus/scaleway/*.jsonl; do
+            echo "::group::$corpus"
+            tools/corpus/cloud.sh "$RUNNER_TEMP/feint" "$corpus" --mark-stale || status=$?
+            echo "::endgroup::"
+          done
+          if [ -n "$(git status --porcelain corpus/accepted.json)" ]; then
+            echo "moved=true" >> "$GITHUB_OUTPUT"
+            {
+              echo '## The cloud answers differently from the committed corpus'
+              echo '```diff'
+              git diff -- corpus/accepted.json
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "moved=false" >> "$GITHUB_OUTPUT"
+            echo 'The committed Scaleway corpus still describes what the cloud answers.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+          # Exit 2 is "the cloud moved", which the pull request below is the response to, so it is
+          # not a failure of this job. Exit 1 is "a call could not be made", which is.
+          [ "$status" != 2 ] || status=0
+          exit "$status"
+
+      - name: The account must be as it was found
+        if: always()
+        env:
+          SCW_CONFIG_PATH: ${{ runner.temp }}/scw/config.yaml
+        run: |
+          set -uo pipefail
+          left=0
+          for kind in "vpc private-network" "vpc vpc" "iam ssh-key"; do
+            # shellcheck disable=SC2086
+            names="$(scw --profile corpus $kind list -o json | grep -c 'feint-corpus-' || true)"
+            [ "$names" = "0" ] || { echo "$kind still holds $names feint-corpus-* object(s)" >&2; left=1; }
+          done
+          exit "$left"
+
+      - name: Upload the marked acceptance file
+        if: steps.replay.outputs.moved == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: corpus-acceptance
+          path: corpus/accepted.json
+
+  propose:
+    name: Open the corpus pull request
+    needs: replay
+    if: needs.replay.outputs.moved == 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write        # push the branch
+      pull-requests: write   # open the PR
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The one thing this job does is push a branch, so it keeps the credentials checkout
+          # leaves behind. It downloads an artifact and uploads none, which is the risk that
+          # setting exists for.
+          persist-credentials: true
+
+      - name: Download the marked acceptance file
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: corpus-acceptance
+          path: corpus/
+
+      # gh rather than a third-party PR action: one less dependency with write access to the repo.
+      - name: Open or update the pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          branch="chore/corpus-cloud-drift"
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$branch"
+          git add corpus/accepted.json
+          git commit -m "chore(corpus): the cloud has moved under a committed recording"
+          git fetch origin "+refs/heads/$branch:refs/remotes/origin/$branch" || true
+          git push --force-with-lease origin "$branch"
+          cat > "$RUNNER_TEMP/body.md" <<'BODY'
+          A committed corpus was reissued at the provider it was recorded from and the
+          answers had moved. The diff marks which file and how many findings; the run log
+          names each one with its operation, its path and the kind of change.
+
+          **What this is not.** It is not proof that the provider changed for everybody: a
+          corpus records one account, in one region, at one time, and a difference can
+          equally be that account's quota or a region's rollout. Deciding which is a
+          human's job, and this pull request does not pretend otherwise.
+
+          **What to do with it.** Re-record the corpus (corpus/README.md, *Recording
+          another one*) and delete the `cloud_moved_at` marks the re-recording makes
+          false. If the emulator now answers what the old recording said and the cloud
+          does not, that is a defect of this emulator and gets its own issue with the
+          recording attached.
+          BODY
+          if [ -z "$(gh pr list --head "$branch" --json number --jq '.[0].number')" ]; then
+            gh pr create --head "$branch" \
+              --title "chore(corpus): the cloud answers differently from a committed recording" \
+              --body-file "$RUNNER_TEMP/body.md"
+          fi

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -853,6 +853,22 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Corrigé
 
+- **La porte du corpus retenait son avertissement « le cloud a bougé »
+  précisément quand il servait le plus.** Les deux avertissements — celui de
+  l'enregistrement vieilli et celui de la bougeotte mesurée que #359 réécrit —
+  étaient émis sous la garde des invariants non exercés (#343) et sous celle des
+  exemptions périmées : une exécution rouge pour l'une de ces deux raisons ne
+  disait pas un mot d'un enregistrement sous lequel le fournisseur a été mesuré
+  bouger. C'est le pire moment pour le taire : *ré-enregistrer ce fichier* est
+  un correctif candidat au rouge qu'on est en train de rapporter, et qui ne le
+  voit pas cherche un défaut dans l'émulateur. Aucun des deux ne lit autre chose
+  que le fichier d'acceptation, aucun ne déplace un code de sortie — leur propre
+  commentaire l'énonce comme leur contrat ; un placement tardif ne pouvait donc
+  que les retenir. `warnMovedCorpora` affirmait « à chaque exécution » sans que
+  rien ne le rende vrai :
+  `TestTheMovedWarningSurvivesARunThatIsRedForAnotherReason` le rend vrai, sur
+  l'exécution la plus pauvre qui atteigne l'impression.
+
 - **Quatre défauts du sanitiseur, tous trouvés en enregistrant un deuxième
   fournisseur, et tous du genre qui fabrique une divergence** (#354). À eux
   quatre ils ont caché tout le cycle de vie du réseau privé Exoscale derrière

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -19,6 +19,75 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Ajouté
 
+- **Le corpus commité est maintenant rejoué contre le cloud, et attrape la
+  dérive qu'aucun scan de SDK ne voit** (#359). `feint corpus --against-cloud
+  --file <corpus> --endpoint <url>` réémet un enregistrement commité chez le
+  fournisseur qui l'a produit. Même artefact, même comparateur, conclusion
+  inverse : `corpus --check` le rejoue contre un émulateur neuf et une divergence
+  veut dire *l'émulateur a tort* ; celui-ci le rejoue chez le fournisseur et une
+  divergence veut dire *le cloud a changé*. Il n'y a ni second enregistreur ni
+  seconde comparaison à tenir en phase — `internal/replay` est appelé par les
+  deux, et ce que la seconde direction ajoute est seulement ce qu'un vrai compte
+  exige.
+
+  **C'est précisément ce que `internal/drift` ne peut pas voir.** Le scan de
+  surface lit les SDK générés des fournisseurs et rapporte exactement une
+  opération apparue ou disparue, parce que ces SDK sont générés depuis leur IDL.
+  Il voit qu'une méthode existe ; il ne voit rien de ce qu'elle répond. Un statut
+  qui passe de 200 à 201, un champ qui apparaît ou disparaît, une liste qui
+  change d'ordre, un refus qui n'en est plus un : la signature Go est identique
+  avant et après, la baseline reste verte, et #270 a trouvé trois cas de cette
+  famille dans une seule lecture d'un seul réseau privé.
+
+  **Trois verdicts, jamais confondus** : *le cloud répond différemment* (code 2),
+  *l'enregistrement n'a pas pu être réémis tel quel* (un défaut d'instrument,
+  jamais compté comme un changement) et *l'appel n'a pas pu être fait* (code 1 —
+  un 401, un 429, un 502, ou un garde qui refuse). Le deuxième n'est pas une
+  politesse : #73 a trouvé la redaction du proxy fabriquant neuf fausses
+  divergences, et #354 quatre de plus, dont trois masquaient tout un cycle de
+  vie. Une requête dont le chemin ou une valeur énumérée a été blanchi par
+  l'assainisseur n'est donc jamais réémise, une requête portant encore le
+  `REDACTED` du proxy non plus, et toute divergence dont la requête porte encore
+  une valeur inventée par l'assainisseur est attribuée à l'enregistrement.
+  **Cette dernière règle vient d'une mesure, pas d'une inquiétude** : un
+  `--dry-run` de `scaleway/terraform.jsonl` contre le vrai compte le 2026-08-21 a
+  produit 145 divergences dont aucune n'était le cloud — les créations étaient
+  refusées, donc chaque lecture suivante répondait 404 et chaque champ enregistré
+  manquait.
+
+  **Ce n'est pas un gate et cela ne doit jamais le devenir.** Il faut des
+  identifiants, il crée de vraies ressources, et son verdict dépend du compte qui
+  l'a exécuté : trois raisons là où `conformance` en a une. Il tourne à la
+  demande (`mise run corpus:cloud`) et sur planification
+  (`.github/workflows/corpus-cloud.yml`, le 1er de chaque mois), et ouvre une
+  pull request quand quelque chose a bougé, ce qui est la forme que `drift.yml` a
+  déjà pour la surface. **Ce workflow est rouge tant que le titulaire du compte
+  n'a pas ajouté `SCW_SECRET_KEY`, `SCW_ACCESS_KEY`, `SCW_DEFAULT_PROJECT_ID` et
+  `SCW_DEFAULT_ORGANIZATION_ID`**, délibérément : un job qui ne ferait rien en
+  silence sans eux rapporterait un succès à chaque exécution et ne mesurerait le
+  fournisseur à aucune, ce qui est le SKIP qui ne mesure rien que ce dépôt a
+  livré une fois et refuse de livrer à nouveau.
+
+  Mesuré contre le vrai compte Scaleway le 2026-08-21, le jour même où les deux
+  fichiers ont été enregistrés : `scaleway/terraform.jsonl` a comparé 16 échanges
+  sur 16 et `scaleway/scw-cli.jsonl` 42 sur 58, **zéro divergence disant que le
+  cloud avait bougé**, onze attribuées à l'enregistrement (les chemins blanchis
+  que `corpus/README.md` documente déjà) et cinq à des routes que cet émulateur
+  ne monte pas. Deux faits qu'il vaut mieux ne pas redécouvrir en sont sortis :
+  Scaleway accepte un sous-réseau de réseau privé dans `198.18.0.0/15`, l'espace
+  synthétique que frappe l'assainisseur, et il accepte la clé `ssh-ed25519`
+  synthétique dont le matériel est entièrement à zéro — l'un ou l'autre refusé
+  aurait rendu tout un cycle de vie irrejouable.
+
+- **Le vieillissement d'un corpus est maintenant mesuré et non plus deviné** (la
+  question ouverte de #353, tranchée). Une exécution qui trouve le fournisseur
+  répondant différemment écrit `cloud_moved_at` et `cloud_moved` dans l'entrée de
+  cet enregistrement dans `corpus/accepted.json` (`--mark-stale`), et `corpus
+  --check` avertit alors avec une date mesurée au lieu de l'horizon de 180 jours
+  choisi de mémoire. Il avertit toujours sans jamais échouer, pour la raison
+  qu'il l'a toujours fait : le fichier à changer est l'enregistrement, pas
+  l'émulateur.
+
 - **`--forward` peut dire où atterrit vraiment un hôte terminé** (#357). Une
   entrée de `feint proxy --forward` peut désormais nommer sa cible — `--forward
   'api.scaleway.com=http://127.0.0.1:4599'` — de sorte qu'un client dont
@@ -617,7 +686,54 @@ change ni l'un ni l'autre a sa place dans `git log`.
   vers lequel retomber et aucun profil stocké de la station qui puisse être
   présenté. `corpus/README.md` porte les deux procédures.
 
+### Sécurité
+
+- **Un rejeu contre un vrai compte refuse de toucher ce qu'il n'a pas créé**
+  (#359). Tout identifiant dans le chemin d'une requête qui change l'état doit
+  être un identifiant que les créations de cette exécution ont produit : c'est
+  `mustOwn` appliqué là où se tromper détruit le bien d'autrui, et il le faut
+  parce qu'une requête enregistrée est bien formée par construction, ce qui n'a
+  jamais été la même question qu'autorisée. Une création est refusée si son
+  opération n'est pas sur une liste écrite de ce qui ne coûte rien, et le refus
+  nomme l'opération, pour que le rapport dise quelle mesure est hors de portée
+  sans dépense au lieu de dépenser pour le découvrir. Tout ce qui est créé
+  s'appelle `feint-corpus-*` et est détruit à la sortie depuis un registre armé
+  avant le premier appel, **chaque destruction étant prouvée par une lecture qui
+  répond 404** et non par le code de retour du delete ; un objet qui survit fait
+  échouer l'exécution quelle qu'ait été la comparaison. Une clé secrète voyage
+  par variable d'environnement et jamais dans argv, et est refusée à un point
+  d'entrée en HTTP clair hors loopback.
+
+  **Vingt-deux mutations, toutes falsifiées**
+  (`tools/falsify/specs/corpus-cloud.json`, exécution du 2026-08-21) : retirer la
+  question de propriété et un `DELETE` enregistré supprime le VPC du compte ;
+  retirer la liste des créations gratuites et le compte est facturé pour une
+  mesure ; croire le code de retour du delete et un fournisseur qui supprime en
+  asynchrone laisse l'objet derrière lui sous une exécution verte. Contre le vrai
+  compte le même jour, cinq objets ont été créés et cinq détruits avec chaque
+  destruction prouvée par une lecture, et l'inventaire pris avant chaque
+  exécution correspondait à celui pris après.
+
 ### Modifié
+
+- **`internal/replay` a gagné les deux coutures qu'un vrai compte exige, et rien
+  d'autre** (#359). `Options.Guard` est consulté avant chaque envoi — sur la
+  requête *après* rebinding, la seule forme qu'il vaille la peine de juger,
+  puisqu'un `DELETE` enregistré nomme l'identifiant que le cloud a frappé la fois
+  précédente — et reçoit chaque réponse. `Options.Bind` amorce la table de
+  rebinding avant la première requête, ce qui est ce qui rend rejouable un
+  enregistrement qui s'ouvre sur une création :
+  `corpus/scaleway/terraform.jsonl` commence par un POST portant un `project_id`
+  qui n'appartient à aucun compte visé. Un échange refusé est `Refused` : jamais
+  une correspondance, jamais une divergence, parce que l'appel n'a pas été fait.
+  Un rejeu contre cet émulateur ne passe ni garde ni amorce, donc `feint corpus
+  --check` et `feint replay` sont inchangés.
+
+- **La surface CLI passe en version 10.** `corpus` gagne `--against-cloud`,
+  `--file`, `--endpoint`, `--credential`, `--bind`, `--format`, `--timeout`,
+  `--dry-run` et `--mark-stale`. Des ajouts sur un verbe existant ; rien n'a été
+  retiré, aucun code de sortie n'a bougé, et un pipeline calé sur la version 9
+  continue de fonctionner.
 
 - **Surface CLI version 8.** Toutes les entrées ci-dessus sont des ajouts : le
   verbe `replay` avec `--endpoint`, `--format` et `--timeout`, `coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,69 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Added
 
+- **The committed corpus is now replayed at the cloud, and catches the drift no
+  SDK scan can see** (#359). `feint corpus --against-cloud --file <corpus>
+  --endpoint <url>` reissues a committed recording at the provider it was
+  recorded from. Same artefact, same comparator, opposite conclusion: `corpus
+  --check` replays it against a fresh emulator and a divergence means *the
+  emulator is wrong*; this replays it at the provider and a divergence means
+  *the cloud has changed*. There is no second recorder and no second comparison
+  to keep in step — `internal/replay` is called by both, and what the second
+  direction adds is only what a real account demands.
+
+  **This is what `internal/drift` cannot see.** The surface scan reads the
+  providers' own generated SDKs and reports an operation that appeared or
+  disappeared, exactly, because those SDKs are generated from their IDL. It sees
+  that a method exists; it sees nothing of what the method answers. A status
+  that moves from 200 to 201, a field that appears or goes, a list that
+  reorders, a refusal that stops being one — the Go signature is identical
+  before and after, the baseline stays green, and #270 found three of that
+  family in one read of one private network.
+
+  **Three verdicts, never blurred**: *the cloud answers differently* (exit 2),
+  *the recording could not be reissued as recorded* (an instrument defect, never
+  counted as a change), and *the call could not be made* (exit 1 — a 401, a 429,
+  a 502, or a guard refusing). The middle one is not a courtesy: #73 found the
+  proxy's own redaction manufacturing nine false divergences and #354 four more,
+  three of which hid an entire lifecycle. So a request whose path or enumerated
+  query value the sanitiser blanked is never reissued, one still carrying the
+  recorder's `REDACTED` is never reissued, and a finding whose request still
+  holds a value the sanitiser minted is attributed to the recording. **That last
+  rule came from a measurement, not a worry**: dry-running
+  `scaleway/terraform.jsonl` at the real account on 2026-08-21 produced 145
+  findings, not one of them the cloud — the creates were refused, so every read
+  that followed answered 404 and every recorded field read as absent.
+
+  **It is not a gate and must not become one.** It needs a credential, it creates
+  real objects, and its verdict depends on whose account ran it — three reasons
+  where `conformance` has one. It runs on demand (`mise run corpus:cloud`) and on
+  a schedule (`.github/workflows/corpus-cloud.yml`, the first of each month),
+  opening a pull request when something moved, which is the shape `drift.yml`
+  already has for the surface. **That workflow is red until the account holder
+  adds `SCW_SECRET_KEY`, `SCW_ACCESS_KEY`, `SCW_DEFAULT_PROJECT_ID` and
+  `SCW_DEFAULT_ORGANIZATION_ID`**, deliberately: a job that quietly did nothing
+  without them would report success on every run and measure the provider on
+  none, which is the SKIP that measures nothing this repository has shipped once
+  and refuses to ship again.
+
+  Measured against the real Scaleway account on 2026-08-21, the day both files
+  were recorded: `scaleway/terraform.jsonl` compared 16 of 16 exchanges and
+  `scaleway/scw-cli.jsonl` 42 of 58, **zero findings saying the cloud had
+  moved**, eleven attributed to the recording (the blanked paths `corpus/README.md`
+  already documents) and five to routes this emulator does not mount. Two facts
+  worth not rediscovering came out of it: Scaleway accepts a private-network
+  subnet inside `198.18.0.0/15`, the synthetic space the sanitiser mints, and it
+  accepts the synthetic `ssh-ed25519` key whose material is all zeroes — either
+  one refusing would have made a whole lifecycle unreplayable.
+
+- **How a corpus ages is now measured rather than guessed** (#353's open
+  question, answered). A run that finds the provider answering differently
+  writes `cloud_moved_at` and `cloud_moved` back into that recording's entry in
+  `corpus/accepted.json` (`--mark-stale`), and `corpus --check` then warns with a
+  date somebody measured instead of the 180-day horizon somebody picked. It still
+  warns and never fails, for the reason it always did: the file to change is the
+  recording, not the emulator.
+
 - **`--forward` can say where a terminated host actually goes** (#357). An entry
   of `feint proxy --forward` may now name its target — `--forward
   'api.scaleway.com=http://127.0.0.1:4599'` — so a client whose endpoint is
@@ -583,7 +646,50 @@ what this project is judged on: **a response shape a client can observe**, and
   no default to fall back to and no stored profile of the station can be
   presented. `corpus/README.md` carries both procedures.
 
+### Security
+
+- **A replay against a real account refuses to touch what it did not create**
+  (#359). Every identifier in the path of a state-changing request has to be one
+  this run's own creates minted — `mustOwn` applied where getting it wrong
+  destroys somebody's property, and it is needed because a recorded request is
+  well formed by construction, which was never the same question as authorised.
+  A create is refused unless its operation is on a written-down list of what
+  costs nothing, and the refusal names the operation, so the report says which
+  measurement is out of reach without spending rather than spending to find out.
+  Everything created is named `feint-corpus-*` and destroyed at exit from a
+  ledger armed before the first call, with **each destruction proved by a read
+  answering 404** rather than by the delete's own answer; an object that survives
+  fails the run whatever the comparison found. A credential travels by
+  environment variable and never in argv, and is refused outright to a
+  plain-HTTP endpoint off loopback.
+
+  **Twenty-two mutations, all of them falsified**
+  (`tools/falsify/specs/corpus-cloud.json`, run of 2026-08-21): remove the
+  ownership question and a recorded `DELETE` removes an account's own VPC; remove
+  the free-to-create list and the account is billed to make a measurement;
+  believe the delete's own answer and a provider that deletes asynchronously
+  leaves the object behind under a green run. Against the real account the same
+  day, five objects were created and five destroyed with every destruction proved
+  by a read, and the inventory taken before each run matched the one taken after.
+
 ### Changed
+
+- **`internal/replay` gained the two seams a real account needs, and nothing
+  else** (#359). `Options.Guard` is asked before every request goes out — on the
+  request *after* rebinding, which is the only form worth judging, since a
+  recorded `DELETE` names the identifier the cloud minted last time — and is
+  handed every answer that comes back. `Options.Bind` seeds the rebinding table
+  before the first request, which is what makes a recording that opens on a
+  create replayable at all: `corpus/scaleway/terraform.jsonl` starts with a POST
+  carrying a `project_id` that belongs to no account the replay is pointed at. A
+  refused exchange is `Refused` — never a match, never a divergence, because the
+  call was not made. Replaying at this emulator passes neither guard nor seed, so
+  `feint corpus --check` and `feint replay` are unchanged.
+
+- **The CLI surface is version 10.** `corpus` gains `--against-cloud`, `--file`,
+  `--endpoint`, `--credential`, `--bind`, `--format`, `--timeout`, `--dry-run`
+  and `--mark-stale`. Additions to one existing verb; nothing was removed, no
+  exit code moved, and a pipeline keyed on version 9 keeps working.
 
 - **CLI surface version 8.** Every entry above is an addition — the verb
   `replay` with `--endpoint`, `--format` and `--timeout`, `coverage --observed`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -802,6 +802,21 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Fixed
 
+- **The corpus gate withheld its "the cloud has moved" warning exactly when it
+  mattered most.** Both warnings — the aged-recording one and the measured-move
+  one #359 writes back — were emitted below the unexercised-invariant guard
+  (#343) and below the stale-exemption guard, so a run that went red for either
+  reason printed no word about a recording the provider has been measured to
+  have moved under. That is the worst moment to withhold it: *re-record this
+  file* is a candidate fix for the very redness being reported, and a maintainer
+  who does not see it goes looking for a defect in the emulator instead. Neither
+  warning reads anything but the acceptance file and neither moves an exit code,
+  which their own doc comments state as their contract; the only thing a late
+  placement could do was withhold them. `warnMovedCorpora` said "on every run"
+  and nothing made it true —
+  `TestTheMovedWarningSurvivesARunThatIsRedForAnotherReason` does, on the
+  poorest run that reaches the print.
+
 - **Four defects of the sanitiser, all found by recording a second provider, and
   all of them the kind that manufactures a divergence** (#354). Between them
   they hid the entire Exoscale private-network lifecycle behind about twenty

--- a/corpus/README.md
+++ b/corpus/README.md
@@ -77,11 +77,118 @@ preference: this gate holds one side of the comparison. A red run says the
 emulator and the recording disagree, and nothing in the process knows which of
 the two moved. Failing on age would be asserting exactly what it cannot measure.
 
-The half that can arbitrate is #359, which replays this corpus against the
-**cloud**. Until it exists, the warning names the file, its age and the
-procedure below, and 180 days is a chosen horizon rather than a measured one:
+The half that can arbitrate is the one below, which replays this corpus against
+the **cloud**. 180 days remains a chosen horizon rather than a measured one —
 about two releases, and short enough that a surface which gained 453 SDK methods
-in twelve months has not silently outrun the file.
+in twelve months has not silently outrun the file — but it is no longer the only
+signal: a run against the provider writes `cloud_moved_at` and `cloud_moved` back
+into the recording's entry, and the gate then warns with a date somebody measured
+instead of a horizon somebody picked. Still a warning, for the same reason: the
+file to change is the recording, not the emulator.
+
+## The other direction: ask the cloud
+
+```bash
+FEINT_SCW_PROFILE=<profile> mise run corpus:cloud -- corpus/scaleway/terraform.jsonl
+```
+
+Same artefact, same comparator, opposite conclusion. `corpus --check` replays a
+recording against a fresh emulator and a divergence means **the emulator is
+wrong**; `corpus --against-cloud` reissues the same file at the provider it was
+recorded from and a divergence means **the cloud has changed**. There is no
+second recorder and no second comparison to keep in step — `internal/replay` is
+called by both, and everything that differs is what a real account demands.
+
+**This is what `internal/drift` cannot see.** The surface scan reads the
+providers' own generated SDKs and reports an operation that appeared or
+disappeared, exactly. It sees that a method exists; it sees nothing of what the
+method answers. A status that moves from 200 to 201, a field that appears or
+goes, a list that reorders, a refusal that stops being one — the Go signature is
+identical before and after, the baseline stays green, and #270 found three of
+that family in one read of one private network.
+
+**It is not a gate and must not become one.** It needs a credential, it creates
+real objects, its verdict depends on whose account ran it. It runs on demand and
+on a schedule (`.github/workflows/corpus-cloud.yml`, the first of each month),
+and opens a pull request when something moved — the shape `drift.yml` already
+has for the surface.
+
+### Three verdicts, and the first reflex is to doubt the instrument
+
+| | |
+|---|---|
+| **the cloud answers differently** | exit 2, and the finding this exists for |
+| **the recording could not be reissued as recorded** | an instrument defect, never counted as a change |
+| **the call could not be made** | exit 1 — a 401, a 429, a 502, or a guard refusing |
+
+The middle one is not a theoretical courtesy. #73 found the proxy's own
+redaction manufacturing nine false divergences and #354 four more, three of which
+hid an entire lifecycle. So the run refuses to reissue a request the sanitiser
+blanked (a path or an enumerated query value), refuses one still carrying the
+recorder's `REDACTED`, and marks any finding whose request still holds a value
+the sanitiser minted — because a corpus is a causal sequence, and a read whose
+create did not happen addresses an identifier that exists nowhere.
+
+That last rule was written because of a measurement, not a worry. Dry-running
+`scaleway/terraform.jsonl` at the real account on 2026-08-21 produced **145
+findings, not one of them the cloud**: the creates were refused by `--dry-run`,
+so every read that followed answered 404 and every recorded field read as absent.
+Grading those as "the provider changed" would have been this tool committing the
+defect it exists to detect.
+
+### What it does to the account, and what it refuses to do
+
+The rules of #352 are mechanical here rather than remembered:
+
+- an **inventory before and after**, compared, and a difference fails the run;
+- **free resources only** — a closed list of operations in
+  `internal/cli/corpus_cloud.go`, each with the reason it costs nothing. An
+  operation absent from it is refused *by name*, so the report says which
+  measurement is out of reach without spending;
+- **nothing this run did not create is ever deleted or reconfigured**: every
+  identifier in the path of a state-changing request has to be one this run's own
+  creates minted. That is `mustOwn` applied where getting it wrong destroys
+  somebody's property, and well-formed was never the same question as authorised;
+- everything is named **`feint-corpus-*`**, so an object an aborted run left
+  behind is identifiable in a console by eye;
+- a **ledger destroyed at exit**, armed before the first call, with each
+  destruction **proved by a read answering 404** — never by the delete's own
+  answer. An object that survives makes the run fail, whatever the comparison
+  found;
+- the **profile is named on every single command**, and the secret key travels by
+  environment variable and never in argv.
+
+### What the first run found, on 2026-08-21
+
+Both Scaleway files were reissued at `https://api.scaleway.com`, the same day
+they were recorded, against the same account:
+
+| file | compared | the cloud moved | the recording | not measured | unserved |
+|---|---|---|---|---|---|
+| `scaleway/terraform.jsonl` | 16 of 16 | 0 | 0 | 0 | 0 |
+| `scaleway/scw-cli.jsonl` | 42 of 58 | 0 | 11 | 0 | 5 |
+
+**Nothing had moved, and at zero days old that is the expected answer rather
+than an impressive one.** What the run does prove is that the loop closes: five
+objects created across the two files (two VPCs, two private networks, one IAM SSH
+key), five destroyed, every destruction proved by a read answering 404, and both
+inventories identical before and after. The eleven under *the recording* are the
+blanked paths this directory already documents below, reported as the instrument
+and never as the cloud.
+
+Two things were measured on the way and are worth writing down rather than
+rediscovering: Scaleway accepts a private-network subnet inside `198.18.0.0/15`,
+which is the synthetic space the sanitiser mints, and it accepts the synthetic
+`ssh-ed25519` key whose material is all zeroes. Neither was obvious, and either
+one refusing would have made a whole lifecycle unreplayable.
+
+### The honest limit
+
+A corpus records one account, in one region, at one time. A difference it
+reports may be the cloud changing for everybody, or one account's quota, or a
+region's rollout. **The tool reports what it measured; deciding which of the
+three it is remains a human's job**, and the report says so on every run rather
+than pretending otherwise.
 
 ## What is here
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -115,11 +115,19 @@ const (
 // not be read or that compared nothing. A pipeline keyed on version 8 keeps
 // working.
 //
+// Version 10 adds the second direction of that same comparison (#359):
+// `corpus --against-cloud`, with --file, --endpoint, --credential, --bind,
+// --format, --timeout, --dry-run and --mark-stale. The corpus is reissued at the provider it
+// was recorded from, where a divergence means the *cloud* moved rather than the
+// emulator — the half `corpus --check` cannot hold, being one side of a
+// comparison. Additions to one existing verb; nothing was removed, no exit code
+// moved, and a pipeline keyed on version 9 keeps working.
+//
 // The surface itself is frozen in testdata/frozen/cli.json, compared by
 // TestTheFrozenSurfacesStillMatchTheirFixture, and a fixture regenerated
 // without bumping this constant fails TestASurfaceChangeDemandsItsVersionBump.
 // The procedure for a deliberate change is in RELEASING.md ("Frozen surfaces").
-const cliSurfaceVersion = 9
+const cliSurfaceVersion = 10
 
 // Run executes one command and returns the process exit code.
 func Run(args []string, stdout, stderr io.Writer) int {
@@ -369,6 +377,22 @@ Usage:
                     pass. An ageing recording warns and never fails: this gate
                     holds one side of the comparison and cannot tell a cloud
                     that moved from an emulator that broke.
+                   --against-cloud --file <corpus> --endpoint <url>
+                   [--credential Header=ENV_VAR] [--bind field=value]
+                   [--format text|json] [--timeout 60s] [--dry-run] [--mark-stale]
+                    The other half of that comparison: reissue one committed
+                    corpus at the cloud it was recorded from, where a divergence
+                    means the CLOUD moved. Never a gate — it spends real calls
+                    on a real account, so it runs on a schedule and on demand.
+                    It creates only what a written-down list says is free,
+                    refuses to delete or reconfigure anything this run did not
+                    create, names everything feint-corpus-*, and destroys its
+                    own ledger at exit with the destruction proved by a read.
+                    Exit 2 when the cloud answers differently, 1 when a call
+                    could not be made. A credential travels by environment
+                    variable, never in argv. --mark-stale writes the finding
+                    into corpus/accepted.json, so the gate above warns with a
+                    measured date instead of a chosen horizon.
 
   feint shapes     <recording.jsonl> --provider <name> [--dir shapes] [--dry-run]
                    [--record [--profile <name>]] [--check]

--- a/internal/cli/corpus.go
+++ b/internal/cli/corpus.go
@@ -321,6 +321,28 @@ func checkCorpus(dir, acceptedPath string, now time.Time, stdout, stderr io.Writ
 	fmt.Fprintf(stdout, "%d divergent finding(s) knowingly accepted, each printed above with its reason\n", excused)
 	fmt.Fprintf(stdout, "%d declared value comparison(s) and %d declared order comparison(s) actually ran\n", values, orders)
 
+	// The two warnings are emitted here, before any early return, and that
+	// placement is the whole point of them.
+	//
+	// Both read `acc` alone: neither depends on a single comparison this run
+	// made, and neither moves an exit code — that is written into their own
+	// doc comments as their contract. So the only thing a later placement can
+	// do is *withhold* them, and it did: they sat below the unexercised-
+	// invariant guard (#343) and below the stale-exemption guard, so a run
+	// that went red for either reason printed no word of the corpus that a
+	// provider has been measured to have moved under. A repository whose gate
+	// is already red is the one that most needs to know its recordings are
+	// stale, because "re-record it" may be the very fix.
+	//
+	// This is the shape CLAUDE.md's "un commentaire n'est pas un contrôle" is
+	// about, one turn further in: the comment on warnMovedCorpora says "on
+	// every run", and there was no test that made it true.
+	// TestTheMovedWarningSurvivesARunThatIsRedForAnotherReason fails without
+	// this placement, and TestACorpusTheCloudHasMovedUnderWarnsAndDoesNotFail
+	// reaches its own subject only because of it.
+	warnAgedCorpora(acc, now, stdout)
+	warnMovedCorpora(acc, stdout)
+
 	// The subject of a declared comparison, asserted rather than hoped for.
 	//
 	// Presence and type are compared everywhere; a value and an order are
@@ -368,9 +390,6 @@ func checkCorpus(dir, acceptedPath string, now time.Time, stdout, stderr io.Writ
 	if stale > 0 {
 		return exitError
 	}
-
-	warnAgedCorpora(acc, now, stdout)
-	warnMovedCorpora(acc, stdout)
 
 	if divergent > 0 {
 		fmt.Fprintf(stderr, "feint: %d divergence(s) between this emulator and the recorded cloud, none of them accepted in %s\n", divergent, acceptedPath)

--- a/internal/cli/corpus.go
+++ b/internal/cli/corpus.go
@@ -69,13 +69,46 @@ const (
 // shape before: the network conformance suite returned SKIP in CI from the day
 // it was written, and five more controls in tools/ui/check-page.py were found
 // measuring nothing in August 2026. **A corpus that replays nothing is red.**
+//
+// # The second direction, and why it is the same command
+//
+//	feint corpus --against-cloud --file scaleway/terraform.jsonl \
+//	  --endpoint https://api.scaleway.com \
+//	  --credential X-Auth-Token=SCW_SECRET_KEY \
+//	  --bind project_id=<project> --bind organization_id=<organisation>
+//
+// reissues one committed corpus at the provider it was recorded from, and a
+// divergence there means *the cloud has changed* (#359). One verb rather than
+// two, because it is one artefact, one comparator and one vocabulary — only the
+// endpoint and the conclusion differ. What the second direction adds is
+// everything a real account demands and an emulator does not, and all of it
+// lives in corpus_cloud.go: a guard that refuses to touch what this run did not
+// create, a closed list of what may be created because it is free, a ledger
+// destroyed at exit with the destruction proved by a read, and three outcomes
+// that are never blurred into one another.
+//
+// It is deliberately **not** a gate: credentials, real objects, real money, a
+// verdict that depends on whose account ran it. It runs on a schedule and on
+// demand, like the Monday drift pull request.
 func corpusCommand(args []string, stdout, stderr io.Writer) int {
 	flags := newFlagSet("corpus")
 	check := flags.Bool("check", false, "replay every committed corpus and fail on a divergence the acceptance list does not carry")
 	dir := flags.String("dir", defaultCorpusDir, "directory of committed corpora, one subdirectory per provider")
 	accepted := flags.String("accepted", defaultCorpusAccepted, "the divergences this repository records rather than fixes, each with its reason")
+	againstCloud := flags.Bool("against-cloud", false, "reissue one committed corpus at the cloud it was recorded from, and report what that cloud answers differently now")
+	file := flags.String("file", "", "the one corpus to reissue, relative to --dir (required with --against-cloud)")
+	endpoint := flags.String("endpoint", "", "the cloud to reissue at, e.g. https://api.scaleway.com (required with --against-cloud)")
+	format := flags.String("format", "text", "output format for --against-cloud: text or json")
+	timeout := flags.Duration("timeout", 60*time.Second, "how long one reissued request may take")
+	dryRun := flags.Bool("dry-run", false, "with --against-cloud, send the reads and refuse everything that would change the account")
+	markStale := flags.Bool("mark-stale", false, "with --against-cloud, write back into the acceptance file that the cloud has moved under this corpus")
+	var credentials, bind repeatable
+	flags.Var(&credentials, "credential", "put a redacted header back, as Header=ENV_VAR; the value never travels in argv (repeatable)")
+	flags.Var(&bind, "bind", "send this value wherever the recording carries an identifier at that field, as field=value (repeatable)")
 	flags.Usage = func() {
 		fmt.Fprint(stderr, "usage: feint corpus --check [--dir corpus] [--accepted corpus/accepted.json]\n")
+		fmt.Fprint(stderr, "       feint corpus --against-cloud --file <corpus> --endpoint <url> [--credential H=ENV] [--bind field=value]\n")
+		fmt.Fprint(stderr, "                    [--dir corpus] [--accepted corpus/accepted.json] [--format text|json] [--timeout 60s] [--dry-run] [--mark-stale]\n")
 		flags.PrintDefaults()
 	}
 	if err := flags.Parse(args); err != nil {
@@ -85,11 +118,36 @@ func corpusCommand(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "feint: unexpected argument %q; corpus takes flags only\n", flags.Arg(0))
 		return exitError
 	}
-	if !*check {
-		fmt.Fprintln(stderr, "feint: corpus has one mode today: --check (see --help)")
+	// Refused rather than silently ordered, because the two directions reach
+	// two different endpoints: one of them creates objects in somebody's
+	// account, and "which one ran" is not a question a reader of the output
+	// should have to answer from the ordering of a switch.
+	if *check && *againstCloud {
+		fmt.Fprintln(stderr, "feint: --check and --against-cloud are the two directions of one comparison; run them one at a time")
 		return exitError
 	}
-	return checkCorpus(*dir, *accepted, time.Now(), stdout, stderr)
+	switch {
+	case *check:
+		return checkCorpus(*dir, *accepted, time.Now(), stdout, stderr)
+	case *againstCloud:
+		creds, err := parseKeyValues("credential", credentials)
+		if err != nil {
+			fmt.Fprintf(stderr, "feint: %v\n", err)
+			return exitError
+		}
+		seeds, err := parseKeyValues("bind", bind)
+		if err != nil {
+			fmt.Fprintf(stderr, "feint: %v\n", err)
+			return exitError
+		}
+		return replayCorpusAtCloud(cloudReplayRequest{
+			dir: *dir, accepted: *accepted, file: *file, endpoint: *endpoint,
+			credentials: creds, bind: seeds, format: *format, timeout: *timeout,
+			dryRun: *dryRun, markStale: *markStale,
+		}, time.Now(), stdout, stderr)
+	}
+	fmt.Fprintln(stderr, "feint: corpus has two modes: --check against a fresh emulator, --against-cloud against the provider (see --help)")
+	return exitError
 }
 
 // corpusAcceptance is the committed judgement on a corpus: when each file was
@@ -124,6 +182,23 @@ type corpusRecording struct {
 	// measurement, and the entry is where that is legible.
 	Client string `json:"client"`
 	Cloud  string `json:"cloud"`
+	// CloudMovedAt and CloudMoved are what `corpus --against-cloud --mark-stale`
+	// writes back, and they are how the two directions of one comparison talk to
+	// each other (#359).
+	//
+	// #353 asked how a corpus ages and could only answer with a chosen horizon —
+	// 180 days, "about two releases" — because this gate holds one side of the
+	// comparison and cannot tell a cloud that moved from an emulator that broke.
+	// The other direction can, so when it finds the provider answering
+	// differently it writes the day and the count here, and the warning below
+	// stops being a guess about age and becomes a measurement.
+	//
+	// Written only when something moved. A clean run writes nothing, which costs
+	// the ability to say "last verified on", and buys a scheduled job that opens
+	// a pull request when there is something to decide and stays silent when
+	// there is not.
+	CloudMovedAt string `json:"cloud_moved_at,omitempty"`
+	CloudMoved   int    `json:"cloud_moved,omitempty"`
 }
 
 // corpusException is one divergence this repository knows about and has decided
@@ -295,6 +370,7 @@ func checkCorpus(dir, acceptedPath string, now time.Time, stdout, stderr io.Writ
 	}
 
 	warnAgedCorpora(acc, now, stdout)
+	warnMovedCorpora(acc, stdout)
 
 	if divergent > 0 {
 		fmt.Fprintf(stderr, "feint: %d divergence(s) between this emulator and the recorded cloud, none of them accepted in %s\n", divergent, acceptedPath)
@@ -562,6 +638,26 @@ type unusableException struct{ key, why string }
 func warnAgedCorpora(acc corpusAcceptance, now time.Time, stdout io.Writer) {
 	for _, name := range agedCorpora(acc.Recorded, now, acc.WarnAfterDays) {
 		fmt.Fprintf(stdout, "warning: %s, and a cloud changes: re-record it (corpus/README.md, \"Recording another one\"), or wait for #359 to say whether it is the cloud that moved\n", name)
+	}
+}
+
+// warnMovedCorpora says which recordings the *cloud* has been measured to have
+// moved under, and changes no exit code either.
+//
+// The same argument as [warnAgedCorpora], one step less speculative: there, the
+// gate warns because a recording is old and a cloud might have moved; here it
+// warns because somebody pointed `corpus --against-cloud` at the provider and it
+// did. Still a warning, because the finding names a file to re-record rather
+// than a defect of this emulator, and a gate that fails on somebody else's
+// change is a gate that gets disabled.
+// TestACorpusTheCloudHasMovedUnderWarnsAndDoesNotFail fails without this.
+func warnMovedCorpora(acc corpusAcceptance, stdout io.Writer) {
+	for _, r := range acc.Recorded {
+		if r.CloudMovedAt == "" || r.CloudMoved == 0 {
+			continue
+		}
+		fmt.Fprintf(stdout, "warning: %s was reissued at %s on %s and %d answer(s) had moved: re-record it (corpus/README.md, \"Recording another one\"), because this file now describes a cloud that no longer answers that way\n",
+			r.File, r.Cloud, r.CloudMovedAt, r.CloudMoved)
 	}
 }
 

--- a/internal/cli/corpus_cloud.go
+++ b/internal/cli/corpus_cloud.go
@@ -1,0 +1,1028 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/corpus"
+	"github.com/stephrobert/feint/internal/proxy"
+	"github.com/stephrobert/feint/internal/replay"
+	"github.com/stephrobert/feint/internal/shape"
+	"github.com/stephrobert/feint/internal/trace"
+)
+
+// The other direction of one comparison (#359).
+//
+// `feint corpus --check` replays a committed corpus against a fresh emulator,
+// and a divergence there means *this emulator is wrong*. `feint corpus
+// --against-cloud` reissues the same file at the provider it was recorded from,
+// and a divergence there means *the cloud has changed*. Same artefact, same
+// comparator, opposite conclusion — and that is the whole design: internal/replay
+// is called by both, so there is no second recorder and no second comparison to
+// keep in step. Everything below is what a real account demands and an emulator
+// does not.
+//
+// # What this catches that internal/drift cannot
+//
+// The surface scan reads the provider's own generated SDK and reports an
+// operation that appeared or disappeared. It sees that a method exists; it sees
+// nothing of what the method answers. A status that moves from 200 to 201, a
+// field that appears, a field that goes, a list that reorders, a refusal that
+// stops being one: the Go signature is identical before and after, the baseline
+// stays green, and this emulator goes on serving what the cloud stopped
+// answering. #270 measured three of those in one read of one private network.
+//
+// # Why it is not a gate
+//
+// It needs a credential, it creates real objects, it costs money and its verdict
+// depends on whose account ran it. `mise run conformance` is outside the
+// pre-commit hook for a weaker version of the same reason, and CLAUDE.md is
+// explicit that a gate people skip by habit is worse than no gate. So this runs
+// on a schedule and on demand, on a maintainer's account, and opens a pull
+// request when something moved — the shape .github/workflows/drift.yml already
+// has for the surface.
+//
+// # The honest limit, stated where the code is rather than only in prose
+//
+// A corpus records one account, in one region, at one time. A difference is the
+// cloud changing for everybody, or one account's quota, or a region's rollout,
+// and **nothing here can tell those apart**. The report says what was measured
+// and names the recording's date; deciding which of the three it is stays a
+// human's job. What the code *does* separate is the three outcomes it must never
+// blur, and [cloudOutcome] is that separation.
+
+// cloudOutcome is what a reported exchange came to when it was reissued at the
+// provider: the three verdicts #359 says must never be blurred into one another.
+//
+// Three and not five, deliberately. An exchange the provider answered exactly as
+// recorded, and one no route of this emulator serves, are *counts* rather than
+// outcomes: nobody acts on either, and giving them a name in this list would put
+// them in the same sentence as a finding somebody has to read. What the
+// arithmetic must never do is sum the three below, which is how "I could not
+// measure" starts reading as "nothing is wrong".
+type cloudOutcome string
+
+const (
+	// cloudMoved: the provider answers differently now. Exit 2 — the finding
+	// this whole direction exists for.
+	cloudMoved cloudOutcome = "the cloud answers differently"
+	// cloudInstrument: the recording cannot be reissued as it was recorded, or
+	// what came back is explained by a value the recorder invented. **Never a
+	// cloud change**, and it is the first thing to suspect rather than the last:
+	// #73 found the proxy's own redaction manufacturing nine false divergences,
+	// and #354 four more, three of which hid an entire lifecycle.
+	cloudInstrument cloudOutcome = "the recording could not be reissued as recorded"
+	// cloudUnmeasured: the call was not made, or came back with an answer that
+	// is about the caller rather than about the resource — an authentication
+	// refusal, a rate limit, a gateway error, a guard that would not let the
+	// request out. An error, never a pass. Exit 1.
+	cloudUnmeasured cloudOutcome = "the call could not be made"
+)
+
+// cloudFinding is one line of the report, and it is written to be actionable
+// without opening a transcript: the operation, the path it went to, what kind of
+// change it is, and how old the recording that says so is.
+type cloudFinding struct {
+	Seq       int          `json:"seq"`
+	Operation string       `json:"operation"`
+	Method    string       `json:"method"`
+	Path      string       `json:"path"`
+	Outcome   cloudOutcome `json:"outcome"`
+	// Detail is [describeFinding]'s sentence, the vocabulary `feint replay`
+	// already uses, or the guard's own refusal.
+	Detail string `json:"detail"`
+	// Instrument names the values the request still carried that the sanitiser
+	// invented, when there were any. It is the caution the three verdicts turn
+	// on: a refusal landing on a request holding a minted address is a defect of
+	// the recording until somebody proves otherwise.
+	Instrument []string `json:"instrument_values,omitempty"`
+	// RecordedAt is the day the corpus was recorded, so a reader can weigh the
+	// finding without going to look the date up.
+	RecordedAt string `json:"recorded_at"`
+	Cloud      string `json:"cloud"`
+}
+
+// cloudReport is the whole run, and the counts are never summed.
+type cloudReport struct {
+	File       string         `json:"file"`
+	RecordedAt string         `json:"recorded_at"`
+	AgeDays    int            `json:"age_days"`
+	Client     string         `json:"client"`
+	Cloud      string         `json:"cloud"`
+	Endpoint   string         `json:"endpoint"`
+	Exchanges  int            `json:"exchanges"`
+	Compared   int            `json:"compared"`
+	Moved      int            `json:"cloud_changed"`
+	Instrument int            `json:"recording_defective"`
+	Unmeasured int            `json:"not_measured"`
+	Unserved   int            `json:"unserved"`
+	Created    int            `json:"created"`
+	Destroyed  int            `json:"destroyed_and_proved"`
+	Findings   []cloudFinding `json:"findings"`
+}
+
+// cloudReplayRequest is what one run needs. A struct rather than eight
+// parameters, because every one of them is a decision somebody has to be able to
+// read back off a command line.
+type cloudReplayRequest struct {
+	dir, accepted, file string
+	endpoint            string
+	// credentials maps a header name to the environment variable holding its
+	// value. The *name* travels on the command line and the value never does:
+	// argv is world-readable on this platform, and a secret key in it is a
+	// secret key in `ps`.
+	credentials map[string]string
+	// bind seeds [replay.Options.Bind]: which project, which organisation.
+	bind    map[string]string
+	format  string
+	timeout time.Duration
+	dryRun  bool
+	// markStale writes the finding back into the acceptance file, which is how
+	// the two directions of one comparison talk to each other: `corpus --check`
+	// then warns with a *measured* date instead of a chosen horizon. See
+	// [corpusRecording.CloudMovedAt].
+	markStale bool
+}
+
+// replayCorpusAtCloud is the command.
+//
+// The return value is named because the ledger runs in a defer and has to be
+// able to move it: an object this run created and could not destroy is a failure
+// of the run, whatever the comparison found, and a report that said "the cloud
+// has not moved" while leaving a resource behind would be the worst possible
+// combination of true and useless.
+func replayCorpusAtCloud(req cloudReplayRequest, now time.Time, stdout, stderr io.Writer) (code int) {
+	if req.file == "" {
+		fmt.Fprintln(stderr, "feint: --against-cloud needs --file naming one committed corpus: a directory of them would be a directory of real calls nobody named")
+		return exitError
+	}
+	if code := checkCloudEndpoint(req.endpoint, len(req.credentials) > 0, stderr); code != exitOK {
+		return code
+	}
+
+	acc, err := readCorpusAcceptance(req.accepted)
+	if err != nil {
+		fmt.Fprintf(stderr, "feint: %v\n", err)
+		return exitError
+	}
+	rel := filepath.ToSlash(req.file)
+	if trimmed, cut := strings.CutPrefix(rel, filepath.ToSlash(req.dir)+"/"); cut {
+		rel = trimmed
+	}
+	// The recording's own entry, and it is mandatory. A replay that cannot say
+	// how old the recording is cannot report a change against it: "the cloud
+	// moved" and "this file describes a cloud of eight months ago" are the same
+	// observation read at two different ages.
+	// TestAnUndatedCorpusIsNotReplayedAtTheCloud fails without this.
+	var rec corpusRecording
+	for _, r := range acc.Recorded {
+		if r.File == rel {
+			rec = r
+		}
+	}
+	if rec.File == "" {
+		fmt.Fprintf(stderr, "feint: %s has no entry in %s saying when it was recorded, so a difference here could not be dated\n", rel, req.accepted)
+		return exitError
+	}
+	at, err := time.Parse(time.DateOnly, rec.At)
+	if err != nil {
+		fmt.Fprintf(stderr, "feint: the recording entry for %s carries no readable date (%q, want YYYY-MM-DD)\n", rel, rec.At)
+		return exitError
+	}
+
+	exs, err := loadTranscript(filepath.Join(req.dir, filepath.FromSlash(rel)))
+	if err != nil {
+		fmt.Fprintf(stderr, "feint: %v\n", err)
+		return exitError
+	}
+	if len(exs) == 0 {
+		fmt.Fprintf(stderr, "feint: %s holds no exchange, so there was nothing to reissue\n", rel)
+		return exitError
+	}
+
+	rep := cloudReport{
+		File: rel, RecordedAt: rec.At, AgeDays: int(now.Sub(at).Hours() / 24),
+		Client: rec.Client, Cloud: rec.Cloud, Endpoint: req.endpoint, Exchanges: len(exs),
+	}
+
+	// Split before anything is sent: an exchange the sanitiser blanked cannot be
+	// addressed at the provider, and sending it would spend a real call on a
+	// path that exists nowhere and then grade the 404 as a change of the cloud.
+	sendable, refusedByShape := splitReplayable(exs)
+	for _, u := range refusedByShape {
+		rep.Findings = append(rep.Findings, cloudFinding{
+			Seq: u.seq, Method: u.method, Path: shape.AnonymisePath(u.path),
+			Outcome: cloudInstrument, Detail: u.why, RecordedAt: rec.At, Cloud: rec.Cloud,
+		})
+		rep.Instrument++
+	}
+	if len(sendable) == 0 {
+		fmt.Fprintf(stderr, "feint: %s carries no exchange this replay can reissue, so it compared nothing against the cloud\n", rel)
+		return exitError
+	}
+	// Every object this run creates carries a name a human scanning the console
+	// recognises at a glance. The recorded name is the sanitiser's invention
+	// either way (`redacted-2`), so nothing of the measurement is lost — and the
+	// rule that says so is #352's, not a preference.
+	// TestEveryObjectThisRunCreatesIsNamedForItAndIsDestroyed fails without this.
+	renameForThisRun(sendable)
+
+	env := emulator.DefaultEnv()
+	packs, err := packsFor(env)
+	if err != nil {
+		fmt.Fprintf(stderr, "feint: build the emulator: %v\n", err)
+		return exitError
+	}
+	table, err := emulator.NewTable(packs...)
+	if err != nil {
+		fmt.Fprintf(stderr, "feint: build the route table: %v\n", err)
+		return exitError
+	}
+
+	headers, err := credentialHeaders(req.credentials)
+	if err != nil {
+		fmt.Fprintf(stderr, "feint: %v\n", err)
+		return exitError
+	}
+
+	guard := newAccountGuard(req.dryRun)
+	client := &http.Client{
+		Timeout:   req.timeout,
+		Transport: &credentialTransport{base: http.DefaultTransport, headers: headers},
+	}
+	// Armed before the first request, which is `trap … EXIT` written in Go: a
+	// panic, a transport error, a context that dies — every one of them still
+	// runs this, and an aborted run is exactly when an orphan is made.
+	defer func() {
+		destroyed, leftovers := guard.destroy(client, req.endpoint)
+		rep.Created, rep.Destroyed = len(guard.created), destroyed
+		reportLedger(guard, destroyed, leftovers, stdout, stderr)
+		// TestADestructionIsProvedByAReadAndNotByTheDeletesOwnAnswer fails
+		// without this.
+		if len(leftovers) > 0 {
+			code = exitError
+		}
+	}()
+
+	declined, invariants, declarations := replayDeclarations(packs, stderr)
+	if declarations != exitOK {
+		return declarations
+	}
+
+	run, err := replay.Run(context.Background(), sendable, replay.Options{
+		Endpoint:   strings.TrimSuffix(req.endpoint, "/"),
+		Client:     client,
+		Table:      table,
+		Declined:   excusedAtTheCloud(declined),
+		Invariants: invariants,
+		Bind:       req.bind,
+		Guard:      guard,
+	})
+	if err != nil {
+		// A transport failure aborts the run, and it is verdict three: the call
+		// could not be made. The ledger above still empties the account.
+		fmt.Fprintf(stderr, "feint: %s: %v\n", rel, err)
+		return exitError
+	}
+
+	gradeCloudRun(&rep, run, sendable, guard, rec)
+	if req.format == "json" {
+		if err := writeJSON(stdout, rep); err != nil {
+			fmt.Fprintf(stderr, "feint: %v\n", err)
+			return exitError
+		}
+	} else {
+		writeCloudReport(rep, acc.WarnAfterDays, stdout)
+	}
+
+	if req.markStale && rep.Moved > 0 {
+		if err := markCorpusStale(req.accepted, rel, now, rep.Moved); err != nil {
+			fmt.Fprintf(stderr, "feint: %v\n", err)
+			return exitError
+		}
+		fmt.Fprintf(stdout, "\n%s now records in %s that the cloud has moved under it, so `corpus --check` says so on every run\n", rel, req.accepted)
+	}
+
+	switch {
+	case rep.Unmeasured > 0:
+		fmt.Fprintf(stderr, "feint: %d call(s) could not be made, so this run measured less than it says: fix that before reading the rest\n", rep.Unmeasured)
+		return exitError
+	case rep.Moved > 0:
+		fmt.Fprintf(stderr, "feint: %d finding(s) say the cloud answers differently from the recording of %s\n", rep.Moved, rec.At)
+		return exitDrift
+	}
+	return exitOK
+}
+
+// markCorpusStale writes the measurement back into the acceptance file.
+//
+// Read back, edited and rewritten rather than regenerated, because the file is
+// prose as much as data: its "comment" array carries the argument for every
+// exemption in it, and a marshaller that reordered or reflowed that would make
+// the diff of a scheduled job unreadable — which is the same as making it
+// unreviewed.
+//
+// TestMarkingACorpusStaleWritesTheMeasurementAndNothingElse fails without this.
+func markCorpusStale(path, file string, now time.Time, moved int) error {
+	raw, err := os.ReadFile(path) //nolint:gosec // operator-supplied path, just read by readCorpusAcceptance
+	if err != nil {
+		return fmt.Errorf("read the acceptance file %s: %w", path, err)
+	}
+	var doc map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return fmt.Errorf("read the acceptance file %s: %w", path, err)
+	}
+	var recorded []map[string]any
+	if err := json.Unmarshal(doc["recorded"], &recorded); err != nil {
+		return fmt.Errorf("read the recordings of %s: %w", path, err)
+	}
+	marked := false
+	for _, entry := range recorded {
+		if entry["file"] != file {
+			continue
+		}
+		entry["cloud_moved_at"] = now.Format(time.DateOnly)
+		entry["cloud_moved"] = moved
+		marked = true
+	}
+	if !marked {
+		return fmt.Errorf("%s has no recording entry in %s to mark", file, path)
+	}
+	updated, err := json.MarshalIndent(recorded, "  ", "  ")
+	if err != nil {
+		return err
+	}
+	doc["recorded"] = updated
+	// The key order of the document, spelled out: a map has none, and a file
+	// whose keys shuffled on every write would produce a diff nobody reads.
+	var out []byte
+	out = append(out, "{\n"...)
+	for i, key := range []string{"comment", "warn_after_days", "recorded", "accepted"} {
+		value, present := doc[key]
+		if !present {
+			continue
+		}
+		if i > 0 && len(out) > 2 {
+			out = append(out, ",\n"...)
+		}
+		out = append(out, "  \""...)
+		out = append(out, key...)
+		out = append(out, "\": "...)
+		out = append(out, value...)
+	}
+	out = append(out, "\n}\n"...)
+	if err := os.WriteFile(path, out, 0o600); err != nil {
+		return fmt.Errorf("write the acceptance file %s: %w", path, err)
+	}
+	// Read back through the gate's own reader, so a write that produced
+	// something this repository cannot parse fails here rather than on the next
+	// pull request.
+	if _, err := readCorpusAcceptance(path); err != nil {
+		return fmt.Errorf("the acceptance file this run wrote cannot be read back: %w", err)
+	}
+	return nil
+}
+
+// excusedAtTheCloud is what a pack's declined fields are worth against the
+// provider: nothing.
+//
+// A decline excuses a field *this emulator* does not serve, in the pack's own
+// words, and that is right for `corpus --check`. Carrying the same list here
+// would excuse the provider for not answering it — hiding the exact drift this
+// direction exists to catch, since a field that leaves a provider's answers is
+// invisible to every SDK scan.
+//
+// Written as a function rather than as an omitted struct field on purpose: an
+// absence cannot be neutralised, so it cannot be falsified, and a decision
+// nobody can make fail is a comment.
+// TestAPacksDeclineDoesNotExcuseTheCloud fails without this.
+func excusedAtTheCloud([]emulator.FieldDecline) []emulator.FieldDecline { return nil }
+
+// checkCloudEndpoint refuses an endpoint a credential must not travel to.
+//
+// Plain HTTP off loopback is refused outright: this command exists to be pointed
+// at a provider, its client carries an account's secret key in a header, and a
+// typo in a scheme would put that key on the wire in clear. Loopback stays
+// allowed because that is how the falsification runs — an emulator standing in
+// for the cloud, on a port nobody else can reach.
+// TestACredentialNeverTravelsInClear fails without this.
+func checkCloudEndpoint(endpoint string, credentialled bool, stderr io.Writer) int {
+	u, err := url.Parse(endpoint)
+	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		fmt.Fprintf(stderr, "feint: --endpoint %q is not an http(s) URL naming the cloud to reissue at\n", endpoint)
+		return exitError
+	}
+	if u.Scheme == "https" {
+		return exitOK
+	}
+	host := u.Hostname()
+	if ip := net.ParseIP(host); (ip != nil && ip.IsLoopback()) || host == "localhost" {
+		return exitOK
+	}
+	carrying := "no credential"
+	if credentialled {
+		carrying = "an account's credential"
+	}
+	fmt.Fprintf(stderr, "feint: --endpoint %q is plain HTTP off loopback, and this run carries %s: refused rather than sent in clear\n", endpoint, carrying)
+	return exitError
+}
+
+// credentialTransport puts back the headers the recorder took out.
+//
+// The recorder wrote "REDACTED" over every credential-shaped header, which is
+// the right thing for a committed artefact and leaves a replay with no way to
+// authenticate. So the operator names header and environment variable, and the
+// value is read here, held in memory, and written to nothing: not to the report,
+// not to a log line, not to the process arguments.
+type credentialTransport struct {
+	base    http.RoundTripper
+	headers map[string]string
+}
+
+func (t *credentialTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	clone := r.Clone(r.Context())
+	for name, value := range t.headers {
+		clone.Header.Set(name, value)
+	}
+	return t.base.RoundTrip(clone)
+}
+
+// credentialHeaders reads each named environment variable, and fails on one that
+// is empty rather than sending an unauthenticated request that would come back
+// 401 and read like a cloud that changed.
+func credentialHeaders(spec map[string]string) (map[string]string, error) {
+	out := make(map[string]string, len(spec))
+	names := make([]string, 0, len(spec))
+	for header := range spec {
+		names = append(names, header)
+	}
+	sort.Strings(names)
+	for _, header := range names {
+		envName := spec[header]
+		value := os.Getenv(envName)
+		if strings.TrimSpace(value) == "" {
+			return nil, fmt.Errorf("--credential %s=%s: $%s is empty, and an unauthenticated replay answers 401 everywhere, which reads exactly like a cloud that changed", header, envName, envName)
+		}
+		out[header] = value
+	}
+	return out, nil
+}
+
+// unreplayable is one exchange that cannot be reissued, and why.
+type unreplayable struct {
+	seq          int
+	method, path string
+	why          string
+}
+
+// splitReplayable separates what can honestly be sent from what cannot.
+//
+// Two rules, and the difference between them is the difference between verdict
+// one and verdict two:
+//
+//   - a path or a query value the sanitiser **blanked** cannot be addressed at
+//     all. `GET /redacted-1/redacted-2` names no route of any cloud, and
+//     `?status=redacted-6` is an enumerated value the provider refuses. Sending
+//     either spends a real call to collect a 400 the recording caused.
+//   - a body field the sanitiser blanked is ordinary synthetic text — a name, a
+//     tag — and is sent. Refusing those would refuse every create in the corpus.
+//   - the proxy's own "REDACTED" anywhere in the request is fatal wherever it
+//     sits: the value was destroyed rather than replaced, so the request that
+//     went out would carry a string no client ever sent. That is #73's family,
+//     nine false divergences from one substitution.
+//
+// TestABlankedPathIsNeverSentToTheCloud fails without this.
+func splitReplayable(exs []trace.Exchange) ([]trace.Exchange, []unreplayable) {
+	var send []trace.Exchange
+	var refused []unreplayable
+	for i := range exs {
+		x := exs[i]
+		seq := i + 1
+		switch {
+		case blankedSegment(x.Path):
+			refused = append(refused, unreplayable{seq, x.Method, x.Path,
+				"the sanitiser blanked this path, so it addresses no operation of any cloud (corpus/README.md, \"What it still cannot see\")"})
+		case blankedQuery(x.Query):
+			refused = append(refused, unreplayable{seq, x.Method, x.Path,
+				"the sanitiser blanked a query value, and a provider's enumerated parameter refuses an invented one"})
+		case redactedRequest(x):
+			refused = append(refused, unreplayable{seq, x.Method, x.Path,
+				"the recorder wrote REDACTED over a value of this request, so reissuing it would send a string the client never sent (#73)"})
+		default:
+			send = append(send, x)
+		}
+	}
+	return send, refused
+}
+
+// blankedSegment reports whether any path segment is one the sanitiser invented.
+func blankedSegment(path string) bool {
+	for _, seg := range strings.Split(path, "/") {
+		if strings.HasPrefix(seg, corpus.Token) {
+			return true
+		}
+	}
+	return false
+}
+
+// blankedQuery reports whether any query value is one the sanitiser invented.
+func blankedQuery(raw string) bool {
+	for _, pair := range strings.Split(raw, "&") {
+		if _, value, ok := strings.Cut(pair, "="); ok && strings.HasPrefix(value, corpus.Token) {
+			return true
+		}
+	}
+	return false
+}
+
+// redactedRequest reports whether the proxy's placeholder survives anywhere the
+// request would carry it out. Headers are excluded: every recorded credential
+// header is "REDACTED" by construction, [replay.Run] reissues none of them, and
+// --credential is what puts the real one back.
+func redactedRequest(x trace.Exchange) bool {
+	if strings.Contains(x.Path, proxy.Placeholder) || strings.Contains(x.Query, proxy.Placeholder) {
+		return true
+	}
+	if x.Req == nil {
+		return false
+	}
+	found := false
+	walkStrings(x.Req.Body, func(s string) {
+		if s == proxy.Placeholder {
+			found = true
+		}
+	})
+	return found
+}
+
+// thisRunPrefix is the name every object this run creates carries, so that an
+// object left behind by an aborted run is identifiable in a console by eye.
+const thisRunPrefix = "feint-corpus-"
+
+// renameForThisRun rewrites the top-level `name` of every request that changes
+// state, in place.
+//
+// Top level only: a nested `name` belongs to a subnet or a rule the parent
+// object owns, and renaming those would change what the request means. The
+// value is not compared — a replay grades presence, type, and the values a pack
+// declares invariant, and no pack declares one on these operations — so what
+// this changes is what a human sees in the console and nothing of the verdict.
+func renameForThisRun(exs []trace.Exchange) {
+	for i := range exs {
+		x := &exs[i]
+		if x.Method == http.MethodGet || x.Method == http.MethodHead || x.Req == nil {
+			continue
+		}
+		body, isObject := x.Req.Body.(map[string]any)
+		if !isObject {
+			continue
+		}
+		if _, named := body["name"]; !named {
+			continue
+		}
+		renamed := make(map[string]any, len(body))
+		for k, v := range body {
+			renamed[k] = v
+		}
+		renamed["name"] = fmt.Sprintf("%s%d", thisRunPrefix, i+1)
+		copied := *x.Req
+		copied.Body = renamed
+		x.Req = &copied
+	}
+}
+
+// walkStrings visits every string in a decoded JSON value.
+func walkStrings(v any, fn func(string)) {
+	switch t := v.(type) {
+	case map[string]any:
+		for _, nested := range t {
+			walkStrings(nested, fn)
+		}
+	case []any:
+		for _, nested := range t {
+			walkStrings(nested, fn)
+		}
+	case string:
+		fn(t)
+	}
+}
+
+// gradeCloudRun turns the replay's own results into the three verdicts, and it
+// is the only place in this file where they are decided.
+func gradeCloudRun(rep *cloudReport, run replay.Report, sent []trace.Exchange, guard *accountGuard, rec corpusRecording) {
+	for _, r := range run.Results {
+		recorded := 0
+		if i := r.Seq - 1; i >= 0 && i < len(sent) {
+			recorded = sent[i].Status
+		}
+		line := cloudFinding{
+			Seq: r.Seq, Operation: r.Operation, Method: r.Method, Path: r.Path,
+			Instrument: guard.synthetic[r.Seq], RecordedAt: rec.At, Cloud: rec.Cloud,
+		}
+		switch {
+		case r.Verdict == replay.Unserved:
+			rep.Unserved++
+			continue
+		case r.Verdict == replay.Refused:
+			line.Outcome, line.Detail = cloudUnmeasured, r.Refused
+			rep.Unmeasured++
+		case r.Verdict == replay.Skipped:
+			line.Outcome = cloudInstrument
+			line.Detail = "the recording carries no answer for this request, so there was nothing to compare"
+			rep.Instrument++
+		case notAboutTheResource(recorded, r.Status):
+			// An authentication refusal, a rate limit, a gateway error. The
+			// request reached something and came back with an answer about the
+			// caller, and calling that "the cloud changed" is the exact
+			// mistake #359 asks this to never make.
+			line.Outcome = cloudUnmeasured
+			line.Detail = fmt.Sprintf("the recording carries %d and the endpoint answered %d, which is about this caller rather than about the resource", recorded, r.Status)
+			rep.Unmeasured++
+		case r.Verdict == replay.Matched:
+			rep.Compared++
+			continue
+		default:
+			rep.Compared++
+			for _, f := range r.Findings {
+				if f.Kind == replay.KindRedacted {
+					// The recorder erased the type, so there is nothing to
+					// compare and nothing to conclude. Counted, never blurred
+					// into a change of the cloud.
+					continue
+				}
+				one := line
+				one.Detail = describeFinding(f)
+				if len(one.Instrument) > 0 {
+					one.Outcome = cloudInstrument
+					rep.Instrument++
+				} else {
+					one.Outcome = cloudMoved
+					rep.Moved++
+				}
+				rep.Findings = append(rep.Findings, one)
+			}
+			continue
+		}
+		rep.Findings = append(rep.Findings, line)
+	}
+	sort.SliceStable(rep.Findings, func(i, j int) bool { return rep.Findings[i].Seq < rep.Findings[j].Seq })
+}
+
+// notAboutTheResource reports whether an answer describes the caller rather than
+// the thing addressed. A recorded refusal that the provider still refuses is a
+// comparison that held, so the recorded side has to have succeeded.
+func notAboutTheResource(recorded, got int) bool {
+	if recorded >= 400 || got == 0 {
+		return false
+	}
+	switch got {
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusTooManyRequests:
+		return true
+	}
+	return got >= 500
+}
+
+// writeCloudReport renders the run. Every line names the operation, the path,
+// the kind of change and the date of the recording, which is #359's own
+// definition of actionable.
+func writeCloudReport(rep cloudReport, warnAfterDays int, w io.Writer) {
+	fmt.Fprintf(w, "\n%s recorded %s (%d day(s) ago) with %s against %s\n",
+		rep.File, rep.RecordedAt, rep.AgeDays, rep.Client, rep.Cloud)
+	fmt.Fprintf(w, "reissued at %s\n\n", rep.Endpoint)
+
+	for _, f := range rep.Findings {
+		fmt.Fprintf(w, "  seq %-4d %-44s %s %s\n", f.Seq, f.Operation, f.Method, f.Path)
+		fmt.Fprintf(w, "           %s: %s\n", f.Outcome, f.Detail)
+		if len(f.Instrument) > 0 {
+			fmt.Fprintf(w, "           this request still carried %d value(s) the sanitiser invented (%s), so suspect the recording first\n",
+				len(f.Instrument), strings.Join(f.Instrument, ", "))
+		}
+	}
+	if len(rep.Findings) > 0 {
+		fmt.Fprintln(w)
+	}
+
+	fmt.Fprintf(w, "%d exchange(s) in the file, %d compared against %s\n", rep.Exchanges, rep.Compared, rep.Cloud)
+	fmt.Fprintf(w, "%d finding(s) say the cloud answers differently now, which is what this run exists to find\n", rep.Moved)
+	fmt.Fprintf(w, "%d finding(s) are the recording rather than the cloud, and are never counted as a change\n", rep.Instrument)
+	fmt.Fprintf(w, "%d call(s) could not be made, which is an error and never a pass\n", rep.Unmeasured)
+	fmt.Fprintf(w, "%d exchange(s) no route of this emulator serves, which is #74's queue\n", rep.Unserved)
+	if rep.AgeDays > warnAfterDays && warnAfterDays > 0 {
+		fmt.Fprintf(w, "\nwarning: this recording is %d days old, past the %d-day horizon of corpus/accepted.json\n", rep.AgeDays, warnAfterDays)
+	}
+	fmt.Fprintln(w, "\nwhat this cannot tell you: a difference here is the cloud changing for everybody, or one")
+	fmt.Fprintln(w, "account's quota, or a region's rollout. It reports what it measured; which of the three it")
+	fmt.Fprintln(w, "is stays a human's call.")
+}
+
+// reportLedger says what the run created and proves what it destroyed.
+func reportLedger(g *accountGuard, destroyed int, leftovers []string, stdout, stderr io.Writer) {
+	if len(g.created) == 0 {
+		fmt.Fprintln(stdout, "\nthis run created nothing at the endpoint")
+		return
+	}
+	fmt.Fprintf(stdout, "\n%d object(s) created, %d destroyed with the destruction proved by a read answering 404\n",
+		len(g.created), destroyed)
+	for _, left := range leftovers {
+		// The one place an identifier is printed, and it is printed because the
+		// alternative is an operator who cannot find what to delete. A leftover
+		// is a failure of this run, not an artefact of it.
+		fmt.Fprintf(stderr, "feint: NOT DESTROYED: %s — delete it by hand and say so in the report\n", left)
+	}
+}
+
+// accountGuard is "bien formé n'est pas autorisé" for a replay that spends
+// money.
+//
+// A recorded request is well formed by construction; that says nothing about
+// whether the object it addresses is ours. The recording's identifiers are
+// rebound to whatever the endpoint answered, and a rebinding that pairs the
+// recorded object with a pre-existing one of the account turns a recorded DELETE
+// into the deletion of somebody's property. `mustOwn` in the Incus driver asks
+// exactly this question of a label the emulator itself posted; this asks it of
+// the identifiers this run's own creates minted.
+//
+// Two rules, and they are different questions:
+//
+//   - **may this be created at all** — a create is billable or it is not, and
+//     the list of what is free is a decision written down rather than a guess
+//     made per run.
+//   - **is this object ours** — every identifier in the path of a request that
+//     changes state has to be one this run created.
+type accountGuard struct {
+	// created is the ledger, in creation order, so [accountGuard.destroy] can
+	// walk it backwards: a private network is created after the VPC it sits in
+	// and has to go first.
+	created []createdObject
+	// owned is every identifier a create of this run answered.
+	owned map[string]bool
+	// synthetic records, per exchange, the values the sanitiser invented that a
+	// request still carried after rebinding. It is what tells a defect of the
+	// instrument from a change of the cloud when a request is refused.
+	synthetic map[int][]string
+	dryRun    bool
+}
+
+// createdObject is one thing this run made and therefore has to destroy.
+type createdObject struct {
+	// collection is the path the create was POSTed to, and id what the answer
+	// named. The two concatenated are the object's own URL, which is what REST
+	// means and what every operation on this run's free list obeys.
+	collection, id string
+	operation      string
+}
+
+func (o createdObject) url() string { return o.collection + "/" + o.id }
+
+func newAccountGuard(dryRun bool) *accountGuard {
+	return &accountGuard{owned: map[string]bool{}, synthetic: map[int][]string{}, dryRun: dryRun}
+}
+
+// freeToCreate names every operation this replay may create with, and why each
+// one costs nothing.
+//
+// A closed list rather than a rule, because "free" is not a property any request
+// carries: it is a fact about a provider's price list on a given day, and the
+// only honest form for it is a decision a human wrote down and a reviewer can
+// see in a diff. An operation absent from it is refused with its own name, so
+// the report says which measurement is out of reach without spending, which
+// #359 asks for by name.
+//
+// TestABillableCreateIsRefusedRatherThanSent fails without this.
+var freeToCreate = map[string]string{
+	"vpc/v2/API.CreateVPC":            "a Scaleway VPC costs nothing; the account is billed for what runs inside one",
+	"vpc/v2/API.CreatePrivateNetwork": "a Scaleway private network costs nothing, and #352 recorded the same lifecycle under the same rule",
+	"iam/v1alpha1/API.CreateSSHKey":   "an IAM SSH key is a credential record, not a resource, and is free",
+}
+
+// Before is the refusal. It runs on the request as it will actually go out.
+func (g *accountGuard) Before(a replay.Attempt) string {
+	g.noteSynthetic(a)
+	if a.Method == http.MethodGet || a.Method == http.MethodHead {
+		return ""
+	}
+	if g.dryRun {
+		return "--dry-run: nothing that changes an account is sent"
+	}
+	// Every identifier this request addresses has to be one this run made. It
+	// covers the destructive methods and the create that posts into somebody
+	// else's sub-collection with one rule, because they are one question.
+	// TestADeleteOfSomethingThisRunDidNotCreateIsRefused fails without this.
+	minted := 0
+	for _, seg := range strings.Split(a.Path, "/") {
+		id, _, _ := strings.Cut(seg, ":")
+		if !shape.IsMintedIdentifier(id) {
+			continue
+		}
+		minted++
+		if !g.owned[id] {
+			return fmt.Sprintf("%s addresses an object this run did not create, and a replay does not delete or reconfigure an account's own property", a.Operation)
+		}
+	}
+	switch a.Method {
+	case http.MethodDelete, http.MethodPatch:
+		if minted == 0 {
+			return fmt.Sprintf("%s changes state and names no object this run created, so nothing proves what it would have addressed", a.Operation)
+		}
+		return ""
+	case http.MethodPost, http.MethodPut:
+		if _, free := freeToCreate[a.Operation]; !free {
+			return fmt.Sprintf("%s is not on the free-to-create list, so this replay will not bill the account to measure it", a.Operation)
+		}
+		return ""
+	}
+	return fmt.Sprintf("%s uses %s, which this replay has no rule for", a.Operation, a.Method)
+}
+
+// After records what the answer created.
+func (g *accountGuard) After(a replay.Attempt, status int, body any) {
+	if a.Method != http.MethodPost && a.Method != http.MethodPut {
+		return
+	}
+	if status < 200 || status >= 300 {
+		return
+	}
+	for _, id := range mintedIDs(body) {
+		g.owned[id] = true
+	}
+	if id, named := objectID(body); named {
+		g.created = append(g.created, createdObject{collection: a.Path, id: id, operation: a.Operation})
+	}
+}
+
+// noteSynthetic records the values the sanitiser invented that survived into the
+// request. A rebound identifier is not one of them: it is whatever the endpoint
+// answered a moment ago.
+//
+// # The path is where this earns its place
+//
+// A corpus is a causal sequence: the create mints the identifier the read then
+// addresses. When the create does not happen — refused as billable, refused as
+// somebody else's, or simply not sent under --dry-run — nothing rebinds it, and
+// the read goes out carrying the *sanitiser's* identifier. It answers 404, and
+// every field of the recorded body then reads as absent.
+//
+// Measured on 2026-08-21, dry-running corpus/scaleway/terraform.jsonl against
+// the real Scaleway account: 145 findings, not one of them the cloud. Grading
+// those as "the provider changed" would be this tool committing the very defect
+// it exists to detect — #73's family, one layer further out.
+// TestARequestStillCarryingASyntheticIdentifierIsNotACloudChange fails without
+// this.
+func (g *accountGuard) noteSynthetic(a replay.Attempt) {
+	seen := map[string]bool{}
+	var out []string
+	note := func(s string) {
+		if s == "" || seen[s] || !corpus.Minted(s) {
+			return
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	walkStrings(a.Body, note)
+	for _, seg := range strings.Split(a.Path, "/") {
+		id, _, _ := strings.Cut(seg, ":")
+		note(id)
+	}
+	for _, pair := range strings.Split(a.Query, "&") {
+		if _, value, ok := strings.Cut(pair, "="); ok {
+			note(value)
+		}
+	}
+	if len(out) > 0 {
+		sort.Strings(out)
+		g.synthetic[a.Seq] = out
+	}
+}
+
+// mintedIDs is every identifier an answer names under a key called exactly "id".
+//
+// "id" and nothing else, and that narrowness is the control: a create answers
+// project_id, organization_id and vpc_id beside its own id, and a guard that
+// collected those would consider the account's project something this run
+// created — which is the door a `DELETE /projects/{id}` would walk through.
+// TestOwnershipDoesNotFollowAParentIdentifier fails without this.
+func mintedIDs(body any) []string {
+	var out []string
+	var walk func(v any)
+	walk = func(v any) {
+		switch t := v.(type) {
+		case map[string]any:
+			for k, nested := range t {
+				if s, isString := nested.(string); k == "id" && isString && shape.IsMintedIdentifier(s) {
+					out = append(out, s)
+					continue
+				}
+				walk(nested)
+			}
+		case []any:
+			for _, nested := range t {
+				walk(nested)
+			}
+		}
+	}
+	walk(body)
+	return out
+}
+
+// objectID names the object a create answered, for the ledger.
+//
+// The top-level "id", or the "id" of the single object a one-key answer wraps —
+// Scaleway's vpc/v2 answers the first shape and its instance API the second. An
+// answer of neither shape leaves nothing in the ledger, and [accountGuard.destroy]
+// says so rather than pretending the run created nothing.
+func objectID(body any) (string, bool) {
+	top, isObject := body.(map[string]any)
+	if !isObject {
+		return "", false
+	}
+	if s, isString := top["id"].(string); isString && shape.IsMintedIdentifier(s) {
+		return s, true
+	}
+	if len(top) != 1 {
+		return "", false
+	}
+	for _, nested := range top {
+		if inner, wrapped := nested.(map[string]any); wrapped {
+			if s, isString := inner["id"].(string); isString && shape.IsMintedIdentifier(s) {
+				return s, true
+			}
+		}
+	}
+	return "", false
+}
+
+// destroy empties the account and proves it with a read.
+//
+// Never the exit code of the DELETE, which is #352's rule and the reason it is
+// one: a delete that answered 204 on a resource that then takes a minute to go
+// is a delete that proved nothing. The proof is a GET that answers 404. Walked
+// backwards, so a private network goes before the VPC that holds it.
+//
+// Returns how many were proved gone, and the URL of everything that was not.
+func (g *accountGuard) destroy(client *http.Client, endpoint string) (int, []string) {
+	proved := 0
+	var leftovers []string
+	for i := len(g.created) - 1; i >= 0; i-- {
+		o := g.created[i]
+		url := strings.TrimSuffix(endpoint, "/") + o.url()
+		if req, err := http.NewRequest(http.MethodDelete, url, nil); err == nil {
+			if res, err := client.Do(req); err == nil {
+				_ = res.Body.Close()
+			}
+		}
+		gone := false
+		if res, err := client.Get(url); err == nil {
+			_ = res.Body.Close()
+			gone = res.StatusCode == http.StatusNotFound || res.StatusCode == http.StatusGone
+		}
+		if gone {
+			proved++
+			continue
+		}
+		leftovers = append(leftovers, o.operation+" "+o.url())
+	}
+	return proved, leftovers
+}
+
+// parseKeyValues reads a repeatable `key=value` flag into a map, refusing a
+// spelling that would silently mean nothing.
+func parseKeyValues(flagName string, raw []string) (map[string]string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]string, len(raw))
+	for _, entry := range raw {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok || strings.TrimSpace(key) == "" || strings.TrimSpace(value) == "" {
+			return nil, fmt.Errorf("--%s %q: expected key=value with both halves", flagName, entry)
+		}
+		out[strings.TrimSpace(key)] = strings.TrimSpace(value)
+	}
+	return out, nil
+}
+
+// repeatable is a flag that may be given more than once, since the standard
+// flag package has no such thing and a comma-separated string would forbid a
+// comma in a value.
+type repeatable []string
+
+func (r *repeatable) String() string { return strings.Join(*r, ",") }
+
+func (r *repeatable) Set(v string) error {
+	*r = append(*r, v)
+	return nil
+}
+
+// compile-time proof that the guard is one.
+var _ replay.Guard = (*accountGuard)(nil)

--- a/internal/cli/corpus_cloud_test.go
+++ b/internal/cli/corpus_cloud_test.go
@@ -1,0 +1,824 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/proxy"
+)
+
+// The two directions of one comparison meet here (#359).
+//
+// Everything below runs offline: the "cloud" is a second emulator on loopback,
+// which is exactly what makes the falsification possible at all — a control
+// whose proof needed an account would be a control nobody replays. What the
+// stand-in cannot prove is what a *provider* answers, and no test can: that is
+// what the run against the real Scaleway account is for, and its result belongs
+// in the pull request rather than in an assertion.
+
+// A mutated corpus makes the run report the change and exit non-zero; the same
+// corpus unmutated reports nothing and exits 0. #359's own falsification, both
+// halves, because a control that fires on everything is not a control.
+func TestAMutatedCorpusIsReportedAsACloudChangeAndAnUnchangedOneIsNot(t *testing.T) {
+	dir, accepted, _ := vpcCorpusFixture(t)
+
+	cloud, _ := recordingCloud(t)
+	out, errs, code := runCloudReplay(t, dir, accepted, cloud.URL, nil)
+	if code != exitOK {
+		t.Fatalf("an unmutated corpus exited %d, want 0.\nstdout:\n%s\nstderr:\n%s", code, out, errs)
+	}
+	if !strings.Contains(out, "0 finding(s) say the cloud answers differently now") {
+		t.Fatalf("an unmutated corpus reported a change:\n%s", out)
+	}
+	// The subject, asserted rather than hoped for: a run that compared nothing
+	// would also report no change, and this whole direction exists because
+	// those two read identically.
+	if strings.Contains(out, "exchange(s) in the file, 0 compared") {
+		t.Fatalf("the run compared nothing, so its silence measures nothing:\n%s", out)
+	}
+
+	operation := mutateStatus(t, filepath.Join(dir, "self/self.jsonl"), 200, 418)
+	second, _ := recordingCloud(t)
+	out, errs, code = runCloudReplay(t, dir, accepted, second.URL, nil)
+	if code != exitDrift {
+		t.Fatalf("a mutated corpus exited %d, want %d.\nstdout:\n%s\nstderr:\n%s", code, exitDrift, out, errs)
+	}
+	if !strings.Contains(out, operation) || !strings.Contains(out, "the cloud answers differently") {
+		t.Fatalf("the run does not name %s as answering differently:\n%s", operation, out)
+	}
+	// Actionable without a transcript: the operation, the path, the kind of
+	// change, and the date the recording was made.
+	if !strings.Contains(out, "expected 418") || !strings.Contains(out, "recorded 2026-08-21") {
+		t.Fatalf("the finding does not carry the kind of change and the recording's date:\n%s", out)
+	}
+}
+
+// A recorded DELETE addressing an object this run did not create is refused, and
+// the object is still there afterwards.
+//
+// This is "bien formé n'est pas autorisé" on the one path where getting it wrong
+// destroys somebody's property: the request is well formed, its identifier is a
+// real one of the account, and none of that makes it ours. The second assertion
+// is the one that matters — without the guard the VPC is gone, and a test that
+// only read the exit code would not notice.
+func TestADeleteOfSomethingThisRunDidNotCreateIsRefused(t *testing.T) {
+	cloud, _ := recordingCloud(t)
+	existing := createVPC(t, cloud.URL, "somebody-elses-vpc")
+
+	path := "/vpc/v2/regions/fr-par/vpcs/" + existing
+	dir, accepted := cloudCorpusFixture(t, exchangeLine(t, 1, "DELETE", path, "", 204, nil, nil))
+
+	out, errs, code := runCloudReplay(t, dir, accepted, cloud.URL, nil)
+	if code != exitError {
+		t.Fatalf("a delete of a foreign object exited %d, want %d.\nstdout:\n%s\nstderr:\n%s", code, exitError, out, errs)
+	}
+	if !strings.Contains(out, "did not create") {
+		t.Fatalf("the run does not say why the delete was refused:\n%s", out)
+	}
+	if !strings.Contains(out, "the call could not be made") {
+		t.Fatalf("a refusal is not reported as verdict three:\n%s", out)
+	}
+	if status := statusOf(t, cloud.URL+path); status != http.StatusOK {
+		t.Fatalf("the VPC this run did not create answers %d after the run: the guard let the delete through", status)
+	}
+}
+
+// A create of something that is billed is refused before it is sent, and the
+// report names the operation so a reader learns which measurement is out of
+// reach without spending.
+//
+// The account rules of #352 are not negotiable and are not a comment: free
+// resources only. What proves it is the second assertion — no server exists at
+// the endpoint afterwards.
+func TestABillableCreateIsRefusedRatherThanSent(t *testing.T) {
+	cloud, seen := recordingCloud(t)
+	body := map[string]any{"name": "expensive", "commercial_type": "DEV1-S", "image": "ubuntu_jammy"}
+	dir, accepted := cloudCorpusFixture(t, exchangeLine(t, 1, "POST",
+		"/instance/v1/zones/fr-par-1/servers", "", 201, body, map[string]any{"server": map[string]any{"id": "x"}}))
+
+	out, errs, code := runCloudReplay(t, dir, accepted, cloud.URL, nil)
+	if code != exitError {
+		t.Fatalf("a billable create exited %d, want %d.\nstdout:\n%s\nstderr:\n%s", code, exitError, out, errs)
+	}
+	if !strings.Contains(out, "instance/v1/API.CreateServer") || !strings.Contains(out, "free-to-create") {
+		t.Fatalf("the run does not name the operation it refused to bill for:\n%s", out)
+	}
+	for _, r := range seen() {
+		if r.Method == http.MethodPost && strings.HasSuffix(r.Path, "/servers") {
+			t.Fatalf("the create reached the endpoint: %s %s", r.Method, r.Path)
+		}
+	}
+}
+
+// A path the sanitiser blanked is never sent, and is reported as a defect of the
+// recording rather than as a cloud that changed.
+//
+// `GET /redacted-1/redacted-2` addresses no operation of any cloud. Sending it
+// would spend a real call to collect a 404 the instrument caused — which is the
+// family #73 measured as nine false divergences.
+func TestABlankedPathIsNeverSentToTheCloud(t *testing.T) {
+	cloud, seen := recordingCloud(t)
+	dir, accepted := cloudCorpusFixture(t,
+		exchangeLine(t, 1, "GET", "/redacted-1/redacted-2/redacted-3", "", 200, nil, map[string]any{"x": "y"}),
+		exchangeLine(t, 2, "GET", "/vpc/v2/regions/fr-par/vpcs", "order_by=created_at_asc&page=1", 200,
+			nil, map[string]any{"vpcs": []any{}, "total_count": 0}))
+
+	out, errs, code := runCloudReplay(t, dir, accepted, cloud.URL, nil)
+	if code != exitOK {
+		t.Fatalf("the run exited %d, want 0.\nstdout:\n%s\nstderr:\n%s", code, out, errs)
+	}
+	for _, r := range seen() {
+		if strings.Contains(r.Path, "redacted-") {
+			t.Fatalf("a blanked path reached the endpoint: %s", r.Path)
+		}
+	}
+	if !strings.Contains(out, "the recording could not be reissued as recorded") {
+		t.Fatalf("the blanked path is not reported as a defect of the recording:\n%s", out)
+	}
+	if !strings.Contains(out, "1 finding(s) are the recording rather than the cloud") {
+		t.Fatalf("the blanked path is counted somewhere other than as the recording's own defect:\n%s", out)
+	}
+}
+
+// An answer that is about the caller — 401, 403, 429, a gateway error — is
+// verdict three and never verdict one. A run that read a 401 as "the cloud
+// changed" would open a pull request every time a token expired.
+func TestAnAnswerAboutTheCallerIsNotACloudChange(t *testing.T) {
+	for name, status := range map[string]int{"unauthorised": 401, "rate limited": 429, "gateway": 502} {
+		t.Run(name, func(t *testing.T) {
+			cloud := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(status)
+				_, _ = w.Write([]byte(`{"message":"no"}`))
+			}))
+			t.Cleanup(cloud.Close)
+			dir, accepted := cloudCorpusFixture(t, exchangeLine(t, 1, "GET",
+				"/vpc/v2/regions/fr-par/vpcs", "page=1", 200, nil, map[string]any{"vpcs": []any{}, "total_count": 0}))
+
+			out, errs, code := runCloudReplay(t, dir, accepted, cloud.URL, nil)
+			if code != exitError {
+				t.Fatalf("a %d exited %d, want %d.\nstdout:\n%s\nstderr:\n%s", status, code, exitError, out, errs)
+			}
+			if strings.Contains(out, "1 finding(s) say the cloud answers differently") {
+				t.Fatalf("a %d was graded as a change of the cloud:\n%s", status, out)
+			}
+			if !strings.Contains(out, "about this caller rather than about the resource") {
+				t.Fatalf("a %d is not reported as a call that could not be made:\n%s", status, out)
+			}
+		})
+	}
+}
+
+// A field a pack declines is still a finding at the cloud.
+//
+// The declines excuse what *this emulator* does not serve. Excusing them here
+// would hide the day the provider stops answering the field, which is the drift
+// this direction exists to catch, and it is one line away: passing `declined` to
+// the run would do it.
+func TestAPacksDeclineDoesNotExcuseTheCloud(t *testing.T) {
+	recorded := map[string]any{"servers": map[string]any{
+		"DEV1-S": map[string]any{"per_volume_constraint": map[string]any{
+			"l_ssd": map[string]any{"min_size": 1, "max_size": 2}}}}}
+	line := exchangeLine(t, 1, "GET", "/instance/v1/zones/fr-par-1/products/servers", "page=1", 200, nil, recorded)
+
+	// Against the emulator, the pack's own decline excuses it and the gate is
+	// green. Both halves are asserted, because "it is reported at the cloud" is
+	// only interesting beside "it is excused at the emulator".
+	gateDir, gateAccepted := cloudCorpusFixture(t, line)
+	if _, _, code := runCorpusGate(t, gateDir, gateAccepted); code != exitOK {
+		t.Fatalf("the declined field fails the emulator gate, so this fixture no longer isolates the decline")
+	}
+
+	cloud, _ := recordingCloud(t)
+	out, _, code := runCloudReplay(t, gateDir, gateAccepted, cloud.URL, nil)
+	if code != exitDrift {
+		t.Fatalf("a declined field was excused at the cloud (exit %d):\n%s", code, out)
+	}
+	if !strings.Contains(out, "l_ssd") {
+		t.Fatalf("the run does not name the field the cloud carries and this emulator omits:\n%s", out)
+	}
+}
+
+// Everything this run creates carries a name a human scanning a console
+// recognises, and every object it created is destroyed with the destruction
+// proved by a read.
+func TestEveryObjectThisRunCreatesIsNamedForItAndIsDestroyed(t *testing.T) {
+	dir, accepted, _ := vpcCorpusFixture(t)
+	cloud, seen := recordingCloud(t)
+
+	out, errs, code := runCloudReplay(t, dir, accepted, cloud.URL, nil)
+	if code != exitOK {
+		t.Fatalf("the lifecycle exited %d.\nstdout:\n%s\nstderr:\n%s", code, out, errs)
+	}
+
+	creates := 0
+	for _, r := range seen() {
+		if r.Method != http.MethodPost {
+			continue
+		}
+		creates++
+		var body map[string]any
+		if err := json.Unmarshal(r.Body, &body); err != nil {
+			t.Fatalf("decode a create this run sent: %v", err)
+		}
+		name, _ := body["name"].(string)
+		if !strings.HasPrefix(name, thisRunPrefix) {
+			t.Errorf("this run created an object named %q, which nobody scanning a console can attribute to it", name)
+		}
+	}
+	if creates == 0 {
+		t.Fatal("the fixture created nothing, so it proves nothing about what a run leaves behind")
+	}
+	if !strings.Contains(out, "destroyed with the destruction proved by a read answering 404") {
+		t.Fatalf("the run does not prove what it destroyed:\n%s", out)
+	}
+	if strings.Contains(errs, "NOT DESTROYED") {
+		t.Fatalf("the run left something behind:\n%s", errs)
+	}
+	// The account is as it was found. The two lists compared, not the exit code
+	// of a delete: #352's rule, and the reason it is one.
+	if left := vpcCount(t, cloud.URL); left != 1 {
+		t.Fatalf("%d VPC(s) at the endpoint after the run, want the 1 the emulator mints by default", left)
+	}
+}
+
+// A destruction is proved by a read, never by the delete's own answer — and an
+// object this run could not destroy makes the run fail.
+//
+// #352's rule, and the reason it is one: a delete that answers 204 on a resource
+// that is still there proves nothing. The stand-in cloud below answers every
+// DELETE with 204 and deletes nothing, which is the exact shape a provider's
+// asynchronous delete has, and the run has to notice.
+func TestADestructionIsProvedByAReadAndNotByTheDeletesOwnAnswer(t *testing.T) {
+	honest, _ := recordingCloud(t)
+	// A corpus that creates and never deletes: the ledger is the only thing
+	// that can empty the account.
+	create := exchangeLine(t, 1, "POST", "/vpc/v2/regions/fr-par/vpcs", "",
+		200, map[string]any{"name": "left-behind"}, map[string]any{"id": "11111111-1111-4111-8111-111111111111"})
+	dir, accepted := cloudCorpusFixture(t, create)
+
+	if _, _, code := runCloudReplay(t, dir, accepted, honest.URL, nil); code != exitOK {
+		t.Fatalf("a create the recording never deletes exited %d, want 0", code)
+	}
+	if left := vpcCount(t, honest.URL); left != 1 {
+		t.Fatalf("%d VPC(s) after the run: the ledger did not empty the account", left)
+	}
+
+	// The same run against an endpoint that swallows deletes.
+	swallowing, inner := swallowingCloud(t)
+	dir, accepted = cloudCorpusFixture(t, create)
+	out, errs, code := runCloudReplay(t, dir, accepted, swallowing.URL, nil)
+	if code == exitOK {
+		t.Fatalf("a run that left an object behind exited 0.\nstdout:\n%s\nstderr:\n%s", out, errs)
+	}
+	if !strings.Contains(errs, "NOT DESTROYED") {
+		t.Fatalf("the run does not name what it left behind:\n%s", errs)
+	}
+	if left := vpcCount(t, inner); left != 2 {
+		t.Fatalf("this test no longer reproduces a swallowed delete: %d VPC(s) at the endpoint", left)
+	}
+}
+
+// A value the recorder wrote REDACTED over is never sent, and is reported as a
+// defect of the instrument.
+//
+// #73's family, exactly: reissuing such a request sends a string the client
+// never sent, the create answers 400, and every read and delete that follows
+// answers 404 for that one reason — nine false divergences from one
+// substitution.
+func TestARedactedRequestIsNeverSentToTheCloud(t *testing.T) {
+	cloud, seen := recordingCloud(t)
+	dir, accepted := cloudCorpusFixture(t,
+		exchangeLine(t, 1, "POST", "/iam/v1alpha1/ssh-keys", "", 200,
+			map[string]any{"name": "k", "public_key": "REDACTED"}, map[string]any{"id": "x"}),
+		exchangeLine(t, 2, "GET", "/vpc/v2/regions/fr-par/vpcs", "page=1", 200,
+			nil, map[string]any{"vpcs": []any{}, "total_count": 0}))
+
+	out, errs, code := runCloudReplay(t, dir, accepted, cloud.URL, nil)
+	if code != exitOK {
+		t.Fatalf("the run exited %d, want 0.\nstdout:\n%s\nstderr:\n%s", code, out, errs)
+	}
+	for _, r := range seen() {
+		if bytes.Contains(r.Body, []byte("REDACTED")) {
+			t.Fatalf("a request carrying the recorder's placeholder reached the endpoint: %s %s", r.Method, r.Path)
+		}
+	}
+	if !strings.Contains(out, "the recording could not be reissued as recorded") {
+		t.Fatalf("the redacted request is not reported as a defect of the recording:\n%s", out)
+	}
+	if strings.Contains(out, "1 finding(s) say the cloud answers differently") {
+		t.Fatalf("the recorder's own substitution was graded as a change of the cloud:\n%s", out)
+	}
+}
+
+// A read whose path still carries the sanitiser's own identifier is not a cloud
+// that changed.
+//
+// A corpus is a causal sequence, and when the create it opens on does not happen
+// — refused as billable, refused as somebody else's, or not sent at all under
+// --dry-run — nothing rebinds the identifier the read addresses. The read then
+// answers 404 and every recorded field reads as absent. Measured on 2026-08-21,
+// dry-running corpus/scaleway/terraform.jsonl at the real Scaleway account: 145
+// findings, not one of them the provider's.
+func TestARequestStillCarryingASyntheticIdentifierIsNotACloudChange(t *testing.T) {
+	cloud, _ := recordingCloud(t)
+	synthetic := "00000000-0000-4000-8000-000000000002"
+	dir, accepted := cloudCorpusFixture(t, exchangeLine(t, 1, "GET",
+		"/vpc/v2/regions/fr-par/vpcs/"+synthetic, "", 200,
+		nil, map[string]any{"id": synthetic, "name": "n", "tags": []any{}}))
+
+	out, errs, code := runCloudReplay(t, dir, accepted, cloud.URL, nil)
+	if code == exitDrift {
+		t.Fatalf("a read of an identifier the sanitiser invented was graded as a change of the cloud.\nstdout:\n%s\nstderr:\n%s", out, errs)
+	}
+	if !strings.Contains(out, "the sanitiser invented") {
+		t.Fatalf("the report does not say the recording is the likelier cause:\n%s", out)
+	}
+	if !strings.Contains(out, "0 finding(s) say the cloud answers differently now") {
+		t.Fatalf("the finding was counted against the cloud:\n%s", out)
+	}
+}
+
+// The two directions talk to each other: a run that finds the cloud has moved
+// writes the measurement into the acceptance file, and `corpus --check` then
+// warns with a measured date instead of a chosen horizon — which is #353's own
+// open question answered by measurement.
+//
+// Three assertions: the measurement lands, the file still reads back through the
+// gate's own reader, and the gate warns without failing. The last is the one
+// that matters — a gate that failed because somebody else's cloud moved is a
+// gate that gets disabled, taking all of its coverage with it.
+func TestACorpusTheCloudHasMovedUnderWarnsAndDoesNotFail(t *testing.T) {
+	dir, accepted, _ := vpcCorpusFixture(t)
+	operation := mutateStatus(t, filepath.Join(dir, "self/self.jsonl"), 200, 418)
+	cloud, _ := recordingCloud(t)
+
+	req := cloudReplayRequest{dir: dir, accepted: accepted, file: "self/self.jsonl",
+		endpoint: cloud.URL, format: "text", timeout: 30 * time.Second, markStale: true}
+	var out, errb bytes.Buffer
+	if code := replayCorpusAtCloud(req, corpusNow, &out, &errb); code != exitDrift {
+		t.Fatalf("the run exited %d, want %d.\nstdout:\n%s\nstderr:\n%s", code, exitDrift, out.String(), errb.String())
+	}
+	if !strings.Contains(out.String(), "records in") {
+		t.Fatalf("the run does not say it wrote the measurement back:\n%s", out.String())
+	}
+
+	acc, err := readCorpusAcceptance(accepted)
+	if err != nil {
+		t.Fatalf("the acceptance file this run wrote cannot be read back: %v", err)
+	}
+	if len(acc.Recorded) != 1 || acc.Recorded[0].CloudMovedAt != "2026-08-21" || acc.Recorded[0].CloudMoved == 0 {
+		t.Fatalf("the measurement did not land: %+v", acc.Recorded)
+	}
+	if acc.WarnAfterDays != 180 {
+		t.Fatalf("writing the measurement lost the rest of the file: warn_after_days is %d", acc.WarnAfterDays)
+	}
+
+	// And the emulator gate says so, on every run, without failing.
+	gate, _, code := runCorpusGate(t, dir, accepted)
+	if code != exitDrift {
+		// The mutated status makes the emulator gate red too, which is right and
+		// is not what this test is about: what it asserts is the warning.
+		t.Logf("the emulator gate exited %d on the same mutated corpus", code)
+	}
+	if !strings.Contains(gate, "had moved: re-record it") {
+		t.Fatalf("the emulator gate does not warn that the cloud has moved under this corpus:\n%s", gate)
+	}
+	_ = operation
+}
+
+// Marking a corpus stale writes the measurement and nothing else.
+//
+// Run against the committed acceptance file, not a fixture, because that file is
+// prose as much as data: its "comment" array carries the argument for every
+// exemption in it. A writer that reflowed or reordered it would make the diff of
+// a scheduled job unreadable, which is the same as making it unreviewed.
+func TestMarkingACorpusStaleWritesTheMeasurementAndNothingElse(t *testing.T) {
+	original, err := os.ReadFile("../../corpus/accepted.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "accepted.json")
+	if err := os.WriteFile(path, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := markCorpusStale(path, "scaleway/terraform.jsonl", corpusNow, 3); err != nil {
+		t.Fatalf("mark the committed acceptance file: %v", err)
+	}
+
+	before, after := map[string]any{}, map[string]any{}
+	if err := json.Unmarshal(original, &before); err != nil {
+		t.Fatal(err)
+	}
+	written, err := os.ReadFile(path) //nolint:gosec // a file this test just wrote
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(written, &after); err != nil {
+		t.Fatalf("the acceptance file this run wrote cannot be parsed: %v", err)
+	}
+	for _, key := range []string{"comment", "warn_after_days", "accepted"} {
+		if fmt.Sprint(before[key]) != fmt.Sprint(after[key]) {
+			t.Fatalf("marking one recording rewrote %q", key)
+		}
+	}
+	marked := 0
+	for _, entry := range after["recorded"].([]any) {
+		row := entry.(map[string]any)
+		if row["cloud_moved_at"] == nil {
+			continue
+		}
+		marked++
+		if row["file"] != "scaleway/terraform.jsonl" || row["cloud_moved_at"] != "2026-08-21" {
+			t.Fatalf("the wrong recording was marked: %v", row)
+		}
+	}
+	if marked != 1 {
+		t.Fatalf("%d recording(s) marked, want exactly the one named", marked)
+	}
+	if err := markCorpusStale(path, "no/such.jsonl", corpusNow, 1); err == nil {
+		t.Fatal("marking a corpus with no recording entry was accepted, so a typo would write nothing and say nothing")
+	}
+}
+
+// Ownership never follows a parent's identifier.
+//
+// A create answers project_id, organization_id and vpc_id beside its own id. A
+// guard that collected those would consider the account's project something this
+// run created, and `DELETE /projects/{id}` would walk straight through the
+// ownership check.
+func TestOwnershipDoesNotFollowAParentIdentifier(t *testing.T) {
+	body := map[string]any{
+		"id":              "11111111-1111-4111-8111-111111111111",
+		"project_id":      "22222222-2222-4222-8222-222222222222",
+		"organization_id": "33333333-3333-4333-8333-333333333333",
+		"vpc_id":          "44444444-4444-4444-8444-444444444444",
+		"subnets":         []any{map[string]any{"id": "55555555-5555-4555-8555-555555555555"}},
+	}
+	got := map[string]bool{}
+	for _, id := range mintedIDs(body) {
+		got[id] = true
+	}
+	if !got["11111111-1111-4111-8111-111111111111"] || !got["55555555-5555-4555-8555-555555555555"] {
+		t.Fatalf("the object this run created is not owned by it: %v", got)
+	}
+	for _, parent := range []string{
+		"22222222-2222-4222-8222-222222222222",
+		"33333333-3333-4333-8333-333333333333",
+		"44444444-4444-4444-8444-444444444444",
+	} {
+		if got[parent] {
+			t.Fatalf("%s is a parent's identifier and this run claims to own it", parent)
+		}
+	}
+}
+
+// A credential never travels in clear, and never in argv.
+func TestACredentialNeverTravelsInClear(t *testing.T) {
+	var errs bytes.Buffer
+	if code := checkCloudEndpoint("http://api.example.com", true, &errs); code != exitError {
+		t.Fatalf("plain HTTP off loopback was accepted (exit %d)", code)
+	}
+	if !strings.Contains(errs.String(), "in clear") {
+		t.Fatalf("the refusal does not say why:\n%s", errs.String())
+	}
+	if code := checkCloudEndpoint("https://api.scaleway.com", true, io.Discard); code != exitOK {
+		t.Fatal("an https endpoint was refused")
+	}
+	if code := checkCloudEndpoint("http://127.0.0.1:4800", true, io.Discard); code != exitOK {
+		t.Fatal("a loopback endpoint was refused, and it is what every falsification runs against")
+	}
+
+	// The value comes from the environment, never from the command line: argv
+	// is world-readable, and a secret key in it is a secret key in `ps`.
+	t.Setenv("FEINT_TEST_TOKEN", "s3cret")
+	headers, err := credentialHeaders(map[string]string{"X-Auth-Token": "FEINT_TEST_TOKEN"})
+	if err != nil || headers["X-Auth-Token"] != "s3cret" {
+		t.Fatalf("the credential was not read from its environment variable: %v %v", headers, err)
+	}
+	if _, err := credentialHeaders(map[string]string{"X-Auth-Token": "FEINT_TEST_ABSENT"}); err == nil {
+		t.Fatal("an empty credential was accepted, and an unauthenticated replay answers 401 everywhere — which reads exactly like a cloud that changed")
+	}
+}
+
+// A credential the operator named is actually sent, on every request. Asserted
+// rather than assumed: a transport that dropped it would make every run answer
+// 401 and every 401 is verdict three, so the failure would look like a cloud
+// problem forever.
+func TestTheNamedCredentialReachesEveryRequest(t *testing.T) {
+	t.Setenv("FEINT_TEST_TOKEN", "s3cret")
+	cloud, seen := recordingCloud(t)
+	dir, accepted := cloudCorpusFixture(t, exchangeLine(t, 1, "GET",
+		"/vpc/v2/regions/fr-par/vpcs", "page=1", 200, nil, map[string]any{"vpcs": []any{}, "total_count": 0}))
+
+	_, _, code := runCloudReplay(t, dir, accepted, cloud.URL, map[string]string{"X-Auth-Token": "FEINT_TEST_TOKEN"})
+	if code != exitOK {
+		t.Fatalf("the run exited %d", code)
+	}
+	requests := seen()
+	if len(requests) == 0 {
+		t.Fatal("nothing reached the endpoint, so this proves nothing about its headers")
+	}
+	for _, r := range requests {
+		if r.Token != "s3cret" {
+			t.Fatalf("%s %s carried %q as its credential", r.Method, r.Path, r.Token)
+		}
+	}
+}
+
+// A corpus nobody dated is not reissued at a cloud. A difference against an
+// undated recording cannot be read: "the cloud moved" and "this file describes
+// the cloud of eight months ago" are the same observation at two ages.
+func TestAnUndatedCorpusIsNotReplayedAtTheCloud(t *testing.T) {
+	cloud, seen := recordingCloud(t)
+	dir, _ := cloudCorpusFixture(t, exchangeLine(t, 1, "GET",
+		"/vpc/v2/regions/fr-par/vpcs", "page=1", 200, nil, map[string]any{"vpcs": []any{}}))
+	undated := writeAccepted(t, corpusAcceptance{WarnAfterDays: 180})
+
+	out, errs, code := runCloudReplay(t, dir, undated, cloud.URL, nil)
+	if code != exitError {
+		t.Fatalf("an undated corpus exited %d, want %d.\nstdout:\n%s\nstderr:\n%s", code, exitError, out, errs)
+	}
+	if !strings.Contains(errs, "no entry") {
+		t.Fatalf("the refusal does not say the recording carries no date:\n%s", errs)
+	}
+	if len(seen()) != 0 {
+		t.Fatal("an undated corpus reached the endpoint anyway")
+	}
+}
+
+// --dry-run reads and refuses everything that would change the account, so an
+// operator can see what a run would do before it does it.
+func TestADryRunSendsNoChange(t *testing.T) {
+	dir, accepted, _ := vpcCorpusFixture(t)
+	cloud, seen := recordingCloud(t)
+
+	req := cloudReplayRequest{dir: dir, accepted: accepted, file: "self/self.jsonl",
+		endpoint: cloud.URL, format: "text", timeout: 30 * time.Second, dryRun: true}
+	var out, errb bytes.Buffer
+	_ = replayCorpusAtCloud(req, corpusNow, &out, &errb)
+	for _, r := range seen() {
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			t.Fatalf("--dry-run sent %s %s", r.Method, r.Path)
+		}
+	}
+	if !strings.Contains(out.String(), "--dry-run") {
+		t.Fatalf("the run does not say why it changed nothing:\n%s", out.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// harness
+
+func runCloudReplay(t *testing.T, dir, accepted, endpoint string, credentials map[string]string) (string, string, int) {
+	t.Helper()
+	var out, errb bytes.Buffer
+	code := replayCorpusAtCloud(cloudReplayRequest{
+		dir: dir, accepted: accepted, file: "self/self.jsonl", endpoint: endpoint,
+		credentials: credentials, format: "text", timeout: 30 * time.Second,
+	}, corpusNow, &out, &errb)
+	return out.String(), errb.String(), code
+}
+
+// capturedRequest is one call that reached the stand-in cloud.
+type capturedRequest struct {
+	Method, Path, Token string
+	Body                []byte
+}
+
+// recordingCloud is an emulator that also says what was asked of it. The stand-in
+// for a provider, and the only way a test can assert what a run *did not* send —
+// which is what every guard here is about.
+func recordingCloud(t *testing.T) (*httptest.Server, func() []capturedRequest) {
+	t.Helper()
+	srv, _, err := newServer(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inner := srv.Handler()
+
+	var mu sync.Mutex
+	var seen []capturedRequest
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+		_ = r.Body.Close()
+		mu.Lock()
+		seen = append(seen, capturedRequest{Method: r.Method, Path: r.URL.Path,
+			Token: r.Header.Get("X-Auth-Token"), Body: body})
+		mu.Unlock()
+		r.Body = io.NopCloser(bytes.NewReader(body))
+		r.ContentLength = int64(len(body))
+		inner.ServeHTTP(w, r)
+	}))
+	t.Cleanup(ts.Close)
+	return ts, func() []capturedRequest {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]capturedRequest, len(seen))
+		copy(out, seen)
+		return out
+	}
+}
+
+// swallowingCloud answers 204 to every DELETE and forwards nothing, which is
+// what a provider's own asynchronous delete looks like from outside. Returns the
+// front door and the endpoint behind it, so a test can read what is really
+// there.
+func swallowingCloud(t *testing.T) (*httptest.Server, string) {
+	t.Helper()
+	inner, _ := recordingCloud(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		proxied, err := http.NewRequestWithContext(r.Context(), r.Method, inner.URL+r.URL.RequestURI(), r.Body)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		proxied.Header = r.Header.Clone()
+		res, err := http.DefaultClient.Do(proxied)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		defer func() { _ = res.Body.Close() }()
+		for name, values := range res.Header {
+			for _, v := range values {
+				w.Header().Add(name, v)
+			}
+		}
+		w.WriteHeader(res.StatusCode)
+		_, _ = io.Copy(w, res.Body)
+	}))
+	t.Cleanup(ts.Close)
+	return ts, inner.URL
+}
+
+// vpcCorpusFixture records a free lifecycle — a VPC and a private network,
+// created, read, updated, deleted, and each deletion proved by a read answering
+// 404 — through the proxy, exactly as corpus/README.md's procedure does against
+// a real account. Only operations on the free-to-create list, so the fixture
+// obeys the rule it is here to prove.
+func vpcCorpusFixture(t *testing.T) (dir, accepted, recording string) {
+	t.Helper()
+	source := freshEmulator(t)
+
+	recording = filepath.Join(t.TempDir(), "lifecycle.jsonl")
+	file, err := os.OpenFile(recording, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = file.Close() }()
+
+	writer := proxy.NewWriter(file, 0)
+	upstream, err := url.Parse(source.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	table, err := emulator.NewTable(mustPacks(t)...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	px, err := proxy.New(proxy.Options{Upstream: upstream, Writer: writer, Table: table})
+	if err != nil {
+		t.Fatal(err)
+	}
+	front := httptest.NewServer(px)
+	defer front.Close()
+
+	region := "/vpc/v2/regions/fr-par"
+	vpc := topID(t, callJSON(t, front.URL, "POST", region+"/vpcs", `{"name":"fixture-vpc","tags":["a"]}`))
+	callJSON(t, front.URL, "GET", region+"/vpcs/"+vpc, "")
+	pn := topID(t, callJSON(t, front.URL, "POST", region+"/private-networks",
+		`{"name":"fixture-pn","vpc_id":"`+vpc+`"}`))
+	callJSON(t, front.URL, "GET", region+"/private-networks/"+pn, "")
+	callJSON(t, front.URL, "DELETE", region+"/private-networks/"+pn, "")
+	// The read that proves the deletion, which is #352's rule and therefore
+	// belongs in the fixture: the proof of a destruction is a 404, never the
+	// exit code of the delete. callJSON refuses a 4xx, so this one goes raw.
+	callAnything(t, front.URL, "GET", region+"/private-networks/"+pn)
+	callJSON(t, front.URL, "DELETE", region+"/vpcs/"+vpc, "")
+	callAnything(t, front.URL, "GET", region+"/vpcs/"+vpc)
+
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close the transcript writer: %v", err)
+	}
+	raw, err := os.ReadFile(recording) //nolint:gosec // a file this test just wrote
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir, accepted = cloudCorpusFixture(t, strings.Split(strings.TrimRight(string(raw), "\n"), "\n")...)
+	return dir, accepted, recording
+}
+
+// cloudCorpusFixture lays lines out as a corpus with its dated acceptance file.
+func cloudCorpusFixture(t *testing.T, lines ...string) (dir, accepted string) {
+	t.Helper()
+	dir = filepath.Join(t.TempDir(), "corpus")
+	if err := os.MkdirAll(filepath.Join(dir, "self"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	content := strings.Join(lines, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "self", "self.jsonl"), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	accepted = writeAccepted(t, corpusAcceptance{
+		WarnAfterDays: 180,
+		Recorded: []corpusRecording{
+			{File: "self/self.jsonl", At: "2026-08-21", Client: "feint", Cloud: "a stand-in cloud"},
+		},
+	})
+	return dir, accepted
+}
+
+// exchangeLine writes one transcript line by hand, for the shapes no recording
+// of this emulator can produce.
+func exchangeLine(t *testing.T, seq int, method, path, query string, status int, req, res any) string {
+	t.Helper()
+	line := map[string]any{
+		"seq": seq, "t": "2020-01-01T00:00:00Z", "method": method, "path": path,
+		"status": status, "ms": 0, "mounted": true,
+		"res": map[string]any{"headers": map[string]any{"Content-Type": "application/json"}, "body": res},
+	}
+	if query != "" {
+		line["query"] = query
+	}
+	if req != nil {
+		line["req"] = map[string]any{"headers": map[string]any{"Content-Type": "application/json"}, "body": req}
+	}
+	raw, err := json.Marshal(line)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(raw)
+}
+
+func createVPC(t *testing.T, endpoint, name string) string {
+	t.Helper()
+	return topID(t, callJSON(t, endpoint, "POST", "/vpc/v2/regions/fr-par/vpcs", `{"name":"`+name+`"}`))
+}
+
+// topID reads the identifier a Scaleway vpc/v2 create answers at the top level,
+// where instance/v1 wraps its object in a key and [idOf] reads that shape.
+func topID(t *testing.T, body map[string]any) string {
+	t.Helper()
+	id, ok := body["id"].(string)
+	if !ok || id == "" {
+		t.Fatalf("the answer carries no identifier: %v", body)
+	}
+	return id
+}
+
+// callAnything issues a request and reads its answer whatever the status is.
+func callAnything(t *testing.T, base, method, path string) {
+	t.Helper()
+	req, err := http.NewRequest(method, base+path, nil) //nolint:noctx // a loopback test server
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = io.Copy(io.Discard, res.Body)
+	_ = res.Body.Close()
+}
+
+func statusOf(t *testing.T, target string) int {
+	t.Helper()
+	res, err := http.Get(target) //nolint:gosec,noctx // a loopback test server
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	return res.StatusCode
+}
+
+func vpcCount(t *testing.T, endpoint string) int {
+	t.Helper()
+	res, err := http.Get(endpoint + "/vpc/v2/regions/fr-par/vpcs?page=1") //nolint:gosec,noctx // a loopback test server
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	var body struct {
+		VPCs []json.RawMessage `json:"vpcs"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	return len(body.VPCs)
+}

--- a/internal/cli/corpus_cloud_test.go
+++ b/internal/cli/corpus_cloud_test.go
@@ -196,8 +196,14 @@ func TestAPacksDeclineDoesNotExcuseTheCloud(t *testing.T) {
 	// green. Both halves are asserted, because "it is reported at the cloud" is
 	// only interesting beside "it is excused at the emulator".
 	gateDir, gateAccepted := cloudCorpusFixture(t, line)
-	if _, _, code := runCorpusGate(t, gateDir, gateAccepted); code != exitOK {
-		t.Fatalf("the declined field fails the emulator gate, so this fixture no longer isolates the decline")
+	// The subject is asserted, not the exit code. A one-exchange catalogue
+	// fixture reaches no operation carrying an invariant, so #343's guard
+	// makes the whole run exitError for a reason that has nothing to do with
+	// this decline; reading the code alone would have this test measure that
+	// guard instead of the excuse it is about.
+	gate, _, _ := runCorpusGate(t, gateDir, gateAccepted)
+	if !strings.Contains(gate, "\n0 divergent finding(s) nothing accepts") {
+		t.Fatalf("the declined field is not excused at the emulator, so this fixture no longer isolates the decline:\n%s", gate)
 	}
 
 	cloud, _ := recordingCloud(t)
@@ -821,4 +827,52 @@ func vpcCount(t *testing.T, endpoint string) int {
 		t.Fatal(err)
 	}
 	return len(body.VPCs)
+}
+
+// The moved-cloud warning survives a run that is red for another reason.
+//
+// warnMovedCorpora's own comment says the warning is on every run, and until
+// this test existed that sentence was false: the call sat below the
+// unexercised-invariant guard (#343) and below the stale-exemption guard, so a
+// corpus that tripped either printed nothing about the provider having moved
+// under it. That is the worst moment to withhold it — "re-record this file" is
+// a candidate fix for the very redness being reported, and a maintainer who
+// does not see it goes looking for a defect in the emulator instead.
+//
+// The fixture is deliberately the poorest run that reaches the print: a VPC
+// corpus reaches no operation carrying an invariant, so #343's guard returns
+// exitError before the warning's old position. Asserting the exit code as well
+// as the warning is what keeps this honest — if a later change made the run
+// green, the test would still pass while measuring nothing.
+func TestTheMovedWarningSurvivesARunThatIsRedForAnotherReason(t *testing.T) {
+	dir, accepted, _ := vpcCorpusFixture(t)
+
+	acc, err := readCorpusAcceptance(accepted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(acc.Recorded) != 1 {
+		t.Fatalf("the fixture no longer carries exactly one recording: %+v", acc.Recorded)
+	}
+	acc.Recorded[0].CloudMovedAt = "2026-08-21"
+	acc.Recorded[0].CloudMoved = 3
+	body, err := json.MarshalIndent(acc, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(accepted, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, errs, code := runCorpusGate(t, dir, accepted)
+	if code != exitError {
+		t.Fatalf("this fixture no longer goes red for another reason, so it cannot prove the warning survives one (exit %d).\nstdout:\n%s\nstderr:\n%s",
+			code, out, errs)
+	}
+	if !strings.Contains(errs, "invariant(s) and this corpus ran none of them") {
+		t.Fatalf("the run is red for some other reason than the one this test assumes:\n%s", errs)
+	}
+	if !strings.Contains(out, "had moved: re-record it") {
+		t.Fatalf("a run red for another reason withheld the moved-cloud warning:\n%s", out)
+	}
 }

--- a/internal/cli/testdata/frozen/cli.json
+++ b/internal/cli/testdata/frozen/cli.json
@@ -1304,6 +1304,186 @@
           ]
         }
       }
+    },
+    {
+      "schema_version": 10,
+      "content": {
+        "exit_codes": {
+          "drift": 2,
+          "error": 1,
+          "ok": 0
+        },
+        "verbs": {
+          "catalog": [
+            "--format"
+          ],
+          "clean": [
+            "--vm"
+          ],
+          "corpus": [
+            "--accepted",
+            "--against-cloud",
+            "--bind",
+            "--check",
+            "--credential",
+            "--dir",
+            "--dry-run",
+            "--endpoint",
+            "--file",
+            "--format",
+            "--mark-stale",
+            "--timeout"
+          ],
+          "coverage": [
+            "--artefact",
+            "--baseline",
+            "--contract",
+            "--fail-on-unknown",
+            "--format",
+            "--observed",
+            "--products",
+            "--provider",
+            "--sdk",
+            "--write-baseline"
+          ],
+          "docs": [
+            "--check",
+            "--client-pins",
+            "--confidence",
+            "--contracts",
+            "--coverage",
+            "--file",
+            "--install",
+            "--limits",
+            "--proved",
+            "--routes",
+            "--screenshots",
+            "--ui-manifest",
+            "--workflow"
+          ],
+          "doctor": [
+            "--addr",
+            "--vm"
+          ],
+          "env": [
+            "--client",
+            "--endpoint",
+            "--shell",
+            "--unset"
+          ],
+          "evidence": [
+            "--allow-narrowing",
+            "--contracts",
+            "--endpoint",
+            "--join",
+            "--out",
+            "--shapes",
+            "--suites"
+          ],
+          "images": [
+            "--check",
+            "--only",
+            "--vm"
+          ],
+          "logs": [
+            "--addr",
+            "-f",
+            "-n"
+          ],
+          "probe": [
+            "--contracts",
+            "--endpoint",
+            "--provider"
+          ],
+          "proxy": [
+            "--addr",
+            "--expose-to-network",
+            "--forward",
+            "--intercept",
+            "--max-body",
+            "--provider",
+            "--queue",
+            "--record",
+            "--upstream"
+          ],
+          "replay": [
+            "--endpoint",
+            "--format",
+            "--timeout"
+          ],
+          "restart": [
+            "--addr",
+            "--timeout"
+          ],
+          "serve": [
+            "--addr",
+            "--cleanup",
+            "--contracts",
+            "--coverage",
+            "--expose-to-network",
+            "--log-level",
+            "--shapes",
+            "--state",
+            "--vm"
+          ],
+          "shapes": [
+            "--check",
+            "--dir",
+            "--dry-run",
+            "--profile",
+            "--provider",
+            "--record"
+          ],
+          "snapshot list": [
+            "--format"
+          ],
+          "snapshot load": [
+            "--addr"
+          ],
+          "snapshot save": [
+            "--addr",
+            "--force"
+          ],
+          "start": [
+            "--addr",
+            "--cleanup",
+            "--contracts",
+            "--detach",
+            "--foreground",
+            "--log-level",
+            "--state",
+            "--timeout",
+            "--vm"
+          ],
+          "status": [
+            "--addr",
+            "--coverage",
+            "--format"
+          ],
+          "stop": [
+            "--addr",
+            "--timeout"
+          ],
+          "transcript": [
+            "--against",
+            "--contract",
+            "--format",
+            "--sanitise",
+            "--shape"
+          ],
+          "ui": [
+            "--addr",
+            "--print"
+          ],
+          "version": [
+            "--check"
+          ],
+          "wait": [
+            "--addr",
+            "--timeout"
+          ]
+        }
+      }
     }
   ]
 }

--- a/internal/corpus/scan.go
+++ b/internal/corpus/scan.go
@@ -171,6 +171,17 @@ func (a *alphabet) refuse(v value) string {
 	return "not a value a sanitised transcript may carry"
 }
 
+// Minted reports whether a value is one this package invented.
+//
+// Exported for the direction that reads a committed corpus back and reissues it
+// at the provider it was recorded from (#359). There, a value the sanitiser
+// minted is a value the *cloud* never said, so a refusal landing on a request
+// that still carries one is a defect of the instrument before it is anything
+// about the cloud — the class #73 measured as nine false divergences and #354
+// as four more. The question belongs here, where the answer is regenerated from
+// the rules that wrote the value, and not in a caller re-spelling the alphabet.
+func Minted(s string) bool { return synthetic(s) }
+
 // synthetic reports whether a value is one this package mints.
 //
 // Each arm recognises the exact form [mint] writes, rather than a family it

--- a/internal/replay/guard_test.go
+++ b/internal/replay/guard_test.go
@@ -1,0 +1,195 @@
+package replay_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stephrobert/feint/internal/replay"
+	"github.com/stephrobert/feint/internal/trace"
+)
+
+// What a replay needs to stop being an emulator-only tool (#359).
+//
+// The same comparison runs at this emulator, where a request costs nothing, and
+// at a provider, where a POST is an invoice and a DELETE is somebody's property.
+// The two seams below are what the second direction adds, and they are here
+// rather than in the caller because both need the request *as it will go out* —
+// after rebinding, which only this package knows.
+
+// recording is one guard's log, and it is the assertion: what actually went out.
+type recording struct {
+	refuse    func(replay.Attempt) string
+	attempted []replay.Attempt
+	answered  []int
+}
+
+func (g *recording) Before(a replay.Attempt) string {
+	g.attempted = append(g.attempted, a)
+	if g.refuse == nil {
+		return ""
+	}
+	return g.refuse(a)
+}
+
+func (g *recording) After(_ replay.Attempt, status int, _ any) {
+	g.answered = append(g.answered, status)
+}
+
+// A request a guard refuses is not sent, and is neither a match nor a
+// divergence. Three assertions rather than one: the verdict, the reason, and —
+// the one that matters — that the endpoint never saw it.
+func TestAGuardRefusalIsNotSentAndIsNotADivergence(t *testing.T) {
+	var reached int
+	server := answers(t, func(*http.Request) (int, string) {
+		reached++
+		return 201, `{"server":{"id":"` + freshID + `"}}`
+	})
+	guard := &recording{refuse: func(a replay.Attempt) string {
+		if a.Method == http.MethodPost {
+			return "this run does not create"
+		}
+		return ""
+	}}
+
+	rep, err := replay.Run(context.Background(),
+		[]trace.Exchange{exchange(t, createLine(`{"server":{"id":"`+recordedID+`"}}`))},
+		replay.Options{Endpoint: server.URL, Client: &http.Client{Timeout: 5 * time.Second},
+			Table: table(t), Guard: guard})
+	if err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	if reached != 0 {
+		t.Fatalf("a refused request reached the endpoint %d time(s)", reached)
+	}
+	if rep.RefusedCount != 1 || rep.Divergent != 0 || rep.Matched != 0 {
+		t.Fatalf("a refusal was counted as something else: %+v", rep)
+	}
+	if rep.Results[0].Verdict != replay.Refused || rep.Results[0].Refused != "this run does not create" {
+		t.Fatalf("the refusal does not carry the guard's own sentence: %+v", rep.Results[0])
+	}
+	if len(guard.answered) != 0 {
+		t.Fatal("a refused request produced an answer to record")
+	}
+}
+
+// The guard judges the request that will actually go out, not the one on disk.
+//
+// A recorded DELETE names the identifier the cloud minted last time; after
+// rebinding it names whatever this run just created. A guard handed the recorded
+// path would be asking about an object that exists nowhere, and would wave
+// through the one request that can destroy something.
+func TestAGuardSeesTheRequestAfterRebinding(t *testing.T) {
+	server := answers(t, func(r *http.Request) (int, string) {
+		if r.Method == http.MethodPost {
+			return 201, `{"server":{"id":"` + freshID + `"}}`
+		}
+		return 200, `{"server":{"id":"` + freshID + `"}}`
+	})
+	guard := &recording{}
+	if _, err := replay.Run(context.Background(), []trace.Exchange{
+		exchange(t, createLine(`{"server":{"id":"`+recordedID+`"}}`)),
+		exchange(t, getLine()),
+	}, replay.Options{Endpoint: server.URL, Client: &http.Client{Timeout: 5 * time.Second},
+		Table: table(t), Guard: guard}); err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	if len(guard.attempted) != 2 {
+		t.Fatalf("the guard saw %d attempt(s), want 2", len(guard.attempted))
+	}
+	read := guard.attempted[1]
+	if strings.Contains(read.Path, recordedID) {
+		t.Fatalf("the guard was asked about the recorded identifier: %s", read.Path)
+	}
+	if !strings.Contains(read.Path, freshID) {
+		t.Fatalf("the guard was not asked about the identifier this run created: %s", read.Path)
+	}
+	if guard.answered[0] != 201 {
+		t.Fatalf("the guard was handed status %d for the create", guard.answered[0])
+	}
+}
+
+// A seeded binding is sent before anything has been learned.
+//
+// Rebinding otherwise needs a read before the first write, and a recording that
+// opens on a create has none: corpus/scaleway/terraform.jsonl's first line is a
+// POST carrying a project identifier that belongs to no account the replay is
+// pointed at. This is the half that makes the second direction work at all, and
+// it was inert the first time round — the substitution was skipped whenever
+// nothing had been *learned* yet, which on such a recording is forever.
+func TestASeededBindingIsSentBeforeAnythingIsLearned(t *testing.T) {
+	var got map[string]any
+	server := answers(t, func(r *http.Request) (int, string) {
+		_ = json.NewDecoder(r.Body).Decode(&got)
+		return 201, `{"server":{"id":"` + freshID + `"}}`
+	})
+	line := `{"method":"POST","path":"` + serverPath + `","operation":"instance/v1/API.CreateServer",` +
+		`"status":201,"mounted":true,` +
+		`"req":{"headers":{"Content-Type":"application/json"},"body":{"name":"web-1","project_id":"` + recordedID + `"}},` +
+		`"res":{"headers":{"Content-Type":"application/json"},"body":{"server":{"id":"` + recordedID + `"}}}}`
+
+	if _, err := replay.Run(context.Background(), []trace.Exchange{exchange(t, line)},
+		replay.Options{Endpoint: server.URL, Client: &http.Client{Timeout: 5 * time.Second},
+			Table: table(t), Bind: map[string]string{"project_id": freshIPOne}}); err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	if got["project_id"] != freshIPOne {
+		t.Fatalf("the first request carried project_id %v, want the seeded one", got["project_id"])
+	}
+}
+
+// A seed replaces an identifier, and leaves whatever else that field may carry
+// alone.
+//
+// The seed's contract is "wherever the recording carries an identifier at this
+// field name, send this one". A field is not always an identifier — Scaleway's
+// own clients accept a project by name — and a seed that rewrote every value
+// under the name would send a request the recording never made, which is the
+// class of defect this whole direction exists to detect rather than to commit.
+func TestASeedReplacesAnIdentifierAndNotWhateverElseTheFieldMayCarry(t *testing.T) {
+	var got map[string]any
+	server := answers(t, func(r *http.Request) (int, string) {
+		_ = json.NewDecoder(r.Body).Decode(&got)
+		return 201, `{"server":{"id":"` + freshID + `"}}`
+	})
+	line := `{"method":"POST","path":"` + serverPath + `","operation":"instance/v1/API.CreateServer",` +
+		`"status":201,"mounted":true,` +
+		`"req":{"headers":{"Content-Type":"application/json"},"body":{"project_id":"my-project-alias"}},` +
+		`"res":{"headers":{"Content-Type":"application/json"},"body":{"server":{"id":"` + recordedID + `"}}}}`
+
+	if _, err := replay.Run(context.Background(), []trace.Exchange{exchange(t, line)},
+		replay.Options{Endpoint: server.URL, Client: &http.Client{Timeout: 5 * time.Second},
+			Table: table(t), Bind: map[string]string{"project_id": freshIPOne}}); err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	if got["project_id"] != "my-project-alias" {
+		t.Fatalf("the seed rewrote a value that is not an identifier: %v", got["project_id"])
+	}
+}
+
+// A seed with no field would apply where nothing else names a value — every
+// path segment of every URL. Refused rather than ignored.
+func TestASeedWithNoFieldIsRefused(t *testing.T) {
+	for name, bind := range map[string]map[string]string{
+		"no field": {"": freshID},
+		"no value": {"project_id": ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := replay.Run(context.Background(), nil, replay.Options{
+				Endpoint: "http://127.0.0.1:1", Client: &http.Client{Timeout: time.Second},
+				Table: table(t), Bind: bind})
+			if err == nil {
+				t.Fatal("a half-spelled seed was accepted")
+			}
+		})
+	}
+}
+
+func getLine() string {
+	return `{"method":"GET","path":"` + serverPath + `/` + recordedID + `","operation":"instance/v1/API.GetServer",` +
+		`"status":200,"mounted":true,` +
+		`"res":{"headers":{"Content-Type":"application/json"},"body":{"server":{"id":"` + recordedID + `"}}}}`
+}

--- a/internal/replay/replay.go
+++ b/internal/replay/replay.go
@@ -98,6 +98,12 @@ const (
 	// rather than dropped, because a total that shrinks in silence is the
 	// failure `feint shapes --check` already has a paragraph about.
 	Skipped Verdict = "skipped"
+	// Refused: a [Guard] the caller supplied would not let the request go out.
+	// Never a divergence and never a pass — the call was not made, so nothing
+	// was measured, and #359's third verdict is exactly that distinction. It
+	// exists because the same replay that grades an emulator also reissues a
+	// recording at a real account, where a DELETE is a real deletion.
+	Refused Verdict = "refused"
 )
 
 // FindingKind names what went wrong at one place.
@@ -147,6 +153,18 @@ type Result struct {
 	Provider  string    `json:"provider,omitempty"`
 	Verdict   Verdict   `json:"verdict"`
 	Findings  []Finding `json:"findings,omitempty"`
+	// Status is what the endpoint answered, 0 when nothing was sent. A status
+	// is the endpoint's own word and not a value read from the recording, so it
+	// may be published where a body may not: a caller replaying at a real cloud
+	// has to tell "the answer differs" from "the answer never came" (a 401, a
+	// 429, a 502), and reading that off a KindStatus finding only works while
+	// there is one.
+	Status int `json:"status,omitempty"`
+	// Refused is the [Guard]'s own sentence for a request it would not let go
+	// out, empty for every other verdict. Written by the caller, so it carries
+	// whatever the caller put in it — every guard in this repository names an
+	// operation and a rule, never a value of the account.
+	Refused string `json:"refused,omitempty"`
 }
 
 // Report is the whole run.
@@ -156,6 +174,8 @@ type Report struct {
 	Divergent int      `json:"divergent"`
 	Unserved  int      `json:"unserved"`
 	Skipped   int      `json:"skipped"`
+	// RefusedCount is how many requests a [Guard] would not let go out.
+	RefusedCount int `json:"refused"`
 	// Excused counts fields subtracted by a pack's DeclinedFields().
 	Excused int `json:"excused"`
 	// Redacted counts fields the recorder replaced before writing, whose type
@@ -206,6 +226,61 @@ type Options struct {
 	// caller because it is the caller that holds the packs.
 	Declined   []emulator.FieldDecline
 	Invariants []emulator.Invariant
+	// Bind seeds the rebinding table before the first request: a field name,
+	// and the value every recorded identifier sitting at that field must be
+	// sent as.
+	//
+	// Rebinding otherwise learns from what the endpoint answers, which needs a
+	// read before the first write. A recording that opens on a create has none
+	// — corpus/scaleway/terraform.jsonl starts with POST /vpc/v2/…/vpcs — so
+	// its project_id would go out as the identifier the recording carries,
+	// which belongs to no account the replay is pointed at. Seeding it is the
+	// caller saying "this account is the one that stands in for the recorded
+	// one", and only for identifiers: a seed never rewrites a free-text field,
+	// because a name is not something a later request refers back to.
+	Bind map[string]string
+	// Guard, when set, is asked before every request goes out and is handed
+	// every answer that comes back. nil means send everything, which is what
+	// replaying at an emulator wants.
+	//
+	// It exists because the same comparison runs in two directions (#359): at
+	// this emulator, where a request costs nothing and a DELETE deletes a
+	// fixture, and at the provider itself, where a DELETE deletes an account's
+	// property. The refusal has to sit where the rebound path is known — a
+	// caller inspecting the recording sees the identifier the *cloud minted
+	// last time*, not the one this run just created — and that is here.
+	Guard Guard
+}
+
+// Guard is consulted around every request a run would issue.
+//
+// Two methods rather than one, because they answer different questions and only
+// the caller can answer either: whether this request may be sent at all, and
+// what the answer means for the ledger of objects the caller will have to
+// destroy. Neither belongs in this package — a [Report] is published, and the
+// identifiers a real account minted are not.
+type Guard interface {
+	// Before reports why this request must not be sent, or "" to allow it. A
+	// refused request is not issued and its exchange is [Refused].
+	Before(Attempt) string
+	// After is handed the status and the decoded body the endpoint answered,
+	// so the caller can record what the request created.
+	After(a Attempt, status int, body any)
+}
+
+// Attempt is one request as it will actually go out: after rebinding, after
+// seeding, with the operation the route table names it by.
+//
+// Body is the decoded request body, nil when there is none. It is the *sent*
+// body rather than the recorded one, which is the whole point for a guard that
+// has to tell a value this run resolved from a value the recording invented.
+type Attempt struct {
+	Seq       int    `json:"seq"`
+	Operation string `json:"operation,omitempty"`
+	Method    string `json:"method"`
+	Path      string `json:"path"`
+	Query     string `json:"query,omitempty"`
+	Body      any    `json:"-"`
 }
 
 // Run replays a recording in order and reports on each exchange.
@@ -222,6 +297,17 @@ func Run(ctx context.Context, exs []trace.Exchange, opt Options) (Report, error)
 		return Report{}, fmt.Errorf("replay needs the emulator's route table to tell an unserved operation from a divergent one")
 	}
 	b := newBindings()
+	for field, value := range opt.Bind {
+		if field == "" || value == "" {
+			// A seed with no field would apply to path segments, which is the
+			// one place [bindings.resolve] falls back to when nothing else
+			// names the value: it would rewrite every identifier of every URL
+			// to one string. Refused rather than ignored.
+			// TestASeedWithNoFieldIsRefused fails without this.
+			return Report{}, fmt.Errorf("a seeded binding needs both a field name and a value to send under it")
+		}
+		b.forced[field] = value
+	}
 	var rep Report
 	for i := range exs {
 		res, ran, err := replayOne(ctx, &exs[i], i+1, b, opt)
@@ -247,6 +333,8 @@ func Run(ctx context.Context, exs []trace.Exchange, opt Options) (Report, error)
 			rep.Unserved++
 		case Skipped:
 			rep.Skipped++
+		case Refused:
+			rep.RefusedCount++
 		}
 		rep.Results = append(rep.Results, res)
 	}
@@ -297,8 +385,26 @@ func replayOne(ctx context.Context, x *trace.Exchange, seq int, b *bindings, opt
 	res.Operation = mounted.Route.Operation
 	res.Provider = mounted.Provider
 
+	attempt := Attempt{Seq: seq, Operation: mounted.Route.Operation, Method: x.Method, Path: path, Query: query}
 	if x.Req != nil && x.Req.Body != nil {
-		body, err := encodeBody(b.applyValue("", x.Req.Body))
+		attempt.Body = b.applyValue("", x.Req.Body)
+	}
+	// Asked before anything is sent, and after rebinding, because what a guard
+	// has to judge is the request that would actually go out. A DELETE whose
+	// path still carries the identifier the recording holds addresses nothing;
+	// the same DELETE after rebinding addresses whatever this run just created,
+	// or — if the rebinding went wrong — something that was already there.
+	// TestAGuardRefusalIsNotSentAndIsNotADivergence fails without this.
+	if opt.Guard != nil {
+		if why := opt.Guard.Before(attempt); why != "" {
+			res.Verdict = Refused
+			res.Refused = why
+			return res, checked{}, nil
+		}
+	}
+
+	if attempt.Body != nil {
+		body, err := encodeBody(attempt.Body)
 		if err != nil {
 			return res, checked{}, fmt.Errorf("line %d: encode the recorded request body: %w", seq, err)
 		}
@@ -316,6 +422,14 @@ func replayOne(ctx context.Context, x *trace.Exchange, seq int, b *bindings, opt
 	got, err := readBody(resp)
 	if err != nil {
 		return res, checked{}, fmt.Errorf("line %d: read the answer: %w", seq, err)
+	}
+	res.Status = resp.StatusCode
+	// Handed over before the comparison, so that a caller keeping a ledger of
+	// what it created holds the identifier even when the exchange goes on to be
+	// graded divergent. An object created by a request whose answer was not the
+	// recorded one is still an object somebody has to destroy.
+	if opt.Guard != nil {
+		opt.Guard.After(attempt, resp.StatusCode, got)
 	}
 
 	// Compared first, learned from second.
@@ -784,6 +898,12 @@ type bindings struct {
 	// name for "this recording says less than the replay needs", and a run that
 	// resolved one by field name should be able to say so.
 	ambiguous map[string]struct{}
+	// forced is [Options.Bind]: a field name, and the value every recorded
+	// identifier at that field is sent as, whatever the endpoint has answered
+	// so far. It wins over both maps above, because it is the caller stating
+	// which account stands in for the recorded one rather than the replay
+	// inferring it.
+	forced map[string]string
 }
 
 func newBindings() *bindings {
@@ -791,8 +911,16 @@ func newBindings() *bindings {
 		to:        map[string]string{},
 		byField:   map[string]map[string]string{},
 		ambiguous: map[string]struct{}{},
+		forced:    map[string]string{},
 	}
 }
+
+// substituting reports whether anything could be substituted at all. Both maps
+// have to be consulted: a run seeded with [Options.Bind] and no answer yet has
+// learned nothing, and testing only the learned map made every seed inert until
+// the first identifier moved — which on a recording that opens with a create is
+// never.
+func (b *bindings) substituting() bool { return len(b.to) > 0 || len(b.forced) > 0 }
 
 func (b *bindings) count() int { return len(b.to) }
 
@@ -869,6 +997,13 @@ func (b *bindings) learn(field string, want, got any) {
 // ask about: a path segment, or a query parameter whose name no body field
 // carried.
 func (b *bindings) resolve(field, value string) (string, bool) {
+	// The seed, and only over an identifier. A field name the caller seeded is
+	// still an ordinary field for everything else it may carry: `name` is a
+	// free-text field on one operation and an identifier on none, and a seed
+	// that rewrote free text would send a request the recording never made.
+	if to, seeded := b.forced[field]; seeded && looksMinted(value) {
+		return to, true
+	}
 	if to, bound := b.byField[field][value]; bound {
 		return to, true
 	}
@@ -880,7 +1015,7 @@ func (b *bindings) resolve(field, value string) (string, bool) {
 // only: a substring replacement inside a free-text segment would corrupt a
 // request rather than repair it.
 func (b *bindings) applyPath(path string) string {
-	if len(b.to) == 0 {
+	if !b.substituting() {
 		return path
 	}
 	segments := strings.Split(path, "/")
@@ -910,7 +1045,7 @@ func (b *bindings) applyPath(path string) string {
 // spelled exactly like the body fields they filter on. Resolving them globally
 // is what sent one list to the organisation and made the verdict flap.
 func (b *bindings) applyQuery(raw string) string {
-	if raw == "" || len(b.to) == 0 {
+	if raw == "" || !b.substituting() {
 		return raw
 	}
 	pairs := strings.Split(raw, "&")
@@ -935,7 +1070,7 @@ func (b *bindings) applyQuery(raw string) string {
 // field name each value sits at. Whole string values only, for the reason
 // applyPath keeps to whole segments.
 func (b *bindings) applyValue(field string, v any) any {
-	if len(b.to) == 0 {
+	if !b.substituting() {
 		return v
 	}
 	switch value := v.(type) {

--- a/mise.toml
+++ b/mise.toml
@@ -102,6 +102,38 @@ depends = ["build"]
 # gets forgotten: a corpus replaying nothing is a failure, never a pass.
 run = "./feint corpus --check"
 
+[tasks."corpus:cloud"]
+description = "Reissue one committed corpus at the REAL Scaleway account and report what the cloud answers differently now"
+depends = ["build"]
+# The other half of the comparison above, and the only one that can arbitrate it
+# (#359). `corpus:check` holds one side: a red run there says the emulator and
+# the recording disagree, and nothing in it knows which of the two moved. This
+# asks the cloud.
+#
+# It is what internal/drift cannot be. The surface scan reads the provider's own
+# generated SDK and sees that a method exists; it sees nothing of what the method
+# answers. A status that moves from 200 to 201, a field that appears or goes, a
+# list that reorders, a refusal that stops being one — the Go signature is
+# identical before and after. #270 measured three of those in one read.
+#
+# **This is not a gate and must never become one.** It needs a credential, it
+# creates real objects, and its verdict depends on whose account ran it, so it is
+# out of `prepush` and out of the pull-request path for the reason `conformance`
+# already is, only stronger. It runs on demand here and on a schedule in
+# .github/workflows/corpus-cloud.yml, which opens a pull request when something
+# moved — the shape drift.yml already has for the surface.
+#
+# The account rules are in tools/corpus/cloud.sh and are not negotiable: an
+# inventory before and after, free resources only, everything named
+# feint-corpus-*, a trap armed before the first call, and every destruction
+# proved by a read rather than by the delete's own answer.
+#
+#   FEINT_SCW_PROFILE=<name> mise run corpus:cloud -- corpus/scaleway/terraform.jsonl
+#
+# Add --dry-run as a second argument to see what a run would send without
+# sending any of it.
+run = "tools/corpus/cloud.sh ./feint"
+
 # ---- Upstream tracking (the anti-drift loop) --------------------------------------------------
 [tasks."upstream:sync"]
 description = "Fetch the upstream SDKs and API descriptions the scan and the contracts read"

--- a/tools/corpus/cloud.sh
+++ b/tools/corpus/cloud.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Replay one committed corpus at the real Scaleway account, under the account
+# rules that are not negotiable (#352, #354, #359).
+#
+# usage: tools/corpus/cloud.sh <feint-binary> <corpus-file> [--dry-run]
+#   FEINT_SCW_PROFILE   the scw profile to use. REQUIRED, and named on every
+#                       single command below: several profiles on a maintainer's
+#                       station belong to third-party organisations and some sit
+#                       in a sovereign region, so "whichever one is default"
+#                       is not an answer anybody may give on their behalf.
+#
+# One file, two callers — this script and .github/workflows/corpus-cloud.yml —
+# for the reason tools/drift/gate.sh states: the same procedure written twice
+# drifts, and the copy that drifts is the one that touches the account.
+#
+# WHAT THIS DOES TO THE ACCOUNT, IN ORDER
+#
+#   1. an inventory, before anything is created. You cannot say "the account is
+#      as I found it" without the two lists to compare.
+#   2. a trap, armed before the first call, that sweeps anything named
+#      feint-corpus-* whatever happens next — including a Ctrl-C.
+#   3. the replay itself, which creates only what internal/cli/corpus_cloud.go's
+#      free-to-create list allows, refuses to touch an object it did not create,
+#      and destroys its own ledger with each destruction proved by a read.
+#   4. a second inventory, compared with the first. A difference fails the run.
+#
+# The secret key is read by `scw` from its own config and handed to the child
+# through the environment. It never reaches argv (world-readable in `ps`), never
+# a log line, never a file.
+set -euo pipefail
+
+FEINT="${1:?usage: cloud.sh <feint-binary> <corpus-file> [--dry-run]}"
+CORPUS="${2:?usage: cloud.sh <feint-binary> <corpus-file> [--dry-run]}"
+DRY="${3:-}"
+PROFILE="${FEINT_SCW_PROFILE:?name the scw profile explicitly: FEINT_SCW_PROFILE=<name>; there is no default anybody may choose for the account holder}"
+ENDPOINT="${FEINT_SCW_ENDPOINT:-https://api.scaleway.com}"
+
+command -v scw >/dev/null || { echo "cloud.sh: scw is not installed" >&2; exit 1; }
+[ -x "$FEINT" ] || { echo "cloud.sh: $FEINT is not an executable feint binary" >&2; exit 1; }
+[ -f "$CORPUS" ] || { echo "cloud.sh: $CORPUS is not a committed corpus" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'sweep; rm -rf "$WORK"' EXIT
+
+# The families this replay can possibly touch, plus the billable ones it must
+# never have touched. Both halves: an inventory that only counted what the run
+# creates could not notice a server appearing.
+FAMILIES=(
+  "vpc vpc"
+  "vpc private-network"
+  "iam ssh-key"
+  "instance server"
+  "instance ip"
+  "instance volume"
+  "instance snapshot"
+  "lb lb"
+)
+
+inventory() {
+  local label="$1" kind
+  for kind in "${FAMILIES[@]}"; do
+    # shellcheck disable=SC2086 # the family is two words on purpose
+    scw --profile "$PROFILE" $kind list -o json \
+      | python3 -c 'import json,sys; d=json.load(sys.stdin); print(len(d) if isinstance(d,list) else d)' \
+      > "$WORK/$label-${kind// /-}.count"
+  done
+}
+
+# sweep is the second belt. The replay destroys its own ledger; this catches the
+# run that died before it could — and it deletes by name, never by "everything
+# that looks recent", because a sweep that guesses is a sweep that deletes
+# somebody's work.
+# shellcheck disable=SC2329 # invoked by the EXIT trap armed above
+sweep() {
+  local kind id name left=0
+  for kind in "vpc private-network" "vpc vpc" "iam ssh-key"; do
+    # shellcheck disable=SC2086
+    while read -r id name; do
+      [ -n "$id" ] || continue
+      case "$name" in
+        feint-corpus-*) ;;
+        *) continue ;;
+      esac
+      echo "cloud.sh: sweeping $kind $name" >&2
+      # shellcheck disable=SC2086
+      scw --profile "$PROFILE" $kind delete "$id" >/dev/null 2>&1 || true
+      # shellcheck disable=SC2086
+      if scw --profile "$PROFILE" $kind get "$id" >/dev/null 2>&1; then
+        echo "cloud.sh: NOT DESTROYED: $kind $name ($id)" >&2
+        left=1
+      fi
+    done < <(scw --profile "$PROFILE" $kind list -o json 2>/dev/null \
+      | python3 -c 'import json,sys
+try:
+    rows = json.load(sys.stdin)
+except Exception:
+    rows = []
+for r in rows if isinstance(rows, list) else []:
+    print(r.get("id", ""), r.get("name", ""))')
+  done
+  [ "$left" = 0 ] || echo "cloud.sh: the sweep left something behind; delete it by hand" >&2
+}
+
+echo "== inventory before"
+inventory before
+for f in "$WORK"/before-*.count; do printf '  %-28s %s\n' "$(basename "$f" .count | sed 's/^before-//')" "$(cat "$f")"; done
+
+PROJECT="$(scw --profile "$PROFILE" config get default-project-id)"
+ORGANISATION="$(scw --profile "$PROFILE" config get default-organization-id)"
+SCW_SECRET_KEY="$(scw --profile "$PROFILE" config get secret-key)"
+export SCW_SECRET_KEY
+
+echo
+echo "== replaying $CORPUS at $ENDPOINT"
+status=0
+"$FEINT" corpus --against-cloud \
+  --file "$CORPUS" \
+  --endpoint "$ENDPOINT" \
+  --credential X-Auth-Token=SCW_SECRET_KEY \
+  --bind "project_id=$PROJECT" \
+  --bind "organization_id=$ORGANISATION" \
+  ${DRY:+"$DRY"} || status=$?
+
+echo
+echo "== inventory after"
+inventory after
+drifted=0
+for kind in "${FAMILIES[@]}"; do
+  key="${kind// /-}"
+  before="$(cat "$WORK/before-$key.count")"
+  after="$(cat "$WORK/after-$key.count")"
+  printf '  %-28s %s -> %s\n' "$key" "$before" "$after"
+  [ "$before" = "$after" ] || drifted=1
+done
+
+if [ "$drifted" != 0 ]; then
+  echo "cloud.sh: the account is NOT as it was found; the two inventories above disagree" >&2
+  exit 1
+fi
+echo "the account is as it was found"
+exit "$status"

--- a/tools/falsify/specs/corpus-cloud.json
+++ b/tools/falsify/specs/corpus-cloud.json
@@ -1,0 +1,163 @@
+{
+  "package": "./internal/cli/",
+  "mutations": [
+    {
+      "label": "THE COMMAND: a corpus that says the cloud answers differently stops failing the run, which is the whole of #359 — mutate one recorded status and the run goes green",
+      "file": "internal/cli/corpus_cloud.go",
+      "find": "\tcase rep.Moved > 0:",
+      "replace": "\tcase rep.Moved > 0 && false:",
+      "test": "TestAMutatedCorpusIsReportedAsACloudChangeAndAnUnchangedOneIsNot"
+    },
+    {
+      "label": "every finding is blamed on the recording, so the cloud can move as much as it likes and nothing is ever reported as a change",
+      "file": "internal/cli/corpus_cloud.go",
+      "find": "\t\t\t\tif len(one.Instrument) > 0 {",
+      "replace": "\t\t\t\tif len(one.Instrument) >= 0 {",
+      "test": "TestAMutatedCorpusIsReportedAsACloudChangeAndAnUnchangedOneIsNot"
+    },
+    {
+      "label": "the ownership question goes and a recorded DELETE deletes an account's own VPC: well formed was never the same question as authorised",
+      "file": "internal/cli/corpus_cloud.go",
+      "find": "\t\tif !g.owned[id] {",
+      "replace": "\t\tif !g.owned[id] && false {",
+      "test": "TestADeleteOfSomethingThisRunDidNotCreateIsRefused"
+    },
+    {
+      "label": "a create nobody wrote down as free is sent, and the account is billed to make a measurement",
+      "file": "internal/cli/corpus_cloud.go",
+      "find": "\t\tif _, free := freeToCreate[a.Operation]; !free {",
+      "replace": "\t\tif _, free := freeToCreate[a.Operation]; !free && false {",
+      "test": "TestABillableCreateIsRefusedRatherThanSent"
+    },
+    {
+      "label": "a path the sanitiser blanked is reissued at the provider, and the 404 the instrument caused is graded as a cloud that changed",
+      "file": "internal/cli/corpus_cloud.go",
+      "find": "\t\tcase blankedSegment(x.Path):",
+      "replace": "\t\tcase blankedSegment(x.Path) && false:",
+      "test": "TestABlankedPathIsNeverSentToTheCloud"
+    },
+    {
+      "label": "a value the recorder wrote REDACTED over goes out as the client's own, which is #73's nine false divergences reproduced exactly",
+      "file": "internal/cli/corpus_cloud.go",
+      "find": "\t\tcase redactedRequest(x):",
+      "replace": "\t\tcase redactedRequest(x) && false:",
+      "test": "TestARedactedRequestIsNeverSentToTheCloud"
+    },
+    {
+      "label": "a 401, a 429 or a 502 is graded as a change of the cloud, so an expired token opens a pull request saying the provider moved",
+      "file": "internal/cli/corpus_cloud.go",
+      "find": "\t\tcase notAboutTheResource(recorded, r.Status):",
+      "replace": "\t\tcase notAboutTheResource(recorded, r.Status) && false:",
+      "test": "TestAnAnswerAboutTheCallerIsNotACloudChange"
+    },
+    {
+      "label": "THE SECOND DIRECTION: a pack's own declines excuse the provider too, so the day the cloud stops answering a field this emulator never served, nothing anywhere reports it",
+      "file": "internal/cli/corpus_cloud.go",
+      "find": "func excusedAtTheCloud([]emulator.FieldDecline) []emulator.FieldDecline { return nil }",
+      "replace": "func excusedAtTheCloud(d []emulator.FieldDecline) []emulator.FieldDecline { return d }",
+      "test": "TestAPacksDeclineDoesNotExcuseTheCloud"
+    },
+    {
+      "label": "the ledger stops recording what a create answered, so an object this run made is never destroyed and the account keeps it",
+      "file": "internal/cli/corpus_cloud.go",
+      "find": "\tif id, named := objectID(body); named {",
+      "replace": "\tif id, named := objectID(body); named && false {",
+      "test": "TestEveryObjectThisRunCreatesIsNamedForItAndIsDestroyed"
+    },
+    {
+      "label": "objects are no longer named for the run that made them, so nothing in a console says which resource an aborted replay left behind",
+      "file": "internal/cli/corpus_cloud.go",
+      "find": "\t\tif x.Method == http.MethodGet || x.Method == http.MethodHead || x.Req == nil {",
+      "replace": "\t\tif x.Method == http.MethodGet || x.Method == http.MethodHead || x.Req == nil || true {",
+      "test": "TestEveryObjectThisRunCreatesIsNamedForItAndIsDestroyed"
+    },
+    {
+      "label": "a destruction is believed rather than read back: the delete's own answer becomes the proof, and a provider that deletes asynchronously leaves the object behind under a green run",
+      "file": "internal/cli/corpus_cloud.go",
+      "find": "\t\t\tgone = res.StatusCode == http.StatusNotFound || res.StatusCode == http.StatusGone",
+      "replace": "\t\t\tgone = res.StatusCode == http.StatusNotFound || res.StatusCode == http.StatusGone || true",
+      "test": "TestADestructionIsProvedByAReadAndNotByTheDeletesOwnAnswer"
+    },
+    {
+      "label": "an object left behind stops failing the run, so a report says the cloud has not moved while a resource of the account survives it",
+      "file": "internal/cli/corpus_cloud.go",
+      "find": "\t\tif len(leftovers) > 0 {",
+      "replace": "\t\tif len(leftovers) > 0 && false {",
+      "test": "TestADestructionIsProvedByAReadAndNotByTheDeletesOwnAnswer"
+    },
+    {
+      "label": "an account's credential travels in clear to a plain-HTTP endpoint off loopback, which one typo in a scheme is enough to reach",
+      "file": "internal/cli/corpus_cloud.go",
+      "find": "\tif ip := net.ParseIP(host); (ip != nil && ip.IsLoopback()) || host == \"localhost\" {",
+      "replace": "\tif ip := net.ParseIP(host); (ip != nil && ip.IsLoopback()) || host == \"localhost\" || true {",
+      "test": "TestACredentialNeverTravelsInClear"
+    },
+    {
+      "label": "an undated corpus is reissued anyway, so a difference is reported with no way to tell a cloud that moved from a recording eight months old",
+      "file": "internal/cli/corpus_cloud.go",
+      "find": "\tif rec.File == \"\" {",
+      "replace": "\tif rec.File == \"\" && false {",
+      "test": "TestAnUndatedCorpusIsNotReplayedAtTheCloud"
+    },
+    {
+      "label": "the guard is never consulted, so a replay against a real account sends every recorded request including its deletes",
+      "file": "internal/replay/replay.go",
+      "find": "\tif opt.Guard != nil {\n\t\tif why := opt.Guard.Before(attempt); why != \"\" {",
+      "replace": "\tif opt.Guard != nil && false {\n\t\tif why := opt.Guard.Before(attempt); why != \"\" {",
+      "test": "TestAGuardRefusalIsNotSentAndIsNotADivergence",
+      "package": "./internal/replay/"
+    },
+    {
+      "label": "the guard is asked about the recorded path rather than the one that will go out, so a DELETE is judged against an identifier that exists nowhere and the rebound one goes through unexamined",
+      "file": "internal/replay/replay.go",
+      "find": "\tattempt := Attempt{Seq: seq, Operation: mounted.Route.Operation, Method: x.Method, Path: path, Query: query}",
+      "replace": "\tattempt := Attempt{Seq: seq, Operation: mounted.Route.Operation, Method: x.Method, Path: x.Path + path[:0], Query: query}",
+      "test": "TestAGuardSeesTheRequestAfterRebinding",
+      "package": "./internal/replay/"
+    },
+    {
+      "label": "THE SECOND DIRECTION: the seeded binding is inert until something has been learned, which on a recording that opens with a create is never — the defect this pair was written to catch",
+      "file": "internal/replay/replay.go",
+      "find": "func (b *bindings) substituting() bool { return len(b.to) > 0 || len(b.forced) > 0 }",
+      "replace": "func (b *bindings) substituting() bool { return len(b.to) > 0 && len(b.forced) >= 0 }",
+      "test": "TestASeededBindingIsSentBeforeAnythingIsLearned",
+      "package": "./internal/replay/"
+    },
+    {
+      "label": "a seed rewrites free text as well as identifiers, so a request goes out carrying values the recording never held",
+      "file": "internal/replay/replay.go",
+      "find": "\tif to, seeded := b.forced[field]; seeded && looksMinted(value) {",
+      "replace": "\tif to, seeded := b.forced[field]; seeded && (looksMinted(value) || true) {",
+      "test": "TestASeedReplacesAnIdentifierAndNotWhateverElseTheFieldMayCarry",
+      "package": "./internal/replay/"
+    },
+    {
+      "label": "the path stops being read for values the sanitiser invented, so a read whose create never happened answers 404 and the 145 findings of one dry run are published as a provider that changed",
+      "file": "internal/cli/corpus_cloud.go",
+      "find": "\tfor _, seg := range strings.Split(a.Path, \"/\") {\n\t\tid, _, _ := strings.Cut(seg, \":\")\n\t\tnote(id)\n\t}",
+      "replace": "\tfor _, seg := range strings.Split(a.Path, \"/\") {\n\t\tid, _, _ := strings.Cut(seg, \":\")\n\t\tnote(id[:0])\n\t}",
+      "test": "TestARequestStillCarryingASyntheticIdentifierIsNotACloudChange"
+    },
+    {
+      "label": "a run that measured the cloud moving writes nothing back, so the emulator gate goes on warning about a chosen horizon instead of a measurement",
+      "file": "internal/cli/corpus_cloud.go",
+      "find": "\tif req.markStale && rep.Moved > 0 {",
+      "replace": "\tif req.markStale && rep.Moved > 0 && false {",
+      "test": "TestACorpusTheCloudHasMovedUnderWarnsAndDoesNotFail"
+    },
+    {
+      "label": "the emulator gate stops saying that the cloud has been measured to move under a corpus, and the one signal that dates a re-recording goes silent",
+      "file": "internal/cli/corpus.go",
+      "find": "\t\tif r.CloudMovedAt == \"\" || r.CloudMoved == 0 {",
+      "replace": "\t\tif r.CloudMovedAt == \"\" || r.CloudMoved == 0 || true {",
+      "test": "TestACorpusTheCloudHasMovedUnderWarnsAndDoesNotFail"
+    },
+    {
+      "label": "a file name nobody recorded is marked without complaint, so a typo in a scheduled job writes nothing and reports success",
+      "file": "internal/cli/corpus_cloud.go",
+      "find": "\tif !marked {",
+      "replace": "\tif !marked && false {",
+      "test": "TestMarkingACorpusStaleWritesTheMeasurementAndNothingElse"
+    }
+  ]
+}


### PR DESCRIPTION
The other direction of one comparison. `corpus --check` replays a committed
recording against a fresh emulator and a divergence means *the emulator is
wrong*; `corpus --against-cloud` reissues the same file at the provider it came
from, and a divergence means *the cloud has changed*.

## What `internal/drift` cannot see, and this can

The Monday scan reads the providers' generated SDKs and is exact about what it
covers: an operation that appeared or disappeared. It sees that a method exists
and nothing of what the method answers. A status that moves from 200 to 201, a
field that appears or goes, a list that reorders, a refusal that stops being
one — the Go signature is identical before and after, the baseline stays green,
and this emulator goes on serving what the cloud stopped answering. #270
measured three of that family in one read of one private network.

## One comparator, two seams

`internal/replay.Run` is called by both directions. It gained exactly two, both
acting on the request *after* rebinding, which only that package knows:

- `Options.Guard` — asked before every request, handed every answer. A refusal
  becomes the third verdict: never a match, never a divergence.
- `Options.Bind` — seeds the rebinding table, so a recording opening on a create
  is replayable at all.

Replaying at the emulator passes neither, so `corpus --check` is byte-identical
in behaviour to before.

## The three verdicts, never blurred

| | |
|---|---|
| the cloud answers differently | exit 2 — a finding on a faithfully reissued request |
| the recording could not be reissued as recorded | never counted as a change |
| the call could not be made | exit 1 — a guard refusal, or a 401/403/429/5xx where the recording carried success |

The third matters: an expired token must never read as a provider that changed.

## Measured today, against the real Scaleway

| file | compared | cloud moved | recording | unserved |
|---|---|---|---|---|
| `scaleway/terraform.jsonl` | 16/16 | **0** | 0 | 0 |
| `scaleway/scw-cli.jsonl` | 42/58 | **0** | 11 | 5 |

**Nothing had moved, and at zero days old that is the expected answer, not an
impressive one.** What the run proves is that the loop closes end to end against
a real provider. `--mark-stale` correctly wrote nothing.

Two facts worth not rediscovering: Scaleway **accepts** a private-network subnet
inside `198.18.0.0/15` — the sanitiser's synthetic space — and **accepts** the
synthetic `ssh-ed25519` key whose material is all zeroes. Either refusing would
have made a whole lifecycle unreplayable.

## The account

Ten objects across four measured runs, every one destroyed, each destruction
proved by a `GET` answering 404 rather than by the delete's own answer. Free
resources only, enforced by name against a written-down list rather than by
intention. `trap … EXIT` armed before the first call, plus a Go ledger armed
before the first request. Twelve resource families compared before and after
**by identifier and name**, not by count: identical. The secret was never read,
printed or written.

## The premise the measurement demolished

The first dry run reported **145 findings as "the cloud answers differently"**.
Every one was the instrument: `--dry-run` refuses the creates, nothing rebinds,
every following read addressed a synthetic UUID, answered 404, and every
recorded field read as absent. Requests were checked for sanitiser-minted values
in bodies and queries — **not in paths**. Fixed, re-measured against the real
cloud: same run, 0 cloud-moved, 145 attributed to the recording. That is
`TestARequestStillCarryingASyntheticIdentifierIsNotACloudChange`.

## Falsified

`tools/falsify/specs/corpus-cloud.json`, 22 mutations, all bite. Among them:
remove the ownership question → a recorded `DELETE` removes an account's own VPC
(asserted by reading the VPC back, not by the exit code); remove the free-create
list → the account is billed; believe the delete's own answer → an asynchronous
delete leaves the object behind under a green run; carry a pack's
`DeclinedFields()` into the cloud run → the day the provider drops a field,
nothing anywhere reports it.

## One defect found while integrating, and it was not in this branch

Rebasing onto #343 put two of this branch's tests red, and the cause was worth
keeping: **both corpus warnings were emitted below the guards that can return
early**, so a run that went red for an unexercised invariant or a stale
exemption printed no word about a recording the provider has been measured to
have moved under. That is the worst moment to withhold it — *re-record this
file* is a candidate fix for the very redness being reported.

`warnMovedCorpora`'s comment said "on every run" and nothing made it true. It is
true now, and
`TestTheMovedWarningSurvivesARunThatIsRedForAnotherReason` holds it on the
poorest run that reaches the print. `TestAPacksDeclineDoesNotExcuseTheCloud`
also stopped measuring its subject through an exit code that #343 legitimately
owns, and asserts the excuse itself instead.

## Not measured, and said as such

- **Whether the cloud has actually moved.** The corpus is zero days old. The
  tool is proven; the drift it exists to catch cannot exist yet.
- **Outscale and Exoscale.** `freeToCreate` is Scaleway-only and refuses
  everything else by name.
- **The scheduled workflow.** `corpus-cloud.yml` passes `actionlint` and
  `zizmor`, runs monthly and on dispatch, and is **never on pull requests** — it
  authenticates, creates real objects, and its verdict depends on whose account
  ran it. It will be **red on its first firing until `SCW_SECRET_KEY`,
  `SCW_ACCESS_KEY`, `SCW_DEFAULT_PROJECT_ID` and `SCW_DEFAULT_ORGANIZATION_ID`
  are set**, deliberately: a job that skipped silently would report success on
  every run and measure the provider on none.
- **`--dry-run` exits 1 by design** — every refusal is the third verdict. It is
  a planning mode, not a check.

## Also

`#353`'s open question is answered by measurement rather than by a chosen
number: `--mark-stale` writes `cloud_moved_at`/`cloud_moved` into
`corpus/accepted.json`, and `corpus --check` warns with a measured date instead
of the 180-day horizon. It still warns and never fails.

`cliSurfaceVersion` 9 → 10, fixture regenerated. `prepush`, `corpus:check`,
`docs:check` green on the rebase.

## Related

Closes #359
