### PR TITLE
fix(machine): a network is exclusive while it is being torn down, and a detach that arrives after its delete says so (#386)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -922,6 +922,54 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Corrigé
 
+- **La suite de conformance orphelinait un de ses propres réseaux en cours
+  d'exécution, et cette seule course de démantèlement est ce dont #316, #342 et
+  #375 étaient tous en aval** (#386). `mise run evidence:update` a échoué deux
+  fois en mode pont le 2026-08-21, chaque fois sur un sous-réseau de
+  `examples/stacks/outscale/main.tf`, et chaque échec était précédé dans le
+  journal de l'émulateur par `detach isolation from fnt-… : open
+  /var/lib/incus/networks/…/dnsmasq.raw: no such file or directory`. C'est la
+  réconciliation d'isolation d'une requête qui atteint un réseau qu'une autre
+  requête a déjà supprimé : la passe liste le store, une suppression concurrente
+  retire un des membres qu'elle avait listés, et l'édition de configuration
+  arrive sur un réseau que le démon ne connaît plus. L'objet meurt, l'interface
+  et son `dnsmasq` lui survivent, et l'exécution suivante qui veut ce bloc meurt
+  au bout de plusieurs minutes sur « Address already in use ». **Les trois
+  issues précédentes ont rendu le résidu visible ou survivable ; aucune n'a
+  traité ce qui le produit**, et aucun contrôle sur le pas de la porte ne le
+  peut, puisque l'hôte est propre au démarrage et que c'est l'exécution
+  elle-même qui le salit à la douzième étape.
+
+  **Deux moitiés, parce que l'une sans l'autre laisse la course ouverte.** Le
+  pilote Incus prend désormais `serialise.Lock("incus.network." + name)` dans
+  `EnsureNetwork`, `IsolateNetwork` et `RemoveNetwork` : aucune édition de
+  configuration d'un réseau n'est en vol pendant que sa suppression tourne. Par
+  réseau et jamais global, car un verrou global mettrait tous les sous-réseaux
+  d'une pile en file derrière une seule suppression, c'est-à-dire l'erreur que
+  `internal/core/machine/serialise.go` consigne déjà avoir commise une fois,
+  avec l'allocation d'interface (#348). Et `IsolateNetwork`, sous ce verrou,
+  demande au démon si le réseau est encore là avant d'éditer quoi que ce soit :
+  le verrou seul laisse encore passer une suppression qui l'a gagné, et la
+  question seule est un temps de contrôle qu'une suppression traverse.
+
+  **Un détachement qui n'a pas pu avoir lieu est rapporté, jamais compté comme
+  fait.** Le pilote rend `machine.ErrNetworkGone` et `ReconcileIsolation` le
+  journalise en nommant le réseau. En avertissement plutôt qu'en erreur : aucun
+  jeu de règles n'était nécessaire et aucun ne manque, et une ligne qui se
+  déclenche à chaque destruction parallèle est la façon dont un journal cesse
+  d'être une preuve. Le jeu de règles qui isolait le réseau est maintenant
+  retiré par la suppression elle-même, puisque la passe qui le retirait est
+  celle qui refuse désormais de tourner contre un réseau disparu.
+
+  Reproduite délibérément avant toute correction. Le faux runtime modélise le
+  comportement du démon que le journal a montré (une édition réapplique le
+  réseau, ce qui relève son pont et son `dnsmasq`, avant d'ouvrir
+  `dnsmasq.raw`), de sorte qu'une édition qui croise une suppression laisse un
+  service debout pour un réseau disparu, exactement le résidu mesuré par #342.
+  Falsifiée dans `tools/falsify/specs/teardown-race.json` : cinq mutations,
+  toutes rouges, et la mutation du verrou mesurée hors dépôt à 10/10 rouge sans
+  le verrou et 10/10 vert avec.
+
 - **Trois champs que la vraie API Exoscale répond et que cet émulateur omettait,
   tous invisibles à tout contrôle qui lit un document** (#370, #371). Ils font
   105 des 192 divergences rapportées par l'enregistrement du 2026-08-21 d'un

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -867,6 +867,49 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Fixed
 
+- **The conformance run orphaned one of its own networks mid-run, and that one
+  teardown race is what #316, #342 and #375 were all downstream of** (#386).
+  `mise run evidence:update` failed twice in bridge mode on 2026-08-21, each
+  time on a subnet of `examples/stacks/outscale/main.tf`, and each failure was
+  preceded in the emulator log by `detach isolation from fnt-…: open
+  /var/lib/incus/networks/…/dnsmasq.raw: no such file or directory`. That is one
+  request's isolation reconciliation reaching a network another request had
+  already deleted: the pass lists the store, a concurrent delete removes one of
+  the members it listed, and the config edit lands on a network the daemon no
+  longer knows. The object dies, the interface and its `dnsmasq` outlive it, and
+  the next run wanting that block dies minutes in on "Address already in use".
+  **The three issues before it made the leftover visible or survivable; none
+  addressed what produces it**, and no doorstep can, because the host is clean
+  when the run starts and the run dirties it at step twelve.
+
+  **Two halves, because either alone leaves the race open.** The Incus driver
+  now takes `serialise.Lock("incus.network." + name)` in `EnsureNetwork`,
+  `IsolateNetwork` and `RemoveNetwork`, so no config edit of a network is in
+  flight while its delete runs. Per network and never global: a global lock
+  would queue every subnet of a stack behind one delete, which is the mistake
+  `internal/core/machine/serialise.go` already records having made once, with
+  interface allocation (#348). And `IsolateNetwork`, holding that lock, asks the
+  daemon whether the network is still there before it edits anything, because
+  the lock alone still lets a delete that won it run first, and the question
+  alone is a time-of-check a delete crosses.
+
+  **A detach that could not happen is reported, never counted as done.** The
+  driver returns `machine.ErrNetworkGone` and `ReconcileIsolation` logs it,
+  naming the network. At warn rather than error: no rule set was needed and none
+  is missing, and a line that fires on every parallel destroy is how a log stops
+  being evidence. The rule set that isolated the network is now dropped by the
+  delete itself, since the pass that used to drop it is the one that now refuses
+  to run against a network that is gone.
+
+  Reproduced deliberately before anything was changed. The fake runtime models
+  the daemon behaviour the log showed — an edit re-applies the network, bringing
+  its bridge and its `dnsmasq` back up, before it opens `dnsmasq.raw` — so an
+  edit that meets a delete leaves a service standing for a network that is gone,
+  which is exactly the leftover #342 measured. Falsified in
+  `tools/falsify/specs/teardown-race.json`: five mutations, all red, and the
+  lock mutation measured out of tree at red 10/10 with the lock removed and
+  green 10/10 with it back.
+
 - **Three fields the real Exoscale API answers and this emulator omitted, all
   invisible to every control that reads a document** (#370, #371). They are 105
   of the 192 divergences the 2026-08-21 recording of a real `ch-gva-2` account

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -846,9 +846,33 @@ noting because #316's original measurement holds `10.50.2.1`: the three issues
 of this family are downstream of the same teardown.
 
 What #375 made cheap is the diagnosis and the remedy; the birth of that
-leftover is a separate defect, unmeasured before this and not fixed here. In
-OVN mode it does not arise at all: an OVN network carries no `dnsmasq`, and
+leftover was a separate defect, and #386 is where it was closed. In OVN mode it
+does not arise at all: an OVN network carries no `dnsmasq`, and
 `FEINT_VM=incus-ovn mise run conformance` passed twice the same evening.
+
+**What closed it: a lock named after the network, and a question asked under
+it.** Two requests reach one network because a reconciliation lists the store
+and a concurrent delete removes a member it listed — `terraform destroy` tears
+down subnets in parallel, so this is the ordinary case rather than the unlucky
+one. The driver now takes `serialise.Lock("incus.network." + name)` in
+`EnsureNetwork`, `IsolateNetwork` and `RemoveNetwork`, so no config edit of a
+network is in flight while its delete runs; and `IsolateNetwork`, holding that
+lock, asks the daemon whether the network is still there before it edits
+anything. Both halves are needed, and each has its own falsification in
+`tools/falsify/specs/teardown-race.json`: the lock alone still lets a delete
+that won it run first, and the question alone is a time-of-check a delete
+crosses. Per network and never global — a global lock would queue every subnet
+of a stack behind one delete, which is the mistake `internal/core/machine/
+serialise.go` already records having made once.
+
+A detach that could not happen is reported rather than counted as done:
+`machine.ErrNetworkGone` is what the driver returns, and `ReconcileIsolation`
+logs it at warn, naming the network. Warn and not error, because no rule set
+was needed and none is missing — an error line here would fire on every
+parallel destroy and teach a reader to skip it, which is how a log stops being
+evidence. The rule set that isolated the network is dropped by the delete
+itself, since the pass that used to drop it is now the one that refuses to run
+against a network that is gone.
 
 ## Authentication is accepted, never verified
 

--- a/internal/core/machine/incus.go
+++ b/internal/core/machine/incus.go
@@ -945,6 +945,45 @@ func freeInterface(devices map[string]map[string]string) string {
 	return "eth63"
 }
 
+// networkLock excludes every other command this driver aims at one network
+// until the returned function is called: its create, its config edits, and its
+// delete.
+//
+// The exclusion is the network's name, and #386 is the measurement that named
+// it. `mise run evidence:update` failed twice in bridge mode, each time on a
+// subnet of examples/stacks/outscale, and each failure was preceded in the
+// emulator log by:
+//
+//	detach isolation from fnt-…: open /var/lib/incus/networks/…/dnsmasq.raw:
+//	no such file or directory
+//
+// That is one request's isolation reconciliation reaching a network another
+// request had already deleted. The reconciliation lists the store, a concurrent
+// delete removes one of the members it listed, and the update lands on a
+// network whose state directory is gone — after the daemon has already brought
+// the bridge and its dnsmasq back up. The network object dies, the interface and
+// the DHCP service outlive it, and the next run that wants the block fails on
+// "Address already in use" minutes in. That leftover is what #316 sweeps, what
+// #342 taught doctor to name, and what #375 refused on the doorstep; none of
+// them touched what produces it.
+//
+// Per network and never global, which is serialise.go's rule and the reason
+// this is not d.uplinkMu: a global lock would queue every network of the
+// session behind one delete, and a stack creates its subnets in parallel on
+// purpose. The uplink is a different target — one object shared by every OVN
+// network — and keeps its own mutex; a caller that needs both takes this one
+// first, which is the order EnsureNetwork and RemoveNetwork both use.
+//
+// PeerNetworks deliberately does not take it. It names two networks, and a lock
+// on each would let two peerings of the same pair deadlock on opposite halves;
+// it also calls IsolateNetwork, which takes this lock itself, and serialise.Lock
+// is not reentrant.
+//
+// TestAnIsolationDetachDoesNotOrphanTheNetworkBeingDeleted fails without it.
+func (d *Incus) networkLock(name string) func() {
+	return serialise.Lock("incus.network." + name)
+}
+
 // EnsureNetwork implements Driver. It creates a managed bridge carrying the
 // block the pack computed — or an OVN network in OVN mode — and succeeds when
 // the network is already there.
@@ -964,6 +1003,8 @@ func (d *Incus) EnsureNetwork(ctx context.Context, spec NetworkSpec) error {
 		return fmt.Errorf("network name %q is %d characters, the limit is %d (use NetworkName)",
 			spec.Name, len(spec.Name), MaxNetworkNameLen)
 	}
+	release := d.networkLock(spec.Name)
+	defer release()
 	address, err := gatewayAddress(spec.CIDR, spec.Gateway)
 	if err != nil {
 		return err
@@ -1132,6 +1173,11 @@ func (d *Incus) RemoveNetwork(ctx context.Context, name string) error {
 	if !safeName.MatchString(name) || !ownedNetwork(name) {
 		return fmt.Errorf("refusing to delete network %q: not one the emulator created", name)
 	}
+	// Exclusive on this network for the whole teardown, so no config edit of it
+	// is in flight while the delete runs and none is issued after it. See
+	// networkLock for the measurement (#386).
+	release := d.networkLock(name)
+	defer release()
 	// The delegated block goes with the network it was delegated for. Left
 	// behind, each one is a real route on the host pointed at the uplink for as
 	// long as the uplink lives — seven of them were measured on one station,
@@ -1151,7 +1197,7 @@ func (d *Incus) RemoveNetwork(ctx context.Context, name string) error {
 	}
 	if _, err := d.run(ctx, "network", "delete", name); err != nil {
 		if isNotFound(err) {
-			return d.dropUplinkRouteOVN(ctx, block)
+			return d.afterNetworkDelete(ctx, name, block)
 		}
 		if d.OVN && strings.Contains(strings.ToLower(err.Error()), "in use") {
 			if peers, peersErr := d.networkPeers(ctx, name); peersErr == nil && len(peers) > 0 {
@@ -1159,11 +1205,32 @@ func (d *Incus) RemoveNetwork(ctx context.Context, name string) error {
 					_, _ = d.run(ctx, "network", "peer", "delete", name, peer.Name)
 				}
 				if _, err := d.run(ctx, "network", "delete", name); err == nil || isNotFound(err) {
-					return d.dropUplinkRouteOVN(ctx, block)
+					return d.afterNetworkDelete(ctx, name, block)
 				}
 			}
 		}
 		return fmt.Errorf("delete network %s: %w", name, err)
+	}
+	return d.afterNetworkDelete(ctx, name, block)
+}
+
+// afterNetworkDelete clears what a deleted network leaves attached to it, and
+// runs only once the delete has actually succeeded.
+//
+// Two things outlive a network object, for the same reason: nothing reconciles
+// a network that no longer exists. The delegated block is one, measured on a
+// station as seven live host routes for networks long gone (#341). The
+// isolation rule set is the other, and it is now the only thing that would drop
+// it: IsolateNetwork used to remove it on the pass where a network's foreign
+// list emptied, and that pass is exactly what refuses to run against a deleted
+// network since #386. Left behind, it is a rule set the sweep has to find,
+// which is a leftover reported rather than a leftover avoided.
+//
+// RemoveFirewall is not a refusal here: it treats an absent rule set as done,
+// which is the normal case for a network that was never isolated.
+func (d *Incus) afterNetworkDelete(ctx context.Context, name, block string) error {
+	if err := d.RemoveFirewall(ctx, isolationACL(name)); err != nil {
+		return fmt.Errorf("drop the isolation rule set of %s: %w", name, err)
 	}
 	return d.dropUplinkRouteOVN(ctx, block)
 }

--- a/internal/core/machine/incus_isolate.go
+++ b/internal/core/machine/incus_isolate.go
@@ -63,6 +63,31 @@ func (d *Incus) IsolateNetwork(ctx context.Context, network string, foreign []st
 	if !ownedNetwork(network) {
 		return fmt.Errorf("refusing to isolate network %q: not one the emulator created", network)
 	}
+	// Exclusive on this network, then asked whether it is still there. Both
+	// halves, because either alone leaves the race open (#386):
+	//
+	//   - the lock alone still lets a delete that won it run first, and the
+	//     update that follows lands on a network the daemon has forgotten;
+	//   - the question alone is a time-of-check that a delete crosses between
+	//     the answer and the config edit it authorises.
+	//
+	// The answer comes from the daemon rather than from the prose of a failed
+	// command, and it is the network object that is asked about: an interface
+	// still standing proves nothing, since a network can outlive its object and
+	// that is the leftover shape this exists to stop producing.
+	//
+	// TestIsolationRefusesANetworkWhoseDeleteAlreadyRan fails without the
+	// question; TestAnIsolationDetachDoesNotOrphanTheNetworkBeingDeleted fails
+	// without the lock.
+	release := d.networkLock(network)
+	defer release()
+	gone, err := d.gone(ctx, "/1.0/networks/"+network)
+	if err != nil {
+		return fmt.Errorf("inspect network %s: %w", network, err)
+	}
+	if gone {
+		return fmt.Errorf("%w: %s", ErrNetworkGone, network)
+	}
 	name := isolationACL(network)
 
 	if len(foreign) == 0 {

--- a/internal/core/machine/incus_teardown_race_test.go
+++ b/internal/core/machine/incus_teardown_race_test.go
@@ -1,0 +1,304 @@
+package machine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// The teardown race of #386, staged rather than bet on.
+//
+// `mise run evidence:update` failed twice in bridge mode, each time on a subnet
+// of examples/stacks/outscale/main.tf (10.50.1.0/24, then 10.50.2.0/24), and
+// each failure was preceded in the emulator log by:
+//
+//	detach isolation from fnt-…: open /var/lib/incus/networks/…/dnsmasq.raw:
+//	no such file or directory
+//
+// One request's isolation reconciliation reaching a network another request had
+// already deleted. `terraform destroy` removes subnets in parallel: request A
+// deletes its subnet from the store and calls RemoveNetwork; request B listed
+// the store before that delete, so its reconciliation still names A's network
+// and reaches it afterwards. The config edit then lands on a network the daemon
+// no longer knows, and what it leaves behind is the interface and its dnsmasq —
+// the leftover #316 sweeps, #342 taught doctor to name and #375 refused on the
+// doorstep, none of which touched what produces it.
+//
+// fakeNetd below is the daemon's behaviour as it was observed, not a line-by-
+// line replay of it: an update re-applies the network — bridge up, DHCP service
+// (re)started — and only then opens dnsmasq.raw inside the state directory. A
+// delete that landed in between has taken the directory with it, so the open
+// fails, and nothing puts back down what the re-apply had just brought up. That
+// is the one property the model needs: after the failed update, a service is
+// running for a network that no longer exists.
+
+// fakeNetd is the half of the Incus daemon the race lives in.
+type fakeNetd struct {
+	mu sync.Mutex
+	// exists is the network object together with its state directory under
+	// /var/lib/incus/networks; a delete removes both at once.
+	exists map[string]bool
+	// service is a dnsmasq bound to the network's bridge.
+	service map[string]bool
+	calls   []string
+
+	// landed closes when a delete has been applied, so an update in flight can
+	// meet it instead of hoping to.
+	landed chan struct{}
+	// touched closes on the very first command this driver issues, whichever
+	// path issues it. It is what lets the delete start at the moment the
+	// isolation pass has begun, with the fix in place and with it removed: the
+	// first command is the existence probe in one case and the config edit in
+	// the other, and either is the signal.
+	touched   chan struct{}
+	landOnce  sync.Once
+	touchOnce sync.Once
+	// beat is how long an update waits for a delete to cross it. Long enough
+	// that a racing delete is inside rather than merely likely to be, short
+	// enough that the serialised run costs it only once.
+	beat time.Duration
+}
+
+func newFakeNetd(networks ...string) *fakeNetd {
+	f := &fakeNetd{
+		exists:  map[string]bool{},
+		service: map[string]bool{},
+		landed:  make(chan struct{}),
+		touched: make(chan struct{}),
+		beat:    200 * time.Millisecond,
+	}
+	for _, name := range networks {
+		f.exists[name] = true
+		f.service[name] = true
+	}
+	return f
+}
+
+func (f *fakeNetd) run(_ context.Context, args ...string) ([]byte, error) {
+	f.mu.Lock()
+	f.calls = append(f.calls, strings.Join(args, " "))
+	f.mu.Unlock()
+	f.touchOnce.Do(func() { close(f.touched) })
+
+	joined := strings.Join(args, " ")
+	switch {
+	case strings.HasPrefix(joined, "query /1.0/networks/"):
+		name := strings.TrimPrefix(joined, "query /1.0/networks/")
+		if !f.has(name) {
+			return nil, errors.New("Error: Network not found")
+		}
+		return []byte(`{"type":"bridge","config":{"ipv4.address":"10.50.2.1/24","user.feint":"outscale"}}`), nil
+
+	case len(args) == 3 && args[0] == "network" && args[1] == "delete":
+		f.mu.Lock()
+		f.exists[args[2]] = false
+		f.service[args[2]] = false
+		f.mu.Unlock()
+		f.landOnce.Do(func() { close(f.landed) })
+		return nil, nil
+
+	case len(args) >= 3 && args[0] == "network" && (args[1] == "set" || args[1] == "unset"):
+		return f.update(args[2])
+	}
+	return nil, nil
+}
+
+// update is the daemon's config edit: the network is re-applied first, and its
+// DHCP configuration written second.
+func (f *fakeNetd) update(name string) ([]byte, error) {
+	select {
+	case <-f.landed:
+	case <-time.After(f.beat):
+	}
+	f.mu.Lock()
+	// Brought back up by the re-apply, whether or not the object survives, and
+	// never taken down again by the failure below.
+	f.service[name] = true
+	alive := f.exists[name]
+	f.mu.Unlock()
+	if !alive {
+		return nil, fmt.Errorf("open /var/lib/incus/networks/%s/dnsmasq.raw: no such file or directory", name)
+	}
+	return nil, nil
+}
+
+func (f *fakeNetd) has(name string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.exists[name]
+}
+
+// orphans names every network whose DHCP service outlived it: the leftover, as
+// `feint doctor` and `feint clean --check` describe it.
+func (f *fakeNetd) orphans() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []string
+	for name, running := range f.service {
+		if running && !f.exists[name] {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+func (f *fakeNetd) commands() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.calls...)
+}
+
+func (f *fakeNetd) issued(substr string) bool {
+	for _, cmd := range f.commands() {
+		if strings.Contains(cmd, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func fakeNetdDriver(f *fakeNetd) *Incus {
+	d := NewIncus()
+	d.runner = f.run
+	return d
+}
+
+// The reproduction. A detach and a delete of one network, issued concurrently
+// the way two parallel destroys issue them, must not leave a DHCP service for a
+// network that is gone — whichever of the two runs first.
+//
+// Both orders are covered by the one assertion, and both are reachable here:
+// with the exclusion in place the detach may win and complete against a live
+// network, or the delete may win and the detach then finds nothing to detach
+// from. What must never happen is the third order, where the delete lands
+// inside the detach.
+func TestAnIsolationDetachDoesNotOrphanTheNetworkBeingDeleted(t *testing.T) {
+	const network = "fnt-a1b2c3d4e5f"
+
+	f := newFakeNetd(network)
+	d := fakeNetdDriver(f)
+
+	var wg sync.WaitGroup
+	var detachErr, deleteErr error
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		// Empty foreign list: the detach branch, which is the one the log line
+		// of #386 names ("detach isolation from fnt-…"). It is what a
+		// reconciliation applies to a subnet whose only neighbours are its own
+		// Net's, which is every subnet of examples/stacks/outscale.
+		detachErr = d.IsolateNetwork(context.Background(), network, nil)
+	}()
+	go func() {
+		defer wg.Done()
+		<-f.touched
+		deleteErr = d.RemoveNetwork(context.Background(), network)
+	}()
+	wg.Wait()
+
+	if orphans := f.orphans(); len(orphans) != 0 {
+		t.Fatalf("a DHCP service outlived its network: %v\ncommands:\n%s\ndetach: %v\ndelete: %v",
+			orphans, strings.Join(f.commands(), "\n"), detachErr, deleteErr)
+	}
+	// The delete is the operation that must not be defeated: a network the
+	// control plane says is gone has to be gone.
+	if deleteErr != nil {
+		t.Fatalf("the delete failed: %v", deleteErr)
+	}
+	if f.has(network) {
+		t.Fatalf("the network survived its own delete:\n%s", strings.Join(f.commands(), "\n"))
+	}
+	// And the detach either did its work or said it could not, never both and
+	// never neither.
+	if detachErr != nil && !errors.Is(detachErr, ErrNetworkGone) {
+		t.Fatalf("the detach failed for a reason other than the network being gone: %v", detachErr)
+	}
+}
+
+// The other half, sequential and therefore exact: a detach that arrives after
+// the delete has already run issues no config edit at all, and says so.
+//
+// The lock cannot cover this one — the delete is over, there is nothing left to
+// exclude — which is why the question is asked as well as the order kept.
+func TestIsolationRefusesANetworkWhoseDeleteAlreadyRan(t *testing.T) {
+	const network = "fnt-a1b2c3d4e5f"
+
+	f := newFakeNetd(network)
+	d := fakeNetdDriver(f)
+
+	if err := d.RemoveNetwork(context.Background(), network); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	err := d.IsolateNetwork(context.Background(), network, nil)
+	if !errors.Is(err, ErrNetworkGone) {
+		t.Fatalf("isolate after delete = %v, want ErrNetworkGone: a detach that could not happen "+
+			"must be reported, never reported as done", err)
+	}
+	if f.issued("network unset " + network) {
+		t.Fatalf("the driver edited a deleted network anyway:\n%s", strings.Join(f.commands(), "\n"))
+	}
+	if f.issued("network set " + network) {
+		t.Fatalf("the driver edited a deleted network anyway:\n%s", strings.Join(f.commands(), "\n"))
+	}
+	if orphans := f.orphans(); len(orphans) != 0 {
+		t.Fatalf("a DHCP service outlived its network: %v\n%s", orphans, strings.Join(f.commands(), "\n"))
+	}
+}
+
+// The attach branch takes the same refusal. It is the one that writes a rule set
+// before it touches the network, so a driver that only guarded the detach would
+// still create an ACL for a network nobody can attach it to.
+func TestIsolationWithForeignBlocksRefusesADeletedNetworkToo(t *testing.T) {
+	const network = "fnt-a1b2c3d4e5f"
+
+	f := newFakeNetd(network)
+	d := fakeNetdDriver(f)
+
+	if err := d.RemoveNetwork(context.Background(), network); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	err := d.IsolateNetwork(context.Background(), network, []string{"10.50.1.0/24"})
+	if !errors.Is(err, ErrNetworkGone) {
+		t.Fatalf("isolate after delete = %v, want ErrNetworkGone", err)
+	}
+	if f.issued("network acl create") {
+		t.Fatalf("a rule set was written for a network that is gone:\n%s", strings.Join(f.commands(), "\n"))
+	}
+}
+
+// The rule set goes down with the network it isolated (#386). Nothing
+// reconciles a network that no longer exists, and since the pass that used to
+// drop it now refuses to run against a deleted one, the teardown has to.
+func TestRemoveNetworkDropsTheIsolationRuleSetWithIt(t *testing.T) {
+	const network = "fnt-a1b2c3d4e5f"
+
+	f := newFakeNetd(network)
+	d := fakeNetdDriver(f)
+
+	if err := d.RemoveNetwork(context.Background(), network); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if !f.issued("network acl delete " + isolationACL(network)) {
+		t.Fatalf("the isolation rule set was left behind:\n%s", strings.Join(f.commands(), "\n"))
+	}
+	// After the network, never before: a rule set a live network still carries
+	// cannot be deleted, and Incus refuses it as in use.
+	cmds := f.commands()
+	deleteAt, aclAt := -1, -1
+	for i, cmd := range cmds {
+		if cmd == "network delete "+network {
+			deleteAt = i
+		}
+		if strings.HasPrefix(cmd, "network acl delete ") {
+			aclAt = i
+		}
+	}
+	if aclAt < deleteAt {
+		t.Fatalf("the rule set was dropped before the network:\n%s", strings.Join(cmds, "\n"))
+	}
+}

--- a/internal/core/machine/isolate.go
+++ b/internal/core/machine/isolate.go
@@ -2,8 +2,25 @@ package machine
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 )
+
+// ErrNetworkGone reports that the network an isolation call names is no longer
+// there: a delete of it landed first.
+//
+// It exists because "the network is gone" is not the same answer as "the rules
+// could not be written", and the difference is the whole of #386. A driver that
+// swallowed it would report success for work it never did; one that reported it
+// as a plain failure would cry wolf on every parallel destroy, which is the
+// ordinary way a subnet and its neighbour's reconciliation cross. So it is a
+// value the caller can recognise, and ReconcileIsolation below says so in the
+// log rather than staying quiet.
+//
+// A driver returns it only when it has established the network's absence — not
+// when a call merely failed in a way whose prose mentions it. Incus answers this
+// through d.gone, which asks the daemon.
+var ErrNetworkGone = errors.New("the network was removed while its isolation was being applied")
 
 // Two emulated subnets are two real subnets, and upstream they do not reach each
 // other. Runtimes disagree on which way round that is: some join networks by
@@ -93,8 +110,7 @@ func ReconcileIsolation(ctx context.Context, driver Driver, log *slog.Logger, no
 				}
 			}
 			if err := peerer.PeerNetworks(ctx, m.Network, peers); err != nil {
-				log.Error("could not peer the "+noun+"'s network",
-					noun, m.ID, "network", m.Network, "error", err)
+				report(log, noun, m, err, "peer")
 			}
 		}
 		return true, true
@@ -118,9 +134,30 @@ func ReconcileIsolation(ctx context.Context, driver Driver, log *slog.Logger, no
 			}
 		}
 		if err := isolator.IsolateNetwork(ctx, m.Network, foreign); err != nil {
-			log.Error("could not isolate the "+noun+"'s network",
-				noun, m.ID, "network", m.Network, "error", err)
+			report(log, noun, m, err, "isolate")
 		}
 	}
 	return false, true
+}
+
+// report says what a reconciliation could not do, and separates the two reasons
+// it can fail.
+//
+// A network deleted under the pass is the expected outcome of a parallel
+// destroy: the member was in the store when the list was taken and its delete
+// landed before its turn came. Nothing is wrong with the host and nothing is
+// left to apply, so it is not an error — but it is not a success either, and it
+// is exactly the event whose invisibility made #386 take three issues to find.
+// It is logged at warn, naming the network, so a run that produced one says so.
+//
+// TestAVanishedNetworkIsReportedRatherThanSwallowed fails when this reports
+// nothing.
+func report(log *slog.Logger, noun string, m IsolationMember, err error, verb string) {
+	if errors.Is(err, ErrNetworkGone) {
+		log.Warn("the "+noun+"'s network was removed while its isolation was being reconciled, so none was applied",
+			noun, m.ID, "network", m.Network, "error", err)
+		return
+	}
+	log.Error("could not "+verb+" the "+noun+"'s network",
+		noun, m.ID, "network", m.Network, "error", err)
 }

--- a/internal/core/machine/isolate_test.go
+++ b/internal/core/machine/isolate_test.go
@@ -1,7 +1,11 @@
 package machine_test
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/stephrobert/feint/internal/core/machine"
@@ -114,5 +118,47 @@ func TestReconcileSkipsWhatHasNoNetworkOrNoBlock(t *testing.T) {
 	// so a pack does not resync rule-carried state no rule carries.
 	if _, applied := machine.ReconcileIsolation(t.Context(), machine.Noop{}, nil, "network", members, nobody); applied {
 		t.Error("a capability-less driver reported an isolation it cannot have applied")
+	}
+}
+
+// goneDriver is a runtime whose network was deleted under the reconciliation,
+// which is the ordinary outcome of a parallel destroy (#386): the member was in
+// the store when the list was taken, and its delete landed before its turn came.
+type goneDriver struct {
+	machine.Noop
+	asked []string
+}
+
+func (d *goneDriver) IsolateNetwork(_ context.Context, network string, _ []string) error {
+	d.asked = append(d.asked, network)
+	return fmt.Errorf("%w: %s", machine.ErrNetworkGone, network)
+}
+
+// A detach that could not happen is reported. It is the half of #386 that has
+// nothing to do with locking: the race was invisible for three issues because
+// nothing said out loud that a network had gone missing under a pass, and a
+// driver that refuses without a word is the same silence one layer down.
+//
+// Reported, and not as a plain failure: no rule set could be written and none
+// was needed, so an error line here would fire on every parallel destroy and
+// teach a reader to ignore it — which is how the log stops being evidence.
+func TestAVanishedNetworkIsReportedRatherThanSwallowed(t *testing.T) {
+	var written bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&written, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	driver := &goneDriver{}
+
+	native, applied := machine.ReconcileIsolation(t.Context(), driver, log, "subnet",
+		[]machine.IsolationMember{{ID: "subnet-1", Network: "fnt-aaa", Block: "10.50.1.0/24"}},
+		func(int, int) bool { return false })
+	if native || !applied {
+		t.Fatalf("native=%v applied=%v, want false,true for a rule-set driver", native, applied)
+	}
+
+	said := written.String()
+	if !strings.Contains(said, "fnt-aaa") || !strings.Contains(said, "subnet-1") {
+		t.Fatalf("the vanished network was not reported, so the run said nothing happened: %q", said)
+	}
+	if !strings.Contains(said, "level=WARN") {
+		t.Errorf("a network deleted under the pass was reported as a failure of the pass: %q", said)
 	}
 }

--- a/tools/falsify/specs/teardown-race.json
+++ b/tools/falsify/specs/teardown-race.json
@@ -1,0 +1,41 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "the isolation pass stops excluding the network it is editing, so a delete of that network lands inside the edit",
+      "file": "internal/core/machine/incus_isolate.go",
+      "find": "\trelease := d.networkLock(network)\n\tdefer release()\n\tgone, err := d.gone(ctx, \"/1.0/networks/\"+network)",
+      "replace": "\trelease := d.networkLock(network)\n\trelease()\n\tdefer release()\n\tgone, err := d.gone(ctx, \"/1.0/networks/\"+network)",
+      "test": "TestAnIsolationDetachDoesNotOrphanTheNetworkBeingDeleted"
+    },
+    {
+      "label": "the isolation pass stops asking whether the network is still there, so a detach issued after the delete edits a network the daemon has forgotten",
+      "file": "internal/core/machine/incus_isolate.go",
+      "find": "\tif gone {\n\t\treturn fmt.Errorf(\"%w: %s\", ErrNetworkGone, network)\n\t}",
+      "replace": "\tif gone && false {\n\t\treturn fmt.Errorf(\"%w: %s\", ErrNetworkGone, network)\n\t}",
+      "test": "TestIsolationRefusesANetworkWhoseDeleteAlreadyRan"
+    },
+    {
+      "label": "a vanished network becomes a silent success in the driver: nothing is applied and nothing is said",
+      "file": "internal/core/machine/incus_isolate.go",
+      "find": "\tif gone {\n\t\treturn fmt.Errorf(\"%w: %s\", ErrNetworkGone, network)\n\t}\n\tname := isolationACL(network)",
+      "replace": "\tif gone {\n\t\tif err := fmt.Errorf(\"%w: %s\", ErrNetworkGone, network); err != nil {\n\t\t\treturn nil\n\t\t}\n\t}\n\tname := isolationACL(network)",
+      "test": "TestIsolationRefusesANetworkWhoseDeleteAlreadyRan"
+    },
+    {
+      "label": "a vanished network becomes a silent success in the reconciliation: the driver reports it and the pass says nothing",
+      "file": "internal/core/machine/isolate.go",
+      "find": "\tif errors.Is(err, ErrNetworkGone) {\n\t\tlog.Warn(\"the \"+noun+\"'s network was removed while its isolation was being reconciled, so none was applied\",\n\t\t\tnoun, m.ID, \"network\", m.Network, \"error\", err)\n\t\treturn\n\t}\n\tlog.Error(\"could not \"+verb+\" the \"+noun+\"'s network\",\n\t\tnoun, m.ID, \"network\", m.Network, \"error\", err)",
+      "replace": "\tif errors.Is(err, ErrNetworkGone) {\n\t\treturn\n\t}\n\tlog.Error(\"could not \"+verb+\" the \"+noun+\"'s network\",\n\t\tnoun, m.ID, \"network\", m.Network, \"error\", err)",
+      "test": "TestAVanishedNetworkIsReportedRatherThanSwallowed"
+    },
+    {
+      "label": "the teardown stops dropping the rule set that isolated the network, and leaves one nothing will ever reconcile",
+      "file": "internal/core/machine/incus.go",
+      "find": "\tif err := d.RemoveFirewall(ctx, isolationACL(name)); err != nil {\n\t\treturn fmt.Errorf(\"drop the isolation rule set of %s: %w\", name, err)\n\t}",
+      "replace": "\tif block == \"\\x00never\" {\n\t\tif err := d.RemoveFirewall(ctx, isolationACL(name)); err != nil {\n\t\t\treturn fmt.Errorf(\"drop the isolation rule set of %s: %w\", name, err)\n\t\t}\n\t}",
+      "test": "TestRemoveNetworkDropsTheIsolationRuleSetWithIt"
+    }
+  ],
+  "note": "The interleaving is staged, not bet on. fakeNetd models the one behaviour #386 observed on the station: a config edit re-applies the network — bridge up, dnsmasq restarted — before it opens /var/lib/incus/networks/<name>/dnsmasq.raw, so an edit that meets a delete leaves the service standing for a network that is gone, which is the leftover #342 measured (a dnsmasq holding 10.50.2.1 on a bridge whose network object had vanished). The delete goroutine starts on the first command the isolation path issues, so the two overlap on every run rather than on a lucky schedule: the first mutation was measured out of tree on 2026-08-21, red 10/10 with -count=1 and green 10/10 once the lock is put back. The fifth mutation is the ordinary && false, and it fails to build nothing: err stays evaluated on both sides."
+}


### PR DESCRIPTION
`mise run evidence:update` failed three times, and #316, #342 and #375 were all
downstream of the reason. This is the reason.

## Reproduced before anything was changed

`fakeNetd` models the one daemon behaviour the failure logs showed: a network
config edit **re-applies the network first** — bridge up, `dnsmasq` restarted —
and only then opens `.../dnsmasq.raw`. So an edit that meets a delete leaves a
service standing for a network that is gone. That is #342's leftover, written as
an assertion: `orphans()` is the set of names where a service runs and the
network object does not.

The overlap is staged rather than bet on: the delete goroutine starts on the
**first runtime command the isolation path issues**, so the two always meet.
Measured out of tree, `-count=1`: **red 10/10 without the fix, green 10/10 with
it.**

## Two halves, and either alone leaves the race open

**The exclusion key**: `serialise.Lock("incus.network." + name)`, taken by
`EnsureNetwork`, `IsolateNetwork` and `RemoveNetwork`. Per network, never
global — a global lock queues every subnet of a stack behind one delete, the
mistake `serialise.go` already records having made with interface allocation
(#348). `PeerNetworks` deliberately does not take it: it names two networks, so
it would deadlock on opposite halves, and it calls `IsolateNetwork`, which takes
it itself — `serialise.Lock` is not reentrant. Lock order is always
networkLock → `uplinkMu`, never the reverse.

**The check**: a delete that *wins* the lock runs first, and the edit that
follows still lands on a forgotten network. So `IsolateNetwork`, holding the
lock, asks the daemon whether the network is still there.

Each half has its own falsification, because each alone is insufficient.

## The direct measurement that closes it

In the `evidence:update` bridge leg, during the `examples/stacks/outscale`
destroy, at 00:50:14 — two subnets torn down in the same second:

```
WARN the subnet's network was removed while its isolation was being reconciled,
     so none was applied  subnet=… network=fnt-b827a906a71
WARN …                                 subnet=… network=fnt-1cd0c734168
```

`detach isolation from … dnsmasq.raw: no such file or directory`: **0
occurrences.** The race still happens — it is the ordinary shape of a parallel
destroy — and it is now refused, reported and survived instead of orphaning a
`dnsmasq`. That is the rule this repository already states: the state published
is the one the effect produced, not the one the intent aimed at.

## Gates

- `mise run prepush` — green.
- `FEINT_VM=incus-ovn mise run conformance` — **exit 0**, 1149 s, 346/372.
- **`mise run evidence:update` — exit 0, both legs.** The criterion this branch
  exists for.
- `tools/falsify/specs/teardown-race.json` — 5 mutations, all red, none green on
  first try. Verified again after the rebase, and the race hammered
  `-race -count=10`.

## A premise of the issue that the measurement contradicted

**The first `evidence:update` failure of this branch was not the subject.** It
died on a signal kill at minute twelve, on a station simultaneously running a
second full conformance suite with 4 GiB of swap fully consumed; the emulator
log stopped mid-suite carrying neither the `dnsmasq.raw` line nor any address
conflict. It was not reported as "still failing" — the run was repeated in a
quiet window.

## Not measured, and left uncommitted on purpose

- **The evidence registry narrowed by 2** on regeneration: four operations
  demoted off `behaviour`, one promoted. `generated_from.contracts` and
  `.suites` both moved, because the committed artefact was last generated at
  #376 while `contracts/` changed in #385 and `tools/conformance/` in #387 —
  which makes suite drift the likely cause rather than this branch. It could not
  be attributed without a baseline run, and this repository forbids committing a
  shrink untriaged, so **the artefact is restored and the diff is not in this
  branch**.
- **`RemoveNetwork` still loses to `The network is currently in use`** (twice,
  once per run). That is the pre-existing failure `docs/limits.md` records; it
  leaves the network *object* standing with no service, the inverse of this
  leftover. Swept, not fixed here.

## Related

Closes #386
Refs #316, #342, #375, #348
