### PR TITLE
feat(coverage): the shape axis stops asking a hand-written list, the 619 recorded exchanges feed it, and it reads 134 instead of 52 (#407)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -19,6 +19,53 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Ajouté
 
+- **L'axe `shape` était saturé à son propre plafond, et 619 échanges enregistrés
+  ne nourrissaient rien** (#407). `shape` lisait 52 opérations sur 370, et son
+  plafond valait **52 lui aussi**, à l'unité près par
+  cloud : exoscale 14, outscale 23, scaleway 15 ; les chiffres publiés vivent
+  dans le tableau généré de docs/routes.md. Il résolvait la couverture en
+  parcourant `upstream.Reads`, une liste tenue à la main d'une soixantaine
+  d'appels : aucun enregistrement ne pouvait donc le déplacer. Il nommait
+  pourtant 292 opérations « aucune réponse du vrai cloud n'a été gardée », dont
+  chacun des 619 échanges que ce dépôt détient déjà dans `corpus/`, qu'il n'a
+  jamais consultés. Un contrôle dont le numérateur ne peut pas bouger n'est pas
+  une mesure, et personne n'avait lu celui-ci depuis son écriture.
+
+  Il parcourt désormais tout le catalogue, exactement comme
+  `observedFieldsByOperation` dix lignes plus bas le faisait déjà, et
+  `mise run shapes:fold` verse chaque corpus commité dans `shapes/`, hors ligne,
+  sans compte. **`shape` passe de 52 à 134 sur 370**, et les 52 d'avant y sont
+  toutes : c'est le même ensemble plus 82, pas un nombre neuf. 80 des 292
+  enregistrements réclamés étaient déjà payés ; la file qui reste en compte 212,
+  et `feint coverage --evidence coverage/evidence.json --gaps --axis shape` la
+  nomme.
+
+  **Une rédaction efface un type, elle n'en rapporte pas un**, et verser sans
+  garde l'aurait écrit dans l'artefact dont tout le contenu est fait de types :
+  l'enregistreur remplace une valeur par une chaîne, si bien que
+  `osc/Client.ReadKeypairs.Keypairs` revenait en `array|string` et
+  `LoadBalancers[].SecuredCookies` en `bool|string`, par-dessus des types qu'une
+  lecture directe `--record` avait justes. Vingt-trois couples (opération,
+  champ) des corpus portent un remplaçant, sept d'entre eux sur autre chose
+  qu'une chaîne. `shape.IsRedacted` les refuse, et un chemin réécrit par
+  l'assainisseur ne sert plus de clé du tout.
+
+  `shapes/` n'est **pas** dérivé de `corpus/`, et c'est la mesure qui tranche :
+  13 opérations sont enregistrées dans `shapes/` et dans aucun corpus, dont six
+  qu'aucun pack ne sert, c'est-à-dire le versant « apprentissage » de la liste
+  de lectures, une forme connue avant que le handler existe. Dériver les
+  supprimerait. Le versement va dans un seul sens.
+
+- **`feint evidence --reshape`** (#407) recalcule le seul axe `shape` d'un
+  registre existant, hors ligne, depuis les catalogues sur disque. `shape` est
+  le seul axe qui ne soit pas une propriété d'une exécution : `evidence` jette
+  déjà ce que le serveur a répondu et le redérive. Un catalogue qui a grossi
+  hors ligne ne coûte donc plus deux jambes de conformance, dont une sur un hôte
+  capable de démarrer des machines, pour être publié. La commande refuse un
+  registre dont les contrats ou les suites ont bougé depuis son écriture, et
+  recalcule la colonne en entier : un catalogue qui a perdu une preuve fait
+  baisser le chiffre au lieu de laisser une laisse de haute mer.
+
 - **Un score dit où l'on en est ; une file dit quoi faire ensuite** (#408).
   `feint coverage --evidence <record> --gaps` liste, par cloud et par axe, les
   opérations à zéro **et le travail que chaque zéro nomme**. C'est cette seconde

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,49 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Added
 
+- **The shape axis was saturated at its own ceiling, and 619 recorded exchanges
+  fed nothing** (#407). `shape` read 52 of 370 operations, and its ceiling
+  was **also 52** — per cloud to the unit: exoscale 14,
+  outscale 23, scaleway 15; the published figures live in the generated
+  table of docs/routes.md. It resolved coverage by walking `upstream.Reads`, a
+  curated list of about sixty calls, so no amount of recording could move it.
+  It nevertheless named 292 operations "no answer of the real cloud has been
+  kept", including every one of the 619 exchanges this repository already holds
+  under `corpus/`, which it never asked about. A control whose numerator cannot
+  move is not a measurement, and this one had never been read since it was
+  written.
+
+  It now walks the whole catalogue — the traversal `observedFieldsByOperation`
+  ten lines below it already used — and `mise run shapes:fold` folds every
+  committed corpus into `shapes/`, offline, without an account. **`shape` goes
+  from 52 to 134 of 370**, and the 52 it already had are all still there: it is
+  the same set plus 82, not a new number. 80 of the 292 recording jobs were
+  already paid for; the queue that remains is 212, and it is named by
+  `feint coverage --evidence coverage/evidence.json --gaps --axis shape`.
+
+  **A redaction erases a type rather than reporting one**, and folding blind
+  would have written that into the artefact whose whole content is types: the
+  recorder replaces a value with a string, so `osc/Client.ReadKeypairs.Keypairs`
+  came back `array|string` and `LoadBalancers[].SecuredCookies` came back
+  `bool|string`, on top of types a direct `--record` read had got right.
+  Twenty-three (operation, field) pairs of the corpora carry a placeholder,
+  seven of them over a non-string. `shape.IsRedacted` refuses them, and a path
+  the sanitiser rewrote keys nothing at all.
+
+  `shapes/` is **not** derived from `corpus/`, and the measurement is why: 13
+  operations are recorded in `shapes/` and in no corpus — six of them served by
+  no pack at all, which is the read list's "learning side", a shape known before
+  a handler exists. Deriving would delete them. The fold is one-way.
+
+- **`feint evidence --reshape`** (#407) recomputes only the shape axis of an
+  existing record, offline, from the catalogues on disk. The shape axis is the
+  one axis that is not a property of a run — `evidence` already discards what
+  the server answered and re-derives it — so a catalogue that grew offline no
+  longer costs two conformance legs, one of them on a host that can start
+  machines, to publish. It refuses a record whose contracts or suites moved
+  since it was written, and recomputes the column wholesale so a catalogue that
+  lost evidence lowers the figure instead of leaving a high-water mark.
+
 - **A score says where we stand; a queue says what to do next** (#408). `feint
   coverage --evidence <record> --gaps` lists, per cloud and per axis, the
   operations at zero **and the work each zero names**. That last half is the

--- a/coverage/evidence.json
+++ b/coverage/evidence.json
@@ -7,7 +7,7 @@
   ],
   "generated_from": {
     "contracts": "785544edee4f7a99",
-    "shapes": "8e5226e786207180",
+    "shapes": "218e191863d7cf4b",
     "suites": "1403171316f810e7"
   },
   "operations": {
@@ -142,7 +142,7 @@
       "probed": "none",
       "contract": "unchecked",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -160,7 +160,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": false,
       "negative": true
     },
@@ -232,7 +232,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": false
     },
@@ -295,7 +295,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": false
     },
@@ -358,7 +358,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -367,7 +367,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": false
     },
@@ -385,7 +385,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": false
     },
@@ -457,7 +457,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -466,7 +466,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": false
     },
@@ -475,7 +475,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": false
     },
@@ -493,7 +493,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -565,7 +565,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": false
     },
@@ -655,7 +655,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": false,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": false,
       "negative": false
     },
@@ -673,7 +673,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": false
     },
@@ -691,7 +691,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": false,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": false,
       "negative": false
     },
@@ -745,7 +745,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": false
     },
@@ -826,7 +826,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": false,
       "negative": false
     },
@@ -898,7 +898,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -1123,7 +1123,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": false
     },
@@ -1150,7 +1150,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -1159,7 +1159,7 @@
       "probed": "none",
       "contract": "unchecked",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -1168,7 +1168,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -1204,7 +1204,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": false
     },
@@ -1258,7 +1258,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": false
     },
@@ -1285,7 +1285,7 @@
       "probed": "none",
       "contract": "unchecked",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -1339,7 +1339,7 @@
       "probed": "none",
       "contract": "unchecked",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": false
     },
@@ -1393,7 +1393,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": false
     },
@@ -1447,7 +1447,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -1681,7 +1681,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": false
     },
@@ -2095,7 +2095,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": false
     },
@@ -2194,7 +2194,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": false,
       "negative": false
     },
@@ -2230,7 +2230,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": false
     },
@@ -2239,7 +2239,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2248,7 +2248,7 @@
       "probed": "refusal",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2266,7 +2266,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2275,7 +2275,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2293,7 +2293,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2302,7 +2302,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": false
     },
@@ -2311,7 +2311,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2320,7 +2320,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2329,7 +2329,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2338,7 +2338,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2347,7 +2347,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2356,7 +2356,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2365,7 +2365,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2374,7 +2374,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2383,7 +2383,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2410,7 +2410,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2419,7 +2419,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2428,7 +2428,7 @@
       "probed": "refusal",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2446,7 +2446,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2455,7 +2455,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2473,7 +2473,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2482,7 +2482,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2491,7 +2491,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2500,7 +2500,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2509,7 +2509,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2527,7 +2527,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2536,7 +2536,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2545,7 +2545,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": false,
       "negative": true
     },
@@ -2554,7 +2554,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2563,7 +2563,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2572,7 +2572,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2590,7 +2590,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2608,7 +2608,7 @@
       "probed": "refusal",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2617,7 +2617,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2626,7 +2626,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2896,7 +2896,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2914,7 +2914,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2932,7 +2932,7 @@
       "probed": "refusal",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2941,7 +2941,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -2950,7 +2950,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -3013,7 +3013,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -3022,7 +3022,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": false,
       "negative": true
     },
@@ -3040,7 +3040,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -3058,7 +3058,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": false
     },
@@ -3067,7 +3067,7 @@
       "probed": "none",
       "contract": "unchecked",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -3085,7 +3085,7 @@
       "probed": "none",
       "contract": "unchecked",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -3139,7 +3139,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -3184,7 +3184,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -3202,7 +3202,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": true
     },
@@ -3301,7 +3301,7 @@
       "probed": "response",
       "contract": "clean",
       "dataplane": true,
-      "shape": "unobserved",
+      "shape": "observed",
       "behaviour": true,
       "negative": false
     },

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -139,6 +139,54 @@ seven-axis evidence record, and the versioned surface a pipeline reads.
 [The conformance system](conformance.md) describes the whole of it, what each
 link proves, and which links are stated but not yet enforced.
 
+## `shapes/` and `corpus/`: one derives nothing from the other
+
+Two committed artefacts hold what a real cloud answered, and the difference
+between them is a decision rather than an accident.
+
+`shapes/*.json` holds **field paths and JSON types, no values**. That is what
+makes it committable: a shape describes an API, not an account. `corpus/*.jsonl`
+holds **whole exchanges, sanitised**: request, response body, status, so a
+replay can reissue the call and compare the answer.
+
+The second is strictly richer, which invites the obvious question: should
+`shapes/` simply be generated from `corpus/`? **No, and the measurement is why.**
+
+- **13 operations are recorded in `shapes/` and in no corpus.** Six of them are
+  served by no pack at all: `osc/Client.ReadQuotas`, `ReadAccounts`,
+  `ReadListenerRules`, `ReadNetAccessPoints`, `ReadServerCertificates`,
+  `ReadVolumeUpdateTasks`. That is the "learning side" of `upstream.Reads` doing
+  its job, a shape known before the handler is written. A corpus cannot hold
+  them, because a corpus is a recording of a client that had a reason to call.
+  Deriving would delete them.
+- **The two artefacts pass different admissibility bars.** A shape is
+  committable because it carries no value; a corpus is committable only after a
+  sanitiser rewrites every value, and that sanitiser has had defects of its own
+  (#390, #395). Deriving would put the shape axis behind the sanitiser's
+  correctness, for no gain.
+- **A sanitised value has lost its type.** The recorder writes a string over
+  whatever it replaced, so `osc/Client.ReadKeypairs.Keypairs` reaches the corpus
+  as `"REDACTED-20"` where the API answers an array, and
+  `instance-types[].authorized` as a string where it is a bool. A shape is
+  nothing but types, so folding those in would publish a polymorphism no
+  provider has. `shape.IsRedacted` refuses them at the boundary.
+
+So the relationship is a **one-way fold**, not a derivation:
+`mise run shapes:fold` folds every committed corpus into `shapes/`, offline and
+without an account, and `shapes/` remains the artefact the shape axis and the
+field gate read. It closed 80 of the 292 recordings the axis was asking for.
+
+One consequence worth knowing before reading a catalogue: an operation can
+appear under two keys, `"GET /instance/v1/zones/fr-par-1/servers"` from a direct
+`feint shapes --record` read and `"instance/v1/API.ListServers"` from a corpus
+that could name it — 25 operations are in that state. The readers cope
+(`observedFieldsByOperation` resolves both onto the mounted operation and unions
+them), but the offline `feint shapes --check` walks the read list, so it reads
+only the first spelling. That gate compares by *reissuing* the call against an
+empty store, which is why it can only ever walk reads: it is a narrower
+population than the shape axis by construction, and the two must not be read as
+one number.
+
 ## Adding a provider
 
 **Adding a provider requires no behavioural change to `internal/core`; the

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -41,10 +41,10 @@ a workflow. None of them opens a socket.
 
 | Cloud | Served | `driven` | `probed` | `contract` | `dataplane` | `shape` | `behaviour` | `negative` |
 |---|---|---|---|---|---|---|---|---|
-| Exoscale | 104 | 82 % (85) | 92 % (96) | 91 % (95) | 82 % (85) | 13 % (14) | 75 % (78) | 10 % (10) |
-| Outscale | 93 | 100 % (93) | 100 % (93) | 100 % (93) | 100 % (93) | 25 % (23) | 85 % (79) | 71 % (66) |
-| Scaleway | 173 | 96 % (166) | 82 % (141) | 82 % (141) | 96 % (166) | 9 % (15) | 92 % (159) | 56 % (97) |
-| **All three** | 370 | 93 % (344) | 89 % (330) | 89 % (329) | 93 % (344) | 14 % (52) | 85 % (316) | 47 % (173) |
+| Exoscale | 104 | 82 % (85) | 92 % (96) | 91 % (95) | 82 % (85) | 30 % (31) | 75 % (78) | 10 % (10) |
+| Outscale | 93 | 100 % (93) | 100 % (93) | 100 % (93) | 100 % (93) | 71 % (66) | 85 % (79) | 71 % (66) |
+| Scaleway | 173 | 96 % (166) | 82 % (141) | 82 % (141) | 96 % (166) | 21 % (37) | 92 % (159) | 56 % (97) |
+| **All three** | 370 | 93 % (344) | 89 % (330) | 89 % (329) | 93 % (344) | 36 % (134) | 85 % (316) | 47 % (173) |
 
 What each axis says, one line each. They are independent and are never added
 into one number: none of them implies another, and an operation can be driven
@@ -56,7 +56,7 @@ by a real client and never contract-checked, or probed and never driven.
 | `probed` | the contract-driven probe validated an answer here against the operation's own schema, a success (`response`) or a refusal (`refusal`) |
 | `contract` | at least one answer was validated against the provider's own API description and none violated it (`unchecked`: none was ever validated, which is not the same as no violation) |
 | `dataplane` | it was driven in a run whose machines were real, so the control plane ran with its side effects on |
-| `shape` | a recorded real-cloud answer covers it and the shapes gate holds the emulator to that record, field by field |
+| `shape` | a recorded real-cloud answer covers it, from `shapes/` — which `mise run shapes:fold` also fills from the committed corpora; it says the answer has been held against a real one, not that the offline gate re-issues the call |
 | `behaviour` | it took part in a create-to-destroy sequence the emulator's own store observed, inside a span a suite declared |
 | `negative` | it really answered 4xx to a real client inside a span where a suite demanded a refusal; **an injected fault never earns it**, so arming faults cannot move this number |
 
@@ -153,7 +153,7 @@ disappears from the suite.
 | `DELETE` | `/block/v1/zones/{zone}/snapshots/{id}` | `block/v1/API.DeleteSnapshot` | `client` `runtime` `behaviour` |
 | `DELETE` | `/block/v1/zones/{zone}/volumes/{id}` | `block/v1/API.DeleteVolume` | `client` `runtime` `behaviour` |
 | `DELETE` | `/block/v1alpha1/zones/{zone}/snapshots/{id}` | `block/v1alpha1/API.DeleteSnapshot` | `client` `runtime` `behaviour` `negative` |
-| `DELETE` | `/block/v1alpha1/zones/{zone}/volumes/{id}` | `block/v1alpha1/API.DeleteVolume` | `client` `runtime` `behaviour` `negative` |
+| `DELETE` | `/block/v1alpha1/zones/{zone}/volumes/{id}` | `block/v1alpha1/API.DeleteVolume` | `client` `shape` `runtime` `behaviour` `negative` |
 | `GET` | `/block/v1/zones/{zone}/snapshots/{id}` | `block/v1/API.GetSnapshot` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 | `GET` | `/block/v1/zones/{zone}/snapshots` | `block/v1/API.ListSnapshots` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 | `GET` | `/block/v1/zones/{zone}/volume-types` | `block/v1/API.ListVolumeTypes` | `no-client` `contract` `probe` |
@@ -162,7 +162,7 @@ disappears from the suite.
 | `GET` | `/block/v1alpha1/zones/{zone}/snapshots/{id}` | `block/v1alpha1/API.GetSnapshot` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 | `GET` | `/block/v1alpha1/zones/{zone}/snapshots` | `block/v1alpha1/API.ListSnapshots` | `client` `contract` `runtime` `probe` `behaviour` |
 | `GET` | `/block/v1alpha1/zones/{zone}/volume-types` | `block/v1alpha1/API.ListVolumeTypes` | `client` `contract` `runtime` `probe` |
-| `GET` | `/block/v1alpha1/zones/{zone}/volumes/{id}` | `block/v1alpha1/API.GetVolume` | `client` `contract` `runtime` `probe` `negative` |
+| `GET` | `/block/v1alpha1/zones/{zone}/volumes/{id}` | `block/v1alpha1/API.GetVolume` | `client` `contract` `shape` `runtime` `probe` `negative` |
 | `GET` | `/block/v1alpha1/zones/{zone}/volumes` | `block/v1alpha1/API.ListVolumes` | `client` `contract` `runtime` `probe` `behaviour` |
 | `PATCH` | `/block/v1/zones/{zone}/snapshots/{id}` | `block/v1/API.UpdateSnapshot` | `client` `contract` `runtime` `probe` `behaviour` |
 | `PATCH` | `/block/v1/zones/{zone}/volumes/{id}` | `block/v1/API.UpdateVolume` | `client` `contract` `runtime` `probe` `behaviour` |
@@ -177,29 +177,29 @@ disappears from the suite.
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `DELETE` | `/iam/v1alpha1/ssh-keys/{id}` | `iam/v1alpha1/API.DeleteSSHKey` | `client` `runtime` `behaviour` `negative` |
-| `GET` | `/iam/v1alpha1/ssh-keys/{id}` | `iam/v1alpha1/API.GetSSHKey` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `DELETE` | `/iam/v1alpha1/ssh-keys/{id}` | `iam/v1alpha1/API.DeleteSSHKey` | `client` `shape` `runtime` `behaviour` `negative` |
+| `GET` | `/iam/v1alpha1/ssh-keys/{id}` | `iam/v1alpha1/API.GetSSHKey` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `GET` | `/iam/v1alpha1/ssh-keys` | `iam/v1alpha1/API.ListSSHKeys` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 | `PATCH` | `/iam/v1alpha1/ssh-keys/{id}` | `iam/v1alpha1/API.UpdateSSHKey` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
-| `POST` | `/iam/v1alpha1/ssh-keys` | `iam/v1alpha1/API.CreateSSHKey` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/iam/v1alpha1/ssh-keys` | `iam/v1alpha1/API.CreateSSHKey` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 
 ### `instance`
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
 | `DELETE` | `/instance/v1/zones/{zone}/images/{id}` | `instance/v1/API.DeleteImage` | `client` `runtime` `behaviour` `negative` |
-| `DELETE` | `/instance/v1/zones/{zone}/ips/{id}` | `instance/v1/API.DeleteIP` | `client` `runtime` `behaviour` `negative` |
+| `DELETE` | `/instance/v1/zones/{zone}/ips/{id}` | `instance/v1/API.DeleteIP` | `client` `shape` `runtime` `behaviour` `negative` |
 | `DELETE` | `/instance/v1/zones/{zone}/placement_groups/{id}` | `instance/v1/API.DeletePlacementGroup` | `client` `runtime` `behaviour` `negative` |
 | `DELETE` | `/instance/v1/zones/{zone}/security_groups/{id}/rules/{ruleID}` | `instance/v1/API.DeleteSecurityGroupRule` | `client` `runtime` `behaviour` `negative` |
 | `DELETE` | `/instance/v1/zones/{zone}/security_groups/{id}` | `instance/v1/API.DeleteSecurityGroup` | `client` `runtime` `behaviour` `negative` |
 | `DELETE` | `/instance/v1/zones/{zone}/servers/{id}/private_nics/{nicID}` | `instance/v1/API.DeletePrivateNIC` | `client` `runtime` `behaviour` `negative` |
 | `DELETE` | `/instance/v1/zones/{zone}/servers/{id}/user_data/{key}` | `instance/v1/API.DeleteServerUserData` | `client` `runtime` `behaviour` `negative` |
-| `DELETE` | `/instance/v1/zones/{zone}/servers/{id}` | `instance/v1/API.DeleteServer` | `client` `runtime` `behaviour` |
+| `DELETE` | `/instance/v1/zones/{zone}/servers/{id}` | `instance/v1/API.DeleteServer` | `client` `shape` `runtime` `behaviour` |
 | `DELETE` | `/instance/v1/zones/{zone}/snapshots/{id}` | `instance/v1/API.DeleteSnapshot` | `client` `runtime` `behaviour` `negative` |
 | `DELETE` | `/instance/v1/zones/{zone}/volumes/{id}` | `instance/v1/API.DeleteVolume` | `client` `runtime` `behaviour` `negative` |
 | `DELETE` | `/instance/v2alpha1/zones/{zone}/placement-groups/{id}` | `instance/v2alpha1/API.DeletePlacementGroup` | `client` `runtime` `behaviour` |
 | `DELETE` | `/instance/v2alpha1/zones/{zone}/private-network-interfaces/{id}` | `instance/v2alpha1/API.DeletePrivateNetworkInterface` | `client` `runtime` `behaviour` |
-| `GET` | `/instance/v1/zones/{zone}/images/{id}` | `instance/v1/API.GetImage` | `client` `contract` `runtime` `probe` `behaviour` |
+| `GET` | `/instance/v1/zones/{zone}/images/{id}` | `instance/v1/API.GetImage` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 | `GET` | `/instance/v1/zones/{zone}/images` | `instance/v1/API.ListImages` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 | `GET` | `/instance/v1/zones/{zone}/ips/{id}` | `instance/v1/API.GetIP` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 | `GET` | `/instance/v1/zones/{zone}/ips` | `instance/v1/API.ListIPs` | `client` `contract` `shape` `runtime` `probe` |
@@ -215,7 +215,7 @@ disappears from the suite.
 | `GET` | `/instance/v1/zones/{zone}/servers/{id}/private_nics` | `instance/v1/API.ListPrivateNICs` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 | `GET` | `/instance/v1/zones/{zone}/servers/{id}/user_data/{key}` | `instance/v1/API.GetServerUserData` | `client` `contract` `runtime` `behaviour` `negative` |
 | `GET` | `/instance/v1/zones/{zone}/servers/{id}/user_data` | `instance/v1/API.ListServerUserData` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
-| `GET` | `/instance/v1/zones/{zone}/servers/{id}` | `instance/v1/API.GetServer` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `GET` | `/instance/v1/zones/{zone}/servers/{id}` | `instance/v1/API.GetServer` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `GET` | `/instance/v1/zones/{zone}/servers` | `instance/v1/API.ListServers` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 | `GET` | `/instance/v1/zones/{zone}/snapshots/{id}` | `instance/v1/API.GetSnapshot` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 | `GET` | `/instance/v1/zones/{zone}/snapshots` | `instance/v1/API.ListSnapshots` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
@@ -232,13 +232,13 @@ disappears from the suite.
 | `PATCH` | `/instance/v1/zones/{zone}/security_groups/{id}/rules/{ruleID}` | `instance/v1/API.UpdateSecurityGroupRule` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 | `PATCH` | `/instance/v1/zones/{zone}/security_groups/{id}` | `instance/v1/API.UpdateSecurityGroup` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 | `PATCH` | `/instance/v1/zones/{zone}/servers/{id}/user_data/{key}` | `instance/v1/API.SetServerUserData` | `client` `runtime` `behaviour` |
-| `PATCH` | `/instance/v1/zones/{zone}/servers/{id}` | `instance/v1/API.UpdateServer` | `client` `contract` `runtime` `probe` `behaviour` |
+| `PATCH` | `/instance/v1/zones/{zone}/servers/{id}` | `instance/v1/API.UpdateServer` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 | `PATCH` | `/instance/v1/zones/{zone}/snapshots/{id}` | `instance/v1/API.UpdateSnapshot` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 | `PATCH` | `/instance/v1/zones/{zone}/volumes/{id}` | `instance/v1/API.UpdateVolume` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 | `PATCH` | `/instance/v2alpha1/zones/{zone}/placement-groups/{id}` | `instance/v2alpha1/API.UpdatePlacementGroup` | `no-client` `contract` `probe` |
 | `PATCH` | `/instance/v2alpha1/zones/{zone}/private-network-interfaces/{id}` | `instance/v2alpha1/API.UpdatePrivateNetworkInterface` | `no-client` `probe-refusal` |
 | `POST` | `/instance/v1/zones/{zone}/images` | `instance/v1/API.CreateImage` | `client` `contract` `runtime` `probe` `behaviour` |
-| `POST` | `/instance/v1/zones/{zone}/ips` | `instance/v1/API.CreateIP` | `client` `contract` `runtime` `probe` `behaviour` |
+| `POST` | `/instance/v1/zones/{zone}/ips` | `instance/v1/API.CreateIP` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 | `POST` | `/instance/v1/zones/{zone}/placement_groups` | `instance/v1/API.CreatePlacementGroup` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/instance/v1/zones/{zone}/security_groups/{id}/rules` | `instance/v1/API.CreateSecurityGroupRule` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 | `POST` | `/instance/v1/zones/{zone}/security_groups` | `instance/v1/API.CreateSecurityGroup` | `client` `contract` `runtime` `probe` `behaviour` |
@@ -246,7 +246,7 @@ disappears from the suite.
 | `POST` | `/instance/v1/zones/{zone}/servers/{id}/attach-volume` | `instance/v1/API.AttachServerVolume` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/instance/v1/zones/{zone}/servers/{id}/detach-volume` | `instance/v1/API.DetachServerVolume` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/instance/v1/zones/{zone}/servers/{id}/private_nics` | `instance/v1/API.CreatePrivateNIC` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
-| `POST` | `/instance/v1/zones/{zone}/servers` | `instance/v1/API.CreateServer` | `client` `contract` `runtime` `probe` `behaviour` |
+| `POST` | `/instance/v1/zones/{zone}/servers` | `instance/v1/API.CreateServer` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 | `POST` | `/instance/v1/zones/{zone}/snapshots` | `instance/v1/API.CreateSnapshot` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/instance/v1/zones/{zone}/volumes` | `instance/v1/API.CreateVolume` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/instance/v2alpha1/zones/{zone}/placement-groups` | `instance/v2alpha1/API.CreatePlacementGroup` | `client` `contract` `runtime` `probe` `behaviour` |
@@ -289,7 +289,7 @@ disappears from the suite.
 | `GET` | `/lb/v1/zones/{zone}/lbs/{lbID}/frontends` | `lb/v1/ZonedAPI.ListFrontends` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
 | `GET` | `/lb/v1/zones/{zone}/lbs/{lbID}/private-networks` | `lb/v1/ZonedAPI.ListLBPrivateNetworks` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
 | `GET` | `/lb/v1/zones/{zone}/lbs/{lbID}` | `lb/v1/ZonedAPI.GetLB` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
-| `GET` | `/lb/v1/zones/{zone}/lbs` | `lb/v1/ZonedAPI.ListLBs` | `client` `contract` `runtime` `probe` `behaviour` |
+| `GET` | `/lb/v1/zones/{zone}/lbs` | `lb/v1/ZonedAPI.ListLBs` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 | `GET` | `/lb/v1/zones/{zone}/routes/{routeID}` | `lb/v1/ZonedAPI.GetRoute` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
 | `GET` | `/lb/v1/zones/{zone}/routes` | `lb/v1/ZonedAPI.ListRoutes` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 | `PATCH` | `/lb/v1/zones/{zone}/ips/{ipID}` | `lb/v1/ZonedAPI.UpdateIP` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
@@ -315,30 +315,30 @@ disappears from the suite.
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `GET` | `/marketplace/v2/local-images` | `marketplace/v2/API.ListLocalImages` | `client` `contract` `runtime` `probe` |
+| `GET` | `/marketplace/v2/local-images` | `marketplace/v2/API.ListLocalImages` | `client` `contract` `shape` `runtime` `probe` |
 
 ### `vpc`
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `DELETE` | `/vpc/v2/regions/{region}/private-networks/{pnID}` | `vpc/v2/API.DeletePrivateNetwork` | `client` `runtime` `behaviour` `negative` |
+| `DELETE` | `/vpc/v2/regions/{region}/private-networks/{pnID}` | `vpc/v2/API.DeletePrivateNetwork` | `client` `shape` `runtime` `behaviour` `negative` |
 | `DELETE` | `/vpc/v2/regions/{region}/routes/{routeID}` | `vpc/v2/API.DeleteRoute` | `client` `runtime` `behaviour` `negative` |
-| `DELETE` | `/vpc/v2/regions/{region}/vpcs/{vpc_id}` | `vpc/v2/API.DeleteVPC` | `client` `runtime` `behaviour` `negative` |
+| `DELETE` | `/vpc/v2/regions/{region}/vpcs/{vpc_id}` | `vpc/v2/API.DeleteVPC` | `client` `shape` `runtime` `behaviour` `negative` |
 | `GET` | `/vpc/v2/regions/{region}/private-networks/{pnID}` | `vpc/v2/API.GetPrivateNetwork` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `GET` | `/vpc/v2/regions/{region}/private-networks` | `vpc/v2/API.ListPrivateNetworks` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 | `GET` | `/vpc/v2/regions/{region}/routes/{routeID}` | `vpc/v2/API.GetRoute` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 | `GET` | `/vpc/v2/regions/{region}/subnets` | `vpc/v2/API.ListSubnets` | `no-client` `contract` `probe` |
 | `GET` | `/vpc/v2/regions/{region}/vpcs/{vpc_id}/acl-rules` | `vpc/v2/API.GetACL` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
-| `GET` | `/vpc/v2/regions/{region}/vpcs/{vpc_id}` | `vpc/v2/API.GetVPC` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `GET` | `/vpc/v2/regions/{region}/vpcs/{vpc_id}` | `vpc/v2/API.GetVPC` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `GET` | `/vpc/v2/regions/{region}/vpcs` | `vpc/v2/API.ListVPCs` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
-| `PATCH` | `/vpc/v2/regions/{region}/private-networks/{pnID}` | `vpc/v2/API.UpdatePrivateNetwork` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `PATCH` | `/vpc/v2/regions/{region}/private-networks/{pnID}` | `vpc/v2/API.UpdatePrivateNetwork` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `PATCH` | `/vpc/v2/regions/{region}/routes/{routeID}` | `vpc/v2/API.UpdateRoute` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
-| `PATCH` | `/vpc/v2/regions/{region}/vpcs/{vpc_id}` | `vpc/v2/API.UpdateVPC` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `PATCH` | `/vpc/v2/regions/{region}/vpcs/{vpc_id}` | `vpc/v2/API.UpdateVPC` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `POST` | `/vpc/v2/regions/{region}/private-networks/{pnID}/enable-dhcp` | `vpc/v2/API.EnableDHCP` | `client` `contract` `runtime` `probe` `behaviour` |
-| `POST` | `/vpc/v2/regions/{region}/private-networks` | `vpc/v2/API.CreatePrivateNetwork` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/vpc/v2/regions/{region}/private-networks` | `vpc/v2/API.CreatePrivateNetwork` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `POST` | `/vpc/v2/regions/{region}/routes` | `vpc/v2/API.CreateRoute` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 | `POST` | `/vpc/v2/regions/{region}/vpcs/{vpc_id}/enable-routing` | `vpc/v2/API.EnableRouting` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
-| `POST` | `/vpc/v2/regions/{region}/vpcs` | `vpc/v2/API.CreateVPC` | `client` `contract` `runtime` `probe` `behaviour` |
+| `POST` | `/vpc/v2/regions/{region}/vpcs` | `vpc/v2/API.CreateVPC` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 | `PUT` | `/vpc/v2/regions/{region}/vpcs/{vpc_id}/acl-rules` | `vpc/v2/API.SetACL` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
 
 ### `vpcgw`
@@ -351,7 +351,7 @@ disappears from the suite.
 | `GET` | `/vpc-gw/v2/zones/{zone}/gateway-networks/{gatewayNetworkID}` | `vpcgw/v2/API.GetGatewayNetwork` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
 | `GET` | `/vpc-gw/v2/zones/{zone}/gateway-networks` | `vpcgw/v2/API.ListGatewayNetworks` | `client` `contract` `runtime` `probe` `behaviour` |
 | `GET` | `/vpc-gw/v2/zones/{zone}/gateways/{gatewayID}` | `vpcgw/v2/API.GetGateway` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
-| `GET` | `/vpc-gw/v2/zones/{zone}/gateways` | `vpcgw/v2/API.ListGateways` | `client` `contract` `runtime` `probe` `behaviour` |
+| `GET` | `/vpc-gw/v2/zones/{zone}/gateways` | `vpcgw/v2/API.ListGateways` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 | `GET` | `/vpc-gw/v2/zones/{zone}/ips/{ipID}` | `vpcgw/v2/API.GetIP` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 | `GET` | `/vpc-gw/v2/zones/{zone}/ips` | `vpcgw/v2/API.ListIPs` | `client` `contract` `runtime` `probe` `behaviour` |
 | `PATCH` | `/vpc-gw/v2/zones/{zone}/gateway-networks/{gatewayNetworkID}` | `vpcgw/v2/API.UpdateGatewayNetwork` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
@@ -449,18 +449,18 @@ are in `coverage/`, one artefact per provider.
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `POST` | `/api/v1/CreateInternetService` | `osc/Client.CreateInternetService` | `client` `contract` `runtime` `probe` `behaviour` |
-| `POST` | `/api/v1/DeleteInternetService` | `osc/Client.DeleteInternetService` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
-| `POST` | `/api/v1/LinkInternetService` | `osc/Client.LinkInternetService` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/CreateInternetService` | `osc/Client.CreateInternetService` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
+| `POST` | `/api/v1/DeleteInternetService` | `osc/Client.DeleteInternetService` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/LinkInternetService` | `osc/Client.LinkInternetService` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `POST` | `/api/v1/ReadInternetServices` | `osc/Client.ReadInternetServices` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
-| `POST` | `/api/v1/UnlinkInternetService` | `osc/Client.UnlinkInternetService` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/UnlinkInternetService` | `osc/Client.UnlinkInternetService` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 
 ### `Keypair`
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `POST` | `/api/v1/CreateKeypair` | `osc/Client.CreateKeypair` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
-| `POST` | `/api/v1/DeleteKeypair` | `osc/Client.DeleteKeypair` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/CreateKeypair` | `osc/Client.CreateKeypair` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/DeleteKeypair` | `osc/Client.DeleteKeypair` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `POST` | `/api/v1/ReadKeypairs` | `osc/Client.ReadKeypairs` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 
 ### `Listener`
@@ -474,8 +474,8 @@ are in `coverage/`, one artefact per provider.
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `POST` | `/api/v1/CreateLoadBalancer` | `osc/Client.CreateLoadBalancer` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
-| `POST` | `/api/v1/DeleteLoadBalancer` | `osc/Client.DeleteLoadBalancer` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
+| `POST` | `/api/v1/CreateLoadBalancer` | `osc/Client.CreateLoadBalancer` | `client` `contract` `shape` `runtime` `probe-refusal` `behaviour` `negative` |
+| `POST` | `/api/v1/DeleteLoadBalancer` | `osc/Client.DeleteLoadBalancer` | `client` `contract` `shape` `runtime` `probe-refusal` `behaviour` `negative` |
 | `POST` | `/api/v1/LinkLoadBalancerBackendMachines` | `osc/Client.LinkLoadBalancerBackendMachines` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
 | `POST` | `/api/v1/ReadLoadBalancers` | `osc/Client.ReadLoadBalancers` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 | `POST` | `/api/v1/RegisterVmsInLoadBalancer` | `osc/Client.RegisterVmsInLoadBalancer` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
@@ -486,16 +486,16 @@ are in `coverage/`, one artefact per provider.
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `POST` | `/api/v1/CreateNatService` | `osc/Client.CreateNatService` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
-| `POST` | `/api/v1/DeleteNatService` | `osc/Client.DeleteNatService` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/CreateNatService` | `osc/Client.CreateNatService` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/DeleteNatService` | `osc/Client.DeleteNatService` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `POST` | `/api/v1/ReadNatServices` | `osc/Client.ReadNatServices` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 
 ### `Net`
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `POST` | `/api/v1/CreateNet` | `osc/Client.CreateNet` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
-| `POST` | `/api/v1/DeleteNet` | `osc/Client.DeleteNet` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/CreateNet` | `osc/Client.CreateNet` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/DeleteNet` | `osc/Client.DeleteNet` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `POST` | `/api/v1/ReadNets` | `osc/Client.ReadNets` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 | `POST` | `/api/v1/UpdateNet` | `osc/Client.UpdateNet` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 
@@ -519,12 +519,12 @@ are in `coverage/`, one artefact per provider.
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `POST` | `/api/v1/CreateNic` | `osc/Client.CreateNic` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
-| `POST` | `/api/v1/DeleteNic` | `osc/Client.DeleteNic` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
-| `POST` | `/api/v1/LinkNic` | `osc/Client.LinkNic` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/CreateNic` | `osc/Client.CreateNic` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/DeleteNic` | `osc/Client.DeleteNic` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/LinkNic` | `osc/Client.LinkNic` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `POST` | `/api/v1/LinkPrivateIps` | `osc/Client.LinkPrivateIps` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
 | `POST` | `/api/v1/ReadNics` | `osc/Client.ReadNics` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
-| `POST` | `/api/v1/UnlinkNic` | `osc/Client.UnlinkNic` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/UnlinkNic` | `osc/Client.UnlinkNic` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `POST` | `/api/v1/UnlinkPrivateIps` | `osc/Client.UnlinkPrivateIps` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
 | `POST` | `/api/v1/UpdateNic` | `osc/Client.UpdateNic` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 
@@ -532,12 +532,12 @@ are in `coverage/`, one artefact per provider.
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `POST` | `/api/v1/CreatePublicIp` | `osc/Client.CreatePublicIp` | `client` `contract` `runtime` `probe` `behaviour` |
-| `POST` | `/api/v1/DeletePublicIp` | `osc/Client.DeletePublicIp` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
-| `POST` | `/api/v1/LinkPublicIp` | `osc/Client.LinkPublicIp` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
+| `POST` | `/api/v1/CreatePublicIp` | `osc/Client.CreatePublicIp` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
+| `POST` | `/api/v1/DeletePublicIp` | `osc/Client.DeletePublicIp` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/LinkPublicIp` | `osc/Client.LinkPublicIp` | `client` `contract` `shape` `runtime` `probe-refusal` `behaviour` `negative` |
 | `POST` | `/api/v1/ReadPublicIpRanges` | `osc/Client.ReadPublicIpRanges` | `client` `contract` `shape` `runtime` `probe` |
 | `POST` | `/api/v1/ReadPublicIps` | `osc/Client.ReadPublicIps` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
-| `POST` | `/api/v1/UnlinkPublicIp` | `osc/Client.UnlinkPublicIp` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
+| `POST` | `/api/v1/UnlinkPublicIp` | `osc/Client.UnlinkPublicIp` | `client` `contract` `shape` `runtime` `probe-refusal` `behaviour` `negative` |
 
 ### `Region`
 
@@ -549,52 +549,52 @@ are in `coverage/`, one artefact per provider.
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `POST` | `/api/v1/CreateRoute` | `osc/Client.CreateRoute` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
-| `POST` | `/api/v1/DeleteRoute` | `osc/Client.DeleteRoute` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/CreateRoute` | `osc/Client.CreateRoute` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/DeleteRoute` | `osc/Client.DeleteRoute` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `POST` | `/api/v1/UpdateRoute` | `osc/Client.UpdateRoute` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 
 ### `RouteTable`
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `POST` | `/api/v1/CreateRouteTable` | `osc/Client.CreateRouteTable` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
-| `POST` | `/api/v1/DeleteRouteTable` | `osc/Client.DeleteRouteTable` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
-| `POST` | `/api/v1/LinkRouteTable` | `osc/Client.LinkRouteTable` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/CreateRouteTable` | `osc/Client.CreateRouteTable` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/DeleteRouteTable` | `osc/Client.DeleteRouteTable` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/LinkRouteTable` | `osc/Client.LinkRouteTable` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `POST` | `/api/v1/ReadRouteTables` | `osc/Client.ReadRouteTables` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
-| `POST` | `/api/v1/UnlinkRouteTable` | `osc/Client.UnlinkRouteTable` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/UnlinkRouteTable` | `osc/Client.UnlinkRouteTable` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `POST` | `/api/v1/UpdateRouteTableLink` | `osc/Client.UpdateRouteTableLink` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 
 ### `SecurityGroup`
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `POST` | `/api/v1/CreateSecurityGroup` | `osc/Client.CreateSecurityGroup` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
-| `POST` | `/api/v1/DeleteSecurityGroup` | `osc/Client.DeleteSecurityGroup` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/CreateSecurityGroup` | `osc/Client.CreateSecurityGroup` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/DeleteSecurityGroup` | `osc/Client.DeleteSecurityGroup` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `POST` | `/api/v1/ReadSecurityGroups` | `osc/Client.ReadSecurityGroups` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 
 ### `SecurityGroupRule`
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `POST` | `/api/v1/CreateSecurityGroupRule` | `osc/Client.CreateSecurityGroupRule` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/CreateSecurityGroupRule` | `osc/Client.CreateSecurityGroupRule` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `POST` | `/api/v1/DeleteSecurityGroupRule` | `osc/Client.DeleteSecurityGroupRule` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 
 ### `Snapshot`
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `POST` | `/api/v1/CreateSnapshot` | `osc/Client.CreateSnapshot` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
-| `POST` | `/api/v1/DeleteSnapshot` | `osc/Client.DeleteSnapshot` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/CreateSnapshot` | `osc/Client.CreateSnapshot` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/DeleteSnapshot` | `osc/Client.DeleteSnapshot` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `POST` | `/api/v1/ReadSnapshots` | `osc/Client.ReadSnapshots` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 
 ### `Subnet`
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `POST` | `/api/v1/CreateSubnet` | `osc/Client.CreateSubnet` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
-| `POST` | `/api/v1/DeleteSubnet` | `osc/Client.DeleteSubnet` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/CreateSubnet` | `osc/Client.CreateSubnet` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/DeleteSubnet` | `osc/Client.DeleteSubnet` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `POST` | `/api/v1/ReadSubnets` | `osc/Client.ReadSubnets` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
-| `POST` | `/api/v1/UpdateSubnet` | `osc/Client.UpdateSubnet` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/UpdateSubnet` | `osc/Client.UpdateSubnet` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 
 ### `Subregion`
 
@@ -606,16 +606,16 @@ are in `coverage/`, one artefact per provider.
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `POST` | `/api/v1/CreateTags` | `osc/Client.CreateTags` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
-| `POST` | `/api/v1/DeleteTags` | `osc/Client.DeleteTags` | `client` `contract` `runtime` `probe` `negative` |
+| `POST` | `/api/v1/CreateTags` | `osc/Client.CreateTags` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/DeleteTags` | `osc/Client.DeleteTags` | `client` `contract` `shape` `runtime` `probe` `negative` |
 | `POST` | `/api/v1/ReadTags` | `osc/Client.ReadTags` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 
 ### `Vm`
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `POST` | `/api/v1/CreateVms` | `osc/Client.CreateVms` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
-| `POST` | `/api/v1/DeleteVms` | `osc/Client.DeleteVms` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/CreateVms` | `osc/Client.CreateVms` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/DeleteVms` | `osc/Client.DeleteVms` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `POST` | `/api/v1/ReadAdminPassword` | `osc/Client.ReadAdminPassword` | `client` `contract` `runtime` `probe` `negative` |
 | `POST` | `/api/v1/ReadVmTypes` | `osc/Client.ReadVmTypes` | `client` `contract` `shape` `runtime` `probe` |
 | `POST` | `/api/v1/ReadVmsState` | `osc/Client.ReadVmsState` | `client` `contract` `shape` `runtime` `probe` |
@@ -623,17 +623,17 @@ are in `coverage/`, one artefact per provider.
 | `POST` | `/api/v1/RebootVms` | `osc/Client.RebootVms` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 | `POST` | `/api/v1/StartVms` | `osc/Client.StartVms` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 | `POST` | `/api/v1/StopVms` | `osc/Client.StopVms` | `client` `contract` `runtime` `probe` `negative` |
-| `POST` | `/api/v1/UpdateVm` | `osc/Client.UpdateVm` | `client` `contract` `runtime` `probe` `negative` |
+| `POST` | `/api/v1/UpdateVm` | `osc/Client.UpdateVm` | `client` `contract` `shape` `runtime` `probe` `negative` |
 
 ### `Volume`
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `POST` | `/api/v1/CreateVolume` | `osc/Client.CreateVolume` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
-| `POST` | `/api/v1/DeleteVolume` | `osc/Client.DeleteVolume` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
-| `POST` | `/api/v1/LinkVolume` | `osc/Client.LinkVolume` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/CreateVolume` | `osc/Client.CreateVolume` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/DeleteVolume` | `osc/Client.DeleteVolume` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/LinkVolume` | `osc/Client.LinkVolume` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `POST` | `/api/v1/ReadVolumes` | `osc/Client.ReadVolumes` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
-| `POST` | `/api/v1/UnlinkVolume` | `osc/Client.UnlinkVolume` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/api/v1/UnlinkVolume` | `osc/Client.UnlinkVolume` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `POST` | `/api/v1/UpdateVolume` | `osc/Client.UpdateVolume` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 
 ### Declined on purpose (170)
@@ -704,7 +704,7 @@ are in `coverage/`, one artefact per provider.
 | `GET` | `/v2/block-storage-snapshot/{id}` | `exoscale/v2.get-block-storage-snapshot` | `no-client` `probe-refusal` |
 | `GET` | `/v2/block-storage-snapshot` | `exoscale/v2.list-block-storage-snapshots` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 | `GET` | `/v2/block-storage/{id}` | `exoscale/v2.get-block-storage-volume` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `GET` | `/v2/block-storage` | `exoscale/v2.list-block-storage-volumes` | `client` `contract` `runtime` `probe` `behaviour` |
+| `GET` | `/v2/block-storage` | `exoscale/v2.list-block-storage-volumes` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 | `POST` | `/v2/block-storage/{id}:create-snapshot` | `exoscale/v2.create-block-storage-snapshot` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
 | `POST` | `/v2/block-storage` | `exoscale/v2.create-block-storage-volume` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
 | `PUT` | `/v2/block-storage-snapshot/{id}` | `exoscale/v2.update-block-storage-snapshot` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
@@ -717,7 +717,7 @@ are in `coverage/`, one artefact per provider.
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `DELETE` | `/v2/anti-affinity-group/{id}` | `exoscale/v2.delete-anti-affinity-group` | `client` `contract` `runtime` `probe` `behaviour` |
+| `DELETE` | `/v2/anti-affinity-group/{id}` | `exoscale/v2.delete-anti-affinity-group` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 | `DELETE` | `/v2/elastic-ip/{id}/{field}` | `exoscale/v2.reset-elastic-ip-field` | `no-client` |
 | `DELETE` | `/v2/elastic-ip/{id}` | `exoscale/v2.delete-elastic-ip` | `client` `contract` `runtime` `probe` `behaviour` |
 | `DELETE` | `/v2/instance-pool/{id}/{field}` | `exoscale/v2.reset-instance-pool-field` | `no-client` |
@@ -729,13 +729,13 @@ are in `coverage/`, one artefact per provider.
 | `DELETE` | `/v2/load-balancer/{id}/{field}` | `exoscale/v2.reset-load-balancer-field` | `no-client` |
 | `DELETE` | `/v2/load-balancer/{id}` | `exoscale/v2.delete-load-balancer` | `client` `contract` `runtime` `probe` `behaviour` |
 | `DELETE` | `/v2/private-network/{id}/{field}` | `exoscale/v2.reset-private-network-field` | `no-client` |
-| `DELETE` | `/v2/private-network/{id}` | `exoscale/v2.delete-private-network` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
-| `DELETE` | `/v2/security-group/{id}/rules/{rule}` | `exoscale/v2.delete-rule-from-security-group` | `client` `contract` `runtime` `probe` `behaviour` |
-| `DELETE` | `/v2/security-group/{id}` | `exoscale/v2.delete-security-group` | `client` `contract` `runtime` `probe` `behaviour` |
+| `DELETE` | `/v2/private-network/{id}` | `exoscale/v2.delete-private-network` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
+| `DELETE` | `/v2/security-group/{id}/rules/{rule}` | `exoscale/v2.delete-rule-from-security-group` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
+| `DELETE` | `/v2/security-group/{id}` | `exoscale/v2.delete-security-group` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 | `DELETE` | `/v2/snapshot/{id}` | `exoscale/v2.delete-snapshot` | `client` `contract` `runtime` `probe` `behaviour` |
-| `DELETE` | `/v2/ssh-key/{name}` | `exoscale/v2.delete-ssh-key` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `DELETE` | `/v2/ssh-key/{name}` | `exoscale/v2.delete-ssh-key` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `DELETE` | `/v2/template/{id}` | `exoscale/v2.delete-template` | `client` `contract` `runtime` `probe` `behaviour` |
-| `GET` | `/v2/anti-affinity-group/{id}` | `exoscale/v2.get-anti-affinity-group` | `client` `contract` `runtime` `probe` `behaviour` |
+| `GET` | `/v2/anti-affinity-group/{id}` | `exoscale/v2.get-anti-affinity-group` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 | `GET` | `/v2/anti-affinity-group` | `exoscale/v2.list-anti-affinity-groups` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 | `GET` | `/v2/deploy-target/{id}` | `exoscale/v2.get-deploy-target` | `no-client` `probe-refusal` |
 | `GET` | `/v2/deploy-target` | `exoscale/v2.list-deploy-targets` | `client` `contract` `shape` `runtime` `probe` |
@@ -750,9 +750,9 @@ are in `coverage/`, one artefact per provider.
 | `GET` | `/v2/load-balancer/{id}/service/{serviceID}` | `exoscale/v2.get-load-balancer-service` | `no-client` `contract` `probe` |
 | `GET` | `/v2/load-balancer/{id}` | `exoscale/v2.get-load-balancer` | `no-client` `contract` `probe` |
 | `GET` | `/v2/load-balancer` | `exoscale/v2.list-load-balancers` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
-| `GET` | `/v2/private-network/{id}` | `exoscale/v2.get-private-network` | `client` `contract` `runtime` `probe` `behaviour` |
+| `GET` | `/v2/private-network/{id}` | `exoscale/v2.get-private-network` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 | `GET` | `/v2/private-network` | `exoscale/v2.list-private-networks` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
-| `GET` | `/v2/security-group/{id}` | `exoscale/v2.get-security-group` | `no-client` `contract` `probe` |
+| `GET` | `/v2/security-group/{id}` | `exoscale/v2.get-security-group` | `no-client` `contract` `shape` `probe` |
 | `GET` | `/v2/security-group` | `exoscale/v2.list-security-groups` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 | `GET` | `/v2/snapshot/{id}` | `exoscale/v2.get-snapshot` | `no-client` `contract` `probe` |
 | `GET` | `/v2/snapshot` | `exoscale/v2.list-snapshots` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
@@ -760,7 +760,7 @@ are in `coverage/`, one artefact per provider.
 | `GET` | `/v2/ssh-key` | `exoscale/v2.list-ssh-keys` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 | `GET` | `/v2/template/{id}` | `exoscale/v2.get-template` | `client` `contract` `runtime` `probe` `behaviour` |
 | `GET` | `/v2/template` | `exoscale/v2.list-templates` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
-| `POST` | `/v2/anti-affinity-group` | `exoscale/v2.create-anti-affinity-group` | `client` `contract` `runtime` `probe` `behaviour` |
+| `POST` | `/v2/anti-affinity-group` | `exoscale/v2.create-anti-affinity-group` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 | `POST` | `/v2/elastic-ip` | `exoscale/v2.create-elastic-ip` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/v2/instance-pool` | `exoscale/v2.create-instance-pool` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/v2/instance/{id}:create-snapshot` | `exoscale/v2.create-snapshot` | `client` `contract` `runtime` `probe` `behaviour` |
@@ -769,11 +769,11 @@ are in `coverage/`, one artefact per provider.
 | `POST` | `/v2/instance` | `exoscale/v2.create-instance` | `client` `contract` `runtime` `probe` `behaviour` |
 | `POST` | `/v2/load-balancer/{id}/service` | `exoscale/v2.add-service-to-load-balancer` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 | `POST` | `/v2/load-balancer` | `exoscale/v2.create-load-balancer` | `client` `contract` `runtime` `probe` `behaviour` |
-| `POST` | `/v2/private-network` | `exoscale/v2.create-private-network` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
-| `POST` | `/v2/security-group/{id}/rules` | `exoscale/v2.add-rule-to-security-group` | `client` `contract` `runtime` `probe` `behaviour` |
-| `POST` | `/v2/security-group` | `exoscale/v2.create-security-group` | `client` `contract` `runtime` `probe` `behaviour` |
+| `POST` | `/v2/private-network` | `exoscale/v2.create-private-network` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/v2/security-group/{id}/rules` | `exoscale/v2.add-rule-to-security-group` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
+| `POST` | `/v2/security-group` | `exoscale/v2.create-security-group` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 | `POST` | `/v2/snapshot/{id}:promote` | `exoscale/v2.promote-snapshot-to-template` | `no-client` `contract` `probe` |
-| `POST` | `/v2/ssh-key` | `exoscale/v2.register-ssh-key` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/v2/ssh-key` | `exoscale/v2.register-ssh-key` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `POST` | `/v2/template/{id}` | `exoscale/v2.copy-template` | `no-client` `contract` `probe` |
 | `POST` | `/v2/template` | `exoscale/v2.register-template` | `client` `contract` `runtime` `probe` `behaviour` |
 | `PUT` | `/v2/elastic-ip/{id}:attach` | `exoscale/v2.attach-instance-to-elastic-ip` | `client` `contract` `runtime` `probe` `behaviour` |
@@ -796,7 +796,7 @@ are in `coverage/`, one artefact per provider.
 | `PUT` | `/v2/private-network/{id}:attach` | `exoscale/v2.attach-instance-to-private-network` | `client` `contract` `runtime` `probe` `behaviour` |
 | `PUT` | `/v2/private-network/{id}:detach` | `exoscale/v2.detach-instance-from-private-network` | `client` `contract` `runtime` `probe` `behaviour` |
 | `PUT` | `/v2/private-network/{id}:update-ip` | `exoscale/v2.update-private-network-instance-ip` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
-| `PUT` | `/v2/private-network/{id}` | `exoscale/v2.update-private-network` | `client` `contract` `runtime` `probe` `behaviour` |
+| `PUT` | `/v2/private-network/{id}` | `exoscale/v2.update-private-network` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
 | `PUT` | `/v2/security-group/{id}:add-source` | `exoscale/v2.add-external-source-to-security-group` | `client` `contract` `runtime` `probe` `behaviour` |
 | `PUT` | `/v2/security-group/{id}:attach` | `exoscale/v2.attach-instance-to-security-group` | `client` `contract` `runtime` `probe` `behaviour` |
 | `PUT` | `/v2/security-group/{id}:detach` | `exoscale/v2.detach-instance-from-security-group` | `client` `contract` `runtime` `probe` `behaviour` |
@@ -807,7 +807,7 @@ are in `coverage/`, one artefact per provider.
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `GET` | `/v2/operation/{id}` | `exoscale/v2.get-operation` | `no-client` `contract` `probe` |
+| `GET` | `/v2/operation/{id}` | `exoscale/v2.get-operation` | `no-client` `contract` `shape` `probe` |
 | `GET` | `/v2/zone` | `exoscale/v2.list-zones` | `client` `contract` `shape` `runtime` `probe` |
 
 ### `organization`
@@ -821,7 +821,7 @@ are in `coverage/`, one artefact per provider.
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
 | `GET` | `/v2/quota/{name}` | `exoscale/v2.get-quota` | `no-client` |
-| `GET` | `/v2/quota` | `exoscale/v2.list-quotas` | `client` `contract` `runtime` `probe` |
+| `GET` | `/v2/quota` | `exoscale/v2.list-quotas` | `client` `contract` `shape` `runtime` `probe` |
 
 ### Served, and driven by no client (19)
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -145,11 +145,20 @@ const (
 // removed, no exit code moved, and a pipeline keyed on version 12 keeps
 // working.
 //
+// Version 15 adds `evidence --reshape` (#407): the shape axis is the one axis
+// that is not a property of a run — `evidence` already discards whatever the
+// server answered and re-derives it from --shapes — so a catalogue that grew
+// offline can be published without two conformance legs, one of them on a host
+// that can start machines. It refuses a record whose contracts or suites moved,
+// and it recomputes the column wholesale so a catalogue that lost evidence
+// lowers the figure. An addition to one existing verb; nothing was removed, no
+// exit code moved, and a pipeline keyed on version 14 keeps working.
+//
 // The surface itself is frozen in testdata/frozen/cli.json, compared by
 // TestTheFrozenSurfacesStillMatchTheirFixture, and a fixture regenerated
 // without bumping this constant fails TestASurfaceChangeDemandsItsVersionBump.
 // The procedure for a deliberate change is in RELEASING.md ("Frozen surfaces").
-const cliSurfaceVersion = 14
+const cliSurfaceVersion = 15
 
 // Run executes one command and returns the process exit code.
 func Run(args []string, stdout, stderr io.Writer) int {
@@ -449,7 +458,7 @@ Usage:
   feint evidence   [--endpoint http://127.0.0.1:4599] [--shapes shapes]
                    [--contracts contracts] [--suites tools/conformance]
                    [--out coverage/evidence.json] [--join <other.json>]
-                   [--allow-narrowing]
+                   [--allow-narrowing] [--reshape]
                     Write the per-operation evidence record from a running
                     emulator's /_feint/conformance: which independent proofs
                     each operation has earned, side by side, never summed.
@@ -458,6 +467,10 @@ Usage:
                     regeneration, and --allow-narrowing is what a run reaching
                     fewer runtimes than the record it replaces has to say out
                     loud before it may overwrite it.
+                    --reshape needs no run at all: it recomputes only the shape
+                    axis of the record at --out from the catalogues in --shapes,
+                    offline, and refuses a record whose contracts or suites have
+                    moved since it was written.
 
   feint docs       [--file README.md] [--coverage <dir>] [--contracts <dir>] [--check]
                     [--limits <file>] [--routes <file>] [--confidence <file>]

--- a/internal/cli/evidence.go
+++ b/internal/cli/evidence.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/stephrobert/feint/internal/core/emulator"
-	"github.com/stephrobert/feint/internal/upstream"
 )
 
 // The per-operation evidence record (#123): what is proven about an operation
@@ -173,8 +172,13 @@ func evidence(args []string, stdout, stderr io.Writer) int {
 	allowNarrowing := fs.Bool("allow-narrowing", false,
 		"write even when this run reaches fewer runtimes than the record it replaces; "+
 			"for the single-leg caller of evidence:update, never for a committed artefact")
+	reshape := fs.Bool("reshape", false,
+		"recompute only the shape axis of an existing record from --shapes, offline, without a run")
 	if err := fs.Parse(args); err != nil {
 		return exitError
+	}
+	if *reshape {
+		return reshapeEvidence(*out, *shapesDir, *contractsDir, *suitesDir, stdout, stderr)
 	}
 
 	var view emulator.ConformanceView
@@ -287,18 +291,25 @@ func evidence(args []string, stdout, stderr io.Writer) int {
 	// Said before the write, so it is still true of the file being replaced.
 	reportAxesLost(stderr, *out, art)
 
-	blob, err := json.MarshalIndent(art, "", "  ")
-	if err != nil {
-		fmt.Fprintf(stderr, "feint: %v\n", err)
-		return exitError
-	}
-	if err := os.WriteFile(*out, append(blob, '\n'), 0o644); err != nil { //nolint:gosec // a versioned artefact is world-readable by design
+	if err := writeEvidence(*out, art); err != nil {
 		fmt.Fprintf(stderr, "feint: %v\n", err)
 		return exitError
 	}
 	fmt.Fprintf(stdout, "evidence for %d operation(s) written to %s (machines: %s)\n",
 		len(art.Operations), *out, strings.Join(art.Machines, ", "))
 	return exitOK
+}
+
+// writeEvidence renders an artefact where every writer of one puts it: indented,
+// key-sorted by encoding/json, and newline-terminated, because the file is
+// committed and read by `git diff`.
+func writeEvidence(path string, art *evidenceArtefact) error {
+	blob, err := json.MarshalIndent(art, "", "  ")
+	if err != nil {
+		return err
+	}
+	//nolint:gosec // a versioned artefact is world-readable by design
+	return os.WriteFile(path, append(blob, '\n'), 0o644)
 }
 
 // readEvidence loads an artefact, refusing what it cannot account for — the
@@ -429,49 +440,126 @@ func strongerShape(a, b string) string {
 	return a
 }
 
-// shapeCoveredOperations maps the observed catalogues onto mounted
-// operations: for every entry of the curated read list that the catalogue
-// covers with at least one field — the same bar the shapes gate applies — the
-// mounted route answering that call contributes its operation name.
+// reshapeEvidence recomputes the shape axis of a record already on disk, from
+// the catalogues on disk, and writes nothing else.
+//
+// It exists because the shape axis is the one axis that is *not* a property of
+// a run: [evidence] already discards whatever the server answered and re-derives
+// it from --shapes. So a catalogue that grows — `mise run shapes:fold` folding
+// the committed corpora is the case #407 built it for — moves a published figure
+// that no conformance run is needed to establish. Without this, refreshing it
+// would mean two full conformance legs, one of them on a host that can start
+// machines, to publish a number computed offline in milliseconds.
+//
+// Two refusals keep it from becoming a way to write a number by hand, which is
+// the defect #406 closed elsewhere and which a narrow rewrite invites:
+//
+//   - the contracts and the suites must digest to what the record was produced
+//     from. If either moved, the record is stale for a reason a reshape cannot
+//     fix, and refreshing one axis would put a fresh figure on a stale record.
+//   - every other axis is carried over untouched, and the shape column is
+//     recomputed wholesale rather than raised: an operation the catalogue no
+//     longer covers is demoted, so a fold that removed evidence lowers the
+//     figure instead of leaving a high-water mark.
+//
+// TestAReshapeRefusesARecordWhoseOtherInputsMoved and
+// TestAReshapeDemotesAnOperationTheCatalogueNoLongerCovers fail without these.
+func reshapeEvidence(path, shapesDir, contractsDir, suitesDir string, stdout, stderr io.Writer) int {
+	if shapesDir == "" {
+		fmt.Fprintln(stderr, "feint: --reshape reads the catalogues; it cannot run with --shapes empty")
+		return exitError
+	}
+	art, err := readEvidence(path)
+	if err != nil {
+		fmt.Fprintf(stderr, "feint: %v\n", err)
+		return exitError
+	}
+	from, err := provenanceOf(contractsDir, shapesDir, suitesDir)
+	if err != nil {
+		fmt.Fprintf(stderr, "feint: %v\n", err)
+		return exitError
+	}
+	var moved []string
+	if from.Contracts != art.GeneratedFrom.Contracts {
+		moved = append(moved, "contracts")
+	}
+	if from.Suites != art.GeneratedFrom.Suites {
+		moved = append(moved, "suites")
+	}
+	if len(moved) > 0 {
+		fmt.Fprintf(stderr,
+			"feint: %s was produced from other %s, so its other axes are stale and a fresh shape "+
+				"column would sit on them; regenerate it with `mise run evidence:update`\n",
+			path, strings.Join(moved, " and "))
+		return exitError
+	}
+
+	covered, err := shapeCoveredOperations(shapesDir)
+	if err != nil {
+		fmt.Fprintf(stderr, "feint: %v\n", err)
+		return exitError
+	}
+	if covered == nil {
+		fmt.Fprintf(stderr, "feint: no catalogue in %s, so there is nothing to resolve the shape axis from\n", shapesDir)
+		return exitError
+	}
+
+	was, now := 0, 0
+	for op, ev := range art.Operations {
+		if ev.Shape == emulator.ShapeObserved {
+			was++
+		}
+		ev.Shape = emulator.ShapeUnobserved
+		if covered[op] {
+			ev.Shape = emulator.ShapeObserved
+			now++
+		}
+		art.Operations[op] = ev
+	}
+	art.GeneratedFrom.Shapes = from.Shapes
+
+	reportAxesLost(stderr, path, art)
+	if err := writeEvidence(path, art); err != nil {
+		fmt.Fprintf(stderr, "feint: %v\n", err)
+		return exitError
+	}
+	fmt.Fprintf(stdout, "%s: shape %d -> %d of %d operation(s), from %s; no other axis touched\n",
+		path, was, now, len(art.Operations), shapesDir)
+	return exitOK
+}
+
+// shapeCoveredOperations names the mounted operations whose answer has been
+// held against one recorded from the real cloud: every catalogue entry
+// carrying at least one field, resolved onto the operation that serves the
+// same call.
+//
+// It walks the whole catalogue, and that is the correction #407 measured. It
+// used to walk [upstream.Reads] instead — thirty-odd curated calls per
+// provider — which capped the axis at the size of a hand-written list however
+// much had been recorded. The cap was not theoretical: the axis read 52 of 370
+// and its ceiling was **also 52**, per provider to the unit (exoscale 14,
+// outscale 23, scaleway 15). Saturated at its own ceiling, it published 14 %
+// and named 292 operations "no answer of the real cloud has been kept" —
+// including every operation the committed corpora had already recorded, which
+// the axis never asked about. A control whose numerator cannot move is not a
+// measurement.
 //
 // nil with no error means no catalogue exists at all, which callers report as
 // "unknown" rather than demoting every operation to "unobserved".
+//
+// TestAShapeRecordedOutsideTheReadListStillCounts fails without this.
 func shapeCoveredOperations(dir string) (map[string]bool, error) {
 	srv, _, err := newServer(nil)
 	if err != nil {
 		return nil, err
 	}
-	routes := srv.AllRoutes()
-
-	covered := map[string]bool{}
-	found := false
-	for _, p := range srv.Packs() {
-		cat, err := readCatalogue(filepath.Join(dir, p.Name()+".json"), p.Name())
-		if err != nil {
-			return nil, err
-		}
-		if cat == nil {
-			continue
-		}
-		found = true
-		provider := upstream.Provider(p.Name())
-		for _, call := range upstream.Reads[provider] {
-			key, method, path := callIdentity(provider, call)
-			want, known := cat.Operations[key]
-			if !known || len(want.Fields) == 0 {
-				continue
-			}
-			op, err := operationForCall(routes, method, path)
-			if err != nil {
-				return nil, fmt.Errorf("%s: %w", key, err)
-			}
-			if op != "" {
-				covered[op] = true
-			}
-		}
+	observed, err := observedFieldsByOperation(dir, srv)
+	if err != nil || observed == nil {
+		return nil, err
 	}
-	if !found {
-		return nil, nil
+	covered := make(map[string]bool, len(observed))
+	for op := range observed {
+		covered[op] = true
 	}
 	return covered, nil
 }

--- a/internal/cli/evidence_axes.go
+++ b/internal/cli/evidence_axes.go
@@ -110,7 +110,7 @@ func evidenceAxisList() []evidenceAxis {
 		},
 		{
 			Name:    "shape",
-			Meaning: "a recorded real-cloud answer covers it and the shapes gate holds the emulator to that record, field by field",
+			Meaning: "a recorded real-cloud answer covers it, from `shapes/` — which `mise run shapes:fold` also fills from the committed corpora; it says the answer has been held against a real one, not that the offline gate re-issues the call",
 			earned:  func(e emulator.Evidence) bool { return e.Shape == emulator.ShapeObserved },
 			verdict: func(e emulator.Evidence) string { return e.Shape },
 		},

--- a/internal/cli/evidence_test.go
+++ b/internal/cli/evidence_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/upstream"
 )
 
 // The artefact is what docs/routes.md prints and what the /falsify criterion
@@ -482,5 +483,265 @@ func TestAnAxisWithNoVerdictIsNotEarned(t *testing.T) {
 	})
 	if _, err := readEvidence(path); err != nil {
 		t.Errorf("a record that accounts for itself was refused: %v", err)
+	}
+}
+
+// A shape recorded outside the curated read list still counts.
+//
+// This is the defect #407 measured, and it is invisible from a total.
+// shapeCoveredOperations used to walk upstream.Reads — thirty-odd calls per
+// provider — so the axis could not exceed the length of a hand-written list
+// however much had been recorded. The measurement: the axis read 52 of 370 and
+// its ceiling was **also 52**, per provider to the unit (exoscale 14, outscale
+// 23, scaleway 15). Saturated at its own ceiling, it named 292 operations "no
+// answer of the real cloud has been kept", including every one of the 619
+// exchanges already committed under corpus/, which it never asked about.
+//
+// The fixture below is the shape of that blindness: `CreateServer` is mounted,
+// it is recorded, and it is not a read, so no entry of upstream.Reads can ever
+// name it.
+func TestAShapeRecordedOutsideTheReadListStillCounts(t *testing.T) {
+	dir := t.TempDir()
+	catalogue := `{
+	  "provider": "scaleway",
+	  "operations": {
+	    "instance/v1/API.CreateServer": {
+	      "method": "POST",
+	      "path": "/instance/v1/zones/fr-par-1/servers",
+	      "fields": [{"path": "server.id", "type": "string"}],
+	      "statuses": [201]
+	    }
+	  }
+	}`
+	if err := os.WriteFile(filepath.Join(dir, "scaleway.json"), []byte(catalogue), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, call := range upstream.Reads[upstream.Scaleway] {
+		if strings.Contains(call, "CreateServer") {
+			t.Fatalf("the fixture stopped being a fixture: %q is in the read list, so this "+
+				"test would pass on the code it exists to refuse", call)
+		}
+	}
+
+	covered, err := shapeCoveredOperations(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !covered["instance/v1/API.CreateServer"] {
+		t.Errorf("a recorded create is mounted and observed, and the axis did not count it; covered = %v", covered)
+	}
+}
+
+// An entry with no field is not an observation, whichever list it is in.
+//
+// A refusal recorded against a real cloud lands in the catalogue with its
+// status and an empty field list — deliberately, so "called and refused" is
+// distinguishable from "never called". Counting it would credit the shape axis
+// for corpora of 4xx, which prove something else entirely (the negative axis).
+func TestAnOperationRecordedWithoutFieldsEarnsNoShape(t *testing.T) {
+	dir := t.TempDir()
+	catalogue := `{
+	  "provider": "scaleway",
+	  "operations": {
+	    "instance/v1/API.CreateServer": {
+	      "method": "POST",
+	      "path": "/instance/v1/zones/fr-par-1/servers",
+	      "fields": [],
+	      "statuses": [404]
+	    },
+	    "instance/v1/API.ListServers": {
+	      "method": "GET",
+	      "path": "/instance/v1/zones/fr-par-1/servers",
+	      "fields": [{"path": "servers", "type": "array"}],
+	      "statuses": [200]
+	    }
+	  }
+	}`
+	if err := os.WriteFile(filepath.Join(dir, "scaleway.json"), []byte(catalogue), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	covered, err := shapeCoveredOperations(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if covered["instance/v1/API.CreateServer"] {
+		t.Errorf("a refusal with no field was counted as a recorded shape")
+	}
+	// The witness: the reader must still find the operation beside it, or a
+	// scan that read nothing would pass this test.
+	if !covered["instance/v1/API.ListServers"] {
+		t.Fatalf("the reader found nothing at all; covered = %v", covered)
+	}
+}
+
+// writeRecord puts an artefact on disk the way `feint evidence` would, with a
+// provenance matching the directories named.
+func writeRecord(t *testing.T, path, contractsDir, shapesDir, suitesDir string, ops map[string]emulator.Evidence) {
+	t.Helper()
+	from, err := provenanceOf(contractsDir, shapesDir, suitesDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	art := &evidenceArtefact{
+		Format: evidenceFormat, Version: evidenceVersion,
+		Machines: []string{"none"}, GeneratedFrom: from, Operations: ops,
+	}
+	if err := writeEvidence(path, art); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A reshape refuses a record whose other inputs moved.
+//
+// It rewrites one axis of a file it did not produce, which is exactly the
+// operation that can put a fresh figure on a stale record. The shape axis is
+// static, so recomputing it needs no run — but the six axes beside it are not,
+// and a suite that gained or lost an assertion since the record was written
+// makes them wrong in a way no reshape can see.
+func TestAReshapeRefusesARecordWhoseOtherInputsMoved(t *testing.T) {
+	dir := t.TempDir()
+	record := filepath.Join(dir, "evidence.json")
+	suites := filepath.Join(dir, "suites")
+	shapes := filepath.Join(dir, "shapes")
+	if err := os.MkdirAll(suites, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(shapes, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(shapes, "scaleway.json"), []byte(`{
+	  "provider": "scaleway",
+	  "operations": {"instance/v1/API.ListServers": {"method":"GET",
+	    "path":"/instance/v1/zones/fr-par-1/servers",
+	    "fields":[{"path":"servers","type":"array"}],"statuses":[200]}}
+	}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(suites, "one.sh"), []byte("echo one\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writeRecord(t, record, "contracts", shapes, suites,
+		map[string]emulator.Evidence{"instance/v1/API.ListServers": {
+			Probed: emulator.ProbeNone, Contract: emulator.ContractUnchecked,
+			Shape: emulator.ShapeUnobserved,
+		}})
+
+	// An assertion is removed from the suite: the digest moves.
+	if err := os.WriteFile(filepath.Join(suites, "one.sh"), []byte("echo nothing\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var out, errs strings.Builder
+	if code := reshapeEvidence(record, shapes, "contracts", suites, &out, &errs); code != exitError {
+		t.Fatalf("exit %d, want %d: a reshape wrote onto a record whose suites moved", code, exitError)
+	}
+	if !strings.Contains(errs.String(), "suites") {
+		t.Errorf("the refusal must name what moved, got %q", errs.String())
+	}
+	// The witness: with the suite put back, the same call must go through, or
+	// this test would pass on a reshape that refuses everything.
+	if err := os.WriteFile(filepath.Join(suites, "one.sh"), []byte("echo one\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	errs.Reset()
+	if code := reshapeEvidence(record, shapes, "contracts", suites, &out, &errs); code != exitOK {
+		t.Fatalf("exit %d, want %d, on unmoved inputs: %s", code, exitOK, errs.String())
+	}
+}
+
+// A reshape demotes an operation the catalogue no longer covers.
+//
+// The column is recomputed wholesale rather than raised, so a catalogue that
+// lost evidence lowers the figure. Written as a control because a "refresh"
+// that only ever adds is a high-water mark, which is the thing this record was
+// built not to be.
+func TestAReshapeDemotesAnOperationTheCatalogueNoLongerCovers(t *testing.T) {
+	dir := t.TempDir()
+	record := filepath.Join(dir, "evidence.json")
+	shapes := filepath.Join(dir, "shapes")
+	if err := os.MkdirAll(shapes, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	catalogue := `{
+	  "provider": "scaleway",
+	  "operations": {
+	    "instance/v1/API.ListServers": {
+	      "method": "GET", "path": "/instance/v1/zones/fr-par-1/servers",
+	      "fields": [{"path": "servers", "type": "array"}], "statuses": [200]
+	    }
+	  }
+	}`
+	if err := os.WriteFile(filepath.Join(shapes, "scaleway.json"), []byte(catalogue), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writeRecord(t, record, "contracts", shapes, filepath.Join("tools", "conformance"),
+		map[string]emulator.Evidence{
+			"instance/v1/API.ListServers": {Probed: emulator.ProbeNone,
+				Contract: emulator.ContractUnchecked, Shape: emulator.ShapeObserved},
+			"instance/v1/API.CreateIP": {Probed: emulator.ProbeNone,
+				Contract: emulator.ContractUnchecked, Shape: emulator.ShapeObserved},
+		})
+
+	var out, errs strings.Builder
+	code := reshapeEvidence(record, shapes, "contracts", filepath.Join("tools", "conformance"), &out, &errs)
+	if code != exitOK {
+		t.Fatalf("exit %d: %s", code, errs.String())
+	}
+	got, err := readEvidence(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Operations["instance/v1/API.CreateIP"].Shape != emulator.ShapeUnobserved {
+		t.Errorf("CreateIP is covered by no catalogue entry and kept %q: the column is a high-water mark",
+			got.Operations["instance/v1/API.CreateIP"].Shape)
+	}
+	// The witness: the operation the catalogue does cover must survive, or a
+	// reshape that demoted everything would pass.
+	if got.Operations["instance/v1/API.ListServers"].Shape != emulator.ShapeObserved {
+		t.Errorf("ListServers is covered and was demoted; the reshape demotes indiscriminately")
+	}
+	if !strings.Contains(errs.String(), "instance/v1/API.CreateIP") {
+		t.Errorf("a demotion must be said out loud, got %q", errs.String())
+	}
+}
+
+// A reshape touches the shape axis and nothing else.
+func TestAReshapeMovesNoOtherAxis(t *testing.T) {
+	dir := t.TempDir()
+	record := filepath.Join(dir, "evidence.json")
+	shapes := filepath.Join(dir, "shapes")
+	if err := os.MkdirAll(shapes, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(shapes, "scaleway.json"), []byte(`{
+	  "provider": "scaleway",
+	  "operations": {"instance/v1/API.ListServers": {"method":"GET",
+	    "path":"/instance/v1/zones/fr-par-1/servers",
+	    "fields":[{"path":"servers","type":"array"}],"statuses":[200]}}
+	}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	before := emulator.Evidence{
+		Driven: true, Probed: emulator.ProbeResponse, Contract: emulator.ContractClean,
+		Dataplane: true, Shape: emulator.ShapeUnobserved, Behaviour: true, Negative: true,
+	}
+	writeRecord(t, record, "contracts", shapes, filepath.Join("tools", "conformance"),
+		map[string]emulator.Evidence{"instance/v1/API.ListServers": before})
+
+	var out, errs strings.Builder
+	if code := reshapeEvidence(record, shapes, "contracts", filepath.Join("tools", "conformance"), &out, &errs); code != exitOK {
+		t.Fatalf("exit %d: %s", code, errs.String())
+	}
+	got, err := readEvidence(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	after := got.Operations["instance/v1/API.ListServers"]
+	if after.Shape != emulator.ShapeObserved {
+		t.Fatalf("the shape axis did not move, so this test measures nothing")
+	}
+	after.Shape = before.Shape
+	if after != before {
+		t.Errorf("another axis moved: %+v became %+v", before, after)
 	}
 }

--- a/internal/cli/testdata/frozen/cli.json
+++ b/internal/cli/testdata/frozen/cli.json
@@ -2216,6 +2216,192 @@
           ]
         }
       }
+    },
+    {
+      "schema_version": 15,
+      "content": {
+        "exit_codes": {
+          "drift": 2,
+          "error": 1,
+          "ok": 0
+        },
+        "verbs": {
+          "catalog": [
+            "--format"
+          ],
+          "clean": [
+            "--check",
+            "--vm"
+          ],
+          "corpus": [
+            "--accepted",
+            "--against-cloud",
+            "--bind",
+            "--check",
+            "--credential",
+            "--dir",
+            "--dry-run",
+            "--endpoint",
+            "--file",
+            "--format",
+            "--mark-stale",
+            "--timeout"
+          ],
+          "coverage": [
+            "--artefact",
+            "--axis",
+            "--baseline",
+            "--contract",
+            "--evidence",
+            "--fail-on-unknown",
+            "--format",
+            "--gaps",
+            "--observed",
+            "--products",
+            "--provider",
+            "--sdk",
+            "--write-baseline"
+          ],
+          "docs": [
+            "--check",
+            "--client-pins",
+            "--confidence",
+            "--contracts",
+            "--coverage",
+            "--file",
+            "--install",
+            "--limits",
+            "--proved",
+            "--routes",
+            "--screenshots",
+            "--ui-manifest",
+            "--workflow"
+          ],
+          "doctor": [
+            "--addr",
+            "--vm"
+          ],
+          "env": [
+            "--client",
+            "--endpoint",
+            "--shell",
+            "--unset"
+          ],
+          "evidence": [
+            "--allow-narrowing",
+            "--contracts",
+            "--endpoint",
+            "--join",
+            "--out",
+            "--reshape",
+            "--shapes",
+            "--suites"
+          ],
+          "images": [
+            "--check",
+            "--only",
+            "--vm"
+          ],
+          "logs": [
+            "--addr",
+            "-f",
+            "-n"
+          ],
+          "probe": [
+            "--contracts",
+            "--endpoint",
+            "--provider"
+          ],
+          "proxy": [
+            "--addr",
+            "--expose-to-network",
+            "--forward",
+            "--intercept",
+            "--max-body",
+            "--provider",
+            "--queue",
+            "--record",
+            "--upstream"
+          ],
+          "replay": [
+            "--endpoint",
+            "--format",
+            "--refusals-only",
+            "--timeout"
+          ],
+          "restart": [
+            "--addr",
+            "--timeout"
+          ],
+          "serve": [
+            "--addr",
+            "--cleanup",
+            "--contracts",
+            "--coverage",
+            "--expose-to-network",
+            "--log-level",
+            "--shapes",
+            "--state",
+            "--vm"
+          ],
+          "shapes": [
+            "--check",
+            "--dir",
+            "--dry-run",
+            "--profile",
+            "--provider",
+            "--record"
+          ],
+          "snapshot list": [
+            "--format"
+          ],
+          "snapshot load": [
+            "--addr"
+          ],
+          "snapshot save": [
+            "--addr",
+            "--force"
+          ],
+          "start": [
+            "--addr",
+            "--cleanup",
+            "--contracts",
+            "--detach",
+            "--foreground",
+            "--log-level",
+            "--state",
+            "--timeout",
+            "--vm"
+          ],
+          "status": [
+            "--addr",
+            "--coverage",
+            "--format"
+          ],
+          "stop": [
+            "--addr",
+            "--timeout"
+          ],
+          "transcript": [
+            "--against",
+            "--contract",
+            "--format",
+            "--sanitise",
+            "--shape"
+          ],
+          "ui": [
+            "--addr",
+            "--print"
+          ],
+          "version": [
+            "--check"
+          ],
+          "wait": [
+            "--addr",
+            "--timeout"
+          ]
+        }
+      }
     }
   ]
 }

--- a/internal/core/emulator/conformance.go
+++ b/internal/core/emulator/conformance.go
@@ -664,9 +664,22 @@ type Evidence struct {
 	// the behaviour axis, which does not exist yet.
 	Dataplane bool `json:"dataplane"`
 	// Shape: "observed" when a real cloud's recorded answer covers this
-	// operation and the shapes gate holds the emulator to it, "unobserved"
-	// when the catalogue does not cover it, "unknown" when this server was
-	// given no catalogue to look in.
+	// operation with at least one field, "unobserved" when the catalogue does
+	// not cover it, "unknown" when this server was given no catalogue to look
+	// in.
+	//
+	// It says the answer has been held against a real one; it does not say the
+	// offline shapes gate re-issues the call. That gate can only compare what
+	// it can safely reissue against an empty store, so it drives a curated list
+	// of reads (upstream.Reads) and no create — which is why this axis and
+	// `feint shapes --check` count different populations, and why the sentence
+	// used to conflate them: until #407 the axis walked that same read list, so
+	// the two happened to coincide at 52 operations, which was also the axis's
+	// ceiling.
+	//
+	// What does hold the emulator to the whole catalogue is the live field gate
+	// (SetObservedFields below), which corroborates a declared-but-absent field
+	// against every recorded answer, not against a read list.
 	Shape string `json:"shape"`
 	// Behaviour: this operation touched a resource whose full lifecycle —
 	// created, then destroyed — the store itself observed inside an assertion

--- a/internal/corpus/corpus.go
+++ b/internal/corpus/corpus.go
@@ -639,7 +639,12 @@ func (m *mint) synthesise(s string) string {
 // Exported because [Scan] recognises it and because a reader of a committed
 // corpus should be able to tell an invented value from a surviving one at a
 // glance.
-const Token = "redacted-"
+//
+// Aliased rather than restated: internal/shape refuses to learn a type or a
+// route from a value carrying this prefix, and two spellings of the same token
+// would let a fold read as observed exactly what this package invented.
+// TestTheSanitisersTokenIsTheOneShapeRefuses fails if they drift apart.
+const Token = shape.RedactionToken
 
 // isPrefix recognises Outscale's "i-<hex>" family without recognising a UUID,
 // which shape.IsMintedIdentifier answers for as well.

--- a/internal/corpus/corpus_test.go
+++ b/internal/corpus/corpus_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stephrobert/feint/internal/contract"
 	"github.com/stephrobert/feint/internal/core/sshkey"
+	"github.com/stephrobert/feint/internal/shape"
 	"github.com/stephrobert/feint/internal/trace"
 	"github.com/stephrobert/feint/internal/transcript"
 )
@@ -819,5 +820,31 @@ func TestABlockShorterThanTheSyntheticSpaceStaysInsideIt(t *testing.T) {
 	}
 	if leaks := Scan(out, options(t)); len(leaks) != 0 {
 		t.Fatalf("the alphabet refused a block it minted itself: %v", leaks)
+	}
+}
+
+// The token this package hands out is the one internal/shape refuses.
+//
+// Token is an alias rather than a second literal, which makes them equal by
+// construction — but the property that matters is not that two constants match,
+// it is that a value this package actually mints is one a fold will not learn a
+// type from. So this mints values and asks internal/shape about them, and it is
+// what goes red the day the sanitiser writes a spelling shape does not know.
+//
+// Without it, `mise run shapes:fold` would record every sanitised string as an
+// observation of the API, when it is an observation of this package.
+func TestTheSanitisersTokenIsTheOneShapeRefuses(t *testing.T) {
+	m := newMint(Options{})
+	for _, original := range []string{"my-vm", "some description", "eu-west-2"} {
+		minted := m.synthesise(original)
+		if !shape.IsRedacted(minted) {
+			t.Errorf("this package mints %q for %q, and shape.IsRedacted says it is an observation",
+				minted, original)
+		}
+	}
+	// The witness: a value this package leaves alone must stay learnable, or a
+	// predicate refusing everything would pass and empty every catalogue.
+	if shape.IsRedacted("running") {
+		t.Errorf("shape.IsRedacted(%q) = true, and nothing mints it", "running")
 	}
 }

--- a/internal/proxy/redact_internal_test.go
+++ b/internal/proxy/redact_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/stephrobert/feint/internal/core/sshkey"
+	"github.com/stephrobert/feint/internal/shape"
 	"github.com/stephrobert/feint/internal/trace"
 )
 
@@ -454,4 +455,36 @@ func privateKeyArmour(t *testing.T) string {
 		t.Fatalf("the key reader accepts an armoured private key, which would make the exemption a hole")
 	}
 	return armoured
+}
+
+// Every value this recorder writes is one internal/shape refuses to learn from.
+//
+// internal/shape restates the `REDACTED` prefix rather than importing it: this
+// package mounts an emulator and internal/core/emulator reads internal/shape,
+// so the import can only go one way. A restatement is a second spelling, and
+// this repository has paid twice for two spellings of one fact — so the
+// restatement is not trusted, it is fed this recorder's own output.
+//
+// Without it, a recorder that changed its placeholder would leave the fold
+// learning "string" for every bool and array it replaced, silently, and the
+// catalogue would publish a polymorphism no provider has.
+func TestEveryValueTheRecorderWritesIsOneShapeRefuses(t *testing.T) {
+	for _, value := range []string{
+		Placeholder,
+		placeholderFor(""),
+		placeholderFor("a-secret"),
+		placeholderFor("feint-corpus-key"),
+	} {
+		if !shape.IsRedacted(value) {
+			t.Errorf("shape.IsRedacted(%q) = false: the recorder writes it and the catalogue would learn its type", value)
+		}
+	}
+	// The witness: a value the recorder never writes must not be refused, or a
+	// predicate that answered true to everything would pass this test and erase
+	// the catalogue.
+	for _, value := range []string{"REDACTEDLY", "REDACTED-zz", "running", ""} {
+		if shape.IsRedacted(value) {
+			t.Errorf("shape.IsRedacted(%q) = true, and the recorder never writes it", value)
+		}
+	}
 }

--- a/internal/shape/redaction.go
+++ b/internal/shape/redaction.go
@@ -1,0 +1,106 @@
+package shape
+
+import (
+	"strconv"
+	"strings"
+)
+
+// RedactionToken is the prefix of every synthetic string the corpus sanitiser
+// hands out for a value that has no shape of its own.
+//
+// It lives here rather than in internal/corpus because two packages must
+// recognise the same spelling from opposite ends of the same chain, and
+// internal/corpus already imports this one: the sanitiser writes the token, and
+// this package must refuse to learn a type or a route from it. Two spellings
+// would answer differently the day one of them learned a case — the duplication
+// [IsMintedIdentifier] already exists to avoid, and internal/corpus aliases this
+// constant rather than restating it.
+const RedactionToken = "redacted-"
+
+// recorderToken is the prefix the proxy writes over every value it replaces.
+//
+// Restated here rather than imported, and the reason is the import graph:
+// internal/proxy mounts an emulator, internal/core/emulator reads this package,
+// so a dependency the other way is a cycle. The restatement is not trusted —
+// TestEveryValueTheRecorderWritesIsOneShapeRefuses (internal/proxy, which can
+// see both) feeds this function the recorder's own output, so the day the
+// recorder changes its spelling the test goes red here rather than a fold
+// silently learning "string" again.
+const recorderToken = "REDACTED"
+
+// IsRedacted reports whether a recorded value was replaced rather than
+// observed — by the recorder (proxy's `REDACTED`, bare or suffixed) or by the
+// corpus sanitiser (this package's [RedactionToken]).
+//
+// The distinction it protects is the one this package is made of. A shape is
+// paths and types and nothing else, so a value whose type was erased by a
+// redaction is not evidence about the API: the recorder writes a string over
+// whatever it replaced, and folding that in teaches "string" for a bool.
+//
+// Measured on the committed corpora before this existed: folding them into the
+// catalogues turned `osc/Client.ReadKeypairs.Keypairs` from `array` into
+// `array|string` and `osc/Client.ReadLoadBalancers.LoadBalancers[].SecuredCookies`
+// from `bool` into `bool|string`, on top of types a direct `feint shapes
+// --record` run had already got right. Twenty-three (operation, field) pairs of
+// those corpora carry a placeholder, seven of them over a non-string.
+//
+// TestARedactedValueTeachesNoType and TestFoldingACorpusDoesNotUnlearnAType
+// fail without this.
+func IsRedacted(v any) bool {
+	s, isText := v.(string)
+	if !isText {
+		return false
+	}
+	if s == recorderToken {
+		return true
+	}
+	// The recorder suffixes a keyed digest and the sanitiser a decimal counter;
+	// both are numbered forms of the same erasure, and neither carries the type
+	// it replaced. A value that merely starts with one of the words is not one
+	// of ours.
+	if rest, found := strings.CutPrefix(s, recorderToken+"-"); found {
+		return isHex(rest) || isDigits(rest)
+	}
+	rest, found := strings.CutPrefix(s, RedactionToken)
+	return found && isDigits(rest)
+}
+
+func isDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	_, err := strconv.Atoi(s)
+	return err == nil
+}
+
+func isHex(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+// PathIsRedacted reports whether any segment of a request path was replaced
+// rather than recorded.
+//
+// Such a path names no API. It cannot be a catalogue key — `GET
+// /redacted-749/redacted-750/redacted-751/fr-par-3/redacted-752` is what the
+// committed Scaleway corpus produced, and the number in it moves every time the
+// corpus is re-sanitised, which is exactly the volatility this package's own
+// header forbids storing — and it cannot be an [Operation.Path] either, because
+// that field exists so a reader can reproduce the call.
+//
+// TestARedactedPathIsNeverAKey fails without this.
+func PathIsRedacted(path string) bool {
+	for _, seg := range strings.Split(path, "/") {
+		if IsRedacted(seg) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/shape/redaction_test.go
+++ b/internal/shape/redaction_test.go
@@ -1,0 +1,171 @@
+package shape
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/trace"
+)
+
+// A redaction erases a type; it does not report one.
+//
+// The recorder writes a string over whatever it replaced, so a bool comes back
+// as "REDACTED-3f2a" and an array as "REDACTED-20". A catalogue whose entire
+// content is paths and types must learn nothing from that: folding it in
+// publishes a polymorphism the provider does not have.
+//
+// Measured on the committed corpora on 2026-08-23, before this guard existed:
+// folding corpus/outscale/oapi-cli-lifecycle.jsonl turned
+// `osc/Client.ReadKeypairs.Keypairs` from `array` into `array|string` and
+// `osc/Client.ReadLoadBalancers.LoadBalancers[].SecuredCookies` from `bool` into
+// `bool|string`, on top of types a `feint shapes --record` run had got right.
+func TestARedactedValueTeachesNoType(t *testing.T) {
+	cat := New("outscale")
+	cat.Merge([]trace.Exchange{exchange("ReadKeypairs", map[string]any{
+		"Keypairs": "REDACTED-20",
+		"Name":     "redacted-7",
+		"Count":    json.Number("2"),
+	})})
+
+	op := cat.Operations["osc/Client.ReadKeypairs"]
+	if op == nil {
+		t.Fatalf("the operation was dropped entirely; only the redacted field should be")
+	}
+	types := map[string]string{}
+	for _, f := range op.Fields {
+		types[f.Path] = f.Type
+	}
+	if got, present := types["Keypairs"]; present {
+		t.Errorf("Keypairs was learned as %q from a value the recorder replaced", got)
+	}
+	// The witness: a field the recorder did not touch must still be learned, or
+	// this test would pass on a walk that returned nothing at all.
+	if types["Count"] != "number" {
+		t.Errorf("Count = %q, want number: the walk stopped finding anything", types["Count"])
+	}
+	// The sanitiser's own token is a string that replaced a string, so the type
+	// it reports is right and only the value is gone — but it is still not an
+	// observation, and a catalogue that recorded it would say the API returns a
+	// field whose only witness is an invention.
+	if got, present := types["Name"]; present {
+		t.Errorf("Name was learned as %q from the sanitiser's own token", got)
+	}
+}
+
+// Folding a recording never unlearns a type a richer recording already had.
+//
+// The regression this pins is the one measured on the committed corpora: the
+// catalogue held `Keypairs: array` from a direct `--record` read, and folding a
+// sanitised corpus over it produced `array|string`. mergeType is right to keep
+// a genuine conflict — the defect is upstream of it, in taking a redaction for
+// an observation.
+func TestFoldingACorpusDoesNotUnlearnAType(t *testing.T) {
+	cat := New("outscale")
+	cat.Merge([]trace.Exchange{exchange("ReadKeypairs", map[string]any{
+		"Keypairs": []any{map[string]any{"KeypairName": "k"}},
+	})})
+	cat.Merge([]trace.Exchange{exchange("ReadKeypairs", map[string]any{
+		"Keypairs": "REDACTED-20",
+	})})
+
+	for _, f := range cat.Operations["osc/Client.ReadKeypairs"].Fields {
+		if f.Path == "Keypairs" && f.Type != "array" {
+			t.Fatalf("Keypairs = %q after folding a redacted recording, want array", f.Type)
+		}
+	}
+}
+
+// A path the sanitiser rewrote keys nothing.
+//
+// corpus/scaleway/scw-cli.jsonl carries exchanges whose every path segment is
+// `redacted-<n>`, and the number moves each time the corpus is re-sanitised.
+// Keyed on that, the catalogue would carry a name that names no API and that
+// changes under `git diff` for reasons unrelated to any cloud — the volatility
+// this package's own header forbids storing.
+func TestARedactedPathIsNeverAKey(t *testing.T) {
+	cat := New("scaleway")
+	ch := cat.Merge([]trace.Exchange{{
+		Method: "GET", Path: "/redacted-749/redacted-750/redacted-751",
+		Status: 200, Res: &trace.Message{Body: map[string]any{"total_count": json.Number("0")}},
+	}, {
+		// The witness: an ordinary unnamed exchange must still be kept under
+		// its route, or a guard that dropped everything would look identical.
+		Method: "GET", Path: "/instance/v1/zones/fr-par-1/servers",
+		Status: 200, Res: &trace.Message{Body: map[string]any{"total_count": json.Number("0")}},
+	}})
+
+	for key := range cat.Operations {
+		if strings.Contains(key, RedactionToken) {
+			t.Errorf("the catalogue is keyed on %q, which names no API", key)
+		}
+	}
+	if _, kept := cat.Operations["GET /instance/v1/zones/fr-par-1/servers"]; !kept {
+		t.Fatalf("the unnamed exchange with a real path was dropped too: the guard is too wide")
+	}
+	if ch.Unkeyable != 1 {
+		t.Errorf("Unkeyable = %d, want 1: an exchange left on the floor must be counted", ch.Unkeyable)
+	}
+}
+
+// A named operation first met through a sanitised path carries no route until a
+// real one turns up, and then carries that one whatever the order.
+func TestAnOperationTakesTheRouteThatWasActuallyRecorded(t *testing.T) {
+	redacted := trace.Exchange{
+		Method: "GET", Path: "/redacted-1/redacted-2", Operation: "instance/v1/API.ListServers",
+		Status: 200, Res: &trace.Message{Body: map[string]any{"total_count": json.Number("0")}},
+	}
+	real := trace.Exchange{
+		Method: "GET", Path: "/instance/v1/zones/fr-par-1/servers", Operation: "instance/v1/API.ListServers",
+		Status: 200, Res: &trace.Message{Body: map[string]any{"total_count": json.Number("0")}},
+	}
+	for _, order := range [][]trace.Exchange{{redacted, real}, {real, redacted}} {
+		cat := New("scaleway")
+		cat.Merge(order)
+		op := cat.Operations["instance/v1/API.ListServers"]
+		if op == nil {
+			t.Fatalf("the named operation was dropped")
+		}
+		if op.Path != "/instance/v1/zones/fr-par-1/servers" {
+			t.Errorf("Path = %q, want the recorded route", op.Path)
+		}
+	}
+}
+
+// The committed catalogues carry no redaction, read from the bytes on disk.
+//
+// The same disbelief TestNoCommittedCatalogueCarriesAnIdentifier applies to
+// identifiers: this asserts the property the files must have, rather than the
+// rule that is supposed to produce it. `mise run shapes:fold` writes these
+// files from sanitised corpora, so the day a placeholder spelling changes it is
+// this that goes red.
+func TestNoCommittedCatalogueCarriesARedaction(t *testing.T) {
+	dir := filepath.Join("..", "..", "shapes")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+	scanned := 0
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join(dir, e.Name())) //nolint:gosec // a committed artefact of this repository
+		if err != nil {
+			t.Fatalf("read %s: %v", e.Name(), err)
+		}
+		scanned++
+		for _, token := range []string{RedactionToken, recorderToken} {
+			if i := strings.Index(string(body), token); i >= 0 {
+				t.Errorf("%s carries %q at byte %d, which the sanitiser invented", e.Name(), token, i)
+			}
+		}
+	}
+	// Asserted rather than assumed: a scan that found no file would pass while
+	// measuring nothing.
+	if scanned == 0 {
+		t.Fatalf("no catalogue found in %s: the scan is broken, not the files", dir)
+	}
+}

--- a/internal/shape/shape.go
+++ b/internal/shape/shape.go
@@ -90,6 +90,18 @@ func (c *Catalogue) Merge(exs []trace.Exchange) Changes {
 		// operation key when the recording could not name the operation, and it
 		// is stored on the operation either way.
 		path := AnonymisePath(x.Path)
+		// A path the sanitiser rewrote names no API, so it can key nothing and
+		// describe nothing. An exchange that also carries no operation name is
+		// therefore unkeyable, and is counted rather than dropped in silence:
+		// a fold that quietly ignored part of its input would be a fold whose
+		// total nobody could check.
+		if PathIsRedacted(path) {
+			if x.Operation == "" {
+				ch.Unkeyable++
+				continue
+			}
+			path = ""
+		}
 		key := keyFor(x, path)
 		op, known := c.Operations[key]
 		if !known {
@@ -102,6 +114,14 @@ func (c *Catalogue) Merge(exs []trace.Exchange) Changes {
 			op = &Operation{Method: x.Method, Path: path, Fields: []transcript.Field{}}
 			c.Operations[key] = op
 			ch.Added = append(ch.Added, key)
+		}
+		// A named operation first met through a sanitised path has no route to
+		// show; the first exchange that carries a real one fills it in. Written
+		// as an upgrade rather than an overwrite so the merge stays commutative:
+		// whichever order the recordings arrive in, the route that survives is
+		// the one that was actually recorded.
+		if op.Path == "" && path != "" {
+			op.Method, op.Path = x.Method, path
 		}
 		op.absorb(x, key, &ch)
 	}
@@ -136,7 +156,7 @@ func (o *Operation) absorb(x *trace.Exchange, key string, ch *Changes) {
 		seen[f.Path] = f.Type
 	}
 	fresh := map[string]string{}
-	for _, f := range transcript.FieldsOf(x.Res.Body) {
+	for _, f := range transcript.FieldsOfObserved(x.Res.Body, IsRedacted) {
 		fresh[f.Path] = f.Type
 	}
 
@@ -281,6 +301,11 @@ func IsUUID(seg string) bool {
 type Changes struct {
 	Added  []string      `json:"added_operations,omitempty"`
 	Fields []FieldChange `json:"fields,omitempty"`
+	// Unkeyable counts the exchanges this merge could not name: their path was
+	// rewritten by the sanitiser and they carry no operation, so there is no
+	// honest key for what they answered. Reported so a fold says how much of
+	// its input it left on the floor.
+	Unkeyable int `json:"unkeyable,omitempty"`
 }
 
 // FieldChange is one field that appeared or changed type.

--- a/internal/transcript/transcript.go
+++ b/internal/transcript/transcript.go
@@ -204,7 +204,7 @@ func Shape(exs []trace.Exchange, selector string) ([]Field, bool) {
 			continue
 		}
 		found = true
-		walk("", x.Res.Body, fields)
+		walk("", x.Res.Body, fields, nil)
 	}
 	if !found {
 		return nil, false
@@ -300,12 +300,37 @@ func lastSegment(s string) string {
 // merged, an empty list not a type change) have to hold identically for the
 // reader and for the store, which is only true when there is one of them.
 func FieldsOf(body any) []Field {
+	return FieldsOfObserved(body, nil)
+}
+
+// FieldsOfObserved is [FieldsOf] restricted to the values a recording actually
+// observed: a scalar the caller's predicate recognises as replaced contributes
+// no path at all.
+//
+// It exists because a redaction erases a type rather than preserving it. The
+// recorder writes a string over whatever it replaces, so a bool comes back as
+// `"REDACTED-3f2a"` and an array as `"REDACTED-20"` — measured on the committed
+// corpora, where `osc/Client.ReadKeypairs.Keypairs` is an array the recorder
+// replaced with a string, and `exoscale/v2.list-instance-types` carries the same
+// loss on `instance-types[].authorized`, a bool, forty-nine times. A catalogue
+// whose entire content is paths and types must not learn "string" from one of
+// those: it would publish a polymorphism the provider does not have, and
+// [internal/shape.mergeType] would join the two into `array|string` on top of a
+// type a real recording had got right.
+//
+// The predicate is a parameter rather than a rule of this package: which values
+// count as replaced is the recorder's and the sanitiser's business, and this
+// walk is only the grammar. A nil predicate means every value was observed,
+// which is what [FieldsOf] asks for.
+//
+// TestARedactedValueTeachesNoType fails without this.
+func FieldsOfObserved(body any, redacted func(any) bool) []Field {
 	fields := map[string]string{}
-	walk("", body, fields)
+	walk("", body, fields, redacted)
 	return sortedFields(fields)
 }
 
-func walk(path string, v any, into map[string]string) {
+func walk(path string, v any, into map[string]string, redacted func(any) bool) {
 	switch val := v.(type) {
 	case map[string]any:
 		if path != "" {
@@ -316,16 +341,19 @@ func walk(path string, v any, into map[string]string) {
 			if path != "" {
 				child = path + "." + k
 			}
-			walk(child, nested, into)
+			walk(child, nested, into, redacted)
 		}
 	case []any:
 		if path != "" {
 			into[path] = "array"
 		}
 		for _, item := range val {
-			walk(path+"[]", item, into)
+			walk(path+"[]", item, into, redacted)
 		}
 	default:
+		if redacted != nil && redacted(v) {
+			return
+		}
 		into[path] = jsonType(v)
 	}
 }

--- a/internal/transcript/transcript_test.go
+++ b/internal/transcript/transcript_test.go
@@ -1,6 +1,7 @@
 package transcript_test
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -261,5 +262,49 @@ func TestAnEmptyObjectIsNotADictionary(t *testing.T) {
 	}
 	if transcript.DataKeyed([][]string{{}, {}, {}}) {
 		t.Error("three children with no keys of their own were read as a dictionary")
+	}
+}
+
+// A value the caller calls replaced contributes no path at all — not the path
+// with the replacement's type, which is the failure this guards.
+//
+// FieldsOfObserved is the grammar; which values count as replaced belongs to
+// whoever recorded them, so it arrives as a predicate. internal/shape passes
+// shape.IsRedacted; this test passes a predicate of its own, which is what
+// proves the parameter is honoured rather than a rule of this package.
+func TestAReplacedValueContributesNoPath(t *testing.T) {
+	body := map[string]any{
+		"Keypairs":  "GONE",
+		"Nested":    map[string]any{"Flag": "GONE", "Name": "kept"},
+		"Numbers":   []any{json.Number("1")},
+		"Untouched": true,
+	}
+	replaced := func(v any) bool { s, ok := v.(string); return ok && s == "GONE" }
+
+	got := map[string]string{}
+	for _, f := range transcript.FieldsOfObserved(body, replaced) {
+		got[f.Path] = f.Type
+	}
+	for _, path := range []string{"Keypairs", "Nested.Flag"} {
+		if typ, present := got[path]; present {
+			t.Errorf("%s was learned as %q from a replaced value", path, typ)
+		}
+	}
+	// The witness, in both directions: the walk must still reach a sibling of a
+	// replaced field, and a container above one must survive.
+	for path, want := range map[string]string{
+		"Nested": "object", "Nested.Name": "string", "Numbers": "array", "Untouched": "bool",
+	} {
+		if got[path] != want {
+			t.Errorf("%s = %q, want %q: the walk stopped short of what it must still see", path, got[path], want)
+		}
+	}
+	// And FieldsOf, which passes no predicate, learns everything as before.
+	plain := map[string]string{}
+	for _, f := range transcript.FieldsOf(body) {
+		plain[f.Path] = f.Type
+	}
+	if plain["Keypairs"] != "string" {
+		t.Errorf("FieldsOf lost Keypairs: a nil predicate must change nothing")
 	}
 }

--- a/mise.toml
+++ b/mise.toml
@@ -84,6 +84,30 @@ depends = ["build"]
 # with the field list and the exit-code contract (0 ok, 1 error, 2 drift).
 run = "./feint shapes --check"
 
+[tasks."shapes:fold"]
+description = "Fold every committed corpus into shapes/, so an answer already recorded from a real cloud feeds the shape axis"
+depends = ["build"]
+# Offline, no credential, no account. The 619 exchanges under corpus/ are real
+# cloud answers this repository already paid for; until #407 they fed the replay
+# and nothing else, because the shape axis reads shapes/ and nobody had ever
+# folded one artefact into the other. This is the fold, and it is one-way on
+# purpose: shapes/ keeps entries no corpus holds — the "learning side" of
+# upstream.Reads, operations recorded before a handler exists and which no
+# client drives — so deriving shapes/ from corpus/ would delete 13 recorded
+# shapes, measured. See docs/architecture.md.
+#
+# Idempotent: a merge that learns nothing prints so. Re-run it after
+# `mise run corpus:cloud`, then commit shapes/ with the corpus that taught it.
+run = """
+set -e
+for provider in scaleway outscale exoscale; do
+  for file in corpus/"$provider"/*.jsonl; do
+    [ -e "$file" ] || continue
+    ./feint shapes "$file" --provider "$provider"
+  done
+done
+"""
+
 [tasks."corpus:check"]
 description = "Replay every committed corpus and fail (exit 2) where this emulator answers differently from the real cloud"
 depends = ["build"]

--- a/shapes/exoscale.json
+++ b/shapes/exoscale.json
@@ -338,6 +338,755 @@
       "statuses": [
         200
       ]
+    },
+    "exoscale/v2.add-rule-to-security-group": {
+      "method": "POST",
+      "path": "/v2/security-group/{id}/rules",
+      "fields": [
+        {
+          "path": "id",
+          "type": "string"
+        },
+        {
+          "path": "reference",
+          "type": "object"
+        },
+        {
+          "path": "reference.id",
+          "type": "string"
+        },
+        {
+          "path": "state",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "exoscale/v2.create-anti-affinity-group": {
+      "method": "POST",
+      "path": "/v2/anti-affinity-group",
+      "fields": [
+        {
+          "path": "id",
+          "type": "string"
+        },
+        {
+          "path": "reference",
+          "type": "object"
+        },
+        {
+          "path": "reference.id",
+          "type": "string"
+        },
+        {
+          "path": "state",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "exoscale/v2.create-private-network": {
+      "method": "POST",
+      "path": "/v2/private-network",
+      "fields": [
+        {
+          "path": "id",
+          "type": "string"
+        },
+        {
+          "path": "reference",
+          "type": "object"
+        },
+        {
+          "path": "reference.id",
+          "type": "string"
+        },
+        {
+          "path": "state",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "exoscale/v2.create-security-group": {
+      "method": "POST",
+      "path": "/v2/security-group",
+      "fields": [
+        {
+          "path": "id",
+          "type": "string"
+        },
+        {
+          "path": "reference",
+          "type": "object"
+        },
+        {
+          "path": "reference.id",
+          "type": "string"
+        },
+        {
+          "path": "state",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "exoscale/v2.delete-anti-affinity-group": {
+      "method": "DELETE",
+      "path": "/v2/anti-affinity-group/{id}",
+      "fields": [
+        {
+          "path": "id",
+          "type": "string"
+        },
+        {
+          "path": "reference",
+          "type": "object"
+        },
+        {
+          "path": "reference.id",
+          "type": "string"
+        },
+        {
+          "path": "state",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "exoscale/v2.delete-private-network": {
+      "method": "DELETE",
+      "path": "/v2/private-network/{id}",
+      "fields": [
+        {
+          "path": "id",
+          "type": "string"
+        },
+        {
+          "path": "reference",
+          "type": "object"
+        },
+        {
+          "path": "reference.id",
+          "type": "string"
+        },
+        {
+          "path": "state",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "exoscale/v2.delete-rule-from-security-group": {
+      "method": "DELETE",
+      "path": "/v2/security-group/{id}/rules/{id}",
+      "fields": [
+        {
+          "path": "id",
+          "type": "string"
+        },
+        {
+          "path": "reference",
+          "type": "object"
+        },
+        {
+          "path": "reference.id",
+          "type": "string"
+        },
+        {
+          "path": "state",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "exoscale/v2.delete-security-group": {
+      "method": "DELETE",
+      "path": "/v2/security-group/{id}",
+      "fields": [
+        {
+          "path": "id",
+          "type": "string"
+        },
+        {
+          "path": "reference",
+          "type": "object"
+        },
+        {
+          "path": "reference.id",
+          "type": "string"
+        },
+        {
+          "path": "state",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "exoscale/v2.delete-ssh-key": {
+      "method": "DELETE",
+      "fields": [
+        {
+          "path": "id",
+          "type": "string"
+        },
+        {
+          "path": "state",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        404
+      ]
+    },
+    "exoscale/v2.get-anti-affinity-group": {
+      "method": "GET",
+      "path": "/v2/anti-affinity-group/{id}",
+      "fields": [
+        {
+          "path": "id",
+          "type": "string"
+        },
+        {
+          "path": "instances",
+          "type": "array"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "exoscale/v2.get-operation": {
+      "method": "GET",
+      "path": "/v2/operation/{id}",
+      "fields": [
+        {
+          "path": "id",
+          "type": "string"
+        },
+        {
+          "path": "reference",
+          "type": "object"
+        },
+        {
+          "path": "reference.id",
+          "type": "string"
+        },
+        {
+          "path": "state",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "exoscale/v2.get-private-network": {
+      "method": "GET",
+      "path": "/v2/private-network/{id}",
+      "fields": [
+        {
+          "path": "end-ip",
+          "type": "string"
+        },
+        {
+          "path": "id",
+          "type": "string"
+        },
+        {
+          "path": "netmask",
+          "type": "string"
+        },
+        {
+          "path": "start-ip",
+          "type": "string"
+        },
+        {
+          "path": "vni",
+          "type": "number"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "exoscale/v2.get-security-group": {
+      "method": "GET",
+      "path": "/v2/security-group/{id}",
+      "fields": [
+        {
+          "path": "id",
+          "type": "string"
+        },
+        {
+          "path": "rules",
+          "type": "array"
+        },
+        {
+          "path": "rules[]",
+          "type": "object"
+        },
+        {
+          "path": "rules[].description",
+          "type": "string"
+        },
+        {
+          "path": "rules[].end-port",
+          "type": "number"
+        },
+        {
+          "path": "rules[].flow-direction",
+          "type": "string"
+        },
+        {
+          "path": "rules[].id",
+          "type": "string"
+        },
+        {
+          "path": "rules[].network",
+          "type": "string"
+        },
+        {
+          "path": "rules[].protocol",
+          "type": "string"
+        },
+        {
+          "path": "rules[].start-port",
+          "type": "number"
+        },
+        {
+          "path": "visibility",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "exoscale/v2.get-ssh-key": {
+      "method": "GET",
+      "fields": [],
+      "statuses": [
+        200,
+        404
+      ]
+    },
+    "exoscale/v2.list-anti-affinity-groups": {
+      "method": "GET",
+      "path": "/v2/anti-affinity-group",
+      "fields": [
+        {
+          "path": "anti-affinity-groups",
+          "type": "array"
+        },
+        {
+          "path": "anti-affinity-groups[]",
+          "type": "object"
+        },
+        {
+          "path": "anti-affinity-groups[].id",
+          "type": "string"
+        },
+        {
+          "path": "anti-affinity-groups[].instances",
+          "type": "array"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "exoscale/v2.list-block-storage-volumes": {
+      "method": "GET",
+      "path": "/v2/block-storage",
+      "fields": [
+        {
+          "path": "block-storage-volumes",
+          "type": "array"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "exoscale/v2.list-elastic-ips": {
+      "method": "GET",
+      "path": "/v2/elastic-ip",
+      "fields": [
+        {
+          "path": "elastic-ips",
+          "type": "array"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "exoscale/v2.list-instance-pools": {
+      "method": "GET",
+      "path": "/v2/instance-pool",
+      "fields": [
+        {
+          "path": "instance-pools",
+          "type": "array"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "exoscale/v2.list-instance-types": {
+      "method": "GET",
+      "path": "/v2/instance-type",
+      "fields": [
+        {
+          "path": "instance-types",
+          "type": "array"
+        },
+        {
+          "path": "instance-types[]",
+          "type": "object"
+        },
+        {
+          "path": "instance-types[].cpus",
+          "type": "number"
+        },
+        {
+          "path": "instance-types[].family",
+          "type": "string"
+        },
+        {
+          "path": "instance-types[].gpus",
+          "type": "number"
+        },
+        {
+          "path": "instance-types[].id",
+          "type": "string"
+        },
+        {
+          "path": "instance-types[].memory",
+          "type": "number"
+        },
+        {
+          "path": "instance-types[].size",
+          "type": "string"
+        },
+        {
+          "path": "instance-types[].zones",
+          "type": "array"
+        },
+        {
+          "path": "instance-types[].zones[]",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "exoscale/v2.list-instances": {
+      "method": "GET",
+      "path": "/v2/instance",
+      "fields": [
+        {
+          "path": "instances",
+          "type": "array"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "exoscale/v2.list-load-balancers": {
+      "method": "GET",
+      "path": "/v2/load-balancer",
+      "fields": [
+        {
+          "path": "load-balancers",
+          "type": "array"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "exoscale/v2.list-private-networks": {
+      "method": "GET",
+      "path": "/v2/private-network",
+      "fields": [
+        {
+          "path": "private-networks",
+          "type": "array"
+        },
+        {
+          "path": "private-networks[]",
+          "type": "object"
+        },
+        {
+          "path": "private-networks[].end-ip",
+          "type": "string"
+        },
+        {
+          "path": "private-networks[].id",
+          "type": "string"
+        },
+        {
+          "path": "private-networks[].netmask",
+          "type": "string"
+        },
+        {
+          "path": "private-networks[].start-ip",
+          "type": "string"
+        },
+        {
+          "path": "private-networks[].vni",
+          "type": "number"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "exoscale/v2.list-quotas": {
+      "method": "GET",
+      "path": "/v2/quota",
+      "fields": [
+        {
+          "path": "quotas",
+          "type": "array"
+        },
+        {
+          "path": "quotas[]",
+          "type": "object"
+        },
+        {
+          "path": "quotas[].limit",
+          "type": "number"
+        },
+        {
+          "path": "quotas[].resource",
+          "type": "string"
+        },
+        {
+          "path": "quotas[].usage",
+          "type": "number"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "exoscale/v2.list-security-groups": {
+      "method": "GET",
+      "path": "/v2/security-group",
+      "fields": [
+        {
+          "path": "security-groups",
+          "type": "array"
+        },
+        {
+          "path": "security-groups[]",
+          "type": "object"
+        },
+        {
+          "path": "security-groups[].id",
+          "type": "string"
+        },
+        {
+          "path": "security-groups[].rules",
+          "type": "array"
+        },
+        {
+          "path": "security-groups[].rules[]",
+          "type": "object"
+        },
+        {
+          "path": "security-groups[].rules[].description",
+          "type": "string"
+        },
+        {
+          "path": "security-groups[].rules[].end-port",
+          "type": "number"
+        },
+        {
+          "path": "security-groups[].rules[].flow-direction",
+          "type": "string"
+        },
+        {
+          "path": "security-groups[].rules[].id",
+          "type": "string"
+        },
+        {
+          "path": "security-groups[].rules[].network",
+          "type": "string"
+        },
+        {
+          "path": "security-groups[].rules[].protocol",
+          "type": "string"
+        },
+        {
+          "path": "security-groups[].rules[].security-group",
+          "type": "object"
+        },
+        {
+          "path": "security-groups[].rules[].security-group.id",
+          "type": "string"
+        },
+        {
+          "path": "security-groups[].rules[].start-port",
+          "type": "number"
+        },
+        {
+          "path": "security-groups[].visibility",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "exoscale/v2.list-ssh-keys": {
+      "method": "GET",
+      "path": "/v2/ssh-key",
+      "fields": [],
+      "statuses": [
+        200
+      ]
+    },
+    "exoscale/v2.list-templates": {
+      "method": "GET",
+      "path": "/v2/template",
+      "fields": [
+        {
+          "path": "templates",
+          "type": "array"
+        },
+        {
+          "path": "templates[]",
+          "type": "object"
+        },
+        {
+          "path": "templates[].application-consistent-snapshot-enabled",
+          "type": "bool"
+        },
+        {
+          "path": "templates[].boot-mode",
+          "type": "string"
+        },
+        {
+          "path": "templates[].created-at",
+          "type": "string"
+        },
+        {
+          "path": "templates[].default-user",
+          "type": "string"
+        },
+        {
+          "path": "templates[].id",
+          "type": "string"
+        },
+        {
+          "path": "templates[].size",
+          "type": "number"
+        },
+        {
+          "path": "templates[].version",
+          "type": "string"
+        },
+        {
+          "path": "templates[].visibility",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "exoscale/v2.list-zones": {
+      "method": "GET",
+      "path": "/v2/zone",
+      "fields": [
+        {
+          "path": "zones",
+          "type": "array"
+        },
+        {
+          "path": "zones[]",
+          "type": "object"
+        },
+        {
+          "path": "zones[].id",
+          "type": "string"
+        },
+        {
+          "path": "zones[].name",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "exoscale/v2.register-ssh-key": {
+      "method": "POST",
+      "path": "/v2/ssh-key",
+      "fields": [
+        {
+          "path": "id",
+          "type": "string"
+        },
+        {
+          "path": "state",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        409
+      ]
+    },
+    "exoscale/v2.update-private-network": {
+      "method": "PUT",
+      "path": "/v2/private-network/{id}",
+      "fields": [
+        {
+          "path": "id",
+          "type": "string"
+        },
+        {
+          "path": "reference",
+          "type": "object"
+        },
+        {
+          "path": "reference.id",
+          "type": "string"
+        },
+        {
+          "path": "state",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200
+      ]
     }
   }
 }

--- a/shapes/outscale.json
+++ b/shapes/outscale.json
@@ -1,6 +1,1847 @@
 {
   "provider": "outscale",
   "operations": {
+    "POST /api/v1/ReadFlexibleGpuCatalog": {
+      "method": "POST",
+      "path": "/api/v1/ReadFlexibleGpuCatalog",
+      "fields": [
+        {
+          "path": "FlexibleGpuCatalog",
+          "type": "array"
+        },
+        {
+          "path": "FlexibleGpuCatalog[]",
+          "type": "object"
+        },
+        {
+          "path": "FlexibleGpuCatalog[].Generations",
+          "type": "array"
+        },
+        {
+          "path": "FlexibleGpuCatalog[].MaxCpu",
+          "type": "number"
+        },
+        {
+          "path": "FlexibleGpuCatalog[].MaxRam",
+          "type": "number"
+        },
+        {
+          "path": "FlexibleGpuCatalog[].VRam",
+          "type": "number"
+        },
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "POST /api/v1/ReadPublicCatalog": {
+      "method": "POST",
+      "path": "/api/v1/ReadPublicCatalog",
+      "fields": [
+        {
+          "path": "Catalog",
+          "type": "object"
+        },
+        {
+          "path": "Catalog.Entries",
+          "type": "array"
+        },
+        {
+          "path": "Catalog.Entries[]",
+          "type": "object"
+        },
+        {
+          "path": "Catalog.Entries[].UnitPrice",
+          "type": "number"
+        },
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "osc/Client.AcceptNetPeering": {
+      "method": "POST",
+      "path": "/api/v1/AcceptNetPeering",
+      "fields": [],
+      "statuses": [
+        400
+      ]
+    },
+    "osc/Client.CreateDhcpOptions": {
+      "method": "POST",
+      "path": "/api/v1/CreateDhcpOptions",
+      "fields": [],
+      "statuses": [
+        400
+      ]
+    },
+    "osc/Client.CreateImage": {
+      "method": "POST",
+      "path": "/api/v1/CreateImage",
+      "fields": [],
+      "statuses": [
+        400
+      ]
+    },
+    "osc/Client.CreateInternetService": {
+      "method": "POST",
+      "path": "/api/v1/CreateInternetService",
+      "fields": [
+        {
+          "path": "InternetService",
+          "type": "object"
+        },
+        {
+          "path": "InternetService.InternetServiceId",
+          "type": "string"
+        },
+        {
+          "path": "InternetService.Tags",
+          "type": "array"
+        },
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "osc/Client.CreateKeypair": {
+      "method": "POST",
+      "path": "/api/v1/CreateKeypair",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.CreateLoadBalancer": {
+      "method": "POST",
+      "path": "/api/v1/CreateLoadBalancer",
+      "fields": [
+        {
+          "path": "LoadBalancer",
+          "type": "object"
+        },
+        {
+          "path": "LoadBalancer.AccessLog",
+          "type": "object"
+        },
+        {
+          "path": "LoadBalancer.AccessLog.IsEnabled",
+          "type": "bool"
+        },
+        {
+          "path": "LoadBalancer.AccessLog.PublicationInterval",
+          "type": "number"
+        },
+        {
+          "path": "LoadBalancer.BackendIps",
+          "type": "array"
+        },
+        {
+          "path": "LoadBalancer.BackendVmIds",
+          "type": "array"
+        },
+        {
+          "path": "LoadBalancer.HealthCheck",
+          "type": "object"
+        },
+        {
+          "path": "LoadBalancer.HealthCheck.CheckInterval",
+          "type": "number"
+        },
+        {
+          "path": "LoadBalancer.HealthCheck.HealthyThreshold",
+          "type": "number"
+        },
+        {
+          "path": "LoadBalancer.HealthCheck.Port",
+          "type": "number"
+        },
+        {
+          "path": "LoadBalancer.HealthCheck.Protocol",
+          "type": "string"
+        },
+        {
+          "path": "LoadBalancer.HealthCheck.Timeout",
+          "type": "number"
+        },
+        {
+          "path": "LoadBalancer.HealthCheck.UnhealthyThreshold",
+          "type": "number"
+        },
+        {
+          "path": "LoadBalancer.Listeners",
+          "type": "array"
+        },
+        {
+          "path": "LoadBalancer.Listeners[]",
+          "type": "object"
+        },
+        {
+          "path": "LoadBalancer.Listeners[].BackendPort",
+          "type": "number"
+        },
+        {
+          "path": "LoadBalancer.Listeners[].BackendProtocol",
+          "type": "string"
+        },
+        {
+          "path": "LoadBalancer.Listeners[].LoadBalancerPort",
+          "type": "number"
+        },
+        {
+          "path": "LoadBalancer.Listeners[].LoadBalancerProtocol",
+          "type": "string"
+        },
+        {
+          "path": "LoadBalancer.LoadBalancerType",
+          "type": "string"
+        },
+        {
+          "path": "LoadBalancer.NetId",
+          "type": "string"
+        },
+        {
+          "path": "LoadBalancer.SecurityGroups",
+          "type": "array"
+        },
+        {
+          "path": "LoadBalancer.SecurityGroups[]",
+          "type": "string"
+        },
+        {
+          "path": "LoadBalancer.SourceSecurityGroup",
+          "type": "object"
+        },
+        {
+          "path": "LoadBalancer.Subnets",
+          "type": "array"
+        },
+        {
+          "path": "LoadBalancer.Subnets[]",
+          "type": "string"
+        },
+        {
+          "path": "LoadBalancer.SubregionNames",
+          "type": "array"
+        },
+        {
+          "path": "LoadBalancer.SubregionNames[]",
+          "type": "string"
+        },
+        {
+          "path": "LoadBalancer.Tags",
+          "type": "array"
+        },
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.CreateLoadBalancerListeners": {
+      "method": "POST",
+      "path": "/api/v1/CreateLoadBalancerListeners",
+      "fields": [],
+      "statuses": [
+        400
+      ]
+    },
+    "osc/Client.CreateNatService": {
+      "method": "POST",
+      "path": "/api/v1/CreateNatService",
+      "fields": [
+        {
+          "path": "NatService",
+          "type": "object"
+        },
+        {
+          "path": "NatService.NatServiceId",
+          "type": "string"
+        },
+        {
+          "path": "NatService.NetId",
+          "type": "string"
+        },
+        {
+          "path": "NatService.PublicIps",
+          "type": "array"
+        },
+        {
+          "path": "NatService.PublicIps[]",
+          "type": "object"
+        },
+        {
+          "path": "NatService.PublicIps[].PublicIp",
+          "type": "string"
+        },
+        {
+          "path": "NatService.PublicIps[].PublicIpId",
+          "type": "string"
+        },
+        {
+          "path": "NatService.State",
+          "type": "string"
+        },
+        {
+          "path": "NatService.SubnetId",
+          "type": "string"
+        },
+        {
+          "path": "NatService.Tags",
+          "type": "array"
+        },
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.CreateNet": {
+      "method": "POST",
+      "path": "/api/v1/CreateNet",
+      "fields": [
+        {
+          "path": "Net",
+          "type": "object"
+        },
+        {
+          "path": "Net.DhcpOptionsSetId",
+          "type": "string"
+        },
+        {
+          "path": "Net.IpRange",
+          "type": "string"
+        },
+        {
+          "path": "Net.NetId",
+          "type": "string"
+        },
+        {
+          "path": "Net.State",
+          "type": "string"
+        },
+        {
+          "path": "Net.Tags",
+          "type": "array"
+        },
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.CreateNetPeering": {
+      "method": "POST",
+      "path": "/api/v1/CreateNetPeering",
+      "fields": [],
+      "statuses": [
+        400
+      ]
+    },
+    "osc/Client.CreateNic": {
+      "method": "POST",
+      "path": "/api/v1/CreateNic",
+      "fields": [
+        {
+          "path": "Nic",
+          "type": "object"
+        },
+        {
+          "path": "Nic.IsSourceDestChecked",
+          "type": "bool"
+        },
+        {
+          "path": "Nic.NetId",
+          "type": "string"
+        },
+        {
+          "path": "Nic.NicId",
+          "type": "string"
+        },
+        {
+          "path": "Nic.PrivateIps",
+          "type": "array"
+        },
+        {
+          "path": "Nic.PrivateIps[]",
+          "type": "object"
+        },
+        {
+          "path": "Nic.PrivateIps[].IsPrimary",
+          "type": "bool"
+        },
+        {
+          "path": "Nic.PrivateIps[].PrivateIp",
+          "type": "string"
+        },
+        {
+          "path": "Nic.SecurityGroups",
+          "type": "array"
+        },
+        {
+          "path": "Nic.SecurityGroups[]",
+          "type": "object"
+        },
+        {
+          "path": "Nic.SecurityGroups[].SecurityGroupId",
+          "type": "string"
+        },
+        {
+          "path": "Nic.State",
+          "type": "string"
+        },
+        {
+          "path": "Nic.SubnetId",
+          "type": "string"
+        },
+        {
+          "path": "Nic.SubregionName",
+          "type": "string"
+        },
+        {
+          "path": "Nic.Tags",
+          "type": "array"
+        },
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.CreatePublicIp": {
+      "method": "POST",
+      "path": "/api/v1/CreatePublicIp",
+      "fields": [
+        {
+          "path": "PublicIp",
+          "type": "object"
+        },
+        {
+          "path": "PublicIp.PublicIp",
+          "type": "string"
+        },
+        {
+          "path": "PublicIp.PublicIpId",
+          "type": "string"
+        },
+        {
+          "path": "PublicIp.Tags",
+          "type": "array"
+        },
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "osc/Client.CreateRoute": {
+      "method": "POST",
+      "path": "/api/v1/CreateRoute",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        },
+        {
+          "path": "RouteTable",
+          "type": "object"
+        },
+        {
+          "path": "RouteTable.LinkRouteTables",
+          "type": "array"
+        },
+        {
+          "path": "RouteTable.LinkRouteTables[]",
+          "type": "object"
+        },
+        {
+          "path": "RouteTable.LinkRouteTables[].LinkRouteTableId",
+          "type": "string"
+        },
+        {
+          "path": "RouteTable.LinkRouteTables[].Main",
+          "type": "bool"
+        },
+        {
+          "path": "RouteTable.LinkRouteTables[].RouteTableId",
+          "type": "string"
+        },
+        {
+          "path": "RouteTable.LinkRouteTables[].SubnetId",
+          "type": "string"
+        },
+        {
+          "path": "RouteTable.NetId",
+          "type": "string"
+        },
+        {
+          "path": "RouteTable.RoutePropagatingVirtualGateways",
+          "type": "array"
+        },
+        {
+          "path": "RouteTable.RouteTableId",
+          "type": "string"
+        },
+        {
+          "path": "RouteTable.Routes",
+          "type": "array"
+        },
+        {
+          "path": "RouteTable.Routes[]",
+          "type": "object"
+        },
+        {
+          "path": "RouteTable.Routes[].DestinationIpRange",
+          "type": "string"
+        },
+        {
+          "path": "RouteTable.Routes[].GatewayId",
+          "type": "string"
+        },
+        {
+          "path": "RouteTable.Tags",
+          "type": "array"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.CreateRouteTable": {
+      "method": "POST",
+      "path": "/api/v1/CreateRouteTable",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        },
+        {
+          "path": "RouteTable",
+          "type": "object"
+        },
+        {
+          "path": "RouteTable.LinkRouteTables",
+          "type": "array"
+        },
+        {
+          "path": "RouteTable.NetId",
+          "type": "string"
+        },
+        {
+          "path": "RouteTable.RoutePropagatingVirtualGateways",
+          "type": "array"
+        },
+        {
+          "path": "RouteTable.RouteTableId",
+          "type": "string"
+        },
+        {
+          "path": "RouteTable.Routes",
+          "type": "array"
+        },
+        {
+          "path": "RouteTable.Routes[]",
+          "type": "object"
+        },
+        {
+          "path": "RouteTable.Routes[].DestinationIpRange",
+          "type": "string"
+        },
+        {
+          "path": "RouteTable.Tags",
+          "type": "array"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.CreateSecurityGroup": {
+      "method": "POST",
+      "path": "/api/v1/CreateSecurityGroup",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        },
+        {
+          "path": "SecurityGroup",
+          "type": "object"
+        },
+        {
+          "path": "SecurityGroup.InboundRules",
+          "type": "array"
+        },
+        {
+          "path": "SecurityGroup.NetId",
+          "type": "string"
+        },
+        {
+          "path": "SecurityGroup.OutboundRules",
+          "type": "array"
+        },
+        {
+          "path": "SecurityGroup.OutboundRules[]",
+          "type": "object"
+        },
+        {
+          "path": "SecurityGroup.OutboundRules[].FromPortRange",
+          "type": "number"
+        },
+        {
+          "path": "SecurityGroup.OutboundRules[].IpRanges",
+          "type": "array"
+        },
+        {
+          "path": "SecurityGroup.OutboundRules[].IpRanges[]",
+          "type": "string"
+        },
+        {
+          "path": "SecurityGroup.OutboundRules[].SecurityGroupRuleId",
+          "type": "string"
+        },
+        {
+          "path": "SecurityGroup.OutboundRules[].ToPortRange",
+          "type": "number"
+        },
+        {
+          "path": "SecurityGroup.SecurityGroupId",
+          "type": "string"
+        },
+        {
+          "path": "SecurityGroup.Tags",
+          "type": "array"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.CreateSecurityGroupRule": {
+      "method": "POST",
+      "path": "/api/v1/CreateSecurityGroupRule",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        },
+        {
+          "path": "SecurityGroup",
+          "type": "object"
+        },
+        {
+          "path": "SecurityGroup.InboundRules",
+          "type": "array"
+        },
+        {
+          "path": "SecurityGroup.InboundRules[]",
+          "type": "object"
+        },
+        {
+          "path": "SecurityGroup.InboundRules[].FromPortRange",
+          "type": "number"
+        },
+        {
+          "path": "SecurityGroup.InboundRules[].IpRanges",
+          "type": "array"
+        },
+        {
+          "path": "SecurityGroup.InboundRules[].IpRanges[]",
+          "type": "string"
+        },
+        {
+          "path": "SecurityGroup.InboundRules[].SecurityGroupRuleId",
+          "type": "string"
+        },
+        {
+          "path": "SecurityGroup.InboundRules[].SecurityGroupsMembers",
+          "type": "array"
+        },
+        {
+          "path": "SecurityGroup.InboundRules[].SecurityGroupsMembers[]",
+          "type": "object"
+        },
+        {
+          "path": "SecurityGroup.InboundRules[].SecurityGroupsMembers[].SecurityGroupId",
+          "type": "string"
+        },
+        {
+          "path": "SecurityGroup.InboundRules[].ToPortRange",
+          "type": "number"
+        },
+        {
+          "path": "SecurityGroup.NetId",
+          "type": "string"
+        },
+        {
+          "path": "SecurityGroup.OutboundRules",
+          "type": "array"
+        },
+        {
+          "path": "SecurityGroup.OutboundRules[]",
+          "type": "object"
+        },
+        {
+          "path": "SecurityGroup.OutboundRules[].FromPortRange",
+          "type": "number"
+        },
+        {
+          "path": "SecurityGroup.OutboundRules[].IpRanges",
+          "type": "array"
+        },
+        {
+          "path": "SecurityGroup.OutboundRules[].IpRanges[]",
+          "type": "string"
+        },
+        {
+          "path": "SecurityGroup.OutboundRules[].SecurityGroupRuleId",
+          "type": "string"
+        },
+        {
+          "path": "SecurityGroup.OutboundRules[].ToPortRange",
+          "type": "number"
+        },
+        {
+          "path": "SecurityGroup.SecurityGroupId",
+          "type": "string"
+        },
+        {
+          "path": "SecurityGroup.Tags",
+          "type": "array"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.CreateSnapshot": {
+      "method": "POST",
+      "path": "/api/v1/CreateSnapshot",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        },
+        {
+          "path": "Snapshot",
+          "type": "object"
+        },
+        {
+          "path": "Snapshot.CreationDate",
+          "type": "string"
+        },
+        {
+          "path": "Snapshot.PermissionsToCreateVolume",
+          "type": "object"
+        },
+        {
+          "path": "Snapshot.PermissionsToCreateVolume.AccountIds",
+          "type": "array"
+        },
+        {
+          "path": "Snapshot.PermissionsToCreateVolume.GlobalPermission",
+          "type": "bool"
+        },
+        {
+          "path": "Snapshot.Progress",
+          "type": "number"
+        },
+        {
+          "path": "Snapshot.SnapshotId",
+          "type": "string"
+        },
+        {
+          "path": "Snapshot.Tags",
+          "type": "array"
+        },
+        {
+          "path": "Snapshot.VolumeId",
+          "type": "string"
+        },
+        {
+          "path": "Snapshot.VolumeSize",
+          "type": "number"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.CreateSubnet": {
+      "method": "POST",
+      "path": "/api/v1/CreateSubnet",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        },
+        {
+          "path": "Subnet",
+          "type": "object"
+        },
+        {
+          "path": "Subnet.AvailableIpsCount",
+          "type": "number"
+        },
+        {
+          "path": "Subnet.IpRange",
+          "type": "string"
+        },
+        {
+          "path": "Subnet.MapPublicIpOnLaunch",
+          "type": "bool"
+        },
+        {
+          "path": "Subnet.NetId",
+          "type": "string"
+        },
+        {
+          "path": "Subnet.State",
+          "type": "string"
+        },
+        {
+          "path": "Subnet.SubnetId",
+          "type": "string"
+        },
+        {
+          "path": "Subnet.SubregionName",
+          "type": "string"
+        },
+        {
+          "path": "Subnet.Tags",
+          "type": "array"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.CreateTags": {
+      "method": "POST",
+      "path": "/api/v1/CreateTags",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.CreateVms": {
+      "method": "POST",
+      "path": "/api/v1/CreateVms",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        },
+        {
+          "path": "Vms",
+          "type": "array"
+        },
+        {
+          "path": "Vms[]",
+          "type": "object"
+        },
+        {
+          "path": "Vms[].ActionsOnNextBoot",
+          "type": "object"
+        },
+        {
+          "path": "Vms[].ActionsOnNextBoot.SecureBoot",
+          "type": "string"
+        },
+        {
+          "path": "Vms[].BlockDeviceMappings",
+          "type": "array"
+        },
+        {
+          "path": "Vms[].BlockDeviceMappings[]",
+          "type": "object"
+        },
+        {
+          "path": "Vms[].BlockDeviceMappings[].Bsu",
+          "type": "object"
+        },
+        {
+          "path": "Vms[].BlockDeviceMappings[].Bsu.DeleteOnVmDeletion",
+          "type": "bool"
+        },
+        {
+          "path": "Vms[].BlockDeviceMappings[].Bsu.LinkDate",
+          "type": "string"
+        },
+        {
+          "path": "Vms[].BlockDeviceMappings[].Bsu.VolumeId",
+          "type": "string"
+        },
+        {
+          "path": "Vms[].BootMode",
+          "type": "string"
+        },
+        {
+          "path": "Vms[].BsuOptimized",
+          "type": "bool"
+        },
+        {
+          "path": "Vms[].CreationDate",
+          "type": "string"
+        },
+        {
+          "path": "Vms[].DeletionProtection",
+          "type": "bool"
+        },
+        {
+          "path": "Vms[].ImageId",
+          "type": "string"
+        },
+        {
+          "path": "Vms[].IsSourceDestChecked",
+          "type": "bool"
+        },
+        {
+          "path": "Vms[].LaunchNumber",
+          "type": "number"
+        },
+        {
+          "path": "Vms[].NestedVirtualization",
+          "type": "bool"
+        },
+        {
+          "path": "Vms[].NetId",
+          "type": "string"
+        },
+        {
+          "path": "Vms[].Nics",
+          "type": "array"
+        },
+        {
+          "path": "Vms[].Nics[]",
+          "type": "object"
+        },
+        {
+          "path": "Vms[].Nics[].IsSourceDestChecked",
+          "type": "bool"
+        },
+        {
+          "path": "Vms[].Nics[].LinkNic",
+          "type": "object"
+        },
+        {
+          "path": "Vms[].Nics[].LinkNic.DeleteOnVmDeletion",
+          "type": "bool"
+        },
+        {
+          "path": "Vms[].Nics[].LinkNic.DeviceNumber",
+          "type": "number"
+        },
+        {
+          "path": "Vms[].Nics[].LinkNic.LinkNicId",
+          "type": "string"
+        },
+        {
+          "path": "Vms[].Nics[].NetId",
+          "type": "string"
+        },
+        {
+          "path": "Vms[].Nics[].NicId",
+          "type": "string"
+        },
+        {
+          "path": "Vms[].Nics[].PrivateIps",
+          "type": "array"
+        },
+        {
+          "path": "Vms[].Nics[].PrivateIps[]",
+          "type": "object"
+        },
+        {
+          "path": "Vms[].Nics[].PrivateIps[].IsPrimary",
+          "type": "bool"
+        },
+        {
+          "path": "Vms[].Nics[].PrivateIps[].PrivateIp",
+          "type": "string"
+        },
+        {
+          "path": "Vms[].Nics[].SecurityGroups",
+          "type": "array"
+        },
+        {
+          "path": "Vms[].Nics[].SecurityGroups[]",
+          "type": "object"
+        },
+        {
+          "path": "Vms[].Nics[].SecurityGroups[].SecurityGroupId",
+          "type": "string"
+        },
+        {
+          "path": "Vms[].Nics[].SubnetId",
+          "type": "string"
+        },
+        {
+          "path": "Vms[].Performance",
+          "type": "string"
+        },
+        {
+          "path": "Vms[].Placement",
+          "type": "object"
+        },
+        {
+          "path": "Vms[].Placement.SubregionName",
+          "type": "string"
+        },
+        {
+          "path": "Vms[].PrivateIp",
+          "type": "string"
+        },
+        {
+          "path": "Vms[].ProductCodes",
+          "type": "array"
+        },
+        {
+          "path": "Vms[].ProductCodes[]",
+          "type": "string"
+        },
+        {
+          "path": "Vms[].ReservationId",
+          "type": "string"
+        },
+        {
+          "path": "Vms[].SecurityGroups",
+          "type": "array"
+        },
+        {
+          "path": "Vms[].SecurityGroups[]",
+          "type": "object"
+        },
+        {
+          "path": "Vms[].SecurityGroups[].SecurityGroupId",
+          "type": "string"
+        },
+        {
+          "path": "Vms[].ShutdownBehaviorConfiguration",
+          "type": "object"
+        },
+        {
+          "path": "Vms[].ShutdownBehaviorConfiguration.GuestAction",
+          "type": "string"
+        },
+        {
+          "path": "Vms[].ShutdownBehaviorConfiguration.HostAction",
+          "type": "string"
+        },
+        {
+          "path": "Vms[].State",
+          "type": "string"
+        },
+        {
+          "path": "Vms[].StateReason",
+          "type": "string"
+        },
+        {
+          "path": "Vms[].SubnetId",
+          "type": "string"
+        },
+        {
+          "path": "Vms[].Tags",
+          "type": "array"
+        },
+        {
+          "path": "Vms[].TpmEnabled",
+          "type": "bool"
+        },
+        {
+          "path": "Vms[].UserData",
+          "type": "string"
+        },
+        {
+          "path": "Vms[].VmId",
+          "type": "string"
+        },
+        {
+          "path": "Vms[].VmInitiatedShutdownBehavior",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.CreateVolume": {
+      "method": "POST",
+      "path": "/api/v1/CreateVolume",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        },
+        {
+          "path": "Volume",
+          "type": "object"
+        },
+        {
+          "path": "Volume.CreationDate",
+          "type": "string"
+        },
+        {
+          "path": "Volume.LinkedVolumes",
+          "type": "array"
+        },
+        {
+          "path": "Volume.Size",
+          "type": "number"
+        },
+        {
+          "path": "Volume.SubregionName",
+          "type": "string"
+        },
+        {
+          "path": "Volume.Tags",
+          "type": "array"
+        },
+        {
+          "path": "Volume.VolumeId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.DeleteDhcpOptions": {
+      "method": "POST",
+      "path": "/api/v1/DeleteDhcpOptions",
+      "fields": [],
+      "statuses": [
+        400
+      ]
+    },
+    "osc/Client.DeleteImage": {
+      "method": "POST",
+      "path": "/api/v1/DeleteImage",
+      "fields": [],
+      "statuses": [
+        400
+      ]
+    },
+    "osc/Client.DeleteInternetService": {
+      "method": "POST",
+      "path": "/api/v1/DeleteInternetService",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.DeleteKeypair": {
+      "method": "POST",
+      "path": "/api/v1/DeleteKeypair",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.DeleteLoadBalancer": {
+      "method": "POST",
+      "path": "/api/v1/DeleteLoadBalancer",
+      "fields": [
+        {
+          "path": "LoadBalancer",
+          "type": "object"
+        },
+        {
+          "path": "LoadBalancer.AccessLog",
+          "type": "object"
+        },
+        {
+          "path": "LoadBalancer.AccessLog.IsEnabled",
+          "type": "bool"
+        },
+        {
+          "path": "LoadBalancer.AccessLog.PublicationInterval",
+          "type": "number"
+        },
+        {
+          "path": "LoadBalancer.BackendIps",
+          "type": "array"
+        },
+        {
+          "path": "LoadBalancer.BackendVmIds",
+          "type": "array"
+        },
+        {
+          "path": "LoadBalancer.HealthCheck",
+          "type": "object"
+        },
+        {
+          "path": "LoadBalancer.HealthCheck.CheckInterval",
+          "type": "number"
+        },
+        {
+          "path": "LoadBalancer.HealthCheck.HealthyThreshold",
+          "type": "number"
+        },
+        {
+          "path": "LoadBalancer.HealthCheck.Port",
+          "type": "number"
+        },
+        {
+          "path": "LoadBalancer.HealthCheck.Protocol",
+          "type": "string"
+        },
+        {
+          "path": "LoadBalancer.HealthCheck.Timeout",
+          "type": "number"
+        },
+        {
+          "path": "LoadBalancer.HealthCheck.UnhealthyThreshold",
+          "type": "number"
+        },
+        {
+          "path": "LoadBalancer.Listeners",
+          "type": "array"
+        },
+        {
+          "path": "LoadBalancer.Listeners[]",
+          "type": "object"
+        },
+        {
+          "path": "LoadBalancer.Listeners[].BackendPort",
+          "type": "number"
+        },
+        {
+          "path": "LoadBalancer.Listeners[].BackendProtocol",
+          "type": "string"
+        },
+        {
+          "path": "LoadBalancer.Listeners[].LoadBalancerPort",
+          "type": "number"
+        },
+        {
+          "path": "LoadBalancer.Listeners[].LoadBalancerProtocol",
+          "type": "string"
+        },
+        {
+          "path": "LoadBalancer.LoadBalancerType",
+          "type": "string"
+        },
+        {
+          "path": "LoadBalancer.NetId",
+          "type": "string"
+        },
+        {
+          "path": "LoadBalancer.PrivateIp",
+          "type": "string"
+        },
+        {
+          "path": "LoadBalancer.SecurityGroups",
+          "type": "array"
+        },
+        {
+          "path": "LoadBalancer.SecurityGroups[]",
+          "type": "string"
+        },
+        {
+          "path": "LoadBalancer.SourceSecurityGroup",
+          "type": "object"
+        },
+        {
+          "path": "LoadBalancer.State",
+          "type": "string"
+        },
+        {
+          "path": "LoadBalancer.Subnets",
+          "type": "array"
+        },
+        {
+          "path": "LoadBalancer.Subnets[]",
+          "type": "string"
+        },
+        {
+          "path": "LoadBalancer.SubregionNames",
+          "type": "array"
+        },
+        {
+          "path": "LoadBalancer.SubregionNames[]",
+          "type": "string"
+        },
+        {
+          "path": "LoadBalancer.Tags",
+          "type": "array"
+        },
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.DeleteLoadBalancerListeners": {
+      "method": "POST",
+      "path": "/api/v1/DeleteLoadBalancerListeners",
+      "fields": [],
+      "statuses": [
+        400
+      ]
+    },
+    "osc/Client.DeleteNatService": {
+      "method": "POST",
+      "path": "/api/v1/DeleteNatService",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.DeleteNet": {
+      "method": "POST",
+      "path": "/api/v1/DeleteNet",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.DeleteNetPeering": {
+      "method": "POST",
+      "path": "/api/v1/DeleteNetPeering",
+      "fields": [],
+      "statuses": [
+        400
+      ]
+    },
+    "osc/Client.DeleteNic": {
+      "method": "POST",
+      "path": "/api/v1/DeleteNic",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.DeletePublicIp": {
+      "method": "POST",
+      "path": "/api/v1/DeletePublicIp",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.DeleteRoute": {
+      "method": "POST",
+      "path": "/api/v1/DeleteRoute",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        },
+        {
+          "path": "RouteTable",
+          "type": "object"
+        },
+        {
+          "path": "RouteTable.LinkRouteTables",
+          "type": "array"
+        },
+        {
+          "path": "RouteTable.LinkRouteTables[]",
+          "type": "object"
+        },
+        {
+          "path": "RouteTable.LinkRouteTables[].LinkRouteTableId",
+          "type": "string"
+        },
+        {
+          "path": "RouteTable.LinkRouteTables[].Main",
+          "type": "bool"
+        },
+        {
+          "path": "RouteTable.LinkRouteTables[].RouteTableId",
+          "type": "string"
+        },
+        {
+          "path": "RouteTable.LinkRouteTables[].SubnetId",
+          "type": "string"
+        },
+        {
+          "path": "RouteTable.NetId",
+          "type": "string"
+        },
+        {
+          "path": "RouteTable.RoutePropagatingVirtualGateways",
+          "type": "array"
+        },
+        {
+          "path": "RouteTable.RouteTableId",
+          "type": "string"
+        },
+        {
+          "path": "RouteTable.Routes",
+          "type": "array"
+        },
+        {
+          "path": "RouteTable.Routes[]",
+          "type": "object"
+        },
+        {
+          "path": "RouteTable.Routes[].DestinationIpRange",
+          "type": "string"
+        },
+        {
+          "path": "RouteTable.Tags",
+          "type": "array"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.DeleteRouteTable": {
+      "method": "POST",
+      "path": "/api/v1/DeleteRouteTable",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.DeleteSecurityGroup": {
+      "method": "POST",
+      "path": "/api/v1/DeleteSecurityGroup",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400,
+        409
+      ]
+    },
+    "osc/Client.DeleteSecurityGroupRule": {
+      "method": "POST",
+      "path": "/api/v1/DeleteSecurityGroupRule",
+      "fields": [],
+      "statuses": [
+        400
+      ]
+    },
+    "osc/Client.DeleteSnapshot": {
+      "method": "POST",
+      "path": "/api/v1/DeleteSnapshot",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.DeleteSubnet": {
+      "method": "POST",
+      "path": "/api/v1/DeleteSubnet",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.DeleteTags": {
+      "method": "POST",
+      "path": "/api/v1/DeleteTags",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.DeleteVms": {
+      "method": "POST",
+      "path": "/api/v1/DeleteVms",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        },
+        {
+          "path": "Vms",
+          "type": "array"
+        },
+        {
+          "path": "Vms[]",
+          "type": "object"
+        },
+        {
+          "path": "Vms[].VmId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.DeleteVolume": {
+      "method": "POST",
+      "path": "/api/v1/DeleteVolume",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.LinkInternetService": {
+      "method": "POST",
+      "path": "/api/v1/LinkInternetService",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.LinkNic": {
+      "method": "POST",
+      "path": "/api/v1/LinkNic",
+      "fields": [
+        {
+          "path": "LinkNicId",
+          "type": "string"
+        },
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.LinkPrivateIps": {
+      "method": "POST",
+      "path": "/api/v1/LinkPrivateIps",
+      "fields": [],
+      "statuses": [
+        400
+      ]
+    },
+    "osc/Client.LinkPublicIp": {
+      "method": "POST",
+      "path": "/api/v1/LinkPublicIp",
+      "fields": [
+        {
+          "path": "LinkPublicIpId",
+          "type": "string"
+        },
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.LinkRouteTable": {
+      "method": "POST",
+      "path": "/api/v1/LinkRouteTable",
+      "fields": [
+        {
+          "path": "LinkRouteTableId",
+          "type": "string"
+        },
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.LinkVolume": {
+      "method": "POST",
+      "path": "/api/v1/LinkVolume",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
     "osc/Client.ReadAccounts": {
       "method": "POST",
       "path": "/api/v1/ReadAccounts",
@@ -80,6 +1921,14 @@
       ],
       "statuses": [
         200
+      ]
+    },
+    "osc/Client.ReadAdminPassword": {
+      "method": "POST",
+      "path": "/api/v1/ReadAdminPassword",
+      "fields": [],
+      "statuses": [
+        400
       ]
     },
     "osc/Client.ReadDhcpOptions": {
@@ -605,6 +2454,46 @@
           "type": "array"
         },
         {
+          "path": "NatServices[]",
+          "type": "object"
+        },
+        {
+          "path": "NatServices[].NatServiceId",
+          "type": "string"
+        },
+        {
+          "path": "NatServices[].NetId",
+          "type": "string"
+        },
+        {
+          "path": "NatServices[].PublicIps",
+          "type": "array"
+        },
+        {
+          "path": "NatServices[].PublicIps[]",
+          "type": "object"
+        },
+        {
+          "path": "NatServices[].PublicIps[].PublicIp",
+          "type": "string"
+        },
+        {
+          "path": "NatServices[].PublicIps[].PublicIpId",
+          "type": "string"
+        },
+        {
+          "path": "NatServices[].State",
+          "type": "string"
+        },
+        {
+          "path": "NatServices[].SubnetId",
+          "type": "string"
+        },
+        {
+          "path": "NatServices[].Tags",
+          "type": "array"
+        },
+        {
           "path": "ResponseContext",
           "type": "object"
         },
@@ -974,6 +2863,38 @@
         {
           "path": "PublicIps",
           "type": "array"
+        },
+        {
+          "path": "PublicIps[]",
+          "type": "object"
+        },
+        {
+          "path": "PublicIps[].LinkPublicIpId",
+          "type": "string"
+        },
+        {
+          "path": "PublicIps[].NicId",
+          "type": "string"
+        },
+        {
+          "path": "PublicIps[].PrivateIp",
+          "type": "string"
+        },
+        {
+          "path": "PublicIps[].PublicIp",
+          "type": "string"
+        },
+        {
+          "path": "PublicIps[].PublicIpId",
+          "type": "string"
+        },
+        {
+          "path": "PublicIps[].Tags",
+          "type": "array"
+        },
+        {
+          "path": "PublicIps[].VmId",
+          "type": "string"
         },
         {
           "path": "ResponseContext",
@@ -1667,6 +3588,10 @@
           "type": "object"
         },
         {
+          "path": "Vms[].ActionsOnNextBoot.SecureBoot",
+          "type": "string"
+        },
+        {
           "path": "Vms[].Architecture",
           "type": "string"
         },
@@ -2008,7 +3933,8 @@
         }
       ],
       "statuses": [
-        200
+        200,
+        400
       ]
     },
     "osc/Client.ReadVmsHealth": {
@@ -2168,6 +4094,492 @@
       ],
       "statuses": [
         200
+      ]
+    },
+    "osc/Client.RebootVms": {
+      "method": "POST",
+      "path": "/api/v1/RebootVms",
+      "fields": [],
+      "statuses": [
+        400
+      ]
+    },
+    "osc/Client.RegisterVmsInLoadBalancer": {
+      "method": "POST",
+      "path": "/api/v1/RegisterVmsInLoadBalancer",
+      "fields": [],
+      "statuses": [
+        400
+      ]
+    },
+    "osc/Client.RejectNetPeering": {
+      "method": "POST",
+      "path": "/api/v1/RejectNetPeering",
+      "fields": [],
+      "statuses": [
+        400
+      ]
+    },
+    "osc/Client.StartVms": {
+      "method": "POST",
+      "path": "/api/v1/StartVms",
+      "fields": [],
+      "statuses": [
+        400
+      ]
+    },
+    "osc/Client.StopVms": {
+      "method": "POST",
+      "path": "/api/v1/StopVms",
+      "fields": [],
+      "statuses": [
+        400
+      ]
+    },
+    "osc/Client.UnlinkInternetService": {
+      "method": "POST",
+      "path": "/api/v1/UnlinkInternetService",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.UnlinkNic": {
+      "method": "POST",
+      "path": "/api/v1/UnlinkNic",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.UnlinkPrivateIps": {
+      "method": "POST",
+      "path": "/api/v1/UnlinkPrivateIps",
+      "fields": [],
+      "statuses": [
+        400
+      ]
+    },
+    "osc/Client.UnlinkPublicIp": {
+      "method": "POST",
+      "path": "/api/v1/UnlinkPublicIp",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.UnlinkRouteTable": {
+      "method": "POST",
+      "path": "/api/v1/UnlinkRouteTable",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.UnlinkVolume": {
+      "method": "POST",
+      "path": "/api/v1/UnlinkVolume",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.UpdateImage": {
+      "method": "POST",
+      "path": "/api/v1/UpdateImage",
+      "fields": [],
+      "statuses": [
+        400
+      ]
+    },
+    "osc/Client.UpdateLoadBalancer": {
+      "method": "POST",
+      "path": "/api/v1/UpdateLoadBalancer",
+      "fields": [],
+      "statuses": [
+        400
+      ]
+    },
+    "osc/Client.UpdateNet": {
+      "method": "POST",
+      "path": "/api/v1/UpdateNet",
+      "fields": [],
+      "statuses": [
+        400
+      ]
+    },
+    "osc/Client.UpdateNic": {
+      "method": "POST",
+      "path": "/api/v1/UpdateNic",
+      "fields": [],
+      "statuses": [
+        400
+      ]
+    },
+    "osc/Client.UpdateRoute": {
+      "method": "POST",
+      "path": "/api/v1/UpdateRoute",
+      "fields": [],
+      "statuses": [
+        400
+      ]
+    },
+    "osc/Client.UpdateRouteTableLink": {
+      "method": "POST",
+      "path": "/api/v1/UpdateRouteTableLink",
+      "fields": [],
+      "statuses": [
+        400
+      ]
+    },
+    "osc/Client.UpdateSubnet": {
+      "method": "POST",
+      "path": "/api/v1/UpdateSubnet",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        },
+        {
+          "path": "Subnet",
+          "type": "object"
+        },
+        {
+          "path": "Subnet.AvailableIpsCount",
+          "type": "number"
+        },
+        {
+          "path": "Subnet.IpRange",
+          "type": "string"
+        },
+        {
+          "path": "Subnet.MapPublicIpOnLaunch",
+          "type": "bool"
+        },
+        {
+          "path": "Subnet.NetId",
+          "type": "string"
+        },
+        {
+          "path": "Subnet.State",
+          "type": "string"
+        },
+        {
+          "path": "Subnet.SubnetId",
+          "type": "string"
+        },
+        {
+          "path": "Subnet.SubregionName",
+          "type": "string"
+        },
+        {
+          "path": "Subnet.Tags",
+          "type": "array"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.UpdateVm": {
+      "method": "POST",
+      "path": "/api/v1/UpdateVm",
+      "fields": [
+        {
+          "path": "ResponseContext",
+          "type": "object"
+        },
+        {
+          "path": "ResponseContext.RequestId",
+          "type": "string"
+        },
+        {
+          "path": "Vm",
+          "type": "object"
+        },
+        {
+          "path": "Vm.ActionsOnNextBoot",
+          "type": "object"
+        },
+        {
+          "path": "Vm.ActionsOnNextBoot.SecureBoot",
+          "type": "string"
+        },
+        {
+          "path": "Vm.BlockDeviceMappings",
+          "type": "array"
+        },
+        {
+          "path": "Vm.BlockDeviceMappings[]",
+          "type": "object"
+        },
+        {
+          "path": "Vm.BlockDeviceMappings[].Bsu",
+          "type": "object"
+        },
+        {
+          "path": "Vm.BlockDeviceMappings[].Bsu.DeleteOnVmDeletion",
+          "type": "bool"
+        },
+        {
+          "path": "Vm.BlockDeviceMappings[].Bsu.LinkDate",
+          "type": "string"
+        },
+        {
+          "path": "Vm.BlockDeviceMappings[].Bsu.VolumeId",
+          "type": "string"
+        },
+        {
+          "path": "Vm.BootMode",
+          "type": "string"
+        },
+        {
+          "path": "Vm.BsuOptimized",
+          "type": "bool"
+        },
+        {
+          "path": "Vm.CreationDate",
+          "type": "string"
+        },
+        {
+          "path": "Vm.DeletionProtection",
+          "type": "bool"
+        },
+        {
+          "path": "Vm.ImageId",
+          "type": "string"
+        },
+        {
+          "path": "Vm.IsSourceDestChecked",
+          "type": "bool"
+        },
+        {
+          "path": "Vm.LaunchNumber",
+          "type": "number"
+        },
+        {
+          "path": "Vm.NestedVirtualization",
+          "type": "bool"
+        },
+        {
+          "path": "Vm.NetId",
+          "type": "string"
+        },
+        {
+          "path": "Vm.Nics",
+          "type": "array"
+        },
+        {
+          "path": "Vm.Nics[]",
+          "type": "object"
+        },
+        {
+          "path": "Vm.Nics[].IsSourceDestChecked",
+          "type": "bool"
+        },
+        {
+          "path": "Vm.Nics[].LinkNic",
+          "type": "object"
+        },
+        {
+          "path": "Vm.Nics[].LinkNic.DeleteOnVmDeletion",
+          "type": "bool"
+        },
+        {
+          "path": "Vm.Nics[].LinkNic.DeviceNumber",
+          "type": "number"
+        },
+        {
+          "path": "Vm.Nics[].LinkNic.LinkNicId",
+          "type": "string"
+        },
+        {
+          "path": "Vm.Nics[].NetId",
+          "type": "string"
+        },
+        {
+          "path": "Vm.Nics[].NicId",
+          "type": "string"
+        },
+        {
+          "path": "Vm.Nics[].PrivateIps",
+          "type": "array"
+        },
+        {
+          "path": "Vm.Nics[].PrivateIps[]",
+          "type": "object"
+        },
+        {
+          "path": "Vm.Nics[].PrivateIps[].IsPrimary",
+          "type": "bool"
+        },
+        {
+          "path": "Vm.Nics[].PrivateIps[].PrivateIp",
+          "type": "string"
+        },
+        {
+          "path": "Vm.Nics[].SecurityGroups",
+          "type": "array"
+        },
+        {
+          "path": "Vm.Nics[].SecurityGroups[]",
+          "type": "object"
+        },
+        {
+          "path": "Vm.Nics[].SecurityGroups[].SecurityGroupId",
+          "type": "string"
+        },
+        {
+          "path": "Vm.Nics[].SubnetId",
+          "type": "string"
+        },
+        {
+          "path": "Vm.Performance",
+          "type": "string"
+        },
+        {
+          "path": "Vm.Placement",
+          "type": "object"
+        },
+        {
+          "path": "Vm.Placement.SubregionName",
+          "type": "string"
+        },
+        {
+          "path": "Vm.PrivateIp",
+          "type": "string"
+        },
+        {
+          "path": "Vm.ProductCodes",
+          "type": "array"
+        },
+        {
+          "path": "Vm.ProductCodes[]",
+          "type": "string"
+        },
+        {
+          "path": "Vm.ReservationId",
+          "type": "string"
+        },
+        {
+          "path": "Vm.SecurityGroups",
+          "type": "array"
+        },
+        {
+          "path": "Vm.SecurityGroups[]",
+          "type": "object"
+        },
+        {
+          "path": "Vm.SecurityGroups[].SecurityGroupId",
+          "type": "string"
+        },
+        {
+          "path": "Vm.ShutdownBehaviorConfiguration",
+          "type": "object"
+        },
+        {
+          "path": "Vm.ShutdownBehaviorConfiguration.GuestAction",
+          "type": "string"
+        },
+        {
+          "path": "Vm.ShutdownBehaviorConfiguration.HostAction",
+          "type": "string"
+        },
+        {
+          "path": "Vm.SubnetId",
+          "type": "string"
+        },
+        {
+          "path": "Vm.Tags",
+          "type": "array"
+        },
+        {
+          "path": "Vm.Tags[]",
+          "type": "object"
+        },
+        {
+          "path": "Vm.TpmEnabled",
+          "type": "bool"
+        },
+        {
+          "path": "Vm.UserData",
+          "type": "string"
+        },
+        {
+          "path": "Vm.VmId",
+          "type": "string"
+        },
+        {
+          "path": "Vm.VmInitiatedShutdownBehavior",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "osc/Client.UpdateVolume": {
+      "method": "POST",
+      "path": "/api/v1/UpdateVolume",
+      "fields": [],
+      "statuses": [
+        400
       ]
     }
   }

--- a/shapes/scaleway.json
+++ b/shapes/scaleway.json
@@ -7888,6 +7888,1107 @@
         200
       ]
     },
+    "GET /instance/v1/zones/fr-par-1/products/servers/availability": {
+      "method": "GET",
+      "path": "/instance/v1/zones/fr-par-1/products/servers/availability",
+      "fields": [
+        {
+          "path": "servers",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.DEV1-L",
+          "type": "object"
+        },
+        {
+          "path": "servers.DEV1-L.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.DEV1-M",
+          "type": "object"
+        },
+        {
+          "path": "servers.DEV1-M.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.DEV1-S",
+          "type": "object"
+        },
+        {
+          "path": "servers.DEV1-S.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.DEV1-XL",
+          "type": "object"
+        },
+        {
+          "path": "servers.DEV1-XL.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.GP1-L",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-L.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.GP1-M",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-M.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.GP1-S",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-S.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.GP1-XL",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-XL.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.GP1-XS",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-XS.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.L4-1-24G",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-1-24G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.L4-2-24G",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-2-24G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.L4-4-24G",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-4-24G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.L4-8-24G",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-8-24G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.PLAY2-MICRO",
+          "type": "object"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.PLAY2-NANO",
+          "type": "object"
+        },
+        {
+          "path": "servers.PLAY2-NANO.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.PLAY2-PICO",
+          "type": "object"
+        },
+        {
+          "path": "servers.PLAY2-PICO.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-12C-48G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-12C-48G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-16C-64G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-16C-64G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-24C-96G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-24C-96G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-2C-8G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-2C-8G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-32C-128G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-32C-128G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-48C-192G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-48C-192G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-4C-16G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-4C-16G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-64C-256G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-64C-256G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-6C-24G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-6C-24G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-8C-32G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-8C-32G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HN-10",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HN-10.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HN-3",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HN-3.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HN-5",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HN-5.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.PRO2-L",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-L.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.PRO2-M",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-M.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.PRO2-S",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-S.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.PRO2-XS",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-XS.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.PRO2-XXS",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-XXS.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.RENDER-S",
+          "type": "object"
+        },
+        {
+          "path": "servers.RENDER-S.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.STARDUST1-S",
+          "type": "object"
+        },
+        {
+          "path": "servers.STARDUST1-S.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.START1-L",
+          "type": "object"
+        },
+        {
+          "path": "servers.START1-L.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.START1-M",
+          "type": "object"
+        },
+        {
+          "path": "servers.START1-M.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.START1-S",
+          "type": "object"
+        },
+        {
+          "path": "servers.START1-S.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.START1-XS",
+          "type": "object"
+        },
+        {
+          "path": "servers.START1-XS.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.VC1L",
+          "type": "object"
+        },
+        {
+          "path": "servers.VC1L.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.VC1M",
+          "type": "object"
+        },
+        {
+          "path": "servers.VC1M.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.VC1S",
+          "type": "object"
+        },
+        {
+          "path": "servers.VC1S.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.X64-120GB",
+          "type": "object"
+        },
+        {
+          "path": "servers.X64-120GB.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.X64-15GB",
+          "type": "object"
+        },
+        {
+          "path": "servers.X64-15GB.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.X64-30GB",
+          "type": "object"
+        },
+        {
+          "path": "servers.X64-30GB.availability",
+          "type": "string"
+        },
+        {
+          "path": "servers.X64-60GB",
+          "type": "object"
+        },
+        {
+          "path": "servers.X64-60GB.availability",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
     "GET /instance/v1/zones/fr-par-1/security_groups": {
       "method": "GET",
       "path": "/instance/v1/zones/fr-par-1/security_groups",
@@ -8489,6 +9590,47 @@
         200
       ]
     },
+    "GET /marketplace/v2/images": {
+      "method": "GET",
+      "path": "/marketplace/v2/images",
+      "fields": [
+        {
+          "path": "images",
+          "type": "array"
+        },
+        {
+          "path": "images[]",
+          "type": "object"
+        },
+        {
+          "path": "images[].categories",
+          "type": "array"
+        },
+        {
+          "path": "images[].created_at",
+          "type": "string"
+        },
+        {
+          "path": "images[].id",
+          "type": "string"
+        },
+        {
+          "path": "images[].updated_at",
+          "type": "string"
+        },
+        {
+          "path": "images[].valid_until",
+          "type": "null"
+        },
+        {
+          "path": "total_count",
+          "type": "number"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
     "GET /marketplace/v2/local-images": {
       "method": "GET",
       "path": "/marketplace/v2/local-images",
@@ -8782,6 +9924,23462 @@
       ],
       "statuses": [
         200
+      ]
+    },
+    "block/v1alpha1/API.DeleteSnapshot": {
+      "method": "DELETE",
+      "path": "/block/v1alpha1/zones/fr-par-1/snapshots/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "block/v1alpha1/API.DeleteVolume": {
+      "method": "DELETE",
+      "path": "/block/v1alpha1/zones/fr-par-1/volumes/{id}",
+      "fields": [
+        {
+          "path": "",
+          "type": "null"
+        }
+      ],
+      "statuses": [
+        204,
+        404
+      ]
+    },
+    "block/v1alpha1/API.GetSnapshot": {
+      "method": "GET",
+      "path": "/block/v1alpha1/zones/fr-par-1/snapshots/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "block/v1alpha1/API.GetVolume": {
+      "method": "GET",
+      "path": "/block/v1alpha1/zones/fr-par-1/volumes/{id}",
+      "fields": [
+        {
+          "path": "created_at",
+          "type": "string"
+        },
+        {
+          "path": "id",
+          "type": "string"
+        },
+        {
+          "path": "last_detached_at",
+          "type": "string"
+        },
+        {
+          "path": "parent_snapshot_id",
+          "type": "string"
+        },
+        {
+          "path": "project_id",
+          "type": "string"
+        },
+        {
+          "path": "references",
+          "type": "array"
+        },
+        {
+          "path": "references[]",
+          "type": "object"
+        },
+        {
+          "path": "references[].created_at",
+          "type": "string"
+        },
+        {
+          "path": "references[].id",
+          "type": "string"
+        },
+        {
+          "path": "references[].product_resource_id",
+          "type": "string"
+        },
+        {
+          "path": "references[].product_resource_type",
+          "type": "string"
+        },
+        {
+          "path": "references[].status",
+          "type": "string"
+        },
+        {
+          "path": "references[].type",
+          "type": "string"
+        },
+        {
+          "path": "size",
+          "type": "number"
+        },
+        {
+          "path": "specs",
+          "type": "object"
+        },
+        {
+          "path": "specs.class",
+          "type": "string"
+        },
+        {
+          "path": "specs.perf_iops",
+          "type": "number"
+        },
+        {
+          "path": "status",
+          "type": "string"
+        },
+        {
+          "path": "tags",
+          "type": "array"
+        },
+        {
+          "path": "updated_at",
+          "type": "string"
+        },
+        {
+          "path": "zone",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        404
+      ]
+    },
+    "block/v1alpha1/API.UpdateSnapshot": {
+      "method": "PATCH",
+      "path": "/block/v1alpha1/zones/fr-par-1/snapshots/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "block/v1alpha1/API.UpdateVolume": {
+      "method": "PATCH",
+      "path": "/block/v1alpha1/zones/fr-par-1/volumes/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "iam/v1alpha1/API.CreateSSHKey": {
+      "method": "POST",
+      "path": "/iam/v1alpha1/ssh-keys",
+      "fields": [
+        {
+          "path": "created_at",
+          "type": "string"
+        },
+        {
+          "path": "disabled",
+          "type": "bool"
+        },
+        {
+          "path": "id",
+          "type": "string"
+        },
+        {
+          "path": "organization_id",
+          "type": "string"
+        },
+        {
+          "path": "project_id",
+          "type": "string"
+        },
+        {
+          "path": "public_key",
+          "type": "string"
+        },
+        {
+          "path": "updated_at",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        400
+      ]
+    },
+    "iam/v1alpha1/API.DeleteSSHKey": {
+      "method": "DELETE",
+      "path": "/iam/v1alpha1/ssh-keys/{id}",
+      "fields": [
+        {
+          "path": "",
+          "type": "null"
+        }
+      ],
+      "statuses": [
+        204,
+        404
+      ]
+    },
+    "iam/v1alpha1/API.GetSSHKey": {
+      "method": "GET",
+      "path": "/iam/v1alpha1/ssh-keys/{id}",
+      "fields": [
+        {
+          "path": "created_at",
+          "type": "string"
+        },
+        {
+          "path": "disabled",
+          "type": "bool"
+        },
+        {
+          "path": "id",
+          "type": "string"
+        },
+        {
+          "path": "organization_id",
+          "type": "string"
+        },
+        {
+          "path": "project_id",
+          "type": "string"
+        },
+        {
+          "path": "public_key",
+          "type": "string"
+        },
+        {
+          "path": "updated_at",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        404
+      ]
+    },
+    "iam/v1alpha1/API.ListSSHKeys": {
+      "method": "GET",
+      "path": "/iam/v1alpha1/ssh-keys",
+      "fields": [
+        {
+          "path": "total_count",
+          "type": "number"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "iam/v1alpha1/API.UpdateSSHKey": {
+      "method": "PATCH",
+      "path": "/iam/v1alpha1/ssh-keys/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "instance/v1/API.CreateIP": {
+      "method": "POST",
+      "path": "/instance/v1/zones/fr-par-1/ips",
+      "fields": [
+        {
+          "path": "ip",
+          "type": "object"
+        },
+        {
+          "path": "ip.address",
+          "type": "string"
+        },
+        {
+          "path": "ip.id",
+          "type": "string"
+        },
+        {
+          "path": "ip.ipam_id",
+          "type": "string"
+        },
+        {
+          "path": "ip.organization",
+          "type": "string"
+        },
+        {
+          "path": "ip.prefix",
+          "type": "null"
+        },
+        {
+          "path": "ip.project",
+          "type": "string"
+        },
+        {
+          "path": "ip.reverse",
+          "type": "null"
+        },
+        {
+          "path": "ip.server",
+          "type": "null"
+        },
+        {
+          "path": "ip.state",
+          "type": "string"
+        },
+        {
+          "path": "ip.tags",
+          "type": "array"
+        },
+        {
+          "path": "ip.type",
+          "type": "string"
+        },
+        {
+          "path": "ip.zone",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        201,
+        403
+      ]
+    },
+    "instance/v1/API.CreatePlacementGroup": {
+      "method": "POST",
+      "path": "/instance/v1/zones/fr-par-1/placement_groups",
+      "fields": [],
+      "statuses": [
+        403
+      ]
+    },
+    "instance/v1/API.CreatePrivateNIC": {
+      "method": "POST",
+      "path": "/instance/v1/zones/fr-par-1/servers/{id}/private_nics",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "instance/v1/API.CreateSecurityGroup": {
+      "method": "POST",
+      "path": "/instance/v1/zones/fr-par-1/security_groups",
+      "fields": [],
+      "statuses": [
+        403
+      ]
+    },
+    "instance/v1/API.CreateSecurityGroupRule": {
+      "method": "POST",
+      "path": "/instance/v1/zones/fr-par-1/security_groups/{id}/rules",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "instance/v1/API.CreateServer": {
+      "method": "POST",
+      "path": "/instance/v1/zones/fr-par-1/servers",
+      "fields": [
+        {
+          "path": "server",
+          "type": "object"
+        },
+        {
+          "path": "server.allowed_actions",
+          "type": "array"
+        },
+        {
+          "path": "server.allowed_actions[]",
+          "type": "string"
+        },
+        {
+          "path": "server.arch",
+          "type": "string"
+        },
+        {
+          "path": "server.boot_type",
+          "type": "string"
+        },
+        {
+          "path": "server.bootscript",
+          "type": "null"
+        },
+        {
+          "path": "server.creation_date",
+          "type": "string"
+        },
+        {
+          "path": "server.dynamic_ip_required",
+          "type": "bool"
+        },
+        {
+          "path": "server.enable_ipv6",
+          "type": "bool"
+        },
+        {
+          "path": "server.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "server.extra_networks",
+          "type": "array"
+        },
+        {
+          "path": "server.filesystems",
+          "type": "array"
+        },
+        {
+          "path": "server.id",
+          "type": "string"
+        },
+        {
+          "path": "server.image",
+          "type": "object"
+        },
+        {
+          "path": "server.image.arch",
+          "type": "string"
+        },
+        {
+          "path": "server.image.creation_date",
+          "type": "string"
+        },
+        {
+          "path": "server.image.default_bootscript",
+          "type": "null"
+        },
+        {
+          "path": "server.image.extra_volumes",
+          "type": "object"
+        },
+        {
+          "path": "server.image.from_server",
+          "type": "string"
+        },
+        {
+          "path": "server.image.id",
+          "type": "string"
+        },
+        {
+          "path": "server.image.modification_date",
+          "type": "string"
+        },
+        {
+          "path": "server.image.organization",
+          "type": "string"
+        },
+        {
+          "path": "server.image.project",
+          "type": "string"
+        },
+        {
+          "path": "server.image.public",
+          "type": "bool"
+        },
+        {
+          "path": "server.image.root_volume",
+          "type": "object"
+        },
+        {
+          "path": "server.image.root_volume.id",
+          "type": "string"
+        },
+        {
+          "path": "server.image.root_volume.name",
+          "type": "string"
+        },
+        {
+          "path": "server.image.root_volume.size",
+          "type": "number"
+        },
+        {
+          "path": "server.image.root_volume.volume_type",
+          "type": "string"
+        },
+        {
+          "path": "server.image.state",
+          "type": "string"
+        },
+        {
+          "path": "server.image.tags",
+          "type": "array"
+        },
+        {
+          "path": "server.image.zone",
+          "type": "string"
+        },
+        {
+          "path": "server.ipv6",
+          "type": "null"
+        },
+        {
+          "path": "server.location",
+          "type": "null"
+        },
+        {
+          "path": "server.maintenances",
+          "type": "array"
+        },
+        {
+          "path": "server.modification_date",
+          "type": "string"
+        },
+        {
+          "path": "server.organization",
+          "type": "string"
+        },
+        {
+          "path": "server.placement_group",
+          "type": "null"
+        },
+        {
+          "path": "server.private_ip",
+          "type": "null"
+        },
+        {
+          "path": "server.private_nics",
+          "type": "array"
+        },
+        {
+          "path": "server.project",
+          "type": "string"
+        },
+        {
+          "path": "server.protected",
+          "type": "bool"
+        },
+        {
+          "path": "server.public_ip",
+          "type": "object"
+        },
+        {
+          "path": "server.public_ip.address",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ip.dynamic",
+          "type": "bool"
+        },
+        {
+          "path": "server.public_ip.family",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ip.gateway",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ip.id",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ip.ipam_id",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ip.netmask",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ip.provisioning_mode",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ip.state",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ip.tags",
+          "type": "array"
+        },
+        {
+          "path": "server.public_ips",
+          "type": "array"
+        },
+        {
+          "path": "server.public_ips[]",
+          "type": "object"
+        },
+        {
+          "path": "server.public_ips[].address",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ips[].dynamic",
+          "type": "bool"
+        },
+        {
+          "path": "server.public_ips[].family",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ips[].gateway",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ips[].id",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ips[].ipam_id",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ips[].netmask",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ips[].provisioning_mode",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ips[].state",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ips[].tags",
+          "type": "array"
+        },
+        {
+          "path": "server.routed_ip_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "server.security_group",
+          "type": "object"
+        },
+        {
+          "path": "server.security_group.id",
+          "type": "string"
+        },
+        {
+          "path": "server.state",
+          "type": "string"
+        },
+        {
+          "path": "server.state_detail",
+          "type": "string"
+        },
+        {
+          "path": "server.tags",
+          "type": "array"
+        },
+        {
+          "path": "server.volumes",
+          "type": "object"
+        },
+        {
+          "path": "server.volumes.0",
+          "type": "object"
+        },
+        {
+          "path": "server.volumes.0.boot",
+          "type": "bool"
+        },
+        {
+          "path": "server.volumes.0.id",
+          "type": "string"
+        },
+        {
+          "path": "server.volumes.0.state",
+          "type": "string"
+        },
+        {
+          "path": "server.volumes.0.volume_type",
+          "type": "string"
+        },
+        {
+          "path": "server.volumes.0.zone",
+          "type": "string"
+        },
+        {
+          "path": "server.zone",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        201,
+        403
+      ]
+    },
+    "instance/v1/API.CreateVolume": {
+      "method": "POST",
+      "path": "/instance/v1/zones/fr-par-1/volumes",
+      "fields": [],
+      "statuses": [
+        400
+      ]
+    },
+    "instance/v1/API.DeleteIP": {
+      "method": "DELETE",
+      "path": "/instance/v1/zones/fr-par-1/ips/{id}",
+      "fields": [
+        {
+          "path": "",
+          "type": "null"
+        }
+      ],
+      "statuses": [
+        204,
+        404
+      ]
+    },
+    "instance/v1/API.DeleteImage": {
+      "method": "DELETE",
+      "path": "/instance/v1/zones/fr-par-1/images/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "instance/v1/API.DeletePlacementGroup": {
+      "method": "DELETE",
+      "path": "/instance/v1/zones/fr-par-1/placement_groups/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "instance/v1/API.DeletePrivateNIC": {
+      "method": "DELETE",
+      "path": "/instance/v1/zones/fr-par-1/servers/{id}/private_nics/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "instance/v1/API.DeleteSecurityGroup": {
+      "method": "DELETE",
+      "path": "/instance/v1/zones/fr-par-1/security_groups/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "instance/v1/API.DeleteSecurityGroupRule": {
+      "method": "DELETE",
+      "path": "/instance/v1/zones/fr-par-1/security_groups/{id}/rules/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "instance/v1/API.DeleteServer": {
+      "method": "DELETE",
+      "path": "/instance/v1/zones/fr-par-1/servers/{id}",
+      "fields": [
+        {
+          "path": "",
+          "type": "null"
+        }
+      ],
+      "statuses": [
+        204
+      ]
+    },
+    "instance/v1/API.DeleteServerUserData": {
+      "method": "DELETE",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "instance/v1/API.DeleteSnapshot": {
+      "method": "DELETE",
+      "path": "/instance/v1/zones/fr-par-1/snapshots/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "instance/v1/API.DeleteVolume": {
+      "method": "DELETE",
+      "path": "/instance/v1/zones/fr-par-1/volumes/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "instance/v1/API.GetIP": {
+      "method": "GET",
+      "path": "/instance/v1/zones/fr-par-1/ips/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "instance/v1/API.GetImage": {
+      "method": "GET",
+      "path": "/instance/v1/zones/fr-par-1/images/{id}",
+      "fields": [
+        {
+          "path": "image",
+          "type": "object"
+        },
+        {
+          "path": "image.arch",
+          "type": "string"
+        },
+        {
+          "path": "image.creation_date",
+          "type": "string"
+        },
+        {
+          "path": "image.default_bootscript",
+          "type": "null"
+        },
+        {
+          "path": "image.extra_volumes",
+          "type": "object"
+        },
+        {
+          "path": "image.from_server",
+          "type": "string"
+        },
+        {
+          "path": "image.id",
+          "type": "string"
+        },
+        {
+          "path": "image.modification_date",
+          "type": "string"
+        },
+        {
+          "path": "image.organization",
+          "type": "string"
+        },
+        {
+          "path": "image.project",
+          "type": "string"
+        },
+        {
+          "path": "image.public",
+          "type": "bool"
+        },
+        {
+          "path": "image.root_volume",
+          "type": "object"
+        },
+        {
+          "path": "image.root_volume.id",
+          "type": "string"
+        },
+        {
+          "path": "image.root_volume.name",
+          "type": "string"
+        },
+        {
+          "path": "image.root_volume.size",
+          "type": "number"
+        },
+        {
+          "path": "image.root_volume.volume_type",
+          "type": "string"
+        },
+        {
+          "path": "image.state",
+          "type": "string"
+        },
+        {
+          "path": "image.tags",
+          "type": "array"
+        },
+        {
+          "path": "image.zone",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        404
+      ]
+    },
+    "instance/v1/API.GetPlacementGroup": {
+      "method": "GET",
+      "path": "/instance/v1/zones/fr-par-1/placement_groups/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "instance/v1/API.GetPlacementGroupServers": {
+      "method": "GET",
+      "path": "/instance/v1/zones/fr-par-1/placement_groups/{id}/servers",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "instance/v1/API.GetPrivateNIC": {
+      "method": "GET",
+      "path": "/instance/v1/zones/fr-par-1/servers/{id}/private_nics/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "instance/v1/API.GetSecurityGroup": {
+      "method": "GET",
+      "path": "/instance/v1/zones/fr-par-1/security_groups/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "instance/v1/API.GetSecurityGroupRule": {
+      "method": "GET",
+      "path": "/instance/v1/zones/fr-par-1/security_groups/{id}/rules/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "instance/v1/API.GetServer": {
+      "method": "GET",
+      "path": "/instance/v1/zones/fr-par-1/servers/{id}",
+      "fields": [
+        {
+          "path": "server",
+          "type": "object"
+        },
+        {
+          "path": "server.allowed_actions",
+          "type": "array"
+        },
+        {
+          "path": "server.allowed_actions[]",
+          "type": "string"
+        },
+        {
+          "path": "server.arch",
+          "type": "string"
+        },
+        {
+          "path": "server.boot_type",
+          "type": "string"
+        },
+        {
+          "path": "server.bootscript",
+          "type": "null"
+        },
+        {
+          "path": "server.creation_date",
+          "type": "string"
+        },
+        {
+          "path": "server.dynamic_ip_required",
+          "type": "bool"
+        },
+        {
+          "path": "server.enable_ipv6",
+          "type": "bool"
+        },
+        {
+          "path": "server.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "server.extra_networks",
+          "type": "array"
+        },
+        {
+          "path": "server.filesystems",
+          "type": "array"
+        },
+        {
+          "path": "server.id",
+          "type": "string"
+        },
+        {
+          "path": "server.image",
+          "type": "object"
+        },
+        {
+          "path": "server.image.arch",
+          "type": "string"
+        },
+        {
+          "path": "server.image.creation_date",
+          "type": "string"
+        },
+        {
+          "path": "server.image.default_bootscript",
+          "type": "null"
+        },
+        {
+          "path": "server.image.extra_volumes",
+          "type": "object"
+        },
+        {
+          "path": "server.image.from_server",
+          "type": "string"
+        },
+        {
+          "path": "server.image.id",
+          "type": "string"
+        },
+        {
+          "path": "server.image.modification_date",
+          "type": "string"
+        },
+        {
+          "path": "server.image.organization",
+          "type": "string"
+        },
+        {
+          "path": "server.image.project",
+          "type": "string"
+        },
+        {
+          "path": "server.image.public",
+          "type": "bool"
+        },
+        {
+          "path": "server.image.root_volume",
+          "type": "object"
+        },
+        {
+          "path": "server.image.root_volume.id",
+          "type": "string"
+        },
+        {
+          "path": "server.image.root_volume.name",
+          "type": "string"
+        },
+        {
+          "path": "server.image.root_volume.size",
+          "type": "number"
+        },
+        {
+          "path": "server.image.root_volume.volume_type",
+          "type": "string"
+        },
+        {
+          "path": "server.image.state",
+          "type": "string"
+        },
+        {
+          "path": "server.image.tags",
+          "type": "array"
+        },
+        {
+          "path": "server.image.zone",
+          "type": "string"
+        },
+        {
+          "path": "server.ipv6",
+          "type": "null"
+        },
+        {
+          "path": "server.location",
+          "type": "null"
+        },
+        {
+          "path": "server.maintenances",
+          "type": "array"
+        },
+        {
+          "path": "server.modification_date",
+          "type": "string"
+        },
+        {
+          "path": "server.organization",
+          "type": "string"
+        },
+        {
+          "path": "server.placement_group",
+          "type": "null"
+        },
+        {
+          "path": "server.private_ip",
+          "type": "null"
+        },
+        {
+          "path": "server.private_nics",
+          "type": "array"
+        },
+        {
+          "path": "server.project",
+          "type": "string"
+        },
+        {
+          "path": "server.protected",
+          "type": "bool"
+        },
+        {
+          "path": "server.public_ip",
+          "type": "object"
+        },
+        {
+          "path": "server.public_ip.address",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ip.dynamic",
+          "type": "bool"
+        },
+        {
+          "path": "server.public_ip.family",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ip.gateway",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ip.id",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ip.ipam_id",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ip.netmask",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ip.provisioning_mode",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ip.state",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ip.tags",
+          "type": "array"
+        },
+        {
+          "path": "server.public_ips",
+          "type": "array"
+        },
+        {
+          "path": "server.public_ips[]",
+          "type": "object"
+        },
+        {
+          "path": "server.public_ips[].address",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ips[].dynamic",
+          "type": "bool"
+        },
+        {
+          "path": "server.public_ips[].family",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ips[].gateway",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ips[].id",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ips[].ipam_id",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ips[].netmask",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ips[].provisioning_mode",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ips[].state",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ips[].tags",
+          "type": "array"
+        },
+        {
+          "path": "server.routed_ip_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "server.security_group",
+          "type": "object"
+        },
+        {
+          "path": "server.security_group.id",
+          "type": "string"
+        },
+        {
+          "path": "server.state",
+          "type": "string"
+        },
+        {
+          "path": "server.state_detail",
+          "type": "string"
+        },
+        {
+          "path": "server.tags",
+          "type": "array"
+        },
+        {
+          "path": "server.volumes",
+          "type": "object"
+        },
+        {
+          "path": "server.volumes.0",
+          "type": "object"
+        },
+        {
+          "path": "server.volumes.0.boot",
+          "type": "bool"
+        },
+        {
+          "path": "server.volumes.0.id",
+          "type": "string"
+        },
+        {
+          "path": "server.volumes.0.state",
+          "type": "string"
+        },
+        {
+          "path": "server.volumes.0.volume_type",
+          "type": "string"
+        },
+        {
+          "path": "server.volumes.0.zone",
+          "type": "string"
+        },
+        {
+          "path": "server.zone",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        404
+      ]
+    },
+    "instance/v1/API.GetServerUserData": {
+      "method": "GET",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "instance/v1/API.GetSnapshot": {
+      "method": "GET",
+      "path": "/instance/v1/zones/fr-par-1/snapshots/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "instance/v1/API.GetVolume": {
+      "method": "GET",
+      "path": "/instance/v1/zones/fr-par-1/volumes/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "instance/v1/API.ListIPs": {
+      "method": "GET",
+      "path": "/instance/v1/zones/fr-par-1/ips",
+      "fields": [
+        {
+          "path": "ips",
+          "type": "array"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "instance/v1/API.ListImages": {
+      "method": "GET",
+      "path": "/instance/v1/zones/fr-par-1/images",
+      "fields": [
+        {
+          "path": "images",
+          "type": "array"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "instance/v1/API.ListPlacementGroups": {
+      "method": "GET",
+      "path": "/instance/v1/zones/fr-par-1/placement_groups",
+      "fields": [
+        {
+          "path": "placement_groups",
+          "type": "array"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "instance/v1/API.ListPrivateNICs": {
+      "method": "GET",
+      "path": "/instance/v1/zones/fr-par-1/servers/{id}/private_nics",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "instance/v1/API.ListSecurityGroupRules": {
+      "method": "GET",
+      "path": "/instance/v1/zones/fr-par-1/security_groups/{id}/rules",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "instance/v1/API.ListSecurityGroups": {
+      "method": "GET",
+      "path": "/instance/v1/zones/fr-par-1/security_groups",
+      "fields": [
+        {
+          "path": "security_groups",
+          "type": "array"
+        },
+        {
+          "path": "security_groups[]",
+          "type": "object"
+        },
+        {
+          "path": "security_groups[].creation_date",
+          "type": "string"
+        },
+        {
+          "path": "security_groups[].enable_default_security",
+          "type": "bool"
+        },
+        {
+          "path": "security_groups[].id",
+          "type": "string"
+        },
+        {
+          "path": "security_groups[].inbound_default_policy",
+          "type": "string"
+        },
+        {
+          "path": "security_groups[].modification_date",
+          "type": "string"
+        },
+        {
+          "path": "security_groups[].organization",
+          "type": "string"
+        },
+        {
+          "path": "security_groups[].organization_default",
+          "type": "bool"
+        },
+        {
+          "path": "security_groups[].outbound_default_policy",
+          "type": "string"
+        },
+        {
+          "path": "security_groups[].project",
+          "type": "string"
+        },
+        {
+          "path": "security_groups[].project_default",
+          "type": "bool"
+        },
+        {
+          "path": "security_groups[].servers",
+          "type": "array"
+        },
+        {
+          "path": "security_groups[].state",
+          "type": "string"
+        },
+        {
+          "path": "security_groups[].stateful",
+          "type": "bool"
+        },
+        {
+          "path": "security_groups[].tags",
+          "type": "array"
+        },
+        {
+          "path": "security_groups[].zone",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "instance/v1/API.ListServerUserData": {
+      "method": "GET",
+      "path": "/instance/v1/zones/fr-par-1/servers/{id}/user_data",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "instance/v1/API.ListServers": {
+      "method": "GET",
+      "path": "/instance/v1/zones/fr-par-1/servers",
+      "fields": [
+        {
+          "path": "servers",
+          "type": "array"
+        },
+        {
+          "path": "servers[]",
+          "type": "object"
+        },
+        {
+          "path": "servers[].allowed_actions",
+          "type": "array"
+        },
+        {
+          "path": "servers[].allowed_actions[]",
+          "type": "string"
+        },
+        {
+          "path": "servers[].arch",
+          "type": "string"
+        },
+        {
+          "path": "servers[].boot_type",
+          "type": "string"
+        },
+        {
+          "path": "servers[].bootscript",
+          "type": "null"
+        },
+        {
+          "path": "servers[].creation_date",
+          "type": "string"
+        },
+        {
+          "path": "servers[].dynamic_ip_required",
+          "type": "bool"
+        },
+        {
+          "path": "servers[].enable_ipv6",
+          "type": "bool"
+        },
+        {
+          "path": "servers[].end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers[].extra_networks",
+          "type": "array"
+        },
+        {
+          "path": "servers[].filesystems",
+          "type": "array"
+        },
+        {
+          "path": "servers[].id",
+          "type": "string"
+        },
+        {
+          "path": "servers[].image",
+          "type": "object"
+        },
+        {
+          "path": "servers[].image.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers[].image.creation_date",
+          "type": "string"
+        },
+        {
+          "path": "servers[].image.default_bootscript",
+          "type": "null"
+        },
+        {
+          "path": "servers[].image.extra_volumes",
+          "type": "object"
+        },
+        {
+          "path": "servers[].image.from_server",
+          "type": "string"
+        },
+        {
+          "path": "servers[].image.id",
+          "type": "string"
+        },
+        {
+          "path": "servers[].image.modification_date",
+          "type": "string"
+        },
+        {
+          "path": "servers[].image.organization",
+          "type": "string"
+        },
+        {
+          "path": "servers[].image.project",
+          "type": "string"
+        },
+        {
+          "path": "servers[].image.public",
+          "type": "bool"
+        },
+        {
+          "path": "servers[].image.root_volume",
+          "type": "object"
+        },
+        {
+          "path": "servers[].image.root_volume.id",
+          "type": "string"
+        },
+        {
+          "path": "servers[].image.root_volume.name",
+          "type": "string"
+        },
+        {
+          "path": "servers[].image.root_volume.size",
+          "type": "number"
+        },
+        {
+          "path": "servers[].image.root_volume.volume_type",
+          "type": "string"
+        },
+        {
+          "path": "servers[].image.state",
+          "type": "string"
+        },
+        {
+          "path": "servers[].image.tags",
+          "type": "array"
+        },
+        {
+          "path": "servers[].image.zone",
+          "type": "string"
+        },
+        {
+          "path": "servers[].ipv6",
+          "type": "null"
+        },
+        {
+          "path": "servers[].location",
+          "type": "null"
+        },
+        {
+          "path": "servers[].maintenances",
+          "type": "array"
+        },
+        {
+          "path": "servers[].modification_date",
+          "type": "string"
+        },
+        {
+          "path": "servers[].organization",
+          "type": "string"
+        },
+        {
+          "path": "servers[].placement_group",
+          "type": "null"
+        },
+        {
+          "path": "servers[].private_ip",
+          "type": "null"
+        },
+        {
+          "path": "servers[].private_nics",
+          "type": "array"
+        },
+        {
+          "path": "servers[].project",
+          "type": "string"
+        },
+        {
+          "path": "servers[].protected",
+          "type": "bool"
+        },
+        {
+          "path": "servers[].public_ip",
+          "type": "object"
+        },
+        {
+          "path": "servers[].public_ip.address",
+          "type": "string"
+        },
+        {
+          "path": "servers[].public_ip.dynamic",
+          "type": "bool"
+        },
+        {
+          "path": "servers[].public_ip.family",
+          "type": "string"
+        },
+        {
+          "path": "servers[].public_ip.gateway",
+          "type": "string"
+        },
+        {
+          "path": "servers[].public_ip.id",
+          "type": "string"
+        },
+        {
+          "path": "servers[].public_ip.ipam_id",
+          "type": "string"
+        },
+        {
+          "path": "servers[].public_ip.netmask",
+          "type": "string"
+        },
+        {
+          "path": "servers[].public_ip.provisioning_mode",
+          "type": "string"
+        },
+        {
+          "path": "servers[].public_ip.state",
+          "type": "string"
+        },
+        {
+          "path": "servers[].public_ip.tags",
+          "type": "array"
+        },
+        {
+          "path": "servers[].public_ips",
+          "type": "array"
+        },
+        {
+          "path": "servers[].public_ips[]",
+          "type": "object"
+        },
+        {
+          "path": "servers[].public_ips[].address",
+          "type": "string"
+        },
+        {
+          "path": "servers[].public_ips[].dynamic",
+          "type": "bool"
+        },
+        {
+          "path": "servers[].public_ips[].family",
+          "type": "string"
+        },
+        {
+          "path": "servers[].public_ips[].gateway",
+          "type": "string"
+        },
+        {
+          "path": "servers[].public_ips[].id",
+          "type": "string"
+        },
+        {
+          "path": "servers[].public_ips[].ipam_id",
+          "type": "string"
+        },
+        {
+          "path": "servers[].public_ips[].netmask",
+          "type": "string"
+        },
+        {
+          "path": "servers[].public_ips[].provisioning_mode",
+          "type": "string"
+        },
+        {
+          "path": "servers[].public_ips[].state",
+          "type": "string"
+        },
+        {
+          "path": "servers[].public_ips[].tags",
+          "type": "array"
+        },
+        {
+          "path": "servers[].routed_ip_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "servers[].security_group",
+          "type": "object"
+        },
+        {
+          "path": "servers[].security_group.id",
+          "type": "string"
+        },
+        {
+          "path": "servers[].state",
+          "type": "string"
+        },
+        {
+          "path": "servers[].state_detail",
+          "type": "string"
+        },
+        {
+          "path": "servers[].tags",
+          "type": "array"
+        },
+        {
+          "path": "servers[].volumes",
+          "type": "object"
+        },
+        {
+          "path": "servers[].volumes.0",
+          "type": "object"
+        },
+        {
+          "path": "servers[].volumes.0.boot",
+          "type": "bool"
+        },
+        {
+          "path": "servers[].volumes.0.id",
+          "type": "string"
+        },
+        {
+          "path": "servers[].volumes.0.state",
+          "type": "string"
+        },
+        {
+          "path": "servers[].volumes.0.volume_type",
+          "type": "string"
+        },
+        {
+          "path": "servers[].volumes.0.zone",
+          "type": "string"
+        },
+        {
+          "path": "servers[].zone",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "instance/v1/API.ListServersTypes": {
+      "method": "GET",
+      "path": "/instance/v1/zones/fr-par-1/products/servers",
+      "fields": [
+        {
+          "path": "servers",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-24G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A12C-48G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-32G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A16C-64G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-4G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A2C-8G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-16G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A4C-8G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-12G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A6C-24G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-16G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC2-A8C-32G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-24G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X12C-48G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-32G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X16C-64G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-4G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X2C-8G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-16G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X4C-8G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-12G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X6C-24G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-16G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.BASIC3-X8C-32G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X12C-24G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X16C-32G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X24C-48G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X2C-4G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X32C-64G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X48C-96G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X4C-8G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X64C-128G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X6C-12G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X8C-16G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.COMPUTE3-X96C-192G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-L",
+          "type": "object"
+        },
+        {
+          "path": "servers.DEV1-L.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.DEV1-L.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.DEV1-L.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-L.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.DEV1-L.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.DEV1-L.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.DEV1-L.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.DEV1-L.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.DEV1-L.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-L.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.DEV1-L.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-L.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.DEV1-L.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-L.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.DEV1-L.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-L.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.DEV1-L.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-L.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-L.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.DEV1-L.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.DEV1-L.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.DEV1-L.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-L.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-L.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.DEV1-L.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-L.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-L.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.DEV1-L.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.DEV1-L.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-L.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-L.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-L.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-L.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-L.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.DEV1-L.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-L.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-M",
+          "type": "object"
+        },
+        {
+          "path": "servers.DEV1-M.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.DEV1-M.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.DEV1-M.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-M.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.DEV1-M.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.DEV1-M.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.DEV1-M.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.DEV1-M.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.DEV1-M.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-M.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.DEV1-M.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-M.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.DEV1-M.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-M.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.DEV1-M.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-M.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.DEV1-M.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-M.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-M.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.DEV1-M.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.DEV1-M.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.DEV1-M.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-M.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-M.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.DEV1-M.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-M.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-M.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.DEV1-M.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.DEV1-M.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-M.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-M.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-M.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-M.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-M.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.DEV1-M.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-M.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-S",
+          "type": "object"
+        },
+        {
+          "path": "servers.DEV1-S.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.DEV1-S.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.DEV1-S.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-S.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.DEV1-S.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.DEV1-S.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.DEV1-S.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.DEV1-S.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.DEV1-S.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-S.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.DEV1-S.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-S.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.DEV1-S.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-S.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.DEV1-S.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-S.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.DEV1-S.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-S.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-S.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.DEV1-S.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.DEV1-S.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.DEV1-S.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-S.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-S.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.DEV1-S.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-S.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-S.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.DEV1-S.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.DEV1-S.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-S.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-S.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-S.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-S.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-S.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.DEV1-S.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-S.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-XL",
+          "type": "object"
+        },
+        {
+          "path": "servers.DEV1-XL.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.DEV1-XL.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.DEV1-XL.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-XL.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.DEV1-XL.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.DEV1-XL.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.DEV1-XL.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.DEV1-XL.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.DEV1-XL.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-XL.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.DEV1-XL.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-XL.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.DEV1-XL.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-XL.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.DEV1-XL.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-XL.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.DEV1-XL.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-XL.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-XL.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.DEV1-XL.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.DEV1-XL.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.DEV1-XL.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-XL.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-XL.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.DEV1-XL.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-XL.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-XL.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.DEV1-XL.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.DEV1-XL.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-XL.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-XL.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-XL.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-XL.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-XL.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.DEV1-XL.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.DEV1-XL.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-L",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-L.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.GP1-L.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.GP1-L.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-L.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-L.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.GP1-L.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.GP1-L.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.GP1-L.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.GP1-L.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-L.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.GP1-L.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-L.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.GP1-L.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-L.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.GP1-L.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-L.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.GP1-L.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-L.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-L.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-L.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.GP1-L.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-L.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-L.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-L.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.GP1-L.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-L.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-L.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-L.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-L.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-L.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-L.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-L.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-L.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-L.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-L.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-L.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-M",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-M.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.GP1-M.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.GP1-M.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-M.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-M.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.GP1-M.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.GP1-M.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.GP1-M.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.GP1-M.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-M.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.GP1-M.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-M.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.GP1-M.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-M.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.GP1-M.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-M.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.GP1-M.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-M.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-M.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-M.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.GP1-M.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-M.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-M.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-M.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.GP1-M.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-M.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-M.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-M.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-M.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-M.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-M.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-M.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-M.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-M.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-M.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-M.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-S",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-S.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.GP1-S.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.GP1-S.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-S.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-S.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.GP1-S.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.GP1-S.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.GP1-S.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.GP1-S.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-S.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.GP1-S.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-S.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.GP1-S.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-S.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.GP1-S.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-S.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.GP1-S.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-S.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-S.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-S.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.GP1-S.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-S.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-S.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-S.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.GP1-S.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-S.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-S.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-S.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-S.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-S.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-S.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-S.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-S.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-S.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-S.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-S.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XL",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-XL.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.GP1-XL.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.GP1-XL.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XL.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-XL.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.GP1-XL.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.GP1-XL.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.GP1-XL.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.GP1-XL.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XL.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.GP1-XL.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XL.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.GP1-XL.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XL.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.GP1-XL.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XL.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.GP1-XL.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XL.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XL.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-XL.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.GP1-XL.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-XL.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XL.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XL.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.GP1-XL.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XL.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XL.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-XL.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-XL.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XL.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XL.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XL.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XL.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XL.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-XL.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XL.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XS",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-XS.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.GP1-XS.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.GP1-XS.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XS.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-XS.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.GP1-XS.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.GP1-XS.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.GP1-XS.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.GP1-XS.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XS.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.GP1-XS.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XS.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.GP1-XS.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XS.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.GP1-XS.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XS.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.GP1-XS.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XS.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XS.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-XS.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.GP1-XS.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-XS.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XS.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XS.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.GP1-XS.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XS.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XS.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-XS.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-XS.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XS.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XS.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XS.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XS.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XS.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.GP1-XS.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.GP1-XS.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-1-24G",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-1-24G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.L4-1-24G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.L4-1-24G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-1-24G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-1-24G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.L4-1-24G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.L4-1-24G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.L4-1-24G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.L4-1-24G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-1-24G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.L4-1-24G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-1-24G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.L4-1-24G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-1-24G.gpu_info",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-1-24G.gpu_info.gpu_memory",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-1-24G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-1-24G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.L4-1-24G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-1-24G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-1-24G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-1-24G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.L4-1-24G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-1-24G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-1-24G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-1-24G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.L4-1-24G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-1-24G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-1-24G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-1-24G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-1-24G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-1-24G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-1-24G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-1-24G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-1-24G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-1-24G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-1-24G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-1-24G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-2-24G",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-2-24G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.L4-2-24G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.L4-2-24G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-2-24G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-2-24G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.L4-2-24G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.L4-2-24G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.L4-2-24G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.L4-2-24G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-2-24G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.L4-2-24G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-2-24G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.L4-2-24G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-2-24G.gpu_info",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-2-24G.gpu_info.gpu_memory",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-2-24G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-2-24G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.L4-2-24G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-2-24G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-2-24G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-2-24G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.L4-2-24G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-2-24G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-2-24G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-2-24G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.L4-2-24G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-2-24G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-2-24G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-2-24G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-2-24G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-2-24G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-2-24G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-2-24G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-2-24G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-2-24G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-2-24G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-2-24G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-4-24G",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-4-24G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.L4-4-24G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.L4-4-24G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-4-24G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-4-24G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.L4-4-24G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.L4-4-24G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.L4-4-24G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.L4-4-24G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-4-24G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.L4-4-24G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-4-24G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.L4-4-24G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-4-24G.gpu_info",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-4-24G.gpu_info.gpu_memory",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-4-24G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-4-24G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.L4-4-24G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-4-24G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-4-24G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-4-24G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.L4-4-24G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-4-24G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-4-24G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-4-24G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.L4-4-24G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-4-24G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-4-24G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-4-24G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-4-24G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-4-24G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-4-24G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-4-24G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-4-24G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-4-24G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-4-24G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-4-24G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-8-24G",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-8-24G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.L4-8-24G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.L4-8-24G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-8-24G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-8-24G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.L4-8-24G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.L4-8-24G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.L4-8-24G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.L4-8-24G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-8-24G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.L4-8-24G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-8-24G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.L4-8-24G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-8-24G.gpu_info",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-8-24G.gpu_info.gpu_memory",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-8-24G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-8-24G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.L4-8-24G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-8-24G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-8-24G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-8-24G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.L4-8-24G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-8-24G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-8-24G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-8-24G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.L4-8-24G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-8-24G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-8-24G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-8-24G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-8-24G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-8-24G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-8-24G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-8-24G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-8-24G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-8-24G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.L4-8-24G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.L4-8-24G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X12C-96G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X16C-128G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X24C-192G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X2C-16G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X32C-256G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X48C-384G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X4C-32G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X6C-48G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.MEMORY3-X8C-64G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-MICRO",
+          "type": "object"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-MICRO.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-NANO",
+          "type": "object"
+        },
+        {
+          "path": "servers.PLAY2-NANO.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.PLAY2-NANO.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.PLAY2-NANO.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-NANO.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.PLAY2-NANO.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PLAY2-NANO.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.PLAY2-NANO.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.PLAY2-NANO.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PLAY2-NANO.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-NANO.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PLAY2-NANO.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-NANO.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PLAY2-NANO.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-NANO.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.PLAY2-NANO.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-NANO.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.PLAY2-NANO.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-NANO.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-NANO.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.PLAY2-NANO.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.PLAY2-NANO.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.PLAY2-NANO.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-NANO.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-NANO.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PLAY2-NANO.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-NANO.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-NANO.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.PLAY2-NANO.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.PLAY2-NANO.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-NANO.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-NANO.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-NANO.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-NANO.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-NANO.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.PLAY2-NANO.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-NANO.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-PICO",
+          "type": "object"
+        },
+        {
+          "path": "servers.PLAY2-PICO.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.PLAY2-PICO.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.PLAY2-PICO.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-PICO.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.PLAY2-PICO.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PLAY2-PICO.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.PLAY2-PICO.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.PLAY2-PICO.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PLAY2-PICO.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-PICO.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PLAY2-PICO.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-PICO.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PLAY2-PICO.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-PICO.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.PLAY2-PICO.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-PICO.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.PLAY2-PICO.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-PICO.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-PICO.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.PLAY2-PICO.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.PLAY2-PICO.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.PLAY2-PICO.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-PICO.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-PICO.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PLAY2-PICO.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-PICO.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-PICO.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.PLAY2-PICO.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.PLAY2-PICO.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-PICO.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-PICO.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-PICO.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-PICO.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-PICO.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.PLAY2-PICO.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PLAY2-PICO.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-12C-48G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-12C-48G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-12C-48G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-12C-48G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-12C-48G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-12C-48G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-12C-48G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-12C-48G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-12C-48G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-12C-48G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-12C-48G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-12C-48G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-12C-48G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-12C-48G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-12C-48G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-12C-48G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-12C-48G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-12C-48G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-12C-48G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-12C-48G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-12C-48G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-12C-48G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-12C-48G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-12C-48G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-12C-48G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-12C-48G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-12C-48G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-12C-48G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-12C-48G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-12C-48G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-12C-48G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-12C-48G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-12C-48G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-12C-48G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-12C-48G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-12C-48G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-12C-48G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G-WIN.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-16C-64G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-16C-64G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-16C-64G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-16C-64G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-16C-64G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-16C-64G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-16C-64G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-16C-64G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-16C-64G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-16C-64G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-16C-64G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-16C-64G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-16C-64G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-16C-64G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-16C-64G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-16C-64G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-16C-64G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-16C-64G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-16C-64G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-24C-96G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-24C-96G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-24C-96G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-24C-96G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-24C-96G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-24C-96G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-24C-96G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-24C-96G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-24C-96G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-24C-96G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-24C-96G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-24C-96G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-24C-96G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-24C-96G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-24C-96G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-24C-96G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-24C-96G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-24C-96G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-24C-96G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-24C-96G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-24C-96G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-24C-96G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-24C-96G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-24C-96G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-24C-96G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-24C-96G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-24C-96G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-24C-96G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-24C-96G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-24C-96G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-24C-96G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-24C-96G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-24C-96G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-24C-96G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-24C-96G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-24C-96G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-24C-96G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G-WIN.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-2C-8G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-2C-8G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-2C-8G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-2C-8G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-2C-8G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-2C-8G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-2C-8G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-2C-8G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-2C-8G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-2C-8G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-2C-8G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-2C-8G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-2C-8G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-2C-8G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-2C-8G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-2C-8G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-2C-8G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-2C-8G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-2C-8G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G-WIN.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-32C-128G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-32C-128G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-32C-128G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-32C-128G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-32C-128G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-32C-128G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-32C-128G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-32C-128G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-32C-128G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-32C-128G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-32C-128G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-32C-128G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-32C-128G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-32C-128G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-32C-128G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-32C-128G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-32C-128G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-32C-128G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-32C-128G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-48C-192G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-48C-192G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-48C-192G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-48C-192G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-48C-192G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-48C-192G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-48C-192G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-48C-192G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-48C-192G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-48C-192G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-48C-192G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-48C-192G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-48C-192G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-48C-192G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-48C-192G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-48C-192G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-48C-192G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-48C-192G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-48C-192G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-48C-192G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-48C-192G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-48C-192G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-48C-192G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-48C-192G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-48C-192G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-48C-192G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-48C-192G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-48C-192G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-48C-192G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-48C-192G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-48C-192G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-48C-192G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-48C-192G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-48C-192G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-48C-192G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-48C-192G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-48C-192G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G-WIN.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-4C-16G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-4C-16G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-4C-16G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-4C-16G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-4C-16G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-4C-16G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-4C-16G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-4C-16G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-4C-16G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-4C-16G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-4C-16G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-4C-16G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-4C-16G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-4C-16G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-4C-16G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-4C-16G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-4C-16G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-4C-16G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-4C-16G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-64C-256G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-64C-256G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-64C-256G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-64C-256G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-64C-256G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-64C-256G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-64C-256G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-64C-256G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-64C-256G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-64C-256G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-64C-256G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-64C-256G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-64C-256G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-64C-256G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-64C-256G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-64C-256G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-64C-256G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-64C-256G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-64C-256G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-64C-256G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-64C-256G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-64C-256G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-64C-256G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-64C-256G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-64C-256G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-64C-256G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-64C-256G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-64C-256G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-64C-256G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-64C-256G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-64C-256G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-64C-256G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-64C-256G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-64C-256G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-64C-256G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-64C-256G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-64C-256G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-6C-24G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-6C-24G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-6C-24G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-6C-24G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-6C-24G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-6C-24G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-6C-24G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-6C-24G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-6C-24G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-6C-24G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-6C-24G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-6C-24G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-6C-24G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-6C-24G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-6C-24G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-6C-24G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-6C-24G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-6C-24G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-6C-24G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-6C-24G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-6C-24G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-6C-24G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-6C-24G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-6C-24G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-6C-24G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-6C-24G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-6C-24G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-6C-24G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-6C-24G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-6C-24G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-6C-24G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-6C-24G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-6C-24G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-6C-24G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-6C-24G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-6C-24G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-6C-24G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G-WIN.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-8C-32G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-8C-32G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-8C-32G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-8C-32G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-8C-32G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-8C-32G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-8C-32G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-8C-32G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-8C-32G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-8C-32G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-8C-32G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-8C-32G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-8C-32G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-8C-32G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-8C-32G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-8C-32G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-8C-32G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-8C-32G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-8C-32G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-12C-24G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-16C-32G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-24C-48G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-2C-4G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-32C-64G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-48C-96G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-4C-8G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-64C-128G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-6C-12G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HC-8C-16G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-12C-96G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-16C-128G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-24C-192G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-2C-16G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-32C-256G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-48C-384G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-4C-32G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-64C-512G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-6C-48G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HM-8C-64G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-10",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HN-10.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HN-10.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HN-10.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-10.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HN-10.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HN-10.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HN-10.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HN-10.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HN-10.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-10.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HN-10.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-10.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HN-10.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-10.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HN-10.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-10.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HN-10.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-10.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-10.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HN-10.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HN-10.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HN-10.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-10.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-10.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HN-10.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-10.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-10.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HN-10.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HN-10.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-10.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-10.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-10.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-10.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-10.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HN-10.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-10.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-3",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HN-3.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HN-3.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HN-3.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-3.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HN-3.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HN-3.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HN-3.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HN-3.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HN-3.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-3.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HN-3.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-3.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HN-3.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-3.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HN-3.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-3.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HN-3.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-3.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-3.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HN-3.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HN-3.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HN-3.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-3.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-3.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HN-3.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-3.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-3.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HN-3.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HN-3.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-3.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-3.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-3.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-3.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-3.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HN-3.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-3.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-5",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HN-5.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HN-5.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HN-5.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-5.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HN-5.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HN-5.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HN-5.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.POP2-HN-5.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HN-5.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-5.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HN-5.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-5.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HN-5.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-5.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HN-5.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-5.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.POP2-HN-5.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-5.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-5.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HN-5.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.POP2-HN-5.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HN-5.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-5.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-5.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.POP2-HN-5.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-5.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-5.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HN-5.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HN-5.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-5.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-5.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-5.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-5.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-5.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.POP2-HN-5.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.POP2-HN-5.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-L",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-L.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.PRO2-L.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.PRO2-L.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-L.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-L.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PRO2-L.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.PRO2-L.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.PRO2-L.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PRO2-L.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-L.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PRO2-L.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-L.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PRO2-L.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-L.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.PRO2-L.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-L.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.PRO2-L.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-L.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-L.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-L.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.PRO2-L.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-L.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-L.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-L.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PRO2-L.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-L.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-L.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-L.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-L.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-L.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-L.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-L.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-L.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-L.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-L.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-L.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-M",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-M.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.PRO2-M.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.PRO2-M.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-M.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-M.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PRO2-M.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.PRO2-M.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.PRO2-M.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PRO2-M.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-M.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PRO2-M.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-M.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PRO2-M.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-M.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.PRO2-M.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-M.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.PRO2-M.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-M.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-M.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-M.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.PRO2-M.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-M.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-M.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-M.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PRO2-M.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-M.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-M.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-M.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-M.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-M.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-M.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-M.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-M.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-M.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-M.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-M.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-S",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-S.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.PRO2-S.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.PRO2-S.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-S.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-S.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PRO2-S.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.PRO2-S.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.PRO2-S.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PRO2-S.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-S.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PRO2-S.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-S.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PRO2-S.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-S.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.PRO2-S.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-S.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.PRO2-S.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-S.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-S.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-S.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.PRO2-S.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-S.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-S.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-S.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PRO2-S.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-S.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-S.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-S.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-S.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-S.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-S.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-S.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-S.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-S.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-S.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-S.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XS",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-XS.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.PRO2-XS.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.PRO2-XS.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XS.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-XS.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PRO2-XS.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.PRO2-XS.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.PRO2-XS.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PRO2-XS.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XS.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PRO2-XS.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XS.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PRO2-XS.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XS.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.PRO2-XS.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XS.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.PRO2-XS.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XS.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XS.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-XS.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.PRO2-XS.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-XS.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XS.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XS.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PRO2-XS.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XS.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XS.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-XS.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-XS.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XS.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XS.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XS.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XS.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XS.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-XS.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XS.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XXS",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-XXS.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.PRO2-XXS.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.PRO2-XXS.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XXS.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-XXS.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PRO2-XXS.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.PRO2-XXS.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.PRO2-XXS.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PRO2-XXS.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XXS.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PRO2-XXS.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XXS.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PRO2-XXS.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XXS.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.PRO2-XXS.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XXS.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.PRO2-XXS.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XXS.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XXS.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-XXS.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.PRO2-XXS.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-XXS.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XXS.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XXS.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.PRO2-XXS.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XXS.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XXS.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-XXS.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-XXS.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XXS.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XXS.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XXS.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XXS.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XXS.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.PRO2-XXS.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.PRO2-XXS.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.RENDER-S",
+          "type": "object"
+        },
+        {
+          "path": "servers.RENDER-S.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.RENDER-S.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.RENDER-S.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.RENDER-S.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.RENDER-S.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.RENDER-S.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.RENDER-S.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.RENDER-S.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.RENDER-S.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.RENDER-S.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.RENDER-S.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.RENDER-S.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.RENDER-S.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.RENDER-S.gpu_info",
+          "type": "object"
+        },
+        {
+          "path": "servers.RENDER-S.gpu_info.gpu_memory",
+          "type": "number"
+        },
+        {
+          "path": "servers.RENDER-S.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.RENDER-S.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.RENDER-S.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.RENDER-S.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.RENDER-S.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.RENDER-S.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.RENDER-S.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.RENDER-S.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.RENDER-S.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.RENDER-S.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.RENDER-S.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.RENDER-S.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.RENDER-S.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.RENDER-S.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.RENDER-S.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.RENDER-S.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.RENDER-S.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.RENDER-S.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.RENDER-S.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.RENDER-S.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.RENDER-S.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.RENDER-S.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A12C-48G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A16C-64G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A24C-96G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A2C-8G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A32C-128G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A48C-192G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A4C-16G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A64C-256G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A6C-24G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD2-A8C-32G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X12C-48G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X16C-64G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X24C-96G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X2C-8G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X32C-128G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X48C-192G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X4C-16G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X64C-256G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X6C-24G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STANDARD3-X8C-32G.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STARDUST1-S",
+          "type": "object"
+        },
+        {
+          "path": "servers.STARDUST1-S.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.STARDUST1-S.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.STARDUST1-S.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STARDUST1-S.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.STARDUST1-S.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STARDUST1-S.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.STARDUST1-S.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.STARDUST1-S.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STARDUST1-S.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.STARDUST1-S.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STARDUST1-S.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.STARDUST1-S.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STARDUST1-S.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.STARDUST1-S.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.STARDUST1-S.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STARDUST1-S.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.STARDUST1-S.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.STARDUST1-S.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.STARDUST1-S.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.STARDUST1-S.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.STARDUST1-S.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.STARDUST1-S.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STARDUST1-S.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STARDUST1-S.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.STARDUST1-S.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STARDUST1-S.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.STARDUST1-S.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STARDUST1-S.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.STARDUST1-S.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STARDUST1-S.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STARDUST1-S.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.STARDUST1-S.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STARDUST1-S.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.STARDUST1-S.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.STARDUST1-S.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.STARDUST1-S.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-L",
+          "type": "object"
+        },
+        {
+          "path": "servers.START1-L.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.START1-L.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.START1-L.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-L.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.START1-L.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.START1-L.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.START1-L.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.START1-L.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.START1-L.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-L.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.START1-L.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-L.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.START1-L.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-L.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.START1-L.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-L.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.START1-L.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-L.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-L.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.START1-L.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.START1-L.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.START1-L.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-L.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-L.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.START1-L.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-L.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-L.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.START1-L.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.START1-L.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-L.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-L.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-L.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-L.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-L.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.START1-L.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-L.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-M",
+          "type": "object"
+        },
+        {
+          "path": "servers.START1-M.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.START1-M.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.START1-M.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-M.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.START1-M.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.START1-M.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.START1-M.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.START1-M.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.START1-M.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-M.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.START1-M.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-M.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.START1-M.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-M.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.START1-M.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-M.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.START1-M.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-M.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-M.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.START1-M.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.START1-M.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.START1-M.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-M.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-M.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.START1-M.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-M.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-M.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.START1-M.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.START1-M.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-M.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-M.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-M.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-M.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-M.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.START1-M.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-M.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-S",
+          "type": "object"
+        },
+        {
+          "path": "servers.START1-S.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.START1-S.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.START1-S.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-S.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.START1-S.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.START1-S.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.START1-S.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.START1-S.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.START1-S.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-S.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.START1-S.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-S.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.START1-S.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-S.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.START1-S.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-S.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.START1-S.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-S.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-S.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.START1-S.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.START1-S.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.START1-S.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-S.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-S.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.START1-S.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-S.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-S.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.START1-S.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.START1-S.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-S.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-S.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-S.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-S.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-S.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.START1-S.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-S.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-XS",
+          "type": "object"
+        },
+        {
+          "path": "servers.START1-XS.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.START1-XS.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.START1-XS.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-XS.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.START1-XS.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.START1-XS.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.START1-XS.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.START1-XS.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.START1-XS.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-XS.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.START1-XS.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-XS.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.START1-XS.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-XS.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.START1-XS.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-XS.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.START1-XS.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-XS.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-XS.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.START1-XS.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.START1-XS.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.START1-XS.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-XS.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-XS.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.START1-XS.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-XS.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-XS.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.START1-XS.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.START1-XS.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-XS.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-XS.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-XS.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-XS.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-XS.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.START1-XS.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.START1-XS.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1L",
+          "type": "object"
+        },
+        {
+          "path": "servers.VC1L.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.VC1L.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.VC1L.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1L.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.VC1L.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.VC1L.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.VC1L.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.VC1L.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.VC1L.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1L.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.VC1L.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1L.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.VC1L.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1L.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.VC1L.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1L.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.VC1L.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1L.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1L.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.VC1L.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.VC1L.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.VC1L.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1L.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1L.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.VC1L.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1L.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1L.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.VC1L.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.VC1L.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1L.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1L.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1L.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1L.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1L.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.VC1L.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1L.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1M",
+          "type": "object"
+        },
+        {
+          "path": "servers.VC1M.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.VC1M.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.VC1M.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1M.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.VC1M.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.VC1M.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.VC1M.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.VC1M.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.VC1M.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1M.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.VC1M.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1M.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.VC1M.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1M.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.VC1M.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1M.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.VC1M.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1M.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1M.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.VC1M.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.VC1M.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.VC1M.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1M.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1M.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.VC1M.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1M.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1M.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.VC1M.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.VC1M.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1M.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1M.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1M.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1M.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1M.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.VC1M.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1M.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1S",
+          "type": "object"
+        },
+        {
+          "path": "servers.VC1S.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.VC1S.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.VC1S.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1S.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.VC1S.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.VC1S.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.VC1S.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.VC1S.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.VC1S.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1S.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.VC1S.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1S.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.VC1S.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1S.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.VC1S.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1S.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.VC1S.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1S.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1S.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.VC1S.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.VC1S.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.VC1S.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1S.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1S.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.VC1S.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1S.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1S.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.VC1S.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.VC1S.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1S.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1S.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1S.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1S.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1S.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.VC1S.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.VC1S.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-120GB",
+          "type": "object"
+        },
+        {
+          "path": "servers.X64-120GB.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.X64-120GB.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.X64-120GB.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-120GB.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.X64-120GB.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.X64-120GB.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.X64-120GB.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.X64-120GB.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.X64-120GB.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-120GB.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.X64-120GB.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-120GB.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.X64-120GB.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-120GB.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.X64-120GB.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-120GB.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.X64-120GB.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-120GB.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-120GB.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.X64-120GB.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.X64-120GB.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.X64-120GB.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-120GB.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-120GB.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.X64-120GB.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-120GB.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-120GB.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.X64-120GB.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.X64-120GB.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-120GB.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-120GB.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-120GB.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-120GB.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-120GB.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.X64-120GB.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-120GB.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-15GB",
+          "type": "object"
+        },
+        {
+          "path": "servers.X64-15GB.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.X64-15GB.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.X64-15GB.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-15GB.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.X64-15GB.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.X64-15GB.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.X64-15GB.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.X64-15GB.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.X64-15GB.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-15GB.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.X64-15GB.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-15GB.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.X64-15GB.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-15GB.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.X64-15GB.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-15GB.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.X64-15GB.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-15GB.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-15GB.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.X64-15GB.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.X64-15GB.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.X64-15GB.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-15GB.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-15GB.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.X64-15GB.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-15GB.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-15GB.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.X64-15GB.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.X64-15GB.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-15GB.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-15GB.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-15GB.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-15GB.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-15GB.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.X64-15GB.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-15GB.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-30GB",
+          "type": "object"
+        },
+        {
+          "path": "servers.X64-30GB.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.X64-30GB.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.X64-30GB.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-30GB.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.X64-30GB.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.X64-30GB.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.X64-30GB.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.X64-30GB.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.X64-30GB.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-30GB.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.X64-30GB.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-30GB.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.X64-30GB.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-30GB.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.X64-30GB.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-30GB.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.X64-30GB.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-30GB.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-30GB.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.X64-30GB.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.X64-30GB.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.X64-30GB.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-30GB.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-30GB.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.X64-30GB.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-30GB.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-30GB.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.X64-30GB.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.X64-30GB.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-30GB.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-30GB.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-30GB.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-30GB.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-30GB.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.X64-30GB.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-30GB.volumes_constraint.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-60GB",
+          "type": "object"
+        },
+        {
+          "path": "servers.X64-60GB.alt_names",
+          "type": "array"
+        },
+        {
+          "path": "servers.X64-60GB.arch",
+          "type": "string"
+        },
+        {
+          "path": "servers.X64-60GB.block_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-60GB.capabilities",
+          "type": "object"
+        },
+        {
+          "path": "servers.X64-60GB.capabilities.block_storage",
+          "type": "bool"
+        },
+        {
+          "path": "servers.X64-60GB.capabilities.boot_types",
+          "type": "array"
+        },
+        {
+          "path": "servers.X64-60GB.capabilities.boot_types[]",
+          "type": "string"
+        },
+        {
+          "path": "servers.X64-60GB.capabilities.hot_snapshots_local_volume",
+          "type": "bool"
+        },
+        {
+          "path": "servers.X64-60GB.capabilities.max_file_systems",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-60GB.capabilities.placement_groups",
+          "type": "bool"
+        },
+        {
+          "path": "servers.X64-60GB.capabilities.private_network",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-60GB.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "servers.X64-60GB.gpu",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-60GB.gpu_info",
+          "type": "null"
+        },
+        {
+          "path": "servers.X64-60GB.hourly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-60GB.mig_profile",
+          "type": "null"
+        },
+        {
+          "path": "servers.X64-60GB.monthly_price",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-60GB.ncpus",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-60GB.network",
+          "type": "object"
+        },
+        {
+          "path": "servers.X64-60GB.network.interfaces",
+          "type": "array"
+        },
+        {
+          "path": "servers.X64-60GB.network.interfaces[]",
+          "type": "object"
+        },
+        {
+          "path": "servers.X64-60GB.network.interfaces[].internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-60GB.network.interfaces[].internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-60GB.network.ipv6_support",
+          "type": "bool"
+        },
+        {
+          "path": "servers.X64-60GB.network.sum_internal_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-60GB.network.sum_internet_bandwidth",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-60GB.per_volume_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.X64-60GB.per_volume_constraint.l_ssd",
+          "type": "object"
+        },
+        {
+          "path": "servers.X64-60GB.per_volume_constraint.l_ssd.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-60GB.per_volume_constraint.l_ssd.min_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-60GB.ram",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-60GB.scratch_storage_max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-60GB.scratch_storage_max_volumes_count",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-60GB.volumes_constraint",
+          "type": "object"
+        },
+        {
+          "path": "servers.X64-60GB.volumes_constraint.max_size",
+          "type": "number"
+        },
+        {
+          "path": "servers.X64-60GB.volumes_constraint.min_size",
+          "type": "number"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "instance/v1/API.ListSnapshots": {
+      "method": "GET",
+      "path": "/instance/v1/zones/fr-par-1/snapshots",
+      "fields": [
+        {
+          "path": "snapshots",
+          "type": "array"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "instance/v1/API.ListVolumes": {
+      "method": "GET",
+      "path": "/instance/v1/zones/fr-par-1/volumes",
+      "fields": [
+        {
+          "path": "volumes",
+          "type": "array"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "instance/v1/API.ServerAction": {
+      "method": "POST",
+      "path": "/instance/v1/zones/fr-par-1/servers/{id}/action",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "instance/v1/API.UpdateIP": {
+      "method": "PATCH",
+      "path": "/instance/v1/zones/fr-par-1/ips/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "instance/v1/API.UpdateImage": {
+      "method": "PATCH",
+      "path": "/instance/v1/zones/fr-par-1/images/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "instance/v1/API.UpdatePlacementGroup": {
+      "method": "PATCH",
+      "path": "/instance/v1/zones/fr-par-1/placement_groups/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "instance/v1/API.UpdateSecurityGroup": {
+      "method": "PATCH",
+      "path": "/instance/v1/zones/fr-par-1/security_groups/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "instance/v1/API.UpdateSecurityGroupRule": {
+      "method": "PATCH",
+      "path": "/instance/v1/zones/fr-par-1/security_groups/{id}/rules/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "instance/v1/API.UpdateServer": {
+      "method": "PATCH",
+      "path": "/instance/v1/zones/fr-par-1/servers/{id}",
+      "fields": [
+        {
+          "path": "server",
+          "type": "object"
+        },
+        {
+          "path": "server.allowed_actions",
+          "type": "array"
+        },
+        {
+          "path": "server.allowed_actions[]",
+          "type": "string"
+        },
+        {
+          "path": "server.arch",
+          "type": "string"
+        },
+        {
+          "path": "server.boot_type",
+          "type": "string"
+        },
+        {
+          "path": "server.bootscript",
+          "type": "null"
+        },
+        {
+          "path": "server.creation_date",
+          "type": "string"
+        },
+        {
+          "path": "server.dynamic_ip_required",
+          "type": "bool"
+        },
+        {
+          "path": "server.enable_ipv6",
+          "type": "bool"
+        },
+        {
+          "path": "server.end_of_service",
+          "type": "bool"
+        },
+        {
+          "path": "server.extra_networks",
+          "type": "array"
+        },
+        {
+          "path": "server.filesystems",
+          "type": "array"
+        },
+        {
+          "path": "server.id",
+          "type": "string"
+        },
+        {
+          "path": "server.image",
+          "type": "object"
+        },
+        {
+          "path": "server.image.arch",
+          "type": "string"
+        },
+        {
+          "path": "server.image.creation_date",
+          "type": "string"
+        },
+        {
+          "path": "server.image.default_bootscript",
+          "type": "null"
+        },
+        {
+          "path": "server.image.extra_volumes",
+          "type": "object"
+        },
+        {
+          "path": "server.image.from_server",
+          "type": "string"
+        },
+        {
+          "path": "server.image.id",
+          "type": "string"
+        },
+        {
+          "path": "server.image.modification_date",
+          "type": "string"
+        },
+        {
+          "path": "server.image.organization",
+          "type": "string"
+        },
+        {
+          "path": "server.image.project",
+          "type": "string"
+        },
+        {
+          "path": "server.image.public",
+          "type": "bool"
+        },
+        {
+          "path": "server.image.root_volume",
+          "type": "object"
+        },
+        {
+          "path": "server.image.root_volume.id",
+          "type": "string"
+        },
+        {
+          "path": "server.image.root_volume.name",
+          "type": "string"
+        },
+        {
+          "path": "server.image.root_volume.size",
+          "type": "number"
+        },
+        {
+          "path": "server.image.root_volume.volume_type",
+          "type": "string"
+        },
+        {
+          "path": "server.image.state",
+          "type": "string"
+        },
+        {
+          "path": "server.image.tags",
+          "type": "array"
+        },
+        {
+          "path": "server.image.zone",
+          "type": "string"
+        },
+        {
+          "path": "server.ipv6",
+          "type": "null"
+        },
+        {
+          "path": "server.location",
+          "type": "null"
+        },
+        {
+          "path": "server.maintenances",
+          "type": "array"
+        },
+        {
+          "path": "server.modification_date",
+          "type": "string"
+        },
+        {
+          "path": "server.organization",
+          "type": "string"
+        },
+        {
+          "path": "server.placement_group",
+          "type": "null"
+        },
+        {
+          "path": "server.private_ip",
+          "type": "null"
+        },
+        {
+          "path": "server.private_nics",
+          "type": "array"
+        },
+        {
+          "path": "server.project",
+          "type": "string"
+        },
+        {
+          "path": "server.protected",
+          "type": "bool"
+        },
+        {
+          "path": "server.public_ip",
+          "type": "object"
+        },
+        {
+          "path": "server.public_ip.address",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ip.dynamic",
+          "type": "bool"
+        },
+        {
+          "path": "server.public_ip.family",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ip.gateway",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ip.id",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ip.ipam_id",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ip.netmask",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ip.provisioning_mode",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ip.state",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ip.tags",
+          "type": "array"
+        },
+        {
+          "path": "server.public_ips",
+          "type": "array"
+        },
+        {
+          "path": "server.public_ips[]",
+          "type": "object"
+        },
+        {
+          "path": "server.public_ips[].address",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ips[].dynamic",
+          "type": "bool"
+        },
+        {
+          "path": "server.public_ips[].family",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ips[].gateway",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ips[].id",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ips[].ipam_id",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ips[].netmask",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ips[].provisioning_mode",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ips[].state",
+          "type": "string"
+        },
+        {
+          "path": "server.public_ips[].tags",
+          "type": "array"
+        },
+        {
+          "path": "server.routed_ip_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "server.security_group",
+          "type": "object"
+        },
+        {
+          "path": "server.security_group.id",
+          "type": "string"
+        },
+        {
+          "path": "server.state",
+          "type": "string"
+        },
+        {
+          "path": "server.state_detail",
+          "type": "string"
+        },
+        {
+          "path": "server.tags",
+          "type": "array"
+        },
+        {
+          "path": "server.volumes",
+          "type": "object"
+        },
+        {
+          "path": "server.volumes.0",
+          "type": "object"
+        },
+        {
+          "path": "server.volumes.0.boot",
+          "type": "bool"
+        },
+        {
+          "path": "server.volumes.0.id",
+          "type": "string"
+        },
+        {
+          "path": "server.volumes.0.state",
+          "type": "string"
+        },
+        {
+          "path": "server.volumes.0.volume_type",
+          "type": "string"
+        },
+        {
+          "path": "server.volumes.0.zone",
+          "type": "string"
+        },
+        {
+          "path": "server.zone",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "instance/v1/API.UpdateSnapshot": {
+      "method": "PATCH",
+      "path": "/instance/v1/zones/fr-par-1/snapshots/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "instance/v1/API.UpdateVolume": {
+      "method": "PATCH",
+      "path": "/instance/v1/zones/fr-par-1/volumes/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "ipam/v1/API.BookIP": {
+      "method": "POST",
+      "path": "/ipam/v1/regions/fr-par/ips",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "ipam/v1/API.GetIP": {
+      "method": "GET",
+      "path": "/ipam/v1/regions/fr-par/ips/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "ipam/v1/API.ListIPs": {
+      "method": "GET",
+      "path": "/ipam/v1/regions/fr-par/ips",
+      "fields": [
+        {
+          "path": "ips",
+          "type": "array"
+        },
+        {
+          "path": "total_count",
+          "type": "number"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "ipam/v1/API.ReleaseIP": {
+      "method": "DELETE",
+      "path": "/ipam/v1/regions/fr-par/ips/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "ipam/v1/API.UpdateIP": {
+      "method": "PATCH",
+      "path": "/ipam/v1/regions/fr-par/ips/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "lb/v1/ZonedAPI.CreateACL": {
+      "method": "POST",
+      "path": "/lb/v1/zones/fr-par-1/frontends/{id}/acls",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "lb/v1/ZonedAPI.CreateFrontend": {
+      "method": "POST",
+      "path": "/lb/v1/zones/fr-par-1/lbs/{id}/frontends",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "lb/v1/ZonedAPI.CreateIP": {
+      "method": "POST",
+      "path": "/lb/v1/zones/fr-par-1/ips",
+      "fields": [],
+      "statuses": [
+        403
+      ]
+    },
+    "lb/v1/ZonedAPI.CreateLB": {
+      "method": "POST",
+      "path": "/lb/v1/zones/fr-par-1/lbs",
+      "fields": [],
+      "statuses": [
+        403
+      ]
+    },
+    "lb/v1/ZonedAPI.CreateRoute": {
+      "method": "POST",
+      "path": "/lb/v1/zones/fr-par-1/routes",
+      "fields": [],
+      "statuses": [
+        403
+      ]
+    },
+    "lb/v1/ZonedAPI.DeleteACL": {
+      "method": "DELETE",
+      "path": "/lb/v1/zones/fr-par-1/acls/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "lb/v1/ZonedAPI.DeleteRoute": {
+      "method": "DELETE",
+      "path": "/lb/v1/zones/fr-par-1/routes/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "lb/v1/ZonedAPI.DetachPrivateNetwork": {
+      "method": "POST",
+      "path": "/lb/v1/zones/fr-par-1/lbs/{id}/detach-private-network",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "lb/v1/ZonedAPI.GetACL": {
+      "method": "GET",
+      "path": "/lb/v1/zones/fr-par-1/acls/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "lb/v1/ZonedAPI.GetBackend": {
+      "method": "GET",
+      "path": "/lb/v1/zones/fr-par-1/backends/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "lb/v1/ZonedAPI.GetFrontend": {
+      "method": "GET",
+      "path": "/lb/v1/zones/fr-par-1/frontends/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "lb/v1/ZonedAPI.GetIP": {
+      "method": "GET",
+      "path": "/lb/v1/zones/fr-par-1/ips/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "lb/v1/ZonedAPI.GetLB": {
+      "method": "GET",
+      "path": "/lb/v1/zones/fr-par-1/lbs/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "lb/v1/ZonedAPI.GetRoute": {
+      "method": "GET",
+      "path": "/lb/v1/zones/fr-par-1/routes/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "lb/v1/ZonedAPI.ListACLs": {
+      "method": "GET",
+      "path": "/lb/v1/zones/fr-par-1/frontends/{id}/acls",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "lb/v1/ZonedAPI.ListBackends": {
+      "method": "GET",
+      "path": "/lb/v1/zones/fr-par-1/lbs/{id}/backends",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "lb/v1/ZonedAPI.ListFrontends": {
+      "method": "GET",
+      "path": "/lb/v1/zones/fr-par-1/lbs/{id}/frontends",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "lb/v1/ZonedAPI.ListLBPrivateNetworks": {
+      "method": "GET",
+      "path": "/lb/v1/zones/fr-par-1/lbs/{id}/private-networks",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "lb/v1/ZonedAPI.ListLBs": {
+      "method": "GET",
+      "path": "/lb/v1/zones/fr-par-1/lbs",
+      "fields": [
+        {
+          "path": "lbs",
+          "type": "array"
+        },
+        {
+          "path": "total_count",
+          "type": "number"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "lb/v1/ZonedAPI.ListRoutes": {
+      "method": "GET",
+      "path": "/lb/v1/zones/fr-par-1/routes",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "lb/v1/ZonedAPI.ReleaseIP": {
+      "method": "DELETE",
+      "path": "/lb/v1/zones/fr-par-1/ips/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "lb/v1/ZonedAPI.SetBackendServers": {
+      "method": "PUT",
+      "path": "/lb/v1/zones/fr-par-1/backends/{id}/servers",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "lb/v1/ZonedAPI.UpdateACL": {
+      "method": "PUT",
+      "path": "/lb/v1/zones/fr-par-1/acls/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "lb/v1/ZonedAPI.UpdateBackend": {
+      "method": "PUT",
+      "path": "/lb/v1/zones/fr-par-1/backends/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "lb/v1/ZonedAPI.UpdateFrontend": {
+      "method": "PUT",
+      "path": "/lb/v1/zones/fr-par-1/frontends/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "lb/v1/ZonedAPI.UpdateIP": {
+      "method": "PATCH",
+      "path": "/lb/v1/zones/fr-par-1/ips/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "lb/v1/ZonedAPI.UpdateRoute": {
+      "method": "PUT",
+      "path": "/lb/v1/zones/fr-par-1/routes/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "marketplace/v2/API.ListLocalImages": {
+      "method": "GET",
+      "path": "/marketplace/v2/local-images",
+      "fields": [
+        {
+          "path": "local_images",
+          "type": "array"
+        },
+        {
+          "path": "local_images[]",
+          "type": "object"
+        },
+        {
+          "path": "local_images[].arch",
+          "type": "string"
+        },
+        {
+          "path": "local_images[].compatible_commercial_types",
+          "type": "array"
+        },
+        {
+          "path": "local_images[].id",
+          "type": "string"
+        },
+        {
+          "path": "local_images[].type",
+          "type": "string"
+        },
+        {
+          "path": "local_images[].zone",
+          "type": "string"
+        },
+        {
+          "path": "total_count",
+          "type": "number"
+        }
+      ],
+      "statuses": [
+        200,
+        404
+      ]
+    },
+    "vpc/v2/API.CreatePrivateNetwork": {
+      "method": "POST",
+      "path": "/vpc/v2/regions/fr-par/private-networks",
+      "fields": [
+        {
+          "path": "created_at",
+          "type": "string"
+        },
+        {
+          "path": "default_route_propagation_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "dhcp_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "has_s3_integration",
+          "type": "bool"
+        },
+        {
+          "path": "id",
+          "type": "string"
+        },
+        {
+          "path": "organization_id",
+          "type": "string"
+        },
+        {
+          "path": "project_id",
+          "type": "string"
+        },
+        {
+          "path": "region",
+          "type": "string"
+        },
+        {
+          "path": "subnets",
+          "type": "array"
+        },
+        {
+          "path": "subnets[]",
+          "type": "object"
+        },
+        {
+          "path": "subnets[].created_at",
+          "type": "string"
+        },
+        {
+          "path": "subnets[].id",
+          "type": "string"
+        },
+        {
+          "path": "subnets[].private_network_id",
+          "type": "string"
+        },
+        {
+          "path": "subnets[].project_id",
+          "type": "string"
+        },
+        {
+          "path": "subnets[].region",
+          "type": "string"
+        },
+        {
+          "path": "subnets[].subnet",
+          "type": "string"
+        },
+        {
+          "path": "subnets[].updated_at",
+          "type": "string"
+        },
+        {
+          "path": "subnets[].vpc_id",
+          "type": "string"
+        },
+        {
+          "path": "tags",
+          "type": "array"
+        },
+        {
+          "path": "updated_at",
+          "type": "string"
+        },
+        {
+          "path": "vpc_id",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        404
+      ]
+    },
+    "vpc/v2/API.CreateRoute": {
+      "method": "POST",
+      "path": "/vpc/v2/regions/fr-par/routes",
+      "fields": [],
+      "statuses": [
+        400
+      ]
+    },
+    "vpc/v2/API.CreateVPC": {
+      "method": "POST",
+      "path": "/vpc/v2/regions/fr-par/vpcs",
+      "fields": [
+        {
+          "path": "created_at",
+          "type": "string"
+        },
+        {
+          "path": "custom_routes_propagation_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "id",
+          "type": "string"
+        },
+        {
+          "path": "is_default",
+          "type": "bool"
+        },
+        {
+          "path": "organization_id",
+          "type": "string"
+        },
+        {
+          "path": "private_network_count",
+          "type": "number"
+        },
+        {
+          "path": "project_id",
+          "type": "string"
+        },
+        {
+          "path": "region",
+          "type": "string"
+        },
+        {
+          "path": "routing_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "s3_integration_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "tags",
+          "type": "array"
+        },
+        {
+          "path": "transitivity_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "updated_at",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        404
+      ]
+    },
+    "vpc/v2/API.DeletePrivateNetwork": {
+      "method": "DELETE",
+      "path": "/vpc/v2/regions/fr-par/private-networks/{id}",
+      "fields": [
+        {
+          "path": "",
+          "type": "null"
+        }
+      ],
+      "statuses": [
+        204,
+        404
+      ]
+    },
+    "vpc/v2/API.DeleteRoute": {
+      "method": "DELETE",
+      "path": "/vpc/v2/regions/fr-par/routes/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "vpc/v2/API.DeleteVPC": {
+      "method": "DELETE",
+      "path": "/vpc/v2/regions/fr-par/vpcs/{id}",
+      "fields": [
+        {
+          "path": "",
+          "type": "null"
+        }
+      ],
+      "statuses": [
+        204,
+        404
+      ]
+    },
+    "vpc/v2/API.EnableRouting": {
+      "method": "POST",
+      "path": "/vpc/v2/regions/fr-par/vpcs/{id}/enable-routing",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "vpc/v2/API.GetACL": {
+      "method": "GET",
+      "path": "/vpc/v2/regions/fr-par/vpcs/{id}/acl-rules",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "vpc/v2/API.GetPrivateNetwork": {
+      "method": "GET",
+      "path": "/vpc/v2/regions/fr-par/private-networks/{id}",
+      "fields": [
+        {
+          "path": "created_at",
+          "type": "string"
+        },
+        {
+          "path": "default_route_propagation_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "dhcp_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "has_s3_integration",
+          "type": "bool"
+        },
+        {
+          "path": "id",
+          "type": "string"
+        },
+        {
+          "path": "organization_id",
+          "type": "string"
+        },
+        {
+          "path": "project_id",
+          "type": "string"
+        },
+        {
+          "path": "region",
+          "type": "string"
+        },
+        {
+          "path": "subnets",
+          "type": "array"
+        },
+        {
+          "path": "subnets[]",
+          "type": "object"
+        },
+        {
+          "path": "subnets[].created_at",
+          "type": "string"
+        },
+        {
+          "path": "subnets[].id",
+          "type": "string"
+        },
+        {
+          "path": "subnets[].private_network_id",
+          "type": "string"
+        },
+        {
+          "path": "subnets[].project_id",
+          "type": "string"
+        },
+        {
+          "path": "subnets[].region",
+          "type": "string"
+        },
+        {
+          "path": "subnets[].subnet",
+          "type": "string"
+        },
+        {
+          "path": "subnets[].updated_at",
+          "type": "string"
+        },
+        {
+          "path": "subnets[].vpc_id",
+          "type": "string"
+        },
+        {
+          "path": "tags",
+          "type": "array"
+        },
+        {
+          "path": "updated_at",
+          "type": "string"
+        },
+        {
+          "path": "vpc_id",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        404
+      ]
+    },
+    "vpc/v2/API.GetRoute": {
+      "method": "GET",
+      "path": "/vpc/v2/regions/fr-par/routes/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "vpc/v2/API.GetVPC": {
+      "method": "GET",
+      "path": "/vpc/v2/regions/fr-par/vpcs/{id}",
+      "fields": [
+        {
+          "path": "created_at",
+          "type": "string"
+        },
+        {
+          "path": "custom_routes_propagation_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "id",
+          "type": "string"
+        },
+        {
+          "path": "is_default",
+          "type": "bool"
+        },
+        {
+          "path": "organization_id",
+          "type": "string"
+        },
+        {
+          "path": "private_network_count",
+          "type": "number"
+        },
+        {
+          "path": "project_id",
+          "type": "string"
+        },
+        {
+          "path": "region",
+          "type": "string"
+        },
+        {
+          "path": "routing_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "s3_integration_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "tags",
+          "type": "array"
+        },
+        {
+          "path": "transitivity_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "updated_at",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        404
+      ]
+    },
+    "vpc/v2/API.ListPrivateNetworks": {
+      "method": "GET",
+      "path": "/vpc/v2/regions/fr-par/private-networks",
+      "fields": [
+        {
+          "path": "private_networks",
+          "type": "array"
+        },
+        {
+          "path": "private_networks[]",
+          "type": "object"
+        },
+        {
+          "path": "private_networks[].created_at",
+          "type": "string"
+        },
+        {
+          "path": "private_networks[].default_route_propagation_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "private_networks[].dhcp_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "private_networks[].has_s3_integration",
+          "type": "bool"
+        },
+        {
+          "path": "private_networks[].id",
+          "type": "string"
+        },
+        {
+          "path": "private_networks[].organization_id",
+          "type": "string"
+        },
+        {
+          "path": "private_networks[].project_id",
+          "type": "string"
+        },
+        {
+          "path": "private_networks[].region",
+          "type": "string"
+        },
+        {
+          "path": "private_networks[].subnets",
+          "type": "array"
+        },
+        {
+          "path": "private_networks[].subnets[]",
+          "type": "object"
+        },
+        {
+          "path": "private_networks[].subnets[].created_at",
+          "type": "string"
+        },
+        {
+          "path": "private_networks[].subnets[].id",
+          "type": "string"
+        },
+        {
+          "path": "private_networks[].subnets[].private_network_id",
+          "type": "string"
+        },
+        {
+          "path": "private_networks[].subnets[].project_id",
+          "type": "string"
+        },
+        {
+          "path": "private_networks[].subnets[].region",
+          "type": "string"
+        },
+        {
+          "path": "private_networks[].subnets[].subnet",
+          "type": "string"
+        },
+        {
+          "path": "private_networks[].subnets[].updated_at",
+          "type": "string"
+        },
+        {
+          "path": "private_networks[].subnets[].vpc_id",
+          "type": "string"
+        },
+        {
+          "path": "private_networks[].tags",
+          "type": "array"
+        },
+        {
+          "path": "private_networks[].updated_at",
+          "type": "string"
+        },
+        {
+          "path": "private_networks[].vpc_id",
+          "type": "string"
+        },
+        {
+          "path": "total_count",
+          "type": "number"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "vpc/v2/API.ListVPCs": {
+      "method": "GET",
+      "path": "/vpc/v2/regions/fr-par/vpcs",
+      "fields": [
+        {
+          "path": "total_count",
+          "type": "number"
+        },
+        {
+          "path": "vpcs",
+          "type": "array"
+        },
+        {
+          "path": "vpcs[]",
+          "type": "object"
+        },
+        {
+          "path": "vpcs[].created_at",
+          "type": "string"
+        },
+        {
+          "path": "vpcs[].custom_routes_propagation_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "vpcs[].id",
+          "type": "string"
+        },
+        {
+          "path": "vpcs[].is_default",
+          "type": "bool"
+        },
+        {
+          "path": "vpcs[].name",
+          "type": "string"
+        },
+        {
+          "path": "vpcs[].organization_id",
+          "type": "string"
+        },
+        {
+          "path": "vpcs[].private_network_count",
+          "type": "number"
+        },
+        {
+          "path": "vpcs[].project_id",
+          "type": "string"
+        },
+        {
+          "path": "vpcs[].region",
+          "type": "string"
+        },
+        {
+          "path": "vpcs[].routing_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "vpcs[].s3_integration_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "vpcs[].tags",
+          "type": "array"
+        },
+        {
+          "path": "vpcs[].tags[]",
+          "type": "string"
+        },
+        {
+          "path": "vpcs[].transitivity_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "vpcs[].updated_at",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "vpc/v2/API.UpdatePrivateNetwork": {
+      "method": "PATCH",
+      "path": "/vpc/v2/regions/fr-par/private-networks/{id}",
+      "fields": [
+        {
+          "path": "created_at",
+          "type": "string"
+        },
+        {
+          "path": "default_route_propagation_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "dhcp_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "has_s3_integration",
+          "type": "bool"
+        },
+        {
+          "path": "id",
+          "type": "string"
+        },
+        {
+          "path": "organization_id",
+          "type": "string"
+        },
+        {
+          "path": "project_id",
+          "type": "string"
+        },
+        {
+          "path": "region",
+          "type": "string"
+        },
+        {
+          "path": "subnets",
+          "type": "array"
+        },
+        {
+          "path": "subnets[]",
+          "type": "object"
+        },
+        {
+          "path": "subnets[].created_at",
+          "type": "string"
+        },
+        {
+          "path": "subnets[].id",
+          "type": "string"
+        },
+        {
+          "path": "subnets[].private_network_id",
+          "type": "string"
+        },
+        {
+          "path": "subnets[].project_id",
+          "type": "string"
+        },
+        {
+          "path": "subnets[].region",
+          "type": "string"
+        },
+        {
+          "path": "subnets[].subnet",
+          "type": "string"
+        },
+        {
+          "path": "subnets[].updated_at",
+          "type": "string"
+        },
+        {
+          "path": "subnets[].vpc_id",
+          "type": "string"
+        },
+        {
+          "path": "tags",
+          "type": "array"
+        },
+        {
+          "path": "updated_at",
+          "type": "string"
+        },
+        {
+          "path": "vpc_id",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        404
+      ]
+    },
+    "vpc/v2/API.UpdateRoute": {
+      "method": "PATCH",
+      "path": "/vpc/v2/regions/fr-par/routes/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "vpc/v2/API.UpdateVPC": {
+      "method": "PATCH",
+      "path": "/vpc/v2/regions/fr-par/vpcs/{id}",
+      "fields": [
+        {
+          "path": "created_at",
+          "type": "string"
+        },
+        {
+          "path": "custom_routes_propagation_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "id",
+          "type": "string"
+        },
+        {
+          "path": "is_default",
+          "type": "bool"
+        },
+        {
+          "path": "organization_id",
+          "type": "string"
+        },
+        {
+          "path": "private_network_count",
+          "type": "number"
+        },
+        {
+          "path": "project_id",
+          "type": "string"
+        },
+        {
+          "path": "region",
+          "type": "string"
+        },
+        {
+          "path": "routing_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "s3_integration_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "tags",
+          "type": "array"
+        },
+        {
+          "path": "transitivity_enabled",
+          "type": "bool"
+        },
+        {
+          "path": "updated_at",
+          "type": "string"
+        }
+      ],
+      "statuses": [
+        200,
+        404
+      ]
+    },
+    "vpcgw/v2/API.CreateGateway": {
+      "method": "POST",
+      "path": "/vpc-gw/v2/zones/fr-par-1/gateways",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "vpcgw/v2/API.CreateGatewayNetwork": {
+      "method": "POST",
+      "path": "/vpc-gw/v2/zones/fr-par-1/gateway-networks",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "vpcgw/v2/API.CreateIP": {
+      "method": "POST",
+      "path": "/vpc-gw/v2/zones/fr-par-1/ips",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "vpcgw/v2/API.DeleteGateway": {
+      "method": "DELETE",
+      "path": "/vpc-gw/v2/zones/fr-par-1/gateways/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "vpcgw/v2/API.DeleteGatewayNetwork": {
+      "method": "DELETE",
+      "path": "/vpc-gw/v2/zones/fr-par-1/gateway-networks/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "vpcgw/v2/API.DeleteIP": {
+      "method": "DELETE",
+      "path": "/vpc-gw/v2/zones/fr-par-1/ips/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "vpcgw/v2/API.GetGateway": {
+      "method": "GET",
+      "path": "/vpc-gw/v2/zones/fr-par-1/gateways/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "vpcgw/v2/API.GetGatewayNetwork": {
+      "method": "GET",
+      "path": "/vpc-gw/v2/zones/fr-par-1/gateway-networks/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "vpcgw/v2/API.GetIP": {
+      "method": "GET",
+      "path": "/vpc-gw/v2/zones/fr-par-1/ips/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "vpcgw/v2/API.ListGateways": {
+      "method": "GET",
+      "path": "/vpc-gw/v2/zones/fr-par-1/gateways",
+      "fields": [
+        {
+          "path": "gateways",
+          "type": "array"
+        },
+        {
+          "path": "total_count",
+          "type": "number"
+        }
+      ],
+      "statuses": [
+        200
+      ]
+    },
+    "vpcgw/v2/API.UpdateGateway": {
+      "method": "PATCH",
+      "path": "/vpc-gw/v2/zones/fr-par-1/gateways/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "vpcgw/v2/API.UpdateGatewayNetwork": {
+      "method": "PATCH",
+      "path": "/vpc-gw/v2/zones/fr-par-1/gateway-networks/{id}",
+      "fields": [],
+      "statuses": [
+        404
+      ]
+    },
+    "vpcgw/v2/API.UpdateIP": {
+      "method": "PATCH",
+      "path": "/vpc-gw/v2/zones/fr-par-1/ips/{id}",
+      "fields": [],
+      "statuses": [
+        404
       ]
     }
   }

--- a/tools/conformance/exoscale/exo-cli.sh
+++ b/tools/conformance/exoscale/exo-cli.sh
@@ -199,9 +199,37 @@ rules="$(exoc -O json compute security-group show conformance-sg | jq '.ingress_
   || fail "security-group show rejected"
 printf '%s' "$rules" | jq -e 'length == 1 and .[0].network == "203.0.113.0/24"' >/dev/null \
   || fail "the delete did not take exactly the rule it was given: $rules"
+# A rule that names another group as its source, and carries a description.
+# Both are fields the real cloud returns on every such rule and this suite had
+# no answer carrying either, so the field gate (#88) had nothing to hold
+# `security-groups[].rules[].description` and `.security-group` to and deleting
+# them from the view would have stayed green. Found the day the committed
+# corpora started feeding shapes/ (#407): the recording had them, the run did
+# not, and the gate said so.
+exoc compute security-group create conformance-src --description 'the source group' >/dev/null \
+  || fail "the source security group was rejected"
+# The source group gets a rule of its own before anything reads it. `rule add`
+# resolves the group it points at by reading that group, so a source with no
+# rule is the one read the run makes of get-security-group — and `rules` is a
+# key the real cloud omits on an empty group and sends on a populated one
+# (measured in corpus/exoscale/exo-cli.jsonl), so the run would compare the
+# operation against an answer that legitimately carries nothing.
+exoc compute security-group rule add conformance-src --flow ingress --protocol tcp --port 443 \
+  --description 'https from a range' --network 192.0.2.0/24 >/dev/null \
+  || fail "the source group's own rule was rejected"
+exoc compute security-group rule add conformance-sg --flow ingress --protocol tcp --port 2222 \
+  --description 'ssh from the source group' --security-group conformance-src >/dev/null \
+  || fail "a rule sourced from another group was rejected"
+sourced="$(exoc -O json compute security-group show conformance-sg | jq '.ingress_rules')" \
+  || fail "security-group show rejected"
+# The CLI renders a group reference as "SG:<name>"; the API answers the object
+# under `security-group`, which is the field the gate holds.
+printf '%s' "$sourced" | jq -e \
+  'any(.[]; .description == "ssh from the source group" and .security_group == "SG:conformance-src")' \
+  >/dev/null || fail "the rule came back without its description or its source group: $sourced"
 exoc compute instance security-group add "$id" conformance-sg >/dev/null || fail "sg attach rejected"
 exoc compute instance security-group remove "$id" conformance-sg >/dev/null || fail "sg detach rejected"
-ok "default present, rule round-trips, attach and detach pass"
+ok "default present, rule round-trips, a group-sourced rule keeps its description, attach and detach pass"
 
 echo "- anti-affinity groups: membership is computed"
 exoc compute anti-affinity-group create conformance-aag --description 'conformance' >/dev/null \

--- a/tools/conformance/outscale/oapi-cli.sh
+++ b/tools/conformance/outscale/oapi-cli.sh
@@ -709,6 +709,55 @@ osc DeleteNet --NetId "$nic_net_id" >/dev/null || fail "DeleteNet rejected once 
 prove_end "$reads_span"
 ok "ranges, services, admin password, a tag removed, a secondary address linked and unlinked"
 
+# A machine inside a Net, updated there. The machine above is created without a
+# Subnet, so every UpdateVm answer of a run carried none of the five keys a
+# machine in a Net carries — NetId, SubnetId, PrivateIp, Nics, SecurityGroups —
+# and the field gate (#88) had no populated answer to hold them to. Verified
+# before this block was written: the view emits all five when the machine has
+# them, so what was missing was the call and not the view. Found the day the
+# committed corpora started feeding shapes/ (#407).
+echo "- a machine inside a Net, updated there"
+in_net="$(osc CreateNet --IpRange 10.194.0.0/16)" || fail "CreateNet rejected: $in_net"
+in_net_id="$(printf '%s' "$in_net" | jq -r '.Net.NetId // empty')"
+[ -n "$in_net_id" ] || fail "no NetId for the in-Net machine: $in_net"
+in_sub="$(osc CreateSubnet --NetId "$in_net_id" --IpRange 10.194.1.0/24)" \
+  || fail "CreateSubnet rejected: $in_sub"
+in_sub_id="$(printf '%s' "$in_sub" | jq -r '.Subnet.SubnetId // empty')"
+[ -n "$in_sub_id" ] || fail "no SubnetId for the in-Net machine: $in_sub"
+in_sg="$(osc CreateSecurityGroup --NetId "$in_net_id" --SecurityGroupName conformance-in-net \
+  --Description 'the group the in-Net machine wears')" || fail "CreateSecurityGroup rejected: $in_sg"
+in_sg_id="$(printf '%s' "$in_sg" | jq -r '.SecurityGroup.SecurityGroupId // empty')"
+[ -n "$in_sg_id" ] || fail "no SecurityGroupId: $in_sg"
+# A rule whose source is another group rather than a range. SecurityGroupsMembers
+# is what the real cloud answers there and no rule of this run named a group, so
+# the key had never been held to anything.
+peer_sg="$(osc CreateSecurityGroup --NetId "$in_net_id" --SecurityGroupName conformance-peer \
+  --Description 'the group a rule points at')" || fail "CreateSecurityGroup rejected: $peer_sg"
+peer_sg_id="$(printf '%s' "$peer_sg" | jq -r '.SecurityGroup.SecurityGroupId // empty')"
+ruled="$(osc CreateSecurityGroupRule --SecurityGroupId "$in_sg_id" --Flow Inbound \
+  --Rules "[{\"FromPortRange\":22,\"ToPortRange\":22,\"IpProtocol\":\"tcp\",\"SecurityGroupsMembers\":[{\"SecurityGroupId\":\"$peer_sg_id\"}]}]")" \
+  || fail "a rule sourced from another group was rejected: $ruled"
+printf '%s' "$ruled" | jq -e --arg id "$peer_sg_id" \
+  'any(.SecurityGroup.InboundRules[]; any(.SecurityGroupsMembers[]?; .SecurityGroupId == $id))' \
+  >/dev/null || fail "the rule came back without the group it points at: $ruled"
+in_vm="$(osc CreateVms --ImageId "$image_id" --VmType "$default_type" --SubnetId "$in_sub_id" \
+  '--SecurityGroupIds[]' "$in_sg_id")" || fail "CreateVms in a Subnet rejected: $in_vm"
+in_vm_id="$(printf '%s' "$in_vm" | jq -r '.Vms[0].VmId // empty')"
+[ -n "$in_vm_id" ] || fail "no VmId for the in-Net machine: $in_vm"
+osc StopVms '--VmIds[]' "$in_vm_id" >/dev/null || fail "StopVms rejected for the in-Net machine"
+in_updated="$(osc UpdateVm --VmId "$in_vm_id" --VmType tinav6.c2r2p2)" \
+  || fail "UpdateVm rejected for the in-Net machine: $in_updated"
+printf '%s' "$in_updated" | jq -e --arg n "$in_net_id" --arg s "$in_sub_id" \
+  '.Vm | .NetId == $n and .SubnetId == $s and (.PrivateIp | length > 0)
+        and (.Nics | length >= 1) and (.SecurityGroups | length >= 1)' >/dev/null \
+  || fail "an updated machine in a Net answers without its network keys: $in_updated"
+osc DeleteVms '--VmIds[]' "$in_vm_id" >/dev/null || fail "DeleteVms rejected for the in-Net machine"
+osc DeleteSecurityGroup --SecurityGroupId "$in_sg_id" >/dev/null || fail "DeleteSecurityGroup rejected"
+osc DeleteSecurityGroup --SecurityGroupId "$peer_sg_id" >/dev/null || fail "DeleteSecurityGroup rejected"
+osc DeleteSubnet --SubnetId "$in_sub_id" >/dev/null || fail "DeleteSubnet rejected"
+osc DeleteNet --NetId "$in_net_id" >/dev/null || fail "DeleteNet rejected once empty"
+ok "a machine in a Net keeps its network keys through an update, and a rule names a group"
+
 echo "- delete"
 deleted="$(osc DeleteVms '--VmIds[]' "$vm_id")" || fail "DeleteVms rejected: $deleted"
 printf '%s' "$deleted" | jq -e --arg id "$vm_id" \

--- a/tools/falsify/specs/shape-axis-from-corpus.json
+++ b/tools/falsify/specs/shape-axis-from-corpus.json
@@ -1,0 +1,78 @@
+{
+  "subject": "the shape axis reading the whole catalogue, and the fold that refuses a redaction (#407)",
+  "why": "This axis published 52 of 370 while its ceiling was also 52: it walked a hand-written read list, so no amount of recording could move it, and it still named 292 operations 'no answer of the real cloud has been kept' — including the 619 exchanges already committed under corpus/. Two families of guard now hold it up: one that makes the axis ask the catalogue rather than the list, and one that keeps a sanitised recording from teaching a type it does not carry. A mutation of either reads exactly like the working code, because the first is invisible in a total and the second writes a plausible type.",
+  "mutations": [
+    {
+      "file": "internal/cli/evidence.go",
+      "find": "\tobserved, err := observedFieldsByOperation(dir, srv)\n\tif err != nil || observed == nil {\n\t\treturn nil, err\n\t}\n\tcovered := make(map[string]bool, len(observed))\n\tfor op := range observed {\n\t\tcovered[op] = true\n\t}\n\treturn covered, nil",
+      "replace": "\tobserved, err := observedFieldsByOperation(dir, srv)\n\tif err != nil || observed == nil {\n\t\treturn nil, err\n\t}\n\tcovered := make(map[string]bool, len(observed))\n\tfor op := range observed {\n\t\tif !strings.Contains(op, \"List\") {\n\t\t\tcontinue\n\t\t}\n\t\tcovered[op] = true\n\t}\n\treturn covered, nil",
+      "expect": "the axis counts only the operations a curated read list could ever name, which is the cap #407 measured: recorded creates stop counting however many are recorded",
+      "test": "TestAShapeRecordedOutsideTheReadListStillCounts",
+      "label": "the axis goes back to counting reads only"
+    },
+    {
+      "file": "internal/cli/evidence.go",
+      "find": "\t\tfor key, rec := range cat.Operations {\n\t\t\tif len(rec.Fields) == 0 {\n\t\t\t\tcontinue\n\t\t\t}",
+      "replace": "\t\tfor key, rec := range cat.Operations {\n\t\t\tif len(rec.Fields) == 0 && false {\n\t\t\t\tcontinue\n\t\t\t}",
+      "expect": "an operation recorded only refusing counts as a recorded shape, so a corpus of 4xx raises the axis that says a response was held against a real one",
+      "test": "TestAnOperationRecordedWithoutFieldsEarnsNoShape",
+      "label": "a recorded refusal counts as a recorded shape"
+    },
+    {
+      "file": "internal/shape/shape.go",
+      "find": "\tfor _, f := range transcript.FieldsOfObserved(x.Res.Body, IsRedacted) {",
+      "replace": "\tfor _, f := range transcript.FieldsOfObserved(x.Res.Body, func(any) bool { _ = IsRedacted; return false }) {",
+      "expect": "a value the recorder replaced teaches its replacement's type, so folding a sanitised corpus turns an array into array|string and a bool into bool|string, over types a direct --record read had right",
+      "test": "TestARedactedValueTeachesNoType",
+      "label": "a redaction teaches the type of its replacement"
+    },
+    {
+      "file": "internal/shape/shape.go",
+      "find": "\t\tif PathIsRedacted(path) {\n\t\t\tif x.Operation == \"\" {\n\t\t\t\tch.Unkeyable++\n\t\t\t\tcontinue\n\t\t\t}\n\t\t\tpath = \"\"\n\t\t}",
+      "replace": "\t\tif PathIsRedacted(path) && false {\n\t\t\tif x.Operation == \"\" {\n\t\t\t\tch.Unkeyable++\n\t\t\t\tcontinue\n\t\t\t}\n\t\t\tpath = \"\"\n\t\t}",
+      "expect": "a path the sanitiser rewrote becomes a catalogue key, so the committed file carries a name that names no API and whose number moves every time the corpus is re-sanitised",
+      "test": "TestARedactedPathIsNeverAKey",
+      "label": "a sanitised path becomes a catalogue key"
+    },
+    {
+      "file": "internal/transcript/transcript.go",
+      "find": "\t\tif redacted != nil && redacted(v) {\n\t\t\treturn\n\t\t}\n\t\tinto[path] = jsonType(v)",
+      "replace": "\t\tif redacted != nil && redacted(v) && false {\n\t\t\treturn\n\t\t}\n\t\tinto[path] = jsonType(v)",
+      "expect": "the predicate is accepted and ignored, so every caller believes it is filtering replaced values and none is",
+      "test": "TestAReplacedValueContributesNoPath",
+      "label": "the walk accepts the predicate and ignores it"
+    },
+    {
+      "file": "internal/cli/evidence.go",
+      "find": "\tif len(moved) > 0 {\n\t\tfmt.Fprintf(stderr,\n\t\t\t\"feint: %s was produced from other %s, so its other axes are stale and a fresh shape \"+",
+      "replace": "\tif len(moved) > 0 && false {\n\t\tfmt.Fprintf(stderr,\n\t\t\t\"feint: %s was produced from other %s, so its other axes are stale and a fresh shape \"+",
+      "expect": "a reshape writes a fresh shape column onto a record whose suites moved, so the six axes beside it are stale and nothing says so",
+      "test": "TestAReshapeRefusesARecordWhoseOtherInputsMoved",
+      "label": "a reshape refreshes one axis of a stale record"
+    },
+    {
+      "file": "internal/cli/evidence.go",
+      "find": "\t\tev.Shape = emulator.ShapeUnobserved\n\t\tif covered[op] {\n\t\t\tev.Shape = emulator.ShapeObserved\n\t\t\tnow++\n\t\t}",
+      "replace": "\t\tif covered[op] {\n\t\t\tev.Shape = emulator.ShapeObserved\n\t\t\tnow++\n\t\t} else if ev.Shape != emulator.ShapeObserved {\n\t\t\tev.Shape = emulator.ShapeUnobserved\n\t\t}",
+      "expect": "the shape column becomes a high-water mark: an operation the catalogue no longer covers keeps the level a deleted recording once earned it",
+      "test": "TestAReshapeDemotesAnOperationTheCatalogueNoLongerCovers",
+      "label": "the reshape only ever raises"
+    },
+    {
+      "file": "internal/shape/redaction.go",
+      "find": "const recorderToken = \"REDACTED\"",
+      "replace": "const recorderToken = \"REDACTED_RENAMED_BY_THE_RECORDER\"",
+      "expect": "the restated prefix drifts from the one the recorder actually writes, which is the whole risk of restating it instead of importing it: every replaced value reads as an observation again",
+      "test": "TestEveryValueTheRecorderWritesIsOneShapeRefuses",
+      "label": "the restated recorder prefix drifts from the recorder"
+    },
+    {
+      "file": "internal/corpus/corpus.go",
+      "find": "const Token = shape.RedactionToken",
+      "replace": "const Token = \"redacted_\" // was shape.RedactionToken, restated as a literal",
+      "expect": "internal/corpus stops aliasing the constant internal/shape refuses and restates it, which is the only way the two can drift: the sanitiser then mints a spelling the fold reads as an observation of the API",
+      "test": "TestTheSanitisersTokenIsTheOneShapeRefuses",
+      "label": "the sanitiser restates the token instead of aliasing it"
+    }
+  ]
+}


### PR DESCRIPTION
Wave 2 of 0.11.0. The brief asked one question — *how many of `shape`'s 292
`unrecorded` operations are already covered by `corpus/`?* — and the answer is
**80**. But the premise underneath the question was false, and that is the
finding.

## The axis was saturated at its own ceiling while publishing 14 %

`shape` read **52 of 370**. Its ceiling was **also 52**, per cloud to the unit
(exoscale 14, outscale 23, scaleway 15).

`shapeCoveredOperations` resolved coverage by walking `upstream.Reads`, about
sixty curated calls. **No amount of recording could ever have moved it.** It was
full, and it published 14 % while naming 292 operations as *"no answer of the
real cloud has been kept"* — including all 619 exchanges committed in `corpus/`,
which it never asked about.

Three independent computations agree the ceiling was 52: the published value,
the route table per provider, and the committed record's own `shape=observed`
set.

So the queue this repository was about to work was not a recording backlog. It
was an axis that could not see.

## The architecture decision: a one-way fold, not a derivation

The brief leaned toward deriving `shapes/` from `corpus/`. **Measured, that
loses evidence**, and twice over:

- **13 operations are in `shapes/` and in no corpus**, six of them served by no
  pack at all (`ReadQuotas`, `ReadAccounts`, `ReadListenerRules`,
  `ReadNetAccessPoints`, `ReadServerCertificates`, `ReadVolumeUpdateTasks`).
  That is the read list's *learning side*, which a corpus cannot hold: a corpus
  records a client that had a reason to call.
- **A sanitised corpus has lost the type.** The recorder writes a string over
  whatever it replaced. 23 (operation, field) pairs carry a placeholder, 7 of
  them over a non-string. Folding blind turned `ReadKeypairs.Keypairs` into
  `array|string` and `LoadBalancers[].SecuredCookies` into `bool|string`, over
  types a direct `--record` read had right.

So the corpus folds *into* the catalogue, and `shape.IsRedacted` refuses a
placeholder rather than learning from it. A sanitised path keys nothing.
Recorded in `docs/architecture.md`.

## The number, as it comes out

**`shape`: 52 → 134 of 370.** Per cloud: exoscale 14 → 31, outscale 23 → 66,
scaleway 15 → 37.

Proved **as sets, never as totals**: the 52 are a strict subset of the 134,
gained 82, lost 0, and no other axis moved for any operation. Two readings name
the same 236 remaining. The fold is byte-idempotent.

## The brief's criterion would have passed on broken code — and worse, it pays for the defect

Asked to check that, the answer is the most useful thing in this branch.

The defective variant was built and measured: with the redaction guard
neutralised, `shape` reads **135, not 134** — *one higher* — while the catalogue
carries four false polymorphic types. `exoscale/v2.list-ssh-keys` is recorded as
`ssh-keys: string` where the API answers an array, **and that lie raises the
axis**.

Any criterion phrased on the axis total therefore rewards removing the guard.
What catches it is the type-level comparison: no type moved, no field lost.

## Falsified

`tools/falsify/specs/shape-axis-from-corpus.json`, **9 mutations, all red** —
verified again here after the rebase. Among them: *a recorded refusal counts as
a recorded shape*, *a redaction teaches the type of its replacement*, *a reshape
refreshes one axis of a stale record*, and *the reshape only ever raises*.

**One stayed green at the first attempt**, and the weakness was in the mutation
rather than the code: `corpus.Token` is an alias of `shape.RedactionToken`, so
drift is impossible by construction. Re-aimed at the alias itself, it bites.

## Fallout handled rather than hidden

The fold handed the live field gate 82 more operations of real-cloud data, and
its first run found **8 fields no answer carried**. Verified by hand: the
emulator serves all eight on a populated object, so they were thin-object
findings. The *suites* gained the calls — an Outscale machine updated inside a
Net, a rule naming a group, an Exoscale rule with a description and a group
source. `mise run conformance` green, score **346 → 347** of 372.

## Three instruments lied during the work

Worth recording, since this repository counts them: `/_feint/conformance`
publishes omission gaps under `fields`, not `field_gaps`, so two "not
reproduced" verdicts were a `KeyError` read as an absence; a probe-only run
compares nothing, because a synthetic answer deliberately vouches for no served
field; and a `feint start` in the repro loaded no contracts, giving the same
`compared: 0` for a different reason.

## What remains, and what the maintainer must run

The real recording queue is **236, was 318**: exoscale 56, outscale 27,
scaleway 129, plus 24 `undriven` that belong to #409–#415.

`coverage/evidence.json` carries the refreshed `shape` column, but its **suites
digest is now stale**: the suite additions mean `driven`, `behaviour` and
`negative` understate reality. `feint evidence --reshape` correctly refuses to
touch it, and that refusal was demonstrated. `mise run evidence:update` on a
host that can start machines is the fix.

**Nothing was recorded against any cloud account.**

## Related

Closes #407
Refs #409–#415, whose recording volume this changes
