### PR TITLE
chore(evidence): the record is regenerated on causal attribution, and behaviour reads 316

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -857,6 +857,18 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Modifié
 
+- **Le registre de preuves est régénéré sur l'attribution causale, et
+  `behaviour` vaut 316** (#398). Le registre commité portait 312, un tirage fait
+  avant qu'une écriture dans le store soit créditée à la requête qui l'a faite.
+  Outscale passe de 77 à 79, Scaleway de 157 à 159, et **aucune opération n'a
+  rien perdu sur aucun axe** : vérifié opération par opération contre le registre
+  remplacé, et non en comparant des totaux, parce qu'un total peut cacher une
+  perte sous un gain. Les six autres axes sont inchangés à l'opération près.
+
+  Les deux jambes ont tourné sur une station au calme, machines allumées pour la
+  seconde, et l'hôte a été relu ensuite : aucun conteneur ni réseau de
+  l'exécution ne subsistait.
+
 - **`internal/replay` a gagné les deux coutures qu'un vrai compte exige, et rien
   d'autre** (#359). `Options.Guard` est consulté avant chaque envoi — sur la
   requête *après* rebinding, la seule forme qu'il vaille la peine de juger,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -826,6 +826,17 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Changed
 
+- **The evidence record is regenerated on causal attribution, and `behaviour`
+  reads 316** (#398). The committed record carried 312, a draw made before a
+  store touch was credited to the request that made it. Outscale goes 77 to 79,
+  Scaleway 157 to 159, and **no operation lost anything on any axis** — checked
+  operation by operation against the replaced record, not by comparing totals,
+  because a total can hide a loss under a gain. The other six axes are unchanged
+  to the operation.
+
+  Both legs ran on a quiet station, machines on for the second, and the host was
+  read back afterwards: no container and no network of the run remained.
+
 - **`internal/replay` gained the two seams a real account needs, and nothing
   else** (#359). `Options.Guard` is asked before every request goes out — on the
   request *after* rebinding, which is the only form worth judging, since a

--- a/coverage/evidence.json
+++ b/coverage/evidence.json
@@ -8,7 +8,7 @@
   "generated_from": {
     "contracts": "785544edee4f7a99",
     "shapes": "8e5226e786207180",
-    "suites": "6f3d60d14a308cbd"
+    "suites": "1403171316f810e7"
   },
   "operations": {
     "block/v1/API.CreateSnapshot": {
@@ -107,7 +107,7 @@
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
-      "behaviour": false,
+      "behaviour": true,
       "negative": false
     },
     "block/v1alpha1/API.CreateSnapshot": {
@@ -1709,7 +1709,7 @@
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
-      "behaviour": false,
+      "behaviour": true,
       "negative": false
     },
     "instance/v2alpha1/API.CreatePrivateNetworkInterface": {
@@ -2906,7 +2906,7 @@
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
-      "behaviour": false,
+      "behaviour": true,
       "negative": false
     },
     "osc/Client.UnlinkNic": {
@@ -2951,7 +2951,7 @@
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
-      "behaviour": false,
+      "behaviour": true,
       "negative": true
     },
     "osc/Client.UpdateImage": {

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -42,9 +42,9 @@ a workflow. None of them opens a socket.
 | Cloud | Served | `driven` | `probed` | `contract` | `dataplane` | `shape` | `behaviour` | `negative` |
 |---|---|---|---|---|---|---|---|---|
 | Exoscale | 104 | 82 % (85) | 92 % (96) | 91 % (95) | 82 % (85) | 13 % (14) | 75 % (78) | 10 % (10) |
-| Outscale | 93 | 100 % (93) | 100 % (93) | 100 % (93) | 100 % (93) | 25 % (23) | 83 % (77) | 71 % (66) |
-| Scaleway | 173 | 96 % (166) | 82 % (141) | 82 % (141) | 96 % (166) | 9 % (15) | 91 % (157) | 56 % (97) |
-| **All three** | 370 | 93 % (344) | 89 % (330) | 89 % (329) | 93 % (344) | 14 % (52) | 84 % (312) | 47 % (173) |
+| Outscale | 93 | 100 % (93) | 100 % (93) | 100 % (93) | 100 % (93) | 25 % (23) | 85 % (79) | 71 % (66) |
+| Scaleway | 173 | 96 % (166) | 82 % (141) | 82 % (141) | 96 % (166) | 9 % (15) | 92 % (159) | 56 % (97) |
+| **All three** | 370 | 93 % (344) | 89 % (330) | 89 % (329) | 93 % (344) | 14 % (52) | 85 % (316) | 47 % (173) |
 
 What each axis says, one line each. They are independent and are never added
 into one number: none of them implies another, and an operation can be driven
@@ -165,7 +165,7 @@ disappears from the suite.
 | `GET` | `/block/v1alpha1/zones/{zone}/volumes/{id}` | `block/v1alpha1/API.GetVolume` | `client` `contract` `runtime` `probe` `negative` |
 | `GET` | `/block/v1alpha1/zones/{zone}/volumes` | `block/v1alpha1/API.ListVolumes` | `client` `contract` `runtime` `probe` `behaviour` |
 | `PATCH` | `/block/v1/zones/{zone}/snapshots/{id}` | `block/v1/API.UpdateSnapshot` | `client` `contract` `runtime` `probe` `behaviour` |
-| `PATCH` | `/block/v1/zones/{zone}/volumes/{id}` | `block/v1/API.UpdateVolume` | `client` `contract` `runtime` `probe` |
+| `PATCH` | `/block/v1/zones/{zone}/volumes/{id}` | `block/v1/API.UpdateVolume` | `client` `contract` `runtime` `probe` `behaviour` |
 | `PATCH` | `/block/v1alpha1/zones/{zone}/snapshots/{id}` | `block/v1alpha1/API.UpdateSnapshot` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 | `PATCH` | `/block/v1alpha1/zones/{zone}/volumes/{id}` | `block/v1alpha1/API.UpdateVolume` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 | `POST` | `/block/v1/zones/{zone}/snapshots` | `block/v1/API.CreateSnapshot` | `client` `contract` `runtime` `probe` `behaviour` |
@@ -249,7 +249,7 @@ disappears from the suite.
 | `POST` | `/instance/v1/zones/{zone}/servers` | `instance/v1/API.CreateServer` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/instance/v1/zones/{zone}/snapshots` | `instance/v1/API.CreateSnapshot` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/instance/v1/zones/{zone}/volumes` | `instance/v1/API.CreateVolume` | `client` `contract` `runtime` `probe` `behaviour` |
-| `POST` | `/instance/v2alpha1/zones/{zone}/placement-groups` | `instance/v2alpha1/API.CreatePlacementGroup` | `client` `contract` `runtime` `probe` |
+| `POST` | `/instance/v2alpha1/zones/{zone}/placement-groups` | `instance/v2alpha1/API.CreatePlacementGroup` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/instance/v2alpha1/zones/{zone}/private-network-interfaces` | `instance/v2alpha1/API.CreatePrivateNetworkInterface` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
 | `PUT` | `/instance/v1/zones/{zone}/placement_groups/{id}/servers` | `instance/v1/API.SetPlacementGroupServers` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
 | `PUT` | `/instance/v1/zones/{zone}/placement_groups/{id}` | `instance/v1/API.SetPlacementGroup` | `client` `contract` `runtime` `probe` `behaviour` |
@@ -479,7 +479,7 @@ are in `coverage/`, one artefact per provider.
 | `POST` | `/api/v1/LinkLoadBalancerBackendMachines` | `osc/Client.LinkLoadBalancerBackendMachines` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
 | `POST` | `/api/v1/ReadLoadBalancers` | `osc/Client.ReadLoadBalancers` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 | `POST` | `/api/v1/RegisterVmsInLoadBalancer` | `osc/Client.RegisterVmsInLoadBalancer` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
-| `POST` | `/api/v1/UnlinkLoadBalancerBackendMachines` | `osc/Client.UnlinkLoadBalancerBackendMachines` | `client` `contract` `runtime` `probe-refusal` |
+| `POST` | `/api/v1/UnlinkLoadBalancerBackendMachines` | `osc/Client.UnlinkLoadBalancerBackendMachines` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
 | `POST` | `/api/v1/UpdateLoadBalancer` | `osc/Client.UpdateLoadBalancer` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
 
 ### `NatService`
@@ -633,7 +633,7 @@ are in `coverage/`, one artefact per provider.
 | `POST` | `/api/v1/DeleteVolume` | `osc/Client.DeleteVolume` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 | `POST` | `/api/v1/LinkVolume` | `osc/Client.LinkVolume` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 | `POST` | `/api/v1/ReadVolumes` | `osc/Client.ReadVolumes` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
-| `POST` | `/api/v1/UnlinkVolume` | `osc/Client.UnlinkVolume` | `client` `contract` `runtime` `probe` `negative` |
+| `POST` | `/api/v1/UnlinkVolume` | `osc/Client.UnlinkVolume` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 | `POST` | `/api/v1/UpdateVolume` | `osc/Client.UpdateVolume` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 
 ### Declined on purpose (170)


### PR DESCRIPTION
The committed record carried **312** on `behaviour`, drawn before #398 credited a store touch to the request that made it. Regenerated on `main` after #420 landed: **316**.

| provider | before | after |
|---|---|---|
| Outscale | 77 | **79** |
| Scaleway | 157 | **159** |
| Exoscale | 78 | 78 |
| all | 312 | **316** |

It is the figure the delivering agent measured on two quiescent runs, reproduced here independently.

## No narrowing, and checked the way that can see one

**No operation lost anything on any axis** — verified operation by operation against the replaced record, not by comparing totals. A total can hide a loss under a gain, and this repository forbids committing a narrowing it has not triaged. The other six axes are unchanged to the operation.

The demotion report #420 added stayed silent, which is the second, independent way of saying the same thing.

## The station

Both legs ran on a quiet host, machines on for the second. The host was **read back** afterwards rather than trusted: no container and no network of the run remained.

## Related

Follows #420, which made this figure worth regenerating. The 312 it replaces is what #398 called an unreproducible draw.