### PR TITLE
feat(conformance): fifty operations are refused by a real client, and not one line of pack code moved (#428)

### DIFF
--- a/tools/conformance/exoscale/exo-cli.sh
+++ b/tools/conformance/exoscale/exo-cli.sh
@@ -53,42 +53,15 @@ fail() { echo "FAIL: $*" >&2; exit 1; }
 ok() { echo "  ok: $*"; }
 exoc() { exo "$@"; }
 
-# refuse_exo drives one command that must be refused BY THE EMULATOR, and reads
-# the emulator's own verdict rather than the client's output (#428).
-#
-# Three outcomes, never two. `exo` resolves a NAME|ID argument by listing first,
-# so a command aimed at something that does not exist fails on the CLI's own
-# lookup and never reaches the API: of 65 such commands measured on 2026-08-24,
-# three got that far. A case that stops reaching the emulator would read exactly
-# like this suite working, so it fails by name instead:
-#
-#   - the CLI succeeded            -> the API accepted what must be refused;
-#   - the CLI failed, span closes  -> the emulator answered a 4xx: the case holds;
-#   - the CLI failed, span 409s    -> nothing reached the emulator, so the case
-#                                     proves nothing and says so.
-#
-# TestANegativeSpanNeedsARefusal (internal/core/emulator) is what makes the
-# third outcome a 409 rather than a green close.
-#
-# Nothing here arms a fault, and nothing could: an injected refusal leaves the
-# observed path before the observer records it, and a span whose only 4xx were
-# injected is refused outright.
+# refuse_exo names the client; everything else is refuse_client's, in
+# tools/conformance/prove.sh. `exo` resolves a NAME|ID argument by LISTING
+# first, so a command aimed at something that does not exist fails on the CLI's
+# own lookup and never reaches the API: of 65 such commands measured on
+# 2026-08-24, one got through. That ceiling is why the shared helper fails a
+# case whose refusal never reached the emulator instead of passing it.
 refuse_exo() { # label args...
   local label="$1"; shift
-  local span out rc=0 close code body
-  span="$(prove_begin negative)"
-  out="$(exoc "$@" 2>&1)" || rc=$?
-  close="$(curl -s -w '\n%{http_code}' -X POST "$ENDPOINT/_feint/assert/$span")"
-  code="${close##*$'\n'}"
-  body="${close%$'\n'*}"
-  if [ "$rc" -eq 0 ]; then
-    fail "$label: the CLI was answered success where a refusal was demanded: $out"
-  fi
-  case "$code" in
-    200) ;;
-    409) fail "$label: the CLI refused this on its own and the emulator never saw it, so the case measures nothing: $out" ;;
-    *)   fail "$label: the emulator answered HTTP $code closing the span: $body" ;;
-  esac
+  refuse_client "$label" exoc "$@"
 }
 
 echo "conformance: exo CLI against $ENDPOINT"

--- a/tools/conformance/exoscale/exo-cli.sh
+++ b/tools/conformance/exoscale/exo-cli.sh
@@ -53,6 +53,44 @@ fail() { echo "FAIL: $*" >&2; exit 1; }
 ok() { echo "  ok: $*"; }
 exoc() { exo "$@"; }
 
+# refuse_exo drives one command that must be refused BY THE EMULATOR, and reads
+# the emulator's own verdict rather than the client's output (#428).
+#
+# Three outcomes, never two. `exo` resolves a NAME|ID argument by listing first,
+# so a command aimed at something that does not exist fails on the CLI's own
+# lookup and never reaches the API: of 65 such commands measured on 2026-08-24,
+# three got that far. A case that stops reaching the emulator would read exactly
+# like this suite working, so it fails by name instead:
+#
+#   - the CLI succeeded            -> the API accepted what must be refused;
+#   - the CLI failed, span closes  -> the emulator answered a 4xx: the case holds;
+#   - the CLI failed, span 409s    -> nothing reached the emulator, so the case
+#                                     proves nothing and says so.
+#
+# TestANegativeSpanNeedsARefusal (internal/core/emulator) is what makes the
+# third outcome a 409 rather than a green close.
+#
+# Nothing here arms a fault, and nothing could: an injected refusal leaves the
+# observed path before the observer records it, and a span whose only 4xx were
+# injected is refused outright.
+refuse_exo() { # label args...
+  local label="$1"; shift
+  local span out rc=0 close code body
+  span="$(prove_begin negative)"
+  out="$(exoc "$@" 2>&1)" || rc=$?
+  close="$(curl -s -w '\n%{http_code}' -X POST "$ENDPOINT/_feint/assert/$span")"
+  code="${close##*$'\n'}"
+  body="${close%$'\n'*}"
+  if [ "$rc" -eq 0 ]; then
+    fail "$label: the CLI was answered success where a refusal was demanded: $out"
+  fi
+  case "$code" in
+    200) ;;
+    409) fail "$label: the CLI refused this on its own and the emulator never saw it, so the case measures nothing: $out" ;;
+    *)   fail "$label: the emulator answered HTTP $code closing the span: $body" ;;
+  esac
+}
+
 echo "conformance: exo CLI against $ENDPOINT"
 
 # The zone list is the first call the CLI makes and the address every call after
@@ -144,6 +182,12 @@ state="$(exoc -O json compute instance show "$id" | jq -r '.state')"
 [ "$state" = "running" ] || fail "the instance is $state after start, not running"
 exoc compute instance reboot "$id" --force >/dev/null || fail "instance reboot rejected"
 ok "stopped, started, rebooted, and the state followed"
+# Two calls this emulator refuses on a machine that is up, and that no case had
+# ever asked it for. The instance is running here, which is the whole condition.
+echo "- a reset and a TPM are refused on a running instance"
+refuse_exo "reset a running instance" -Q compute instance reset "$id" --force
+refuse_exo "enable a TPM on a running instance" -Q compute instance enable-tpm "$id" --force
+ok "both refused while it runs"
 
 echo "- scale and resize-disk, on a stopped instance as upstream requires"
 exoc compute instance stop "$id" --force >/dev/null || fail "second stop rejected"
@@ -289,6 +333,13 @@ esac
 shown="$(exoc -O json compute instance show "$id")" || fail "instance show after attach rejected"
 printf '%s' "$shown" | jq -e '(.private_networks // []) | length == 1' >/dev/null \
   || fail "the instance does not publish its private network: $shown"
+# The same attach a second time. An instance holds one lease per network, so the
+# second call is the refusal this operation owns and the only one `exo` can put
+# to it: every identifier it takes is resolved by listing before the request
+# leaves.
+refuse_exo "attach to a network it is already on" \
+  -Q compute instance private-network attach "$id" conformance-pn
+ok "a second attach to the same network is refused"
 
 echo "- update-ip moves the lease, the network publishes the move"
 exoc compute instance private-network update-ip "$id" conformance-pn --ip 10.90.0.99 >/dev/null \
@@ -343,6 +394,22 @@ sg="$(exoc -O json compute security-group show conformance-sg)" || fail "sg show
 printf '%s' "$sg" | jq -e '(.external_sources // []) | length == 0' >/dev/null \
   || fail "the source survived its removal: $sg"
 ok "source added, published, removed"
+# A group an instance still carries does not vanish under it, and the two
+# listings refuse a visibility outside the enum their own API description
+# declares — the reads of this pack own no other refusal, since `exo` resolves
+# every identifier by listing before it asks.
+echo "- a group in use, and two listings asked for a visibility that does not exist"
+exoc -Q compute instance security-group add "$id" conformance-sg >/dev/null \
+  || fail "security-group attach rejected"
+refuse_exo "delete a group an instance carries" \
+  -Q compute security-group delete conformance-sg --force
+exoc -Q compute instance security-group remove "$id" conformance-sg >/dev/null \
+  || fail "security-group detach rejected"
+refuse_exo "list templates by an unknown visibility" \
+  -O json compute instance-template list --visibility nowhere
+refuse_exo "list security groups by an unknown visibility" \
+  -O json compute security-group list --visibility nowhere
+ok "the group held, and both listings refused the visibility by name"
 
 # The reads and edits this pack served and no client had walked (#174), plus the
 # snapshot and template surface #173 added. Each is one `exo` call; the reason
@@ -537,6 +604,11 @@ if exoc -Q compute block-storage delete "$block_id" --force >/dev/null 2>&1; the
 fi
 prove_end "$neg"
 
+# And a detach of a volume nothing holds any more, which is the refusal that
+# operation owns: the detach above already took it off its instance.
+refuse_exo "detach a volume that is not attached" \
+  -Q compute block-storage detach "$block_id" --force
+
 exoc -Q compute block-storage snapshot delete "$block_snap_id" --force >/dev/null \
   || fail "block-storage snapshot delete rejected"
 exoc -Q compute block-storage delete "$block_id" --force >/dev/null \
@@ -593,6 +665,12 @@ victim="$(exoc -O json compute instance-pool show "$pool_id" | jq -r '.instances
 exoc -Q compute instance-pool evict "$pool_id" "$victim" --force >/dev/null \
   || fail "instance-pool evict rejected"
 [ "$(members_of)" = "1" ] || fail "after evicting one member the pool holds $(members_of)"
+# Evicting something the pool does not hold. `$id` is the standalone instance
+# this suite created before the pool existed, so it is a real instance that the
+# CLI resolves and the emulator then refuses — which is the only way to reach
+# this operation's refusal at all.
+refuse_exo "evict an instance the pool does not hold" \
+  -Q compute instance-pool evict "$pool_id" "$id" --force
 
 # The Network Load Balancer (EXO-5, #345), driven while the pool it forwards to
 # still exists — which is the only order a real stack can build it in.

--- a/tools/conformance/prove.sh
+++ b/tools/conformance/prove.sh
@@ -64,3 +64,56 @@ prove_end() {
     echo "        so the behaviour axis is short by that much for this block (#398)" >&2
   fi
 }
+
+# refuse_client drives one command that must be refused BY THE EMULATOR, and
+# reads the emulator's own verdict rather than the client's output (#428).
+#
+# It is here rather than in each suite for the reason the shared layer exists at
+# all: three clients, one rule. `scw`, `exo` and `oapi-cli` all answer a refusal
+# they made THEMSELVES and a refusal the API made with the same non-zero exit
+# code and a similar JSON envelope, so a suite parsing that text cannot tell the
+# two apart — and the difference is the whole measurement. `scw` validates enums
+# against its own SDK and `exo` resolves a NAME|ID by listing first, so a case
+# aimed at something that does not exist never reaches the emulator at all.
+#
+# Three outcomes, never two:
+#
+#   - the client succeeded          -> the API accepted what must be refused;
+#   - the client failed, span closes -> the emulator answered a 4xx: it holds;
+#   - the client failed, span 409s   -> nothing reached the emulator, so this
+#                                       case proves nothing and says so by name.
+#
+# The third is the one that matters, and it is a guard rather than a comment:
+# a case that quietly stops reaching the API reads exactly like this suite
+# working, and it would keep passing for as long as nobody read the axis.
+# TestARefusalTheClientMadeItselfFailsTheCase fails without it, and
+# TestARefusalTheEmulatorMadePassesTheCase is the other half, without which a
+# helper that refused everything would satisfy the first.
+#
+# The caller passes its own client word — `scw`, `exoc`, `osc` — because that is
+# the only thing that varies.
+refuse_client() { # label client args...
+  local label="$1"; shift
+  local span out rc=0 close code body
+  span="$(prove_begin negative)"
+  out="$("$@" 2>&1)" || rc=$?
+  close="$(curl -s -w '\n%{http_code}' -X POST "$ENDPOINT/_feint/assert/$span")"
+  code="${close##*$'\n'}"
+  body="${close%$'\n'*}"
+  if [ "$rc" -eq 0 ]; then
+    echo "FAIL: $label: the client was answered success where a refusal was demanded: $out" >&2
+    exit 1
+  fi
+  case "$code" in
+    200) ;;
+    409)
+      echo "FAIL: $label: the client refused this on its own and the emulator never saw it," >&2
+      echo "      so the case measures nothing: $out" >&2
+      exit 1
+      ;;
+    *)
+      echo "FAIL: $label: the emulator answered HTTP $code closing the span: $body" >&2
+      exit 1
+      ;;
+  esac
+}

--- a/tools/conformance/refuse_test.go
+++ b/tools/conformance/refuse_test.go
@@ -1,0 +1,148 @@
+package conformance
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// refuse_client is the control behind the `negative` cases of #428, and it
+// exists because the three official clients make this measurement ambiguous.
+//
+// `scw` validates enums against its own SDK, `exo` resolves a NAME|ID by
+// listing before it acts, and both then report their OWN refusal with a
+// non-zero exit code and a `{"message": ...}` body — the same two things the
+// API's refusal produces. A suite reading the client's text cannot tell the two
+// apart, so a case that silently stops reaching the emulator reads exactly like
+// the suite working, and the operation it was written for falls back to zero
+// with nothing red.
+//
+// So the helper reads the EMULATOR's verdict: a `negative` span that closes 409
+// is the emulator saying it observed no client refusal inside the block. The
+// three tests below are the three outcomes, and each is needed:
+//
+//   - a client refusal that never reached the emulator must FAIL the case;
+//   - a refusal the emulator made must PASS it, or a helper that refused
+//     everything would satisfy the first test;
+//   - a call the API ACCEPTED must fail too, which is the defect the case is
+//     written to catch in the first place.
+func TestARefusalTheClientMadeItselfFailsTheCase(t *testing.T) {
+	code, output := runRefuseClient(t, spanClose{status: http.StatusConflict}, clientExit(1))
+	if code == 0 {
+		t.Errorf("a case whose refusal never reached the emulator passed, so it measures nothing:\n%s", output)
+	}
+	for _, want := range []string{"the-case", "measures nothing"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("the failure never says %q, so nobody reading it knows which case is blind:\n%s", want, output)
+		}
+	}
+}
+
+func TestARefusalTheEmulatorMadePassesTheCase(t *testing.T) {
+	code, output := runRefuseClient(t, spanClose{status: http.StatusOK}, clientExit(1))
+	if code != 0 {
+		t.Errorf("a refusal the emulator itself answered was rejected (exit %d):\n%s", code, output)
+	}
+}
+
+func TestACallTheAPIAcceptedFailsTheCase(t *testing.T) {
+	code, output := runRefuseClient(t, spanClose{status: http.StatusOK}, clientExit(0))
+	if code == 0 {
+		t.Errorf("the case passed on a call the API accepted, which is the defect it exists to catch:\n%s", output)
+	}
+	if !strings.Contains(output, "answered success") {
+		t.Errorf("the failure does not say the call was accepted:\n%s", output)
+	}
+}
+
+// The span must actually have been opened and closed. Without this, a helper
+// that never called the emulator at all would satisfy the passing case above:
+// "nothing was found" and "nothing was looked for" read the same.
+func TestTheCaseOpensAndClosesASpan(t *testing.T) {
+	var opened, closed int32
+	code, output := runRefuseClientCounting(t, spanClose{status: http.StatusOK}, clientExit(1), &opened, &closed)
+	if code != 0 {
+		t.Fatalf("the case failed (exit %d):\n%s", code, output)
+	}
+	if atomic.LoadInt32(&opened) != 1 || atomic.LoadInt32(&closed) != 1 {
+		t.Errorf("the case opened %d span(s) and closed %d, so its verdict came from somewhere else",
+			atomic.LoadInt32(&opened), atomic.LoadInt32(&closed))
+	}
+}
+
+type spanClose struct{ status int }
+
+// clientExit builds a stand-in client: a shell command that prints and exits
+// with the code given. The real clients are not driven here — what is under
+// test is how the helper reads their outcome against the emulator's, and a
+// stand-in makes the third outcome reproducible, which no installed client
+// would.
+func clientExit(code int) []string {
+	return []string{"sh", "-c", fmt.Sprintf(`echo "client said something"; exit %d`, code)}
+}
+
+func runRefuseClient(t *testing.T, close spanClose, client []string) (int, string) {
+	t.Helper()
+	var opened, closed int32
+	return runRefuseClientCounting(t, close, client, &opened, &closed)
+}
+
+// runRefuseClientCounting sources the real prove.sh — the subject, never a copy
+// — and calls refuse_client against a stub emulator.
+func runRefuseClientCounting(t *testing.T, closeWith spanClose, client []string, opened, closed *int32) (int, string) {
+	t.Helper()
+	requireTool(t, "bash")
+	requireTool(t, "curl")
+	requireTool(t, "jq")
+
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/_feint/assert":
+			atomic.AddInt32(opened, 1)
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"id":"span-1"}`)
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/_feint/assert/"):
+			atomic.AddInt32(closed, 1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(closeWith.status)
+			if closeWith.status == http.StatusOK {
+				fmt.Fprint(w, `{"operations":["stub/v1/API.GetThing"],"unattributed":0}`)
+			} else {
+				fmt.Fprint(w, `{"error":"the span demanded a refusal and the emulator answered no client with a 4xx inside it"}`)
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer stub.Close()
+
+	prove, err := filepath.Abs("prove.sh")
+	if err != nil {
+		t.Fatalf("locate prove.sh: %v", err)
+	}
+	if _, err := os.Stat(prove); err != nil {
+		t.Fatalf("prove.sh is not where this test looks (%s): %v", prove, err)
+	}
+
+	script := `set -uo pipefail; . "$1"; shift; refuse_client "the-case" "$@"`
+	args := append([]string{"-c", script, "bash", prove}, client...)
+	cmd := exec.Command("bash", args...) //nolint:gosec // fixed script, test-controlled arguments
+	cmd.Env = append(os.Environ(), "ENDPOINT="+stub.URL)
+	out, err := cmd.CombinedOutput()
+	code := 0
+	if err != nil {
+		var exit *exec.ExitError
+		if !errors.As(err, &exit) {
+			t.Fatalf("run refuse_client: %v\n%s", err, out)
+		}
+		code = exit.ExitCode()
+	}
+	return code, string(out)
+}

--- a/tools/conformance/scaleway/scw-cli.sh
+++ b/tools/conformance/scaleway/scw-cli.sh
@@ -1058,36 +1058,12 @@ REGION="${REGION:-fr-par}"
 # of passing it: a case that stops reaching the API measures nothing, and it
 # would look exactly like this suite working.
 
-# refuse_scw drives one command that must be refused BY THE EMULATOR, and reads
-# the emulator's own verdict rather than the client's output.
-#
-# Three outcomes, never two, because `scw` answers a refusal it made itself and
-# a refusal the API made with the same exit code and the same `{"message":...}`
-# envelope — parsing that text is how this block would lie:
-#
-#   - the CLI succeeded            -> the API accepted what must be refused;
-#   - the CLI failed, span closes  -> the emulator answered a 4xx: the case holds;
-#   - the CLI failed, span 409s    -> the request never reached the emulator,
-#                                     so this case proves nothing and says so.
-#
-# TestANegativeSpanNeedsARefusal (internal/core/emulator) is what makes the
-# third outcome a 409 rather than a green close.
+# refuse_scw names the client; everything else is refuse_client's, in
+# tools/conformance/prove.sh, because the rule is the same for all three clouds
+# and a control recopied into each suite is a control one suite forgets.
 refuse_scw() { # label args...
   local label="$1"; shift
-  local span out rc=0 close code body
-  span="$(prove_begin negative)"
-  out="$(scw "$@" 2>&1)" || rc=$?
-  close="$(curl -s -w '\n%{http_code}' -X POST "$ENDPOINT/_feint/assert/$span")"
-  code="${close##*$'\n'}"
-  body="${close%$'\n'*}"
-  if [ "$rc" -eq 0 ]; then
-    fail "$label: the CLI was answered success where a refusal was demanded: $out"
-  fi
-  case "$code" in
-    200) ;;
-    409) fail "$label: the CLI refused this on its own and the emulator never saw it, so the case measures nothing: $out" ;;
-    *)   fail "$label: the emulator answered HTTP $code closing the span: $body" ;;
-  esac
+  refuse_client "$label" scw "$@"
 }
 
 echo "- the refusals each operation owns"

--- a/tools/conformance/scaleway/scw-cli.sh
+++ b/tools/conformance/scaleway/scw-cli.sh
@@ -1016,4 +1016,150 @@ scw vpc private-network delete "$gw_pn_id" region=fr-par >/dev/null \
 prove_end "$span"
 ok "the gateway chain round-tripped, its address resolved through IPAM, and the wrong destroy order was refused"
 
+# The three values every refusal below is composed from. They are chosen to be
+# unmintable rather than merely unused: knownZones and knownRegions (servers.go,
+# vpc.go) are closed lists, and no Scaleway place is named xx-yyy.
+UNKNOWN_ID="99999999-9999-4999-8999-999999999999"
+NOWHERE_ZONE="xx-yyy-1"
+NOWHERE_REGION="xx-yyy"
+REGION="${REGION:-fr-par}"
+
+# The refusals a real client can ask for, on the operations nothing ever refused.
+#
+# `negative` is earned by an operation really answering 4xx to a real client
+# inside a span where a suite demanded a refusal (#428). Seventy-six Scaleway
+# operations stood at zero, and the reason was never that the emulator lacked
+# the behaviour: nobody had ever asked it to say no on those calls. The corpus
+# of recorded cloud refusals (refusals.sh, #390) covers the reads and writes a
+# recording session drove at bogus identifiers, and stops there.
+#
+# Nothing below arms a fault. It could not: an injected refusal leaves the
+# observed path before the observer records it, and a span whose only 4xx were
+# injected is refused outright by the emulator. Every refusal here is this
+# emulator's own rule meeting a request the real CLI composed.
+#
+# TWO SHAPES, AND THE ORDER MATTERS. Where an operation owns a refusal of its
+# own — an identifier that names nothing, a resource still in use, a state that
+# forbids the call — that is the one driven, because it exercises the handler's
+# subject. Where it owns none that `scw` can compose, the request is sent at a
+# zone or a region that names no place. That refusal is real and it is this
+# emulator's own (`zoneOf`/`regionOf` answer `invalid_arguments` naming the
+# segment, and `knownZones` says why), but it is worth stating what it proves
+# and what it does not: the route is mounted, its handler runs and refuses a
+# scope it does not serve. It says nothing about how that operation treats a
+# bad payload. Anything stronger is used where it exists.
+#
+# WHAT `scw` CANNOT ASK FOR, MEASURED RATHER THAN ASSUMED. The CLI validates
+# enums against its own SDK (`state=bogus`, `order-by=nope` never leave the
+# machine) and resolves a target before acting, so `server delete <unknown>`,
+# `lb delete <unknown>` and `snapshot create volume-id=<unknown>` are answered
+# by the GET that precedes them and the write is never sent. That ceiling is
+# why refuse_scw fails a case whose refusal never reached the emulator instead
+# of passing it: a case that stops reaching the API measures nothing, and it
+# would look exactly like this suite working.
+
+# refuse_scw drives one command that must be refused BY THE EMULATOR, and reads
+# the emulator's own verdict rather than the client's output.
+#
+# Three outcomes, never two, because `scw` answers a refusal it made itself and
+# a refusal the API made with the same exit code and the same `{"message":...}`
+# envelope — parsing that text is how this block would lie:
+#
+#   - the CLI succeeded            -> the API accepted what must be refused;
+#   - the CLI failed, span closes  -> the emulator answered a 4xx: the case holds;
+#   - the CLI failed, span 409s    -> the request never reached the emulator,
+#                                     so this case proves nothing and says so.
+#
+# TestANegativeSpanNeedsARefusal (internal/core/emulator) is what makes the
+# third outcome a 409 rather than a green close.
+refuse_scw() { # label args...
+  local label="$1"; shift
+  local span out rc=0 close code body
+  span="$(prove_begin negative)"
+  out="$(scw "$@" 2>&1)" || rc=$?
+  close="$(curl -s -w '\n%{http_code}' -X POST "$ENDPOINT/_feint/assert/$span")"
+  code="${close##*$'\n'}"
+  body="${close%$'\n'*}"
+  if [ "$rc" -eq 0 ]; then
+    fail "$label: the CLI was answered success where a refusal was demanded: $out"
+  fi
+  case "$code" in
+    200) ;;
+    409) fail "$label: the CLI refused this on its own and the emulator never saw it, so the case measures nothing: $out" ;;
+    *)   fail "$label: the emulator answered HTTP $code closing the span: $body" ;;
+  esac
+}
+
+echo "- the refusals each operation owns"
+
+# An identifier that names nothing, on the operations whose own subject is that
+# identifier. `scw` sends these: they are path segments and request fields, not
+# enums it can check.
+refuse_scw "placement group get"      instance placement-group get "$UNKNOWN_ID" zone="$ZONE" -o json
+refuse_scw "attach volume"            instance server attach-volume server-id="$UNKNOWN_ID" volume-id="$UNKNOWN_ID" zone="$ZONE" -o json
+refuse_scw "detach volume"            instance server detach-volume server-id="$UNKNOWN_ID" volume-id="$UNKNOWN_ID" zone="$ZONE" -o json
+refuse_scw "image from a snapshot"    instance image create name=refused snapshot-id="$UNKNOWN_ID" arch=x86_64 zone="$ZONE" -o json
+refuse_scw "placement group servers"  instance placement-group update-servers placement-group-id="$UNKNOWN_ID" servers.0="$UNKNOWN_ID" zone="$ZONE" -o json
+refuse_scw "security group rules"     instance security-group set-rules security-group-id="$UNKNOWN_ID" zone="$ZONE" -o json
+refuse_scw "user data"                instance user-data set server-id="$UNKNOWN_ID" key=refused content=refused zone="$ZONE"
+refuse_scw "load balancer backend"    lb backend create lb-id="$UNKNOWN_ID" name=refused forward-protocol=tcp forward-port=80 \
+                                        forward-port-algorithm=roundrobin sticky-sessions=none health-check.port=80 zone="$ZONE" -o json
+refuse_scw "load balancer attach"     lb private-network attach lb-id="$UNKNOWN_ID" private-network-id="$UNKNOWN_ID" zone="$ZONE" -o json
+refuse_scw "load balancer from an ip" lb lb create name=refused type=LB-S ip-ids.0="$UNKNOWN_ID" zone="$ZONE" -o json
+refuse_scw "block volume from a snapshot" block volume create name=refused from-snapshot.snapshot-id="$UNKNOWN_ID" perf-iops=5000 zone="$ZONE" -o json
+refuse_scw "block snapshot of a volume"   block snapshot create name=refused volume-id="$UNKNOWN_ID" zone="$ZONE" -o json
+refuse_scw "acl of a vpc"             vpc rule set vpc-id="$UNKNOWN_ID" is-ipv6=false default-policy=drop region="$REGION" -o json
+ok "an identifier that names nothing is refused where it is the subject"
+
+# A state that forbids the call. DeleteServer is the one write of this pack that
+# `scw` reaches at all with a real target: the CLI resolves the server first, so
+# the only way to the DELETE is a server that exists and refuses to be deleted.
+echo "- a running server does not delete"
+doomed="$(scw instance server create name=conformance-refused type=DEV1-S zone="$ZONE" -o json)" \
+  || fail "create rejected: $doomed"
+doomed_id="$(printf '%s' "$doomed" | jq -r '.id // empty')"
+[ -n "$doomed_id" ] || fail "no id in the create response: $doomed"
+refuse_scw "delete a running server"  instance server delete "$doomed_id" zone="$ZONE"
+scw instance server stop "$doomed_id" zone="$ZONE" >/dev/null || fail "cleanup: poweroff rejected"
+scw instance server delete "$doomed_id" zone="$ZONE" >/dev/null || fail "cleanup: delete rejected once stopped"
+ok "the running server was kept, and deleted once stopped"
+
+# A zone and a region that name no place, for the operations that own no other
+# refusal a client can compose. See the note above on what this proves.
+echo "- a zone and a region that name no place"
+refuse_scw "instance ip list"          instance ip list zone="$NOWHERE_ZONE" -o json
+refuse_scw "instance image list"       instance image list zone="$NOWHERE_ZONE" -o json
+refuse_scw "instance volume list"      instance volume list zone="$NOWHERE_ZONE" -o json
+refuse_scw "instance snapshot list"    instance snapshot list zone="$NOWHERE_ZONE" -o json
+refuse_scw "security group list"       instance security-group list zone="$NOWHERE_ZONE" -o json
+refuse_scw "placement group list"      instance placement-group list zone="$NOWHERE_ZONE" -o json
+refuse_scw "instance server list"      instance server list zone="$NOWHERE_ZONE" -o json
+refuse_scw "instance ip create"        instance ip create zone="$NOWHERE_ZONE" -o json
+refuse_scw "security group create"     instance security-group create name=refused zone="$NOWHERE_ZONE" -o json
+refuse_scw "placement group create"    instance placement-group create name=refused zone="$NOWHERE_ZONE" -o json
+refuse_scw "instance volume create"    instance volume create name=refused size=10GB volume-type=l_ssd zone="$NOWHERE_ZONE" -o json
+# The create the CLI walks in four calls: the type catalogue, the default image,
+# the address, then the server. It is refused on the first three, which is where
+# `GetImage` and `ListServersTypes` earn theirs — `GetImage` owns no refusal of
+# its own, an identifier it never minted being served on purpose (docs/limits.md,
+# and the divergence that decision costs is corpus/accepted.json's #392).
+refuse_scw "instance server create"    instance server create name=refused type=DEV1-S zone="$NOWHERE_ZONE" -o json
+refuse_scw "block volume list"         block volume list zone="$NOWHERE_ZONE" -o json
+refuse_scw "block snapshot list"       block snapshot list zone="$NOWHERE_ZONE" -o json
+refuse_scw "block volume type list"    block volume-type list zone="$NOWHERE_ZONE" -o json
+refuse_scw "load balancer list"        lb lb list zone="$NOWHERE_ZONE" -o json
+refuse_scw "load balancer ip list"     lb ip list zone="$NOWHERE_ZONE" -o json
+refuse_scw "load balancer ip create"   lb ip create zone="$NOWHERE_ZONE" -o json
+refuse_scw "gateway list"              vpc-gw gateway list zone="$NOWHERE_ZONE" -o json
+refuse_scw "gateway network list"      vpc-gw gateway-network list zone="$NOWHERE_ZONE" -o json
+refuse_scw "gateway ip list"           vpc-gw ip list zone="$NOWHERE_ZONE" -o json
+refuse_scw "gateway ip create"         vpc-gw ip create zone="$NOWHERE_ZONE" -o json
+refuse_scw "vpc list"                  vpc vpc list region="$NOWHERE_REGION" -o json
+refuse_scw "private network list"      vpc private-network list region="$NOWHERE_REGION" -o json
+refuse_scw "vpc create"                vpc vpc create name=refused region="$NOWHERE_REGION" -o json
+refuse_scw "private network dhcp"      vpc private-network enable-dhcp private-network-id="$UNKNOWN_ID" region="$NOWHERE_REGION" -o json
+refuse_scw "ipam ip list"              ipam ip list region="$NOWHERE_REGION" -o json
+refuse_scw "ipam ip set release"       ipam ip-set release region="$NOWHERE_REGION" -o json
+ok "every one of them refused by name"
+
 echo "conformance: scw CLI passed"

--- a/tools/falsify/specs/refusal-reached-the-emulator.json
+++ b/tools/falsify/specs/refusal-reached-the-emulator.json
@@ -1,0 +1,27 @@
+{
+  "package": "./tools/conformance/",
+  "note": "refuse_client is the control behind the negative cases of #428. `scw` validates enums against its own SDK and `exo` resolves a NAME|ID by listing before it acts, so a case aimed at something that does not exist is refused by the CLI and never reaches the emulator — with the same non-zero exit code and the same JSON envelope the API's own refusal produces. Each mutation below removes one of the three outcomes and must make the test that owns it fail.",
+  "mutations": [
+    {
+      "label": "a refusal the client made itself closes the case green, so an operation quietly stops earning the axis and nothing goes red",
+      "file": "tools/conformance/prove.sh",
+      "find": "  case \"$code\" in\n    200) ;;",
+      "replace": "  case \"$code\" in\n    200|409) ;;",
+      "test": "TestARefusalTheClientMadeItselfFailsTheCase"
+    },
+    {
+      "label": "a call the API accepted closes the case green, which is the defect the case is written to catch",
+      "file": "tools/conformance/prove.sh",
+      "find": "  if [ \"$rc\" -eq 0 ]; then\n    echo \"FAIL: $label: the client was answered success where a refusal was demanded: $out\" >&2\n    exit 1\n  fi",
+      "replace": "  if [ \"$rc\" -eq 0 ] && false; then\n    echo \"FAIL: $label: the client was answered success where a refusal was demanded: $out\" >&2\n    exit 1\n  fi",
+      "test": "TestACallTheAPIAcceptedFailsTheCase"
+    },
+    {
+      "label": "the span is never closed, so the case reports a verdict the emulator never gave",
+      "file": "tools/conformance/prove.sh",
+      "find": "  close=\"$(curl -s -w '\\n%{http_code}' -X POST \"$ENDPOINT/_feint/assert/$span\")\"",
+      "replace": "  close=\"$(printf '%s\\n200' '{}')\" # close=\"$(curl -s -w '\\n%{http_code}' -X POST \"$ENDPOINT/_feint/assert/$span\")\"",
+      "test": "TestTheCaseOpensAndClosesASpan"
+    }
+  ]
+}


### PR DESCRIPTION
Fifty operations earn the `negative` axis, and **not one line of pack code
moved**. Every one is a conformance case against a refusal this emulator already
served and nobody had ever asked for.

| cloud | before | after |
|---|---|---|
| Scaleway | 97 / 173 (56 %) | **139 / 173 (80 %)** |
| Exoscale | 10 / 104 | **18 / 104** |
| Outscale | 90 / 93 | 90 / 93 |
| **all** | **197 / 370** | **247 / 370** |

Measured on a scratch record, one machines-off pass, so it is a **lower bound**:
the network suites did not run. `coverage/evidence.json` is untouched, as asked.

## How the fifty break down

**Scaleway, 42.** Thirteen own a refusal `scw` can compose directly — an
identifier naming nothing where that identifier *is* the operation's subject, a
running server refusing its own delete. The other twenty-nine own none, and are
driven at a zone or region that names no place: `scw` passes an arbitrary zone
straight through, and the pack answers `invalid_arguments` against its closed
list. The code says exactly what that proves — route mounted, handler runs,
scope refused — and what it does not: nothing about a bad payload. The stronger
case is used wherever one exists.

**Exoscale, 8.** `reset-instance` and `enable-tpm` on a running machine,
`attach-instance-to-private-network` on a network it already sits on,
`delete-security-group` while an instance wears it, `detach-block-storage-volume`
on a volume nothing holds, `evict-instance-pool-members` at a non-member, and
`list-templates` / `list-security-groups` at a `visibility` outside their
declared enum — the only two reads of that pack a client can put a refusal to at
all.

## No `Unearnable` declaration was written, and that is the decision

Of the 34 remaining Scaleway zeros, **33 are blocked by the client, not the
emulator**: `scw` resolves a target with a GET before every delete and update, so
a bogus id credits `GetServer` and never the write; it has no `v2alpha1`
commands; it reaches `block/v1alpha1` where the Terraform provider uses
`block/v1`; and it has no `subnet` or `ipam attach/detach/move` subcommands.
Exoscale's 86 are the same shape.

**A declaration whose cause is "our CLI has no subcommand" can never expire
correctly**, which is precisely why the Outscale lot refused to declare
`ReadLoadBalancers`. Declaring these would put 119 permanent excuses in the pack
for a fact about tooling. The single exception is
`marketplace/v2/API.ListLocalImages`, a deliberate divergence already owned by
#392.

**The Exoscale ceiling is measured rather than assumed**: across 14 resource
families driven at bogus identifiers, **exactly one** call reached the API
(`get-ssh-key`, because a key is named rather than minted). The brief said three
of sixty-five; same conclusion, tighter number.

## Premises the brief got wrong

1. **"147 operations (Exoscale 76, Scaleway 71)."** The fresh record says
   **Exoscale 94, Scaleway 76 — 170**. The issue's own table reconciles with no
   record that could be found, and its Outscale figure predates the wave that
   took that cloud to three.
2. **"Eighteen of twenty-four needed no pack code."** Here it was **fifty out of
   fifty**.
3. `instance/v1/API.GetImage` was nearly filed as a defect — a bogus image id
   answers 200 with a fabricated image. Verified before fixing: it is a
   documented decision (#392), and the operation turned out earnable anyway
   through the zone route.

## One criterion of the brief passes on uncorrected code

**`mise run conformance` green proves nothing about this work** — it was green
before. The only criterion that detects it is the axis count, which is why a
scratch record was produced rather than reporting from the suite's own output.

## An instrument lied twice, and the fix is why the spec exists

The first Exoscale sweep printed **18 "NO-4XX" verdicts for a scenario that was
never built**: a template lookup returned empty, so every command ran against an
empty id and every verdict was **vacuously true**. The block-storage batch
repeated it. Both were caught only because a whole series failed at once.

That is why `refuse_client` reads the **emulator's own span verdict** rather than
the client's text, and why `TestTheCaseOpensAndClosesASpan` exists.

## Falsified

`refuse_scw` and `refuse_exo` were the same function written twice, so the rule
moved into `prove.sh` as `refuse_client` — which is what made it testable at all.
Four tests source the real `prove.sh`, and
`tools/falsify/specs/refusal-reached-the-emulator.json` carries three mutations.
**None was green at the first attempt.**

One was rejected by `falsify:lint` first, for dropping `echo` from its fragment —
the harness rule `HANDOVER.md` warns about. Rewritten as a truth-value change, it
bit.

## Gates

`prepush` 0 · `corpus:check` 0 · `conformance` 0, 349/372 · legs `probe` and
`fields` 0 · `falsify:lint` 0, with 529 mutations across 95 specs. Exit codes
captured before any pipe.

## Issues

**#428 is remeasured and reported as it comes out — not closed.** 123 zeros
remain, and the reachable half now needs a client this project does not drive: an
Exoscale Terraform provider, or `egoscale` and `block/v1` directly. That is the
natural follow-up.

**#409–#414** are each touched by earned operations, and **none is closed**: they
are about *serving* parity, not refusing.

## Related

Refs #428, #409, #410, #411, #412, #413, #414, #392
