### PR TITLE
feat(coverage): the queue stops asking for suites that cannot be written, and parity.sh is rescued (#419, #409, #410)

### DIFF
--- a/docs/limits.md
+++ b/docs/limits.md
@@ -1159,6 +1159,42 @@ the runtime carries one address on one machine whatever the pack's API allows â€
 Scaleway moving a flexible IP on request, Outscale refusing without `AllowRelink`,
 Exoscale accepting both holders.
 
+### An Exoscale instance carries an address its API publishes nowhere (measured 2026-08-24)
+
+`tools/conformance/parity.sh` drives one equivalent request through the three
+providers' own surfaces and counts what the **host** carries, read from the
+runtime rather than from the API under test. Run against `main` on 2026-08-24
+with `FEINT_VM=incus`, it reports four divergences with a single root cause.
+
+| row | scaleway | outscale | exoscale |
+|---|---|---|---|
+| a machine on a private network, no public address asked for | 1 iface / 1 addr | 1 / 1 | **2 / 2** |
+| the same, one public address explicitly requested | 1 / 2 | 1 / 2 | **2 / 3** |
+
+The extra address is `192.0.2.1` on `eth0`. The instance's own read answers
+`public_ip: null`, and no other field of the API names it, so it is carried and
+published nowhere. It is present from boot: the first run aborted before any
+Elastic IP existed and already measured `2/2`, which rules out a leftover from
+an earlier attachment.
+
+Two things follow, and the second is the reason this is written here rather than
+fixed in passing:
+
+- **The parity claim itself is sound.** Remove that one address and all four
+  findings go: both rows read the same interface and address counts on the three
+  clouds, and the orphan check reads zero. The equality this suite asserts is not
+  too strong for Exoscale.
+- **What the fix should be is a product decision, not a patch.** Either the
+  machine must not carry the address, or the API must publish it â€”
+  `machines.go` states the intent ("Exoscale's eth0 is the public interface, the
+  address this pack publishes as public-ip is the primary interface's"), and the
+  measurement says the published half is missing. Choosing costs a reading of
+  what a real Exoscale instance answers when no Elastic IP is attached.
+
+Until then `mise run conformance:parity` runs on demand and is deliberately not
+in the `conformance` aggregate: a red suite inside the gate every other change is
+judged by teaches people to skip the gate.
+
 ## Subnet isolation depends on the runtime mode
 
 Upstream, two private networks of two different VPCs do not reach each other.

--- a/internal/cli/evidence_axes.go
+++ b/internal/cli/evidence_axes.go
@@ -458,3 +458,33 @@ func evidenceAxesView(record, provider, axis, format string, stdout, stderr io.W
 	}
 	return exitOK
 }
+
+// undrivenReasons answers, per operation, what the pack declares at the route
+// about why no official client reaches it — Route.Undriven, empty for every
+// operation a client drives.
+//
+// From the packs in process, for the same reason operationOwners is: the
+// alternative is a list in this file, and a list disagrees with the packs at
+// the first edit and keeps being the thing people read.
+//
+// Two routes may mount one operation (372 routes for 370 operations). A reason
+// on either is the operation's reason, and the longer one wins so that the
+// answer cannot depend on mount order — a silent tie-break by iteration order
+// is how a report becomes irreproducible.
+func undrivenReasons() (map[string]string, error) {
+	srv, _, err := newServer(nil)
+	if err != nil {
+		return nil, err
+	}
+	reasons := make(map[string]string)
+	for _, r := range srv.AllRoutes() {
+		if r.Operation == "" || r.Undriven == "" {
+			continue
+		}
+		if prev, seen := reasons[r.Operation]; seen && len(prev) >= len(r.Undriven) {
+			continue
+		}
+		reasons[r.Operation] = r.Undriven
+	}
+	return reasons, nil
+}

--- a/internal/cli/evidence_gaps.go
+++ b/internal/cli/evidence_gaps.go
@@ -40,15 +40,49 @@ const (
 	// cloud's answer exists" — one recording session away from earned, which
 	// is why it outranks the two below.
 	gapUnrecorded
-	// gapUndriven: no real client reaches this operation at all. Most axes
-	// cannot be earned without that, so this is the upstream job: a conformance
-	// suite, not a pack change.
+	// gapUndriven: no real client reaches this operation, and no route says
+	// why. Most axes cannot be earned without a client, so this is the upstream
+	// job: a conformance suite, not a pack change.
+	//
+	// It reads zero on a green repository, and that is the design rather than a
+	// dead branch: TestEveryUndrivenOperationSaysWhy already refuses an undriven
+	// operation with no reason, so this kind is the window between mounting a
+	// route and explaining it — an incoming-work signal, not a backlog. The
+	// backlog it used to hold is now `declared` below, where each line carries
+	// the reason that retired it.
 	gapUndriven
 	// gapUnproven: driven, not violating, and still not earned, for a reason
 	// the record does not spell. Named rather than folded into another kind,
 	// because a bucket that absorbs the unexplained is how a queue starts
 	// lying.
+	//
+	// It is the largest bucket, and 172 of its 264 zeros are the `negative`
+	// axis. A tempting reading — measured and rejected on 2026-08-24 — is that
+	// those are recordings like `shape`, and should be reclassified as such.
+	// They are not. `shape` is earned by a recorded real-cloud answer and by
+	// nothing else, so "no recording exists" is its whole story; `negative` is
+	// earned by an operation really answering 4xx to a real client inside a span
+	// where a suite demanded a refusal, which a suite can produce without any
+	// recording at all. Calling those 172 "a recording" would have sent a reader
+	// to a cloud account for work a conformance case can do offline. Left in the
+	// honest bucket rather than moved to a wrong one.
 	gapUnproven
+	// gapDeclared: no client reaches it, and the route says why in
+	// Route.Undriven. This is the one entry of the queue that is not work.
+	//
+	// It exists because the four kinds above could not tell "nobody has written
+	// the suite yet" from "no client path exists to write one with", and the
+	// queue told both to go and write a suite. Measured on 2026-08-24: all
+	// twenty-five operations the record left undriven already carried a reason
+	// at their route — `scw ipam ip` has no attach subcommand, `scw vpc` has no
+	// subnet subcommand — so every one of those 141 zeros was asking for a
+	// suite that cannot be written. That is the same defect #407 removed from
+	// the `shape` axis: a queue entry no amount of work can retire.
+	//
+	// It is last in the order for the same reason it is kept rather than
+	// filtered: a reader picking work must not meet it first, and a decision
+	// that disappears from the report is a decision nobody can review.
+	gapDeclared
 )
 
 // gapKindNames are what the output prints, and the keys --format json uses.
@@ -58,6 +92,7 @@ var gapKindNames = map[gapKind]string{
 	gapUnrecorded: "unrecorded",
 	gapUndriven:   "undriven",
 	gapUnproven:   "unproven",
+	gapDeclared:   "declared",
 }
 
 // gapKindWork is the sentence the text output prints once per group. It names
@@ -68,20 +103,32 @@ var gapKindWork = map[gapKind]string{
 	gapUnrecorded: "a recording: a real client already drives it, and no answer of the real cloud has been kept",
 	gapUndriven:   "a conformance suite: no real client reaches this operation, so most axes cannot be earned",
 	gapUnproven:   "unexplained: driven, not violating, still not earned — the record does not say why",
+	gapDeclared:   "not work: no client path exists to reach it, and the route says so — the reason is printed with each line",
 }
 
-// classifyGap decides which of the four a zero is, from the record alone.
+// classifyGap decides which of the five a zero is, from the record and from
+// what the pack declares at the route — never from the operation's name.
 //
 // The order of the tests is the classification: a violation outranks everything
 // because it is the only defect here, and "undriven" is asked before the
 // catch-all so that the unexplained bucket stays as small as the record allows.
 //
-// TestAGapIsClassifiedFromTheRecordRatherThanTheName fails without this.
-func classifyGap(ev emulator.Evidence, axis evidenceAxis) gapKind {
+// `reason` is Route.Undriven for this operation, empty when the route declares
+// none. It is only ever consulted for an operation the record says no client
+// drove: a reason on a driven operation is a stale excuse, and
+// TestEveryUndrivenOperationSaysWhy is the control that refuses one — this
+// function must not quietly honour what that test exists to reject.
+//
+// TestAGapIsClassifiedFromTheRecordRatherThanTheName and
+// TestADeclaredReasonSplitsTheUndrivenQueue fail without this.
+func classifyGap(ev emulator.Evidence, axis evidenceAxis, reason string) gapKind {
 	if v := axis.verdict(ev); v == "violating" {
 		return gapViolating
 	}
 	if !ev.Driven {
+		if reason != "" {
+			return gapDeclared
+		}
 		return gapUndriven
 	}
 	if axis.Name == "shape" {
@@ -98,6 +145,10 @@ type gapEntry struct {
 	// Verdict carries the record's own word for a non-boolean axis, so a
 	// consumer never has to re-derive it from Kind.
 	Verdict string `json:"verdict,omitempty"`
+	// Reason is Route.Undriven, carried on the "declared" lines only. Published
+	// rather than left for the reader to go and find in a pack file: a decision
+	// a report names but does not state is a decision nobody re-examines.
+	Reason string `json:"reason,omitempty"`
 }
 
 // gapGroup is one (provider, axis) pair's queue.
@@ -123,7 +174,7 @@ type gapReport struct {
 // uses. No second source of truth: this computes nothing a gate does not
 // already compute, it only says what the zeros are for.
 func buildGaps(record string, art *evidenceArtefact, owners map[string]string,
-	providers []string, onlyProvider, onlyAxis string) (*gapReport, error) {
+	reasons map[string]string, providers []string, onlyProvider, onlyAxis string) (*gapReport, error) {
 	axes := evidenceAxisList()
 	if onlyAxis != "" {
 		found := false
@@ -169,13 +220,17 @@ func buildGaps(record string, art *evidenceArtefact, owners map[string]string,
 				if a.earned(ev) {
 					continue
 				}
-				kind := classifyGap(ev, a)
-				group.Entries = append(group.Entries, gapEntry{
+				kind := classifyGap(ev, a, reasons[op])
+				entry := gapEntry{
 					Operation: op,
 					Axis:      a.Name,
 					Kind:      gapKindNames[kind],
 					Verdict:   a.verdict(ev),
-				})
+				}
+				if kind == gapDeclared {
+					entry.Reason = reasons[op]
+				}
+				group.Entries = append(group.Entries, entry)
 			}
 			if len(group.Entries) == 0 {
 				continue
@@ -238,6 +293,9 @@ func writeGapsText(w io.Writer, r *gapReport) error {
 			if e.Verdict != "" {
 				line += "  (" + e.Verdict + ")"
 			}
+			if e.Reason != "" {
+				line += "\n          " + e.Reason
+			}
 			if _, err := fmt.Fprintln(w, line); err != nil {
 				return err
 			}
@@ -269,7 +327,12 @@ func evidenceGapsView(record, provider, axis, format string, stdout, stderr io.W
 		fmt.Fprintf(stderr, "feint: %v\n", err)
 		return exitError
 	}
-	report, err := buildGaps(record, art, owners, providers, provider, axis)
+	reasons, err := undrivenReasons()
+	if err != nil {
+		fmt.Fprintf(stderr, "feint: %v\n", err)
+		return exitError
+	}
+	report, err := buildGaps(record, art, owners, reasons, providers, provider, axis)
 	if err != nil {
 		fmt.Fprintf(stderr, "feint: %v\n", err)
 		return exitError

--- a/internal/cli/evidence_gaps_test.go
+++ b/internal/cli/evidence_gaps_test.go
@@ -23,23 +23,37 @@ func TestAGapIsClassifiedFromTheRecordRatherThanTheName(t *testing.T) {
 	negative := namedAxis(t, "negative")
 
 	cases := []struct {
-		name string
-		ev   emulator.Evidence
-		axis evidenceAxis
-		want gapKind
+		name   string
+		ev     emulator.Evidence
+		axis   evidenceAxis
+		reason string
+		want   gapKind
 	}{
 		{"a violating verdict outranks everything",
-			emulator.Evidence{Driven: true, Shape: "violating"}, shape, gapViolating},
-		{"undriven, whatever else is true",
-			emulator.Evidence{Driven: false, Shape: "unobserved"}, shape, gapUndriven},
+			emulator.Evidence{Driven: true, Shape: "violating"}, shape, "", gapViolating},
+		{"undriven and nothing says why is a suite to write",
+			emulator.Evidence{Driven: false, Shape: "unobserved"}, shape, "", gapUndriven},
 		{"driven and unobserved is a recording",
-			emulator.Evidence{Driven: true, Shape: "unobserved"}, shape, gapUnrecorded},
+			emulator.Evidence{Driven: true, Shape: "unobserved"}, shape, "", gapUnrecorded},
 		{"driven, not violating, another axis: unexplained rather than guessed",
-			emulator.Evidence{Driven: true}, negative, gapUnproven},
+			emulator.Evidence{Driven: true}, negative, "", gapUnproven},
+		// The two that separate "no suite yet" from "no client to write one
+		// with". Same record, same axis, different answer — so the reason is
+		// what decides, and it is read from the route rather than from the name.
+		{"undriven with a declared reason is not work",
+			emulator.Evidence{Driven: false, Shape: "unobserved"}, shape,
+			"no official client calls it: the CLI has no attach subcommand", gapDeclared},
+		// A reason must never rescue a driven operation from its zero. The
+		// stale half of TestEveryUndrivenOperationSaysWhy exists to reject such
+		// a reason, and this asserts the queue does not honour it meanwhile:
+		// otherwise a stale excuse would empty a real recording queue.
+		{"a reason on a driven operation changes nothing",
+			emulator.Evidence{Driven: true, Shape: "unobserved"}, shape,
+			"no official client calls it: the CLI has no attach subcommand", gapUnrecorded},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := classifyGap(c.ev, c.axis); got != c.want {
+			if got := classifyGap(c.ev, c.axis, c.reason); got != c.want {
 				t.Fatalf("classified as %s, want %s", gapKindNames[got], gapKindNames[c.want])
 			}
 		})
@@ -58,7 +72,7 @@ func TestAGapIsClassifiedFromTheRecordRatherThanTheName(t *testing.T) {
 // served operations" is exactly the kind of sentence that stops being true.
 func TestTheQueueOnlyNamesOperationsTheRecordHolds(t *testing.T) {
 	art, owners, providers := gapFixture(t)
-	report, err := buildGaps("fixture", art, owners, providers, "", "")
+	report, err := buildGaps("fixture", art, owners, nil, providers, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,7 +104,7 @@ func TestTheQueueOnlyNamesOperationsTheRecordHolds(t *testing.T) {
 // the same list to three different people.
 func TestTheQueueIsOrderedByTheWorkItNames(t *testing.T) {
 	art, owners, providers := gapFixture(t)
-	report, err := buildGaps("fixture", art, owners, providers, "", "")
+	report, err := buildGaps("fixture", art, owners, nil, providers, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +136,7 @@ func TestTheQueueIsOrderedByTheWorkItNames(t *testing.T) {
 // a queue gets misread by everybody who did not write it.
 func TestTheJSONCarriesWhatEachKindMeans(t *testing.T) {
 	art, owners, providers := gapFixture(t)
-	report, err := buildGaps("fixture", art, owners, providers, "", "")
+	report, err := buildGaps("fixture", art, owners, nil, providers, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -155,7 +169,7 @@ func TestTheJSONCarriesWhatEachKindMeans(t *testing.T) {
 // blur for a replay of nothing.
 func TestAnUnknownAxisIsRefused(t *testing.T) {
 	art, owners, providers := gapFixture(t)
-	if _, err := buildGaps("fixture", art, owners, providers, "", "no-such-axis"); err == nil {
+	if _, err := buildGaps("fixture", art, owners, nil, providers, "", "no-such-axis"); err == nil {
 		t.Fatal("an axis nobody declares was accepted, so a typo prints an empty queue and reads as a clean one")
 	}
 }
@@ -207,4 +221,101 @@ func gapFixture(t *testing.T) (*evidenceArtefact, map[string]string, []string) {
 	// same terms as the other fixtures in this package.
 	_ = filepath.Join(os.TempDir(), "gapfixture")
 	return art, owners, []string{"outscale", "scaleway"}
+}
+
+// The queue separates "nobody has written the suite" from "no client exists to
+// write one with", and it does it from what the packs declare.
+//
+// Measured on 2026-08-24, before this split existed: the record left twenty-five
+// operations undriven, and every single one already carried a Route.Undriven
+// reason — `scw ipam ip` has no attach subcommand, `scw vpc` has no subnet
+// subcommand, `scw block volume-type list` is pinned to v1alpha1. The queue
+// nonetheless printed all 141 of their zeros under "a conformance suite: no
+// real client reaches this operation", which asks a reader for a suite that
+// cannot be written. It is the shape of defect #407 removed from the `shape`
+// axis: an entry no amount of work retires.
+//
+// The assertion is a set equality between two independently derived sets, in
+// both directions, and both are required to be non-empty. A subset check in one
+// direction alone is satisfied by a queue that classifies nothing, which is
+// exactly how a control of this kind passes while measuring nothing.
+func TestADeclaredReasonSplitsTheUndrivenQueue(t *testing.T) {
+	art, err := loadEvidenceArtefact(filepath.Join("..", "..", "coverage", "evidence.json"))
+	if err != nil {
+		t.Fatalf("read the evidence artefact: %v", err)
+	}
+	if art == nil || len(art.Operations) == 0 {
+		t.Fatal("the evidence artefact is empty, so this test would pass while measuring nothing")
+	}
+	owners, providers, err := operationOwners()
+	if err != nil {
+		t.Fatal(err)
+	}
+	reasons, err := undrivenReasons()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The set the packs declare: undriven in the record AND carrying a reason.
+	// Derived from the two inputs, never from the report being tested.
+	declaredByPacks := map[string]bool{}
+	undrivenWithoutReason := map[string]bool{}
+	for op := range art.Operations {
+		if _, owned := owners[op]; !owned {
+			continue
+		}
+		if art.Operations[op].Driven {
+			continue
+		}
+		if reasons[op] != "" {
+			declaredByPacks[op] = true
+		} else {
+			undrivenWithoutReason[op] = true
+		}
+	}
+	if len(declaredByPacks) == 0 {
+		t.Fatal("no operation is both undriven and declared, so the split this test " +
+			"describes is untestable on this record and the test would pass on any code")
+	}
+
+	report, err := buildGaps("coverage/evidence.json", art, owners, reasons, providers, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	declaredByQueue := map[string]bool{}
+	undrivenByQueue := map[string]bool{}
+	for _, g := range report.Groups {
+		for _, e := range g.Entries {
+			switch e.Kind {
+			case "declared":
+				declaredByQueue[e.Operation] = true
+				if e.Reason == "" {
+					t.Errorf("%s is queued as declared and prints no reason; "+
+						"a decision a report names but does not state is one nobody re-examines", e.Operation)
+				}
+			case "undriven":
+				undrivenByQueue[e.Operation] = true
+			}
+		}
+	}
+
+	for op := range declaredByPacks {
+		if !declaredByQueue[op] {
+			t.Errorf("%s is undriven and its route says why, and the queue does not call it declared", op)
+		}
+		if undrivenByQueue[op] {
+			t.Errorf("%s carries a reason at its route and the queue still asks for a conformance suite", op)
+		}
+	}
+	for op := range declaredByQueue {
+		if !declaredByPacks[op] {
+			t.Errorf("%s is queued as declared and the packs declare no reason for it: "+
+				"the queue is excusing an operation nobody excused", op)
+		}
+	}
+	for op := range undrivenByQueue {
+		if !undrivenWithoutReason[op] {
+			t.Errorf("%s is queued as undriven and is not an undriven operation without a reason", op)
+		}
+	}
 }

--- a/mise.toml
+++ b/mise.toml
@@ -263,6 +263,21 @@ run = [
   "tools/conformance/exoscale/ssh.sh http://$FEINT_ADDR",
 ]
 
+[tasks."conformance:parity"]
+description = "The same request, on the three clouds: assert the machines match, by reading the host. Needs FEINT_VM=incus or incus-ovn"
+# Deliberately NOT in the `conformance` aggregate, and the reason is a
+# measurement rather than a preference: run against main on 2026-08-24 with
+# FEINT_VM=incus, it reports four divergences with one root cause — an Exoscale
+# instance carries 192.0.2.1 on eth0 that its own API publishes nowhere, so the
+# counts read scaleway=1/1 outscale=1/1 exoscale=2/2. Putting a red suite in the
+# aggregate would break the gate every other change is judged by, and the
+# reflex that teaches is the one .pre-commit-config.yaml already refuses.
+#
+# It runs here, on demand, until that address is either published or not
+# allocated. Then it joins the aggregate — and the line above is the test of
+# whether it may.
+run = "tools/conformance/parity.sh http://$FEINT_ADDR"
+
 [tasks."conformance:crash"]
 description = "Kill a serving emulator and prove the crash policy: leftovers labelled, restart warns, clean sweeps to zero. Needs FEINT_VM=incus"
 depends = ["build"]

--- a/mise.toml
+++ b/mise.toml
@@ -643,6 +643,22 @@ depends = ["build"]
 # with a stale artefact would let a proof survive the removal of its evidence.
 # Removing an assertion from a suite and re-running this task must demote the
 # operations it proved — that is the falsification the record lives under.
+#
+# MEASURED 2026-08-24, and it will bite whoever runs this next: leg 2 fails
+# intermittently in tools/conformance/stacks.sh, and only with a machine runtime
+# on. `scaleway_vpc_private_network` is refused with "subnet X overlaps X" — the
+# block it collides with is itself, and it is a DIFFERENT block each run
+# (10.40.1.0/24, then 10.30.1.0/24). Isolated: stacks.sh alone on a clean host
+# failed twice and passed once with FEINT_VM=incus, and passed with machines
+# off. So it is a race in the runtime-backed create path, not this task and not
+# the fixture, and the mechanism is NOT established — the passing run showed 3
+# CreatePrivateNetwork for 3 DeletePrivateNetwork, so the obvious "the provider
+# retried" reading is unsupported.
+#
+# The consequence is the part that matters: this task is the only way to
+# regenerate a record carrying `machines: incus`, and on any host that has Incus
+# it completes only by chance. Re-running is the workaround; fixing the race is
+# the answer.
 run = """
 set -e
 tmp="$(mktemp -d)"

--- a/tools/conformance/parity.sh
+++ b/tools/conformance/parity.sh
@@ -1,0 +1,339 @@
+#!/usr/bin/env bash
+# Conformance check: the same request produces the same machine on every
+# provider.
+#
+# The rule is the author's, stated during #201: "I must see the same number of
+# IPs whatever the cloud provider." What triggered it was measured on one
+# station: a Scaleway server on one private network carried three addresses on
+# two interfaces where an Outscale Vm carried one on one — and the difference
+# was the runtime's fallback interface surviving the attachment, an address no
+# provider API publishes.
+#
+# So this suite compares, it does not recite: it drives an equivalent request
+# through each provider's own surface, counts what the HOST carries (read from
+# the runtime, never from the API that is under test), and requires the counts
+# to agree line by line. No expected number is written anywhere: a hard-coded
+# count gets updated without anyone noticing the providers diverged.
+#
+# Two configurations, made equivalent explicitly:
+#   1. a machine on a private network, no public address asked for — the
+#      baseline, because in a real cloud a public address costs money and
+#      nothing must allocate one the client did not request;
+#   2. the same machine with one public address, explicitly requested.
+#
+# And one property per row on top of the counts: every address the machine
+# carries is published by its provider's API. Zero orphan addresses, on the
+# three — this is what replaced the long-standing "carried but not published"
+# skip of the Scaleway network suite.
+#
+# A verdict about "this run" must hold on the poorest run that triggers it: a
+# provider whose client is not installed is skipped BY NAME, and with fewer
+# than two participants the equality is skipped explicitly rather than
+# affirmed on a population of one.
+#
+# Usage: tools/conformance/parity.sh [endpoint]
+set -euo pipefail
+
+ENDPOINT="${1:-http://127.0.0.1:4599}"
+ZONE="${ZONE:-fr-par-1}"
+REGION="${REGION:-fr-par}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/guard.sh"
+guard_local "$ENDPOINT"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ok()   { echo "  ok: $*"; }
+skip() { echo "  SKIP: $*" >&2; }
+
+# Two kinds of bad news, and they must not share an exit.
+#
+# `fail` is the harness giving up: a client refused a create, an address never
+# appeared. Nothing has been compared, and stopping is right.
+#
+# `note` is a finding: the comparison ran and the providers disagreed. Findings
+# accumulate and are printed together at the end, because the first version of
+# this script exited on the first one — and the check that exited was the count
+# equality, which is the weaker of the two. It aborted before the orphan check,
+# which is the universal one, so the run that found a divergence reported the
+# debatable half and never measured the half nobody disputes. A control that
+# stops the control behind it is a control that hides it.
+FINDINGS=0
+note() { echo "  FINDING: $*" >&2; FINDINGS=$((FINDINGS + 1)); }
+api()  { curl -sf -H 'Content-Type: application/json' "$@"; }
+
+command -v jq >/dev/null 2>&1 || fail "jq is not installed"
+command -v incus >/dev/null 2>&1 || fail "the incus client is not on PATH, so nothing can be counted"
+
+echo "conformance: address parity against $ENDPOINT"
+
+MACHINES="$(curl -sf "$ENDPOINT/_feint/health" | jq -r '.machines')"
+if [ "$MACHINES" = "none" ]; then
+  skip "no machine runtime (start with FEINT_VM=incus); nothing to count"
+  exit 0
+fi
+
+# Which providers can be driven from this station. Each absence is named: a
+# comparison that silently shrank its population is a comparison that lies.
+HAVE_OSC=""; HAVE_EXO=""
+# if/else rather than `A && B || C`: with the short form C also runs when A
+# succeeded and B returned non-zero, so a station that HAS the client could be
+# told it does not — and this suite's whole verdict is a population count.
+if command -v oapi-cli >/dev/null 2>&1; then HAVE_OSC=1; else skip "oapi-cli is not installed; Outscale sits out this comparison"; fi
+if command -v exo      >/dev/null 2>&1; then HAVE_EXO=1; else skip "exo is not installed; Exoscale sits out this comparison"; fi
+
+# Blocks, distinct from every other suite on this host.
+SCW_BLOCK="10.171.0.0/24"
+OSC_BLOCK="10.172.0.0/16"; OSC_SUBBLOCK="10.172.1.0/24"
+EXO_START="10.173.0.20"; EXO_END="10.173.0.200"; EXO_MASK="255.255.255.0"
+
+# ---- What the host carries, read from the runtime ----------------------------
+
+iface_count() { # machine-name
+  incus query "/1.0/instances/$1" 2>/dev/null \
+    | jq '[.expanded_devices | to_entries[] | select(.value.type == "nic")] | length'
+}
+addr_list() { # machine-name -> one address per line, no mask
+  incus exec "$1" -- ip -4 -o addr show scope global 2>/dev/null \
+    | awk '{print $4}' | cut -d/ -f1
+}
+counts_of() { # machine-name -> "ifaces/addrs"
+  echo "$(iface_count "$1")/$(addr_list "$1" | grep -c . || true)"
+}
+orphans_of() { # machine-name published... -> addresses carried but not published
+  local m="$1"; shift
+  local out=""
+  for addr in $(addr_list "$m"); do
+    case " $* " in
+      *" $addr "*) ;;
+      *) out="$out $addr" ;;
+    esac
+  done
+  echo "$out"
+}
+wait_carried() { # address
+  for _ in $(seq 1 15); do
+    incus list -f csv -c n4 2>/dev/null | grep -q "$1" && return 0
+    sleep 2
+  done
+  return 1
+}
+
+# ---- Cleanup ----------------------------------------------------------------
+
+scw_srv=""; scw_pn=""; scw_ip_id=""
+osc_vm=""; osc_sub=""; osc_net=""; osc_ip_id=""
+exo_id=""; exo_eip=""
+WORK="$(mktemp -d)"
+cleanup() {
+  [ -n "$scw_srv" ] && api -X POST "$ENDPOINT/instance/v1/zones/$ZONE/servers/$scw_srv/action" \
+    -d '{"action":"terminate"}' >/dev/null 2>&1
+  [ -n "$osc_vm" ] && osc DeleteVms '--VmIds[]' "$osc_vm" >/dev/null 2>&1
+  [ -n "$exo_id" ] && curl -sf -X DELETE "$ENDPOINT/v2/instance/$exo_id" >/dev/null 2>&1
+  sleep 8
+  [ -n "$scw_ip_id" ] && api -X DELETE "$ENDPOINT/instance/v1/zones/$ZONE/ips/$scw_ip_id" >/dev/null 2>&1
+  [ -n "$osc_ip_id" ] && osc DeletePublicIp --PublicIpId "$osc_ip_id" >/dev/null 2>&1
+  [ -n "$exo_eip" ] && exo -Q compute elastic-ip delete "$exo_eip" --force >/dev/null 2>&1
+  [ -n "$scw_pn" ] && api -X DELETE "$ENDPOINT/vpc/v2/regions/$REGION/private-networks/$scw_pn" >/dev/null 2>&1
+  [ -n "$osc_sub" ] && osc DeleteSubnet --SubnetId "$osc_sub" >/dev/null 2>&1
+  [ -n "$osc_net" ] && osc DeleteNet --NetId "$osc_net" >/dev/null 2>&1
+  [ -n "$HAVE_EXO" ] && exo -Q compute private-network delete parity-exo-net --force >/dev/null 2>&1
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+# ---- Scaleway: server on a private network, nothing public asked for --------
+# The raw API is the minimal request: dynamic_ip_required defaults to false and
+# no flexible IP is attached, which is what "no public address" means here. The
+# scw CLI's own default is ip=new — a real client asking for an address — and
+# that path stays covered by scw-cli.sh; this suite is about what the emulator
+# does when nobody asks.
+
+echo "- scaleway: a server on a private network"
+scw_pn="$(api -X POST "$ENDPOINT/vpc/v2/regions/$REGION/private-networks" \
+          -d "{\"name\":\"parity\",\"subnets\":[\"$SCW_BLOCK\"]}" | jq -r '.id')"
+[ -n "$scw_pn" ] && [ "$scw_pn" != null ] || fail "scaleway refused the block $SCW_BLOCK"
+scw_srv="$(api -X POST "$ENDPOINT/instance/v1/zones/$ZONE/servers" \
+           -d '{"name":"parity-scw","commercial_type":"DEV1-S","image":"alpine"}' | jq -r '.server.id')"
+[ -n "$scw_srv" ] && [ "$scw_srv" != null ] || fail "the scaleway server was not created"
+api -X POST "$ENDPOINT/instance/v1/zones/$ZONE/servers/$scw_srv/action" -d '{"action":"poweron"}' >/dev/null
+scw_nic="$(api -X POST "$ENDPOINT/instance/v1/zones/$ZONE/servers/$scw_srv/private_nics" \
+           -d "{\"private_network_id\":\"$scw_pn\"}")"
+scw_ipam="$(printf '%s' "$scw_nic" | jq -r '.private_nic.ipam_ip_ids[0] // empty')"
+[ -n "$scw_ipam" ] || fail "the scaleway NIC names no IPAM address"
+scw_priv="$(api "$ENDPOINT/ipam/v1/regions/$REGION/ips/$scw_ipam" | jq -r '.address' | cut -d/ -f1)"
+wait_carried "$scw_priv" || fail "no machine carries $scw_priv"
+scw_public_baseline="$(api "$ENDPOINT/instance/v1/zones/$ZONE/servers/$scw_srv" \
+                       | jq -r '[.server.public_ips[]?.address] | length')"
+[ "$scw_public_baseline" = "0" ] \
+  || fail "scaleway allocated a public address nobody asked for"
+scw_m="feint-scw-$scw_srv"
+
+# ---- Outscale: a Vm born in a Subnet ----------------------------------------
+
+osc() { oapi-cli --config "$WORK/osc-config.json" "$@"; }
+if [ -n "$HAVE_OSC" ]; then
+  echo "- outscale: a Vm in a Subnet"
+  set -a
+  # shellcheck source=/dev/null
+  . "$SCRIPT_DIR/outscale/fake-credentials.env"
+  # shellcheck disable=SC2034 # read by oapi-cli from the environment, not here
+  OSC_ENDPOINT_API="$ENDPOINT"
+  set +a
+  # oapi-cli falls back to its stored credentials when the environment says
+  # nothing, and this station carries real Outscale profiles. Every other
+  # Outscale suite asks this question before its first call; this one drives
+  # CreateNet and CreateVms, so it asks it too.
+  guard_no_real_profile OSC_ENDPOINT_API oapi-cli
+  cat > "$WORK/osc-config.json" <<EOF
+{
+  "default": {
+    "access_key": "$OSC_ACCESS_KEY",
+    "secret_key": "$OSC_SECRET_KEY",
+    "region": "$OSC_REGION",
+    "protocol": "http",
+    "endpoints": { "api": "$ENDPOINT" }
+  }
+}
+EOF
+  osc_net="$(osc CreateNet --IpRange "$OSC_BLOCK" | jq -r '.Net.NetId')"
+  osc_sub="$(osc CreateSubnet --NetId "$osc_net" --IpRange "$OSC_SUBBLOCK" | jq -r '.Subnet.SubnetId')"
+  osc_doc="$(osc CreateVms --ImageId ami-00000003 --VmType tinav6.c1r1p2 --SubnetId "$osc_sub")"
+  osc_vm="$(printf '%s' "$osc_doc" | jq -r '.Vms[0].VmId')"
+  osc_priv="$(printf '%s' "$osc_doc" | jq -r '.Vms[0].PrivateIp // empty')"
+  [ -n "$osc_vm" ] && [ -n "$osc_priv" ] || fail "the outscale Vm was not created with a PrivateIp"
+  wait_carried "$osc_priv" || fail "no machine carries $osc_priv"
+  osc_public_baseline="$(osc ReadVms '--Filters.VmIds[]' "$osc_vm" | jq -r '.Vms[0].PublicIp // empty')"
+  [ -z "$osc_public_baseline" ] || fail "outscale allocated a public address nobody asked for"
+  osc_m="feint-osc-$osc_vm"
+fi
+
+# ---- Exoscale: an instance attached to a private network --------------------
+
+if [ -n "$HAVE_EXO" ]; then
+  echo "- exoscale: an instance on a private network"
+  set -a
+  # shellcheck source=/dev/null
+  . "$SCRIPT_DIR/exoscale/fake-credentials.env"
+  set +a
+  export EXOSCALE_API_ENDPOINT=${ENDPOINT}/v2
+  guard_no_real_profile EXOSCALE_API_ENDPOINT exo
+  exo compute private-network create parity-exo-net \
+    --start-ip "$EXO_START" --end-ip "$EXO_END" --netmask "$EXO_MASK" >/dev/null \
+    || fail "exoscale refused the range $EXO_START-$EXO_END"
+  exo compute instance create parity-exo \
+    --template "Linux Ubuntu 24.04 LTS 64-bit" --instance-type standard.tiny >/dev/null \
+    || fail "the exoscale instance was not created"
+  exo_id="$(exo -O json compute instance list | jq -r '.[] | select(.name == "parity-exo") | .id')"
+  [ -n "$exo_id" ] || fail "the exoscale instance is not in the list"
+  exo compute instance private-network attach parity-exo parity-exo-net >/dev/null \
+    || fail "the exoscale attach was refused"
+  exo_priv="$(exo -O json compute private-network show parity-exo-net \
+              | jq -r '.leases[] | select(.instance == "parity-exo") | .ip_address')"
+  [ -n "$exo_priv" ] || fail "the exoscale lease publishes no address"
+  wait_carried "$exo_priv" || fail "no machine carries $exo_priv"
+  exo_m="feint-exo-$exo_id"
+fi
+sleep 3
+
+# ---- Row 1: private network, no public address ------------------------------
+
+echo "- row 1: same request, no public address: the counts must agree"
+rows=""
+verdict=""
+scw_c="$(counts_of "$scw_m")"; rows="scaleway=$scw_c"
+[ -n "$HAVE_OSC" ] && { osc_c="$(counts_of "$osc_m")"; rows="$rows outscale=$osc_c"; }
+[ -n "$HAVE_EXO" ] && { exo_c="$(counts_of "$exo_m")"; rows="$rows exoscale=$exo_c"; }
+participants=$(echo "$rows" | wc -w)
+if [ "$participants" -lt 2 ]; then
+  skip "only $participants provider(s) drivable; equality not measurable on a population of one"
+else
+  first="${rows%% *}"; first="${first#*=}"
+  for entry in $rows; do
+    [ "${entry#*=}" = "$first" ] || verdict="diverged"
+  done
+  if [ -n "$verdict" ]; then
+    note "the same request produced different machines: $rows (interfaces/addresses)"
+  else
+    ok "one request, one shape: $rows (interfaces/addresses)"
+  fi
+fi
+
+echo "- row 1: every carried address is published"
+orphans=0
+o="$(orphans_of "$scw_m" "$scw_priv")"
+[ -z "${o// /}" ] || { note "scaleway carries unpublished address(es):$o"; orphans=1; }
+if [ -n "$HAVE_OSC" ]; then
+  o="$(orphans_of "$osc_m" "$osc_priv")"
+  [ -z "${o// /}" ] || { note "outscale carries unpublished address(es):$o"; orphans=1; }
+fi
+if [ -n "$HAVE_EXO" ]; then
+  o="$(orphans_of "$exo_m" "$exo_priv")"
+  [ -z "${o// /}" ] || { note "exoscale carries unpublished address(es):$o"; orphans=1; }
+fi
+[ "$orphans" = "1" ] || ok "zero orphan addresses"
+
+# ---- Row 2: one public address, explicitly requested ------------------------
+
+echo "- row 2: one public address each, explicitly requested"
+scw_ip_doc="$(api -X POST "$ENDPOINT/instance/v1/zones/$ZONE/ips" -d '{}')"
+scw_ip_id="$(printf '%s' "$scw_ip_doc" | jq -r '.ip.id')"
+scw_pub="$(printf '%s' "$scw_ip_doc" | jq -r '.ip.address')"
+api -X PATCH "$ENDPOINT/instance/v1/zones/$ZONE/ips/$scw_ip_id" -d "{\"server\":\"$scw_srv\"}" >/dev/null \
+  || fail "attaching the scaleway flexible IP was refused"
+if [ -n "$HAVE_OSC" ]; then
+  osc_ip_doc="$(osc CreatePublicIp)"
+  osc_ip_id="$(printf '%s' "$osc_ip_doc" | jq -r '.PublicIp.PublicIpId')"
+  osc_pub="$(printf '%s' "$osc_ip_doc" | jq -r '.PublicIp.PublicIp')"
+  osc LinkPublicIp --PublicIpId "$osc_ip_id" --VmId "$osc_vm" >/dev/null \
+    || fail "linking the outscale public IP was refused"
+fi
+if [ -n "$HAVE_EXO" ]; then
+  exo -O json compute elastic-ip create --description parity >/dev/null \
+    || fail "the exoscale elastic IP was not created"
+  exo_eip="$(exo -O json compute elastic-ip list | jq -r '.[0].ip_address // .[0].ip // empty')"
+  [ -n "$exo_eip" ] || fail "no address on the exoscale elastic IP"
+  exo compute instance elastic-ip attach parity-exo "$exo_eip" >/dev/null \
+    || fail "attaching the exoscale elastic IP was refused"
+fi
+sleep 5
+
+rows=""
+verdict=""
+scw_c="$(counts_of "$scw_m")"; rows="scaleway=$scw_c"
+[ -n "$HAVE_OSC" ] && { osc_c="$(counts_of "$osc_m")"; rows="$rows outscale=$osc_c"; }
+[ -n "$HAVE_EXO" ] && { exo_c="$(counts_of "$exo_m")"; rows="$rows exoscale=$exo_c"; }
+if [ "$participants" -lt 2 ]; then
+  skip "only $participants provider(s) drivable; equality not measurable on a population of one"
+else
+  first="${rows%% *}"; first="${first#*=}"
+  for entry in $rows; do
+    [ "${entry#*=}" = "$first" ] || verdict="diverged"
+  done
+  if [ -n "$verdict" ]; then
+    note "with one public address each, the machines differ: $rows (interfaces/addresses)"
+  else
+    ok "one request, one shape: $rows (interfaces/addresses)"
+  fi
+fi
+
+echo "- row 2: every carried address is published"
+orphans=0
+o="$(orphans_of "$scw_m" "$scw_priv" "$scw_pub")"
+[ -z "${o// /}" ] || { note "scaleway carries unpublished address(es):$o"; orphans=1; }
+if [ -n "$HAVE_OSC" ]; then
+  o="$(orphans_of "$osc_m" "$osc_priv" "$osc_pub")"
+  [ -z "${o// /}" ] || { note "outscale carries unpublished address(es):$o"; orphans=1; }
+fi
+if [ -n "$HAVE_EXO" ]; then
+  o="$(orphans_of "$exo_m" "$exo_priv" "$exo_eip")"
+  [ -z "${o// /}" ] || { note "exoscale carries unpublished address(es):$o"; orphans=1; }
+fi
+[ "$orphans" = "1" ] || ok "zero orphan addresses"
+
+if [ "$FINDINGS" -gt 0 ]; then
+  echo "conformance: address parity found $FINDINGS divergence(s)" >&2
+  exit 1
+fi
+echo "conformance: address parity passed"

--- a/tools/conformance/scaleway/terraform.sh
+++ b/tools/conformance/scaleway/terraform.sh
@@ -188,6 +188,14 @@ volume_uuid="${volume_id##*/}"
 # the snapshot are asked of the emulator directly, so a state file agreeing with
 # itself cannot pass for a resource that exists.
 echo "- the block volume and its snapshot are served by block/v1"
+# Captured before the second apply, because the "updated rather than replaced"
+# assertion below compares across the apply. Reading the id afterwards and
+# comparing it to itself is true whatever the provider did — that is a vacuous
+# assertion, and this file is where it would have hidden.
+pg_id_before="$("$TF" output -raw placement_group_id)"
+nic_id_before="$("$TF" output -raw private_nic_id)"
+[ -n "$pg_id_before" ] || fail "no placement group id in the outputs"
+[ -n "$nic_id_before" ] || fail "no private nic id in the outputs"
 block_volume_id="$("$TF" output -raw block_volume_id)"
 block_volume_uuid="${block_volume_id##*/}"
 block_snapshot_id="$("$TF" output -raw block_snapshot_id)"
@@ -236,6 +244,29 @@ acl="$(curl -s "$ENDPOINT/vpc/v2/regions/fr-par/vpcs/$vpc_uuid/acl-rules?is_ipv6
 printf '%s' "$acl" | jq -e '.rules[0].description == "https, phase two"' >/dev/null \
   || fail "the second SetACL answered 200 and stored the first rule set: $acl"
 ok "updated in place, and read back"
+
+# The two v2alpha1 PATCH doors, which nothing drove until this apply existed.
+# Provider 2.81.0 moved the placement group and the private NIC onto
+# /instance/v2alpha1/..., and both were mounted so that the first apply editing
+# a tag would not meet a 501 — then no fixture ever edited one, so both carried
+# a Route.Undriven reason naming this file. The assertion is here rather than in
+# the coverage record on purpose: a run that stops driving them fails on this
+# line, not on a nightly regeneration three days later.
+pg_uuid="${pg_id_before##*/}"
+body="$(curl -s "$ENDPOINT/instance/v2alpha1/zones/$ZONE/placement-groups/$pg_uuid")"
+printf '%s' "$body" | jq -e '.tags | index("two")' >/dev/null \
+  || fail "the placement group update did not reach the emulator: $body"
+nic_uuid="${nic_id_before##*/}"
+body="$(curl -s "$ENDPOINT/instance/v2alpha1/zones/$ZONE/private-network-interfaces/$nic_uuid")"
+printf '%s' "$body" | jq -e '.tags | index("two")' >/dev/null \
+  || fail "the private nic update did not reach the emulator: $body"
+# Updated, not replaced: a provider that destroyed and recreated would carry the
+# new tag while having driven Create and Delete instead of the PATCH this proves.
+[ "$("$TF" output -raw placement_group_id)" = "$pg_id_before" ] \
+  || fail "the placement group was replaced rather than updated: UpdatePlacementGroup is still unproven"
+[ "$("$TF" output -raw private_nic_id)" = "$nic_id_before" ] \
+  || fail "the private nic was replaced rather than updated: UpdatePrivateNetworkInterface is still unproven"
+ok "the two v2alpha1 PATCH doors were driven and read back"
 
 echo "- the plan after the update is empty too"
 plan_status=0

--- a/tools/conformance/scaleway/terraform.sh
+++ b/tools/conformance/scaleway/terraform.sh
@@ -249,7 +249,14 @@ ok "updated in place, and read back"
 # Provider 2.81.0 moved the placement group and the private NIC onto
 # /instance/v2alpha1/..., and both were mounted so that the first apply editing
 # a tag would not meet a 501 — then no fixture ever edited one, so both carried
-# a Route.Undriven reason naming this file. The assertion is here rather than in
+# a Route.Undriven reason naming this file. Those two reasons are still in
+# internal/providers/scaleway/pack.go and are stale from this commit on:
+# coverage/evidence.json has not been regenerated since, because
+# `mise run evidence:update` fails intermittently on a host with Incus and
+# mise.toml carries that measurement. The next regeneration turns them red
+# through TestEveryUndrivenOperationSaysWhy's stale half, which is the designed
+# way to find them; delete them then.
+# The assertion is here rather than in
 # the coverage record on purpose: a run that stops driving them fails on this
 # line, not on a nightly regeneration three days later.
 pg_uuid="${pg_id_before##*/}"

--- a/tools/conformance/scaleway/terraform/main.tf
+++ b/tools/conformance/scaleway/terraform/main.tf
@@ -246,6 +246,13 @@ resource "scaleway_instance_placement_group" "conformance" {
   policy_type = "max_availability"
   policy_mode = "enforced"
   zone        = "fr-par-1"
+  # The phase tag is what drives instance/v2alpha1/API.UpdatePlacementGroup.
+  # Provider 2.81.0 PATCHes this door for name, policy type and tags; the
+  # fixture created the group and destroyed it without ever editing it, so the
+  # route was mounted and unreachable — the route carried the reason in
+  # Route.Undriven, and the reason named this exact fixture. One changed tag is
+  # the cheapest edit the provider will PATCH rather than replace.
+  tags = ["conformance", var.phase]
 }
 
 # The name lookup of the provider's data source reads the v2alpha1 list, the
@@ -326,6 +333,11 @@ resource "scaleway_instance_private_nic" "conformance" {
   private_network_id = scaleway_vpc_private_network.conformance.id
   ipam_ip_ids        = [scaleway_ipam_ip.conformance.id]
   zone               = "fr-par-1"
+  # The phase tag is what drives instance/v2alpha1/API.UpdatePrivateNetworkInterface,
+  # the PATCH door provider 2.81.0 uses for an interface's tags. Same story as the
+  # placement group above: mounted on 2026-08-17 so that the first apply editing a
+  # tag would not meet a 501, then never edited by this fixture.
+  tags = ["conformance", var.phase]
 }
 
 # The exact expression that killed the talos stack (#270): upstream always
@@ -491,4 +503,18 @@ output "gateway_ip_address" {
 
 output "gateway_network_id" {
   value = scaleway_vpc_gateway_network.conformance.id
+}
+
+# The two identifiers the second apply needs in order to prove its PATCH landed.
+# Both families were mounted on 2026-08-17 so that a first apply editing a tag
+# would not meet a 501, and both then sat undriven because this fixture created
+# and destroyed without ever editing them — the reason was written at the route
+# in Route.Undriven and named this file. The suite reads them back from the
+# emulator after the second apply, so a 200 that stored nothing fails here.
+output "placement_group_id" {
+  value = scaleway_instance_placement_group.conformance.id
+}
+
+output "private_nic_id" {
+  value = scaleway_instance_private_nic.conformance.id
 }

--- a/tools/falsify/specs/evidence-gaps.json
+++ b/tools/falsify/specs/evidence-gaps.json
@@ -1,6 +1,6 @@
 {
   "subject": "the work queue behind `feint coverage --evidence --gaps` (#408)",
-  "why": "A score says where we stand; this says what to do next. Its whole value is that four zeros name four different jobs, so every mutation below turns the queue back into an undifferentiated list — which is the state it was built to replace, and which reads exactly the same to somebody who did not write it.",
+  "why": "A score says where we stand; this says what to do next. Its whole value is that four zeros name four different jobs, so every mutation below turns the queue back into an undifferentiated list — which is the state it was built to replace, and which reads exactly the same to somebody who did not write it. Since 2026-08-24 it also separates work from decisions: the four mutations added last turn the `declared` kind back into an undifferentiated `undriven` backlog, honour a reason on an operation a client drives, strip the reason from the line, or cut the packs off as the source of reasons entirely.",
   "mutations": [
     {
       "file": "internal/cli/evidence_gaps.go",
@@ -12,8 +12,8 @@
     },
     {
       "file": "internal/cli/evidence_gaps.go",
-      "find": "\tif !ev.Driven {\n\t\treturn gapUndriven\n\t}",
-      "replace": "\tif !ev.Driven && false {\n\t\treturn gapUndriven\n\t}",
+      "find": "\tif !ev.Driven {\n\t\tif reason != \"\" {\n\t\t\treturn gapDeclared\n\t\t}\n\t\treturn gapUndriven\n\t}",
+      "replace": "\tif !ev.Driven && false {\n\t\tif reason != \"\" {\n\t\t\treturn gapDeclared\n\t\t}\n\t\treturn gapUndriven\n\t}",
       "expect": "an operation no client reaches is filed as a recording session, so somebody records a cloud answer for a route nothing calls",
       "test": "TestAGapIsClassifiedFromTheRecordRatherThanTheName",
       "label": "an undriven operation is filed as a recording"
@@ -49,6 +49,38 @@
       "expect": "a typo in --axis prints an empty queue, and 'no gap on that axis' reads exactly like 'there is no such axis'",
       "test": "TestAnUnknownAxisIsRefused",
       "label": "an unknown axis prints an empty queue"
+    },
+    {
+      "file": "internal/cli/evidence_gaps.go",
+      "find": "\t\tif reason != \"\" {\n\t\t\treturn gapDeclared\n\t\t}\n\t\treturn gapUndriven",
+      "replace": "\t\tif reason != \"\" && false {\n\t\t\treturn gapDeclared\n\t\t}\n\t\treturn gapUndriven",
+      "expect": "the reason a pack wrote at the route stops retiring its zero, so all 141 of them go back to asking for a conformance suite that no client exists to write",
+      "test": "TestADeclaredReasonSplitsTheUndrivenQueue",
+      "label": "a declared reason stops retiring its zero"
+    },
+    {
+      "file": "internal/cli/evidence_gaps.go",
+      "find": "\tif !ev.Driven {\n\t\tif reason != \"\" {\n\t\t\treturn gapDeclared\n\t\t}\n\t\treturn gapUndriven\n\t}\n\tif axis.Name == \"shape\" {",
+      "replace": "\tif !ev.Driven || true {\n\t\tif reason != \"\" {\n\t\t\treturn gapDeclared\n\t\t}\n\t\treturn gapUndriven\n\t}\n\tif axis.Name == \"shape\" {",
+      "expect": "a reason is honoured on an operation a client does drive, so a stale excuse — the exact thing TestEveryUndrivenOperationSaysWhy exists to reject — empties a real recording queue",
+      "test": "TestAGapIsClassifiedFromTheRecordRatherThanTheName",
+      "label": "a stale reason excuses an operation a client drives"
+    },
+    {
+      "file": "internal/cli/evidence_gaps.go",
+      "find": "\t\t\t\tif kind == gapDeclared {\n\t\t\t\t\tentry.Reason = reasons[op]\n\t\t\t\t}",
+      "replace": "\t\t\t\tif kind == gapDeclared && false {\n\t\t\t\t\tentry.Reason = reasons[op]\n\t\t\t\t}",
+      "expect": "the queue calls an operation declared and never says on what grounds, so a decision it names is one no reader can re-examine without opening three pack files",
+      "test": "TestADeclaredReasonSplitsTheUndrivenQueue",
+      "label": "a declared line stops carrying its reason"
+    },
+    {
+      "file": "internal/cli/evidence_axes.go",
+      "find": "\t\tif r.Operation == \"\" || r.Undriven == \"\" {\n\t\t\tcontinue\n\t\t}",
+      "replace": "\t\tif r.Operation == \"\" || r.Undriven == \"\" || true {\n\t\t\tcontinue\n\t\t}",
+      "expect": "no reason is ever read from the packs, so the split has no input and the guard's own non-vacuity check is what must catch it",
+      "test": "TestADeclaredReasonSplitsTheUndrivenQueue",
+      "label": "the reasons are never read from the packs"
     }
   ]
 }


### PR DESCRIPTION
Wave 4 of 0.11.0. The brief asked to remeasure before working, and the remeasure
reframed six of the seven issues.

## The queue was asking for suites that cannot be written

`--gaps` printed **141 zeros** under *"a conformance suite: no real client
reaches this operation"*. Measured: those 141 zeros are **25 distinct
operations** (7 Scaleway, 18 Exoscale, 0 Outscale), each contributing five to
seven of them — which is where the issues' large numbers come from.

**All 25 already carried a `Route.Undriven` reason**, and
`TestEveryUndrivenOperationSaysWhy` was green proving it. The queue was asking
for work that cannot be done: `scw ipam ip` has no attach subcommand and
`scw vpc` has no subnet subcommand, both verified against the installed CLI.

Same defect class as #407, one level out: a queue entry no amount of work
retires. A fifth kind, `declared`, now prints the reason on the line.
**`undriven` reads 0/0/0** and becomes an incoming-work signal rather than a
backlog.

Guarded by `TestADeclaredReasonSplitsTheUndrivenQueue`: set equality in **both**
directions between named sets, failing if either is empty.

## What the remeasure gives, per issue

| issue | its `undriven` claim | measured today, distinct operations |
|---|---|---|
| #414 addresses | Scaleway 15, Exoscale 12 | 3 IPAM (`Attach`/`Detach`/`MoveIP`) + 2 Exoscale elastic-ip |
| #410 private network | Scaleway 5 | `ListSubnets`, `UpdatePrivateNetworkInterface`, +1 Exoscale |
| #412 load balancer | Exoscale 24 | 4 Exoscale LB operations |
| #411 block storage | Exoscale 16 snapshot | 3 Exoscale snapshot + `block/v1 ListVolumeTypes` |
| #409 machines | Scaleway 11 | `UpdatePlacementGroup` + 1 Exoscale |
| #413 security group | Exoscale 5 | **0 — none left** |

Provider totals moved too, since #408 was written: Outscale `unrecorded` 70→27,
Scaleway 151→129, Exoscale `undriven` 111→105.

## Premises the measurement contradicted

- **#414's "the routes exist, the clients exist, nothing has connected them" is
  false for IPAM.** The clients do not exist, and the pack said so at the route.
- **The 172 `negative` zeros are not recordings.** Reclassifying them beside
  `shape`'s would have sent a reader to a cloud account for work a conformance
  case does offline. The disproof is written into the code.
- **A suspected `set -e` cleanup bug in `parity.sh` was not one** — disproved
  with a witness script before "fixing" a non-defect.

## Delivered

**Two operations genuinely driven** (#409, #410). The fixture applied once and
destroyed, so `UpdatePlacementGroup` and `UpdatePrivateNetworkInterface` were
unreachable. Both gained a phase tag, the real provider now PATCHes them, and the
`fields` leg's undriven-route count fell 25 → 23.

**`parity.sh` is rescued from `wip/172-peering` (#419), and it still holds.** Its
first run on `main` found four divergences with **one root cause**: an Exoscale
instance carries `192.0.2.1`, an address its API publishes nowhere. Remove it and
all four go. Wired as `conformance:parity`, deliberately **not** in the aggregate
suite — a red suite inside the main gate teaches people to skip it. Its findings
now accumulate, because the weaker count check was aborting before the universal
orphan check.

## Left, and named

- **#415's classifier is not built.** The per-issue numbers above are exact named
  sets rather than a throwaway grouping, but committing the classifier remains
  the right follow-up.
- **The 212 `unrecorded` gaps: no cloud recording done.** The authorisation
  arrived mid-task; the measurement said the profitable work needed no account,
  and the brief said the authorisation lifts a block without imposing one.
  **No cloud account was touched.**
- **#419's two falsification specs and `incus_fallback_test.go` are dropped, and
  that is measured**: both specs mutate code (`isolateUplink`, the
  fallback-retirement loop) that **does not exist on `main`**, so `falsify:lint`
  would fail immediately. Re-running them under the fixed harness is impossible,
  not pending. The peering commits already landed on `main`.

## A blocker worth knowing about

**`mise run evidence:update` fails intermittently on any host with Incus.**
Leg 2's `stacks.sh` is refused with *"subnet X overlaps X"*, a **different block
each run**. Isolated on a clean host: alone it failed twice, passed once with the
runtime on, and passed with machines off. This branch touches nothing it reads.

Pre-existing race, and the mechanism is deliberately **not** claimed — the
passing run showed three creates for three deletes, so "the provider retried" is
unsupported. Consequence: `coverage/evidence.json` is unregenerated, and the two
`Route.Undriven` reasons removed here are stale from this commit; the next
regeneration turns them red through the test's stale half. Recorded in
`mise.toml` and `terraform.sh`.

## Falsified

**10 mutations, all red at the first attempt**, verified again after the rebase.
No mutation stayed green.

**One criterion would have passed on broken code — the author's own**: the first
`updated rather than replaced` assertion compared an id read *after* the apply to
itself, true whatever the provider did. Caught and fixed before it landed.

## Gates

`prepush` 0 · `corpus:check` 0, and it compared something (5 value and 8 order
comparisons ran) · `conformance` green, **349/372** · `conformance:leg -- fields`
0. Exit codes captured before any pipe.

## Related

Closes #419
Refs #409, #410, #411, #412, #413, #414, #415
