### PR TITLE
fix(clean): the orphan a run cannot end refuses on the doorstep, and the remedy is one command (#375)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -911,6 +911,59 @@ change ni l'un ni l'autre a sa place dans `git log`.
   de contrat : le document déclarait déjà le champ, seul le pack l'avait laissé
   tomber.
 
+- **Un service DHCP laissé derrière lui par une exécution faisait échouer la
+  jambe runtime à chaque fois, et le seul remède était un humain qui lise le
+  journal** (#375). Le balayage de `tools/conformance/*/network.sh` trouvait le
+  résidu, le nommait exactement et imprimait `sudo kill <pid>`, puis sortait en
+  1 : le processus appartient à l'utilisateur `incus`, et l'opérateur qui lance
+  la suite n'a pas le droit de le signaler. Le diagnostic était juste et
+  personne n'exécutait le remède, donc la jambe runtime de
+  `mise run evidence:update` est morte au même endroit trois fois de suite,
+  chaque fois *après* que toutes les suites clientes aient tourné. **Une porte
+  dont le seul remède est un geste manuel que quelqu'un doit remarquer est une
+  porte qu'on finit par contourner**, et c'est exactement comme on apprend
+  `--no-verify`.
+
+  Deux changements, et aucun des deux ne monte en privilèges. `feint clean
+  --check` pose la question du balayage sans rien faire : il nomme ce qu'une
+  exécution précédente a laissé sur un bloc d'adresses, sépare ce que cet
+  utilisateur peut terminer de ce qu'il ne peut pas, et ne sort en 1 que pour le
+  second cas. La sonde de permission derrière lui est le signal 0 : le noyau
+  fait le contrôle qu'il ferait pour un vrai signal et ne délivre rien, seule
+  forme acceptable pour une question dont le sujet est un processus que
+  personne ici n'a démarré. Et `guard_leftovers`
+  (`tools/conformance/guard.sh`) met cette question sur le pas de la porte : les
+  trois suites réseau et `mise run conformance` lui-même la posent avant que
+  quoi que ce soit ne démarre, si bien que la réponse arrive à la seconde zéro
+  au lieu de douze étapes plus loin. Mesuré sur la reproduction : **1 seconde
+  pour refuser, en nommant le pid**, là où le même hôte passait d'abord par
+  toute la série des clients.
+
+  **Ce que ce n'est pas, c'est une suite qui monte en privilèges.** Une
+  exécution de conformance qui s'arrogerait le droit de terminer un démon
+  qu'elle n'a pas démarré serait un défaut pire que celui qu'elle contourne :
+  c'est la question que `mustOwn` pose au pilote, un étage plus haut.
+  L'élévation appartient à l'opérateur, en une ligne plutôt qu'un pid à
+  retaper : `sudo feint clean --vm <mode>`, le même balayage, qui repose chaque
+  question de propriété au moment du signal. Le défaut a été reproduit
+  délibérément avant toute correction, et falsifié dans
+  `tools/falsify/specs/unkillable-dhcp-orphan.json`.
+
+  **Une prémisse ne survit pas à la mesure.** Ces résidus avaient été mesurés
+  comme des restes d'une exécution *précédente* (#316, #342) ; la jambe
+  machines-on en a produit un elle-même le 21 août 2026, en cours d'exécution et
+  en mode pont, à partir d'un réseau qu'elle venait de créer : le runtime
+  listait ce réseau comme non géré alors que son pont et son `dnsmasq` étaient
+  toujours là. Les messages disent donc « une exécution » et non « une exécution
+  précédente », parce qu'envoyer l'opérateur chercher une exécution passée
+  l'envoie au mauvais endroit, et parce qu'aucune porte n'empêche ce que
+  l'exécution crée elle-même. C'est déterministe : la jambe a été lancée deux
+  fois et a échoué les deux fois, dans la même suite, sur un sous-réseau
+  d'`examples/stacks/outscale/main.tf`, chaque échec précédé d'un détachement de
+  l'isolation arrivant sur un réseau dont la suppression avait déjà retiré le
+  répertoire d'état. `docs/limits.md` porte les lignes de journal. Cette
+  naissance est un défaut distinct, non corrigé ici.
+
 - **La porte du corpus retenait son avertissement « le cloud a bougé »
   précisément quand il servait le plus.** Les deux avertissements — celui de
   l'enregistrement vieilli et celui de la bougeotte mesurée que #359 réécrit —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -855,6 +855,52 @@ what this project is judged on: **a response shape a client can observe**, and
   needed no contract change at all: the document already declared the field and
   only the pack had dropped it.
 
+- **A DHCP service left behind by a run failed the runtime leg every time, and
+  the only remedy was a human reading a log** (#375). The sweep in
+  `tools/conformance/*/network.sh` found the leftover, named it exactly and
+  printed `sudo kill <pid>` — then exited 1, because the process belongs to the
+  `incus` user and the operator running the suite may not signal it. The
+  diagnosis was right and nothing ran the remedy, so the runtime leg of
+  `mise run evidence:update` died in the same place three runs in a row, each
+  time *after* every client suite had already run. **A gate whose only remedy is
+  a manual step somebody has to notice is a gate that gets worked around**, which
+  is how `--no-verify` is learned.
+
+  Two changes, and neither of them escalates. `feint clean --check` asks the
+  sweep's own question without doing anything: it names what an earlier run left
+  holding an address block, separates what this user may end from what it may
+  not, and exits 1 only for the second. The permission probe behind it is signal
+  0 — the kernel runs the check it would run for a real signal and delivers
+  nothing, which is the only acceptable shape for a question whose subject is a
+  process nobody here started. And `guard_leftovers`
+  (`tools/conformance/guard.sh`) puts that question on the doorstep: the three
+  network suites and `mise run conformance` itself ask it before anything starts,
+  so the answer arrives at second zero instead of twelve steps in. Measured on
+  the reproduction: **1 second to refuse, naming the pid**, where the same host
+  used to spend the whole client run first.
+
+  **What it is not is a suite that escalates.** A conformance run that acquired
+  the right to end a daemon it did not start would be a worse defect than the one
+  it works around — it is the question `mustOwn` asks of the driver, one layer
+  up. The elevation is the operator's, in one line rather than a pid to retype:
+  `sudo feint clean --vm <mode>`, the same sweep, re-asking every ownership
+  question at the moment of the signal. Reproduced deliberately before anything
+  was changed, and falsified in
+  `tools/falsify/specs/unkillable-dhcp-orphan.json`.
+
+  **And one premise it does not carry over.** These leftovers were measured as
+  debris of an *earlier* run (#316, #342); the machines-on leg produced one of
+  its own on 2026-08-21, mid-run and in bridge mode, from a network it had
+  created minutes earlier — the runtime listed that network as unmanaged while
+  its bridge and its `dnsmasq` stayed up. So the messages say "a run" rather
+  than "an earlier run", because sending the operator to look for a previous run
+  would send them to the wrong place, and no doorstep prevents what the run
+  itself creates. It is deterministic: the leg was run twice and failed both
+  times, in the same suite, on a subnet of `examples/stacks/outscale/main.tf`,
+  each failure preceded by a detach of the isolation arriving at a network whose
+  state directory the delete had already removed. `docs/limits.md` carries the
+  log lines. That birth is a separate defect and is not fixed here.
+
 - **The corpus gate withheld its "the cloud has moved" warning exactly when it
   mattered most.** Both warnings — the aged-recording one and the measured-move
   one #359 writes back — were emitted below the unexercised-invariant guard

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -775,15 +775,80 @@ longer exists. One whose interface is alive is somebody's working service,
 whoever owns it — this station runs libvirt's and two other Incus projects'
 `dnsmasq` beside feint's, and none of them is ours to name, let alone signal.
 
-Three consumers share the one check (`internal/core/machine/leftover.go`):
+Four consumers share the one check (`internal/core/machine/leftover.go`):
 `feint doctor` reports it and touches nothing; `feint clean` ends it, after
 re-checking at the moment of the signal that the pid still is that leftover
-(pids are reused), and when the process belongs to another user — the
-runtime's `dnsmasq` runs as the `incus` user — it prints the exact `sudo kill`
-command and exits 1 instead of claiming a clean host; and the network-create
-error names the process when its listen address falls inside the failing
-block. `TestLeftoverDHCPRefusesAProcessItCannotAttribute` holds the refusal,
-and `tools/falsify/specs/dhcp-leftover-ownership.json` proves the test bites.
+(pids are reused); `feint clean --check` answers the same question without
+ending anything, which is what the conformance suites ask before they start;
+and the network-create error names the process when its listen address falls
+inside the failing block. `TestLeftoverDHCPRefusesAProcessItCannotAttribute`
+holds the refusal, and `tools/falsify/specs/dhcp-leftover-ownership.json`
+proves the test bites.
+
+**Nothing here escalates, and the remedy is a command rather than a paragraph.**
+The runtime's `dnsmasq` runs as the `incus` user, so an ordinary sweep cannot
+signal it: `feint clean` says so and exits 1 instead of claiming a clean host,
+and every suite that takes an address block asks `feint clean --check` on its
+doorstep (`guard_leftovers`, `tools/conformance/guard.sh`) rather than meeting
+the state twelve steps into a run. That was measured — the runtime leg of
+`mise run evidence:update` failed three times in a row, each time after every
+client suite had already run, with the right remedy printed and nobody running
+it (#375).
+
+What none of them does is acquire a privilege it did not have. A conformance
+suite that escalated to end a daemon it did not start would be a worse defect
+than the one it works around: it is the question `mustOwn` asks of the driver,
+one layer up, and a process nobody here created is not ours to end. So the
+elevation is the operator's, in one line — `sudo feint clean --vm <mode>`, the
+same sweep run by somebody who may signal it, re-asking every ownership question
+at the moment of the signal. The permission probe behind `--check` is signal 0:
+the kernel runs the check it would run for a real signal and delivers nothing,
+which is the only acceptable shape for a question whose subject belongs to
+somebody else.
+
+One half of the remedy stays manual, and it is the #342 case above: when the
+bridge survived alongside its service, ending the service leaves the interface
+holding the same address, and nothing on the host proves this emulator created
+that bridge. Both commands are printed; only the second needs a human to decide
+the bridge is theirs.
+
+**A leftover is not always debris of an earlier run, and a doorstep cannot
+prevent the other kind.** #316 and #342 both measured leftovers surviving a run;
+on 2026-08-21 the machines-on leg of `mise run evidence:update` produced one of
+its own, in bridge mode, from a network it had created minutes earlier. The
+runtime listed that network as unmanaged while its bridge and its `dnsmasq`
+stayed up, and the emulator's log names the moment it broke:
+
+```text
+could not isolate the subnet's network network=fnt-8488bc9e9e1
+  error="detach isolation from fnt-8488bc9e9e1: incus network:
+         open /var/lib/incus/networks/fnt-8488bc9e9e1/dnsmasq.raw:
+         no such file or directory"
+```
+
+The same run's log carries the load that produced it: NIC ACL writes failing on
+`Unknown or missing host side veth device`, instance updates refused with
+`Instance is busy running a "delete" operation`, a network delete refused with
+`The network is currently in use`. So a network object can die under a bridge
+this emulator created while the bridge and its service stay up, and the
+doorstep then catches it at the next suite rather than at the start of the leg.
+
+**It is deterministic, and the lifecycle has a name.** The leg was run twice
+that evening and failed both times, in the same suite, on a subnet of
+`examples/stacks/outscale/main.tf` — `10.50.1.0/24` the first time,
+`10.50.2.0/24` the second, both inside the `10.50.0.0/16` that stack declares.
+Each failure is preceded by the pair above: two subnets torn down in the same
+second, one answering `Network not found` (gone cleanly) and the other
+answering `open …/dnsmasq.raw: no such file or directory` — a detach of the
+isolation arriving at a network whose state directory the delete has already
+removed. The one that answers the second way is the one left standing. Worth
+noting because #316's original measurement holds `10.50.2.1`: the three issues
+of this family are downstream of the same teardown.
+
+What #375 made cheap is the diagnosis and the remedy; the birth of that
+leftover is a separate defect, unmeasured before this and not fixed here. In
+OVN mode it does not arise at all: an OVN network carries no `dnsmasq`, and
+`FEINT_VM=incus-ovn mise run conformance` passed twice the same evening.
 
 ## Authentication is accepted, never verified
 

--- a/internal/cli/clean.go
+++ b/internal/cli/clean.go
@@ -22,8 +22,12 @@ import (
 func clean(args []string, stdout io.Writer) error {
 	fs := newFlagSet("clean")
 	vm := fs.String("vm", "incus", "machine runtime to sweep: incus, incus-vm, incus-ovn")
+	check := fs.Bool("check", false, "report what this user cannot remove and remove nothing; exit 1 if anything is stuck")
 	if err := fs.Parse(args); err != nil {
 		return err
+	}
+	if *check {
+		return reportStuckLeftovers(stdout, *vm)
 	}
 
 	// The state directories go first, and deliberately before the runtime is
@@ -62,7 +66,7 @@ func clean(args []string, stdout io.Writer) error {
 			fmt.Fprintln(stdout, "nothing was left behind on the runtime")
 			// Still swept: the leftover is a process, not a runtime object, so
 			// it is findable and endable with no runtime answering at all.
-			return sweepLeftoverDHCP(stdout)
+			return sweepLeftoverDHCP(stdout, *vm)
 		}
 		return fmt.Errorf("the %s runtime cannot be swept", driver.Name())
 	}
@@ -86,7 +90,7 @@ func clean(args []string, stdout io.Writer) error {
 	// After the prune, deliberately: a leftover whose network object still
 	// exists is reaped by the runtime with that object, and only what survives
 	// the ordinary sweep is a process the runtime no longer knows about.
-	return sweepLeftoverDHCP(stdout)
+	return sweepLeftoverDHCP(stdout, *vm)
 }
 
 // The seams doctor and the tests share. Wired to internal/core/machine, and
@@ -96,9 +100,98 @@ func clean(args []string, stdout io.Writer) error {
 var (
 	findLeftoverDHCP = machine.LeftoverDHCP
 	endLeftoverDHCP  = machine.TerminateLeftover
+	canEndLeftover   = machine.CanEndLeftover
 )
 
-// sweepLeftoverDHCP ends the DHCP services an earlier run left holding an
+// reportStuckLeftovers is `feint clean --check` (#375): the question the sweep
+// answers by doing, asked without doing it.
+//
+// The measurement behind it. The runtime leg of `mise run evidence:update`
+// failed three times in a row, in the same place each time: the sweep found a
+// dnsmasq whose interface had outlived its network, named it exactly, printed
+// `sudo kill <pid>` — and exited 1, because the process belongs to the incus
+// user and this one may not signal it. Every run died there until a human read
+// the log and typed the line. A gate whose only remedy is a manual step
+// somebody has to notice is a gate that gets worked around, which is how
+// `--no-verify` is learned.
+//
+// What it deliberately is not is an escalation. A conformance suite that
+// acquired the right to end a daemon it did not start would be a worse defect
+// than the one it works around, and it is the question mustOwn asks of the
+// driver, one layer up: a process nobody here created is not ours to end. So
+// this reports, and the elevation is a command the operator runs, on purpose,
+// with their own hands.
+//
+// The sentences below say "a run" and not "an earlier run", and the difference
+// was measured on 2026-08-21. #316 found these as debris of a previous run;
+// the machines-on leg of `mise run evidence:update` produced one of its own,
+// mid-run, in bridge mode: a network it had created minutes earlier went
+// unmanaged in the runtime while its bridge and its dnsmasq stayed up, and the
+// emulator's own log names the moment ("open
+// /var/lib/incus/networks/<name>/dnsmasq.raw: no such file or directory").
+// Two consequences worth carrying: telling the operator to look for an earlier
+// run would send them to the wrong place, and no doorstep can prevent what the
+// run itself creates — what this makes cheap is the diagnosis and the remedy,
+// not the birth of the leftover.
+//
+// Three verdicts rather than two, because "nothing found" and "found, and you
+// can clear it yourself" are different facts with different remedies:
+//
+//   - nothing at all: said out loud, exit 0. A check silent on the case it
+//     exists for reads as green when it never ran.
+//   - found, and this user may end them: named, exit 0. The ordinary sweep
+//     clears them, and every suite runs it before it starts; refusing here
+//     would be a doorstep that fires on a host nothing was going to fail on,
+//     which is how a doorstep gets disarmed.
+//   - found, and this user may not: named with their pid, the one command
+//     named too, exit 1.
+//
+// TestCleanCheckRefusesAHostWhoseLeftoverThisUserCannotEnd and
+// TestCleanCheckPassesWhenTheSweepItselfWouldClearThem fail without it.
+func reportStuckLeftovers(stdout io.Writer, vm string) error {
+	leftovers, err := findLeftoverDHCP()
+	if err != nil {
+		return fmt.Errorf("could not look for leftover DHCP services: %w", err)
+	}
+	if len(leftovers) == 0 {
+		fmt.Fprintln(stdout, "no DHCP service of this emulator's outlives its network on this host")
+		return nil
+	}
+	var stuck []machine.DHCPLeftover
+	for _, leftover := range leftovers {
+		if err := canEndLeftover(leftover); err != nil {
+			// The reason is relayed rather than named, because the probe knows
+			// it and this does not. Permission is the case that matters — the
+			// runtime starts its own DHCP services under the incus account —
+			// but a pid the scan no longer attributes answers here too, and
+			// calling that "another user" would be a sentence nobody measured.
+			fmt.Fprintf(stdout, "a DHCP service a run left behind, which this user cannot end: %s\n", leftover)
+			fmt.Fprintf(stdout, "  %v\n", err)
+			stuck = append(stuck, leftover)
+			continue
+		}
+		fmt.Fprintf(stdout, "a DHCP service a run left behind, which this user can end: %s\n", leftover)
+	}
+	if len(stuck) == 0 {
+		fmt.Fprintf(stdout, "  → feint clean --vm %s ends them\n", vm)
+		return nil
+	}
+	for _, leftover := range stuck {
+		if leftover.InterfaceAlive {
+			// Named here as well as in the sweep, because it is the second half
+			// of the remedy and the operator is reading this one: ending the
+			// service leaves the bridge holding the same address, and nothing
+			// on the host proves this emulator created that bridge.
+			fmt.Fprintf(stdout, "  the bridge %s survived its network too, and nothing proves this emulator created it — `sudo ip link delete %s` if it is yours\n",
+				leftover.Interface, leftover.Interface)
+		}
+	}
+	fmt.Fprintf(stdout, "  → sudo feint clean --vm %s\n", vm)
+	return fmt.Errorf("%d DHCP service(s) left behind by a run hold their block and this user cannot end them; "+
+		"nothing here may signal what it does not own", len(stuck))
+}
+
+// sweepLeftoverDHCP ends the DHCP services a run left holding an
 // address block (#316, #342): dnsmasq processes attributable to this emulator
 // whose network is gone — the interface with it, or the network object alone.
 // They are invisible to `ip addr` and to the runtime's own listings — only
@@ -117,7 +210,7 @@ var (
 // bridge nobody here created is not ours to delete. Saying so beats deleting
 // it and beats silence: the operator gets the exact command and the decision.
 // TestCleanSaysWhatItWillNotTouchWhenTheBridgeSurvived fails without the line.
-func sweepLeftoverDHCP(stdout io.Writer) error {
+func sweepLeftoverDHCP(stdout io.Writer, vm string) error {
 	leftovers, err := findLeftoverDHCP()
 	if err != nil {
 		// An operator who cannot be told "there is a leftover" must at least
@@ -130,14 +223,20 @@ func sweepLeftoverDHCP(stdout io.Writer) error {
 		err := endLeftoverDHCP(leftover)
 		switch {
 		case err == nil:
-			fmt.Fprintf(stdout, "ended a DHCP service an earlier run left behind: %s\n", leftover)
+			fmt.Fprintf(stdout, "ended a DHCP service a run left behind: %s\n", leftover)
 			if leftover.InterfaceAlive {
 				fmt.Fprintf(stdout, "  left untouched: the bridge %s survived its network, and nothing proves this emulator created it — `sudo ip link delete %s` if it is yours\n",
 					leftover.Interface, leftover.Interface)
 			}
 		case errors.Is(err, os.ErrPermission):
-			fmt.Fprintf(stdout, "a DHCP service an earlier run left behind belongs to another user: %s\n", leftover)
-			fmt.Fprintf(stdout, "  → sudo kill %d\n", leftover.PID)
+			fmt.Fprintf(stdout, "a DHCP service a run left behind belongs to another user: %s\n", leftover)
+			// Two commands, and the order matters (#375). `sudo kill` is exact
+			// and demands that a pid be read out of a log and retyped, which is
+			// the manual step that failed to happen three runs in a row; the
+			// sweep re-run as root is one line, needs nothing copied, and
+			// re-asks every ownership question at the moment of the signal, so
+			// root ends only what this emulator can prove is its own.
+			fmt.Fprintf(stdout, "  → sudo feint clean --vm %s   (or: sudo kill %d)\n", vm, leftover.PID)
 			stuck = append(stuck, leftover.String())
 		default:
 			fmt.Fprintf(stdout, "could not end a leftover DHCP service: %s: %v\n", leftover, err)
@@ -147,8 +246,8 @@ func sweepLeftoverDHCP(stdout io.Writer) error {
 	if len(stuck) > 0 {
 		// An exit 0 here would say "clean" about a host whose next run fails
 		// at the bind, which is the ambiguity this command exists to remove.
-		return fmt.Errorf("%d leftover DHCP service(s) still hold their block: %s",
-			len(stuck), strings.Join(stuck, "; "))
+		return fmt.Errorf("%d leftover DHCP service(s) still hold their block: %s; `sudo feint clean --vm %s` ends them",
+			len(stuck), strings.Join(stuck, "; "), vm)
 	}
 	return nil
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -123,11 +123,18 @@ const (
 // comparison. Additions to one existing verb; nothing was removed, no exit code
 // moved, and a pipeline keyed on version 9 keeps working.
 //
+// Version 11 adds `clean --check` (#375): the sweep's own question — what did
+// a run leave holding an address block, and which of it may this user
+// not end — asked without ending anything, so a suite can refuse on the
+// doorstep and name the command instead of dying on the block minutes in. An
+// addition to one existing verb; nothing was removed, no exit code moved, and a
+// pipeline keyed on version 10 keeps working.
+//
 // The surface itself is frozen in testdata/frozen/cli.json, compared by
 // TestTheFrozenSurfacesStillMatchTheirFixture, and a fixture regenerated
 // without bumping this constant fails TestASurfaceChangeDemandsItsVersionBump.
 // The procedure for a deliberate change is in RELEASING.md ("Frozen surfaces").
-const cliSurfaceVersion = 10
+const cliSurfaceVersion = 11
 
 // Run executes one command and returns the process exit code.
 func Run(args []string, stdout, stderr io.Writer) int {
@@ -431,9 +438,13 @@ Usage:
   feint catalog    [--format json]
                     Print the emulated inventory a client reads before creating.
 
-  feint clean      [--vm incus|incus-vm|incus-ovn]
+  feint clean      [--vm incus|incus-vm|incus-ovn] [--check]
                     Remove every machine, network and rule set the emulator
                     created. Labelled resources only; nothing else is touched.
+                    --check removes nothing: it names what a run left behind
+                    holding an address block, and which of it this user may not
+                    end, exiting 1 in that case so a suite can refuse on the
+                    doorstep instead of dying on the block minutes in.
 
   feint version    [--check]
                     Print the version. --check asks GitHub whether a newer

--- a/internal/cli/dhcp_leftover_test.go
+++ b/internal/cli/dhcp_leftover_test.go
@@ -123,7 +123,7 @@ func TestCleanEndsTheLeftoverDHCPService(t *testing.T) {
 		func(l machine.DHCPLeftover) error { ended = append(ended, l); return nil })
 
 	var out bytes.Buffer
-	if err := sweepLeftoverDHCP(&out); err != nil {
+	if err := sweepLeftoverDHCP(&out, "incus"); err != nil {
 		t.Fatalf("a swept leftover still failed the sweep: %v", err)
 	}
 	if len(ended) != 1 || ended[0].PID != aLeftover.PID {
@@ -145,12 +145,109 @@ func TestCleanReportsTheCommandWhenTheLeftoverBelongsToAnotherUser(t *testing.T)
 		func(machine.DHCPLeftover) error { return fmt.Errorf("signal: %w", os.ErrPermission) })
 
 	var out bytes.Buffer
-	err := sweepLeftoverDHCP(&out)
+	err := sweepLeftoverDHCP(&out, "incus")
 	if err == nil {
 		t.Fatal("a block still held was reported as swept")
 	}
 	if !strings.Contains(out.String(), "sudo kill 4071323") {
 		t.Errorf("the report does not carry the exact command:\n%s", out.String())
+	}
+	// And the command that needs nothing copied (#375). The pid above is exact
+	// and has to be read out of a log and retyped, which is the step that did
+	// not happen three runs in a row; this one is a single line naming the mode
+	// the run uses.
+	if !strings.Contains(out.String(), "sudo feint clean --vm incus") {
+		t.Errorf("the report offers only a command with a pid in it:\n%s", out.String())
+	}
+}
+
+// swapProbeSeam replaces the permission probe. The real one asks the kernel
+// about a pid on the tester's own host, and both answers this file needs —
+// "yours" and "somebody else's" — would require a foreign process no test
+// should go create.
+func swapProbeSeam(t *testing.T, can func(machine.DHCPLeftover) error) {
+	t.Helper()
+	saved := canEndLeftover
+	canEndLeftover = can
+	t.Cleanup(func() { canEndLeftover = saved })
+}
+
+// TestCleanCheckRefusesAHostWhoseLeftoverThisUserCannotEnd is #375's doorstep,
+// on the emulator's side: the state that failed the runtime leg three times is
+// reported before anything starts, with the pid, and with a command that needs
+// nothing transcribed.
+//
+// The end seam fails the test if it is called at all. `--check` that ended
+// anything would be a check with a side effect, and the side effect in question
+// is a signal to a process this run did not start.
+func TestCleanCheckRefusesAHostWhoseLeftoverThisUserCannotEnd(t *testing.T) {
+	survivor := machine.DHCPLeftover{
+		PID:            612421,
+		Interface:      "fnt-99109f524b2",
+		Addresses:      []string{"10.50.2.1"},
+		InterfaceAlive: true,
+	}
+	swapLeftoverSeams(t,
+		func() ([]machine.DHCPLeftover, error) { return []machine.DHCPLeftover{survivor}, nil },
+		func(machine.DHCPLeftover) error { t.Fatal("a check signalled a process"); return nil })
+	swapProbeSeam(t, func(machine.DHCPLeftover) error { return fmt.Errorf("signal: %w", os.ErrPermission) })
+
+	var out bytes.Buffer
+	err := reportStuckLeftovers(&out, "incus")
+	if err == nil {
+		t.Fatal("a host whose block is held by a process nobody here may end was reported as ready")
+	}
+	report := out.String()
+	for _, fact := range []string{"612421", "10.50.2.1", "sudo feint clean --vm incus"} {
+		if !strings.Contains(report, fact) {
+			t.Errorf("the refusal does not name %q, so it does not say what to do:\n%s", fact, report)
+		}
+	}
+	// The bridge is the second half of the remedy: ending the service leaves it
+	// holding the same address, and it is not this emulator's to delete.
+	if !strings.Contains(report, "ip link delete fnt-99109f524b2") {
+		t.Errorf("the refusal stops at the service and says nothing of the bridge:\n%s", report)
+	}
+}
+
+// And the half that keeps the doorstep usable: a leftover this user *can* end
+// is not a reason to refuse, because the sweep every suite runs first ends it.
+// A doorstep that fired on a host nothing was going to fail on is a doorstep
+// somebody disarms, which is the failure mode this whole issue is about.
+func TestCleanCheckPassesWhenTheSweepItselfWouldClearThem(t *testing.T) {
+	swapLeftoverSeams(t,
+		func() ([]machine.DHCPLeftover, error) { return []machine.DHCPLeftover{aLeftover}, nil },
+		func(machine.DHCPLeftover) error { t.Fatal("a check signalled a process"); return nil })
+	swapProbeSeam(t, func(machine.DHCPLeftover) error { return nil })
+
+	var out bytes.Buffer
+	if err := reportStuckLeftovers(&out, "incus"); err != nil {
+		t.Fatalf("a leftover this user can end refused the run: %v\n%s", err, out.String())
+	}
+	report := out.String()
+	if !strings.Contains(report, "4071323") {
+		t.Errorf("the leftover was passed over in silence:\n%s", report)
+	}
+	if strings.Contains(report, "sudo") {
+		t.Errorf("a leftover this user can end was reported as needing elevation:\n%s", report)
+	}
+}
+
+// A host with nothing left behind gets a sentence, not silence: "checked and
+// fine" and "never looked" must not read the same, and the caller of this one
+// is a shell guard whose only alternative to reading it is assuming.
+func TestCleanCheckSaysSoOnAHostWithNothingLeftBehind(t *testing.T) {
+	swapLeftoverSeams(t,
+		func() ([]machine.DHCPLeftover, error) { return nil, nil },
+		func(machine.DHCPLeftover) error { t.Fatal("a check signalled a process"); return nil })
+	swapProbeSeam(t, func(machine.DHCPLeftover) error { t.Fatal("a check probed a process it never found"); return nil })
+
+	var out bytes.Buffer
+	if err := reportStuckLeftovers(&out, "incus"); err != nil {
+		t.Fatalf("a clean host was refused: %v", err)
+	}
+	if !strings.Contains(out.String(), "no DHCP service") {
+		t.Errorf("the check passed in silence:\n%s", out.String())
 	}
 }
 
@@ -172,7 +269,7 @@ func TestCleanSaysWhatItWillNotTouchWhenTheBridgeSurvived(t *testing.T) {
 		func(l machine.DHCPLeftover) error { ended = append(ended, l); return nil })
 
 	var out bytes.Buffer
-	if err := sweepLeftoverDHCP(&out); err != nil {
+	if err := sweepLeftoverDHCP(&out, "incus"); err != nil {
 		t.Fatalf("a swept leftover still failed the sweep: %v", err)
 	}
 	if len(ended) != 1 || ended[0].PID != survivor.PID {
@@ -195,7 +292,7 @@ func TestCleanSaysNothingAboutDHCPOnAHealthyHost(t *testing.T) {
 		func(machine.DHCPLeftover) error { t.Fatal("a healthy host was signalled"); return nil })
 
 	var out bytes.Buffer
-	if err := sweepLeftoverDHCP(&out); err != nil {
+	if err := sweepLeftoverDHCP(&out, "incus"); err != nil {
 		t.Fatalf("a healthy host failed the sweep: %v", err)
 	}
 	if out.Len() != 0 {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -309,7 +309,7 @@ func checkIncusVersion(ctx context.Context) check {
 	return check{title: fmt.Sprintf("Incus %d.%d.%d, new enough for NIC ACLs", got[0], got[1], got[2]), state: verdictOK}
 }
 
-// checkLeftoverDHCP reports the DHCP services an earlier run left holding an
+// checkLeftoverDHCP reports the DHCP services a run left holding an
 // address block (#316, #342): dnsmasq processes attributable to this emulator
 // whose network is gone — the interface with it, or the network object alone,
 // the interface having survived. The condition is invisible to `ip addr` and
@@ -354,10 +354,10 @@ func checkLeftoverDHCP() check {
 		held = append(held, leftover.String())
 	}
 	return check{
-		title:  fmt.Sprintf("%d DHCP service(s) left by an earlier run still hold an address block this emulator will want", len(leftovers)),
+		title:  fmt.Sprintf("%d DHCP service(s) left behind by a run still hold an address block this emulator will want", len(leftovers)),
 		state:  verdictFail,
 		detail: strings.Join(held, "; "),
-		fix:    "the next run on such a block dies on 'Address already in use'; feint clean ends them (sudo kill <pid> if they belong to another user)",
+		fix:    "the next run on such a block dies on 'Address already in use'; `feint clean` ends them, and `sudo feint clean --vm <mode>` ends the ones that belong to another user — `feint clean --check` says which is which without touching anything",
 	}
 }
 

--- a/internal/cli/testdata/frozen/cli.json
+++ b/internal/cli/testdata/frozen/cli.json
@@ -1484,6 +1484,187 @@
           ]
         }
       }
+    },
+    {
+      "schema_version": 11,
+      "content": {
+        "exit_codes": {
+          "drift": 2,
+          "error": 1,
+          "ok": 0
+        },
+        "verbs": {
+          "catalog": [
+            "--format"
+          ],
+          "clean": [
+            "--check",
+            "--vm"
+          ],
+          "corpus": [
+            "--accepted",
+            "--against-cloud",
+            "--bind",
+            "--check",
+            "--credential",
+            "--dir",
+            "--dry-run",
+            "--endpoint",
+            "--file",
+            "--format",
+            "--mark-stale",
+            "--timeout"
+          ],
+          "coverage": [
+            "--artefact",
+            "--baseline",
+            "--contract",
+            "--fail-on-unknown",
+            "--format",
+            "--observed",
+            "--products",
+            "--provider",
+            "--sdk",
+            "--write-baseline"
+          ],
+          "docs": [
+            "--check",
+            "--client-pins",
+            "--confidence",
+            "--contracts",
+            "--coverage",
+            "--file",
+            "--install",
+            "--limits",
+            "--proved",
+            "--routes",
+            "--screenshots",
+            "--ui-manifest",
+            "--workflow"
+          ],
+          "doctor": [
+            "--addr",
+            "--vm"
+          ],
+          "env": [
+            "--client",
+            "--endpoint",
+            "--shell",
+            "--unset"
+          ],
+          "evidence": [
+            "--allow-narrowing",
+            "--contracts",
+            "--endpoint",
+            "--join",
+            "--out",
+            "--shapes",
+            "--suites"
+          ],
+          "images": [
+            "--check",
+            "--only",
+            "--vm"
+          ],
+          "logs": [
+            "--addr",
+            "-f",
+            "-n"
+          ],
+          "probe": [
+            "--contracts",
+            "--endpoint",
+            "--provider"
+          ],
+          "proxy": [
+            "--addr",
+            "--expose-to-network",
+            "--forward",
+            "--intercept",
+            "--max-body",
+            "--provider",
+            "--queue",
+            "--record",
+            "--upstream"
+          ],
+          "replay": [
+            "--endpoint",
+            "--format",
+            "--timeout"
+          ],
+          "restart": [
+            "--addr",
+            "--timeout"
+          ],
+          "serve": [
+            "--addr",
+            "--cleanup",
+            "--contracts",
+            "--coverage",
+            "--expose-to-network",
+            "--log-level",
+            "--shapes",
+            "--state",
+            "--vm"
+          ],
+          "shapes": [
+            "--check",
+            "--dir",
+            "--dry-run",
+            "--profile",
+            "--provider",
+            "--record"
+          ],
+          "snapshot list": [
+            "--format"
+          ],
+          "snapshot load": [
+            "--addr"
+          ],
+          "snapshot save": [
+            "--addr",
+            "--force"
+          ],
+          "start": [
+            "--addr",
+            "--cleanup",
+            "--contracts",
+            "--detach",
+            "--foreground",
+            "--log-level",
+            "--state",
+            "--timeout",
+            "--vm"
+          ],
+          "status": [
+            "--addr",
+            "--coverage",
+            "--format"
+          ],
+          "stop": [
+            "--addr",
+            "--timeout"
+          ],
+          "transcript": [
+            "--against",
+            "--contract",
+            "--format",
+            "--sanitise",
+            "--shape"
+          ],
+          "ui": [
+            "--addr",
+            "--print"
+          ],
+          "version": [
+            "--check"
+          ],
+          "wait": [
+            "--addr",
+            "--timeout"
+          ]
+        }
+      }
     }
   ]
 }

--- a/internal/core/machine/incus.go
+++ b/internal/core/machine/incus.go
@@ -1062,9 +1062,15 @@ func (d *Incus) networkCreateError(name, address, cidr string, err error) error 
 		if !leftoverHolds(leftover, block) {
 			continue
 		}
+		// One command rather than a pid to retype (#375): `sudo feint clean`
+		// is the same sweep elevated, and it re-asks every ownership question
+		// at the moment of the signal, so root ends only what this emulator
+		// can prove is its own. The pid stays in the sentence because it is
+		// the fact `ss -lnp` was the only tool to give.
 		return fmt.Errorf("%w; a DHCP service left by an interrupted run still holds the block: %s"+
-			" — `feint clean` ends it (sudo kill %d if it belongs to another user)",
-			base, leftover, leftover.PID)
+			" — `feint clean` ends it, or `sudo feint clean --vm %s` when it belongs to another user"+
+			" (pid %d)",
+			base, leftover, d.Name(), leftover.PID)
 	}
 	for _, holder := range d.blockHolders(block) {
 		return fmt.Errorf("%w; a DHCP service this emulator cannot claim holds an address in the block: %s"+

--- a/internal/core/machine/leftover.go
+++ b/internal/core/machine/leftover.go
@@ -224,16 +224,52 @@ func flagValues(argv []string, flag string) []string {
 // TestTerminateLeftoverRefusesAPidThatIsNoLongerTheLeftover fails without the
 // re-check.
 func TerminateLeftover(leftover DHCPLeftover) error {
-	return terminateLeftover(leftover, procArgv, interfaceGone, networkUnknown(), func(pid int) error {
-		process, err := os.FindProcess(pid)
-		if err != nil {
-			return err
-		}
-		return process.Signal(syscall.SIGTERM)
-	})
+	return signalLeftover(leftover, procArgv, interfaceGone, networkUnknown(), sendSignal, syscall.SIGTERM)
 }
 
-func terminateLeftover(leftover DHCPLeftover, argvOf func(int) ([]string, error), gone, unknown func(string) bool, signal func(int) error) error {
+// probeSignal is the signal that is not one. Number 0 runs every permission
+// check the kernel would run for a real signal and then delivers nothing, which
+// is the only acceptable shape for a question whose subject is a process
+// nobody here started. It is named rather than written as a literal so that the
+// single place it could quietly become a real signal has a name to search for.
+const probeSignal = syscall.Signal(0)
+
+// CanEndLeftover answers whether this user may end a leftover, without ending
+// it. A nil error means a sweep run by this user would get through; anything
+// else is the reason it would not, os.ErrPermission being the one that matters
+// (#375).
+//
+// It exists because the sweep's usual refusal is not "this is not ours" but
+// "this belongs to the incus user", and until now the only way to learn that
+// was to run the sweep and read its failure. That cost the runtime leg of
+// `mise run evidence:update` three consecutive runs: each one died on a dnsmasq
+// the sweep could see, name and not signal, and the printed remedy waited for a
+// human to notice it. A question that can be asked before the run is what turns
+// that into a doorstep refusal.
+//
+// The re-classification of signalLeftover is not skipped for the probe, and the
+// reason is the same as for the signal: a probe aimed at a pid the scan no
+// longer attributes would be asking about a stranger. Refusing to answer costs
+// nothing; answering about the wrong process is how the pid recycling this file
+// already guards against comes back through the check meant to prevent it.
+//
+// TestCanEndLeftoverAsksWithoutEnding fails when the probe carries a real
+// signal.
+func CanEndLeftover(leftover DHCPLeftover) error {
+	return signalLeftover(leftover, procArgv, interfaceGone, networkUnknown(), sendSignal, probeSignal)
+}
+
+// sendSignal is the one path to the kernel both callers share, so the signal
+// they differ by is the only thing they differ by.
+func sendSignal(pid int, sig syscall.Signal) error {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return process.Signal(sig)
+}
+
+func signalLeftover(leftover DHCPLeftover, argvOf func(int) ([]string, error), gone, unknown func(string) bool, signal func(int, syscall.Signal) error, sig syscall.Signal) error {
 	argv, err := argvOf(leftover.PID)
 	if err != nil {
 		// The process is already gone, which is the goal state, not a failure.
@@ -244,7 +280,7 @@ func terminateLeftover(leftover DHCPLeftover, argvOf func(int) ([]string, error)
 		return fmt.Errorf("pid %d is no longer the DHCP service that outlived %s; refusing to signal it",
 			leftover.PID, leftover.Interface)
 	}
-	return signal(leftover.PID)
+	return signal(leftover.PID, sig)
 }
 
 // A BlockHolder is any DHCP service, whoever owns it, holding an address

--- a/internal/core/machine/leftover_test.go
+++ b/internal/core/machine/leftover_test.go
@@ -3,8 +3,13 @@ package machine
 import (
 	"errors"
 	"net/netip"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 )
 
 // Every command line below except the synthetic zsh one was measured on the
@@ -154,11 +159,12 @@ func TestTerminateLeftoverRefusesAPidThatIsNoLongerTheLeftover(t *testing.T) {
 	}
 	for name, tc := range cases {
 		var signalled []int
-		err := terminateLeftover(leftover,
+		err := signalLeftover(leftover,
 			func(int) ([]string, error) { return tc.argv, tc.err },
 			func(string) bool { return tc.gone },
 			runtimeKnows,
-			func(pid int) error { signalled = append(signalled, pid); return nil })
+			func(pid int, _ syscall.Signal) error { signalled = append(signalled, pid); return nil },
+			syscall.SIGTERM)
 		if len(signalled) != 0 {
 			t.Errorf("%s: a signal was sent anyway, to %v", name, signalled)
 		}
@@ -173,11 +179,12 @@ func TestTerminateLeftoverRefusesAPidThatIsNoLongerTheLeftover(t *testing.T) {
 // longer exists.
 func TestTerminateLeftoverTreatsAGoneProcessAsDone(t *testing.T) {
 	var signalled []int
-	err := terminateLeftover(DHCPLeftover{PID: 1, Interface: "fnt-x"},
+	err := signalLeftover(DHCPLeftover{PID: 1, Interface: "fnt-x"},
 		func(int) ([]string, error) { return nil, errors.New("no such process") },
 		func(string) bool { return true },
 		runtimeKnows,
-		func(pid int) error { signalled = append(signalled, pid); return nil })
+		func(pid int, _ syscall.Signal) error { signalled = append(signalled, pid); return nil },
+		syscall.SIGTERM)
 	if err != nil || len(signalled) != 0 {
 		t.Fatalf("a vanished process was not treated as done: err=%v signals=%v", err, signalled)
 	}
@@ -188,17 +195,181 @@ func TestTerminateLeftoverTreatsAGoneProcessAsDone(t *testing.T) {
 func TestTerminateLeftoverEndsTheLeftoverItWasGiven(t *testing.T) {
 	leftover := DHCPLeftover{PID: 4071323, Interface: "fnt-99109f524b2"}
 	var signalled []int
-	err := terminateLeftover(leftover,
+	err := signalLeftover(leftover,
 		func(int) ([]string, error) { return incusDNSMasq("fnt-99109f524b2", "10.50.2.1"), nil },
 		func(string) bool { return true },
 		runtimeKnows,
-		func(pid int) error { signalled = append(signalled, pid); return nil })
+		func(pid int, _ syscall.Signal) error { signalled = append(signalled, pid); return nil },
+		syscall.SIGTERM)
 	if err != nil {
 		t.Fatalf("the leftover was refused: %v", err)
 	}
 	if len(signalled) != 1 || signalled[0] != 4071323 {
 		t.Fatalf("the signal did not reach the leftover: %v", signalled)
 	}
+}
+
+// TestCanEndLeftoverAsksWithoutEnding is the control behind `feint clean
+// --check` (#375). The probe answers "may this user end it" by running the
+// kernel's permission check for a signal it then does not deliver, so the
+// question costs its subject nothing — and the assertion is on the subject, not
+// on a recorded argument: a real process of this test's own is put through the
+// real signal path, and it must still be running afterwards.
+//
+// Written that way because the mutation worth catching is exactly the one an
+// argument recorder would miss in a year's time: probeSignal quietly becoming a
+// real signal turns a diagnostic into a killer, and the only witness that
+// notices is the process itself.
+func TestCanEndLeftoverAsksWithoutEnding(t *testing.T) {
+	subject := sleepingProcess(t)
+	leftover := DHCPLeftover{PID: subject.pid, Interface: "fnt-99109f524b2", Addresses: []string{"10.50.2.1"}}
+
+	// The real sendSignal, so what is measured is what the kernel does, and the
+	// real probeSignal, so what is measured is the constant the sweep uses.
+	err := signalLeftover(leftover,
+		func(int) ([]string, error) { return incusDNSMasq("fnt-99109f524b2", "10.50.2.1"), nil },
+		func(string) bool { return true },
+		runtimeKnows,
+		sendSignal, probeSignal)
+	if err != nil {
+		t.Fatalf("the probe reported that this user may not end its own process: %v", err)
+	}
+	subject.mustSurvive(t, "the probe ended the process it was only asked about")
+}
+
+// And the exported entry point, through the host's own /proc, because the
+// pairing of CanEndLeftover with probeSignal is the other half a recorded
+// argument would not hold: a child whose command line is a dnsmasq's on an
+// interface that does not exist is a leftover by every criterion this file
+// applies, and it must survive being asked about.
+func TestCanEndLeftoverIsTheOneTheSweepCallsAndItStillDoesNotKill(t *testing.T) {
+	subject := fakeDNSMasq(t)
+	argv := commandLineOf(t, subject)
+	if _, ok := classifyDHCP(HostProcess{PID: subject.pid, Argv: argv}, interfaceGone, runtimeKnows); !ok {
+		t.Fatalf("the child was not attributable, so the probe below would refuse for the wrong "+
+			"reason and prove nothing: %v", argv)
+	}
+
+	if err := CanEndLeftover(DHCPLeftover{PID: subject.pid, Interface: leftoverIface}); err != nil {
+		t.Fatalf("the sweep's own probe reported that this user may not end its own process: %v", err)
+	}
+	subject.mustSurvive(t, "the sweep's own probe ended the process it was only asked about")
+}
+
+// commandLineOf reads a child's command line once the exec has landed.
+//
+// Polled rather than read straight after Start, and that is a measured fix: a
+// child between fork and exec publishes an empty /proc/<pid>/cmdline, and the
+// first version of this test read it there. It passed, then failed in the
+// middle of an unrelated falsification with an empty argv and an accusation
+// aimed at the wrong thing — a test whose verdict depended on how busy the
+// station was, which is the harness measuring its own panic rather than the
+// subject.
+func commandLineOf(t *testing.T, subject *subjectProcess) []string {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var last error
+	for time.Now().Before(deadline) {
+		argv, err := procArgv(subject.pid)
+		last = err
+		if err == nil && len(argv) > 0 && filepath.Base(argv[0]) == "dnsmasq" {
+			return argv
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if last != nil {
+		t.Skipf("this host does not publish command lines under /proc (%v), so the survey "+
+			"this probe belongs to cannot run here at all", last)
+	}
+	t.Fatalf("the child never wore the command line under test")
+	return nil
+}
+
+// leftoverIface is a name only this emulator derives, on an interface no host
+// has: the "vanished interface" half of the classification, obtained without
+// creating or removing anything on the machine running the test.
+const leftoverIface = "fnt-00000000375"
+
+// A subject is a live child of this test, watched so that its death is
+// observable.
+//
+// Watching it is not optional, and the first version of these tests got it
+// wrong in a way worth recording: liveness was read with signal 0, the same
+// probe the subject under test uses, and a child killed by its own parent
+// becomes a zombie that answers signal 0 exactly as a live process does. The
+// mutation that turns probeSignal into a real SIGTERM therefore stayed green —
+// the control was a sentence, not a measurement, in a file whose whole subject
+// is that difference. What settles it is wait(2): a process that has exited is
+// reaped, and only then is it gone.
+type subjectProcess struct {
+	pid  int
+	done chan struct{}
+}
+
+// mustSurvive fails when the child ended inside the settle window.
+//
+// The window is a thousandfold margin on what it measures: a SIGTERM to a
+// sleeping child is delivered and reaped in microseconds, so anything under a
+// second is the signal having arrived. It is spent only on the passing path,
+// where nothing was signalled and nothing will ever close the channel.
+func (s *subjectProcess) mustSurvive(t *testing.T, what string) {
+	t.Helper()
+	select {
+	case <-s.done:
+		t.Fatal(what)
+	case <-time.After(time.Second):
+	}
+}
+
+// watch starts a child and reaps it in the background, so the channel closes
+// the moment the process ends, whoever ended it.
+func watch(t *testing.T, cmd *exec.Cmd, what string) *subjectProcess {
+	t.Helper()
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start %s: %v", what, err)
+	}
+	subject := &subjectProcess{pid: cmd.Process.Pid, done: make(chan struct{})}
+	go func() {
+		_, _ = cmd.Process.Wait()
+		close(subject.done)
+	}()
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+	return subject
+}
+
+// sleepingProcess starts a child this test owns and may signal.
+func sleepingProcess(t *testing.T) *subjectProcess {
+	t.Helper()
+	return watch(t, exec.Command("sleep", "300"), "a process to ask about")
+}
+
+// fakeDNSMasq starts a child whose command line is the one the classification
+// reads: argv[0] is a dnsmasq and the interface it names does not exist.
+//
+// It is the test binary re-executed rather than a copy of some tool, because
+// the requirement is unusual — a process that ignores its arguments and stays
+// alive — and every ordinary program refuses the arguments that make this
+// command line the one under test. `--` stops the testing package's own flag
+// parsing, so the arguments after it are carried on argv and read by nothing.
+func fakeDNSMasq(t *testing.T) *subjectProcess {
+	t.Helper()
+	cmd := exec.Command(os.Args[0]) //nolint:gosec // the test binary itself
+	cmd.Args = []string{
+		"dnsmasq", "-test.run=TestLeftoverHelperProcessSleeps", "--",
+		"--interface=" + leftoverIface, "--listen-address=10.183.99.1",
+		"--dhcp-leasefile=/var/lib/incus/networks/" + leftoverIface + "/dnsmasq.leases",
+	}
+	cmd.Env = append(os.Environ(), "FEINT_LEFTOVER_HELPER=1")
+	return watch(t, cmd, "a process wearing a dnsmasq's command line")
+}
+
+// TestLeftoverHelperProcessSleeps is not a test: it is the body of the child
+// fakeDNSMasq starts, and it does nothing at all unless that variable is set.
+func TestLeftoverHelperProcessSleeps(t *testing.T) {
+	if os.Getenv("FEINT_LEFTOVER_HELPER") != "1" {
+		t.Skip("the body of fakeDNSMasq's child, run only as that child")
+	}
+	time.Sleep(30 * time.Second)
 }
 
 // The minute-eight failure, as the operator reads it: the create fails on a

--- a/mise.toml
+++ b/mise.toml
@@ -408,6 +408,13 @@ run = """
 # --contracts turns on the response check: every answer a real client provokes is
 # validated against the provider's own API description, which is broader than any
 # set of cases somebody thought to write.
+# The doorstep (#375). A DHCP service an earlier run left holding an address
+# block, and that this user cannot end, fails the runtime leg every time — and
+# it did, three runs in a row, in the twelfth step of this task, after every
+# client suite had already run. The answer had not changed since second zero,
+# so it is asked at second zero. With FEINT_VM off, which is the default and the
+# whole of the CI matrix, it says so and asks nothing.
+tools/conformance/guard.sh leftovers "${FEINT_VM:-off}"
 ./feint start --addr $FEINT_ADDR --vm ${FEINT_VM:-off} --contracts contracts --timeout 60s
 trap './feint stop --addr $FEINT_ADDR >/dev/null 2>&1 || true' EXIT
 tools/conformance/scaleway/scw-cli.sh "http://$FEINT_ADDR"

--- a/tools/conformance/exoscale/network.sh
+++ b/tools/conformance/exoscale/network.sh
@@ -106,6 +106,18 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# And the host must not already be holding a block this suite is about to ask
+# for (#375). The sweep below meets that state and cannot fix it — the leftover
+# belongs to the runtime's user — so the answer is given here, before the run,
+# rather than as a sweep failure whose remedy nobody runs.
+#
+# After the trap, deliberately, and that ordering was measured: put before it,
+# the refusal exits without the EXIT trap installed, so the sweep that removes
+# this run's own labelled objects never happens and the operator is left with a
+# host dirtier than the old failure left it. Refusing must cost the host
+# nothing.
+guard_leftovers "$ENDPOINT"
+
 sweep_runtime
 
 echo "- a managed private network keeps the range it was given"

--- a/tools/conformance/guard.sh
+++ b/tools/conformance/guard.sh
@@ -20,13 +20,15 @@
 #   guard_local "$ENDPOINT"
 #   guard_no_real_profile SCW_API_URL scw
 #   guard_images "$ENDPOINT"          # suites that log into a machine
+#   guard_leftovers "$ENDPOINT"       # suites that take an address block
 #
 # Usage of the functions is deliberately separate: the first checks where the
 # script intends to go, the second checks that the client cannot go anywhere
-# else, and the third checks that the emulator can keep the promise the suite is
-# about to make. All three live here rather than in each suite for the reason
-# CLAUDE.md gives about the shared layer: a control copied into three scripts is
-# a control the fourth forgets.
+# else, the third checks that the emulator can keep the promise the suite is
+# about to make, and the fourth checks that the host is not already holding the
+# blocks it is about to ask for. All four live here rather than in each suite
+# for the reason CLAUDE.md gives about the shared layer: a control copied into
+# three scripts is a control the fourth forgets.
 
 # guard_local refuses an endpoint that is not on this machine.
 #
@@ -72,6 +74,26 @@ EOF
       echo "FAIL: $var is ${!var}, which is not local; refusing to run $client" >&2
       exit 1 ;;
   esac
+}
+
+# feint_binary answers where the binary under test is, as a path somebody can
+# paste. FEINT_BIN wins when it is set; otherwise it is the repository root
+# beside this file.
+#
+# Normalised, and that is not tidiness: both guards below print this path inside
+# a command they are asking an operator to run. The suites derive FEINT_BIN from
+# their own directory, so it arrives as `.../scaleway/../../../feint` and the
+# remedy comes out unpasteable — which is #375's own lesson one size down, a
+# remedy nobody runs being the same as no remedy. `cd` failing leaves the
+# candidate alone rather than inventing a path, so an unreadable directory still
+# reaches the "no feint binary at" refusal with the name it was given.
+feint_binary() {
+  local candidate dir
+  candidate="${FEINT_BIN:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)/feint}"
+  if dir="$(cd "$(dirname "$candidate")" 2>/dev/null && pwd -P)"; then
+    candidate="$dir/${candidate##*/}"
+  fi
+  printf '%s' "$candidate"
 }
 
 # guard_images refuses a suite whose machines cannot answer, and names the one
@@ -121,7 +143,7 @@ guard_images() {
     return 0
   fi
 
-  binary="${FEINT_BIN:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/feint}"
+  binary="$(feint_binary)"
   if [ ! -x "$binary" ]; then
     cat >&2 <<EOF
 FAIL: no feint binary at $binary.
@@ -153,3 +175,127 @@ EOF
   fi
   echo "  images: the $machines runtime holds every image this suite boots" >&2
 }
+
+# guard_leftovers refuses a run whose host already holds a DHCP service an
+# earlier run left behind and this user cannot end (#375).
+#
+# The measurement. The runtime leg of `mise run evidence:update` failed three
+# times in a row, in the same place each time: `network.sh` swept the runtime,
+# the sweep found a dnsmasq whose interface had outlived its network, named it
+# exactly — and exited 1, because the process belongs to the `incus` user and
+# the operator running the suite may not signal it. The printed remedy was
+# right. Nothing ran it. Every run died there until a human read the log and
+# retyped a pid, and a gate whose only remedy is a manual step somebody has to
+# notice is a gate that gets worked around, which is how `--no-verify` is
+# learned.
+#
+# What it must never become is the obvious shortcut. **Nothing here escalates.**
+# A conformance suite that acquired the right to end a daemon it did not start
+# would be a worse defect than the one it works around: it is the question
+# `mustOwn` asks of the driver, one layer up, and a process nobody here created
+# is not ours to end. So this refuses, names the pid, and names one command the
+# operator runs with their own hands.
+#
+# The refusal is a doorstep and not a verdict thirty lines in, for the reason
+# #335 gave for the image guard. The sweep that meets this state is the twelfth
+# step of `mise run conformance`, so the leg burned every client suite before
+# saying anything, and the answer had not changed since second zero.
+#
+# What it does not do is prevent one appearing. Measured on 2026-08-21: the
+# machines-on leg produced a leftover of its own, mid-run, in bridge mode, from
+# a network it had created minutes earlier — so this refusal caught it at the
+# next suite's doorstep rather than at the start of the leg, and the leg still
+# failed. That is the honest outcome and it is a different defect from this
+# one: what the doorstep makes cheap is the diagnosis and the remedy, not the
+# birth of the leftover.
+#
+# It refuses on any such leftover rather than only on one holding a block this
+# run happens to need, and that is deliberate three times over. A leftover that
+# gets this far is this emulator's own debris by construction — an `fnt-` name
+# it derives, a network the runtime no longer knows, a service running off the
+# runtime's own state directory — so it is never somebody's working service
+# caught in the way. The blocks a run needs are not knowable here: they come
+# from the clients, from three FEINT_TEST_* variables and from fixtures, and a
+# guard that guessed that set would pass on the one block it forgot. And a
+# doorstep more permissive than the sweep behind it changes nothing: `feint
+# clean` fails on any leftover it cannot end, so the run would simply die where
+# it used to.
+#
+# TestTheLeftoverGuardRefusesAHostItCannotClean fails without it, and
+# tools/falsify/specs/unkillable-dhcp-orphan.json replays that.
+guard_leftovers() {
+  local endpoint="${1:-}" health machines
+
+  health="$(curl -sf "$endpoint/_feint/health" || true)"
+  if [ -z "$health" ]; then
+    echo "FAIL: $endpoint answered no health payload, so nothing here knows what its machines are" >&2
+    exit 1
+  fi
+  machines="$(printf '%s' "$health" | jq -r '.machines // "none"')"
+  guard_leftovers_for "$machines"
+}
+
+# guard_leftovers_for is the same refusal for a caller that has no emulator to
+# ask yet: `mise run conformance` runs it before it starts anything, from the
+# mode it is about to pass to `feint start`.
+guard_leftovers_for() {
+  local machines="${1:-off}" binary
+
+  # With no machine runtime nothing will take an address block, so the question
+  # does not apply. Said out loud rather than returned in silence, per the rule
+  # the image guard above states: a precondition that passes quietly on the very
+  # case it exists for reads as green when it never ran. This is also the leg
+  # that runs most often — `FEINT_VM=off` is the default and the whole of CI's
+  # conformance matrix — so a guard that fired here would be a brand new failure
+  # on the path nothing was wrong with.
+  if [ "$machines" = "none" ] || [ "$machines" = "off" ] || [ "$machines" = "null" ] || [ -z "$machines" ]; then
+    echo "  leftovers: not asked, this run starts no machine" >&2
+    return 0
+  fi
+
+  binary="$(feint_binary)"
+  if [ ! -x "$binary" ]; then
+    cat >&2 <<EOF
+FAIL: no feint binary at $binary.
+
+This suite needs it to ask what a run left holding an address block on this
+host. Build it (mise run build, or go build -o feint ./cmd/feint), or point
+FEINT_BIN at one. Skipping the question instead would let the suite start on a
+host whose blocks are already taken, which is the failure this check names.
+EOF
+    exit 1
+  fi
+
+  if ! "$binary" clean --check --vm "$machines" >&2; then
+    cat >&2 <<EOF
+
+FAIL: a DHCP service left behind by a run holds an address block on this host,
+and this user cannot end it. Its pid, its block and the reason are named above.
+
+Usually it belongs to the runtime's own user rather than to you: Incus starts
+the DHCP service of every managed bridge under the incus account. Nothing in
+this suite may signal it either way: a conformance run that escalated to end a
+daemon it did not start would be a worse defect than the one it works around.
+
+Run:  sudo $binary clean --vm $machines
+
+That is this same sweep, elevated by you on purpose. It re-asks every ownership
+question at the moment of the signal, so it ends only what this emulator can
+prove is its own.
+EOF
+    exit 1
+  fi
+}
+
+# Sourced by the suites above, and runnable for the one caller that has no suite
+# to source it into: `mise run conformance` asks this before `feint start`, so a
+# leg refuses at second zero instead of after every client suite has run.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  case "${1:-}" in
+    leftovers) guard_leftovers_for "${2:-off}" ;;
+    *)
+      echo "usage: tools/conformance/guard.sh leftovers <machine runtime>" >&2
+      echo "  (the other guards take an endpoint and are sourced, not run)" >&2
+      exit 2 ;;
+  esac
+fi

--- a/tools/conformance/guard_test.go
+++ b/tools/conformance/guard_test.go
@@ -100,7 +100,7 @@ func TestTheImageGuardRefusesWhenItCannotAsk(t *testing.T) {
 	}))
 	defer health.Close()
 
-	code, output := bashGuard(t, health.URL, filepath.Join(t.TempDir(), "no-such-feint"))
+	code, output := bashGuard(t, `. "$1"; guard_images "$2"`, health.URL, filepath.Join(t.TempDir(), "no-such-feint"))
 	if code == 0 {
 		t.Errorf("the guard passed with no binary to ask:\n%s", output)
 	}
@@ -162,17 +162,15 @@ func runGuard(t *testing.T, healthBody string, binaryExit int) (int, string) {
 	}))
 	defer health.Close()
 
-	stub := filepath.Join(t.TempDir(), "feint")
-	script := fmt.Sprintf("#!/bin/sh\necho \"stub feint: $*\" >&2\nexit %d\n", binaryExit)
-	if err := os.WriteFile(stub, []byte(script), 0o700); err != nil { //nolint:gosec // a stub in a test temp dir
-		t.Fatalf("write the stub binary: %v", err)
-	}
-	return bashGuard(t, health.URL, stub)
+	return bashGuard(t, `. "$1"; guard_images "$2"`, health.URL, stubBinary(t, binaryExit))
 }
 
-// bashGuard sources the real guard.sh and calls guard_images in a subshell, so
-// what is measured is the shell the suites source and not a copy of it.
-func bashGuard(t *testing.T, endpoint, binary string) (int, string) {
+// bashGuard sources the real guard.sh and calls one of its functions in a
+// subshell, so what is measured is the shell the suites source and not a copy
+// of it. The script and its single argument are passed in because the guards
+// differ in what they take: an endpoint for the ones that ask an emulator, a
+// runtime name for the one the conformance task runs before an emulator exists.
+func bashGuard(t *testing.T, script, argument, binary string) (int, string) {
 	t.Helper()
 	requireTool(t, "bash")
 	requireTool(t, "curl")
@@ -186,7 +184,7 @@ func bashGuard(t *testing.T, endpoint, binary string) (int, string) {
 		t.Fatalf("guard.sh is not where this test looks (%s): %v", guard, err)
 	}
 
-	cmd := exec.Command("bash", "-c", `. "$1"; guard_images "$2"`, "bash", guard, endpoint) //nolint:gosec // fixed script, test-controlled arguments
+	cmd := exec.Command("bash", "-c", script, "bash", guard, argument) //nolint:gosec // fixed script, test-controlled arguments
 	cmd.Env = append(os.Environ(), "FEINT_BIN="+binary)
 	out, err := cmd.CombinedOutput()
 	code := 0
@@ -210,4 +208,173 @@ func requireTool(t *testing.T, name string) {
 		t.Fatalf("%s is not on PATH: the conformance suites need it, so this test cannot "+
 			"be skipped into looking green", name)
 	}
+}
+
+// The suites also ask whether the host is already holding the blocks they are
+// about to take (#375).
+//
+// The measurement behind it: the runtime leg of `mise run evidence:update`
+// failed three times in a row on a dnsmasq an earlier run had left holding a
+// gateway address. The sweep in network.sh found it, named it, printed
+// `sudo kill <pid>` and exited 1 — the process belongs to the `incus` user and
+// the operator running the suite may not signal it. Nothing ran the remedy, so
+// every run died in the same place until a human read the log.
+//
+// The refusal below is what replaces that, and what it refuses to do is as
+// important as what it does: it never escalates. The stub binary here stands in
+// for `feint clean --check`, whose exit code is the one fact the guard reads.
+func TestTheLeftoverGuardRefusesAHostItCannotClean(t *testing.T) {
+	code, output := runLeftoverGuard(t, "incus", 1)
+	if code == 0 {
+		t.Errorf("the guard let a run start on a host whose block is held:\n%s", output)
+	}
+	for _, want := range []string{"sudo", "clean --vm incus", "cannot end it"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("the refusal never says %q, so it does not say what to do:\n%s", want, output)
+		}
+	}
+	// And it must never suggest that the suite do the elevating. The command is
+	// printed for the operator to run; nothing in this path may acquire a
+	// privilege it did not have.
+	if strings.Contains(output, "sudo kill") {
+		t.Errorf("the refusal falls back to a command with a pid to retype:\n%s", output)
+	}
+}
+
+// The accepting half: a host the check reports clean starts its run. A guard
+// that only knows how to refuse is as useless as one that only knows how to
+// pass, and this one sits in front of every runtime suite.
+func TestTheLeftoverGuardLetsAPreparedHostThrough(t *testing.T) {
+	code, output := runLeftoverGuard(t, "incus", 0)
+	if code != 0 {
+		t.Errorf("the guard refused a host with nothing left behind (exit %d):\n%s", code, output)
+	}
+}
+
+// The poorest run this guard will ever meet, and the one it must not touch.
+//
+// `FEINT_VM=off` is the default, the first leg of `mise run evidence:update`
+// and the whole of CI's conformance matrix: nothing there takes an address
+// block, so nothing there can be blocked by one being held. The stub exits 1 on
+// any call, so a guard that asked would fail this — which is the point, since
+// the cost of getting it wrong is a brand new red on the path that was never
+// broken, and a doorstep that fires on healthy runs is a doorstep somebody
+// disarms.
+func TestTheLeftoverGuardAsksNothingWhenNoRuntimeIsOn(t *testing.T) {
+	for _, machines := range []string{"none", "off", "null", ""} {
+		code, output := runLeftoverGuardFor(t, machines, 1)
+		if code != 0 {
+			t.Errorf("machines=%q: the guard refused a run that starts no machine (exit %d):\n%s",
+				machines, code, output)
+		}
+		if !strings.Contains(output, "not asked") {
+			t.Errorf("machines=%q: the guard passed in silence; a precondition that says nothing "+
+				"on the case it exists for reads as green when it never ran:\n%s", machines, output)
+		}
+	}
+}
+
+// An endpoint that answers nothing is a broken harness, not a runtime-free
+// mode, and the two must not read the same.
+func TestTheLeftoverGuardRefusesAnEndpointThatAnswersNothing(t *testing.T) {
+	code, output := runLeftoverGuard(t, "", 0)
+	if code == 0 {
+		t.Errorf("the guard passed against an emulator that answered no health payload:\n%s", output)
+	}
+}
+
+// The call sites, because a shared guard nobody calls guards nothing — the same
+// weaker-but-necessary structural half TestEverySuiteThatLogsInAsksForItsImages
+// holds for #335.
+//
+// The mise task is in the list, and it is the entry that closes #375 rather
+// than merely improving it: the suites below are the twelfth step of
+// `mise run conformance`, so a refusal that lives only in them still lets the
+// leg burn every client suite first. The answer has not changed since second
+// zero, so the task asks at second zero.
+func TestEveryRuntimeSuiteAsksAboutLeftovers(t *testing.T) {
+	suites := []string{
+		filepath.Join("scaleway", "network.sh"),
+		filepath.Join("outscale", "network.sh"),
+		filepath.Join("exoscale", "network.sh"),
+	}
+	for _, suite := range suites {
+		body, err := os.ReadFile(suite) //nolint:gosec // a fixed path in this directory
+		if err != nil {
+			t.Fatalf("read %s: %v", suite, err)
+		}
+		// A line of its own, so the call is a statement rather than a mention:
+		// `true || guard_leftovers "$ENDPOINT"` still contains the name and
+		// calls nothing. The sibling test above matched the name anywhere in
+		// the file when it was first written, and its own falsification caught
+		// that at once; this one starts where that one ended up.
+		called := false
+		for _, line := range strings.Split(string(body), "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), `guard_leftovers "`) {
+				called = true
+				break
+			}
+		}
+		if !called {
+			t.Errorf("%s takes an address block and never calls guard_leftovers on a line of its "+
+				"own: it will start on a host whose block is already held and die in the sweep", suite)
+		}
+	}
+
+	task, err := os.ReadFile(filepath.Join("..", "..", "mise.toml")) //nolint:gosec // a fixed path in this repository
+	if err != nil {
+		t.Fatalf("read mise.toml: %v", err)
+	}
+	asked := false
+	for _, line := range strings.Split(string(task), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "tools/conformance/guard.sh leftovers ") {
+			asked = true
+			break
+		}
+	}
+	if !asked {
+		t.Error("the conformance task never runs guard.sh leftovers on a line of its own: the leg " +
+			"goes back to burning every client suite before it says the host was never ready")
+	}
+}
+
+// runLeftoverGuard drives guard_leftovers against a stub emulator and a stub
+// binary, the way runGuard does for the image guard: `feint clean --check`
+// needs a real /proc survey and a real Incus, and the guard's own behaviour is
+// what is under test, not the survey's.
+func runLeftoverGuard(t *testing.T, machines string, binaryExit int) (int, string) {
+	t.Helper()
+	body := ""
+	if machines != "" {
+		body = fmt.Sprintf(`{"machines":%q}`, machines)
+	}
+	health := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if body == "" {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, body)
+	}))
+	defer health.Close()
+
+	return bashGuard(t, `. "$1"; guard_leftovers "$2"`, health.URL, stubBinary(t, binaryExit))
+}
+
+// runLeftoverGuardFor drives the entry point the conformance task uses, which
+// takes the mode directly because it runs before any emulator exists.
+func runLeftoverGuardFor(t *testing.T, machines string, binaryExit int) (int, string) {
+	t.Helper()
+	return bashGuard(t, `. "$1"; guard_leftovers_for "$2"`, machines, stubBinary(t, binaryExit))
+}
+
+// stubBinary is a fake feint whose exit code is the one thing the guard reads.
+func stubBinary(t *testing.T, exit int) string {
+	t.Helper()
+	stub := filepath.Join(t.TempDir(), "feint")
+	script := fmt.Sprintf("#!/bin/sh\necho \"stub feint: $*\" >&2\nexit %d\n", exit)
+	if err := os.WriteFile(stub, []byte(script), 0o700); err != nil { //nolint:gosec // a stub in a test temp dir
+		t.Fatalf("write the stub binary: %v", err)
+	}
+	return stub
 }

--- a/tools/conformance/outscale/network.sh
+++ b/tools/conformance/outscale/network.sh
@@ -64,6 +64,12 @@ fi
 command -v incus >/dev/null 2>&1 \
   || fail "the incus client is not on PATH, so nothing can be verified"
 
+# And the host must not already be holding a block this suite is about to ask
+# for (#375). Nothing has been created at this point, so refusing here costs
+# the host nothing — which is the property the two sibling suites get by
+# putting the same call after their EXIT trap.
+guard_leftovers "$ENDPOINT"
+
 # Deliberately obscure. A lab bridge or a VPN already holding this range makes
 # the create fail, which is the emulator being honest rather than handing back a
 # network that exists nowhere.

--- a/tools/conformance/scaleway/network.sh
+++ b/tools/conformance/scaleway/network.sh
@@ -122,6 +122,18 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# And the host must not already be holding a block this suite is about to ask
+# for (#375). The sweep below meets that state and cannot fix it — the leftover
+# belongs to the runtime's user — so the answer is given here, before the run,
+# rather than as a sweep failure whose remedy nobody runs.
+#
+# After the trap, deliberately, and that ordering was measured: put before it,
+# the refusal exits without the EXIT trap installed, so the sweep that removes
+# this run's own labelled objects never happens and the operator is left with a
+# host dirtier than the old failure left it. Refusing must cost the host
+# nothing.
+guard_leftovers "$ENDPOINT"
+
 sweep_runtime
 
 echo "- a private network keeps the block it was given"

--- a/tools/falsify/specs/dhcp-doctor-network-question.json
+++ b/tools/falsify/specs/dhcp-doctor-network-question.json
@@ -4,8 +4,8 @@
     {
       "label": "the held block goes back to a warning, so a state that kills the next run with certainty leaves doctor green for CI (#342)",
       "file": "internal/cli/doctor.go",
-      "find": "\t\ttitle:  fmt.Sprintf(\"%d DHCP service(s) left by an earlier run still hold an address block this emulator will want\", len(leftovers)),\n\t\tstate:  verdictFail,",
-      "replace": "\t\ttitle:  fmt.Sprintf(\"%d DHCP service(s) left by an earlier run still hold an address block this emulator will want\", len(leftovers)),\n\t\tstate:  verdictFail * 0,",
+      "find": "\t\ttitle:  fmt.Sprintf(\"%d DHCP service(s) left behind by a run still hold an address block this emulator will want\", len(leftovers)),\n\t\tstate:  verdictFail,",
+      "replace": "\t\ttitle:  fmt.Sprintf(\"%d DHCP service(s) left behind by a run still hold an address block this emulator will want\", len(leftovers)),\n\t\tstate:  verdictFail * 0,",
       "test": "TestDoctorFailsOnTheDHCPServiceWhoseNetworkIsGone"
     },
     {

--- a/tools/falsify/specs/unkillable-dhcp-orphan.json
+++ b/tools/falsify/specs/unkillable-dhcp-orphan.json
@@ -1,0 +1,75 @@
+{
+  "package": "./internal/cli/",
+  "mutations": [
+    {
+      "label": "the permission probe carries a real signal, so the check that only asks becomes the sweep that kills — and kills a process nobody here started",
+      "file": "internal/core/machine/leftover.go",
+      "find": "const probeSignal = syscall.Signal(0)",
+      "replace": "const probeSignal = syscall.SIGTERM",
+      "test": "TestCanEndLeftoverAsksWithoutEnding",
+      "package": "./internal/core/machine/"
+    },
+    {
+      "label": "the probe stops being the one the sweep calls, so CanEndLeftover ends what it was asked about",
+      "file": "internal/core/machine/leftover.go",
+      "find": "\treturn signalLeftover(leftover, procArgv, interfaceGone, networkUnknown(), sendSignal, probeSignal)",
+      "replace": "\treturn signalLeftover(leftover, procArgv, interfaceGone, networkUnknown(), sendSignal, syscall.SIGTERM+probeSignal)",
+      "test": "TestCanEndLeftoverIsTheOneTheSweepCallsAndItStillDoesNotKill",
+      "package": "./internal/core/machine/"
+    },
+    {
+      "label": "the check stops separating what this user may end from what it may not, so the host that failed the leg three times reads as ready",
+      "file": "internal/cli/clean.go",
+      "find": "\t\tif err := canEndLeftover(leftover); err != nil {",
+      "replace": "\t\tif err := canEndLeftover(leftover); err != nil && false {",
+      "test": "TestCleanCheckRefusesAHostWhoseLeftoverThisUserCannotEnd"
+    },
+    {
+      "label": "the check refuses every leftover, endable or not, so the doorstep fires on hosts the ordinary sweep would clear — which is how a doorstep gets disarmed",
+      "file": "internal/cli/clean.go",
+      "find": "\t\tif err := canEndLeftover(leftover); err != nil {",
+      "replace": "\t\tif err := canEndLeftover(leftover); err != nil || true {",
+      "test": "TestCleanCheckPassesWhenTheSweepItselfWouldClearThem"
+    },
+    {
+      "label": "the sweep goes back to offering only a command with a pid to retype, which is the manual step that did not happen three runs in a row",
+      "file": "internal/cli/clean.go",
+      "find": "\t\t\tfmt.Fprintf(stdout, \"  → sudo feint clean --vm %s   (or: sudo kill %d)\\n\", vm, leftover.PID)",
+      "replace": "\t\t\tfmt.Fprintf(stdout, \"  → sudo kill %d (%s)\\n\", leftover.PID, vm[:0])",
+      "test": "TestCleanReportsTheCommandWhenTheLeftoverBelongsToAnotherUser"
+    },
+    {
+      "label": "the shell refusal never fires, so the leg starts on a host whose block is held and dies in the sweep twelve steps later",
+      "file": "tools/conformance/guard.sh",
+      "find": "  if ! \"$binary\" clean --check --vm \"$machines\" >&2; then",
+      "replace": "  if ! \"$binary\" clean --check --vm \"$machines\" >&2 && false; then",
+      "test": "TestTheLeftoverGuardRefusesAHostItCannotClean",
+      "package": "./tools/conformance/"
+    },
+    {
+      "label": "the guard fires on a run that starts no machine, which reddens FEINT_VM=off — the default, the first evidence leg and the whole CI matrix",
+      "file": "tools/conformance/guard.sh",
+      "find": "  if [ \"$machines\" = \"none\" ] || [ \"$machines\" = \"off\" ] || [ \"$machines\" = \"null\" ] || [ -z \"$machines\" ]; then",
+      "replace": "  if ([ \"$machines\" = \"none\" ] || [ \"$machines\" = \"off\" ] || [ \"$machines\" = \"null\" ] || [ -z \"$machines\" ]) && false; then",
+      "test": "TestTheLeftoverGuardAsksNothingWhenNoRuntimeIsOn",
+      "package": "./tools/conformance/"
+    },
+    {
+      "label": "the Scaleway network suite stops asking, which is the shape of the defect one layer up: a shared guard nobody calls",
+      "file": "tools/conformance/scaleway/network.sh",
+      "find": "guard_leftovers \"$ENDPOINT\"",
+      "replace": "true || guard_leftovers \"$ENDPOINT\"",
+      "test": "TestEveryRuntimeSuiteAsksAboutLeftovers",
+      "package": "./tools/conformance/"
+    },
+    {
+      "label": "the conformance task stops asking, so the leg goes back to burning every client suite before saying the host was never ready",
+      "file": "mise.toml",
+      "find": "tools/conformance/guard.sh leftovers \"${FEINT_VM:-off}\"",
+      "replace": "true || tools/conformance/guard.sh leftovers \"${FEINT_VM:-off}\"",
+      "test": "TestEveryRuntimeSuiteAsksAboutLeftovers",
+      "package": "./tools/conformance/"
+    }
+  ],
+  "note": "The subject is #375. The runtime leg of `mise run evidence:update` failed three times in a row on a dnsmasq an earlier run had left holding a gateway address: the sweep found it, named it exactly, printed `sudo kill <pid>` and exited 1, because the process belongs to the `incus` user and the operator running the suite may not signal it. The diagnosis was right and nothing ran the remedy, so every run died in the same place until a human read the log.\n\nReproduced deliberately on 2026-08-21, on the author's station and reversibly: `incus network create fnt-3750badbeef ipv4.address=10.183.75.1/24` gives a real bridge and a real dnsmasq running as the `incus` user, and dropping that network's rows from the runtime's database leaves the interface and the service alive with the network object gone — the exact #342 shape. `feint clean --vm incus` then exited 1 with `→ sudo kill 1154779`, and the Scaleway network suite died on it one second in. `sudo feint clean --vm incus` ended it, exit 0, and named the surviving bridge as the half it will not delete.\n\nWhat the fix is not: an escalation. Mutation 1 is the one worth reading twice — the whole remedy hangs on a permission probe that runs the kernel's check for a signal it does not deliver, and a probe that quietly gains a real signal turns a diagnostic into a killer of processes nobody here started. Its test does not record an argument; it puts a real child through the real signal path and requires it to still be there afterwards. The first version of that test read liveness with signal 0 — the same probe — and a child killed by its own parent is a zombie that answers signal 0 exactly as a live process does, so mutation 1 stayed green. wait(2) is what settles it.\n\nMutations 4 and 7 are the false-refusal half, and they matter as much as the rest: a doorstep that fires on hosts nothing was going to fail on is a doorstep somebody disarms, which is the same lesson `--no-verify` teaches. Mutation 7 is the poorest execution this guard will meet — `FEINT_VM=off`, the default, the first evidence leg and the whole of CI's conformance matrix."
+}


### PR DESCRIPTION
The runtime leg failed three times in the same place: the sweep finds a
`dnsmasq` whose interface outlived its network, cannot signal it — the process
belongs to `incus`, not to the user running the suite — prints the exact `sudo
kill <pid>`, and fails. The diagnosis was right and **nothing executed it**. A
gate whose only remedy is a manual step somebody must notice is a gate that gets
worked around, which is how `--no-verify` is learned.

## Reproduced before anything was changed

`incus network create` gives a real bridge and a real `dnsmasq` spawned by
incusd as uid `incus`; dropping that network's rows from the runtime database
leaves the interface and the service alive with the network object gone. Read
back three ways (`incus` lists it `MANAGED=NO`, `ip link` shows it, `ps` shows
the service). Then: `doctor` FAIL naming pid, address and interface; `clean`
exit 1 with the sudo line; `network.sh` exit 1 after one second. `kill -0 <pid>`
returns EPERM — that is the probe the whole fix is built on.

## The decision: candidates 1 and 2 together

- **2 alone loses**: a better remedy printed at minute eight is still printed at
  minute eight.
- **1 alone loses**: an early refusal still leaves a pid to read out of a log and
  retype.
- **3 loses outright**: the log already documents the manual step, and a
  paragraph is not a control.

Shipped: `feint clean --check` — reports, signals nothing, exits 1 only for what
this user cannot end — and `guard_leftovers` in `tools/conformance/guard.sh`,
called by the three network suites and by `mise run conformance` before `feint
start`. The remedy printed is `sudo feint clean --vm <mode>`: one line, nothing
transcribed, the same sweep re-asking every ownership question at the moment of
the signal. **No path in the suite acquires a privilege it did not have.**

The doorstep is deliberately **not** narrowed to "a block this run needs", as
the issue words it: the blocks come from clients, fixtures and three
`FEINT_TEST_*` variables, so a guessed set passes on the one it forgot — and
`clean` already fails on any stuck leftover, so a doorstep more permissive than
the sweep behind it just moves the failure back where it was.

## The premise that reframes three issues — and it is why this leg is still red

**The orphan is not left behind by an earlier run. The run orphans one of its
own networks mid-run.** Both `evidence:update` failures landed on a subnet of
`examples/stacks/outscale/main.tf`, each preceded by `detach isolation from
fnt-…: open …/dnsmasq.raw: no such file or directory` — an isolation detach
arriving at a network whose delete already removed its state directory. #316's
original address, `10.50.2.1`, is from that same stack.

**#316, #342 and #375 are all downstream of one teardown race**, filed as #386.

No doorstep can fix that leg: the host is clean at the start and the run dirties
it at step twelve. So `mise run evidence:update` **still fails**, and this pull
request says so rather than claiming the leg green. The messages now say "a run"
instead of "an earlier run", because sending the operator to look for a previous
run sends them to the wrong place.

Two smaller premises also fell: only Scaleway's and Exoscale's `network.sh` call
`clean` (Outscale's has no sweep and could not have produced the failure), and
the failure was one second in, not thirty lines — what was late was the *leg*,
which is where the win is.

## Mutations that stayed green at first, and what they caught

- **`probeSignal = Signal(0)` → `SIGTERM` was green.** The control read liveness
  with `Signal(0)` — the same probe — and a child killed by its own parent is a
  **zombie that answers signal 0 exactly like a live process**. The control was a
  sentence, in the file whose entire subject is that distinction. Fixed by
  reaping and waiting on `wait(2)`.
- **A fork/exec race**: the `/proc` test read `cmdline` right after `Start()`,
  which is empty before exec. It passed by luck, then failed a mutation run for
  the wrong reason. It now polls until the command line lands.
- **The doorstep placed before `trap cleanup EXIT`** exited with no trap
  installed, so the sweep that removes the run's own labelled objects never ran
  — the refusal left the host dirtier than the old failure did. Moved after the
  trap and measured: one labelled network removed on the way out, orphan
  untouched, process still alive.

## Gates

`prepush` green. `FEINT_VM=incus-ovn mise run conformance` **exit 0 twice**
(1134 s and 1121 s, 346/372 routes), doorstep asked four times per run.
`tools/falsify/specs/unkillable-dhcp-orphan.json`: **9 mutations, all red**,
including both false-refusal halves and the poorest execution the guard meets
(`FEINT_VM=off` — the default, the first evidence leg and the whole CI matrix).
Verified again after the rebase. One mutation in the existing
`dhcp-doctor-network-question.json` had to be retargeted, killed by a wording
change.

## Not measured

CI's `runtime-proof.yml` path, where suites run under `sudo` and the leftover is
endable — reasoned, not run. The macOS branch of the `/proc` test. Whether the
teardown race occurs without the Outscale stacks suite.

## Station

`incus network list`, `incus list`, `incus network acl list`, the `dnsmasq`
process table and the link list, all `--all-projects`, byte-for-byte identical
before and after. `incusbr0`, `hp-test-net`, `incusbr-1000`, the `acltest` ACL
and the libvirt/docker bridges untouched. Everything created is gone, proved by
reading the host back rather than by return codes.

## Related

Closes #375
Refs #316, #342, #386
