### PR TITLE
fix(exoscale): the zone list, a security group and a rule that names one answer what the cloud answers (#370, #371)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -19,6 +19,28 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Ajouté
 
+- **Un contrat peut désormais porter un champ que la description d'API du
+  fournisseur ne déclare pas, et seulement avec l'enregistrement qui le prouve**
+  (#370, #371). `tools/contract/extract-openapi.py --recorded-fields` replie un
+  tel champ dans le schéma auquel il appartient, depuis un fragment YAML
+  versionné, et recopie la citation (fichier de corpus, opération, chemin, date,
+  raison) dans `contracts/<fournisseur>.json`, sous `recordedFields`. Ce
+  mécanisme existe parce qu'une description d'API publiée peut être en retard
+  sur l'API qu'elle décrit, et celle d'Exoscale l'est.
+
+  **Ce qui compte, ce n'est pas la porte, c'est la serrure.** Un contrat est
+  sinon extrait, puis ré-extrait par un crochet pre-commit : il ne s'édite pas à
+  la main, et une porte ouverte sur « ce qu'une réponse a le droit de contenir »
+  est exactement ce que la règle 4 interdit de laisser sans serrure.
+  L'extraction refuse un schéma que ses documents ne définissent pas, et refuse
+  une propriété que le document déclare déjà : quand l'amont rattrape son
+  retard, l'entrée disparaît au lieu de laisser une citation que personne ne
+  relira. Ensuite, `TestEveryRecordedFieldIsStillOnTheWire` rejoue à chaque
+  exécution l'enregistrement cité et fait échouer l'entrée dont le chemin n'y
+  est plus. C'est la règle de péremption de `corpus/accepted.json`, retournée :
+  une exemption qui n'excuse rien est morte, une citation qui ne cite rien
+  aussi.
+
 - **Le corpus commité est maintenant rejoué contre le cloud, et attrape la
   dérive qu'aucun scan de SDK ne voit** (#359). `feint corpus --against-cloud
   --file <corpus> --endpoint <url>` réémet un enregistrement commité chez le
@@ -852,6 +874,42 @@ change ni l'un ni l'autre a sa place dans `git log`.
   replay sait qu'elles en sont.
 
 ### Corrigé
+
+- **Trois champs que la vraie API Exoscale répond et que cet émulateur omettait,
+  tous invisibles à tout contrôle qui lit un document** (#370, #371). Ils font
+  105 des 192 divergences rapportées par l'enregistrement du 2026-08-21 d'un
+  vrai compte `ch-gva-2`, et `corpus/accepted.json` retombe à 87 en conséquence.
+
+  `GET /v2/zone` répond maintenant un `id` par zone, dérivé du nom de la zone :
+  deux lectures d'un même émulateur s'accordent, et un émulateur redémarré
+  s'accorde encore avec lui-même. #370 dit pourquoi cette moitié compte : un
+  identifiant qui bougerait d'une lecture à l'autre serait pire que pas
+  d'identifiant du tout, puisqu'un client qui l'a stocké détiendrait une valeur
+  qui ne nomme rien. À lui seul, c'est 51 constats, parce que `exo` liste les
+  zones avant presque chaque commande. `GET /v2/security-group` répond
+  maintenant `visibility` sur chaque groupe, sur la liste comme sur la lecture
+  d'un groupe (46). Et une règle qui pointe vers un autre groupe publie
+  maintenant le `name` de ce groupe à côté de son `id` (8) : c'est la forme
+  qu'`examples/stacks/exoscale/main.tf` écrit sous `user_security_group_id`,
+  « la couche applicative accepte la couche web et personne d'autre ».
+  **#371 affirme qu'un consommateur qui lit le nom sur la règle ne voit rien, et
+  cette moitié-là ne survit pas à la mesure** : `exo compute security-group
+  show` affiche `SG:web` avec le nom comme sans lui, parce qu'il résout la
+  référence par son id contre les groupes qu'il a déjà listés. La raison de le
+  servir est la seule dont ce projet ait jamais besoin, à savoir que
+  l'enregistrement dit que le cloud envoie un nom, et non un symptôme client que
+  personne n'a reproduit.
+
+  **Pourquoi rien ne les avait vus, et c'est la part qu'il faut garder.** Deux
+  des trois ne sont pas non plus dans le `source.yaml` publié par Exoscale :
+  le contrat, la porte des formes, la sonde et le pack étaient donc d'accord
+  entre eux, et tous les quatre avaient tort de la même façon. L'id de zone
+  avait même été levé une fois, sous #94, et clos en non-défaut au motif que le
+  servir faisait échouer le contrôle de contrat de cet émulateur. C'était vrai,
+  et c'était le mauvais bout à corriger. Seul un enregistrement du fil pouvait
+  les contredire, et il en existe un. Le troisième n'a demandé aucun changement
+  de contrat : le document déclarait déjà le champ, seul le pack l'avait laissé
+  tomber.
 
 - **La porte du corpus retenait son avertissement « le cloud a bougé »
   précisément quand il servait le plus.** Les deux avertissements — celui de

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,27 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Added
 
+- **A contract can now carry a field the provider's own document does not
+  declare, and only with the recording that proves it** (#370, #371).
+  `tools/contract/extract-openapi.py --recorded-fields` folds such a field into
+  the schema it belongs to from a versioned YAML fragment, and copies the
+  citation — corpus file, operation, path, date, reason — into
+  `contracts/<provider>.json` under `recordedFields`. It exists because a
+  published API description can be behind the API it describes, and Exoscale's
+  is.
+
+  **The point is the lock, not the door.** A contract is otherwise extracted and
+  re-extracted by a pre-commit hook, so it cannot be hand-edited; a door into
+  "what a response may contain" is exactly what rule 4 forbids leaving open. The
+  extraction refuses a schema its documents do not define, and refuses a
+  property the document *does* declare — upstream catching up retires the entry
+  rather than leaving a citation nobody re-reads. Then
+  `TestEveryRecordedFieldIsStillOnTheWire` replays the named recording on every
+  run and fails an entry whose path it no longer carries. That is
+  `corpus/accepted.json`'s own staleness rule pointed the other way: an
+  exemption that excuses nothing is dead, and so is a citation that cites
+  nothing.
+
 - **The committed corpus is now replayed at the cloud, and catches the drift no
   SDK scan can see** (#359). `feint corpus --against-cloud --file <corpus>
   --endpoint <url>` reissues a committed recording at the provider it was
@@ -801,6 +822,38 @@ what this project is judged on: **a response shape a client can observe**, and
   identifiers.
 
 ### Fixed
+
+- **Three fields the real Exoscale API answers and this emulator omitted, all
+  invisible to every control that reads a document** (#370, #371). They are 105
+  of the 192 divergences the 2026-08-21 recording of a real `ch-gva-2` account
+  reported, and `corpus/accepted.json` is down to 87 accordingly.
+
+  `GET /v2/zone` now answers an `id` per zone, derived from the zone name so
+  that two reads of one emulator agree and a restarted one still does — #370
+  states why that half matters: an identifier that moved between reads would be
+  worse than none, because a client that stored it would hold a value naming
+  nothing. It is 51 findings on its own, because `exo` lists the zones before
+  very nearly every command it runs. `GET /v2/security-group` now answers
+  `visibility` on every group, on the list and on the read of one group alike
+  (46). And a rule that points at another group now publishes that group's
+  `name` beside its `id` (8) — the shape `examples/stacks/exoscale/main.tf`
+  writes as `user_security_group_id`, "the application tier accepts the web tier
+  and nobody else". **#371 says a consumer reading the name off the rule sees
+  nothing, and that half does not survive measurement**: `exo compute
+  security-group show` prints `SG:web` with the name and without it, because it
+  resolves the reference by id against the groups it has already listed. The
+  reason to serve it is the only one this project ever needs — the recording
+  says the cloud sends a name — not a client symptom nobody has reproduced.
+
+  **Why nothing had seen them, which is the part worth keeping.** Two of the
+  three are not in Exoscale's published `source.yaml` either, so the contract,
+  the shapes gate, the probe and the pack all agreed with one another and all
+  four were wrong the same way. The zone id had even been raised once, as #94,
+  and closed as not-a-defect on the grounds that serving it failed this
+  emulator's own contract check — which was true, and was the wrong end to fix.
+  Only a recording of the wire could disagree, and now one does. The third
+  needed no contract change at all: the document already declared the field and
+  only the pack had dropped it.
 
 - **The corpus gate withheld its "the cloud has moved" warning exactly when it
   mattered most.** Both warnings — the aged-recording one and the measured-move

--- a/contracts/exoscale.json
+++ b/contracts/exoscale.json
@@ -5,6 +5,26 @@
  "pathPrefix": "/v2",
  "closedPolicy": "assumed",
  "errorSchema": "egoscale.APIError",
+ "recordedFields": [
+  {
+   "schema": "security-group",
+   "property": "visibility",
+   "corpus": "exoscale/exo-cli.jsonl",
+   "operation": "exoscale/v2.list-security-groups",
+   "path": "security-groups[].visibility",
+   "recorded": "2026-08-21",
+   "why": "Every group a real account answers carries visibility, private included, on the list and on the read of one group alike. The document declares the field on security-group-resource \u2014 the shape a rule uses to point at another group \u2014 and not on security-group, the shape a list answers, which is precisely the kind of gap no document-reading control can see. 46 of the recording's divergences, and the enum is the document's own, taken from the schema that does declare the field."
+  },
+  {
+   "schema": "zone",
+   "property": "id",
+   "corpus": "exoscale/exo-cli.jsonl",
+   "operation": "exoscale/v2.list-zones",
+   "path": "zones[].id",
+   "recorded": "2026-08-21",
+   "why": "Every zone the real API lists carries an id and their `zone` schema declares three fields, none of them it. `exo` lists the zones before very nearly every command it runs, which is why one omission produced 51 of the 105 divergences that recording reported \u2014 the single most-answered operation of the whole file. Raised once before as #94, from a shape diff, and closed as not-a-defect on the grounds that serving it would fail this emulator's own contract check. That was true, and it was the wrong end to fix: the contract is what had to move."
+  }
+ ],
  "operations": {
   "add-external-source-to-security-group": {
    "path": "/security-group/{id}:add-source",
@@ -11413,6 +11433,13 @@
      "items": {
       "ref": "security-group-rule"
      }
+    },
+    "visibility": {
+     "type": "string",
+     "enum": [
+      "private",
+      "public"
+     ]
     }
    }
   },
@@ -12981,6 +13008,9 @@
    "closed": true,
    "properties": {
     "api-endpoint": {
+     "type": "string"
+    },
+    "id": {
      "type": "string"
     },
     "name": {

--- a/corpus/README.md
+++ b/corpus/README.md
@@ -397,24 +397,35 @@ never a recording target.**
 
 ### Exoscale and Outscale (#354)
 
-`exoscale/exo-cli.jsonl` replays 132 of its 203 exchanges clean and reports
-**three fields the cloud answers and this emulator omits**, each with an
-exemption in `corpus/accepted.json` naming the issue that deletes it:
+`exoscale/exo-cli.jsonl` reported **three fields the cloud answers and this
+emulator omitted**, over four exemptions in `corpus/accepted.json`, each naming
+the issue that deleted it. All four are gone: the emulator answers all
+three, and the file now replays **203 of its 203 exchanges matched, zero
+divergent, zero unserved** — it used to be 132 clean.
 
-| operation | field | findings | issue |
+| operation | field | findings | retired by |
 |---|---|---|---|
 | `exoscale/v2.list-zones` | `zones[].id` | 51 | [#370](https://github.com/stephrobert/feint/issues/370) |
 | `exoscale/v2.list-security-groups` | `security-groups[].visibility` | 44 | [#371](https://github.com/stephrobert/feint/issues/371) |
 | `exoscale/v2.get-security-group` | `visibility` | 2 | [#371](https://github.com/stephrobert/feint/issues/371) |
 | `exoscale/v2.list-security-groups` | `security-groups[].rules[].security-group.name` | 8 | [#371](https://github.com/stephrobert/feint/issues/371) |
 
-**All three have one root, and it is the argument for this whole directory.**
-`contracts/exoscale.json` does not declare any of them either: it is generated
-from Exoscale's own published description, and the cloud answers fields that
-description does not carry. So the shapes gate, the probe and the pack agree
-with one another because they read the same document, and no control that reads
-a document could ever have disagreed. It is the family of #352's
-`has_s3_integration`, one provider further out.
+**Two of the three had one root, and it is the argument for this whole
+directory.** `contracts/exoscale.json` did not declare `zones[].id` or
+`security-group.visibility` either: it is generated from Exoscale's own
+published description, and the cloud answers fields that description does not
+carry. So the shapes gate, the probe and the pack agreed with one another
+because they read the same document, and no control that reads a document could
+ever have disagreed. It is the family of #352's `has_s3_integration`, one
+provider further out.
+
+Serving them therefore meant moving the contract, which is a generated artefact:
+`tools/contract/exoscale-recorded-fields.yaml` adds a field only with the
+recording that proves it, and `TestEveryRecordedFieldIsStillOnTheWire` fails an
+entry this directory no longer supports — this file's own staleness rule,
+pointed at citations instead of exemptions. The third field needed no contract
+change at all; the document already declared `name` on the schema a rule's
+reference uses, and only the pack had dropped it.
 
 `outscale/oapi-cli-catalogue.jsonl` replays **three matched, zero divergent, two
 unserved**: `ReadRegions`, `ReadVmTypes` and `ReadPublicIpRanges` answer the

--- a/corpus/accepted.json
+++ b/corpus/accepted.json
@@ -33,11 +33,12 @@
     "That single recording moved values_checked to 2 and orders_checked to 6, and",
     "surfaced the twenty-six divergences below.",
     "",
-    "The three now here come from the Exoscale recording of #354, and they are",
-    "all one kind: a field the cloud answers that this emulator omits. The",
-    "instrument was fixed first, again, and again that is what let them be seen —",
-    "three sanitiser defects buried them, all measured on the same file and all",
-    "falsified in tools/falsify/specs/sanitised-corpus.json:",
+    "THE FOUR EXOSCALE ENTRIES ARE GONE, AND THAT IS THE RULE ABOVE DOING ITS",
+    "WORK. The #354 recording surfaced four divergences of one kind — a field the",
+    "cloud answers that this emulator omitted — and getting to see them at all",
+    "took fixing the instrument first: three sanitiser defects buried them, all",
+    "measured on the same file and all falsified in",
+    "tools/falsify/specs/sanitised-corpus.json:",
     "",
     "  - `0.0.0.0/0` cannot be replaced: masking a zero-length prefix yields the",
     "    same prefix, so the cross-reference found it in the recording and in the",
@@ -51,10 +52,22 @@
     "    below start-ip`. Together those two hid the whole private-network",
     "    lifecycle behind about twenty findings, not one of them the emulator's.",
     "",
-    "What is left after that is three fields, and #370 and #371 name them. Both",
-    "have the same root: `contracts/exoscale.json` does not declare them either,",
-    "because the cloud answers fields its own published API description does not",
-    "carry — which is why no document-reading control could ever have seen them.",
+    "What was left after that was three fields across four entries — zones[].id",
+    "(51 findings), security-groups[].visibility on the list (44) and on the get",
+    "(2), and rules[].security-group.name (8) — and #370 and #371 retired all",
+    "four. Their shared root is worth keeping written down, because it is the one",
+    "no document-reading control could ever have found: the cloud answers fields",
+    "its own published API description does not declare, so the contract, the",
+    "shapes gate, the probe and the pack all agreed with each other and all four",
+    "were wrong the same way. Two of the three now live in",
+    "tools/contract/exoscale-recorded-fields.yaml, which folds a field into the",
+    "contract only with the recording that proves it and is held to that recording",
+    "by internal/cli's TestEveryRecordedFieldIsStillOnTheWire — the same staleness",
+    "rule as this list, pointed the other way: a citation that cites nothing is as",
+    "dead as an exemption that excuses nothing. The third needed no contract",
+    "change at all; the document already declared the field and only the pack had",
+    "dropped it.",
+    "",
     "An empty list is not a licence. The next divergence a recording surfaces",
     "goes here with its reason and the issue that retires it, or the gate stays",
     "red — and a corpus trimmed until it passes is the one outcome this file",
@@ -147,30 +160,6 @@
     }
   ],
   "accepted": [
-    {
-      "file": "exoscale/exo-cli.jsonl",
-      "operation": "exoscale/v2.list-zones",
-      "kind": "absent",
-      "path": "zones[].id",
-      "reason": "The real zone list answers an id per zone and this emulator answers none, so every one of the 51 zone reads this recording carries reports it. The field is not in contracts/exoscale.json either, which is generated from Exoscale's own published description: the cloud answers a field its document does not declare, so no gate that reads a document could have seen it. Serving it means adding it to the contract first, and that is a change to a versioned artefact rather than a line in a handler.",
-      "issue": "https://github.com/stephrobert/feint/issues/370"
-    },
-    {
-      "file": "exoscale/exo-cli.jsonl",
-      "operation": "exoscale/v2.list-security-groups",
-      "kind": "absent",
-      "path": "security-groups[].visibility",
-      "reason": "A real security group answers visibility (private here) and this emulator answers none. Same root as the zone id above: contracts/exoscale.json puts visibility on the security-group-resource schema and not on security-group, so the document the pack was written from is behind the cloud and every document-reading control agrees with the emulator.",
-      "issue": "https://github.com/stephrobert/feint/issues/371"
-    },
-    {
-      "file": "exoscale/exo-cli.jsonl",
-      "operation": "exoscale/v2.get-security-group",
-      "kind": "absent",
-      "path": "visibility",
-      "reason": "The same missing field on the read of one group rather than the list of them, and it is a separate entry on purpose: an exemption keyed to the list would go on excusing the get long after the list was fixed, which is the stale exemption this file exists to make impossible.",
-      "issue": "https://github.com/stephrobert/feint/issues/371"
-    },
     {
       "file": "scaleway/scw-instance.jsonl",
       "operation": "block/v1alpha1/API.GetVolume",
@@ -378,14 +367,6 @@
       "path": "servers[]",
       "reason": "the create honours the project the request named and the unfiltered list is scoped to the default project, so the server the cloud listed is invisible to the list that follows it here",
       "issue": "#369"
-    },
-    {
-      "file": "exoscale/exo-cli.jsonl",
-      "operation": "exoscale/v2.list-security-groups",
-      "kind": "absent",
-      "path": "security-groups[].rules[].security-group.name",
-      "reason": "A rule whose target is another group publishes that group's id and name upstream, and only its id here. It is the shape examples/stacks/exoscale/main.tf writes as user_security_group_id — the application tier accepts the web tier and nobody else — so a consumer reading the target's name off the rule sees nothing where the cloud shows a name.",
-      "issue": "https://github.com/stephrobert/feint/issues/371"
     }
   ]
 }

--- a/docs/fourth-pack.md
+++ b/docs/fourth-pack.md
@@ -176,7 +176,11 @@ What is **not** industrial today is three things, none structural:
    0), and Exoscale's `zones[].id` and `security-groups[].visibility` (live on
    the wire, absent from the published OpenAPI this emulator enforces as
    closed; the 98f8df6 commit message recorded the decision in prose, which is
-   the one place a gate cannot read). A reason faces the same guard as an
+   the one place a gate cannot read). The two Exoscale entries have since gone:
+   #370 and #371 moved the contract instead, through
+   `tools/contract/exoscale-recorded-fields.yaml`, and the same staleness rule
+   named below is what made deleting the declines compulsory once the pack
+   answered the fields. A reason faces the same guard as an
    operation's (`TestEveryDeclinedFieldSaysWhy`), and a decline that excuses
    nothing fails the gate as stale (`TestAStaleFieldDeclineFailsTheGate`), so
    the list cannot rot. The gate is wired into every pull request — a go.yml

--- a/internal/cli/recorded_fields.go
+++ b/internal/cli/recorded_fields.go
@@ -1,0 +1,154 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/stephrobert/feint/internal/contract"
+	"github.com/stephrobert/feint/internal/transcript"
+)
+
+// The gate behind `recordedFields` in contracts/*.json.
+//
+// A contract is extracted from the provider's own API description and may not be
+// edited by hand — the pre-commit hook re-runs the extraction and diffs. One
+// exception exists, and it exists because a document can be behind the API it
+// describes: tools/contract/*-recorded-fields.yaml adds a field a recording of
+// the real cloud carries and the document does not declare. Exoscale's zone id
+// and security-group visibility are the first two (#370, #371).
+//
+// That exception is a door, and a door into "the shape of a response" is
+// precisely what rule 4 forbids leaving unlocked. What locks it is here: every
+// entry names the recording that proves it, and this holds the entry against
+// that recording. A field nothing in corpus/ still carries is not a field this
+// emulator may answer, whatever the fragment says.
+//
+// It is the rule corpus/accepted.json already lives under, applied to the
+// opposite kind of entry. There, an exemption that excuses no divergence is
+// deleted, because a stale exemption is a gate that quietly stopped covering
+// what it names. Here, a citation that cites nothing is deleted, because a
+// stale citation is an invented field with a footnote.
+//
+// # Why this is not inside `feint corpus --check`
+//
+// That would be the obvious home: same artefacts, same rule, one command. It
+// would also be wrong, and for the reason #88's two red pull requests wrote
+// down. The corpus gate takes a --dir and is pointed at fixtures by half a dozen
+// of its own tests — a temporary directory holding one self-recording. Its
+// population is "whatever this run was pointed at", so a verdict of "no
+// recording carries this field" would be true of every fixture run and would
+// have to be either a false failure or a silent skip. This verdict needs the
+// whole committed corpus, so it reads the whole committed corpus, and a test
+// rather than a flag is what guarantees that.
+
+// staleRecordedField is one entry of a contract's recordedFields list that the
+// recording it names no longer supports, with what is wrong stated in the terms
+// the reader has to act on.
+type staleRecordedField struct {
+	Contract string
+	Field    contract.RecordedField
+	Why      string
+}
+
+func (s staleRecordedField) String() string {
+	return fmt.Sprintf("%s: %s.%s, cited from %s %s %s: %s",
+		s.Contract, s.Field.Schema, s.Field.Property,
+		s.Field.Corpus, s.Field.Operation, s.Field.Path, s.Why)
+}
+
+// staleRecordedFields holds every contract's recordedFields against the corpus
+// each entry cites, and reports the entries the recordings no longer support.
+//
+// The second return is how many entries were examined, and a caller must refuse
+// a run that examined none. That is not defensive noise: the way this control
+// dies silently is `--recorded-fields` dropping out of tools/contract/update.sh,
+// which empties the list, leaves the packs answering fields the contract no
+// longer declares, and leaves this reporting nothing wrong.
+func staleRecordedFields(contractsDir, corpusDir string) ([]staleRecordedField, int, error) {
+	docs, err := loadContracts(contractsDir)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// Recordings are loaded once each and shared: exo-cli.jsonl is 203
+	// exchanges, and every entry citing it would otherwise re-read it.
+	shapes := map[string]map[string]bool{}
+	pathsOf := func(corpus, operation string) (map[string]bool, error) {
+		key := corpus + "\x00" + operation
+		if known, ok := shapes[key]; ok {
+			return known, nil
+		}
+		exs, err := loadTranscript(filepath.Join(corpusDir, filepath.FromSlash(corpus)))
+		if err != nil {
+			return nil, err
+		}
+		fields, found := transcript.Shape(exs, operation)
+		if !found {
+			shapes[key] = nil
+			return nil, nil
+		}
+		known := make(map[string]bool, len(fields))
+		for _, f := range fields {
+			known[f.Path] = true
+		}
+		shapes[key] = known
+		return known, nil
+	}
+
+	var stale []staleRecordedField
+	checked := 0
+	for _, provider := range sortedContractNames(docs) {
+		doc := docs[provider]
+		for _, f := range doc.RecordedFields {
+			checked++
+			bad := func(why string) {
+				stale = append(stale, staleRecordedField{Contract: provider, Field: f, Why: why})
+			}
+
+			// The extraction folds the property into the schema and writes the
+			// citation; the two arriving apart means the artefact was edited by
+			// hand or the extraction stopped applying the fragment.
+			schema, ok := doc.Schemas[f.Schema]
+			if !ok {
+				bad("the contract declares no such schema, so the citation stands for nothing")
+				continue
+			}
+			if _, ok := schema.Properties[f.Property]; !ok {
+				bad("the schema does not declare the property this entry says was added to it")
+				continue
+			}
+
+			if _, err := os.Stat(filepath.Join(corpusDir, filepath.FromSlash(f.Corpus))); err != nil {
+				bad("the recording it names is not under " + corpusDir +
+					"; a citation whose recording left is a claim nobody can check")
+				continue
+			}
+			known, err := pathsOf(f.Corpus, f.Operation)
+			if err != nil {
+				return nil, checked, err
+			}
+			if known == nil {
+				bad("that recording holds no exchange for this operation any more")
+				continue
+			}
+			if !known[f.Path] {
+				bad("that recording's answers no longer carry this path, so nothing proves the " +
+					"cloud still sends it: re-record it, or delete the entry and stop answering the field")
+			}
+		}
+	}
+	return stale, checked, nil
+}
+
+// sortedContractNames keeps the report in the same order on every run, whatever
+// order the map iterates in.
+func sortedContractNames(docs map[string]*contract.Doc) []string {
+	out := make([]string, 0, len(docs))
+	for name := range docs {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/cli/recorded_fields_test.go
+++ b/internal/cli/recorded_fields_test.go
@@ -1,0 +1,219 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Every citation in a committed contract's recordedFields still has its
+// recording, and that recording still carries the field.
+//
+// This is the lock on the one door through which a hand-written shape can reach
+// contracts/*.json. A contract is otherwise extracted from the provider's own
+// API description and re-extracted by a pre-commit hook, so it cannot be edited;
+// tools/contract/*-recorded-fields.yaml is the exception, and it exists because
+// Exoscale's document is behind Exoscale's API. Without this test that exception
+// is a place to write any field at all and call it measured.
+//
+// The rule and its wording come from corpus/accepted.json, which states it for
+// the opposite kind of entry: an exemption that excuses nothing fails the gate,
+// because a stale exemption is a gate that quietly stopped covering what it
+// names. A citation that cites nothing is the same failure wearing the other
+// hat — an invented field with a footnote.
+//
+// tools/falsify/specs/recorded-fields.json proves the comparison bites, on
+// fixtures rather than on this, because a falsification that mutates the
+// committed corpus proves nothing about the code.
+func TestEveryRecordedFieldIsStillOnTheWire(t *testing.T) {
+	stale, checked, err := staleRecordedFields(
+		filepath.Join("..", "..", "contracts"), filepath.Join("..", "..", "corpus"))
+	if err != nil {
+		t.Fatalf("hold the contracts against the corpus: %v", err)
+	}
+	for _, s := range stale {
+		t.Errorf("%s", s)
+	}
+	// A run that examined nothing reads exactly like a run that found nothing
+	// wrong, which is the failure this whole family of gates exists to name.
+	// The way it happens here is --recorded-fields dropping out of
+	// tools/contract/update.sh: the list empties, the packs go on answering
+	// fields the contract no longer declares, and this reports success.
+	//
+	// The day every recorded field is legitimately retired — Exoscale
+	// publishing both in their document, which the extraction refuses to
+	// paper over — the fragment goes and this test goes with it. Deleting a
+	// control deliberately is a decision; letting one fall silent is not.
+	if checked == 0 {
+		t.Fatal("no recordedFields entry was examined, so this measured nothing: either " +
+			"tools/contract/update.sh stopped passing --recorded-fields, or the fragment is gone " +
+			"and this test should have gone with it")
+	}
+	t.Logf("%d recorded field(s) still carried by the recording each one names", checked)
+}
+
+// And the comparison itself, on fixtures: a citation the recording supports
+// passes, and every way one can stop being supported is reported — the path
+// gone, the operation gone, the recording gone, and either half of the pair the
+// extraction writes arriving without the other.
+//
+// Fixtures rather than the committed artefacts, because the committed ones are
+// meant to be green — a test that mutated corpus/ to prove the gate bites would
+// be proving something about the corpus.
+func TestARecordedFieldNoRecordingCarriesIsRefused(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		mutate    func(*recordedFieldFixture)
+		wantStale string
+	}{
+		{
+			name:   "the recording still carries it",
+			mutate: func(*recordedFieldFixture) {},
+		},
+		{
+			name: "the recording no longer carries the path",
+			mutate: func(f *recordedFieldFixture) {
+				f.Path = "zones[].no-such-field"
+			},
+			wantStale: "no longer carry this path",
+		},
+		{
+			name: "the recording holds no such operation",
+			mutate: func(f *recordedFieldFixture) {
+				f.Operation = "exoscale/v2.list-nothing"
+			},
+			wantStale: "holds no exchange for this operation",
+		},
+		{
+			name: "the recording it names is not there",
+			mutate: func(f *recordedFieldFixture) {
+				f.Corpus = "exoscale/gone.jsonl"
+			},
+			wantStale: "is not under",
+		},
+		{
+			name: "the schema does not declare the property",
+			mutate: func(f *recordedFieldFixture) {
+				f.Property = "never-added"
+			},
+			wantStale: "does not declare the property",
+		},
+		{
+			name: "the schema is not in the contract",
+			mutate: func(f *recordedFieldFixture) {
+				f.Schema = "no-such-schema"
+			},
+			wantStale: "declares no such schema",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newRecordedFieldFixture()
+			tc.mutate(&f)
+			contracts, corpus := f.write(t)
+
+			stale, checked, err := staleRecordedFields(contracts, corpus)
+			if err != nil {
+				t.Fatalf("hold the fixture contract against the fixture corpus: %v", err)
+			}
+			if checked != 1 {
+				t.Fatalf("examined %d entries, want the fixture's one", checked)
+			}
+			if tc.wantStale == "" {
+				if len(stale) != 0 {
+					t.Fatalf("a citation the recording supports was reported stale: %v", stale)
+				}
+				return
+			}
+			if len(stale) != 1 {
+				t.Fatalf("%d entries reported stale, want 1: %v", len(stale), stale)
+			}
+			if got := stale[0].String(); !strings.Contains(got, tc.wantStale) {
+				t.Fatalf("the report does not say %q: %s", tc.wantStale, got)
+			}
+		})
+	}
+}
+
+// recordedFieldFixture is one citation and the pair of artefacts it is judged
+// against, each field separately mutable so a subtest can break exactly one
+// link of the chain.
+type recordedFieldFixture struct {
+	Schema, Property, Corpus, Operation, Path string
+}
+
+func newRecordedFieldFixture() recordedFieldFixture {
+	return recordedFieldFixture{
+		Schema:    "zone",
+		Property:  "id",
+		Corpus:    "exoscale/fixture.jsonl",
+		Operation: "exoscale/v2.list-zones",
+		Path:      "zones[].id",
+	}
+}
+
+// write lays down a contract naming the citation and a one-line recording that
+// carries the field, and returns the two directories.
+//
+// The recording is written here rather than copied from corpus/ so that the
+// subtests above break the link and not the committed measurement.
+func (f recordedFieldFixture) write(t *testing.T) (contracts, corpus string) {
+	t.Helper()
+	root := t.TempDir()
+	contracts = filepath.Join(root, "contracts")
+	corpus = filepath.Join(root, "corpus", "exoscale")
+	for _, dir := range []string{contracts, corpus} {
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			t.Fatalf("make %s: %v", dir, err)
+		}
+	}
+
+	doc := map[string]any{
+		"provider":   "fixture",
+		"source":     "a fixture, not a provider",
+		"apiVersion": "0",
+		"pathPrefix": "/v2",
+		"recordedFields": []map[string]string{{
+			"schema": f.Schema, "property": f.Property, "corpus": f.Corpus,
+			"operation": f.Operation, "path": f.Path,
+			"recorded": "2026-08-21", "why": "a fixture",
+		}},
+		"operations": map[string]any{},
+		"schemas": map[string]any{
+			"zone": map[string]any{
+				"closed":     true,
+				"properties": map[string]any{"id": map[string]any{"type": "string"}},
+			},
+		},
+	}
+	writeFixtureJSON(t, filepath.Join(contracts, "fixture.json"), doc)
+
+	exchange := map[string]any{
+		"seq": 1, "method": "GET", "path": "/v2/zone",
+		"operation": "exoscale/v2.list-zones", "provider": "exoscale",
+		"status": 200, "mounted": true,
+		"res": map[string]any{"body": map[string]any{
+			"zones": []any{map[string]any{"id": "00000000-0000-4000-8000-000000000001", "name": "ch-gva-2"}},
+		}},
+	}
+	raw, err := json.Marshal(exchange)
+	if err != nil {
+		t.Fatalf("marshal the fixture exchange: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(corpus, "fixture.jsonl"), append(raw, '\n'), 0o600); err != nil {
+		t.Fatalf("write the fixture recording: %v", err)
+	}
+	return contracts, filepath.Dir(corpus)
+}
+
+func writeFixtureJSON(t *testing.T, path string, value any) {
+	t.Helper()
+	raw, err := json.MarshalIndent(value, "", " ")
+	if err != nil {
+		t.Fatalf("marshal %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, append(raw, '\n'), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/contract/contract.go
+++ b/internal/contract/contract.go
@@ -55,9 +55,22 @@ type Doc struct {
 	// struct, and Scaleway's scw/errors.go does the same. Empty when nothing
 	// upstream states the shape, and a refusal is then not validatable — which
 	// the probe reports as such rather than passing it.
-	ErrorSchema string               `json:"errorSchema,omitempty"`
-	Operations  map[string]Operation `json:"operations"`
-	Schemas     map[string]Schema    `json:"schemas"`
+	ErrorSchema string `json:"errorSchema,omitempty"`
+	// RecordedFields are the properties the extraction added to a schema
+	// because a recording of the real cloud carries them and the provider's own
+	// document does not declare them. Empty for a provider whose document is
+	// level with its API, which is where every provider is presumed to be until
+	// a recording says otherwise.
+	//
+	// They are here rather than folded silently into Schemas so that the
+	// artefact says which of its fields came from a wire instead of a document,
+	// and so that a gate can hold each one against the recording it names —
+	// internal/cli's TestEveryRecordedFieldIsStillOnTheWire, on the model
+	// corpus/accepted.json states: an entry that covers nothing is deleted, or
+	// the register quietly becomes a place where a shape can be invented.
+	RecordedFields []RecordedField      `json:"recordedFields,omitempty"`
+	Operations     map[string]Operation `json:"operations"`
+	Schemas        map[string]Schema    `json:"schemas"`
 
 	// folded indexes the operations by their name lower-cased, so a lookup can
 	// survive the one difference between a document and the SDK generated from
@@ -65,6 +78,32 @@ type Doc struct {
 	// their SDK, and the routes here carry the SDK spelling because that is what
 	// the drift scan reads. Same operation, two ways of writing it.
 	folded map[string]string
+}
+
+// RecordedField is one property a recording of the real cloud carries and the
+// provider's own API description does not declare, with the citation that
+// proves it.
+//
+// Every field is load-bearing, and each one answers a question somebody will
+// ask of the entry later: Schema and Property say what was added and where;
+// Corpus, Operation and Path say where to go and look; Recorded says how old
+// the measurement is; Why says what the reader is meant to conclude. An entry
+// missing any of them is refused by the extraction, because a field with no
+// citation behind it is exactly what rule 4 calls an invented format.
+type RecordedField struct {
+	Schema   string `json:"schema"`
+	Property string `json:"property"`
+	// Corpus is the recording, relative to corpus/ — the same spelling
+	// corpus/accepted.json uses for its own files, so one name reaches both.
+	Corpus string `json:"corpus"`
+	// Operation is the name the recording files the exchange under, and Path is
+	// where the field sits in the answer, in the notation internal/transcript
+	// produces: zones[].id, security-groups[].visibility.
+	Operation string `json:"operation"`
+	Path      string `json:"path"`
+	// Recorded is the day the recording was made, YYYY-MM-DD.
+	Recorded string `json:"recorded"`
+	Why      string `json:"why"`
 }
 
 // Operation ties an API call to the schemas on either side of it.

--- a/internal/core/resource/id.go
+++ b/internal/core/resource/id.go
@@ -1,0 +1,34 @@
+package resource
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// DerivedID builds a UUID-shaped identifier from a seed, deterministically.
+//
+// Two packs need the same thing for the same reason, which is what makes this
+// the core's business rather than either pack's: an emulated object that has no
+// row of its own still has to answer an identifier, and that identifier must be
+// the same on the second read as on the first. Scaleway derives the id of a
+// subnet the API publishes but this emulator does not store separately
+// (internal/providers/scaleway/vpc.go); Exoscale derives the id of a zone, which
+// is a property of the deployment and not a resource anybody created
+// (internal/providers/exoscale/catalog.go). Written twice, a defect fixed on one
+// side survives on the other — CLAUDE.md's factorisation rule, and the seam it
+// names.
+//
+// Derived rather than random so it survives a restart: a client that stored the
+// value yesterday finds the same one today, the way it would upstream. The seed
+// is the caller's, and it must name what the identifier is for as well as which
+// object it belongs to — two records under one seed would be one UUID for two
+// things, and a client holding both could not tell which it had stored.
+//
+// The shape is a version-4 variant-8 UUID because that is what all three of
+// these APIs publish; the bits are a hash rather than randomness, which nothing
+// on the wire can tell apart and no client parses for entropy.
+func DerivedID(seed string) string {
+	sum := sha256.Sum256([]byte(seed))
+	hexed := hex.EncodeToString(sum[:])
+	return hexed[0:8] + "-" + hexed[8:12] + "-4" + hexed[13:16] + "-8" + hexed[17:20] + "-" + hexed[20:32]
+}

--- a/internal/providers/exoscale/catalog.go
+++ b/internal/providers/exoscale/catalog.go
@@ -84,6 +84,29 @@ func zoneList() string {
 // suffix a client needs on the address it is handed.
 const apiPrefix = "/v2"
 
+// zoneIDSeed namespaces the zone identifiers so they cannot collide with any
+// other derived id this emulator answers. A zone is not a resource anybody
+// created and holds no row in the store, so its id has nowhere to be kept: it
+// is computed, from the one thing that identifies a zone, its name.
+const zoneIDSeed = "exoscale-zone:"
+
+// zoneID is the identifier the zone list publishes for a zone.
+//
+// Stable is the whole requirement, and it is stronger than "the same within one
+// response". #370 states it: an identifier that changed between two reads would
+// be worse than none, because a client that stored it would hold a value that
+// names nothing on the next call. Deriving it from the zone name gives that for
+// free and gives more — the same emulator restarted, and a second emulator in
+// the same zone, answer the same id, which is what a real cloud does with a
+// zone that has existed for years.
+//
+// TestZonesCarryAStableIdentifier fails without it, in both directions: it
+// reads the list twice and compares, and it requires the value to be a
+// UUID-shaped identifier rather than any stable string at all.
+func zoneID(name string) string {
+	return resource.DerivedID(zoneIDSeed + name)
+}
+
 // listZones answers the first call the official CLI makes.
 //
 // api-endpoint points back at this emulator, which is the whole reason the route
@@ -102,26 +125,25 @@ const apiPrefix = "/v2"
 // upload to a route that does not exist. An empty string is what "not here"
 // looks like; an invented address is a promise the emulator cannot keep.
 func (p *Pack) listZones(w http.ResponseWriter, r *http.Request) {
-	// One row: the zone this deployment serves (Pack.zone, #278). The real
-	// answer also carries an id per zone, measured on 2026-08-10 and absent
-	// from their published schema, which this emulator's contract check
-	// enforces as closed. The field stays off the wire for the same reason as
-	// security-group's visibility: a response the emulator would refuse itself
-	// is not one it may send.
+	// One row: the zone this deployment serves (Pack.zone, #278).
 	zones := []map[string]any{{
 		"name": p.zone,
-		// No id, and that is measured rather than an oversight. The live API
-		// sends one on every zone — recorded in shapes/exoscale.json — while
-		// their published OpenAPI declares no such field on `zone`. Emitting
-		// it fails this emulator's own contract check, which is the gate that
-		// keeps every other answer honest.
+		// The id every zone of a real answer carries. It used to be omitted,
+		// deliberately and with a paragraph saying why: the live API sends one
+		// and their published OpenAPI declares no such field on `zone`, so
+		// emitting it failed this emulator's own contract check. Raised as #94
+		// from a shape diff and closed as not-a-defect on that basis.
 		//
-		// Same call as start/stop's `resource` envelope in lifecycle.go: the
-		// live API is ahead of its own description in four measured places,
-		// and the rule is to serve what clients decode and what the contract
-		// accepts. Raised as #94 from a shape diff and closed as not-a-defect
-		// on that basis: TestEveryRouteAnswersItsContract in internal/probe fails
-		// the moment the field is added.
+		// The corpus reopened it and reversed the conclusion (#370): `exo`
+		// lists the zones before very nearly every command, so that one
+		// omission was 51 of the 105 divergences the 2026-08-21 recording of a
+		// real ch-gva-2 account reported — the most-answered operation of the
+		// whole file. The contract was the thing that had to move, and it did:
+		// tools/contract/exoscale-recorded-fields.yaml adds the property with
+		// the recording that proves it, and internal/cli's
+		// TestEveryRecordedFieldIsStillOnTheWire deletes the entry the day no
+		// recording carries it any more.
+		"id":           zoneID(p.zone),
 		"api-endpoint": emulator.EndpointOf(r) + apiPrefix,
 		"sos-endpoint": "",
 	}}
@@ -155,6 +177,7 @@ func (p *Pack) listZones(w http.ResponseWriter, r *http.Request) {
 			}
 			zones = append(zones, map[string]any{
 				"name":         name,
+				"id":           zoneID(name),
 				"api-endpoint": emulator.EndpointOf(r) + unservedZonePathPrefix + name,
 				"sos-endpoint": "",
 			})

--- a/internal/providers/exoscale/declined_fields.go
+++ b/internal/providers/exoscale/declined_fields.go
@@ -5,25 +5,25 @@ import "github.com/stephrobert/feint/internal/core/emulator"
 // DeclinedFields implements emulator.FieldDecliner: fields the recorded shapes
 // prove the live API returns and this pack knowingly does not serve.
 //
-// Both entries are the same decision, recorded in prose by 98f8df6 and until
-// now readable nowhere a gate could see: the live wire is ahead of Exoscale's
-// published OpenAPI description, and this emulator enforces that description as
-// closed — internal/contract fails a response carrying a field the schema does
-// not declare. Serving these would trade a shape finding for a contract
-// finding; the description is the API the SDKs are generated from, so the
-// description wins until Exoscale publishes the field.
+// Empty, and that is a measurement rather than an omission. It carried two
+// entries — GET /v2/security-group's visibility and GET /v2/zone's id — both
+// declined for one reason written in prose by 98f8df6: the live wire is ahead of
+// Exoscale's published OpenAPI description, this emulator enforces that
+// description as closed, and serving either field traded a shape finding for a
+// contract finding.
+//
+// #370 and #371 retired both by moving the thing that was actually wrong. The
+// description is behind the API, so the contract now records that explicitly:
+// tools/contract/exoscale-recorded-fields.yaml adds each field with the
+// recording that proves the cloud answers it, and internal/cli's
+// TestEveryRecordedFieldIsStillOnTheWire fails the day no recording does. The
+// pack answers both, and the declines had to go with them — a decline that
+// declines nothing fails `feint shapes --check` under the same staleness rule
+// corpus/accepted.json states (TestAStaleFieldDeclineFailsTheGate).
+//
+// The nil is the honest answer while there is nothing to decline. A pack that
+// starts refusing a field again declares it here, with the reason, because
+// "not served" and "not triaged" are not the same answer.
 func (p *Pack) DeclinedFields() []emulator.FieldDecline {
-	const liveAheadOfSpec = "live on the wire but absent from the published OpenAPI description, which the contract gate enforces as closed"
-	return []emulator.FieldDecline{
-		{
-			Operation: "GET /v2/security-group",
-			Path:      "security-groups[].visibility",
-			Reason:    liveAheadOfSpec,
-		},
-		{
-			Operation: "GET /v2/zone",
-			Path:      "zones[].id",
-			Reason:    liveAheadOfSpec,
-		},
-	}
+	return nil
 }

--- a/internal/providers/exoscale/recordedfields_test.go
+++ b/internal/providers/exoscale/recordedfields_test.go
@@ -1,0 +1,220 @@
+package exoscale_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The three fields the 2026-08-21 recording of a real ch-gva-2 account proved
+// this emulator was omitting (#370, #371).
+//
+// They are together because they are one defect with one cause, stated in
+// tools/contract/exoscale-recorded-fields.yaml: the cloud answers fields its own
+// published API description does not declare, so the contract, the shapes gate,
+// the probe and this pack all agreed with one another and all four were wrong.
+// corpus/exoscale/exo-cli.jsonl is the only thing in the repository that could
+// disagree, and `feint corpus --check` is where it does — these tests are the
+// per-field half, close enough to the handler to say which line is wrong.
+
+// uuidShaped is the form every identifier these APIs publish takes. Asserted
+// rather than assumed: "stable" is satisfied by the empty string too, and an
+// empty id would pass a comparison of two reads while telling a client nothing.
+var uuidShaped = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+// Every zone row carries an id, and it is the same id on the next read.
+//
+// #370 states the requirement and states why it is the interesting half: an
+// identifier that changed per request would be worse than none at all, because
+// a client that stored it would hold a value naming nothing. The zone list is
+// also the most-answered operation of the whole recording — `exo` calls it
+// before very nearly every command — so this is 51 of that file's 105
+// divergences on its own.
+//
+// Both zone lists are read, because they are built by different code: the CLI
+// gets the one row this deployment serves, and a split client gets that row plus
+// a signpost per published zone (#284). An id on the first and not the second
+// would be a hole exactly one client family falls into.
+func TestZonesCarryAStableIdentifier(t *testing.T) {
+	h := serve(t)
+
+	for _, agent := range []struct{ name, userAgent string }{
+		{"the CLI", "exoscale-cli"},
+		{"a split client", "Exoscale-Terraform-Provider/0.70.0 (something) Terraform-SDK/2.31.0"},
+	} {
+		t.Run(agent.name, func(t *testing.T) {
+			// The split client is refused by user agent unless the operator
+			// opts in, because the Terraform provider only honours
+			// EXOSCALE_API_ENDPOINT for half its calls (docs/limits.md). The
+			// opt-in is what gets this test to the zone list at all.
+			t.Setenv("FEINT_EXOSCALE_ALLOW_TERRAFORM", "1")
+
+			first := zoneIdentifiers(t, h, agent.userAgent)
+			if len(first) == 0 {
+				t.Fatal("the zone list answered no row, so this measured nothing")
+			}
+			for name, id := range first {
+				if !uuidShaped.MatchString(id) {
+					t.Errorf("zone %s answers id %q, which is not the UUID shape every "+
+						"identifier of this API takes: a client storing it holds nothing", name, id)
+				}
+			}
+
+			second := zoneIdentifiers(t, h, agent.userAgent)
+			for name, id := range first {
+				if second[name] != id {
+					t.Errorf("zone %s answered id %q and then %q: an identifier that moves "+
+						"between two reads of one emulator is worse than none (#370)", name, id, second[name])
+				}
+			}
+		})
+	}
+}
+
+// zoneIdentifiers reads GET /v2/zone as the named client and returns the id of
+// every row, by zone name.
+func zoneIdentifiers(t *testing.T, h http.Handler, userAgent string) map[string]string {
+	t.Helper()
+	rec, body := callAs(t, h, "GET", "/v2/zone", userAgent)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /v2/zone: status %d, want 200", rec.Code)
+	}
+	rows, _ := body["zones"].([]any)
+	out := map[string]string{}
+	for _, raw := range rows {
+		row, _ := raw.(map[string]any)
+		name, _ := row["name"].(string)
+		id, ok := row["id"].(string)
+		if !ok {
+			t.Fatalf("zone %s answers no id, which is what the real list carries on every row (#370): %v", name, row)
+		}
+		out[name] = id
+	}
+	return out
+}
+
+// Every security group answers visibility, on the list and on the read of one
+// group alike — 46 of the recording's divergences, and two entries in
+// corpus/accepted.json rather than one, precisely so that fixing the list could
+// not quietly leave the get behind (#371).
+func TestASecurityGroupPublishesItsVisibility(t *testing.T) {
+	h := serve(t)
+
+	_, listed := call(t, h, "GET", "/v2/security-group", "")
+	groups, _ := listed["security-groups"].([]any)
+	if len(groups) == 0 {
+		t.Fatal("a fresh account listed no group, so this measured nothing")
+	}
+	for _, raw := range groups {
+		group, _ := raw.(map[string]any)
+		if group["visibility"] != "private" {
+			t.Errorf("the listed group %v answers visibility %v, want private", group["name"], group["visibility"])
+		}
+	}
+
+	// The default group, read on its own. Same view, different door, and the
+	// door is what #371 keeps a separate exemption for.
+	first, _ := groups[0].(map[string]any)
+	id, _ := first["id"].(string)
+	_, read := call(t, h, "GET", "/v2/security-group/"+id, "")
+	if read["visibility"] != "private" {
+		t.Errorf("the group read on its own answers visibility %v, want private: %v", read["visibility"], read)
+	}
+}
+
+// A rule whose target is another group publishes that group's name beside its
+// id, which is what the wire carries and what a consumer of the rule reads.
+//
+// It is the shape examples/stacks/exoscale/main.tf writes as
+// user_security_group_id — "the application tier accepts the web tier and nobody
+// else". What it is not is a client symptom: `exo compute security-group show`
+// prints the right name either way, because it resolves the reference by id
+// itself, and that was measured before the claim was written down. The subject
+// is the wire, which is the only thing corpus/ compares.
+//
+// The reference carries id and name and nothing else, and that is measured too:
+// their document declares visibility on the same schema, and no recorded rule
+// reference has one. Answering it would be a field this emulator invented.
+func TestARuleThatNamesAGroupPublishesThatGroupsName(t *testing.T) {
+	h := serve(t)
+
+	web := createGroup(t, h, "web")
+	app := createGroup(t, h, "app")
+
+	rec, _ := call(t, h, "POST", "/v2/security-group/"+app+"/rules",
+		`{"flow-direction":"ingress","protocol":"tcp","start-port":8080,"end-port":8080,`+
+			`"security-group":{"id":"`+web+`"}}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("adding a group-to-group rule answered %d", rec.Code)
+	}
+
+	_, group := call(t, h, "GET", "/v2/security-group/"+app, "")
+	rules, _ := group["rules"].([]any)
+	if len(rules) != 1 {
+		t.Fatalf("the rule did not land: %v", group)
+	}
+	rule, _ := rules[0].(map[string]any)
+	target, _ := rule["security-group"].(map[string]any)
+	if target["id"] != web {
+		t.Fatalf("the rule points at %v, want the web group %s", target["id"], web)
+	}
+	if target["name"] != "web" {
+		t.Errorf("the rule's target publishes name %v, want web: the cloud sends a name "+
+			"beside the id and this emulator sent the id alone (#371)", target["name"])
+	}
+	if len(target) != 2 {
+		t.Errorf("the rule's target carries %v, want id and name alone: no recorded "+
+			"reference carries anything else, and a third key would be invented", target)
+	}
+
+	// The name follows the group rather than a copy of it: renaming is not
+	// served here, but deleting is, and a reference to a group that is gone
+	// must publish its id alone rather than a name from nowhere.
+	rec, _ = call(t, h, "DELETE", "/v2/security-group/"+web, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("deleting the unworn web group answered %d", rec.Code)
+	}
+	_, group = call(t, h, "GET", "/v2/security-group/"+app, "")
+	rules, _ = group["rules"].([]any)
+	rule, _ = rules[0].(map[string]any)
+	target, _ = rule["security-group"].(map[string]any)
+	if _, named := target["name"]; named {
+		t.Errorf("the rule still names a group that no longer exists: %v", target)
+	}
+}
+
+// callAs is call() with a User-Agent, which is what tells the two client
+// families apart on the zone list (splitClient, #284).
+func callAs(t *testing.T, h http.Handler, method, path, userAgent string) (*httptest.ResponseRecorder, map[string]any) {
+	t.Helper()
+	req := httptest.NewRequest(method, path, strings.NewReader(""))
+	req.Header.Set("User-Agent", userAgent)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	decoded := map[string]any{}
+	if rec.Body.Len() > 0 {
+		if err := json.Unmarshal(rec.Body.Bytes(), &decoded); err != nil {
+			t.Fatalf("%s %s answered something that is not a JSON object: %s", method, path, rec.Body.String())
+		}
+	}
+	return rec, decoded
+}
+
+// createGroup creates one security group and returns its identifier.
+func createGroup(t *testing.T, h http.Handler, name string) string {
+	t.Helper()
+	rec, op := call(t, h, "POST", "/v2/security-group", `{"name":"`+name+`","description":"`+name+`"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("creating the %s group answered %d: %s", name, rec.Code, rec.Body.String())
+	}
+	ref, _ := op["reference"].(map[string]any)
+	id, _ := ref["id"].(string)
+	if id == "" {
+		t.Fatalf("the create names no group: %v", op)
+	}
+	return id
+}

--- a/internal/providers/exoscale/securitygroups.go
+++ b/internal/providers/exoscale/securitygroups.go
@@ -27,6 +27,12 @@ const (
 	// defaultSecurityGroupID is stable across runs: a client that recorded it
 	// yesterday must find the same group today, the way it would upstream.
 	defaultSecurityGroupID = "00000000-0000-4000-8000-000000000001"
+
+	// securityGroupVisibility is what every group of an emulated account
+	// answers. Their enum is private|public and public names the groups
+	// Exoscale publishes itself, of which this emulator has none — see
+	// listSecurityGroups, which answers the empty list for that filter.
+	securityGroupVisibility = "private"
 )
 
 // ensureDefaultSecurityGroup seeds the group a fresh account starts with.
@@ -105,7 +111,7 @@ func (p *Pack) listSecurityGroups(w http.ResponseWriter, r *http.Request) {
 		list := p.env.Store.List(kindSecurityGroup, resource.Tenant{Provider: Name})
 		sort.Slice(list, func(i, j int) bool { return list[i].Created.Before(list[j].Created) })
 		for _, res := range list {
-			groups = append(groups, securityGroupView(res))
+			groups = append(groups, p.securityGroupView(res))
 		}
 	case "public":
 		// None to list: see above.
@@ -123,7 +129,7 @@ func (p *Pack) getSecurityGroup(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "resource not found")
 		return
 	}
-	emulator.WriteJSON(w, http.StatusOK, securityGroupView(res))
+	emulator.WriteJSON(w, http.StatusOK, p.securityGroupView(res))
 }
 
 func (p *Pack) deleteSecurityGroup(w http.ResponseWriter, r *http.Request) {
@@ -369,24 +375,98 @@ func (p *Pack) changeExternalSources(w http.ResponseWriter, r *http.Request, add
 // securityGroupView is the measured shape: rules and external-sources are
 // omitted keys when empty.
 //
-// The live API also answers `visibility: "private"` on every group, and their
-// published schema does not declare the field — the same live-ahead-of-spec gap
-// as the operation's resource field. This emulator validates its responses
-// against the published contract, so the field stays off the wire; the CLI
-// prints groups without it.
-func securityGroupView(res *resource.Resource) map[string]any {
+// visibility is on every group the real API answers, the default one included,
+// and it used to be off the wire here with a paragraph explaining that their
+// published schema declares the field on security-group-resource — the shape a
+// rule uses to point at another group — and not on security-group, which is what
+// a list and a get answer. The 2026-08-21 recording of a real account reported
+// the omission 46 times (#371), so the contract moved rather than the reasoning:
+// tools/contract/exoscale-recorded-fields.yaml adds the property with the
+// recording that proves it.
+//
+// private and not a stored attribute, because this emulator publishes nothing:
+// their document's enum is private|public, public names the groups Exoscale
+// itself offers, and listSecurityGroups already answers the empty list for that
+// filter. A group here is always the account's own.
+//
+// A method rather than a function since #371's second half: a rule that points
+// at another group publishes that group's name beside its id, which needs the
+// store. TestASecurityGroupPublishesItsVisibility and
+// TestARuleThatNamesAGroupPublishesThatGroupsName fail without either half.
+func (p *Pack) securityGroupView(res *resource.Resource) map[string]any {
 	out := map[string]any{
-		"id":   res.ID,
-		"name": res.Attrs["name"],
+		"id":         res.ID,
+		"name":       res.Attrs["name"],
+		"visibility": securityGroupVisibility,
 	}
 	if description, _ := res.Attrs["description"].(string); description != "" {
 		out["description"] = description
 	}
 	if rules, _ := res.Attrs["rules"].([]any); len(rules) > 0 {
-		out["rules"] = rules
+		out["rules"] = p.ruleViews(rules)
 	}
 	if sources, _ := res.Attrs["external-sources"].([]any); len(sources) > 0 {
 		out["external-sources"] = sources
+	}
+	return out
+}
+
+// ruleViews renders a group's stored rules, resolving the name of every group a
+// rule points at.
+//
+// The recording is what settled the shape: `{"security-group": {"id": …,
+// "name": …}}`, and no visibility on the reference even though their schema
+// declares one there — so this publishes the two fields the wire carries and
+// not the third the document offers. It is the shape
+// examples/stacks/exoscale/main.tf writes as user_security_group_id, the rule
+// "the application tier accepts the web tier and nobody else".
+//
+// What it is NOT is something a user of `exo` can see, and that was measured
+// rather than assumed: with the name omitted, `exo compute security-group show`
+// still prints `SG:web` correctly, because the CLI resolves the reference by id
+// against the groups it has already listed. #371 says "a consumer reading the
+// group's name off the rule sees nothing", and for the one client this
+// repository drives that is not true. The reason to serve it is the one this
+// project actually rests on — the answer must be the cloud's answer, and
+// corpus/exoscale/exo-cli.jsonl says the cloud sends a name — not a client
+// symptom nobody has reproduced.
+//
+// Resolved at render time rather than copied in when the rule is added: the
+// name a reference publishes is the target's name now, so renaming a group
+// cannot leave a rule quoting what it used to be called. The store is the only
+// thing that knows, which is what makes this a method.
+//
+// The rule maps are rebuilt rather than edited. resource.Clone shares whatever
+// sits inside Attrs, so writing a key into a stored rule would write it into
+// the store from a reader — the mutation no lock covers.
+func (p *Pack) ruleViews(rules []any) []any {
+	out := make([]any, 0, len(rules))
+	for _, raw := range rules {
+		rule, ok := raw.(map[string]any)
+		if !ok {
+			out = append(out, raw)
+			continue
+		}
+		target, ok := rule["security-group"].(map[string]any)
+		if !ok {
+			out = append(out, rule)
+			continue
+		}
+		copied := make(map[string]any, len(rule))
+		for k, v := range rule {
+			copied[k] = v
+		}
+		reference := map[string]any{"id": target["id"]}
+		// A group that is gone publishes its id alone. Nothing measured says
+		// what the cloud does there — the recording deletes the pointed-at
+		// group last — so the emulator says less rather than inventing a name.
+		if id, _ := target["id"].(string); id != "" {
+			if group, found := p.env.Store.Get(Name, kindSecurityGroup, id); found {
+				reference["name"] = group.Attrs["name"]
+			}
+		}
+		copied["security-group"] = reference
+		out = append(out, copied)
 	}
 	return out
 }

--- a/internal/providers/scaleway/vpc.go
+++ b/internal/providers/scaleway/vpc.go
@@ -2,8 +2,6 @@ package scaleway
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"net/http"
 	"net/netip"
@@ -1155,8 +1153,11 @@ func subnetV6IDOf(privateNetworkID string) string {
 
 // derivedID builds a UUID-shaped identifier from a seed, deterministically.
 // Shared by the subnet and the computed route ids: same reasons, same shape.
+//
+// The derivation itself moved to [resource.DerivedID] when the Exoscale pack
+// needed the same thing for its zone identifiers: an object with no row of its
+// own still has to answer the same id twice. This wrapper stays because the
+// seeds are Scaleway's and the callers read better for it.
 func derivedID(seed string) string {
-	sum := sha256.Sum256([]byte(seed))
-	hexed := hex.EncodeToString(sum[:])
-	return hexed[0:8] + "-" + hexed[8:12] + "-4" + hexed[13:16] + "-8" + hexed[17:20] + "-" + hexed[20:32]
+	return resource.DerivedID(seed)
 }

--- a/tools/contract/exoscale-recorded-fields.yaml
+++ b/tools/contract/exoscale-recorded-fields.yaml
@@ -1,0 +1,93 @@
+# Fields a recording of the real Exoscale API carries that their own published
+# API description does not declare.
+#
+# Sibling of exoscale-error.yaml, and the same kind of correction: the document
+# is not always the API. That fragment overrides an error envelope the document
+# declares and egoscale does not read; this one adds two fields the wire answers
+# and the document never mentions. Both say out loud where the shape came from,
+# because rule 4 forbids inventing one.
+#
+# WHY NOTHING HAD SEEN THIS, AND IT IS THE POINT OF THE FILE. contracts/
+# exoscale.json is generated from https://openapi-v2.exoscale.com/source.yaml.
+# The pack was written from it, the shapes gate reads it, the probe validates
+# against it, and the contract checker refuses any field it does not declare. So
+# all four agree with one another by construction, and every one of them was
+# wrong in the same direction. Only a recording of the wire could disagree —
+# corpus/exoscale/exo-cli.jsonl, taken on 2026-08-21 against a real ch-gva-2
+# account through `feint proxy --forward '*.exoscale.com'` — and it reported the
+# two fields below 97 times between them (#370, #371).
+#
+# WHAT KEEPS THIS FROM BECOMING A PLACE TO INVENT A FORMAT. Three refusals, and
+# the third is the one that matters:
+#
+#   1. extract-openapi.py refuses a schema its documents do not define;
+#   2. it refuses a property the document declares itself — upstream catching up
+#      retires the entry rather than leaving a citation nobody re-reads;
+#   3. every entry's citation is copied into contracts/exoscale.json under
+#      recordedFields, and internal/cli's TestEveryRecordedFieldIsStillOnTheWire
+#      replays the named corpus and requires the named path to still be in it.
+#      An entry no recording carries fails that test, exactly as an entry that
+#      excuses nothing fails the corpus gate (corpus/accepted.json).
+#
+# So a field may be added here only by recording it, and it stays only while the
+# recording does. Deleting the recording does not silence the claim: it fails it.
+#
+# WHAT `exo` SHOWS, MEASURED, BECAUSE SOMEBODY WILL ASK. Neither field changes a
+# line of the official CLI's output: `exo -O json zone` prints `{"name": …}` and
+# drops everything else, and `exo -O json compute security-group list` prints
+# `"visibility":"private"` even against a server that sends no visibility at all
+# (measured 2026-08-21 against a stub answering the list without the field). That
+# is not an argument against serving them, it is the argument for corpus/. The
+# north star is that a client cannot tell this emulator from the cloud, and a
+# client that drops a field can no more confirm the answer is right than deny it
+# — only a recording of the wire arbitrates, which is the whole reason one is
+# committed.
+#
+# WHAT IS NOT HERE, AND WHY. The third divergence #371 names —
+# `rules[].security-group.name`, a rule that points at another group publishing
+# `{id, name}` upstream against `{id}` here — needed no entry: the document
+# already declares `name` on security-group-resource, which is the schema that
+# reference uses. It was a pack omission alone, and the pack now answers it.
+# Worth knowing before anybody reasons from #371's wording: `exo compute
+# security-group show` prints the target's name with or without the field,
+# because it resolves the reference by id itself. The wire is the subject, and
+# the recording is the only thing that can arbitrate it.
+#
+# `visibility` is likewise already declared on security-group-resource. It is
+# `security-group`, the schema a list and a get answer, that omits it — so the
+# entry below names that schema and not the reference one. The recording agrees:
+# the rule's `security-group` object carries `{id, name}` and no visibility.
+
+fields:
+  - schema: zone
+    property: id
+    shape: {type: string, format: uuid}
+    corpus: exoscale/exo-cli.jsonl
+    operation: exoscale/v2.list-zones
+    path: zones[].id
+    recorded: 2026-08-21
+    why: >
+      Every zone the real API lists carries an id and their `zone` schema
+      declares three fields, none of them it. `exo` lists the zones before very
+      nearly every command it runs, which is why one omission produced 51 of the
+      105 divergences that recording reported — the single most-answered
+      operation of the whole file. Raised once before as #94, from a shape diff,
+      and closed as not-a-defect on the grounds that serving it would fail this
+      emulator's own contract check. That was true, and it was the wrong end to
+      fix: the contract is what had to move.
+
+  - schema: security-group
+    property: visibility
+    shape: {type: string, enum: [private, public]}
+    corpus: exoscale/exo-cli.jsonl
+    operation: exoscale/v2.list-security-groups
+    path: security-groups[].visibility
+    recorded: 2026-08-21
+    why: >
+      Every group a real account answers carries visibility, private included,
+      on the list and on the read of one group alike. The document declares the
+      field on security-group-resource — the shape a rule uses to point at
+      another group — and not on security-group, the shape a list answers, which
+      is precisely the kind of gap no document-reading control can see. 46 of
+      the recording's divergences, and the enum is the document's own, taken
+      from the schema that does declare the field.

--- a/tools/contract/extract-openapi.py
+++ b/tools/contract/extract-openapi.py
@@ -48,6 +48,29 @@ declares a shape its own SDK does not read, `--error-shape` supplies a YAML
 fragment transcribed from the SDK's error structs — rule 4: the shape comes
 from the SDK, never from a guess. The fragment file carries the citation.
 
+Fields the wire carries and the document does not declare
+---------------------------------------------------------
+A published API description can be behind the API it describes, and Exoscale's
+is: `GET /v2/zone` answers an `id` per zone and `GET /v2/security-group` a
+`visibility` per group, neither of which their `source.yaml` declares. Nothing
+that reads a document could ever see that — the contract gate, the probe and the
+pack all read this artefact, so they agree with each other by construction. Only
+a recording of the real wire disagrees, and `corpus/` holds one.
+
+`--recorded-fields` folds such a field into the schema it belongs to, from a
+versioned YAML fragment where every entry cites the recording that proves it:
+the corpus file, the operation, the path inside the answer, and the day it was
+recorded. This is not a door for inventing a shape — rule 4 forbids that — and
+three refusals keep it shut:
+
+  * a schema the extracted document does not define is a typo or a rename;
+  * a property the document *does* declare means upstream has caught up, and
+    the entry has to go rather than quietly do nothing;
+  * the citation is copied into the artefact under `recordedFields`, where
+    `TestEveryRecordedFieldIsStillOnTheWire` (internal/cli) holds it against the
+    corpus it names. An entry no recording still carries fails that gate, on the
+    model of corpus/accepted.json: an entry that excuses nothing is deleted.
+
 Usage:
   tools/contract/extract-openapi.py <output.json> --provider <name>
       --spec <file>                      one document for the whole API
@@ -55,6 +78,8 @@ Usage:
       [--source <where it came from>] [--assume-closed]
       [--error-shape <fragment.yaml>]    the refusal shape, when the documents
                                          declare none or the SDK disagrees
+      [--recorded-fields <fragment.yaml>] fields a recording of the real cloud
+                                         carries and the document omits
 """
 
 import argparse
@@ -334,6 +359,77 @@ def read_spec(
     return spec["info"]["version"], path_prefix(spec), declared_closed
 
 
+# The keys every recorded-field entry must carry. `why` is in the list because
+# an entry without one is a field with no argument behind it, and that is the
+# shape of an invented format: the citation says the cloud answers it, the
+# sentence says why the document does not.
+RECORDED_FIELD_KEYS = (
+    "schema",
+    "property",
+    "shape",
+    "corpus",
+    "operation",
+    "path",
+    "recorded",
+    "why",
+)
+
+
+def apply_recorded_fields(path: str, schemas: dict) -> tuple[list[dict], list[str]]:
+    """Fold the fragment's fields into their schemas, and return their citations.
+
+    The second return is the refusals. They are collected rather than raised at
+    the first one, so an author fixing a fragment sees every problem in one run
+    instead of one per attempt.
+    """
+    with open(path) as f:
+        fragment = yaml.safe_load(f) or {}
+
+    entries = fragment.get("fields") or []
+    if not entries:
+        return [], [f"{path} declares no field, so passing it adds nothing"]
+
+    cited, refusals = [], []
+    for entry in entries:
+        if missing := [k for k in RECORDED_FIELD_KEYS if not entry.get(k)]:
+            refusals.append(f"{path}: an entry is missing {', '.join(missing)}: {entry!r}")
+            continue
+        name, prop = entry["schema"], entry["property"]
+        schema = schemas.get(name)
+        if schema is None:
+            refusals.append(
+                f"{path}: schema {name!r} is not in the extracted document, so {prop!r} "
+                f"would be added to nothing; the schema was renamed or the name is a typo"
+            )
+            continue
+        properties = schema.setdefault("properties", {})
+        if prop in properties:
+            # Upstream caught up. Keeping the entry would leave a citation
+            # standing for a field the document now carries on its own, which is
+            # a claim nobody would ever re-check.
+            refusals.append(
+                f"{path}: {name}.{prop} is declared by the document itself now, so this entry "
+                f"adds nothing — delete it, and the pack keeps answering the field"
+            )
+            continue
+        properties[prop] = property_shape(entry["shape"])
+        schema["properties"] = dict(sorted(properties.items()))
+        cited.append(
+            {
+                "schema": name,
+                "property": prop,
+                "corpus": entry["corpus"],
+                "operation": entry["operation"],
+                "path": entry["path"],
+                "recorded": str(entry["recorded"]),
+                "why": " ".join(str(entry["why"]).split()),
+            }
+        )
+
+    cited.sort(key=lambda c: (c["schema"], c["property"]))
+    return cited, refusals
+
+
 def main() -> int:
     global NAMESPACE
 
@@ -358,6 +454,12 @@ def main() -> int:
         metavar="FILE",
         help="a YAML fragment {name, schema} stating the refusal shape, transcribed "
         "from the SDK's error structs; overrides whatever the documents declare",
+    )
+    parser.add_argument(
+        "--recorded-fields",
+        metavar="FILE",
+        help="a YAML fragment {fields: [...]} adding fields a recording of the real cloud "
+        "carries and the document does not declare; every entry cites its recording",
     )
     args = parser.parse_args()
 
@@ -410,6 +512,18 @@ def main() -> int:
         print(f"errorSchema {error_schema} names no extracted schema", file=sys.stderr)
         return 1
 
+    # The fields the wire carries and the document does not declare. Applied
+    # last, so "the document already declares this" is judged against every
+    # document folded in, and a refusal here fails the extraction rather than
+    # writing an artefact whose citations nobody has checked.
+    recorded_fields: list[dict] = []
+    if args.recorded_fields:
+        recorded_fields, refusals = apply_recorded_fields(args.recorded_fields, schemas)
+        for line in refusals:
+            print(line, file=sys.stderr)
+        if refusals:
+            return 1
+
     artefact = {
         "provider": args.provider,
         "source": args.source or ", ".join(args.spec),
@@ -419,6 +533,8 @@ def main() -> int:
     }
     if error_schema:
         artefact["errorSchema"] = error_schema
+    if recorded_fields:
+        artefact["recordedFields"] = recorded_fields
     artefact["operations"] = dict(sorted(operations.items()))
     artefact["schemas"] = dict(sorted(schemas.items()))
 
@@ -443,6 +559,11 @@ def main() -> int:
         f"{len(operations)} operations, {len(schemas)} schemas "
         f"({closed} closed, {declared_closed} of them declared), "
         f"errorSchema {error_schema or 'none — refusals cannot be validated'}"
+        + (
+            f", {len(recorded_fields)} field(s) from a recording the document does not declare"
+            if recorded_fields
+            else ""
+        )
     )
     return 0
 

--- a/tools/contract/update.sh
+++ b/tools/contract/update.sh
@@ -34,9 +34,15 @@ extract contracts/outscale.json --provider outscale \
 #
 # --error-shape overrides the document's RFC 9457 error envelope with what
 # egoscale actually decodes; the fragment file carries the citation.
+#
+# --recorded-fields adds the two fields corpus/exoscale/exo-cli.jsonl proves the
+# live API answers and their document never declares (#370, #371). Its own
+# header explains what stops it becoming a place to invent a shape, and
+# TestEveryRecordedFieldIsStillOnTheWire is the half of that which executes.
 extract contracts/exoscale.json --provider exoscale \
   --source "https://openapi-v2.exoscale.com/source.yaml" --assume-closed \
   --error-shape tools/contract/exoscale-error.yaml \
+  --recorded-fields tools/contract/exoscale-recorded-fields.yaml \
   --spec "$SPEC_EXOSCALE"
 
 # Scaleway publishes one document per product, so its names are qualified: it

--- a/tools/falsify/specs/recorded-fields.json
+++ b/tools/falsify/specs/recorded-fields.json
@@ -1,0 +1,88 @@
+{
+  "package": "./internal/providers/exoscale/",
+  "mutations": [
+    {
+      "label": "the zone list answers an empty id again, which is what \"stable\" alone would let through: two reads agree and a client that stored the value holds nothing (#370)",
+      "file": "internal/providers/exoscale/catalog.go",
+      "find": "\t\t\"id\":           zoneID(p.zone),",
+      "replace": "\t\t\"id\":           zoneID(p.zone)[:0],",
+      "test": "TestZonesCarryAStableIdentifier"
+    },
+    {
+      "label": "the zone identifier moves between two reads of one emulator, which #370 states is worse than answering none at all",
+      "file": "internal/providers/exoscale/catalog.go",
+      "find": "func zoneID(name string) string {\n\treturn resource.DerivedID(zoneIDSeed + name)\n}",
+      "replace": "var zoneIDCalls int\n\nfunc zoneID(name string) string {\n\tzoneIDCalls++\n\treturn resource.DerivedID(zoneIDSeed + name + strings.Repeat(\"x\", zoneIDCalls))\n}",
+      "test": "TestZonesCarryAStableIdentifier"
+    },
+    {
+      "label": "the signpost rows a split client gets lose their id: one client family keeps the field and the other does not, which is the hole a single-population test would not see (#284)",
+      "file": "internal/providers/exoscale/catalog.go",
+      "find": "\t\t\t\t\"id\":           zoneID(name),",
+      "replace": "\t\t\t\t\"id\":           zoneID(name)[:0],",
+      "test": "TestZonesCarryAStableIdentifier"
+    },
+    {
+      "label": "a security group publishes an empty visibility, on the list and on the read alike — 46 of the recording's divergences (#371)",
+      "file": "internal/providers/exoscale/securitygroups.go",
+      "find": "\t\t\"visibility\": securityGroupVisibility,",
+      "replace": "\t\t\"visibility\": securityGroupVisibility[:0],",
+      "test": "TestASecurityGroupPublishesItsVisibility"
+    },
+    {
+      "label": "a rule that points at another group stops resolving that group's name, so a consumer reading the target off the rule sees an opaque id again — the shape examples/stacks/exoscale/main.tf writes as user_security_group_id (#371)",
+      "file": "internal/providers/exoscale/securitygroups.go",
+      "find": "\t\t\tif group, found := p.env.Store.Get(Name, kindSecurityGroup, id); found {",
+      "replace": "\t\t\tif group, found := p.env.Store.Get(Name, kindSecurityGroup, id); found && false {",
+      "test": "TestARuleThatNamesAGroupPublishesThatGroupsName"
+    },
+    {
+      "label": "THE SECOND DIRECTION: the resolved reference is written into the stored rule instead of a copy of it, which is a reader mutating the store — resource.Clone shares whatever sits inside Attrs, so no lock covers that write",
+      "file": "internal/providers/exoscale/securitygroups.go",
+      "find": "\t\tcopied[\"security-group\"] = reference",
+      "replace": "\t\trule[\"security-group\"] = reference\n\t\t_ = copied",
+      "test": "TestARuleThatNamesAGroupPublishesThatGroupsName"
+    },
+    {
+      "label": "a citation whose path no recording carries stops being reported, and contracts/*.json becomes a place where any field at all can be written and called measured — the rule corpus/accepted.json states, pointed the other way",
+      "file": "internal/cli/recorded_fields.go",
+      "find": "\t\t\tif !known[f.Path] {",
+      "replace": "\t\t\tif !known[f.Path] && false {",
+      "test": "TestARecordedFieldNoRecordingCarriesIsRefused",
+      "package": "./internal/cli/"
+    },
+    {
+      "label": "a citation naming a recording that is not there is no longer named as such, so an entry whose evidence left the repository stops being actionable",
+      "file": "internal/cli/recorded_fields.go",
+      "find": "\t\t\tif _, err := os.Stat(filepath.Join(corpusDir, filepath.FromSlash(f.Corpus))); err != nil {",
+      "replace": "\t\t\tif _, err := os.Stat(filepath.Join(corpusDir, filepath.FromSlash(f.Corpus))); err != nil && false {",
+      "test": "TestARecordedFieldNoRecordingCarriesIsRefused",
+      "package": "./internal/cli/"
+    },
+    {
+      "label": "the two halves the extraction writes together — the property in the schema and the citation beside it — stop being held to each other, so a citation for a field nothing declares reads as sound",
+      "file": "internal/cli/recorded_fields.go",
+      "find": "\t\t\tif _, ok := schema.Properties[f.Property]; !ok {",
+      "replace": "\t\t\tif _, ok := schema.Properties[f.Property]; !ok && false {",
+      "test": "TestARecordedFieldNoRecordingCarriesIsRefused",
+      "package": "./internal/cli/"
+    },
+    {
+      "label": "a citation naming a schema the contract does not carry is accepted, which is the state a renamed schema leaves behind",
+      "file": "internal/cli/recorded_fields.go",
+      "find": "\t\t\tschema, ok := doc.Schemas[f.Schema]\n\t\t\tif !ok {",
+      "replace": "\t\t\tschema, ok := doc.Schemas[f.Schema]\n\t\t\tif !ok && false {",
+      "test": "TestARecordedFieldNoRecordingCarriesIsRefused",
+      "package": "./internal/cli/"
+    },
+    {
+      "label": "the count of what was examined stops counting, which is how this gate dies silently: --recorded-fields drops out of tools/contract/update.sh, the list empties, and a run that measured nothing reads exactly like a run that found nothing wrong",
+      "file": "internal/cli/recorded_fields.go",
+      "find": "\t\t\tchecked++",
+      "replace": "\t\t\tchecked += 0",
+      "test": "TestARecordedFieldNoRecordingCarriesIsRefused",
+      "package": "./internal/cli/"
+    }
+  ],
+  "note": "The three refusals inside tools/contract/extract-openapi.py carry no mutation here, and the reason is the harness rather than the guards: it copies the tree, runs `go vet` and `go test`, and a Python branch has no Go test to turn red. They were proved by execution instead — a fragment naming a schema the document does not define, one naming a property the document already declares, and one missing a key each make `mise run contract:update` exit 1 and write no artefact. The Go half above is what a replay can hold, and it is the half that outlives a bad fragment: the extraction refuses at authoring time, TestEveryRecordedFieldIsStillOnTheWire refuses every day after."
+}


### PR DESCRIPTION
The first fields this emulator serves because a **wire** said so, not because a
document did.

## Why nothing had seen these

`contracts/exoscale.json` is generated from Exoscale's own published OpenAPI
document. The shapes gate, the probe and the pack all read it, so they agree
with each other — and they agree because they read the same source. The cloud
answers three fields that document does not declare, and only a recording could
report it. One now does (`corpus/exoscale/exo-cli.jsonl`, recorded 2026-08-21).

This is the family of #352's `has_s3_integration`: invisible to every control
that reads a document rather than a wire.

## The mechanism, and the property that keeps it honest

`tools/contract/exoscale-recorded-fields.yaml` is a versioned, commented
fragment. Each entry carries `schema, property, shape, corpus, operation, path,
recorded, why`. The extraction folds the property into the schema **and copies
the citation into `contracts/exoscale.json` under `recordedFields`** — so the
artefact itself says which of its fields came from a wire.

Two properties matter more than the mechanism:

- **Replayable.** `mise run contract:update` reproduces `contracts/exoscale.json`
  byte for byte; the `contracts are what the extraction produces` hook passes
  untouched. Verified independently on the rebase.
- **It cannot lie silently.** `TestEveryRecordedFieldIsStillOnTheWire` replays
  the recording each entry names and fails an entry whose path it no longer
  carries — the rule `corpus/accepted.json` states, pointed the other way. Plus
  a `checked == 0` failure, because the way this dies quietly is
  `--recorded-fields` dropping out of `update.sh` and a run that measured
  nothing reading exactly like a run that found nothing wrong.

Without that second property this would be a place where any field at all can
be written and called measured, which rule 4 forbids.

### One deviation, argued rather than hidden

The staleness check is a **Go test, not part of `corpus --check`**. That gate
takes `--dir` and half a dozen of its own tests point it at fixture corpora, so
"no recording carries this field" would be true of every fixture run — a false
failure or a silent skip, which is exactly #88's population trap. This verdict
needs the whole committed corpus, so it reads the whole committed corpus. It
also has to be Go: `mise run falsify` only replays Go, and a Python-only guard
could not be falsified.

## Measured

| | before | after |
|---|---|---|
| `corpus --check` accepted divergences | 192 | **87** (−105) |
| `exo-cli.jsonl` | 132 clean | **203/203 matched, 0 divergent** |
| `shapes --check` declined fields | 11 | 9 |

`prepush` green, `conformance` green end to end — including *every response
matched Exoscale's own API description*.

## Premises the measurement contradicted

1. **The issues say three exemptions; there were four.** `corpus/accepted.json`
   also carried `rules[].security-group.name` (8 findings). 51+44+2+8 = 105.
2. **#370's "absent from the contract" is false for the third field.** The
   document already declares `name` on `security-group-resource`, the schema a
   rule's reference uses. That one needed no contract change — only the pack had
   dropped it. Two entries in the fragment, not three.
3. **#371's consumer claim does not survive measurement.** Against a pre-fix
   binary, `exo compute security-group show` still printed the target's name:
   the CLI resolves the reference by id against groups it already listed. `exo
   -O json zone` drops everything but `name`, and the security-group list prints
   `"visibility":"private"` even against a stub sending none. **No official
   client's output changes.** The justification is the wire and the recording,
   not a client symptom — corrected in the code, the fragment header and both
   changelogs rather than left standing.
4. **A near-miss worth naming.** The first measurement of (3) used a hand-rolled
   stub and appeared to *confirm* the issue. It was an artefact of the stub
   answering the wrong object for the reference lookup; re-measuring against a
   real pre-fix emulator reversed it.

## Falsified

`tools/falsify/specs/recorded-fields.json` — 11 mutations, all red on the first
run, verified again here. They include the second direction (a resolved
reference written into the stored rule instead of a copy — a reader mutating the
store, which no lock covers), the split-client population (#284), and the
silent-death case above.

Two limits stated in the spec rather than papered over: one mutation reddens its
subtest as an I/O error rather than as a named stale entry, and the extraction's
three Python-side refusals carry no mutation because the harness replays Go —
they are proved by execution instead (four bad fragments each exit 1 and write
no artefact).

## Not measured

- No real cloud touched; everything comes from the committed corpus.
- What the cloud does with a rule reference after the target group is renamed or
  deleted — the recording deletes the referenced group last. The name is
  resolved at render time and the id alone is published when the group is gone:
  both are choices, not measurements.

## Also

`resource.DerivedID` is Scaleway's `derivedID` moved to the core unchanged, per
CLAUDE.md's factorisation rule; `scaleway/vpc.go` delegates and Exoscale's zone
ids use it.

## Related

Closes #370
Closes #371
