### PR TITLE
docs(roadmap): the order 0.11.0 is worked in, and why it is a dependency rather than a preference

### DIFF
--- a/docs/roadmap.fr.md
+++ b/docs/roadmap.fr.md
@@ -14,6 +14,74 @@ ce qui est intéressant à construire.
 Ce qui est *mesuré* plutôt que planifié vit dans [limits.md](limits.md) ; la
 façon dont les pièces s'assemblent, dans [architecture.md](architecture.md).
 
+
+## L'ordre dans lequel la 0.11.0 est traitée
+
+Figé le 2026-08-22. Treize issues restent, et elles ne sont pas indépendantes :
+deux d'entre elles déplacent les chiffres que les onze autres citent. L'ordre
+ci-dessous est la dépendance, pas une préférence.
+
+**1 — Rendre la mesure digne de confiance. Bloquant.**
+
+- **#398** — `behaviour` n'est pas reproductible : 313 puis 314 sur deux
+  exécutions identiques. Cause localisée dans `soleClientFlightLocked`, qui jette
+  l'attribution quand deux requêtes clientes sont en vol, sous un span couvrant
+  tout le cycle de vie d'un Terraform en `-parallelism=10`.
+- **#406** — trois pourcentages d'axe publiés sont faux, et rien ne refuse qu'un
+  chiffre mesuré soit écrit à la main hors d'un bloc généré.
+
+*Pourquoi d'abord :* les sept issues de parité citent des chiffres que ces deux-là
+vont déplacer. L'ordre inverse revient à viser une cible mouvante et à republier
+des nombres faux. Les deux sont courtes.
+
+**2 — Répondre à la question qui peut annuler l'essentiel du reste.**
+
+- **#407** — `shape` est le maillon faible à 14 %, et **292 de ses 318 zéros sont
+  `unrecorded`** : des opérations qu'un vrai client pilote déjà, dont la réponse
+  réelle n'a jamais été gardée. Ce dépôt possède déjà **619 échanges enregistrés**
+  dans `corpus/`, et ils n'alimentent pas `shapes/`. Savoir s'ils le peuvent se
+  répond **hors ligne, sans compte, en une session** — et si oui, l'essentiel du
+  volume de parité disparaît sans toucher un cloud.
+
+*Pourquoi ici :* retourner demander à trois comptes des réponses déjà commitées
+serait le pire ordre possible.
+
+**3 — La chaîne du catalogue d'images.**
+
+- **#389**, puis **#383**, puis **#378** — un seul modèle : catalogue → un
+  snapshot que le store détient vraiment → volume BSU racine → Vm, où chaque
+  identifiant publié désigne un objet qui existe. Les deux dernières se ferment
+  derrière sans travail propre.
+
+**4 — La parité, une fois les cibles stables.**
+
+- **#414** d'abord : plus de la moitié de ses opérations sont servies et atteintes
+  par personne — les routes existent, les clients existent, rien ne les a reliés.
+- puis **#413**, **#411**, **#412**, **#410**, et **#409** en dernier (134
+  manques).
+- **#415** voyage avec elles, et relève en partie d'une *décision* : un pool
+  d'instances qu'aucun client supporté ne pilote vaut peut-être mieux décliné
+  avec une raison que servi sans preuve. Elle porte aussi la question de commiter
+  le classificateur de domaines, qui vit encore dans un script jetable.
+
+**5 — La documentation, juste avant le tag.**
+
+- **#403** — délibérément en dernier : la roadmap, `confidence.md` et le README
+  doivent décrire l'état *final* de la release. Les corriger plus tôt, c'est les
+  corriger deux fois.
+
+### La coupe, si la release doit sortir plus tôt
+
+La rupture naturelle est **après la vague 3** : la 0.11.0 livrerait alors la
+mesure, sa fiabilité et la chaîne du catalogue, et les six issues de parité
+deviendraient le cœur de la release suivante. Une release qui ne sort jamais ne
+prouve rien à personne. Prendre cette coupe est une décision, pas un renoncement,
+et elle appartient au mainteneur.
+
+> **Le reste de cette page est périmé et #403 la réécrit.** Elle présente encore
+> `feint replay`, `coverage --observed` et l'injection de fautes comme du travail
+> à venir ; les trois sont livrés. Lire les jalons pour ce qui est vrai.
+
 ## Comment lire cette page
 
 Chaque élément énonce sa **preuve** : la chose qui sera vraie quand il sera

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,6 +8,73 @@ done. It is ordered by what unblocks a user, not by what is interesting to build
 What is *measured* rather than planned lives in [limits.md](limits.md), and how
 the pieces fit together in [architecture.md](architecture.md).
 
+
+## The order 0.11.0 is being worked in
+
+Frozen 2026-08-22. Thirteen issues remain, and they are not independent: two of
+them move the numbers the other eleven quote. The order below is the dependency,
+not a preference.
+
+**1 — Make the measurement trustworthy. Blocking.**
+
+- **#398** — `behaviour` is not reproducible: 313 and 314 on two identical runs.
+  Cause located in `soleClientFlightLocked`, which discards the attribution when
+  two client requests are in flight, under a span covering the whole lifecycle
+  of a Terraform running at `-parallelism=10`.
+- **#406** — three published axis percentages are wrong, and nothing refuses a
+  measured number written by hand outside a generated block.
+
+*Why first:* the seven parity issues quote figures these two will move. Working
+them in the other order means aiming at a moving target and republishing wrong
+numbers. Both are short.
+
+**2 — Answer the question that can cancel most of the remaining work.**
+
+- **#407** — `shape` is the weakest axis at 14 %, and **292 of its 318 zeros are
+  `unrecorded`**: operations a real client already drives, whose real answer was
+  never kept. This repository already holds **619 recorded exchanges** in
+  `corpus/`, and they do not feed `shapes/`. Whether they can is answerable
+  **offline, without an account, in one sitting** — and if they can, most of the
+  parity volume disappears without touching a cloud.
+
+*Why here:* going back to three accounts for answers already committed would be
+the worst possible order.
+
+**3 — The image catalogue chain.**
+
+- **#389**, then **#383**, then **#378** — one model: catalogue → a snapshot the
+  store really holds → root BSU volume → Vm, where every published identifier
+  names an object that exists. The last two close behind it with no work of
+  their own.
+
+**4 — Parity, once the targets stop moving.**
+
+- **#414** first: more than half its operations are served and reached by
+  nobody — the routes exist, the clients exist, nothing connected them.
+- then **#413**, **#411**, **#412**, **#410**, and **#409** last (134 gaps).
+- **#415** travels with them, and is partly a *decision*: an instance pool no
+  supported client drives may be better declined with a reason than served
+  without evidence. It also carries the question of committing the domain
+  classifier, which still lives in a throwaway script.
+
+**5 — Documentation, immediately before the tag.**
+
+- **#403** — deliberately last: the roadmap, `confidence.md` and the README must
+  describe the release's final state. Correcting them earlier means correcting
+  them twice.
+
+### The cut, if the release needs to ship sooner
+
+The natural break is **after wave 3**: 0.11.0 would then deliver the
+measurement, its trustworthiness and the catalogue chain, and the six parity
+issues would become the core of the next release. A release that never ships
+proves nothing to anybody. Taking that cut is a decision, not a slip, and it
+belongs to the maintainer.
+
+> **The rest of this page is out of date and #403 rewrites it.** It still
+> presents `feint replay`, `coverage --observed` and fault injection as work to
+> come; all three shipped. Read the milestones for what is true.
+
 ## How to read this
 
 Every item states its **evidence**: the thing that will be true when it is done,


### PR DESCRIPTION
Thirteen issues remain in 0.11.0 and **two of them move the numbers the other eleven quote**. The order is written down because it is not obvious and is expensive to get wrong.

## What it says

1. **Trust the measurement** — #398 (`behaviour` returns 313 and 314 on two identical runs) and #406 (three published axis percentages are wrong, and nothing refuses a measured number written by hand). Working parity before these means aiming at a moving target and republishing wrong figures.
2. **The question that can cancel most of the rest** — #407: **292 of `shape`'s 318 zeros are `unrecorded`**, and this repository already holds **619 recorded exchanges** in `corpus/` that do not feed `shapes/`. Whether they can is answerable offline, without an account. Going back to three accounts for answers already committed would be the worst possible order.
3. **The image catalogue chain** — #389, then #383, then #378, as one model rather than three patches.
4. **Parity** — #414 first because it is cheapest, #409 last because it is 134 gaps.
5. **Documentation** — #403 deliberately last, so it describes the release's final state instead of being corrected twice.

The cut, if the release must ship sooner, is named too: **after wave 3**. That is the maintainer's decision, and writing it down is not the same as taking it.

## One thing the page now says about itself

The section ends by stating that **the rest of `roadmap.md` is out of date and #403 rewrites it** — it still presents `feint replay`, `coverage --observed` and fault injection as work to come, and all three shipped.

That warning sits *before* the first stale line rather than after. A roadmap presenting shipped work as future work is worse than no roadmap: it is wrong in the direction that undersells the project, and a reader who catches it stops trusting the pages that are right.

The milestone description carries the same order, for whoever is working rather than reading.

## Related

Refs #403, which rewrites the rest of this page.