### PR TITLE
feat(outscale): twenty-four operations are refused by a real client, and an axis nothing can earn says so at the route

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -1719,6 +1719,37 @@ change ni l'un ni l'autre a sa place dans `git log`.
   l'intérieur de l'enregistrement, et un inventaire de clôture identique octet
   pour octet à celui d'ouverture sur les sept familles de ressources.
 
+### Corrigé
+
+- **Outscale borne `ResultsPerPage` là où sa propre API la borne, et une taille
+  de page hors de 1 à 1000 est désormais refusée** (#428). Vingt et un schémas de
+  requête Read* de la description publiée par Outscale portent la même phrase —
+  « between `1` and `1000`, both included » — et ce pack acceptait n'importe
+  quelle valeur, lisant tout ce qui était inférieur à un comme « pas de limite ».
+  `ResultsPerPage: 0`, exactement la valeur que la vraie API rejette, se voyait
+  donc répondre l'inventaire entier. Un client qui envoie une taille hors bornes
+  reçoit maintenant un 400 qui nomme la borne, comme en amont.
+  `ReadLoadBalancers` n'est volontairement pas bornée : son schéma ne déclare
+  aucun `ResultsPerPage`.
+
+- **`ReadVmTypes` applique le filtre que le client lui envoie** (#428).
+  `FiltersVmType` en déclare neuf et ce gestionnaire n'en lisait aucun : un
+  client qui résolvait son type de machine par son nom recevait le catalogue
+  entier avec un 200, ce qui est indiscernable d'un succès pour un client qui
+  prend ensuite la première ligne. `VmTypeNames` est servi ; les huit qui
+  filtrent sur l'arithmétique matérielle sont refusés par leur nom plutôt
+  qu'ignorés, comme le fait déjà toute autre lecture de ce pack.
+
+- **La `FileLocation` d'une image est déclinée plutôt qu'inventée** (#437). C'est
+  l'URL de stockage objet où vivent les octets d'une OMI en amont ; cet émulateur
+  ne copie aucun octet et ne sert aucun stockage objet, donc il n'existe aucune
+  adresse qu'un client pourrait aller chercher. Sa voisine `BlockDeviceMappings`
+  reste volontairement non déclinée : la même opération la sert quand le client
+  nomme un instantané, et une déclinaison au niveau de l'opération, vraie d'un
+  genre d'objet et fausse pour l'autre, est exactement la forme que #389 a coûté
+  une release à comprendre.
+
+
 ## [0.10.0] - 2026-08-20
 
 ### Ajouté

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,32 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Fixed
 
+- **Outscale bounds `ResultsPerPage` where its own API bounds it, and a page
+  size outside 1 to 1000 is now refused** (#428). Twenty-one Read* request
+  schemas of Outscale's published description carry the same sentence — "between
+  `1` and `1000`, both included" — and this pack took any value, reading
+  everything below one as "no limit". So `ResultsPerPage: 0`, the exact value the
+  real API rejects, was answered with the whole inventory. A client that sends an
+  out-of-range page size now gets a 400 naming the bound, as it would upstream.
+  `ReadLoadBalancers` is deliberately not bounded: its schema declares no
+  `ResultsPerPage` at all.
+
+- **`ReadVmTypes` applies the filter a client sends it** (#428). `FiltersVmType`
+  declares nine filters and this handler read none of them, so a client
+  resolving its machine type by name was handed the whole catalogue with a 200 —
+  indistinguishable from success for a client that then takes the first row.
+  `VmTypeNames` is served; the eight that filter on hardware arithmetic are
+  refused by name rather than ignored, which is what every other read of this
+  pack already did.
+
+- **An image's `FileLocation` is declined rather than invented** (#437). It is
+  the object-storage URL an OMI's bytes live at upstream; this emulator copies no
+  bytes and serves no object storage, so there is no location a client could
+  fetch. Its neighbour `BlockDeviceMappings` is deliberately left undeclined: the
+  same operation serves it when the client names a snapshot, and an
+  operation-level decline true of one kind of object and false for the other is
+  the shape #389 cost a release to understand.
+
 - **Outscale is proven on every operation it serves: `shape` reaches 93 of 93**
   (#427). The last four were the Net peering family, and they had been declared
   unreachable twice — by #354 and again by this batch — for a reason that was

--- a/corpus/accepted.json
+++ b/corpus/accepted.json
@@ -2452,15 +2452,7 @@
       "operation": "osc/Client.CreateImage",
       "kind": "absent",
       "path": "Image.BlockDeviceMappings[]",
-      "reason": "A field a real cloudgouv-eu-west-1 account answers and this emulator omits, recorded 2026-08-24 (#427). An image a client cuts from a machine carries its own device mapping and a FileLocation; a volume resize answers the TaskId that will finish it; a health check carries its Path. #437 carries the measured list and the reason each is a distinct decision.",
-      "issue": "https://github.com/stephrobert/feint/issues/437"
-    },
-    {
-      "file": "outscale/oapi-cli-machine-shapes.jsonl",
-      "operation": "osc/Client.CreateImage",
-      "kind": "absent",
-      "path": "Image.FileLocation",
-      "reason": "A field a real cloudgouv-eu-west-1 account answers and this emulator omits, recorded 2026-08-24 (#427). An image a client cuts from a machine carries its own device mapping and a FileLocation; a volume resize answers the TaskId that will finish it; a health check carries its Path. #437 carries the measured list and the reason each is a distinct decision.",
+      "reason": "An image cut from a VmId answers an empty mapping array where the real account answers the device it snapshotted. Measured 2026-08-24 against cloudgouv-eu-west-1 (#427). It is NOT declined in DeclinedFields, and that is the decision: the same operation DOES serve the mappings when the client names a snapshot, so an operation-level decline would be true of one kind of object and fiction for the other \u2014 the shape #389 cost a release to understand. Serving it means cutting a snapshot of a machine's root volume, which this emulator holds no bytes for. Its neighbour Image.FileLocation left this file on 2026-08-24: it is unserved on every path, so it could be declined honestly.",
       "issue": "https://github.com/stephrobert/feint/issues/437"
     },
     {
@@ -2468,15 +2460,7 @@
       "operation": "osc/Client.UpdateImage",
       "kind": "absent",
       "path": "Image.BlockDeviceMappings[]",
-      "reason": "A field a real cloudgouv-eu-west-1 account answers and this emulator omits, recorded 2026-08-24 (#427). An image a client cuts from a machine carries its own device mapping and a FileLocation; a volume resize answers the TaskId that will finish it; a health check carries its Path. #437 carries the measured list and the reason each is a distinct decision.",
-      "issue": "https://github.com/stephrobert/feint/issues/437"
-    },
-    {
-      "file": "outscale/oapi-cli-machine-shapes.jsonl",
-      "operation": "osc/Client.UpdateImage",
-      "kind": "absent",
-      "path": "Image.FileLocation",
-      "reason": "A field a real cloudgouv-eu-west-1 account answers and this emulator omits, recorded 2026-08-24 (#427). An image a client cuts from a machine carries its own device mapping and a FileLocation; a volume resize answers the TaskId that will finish it; a health check carries its Path. #437 carries the measured list and the reason each is a distinct decision.",
+      "reason": "An image cut from a VmId answers an empty mapping array where the real account answers the device it snapshotted. Measured 2026-08-24 against cloudgouv-eu-west-1 (#427). It is NOT declined in DeclinedFields, and that is the decision: the same operation DOES serve the mappings when the client names a snapshot, so an operation-level decline would be true of one kind of object and fiction for the other \u2014 the shape #389 cost a release to understand. Serving it means cutting a snapshot of a machine's root volume, which this emulator holds no bytes for. Its neighbour Image.FileLocation left this file on 2026-08-24: it is unserved on every path, so it could be declined honestly.",
       "issue": "https://github.com/stephrobert/feint/issues/437"
     },
     {

--- a/internal/cli/evidence_axes.go
+++ b/internal/cli/evidence_axes.go
@@ -471,6 +471,43 @@ func evidenceAxesView(record, provider, axis, format string, stdout, stderr io.W
 // on either is the operation's reason, and the longer one wins so that the
 // answer cannot depend on mount order — a silent tie-break by iteration order
 // is how a report becomes irreproducible.
+// unearnableReasons answers, per operation and per axis, what the pack declares
+// at the route about an axis that can never be earned there — Route.Unearnable,
+// empty for every operation whose axes are all still in play.
+//
+// Separate from undrivenReasons because it answers a different question, and
+// keying it by axis is what keeps the exemption's subject matched to its key: a
+// declaration is written against one axis, and carrying it on the others would
+// excuse zeros nobody examined.
+//
+// From the packs in process, for the same reason the two neighbours are.
+func unearnableReasons() (map[string]map[string]string, error) {
+	srv, _, err := newServer(nil)
+	if err != nil {
+		return nil, err
+	}
+	reasons := make(map[string]map[string]string)
+	for _, r := range srv.AllRoutes() {
+		if r.Operation == "" {
+			continue
+		}
+		for _, u := range r.Unearnable {
+			byAxis := reasons[r.Operation]
+			if byAxis == nil {
+				byAxis = map[string]string{}
+				reasons[r.Operation] = byAxis
+			}
+			// Two routes may mount one operation; the longer reason wins, so
+			// the answer cannot depend on mount order.
+			if prev, seen := byAxis[u.Axis]; seen && len(prev) >= len(u.Reason) {
+				continue
+			}
+			byAxis[u.Axis] = u.Reason
+		}
+	}
+	return reasons, nil
+}
+
 func undrivenReasons() (map[string]string, error) {
 	srv, _, err := newServer(nil)
 	if err != nil {

--- a/internal/cli/evidence_gaps.go
+++ b/internal/cli/evidence_gaps.go
@@ -67,8 +67,18 @@ const (
 	// to a cloud account for work a conformance case can do offline. Left in the
 	// honest bucket rather than moved to a wrong one.
 	gapUnproven
-	// gapDeclared: no client reaches it, and the route says why in
-	// Route.Undriven. This is the one entry of the queue that is not work.
+	// gapDeclared: the route says why this zero cannot be closed, either
+	// because no client reaches the operation (Route.Undriven) or because the
+	// axis itself is out of reach there (Route.Unearnable). This is the one
+	// entry of the queue that is not work.
+	//
+	// The second source was added on 2026-08-24, when thirteen Outscale
+	// operations at zero on `behaviour` turned out to be a ceiling rather than
+	// a backlog: the axis marks an operation whose store touches fall on a
+	// resource created and destroyed inside the span, and those thirteen either
+	// touch no store or touch only kinds this emulator keeps on purpose. Twelve
+	// of the thirteen resisted an attempt to earn them before they were
+	// declared, which is the order this kind of entry has to be written in.
 	//
 	// It exists because the four kinds above could not tell "nobody has written
 	// the suite yet" from "no client path exists to write one with", and the
@@ -103,7 +113,7 @@ var gapKindWork = map[gapKind]string{
 	gapUnrecorded: "a recording: a real client already drives it, and no answer of the real cloud has been kept",
 	gapUndriven:   "a conformance suite: no real client reaches this operation, so most axes cannot be earned",
 	gapUnproven:   "unexplained: driven, not violating, still not earned — the record does not say why",
-	gapDeclared:   "not work: no client path exists to reach it, and the route says so — the reason is printed with each line",
+	gapDeclared:   "not work: no path exists to close this zero, and the route says which — the reason is printed with each line",
 }
 
 // classifyGap decides which of the five a zero is, from the record and from
@@ -121,15 +131,27 @@ var gapKindWork = map[gapKind]string{
 //
 // TestAGapIsClassifiedFromTheRecordRatherThanTheName and
 // TestADeclaredReasonSplitsTheUndrivenQueue fail without this.
-func classifyGap(ev emulator.Evidence, axis evidenceAxis, reason string) gapKind {
+func classifyGap(ev emulator.Evidence, axis evidenceAxis, undriven, unearnable string) gapKind {
 	if v := axis.verdict(ev); v == "violating" {
 		return gapViolating
 	}
 	if !ev.Driven {
-		if reason != "" {
+		if undriven != "" {
 			return gapDeclared
 		}
 		return gapUndriven
+	}
+	// Driven, and the route says this axis can never be earned here. Asked
+	// before the catch-all for the same reason "undriven" is: the unexplained
+	// bucket must stay as small as the declarations allow, and a zero no work
+	// can close is not work.
+	//
+	// It is asked AFTER the driven test on purpose: an operation nothing drives
+	// is Undriven's business, and letting an axis declaration answer for it
+	// would hide a missing suite behind a true statement about a different
+	// thing.
+	if unearnable != "" {
+		return gapDeclared
 	}
 	if axis.Name == "shape" {
 		return gapUnrecorded
@@ -174,7 +196,8 @@ type gapReport struct {
 // uses. No second source of truth: this computes nothing a gate does not
 // already compute, it only says what the zeros are for.
 func buildGaps(record string, art *evidenceArtefact, owners map[string]string,
-	reasons map[string]string, providers []string, onlyProvider, onlyAxis string) (*gapReport, error) {
+	reasons map[string]string, unearnable map[string]map[string]string,
+	providers []string, onlyProvider, onlyAxis string) (*gapReport, error) {
 	axes := evidenceAxisList()
 	if onlyAxis != "" {
 		found := false
@@ -220,7 +243,8 @@ func buildGaps(record string, art *evidenceArtefact, owners map[string]string,
 				if a.earned(ev) {
 					continue
 				}
-				kind := classifyGap(ev, a, reasons[op])
+				unearned := unearnable[op][a.Name]
+				kind := classifyGap(ev, a, reasons[op], unearned)
 				entry := gapEntry{
 					Operation: op,
 					Axis:      a.Name,
@@ -229,6 +253,9 @@ func buildGaps(record string, art *evidenceArtefact, owners map[string]string,
 				}
 				if kind == gapDeclared {
 					entry.Reason = reasons[op]
+					if unearned != "" && ev.Driven {
+						entry.Reason = unearned
+					}
 				}
 				group.Entries = append(group.Entries, entry)
 			}
@@ -327,12 +354,17 @@ func evidenceGapsView(record, provider, axis, format string, stdout, stderr io.W
 		fmt.Fprintf(stderr, "feint: %v\n", err)
 		return exitError
 	}
+	unearnable, err := unearnableReasons()
+	if err != nil {
+		fmt.Fprintf(stderr, "feint: %v\n", err)
+		return exitError
+	}
 	reasons, err := undrivenReasons()
 	if err != nil {
 		fmt.Fprintf(stderr, "feint: %v\n", err)
 		return exitError
 	}
-	report, err := buildGaps(record, art, owners, reasons, providers, provider, axis)
+	report, err := buildGaps(record, art, owners, reasons, unearnable, providers, provider, axis)
 	if err != nil {
 		fmt.Fprintf(stderr, "feint: %v\n", err)
 		return exitError

--- a/internal/cli/evidence_gaps_test.go
+++ b/internal/cli/evidence_gaps_test.go
@@ -23,37 +23,54 @@ func TestAGapIsClassifiedFromTheRecordRatherThanTheName(t *testing.T) {
 	negative := namedAxis(t, "negative")
 
 	cases := []struct {
-		name   string
-		ev     emulator.Evidence
-		axis   evidenceAxis
-		reason string
-		want   gapKind
+		name string
+		ev   emulator.Evidence
+		axis evidenceAxis
+		// reason is Route.Undriven, unearnable is Route.Unearnable for this
+		// axis. They are separate columns because they answer different
+		// questions and the classifier must not confuse them.
+		reason     string
+		unearnable string
+		want       gapKind
 	}{
 		{"a violating verdict outranks everything",
-			emulator.Evidence{Driven: true, Shape: "violating"}, shape, "", gapViolating},
+			emulator.Evidence{Driven: true, Shape: "violating"}, shape, "", "", gapViolating},
 		{"undriven and nothing says why is a suite to write",
-			emulator.Evidence{Driven: false, Shape: "unobserved"}, shape, "", gapUndriven},
+			emulator.Evidence{Driven: false, Shape: "unobserved"}, shape, "", "", gapUndriven},
 		{"driven and unobserved is a recording",
-			emulator.Evidence{Driven: true, Shape: "unobserved"}, shape, "", gapUnrecorded},
+			emulator.Evidence{Driven: true, Shape: "unobserved"}, shape, "", "", gapUnrecorded},
 		{"driven, not violating, another axis: unexplained rather than guessed",
-			emulator.Evidence{Driven: true}, negative, "", gapUnproven},
+			emulator.Evidence{Driven: true}, negative, "", "", gapUnproven},
 		// The two that separate "no suite yet" from "no client to write one
 		// with". Same record, same axis, different answer — so the reason is
 		// what decides, and it is read from the route rather than from the name.
 		{"undriven with a declared reason is not work",
 			emulator.Evidence{Driven: false, Shape: "unobserved"}, shape,
-			"no official client calls it: the CLI has no attach subcommand", gapDeclared},
+			"no official client calls it: the CLI has no attach subcommand", "", gapDeclared},
 		// A reason must never rescue a driven operation from its zero. The
 		// stale half of TestEveryUndrivenOperationSaysWhy exists to reject such
 		// a reason, and this asserts the queue does not honour it meanwhile:
 		// otherwise a stale excuse would empty a real recording queue.
 		{"a reason on a driven operation changes nothing",
 			emulator.Evidence{Driven: true, Shape: "unobserved"}, shape,
-			"no official client calls it: the CLI has no attach subcommand", gapUnrecorded},
+			"no official client calls it: the CLI has no attach subcommand", "", gapUnrecorded},
+		// The axis declaration, which answers a different question from the one
+		// above: the operation IS driven, and the axis is still out of reach.
+		// Without the third branch of classifyGap this is "unproven", which
+		// sends a reader to write a case that cannot exist.
+		{"driven, and the route says the axis is out of reach: not work",
+			emulator.Evidence{Driven: true}, negative, "",
+			"no supported client can compose a request it must refuse", gapDeclared},
+		// And it must not answer for a missing suite. An operation nothing
+		// drives is Undriven's business whatever its axes declare, or a real
+		// gap in the suites hides behind a true statement about something else.
+		{"undriven with an axis declaration and no client reason is still a suite to write",
+			emulator.Evidence{Driven: false}, negative, "",
+			"no supported client can compose a request it must refuse", gapUndriven},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := classifyGap(c.ev, c.axis, c.reason); got != c.want {
+			if got := classifyGap(c.ev, c.axis, c.reason, c.unearnable); got != c.want {
 				t.Fatalf("classified as %s, want %s", gapKindNames[got], gapKindNames[c.want])
 			}
 		})
@@ -72,7 +89,7 @@ func TestAGapIsClassifiedFromTheRecordRatherThanTheName(t *testing.T) {
 // served operations" is exactly the kind of sentence that stops being true.
 func TestTheQueueOnlyNamesOperationsTheRecordHolds(t *testing.T) {
 	art, owners, providers := gapFixture(t)
-	report, err := buildGaps("fixture", art, owners, nil, providers, "", "")
+	report, err := buildGaps("fixture", art, owners, nil, nil, providers, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,7 +121,7 @@ func TestTheQueueOnlyNamesOperationsTheRecordHolds(t *testing.T) {
 // the same list to three different people.
 func TestTheQueueIsOrderedByTheWorkItNames(t *testing.T) {
 	art, owners, providers := gapFixture(t)
-	report, err := buildGaps("fixture", art, owners, nil, providers, "", "")
+	report, err := buildGaps("fixture", art, owners, nil, nil, providers, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -136,7 +153,7 @@ func TestTheQueueIsOrderedByTheWorkItNames(t *testing.T) {
 // a queue gets misread by everybody who did not write it.
 func TestTheJSONCarriesWhatEachKindMeans(t *testing.T) {
 	art, owners, providers := gapFixture(t)
-	report, err := buildGaps("fixture", art, owners, nil, providers, "", "")
+	report, err := buildGaps("fixture", art, owners, nil, nil, providers, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +186,7 @@ func TestTheJSONCarriesWhatEachKindMeans(t *testing.T) {
 // blur for a replay of nothing.
 func TestAnUnknownAxisIsRefused(t *testing.T) {
 	art, owners, providers := gapFixture(t)
-	if _, err := buildGaps("fixture", art, owners, nil, providers, "", "no-such-axis"); err == nil {
+	if _, err := buildGaps("fixture", art, owners, nil, nil, providers, "", "no-such-axis"); err == nil {
 		t.Fatal("an axis nobody declares was accepted, so a typo prints an empty queue and reads as a clean one")
 	}
 }
@@ -278,7 +295,7 @@ func TestADeclaredReasonSplitsTheUndrivenQueue(t *testing.T) {
 			"describes is untestable on this record and the test would pass on any code")
 	}
 
-	report, err := buildGaps("coverage/evidence.json", art, owners, reasons, providers, "", "")
+	report, err := buildGaps("coverage/evidence.json", art, owners, reasons, nil, providers, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/unearnable_test.go
+++ b/internal/cli/unearnable_test.go
@@ -1,0 +1,283 @@
+package cli
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/contract"
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/store"
+)
+
+// The controls behind Route.Unearnable, which is a declaration that an evidence
+// axis can never be earned for an operation.
+//
+// A declaration like that is the most dangerous kind of entry in this
+// repository: it removes work from a queue, it reads like a decision, and
+// nothing about the sentence itself is checkable. Route.Undriven has the same
+// hazard and carries the same answer — the claim is measured, the prose only
+// explains it — and the guard on the stale half has already bitten twice.
+//
+// So there are two independent halves here, and neither is sufficient alone:
+//
+//   - the staleness half (TestAnUnearnableAxisIsNotAlreadyEarned) reads the
+//     committed record and refuses a declaration for an axis the record says
+//     was earned. It is what makes the declaration expire on its own.
+//   - the cause half (the three tests below it) checks the mechanism each
+//     declaration names, against the emulator or the provider's own contract,
+//     never against a list kept here.
+
+// unearnedRoutes are the mounted routes that declare an axis out of reach.
+func unearnedRoutes(t *testing.T) []emulator.Route {
+	t.Helper()
+	srv, _, err := newServer(nil)
+	if err != nil {
+		t.Fatalf("build the emulator: %v", err)
+	}
+	var out []emulator.Route
+	for _, r := range srv.AllRoutes() {
+		if r.Operation != "" && len(r.Unearnable) > 0 {
+			out = append(out, r)
+		}
+	}
+	if len(out) == 0 {
+		t.Skip("no route declares an unearnable axis, so these controls measure nothing")
+	}
+	return out
+}
+
+// A declaration for an axis the record says was earned is a stale excuse.
+//
+// This is the half that makes the mechanism safe to have at all. Without it,
+// declaring an axis out of reach would be a way to empty the queue by writing
+// prose: the thing #390 and #408 both refuse. With it, the moment a suite earns
+// the axis the declaration goes red and has to be removed.
+//
+// It also catches the case the causes cannot: CreatePublicIp has exactly the
+// one-field request CauseNoRefusableRequest describes, and it IS refusable,
+// because the emulator holds a finite address block. The schema check would
+// wave that through; this one does not.
+func TestAnUnearnableAxisIsNotAlreadyEarned(t *testing.T) {
+	artefact, err := loadEvidenceArtefact(filepath.Join("..", "..", "coverage", "evidence.json"))
+	if err != nil {
+		t.Fatalf("read the evidence artefact: %v", err)
+	}
+	if artefact == nil || len(artefact.Operations) == 0 {
+		t.Fatal("the evidence artefact is empty, so this test would pass while measuring nothing")
+	}
+
+	var stale []string
+	checked := 0
+	for _, route := range unearnedRoutes(t) {
+		ev, recorded := artefact.Operations[route.Operation]
+		if !recorded {
+			// An operation the record has never seen is the freshness check's
+			// business, not this one.
+			continue
+		}
+		for _, u := range route.Unearnable {
+			checked++
+			earned := false
+			switch u.Axis {
+			case emulator.ProvesBehaviour:
+				earned = ev.Behaviour
+			case emulator.ProvesNegative:
+				earned = ev.Negative
+			}
+			if earned {
+				stale = append(stale, route.Operation+" — "+u.Axis+": "+u.Reason)
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no declaration was compared against the record, so this test measured nothing")
+	}
+	sort.Strings(stale)
+	if len(stale) > 0 {
+		t.Errorf("%d declaration(s) say an axis can never be earned, and the record says it was.\n"+
+			"Remove Route.Unearnable there: a reason that outlived its cause is read as a decision.\n"+
+			"Stale:\n  %s", len(stale), strings.Join(stale, "\n  "))
+	}
+}
+
+// A no-store-touch claim is measured by driving the route, not by reading it.
+//
+// Both halves matter. Zero store events is the claim; a 2xx answer is what
+// stops the claim from being true of a call that never ran, which is the
+// vacuous-truth failure this repository has already paid for. A route that
+// answers 4xx to an empty body cannot be measured this way and says so rather
+// than passing.
+func TestAnUnearnableNoStoreTouchIsMeasured(t *testing.T) {
+	measured := 0
+	for _, route := range unearnedRoutes(t) {
+		claims := false
+		for _, u := range route.Unearnable {
+			if u.Cause == emulator.CauseNoStoreTouch {
+				claims = true
+			}
+		}
+		if !claims {
+			continue
+		}
+
+		// A fresh emulator per route: a store another route touched would
+		// report events this one did not make.
+		srv, env, err := newServer(nil)
+		if err != nil {
+			t.Fatalf("build the emulator: %v", err)
+		}
+		var touched []string
+		env.Store.Observe(func(ev store.Event) {
+			touched = append(touched, ev.Action+" "+ev.Provider+"/"+ev.Kind)
+		})
+		ts := httptest.NewServer(srv.Handler())
+
+		req, err := http.NewRequest(route.Method, ts.URL+route.Path, strings.NewReader("{}")) //nolint:noctx // test client
+		if err != nil {
+			t.Fatalf("%s: %v", route.Operation, err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		res, err := ts.Client().Do(req)
+		if err != nil {
+			t.Fatalf("%s: %v", route.Operation, err)
+		}
+		status := res.StatusCode
+		_ = res.Body.Close()
+		ts.Close()
+
+		if status < 200 || status >= 300 {
+			t.Errorf("%s declares it touches no store, and answered %d to an empty body: "+
+				"the claim cannot be measured on a call that did not run", route.Operation, status)
+			continue
+		}
+		if len(touched) > 0 {
+			t.Errorf("%s declares it touches no store, and the store saw %d touch(es): %s",
+				route.Operation, len(touched), strings.Join(touched, ", "))
+			continue
+		}
+		measured++
+	}
+	if measured == 0 {
+		t.Fatal("no no-store-touch declaration was driven, so this test measured nothing")
+	}
+}
+
+// A nothing-to-refuse claim is checked against the provider's own contract.
+//
+// The operation's request schema must declare nothing but DryRun: a body of one
+// boolean, where every value a client can send is valid and a true one is
+// answered 200 by design. Read out of contracts/<provider>.json, which is the
+// extraction of the provider's published API description, so the check moves
+// when upstream moves.
+func TestAnUnearnableNegativeHasNothingToRefuse(t *testing.T) {
+	docs := map[string]*contract.Doc{}
+	measured := 0
+	for _, route := range unearnedRoutes(t) {
+		claims := false
+		for _, u := range route.Unearnable {
+			if u.Cause == emulator.CauseNoRefusableRequest {
+				claims = true
+			}
+		}
+		if !claims {
+			continue
+		}
+
+		provider := providerOfOperation(t, route.Operation)
+		doc, loaded := docs[provider]
+		if !loaded {
+			var err error
+			doc, err = contract.Load(filepath.Join("..", "..", "contracts", provider+".json"))
+			if err != nil {
+				t.Fatalf("load the %s contract: %v", provider, err)
+			}
+			docs[provider] = doc
+		}
+
+		op, _, found := doc.OperationFor(route.Operation)
+		if !found {
+			t.Errorf("%s declares nothing to refuse and the contract does not describe it", route.Operation)
+			continue
+		}
+		schema, described := doc.Schemas[op.Request]
+		if !described {
+			t.Errorf("%s: the contract names request schema %q and does not define it", route.Operation, op.Request)
+			continue
+		}
+		var extra []string
+		for name := range schema.Properties {
+			if name != "DryRun" {
+				extra = append(extra, name)
+			}
+		}
+		sort.Strings(extra)
+		if len(extra) > 0 {
+			t.Errorf("%s declares no supported client can compose a refusable request, and its schema %s "+
+				"declares %s beside DryRun", route.Operation, op.Request, strings.Join(extra, ", "))
+			continue
+		}
+		measured++
+	}
+	if measured == 0 {
+		t.Fatal("no nothing-to-refuse declaration was checked, so this test measured nothing")
+	}
+}
+
+// Every declaration names an axis a suite can claim and a cause a control
+// checks. A cause nobody measures is a comment with a constant in front of it.
+func TestAnUnearnableDeclarationNamesAKnownAxisAndCause(t *testing.T) {
+	known := map[string]bool{
+		emulator.CauseNoStoreTouch:       true,
+		emulator.CauseNoDestruction:      true,
+		emulator.CauseNoRefusableRequest: true,
+	}
+	for _, route := range unearnedRoutes(t) {
+		for _, u := range route.Unearnable {
+			if u.Axis != emulator.ProvesBehaviour && u.Axis != emulator.ProvesNegative {
+				t.Errorf("%s declares axis %q; only %q and %q are claimed by a suite",
+					route.Operation, u.Axis, emulator.ProvesBehaviour, emulator.ProvesNegative)
+			}
+			if !known[u.Cause] {
+				t.Errorf("%s declares cause %q, which no control checks", route.Operation, u.Cause)
+			}
+		}
+	}
+}
+
+// A reason reads on its own, next to an operation name, exactly as
+// Route.Undriven's does: these lines print side by side in the same report.
+func TestAnUnearnableReasonReadsOnItsOwn(t *testing.T) {
+	for _, route := range unearnedRoutes(t) {
+		for _, u := range route.Unearnable {
+			reason := u.Reason
+			switch {
+			case len(reason) < 30:
+				t.Errorf("%s: %q is too short to say why the axis is out of reach", route.Operation, reason)
+			case strings.HasSuffix(reason, "."):
+				t.Errorf("%s: the reason ends with a full stop; it is printed inside a sentence", route.Operation)
+			case strings.ToLower(reason[:1]) != reason[:1]:
+				t.Errorf("%s: the reason starts with a capital; it is printed inside a sentence", route.Operation)
+			}
+		}
+	}
+}
+
+// providerOfOperation answers which mounted pack claims an operation, from the
+// packs in process rather than from a prefix table: a table would be right
+// today and silently wrong at the first product rename.
+func providerOfOperation(t *testing.T, operation string) string {
+	t.Helper()
+	owners, _, err := operationOwners()
+	if err != nil {
+		t.Fatalf("build the ownership map: %v", err)
+	}
+	owner, ok := owners[operation]
+	if !ok {
+		t.Fatalf("%s is mounted and no pack claims it", operation)
+	}
+	return owner
+}

--- a/internal/core/emulator/emulator.go
+++ b/internal/core/emulator/emulator.go
@@ -104,6 +104,32 @@ type Route struct {
 	// again when a reason survives the client that came to drive it — a stale
 	// excuse reads exactly like a considered one.
 	Undriven string
+	// Unearnable says, per evidence axis, that this operation can never earn it
+	// here — not that nobody has got to it yet. It is the counterpart of Undriven
+	// one step further in: Undriven answers "no client reaches this", Unearnable
+	// answers "clients reach it, and the axis still cannot be earned, for a
+	// reason that is a property of this emulator rather than a gap in the suites".
+	//
+	// It exists because the queue could not tell those apart and told both to go
+	// and write a conformance case. Measured on 2026-08-24: thirteen Outscale
+	// operations sat at zero on `behaviour` and not one of them was reachable.
+	// The axis marks an operation whose store touches fall on a resource created
+	// and then destroyed inside the span; five of the thirteen touch no store at
+	// all, and the other eight touch only kinds this emulator keeps on purpose —
+	// a terminated Vm and a deleted Net peering stay readable here because they
+	// stay readable upstream. No amount of suite writing retires those zeros, and
+	// a queue entry no work can close is the defect #407 removed from the shape
+	// axis and wave 4 removed from `driven`.
+	//
+	// Cause is what makes this a declaration a control can check rather than a
+	// sentence a reader must believe, and each cause names the control that
+	// measures it.
+	//
+	// TestAnUnearnableAxisIsNotAlreadyEarned (internal/cli) fails when the record
+	// says the axis was earned after all — a reason that outlived its cause reads exactly like
+	// a considered one, which is the failure Undriven carries the same guard
+	// against, and which has bitten twice.
+	Unearnable []Unearnable
 	// Legacy marks a second mounting of an operation at the path an earlier
 	// SDK generation used, and says which client still calls it. The real
 	// APIs keep serving their old spellings after a rename — measured:
@@ -118,6 +144,58 @@ type Route struct {
 	// definition (contract.CheckRoutes).
 	Legacy string
 }
+
+// Unearnable is one evidence axis a route declares out of reach, with the cause
+// a control measures.
+type Unearnable struct {
+	// Axis is ProvesBehaviour or ProvesNegative: the two axes a suite claims, and
+	// so the only two an emulator property can put out of reach.
+	Axis string
+	// Cause is one of the Cause* constants, and picks the control that checks the
+	// claim.
+	Cause string
+	// Reason reads on its own, next to an operation name, in the present tense —
+	// the same bar Undriven and Decline.Reason are held to, because these lines
+	// are printed side by side in the same report.
+	Reason string
+}
+
+// The measured causes an axis can be out of reach for.
+const (
+	// CauseNoStoreTouch: the handler touches no store at all, so the behaviour
+	// axis has nothing to attribute to it. Checked by
+	// TestAnUnearnableNoStoreTouchIsMeasured (internal/cli), which drives the
+	// route against a
+	// fresh emulator under store.Observe and requires BOTH that the call was
+	// answered and that the store saw nothing: "it touched nothing" has to be
+	// measured on a call that really happened, or the claim is equally true of a
+	// call that never ran.
+	CauseNoStoreTouch = "no-store-touch"
+	// CauseNoDestruction: the operation's subject is a kind this emulator never
+	// removes from the store, because the real cloud keeps it readable after its
+	// own delete, so the store never sees the destruction half of a lifecycle
+	// for it. Checked in the pack that makes the claim, where the delete can
+	// actually be driven — for Outscale,
+	// TestATerminatedVmAndADeletedPeeringAreKeptRatherThanRemoved
+	// (internal/providers/outscale).
+	CauseNoDestruction = "no-destruction"
+	// CauseNoRefusableRequest: the operation's request declares nothing a
+	// supported client can fill with a value this emulator must refuse — in
+	// practice a body of DryRun alone, where every value is valid and a true one
+	// is answered 200 by design. Checked by
+	// TestAnUnearnableNegativeHasNothingToRefuse (internal/cli), which reads the
+	// request schema
+	// out of the provider's own contract document rather than a list kept here.
+	//
+	// The schema check alone is necessary and not sufficient: CreatePublicIp has
+	// the same one-field request and IS refusable, because the emulator holds
+	// state that can fail it — a finite address block. What excludes that case is
+	// the other half, TestAnUnearnableAxisIsNotAlreadyEarned (internal/cli): an
+	// operation the
+	// record says earned the axis cannot declare it out of reach. The two
+	// controls are only tight together, which is the shape Undriven already has.
+	CauseNoRefusableRequest = "no-refusable-request"
+)
 
 // Pack is one provider implementation.
 type Pack interface {

--- a/internal/providers/outscale/catalog.go
+++ b/internal/providers/outscale/catalog.go
@@ -373,17 +373,45 @@ const accountID = "000000000001"
 // list of the pack that ignored its ResultsPerPage — found the day the probe
 // started holding paged answers to the size they asked, which is the check
 // that fails without this (TestEveryRouteAnswersItsContract, #156).
+// vmTypeFilters are what the catalogue of types can answer. FiltersVmType
+// declares nine (outscale.yaml, osc-api 1.42.0) and this pack read none of
+// them: a client sending --Filters.VmTypeNames got the whole table back with a
+// 200, which is the defect filters.go exists to stop, on the one call every
+// client makes before it creates anything.
+//
+// VmTypeNames is served because it is the one a client sends — it resolves the
+// type it was given before posting a create. The other eight filter on
+// hardware arithmetic (Eths, Gpus, MemorySizes) and are refused by name rather
+// than ignored, so a client asking for a machine shape this catalogue cannot
+// select on is told, instead of being handed everything.
+//
+// TestAVmTypeFilterIsAppliedRatherThanIgnored fails without this.
+var vmTypeFilters = []string{"VmTypeNames"}
+
 func (p *Pack) readVmTypes(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		ResultsPerPage int   `json:"ResultsPerPage"`
-		DryRun         *bool `json:"DryRun"`
+		Filters        filterSet `json:"Filters"`
+		ResultsPerPage *int      `json:"ResultsPerPage"`
+		DryRun         *bool     `json:"DryRun"`
 	}
 	if err := emulator.DecodeJSON(r, &req); err != nil {
 		p.badRequest(w, err.Error())
 		return
 	}
+	if p.refusePageSize(w, req.ResultsPerPage) {
+		return
+	}
+	if p.refuseUnsupported(w, req.Filters, vmTypeFilters...) {
+		return
+	}
+	out := make([]map[string]any, 0, len(vmTypes))
+	for _, vmType := range vmTypes {
+		if matchesStrings(req.Filters, "VmTypeNames", stringOf(vmType["VmTypeName"])) {
+			out = append(out, vmType)
+		}
+	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"VmTypes":         page(vmTypes, req.ResultsPerPage),
+		"VmTypes":         page(out, pageSize(req.ResultsPerPage)),
 		"ResponseContext": p.context(),
 	})
 }
@@ -399,11 +427,14 @@ var imageFilters = []string{"ImageIds", "ImageNames", "AccountIds", "States", "A
 func (p *Pack) readImages(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Filters        filterSet `json:"Filters"`
-		ResultsPerPage int       `json:"ResultsPerPage"`
+		ResultsPerPage *int      `json:"ResultsPerPage"`
 		DryRun         *bool     `json:"DryRun"`
 	}
 	if err := emulator.DecodeJSON(r, &req); err != nil {
 		p.badRequest(w, err.Error())
+		return
+	}
+	if p.refusePageSize(w, req.ResultsPerPage) {
 		return
 	}
 	if p.refuseUnsupported(w, req.Filters, imageFilters...) {
@@ -422,7 +453,7 @@ func (p *Pack) readImages(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"Images":          page(out, req.ResultsPerPage),
+		"Images":          page(out, pageSize(req.ResultsPerPage)),
 		"ResponseContext": p.context(),
 	})
 }
@@ -459,11 +490,14 @@ func (p *Pack) readRegions(w http.ResponseWriter, r *http.Request) {
 func (p *Pack) readSubregions(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Filters        filterSet `json:"Filters"`
-		ResultsPerPage int       `json:"ResultsPerPage"`
+		ResultsPerPage *int      `json:"ResultsPerPage"`
 		DryRun         *bool     `json:"DryRun"`
 	}
 	if err := emulator.DecodeJSON(r, &req); err != nil {
 		p.badRequest(w, err.Error())
+		return
+	}
+	if p.refusePageSize(w, req.ResultsPerPage) {
 		return
 	}
 	if p.refuseUnsupported(w, req.Filters, "SubregionNames", "RegionNames", "States") {
@@ -479,7 +513,7 @@ func (p *Pack) readSubregions(w http.ResponseWriter, r *http.Request) {
 		out = append(out, subregion)
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"Subregions":      page(out, req.ResultsPerPage),
+		"Subregions":      page(out, pageSize(req.ResultsPerPage)),
 		"ResponseContext": p.context(),
 	})
 }
@@ -510,11 +544,14 @@ func netAccessPointServices(region string) []map[string]any {
 func (p *Pack) readNetAccessPointServices(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Filters        filterSet `json:"Filters"`
-		ResultsPerPage int       `json:"ResultsPerPage"`
+		ResultsPerPage *int      `json:"ResultsPerPage"`
 		DryRun         *bool     `json:"DryRun"`
 	}
 	if err := emulator.DecodeJSON(r, &req); err != nil {
 		p.badRequest(w, err.Error())
+		return
+	}
+	if p.refusePageSize(w, req.ResultsPerPage) {
 		return
 	}
 	if p.refuseUnsupported(w, req.Filters, "ServiceIds", "ServiceNames") {
@@ -530,7 +567,7 @@ func (p *Pack) readNetAccessPointServices(w http.ResponseWriter, r *http.Request
 		out = append(out, service)
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"Services":        page(out, req.ResultsPerPage),
+		"Services":        page(out, pageSize(req.ResultsPerPage)),
 		"ResponseContext": p.context(),
 	})
 }
@@ -541,11 +578,14 @@ func (p *Pack) readNetAccessPointServices(w http.ResponseWriter, r *http.Request
 // strings, not objects — measured, and easy to get wrong from the field name.
 func (p *Pack) readPublicIPRanges(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		ResultsPerPage int   `json:"ResultsPerPage"`
+		ResultsPerPage *int  `json:"ResultsPerPage"`
 		DryRun         *bool `json:"DryRun"`
 	}
 	if err := emulator.DecodeJSON(r, &req); err != nil {
 		p.badRequest(w, err.Error())
+		return
+	}
+	if p.refusePageSize(w, req.ResultsPerPage) {
 		return
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{

--- a/internal/providers/outscale/declined_fields.go
+++ b/internal/providers/outscale/declined_fields.go
@@ -9,6 +9,36 @@ import "github.com/stephrobert/feint/internal/core/emulator"
 // catalogue keys, so an entry here never reads as stale over there.
 func (p *Pack) DeclinedFields() []emulator.FieldDecline {
 	return []emulator.FieldDecline{
+		// FileLocation, on the two operations that answer an image a client
+		// made. It is the OMI's own storage URL upstream — an object-storage
+		// path the account can fetch the image bytes from — and this emulator
+		// holds no object storage and copies no bytes, so there is no location
+		// to publish and inventing one would hand a client a URL that answers
+		// nothing.
+		//
+		// True for every path of both operations, which is what #389 says a
+		// decline has to be: createImage REFUSES a FileLocation rather than
+		// storing one ("creating an image from a FileLocation or a
+		// SourceImageId is not emulated"), so no image either operation can
+		// answer carries the field, whichever way it was made.
+		//
+		// Its neighbour in the same measurement is deliberately NOT declined.
+		// BlockDeviceMappings is empty only for an image cut from a VmId, and
+		// carries the snapshot when the client names one — so an operation-level
+		// decline would be true of one kind of object and fiction for the
+		// other, which is exactly the shape #389 cost a release to understand.
+		// That gap is per-object and stays in the corpus, where it is keyed by
+		// the exchange that shows it.
+		{
+			Operation: "osc/Client.CreateImage",
+			Path:      "Image.FileLocation",
+			Reason:    "FileLocation is the object-storage URL the image's bytes live at upstream, and this emulator copies no bytes and serves no object storage, so there is no location a client could fetch",
+		},
+		{
+			Operation: "osc/Client.UpdateImage",
+			Path:      "Image.FileLocation",
+			Reason:    "FileLocation is the object-storage URL the image's bytes live at upstream, and this emulator copies no bytes and serves no object storage, so there is no location a client could fetch",
+		},
 		// A public address links to a machine here (LinkPublicIp --VmId), and
 		// the link is published on the machine's interfaces (linkPublicIPView).
 		// Linking to a bare interface is not modelled, so a standalone Nic's

--- a/internal/providers/outscale/dhcpoptions.go
+++ b/internal/providers/outscale/dhcpoptions.go
@@ -56,7 +56,7 @@ func (p *Pack) defaultDhcpOptions() *resource.Resource {
 
 type readDhcpOptionsRequest struct {
 	Filters        filterSet `json:"Filters"`
-	ResultsPerPage int       `json:"ResultsPerPage"`
+	ResultsPerPage *int      `json:"ResultsPerPage"`
 	DryRun         *bool     `json:"DryRun"`
 }
 
@@ -66,6 +66,9 @@ func (p *Pack) readDhcpOptions(w http.ResponseWriter, r *http.Request) {
 	var req readDhcpOptionsRequest
 	if err := emulator.DecodeJSON(r, &req); err != nil {
 		p.badRequest(w, err.Error())
+		return
+	}
+	if p.refusePageSize(w, req.ResultsPerPage) {
 		return
 	}
 	if p.refuseUnsupported(w, req.Filters, dhcpOptionsFilters...) {
@@ -86,7 +89,7 @@ func (p *Pack) readDhcpOptions(w http.ResponseWriter, r *http.Request) {
 		out = append(out, dhcpOptionsView(res))
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"DhcpOptionsSets": page(out, req.ResultsPerPage),
+		"DhcpOptionsSets": page(out, pageSize(req.ResultsPerPage)),
 		"ResponseContext": p.context(),
 	})
 }

--- a/internal/providers/outscale/internetservices.go
+++ b/internal/providers/outscale/internetservices.go
@@ -57,11 +57,14 @@ var internetServiceFilters = []string{"InternetServiceIds", "LinkNetIds"}
 func (p *Pack) readInternetServices(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Filters        filterSet `json:"Filters"`
-		ResultsPerPage int       `json:"ResultsPerPage"`
+		ResultsPerPage *int      `json:"ResultsPerPage"`
 		DryRun         *bool     `json:"DryRun"`
 	}
 	if err := emulator.DecodeJSON(r, &req); err != nil {
 		p.badRequest(w, err.Error())
+		return
+	}
+	if p.refusePageSize(w, req.ResultsPerPage) {
 		return
 	}
 	if p.refuseUnsupported(w, req.Filters, internetServiceFilters...) {
@@ -77,7 +80,7 @@ func (p *Pack) readInternetServices(w http.ResponseWriter, r *http.Request) {
 		out = append(out, internetServiceView(res))
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"InternetServices": page(out, req.ResultsPerPage),
+		"InternetServices": page(out, pageSize(req.ResultsPerPage)),
 		"ResponseContext":  p.context(),
 	})
 }

--- a/internal/providers/outscale/kept_test.go
+++ b/internal/providers/outscale/kept_test.go
@@ -1,0 +1,125 @@
+package outscale_test
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/store"
+	"github.com/stephrobert/feint/internal/providers/outscale"
+)
+
+// What this pack keeps after its own delete, measured rather than described.
+//
+// Two families here answer a delete with a state transition and leave the
+// record in the store, because that is what the real cloud does: a terminated
+// Vm stays readable while a client polls it, and a deleted Net peering stays
+// readable in the `deleted` state — a state the SDK's own StateNames filter
+// enumerates.
+//
+// That is a deliberate fidelity choice, and it has a measured consequence on
+// this repository's own evidence: the `behaviour` axis marks an operation whose
+// store touches fall on a resource created and DESTROYED inside a span, so
+// seven operations whose only subject is one of these two kinds can never earn
+// it. They declare that at their route (Route.Unearnable, CauseNoDestruction),
+// and this is the control that makes the declaration a measurement instead of a
+// sentence: if either family ever starts being removed from the store, this
+// test goes red, and the seven declarations become wrong at the same moment.
+func TestATerminatedVmAndADeletedPeeringAreKeptRatherThanRemoved(t *testing.T) {
+	env := emulator.DefaultEnv()
+	srv, err := emulator.NewServer(env, outscale.New(env))
+	if err != nil {
+		t.Fatalf("build emulator: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	// The observer is installed after the fixtures are built, so what it
+	// records is the deletes and nothing else.
+	_, images := post(t, ts, "ReadImages", `{}`)
+	imageList, _ := images["Images"].([]any)
+	if len(imageList) == 0 {
+		t.Fatal("the image catalogue is empty, so no machine can be created here")
+	}
+	first, _ := imageList[0].(map[string]any)
+	imageID, _ := first["ImageId"].(string)
+
+	_, created := post(t, ts, "CreateVms", `{"ImageId":"`+imageID+`","VmType":"tinav6.c1r1p2"}`)
+	vms, _ := created["Vms"].([]any)
+	if len(vms) != 1 {
+		t.Fatalf("CreateVms answered %d machines: %v", len(vms), created)
+	}
+	vm, _ := vms[0].(map[string]any)
+	vmID, _ := vm["VmId"].(string)
+
+	netA, _ := netAndSubnet(t, ts, "10.230.0.0/16", "10.230.1.0/24")
+	_, netBDoc := post(t, ts, "CreateNet", `{"IpRange":"10.231.0.0/16"}`)
+	nb, _ := netBDoc["Net"].(map[string]any)
+	netB, _ := nb["NetId"].(string)
+	_, peering := post(t, ts, "CreateNetPeering", `{"SourceNetId":"`+netA+`","AccepterNetId":"`+netB+`"}`)
+	pcx, _ := peering["NetPeering"].(map[string]any)
+	pcxID, _ := pcx["NetPeeringId"].(string)
+	if vmID == "" || pcxID == "" {
+		t.Fatalf("the fixtures were not created: vm %q peering %q", vmID, pcxID)
+	}
+
+	var events []store.Event
+	env.Store.Observe(func(ev store.Event) { events = append(events, ev) })
+
+	if status, body := post(t, ts, "DeleteVms", `{"VmIds":["`+vmID+`"]}`); status != 200 {
+		t.Fatalf("DeleteVms answered %d: %v", status, body)
+	}
+	if status, body := post(t, ts, "DeleteNetPeering", `{"NetPeeringId":"`+pcxID+`"}`); status != 200 {
+		t.Fatalf("DeleteNetPeering answered %d: %v", status, body)
+	}
+
+	// A witness the observer is really wired: DeleteVms removes the root volume
+	// it created, so at least one deletion of some kind must have been seen. A
+	// test asserting only "no deletion of these two kinds" passes identically
+	// when the observer is not attached at all.
+	sawSomeDeletion := false
+	var removed []string
+	for _, ev := range events {
+		if ev.Action != store.EventDeleted {
+			continue
+		}
+		sawSomeDeletion = true
+		if ev.Kind == "vm" || ev.Kind == "netpeering" {
+			removed = append(removed, ev.Kind+" "+ev.ID)
+		}
+	}
+	if !sawSomeDeletion {
+		t.Fatal("the store observed no deletion at all during two deletes; the observer is not measuring")
+	}
+	sort.Strings(removed)
+	if len(removed) > 0 {
+		t.Errorf("the store saw %d resource(s) removed that this pack declares it keeps: %s\n"+
+			"Route.Unearnable(CauseNoDestruction) is now wrong on the operations whose subject they are.",
+			len(removed), strings.Join(removed, ", "))
+	}
+
+	// And they are still readable, which is the fidelity half: keeping a record
+	// nobody can read would be a leak rather than a behaviour.
+	_, states := post(t, ts, "ReadVmsState", `{"AllVms":true}`)
+	if !strings.Contains(mustJSON(t, states), vmID) {
+		t.Errorf("the terminated machine %s is not readable any more: %v", vmID, states)
+	}
+	_, peerings := post(t, ts, "ReadNetPeerings", `{"Filters":{"NetPeeringIds":["`+pcxID+`"]}}`)
+	if !strings.Contains(mustJSON(t, peerings), pcxID) {
+		t.Errorf("the deleted peering %s is not readable any more: %v", pcxID, peerings)
+	}
+}
+
+// mustJSON renders a decoded body back to text, so a presence check reads the
+// whole answer rather than one field somebody guessed the name of.
+func mustJSON(t *testing.T, body map[string]any) string {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("render the body: %v", err)
+	}
+	return string(raw)
+}

--- a/internal/providers/outscale/keypairs.go
+++ b/internal/providers/outscale/keypairs.go
@@ -31,7 +31,7 @@ type readKeypairsRequest struct {
 	// ResultsPerPage pages like every other Read* — the probe sends it since
 	// it started exercising the parameter (#156), and the unread-fields gate
 	// of `mise run conformance` fails when a handler ignores it.
-	ResultsPerPage int `json:"ResultsPerPage"`
+	ResultsPerPage *int `json:"ResultsPerPage"`
 }
 
 // keypairFilters are what a keypair answers from what is stored. Tags are not
@@ -104,6 +104,9 @@ func (p *Pack) readKeypairs(w http.ResponseWriter, r *http.Request) {
 		p.badRequest(w, err.Error())
 		return
 	}
+	if p.refusePageSize(w, req.ResultsPerPage) {
+		return
+	}
 	if p.refuseUnsupported(w, req.Filters, keypairFilters...) {
 		return
 	}
@@ -122,7 +125,7 @@ func (p *Pack) readKeypairs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"Keypairs":        page(out, req.ResultsPerPage),
+		"Keypairs":        page(out, pageSize(req.ResultsPerPage)),
 		"ResponseContext": p.context(),
 	})
 }

--- a/internal/providers/outscale/natservices.go
+++ b/internal/providers/outscale/natservices.go
@@ -109,11 +109,14 @@ var natServiceFilters = []string{"NatServiceIds", "NetIds", "SubnetIds", "States
 func (p *Pack) readNatServices(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Filters        filterSet `json:"Filters"`
-		ResultsPerPage int       `json:"ResultsPerPage"`
+		ResultsPerPage *int      `json:"ResultsPerPage"`
 		DryRun         *bool     `json:"DryRun"`
 	}
 	if err := emulator.DecodeJSON(r, &req); err != nil {
 		p.badRequest(w, err.Error())
+		return
+	}
+	if p.refusePageSize(w, req.ResultsPerPage) {
 		return
 	}
 	if p.refuseUnsupported(w, req.Filters, natServiceFilters...) {
@@ -131,7 +134,7 @@ func (p *Pack) readNatServices(w http.ResponseWriter, r *http.Request) {
 		out = append(out, natServiceView(res))
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"NatServices":     page(out, req.ResultsPerPage),
+		"NatServices":     page(out, pageSize(req.ResultsPerPage)),
 		"ResponseContext": p.context(),
 	})
 }

--- a/internal/providers/outscale/netpeerings.go
+++ b/internal/providers/outscale/netpeerings.go
@@ -104,7 +104,7 @@ type netPeeringIDRequest struct {
 
 type readNetPeeringsRequest struct {
 	Filters        filterSet `json:"Filters"`
-	ResultsPerPage int       `json:"ResultsPerPage"`
+	ResultsPerPage *int      `json:"ResultsPerPage"`
 	DryRun         *bool     `json:"DryRun"`
 }
 
@@ -339,6 +339,9 @@ func (p *Pack) readNetPeerings(w http.ResponseWriter, r *http.Request) {
 		p.badRequest(w, err.Error())
 		return
 	}
+	if p.refusePageSize(w, req.ResultsPerPage) {
+		return
+	}
 	if p.refuseUnsupported(w, req.Filters, netPeeringFilters...) {
 		return
 	}
@@ -359,7 +362,7 @@ func (p *Pack) readNetPeerings(w http.ResponseWriter, r *http.Request) {
 		out = append(out, netPeeringView(res))
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"NetPeerings":     page(out, req.ResultsPerPage),
+		"NetPeerings":     page(out, pageSize(req.ResultsPerPage)),
 		"ResponseContext": p.context(),
 	})
 }

--- a/internal/providers/outscale/nets.go
+++ b/internal/providers/outscale/nets.go
@@ -71,7 +71,7 @@ type createSubnetRequest struct {
 type readNetsRequest struct {
 	Filters        filterSet `json:"Filters"`
 	DryRun         *bool     `json:"DryRun"`
-	ResultsPerPage int       `json:"ResultsPerPage"`
+	ResultsPerPage *int      `json:"ResultsPerPage"`
 }
 
 // netFilters and subnetFilters are what these resources can answer from what is
@@ -94,7 +94,7 @@ var (
 type readSubnetsRequest struct {
 	Filters        filterSet `json:"Filters"`
 	DryRun         *bool     `json:"DryRun"`
-	ResultsPerPage int       `json:"ResultsPerPage"`
+	ResultsPerPage *int      `json:"ResultsPerPage"`
 }
 
 type deleteNetRequest struct {
@@ -167,6 +167,9 @@ func (p *Pack) readNets(w http.ResponseWriter, r *http.Request) {
 		p.badRequest(w, err.Error())
 		return
 	}
+	if p.refusePageSize(w, req.ResultsPerPage) {
+		return
+	}
 	if p.refuseUnsupported(w, req.Filters, netFilters...) {
 		return
 	}
@@ -184,7 +187,7 @@ func (p *Pack) readNets(w http.ResponseWriter, r *http.Request) {
 	}
 
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"Nets":            page(nets, req.ResultsPerPage),
+		"Nets":            page(nets, pageSize(req.ResultsPerPage)),
 		"ResponseContext": p.context(),
 	})
 }
@@ -381,6 +384,9 @@ func (p *Pack) readSubnets(w http.ResponseWriter, r *http.Request) {
 		p.badRequest(w, err.Error())
 		return
 	}
+	if p.refusePageSize(w, req.ResultsPerPage) {
+		return
+	}
 	if p.refuseUnsupported(w, req.Filters, subnetFilters...) {
 		return
 	}
@@ -400,7 +406,7 @@ func (p *Pack) readSubnets(w http.ResponseWriter, r *http.Request) {
 	}
 
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"Subnets":         page(subnets, req.ResultsPerPage),
+		"Subnets":         page(subnets, pageSize(req.ResultsPerPage)),
 		"ResponseContext": p.context(),
 	})
 }

--- a/internal/providers/outscale/nics.go
+++ b/internal/providers/outscale/nics.go
@@ -50,11 +50,14 @@ var nicFilters = []string{
 func (p *Pack) readNics(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Filters        filterSet `json:"Filters"`
-		ResultsPerPage int       `json:"ResultsPerPage"`
+		ResultsPerPage *int      `json:"ResultsPerPage"`
 		DryRun         *bool     `json:"DryRun"`
 	}
 	if err := emulator.DecodeJSON(r, &req); err != nil {
 		p.badRequest(w, err.Error())
+		return
+	}
+	if p.refusePageSize(w, req.ResultsPerPage) {
 		return
 	}
 	if p.refuseUnsupported(w, req.Filters, nicFilters...) {
@@ -94,7 +97,7 @@ func (p *Pack) readNics(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"Nics":            page(out, req.ResultsPerPage),
+		"Nics":            page(out, pageSize(req.ResultsPerPage)),
 		"ResponseContext": p.context(),
 	})
 }

--- a/internal/providers/outscale/pack.go
+++ b/internal/providers/outscale/pack.go
@@ -175,6 +175,60 @@ func (p *Pack) dryRunnable(handler http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
+// What this pack can never earn on the two axes a suite claims, and why.
+//
+// Every line below was measured before it was written, by opening a real
+// behaviour span against a fresh emulator, driving the operation through a full
+// cycle, and reading back what the span marked (2026-08-24). Two of the
+// thirteen candidates came back earnable and are NOT declared here: DeleteTags
+// is marked when the resource it untags is created and destroyed inside the
+// span, and CreatePublicIp is refused when the address block runs out. Both are
+// driven by oapi-cli.sh instead, which is the point of measuring first.
+
+// statelessBehaviour declares a catalogue read out of reach on `behaviour`.
+//
+// The axis marks an operation whose store touches fall on a resource created
+// and destroyed inside the span. These handlers answer from a table in the
+// binary and touch no store at all, so there is nothing to attribute — measured,
+// not assumed: TestAnUnearnableNoStoreTouchIsMeasured (internal/cli) drives
+// each one and
+// requires the call to be answered AND the store to see nothing.
+func statelessBehaviour(what string) emulator.Unearnable {
+	return emulator.Unearnable{
+		Axis:  emulator.ProvesBehaviour,
+		Cause: emulator.CauseNoStoreTouch,
+		Reason: "no lifecycle can be attributed to it: it answers " + what +
+			" from a fixed table and touches no store, so nothing it reads is ever created and destroyed",
+	}
+}
+
+// keptSubjectBehaviour declares an operation out of reach on `behaviour`
+// because its subject outlives its own delete here, as it does upstream.
+func keptSubjectBehaviour(subject, upstream string) emulator.Unearnable {
+	return emulator.Unearnable{
+		Axis:  emulator.ProvesBehaviour,
+		Cause: emulator.CauseNoDestruction,
+		Reason: "its subject is " + subject + ", which this emulator marks rather than removes, because " + upstream +
+			" — so the store never sees the destruction half of a lifecycle for it",
+	}
+}
+
+// nothingToRefuse declares an operation out of reach on `negative`.
+func nothingToRefuse(what string) emulator.Unearnable {
+	return emulator.Unearnable{
+		Axis:  emulator.ProvesNegative,
+		Cause: emulator.CauseNoRefusableRequest,
+		Reason: "no supported client can compose a request it must refuse: " + what +
+			", and this emulator holds no state that can fail the call either",
+	}
+}
+
+// unearnable attaches axis declarations to a route.
+func unearnable(r emulator.Route, u ...emulator.Unearnable) emulator.Route {
+	r.Unearnable = u
+	return r
+}
+
 // Routes implements emulator.Pack.
 func (p *Pack) Routes() []emulator.Route {
 	return []emulator.Route{
@@ -182,7 +236,8 @@ func (p *Pack) Routes() []emulator.Route {
 		p.route("ReadVms", p.readVms),
 		p.route("CreateVms", p.createVms),
 		p.route("UpdateVm", p.updateVm),
-		p.route("ReadAdminPassword", p.readAdminPassword),
+		unearnable(p.route("ReadAdminPassword", p.readAdminPassword),
+			keptSubjectBehaviour("a Vm", "a terminated machine stays readable on the real cloud and a client polls it there")),
 
 		// Tags, which the Terraform provider calls on almost every resource.
 		p.route("CreateTags", p.createTags),
@@ -197,19 +252,25 @@ func (p *Pack) Routes() []emulator.Route {
 		p.route("DeleteVolume", p.deleteVolume),
 		p.route("LinkVolume", p.linkVolume),
 		p.route("UnlinkVolume", p.unlinkVolume),
-		p.route("ReadVmsState", p.readVmsState),
+		unearnable(p.route("ReadVmsState", p.readVmsState),
+			keptSubjectBehaviour("a Vm", "a terminated machine stays readable on the real cloud and a client polls it there")),
 		p.route("DeleteVms", p.deleteVms),
 		p.route("StartVms", p.startVms),
-		p.route("StopVms", p.stopVms),
+		unearnable(p.route("StopVms", p.stopVms),
+			keptSubjectBehaviour("a Vm", "a terminated machine stays readable on the real cloud and a client polls it there")),
 		p.route("RebootVms", p.rebootVms),
 
 		// The inventory every client reads before it creates anything. The
 		// Scaleway pack learned this the hard way: decline the catalogue and the
 		// official CLI cannot create a server at all.
-		p.route("ReadVmTypes", p.readVmTypes),
+		unearnable(p.route("ReadVmTypes", p.readVmTypes),
+			statelessBehaviour("the type catalogue")),
 		p.route("ReadImages", p.readImages),
-		p.route("ReadRegions", p.readRegions),
-		p.route("ReadSubregions", p.readSubregions),
+		unearnable(p.route("ReadRegions", p.readRegions),
+			statelessBehaviour("the region and the endpoint a client calls next"),
+			nothingToRefuse("ReadRegionsRequest declares DryRun and nothing else")),
+		unearnable(p.route("ReadSubregions", p.readSubregions),
+			statelessBehaviour("the region's zones")),
 
 		// Nets and Subnets: the addressing plane. A block is parsed, its mask
 		// bounded, its containment and its overlap checked, and the address count
@@ -263,7 +324,8 @@ func (p *Pack) Routes() []emulator.Route {
 		// The gateway a Net attaches, and the egress a subnet buys with an
 		// address: the resource algebra Terraform's destroy order depends on.
 		// Control plane only — internetservices.go says what does not flow.
-		p.route("CreateInternetService", p.createInternetService),
+		unearnable(p.route("CreateInternetService", p.createInternetService),
+			nothingToRefuse("CreateInternetServiceRequest declares DryRun and nothing else")),
 		p.route("ReadInternetServices", p.readInternetServices),
 		p.route("LinkInternetService", p.linkInternetService),
 		p.route("UnlinkInternetService", p.unlinkInternetService),
@@ -282,10 +344,14 @@ func (p *Pack) Routes() []emulator.Route {
 		// the SDK's NetPeeringStateName enum; netpeerings.go names what
 		// mono-tenancy makes indistinguishable.
 		p.route("CreateNetPeering", p.createNetPeering),
-		p.route("AcceptNetPeering", p.acceptNetPeering),
-		p.route("RejectNetPeering", p.rejectNetPeering),
-		p.route("DeleteNetPeering", p.deleteNetPeering),
-		p.route("ReadNetPeerings", p.readNetPeerings),
+		unearnable(p.route("AcceptNetPeering", p.acceptNetPeering),
+			keptSubjectBehaviour("a Net peering", "a deleted peering stays readable in the deleted state, which the SDK's own StateNames filter enumerates")),
+		unearnable(p.route("RejectNetPeering", p.rejectNetPeering),
+			keptSubjectBehaviour("a Net peering", "a deleted peering stays readable in the deleted state, which the SDK's own StateNames filter enumerates")),
+		unearnable(p.route("DeleteNetPeering", p.deleteNetPeering),
+			keptSubjectBehaviour("a Net peering", "a deleted peering stays readable in the deleted state, which the SDK's own StateNames filter enumerates")),
+		unearnable(p.route("ReadNetPeerings", p.readNetPeerings),
+			keptSubjectBehaviour("a Net peering", "a deleted peering stays readable in the deleted state, which the SDK's own StateNames filter enumerates")),
 
 		// Snapshots as control-plane records (OSC-4, #13); snapshots.go carries
 		// the no-bytes caveat.
@@ -312,8 +378,10 @@ func (p *Pack) Routes() []emulator.Route {
 		p.route("UnlinkLoadBalancerBackendMachines", p.unlinkLoadBalancerBackendMachines),
 		p.route("DeleteLoadBalancer", p.deleteLoadBalancer),
 
-		p.route("ReadNetAccessPointServices", p.readNetAccessPointServices),
-		p.route("ReadPublicIpRanges", p.readPublicIPRanges),
+		unearnable(p.route("ReadNetAccessPointServices", p.readNetAccessPointServices),
+			statelessBehaviour("the services a Net access point can target")),
+		unearnable(p.route("ReadPublicIpRanges", p.readPublicIPRanges),
+			statelessBehaviour("the public blocks the cloud routes")),
 	}
 }
 

--- a/internal/providers/outscale/paging.go
+++ b/internal/providers/outscale/paging.go
@@ -1,0 +1,82 @@
+package outscale
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// Pagination, and the one bound Outscale states about it.
+//
+// Twenty-one Read* request schemas of their own API description declare
+// ResultsPerPage, and all twenty-one describe it in the same words: "The
+// maximum number of logs returned in a single response (between `1` and
+// `1000`, both included)" (outscale.yaml, osc-api 1.42.0). So the bound is the
+// vendor's, not a number chosen here, and a value outside it is a request the
+// real API refuses.
+//
+// This pack used to take any value and treat everything below one as "no
+// limit", so `ResultsPerPage: 0` — which the API refuses — was answered with
+// the whole inventory. That is the same family as the filter that was ignored
+// rather than applied (filters.go): an argument the client sent, the server
+// did not honour, and nobody was told.
+//
+// The bound lives here rather than in each handler for the reason
+// refuseUnsupported does: a control copied into twenty handlers is a control
+// one handler forgets, and the twenty-first to be written would forget it too.
+//
+// ReadLoadBalancers is the one Read* of this pack that is NOT bounded here, and
+// that is deliberate: ReadLoadBalancersRequest declares no ResultsPerPage at
+// all, so asserting a bound on it would be asserting something the API does not
+// say. The field it reads is dead — no supported client can send it — and it is
+// left alone rather than given a bound nobody published.
+const (
+	resultsPerPageMin = 1
+	resultsPerPageMax = 1000
+)
+
+// refusePageSize answers the client when ResultsPerPage is outside the bound
+// the API declares, and reports whether it did.
+//
+// The parameter is a pointer because zero is a value a client can send and the
+// API refuses. Decoded into an int, `ResultsPerPage: 0` is indistinguishable
+// from a request that never mentioned the field, and the handler would accept
+// exactly the value the real cloud rejects — a hole shaped like the Go zero
+// value, which is why the shape of the field is part of the fix.
+//
+// TestAPageSizeOutsideTheBoundIsRefused and
+// TestAnAbsentPageSizeIsNotAZeroPageSize fail without this.
+func (p *Pack) refusePageSize(w http.ResponseWriter, size *int) bool {
+	if size == nil || (*size >= resultsPerPageMin && *size <= resultsPerPageMax) {
+		return false
+	}
+	p.badRequest(w, fmt.Sprintf(
+		"ResultsPerPage is %d; this call takes a value between %d and %d, both included",
+		*size, resultsPerPageMin, resultsPerPageMax))
+	return true
+}
+
+// pageSize is the size to truncate to: zero when the client asked for none,
+// which page reads as "no limit". Every value it can return other than zero has
+// already passed refusePageSize.
+func pageSize(size *int) int {
+	if size == nil {
+		return 0
+	}
+	return *size
+}
+
+// page truncates a list to the size the client asked for.
+//
+// No NextPageToken is issued: this emulator holds a handful of resources, so
+// there is never a second page to fetch, and a token pointing at nothing is
+// worse than none. What matters is that a client asking for N rows is not
+// handed more — the field was declared and unread, which is the shape that told
+// a client its page size was honoured when it was not.
+//
+// TestResultsPerPageIsHonoured fails without this.
+func page[T any](rows []T, size int) []T {
+	if size <= 0 || len(rows) <= size {
+		return rows
+	}
+	return rows[:size]
+}

--- a/internal/providers/outscale/paging_test.go
+++ b/internal/providers/outscale/paging_test.go
@@ -1,0 +1,135 @@
+package outscale_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+// The bound Outscale states on ResultsPerPage, and the shape of the field that
+// makes it enforceable.
+//
+// These are written against the operations a real client can actually send the
+// field to — the conformance suite drives five of them — but the guard is
+// shared, so the population here is the whole set of actions whose request
+// schema declares it.
+
+// pagedActions are the actions whose Outscale request schema declares
+// ResultsPerPage. ReadLoadBalancers is deliberately absent: its schema declares
+// none, and this pack asserts no bound there.
+var pagedActions = []string{
+	"ReadDhcpOptions", "ReadImages", "ReadInternetServices", "ReadKeypairs",
+	"ReadNatServices", "ReadNetAccessPointServices", "ReadNetPeerings",
+	"ReadNets", "ReadNics", "ReadPublicIpRanges", "ReadPublicIps",
+	"ReadRouteTables", "ReadSecurityGroups", "ReadSnapshots", "ReadSubnets",
+	"ReadSubregions", "ReadTags", "ReadVmTypes", "ReadVms", "ReadVmsState",
+	"ReadVolumes",
+}
+
+// A page size outside the published bound is refused, on every action that
+// declares the field.
+//
+// "The maximum number of logs returned in a single response (between `1` and
+// `1000`, both included)" — outscale.yaml, identical wording on all twenty-one
+// request schemas. Before this, any value was taken and anything below one was
+// silently read as "no limit", so the exact value the API refuses returned the
+// whole inventory with a 200.
+func TestAPageSizeOutsideTheBoundIsRefused(t *testing.T) {
+	ts := newServer(t)
+	for _, action := range pagedActions {
+		for _, size := range []int{0, -1, 1001} {
+			status, body := post(t, ts, action, fmt.Sprintf(`{"ResultsPerPage":%d}`, size))
+			if status != http.StatusBadRequest {
+				t.Errorf("%s with ResultsPerPage %d answered %d; the API takes 1 to 1000", action, size, status)
+				continue
+			}
+			// A refusal a client cannot decode is a refusal it reports as a
+			// parsing failure, which sends whoever reads it to the wrong place.
+			errs, _ := body["Errors"].([]any)
+			if len(errs) == 0 {
+				t.Errorf("%s refused ResultsPerPage %d outside the Outscale envelope: %v", action, size, body)
+			}
+		}
+	}
+}
+
+// An absent page size is not a zero page size, and the pointer is what keeps
+// the two apart.
+//
+// This is the half a bound alone would get wrong. Decoded into an int, a
+// request that never mentions ResultsPerPage arrives as zero — the value the
+// API refuses — so a bound written against the int would refuse every ordinary
+// read of every client. The witness is that both hold at once: 0 sent is
+// refused (above), 0 never sent is served.
+func TestAnAbsentPageSizeIsNotAZeroPageSize(t *testing.T) {
+	ts := newServer(t)
+	for _, action := range pagedActions {
+		status, body := post(t, ts, action, `{}`)
+		if status != http.StatusOK {
+			t.Errorf("%s answered %d to a request that names no page size: %v", action, status, body)
+		}
+	}
+}
+
+// A page size inside the bound is honoured rather than merely accepted, so the
+// guard cannot be satisfied by refusing everything.
+func TestAPageSizeInsideTheBoundStillTruncates(t *testing.T) {
+	ts := newServer(t)
+	// The type catalogue is fixed and holds more than one row, which is what
+	// makes the truncation observable without creating anything.
+	_, all := post(t, ts, "ReadVmTypes", `{}`)
+	rows, _ := all["VmTypes"].([]any)
+	if len(rows) < 2 {
+		t.Fatalf("the type catalogue holds %d rows; this test measures nothing below two", len(rows))
+	}
+	_, one := post(t, ts, "ReadVmTypes", `{"ResultsPerPage":1}`)
+	got, _ := one["VmTypes"].([]any)
+	if len(got) != 1 {
+		t.Fatalf("ResultsPerPage 1 answered %d rows out of %d", len(got), len(rows))
+	}
+}
+
+// A filter ReadVmTypes cannot apply is refused by name, and the one it serves
+// selects.
+//
+// The defect: FiltersVmType declares nine filters and this handler read none of
+// them, so `--Filters.VmTypeNames tinav6.c1r1p2` answered the whole table with
+// a 200. That is indistinguishable from success for a client that then picks
+// row zero, and it is the same family filters.go was written to remove from
+// every other read of this pack.
+func TestAVmTypeFilterIsAppliedRatherThanIgnored(t *testing.T) {
+	ts := newServer(t)
+	_, all := post(t, ts, "ReadVmTypes", `{}`)
+	rows, _ := all["VmTypes"].([]any)
+	if len(rows) < 2 {
+		t.Fatalf("the type catalogue holds %d rows; this test measures nothing below two", len(rows))
+	}
+	first, _ := rows[0].(map[string]any)
+	name, _ := first["VmTypeName"].(string)
+	if name == "" {
+		t.Fatal("the first catalogue row carries no VmTypeName")
+	}
+
+	status, one := post(t, ts, "ReadVmTypes", `{"Filters":{"VmTypeNames":["`+name+`"]}}`)
+	if status != http.StatusOK {
+		t.Fatalf("ReadVmTypes refused the filter it serves: %d %v", status, one)
+	}
+	got, _ := one["VmTypes"].([]any)
+	if len(got) != 1 {
+		t.Fatalf("VmTypeNames [%s] answered %d rows out of %d; the filter is not applied", name, len(got), len(rows))
+	}
+
+	// A name that matches nothing answers nothing. Without this, a filter that
+	// is read but never narrows passes the assertion above whenever the
+	// catalogue holds exactly one match by luck.
+	_, none := post(t, ts, "ReadVmTypes", `{"Filters":{"VmTypeNames":["feint.nosuchtype"]}}`)
+	if empty, _ := none["VmTypes"].([]any); len(empty) != 0 {
+		t.Fatalf("a type name matching nothing answered %d rows", len(empty))
+	}
+
+	// And one it cannot apply is refused rather than ignored.
+	status, refused := post(t, ts, "ReadVmTypes", `{"Filters":{"MemorySizes":[8]}}`)
+	if status != http.StatusBadRequest {
+		t.Fatalf("ReadVmTypes answered %d to a filter it does not apply: %v", status, refused)
+	}
+}

--- a/internal/providers/outscale/publicips.go
+++ b/internal/providers/outscale/publicips.go
@@ -194,11 +194,14 @@ var publicIPFilters = []string{"PublicIpIds", "PublicIps", "LinkPublicIpIds", "V
 func (p *Pack) readPublicIPs(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Filters        filterSet `json:"Filters"`
-		ResultsPerPage int       `json:"ResultsPerPage"`
+		ResultsPerPage *int      `json:"ResultsPerPage"`
 		DryRun         *bool     `json:"DryRun"`
 	}
 	if err := emulator.DecodeJSON(r, &req); err != nil {
 		p.badRequest(w, err.Error())
+		return
+	}
+	if p.refusePageSize(w, req.ResultsPerPage) {
 		return
 	}
 	if p.refuseUnsupported(w, req.Filters, publicIPFilters...) {
@@ -217,7 +220,7 @@ func (p *Pack) readPublicIPs(w http.ResponseWriter, r *http.Request) {
 		out = append(out, publicIPView(res))
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"PublicIps":       page(out, req.ResultsPerPage),
+		"PublicIps":       page(out, pageSize(req.ResultsPerPage)),
 		"ResponseContext": p.context(),
 	})
 }

--- a/internal/providers/outscale/routetables.go
+++ b/internal/providers/outscale/routetables.go
@@ -72,7 +72,7 @@ func (p *Pack) mainRouteTable(netID, ipRange string) *resource.Resource {
 
 type readRouteTablesRequest struct {
 	Filters        filterSet `json:"Filters"`
-	ResultsPerPage int       `json:"ResultsPerPage"`
+	ResultsPerPage *int      `json:"ResultsPerPage"`
 	DryRun         *bool     `json:"DryRun"`
 }
 
@@ -92,6 +92,9 @@ func (p *Pack) readRouteTables(w http.ResponseWriter, r *http.Request) {
 		p.badRequest(w, err.Error())
 		return
 	}
+	if p.refusePageSize(w, req.ResultsPerPage) {
+		return
+	}
 	if p.refuseUnsupported(w, req.Filters, routeTableFilters...) {
 		return
 	}
@@ -104,7 +107,7 @@ func (p *Pack) readRouteTables(w http.ResponseWriter, r *http.Request) {
 		out = append(out, routeTableReadView(res))
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"RouteTables":     page(out, req.ResultsPerPage),
+		"RouteTables":     page(out, pageSize(req.ResultsPerPage)),
 		"ResponseContext": p.context(),
 	})
 }

--- a/internal/providers/outscale/securitygroups.go
+++ b/internal/providers/outscale/securitygroups.go
@@ -81,7 +81,7 @@ func (p *Pack) defaultSecurityGroup(netID string) *resource.Resource {
 
 type readSecurityGroupsRequest struct {
 	Filters        filterSet `json:"Filters"`
-	ResultsPerPage int       `json:"ResultsPerPage"`
+	ResultsPerPage *int      `json:"ResultsPerPage"`
 	DryRun         *bool     `json:"DryRun"`
 }
 
@@ -93,6 +93,9 @@ func (p *Pack) readSecurityGroups(w http.ResponseWriter, r *http.Request) {
 	var req readSecurityGroupsRequest
 	if err := emulator.DecodeJSON(r, &req); err != nil {
 		p.badRequest(w, err.Error())
+		return
+	}
+	if p.refusePageSize(w, req.ResultsPerPage) {
 		return
 	}
 	if p.refuseUnsupported(w, req.Filters, securityGroupFilters...) {
@@ -113,7 +116,7 @@ func (p *Pack) readSecurityGroups(w http.ResponseWriter, r *http.Request) {
 		out = append(out, securityGroupView(res))
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"SecurityGroups":  page(out, req.ResultsPerPage),
+		"SecurityGroups":  page(out, pageSize(req.ResultsPerPage)),
 		"ResponseContext": p.context(),
 	})
 }

--- a/internal/providers/outscale/snapshots.go
+++ b/internal/providers/outscale/snapshots.go
@@ -89,11 +89,14 @@ var snapshotFilters = []string{
 func (p *Pack) readSnapshots(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Filters        filterSet `json:"Filters"`
-		ResultsPerPage int       `json:"ResultsPerPage"`
+		ResultsPerPage *int      `json:"ResultsPerPage"`
 		DryRun         *bool     `json:"DryRun"`
 	}
 	if err := emulator.DecodeJSON(r, &req); err != nil {
 		p.badRequest(w, err.Error())
+		return
+	}
+	if p.refusePageSize(w, req.ResultsPerPage) {
 		return
 	}
 	if p.refuseUnsupported(w, req.Filters, snapshotFilters...) {
@@ -115,7 +118,7 @@ func (p *Pack) readSnapshots(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"Snapshots":       page(out, req.ResultsPerPage),
+		"Snapshots":       page(out, pageSize(req.ResultsPerPage)),
 		"ResponseContext": p.context(),
 	})
 }

--- a/internal/providers/outscale/tags.go
+++ b/internal/providers/outscale/tags.go
@@ -202,10 +202,13 @@ func (p *Pack) deleteTags(w http.ResponseWriter, r *http.Request) {
 func (p *Pack) readTags(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Filters        filterSet `json:"Filters"`
-		ResultsPerPage int       `json:"ResultsPerPage"`
+		ResultsPerPage *int      `json:"ResultsPerPage"`
 	}
 	if err := emulator.DecodeJSON(r, &req); err != nil {
 		p.badRequest(w, err.Error())
+		return
+	}
+	if p.refusePageSize(w, req.ResultsPerPage) {
 		return
 	}
 	if p.refuseUnsupported(w, req.Filters, "ResourceIds", "Keys", "Values", "ResourceTypes") {
@@ -243,7 +246,7 @@ func (p *Pack) readTags(w http.ResponseWriter, r *http.Request) {
 	// holding paged answers to the size they asked (#156); the probe run of
 	// `mise run conformance` fails without it.
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"Tags":            page(out, req.ResultsPerPage),
+		"Tags":            page(out, pageSize(req.ResultsPerPage)),
 		"ResponseContext": p.context(),
 	})
 }

--- a/internal/providers/outscale/vms.go
+++ b/internal/providers/outscale/vms.go
@@ -43,7 +43,7 @@ type readVmsRequest struct {
 	// The page size every Terraform read sends. Declared and unread, it was a
 	// field the client believed was honoured: a client asking for ten rows and
 	// getting a thousand pages nothing.
-	ResultsPerPage int `json:"ResultsPerPage"`
+	ResultsPerPage *int `json:"ResultsPerPage"`
 }
 
 // vmFilters are the ones a Vm can answer from what this pack stores. Everything
@@ -152,6 +152,9 @@ func (p *Pack) readVms(w http.ResponseWriter, r *http.Request) {
 		p.badRequest(w, err.Error())
 		return
 	}
+	if p.refusePageSize(w, req.ResultsPerPage) {
+		return
+	}
 
 	if p.refuseUnsupported(w, req.Filters, vmFilters...) {
 		return
@@ -183,25 +186,9 @@ func (p *Pack) readVms(w http.ResponseWriter, r *http.Request) {
 	}
 
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"Vms":             page(vms, req.ResultsPerPage),
+		"Vms":             page(vms, pageSize(req.ResultsPerPage)),
 		"ResponseContext": p.context(),
 	})
-}
-
-// page truncates a list to the size the client asked for.
-//
-// No NextPageToken is issued: this emulator holds a handful of resources, so
-// there is never a second page to fetch, and a token pointing at nothing is
-// worse than none. What matters is that a client asking for N rows is not
-// handed more — the field was declared and unread, which is the shape that told
-// a client its page size was honoured when it was not.
-//
-// TestResultsPerPageIsHonoured fails without this.
-func page[T any](rows []T, size int) []T {
-	if size <= 0 || len(rows) <= size {
-		return rows
-	}
-	return rows[:size]
 }
 
 // vmMatches applies every filter this pack serves. A Vm has to pass all of

--- a/internal/providers/outscale/volumes.go
+++ b/internal/providers/outscale/volumes.go
@@ -104,7 +104,7 @@ func (p *Pack) createVolume(w http.ResponseWriter, r *http.Request) {
 
 type readVolumesRequest struct {
 	Filters        filterSet `json:"Filters"`
-	ResultsPerPage int       `json:"ResultsPerPage"`
+	ResultsPerPage *int      `json:"ResultsPerPage"`
 	DryRun         *bool     `json:"DryRun"`
 }
 
@@ -125,6 +125,9 @@ func (p *Pack) readVolumes(w http.ResponseWriter, r *http.Request) {
 		p.badRequest(w, err.Error())
 		return
 	}
+	if p.refusePageSize(w, req.ResultsPerPage) {
+		return
+	}
 	if p.refuseUnsupported(w, req.Filters, volumeFilters...) {
 		return
 	}
@@ -137,7 +140,7 @@ func (p *Pack) readVolumes(w http.ResponseWriter, r *http.Request) {
 		out = append(out, p.volumeView(res))
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"Volumes":         page(out, req.ResultsPerPage),
+		"Volumes":         page(out, pageSize(req.ResultsPerPage)),
 		"ResponseContext": p.context(),
 	})
 }
@@ -394,11 +397,14 @@ func (p *Pack) readVmsState(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Filters        filterSet `json:"Filters"`
 		AllVms         *bool     `json:"AllVms"`
-		ResultsPerPage int       `json:"ResultsPerPage"`
+		ResultsPerPage *int      `json:"ResultsPerPage"`
 		DryRun         *bool     `json:"DryRun"`
 	}
 	if err := emulator.DecodeJSON(r, &req); err != nil {
 		p.badRequest(w, err.Error())
+		return
+	}
+	if p.refusePageSize(w, req.ResultsPerPage) {
 		return
 	}
 	if p.refuseUnsupported(w, req.Filters, "VmIds", "VmStates", "SubregionNames") {
@@ -433,7 +439,7 @@ func (p *Pack) readVmsState(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"VmStates":        page(out, req.ResultsPerPage),
+		"VmStates":        page(out, pageSize(req.ResultsPerPage)),
 		"ResponseContext": p.context(),
 	})
 }

--- a/tools/conformance/outscale/oapi-cli.sh
+++ b/tools/conformance/outscale/oapi-cli.sh
@@ -894,6 +894,82 @@ printf '%s' "$keys" | jq -e '.Keypairs | length == 0' >/dev/null \
 prove_end "$span"
 ok "nothing left behind"
 
+# The refusals a client can ask for, on the reads nothing else ever refused.
+#
+# `negative` is earned by an operation really answering 4xx to a real client
+# inside a span where a suite demanded a refusal, and until now the only thing
+# in this repository that earned it for Outscale was refusals.sh, which reissues
+# what the real cloud refused (#390). That left the whole read surface at zero:
+# a recording session is driven at bogus *identifiers*, and a bogus identifier
+# in a Read is an empty list, not a refusal (#428).
+#
+# What refuses a read here is the filter guard of filters.go: a filter this pack
+# does not apply is answered 400 naming the field, never ignored. Each line
+# below sends ONE filter that Outscale's own API description declares on that
+# call and this pack does not serve, so the request is valid to the client,
+# valid to the API, and refused by the emulator on its own terms. That is the
+# whole point of the axis: nobody armed this, and `--Filters.<x>[]` is checked
+# against oapi-cli's embedded schema before it goes out, so a name this client
+# accepts is a name the API declares.
+#
+# It is a table rather than eighteen blocks because the assertion is one
+# assertion — every entry is "the emulator refuses what it does not emulate" —
+# and eighteen copies of it is eighteen places for one of them to rot.
+echo "- every read refuses the filter it does not emulate"
+
+# refuse_read drives one call that must be refused, and distinguishes three
+# outcomes rather than two: refused in the Outscale envelope, accepted, or
+# unreadable. The middle one is the defect this guards, and the third is the
+# harness breaking — reported as itself, never folded into "not refused".
+refuse_read() { # operation args...
+  local op="$1" out rc; shift
+  out="$(osc "$op" "$@" 2>&1)" && rc=0 || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    fail "$op accepted a filter it does not emulate, and answering 200 to a filter nobody applies is what filters.go exists to stop: $out"
+  fi
+  printf '%s' "$out" | jq -e '.Errors[0].Code == "4001" and .Errors[0].Type == "InvalidParameterValue"' >/dev/null 2>&1 \
+    || fail "$op did not refuse in the Outscale error envelope: $out"
+}
+
+neg="$(prove_begin negative)"
+refuse_read ReadVms               '--Filters.Architectures[]' x86_64
+refuse_read ReadNets              '--Filters.TagKeys[]' owner
+refuse_read ReadSubnets           '--Filters.TagKeys[]' owner
+refuse_read ReadKeypairs          '--Filters.KeypairIds[]' key-feintnone
+refuse_read ReadSecurityGroups    '--Filters.InboundRuleAccountIds[]' 000000000001
+refuse_read ReadRouteTables       '--Filters.LinkRouteTableLinkRouteTableIds[]' rtbassoc-feintnone
+refuse_read ReadNics              '--Filters.Descriptions[]' none
+refuse_read ReadVolumes           '--Filters.CreationDates[]' 2026-01-01
+refuse_read ReadSnapshots         '--Filters.AccountAliases[]' none
+refuse_read ReadPublicIps         '--Filters.NicAccountIds[]' 000000000001
+refuse_read ReadNatServices       '--Filters.ClientTokens[]' none
+refuse_read ReadInternetServices  '--Filters.LinkStates[]' available
+refuse_read ReadDhcpOptions       '--Filters.DomainNameServers[]' 192.0.2.53
+refuse_read ReadNetPeerings       '--Filters.ExpirationDates[]' 2026-01-01
+refuse_read ReadImages            '--Filters.AccountAliases[]' none
+refuse_read ReadVmsState          '--Filters.MaintenanceEventCodes[]' none
+prove_end "$neg"
+ok "sixteen reads named the filter they do not apply, instead of answering the whole inventory"
+
+# The two attach spellings, at a balancer that does not exist. LBU is the one
+# family where a wrong name is a refusal rather than an empty list, because the
+# call names its target instead of filtering for it — so this is the refusal
+# these two operations actually own, and the only one they own.
+#
+# LinkLoadBalancerBackendMachines and RegisterVmsInLoadBalancer share a handler
+# and are two routes: each declares its own upstream operation, so the span
+# marks the name that was called. Driving one would say nothing about the other.
+echo "- attaching a backend to a balancer that does not exist is refused"
+neg="$(prove_begin negative)"
+for attach in LinkLoadBalancerBackendMachines UnlinkLoadBalancerBackendMachines; do
+  out="$(osc "$attach" --LoadBalancerName feint-no-such-balancer '--BackendVmIds[]' i-feintnone 2>&1)" && rc=0 || rc=$?
+  [ "${rc:-0}" -ne 0 ] || fail "$attach accepted a balancer that does not exist: $out"
+  printf '%s' "$out" | jq -e '.Errors[0].Code == "5063"' >/dev/null 2>&1 \
+    || fail "$attach did not answer the not-found code a client branches on: $out"
+done
+prove_end "$neg"
+ok "both spellings answered 5063, which osc.IsNotFound reports true on"
+
 # Started with --contracts, the emulator has been validating every response
 # above against Outscale's own OpenAPI document. Reading the verdict here is
 # what makes the check part of the run rather than a report nobody opens.

--- a/tools/conformance/outscale/oapi-cli.sh
+++ b/tools/conformance/outscale/oapi-cli.sh
@@ -897,57 +897,67 @@ ok "nothing left behind"
 # The refusals a client can ask for, on the reads nothing else ever refused.
 #
 # `negative` is earned by an operation really answering 4xx to a real client
-# inside a span where a suite demanded a refusal, and until now the only thing
-# in this repository that earned it for Outscale was refusals.sh, which reissues
-# what the real cloud refused (#390). That left the whole read surface at zero:
-# a recording session is driven at bogus *identifiers*, and a bogus identifier
-# in a Read is an empty list, not a refusal (#428).
+# inside a span where a suite demanded a refusal. For Outscale the only thing
+# that had ever earned it was refusals.sh, reissuing what the real cloud refused
+# (#390), and that left the whole read surface at zero: a recording session is
+# driven at bogus *identifiers*, and a bogus identifier in a Read is an empty
+# list, not a refusal (#428).
 #
-# What refuses a read here is the filter guard of filters.go: a filter this pack
-# does not apply is answered 400 naming the field, never ignored. Each line
-# below sends ONE filter that Outscale's own API description declares on that
-# call and this pack does not serve, so the request is valid to the client,
-# valid to the API, and refused by the emulator on its own terms. That is the
-# whole point of the axis: nobody armed this, and `--Filters.<x>[]` is checked
-# against oapi-cli's embedded schema before it goes out, so a name this client
-# accepts is a name the API declares.
-#
-# It is a table rather than eighteen blocks because the assertion is one
-# assertion — every entry is "the emulator refuses what it does not emulate" —
-# and eighteen copies of it is eighteen places for one of them to rot.
-echo "- every read refuses the filter it does not emulate"
+# Nothing below arms a fault. It could not: an injected refusal leaves the
+# observed path before the observer records it, and a span whose only 4xx were
+# injected is refused outright. Every refusal here is the emulator's own rule
+# meeting a request a real client composed.
 
-# refuse_read drives one call that must be refused, and distinguishes three
-# outcomes rather than two: refused in the Outscale envelope, accepted, or
-# unreadable. The middle one is the defect this guards, and the third is the
-# harness breaking — reported as itself, never folded into "not refused".
-refuse_read() { # operation args...
-  local op="$1" out rc; shift
-  out="$(osc "$op" "$@" 2>&1)" && rc=0 || rc=$?
+# refuse_call drives one call that must be refused, and fails the suite when the
+# emulator accepts it.
+#
+# stdout and stderr are captured SEPARATELY, and that is the fix for a harness
+# that lied here: oapi-cli retries a 409 three times and prints "WARN: attempt 0
+# failed" to stderr, so a reader folding the two together parses warnings as the
+# body and reports a correct refusal as a missing one. The first version of this
+# block did exactly that.
+#
+# Three outcomes, never two: refused in the Outscale envelope with the code
+# asked for, accepted, or unreadable. The middle one is the defect this guards;
+# the third is the harness breaking, reported as itself.
+refuse_call() { # expected-code operation args...
+  local want="$1" op="$2" out rc=0; shift 2
+  out="$(osc "$op" "$@" 2>"$WORK/refusal.err")" || rc=$?
   if [ "$rc" -eq 0 ]; then
-    fail "$op accepted a filter it does not emulate, and answering 200 to a filter nobody applies is what filters.go exists to stop: $out"
+    fail "$op accepted what it must refuse: $out"
   fi
-  printf '%s' "$out" | jq -e '.Errors[0].Code == "4001" and .Errors[0].Type == "InvalidParameterValue"' >/dev/null 2>&1 \
-    || fail "$op did not refuse in the Outscale error envelope: $out"
+  printf '%s' "$out" | jq -e --arg c "$want" '.Errors[0].Code == $c' >/dev/null 2>&1 \
+    || fail "$op did not refuse with code $want: $out"$'\n'"client stderr: $(cat "$WORK/refusal.err")"
 }
 
+# Each line sends ONE filter that Outscale's own API description declares on
+# that call and this pack does not serve, so the request is valid to the client,
+# valid to the API, and refused by the emulator on its own terms — the filter
+# guard of filters.go, which answers 400 naming the field rather than returning
+# the whole inventory. `--Filters.<x>[]` is checked against oapi-cli's embedded
+# schema before it goes out, so a name this client accepts is a name the API
+# declares.
+#
+# It is a table rather than sixteen blocks because the assertion is one
+# assertion, and sixteen copies of it is sixteen places for one of them to rot.
+echo "- every read refuses the filter it does not emulate"
 neg="$(prove_begin negative)"
-refuse_read ReadVms               '--Filters.Architectures[]' x86_64
-refuse_read ReadNets              '--Filters.TagKeys[]' owner
-refuse_read ReadSubnets           '--Filters.TagKeys[]' owner
-refuse_read ReadKeypairs          '--Filters.KeypairIds[]' key-feintnone
-refuse_read ReadSecurityGroups    '--Filters.InboundRuleAccountIds[]' 000000000001
-refuse_read ReadRouteTables       '--Filters.LinkRouteTableLinkRouteTableIds[]' rtbassoc-feintnone
-refuse_read ReadNics              '--Filters.Descriptions[]' none
-refuse_read ReadVolumes           '--Filters.CreationDates[]' 2026-01-01
-refuse_read ReadSnapshots         '--Filters.AccountAliases[]' none
-refuse_read ReadPublicIps         '--Filters.NicAccountIds[]' 000000000001
-refuse_read ReadNatServices       '--Filters.ClientTokens[]' none
-refuse_read ReadInternetServices  '--Filters.LinkStates[]' available
-refuse_read ReadDhcpOptions       '--Filters.DomainNameServers[]' 192.0.2.53
-refuse_read ReadNetPeerings       '--Filters.ExpirationDates[]' 2026-01-01
-refuse_read ReadImages            '--Filters.AccountAliases[]' none
-refuse_read ReadVmsState          '--Filters.MaintenanceEventCodes[]' none
+refuse_call 4001 ReadVms               '--Filters.Architectures[]' x86_64
+refuse_call 4001 ReadNets              '--Filters.TagKeys[]' owner
+refuse_call 4001 ReadSubnets           '--Filters.TagKeys[]' owner
+refuse_call 4001 ReadKeypairs          '--Filters.KeypairIds[]' key-feintnone
+refuse_call 4001 ReadSecurityGroups    '--Filters.InboundRuleAccountIds[]' 000000000001
+refuse_call 4001 ReadRouteTables       '--Filters.LinkRouteTableLinkRouteTableIds[]' rtbassoc-feintnone
+refuse_call 4001 ReadNics              '--Filters.Descriptions[]' none
+refuse_call 4001 ReadVolumes           '--Filters.CreationDates[]' 2026-01-01
+refuse_call 4001 ReadSnapshots         '--Filters.AccountAliases[]' none
+refuse_call 4001 ReadPublicIps         '--Filters.NicAccountIds[]' 000000000001
+refuse_call 4001 ReadNatServices       '--Filters.ClientTokens[]' none
+refuse_call 4001 ReadInternetServices  '--Filters.LinkStates[]' available
+refuse_call 4001 ReadDhcpOptions       '--Filters.DomainNameServers[]' 192.0.2.53
+refuse_call 4001 ReadNetPeerings       '--Filters.ExpirationDates[]' 2026-01-01
+refuse_call 4001 ReadImages            '--Filters.AccountAliases[]' none
+refuse_call 4001 ReadVmsState          '--Filters.MaintenanceEventCodes[]' none
 prove_end "$neg"
 ok "sixteen reads named the filter they do not apply, instead of answering the whole inventory"
 
@@ -961,14 +971,88 @@ ok "sixteen reads named the filter they do not apply, instead of answering the w
 # marks the name that was called. Driving one would say nothing about the other.
 echo "- attaching a backend to a balancer that does not exist is refused"
 neg="$(prove_begin negative)"
-for attach in LinkLoadBalancerBackendMachines UnlinkLoadBalancerBackendMachines; do
-  out="$(osc "$attach" --LoadBalancerName feint-no-such-balancer '--BackendVmIds[]' i-feintnone 2>&1)" && rc=0 || rc=$?
-  [ "${rc:-0}" -ne 0 ] || fail "$attach accepted a balancer that does not exist: $out"
-  printf '%s' "$out" | jq -e '.Errors[0].Code == "5063"' >/dev/null 2>&1 \
-    || fail "$attach did not answer the not-found code a client branches on: $out"
-done
+refuse_call 5063 LinkLoadBalancerBackendMachines \
+  --LoadBalancerName feint-no-such-balancer '--BackendVmIds[]' i-feintnone
+refuse_call 5063 UnlinkLoadBalancerBackendMachines \
+  --LoadBalancerName feint-no-such-balancer '--BackendVmIds[]' i-feintnone
 prove_end "$neg"
 ok "both spellings answered 5063, which osc.IsNotFound reports true on"
+
+# The five reads whose only refusable argument is the page size.
+#
+# Four of these serve every filter their API declares, and the fifth
+# (ReadPublicIpRanges) declares no filters at all, so the filter guard above has
+# nothing to bite on. What they do declare is ResultsPerPage, and Outscale's own
+# API description bounds it in the same words on all twenty-one schemas that
+# carry it: "between `1` and `1000`, both included". A value outside that is a
+# request the real API refuses, and until paging.go it was a request this
+# emulator answered with the whole inventory.
+#
+# 1001 rather than 0 because only one of the two proves the bound is read from
+# the value: 0 is also the Go zero value, so a handler refusing 0 could be
+# refusing "absent" and nobody would know. The unit tests hold both ends
+# (TestAnAbsentPageSizeIsNotAZeroPageSize).
+echo "- a page size outside the published bound is refused"
+neg="$(prove_begin negative)"
+for paged in ReadTags ReadSubregions ReadNetAccessPointServices ReadVmTypes ReadPublicIpRanges; do
+  refuse_call 4001 "$paged" --ResultsPerPage 1001
+done
+prove_end "$neg"
+ok "five reads bounded their page size instead of ignoring it"
+
+# The type catalogue applies the filter a client sends it, and names the ones it
+# cannot. FiltersVmType declares nine and this handler read none of them, so a
+# client resolving its type by name was handed the whole table with a 200 — the
+# defect filters.go removed from every other read of this pack, still standing
+# on the one call every client makes before it creates anything.
+echo "- the type catalogue filters, and refuses what it cannot filter on"
+selected="$(osc ReadVmTypes '--Filters.VmTypeNames[]' "$default_type" | jq -r '.VmTypes | length')" \
+  || fail "ReadVmTypes refused the filter it serves"
+[ "$selected" = "1" ] || fail "VmTypeNames selected $selected rows; the filter is not applied"
+neg="$(prove_begin negative)"
+refuse_call 4001 ReadVmTypes '--Filters.MemorySizes[]' 8
+prove_end "$neg"
+ok "one type selected by name, and the arithmetic filters refused by name"
+
+# The address block is finite, and running it out is the one refusal
+# CreatePublicIp owns. Its request declares nothing but DryRun — there is no
+# argument to malform — so the only thing that can make this call fail is the
+# state of the emulator's own /24, which is exactly what makes it evidence: no
+# fixture, no fault, no account.
+#
+# The inventory is read before and after and compared BY IDENTIFIER, never by
+# count: this suite shares its emulator with the ones that run after it, and an
+# address left behind is an address the Terraform fixture cannot have. The loop
+# is bounded well above the block so a defect in the allocator ends the test
+# rather than the run.
+echo "- the public block runs out, and says so"
+before_ips="$(osc ReadPublicIps | jq -r '.PublicIps[].PublicIpId' | sort)"
+mine=""
+exhausted=""
+for _ in $(seq 1 300); do
+  rc=0
+  out="$(osc CreatePublicIp 2>/dev/null)" || rc=$?
+  if [ "$rc" -ne 0 ]; then exhausted="yes"; break; fi
+  id="$(printf '%s' "$out" | jq -r '.PublicIp.PublicIpId // empty')"
+  [ -n "$id" ] || fail "CreatePublicIp answered no PublicIpId: $out"
+  mine="$mine $id"
+done
+[ -n "$exhausted" ] || fail "300 addresses came out of a /24; the block is not bounded at all"
+# The span opens only now: the fill above is setup, and a span bracketing three
+# hundred successful creates would be claiming a refusal it had not asked for
+# yet. oapi-cli retries a 409 three times before giving up, so this one call is
+# four requests on the wire and several seconds long.
+neg="$(prove_begin negative)"
+refuse_call 9029 CreatePublicIp
+prove_end "$neg"
+
+for id in $mine; do
+  osc DeletePublicIp --PublicIpId "$id" >/dev/null || fail "DeletePublicIp rejected $id, and the address is now stranded"
+done
+after_ips="$(osc ReadPublicIps | jq -r '.PublicIps[].PublicIpId' | sort)"
+[ "$before_ips" = "$after_ips" ] \
+  || fail "the address inventory did not return to what it was, by identifier"$'\n'"before: $before_ips"$'\n'"after: $after_ips"
+ok "the block refused past its last address, and every address taken was given back"
 
 # Started with --contracts, the emulator has been validating every response
 # above against Outscale's own OpenAPI document. Reading the verdict here is

--- a/tools/conformance/outscale/oapi-cli.sh
+++ b/tools/conformance/outscale/oapi-cli.sh
@@ -1054,6 +1054,40 @@ after_ips="$(osc ReadPublicIps | jq -r '.PublicIps[].PublicIpId' | sort)"
   || fail "the address inventory did not return to what it was, by identifier"$'\n'"before: $before_ips"$'\n'"after: $after_ips"
 ok "the block refused past its last address, and every address taken was given back"
 
+# A tag put on and taken off a resource that then dies, which is what DeleteTags
+# needed to earn `behaviour`.
+#
+# The axis marks an operation whose store touches fall on a resource created and
+# destroyed inside the span. Tags are stored ON the resource they name rather
+# than in a table of their own (tags.go), so DeleteTags touches whatever it
+# untags — and the suite had only ever untagged a Vm, which this emulator marks
+# terminated and keeps readable rather than removing. A Net is removed, so the
+# same call becomes attributable.
+#
+# Measured before it was written: with the Net dying inside the span the store
+# reports CreateNet, CreateTags, DeleteTags and DeleteNet; with a Vm it reports
+# neither tag call. That is why this block exists rather than a Route.Unearnable
+# declaration beside its neighbours — twelve of the thirteen candidates resisted
+# this attempt, and this one did not.
+echo "- a tag outlives nothing: the resource it named is gone"
+span="$(prove_begin behaviour)"
+tag_net="$(osc CreateNet --IpRange 10.195.0.0/16)" || fail "CreateNet rejected: $tag_net"
+tag_net_id="$(printf '%s' "$tag_net" | jq -r '.Net.NetId // empty')"
+[ -n "$tag_net_id" ] || fail "no NetId for the tagged Net: $tag_net"
+osc CreateTags --ResourceIds "[\"$tag_net_id\"]" --Tags '[{"Key":"conformance-net","Value":"one"}]' >/dev/null \
+  || fail "CreateTags rejected on a Net"
+osc ReadTags '--Filters.ResourceIds[]' "$tag_net_id" \
+  | jq -e 'any(.Tags[]; .Key == "conformance-net" and .ResourceType == "vpc")' >/dev/null \
+  || fail "the Net tag is not readable, or does not carry the SDK's own ResourceType"
+osc DeleteTags --ResourceIds "[\"$tag_net_id\"]" --Tags '[{"Key":"conformance-net","Value":"one"}]' >/dev/null \
+  || fail "DeleteTags rejected on a Net"
+osc ReadTags '--Filters.ResourceIds[]' "$tag_net_id" \
+  | jq -e 'any(.Tags[]; .Key == "conformance-net") | not' >/dev/null \
+  || fail "the Net tag survived DeleteTags"
+osc DeleteNet --NetId "$tag_net_id" >/dev/null || fail "DeleteNet rejected once its tag was gone"
+prove_end "$span"
+ok "the tag went, and so did the Net that carried it"
+
 # Started with --contracts, the emulator has been validating every response
 # above against Outscale's own OpenAPI document. Reading the verdict here is
 # what makes the check part of the run rather than a report nobody opens.

--- a/tools/falsify/specs/evidence-gaps.json
+++ b/tools/falsify/specs/evidence-gaps.json
@@ -1,6 +1,6 @@
 {
   "subject": "the work queue behind `feint coverage --evidence --gaps` (#408)",
-  "why": "A score says where we stand; this says what to do next. Its whole value is that four zeros name four different jobs, so every mutation below turns the queue back into an undifferentiated list — which is the state it was built to replace, and which reads exactly the same to somebody who did not write it. Since 2026-08-24 it also separates work from decisions: the four mutations added last turn the `declared` kind back into an undifferentiated `undriven` backlog, honour a reason on an operation a client drives, strip the reason from the line, or cut the packs off as the source of reasons entirely.",
+  "why": "A score says where we stand; this says what to do next. Its whole value is that four zeros name four different jobs, so every mutation below turns the queue back into an undifferentiated list \u2014 which is the state it was built to replace, and which reads exactly the same to somebody who did not write it. Since 2026-08-24 it also separates work from decisions: the four mutations added last turn the `declared` kind back into an undifferentiated `undriven` backlog, honour a reason on an operation a client drives, strip the reason from the line, or cut the packs off as the source of reasons entirely.",
   "mutations": [
     {
       "file": "internal/cli/evidence_gaps.go",
@@ -12,8 +12,8 @@
     },
     {
       "file": "internal/cli/evidence_gaps.go",
-      "find": "\tif !ev.Driven {\n\t\tif reason != \"\" {\n\t\t\treturn gapDeclared\n\t\t}\n\t\treturn gapUndriven\n\t}",
-      "replace": "\tif !ev.Driven && false {\n\t\tif reason != \"\" {\n\t\t\treturn gapDeclared\n\t\t}\n\t\treturn gapUndriven\n\t}",
+      "find": "\tif !ev.Driven {\n\t\tif undriven != \"\" {\n\t\t\treturn gapDeclared\n\t\t}\n\t\treturn gapUndriven\n\t}",
+      "replace": "\tif !ev.Driven && false {\n\t\tif undriven != \"\" {\n\t\t\treturn gapDeclared\n\t\t}\n\t\treturn gapUndriven\n\t}",
       "expect": "an operation no client reaches is filed as a recording session, so somebody records a cloud answer for a route nothing calls",
       "test": "TestAGapIsClassifiedFromTheRecordRatherThanTheName",
       "label": "an undriven operation is filed as a recording"
@@ -52,24 +52,24 @@
     },
     {
       "file": "internal/cli/evidence_gaps.go",
-      "find": "\t\tif reason != \"\" {\n\t\t\treturn gapDeclared\n\t\t}\n\t\treturn gapUndriven",
-      "replace": "\t\tif reason != \"\" && false {\n\t\t\treturn gapDeclared\n\t\t}\n\t\treturn gapUndriven",
+      "find": "\t\tif undriven != \"\" {\n\t\t\treturn gapDeclared\n\t\t}\n\t\treturn gapUndriven",
+      "replace": "\t\tif undriven != \"\" && false {\n\t\t\treturn gapDeclared\n\t\t}\n\t\treturn gapUndriven",
       "expect": "the reason a pack wrote at the route stops retiring its zero, so all 141 of them go back to asking for a conformance suite that no client exists to write",
       "test": "TestADeclaredReasonSplitsTheUndrivenQueue",
       "label": "a declared reason stops retiring its zero"
     },
     {
       "file": "internal/cli/evidence_gaps.go",
-      "find": "\tif !ev.Driven {\n\t\tif reason != \"\" {\n\t\t\treturn gapDeclared\n\t\t}\n\t\treturn gapUndriven\n\t}\n\tif axis.Name == \"shape\" {",
-      "replace": "\tif !ev.Driven || true {\n\t\tif reason != \"\" {\n\t\t\treturn gapDeclared\n\t\t}\n\t\treturn gapUndriven\n\t}\n\tif axis.Name == \"shape\" {",
-      "expect": "a reason is honoured on an operation a client does drive, so a stale excuse — the exact thing TestEveryUndrivenOperationSaysWhy exists to reject — empties a real recording queue",
+      "find": "\tif !ev.Driven {\n\t\tif undriven != \"\" {\n\t\t\treturn gapDeclared\n\t\t}\n\t\treturn gapUndriven\n\t}\n\t// Driven, and the route says",
+      "replace": "\tif !ev.Driven || true {\n\t\tif undriven != \"\" {\n\t\t\treturn gapDeclared\n\t\t}\n\t\treturn gapUndriven\n\t}\n\t// Driven, and the route says",
+      "expect": "a reason is honoured on an operation a client does drive, so a stale excuse \u2014 the exact thing TestEveryUndrivenOperationSaysWhy exists to reject \u2014 empties a real recording queue",
       "test": "TestAGapIsClassifiedFromTheRecordRatherThanTheName",
       "label": "a stale reason excuses an operation a client drives"
     },
     {
       "file": "internal/cli/evidence_gaps.go",
-      "find": "\t\t\t\tif kind == gapDeclared {\n\t\t\t\t\tentry.Reason = reasons[op]\n\t\t\t\t}",
-      "replace": "\t\t\t\tif kind == gapDeclared && false {\n\t\t\t\t\tentry.Reason = reasons[op]\n\t\t\t\t}",
+      "find": "\t\t\t\tif kind == gapDeclared {\n\t\t\t\t\tentry.Reason = reasons[op]",
+      "replace": "\t\t\t\tif kind == gapDeclared && false {\n\t\t\t\t\tentry.Reason = reasons[op]",
       "expect": "the queue calls an operation declared and never says on what grounds, so a decision it names is one no reader can re-examine without opening three pack files",
       "test": "TestADeclaredReasonSplitsTheUndrivenQueue",
       "label": "a declared line stops carrying its reason"
@@ -82,5 +82,6 @@
       "test": "TestADeclaredReasonSplitsTheUndrivenQueue",
       "label": "the reasons are never read from the packs"
     }
-  ]
+  ],
+  "note": " Retargeted on 2026-08-24: classifyGap gained a third branch for Route.Unearnable and its first reason parameter was renamed `undriven`, so four fragments here stopped matching. falsify:lint is what caught it, which is the whole reason that gate refuses a spec whose fragment has moved rather than reporting it green."
 }

--- a/tools/falsify/specs/unearnable-axes.json
+++ b/tools/falsify/specs/unearnable-axes.json
@@ -1,0 +1,42 @@
+{
+  "package": "./internal/cli/",
+  "mutations": [
+    {
+      "label": "the queue stops separating an axis nothing can earn from one nobody has proven, and thirteen impossible entries come back as work",
+      "file": "internal/cli/evidence_gaps.go",
+      "find": "\tif unearnable != \"\" {\n\t\treturn gapDeclared\n\t}",
+      "replace": "\tif unearnable != \"\" && false {\n\t\treturn gapDeclared\n\t}",
+      "test": "TestAGapIsClassifiedFromTheRecordRatherThanTheName"
+    },
+    {
+      "label": "an axis the record says was earned is declared out of reach, and the stale excuse survives",
+      "file": "internal/providers/outscale/pack.go",
+      "find": "\t\tp.route(\"CreateNet\", p.createNet),",
+      "replace": "\t\tunearnable(p.route(\"CreateNet\", p.createNet),\n\t\t\tkeptSubjectBehaviour(\"a Net\", \"a sentence that is not true and that the record already contradicts\")),",
+      "test": "TestAnUnearnableAxisIsNotAlreadyEarned"
+    },
+    {
+      "label": "a handler that reads the store claims it touches none, and nothing drives it to find out",
+      "file": "internal/providers/outscale/pack.go",
+      "find": "\t\tunearnable(p.route(\"ReadNetPeerings\", p.readNetPeerings),\n\t\t\tkeptSubjectBehaviour(\"a Net peering\", \"a deleted peering stays readable in the deleted state, which the SDK's own StateNames filter enumerates\")),",
+      "replace": "\t\tunearnable(p.route(\"ReadNetPeerings\", p.readNetPeerings),\n\t\t\tstatelessBehaviour(\"peerings, which it in fact reads out of the store\"),\n\t\t\tkeptSubjectBehaviour(\"a Net peering\", \"a deleted peering stays readable in the deleted state, which the SDK's own StateNames filter enumerates\")),",
+      "test": "TestAnUnearnableNoStoreTouchIsMeasured"
+    },
+    {
+      "label": "an operation whose request carries filters claims no client can compose a refusal for it",
+      "file": "internal/providers/outscale/pack.go",
+      "find": "\t\tp.route(\"ReadNets\", p.readNets),",
+      "replace": "\t\tunearnable(p.route(\"ReadNets\", p.readNets),\n\t\t\tnothingToRefuse(\"ReadNetsRequest declares filters this pack does not all serve, so this claim is false\")),",
+      "test": "TestAnUnearnableNegativeHasNothingToRefuse"
+    },
+    {
+      "package": "./internal/providers/outscale/",
+      "label": "a terminated machine is removed from the store after all, and seven declarations resting on it become fiction",
+      "file": "internal/providers/outscale/vms.go",
+      "find": "\t\t\tres.State = stateTerminated\n\t\t\tres.Attrs[\"State\"] = stateTerminated",
+      "replace": "\t\t\tres.State = stateTerminated\n\t\t\tres.Attrs[\"State\"] = stateTerminated\n\t\t\tp.env.Store.Delete(Name, kindVM, res.ID)",
+      "test": "TestATerminatedVmAndADeletedPeeringAreKeptRatherThanRemoved"
+    }
+  ],
+  "note": "Route.Unearnable removes work from a queue by declaring an axis out of reach, which makes it the most dangerous kind of entry in this repository: it reads like a decision and the sentence itself is not checkable. Every mutation here moves a pack declaration or the classifier, never the test that reads them \u2014 the lesson undriven-says-why.json paid for, where neutralising the branches inside the test file left everything green because a test whose detection is switched off passes by construction. The five cover the two independent halves: the classifier and the staleness guard make the mechanism expire on its own, and the three cause checks make each reason a measurement. The last one runs in the pack, where the delete can actually be driven, and is the one that matters most: it is what stops 'a terminated Vm is kept' from being a comment."
+}


### PR DESCRIPTION
Outscale had five complete axes. This closes the sixth, bounds the seventh
honestly, and **touches no cloud account at all**.

| axis | before | after | earned | declared out of reach | left |
|---|---|---|---|---|---|
| `negative` | 66 / 93 | **90 / 93** | 24 | 2 | **1** |
| `behaviour` | 80 / 93 | **81 / 93** | 1 | 12 | **0** |

**Six axes with no gap that carries work, and a seventh with a single named
operation.**

## The 24 refusals, and why eighteen needed no pack code

- **16 reads on a filter the API declares and the pack did not apply** — 400
  `4001`.
- **2 attach spellings against a load balancer that does not exist** — 400
  `5063`.
- **5 reads on `ResultsPerPage: 1001`**, a bound their own OpenAPI states in
  twenty-one request schemas.
- **`CreatePublicIp` against an exhausted /24** — 409 `9029`.

**Eighteen were conformance cases, not code.** The axis was not short of
behaviour; nobody had asked the emulator to refuse.

**No fault was armed anywhere, and none could have been**: a `negative` span
refuses an injected refusal by construction.

## The premise this lot overturned, and it changed the objective

The brief said *"only forty operations remain"*, which assumes forty are
winnable. **Twelve of the thirteen `behaviour` zeros are a design ceiling, not a
backlog.**

The axis requires a resource created **and removed from the store** inside the
span. This pack deliberately keeps terminated machines and deleted peerings
readable, **because the real cloud does** — the suite's own comment already said
so. So seven operations have no subject that dies, and five never touch the
store at all: a static catalogue has no lifecycle.

That was **measured before being declared**, by opening real spans and reading
what they marked. It is what separated `DeleteTags` — winnable, and won — from
the twelve others.

So the objective is no longer 93 of 93 on seven axes. It is **six complete axes
and a seventh honestly bounded**, and the declaration carries its reason at the
route, on the model `Route.Undriven` established.

## One operation deliberately not declared

**`ReadLoadBalancers` stays `unproven`.** Its refusal is reachable in principle:
`FiltersLoadBalancer.States` is declared by osc-api 1.42, the version
`contracts/outscale.json` carries, and the pack does not serve it. The blocker is
the *client*: `oapi-cli` 0.13.0 embeds osc-api 1.39.1, older than that filter,
and refuses the argument client-side.

That is a client-version ceiling, not a property of this emulator. Declaring it
would be false, and **a declaration nobody can measure is exactly the
comment-that-is-not-a-control** this repository spends its time removing.

## Three of #437's findings do not survive measurement

- **`HealthCheck.Path` is served**, on `UpdateLoadBalancer`, `ReadLoadBalancers`
  and `DeleteLoadBalancer`. Three of the issue's eight rows are not reproducible.
- **`CreateLoadBalancer` ignoring a `HealthCheck` is not a defect**:
  `CreateLoadBalancerRequest` declares none. The contract was read before
  "fixing", and there was nothing to fix.
- **`Volume.TaskId` was already declined**, on both operations.

What remains of #437 is delivered: an image's `FileLocation` is declared unserved
with its reason.

## No account was touched

**Zero network calls to any real cloud, zero spend.** Neither `default` nor
`souverain`. This confirms the brief's most important premise: those 27 were
`unproven`, not `unrecorded` — a conformance case does offline what a recording
session would have paid for.

The exhaustion case still reads `ReadPublicIps` before and after and compares
**by identifier**, never by count, because the suite shares its emulator.

## A criterion of this branch would pass on unfixed code

Named rather than hidden: *"the `no-refusable-request` guard checks that the
schema declares only `DryRun`"* is true of `CreatePublicIp`, which **is**
refusable. The schema check is necessary and not sufficient. The staleness half,
which reads the committed record, is what catches that case, and the code says
the two are only tight together.

## Falsified

`tools/falsify/specs/unearnable-axes.json`, **5 mutations, all red first
attempt**, verified again after the rebase. Among them the two that matter: *an
axis the record says was earned is declared out of reach, and the stale excuse
survives*, and *a terminated machine is removed from the store after all, and
seven declarations resting on it become fiction*.

**No mutation stayed green.** `falsify:lint` did catch **four fragments of
`evidence-gaps.json` gone silent** when `classifyGap` grew its third branch —
retargeted in the same commit, the whole spec replayed green.

## Three traps re-paid

zsh word splitting inverted three verdicts of the first pagination measurement.
`oapi-cli` retries a 409 three times and writes `WARN: attempt 0 failed` to
stderr, so a merged-stream `refuse_call` reported a perfectly correct 9029 as
missing. And the golangci-lint cache, poisoned by the deleted neighbouring
worktree, produced twenty "defects" all located in a directory that no longer
exists.

## Gates

`prepush` 0 · `corpus --check` 0, 1066 exchanges, 0 unaccepted · `conformance` 0
· legs `fields` 0 and `probe` 0. Exit codes captured before any pipe.
`coverage/evidence.json` deliberately not regenerated.

## Related

Closes #437
Refs #428, #409, #410, #411, #412, #413, #414
