### PR TITLE
fix(evidence): a store touch is credited to the request that made it, and no page may state an axis percentage by hand (#398, #406)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -497,8 +497,7 @@ change ni l'un ni l'autre a sa place dans `git log`.
   **La mesure qui l'a demandé.** `coverage/evidence.json` porte sept axes par
   opération montée. `negative` tenait à 34 sur 357, loin en dessous de tous les
   autres : cet émulateur prouvait ce que ses routes répondent quand tout va bien
-  et presque
-  rien de ce qu'elles répondent quand ça se passe mal, de sorte que les chemins
+  et presque rien de ce qu'elles répondent quand ça se passe mal, et les chemins
   de dégradation d'un client ne pouvaient être que simulés, dans les tests de ce
   client. #356 a mesuré l'autre bout du même trou : aucun en-tête
   d'authentification répondait `200`, et un jeton bidon aussi.
@@ -1023,8 +1022,8 @@ change ni l'un ni l'autre a sa place dans `git log`.
   opérations, est désormais identique entre deux exécutions, là où six entrées
   `behaviour` exactement différaient avant, et rien d'autre. Cinq opérations
   récupérées, aucune perdue, et chaque span de chaque suite a rapporté zéro
-  touche non attribuée. Ce qui reste
-  inattribuable est borné et dit plutôt que jeté : une requête déjà en vol quand
+  touche non attribuée. Ce qui reste inattribuable est borné et dit plutôt que
+  jeté : une requête déjà en vol quand
   un span s'ouvre ne porte pas d'identité, la fermeture du span publie combien de
   touches cela a coûté, et `tools/conformance/prove.sh` l'affiche.
 

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -495,8 +495,9 @@ change ni l'un ni l'autre a sa place dans `git log`.
   émulateur neuf n'arme rien.
 
   **La mesure qui l'a demandé.** `coverage/evidence.json` porte sept axes par
-  opération montée. Six dépassaient 85 % ; `negative` tenait à 34 sur 357 : cet
-  émulateur prouvait ce que ses routes répondent quand tout va bien et presque
+  opération montée. `negative` tenait à 34 sur 357, loin en dessous de tous les
+  autres : cet émulateur prouvait ce que ses routes répondent quand tout va bien
+  et presque
   rien de ce qu'elles répondent quand ça se passe mal, de sorte que les chemins
   de dégradation d'un client ne pouvaient être que simulés, dans les tests de ce
   client. #356 a mesuré l'autre bout du même trou : aucun en-tête
@@ -993,6 +994,60 @@ change ni l'un ni l'autre a sa place dans `git log`.
   replay sait qu'elles en sont.
 
 ### Corrigé
+
+- **L'axe `behaviour` était une fonction de l'ordonnanceur, et deux exécutions
+  identiques s'accordaient sur le total en désaccord sur six opérations**
+  (#398). Deux `mise run conformance` du même commit, machines éteintes, ont
+  marqué **311** opérations chacune sans marquer les mêmes :
+  `block/v1/API.CreateVolume`, `osc/Client.DeleteSecurityGroupRule` et
+  `osc/Client.UnlinkLoadBalancerBackendMachines` dans la première,
+  `instance/v2alpha1/API.DeletePrivateNetworkInterface`,
+  `instance/v2alpha1/API.GetPlacementGroup` et `osc/Client.UnlinkVolume` dans la
+  seconde. L'égalité des totaux est le piège, et c'est pourquoi le correctif se
+  mesure sur les ensembles : le critère d'acceptation de l'issue, le même chiffre
+  deux fois, passe sur le code défectueux.
+
+  Une touche du store n'était attribuée que tant qu'une seule requête non sonde
+  était en vol dans tout le processus, et terraform tourne en `-parallelism=10`
+  sous un span qui couvre tout son cycle de vie. Le store répond déjà à la
+  question que cette règle approximait : `Observe` exécute son rappel de façon
+  synchrone, hors du verrou du store, **sur la goroutine qui a fait la touche**.
+  C'est ce qui est lu maintenant, et cela met fin à une surestimation que
+  personne n'avait vue : une touche faite par la goroutine de la sonde, ou par un
+  handler que `serveFault` appelle directement et qui n'entre jamais dans
+  l'ensemble en vol, était créditée à n'importe quelle requête cliente qui se
+  trouvait en vol à côté.
+
+  Mesuré après le changement, même machine, même commit, machines éteintes :
+  **316 et 316, et les mêmes 316**. Le registre entier, sept axes et 370
+  opérations, est désormais identique entre deux exécutions, là où six entrées
+  `behaviour` exactement différaient avant, et rien d'autre. Cinq opérations
+  récupérées, aucune perdue, et chaque span de chaque suite a rapporté zéro
+  touche non attribuée. Ce qui reste
+  inattribuable est borné et dit plutôt que jeté : une requête déjà en vol quand
+  un span s'ouvre ne porte pas d'identité, la fermeture du span publie combien de
+  touches cela a coûté, et `tools/conformance/prove.sh` l'affiche.
+
+- **Trois pourcentages d'axe publiés dans la documentation étaient faux, et rien
+  dans le dépôt ne refusait un chiffre mesuré écrit à la main** (#406).
+  `docs/proxy.md`, `docs/conformance.md`, `corpus/README.md`, les deux CHANGELOG
+  et le tableau d'ouverture de #390 affirmaient que six des sept axes de preuve
+  se tenaient dans une plage de pourcentages. Mesuré avec `feint coverage
+  --evidence coverage/evidence.json` sur le même artefact, trois des six en
+  sortaient, et l'un d'un facteur six. La cause est la règle 2 du skill
+  measurement-integrity appliquée aux chiffres phares du projet : ils venaient
+  d'un script jetable qui lisait chaque axe comme un booléen, `if o.get(axe)`,
+  alors que trois des sept sont des verdicts. `"unobserved"` est une chaîne non
+  vide, donc toute opération dont la forme n'avait jamais été comparée à une
+  réponse de vrai cloud comptait comme une opération qui l'avait été.
+
+  Tous sont corrigés, et `docs/proxy.md` porte une note qui dit ce qu'il
+  affirmait, parce qu'un chiffre édité en silence n'apprend rien. La récidive est
+  l'objet du changement : **un pourcentage d'axe vit dans un bloc généré ou nulle
+  part**, et `feint docs --check`, que lancent prepush et le crochet pre-commit,
+  refuse un pourcentage posé à côté d'un nom d'axe hors d'un bloc, dans tout
+  Markdown du dépôt. Les décomptes sont laissés tels quels : « 35 sur 370 » est
+  ce dont une file de travail est faite.
 
 - **La suite de conformance orphelinait un de ses propres réseaux en cours
   d'exécution, et cette seule course de démantèlement est ce dont #316, #342 et

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -1028,6 +1028,16 @@ change ni l'un ni l'autre a sa place dans `git log`.
   un span s'ouvre ne porte pas d'identité, la fermeture du span publie combien de
   touches cela a coûté, et `tools/conformance/prove.sh` l'affiche.
 
+  Et l'autre moitié de la même issue : `runtimesLost` refusait une régénération
+  qui atteint moins de *runtimes*, et rien ne regardait les opérations, de sorte
+  qu'un registre pouvait rétrograder une opération dont l'assertion était encore
+  dans la suite et passait encore, sans un mot. `feint evidence` nomme désormais,
+  axe par axe, chaque opération que le registre remplacé avait gagnée et que
+  cette exécution n'atteint pas. Un rapport et non un refus : un axe peut
+  légitimement rétrécir quand une affirmation est corrigée, et une suite qui perd
+  une assertion *doit* rétrograder ce qu'elle prouvait, ce qui est la
+  falsification sous laquelle ce registre vit.
+
 - **Trois pourcentages d'axe publiés dans la documentation étaient faux, et rien
   dans le dépôt ne refusait un chiffre mesuré écrit à la main** (#406).
   `docs/proxy.md`, `docs/conformance.md`, `corpus/README.md`, les deux CHANGELOG
@@ -1048,6 +1058,17 @@ change ni l'un ni l'autre a sa place dans `git log`.
   refuse un pourcentage posé à côté d'un nom d'axe hors d'un bloc, dans tout
   Markdown du dépôt. Les décomptes sont laissés tels quels : « 35 sur 370 » est
   ce dont une file de travail est faite.
+
+  **Le même défaut a été trouvé dans le lecteur Go du dépôt pendant que la
+  correction était testée**, et c'est la partie qui mérite d'être gardée.
+  `probed` était gagné par `e.Probed != "none"`, donc une ligne ne portant aucun
+  verdict, la chaîne vide qu'`encoding/json` laisse pour une clé absente, gagnait
+  l'axe, exactement comme `if o.get(axe)` le faisait dans le script. Il est
+  nommé positivement maintenant, et `readEvidence` refuse un registre dont
+  `probed`, `contract` ou `shape` sort de son propre vocabulaire : le commentaire
+  de cette fonction affirmait déjà qu'elle « refuse ce dont elle ne peut rendre
+  compte » et ne le faisait pas, ce qui est le défaut récurrent le plus coûteux
+  de ce dépôt rencontré une fois de plus.
 
 - **La suite de conformance orphelinait un de ses propres réseaux en cours
   d'exécution, et cette seule course de démantèlement est ce dont #316, #342 et

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -988,6 +988,15 @@ what this project is judged on: **a response shape a client can observe**, and
   flight when a span opens carries no identity, the close of the span publishes
   how many touches that cost, and `tools/conformance/prove.sh` prints it.
 
+  And the other half of the same issue: `runtimesLost` refused a regeneration
+  that reached fewer *runtimes*, and nothing ever looked at the operations, so a
+  record could demote one whose assertion was still in the suite and still
+  passing without a word. `feint evidence` now names, axis by axis, every
+  operation the record it replaces had earned and this run does not. A report
+  and not a refusal, because an axis may legitimately shrink when a claim is
+  corrected and a suite that loses an assertion *must* demote what it proved —
+  that is the falsification this record lives under.
+
 - **Three axis percentages published in the documentation were wrong, and
   nothing in the repository refused a measured number written by hand** (#406).
   `docs/proxy.md`, `docs/conformance.md`, `corpus/README.md`, both CHANGELOGs and
@@ -1007,6 +1016,16 @@ what this project is judged on: **a response shape a client can observe**, and
   pre-commit hook run — refuses a percentage sitting next to an axis name outside
   one, in any Markdown of this repository. Counts are untouched: "35 of 370" is
   what a work queue is made of.
+
+  **The same defect was found in this repository's own reader while the
+  correction was being tested**, which is the part worth keeping. `probed` was
+  earned by `e.Probed != "none"`, so a row carrying no verdict at all — the empty
+  string `encoding/json` leaves for a missing key — earned the axis, exactly as
+  `if o.get(axis)` did in the script. It is named positively now, and
+  `readEvidence` refuses a record whose `probed`, `contract` or `shape` is
+  outside its own vocabulary: the function's comment already claimed it "refuses
+  what it cannot account for" and did not, which is this repository's most
+  expensive recurring defect met once more.
 
 - **The conformance run orphaned one of its own networks mid-run, and that one
   teardown race is what #316, #342 and #375 were all downstream of** (#386).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -489,8 +489,8 @@ what this project is judged on: **a response shape a client can observe**, and
   nothing.
 
   **The measurement that asked for it.** `coverage/evidence.json` carries seven
-  axes per mounted operation. Six stood above 85%; `negative` stood at 34 of 357
-  — this emulator proved what its routes answer when everything goes well and
+  axes per mounted operation. `negative` stood at 34 of 357, far below every
+  other — this emulator proved what its routes answer when everything goes well and
   almost nothing about what they answer when it does not, so a client's
   degradation paths could only be simulated in that client's own tests. #356
   measured the other end of the same gap: no authentication header at all
@@ -953,6 +953,60 @@ what this project is judged on: **a response shape a client can observe**, and
   identifiers.
 
 ### Fixed
+
+- **The `behaviour` axis was a function of the scheduler, and two identical runs
+  agreed on the total while disagreeing on six operations** (#398). Two
+  `mise run conformance` runs of the same commit, machines off, marked **311**
+  operations each and did not mark the same 311: `block/v1/API.CreateVolume`,
+  `osc/Client.DeleteSecurityGroupRule` and
+  `osc/Client.UnlinkLoadBalancerBackendMachines` in the first,
+  `instance/v2alpha1/API.DeletePrivateNetworkInterface`,
+  `instance/v2alpha1/API.GetPlacementGroup` and `osc/Client.UnlinkVolume` in the
+  second. The equal totals are the trap, and they are why the fix is measured on
+  sets: the issue's own acceptance criterion — the same figure twice — passes on
+  the broken code.
+
+  A store touch was credited to an operation only while exactly one non-probe
+  request was in flight anywhere in the process, and terraform runs at
+  `-parallelism=10` under a span bracketing its whole lifecycle. The store
+  already answers the question that rule approximated: `Observe` runs its
+  callback synchronously, outside the store's lock, **on the goroutine that made
+  the touch**, so the handler goroutine is the causal link between a request and
+  what it touches. That is read now, and it ends an over-claim nobody had
+  noticed as well: a touch made by the probe's goroutine, or by a handler
+  `serveFault` calls directly and which never enters the flight set, used to be
+  credited to whichever unrelated client request happened to be in flight beside
+  it.
+
+  Measured after the change, same host, same commit, machines off: **316 and
+  316, and the same 316** — the whole record, all seven axes and all 370
+  operations, is now identical between two runs, where before exactly six
+  `behaviour` entries differed and nothing else. Five operations were recovered,
+  none lost, and every span of every suite reported zero touches it could not
+  attribute. What is still
+  unattributable is bounded and said rather than dropped: a request already in
+  flight when a span opens carries no identity, the close of the span publishes
+  how many touches that cost, and `tools/conformance/prove.sh` prints it.
+
+- **Three axis percentages published in the documentation were wrong, and
+  nothing in the repository refused a measured number written by hand** (#406).
+  `docs/proxy.md`, `docs/conformance.md`, `corpus/README.md`, both CHANGELOGs and
+  #390's opening table stated that six of the seven evidence axes stood in a
+  percentage band. Measured with `feint coverage --evidence coverage/evidence.json`
+  on the same artefact, three of the six were outside it and one by a factor of
+  six. The cause is rule 2 of the measurement-integrity skill met on this
+  project's own headline numbers: the figures came from a throwaway script that
+  read each axis as a boolean, `if o.get(axis)`, when three of the seven are
+  verdicts — `"unobserved"` is a non-empty string, so every operation whose shape
+  had never been compared to a real cloud answer counted as one that had.
+
+  Every one of them is corrected, and `docs/proxy.md` carries a note saying what
+  it used to claim, because a number edited in silence teaches nothing. The
+  recurrence is what the change is for: **an axis percentage now lives inside a
+  generated block or nowhere**, and `feint docs --check` — which prepush and the
+  pre-commit hook run — refuses a percentage sitting next to an axis name outside
+  one, in any Markdown of this repository. Counts are untouched: "35 of 370" is
+  what a work queue is made of.
 
 - **The conformance run orphaned one of its own networks mid-run, and that one
   teardown race is what #316, #342 and #375 were all downstream of** (#386).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -490,8 +490,8 @@ what this project is judged on: **a response shape a client can observe**, and
 
   **The measurement that asked for it.** `coverage/evidence.json` carries seven
   axes per mounted operation. `negative` stood at 34 of 357, far below every
-  other — this emulator proved what its routes answer when everything goes well and
-  almost nothing about what they answer when it does not, so a client's
+  other — this emulator proved what its routes answer when everything goes well
+  and almost nothing about what they answer when it does not, so a client's
   degradation paths could only be simulated in that client's own tests. #356
   measured the other end of the same gap: no authentication header at all
   answered `200`, and so did a junk bearer token.

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -315,6 +315,27 @@ enregistrement : elles peuvent bouger aussi.
 
 ## Ce que j'ai ecarte, et pourquoi
 
+> **Fait, et par une troisieme voie que cette section n'avait pas envisagee**
+> (branche `feat/398-406-measurement`). L'identite causale n'a pas demande de
+> `ctx` : `runtime.Stack` publie l'identifiant de la goroutine appelante, et
+> comme `store.Observe` garantit deja que le rappel tourne sur la goroutine qui
+> a fait la touche, cela suffit a attribuer exactement, sans toucher un seul des
+> 593 sites d'appel. `soleClientFlightLocked` a disparu comme prevu. Le cout,
+> une marche de pile de 12 a 22 microsecondes, n'est paye que pendant qu'un span
+> est ouvert.
+>
+> **Mesure** : avant, deux passes identiques marquaient **311 et 311** en
+> desaccord sur **six operations** — le total qui s'accorde est le piege, et le
+> critere « le meme chiffre deux fois » passait sur le code casse. Apres,
+> **316 et 316, et les memes 316** : le registre entier, sept axes et 370
+> operations, est identique entre deux passes, machines eteintes. La prediction
+> « ~314-316 stable » ci-dessous etait juste.
+>
+> **Reste a faire** : `coverage/evidence.json` n'a pas ete regenere, faute
+> d'avoir a demarrer des machines. Sa colonne `behaviour` (312) est donc encore
+> un tirage d'avant le correctif. `mise run evidence:update` sur un hote qui
+> peut demarrer des machines la remet a jour, et `feint docs` suit.
+
 **#398, attribution exacte par le contexte de requete.** `store.Observe`
 documente que le callback tourne **sur la goroutine qui a fait la touche**
 (`store.go:60-63`), donc l'operation pourrait etre portee par le contexte au lieu

--- a/corpus/README.md
+++ b/corpus/README.md
@@ -299,7 +299,7 @@ and that the script proved the account was as it was found.
 ## The refusal corpora, and what a client meets on its worst day
 
 `negative` is the seventh evidence axis and it stood at **35 of 370** while the
-other six stood between 85 and 100 % (#390). This emulator proved what it
+other six stood far above it (#390). This emulator proved what it
 answers when everything goes well and almost nothing about what it answers when
 it does not, and the three files above are the measurement that changes that.
 
@@ -320,7 +320,7 @@ and reported as it came rather than as anybody wanted it:
 
 | | before | after |
 |---|---|---|
-| `negative`, all providers | 35 of 370 (9.5 %) | **173 of 370 (46.8 %)** |
+| `negative`, all providers | 35 of 370 | **173 of 370** |
 | Scaleway | 18 of 173 | 97 of 173 |
 | Outscale | 11 of 93 | 66 of 93 |
 | Exoscale | 6 of 104 | 10 of 104 |

--- a/docs/conformance.fr.md
+++ b/docs/conformance.fr.md
@@ -182,8 +182,8 @@ plus petite.
 
 L'émulateur sait refuser à dessein : `PUT /_feint/faults` arme une règle qui
 nomme une opération et un statut, éteinte par défaut, déterministe, effacée par
-un `DELETE`. Elle existe parce que six des sept axes ci-dessus dépassaient 85 %
-quand `negative` tenait à 34 sur 357 : cet émulateur prouvait ce que ses routes
+un `DELETE`. Elle existe parce que `negative` tenait à 34 sur 357 quand tous les
+autres axes se tenaient loin au-dessus : cet émulateur prouvait ce que ses routes
 répondent quand tout va bien et presque rien de ce qu'elles répondent quand ça se
 passe mal, de sorte que les chemins de dégradation d'un client ne pouvaient être
 que simulés, dans les tests de ce client.

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -191,8 +191,8 @@ publishing a smaller truth quietly.
 The emulator can be made to refuse on purpose: `PUT /_feint/faults` arms a rule
 naming an operation and a status, off by default, deterministic, cleared by a
 `DELETE`. It exists because `negative` stood at 34 of 357 while every other axis
-stood far above it — this emulator proved what its routes answer when
-everything goes well and almost nothing about what they answer when it does not,
+stood far above it — this emulator proved what its routes answer when everything
+goes well and almost nothing about what they answer when it does not,
 so a client's degradation paths could only be simulated in that client's own
 tests.
 

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -190,8 +190,8 @@ publishing a smaller truth quietly.
 
 The emulator can be made to refuse on purpose: `PUT /_feint/faults` arms a rule
 naming an operation and a status, off by default, deterministic, cleared by a
-`DELETE`. It exists because six of the seven axes above stood over 85% while
-`negative` stood at 34 of 357 — this emulator proved what its routes answer when
+`DELETE`. It exists because `negative` stood at 34 of 357 while every other axis
+stood far above it — this emulator proved what its routes answer when
 everything goes well and almost nothing about what they answer when it does not,
 so a client's degradation paths could only be simulated in that client's own
 tests.

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -789,9 +789,20 @@ comparison runs nowhere.
 ### Recording the unhappy path
 
 A refusal is the cheapest recording there is, and for a long time this project
-had none. Six evidence axes stood between 85 and 100 % and `negative` stood at
-35 of 370: this emulator proved what it answers when everything goes well and
-almost nothing about what it answers when it does not (#390).
+had none. `negative` stood at 35 of 370 while every other axis stood far above
+it: this emulator proved what it answers when everything goes well and almost
+nothing about what it answers when it does not (#390).
+
+> **What this paragraph used to say, because a number corrected in silence
+> teaches nothing.** It published a percentage band and put six of the seven
+> evidence axes inside it. Three of those six were outside it, one of them by a
+> factor of six, and #390's opening table repeated the same figures. The cause
+> was a throwaway script that read each axis as a boolean when three of the
+> seven are verdicts: `"unobserved"` is a non-empty string, so every operation
+> whose shape had never been compared to a real cloud answer counted as one that
+> had (#406). The figures now live in one place, the generated table in
+> [What the three packs have proven](routes.md#what-the-three-packs-have-proven),
+> and `feint docs --check` refuses a page that states one by hand.
 
 **It cannot be closed by fabricating refusals.** `PUT /_feint/faults` can make
 any operation answer 403, and #26 made sure such an answer earns nothing, so the

--- a/docs/roadmap.fr.md
+++ b/docs/roadmap.fr.md
@@ -36,7 +36,7 @@ des nombres faux. Les deux sont courtes.
 
 **2 — Répondre à la question qui peut annuler l'essentiel du reste.**
 
-- **#407** — `shape` est le maillon faible à 14 %, et **292 de ses 318 zéros sont
+- **#407** — `shape` est le maillon faible de loin, et **292 de ses 318 zéros sont
   `unrecorded`** : des opérations qu'un vrai client pilote déjà, dont la réponse
   réelle n'a jamais été gardée. Ce dépôt possède déjà **619 échanges enregistrés**
   dans `corpus/`, et ils n'alimentent pas `shapes/`. Savoir s'ils le peuvent se

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -31,8 +31,8 @@ numbers. Both are short.
 **2 — Answer the question that can cancel most of the remaining work.**
 
 - **#407** — `shape` is the weakest axis by a wide margin, and **292 of its 318
-  zeros are `unrecorded`**: operations a real client already drives, whose real answer was
-  never kept. This repository already holds **619 recorded exchanges** in
+  zeros are `unrecorded`**: operations a real client already drives, whose real
+  answer was never kept. This repository already holds **619 recorded exchanges** in
   `corpus/`, and they do not feed `shapes/`. Whether they can is answerable
   **offline, without an account, in one sitting** — and if they can, most of the
   parity volume disappears without touching a cloud.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -30,8 +30,8 @@ numbers. Both are short.
 
 **2 — Answer the question that can cancel most of the remaining work.**
 
-- **#407** — `shape` is the weakest axis at 14 %, and **292 of its 318 zeros are
-  `unrecorded`**: operations a real client already drives, whose real answer was
+- **#407** — `shape` is the weakest axis by a wide margin, and **292 of its 318
+  zeros are `unrecorded`**: operations a real client already drives, whose real answer was
   never kept. This repository already holds **619 recorded exchanges** in
   `corpus/`, and they do not feed `shapes/`. Whether they can is answerable
   **offline, without an account, in one sitting** — and if they can, most of the

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -68,11 +68,11 @@ refusals real clients really got, and no amount of arming faults can raise them.
 
 A percentage here is of the operations this emulator *serves*, never of the
 provider's whole API — that comparison is the coverage table in the
-[README](../README.md#coverage), which counts the upstream surface. And one
-axis is not reproducible to the operation: `behaviour` attributes a store touch
-only while a single client request is in flight, so a parallel client loses
-attribution rather than being guessed about, and the count moves by about one
-between runs (#398).
+[README](../README.md#coverage), which counts the upstream surface. And every
+column is reproducible: `behaviour` used to attribute a store touch only while
+a single client request was in flight, so two identical runs disagreed on which
+operations earned it. It now reads the goroutine that made the touch, and a
+span that still cannot attribute one says how many it lost (#398).
 <!-- axes:end -->
 
 ## Every route

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -68,11 +68,12 @@ refusals real clients really got, and no amount of arming faults can raise them.
 
 A percentage here is of the operations this emulator *serves*, never of the
 provider's whole API — that comparison is the coverage table in the
-[README](../README.md#coverage), which counts the upstream surface. And every
-column is reproducible: `behaviour` used to attribute a store touch only while
-a single client request was in flight, so two identical runs disagreed on which
-operations earned it. It now reads the goroutine that made the touch, and a
-span that still cannot attribute one says how many it lost (#398).
+[README](../README.md#coverage), which counts the upstream surface. And one
+column used to move on its own: `behaviour` attributed a store touch only while
+a single client request was in flight, so two identical runs marked the same
+number of operations and not the same ones. It reads the goroutine that made
+the touch now — two runs with machines off produce an identical record, and a
+span that still cannot attribute a touch says how many it lost (#398).
 <!-- axes:end -->
 
 ## Every route

--- a/internal/cli/docs.go
+++ b/internal/cli/docs.go
@@ -312,6 +312,12 @@ func docs(args []string, stdout, stderr io.Writer) int {
 	// stack CI applies with nothing, declared nowhere. Neither is repaired by
 	// regenerating, which is why they belong here rather than in the render.
 	problems = append(problems, stackProofProblems(*workflow, conformanceRoot, stacksRoot, stacksScript)...)
+	// And the class #406 measured: a percentage about an evidence axis, typed
+	// into a page, that nothing ever compared to coverage/evidence.json. Three
+	// of them were wrong when somebody finally did, one by a factor of six.
+	// Regenerating repairs none of it — the sentence has to go — which is why it
+	// belongs here and not among the splices. See docs_axis_figures.go.
+	problems = append(problems, axisFigureProblems(filepath.Dir(*target))...)
 	if len(problems) > 0 {
 		for _, line := range problems {
 			fmt.Fprintf(stderr, "feint: %s\n", line)

--- a/internal/cli/docs_axes.go
+++ b/internal/cli/docs_axes.go
@@ -132,11 +132,11 @@ func renderAxes(evidence *evidenceArtefact) (string, error) {
 	b.WriteString("refusals real clients really got, and no amount of arming faults can raise them.\n\n")
 	b.WriteString("A percentage here is of the operations this emulator *serves*, never of the\n")
 	b.WriteString("provider's whole API — that comparison is the coverage table in the\n")
-	b.WriteString("[README](../README.md#coverage), which counts the upstream surface. And one\n")
-	b.WriteString("axis is not reproducible to the operation: `behaviour` attributes a store touch\n")
-	b.WriteString("only while a single client request is in flight, so a parallel client loses\n")
-	b.WriteString("attribution rather than being guessed about, and the count moves by about one\n")
-	b.WriteString("between runs (#398).\n")
+	b.WriteString("[README](../README.md#coverage), which counts the upstream surface. And every\n")
+	b.WriteString("column is reproducible: `behaviour` used to attribute a store touch only while\n")
+	b.WriteString("a single client request was in flight, so two identical runs disagreed on which\n")
+	b.WriteString("operations earned it. It now reads the goroutine that made the touch, and a\n")
+	b.WriteString("span that still cannot attribute one says how many it lost (#398).\n")
 	return b.String(), nil
 }
 

--- a/internal/cli/docs_axes.go
+++ b/internal/cli/docs_axes.go
@@ -132,11 +132,12 @@ func renderAxes(evidence *evidenceArtefact) (string, error) {
 	b.WriteString("refusals real clients really got, and no amount of arming faults can raise them.\n\n")
 	b.WriteString("A percentage here is of the operations this emulator *serves*, never of the\n")
 	b.WriteString("provider's whole API — that comparison is the coverage table in the\n")
-	b.WriteString("[README](../README.md#coverage), which counts the upstream surface. And every\n")
-	b.WriteString("column is reproducible: `behaviour` used to attribute a store touch only while\n")
-	b.WriteString("a single client request was in flight, so two identical runs disagreed on which\n")
-	b.WriteString("operations earned it. It now reads the goroutine that made the touch, and a\n")
-	b.WriteString("span that still cannot attribute one says how many it lost (#398).\n")
+	b.WriteString("[README](../README.md#coverage), which counts the upstream surface. And one\n")
+	b.WriteString("column used to move on its own: `behaviour` attributed a store touch only while\n")
+	b.WriteString("a single client request was in flight, so two identical runs marked the same\n")
+	b.WriteString("number of operations and not the same ones. It reads the goroutine that made\n")
+	b.WriteString("the touch now — two runs with machines off produce an identical record, and a\n")
+	b.WriteString("span that still cannot attribute a touch says how many it lost (#398).\n")
 	return b.String(), nil
 }
 

--- a/internal/cli/docs_axis_figures.go
+++ b/internal/cli/docs_axis_figures.go
@@ -1,0 +1,175 @@
+package cli
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// No document states an axis percentage by hand (#406).
+//
+// What happened. `docs/proxy.md` said "Six evidence axes stood between 85 and
+// 100 %", `docs/conformance.md` and both CHANGELOGs said the same in other
+// words, and #390's table published `probed`, `contract` and `shape` at 100 %.
+// Measured against the very artefact they described, with the command that
+// exists to read it — `feint coverage --evidence coverage/evidence.json` — the
+// three were **89 %, 89 % and 14 %**. One was wrong by a factor of six.
+//
+// Nobody lied, and that is the point: the figures came from a throwaway script
+// that read each axis as a boolean, `if o.get(axis)`, when three of the seven
+// are verdicts rather than booleans. `"unobserved"` is a non-empty string, so
+// every operation whose shape had never been compared to a real cloud answer
+// counted as one that had. That is rule 2 of the measurement-integrity skill —
+// three outcomes, never two — met on this project's own headline numbers.
+//
+// Why a correction was not enough, and it is the argument docs.go makes twice
+// already for the coverage tables and the contract policy table: a hand-written
+// number about a measured quantity is a claim nothing compares to anything. #402
+// shipped the mechanism — a generated block held by `feint docs --check` — and
+// it held one block in docs/routes.md. Everywhere else, any page could still
+// print an axis percentage no gate ever read.
+//
+// So: an axis percentage lives inside a generated block or it does not exist.
+// Prose may say "measured per provider, see the table"; it may not carry the
+// number. Counts are left alone deliberately — "35 of 370" is what a work queue
+// is made of, and the defect measured here was a percentage.
+//
+// The check is crude on purpose. It does not recompute anything, because the
+// failure was somebody typing a number rather than somebody computing a wrong
+// one: a percentage sitting next to an axis name, outside a generated block, is
+// refused whatever its value. Being crude is what makes it hold for a figure
+// nobody has invented yet.
+//
+// TestAHandWrittenAxisPercentageIsRefused fails without it, and
+// tools/falsify/specs/axis-figures.json puts the sentence back.
+
+// axisFigureWindow is how close a percentage must sit to an axis name to count
+// as a figure about that axis, in bytes of the stripped document.
+//
+// 120 is not arbitrary: it is one wrapped Markdown line plus a margin, which is
+// the distance across which the ten real sentences in this repository stated
+// theirs, and it leaves the one percentage here that is *not* about an axis
+// alone — "Scaleway marks 11 % of its schemas required", forty characters from
+// a link whose anchor happens to contain the word contract.
+const axisFigureWindow = 120
+
+var (
+	// The seven axis names, as a document writes them: in backticks, which is
+	// how every page here names an axis, and which keeps the ordinary English
+	// words "shape", "contract" and "negative" from anchoring a percentage that
+	// has nothing to do with the record.
+	axisNamePattern = regexp.MustCompile("`(?:driven|probed|contract|dataplane|shape|behaviour|negative)`")
+	// And the word itself, in both languages this repository publishes in.
+	axisWordPattern = regexp.MustCompile(`(?i)\b(?:axis|axes|axe)\b`)
+	// A percentage, however it is spaced or spelled.
+	percentagePattern = regexp.MustCompile(`\d+(?:[.,]\d+)?\s*%`)
+	// A generated block, whatever it is called: every one of them is a marker
+	// pair, and a check that listed them by name would miss the next one.
+	generatedBlockPattern = regexp.MustCompile(`(?s)<!--\s*[a-z-]+:start\s*-->.*?<!--\s*[a-z-]+:end\s*-->`)
+	// A fenced code block. A sample of command output is not prose, and the
+	// generated blocks print one.
+	codeFencePattern = regexp.MustCompile("(?sm)^```.*?^```")
+)
+
+// axisFigureProblems reports every hand-written axis percentage under root, one
+// line per occurrence, sorted so two runs read the same.
+//
+// A tree with no Markdown reports nothing rather than failing: `feint docs` must
+// keep working for somebody who installed the binary and has no docs/ directory.
+func axisFigureProblems(root string) []string {
+	var found []string
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil //nolint:nilerr // an unreadable corner of the tree is not this check's verdict
+		}
+		if d.IsDir() {
+			// .git and .upstream are not this repository's prose, and .claude
+			// holds the worktrees other agents work in — walking it would scan
+			// whole copies of this tree and report the same sentence twice.
+			switch d.Name() {
+			case ".git", ".upstream", ".claude", ".terraform", "node_modules", "dist":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), ".md") {
+			return nil
+		}
+		body, readErr := os.ReadFile(path) //nolint:gosec // a documentation tree, walked by design
+		if readErr != nil {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			rel = path
+		}
+		found = append(found, axisFiguresIn(rel, string(body))...)
+		return nil
+	})
+	sort.Strings(found)
+	return found
+}
+
+// axisFiguresIn is the reader, separated from the walk so a test can hand it a
+// document rather than a tree.
+func axisFiguresIn(name, body string) []string {
+	stripped := blankOut(body, generatedBlockPattern)
+	stripped = blankOut(stripped, codeFencePattern)
+
+	anchors := append(axisNamePattern.FindAllStringIndex(stripped, -1),
+		axisWordPattern.FindAllStringIndex(stripped, -1)...)
+
+	var found []string
+	for _, at := range percentagePattern.FindAllStringIndex(stripped, -1) {
+		for _, anchor := range anchors {
+			if abs(anchor[0]-at[0]) > axisFigureWindow {
+				continue
+			}
+			found = append(found, fmt.Sprintf(
+				"%s:%d states %q beside %q by hand; an axis percentage belongs in a generated "+
+					"block or nowhere (#406) — say \"see the per-provider table in docs/routes.md\", "+
+					"or quote a count instead",
+				name, lineOf(stripped, at[0]),
+				strings.TrimSpace(stripped[at[0]:at[1]]),
+				strings.TrimSpace(stripped[anchor[0]:anchor[1]])))
+			break
+		}
+	}
+	return found
+}
+
+// blankOut replaces every match with spaces, keeping newlines so the offsets and
+// the line numbers of everything after it stay true. Replacing the whole match
+// with spaces was the first version and it reported docs/proxy.md:682 for a
+// sentence on line 792.
+func blankOut(s string, re *regexp.Regexp) string {
+	return re.ReplaceAllStringFunc(s, func(m string) string {
+		var b strings.Builder
+		b.Grow(len(m))
+		// Byte by byte, not rune by rune: a multi-byte character replaced by one
+		// space shortens the document and moves every offset after it.
+		for i := range len(m) {
+			if m[i] == '\n' {
+				b.WriteByte('\n')
+				continue
+			}
+			b.WriteByte(' ')
+		}
+		return b.String()
+	})
+}
+
+func lineOf(s string, offset int) int {
+	return strings.Count(s[:offset], "\n") + 1
+}
+
+func abs(n int) int {
+	if n < 0 {
+		return -n
+	}
+	return n
+}

--- a/internal/cli/docs_axis_figures_test.go
+++ b/internal/cli/docs_axis_figures_test.go
@@ -1,0 +1,145 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #406. A check whose success is "nothing was found" is indistinguishable from
+// a check that looked nowhere, so the first test plants the three sentences
+// this repository actually published and requires each of them to be named,
+// and the second plants one in a tree and requires the walk to reach it.
+// The third holds the documentation itself.
+
+func TestAHandWrittenAxisPercentageIsRefused(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		body     string
+		refused  bool
+		mentions string
+	}{
+		{
+			name: "the sentence docs/proxy.md published",
+			body: "A refusal is the cheapest recording there is, and for a long time this\n" +
+				"project had none. Six evidence axes stood between 85 and 100 % and\n" +
+				"`negative` stood at 35 of 370.\n",
+			refused: true, mentions: "100 %",
+		},
+		{
+			name:    "the sentence docs/conformance.md published",
+			body:    "It exists because six of the seven axes above stood over 85% while\n`negative` stood at 34 of 357.\n",
+			refused: true, mentions: "85%",
+		},
+		{
+			name:    "the sentence docs/roadmap.md published",
+			body:    "- **#407** — `shape` is the weakest axis at 14 %, and 292 of its 318 zeros\n  are `unrecorded`.\n",
+			refused: true, mentions: "14 %",
+		},
+		{
+			// The one form that is allowed, and the reason the check is about
+			// percentages: a count is what a work queue is made of, and it says
+			// its own population out loud.
+			name:    "a count beside an axis is not a percentage",
+			body:    "`negative` stood at 35 of 370, and 138 operations gained it.\n",
+			refused: false,
+		},
+		{
+			// The generated table prints seven percentages per row and must not
+			// report itself. This is the case that would make the check useless
+			// if it were wrong in the other direction.
+			name: "a percentage inside a generated block",
+			body: "Before.\n\n<!-- axes:start -->\n| Cloud | `shape` |\n|---|---|\n| All | 14 % |\n<!-- axes:end -->\n\nAfter.\n",
+
+			refused: false,
+		},
+		{
+			name:    "a percentage inside a fenced code block",
+			body:    "Reproduce it:\n\n```text\nall 370 shape 52 14%\n```\n\nDone.\n",
+			refused: false,
+		},
+		{
+			// Measured on docs/conformance.md: a percentage about required
+			// schemas, forty characters from a link whose anchor contains the
+			// word "contract". Flagging it would teach that the check cries
+			// wolf, which is how a gate stops being read.
+			name: "a percentage that is not about an axis",
+			body: "It can only catch an omitted field where the provider marked it\n" +
+				"`required` — Scaleway does on 11% of its schemas.\n" +
+				"[limits.md](limits.md#what-a-green-contract-run-does-and-does-not-prove)\n" +
+				"carries the measured detail.\n",
+			refused: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			found := axisFiguresIn("docs/example.md", tc.body)
+			switch {
+			case tc.refused && len(found) == 0:
+				t.Fatalf("this sentence was published and the check does not name it:\n%s", tc.body)
+			case !tc.refused && len(found) > 0:
+				t.Fatalf("nothing here states an axis percentage and the check names %v", found)
+			}
+			if tc.refused && !strings.Contains(found[0], tc.mentions) {
+				t.Errorf("the report must quote the figure %q, and says: %s", tc.mentions, found[0])
+			}
+		})
+	}
+}
+
+func TestTheAxisFigureScanReadsTheWholeDocumentationTree(t *testing.T) {
+	root := t.TempDir()
+	for _, dir := range []string{"docs", filepath.Join("corpus"), filepath.Join(".claude", "worktrees", "other")} {
+		if err := os.MkdirAll(filepath.Join(root, dir), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write := func(rel, body string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(root, rel), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	const sentence = "`shape` is the weakest axis at 14 %.\n"
+	write("README.md", "Nothing measured here.\n")
+	write(filepath.Join("docs", "roadmap.md"), sentence)
+	write(filepath.Join("corpus", "README.md"), sentence)
+	// A neighbouring worktree is a whole copy of this repository. Reported, it
+	// would double every line and name a file the operator cannot edit from here.
+	write(filepath.Join(".claude", "worktrees", "other", "roadmap.md"), sentence)
+
+	found := axisFigureProblems(root)
+	if len(found) != 2 {
+		t.Fatalf("two documents state it and the scan reports %d: %v", len(found), found)
+	}
+	if !strings.HasPrefix(found[0], "corpus/README.md:1") || !strings.HasPrefix(found[1], "docs/roadmap.md:1") {
+		t.Errorf("the report must name the file and the line, sorted; it says %v", found)
+	}
+}
+
+// The line number must survive a generated block, and it did not at first: the
+// first version replaced a whole block with spaces, newlines included, so the
+// sentence really on line 792 of docs/proxy.md was reported as line 682. A
+// report that names the wrong line sends the reader to the wrong sentence, and
+// they conclude the check is broken rather than the page.
+func TestTheReportedLineSurvivesAGeneratedBlock(t *testing.T) {
+	body := "one\n<!-- axes:start -->\ntwo\nthree\nfour\n<!-- axes:end -->\nsix\n" +
+		"`shape` is the weakest axis at 14 %.\n"
+	found := axisFiguresIn("docs/example.md", body)
+	if len(found) != 1 {
+		t.Fatalf("one sentence states it and the check reports %d: %v", len(found), found)
+	}
+	if !strings.HasPrefix(found[0], "docs/example.md:8 ") {
+		t.Errorf("the sentence is on line 8 and the report says: %s", found[0])
+	}
+}
+
+// The documentation itself, held to the rule. This is the assertion that fails
+// the day somebody writes the next one, and `feint docs --check` carries the
+// same call so a pull request fails on it too.
+func TestNoDocumentInThisRepositoryStatesAnAxisPercentage(t *testing.T) {
+	if found := axisFigureProblems(repoRoot(t)); len(found) > 0 {
+		t.Errorf("an axis percentage belongs in a generated block or nowhere (#406):\n%s",
+			strings.Join(found, "\n"))
+	}
+}

--- a/internal/cli/evidence.go
+++ b/internal/cli/evidence.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -93,6 +94,72 @@ func runtimesLost(path string, next *evidenceArtefact) ([]string, error) {
 	}
 	sort.Strings(lost)
 	return lost, nil
+}
+
+// axesLost answers, per axis, the operations the record already at path had
+// earned and this one does not.
+//
+// It is a report and not a refusal, and the distinction is the one runtimesLost
+// already draws for a different reason: an axis may legitimately shrink when a
+// claim is corrected — #156 took `probed` from 181 arrivals down to 83 verdicts
+// — and a suite that loses an assertion *must* demote what it proved, which is
+// the falsification this record lives under. Refusing a narrowing here would
+// break that.
+//
+// What it must not do is happen in silence. #398 measured why: two identical
+// conformance runs marked 311 operations each on `behaviour` and disagreed on
+// six of them, so a regeneration could demote an operation whose assertion was
+// still in the suite and still passing, and nothing said a word. The attribution
+// is deterministic now, so a loss printed here names real work — an assertion
+// that went, or a suite that did not run — rather than a scheduling accident.
+//
+// A record that cannot be read loses nothing it can name: the caller has already
+// been told, by runtimesLost, that the comparison could not be made.
+// TestARegenerationNamesTheOperationsItDemotes fails without this.
+func axesLost(path string, next *evidenceArtefact) map[string][]string {
+	existing, err := readEvidence(path)
+	if err != nil || existing == nil {
+		return nil
+	}
+	lost := map[string][]string{}
+	for _, axis := range evidenceAxisList() {
+		for op, was := range existing.Operations {
+			if !axis.earned(was) {
+				continue
+			}
+			now, still := next.Operations[op]
+			if still && axis.earned(now) {
+				continue
+			}
+			lost[axis.Name] = append(lost[axis.Name], op)
+		}
+	}
+	for _, ops := range lost {
+		sort.Strings(ops)
+	}
+	return lost
+}
+
+// reportAxesLost prints what a write demotes, axis by axis, or nothing at all
+// when it demotes nothing.
+func reportAxesLost(w io.Writer, path string, next *evidenceArtefact) {
+	lost := axesLost(path, next)
+	if len(lost) == 0 {
+		return
+	}
+	for _, axis := range evidenceAxisList() {
+		ops := lost[axis.Name]
+		if len(ops) == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "feint: this run no longer reaches %d operation(s) that %s had earned on `%s`:\n",
+			len(ops), path, axis.Name)
+		for _, op := range ops {
+			fmt.Fprintf(w, "feint:   %s\n", op)
+		}
+	}
+	fmt.Fprintf(w, "feint: a record may legitimately shrink when a claim is corrected or an "+
+		"assertion is removed, and this is not a failure — it is the demotion said out loud (#398).\n")
 }
 
 func evidence(args []string, stdout, stderr io.Writer) int {
@@ -217,6 +284,9 @@ func evidence(args []string, stdout, stderr io.Writer) int {
 		}
 	}
 
+	// Said before the write, so it is still true of the file being replaced.
+	reportAxesLost(stderr, *out, art)
+
 	blob, err := json.MarshalIndent(art, "", "  ")
 	if err != nil {
 		fmt.Fprintf(stderr, "feint: %v\n", err)
@@ -248,7 +318,38 @@ func readEvidence(path string) (*evidenceArtefact, error) {
 	if art.Version != evidenceVersion {
 		return nil, fmt.Errorf("%s carries version %d, this binary writes %d; regenerate rather than mix", path, art.Version, evidenceVersion)
 	}
+	// The three axes that are verdicts rather than booleans, held to their own
+	// vocabulary. The comment above this function claims it refuses what it
+	// cannot account for and it did not: a missing key decodes to the empty
+	// string, every reader downstream then had to decide what an empty verdict
+	// means, and #406 is the record of what happens when one of them decides
+	// wrong. Refused here, at the boundary, so no consumer has to.
+	// TestAnAxisWithNoVerdictIsNotEarned fails without it.
+	for op, ev := range art.Operations {
+		if bad := unknownVerdict(ev); bad != "" {
+			return nil, fmt.Errorf("%s: %s carries %s, which is not one of the values this record uses; regenerate it", path, op, bad)
+		}
+	}
 	return &art, nil
+}
+
+// unknownVerdict names the first field of one row whose value is outside its
+// declared vocabulary, or "" when the row accounts for itself.
+func unknownVerdict(ev emulator.Evidence) string {
+	for _, field := range []struct {
+		name  string
+		value string
+		valid []string
+	}{
+		{"probed", ev.Probed, []string{emulator.ProbeResponse, emulator.ProbeRefusal, emulator.ProbeNone}},
+		{"contract", ev.Contract, []string{emulator.ContractClean, emulator.ContractViolating, emulator.ContractUnchecked}},
+		{"shape", ev.Shape, []string{emulator.ShapeObserved, emulator.ShapeUnobserved, emulator.ShapeUnknown}},
+	} {
+		if !slices.Contains(field.valid, field.value) {
+			return fmt.Sprintf("%s: %q", field.name, field.value)
+		}
+	}
+	return ""
 }
 
 // joinEvidence merges the two legs of one regeneration. Booleans take the

--- a/internal/cli/evidence_axes.go
+++ b/internal/cli/evidence_axes.go
@@ -85,7 +85,15 @@ func evidenceAxisList() []evidenceAxis {
 		{
 			Name:    "probed",
 			Meaning: "the contract-driven probe validated an answer here against the operation's own schema, a success (`response`) or a refusal (`refusal`)",
-			earned:  func(e emulator.Evidence) bool { return e.Probed != emulator.ProbeNone },
+			// Named positively, and that is the point. Written as `!= ProbeNone`
+			// it counted a record carrying no verdict at all — an empty string,
+			// a key encoding/json never found — as a success, which is the very
+			// defect #406 measured in the throwaway script that read a verdict
+			// as a boolean. The other two verdict axes were already positive.
+			// TestAnAxisWithNoVerdictIsNotEarned fails without it.
+			earned: func(e emulator.Evidence) bool {
+				return e.Probed == emulator.ProbeResponse || e.Probed == emulator.ProbeRefusal
+			},
 			verdict: func(e emulator.Evidence) string { return e.Probed },
 		},
 		{

--- a/internal/cli/evidence_test.go
+++ b/internal/cli/evidence_test.go
@@ -275,8 +275,13 @@ func TestEvidenceRefusesToNarrowTheRuntimesItWasEarnedUnder(t *testing.T) {
 
 	earned := &evidenceArtefact{
 		Format: evidenceFormat, Version: evidenceVersion,
-		Machines:   []string{"incus", "none"},
-		Operations: map[string]emulator.Evidence{"instance/v1/API.ListServers": {}},
+		Machines: []string{"incus", "none"},
+		// The three verdict fields carry a declared value, because a record that
+		// leaves them empty is one readEvidence refuses (#406) — and a fixture
+		// that cannot be read measures the reader, not the guard under test.
+		Operations: map[string]emulator.Evidence{
+			"instance/v1/API.ListServers": row(false, false, emulator.ShapeUnobserved),
+		},
 	}
 	writeArtefact(t, path, earned)
 
@@ -284,8 +289,10 @@ func TestEvidenceRefusesToNarrowTheRuntimesItWasEarnedUnder(t *testing.T) {
 	// incus. It must refuse, and name what would go.
 	offOnly := &evidenceArtefact{
 		Format: evidenceFormat, Version: evidenceVersion,
-		Machines:   []string{"none"},
-		Operations: map[string]emulator.Evidence{"instance/v1/API.ListServers": {}},
+		Machines: []string{"none"},
+		Operations: map[string]emulator.Evidence{
+			"instance/v1/API.ListServers": row(false, false, emulator.ShapeUnobserved),
+		},
 	}
 	lost, _ := runtimesLost(path, offOnly)
 	if len(lost) != 1 || lost[0] != "incus" {
@@ -319,5 +326,161 @@ func writeArtefact(t *testing.T, path string, art *evidenceArtefact) {
 	}
 	if err := os.WriteFile(path, append(blob, '\n'), 0o600); err != nil {
 		t.Fatalf("write: %v", err)
+	}
+}
+
+// #398. `runtimesLost` refuses a regeneration that reaches fewer runtimes, and
+// nothing looked at the operations. So a record could quietly demote one whose
+// assertion was still in the suite and still passing — which is exactly the
+// property #123 says this artefact must not have, stated for its own evidence
+// and equally true of a scheduling accident.
+//
+// Report, never refusal: an axis may legitimately shrink when a claim is
+// corrected, and a suite that loses an assertion *must* demote what it proved.
+// Both halves are asserted here, because a check that named every write would
+// pass the first and be worthless.
+func TestARegenerationNamesTheOperationsItDemotes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "evidence.json")
+
+	writeArtefact(t, path, &evidenceArtefact{
+		Format: evidenceFormat, Version: evidenceVersion,
+		Machines: []string{"none"},
+		Operations: map[string]emulator.Evidence{
+			"instance/v1/API.ListServers": row(true, true, emulator.ShapeObserved),
+			"instance/v1/API.GetServer":   row(true, true, emulator.ShapeUnobserved),
+			"instance/v1/API.CreateIP":    row(true, false, emulator.ShapeUnobserved),
+		},
+	})
+
+	// One operation loses `behaviour`, one loses `shape`, one disappears from
+	// the record entirely, and one is untouched.
+	thinner := &evidenceArtefact{
+		Format: evidenceFormat, Version: evidenceVersion,
+		Machines: []string{"none"},
+		Operations: map[string]emulator.Evidence{
+			"instance/v1/API.ListServers": row(true, false, emulator.ShapeUnobserved),
+			"instance/v1/API.GetServer":   row(true, true, emulator.ShapeUnobserved),
+		},
+	}
+	lost := axesLost(path, thinner)
+	for axis, want := range map[string][]string{
+		"behaviour": {"instance/v1/API.ListServers"},
+		"shape":     {"instance/v1/API.ListServers"},
+		"driven":    {"instance/v1/API.CreateIP"},
+	} {
+		if got := lost[axis]; len(got) != len(want) || (len(got) > 0 && got[0] != want[0]) {
+			t.Errorf("%s: demoted %v, want %v", axis, got, want)
+		}
+	}
+	if len(lost) != 3 {
+		t.Errorf("three axes lost something and the report names %d: %v", len(lost), lost)
+	}
+
+	var said strings.Builder
+	reportAxesLost(&said, path, thinner)
+	for _, want := range []string{"instance/v1/API.ListServers", "`behaviour`", "`shape`", "(#398)"} {
+		if !strings.Contains(said.String(), want) {
+			t.Errorf("the report does not mention %s:\n%s", want, said.String())
+		}
+	}
+
+	// The accepting halves. A record that keeps everything says nothing, and a
+	// record that gains an axis is a widening.
+	wider := &evidenceArtefact{
+		Format: evidenceFormat, Version: evidenceVersion,
+		Machines: []string{"none"},
+		Operations: map[string]emulator.Evidence{
+			"instance/v1/API.ListServers": row(true, true, emulator.ShapeObserved),
+			"instance/v1/API.GetServer":   negativeToo(row(true, true, emulator.ShapeUnobserved)),
+			"instance/v1/API.CreateIP":    row(true, false, emulator.ShapeUnobserved),
+		},
+	}
+	if got := axesLost(path, wider); len(got) != 0 {
+		t.Errorf("a record that loses nothing reports %v", got)
+	}
+	var quiet strings.Builder
+	reportAxesLost(&quiet, path, wider)
+	if quiet.Len() != 0 {
+		t.Errorf("a write that demotes nothing must say nothing, and says: %s", quiet.String())
+	}
+	// And the first write of an artefact demotes nothing.
+	if got := axesLost(filepath.Join(dir, "absent.json"), thinner); len(got) != 0 {
+		t.Errorf("writing where no record exists reports %v", got)
+	}
+}
+
+// row is one evidence line whose three verdict fields carry a value the record
+// actually uses. Written as a helper because a literal that leaves them empty is
+// exactly the row TestAnAxisWithNoVerdictIsNotEarned refuses, and a fixture that
+// cannot be read is a fixture that measures the reader.
+func row(driven, behaviour bool, shape string) emulator.Evidence {
+	return emulator.Evidence{
+		Driven: driven, Behaviour: behaviour, Shape: shape,
+		Probed: emulator.ProbeNone, Contract: emulator.ContractUnchecked,
+	}
+}
+
+func negativeToo(e emulator.Evidence) emulator.Evidence {
+	e.Negative = true
+	return e
+}
+
+// #406's cause, in this repository's own reader rather than in the throwaway
+// script that carried it first: three of the seven axes are verdicts, and a
+// predicate written as "not the losing value" counts a row that carries no
+// verdict at all as a success. `probed` was written that way — `!= "none"` — so
+// an artefact missing the key, which encoding/json decodes to "", earned it.
+//
+// Two controls, because either alone leaves the hole open: the predicate names
+// what earns the axis, and the boundary refuses a row it cannot account for so
+// no future consumer has to decide again.
+func TestAnAxisWithNoVerdictIsNotEarned(t *testing.T) {
+	// The verdict axes, asked of the list rather than named here, so a fourth
+	// one added later is held to the same rule without editing this test.
+	full := emulator.Evidence{
+		Probed: emulator.ProbeResponse, Contract: emulator.ContractClean, Shape: emulator.ShapeObserved,
+	}
+	var axes []evidenceAxis
+	for _, a := range evidenceAxisList() {
+		if a.verdict(full) != "" {
+			axes = append(axes, a)
+		}
+	}
+	if len(axes) != 3 {
+		t.Fatalf("three axes are verdicts and the list carries %d", len(axes))
+	}
+	// A row with every verdict field empty: nothing about it was ever measured,
+	// so it earns none of the three.
+	for _, a := range axes {
+		if a.earned(emulator.Evidence{}) {
+			t.Errorf("`%s` is earned by a row that carries no verdict at all", a.Name)
+		}
+	}
+
+	// And such a row never reaches a predicate, because the record is refused.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "evidence.json")
+	writeArtefact(t, path, &evidenceArtefact{
+		Format: evidenceFormat, Version: evidenceVersion,
+		Machines:   []string{"none"},
+		Operations: map[string]emulator.Evidence{"instance/v1/API.ListServers": {Driven: true}},
+	})
+	_, err := readEvidence(path)
+	if err == nil {
+		t.Fatal("a record whose verdicts are outside their vocabulary was accepted")
+	}
+	if !strings.Contains(err.Error(), "instance/v1/API.ListServers") || !strings.Contains(err.Error(), "probed") {
+		t.Errorf("the refusal must name the operation and the field, and says: %v", err)
+	}
+
+	// The accepting half: a record whose verdicts are all declared reads back.
+	writeArtefact(t, path, &evidenceArtefact{
+		Format: evidenceFormat, Version: evidenceVersion,
+		Machines:   []string{"none"},
+		Operations: map[string]emulator.Evidence{"instance/v1/API.ListServers": row(true, true, emulator.ShapeObserved)},
+	})
+	if _, err := readEvidence(path); err != nil {
+		t.Errorf("a record that accounts for itself was refused: %v", err)
 	}
 }

--- a/internal/core/emulator/assert.go
+++ b/internal/core/emulator/assert.go
@@ -87,8 +87,11 @@ import (
 //
 //   - it made the axis a function of the scheduler. Terraform runs at
 //     `-parallelism=10` under a span bracketing its whole lifecycle, so how
-//     much the axis lost depended on how the run happened to interleave: 313
-//     and 314 on two identical runs of the same commit (#398).
+//     much the axis lost depended on how the run happened to interleave. #398
+//     filed 313 and 314 on two identical runs of the same commit; two more runs
+//     marked 311 each and disagreed on six operations, which is the sharper
+//     measurement and the one to remember: the count agreeing proves nothing,
+//     only the set does.
 //   - it could also over-claim, which is the half nobody had noticed. A touch
 //     made by the probe's goroutine, or by a handler the fault injector calls
 //     directly (serveFault, which never enters the flight set), was attributed

--- a/internal/core/emulator/assert.go
+++ b/internal/core/emulator/assert.go
@@ -73,12 +73,33 @@ import (
 // demanded refusal earns it, so an operation marked here has had one of its
 // refusals observed and says nothing about the others it owes.
 //
-// Attribution of a store touch to an operation goes through the in-flight set:
-// a touch is attributed only while exactly one non-probe request is being
-// handled. Sequential suites — every span-emitting block is one — always
-// satisfy that; a parallel client like terraform loses attribution for the
-// overlapping windows rather than being guessed about, so the axis can only
-// under-claim, never over-claim.
+// # Attribution: which request caused a store touch
+//
+// The store answers that question itself. `store.Observe` runs its callback
+// synchronously, outside the store's lock, on the goroutine that made the
+// touch, so the goroutine handling a request is the causal link between that
+// request and every touch the handler makes. That is what is read here, and
+// goroutine.go carries how and what it costs.
+//
+// It used to be approximated instead: a touch was attributed while exactly one
+// non-probe request was in flight *anywhere in the process*, and dropped
+// otherwise. The approximation reads as conservative and is not only that:
+//
+//   - it made the axis a function of the scheduler. Terraform runs at
+//     `-parallelism=10` under a span bracketing its whole lifecycle, so how
+//     much the axis lost depended on how the run happened to interleave: 313
+//     and 314 on two identical runs of the same commit (#398).
+//   - it could also over-claim, which is the half nobody had noticed. A touch
+//     made by the probe's goroutine, or by a handler the fault injector calls
+//     directly (serveFault, which never enters the flight set), was attributed
+//     to whichever unrelated client request happened to be in flight beside it.
+//     Reading the goroutine ends both, because a touch is now credited to the
+//     request that made it or to nobody.
+//
+// What remains unattributable is named rather than dropped in silence: a touch
+// made outside any request, or by a request already in flight when the span
+// opened, is counted on the span and reported when it closes.
+// TestASpanReportsTheTouchesItCouldNotAttribute holds that.
 //
 // TestABehaviourSpanNeedsAnObservedLifecycle and
 // TestANegativeSpanNeedsARefusal fail without the verification;
@@ -138,13 +159,28 @@ type spanTouch struct {
 type flightEntry struct {
 	operation string
 	synthetic bool
+	// goroutine identifies the handler goroutine, and is 0 when no span was
+	// open at the moment this request began — see beginFlight. A touch can only
+	// be attributed to an entry carrying a real identity.
+	goroutine uint64
 }
 
+// beginFlight records a request as being handled and returns the token that
+// ends it.
+//
+// The goroutine identity is read only while a span is open. It is not free
+// (goroutine.go measures it), and outside a measurement nothing reads it: a
+// `feint serve` nobody is bracketing must not pay for an axis nobody is
+// computing.
 func (o *observer) beginFlight(operation string, synthetic bool) int64 {
+	var gid uint64
+	if o.spansOpen.Load() > 0 {
+		gid = goroutineID()
+	}
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	o.flightSeq++
-	o.flight[o.flightSeq] = flightEntry{operation: operation, synthetic: synthetic}
+	o.flight[o.flightSeq] = flightEntry{operation: operation, synthetic: synthetic, goroutine: gid}
 	return o.flightSeq
 }
 
@@ -154,18 +190,30 @@ func (o *observer) endFlight(token int64) {
 	delete(o.flight, token)
 }
 
-// soleClientFlightLocked names the operation of the only non-probe request in
-// flight, or "" when there is none or more than one. Callers hold o.mu.
-func (o *observer) soleClientFlightLocked() string {
-	found := ""
-	for _, f := range o.flight {
-		if f.synthetic {
+// attributedOperationLocked names the operation of the request being handled on
+// goroutine gid, or "" when that goroutine is handling none, is handling the
+// probe, or carries no identity. Callers hold o.mu.
+//
+// The probe is excluded here rather than at the call site for the reason every
+// other synthetic boundary in this package is drawn: a request the probe
+// composed from a schema says what the schema allows, never what a client did.
+//
+// The last entry wins when a goroutine holds more than one, which today happens
+// nowhere — no handler re-enters wrap — and would mean the inner call is the
+// one that touched the store.
+func (o *observer) attributedOperationLocked(gid uint64) string {
+	if gid == 0 {
+		return ""
+	}
+	found, at := "", int64(0)
+	for token, f := range o.flight {
+		if f.goroutine != gid || token < at {
 			continue
 		}
-		if found != "" {
-			return ""
+		found, at = f.operation, token
+		if f.synthetic {
+			found = ""
 		}
-		found = f.operation
 	}
 	return found
 }
@@ -197,13 +245,21 @@ func (o *observer) offerExchange(e spanExchange) {
 // and offers it to every open span. It runs on the request path, outside the
 // store's lock, and must not call back into the store.
 func (o *observer) storeTouch(ev store.Event) {
+	// Read before the lock, and only when a span could be open: the identity is
+	// of this goroutine either way, and taking o.mu around a stack walk would
+	// queue every other handler behind it.
+	if o.spansOpen.Load() == 0 {
+		return
+	}
+	gid := goroutineID()
+
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	if len(o.spans) == 0 {
 		return
 	}
 	touch := spanTouch{
-		operation: o.soleClientFlightLocked(),
+		operation: o.attributedOperationLocked(gid),
 		action:    ev.Action,
 		provider:  ev.Provider,
 		kind:      ev.Kind,
@@ -221,18 +277,25 @@ func (o *observer) storeTouch(ev store.Event) {
 // close computes what a span proved, or explains why it proved nothing. The
 // error is the emulator refusing the claim, and the suite must treat it as a
 // failure of its own.
-func (sp *assertSpan) close() ([]string, error) {
+//
+// unattributed is the second return because it is the span's own account of
+// what it could not measure: touches that took part in the lifecycle and that
+// no request could be credited with. It is zero for every span in every suite
+// here, and a span that ever reports otherwise is saying its number is short by
+// that much rather than letting the shortfall pass as a smaller measurement.
+func (sp *assertSpan) close() (ops []string, unattributed int, err error) {
 	if sp.overflowed {
-		return nil, fmt.Errorf("%s", spanOverflowMsg)
+		return nil, 0, fmt.Errorf("%s", spanOverflowMsg)
 	}
 	switch sp.proves {
 	case ProvesNegative:
-		return sp.refusedOperations()
+		ops, err = sp.refusedOperations()
+		return ops, 0, err
 	case ProvesBehaviour:
 		return sp.lifecycleOperations()
 	}
 	// Unreachable through the handler, which validates the axis on open.
-	return nil, fmt.Errorf("unknown axis %q", sp.proves)
+	return nil, 0, fmt.Errorf("unknown axis %q", sp.proves)
 }
 
 func (sp *assertSpan) refusedOperations() ([]string, error) {
@@ -269,7 +332,7 @@ func (sp *assertSpan) refusedOperations() ([]string, error) {
 	return sortedOps(ops), nil
 }
 
-func (sp *assertSpan) lifecycleOperations() ([]string, error) {
+func (sp *assertSpan) lifecycleOperations() (ops []string, unattributed int, err error) {
 	resourceKey := func(t spanTouch) string { return t.provider + "|" + t.kind + "|" + t.id }
 	created := map[string]bool{}
 	completed := map[string]bool{}
@@ -286,7 +349,7 @@ func (sp *assertSpan) lifecycleOperations() ([]string, error) {
 		}
 	}
 	if len(completed) == 0 {
-		return nil, fmt.Errorf("the span declared a lifecycle and the store observed no resource created and then destroyed inside it")
+		return nil, 0, fmt.Errorf("the span declared a lifecycle and the store observed no resource created and then destroyed inside it")
 	}
 
 	// The kinds whose listing counts as reading the lifecycle back.
@@ -295,25 +358,30 @@ func (sp *assertSpan) lifecycleOperations() ([]string, error) {
 		provider, kind, _ := splitResourceKey(k)
 		kinds[provider+"|"+kind] = true
 	}
-	ops := map[string]bool{}
+	marked := map[string]bool{}
 	for _, t := range sp.touches {
-		if t.operation == "" {
-			continue
-		}
+		// Only a touch that would have marked something counts as a loss. A
+		// touch on a resource outside the lifecycle is not attributed and costs
+		// the axis nothing, so counting it would report a shortfall that is not
+		// one — the "three outcomes, never two" rule of the measurement skill
+		// applied to the span's own confession.
+		partOfLifecycle := completed[resourceKey(t)]
 		if t.action == store.EventListed {
-			if kinds[t.provider+"|"+t.kind] {
-				ops[t.operation] = true
-			}
+			partOfLifecycle = kinds[t.provider+"|"+t.kind]
+		}
+		if !partOfLifecycle {
 			continue
 		}
-		if completed[resourceKey(t)] {
-			ops[t.operation] = true
+		if t.operation == "" {
+			unattributed++
+			continue
 		}
+		marked[t.operation] = true
 	}
-	if len(ops) == 0 {
-		return nil, fmt.Errorf("a lifecycle was observed but no operation could be attributed to it")
+	if len(marked) == 0 {
+		return nil, unattributed, fmt.Errorf("a lifecycle was observed but no operation could be attributed to it")
 	}
-	return sortedOps(ops), nil
+	return sortedOps(marked), unattributed, nil
 }
 
 func splitResourceKey(k string) (provider, kind, id string) {
@@ -361,6 +429,7 @@ func (s *Server) handleAssertOpen(w http.ResponseWriter, r *http.Request) {
 	}
 	id := newID()
 	o.spans[id] = &assertSpan{proves: req.Proves}
+	o.spansOpen.Store(int64(len(o.spans)))
 	o.mu.Unlock()
 
 	writeJSON(w, http.StatusCreated, map[string]any{"id": id, "proves": req.Proves})
@@ -379,7 +448,8 @@ func (s *Server) handleAssertClose(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	delete(o.spans, id)
-	ops, err := sp.close()
+	o.spansOpen.Store(int64(len(o.spans)))
+	ops, unattributed, err := sp.close()
 	if err == nil {
 		mark := o.behaviour
 		if sp.proves == ProvesNegative {
@@ -392,8 +462,14 @@ func (s *Server) handleAssertClose(w http.ResponseWriter, r *http.Request) {
 	o.mu.Unlock()
 
 	if err != nil {
-		writeJSON(w, http.StatusConflict, map[string]any{"proves": sp.proves, "error": err.Error()})
+		writeJSON(w, http.StatusConflict, map[string]any{
+			"proves": sp.proves, "error": err.Error(), "unattributed": unattributed})
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"proves": sp.proves, "operations": ops})
+	// unattributed travels with the answer, always, because a span that
+	// silently marked fewer operations than it observed is the defect #398
+	// filed: prove.sh prints it, so a run that loses attribution says so on the
+	// suite's own output instead of moving a number in coverage/evidence.json.
+	writeJSON(w, http.StatusOK, map[string]any{
+		"proves": sp.proves, "operations": ops, "unattributed": unattributed})
 }

--- a/internal/core/emulator/attribution_test.go
+++ b/internal/core/emulator/attribution_test.go
@@ -1,0 +1,162 @@
+package emulator_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/resource"
+)
+
+// #398. Two identical `mise run conformance` runs marked 311 operations each on
+// the `behaviour` axis and disagreed on six of them, because a store touch was
+// attributed to "the only non-probe request in flight" and terraform runs ten
+// requests at a time under one span. The attribution now reads the goroutine
+// that made the touch, which the store guarantees is the one handling the
+// request (goroutine.go).
+//
+// Both tests here drive concurrency deliberately: the first proves the axis
+// survives it, the second proves that what it still cannot attribute is
+// counted and published rather than quietly missing from a number.
+
+// barrierPack mounts two operations that each run a whole lifecycle — create
+// then delete — and hold each other in flight for the entire window in which
+// they touch the store. Nothing about the old attribution could survive it: two
+// non-probe requests were in flight for every touch, so every touch was
+// dropped.
+func barrierPack(env *emulator.Env) stubPack {
+	const provider, kind = "stub", "thing"
+	tenant := resource.Tenant{Provider: provider}
+
+	// Both handlers meet here before the first store touch and leave together,
+	// so the overlap is a fact of the test rather than a hope about timing.
+	var barrier sync.WaitGroup
+	barrier.Add(2)
+	cycle := func(w http.ResponseWriter, _ *http.Request) {
+		barrier.Done()
+		barrier.Wait()
+		id := env.NewID()
+		env.Store.Put(&resource.Resource{ID: id, Kind: kind, Tenant: tenant})
+		env.Store.Delete(provider, kind, id)
+		emulator.WriteJSON(w, http.StatusOK, map[string]string{"id": id})
+	}
+	return stubPack{name: provider, routes: []emulator.Route{
+		{Method: "POST", Path: "/stub/left", Operation: "stub/v1/API.Left", Handler: cycle},
+		{Method: "POST", Path: "/stub/right", Operation: "stub/v1/API.Right", Handler: cycle},
+	}}
+}
+
+func TestConcurrentClientsKeepTheirAttribution(t *testing.T) {
+	env := emulator.DefaultEnv()
+	srv, err := emulator.NewServer(env, barrierPack(env))
+	if err != nil {
+		t.Fatalf("mount the barrier pack: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	span := openSpan(t, ts, "behaviour")
+
+	var wg sync.WaitGroup
+	for _, path := range []string{"/stub/left", "/stub/right"} {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, status := call(t, ts, http.MethodPost, path, "", false); status != http.StatusOK {
+				t.Errorf("%s answered %d", path, status)
+			}
+		}()
+	}
+	wg.Wait()
+
+	body, status := closeSpan(t, ts, span)
+	if status != http.StatusOK {
+		t.Fatalf("two overlapping lifecycles were observed and the close was refused: %d %v", status, body)
+	}
+	// The heart of it: overlapping is not a reason to lose the attribution, and
+	// nothing is left over to confess.
+	if n, _ := body["unattributed"].(float64); n != 0 {
+		t.Errorf("every touch was made by a request being handled, and %v were not attributed", n)
+	}
+
+	ev := viewOf(t, ts).Evidence
+	for _, op := range []string{"stub/v1/API.Left", "stub/v1/API.Right"} {
+		if !ev[op].Behaviour {
+			t.Errorf("%s ran a whole lifecycle inside the span and is not marked", op)
+		}
+	}
+}
+
+// slowPack mounts one operation that waits to be released before touching the
+// store, so a request can be in flight *before* a span opens and still make its
+// touches inside it — the one window the attribution cannot see through,
+// because no identity was recorded when the request began.
+func slowPack(env *emulator.Env, entered chan<- struct{}, release <-chan struct{}) stubPack {
+	const provider, kind = "stub", "thing"
+	tenant := resource.Tenant{Provider: provider}
+	return stubPack{name: provider, routes: []emulator.Route{
+		{Method: "POST", Path: "/stub/slow", Operation: "stub/v1/API.Slow",
+			Handler: func(w http.ResponseWriter, _ *http.Request) {
+				entered <- struct{}{}
+				<-release
+				id := env.NewID()
+				env.Store.Put(&resource.Resource{ID: id, Kind: kind, Tenant: tenant})
+				env.Store.Delete(provider, kind, id)
+				emulator.WriteJSON(w, http.StatusOK, map[string]string{"id": id})
+			}},
+		{Method: "POST", Path: "/stub/quick", Operation: "stub/v1/API.Quick",
+			Handler: func(w http.ResponseWriter, _ *http.Request) {
+				id := env.NewID()
+				env.Store.Put(&resource.Resource{ID: id, Kind: kind, Tenant: tenant})
+				env.Store.Delete(provider, kind, id)
+				emulator.WriteJSON(w, http.StatusOK, map[string]string{"id": id})
+			}},
+	}}
+}
+
+func TestASpanReportsTheTouchesItCouldNotAttribute(t *testing.T) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	env := emulator.DefaultEnv()
+	srv, err := emulator.NewServer(env, slowPack(env, entered, release))
+	if err != nil {
+		t.Fatalf("mount the slow pack: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		call(t, ts, http.MethodPost, "/stub/slow", "", false)
+	}()
+	<-entered // in flight, and no span is open yet
+
+	span := openSpan(t, ts, "behaviour")
+	call(t, ts, http.MethodPost, "/stub/quick", "", false)
+	close(release)
+	<-done
+
+	body, status := closeSpan(t, ts, span)
+	if status != http.StatusOK {
+		t.Fatalf("a lifecycle was observed and the close was refused: %d %v", status, body)
+	}
+	// Two touches — the create and the delete the slow handler made — took part
+	// in a lifecycle this span observed and belong to no request it could name.
+	// Publishing the figure is the whole point: an axis that says "I could not
+	// attribute two of these" is honest, and one that silently marks one
+	// operation fewer is the artefact that moves on its own.
+	if n, _ := body["unattributed"].(float64); n != 2 {
+		t.Errorf("the span made two touches it could not attribute and reports %v", n)
+	}
+	ev := viewOf(t, ts).Evidence
+	if !ev["stub/v1/API.Quick"].Behaviour {
+		t.Error("the attributable lifecycle is not marked")
+	}
+	// And it is still refused the axis rather than guessed onto it.
+	if ev["stub/v1/API.Slow"].Behaviour {
+		t.Error("an operation whose touches could not be attributed earned the axis anyway")
+	}
+}

--- a/internal/core/emulator/conformance.go
+++ b/internal/core/emulator/conformance.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/stephrobert/feint/internal/contract"
@@ -97,14 +98,18 @@ type observer struct {
 	// above say how many; the stream says what happened, once, with its time and
 	// its status.
 	stream *stream
-	// flight is the set of requests currently being handled, so a store touch
-	// can be attributed to the one client exchange that caused it — and only
-	// when there is exactly one, because attributing under concurrency would be
-	// guessing. See assert.go.
+	// flight is the set of requests currently being handled, each with the
+	// identity of its handler goroutine, so a store touch is attributed to the
+	// request that actually made it rather than to whatever else was in flight
+	// beside it. See assert.go and goroutine.go.
 	flight    map[int64]flightEntry
 	flightSeq int64
-	// spans are the assertion spans a suite has opened and not yet closed.
-	spans map[string]*assertSpan
+	// spans are the assertion spans a suite has opened and not yet closed, and
+	// spansOpen is len(spans) readable without the lock: the attribution above
+	// costs a stack walk, and nothing outside a measurement should pay it.
+	// Written under mu, beside every write to spans.
+	spans     map[string]*assertSpan
+	spansOpen atomic.Int64
 	// behaviour and negative record, per operation, the two axes only a closed
 	// span can earn. See assert.go for what each requires.
 	behaviour map[string]bool

--- a/internal/core/emulator/goroutine.go
+++ b/internal/core/emulator/goroutine.go
@@ -1,0 +1,76 @@
+package emulator
+
+import (
+	"runtime"
+)
+
+// Who touched the store: the identity of a goroutine, and why this file exists.
+//
+// The `behaviour` axis credits an operation when the store saw its handler
+// touch a resource whose whole lifecycle a span observed. That needs an answer
+// to "which request caused this touch", and the store gives one for free:
+// `store.Observe` documents that the callback "runs outside the store's lock,
+// **on the goroutine that made the touch**", synchronously, before the touching
+// call returns. So the goroutine handling a request *is* the causal link
+// between that request and every touch it makes. Nothing is guessed.
+//
+// The axis used to approximate that link instead of reading it: a touch was
+// attributed only while exactly one non-probe request was in flight anywhere in
+// the process (soleClientFlightLocked, removed by #398). The approximation is
+// right when nothing overlaps and silent when something does, which made the
+// number a function of the scheduler — 313 and 314 on two identical runs,
+// because terraform runs at `-parallelism=10` under a span that brackets its
+// whole lifecycle.
+//
+// Go publishes no goroutine identity, so this reads the one place the runtime
+// prints it: the header line of `runtime.Stack`, "goroutine 42 [running]:".
+// That is a known cost, not a free one — `runtime.Stack` walks the caller's
+// stack, and an HTTP handler's stack is deep enough for it to measure 12 µs at
+// depth 30 and 22 µs at depth 60 on the machine this was written on. Which is
+// why it is not paid on every request: [observer.beginFlight] asks for an
+// identity only while a span is open, and observer.spansOpen is the check that
+// costs nothing when none is: one atomic load per request, no lock.
+//
+// What that gating means for the record, stated because it is the residual
+// indeterminacy rather than a detail: a request already in flight when a span
+// opens carries no identity, so its touches cannot be attributed. Every suite
+// here opens its span from the shell before launching a client, so no client
+// request is ever in flight at that moment — and when one is, the touch is
+// counted and published by the close of the span, which answers how many
+// touches it could not attribute — see assertSpan.close and prove.sh — instead
+// of silently vanishing.
+//
+// TestConcurrentClientsKeepTheirAttribution fails without this file: it drives
+// two overlapping lifecycles through one span and requires both operations to
+// be marked, which the in-flight approximation could never do.
+
+// goroutineID answers the identity of the calling goroutine, or 0 when the
+// runtime printed something this cannot parse.
+//
+// Zero is not an identity: [observer.attributedOperationLocked] refuses to
+// match on it, so a parse that fails leaves a touch unattributed rather than
+// attributing it to the first flight that also failed to parse.
+func goroutineID() uint64 {
+	// Long enough for "goroutine <id> [", which is all that is read. The rest
+	// of the traceback is written into this buffer and discarded.
+	var buf [32]byte
+	n := runtime.Stack(buf[:], false)
+	b := buf[:n]
+	const prefix = "goroutine "
+	if len(b) < len(prefix)+1 || string(b[:len(prefix)]) != prefix {
+		return 0
+	}
+	var id uint64
+	digits := 0
+	for _, c := range b[len(prefix):] {
+		if c < '0' || c > '9' {
+			break
+		}
+		id = id*10 + uint64(c-'0')
+		digits++
+	}
+	if digits == 0 {
+		return 0
+	}
+	return id
+}

--- a/tools/conformance/prove.sh
+++ b/tools/conformance/prove.sh
@@ -42,13 +42,25 @@ prove_begin() {
 # that supports the span's claim, and that verdict fails the suite: an
 # assertion that says "I proved a lifecycle" or "I demanded a refusal" without
 # the traffic to show for it is a suite defect, not a detail.
+#
+# It also answers how many store touches it could not attribute to a request,
+# and that number is printed rather than dropped. #398 is why: the axis used to
+# lose attribution under a parallel client without saying so, and two identical
+# runs then marked the same *count* of operations while disagreeing on six of
+# them. A span that under-claims must say by how much on the suite's own output,
+# where somebody reads it, rather than by moving a figure in an artefact.
 prove_end() {
-  local id="$1" out code body
+  local id="$1" out code body lost
   out="$(curl -s -w '\n%{http_code}' -X POST "$ENDPOINT/_feint/assert/$id")"
   code="${out##*$'\n'}"
   body="${out%$'\n'*}"
   if [ "$code" != "200" ]; then
     echo "FAIL: the emulator did not observe what this span claims (HTTP $code): $body" >&2
     exit 1
+  fi
+  lost="$(printf '%s' "$body" | jq -r '.unattributed // 0')"
+  if [ "$lost" != "0" ]; then
+    echo "  note: this span made $lost store touch(es) it could not attribute to a request," >&2
+    echo "        so the behaviour axis is short by that much for this block (#398)" >&2
   fi
 }

--- a/tools/falsify/specs/axis-figures.json
+++ b/tools/falsify/specs/axis-figures.json
@@ -1,0 +1,34 @@
+{
+  "package": "./internal/cli/",
+  "mutations": [
+    {
+      "label": "the sentence docs/proxy.md published is written back into the page",
+      "file": "docs/proxy.md",
+      "find": "had none. `negative` stood at 35 of 370 while every other axis stood far above\nit: this emulator proved what it answers when everything goes well and almost",
+      "replace": "had none. Six evidence axes stood between 85 and 100 % and `negative` stood at\n35 of 370 while every other axis stood far above\nit: this emulator proved what it answers when everything goes well and almost",
+      "test": "TestNoDocumentInThisRepositoryStatesAnAxisPercentage"
+    },
+    {
+      "label": "no percentage is ever near enough to an axis name to be reported",
+      "file": "internal/cli/docs_axis_figures.go",
+      "find": "\t\t\tif abs(anchor[0]-at[0]) > axisFigureWindow {",
+      "replace": "\t\t\tif abs(anchor[0]-at[0]) > axisFigureWindow || true {",
+      "test": "TestAHandWrittenAxisPercentageIsRefused"
+    },
+    {
+      "label": "a generated block is blanked with its newlines, and every line after it is reported wrong",
+      "file": "internal/cli/docs_axis_figures.go",
+      "find": "\t\t\tif m[i] == '\\n' {\n\t\t\t\tb.WriteByte('\\n')",
+      "replace": "\t\t\tif m[i] == '\\n' && false {\n\t\t\t\tb.WriteByte('\\n')",
+      "test": "TestTheReportedLineSurvivesAGeneratedBlock"
+    },
+    {
+      "label": "the walk descends into the neighbouring worktrees and reports each sentence twice",
+      "file": "internal/cli/docs_axis_figures.go",
+      "find": "\t\t\tcase \".git\", \".upstream\", \".claude\", \".terraform\", \"node_modules\", \"dist\":",
+      "replace": "\t\t\tcase \".git\", \".upstream\", \".terraform\", \"node_modules\", \"dist\":",
+      "test": "TestTheAxisFigureScanReadsTheWholeDocumentationTree"
+    }
+  ],
+  "note": "#406. Three axis percentages published in docs/proxy.md, docs/conformance.md, both CHANGELOGs, corpus/README.md and #390's opening table were wrong — `probed` and `contract` at 89 % where 100 % was printed, `shape` at 14 % where 100 % was printed — because the script that produced them read a verdict as a boolean and counted `\"unobserved\"` as a success. The correction alone would not survive the next hand, so this is the gate: mutation 1 is the exact sentence going back in, and the other three hold the check's own reading — its window, its line numbers, and the tree it walks."
+}

--- a/tools/falsify/specs/axis-figures.json
+++ b/tools/falsify/specs/axis-figures.json
@@ -28,7 +28,21 @@
       "find": "\t\t\tcase \".git\", \".upstream\", \".claude\", \".terraform\", \"node_modules\", \"dist\":",
       "replace": "\t\t\tcase \".git\", \".upstream\", \".terraform\", \"node_modules\", \"dist\":",
       "test": "TestTheAxisFigureScanReadsTheWholeDocumentationTree"
+    },
+    {
+      "label": "`probed` is earned by anything that is not the losing verdict, an absent one included",
+      "file": "internal/cli/evidence_axes.go",
+      "find": "\t\t\t\treturn e.Probed == emulator.ProbeResponse || e.Probed == emulator.ProbeRefusal",
+      "replace": "\t\t\t\treturn e.Probed != emulator.ProbeNone && (e.Probed == emulator.ProbeResponse || e.Probed == emulator.ProbeRefusal || true)",
+      "test": "TestAnAxisWithNoVerdictIsNotEarned"
+    },
+    {
+      "label": "the record is read without checking that its verdicts are values it uses",
+      "file": "internal/cli/evidence.go",
+      "find": "\t\tif bad := unknownVerdict(ev); bad != \"\" {",
+      "replace": "\t\tif bad := unknownVerdict(ev); bad != \"\" && false {",
+      "test": "TestAnAxisWithNoVerdictIsNotEarned"
     }
   ],
-  "note": "#406. Three axis percentages published in docs/proxy.md, docs/conformance.md, both CHANGELOGs, corpus/README.md and #390's opening table were wrong — `probed` and `contract` at 89 % where 100 % was printed, `shape` at 14 % where 100 % was printed — because the script that produced them read a verdict as a boolean and counted `\"unobserved\"` as a success. The correction alone would not survive the next hand, so this is the gate: mutation 1 is the exact sentence going back in, and the other three hold the check's own reading — its window, its line numbers, and the tree it walks."
+  "note": "#406. Three axis percentages published in docs/proxy.md, docs/conformance.md, both CHANGELOGs, corpus/README.md and #390's opening table were wrong — `probed` and `contract` at 89 % where 100 % was printed, `shape` at 14 % where 100 % was printed — because the script that produced them read a verdict as a boolean and counted `\"unobserved\"` as a success. The correction alone would not survive the next hand, so this is the gate: mutation 1 is the exact sentence going back in, and the other three hold the check's own reading — its window, its line numbers, and the tree it walks. Two later mutations hold the same defect found in this repository's own Go reader while the correction was being tested: `probed` was written as `!= \"none\"`, so a row carrying no verdict at all — the empty string encoding/json leaves for a missing key — earned the axis, and readEvidence accepted such a row despite a comment claiming it refuses what it cannot account for."
 }

--- a/tools/falsify/specs/touch-attribution.json
+++ b/tools/falsify/specs/touch-attribution.json
@@ -21,7 +21,15 @@
       "find": "\t\tif t.operation == \"\" {\n\t\t\tunattributed++\n\t\t\tcontinue\n\t\t}",
       "replace": "\t\tif t.operation == \"\" {\n\t\t\t_ = unattributed\n\t\t\tcontinue\n\t\t}",
       "test": "TestASpanReportsTheTouchesItCouldNotAttribute"
+    },
+    {
+      "label": "a record that reaches fewer operations is written without a word",
+      "file": "internal/cli/evidence.go",
+      "package": "./internal/cli/",
+      "find": "\t\t\tif still && axis.earned(now) {\n\t\t\t\tcontinue\n\t\t\t}",
+      "replace": "\t\t\tif still || axis.earned(now) || true {\n\t\t\t\tcontinue\n\t\t\t}",
+      "test": "TestARegenerationNamesTheOperationsItDemotes"
     }
   ],
-  "note": "#398. The `behaviour` axis marked 311 operations on two identical conformance runs of the same commit and disagreed on six of them — block/v1/API.CreateVolume, osc/Client.DeleteSecurityGroupRule and osc/Client.UnlinkLoadBalancerBackendMachines in one, instance/v2alpha1/API.DeletePrivateNetworkInterface, instance/v2alpha1/API.GetPlacementGroup and osc/Client.UnlinkVolume in the other. The equal totals are the trap: the count alone reads as reproducible and the set is not, which is why the proof of the fix compares sets. Mutation 1 is the old rule's shape (attribution that does not depend on who touched); mutation 2 removes the identity altogether; mutation 3 removes the confession that bounds what is left. All three are neutralising: every identifier the original expression used stays evaluated."
+  "note": "#398. The `behaviour` axis marked 311 operations on two identical conformance runs of the same commit and disagreed on six of them — block/v1/API.CreateVolume, osc/Client.DeleteSecurityGroupRule and osc/Client.UnlinkLoadBalancerBackendMachines in one, instance/v2alpha1/API.DeletePrivateNetworkInterface, instance/v2alpha1/API.GetPlacementGroup and osc/Client.UnlinkVolume in the other. The equal totals are the trap: the count alone reads as reproducible and the set is not, which is why the proof of the fix compares sets. Mutation 1 is the old rule's shape (attribution that does not depend on who touched); mutation 2 removes the identity altogether; mutation 3 removes the confession that bounds what is left. All three are neutralising: every identifier the original expression used stays evaluated. Mutation 4 holds the other half of the issue: runtimesLost refuses a regeneration reaching fewer runtimes and nothing looked at the operations, so a record could demote one whose assertion was still passing without a word."
 }

--- a/tools/falsify/specs/touch-attribution.json
+++ b/tools/falsify/specs/touch-attribution.json
@@ -1,0 +1,27 @@
+{
+  "package": "./internal/core/emulator/",
+  "mutations": [
+    {
+      "label": "a touch is attributed to any request in flight, not to the one that made it",
+      "file": "internal/core/emulator/assert.go",
+      "find": "\t\tif f.goroutine != gid || token < at {",
+      "replace": "\t\tif (f.goroutine != gid && false) || token < at {",
+      "test": "TestConcurrentClientsKeepTheirAttribution"
+    },
+    {
+      "label": "no request records the goroutine handling it, so nothing can be attributed",
+      "file": "internal/core/emulator/assert.go",
+      "find": "\tif o.spansOpen.Load() > 0 {\n\t\tgid = goroutineID()\n\t}",
+      "replace": "\tif o.spansOpen.Load() > 0 && false {\n\t\tgid = goroutineID()\n\t}",
+      "test": "TestConcurrentClientsKeepTheirAttribution"
+    },
+    {
+      "label": "the span stops counting the touches it could not attribute, and under-claims in silence",
+      "file": "internal/core/emulator/assert.go",
+      "find": "\t\tif t.operation == \"\" {\n\t\t\tunattributed++\n\t\t\tcontinue\n\t\t}",
+      "replace": "\t\tif t.operation == \"\" {\n\t\t\t_ = unattributed\n\t\t\tcontinue\n\t\t}",
+      "test": "TestASpanReportsTheTouchesItCouldNotAttribute"
+    }
+  ],
+  "note": "#398. The `behaviour` axis marked 311 operations on two identical conformance runs of the same commit and disagreed on six of them — block/v1/API.CreateVolume, osc/Client.DeleteSecurityGroupRule and osc/Client.UnlinkLoadBalancerBackendMachines in one, instance/v2alpha1/API.DeletePrivateNetworkInterface, instance/v2alpha1/API.GetPlacementGroup and osc/Client.UnlinkVolume in the other. The equal totals are the trap: the count alone reads as reproducible and the set is not, which is why the proof of the fix compares sets. Mutation 1 is the old rule's shape (attribution that does not depend on who touched); mutation 2 removes the identity altogether; mutation 3 removes the confession that bounds what is left. All three are neutralising: every identifier the original expression used stays evaluated."
+}


### PR DESCRIPTION
Wave 1 of 0.11.0: the two issues that had to land before the eleven others,
because they move the numbers those eleven quote.

## The acceptance criterion in the brief was wrong, and the measurement said so

The brief asked for *two identical runs returning the same figure*. Measured on
`origin/main`, before any fix:

**311 and 311 — and the sets differ by six operations.**

```
only run 1  block/v1/API.CreateVolume
            osc/Client.DeleteSecurityGroupRule
            osc/Client.UnlinkLoadBalancerBackendMachines
only run 2  instance/v2alpha1/API.DeletePrivateNetworkInterface
            instance/v2alpha1/API.GetPlacementGroup
            osc/Client.UnlinkVolume
```

**The criterion passes on the broken code.** A count is a bad witness; only the
set is one. Everything below is measured on sets, and the code, the commits and
the changelog say so.

**After**, two quiescent runs at 23:01 and 23:05: **316 and 316, and the same
316.** The whole record — seven axes, 370 operations — is byte-identical between
the two. Five operations recovered, none lost, and every span of every suite
reported zero touches it could not attribute.

## #398 — attribution becomes causal

`store.Observe` already documents that its callback runs synchronously, outside
the store's lock, **on the goroutine that made the touch**. That goroutine *is*
the causal link. `soleClientFlightLocked` was an approximation of it, and reading
identity directly (`internal/core/emulator/goroutine.go`) takes the scheduler out
of the answer.

**The other option loses on its own terms**: making the indeterminacy explicit
cannot deliver the proof, because the residual would itself wobble. It survives
as the *bound* — a request already in flight when a span opens carries no
identity, its touches are counted, and the span's close publishes the number.
Measured at 0 for every span of every suite.

Serialising Terraform was refused: it buys the figure by making the run less like
the client it exists to prove.

### The old rule also over-claimed, which nobody had noticed

A touch made by the probe's goroutine, or by a handler `serveFault` calls
directly — which never enters the flight set — was credited to whichever
unrelated client request happened to be in flight beside it. That **silently
breached bound 4 of `faults.go`**: *nothing an injected fault touches can end up
on an evidence axis*. Causal attribution ends it.

### A premise in HANDOVER.md that the measurement overturned

The brief had discarded exact attribution after weighing threading `ctx` through
**593 store call sites**. Goroutine identity buys the same causality in about
eighty lines and zero call sites. The handover's own prediction — "~314-316,
stable" — was right at 316, and the file now records that its cost estimate had
considered only one of the two ways.

## #406 — ten figures, not three, and a gate so it cannot recur

Re-measured before fixing: the issue's premise holds exactly — `probed` **89 %**,
`contract` **89 %**, `shape` **14 %**, against 100 % published.

**Ten hand-written axis percentages existed, not three**: `docs/proxy.md`,
`docs/conformance.md` and its French half, `corpus/README.md` twice,
both changelogs, and both roadmaps. All gone, with `docs/proxy.md` carrying a
note saying what it had claimed — a silently edited number teaches nothing.
Counts like "35 of 370" are deliberately kept: they name their own population.

The gate is `internal/cli/docs_axis_figures.go`, wired into `docs()`, so
`feint docs --check` exits 2 in prepush and in the pre-commit hook.

**It caught its own first false positive**: the correction note quoted the wrong
band verbatim and had to be rewritten without the figure.

## Two more defects found while proving, both the same family

- **`probed` was earned by `e.Probed != "none"`**, so a row carrying the empty
  string `encoding/json` leaves for a missing key earned the axis. That is
  `if o.get(axis)` in Go — #406's exact cause, living in this repository's own
  reader. Now named positively, and `readEvidence` refuses a record whose
  `probed`/`contract`/`shape` falls outside its vocabulary. That function's
  comment already claimed it "refuses what it cannot account for", and did not.
- **`runtimesLost` refused fewer runtimes and nothing looked at operations.**
  `feint evidence` now names, axis by axis, every operation the replaced record
  had earned and this run does not. A report, never a refusal: a suite that loses
  an assertion *must* demote what it proved.

## Falsified

`touch-attribution.json` and `axis-figures.json`, **10 mutations, every one red
on the first attempt** — verified again here after the rebase. `falsify:lint`
passes over 473 mutations across 88 specs.

## Not measured, and stated rather than smoothed

- **`coverage/evidence.json` is not regenerated.** Its `behaviour` column (312)
  is still a pre-fix draw. Regenerating needs the machines-on leg, which starts
  containers on the maintainer's station, and CLAUDE.md says that is asked for
  rather than taken. Until `mise run evidence:update` and `feint docs` are run,
  the committed record and the generated table carry the old figure.
- **Reproducibility is proven with machines off only.** The generated prose in
  `docs/routes.md` was softened after first claiming "every column is
  reproducible", which was more than had been measured.
- `docs/roadmap.md` still names `soleClientFlightLocked` in its wave-1
  description. Left for #403, which owns that page.
- The correction to #390 was posted as a **comment**, not an edit, so the
  original table survives as the record.

## Related

Closes #398
Closes #406
