### PR TITLE
feat(contract): a provider that documents an empty answer is held to it, and thirty-one Scaleway zeros had no other cause (#429)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -1734,6 +1734,49 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Corrigé
 
+- **Une opération dont la description d'API dit qu'elle ne répond aucun corps
+  est désormais contrôlée sur exactement cela, et trente et une opérations
+  Scaleway cessent d'afficher « personne n'a regardé »** (#429). Scaleway écrit
+  `204: {description: ''}` sur 64 de ses 370 opérations documentées, et c'est le
+  seul fournisseur ici à le faire. C'est le fournisseur qui déclare ce que porte
+  sa réponse : rien. Et ce n'est pas « les DELETE » : quatre de ses DELETE
+  déclarent un corps et en répondent un, et douze des 64 ne sont pas des DELETE.
+
+  L'extraction enregistrait cette déclaration comme l'*absence* de schéma de
+  réponse, ce à quoi ressemble aussi un corps qu'elle ne sait pas nommer, et les
+  deux lecteurs en aval ne voyaient donc qu'un silence. `internal/probe` sautait
+  chacune de ces opérations, et le contrôle de contrat rendait la main avant
+  d'enregistrer quoi que ce soit dès que le corps était vide. Un `scw instance
+  server delete` répondant précisément ce que Scaleway documente était classé
+  `unchecked` — la valeur que cet axe définit comme *personne n'a jamais
+  regardé*.
+
+  `noContent` porte maintenant le statut déclaré, et seulement là où le document
+  déclare un 2xx sans aucun contenu. Le troisième cas reste à part et reste non
+  contrôlé : `list-events`, `get-sks-cluster-inspection` et
+  `list-sks-cluster-deprecated-resources` d'Exoscale déclarent un corps que cette
+  extraction ne sait pas nommer, et lire leur silence comme « ne répond rien »
+  serait un verdict inventé par l'axe. Ce qui est validé, ce sont les mots du
+  document, dans les deux sens : un corps là où il n'en déclare aucun, et un
+  statut qu'il ne nomme pas — celui-là même sur lequel un SDK généré branche pour
+  décider s'il désérialise.
+
+  Mesuré sur deux passes de `mise run conformance` ne différant que par ce
+  changement, même station, même tâche : Scaleway passe de 141 à 170 de ses 173
+  opérations servies sur `probed`, et de 142 à **173 sur 173** sur `contract` —
+  son deuxième axe complet — tandis que toutes les autres cellules du tableau à
+  sept axes, sur les trois packs, sont identiques. Les 31 opérations qui gagnent
+  `contract` sont exactement les 31 opérations servies dont le document déclare
+  une réponse vide, ensemble pour ensemble. Aucune ligne de code de pack n'a
+  bougé. Le tableau par fournisseur est dans `docs/routes.md`.
+
+  Trois restent à zéro sur `probed`, et la cause appartient à la sonde et non à
+  un pack : `Get`, `Set` et `DeleteServerUserData` adressent une clé par son nom,
+  et rien dans une passe de sonde n'en produit — un serveur que la sonde crée
+  répond `{"user_data":[]}`, puisque la seule opération capable d'y poser une clé
+  est celle qui en réclame une. Un client invente ce nom ; une sonde n'a pas le
+  droit.
+
 - **Outscale borne `ResultsPerPage` là où sa propre API la borne, et une taille
   de page hors de 1 à 1000 est désormais refusée** (#428). Vingt et un schémas de
   requête Read* de la description publiée par Outscale portent la même phrase —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,44 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Fixed
 
+- **An operation whose API description says it answers no body is now checked
+  against exactly that, and thirty-one Scaleway operations stop reading
+  "nobody looked"** (#429). Scaleway writes `204: {description: ''}` on 64 of
+  its 370 documented operations, and it is the only provider here that does.
+  That is the provider stating what its answer carries: nothing. Not simply
+  "the DELETEs" either — four of its DELETEs declare a body and answer one, and
+  twelve of the 64 are not DELETEs at all.
+
+  The extraction recorded the statement as the *absence* of a response schema,
+  which is also what a body it cannot name looks like, so two readers could only
+  see silence. `internal/probe` skipped every such operation, and the contract
+  check returned before recording anything as soon as a body was empty. A `scw
+  instance server delete` answering precisely what Scaleway documents was filed
+  as `unchecked` — the value that axis defines as *nobody has ever looked*.
+
+  `noContent` now carries the declared status, and only where the document
+  declares a 2xx with no content at all. The third case stays apart and stays
+  unchecked: Exoscale's `list-events`, `get-sks-cluster-inspection` and
+  `list-sks-cluster-deprecated-resources` declare a body this extraction cannot
+  name, and reading their silence as "answers nothing" would be the axis
+  inventing a verdict. What is validated is the document's own words in both
+  directions — a body where none is declared, and a status the document does not
+  name, which is what a generated SDK branches on to decide whether to unmarshal.
+
+  Measured on two runs of `mise run conformance` differing only by this change,
+  same host, same task: Scaleway goes from 141 to 170 of its 173 served
+  operations on `probed`, and from 142 to **173 of 173** on `contract` — its
+  second complete axis — while every other cell of the seven-axis table, on all
+  three packs, is identical. The 31 operations that gained `contract` are
+  exactly the 31 served operations whose document declares an empty answer, set
+  for set. No pack code moved. The per-provider table is in `docs/routes.md`.
+
+  Three stay at zero on `probed` and the cause is the probe's, not a pack's:
+  `Get`, `Set` and `DeleteServerUserData` address a key by name, and nothing in a
+  probe run produces one — a server the probe creates answers `{"user_data":[]}`,
+  because the only operation that could put a key there is the one that needs it.
+  A client invents that name; a probe may not.
+
 - **Outscale bounds `ResultsPerPage` where its own API bounds it, and a page
   size outside 1 to 1000 is now refused** (#428). Twenty-one Read* request
   schemas of Outscale's published description carry the same sentence — "between

--- a/contracts/scaleway.json
+++ b/contracts/scaleway.json
@@ -23,12 +23,14 @@
   "block/v1.DeleteSnapshot": {
    "path": "/block/v1/zones/{zone}/snapshots/{snapshot_id}",
    "method": "DELETE",
-   "group": "Snapshot"
+   "group": "Snapshot",
+   "noContent": 204
   },
   "block/v1.DeleteVolume": {
    "path": "/block/v1/zones/{zone}/volumes/{volume_id}",
    "method": "DELETE",
-   "group": "Volume"
+   "group": "Volume",
+   "noContent": 204
   },
   "block/v1.ExportSnapshotToObjectStorage": {
    "path": "/block/v1/zones/{zone}/snapshots/{snapshot_id}/export-to-object-storage",
@@ -186,12 +188,14 @@
   "block/v1alpha1.DeleteSnapshot": {
    "path": "/block/v1alpha1/zones/{zone}/snapshots/{snapshot_id}",
    "method": "DELETE",
-   "group": "Snapshot"
+   "group": "Snapshot",
+   "noContent": 204
   },
   "block/v1alpha1.DeleteVolume": {
    "path": "/block/v1alpha1/zones/{zone}/volumes/{volume_id}",
    "method": "DELETE",
-   "group": "Volume"
+   "group": "Volume",
+   "noContent": 204
   },
   "block/v1alpha1.ExportSnapshotToObjectStorage": {
    "path": "/block/v1alpha1/zones/{zone}/snapshots/{snapshot_id}/export-to-object-storage",
@@ -414,62 +418,74 @@
   "iam/v1alpha1.DeleteAPIKey": {
    "path": "/iam/v1alpha1/api-keys/{access_key}",
    "method": "DELETE",
-   "group": "API Keys"
+   "group": "API Keys",
+   "noContent": 204
   },
   "iam/v1alpha1.DeleteApplication": {
    "path": "/iam/v1alpha1/applications/{application_id}",
    "method": "DELETE",
-   "group": "Applications"
+   "group": "Applications",
+   "noContent": 204
   },
   "iam/v1alpha1.DeleteGroup": {
    "path": "/iam/v1alpha1/groups/{group_id}",
    "method": "DELETE",
-   "group": "Groups"
+   "group": "Groups",
+   "noContent": 204
   },
   "iam/v1alpha1.DeleteJWT": {
    "path": "/iam/v1alpha1/jwts/{jti}",
    "method": "DELETE",
-   "group": "JWTs"
+   "group": "JWTs",
+   "noContent": 204
   },
   "iam/v1alpha1.DeletePolicy": {
    "path": "/iam/v1alpha1/policies/{policy_id}",
    "method": "DELETE",
-   "group": "Policies"
+   "group": "Policies",
+   "noContent": 204
   },
   "iam/v1alpha1.DeleteSSHKey": {
    "path": "/iam/v1alpha1/ssh-keys/{ssh_key_id}",
    "method": "DELETE",
-   "group": "SSH Keys"
+   "group": "SSH Keys",
+   "noContent": 204
   },
   "iam/v1alpha1.DeleteSaml": {
    "path": "/iam/v1alpha1/saml/{saml_id}",
    "method": "DELETE",
-   "group": "SAML"
+   "group": "SAML",
+   "noContent": 204
   },
   "iam/v1alpha1.DeleteSamlCertificate": {
    "path": "/iam/v1alpha1/saml-certificates/{certificate_id}",
    "method": "DELETE",
-   "group": "SAML"
+   "group": "SAML",
+   "noContent": 204
   },
   "iam/v1alpha1.DeleteScim": {
    "path": "/iam/v1alpha1/scim/{scim_id}",
    "method": "DELETE",
-   "group": "SCIM"
+   "group": "SCIM",
+   "noContent": 204
   },
   "iam/v1alpha1.DeleteScimToken": {
    "path": "/iam/v1alpha1/scim-tokens/{token_id}",
    "method": "DELETE",
-   "group": "SCIM"
+   "group": "SCIM",
+   "noContent": 204
   },
   "iam/v1alpha1.DeleteUser": {
    "path": "/iam/v1alpha1/users/{user_id}",
    "method": "DELETE",
-   "group": "Users"
+   "group": "Users",
+   "noContent": 204
   },
   "iam/v1alpha1.DeleteUserMFAOTP": {
    "path": "/iam/v1alpha1/users/{user_id}/mfa-otp",
    "method": "DELETE",
-   "group": "Users"
+   "group": "Users",
+   "noContent": 204
   },
   "iam/v1alpha1.EnableOrganizationSaml": {
    "path": "/iam/v1alpha1/organizations/{organization_id}/saml",
@@ -584,7 +600,8 @@
   "iam/v1alpha1.JoinUserConnection": {
    "path": "/iam/v1alpha1/users/{user_id}/join-connection",
    "method": "POST",
-   "request": "iam/v1alpha1.JoinUserConnection.Request"
+   "request": "iam/v1alpha1.JoinUserConnection.Request",
+   "noContent": 204
   },
   "iam/v1alpha1.ListAPIKeys": {
    "path": "/iam/v1alpha1/api-keys",
@@ -1000,7 +1017,8 @@
   "iam/v1alpha1.RemoveUserConnection": {
    "path": "/iam/v1alpha1/users/{user_id}/remove-connection",
    "method": "POST",
-   "request": "iam/v1alpha1.RemoveUserConnection.Request"
+   "request": "iam/v1alpha1.RemoveUserConnection.Request",
+   "noContent": 204
   },
   "iam/v1alpha1.SetGroupMembers": {
    "path": "/iam/v1alpha1/groups/{group_id}/members",
@@ -1128,7 +1146,8 @@
   "instance/v1.CheckBlockMigrationOrganizationQuotas": {
    "path": "/instance/v1/zones/{zone}/block-migration/check-organization-quotas",
    "method": "POST",
-   "request": "instance/v1.CheckBlockMigrationOrganizationQuotas.Request"
+   "request": "instance/v1.CheckBlockMigrationOrganizationQuotas.Request",
+   "noContent": 204
   },
   "instance/v1.CreateImage": {
    "path": "/instance/v1/zones/{zone}/images",
@@ -1196,52 +1215,62 @@
   "instance/v1.DeleteImage": {
    "path": "/instance/v1/zones/{zone}/images/{image_id}",
    "method": "DELETE",
-   "group": "Images"
+   "group": "Images",
+   "noContent": 204
   },
   "instance/v1.DeleteIp": {
    "path": "/instance/v1/zones/{zone}/ips/{ip}",
    "method": "DELETE",
-   "group": "IPs"
+   "group": "IPs",
+   "noContent": 204
   },
   "instance/v1.DeletePlacementGroup": {
    "path": "/instance/v1/zones/{zone}/placement_groups/{placement_group_id}",
    "method": "DELETE",
-   "group": "Placement Groups"
+   "group": "Placement Groups",
+   "noContent": 204
   },
   "instance/v1.DeletePrivateNIC": {
    "path": "/instance/v1/zones/{zone}/servers/{server_id}/private_nics/{private_nic_id}",
    "method": "DELETE",
-   "group": "Private NICs"
+   "group": "Private NICs",
+   "noContent": 204
   },
   "instance/v1.DeleteSecurityGroup": {
    "path": "/instance/v1/zones/{zone}/security_groups/{security_group_id}",
    "method": "DELETE",
-   "group": "Security Groups"
+   "group": "Security Groups",
+   "noContent": 204
   },
   "instance/v1.DeleteSecurityGroupRule": {
    "path": "/instance/v1/zones/{zone}/security_groups/{security_group_id}/rules/{security_group_rule_id}",
    "method": "DELETE",
-   "group": "Security Groups"
+   "group": "Security Groups",
+   "noContent": 204
   },
   "instance/v1.DeleteServer": {
    "path": "/instance/v1/zones/{zone}/servers/{server_id}",
    "method": "DELETE",
-   "group": "Instances"
+   "group": "Instances",
+   "noContent": 204
   },
   "instance/v1.DeleteServerUserData": {
    "path": "/instance/v1/zones/{zone}/servers/{server_id}/user_data/{key}",
    "method": "DELETE",
-   "group": "User Data"
+   "group": "User Data",
+   "noContent": 204
   },
   "instance/v1.DeleteSnapshot": {
    "path": "/instance/v1/zones/{zone}/snapshots/{snapshot_id}",
    "method": "DELETE",
-   "group": "Snapshots"
+   "group": "Snapshots",
+   "noContent": 204
   },
   "instance/v1.DeleteVolume": {
    "path": "/instance/v1/zones/{zone}/volumes/{volume_id}",
    "method": "DELETE",
-   "group": "Volumes"
+   "group": "Volumes",
+   "noContent": 204
   },
   "instance/v1.DetachServerFileSystem": {
    "path": "/instance/v1/zones/{zone}/servers/{server_id}/detach-filesystem",
@@ -1673,7 +1702,8 @@
   "instance/v1.ReleaseIpToIpam": {
    "path": "/instance/v1/zones/{zone}/ips/{ip_id}/release-to-ipam",
    "method": "POST",
-   "group": "IPs"
+   "group": "IPs",
+   "noContent": 204
   },
   "instance/v1.ServerAction": {
    "path": "/instance/v1/zones/{zone}/servers/{server_id}/action",
@@ -1727,7 +1757,8 @@
   "instance/v1.SetServerUserData": {
    "path": "/instance/v1/zones/{zone}/servers/{server_id}/user_data/{key}",
    "method": "PATCH",
-   "group": "User Data"
+   "group": "User Data",
+   "noContent": 204
   },
   "instance/v1.SetSnapshot": {
    "path": "/instance/v1/zones/{zone}/snapshots/{snapshot_id}",
@@ -1851,7 +1882,8 @@
   "instance/v2alpha1.CheckTemplate": {
    "path": "/instance/v2alpha1/zones/{zone}/templates/{template_id}/check",
    "method": "GET",
-   "group": "Templates"
+   "group": "Templates",
+   "noContent": 204
   },
   "instance/v2alpha1.CreatePlacementGroup": {
    "path": "/instance/v2alpha1/zones/{zone}/placement-groups",
@@ -1898,43 +1930,51 @@
   "instance/v2alpha1.DeletePlacementGroup": {
    "path": "/instance/v2alpha1/zones/{zone}/placement-groups/{placement_group_id}",
    "method": "DELETE",
-   "group": "Placement Groups"
+   "group": "Placement Groups",
+   "noContent": 204
   },
   "instance/v2alpha1.DeletePrivateNetworkInterface": {
    "path": "/instance/v2alpha1/zones/{zone}/private-network-interfaces/{private_network_interface_id}",
    "method": "DELETE",
-   "group": "Private Network Interfaces"
+   "group": "Private Network Interfaces",
+   "noContent": 204
   },
   "instance/v2alpha1.DeleteSecurityGroup": {
    "path": "/instance/v2alpha1/zones/{zone}/security-groups/{security_group_id}",
    "method": "DELETE",
-   "group": "Security Groups"
+   "group": "Security Groups",
+   "noContent": 204
   },
   "instance/v2alpha1.DeleteSecurityGroupRules": {
    "path": "/instance/v2alpha1/zones/{zone}/security-group-rules",
    "method": "DELETE",
    "group": "Security Groups",
-   "request": "instance/v2alpha1.DeleteSecurityGroupRules.Request"
+   "request": "instance/v2alpha1.DeleteSecurityGroupRules.Request",
+   "noContent": 204
   },
   "instance/v2alpha1.DeleteServer": {
    "path": "/instance/v2alpha1/zones/{zone}/servers/{server_id}",
    "method": "DELETE",
-   "group": "Instances"
+   "group": "Instances",
+   "noContent": 204
   },
   "instance/v2alpha1.DeleteTemplate": {
    "path": "/instance/v2alpha1/zones/{zone}/templates/{template_id}",
    "method": "DELETE",
-   "group": "Templates"
+   "group": "Templates",
+   "noContent": 204
   },
   "instance/v2alpha1.DeleteTemplateUserData": {
    "path": "/instance/v2alpha1/zones/{zone}/templates/{template_id}/user-data/{key}",
    "method": "DELETE",
-   "group": "Templates"
+   "group": "Templates",
+   "noContent": 204
   },
   "instance/v2alpha1.DeleteUserData": {
    "path": "/instance/v2alpha1/zones/{zone}/servers/{server_id}/user-data/{key}",
    "method": "DELETE",
-   "group": "User Data"
+   "group": "User Data",
+   "noContent": 204
   },
   "instance/v2alpha1.DetachServerFileSystem": {
    "path": "/instance/v2alpha1/zones/{zone}/servers/{server_id}/detach-filesystem",
@@ -2312,7 +2352,8 @@
    "path": "/instance/v2alpha1/zones/{zone}/servers/{server_id}/user-data/cloud-init",
    "method": "PUT",
    "group": "User Data",
-   "request": "instance/v2alpha1.SetServerCloudInit.Request"
+   "request": "instance/v2alpha1.SetServerCloudInit.Request",
+   "noContent": 204
   },
   "instance/v2alpha1.SetServerDefaultIP": {
    "path": "/instance/v2alpha1/zones/{zone}/servers/{server_id}/set-default-ip",
@@ -2325,19 +2366,22 @@
    "path": "/instance/v2alpha1/zones/{zone}/templates/{template_id}/user-data/cloud-init",
    "method": "PUT",
    "group": "Templates",
-   "request": "instance/v2alpha1.SetTemplateCloudInit.Request"
+   "request": "instance/v2alpha1.SetTemplateCloudInit.Request",
+   "noContent": 204
   },
   "instance/v2alpha1.SetTemplateUserData": {
    "path": "/instance/v2alpha1/zones/{zone}/templates/{template_id}/user-data/{key}",
    "method": "PUT",
    "group": "Templates",
-   "request": "instance/v2alpha1.SetTemplateUserData.Request"
+   "request": "instance/v2alpha1.SetTemplateUserData.Request",
+   "noContent": 204
   },
   "instance/v2alpha1.SetUserData": {
    "path": "/instance/v2alpha1/zones/{zone}/servers/{server_id}/user-data/{key}",
    "method": "PUT",
    "group": "User Data",
-   "request": "instance/v2alpha1.SetUserData.Request"
+   "request": "instance/v2alpha1.SetUserData.Request",
+   "noContent": 204
   },
   "instance/v2alpha1.StartServer": {
    "path": "/instance/v2alpha1/zones/{zone}/servers/{server_id}/start",
@@ -2505,12 +2549,14 @@
   "ipam/v1.ReleaseIP": {
    "path": "/ipam/v1/regions/{region}/ips/{ip_id}",
    "method": "DELETE",
-   "group": "IPs"
+   "group": "IPs",
+   "noContent": 204
   },
   "ipam/v1.ReleaseIPSet": {
    "path": "/ipam/v1/regions/{region}/ip-sets/release",
    "method": "POST",
-   "request": "ipam/v1.ReleaseIPSet.Request"
+   "request": "ipam/v1.ReleaseIPSet.Request",
+   "noContent": 204
   },
   "ipam/v1.UpdateIP": {
    "path": "/ipam/v1/regions/{region}/ips/{ip_id}",
@@ -2592,27 +2638,32 @@
   "lb/v1.DeleteAcl": {
    "path": "/lb/v1/zones/{zone}/acls/{acl_id}",
    "method": "DELETE",
-   "group": "ACLs"
+   "group": "ACLs",
+   "noContent": 204
   },
   "lb/v1.DeleteBackend": {
    "path": "/lb/v1/zones/{zone}/backends/{backend_id}",
    "method": "DELETE",
-   "group": "Backends"
+   "group": "Backends",
+   "noContent": 204
   },
   "lb/v1.DeleteCertificate": {
    "path": "/lb/v1/zones/{zone}/certificates/{certificate_id}",
    "method": "DELETE",
-   "group": "Certificate"
+   "group": "Certificate",
+   "noContent": 204
   },
   "lb/v1.DeleteFrontend": {
    "path": "/lb/v1/zones/{zone}/frontends/{frontend_id}",
    "method": "DELETE",
-   "group": "Frontends"
+   "group": "Frontends",
+   "noContent": 204
   },
   "lb/v1.DeleteLb": {
    "path": "/lb/v1/zones/{zone}/lbs/{lb_id}",
    "method": "DELETE",
    "group": "Load Balancer",
+   "noContent": 204,
    "query": {
     "release_ip": {
      "type": "boolean"
@@ -2622,18 +2673,21 @@
   "lb/v1.DeleteRoute": {
    "path": "/lb/v1/zones/{zone}/routes/{route_id}",
    "method": "DELETE",
-   "group": "Route"
+   "group": "Route",
+   "noContent": 204
   },
   "lb/v1.DeleteSubscriber": {
    "path": "/lb/v1/zones/{zone}/lb/subscription/{subscriber_id}",
    "method": "DELETE",
-   "group": "Alert Subscribers"
+   "group": "Alert Subscribers",
+   "noContent": 204
   },
   "lb/v1.DetachPrivateNetwork": {
    "path": "/lb/v1/zones/{zone}/lbs/{lb_id}/detach-private-network",
    "method": "POST",
    "group": "Private Networks",
-   "request": "lb/v1.DetachPrivateNetwork.Request"
+   "request": "lb/v1.DetachPrivateNetwork.Request",
+   "noContent": 204
   },
   "lb/v1.GetAcl": {
    "path": "/lb/v1/zones/{zone}/acls/{acl_id}",
@@ -2948,7 +3002,8 @@
   "lb/v1.ReleaseIp": {
    "path": "/lb/v1/zones/{zone}/ips/{ip_id}",
    "method": "DELETE",
-   "group": "IP addresses"
+   "group": "IP addresses",
+   "noContent": 204
   },
   "lb/v1.RemoveBackendServers": {
    "path": "/lb/v1/zones/{zone}/backends/{backend_id}/servers",
@@ -3202,32 +3257,38 @@
   "vpc/v2.DeleteIngressRule": {
    "path": "/vpc/v2/regions/{region}/ingress-rules/{rule_id}",
    "method": "DELETE",
-   "group": "Ingress Rules"
+   "group": "Ingress Rules",
+   "noContent": 204
   },
   "vpc/v2.DeletePrivateNetwork": {
    "path": "/vpc/v2/regions/{region}/private-networks/{private_network_id}",
    "method": "DELETE",
-   "group": "Private Networks"
+   "group": "Private Networks",
+   "noContent": 204
   },
   "vpc/v2.DeletePrivateNetworkS3Endpoint": {
    "path": "/vpc/v2/regions/{region}/s3-integration/{vpc_id}/private-networks/{private_network_id}",
    "method": "DELETE",
-   "group": "S3 integration"
+   "group": "S3 integration",
+   "noContent": 204
   },
   "vpc/v2.DeleteRoute": {
    "path": "/vpc/v2/regions/{region}/routes/{route_id}",
    "method": "DELETE",
-   "group": "Routes"
+   "group": "Routes",
+   "noContent": 204
   },
   "vpc/v2.DeleteVPC": {
    "path": "/vpc/v2/regions/{region}/vpcs/{vpc_id}",
    "method": "DELETE",
-   "group": "VPCs"
+   "group": "VPCs",
+   "noContent": 204
   },
   "vpc/v2.DeleteVPCConnector": {
    "path": "/vpc/v2/regions/{region}/vpc-connectors/{vpc_connector_id}",
    "method": "DELETE",
-   "group": "VPC Connectors"
+   "group": "VPC Connectors",
+   "noContent": 204
   },
   "vpc/v2.DisableS3Endpoint": {
    "path": "/vpc/v2/regions/{region}/s3-integration/{vpc_id}/disable",
@@ -3608,7 +3669,8 @@
   "vpcgw/v2.DeleteBastionAllowedIPs": {
    "path": "/vpc-gw/v2/zones/{zone}/gateways/{gateway_id}/bastion-allowed-ips/{ip_range}",
    "method": "DELETE",
-   "group": "Allowed IPs"
+   "group": "Allowed IPs",
+   "noContent": 204
   },
   "vpcgw/v2.DeleteGateway": {
    "path": "/vpc-gw/v2/zones/{zone}/gateways/{gateway_id}",
@@ -3630,12 +3692,14 @@
   "vpcgw/v2.DeleteIP": {
    "path": "/vpc-gw/v2/zones/{zone}/ips/{ip_id}",
    "method": "DELETE",
-   "group": "IPs"
+   "group": "IPs",
+   "noContent": 204
   },
   "vpcgw/v2.DeletePatRule": {
    "path": "/vpc-gw/v2/zones/{zone}/pat-rules/{pat_rule_id}",
    "method": "DELETE",
-   "group": "PAT Rules"
+   "group": "PAT Rules",
+   "noContent": 204
   },
   "vpcgw/v2.GetGateway": {
    "path": "/vpc-gw/v2/zones/{zone}/gateways/{gateway_id}",

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -1688,6 +1688,45 @@ entry is one recording away (`feint shapes --record`) from becoming either a
 failure or nothing. That list is this page's kind of sentence: it names
 exactly what nobody has proven.
 
+### An operation the document says answers nothing
+
+A missing response schema in `contracts/*.json` has three causes, and only one
+of them can be checked. The artefact distinguishes them because folding them
+together is what left thirty-one served Scaleway operations reading `unchecked`
+on the contract axis, and thirty-two reading `none` on `probed`, for months
+(#429).
+
+- **The document declares a body.** `response` names its schema, and the answer
+  is validated against it. 306 of Scaleway's 370 documented operations, all 236
+  of Outscale's, 371 of Exoscale's 374.
+- **The document declares a success with no content at all.** Scaleway writes
+  `204: {description: ''}` on 64 operations, and it is the only provider here
+  that does. `noContent` carries the status, and the answer is held to it in both
+  directions — a body where none is declared, and a status the document does not
+  name. **This is a validation, not a silence**, and reading it as one is what
+  put those thirty-one at zero.
+
+  The 64 are not simply "the DELETEs", and that is what makes the field worth
+  reading rather than the method: 52 of Scaleway's 56 DELETEs are here, and the
+  other four — `vpcgw/v2.DeleteGateway`, `vpcgw/v2.DeleteGatewayNetwork`,
+  `lb/v1.RemoveBackendServers`, `lb/v1.UnsubscribeFromLb` — declare a body and
+  answer one. Twelve operations that are not DELETEs are here too, the `Set*`
+  user-data and cloud-init family among them.
+- **The document declares a body this extraction cannot name.** A top-level
+  array, a free-form object, a media type that is not JSON. Three Exoscale
+  operations are in this case — `list-events`, `get-sks-cluster-inspection`,
+  `list-sks-cluster-deprecated-resources` — and they stay `unchecked`, correctly:
+  nothing about the emulator's answer is known.
+
+One thing the probe cannot reach, and it is a property of the probe rather than
+of any pack: `instance/v1/API.{Get,Set,Delete}ServerUserData` address a key by
+name, and no call in a probe run produces one. Measured — a server the probe
+creates answers `{"user_data":[]}`, because the only operation that could put a
+key there is the one that needs the key. A client invents the name
+(`scw instance user-data set key=cloud-init` does), and the probe may not invent
+anything. Those three earn the contract axis from client traffic and stay at
+zero on `probed`.
+
 ## `feint start` detaches on Linux, and not on macOS
 
 `start` backgrounds the emulator itself, with no `&` and no container runtime,

--- a/internal/contract/contract.go
+++ b/internal/contract/contract.go
@@ -118,6 +118,27 @@ type Operation struct {
 	Group    string `json:"group,omitempty"`
 	Request  string `json:"request"`
 	Response string `json:"response"`
+	// NoContent is the success status of an operation whose response the
+	// document declares as carrying no body at all: Scaleway writes
+	// `204: {description: ''}` on 64 of its operations, this project's only
+	// provider that does. Zero everywhere else.
+	//
+	// It is not the same field as an empty Response, and conflating the two is
+	// what put thirty-one served Scaleway operations at zero on both the probed
+	// and the contract axis (#429). An empty Response has three causes and only
+	// one of them is checkable:
+	//
+	//   - the document names a body: Response carries its schema;
+	//   - the document states there is no body: Response is empty, NoContent
+	//     holds the status, and "the answer carried nothing, with that status"
+	//     is a validation like any other;
+	//   - the document declares a body this extraction cannot name — a
+	//     top-level array (Exoscale's list-events), a free-form object, a
+	//     non-JSON media type — or declares no 2xx at all. Both are empty, and
+	//     nothing may be concluded from either.
+	//
+	// TestAnUnnameableResponseIsNotReadAsNoContent pins the third case.
+	NoContent int `json:"noContent,omitempty"`
 	// Query maps each query parameter the document declares to what it may
 	// hold. Scaleway's lists take per_page and their filters here; Outscale
 	// takes nothing (its pagination travels in the request body); Exoscale
@@ -266,6 +287,45 @@ func (d *Doc) ValidateResponse(operation string, value any) Violations {
 		return nil
 	}
 	return d.Validate(op.Response, value)
+}
+
+// ValidateEmptyResponse holds an answer that carried no body to what the
+// document says the operation answers, and reports whether it could hold it to
+// anything at all.
+//
+// The second return is the whole point, and it is the "three outcomes, never
+// two" rule of this repository written into a signature: false means the
+// document states nothing about a bodyless answer here, so the caller has
+// validated nothing and must not record that it did. True means the document
+// declares a no-content success, and the violations are what the answer did
+// against it.
+//
+// Two things are checked, and both are the document's own words: a body where
+// the document declares none, and a status other than the one it names. A
+// client's generated SDK branches on that status — Scaleway's scw/client.go
+// treats 204 as "no body to unmarshal" — so answering 200 where the document
+// says 204 is a divergence a real client can see.
+func (d *Doc) ValidateEmptyResponse(operation string, status, bodyLen int) (Violations, bool) {
+	op, ok := d.Operations[operation]
+	if !ok {
+		return Violations{{Path: operation, Reason: "no such operation in the contract"}}, true
+	}
+	if op.NoContent == 0 {
+		return nil, false
+	}
+	var out Violations
+	if bodyLen > 0 {
+		add(&out, operation, fmt.Sprintf(
+			"the document declares %d with no content, and the answer carried %d byte(s)",
+			op.NoContent, bodyLen))
+	}
+	if status != op.NoContent {
+		add(&out, operation, fmt.Sprintf(
+			"the document declares %d for this success, and the answer was %d",
+			op.NoContent, status))
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Reason < out[j].Reason })
+	return out, true
 }
 
 // Validate checks a decoded value against a named schema.

--- a/internal/contract/nocontent_test.go
+++ b/internal/contract/nocontent_test.go
@@ -1,0 +1,114 @@
+package contract_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/contract"
+)
+
+// A missing response schema has three causes, and only one of them is a
+// statement about the wire. Folding them into one is what left thirty-one
+// served Scaleway operations at zero on the probed and contract axes (#429),
+// so each cause gets a case here.
+
+const emptiness = `{
+  "provider": "test",
+  "operations": {
+    "Erase":  {"path": "/Erase",  "method": "DELETE", "noContent": 204},
+    "Silent": {"path": "/Silent", "method": "DELETE"},
+    "Bodied": {"path": "/Bodied", "method": "GET", "response": "Thing"}
+  },
+  "schemas": {"Thing": {"closed": true, "properties": {"Id": {"type": "string"}}}}
+}`
+
+func emptinessDoc(t *testing.T) *contract.Doc {
+	t.Helper()
+	d, err := contract.Read(strings.NewReader(emptiness))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	return d
+}
+
+func TestADeclaredEmptyAnswerIsValidated(t *testing.T) {
+	d := emptinessDoc(t)
+
+	vs, checkable := d.ValidateEmptyResponse("Erase", 204, 0)
+	if !checkable {
+		t.Fatal("a document declaring 204 with no content states something, and it must be checkable")
+	}
+	if len(vs) > 0 {
+		t.Fatalf("204 with no body against a document declaring exactly that: %v", vs)
+	}
+}
+
+func TestADeclaredEmptyAnswerIsBrokenByABodyAndByAStatus(t *testing.T) {
+	d := emptinessDoc(t)
+
+	for _, tc := range []struct {
+		name        string
+		status, len int
+	}{
+		{"a body where none is declared", 204, 17},
+		{"a status the document does not name", 200, 0},
+		{"both at once", 200, 17},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			vs, checkable := d.ValidateEmptyResponse("Erase", tc.status, tc.len)
+			if !checkable {
+				t.Fatal("checkable must stay true: the document has not stopped declaring anything")
+			}
+			if len(vs) == 0 {
+				t.Fatal("want a violation, got none")
+			}
+		})
+	}
+}
+
+// The witness. `Silent` and `Bodied` are the two causes that are not a
+// statement about an empty answer, and neither may be read as one: the second
+// return says so, and a caller that ignores it records a validation nobody
+// performed.
+func TestAnUnnameableResponseIsNotReadAsNoContent(t *testing.T) {
+	d := emptinessDoc(t)
+
+	for _, op := range []string{"Silent", "Bodied"} {
+		if vs, checkable := d.ValidateEmptyResponse(op, 204, 0); checkable || len(vs) > 0 {
+			t.Errorf("%s: the document declares no empty answer, want (nil, false), got (%v, %v)", op, vs, checkable)
+		}
+	}
+}
+
+// The live half of the same distinction, held against the committed artefacts
+// rather than a fixture, because the fixture cannot go stale and the artefacts
+// can.
+//
+// Exoscale's list-events declares a 200 carrying a top-level array of $ref,
+// which this extraction cannot name, so its `response` is empty for a reason
+// that has nothing to do with emptiness. Scaleway's DeleteServer declares
+// `204: {description: ”}`. Both artefacts must say which is which.
+func TestTheCommittedContractsSeparateSilenceFromDeclaredEmptiness(t *testing.T) {
+	for _, tc := range []struct {
+		file, operation string
+		wantNoContent   int
+	}{
+		{"scaleway.json", "instance/v1.DeleteServer", 204},
+		{"scaleway.json", "instance/v1.SetServerUserData", 204},
+		{"scaleway.json", "instance/v1.GetServerUserData", 0},
+		{"exoscale.json", "list-events", 0},
+	} {
+		d, err := contract.Load(filepath.Join("..", "..", "contracts", tc.file))
+		if err != nil {
+			t.Fatalf("load %s: %v", tc.file, err)
+		}
+		op, ok := d.Operations[tc.operation]
+		if !ok {
+			t.Fatalf("%s: the artefact no longer defines %s", tc.file, tc.operation)
+		}
+		if op.NoContent != tc.wantNoContent {
+			t.Errorf("%s %s: noContent %d, want %d", tc.file, tc.operation, op.NoContent, tc.wantNoContent)
+		}
+	}
+}

--- a/internal/core/emulator/conformance.go
+++ b/internal/core/emulator/conformance.go
@@ -333,7 +333,39 @@ func (o *observer) record(operation string, synthetic bool) {
 // hands the violations back, because the log needs the verdict on this exchange
 // rather than on the operation.
 func (o *observer) check(doc *contract.Doc, operation string, rec *recorder, synthetic bool) contract.Violations {
-	if rec.body == nil || rec.status < 200 || rec.status >= 300 || rec.body.Len() == 0 {
+	if rec.body == nil || rec.status < 200 || rec.status >= 300 {
+		return nil
+	}
+	_, resolved, resolvable := doc.OperationFor(operation)
+
+	// An answer with no body is not an answer nothing can be held to. The
+	// provider's document can state that this operation carries none —
+	// Scaleway writes `204: {description: ''}` on 64 operations, 31 of them
+	// served here — and that statement is checkable in both directions: an
+	// empty answer keeps it, a body breaks it, and so does a status the
+	// document does not name.
+	//
+	// This early return used to be `|| rec.body.Len() == 0`, and it is where
+	// every operation the document declares bodyless lost the contract axis: a
+	// `scw instance server delete` that answered exactly what the document
+	// describes was recorded as `unchecked`, which the axis defines as "nobody
+	// looked" (#429). Not "every DELETE": four of Scaleway's 56 declare a body
+	// and answer one, which is why the field is read rather than the method.
+	//
+	// ValidateEmptyResponse's second return is what keeps that honest: false
+	// where the document says nothing about a bodyless answer, and then nothing
+	// is marked. TestAnAnswerWithNoBodyIsCheckedAgainstTheDocument and
+	// TestAnUndeclaredEmptyAnswerIsStillUnchecked are the two halves.
+	if resolvable {
+		if vs, checkable := doc.ValidateEmptyResponse(resolved, rec.status, rec.body.Len()); checkable {
+			o.markChecked(operation)
+			if len(vs) > 0 {
+				o.report(operation, vs)
+			}
+			return vs
+		}
+	}
+	if rec.body.Len() == 0 {
 		return nil
 	}
 	// A response the API does not describe as JSON is not compared as JSON, and
@@ -361,7 +393,7 @@ func (o *observer) check(doc *contract.Doc, operation string, rec *recorder, syn
 	// validation that failed still looked. What must never count is the early
 	// return above, where nothing was compared with anything.
 	o.markChecked(operation)
-	_, name, known := doc.OperationFor(operation)
+	name, known := resolved, resolvable
 	if !known {
 		vs := contract.Violations{{
 			Path: operation, Reason: "no such operation in the contract",
@@ -413,7 +445,26 @@ func (o *observer) check(doc *contract.Doc, operation string, rec *recorder, syn
 // was asked. Arrival is already counted elsewhere (record), and arrival is not
 // a verdict (#156).
 func (o *observer) noteProbe(doc *contract.Doc, operation string, query url.Values, reqBody []byte, rec *recorder, checked contract.Violations) {
-	if rec.body == nil || rec.body.Len() == 0 {
+	if rec.body == nil {
+		return
+	}
+	if rec.body.Len() == 0 {
+		// An empty body earns the axis only where the document declares one,
+		// and only through the same verdict the contract axis just recorded:
+		// check() held this answer to `204: {description: ''}` and `checked`
+		// carries what it found (#429). Where the document states nothing
+		// about a bodyless answer, NoContent is zero and nothing is marked —
+		// which is the original behaviour of this early return, kept for the
+		// case it was actually right about.
+		// TestAnEmptyAnswerEarnsTheProbeOnlyWhereTheDocumentDeclaresIt fails
+		// without the NoContent condition.
+		op, _, known := doc.OperationFor(operation)
+		if !known || op.NoContent == 0 || len(checked) > 0 {
+			return
+		}
+		if rec.status >= 200 && rec.status < 300 {
+			o.markProbe(o.probeResponse, operation)
+		}
 		return
 	}
 

--- a/internal/core/emulator/nocontent_test.go
+++ b/internal/core/emulator/nocontent_test.go
@@ -1,0 +1,209 @@
+package emulator_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/contract"
+	"github.com/stephrobert/feint/internal/core/emulator"
+)
+
+// An answer that carries no body is still an answer, and #429 is what it cost to
+// treat it as nothing.
+//
+// Thirty-one of the 173 Scaleway operations this emulator serves are DELETEs
+// whose own API description reads `204: {description: ''}` — the provider
+// stating that the answer carries no body. The observer's contract check
+// returned before marking anything as soon as the body was empty, so every one
+// of those thirty-one read `unchecked` on the contract axis, which that axis
+// defines as "nobody ever looked". A `scw instance server delete` answering
+// exactly what Scaleway documents was recorded as unexamined.
+//
+// The distinction these tests hold apart is the one that makes the fix honest:
+// "the document says there is no body" and "the document says nothing" are two
+// different silences, and only the first is checkable.
+
+const noContentContract = `{
+  "provider": "stub",
+  "operations": {
+    "Erase":   {"method": "DELETE", "path": "/stub/erase",   "noContent": 204},
+    "Silent":  {"method": "DELETE", "path": "/stub/silent"},
+    "Bodied":  {"method": "GET",    "path": "/stub/bodied",  "response": "AView"}
+  },
+  "schemas": {
+    "AView": {"closed": true, "properties": {"ok": {"type": "boolean"}}}
+  }
+}`
+
+// noContentServer mounts three routes whose answers the caller chooses, so one
+// test can put a body, a status, or nothing at all against the same document.
+func noContentServer(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	doc, err := contract.Read(strings.NewReader(noContentContract))
+	if err != nil {
+		t.Fatalf("read the stub contract: %v", err)
+	}
+	env := emulator.DefaultEnv()
+	env.Contracts = map[string]*contract.Doc{"stub": doc}
+
+	answer := func(w http.ResponseWriter, _ *http.Request) {
+		if body != "" {
+			w.Header().Set("Content-Type", "application/json")
+		}
+		w.WriteHeader(status)
+		if body != "" {
+			_, _ = w.Write([]byte(body))
+		}
+	}
+	pack := stubPack{name: "stub", routes: []emulator.Route{
+		{Method: "DELETE", Path: "/stub/erase", Operation: "stub/v1/API.Erase", Handler: answer},
+		{Method: "DELETE", Path: "/stub/silent", Operation: "stub/v1/API.Silent", Handler: answer},
+		{Method: "GET", Path: "/stub/bodied", Operation: "stub/v1/API.Bodied", Handler: answer},
+	}}
+	srv, err := emulator.NewServer(env, pack)
+	if err != nil {
+		t.Fatalf("mount the stub pack: %v", err)
+	}
+	return httptest.NewServer(srv.Handler())
+}
+
+func driveMethod(t *testing.T, ts *httptest.Server, method, path string, probe bool) {
+	t.Helper()
+	req, err := http.NewRequest(method, ts.URL+path, nil) //nolint:noctx // a local test server
+	if err != nil {
+		t.Fatal(err)
+	}
+	if probe {
+		req.Header.Set(emulator.ProbeHeader, "1")
+	}
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+}
+
+func TestAnAnswerWithNoBodyIsCheckedAgainstTheDocument(t *testing.T) {
+	ts := noContentServer(t, http.StatusNoContent, "")
+	defer ts.Close()
+
+	driveMethod(t, ts, http.MethodDelete, "/stub/erase", false)
+
+	if got := viewOf(t, ts).Evidence["stub/v1/API.Erase"].Contract; got != emulator.ContractClean {
+		t.Errorf("204 with no body, against a document declaring exactly that, must read clean, got %q", got)
+	}
+}
+
+// The other direction of the same statement. A document saying "no body" is
+// violated by a body, and by a status it does not name — a generated SDK
+// branches on 204 to decide whether to unmarshal at all.
+func TestAnAnswerContradictingTheDeclaredEmptinessIsAViolation(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{"a body where the document declares none", http.StatusNoContent, `{"ok":true}`},
+		{"a status the document does not name", http.StatusOK, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := noContentServer(t, tc.status, tc.body)
+			defer ts.Close()
+
+			driveMethod(t, ts, http.MethodDelete, "/stub/erase", false)
+
+			if got := viewOf(t, ts).Evidence["stub/v1/API.Erase"].Contract; got != emulator.ContractViolating {
+				t.Errorf("want violating, got %q", got)
+			}
+		})
+	}
+}
+
+// The witness for the half of #429 that must not move. `Silent` declares no
+// response schema and no no-content status either: its document is silent, not
+// empty. Exoscale has three live examples — list-events answers a top-level
+// array of $ref, which this extraction cannot name — and reading their silence
+// as "answers nothing" would be the axis inventing a verdict.
+func TestAnUndeclaredEmptyAnswerIsStillUnchecked(t *testing.T) {
+	ts := noContentServer(t, http.StatusNoContent, "")
+	defer ts.Close()
+
+	driveMethod(t, ts, http.MethodDelete, "/stub/silent", false)
+
+	if got := viewOf(t, ts).Evidence["stub/v1/API.Silent"].Contract; got != emulator.ContractUnchecked {
+		t.Errorf("an empty answer the document says nothing about must stay unchecked, got %q", got)
+	}
+}
+
+func TestAnEmptyAnswerEarnsTheProbeOnlyWhereTheDocumentDeclaresIt(t *testing.T) {
+	ts := noContentServer(t, http.StatusNoContent, "")
+	defer ts.Close()
+
+	driveMethod(t, ts, http.MethodDelete, "/stub/erase", true)
+	driveMethod(t, ts, http.MethodDelete, "/stub/silent", true)
+
+	ev := viewOf(t, ts).Evidence
+	if got := ev["stub/v1/API.Erase"].Probed; got != emulator.ProbeResponse {
+		t.Errorf("a probed 204 held to a document that declares it must read response, got %q", got)
+	}
+	if got := ev["stub/v1/API.Silent"].Probed; got != emulator.ProbeNone {
+		t.Errorf("a probed 204 nothing could be held to must read none, got %q", got)
+	}
+}
+
+// A violated no-content declaration must not earn the probe axis either: the
+// two axes report the same exchange, and one of them saying "validated" while
+// the other says "violating" is the half-truth this record exists to refuse.
+//
+// Both ways of breaking the declaration are here because they leave by
+// different doors, and the first version of this test only walked one of them.
+// A body sends the answer down the ordinary JSON path, where the existing
+// verdict guard already stops it; an empty answer with the wrong status is the
+// only case that reaches the bodyless branch with a violation in hand, and
+// neutralising that branch's own guard was "STILL GREEN" until this case
+// existed. The mutation is in tools/falsify/specs/declared-empty-answer.json,
+// labelled "a violating probe still earns the axis".
+func TestAProbedAnswerThatBrokeTheDeclaredEmptinessEarnsNothing(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{"an empty answer with a status the document does not name", http.StatusOK, ""},
+		{"a body where the document declares none", http.StatusNoContent, `{"ok":true}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := noContentServer(t, tc.status, tc.body)
+			defer ts.Close()
+
+			driveMethod(t, ts, http.MethodDelete, "/stub/erase", true)
+
+			ev := viewOf(t, ts).Evidence
+			if got := ev["stub/v1/API.Erase"].Probed; got != emulator.ProbeNone {
+				t.Errorf("a probe that violated the document must not read as validated, got %q", got)
+			}
+			if got := ev["stub/v1/API.Erase"].Contract; got != emulator.ContractViolating {
+				t.Errorf("want violating, got %q", got)
+			}
+		})
+	}
+}
+
+// The third silence, kept apart from the other two on purpose. `Bodied` names a
+// response schema, so an empty answer from it is not "what the document says" —
+// it is an answer the document does not describe at all. Recording it as clean
+// would be the same promotion of silence to proof that #429 is about, in the
+// opposite direction, so it stays unchecked and this test is what keeps it
+// there if somebody widens the guard to "empty is always fine".
+func TestAnEmptyAnswerFromAnOperationThatDeclaresABodyIsUnchecked(t *testing.T) {
+	ts := noContentServer(t, http.StatusNoContent, "")
+	defer ts.Close()
+
+	driveMethod(t, ts, http.MethodGet, "/stub/bodied", false)
+
+	if got := viewOf(t, ts).Evidence["stub/v1/API.Bodied"].Contract; got != emulator.ContractUnchecked {
+		t.Errorf("an empty answer where a body is declared must stay unchecked, got %q", got)
+	}
+}

--- a/internal/probe/nocontent_internal_test.go
+++ b/internal/probe/nocontent_internal_test.go
@@ -1,0 +1,65 @@
+package probe
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/contract"
+)
+
+// The planner used to skip every operation with no response schema, on the
+// reading that there was nothing to hold the answer to. For Scaleway that read
+// `204: {description: ''}` — the provider stating what its DELETEs answer — as
+// silence, and skipped 31 of the 173 operations that pack serves. They were
+// every one of its zeros on the probed axis (#429).
+
+const noContentPlanDoc = `{
+  "provider": "stub",
+  "operations": {
+    "CreateVolume": {"method": "POST",   "path": "/volumes", "response": "V"},
+    "DeleteVolume": {"method": "DELETE", "path": "/volumes/{volume_id}", "noContent": 204},
+    "MuteVolume":   {"method": "DELETE", "path": "/volumes/{volume_id}/mute"}
+  },
+  "schemas": {"V": {"closed": false, "properties": {"id": {"type": "string"}}}}
+}`
+
+var noContentRoutes = []contract.MountedRoute{
+	{Method: "POST", Path: "/volumes", Operation: "stub/v1/API.CreateVolume"},
+	{Method: "DELETE", Path: "/volumes/{volume_id}", Operation: "stub/v1/API.DeleteVolume"},
+	{Method: "DELETE", Path: "/volumes/{volume_id}/mute", Operation: "stub/v1/API.MuteVolume"},
+}
+
+func skipsOf(t *testing.T) map[string]string {
+	t.Helper()
+	doc, err := contract.Read(strings.NewReader(noContentPlanDoc))
+	if err != nil {
+		t.Fatalf("read doc: %v", err)
+	}
+	plan, err := Plan(doc, noContentRoutes)
+	if err != nil {
+		t.Fatalf("plan: %v", err)
+	}
+	out := map[string]string{}
+	for _, s := range plan {
+		out[s.Operation] = s.Skip
+	}
+	return out
+}
+
+func TestAnOperationDeclaredWithNoBodyIsStillProbed(t *testing.T) {
+	if skip := skipsOf(t)["stub/v1/API.DeleteVolume"]; skip != "" {
+		t.Errorf("an operation whose document declares 204 with no content is checkable, "+
+			"and must not be skipped: %q", skip)
+	}
+}
+
+// The witness for the half that must not move: MuteVolume's document says
+// nothing about its answer, so calling it would prove only that it answered.
+// Without this case the test above passes on a planner that stopped skipping
+// anything at all.
+func TestAnOperationWhoseDocumentSaysNothingIsStillSkipped(t *testing.T) {
+	if skip := skipsOf(t)["stub/v1/API.MuteVolume"]; skip == "" {
+		t.Error("an operation with neither a response schema nor a declared empty answer " +
+			"must still be skipped: nothing could hold its answer to anything")
+	}
+}

--- a/internal/probe/plan.go
+++ b/internal/probe/plan.go
@@ -77,10 +77,19 @@ func Plan(doc *contract.Doc, routes []contract.MountedRoute) ([]Step, error) {
 		}
 		step.Kind = kind(name, route.Method)
 		step.Makes = makes(name, step.Kind)
-		if op.Response == "" {
+		if op.Response == "" && op.NoContent == 0 {
 			// Nothing to validate against, so calling it would prove only that
 			// it answered. Said out loud: these are what the extraction reports
 			// as operations with no response schema.
+			//
+			// NoContent is the case this used to swallow (#429). An operation
+			// whose document declares `204: {description: ''}` states what its
+			// answer carries — nothing — and that is as checkable as a schema.
+			// Reading the missing schema as "nothing to check" skipped every
+			// Scaleway DELETE, which is 31 of the 173 operations that pack
+			// serves and every one of its zeros on the probed axis.
+			// TestAnOperationDeclaredWithNoBodyIsStillProbed fails without the
+			// second condition.
 			step.Skip = "the contract declares no response schema"
 		}
 

--- a/internal/probe/probe.go
+++ b/internal/probe/probe.go
@@ -276,7 +276,16 @@ func (r *Runner) call(ctx context.Context, client *http.Client, step Step, pool 
 		result.Err = err
 		return result
 	}
-	if status >= 300 || decoded == nil {
+	if status >= 300 {
+		return result
+	}
+	if decoded == nil {
+		// No body came back. When the document declares this operation answers
+		// none, that is exactly what it promised and holding the answer to it
+		// is a validation; when the document says nothing about a bodyless
+		// answer, the second return is false and nothing has been checked
+		// (#429). There is nothing to harvest either way.
+		result.Violations, _ = r.Doc.ValidateEmptyResponse(step.Contract, status, 0)
 		return result
 	}
 	result.Violations = r.Doc.ValidateResponse(step.Contract, decoded)

--- a/tools/contract/extract-openapi.py
+++ b/tools/contract/extract-openapi.py
@@ -228,11 +228,44 @@ def success_body(op: dict) -> dict:
     throughout, Outscale too, but an API is free to change that and the silence
     would not be visible.
     """
+    return success_response(op)[1]
+
+
+def success_response(op: dict) -> tuple[str, dict]:
+    """The status and the response object of whichever 2xx is the success."""
     responses = op.get("responses") or {}
     for status in sorted(responses):
         if str(status).startswith("2"):
-            return responses[status]
-    return {}
+            return str(status), (responses[status] or {})
+    return "", {}
+
+
+def no_content_status(op: dict) -> int:
+    """The success status of an operation the document states answers no body.
+
+    Three outcomes live behind a missing response schema, and folding two of
+    them together is what put thirty-one Scaleway operations at zero on both the
+    probed and the contract axis for months:
+
+      * the document names a body — `response` carries its schema;
+      * the document declares a 2xx **with no content at all** — Scaleway writes
+        `204: {description: ''}` on 64 of its operations, which is a statement
+        about the wire and not a silence, and this is what returns a status here;
+      * the document declares content this extraction cannot name — a top-level
+        array, a free-form object, a media type that is not JSON — or declares no
+        2xx whatever. Nothing is known, nothing is returned, and the operation
+        stays unchecked. Exoscale's list-events is the live example: its 200
+        carries an array of $ref, so it is silence to us and must never be read
+        as "answers nothing".
+
+    Returns 0 for everything but the middle case.
+    """
+    status, body = success_response(op)
+    if not status.isdigit():
+        return 0
+    if body.get("content"):
+        return 0
+    return int(status)
 
 
 def declared_error_refs(op: dict) -> list[str]:
@@ -351,6 +384,8 @@ def read_spec(
                 entry["request"] = req
             if resp := json_schema_of(success_body(op), schemas, oid + ".Response", args):
                 entry["response"] = resp
+            elif status := no_content_status(op):
+                entry["noContent"] = status
             if query := query_params(item, op):
                 entry["query"] = query
             error_refs.update(declared_error_refs(op))
@@ -543,8 +578,13 @@ def main() -> int:
         f.write("\n")
 
     # Said out loud rather than left to be discovered: an operation with no
-    # response schema is one the emulator can answer anything for.
-    unchecked = sorted(name for name, op in operations.items() if "response" not in op)
+    # response schema is one the emulator can answer anything for. An operation
+    # the document states answers no body at all is not one of them — "carry
+    # nothing" is as checkable as any schema, and noContent is where it is
+    # written down.
+    unchecked = sorted(
+        name for name, op in operations.items() if "response" not in op and "noContent" not in op
+    )
     if unchecked:
         print(
             f"{args.output}: {len(unchecked)} operation(s) declare no response schema "

--- a/tools/falsify/specs/declared-empty-answer.json
+++ b/tools/falsify/specs/declared-empty-answer.json
@@ -1,0 +1,76 @@
+{
+  "subject": "an answer the provider documents as carrying no body is checked, and a silence is not (#429)",
+  "why": "Thirty-one of the 173 Scaleway operations this emulator serves are DELETEs whose own API description reads `204: {description: ''}`. The planner skipped them and the observer returned before marking anything, so all thirty-one read `unchecked` on the contract axis and `none` on probed — verdicts that mean nobody looked, on operations a real client drives every run. The fix rests entirely on one distinction: \"the document says there is no body\" is a statement and is checkable, \"the document says nothing\" is not. Every mutation below either stops checking the first or starts inventing a verdict for the second.",
+  "package": "./internal/core/emulator/",
+  "mutations": [
+    {
+      "file": "internal/probe/plan.go",
+      "find": "\t\tif op.Response == \"\" && op.NoContent == 0 {",
+      "replace": "\t\tif op.Response == \"\" && op.NoContent >= 0 {",
+      "expect": "the planner skips every operation whose document declares a bodyless success again, which is where all 31 Scaleway zeros on the probed axis came from",
+      "test": "TestAnOperationDeclaredWithNoBodyIsStillProbed",
+      "package": "./internal/probe/",
+      "label": "the probe skips what the document declares empty"
+    },
+    {
+      "file": "internal/probe/plan.go",
+      "find": "\t\tif op.Response == \"\" && op.NoContent == 0 {",
+      "replace": "\t\tif op.Response == \"\" && op.NoContent != 0 {",
+      "expect": "an operation whose document says nothing about its answer is called anyway, so the run proves only that something answered and reports it as a probe",
+      "test": "TestAnOperationWhoseDocumentSaysNothingIsStillSkipped",
+      "package": "./internal/probe/",
+      "label": "the probe calls what nothing can hold to account"
+    },
+    {
+      "file": "internal/core/emulator/conformance.go",
+      "find": "\t\tif vs, checkable := doc.ValidateEmptyResponse(resolved, rec.status, rec.body.Len()); checkable {",
+      "replace": "\t\tif vs, checkable := doc.ValidateEmptyResponse(resolved, rec.status, rec.body.Len()); checkable && false {",
+      "expect": "a `scw instance server delete` answering exactly what Scaleway documents is recorded as unchecked, which the axis defines as nobody having looked",
+      "test": "TestAnAnswerWithNoBodyIsCheckedAgainstTheDocument",
+      "label": "the contract axis stops reading a bodyless answer"
+    },
+    {
+      "file": "internal/core/emulator/conformance.go",
+      "find": "\t\tif !known || op.NoContent == 0 || len(checked) > 0 {\n\t\t\treturn\n\t\t}",
+      "replace": "\t\tif !known || op.NoContent >= 0 || len(checked) > 0 {\n\t\t\treturn\n\t\t}",
+      "expect": "the probed axis stops earning anything from a bodyless answer, so the two axes report the same exchange differently and one of them is silently wrong",
+      "test": "TestAnEmptyAnswerEarnsTheProbeOnlyWhereTheDocumentDeclaresIt",
+      "label": "the probed axis stops reading a bodyless answer"
+    },
+    {
+      "file": "internal/core/emulator/conformance.go",
+      "find": "\t\tif !known || op.NoContent == 0 || len(checked) > 0 {\n\t\t\treturn\n\t\t}",
+      "replace": "\t\tif !known || op.NoContent == 0 || (len(checked) > 0 && false) {\n\t\t\treturn\n\t\t}",
+      "expect": "a probe that answered a body where the document declares none is published as validated, which is the axis promising more than the run measured",
+      "test": "TestAProbedAnswerThatBrokeTheDeclaredEmptinessEarnsNothing",
+      "label": "a violating probe still earns the axis"
+    },
+    {
+      "file": "internal/contract/contract.go",
+      "find": "\tif op.NoContent == 0 {\n\t\treturn nil, false\n\t}",
+      "replace": "\tif op.NoContent == 0 {\n\t\treturn nil, true\n\t}",
+      "expect": "an operation whose document names no bodyless success is reported as validated when it answers nothing — Exoscale's list-events declares a top-level array this extraction cannot name, and its silence would be read as a promise",
+      "test": "TestAnUnnameableResponseIsNotReadAsNoContent",
+      "package": "./internal/contract/",
+      "label": "a silence is read as a declared emptiness"
+    },
+    {
+      "file": "internal/contract/contract.go",
+      "find": "\tif bodyLen > 0 {\n\t\tadd(&out, operation, fmt.Sprintf(",
+      "replace": "\tif bodyLen > 0 && false {\n\t\tadd(&out, operation, fmt.Sprintf(",
+      "expect": "a body where the document declares none passes, so the check only ever agrees and the axis records a validation that could not fail",
+      "test": "TestADeclaredEmptyAnswerIsBrokenByABodyAndByAStatus",
+      "package": "./internal/contract/",
+      "label": "a body where none is declared passes"
+    },
+    {
+      "file": "internal/contract/contract.go",
+      "find": "\tif status != op.NoContent {\n\t\tadd(&out, operation, fmt.Sprintf(",
+      "replace": "\tif status != op.NoContent && false {\n\t\tadd(&out, operation, fmt.Sprintf(",
+      "expect": "a 200 where the document declares 204 passes, and a generated SDK branching on the status to decide whether to unmarshal is the client that meets the difference",
+      "test": "TestADeclaredEmptyAnswerIsBrokenByABodyAndByAStatus",
+      "package": "./internal/contract/",
+      "label": "a status the document does not name passes"
+    }
+  ]
+}


### PR DESCRIPTION
Scaleway sat thirty points behind Outscale on two axes, and the whole gap had a
single cause **in the instrument** — not in a pack, not in a client.

| | before | after |
|---|--:|--:|
| Scaleway `probed` | 141 / 173 | **170 / 173** |
| Scaleway `contract` | 142 / 173 | **173 / 173** |
| all `probed` | 330 / 370 | 359 / 370 |
| all `contract` | 330 / 370 | 361 / 370 |

**No line of pack code moved.**

## The cause, read from the documents themselves

The extraction recorded *"the document declares an answer with no body"* and
*"the document declares a body the extraction cannot name"* **the same way**: by
the absence of a `response` key. Both readers downstream saw only a silence.

| | JSON body declared | 2xx with **no content at all** | unnameable body |
|---|--:|--:|--:|
| **Scaleway** | 306 | **64** (`204: {description: ''}`) | 0 |
| Outscale | 236 | **0** | 0 |
| Exoscale | 371 | **0** | 3 |

**Scaleway is the only one of the three that declares empty answers, and that is
the entire thirty-point gap.** Outscale was never "better built": its API simply
never asks the question.

Of the 173 served Scaleway operations, **31** match a 204-no-content entry, and
those 31 are — set for set, not overlapping — exactly the 31 at zero on
`contract`. The 32 at zero on `probed` are those 31 plus `GetServerUserData`,
whose body is `text/plain`.

Two places turned that into a zero:

- `internal/probe/plan.go` skipped the operation outright: *the contract declares
  no response schema*. **The probe never called them.**
- `observer.check()` returned before `markChecked` on an empty body, so a
  `scw instance server delete` answering exactly what Scaleway documents was
  filed `unchecked`.

## And the thirty-one were already right

**Zero violations**, probe and clients alike. Nobody had looked; now that someone
has, there was nothing to fix. That is the verdict `contract` exists to give, and
the reason its zero value is `unchecked` rather than `absent`: *never validated*
is not *no violation*.

## Measured in isolation, because the record moved underneath

`coverage/evidence.json` was regenerated on `main` (#443) **during** this work,
on code without the fix, so a raw comparison against it would have mixed two
lots. So `mise run conformance` was run **twice on the same station, same task,
differing only by this commit**.

Every other cell of the seven-axis table, across all three packs, is
**identical**. Per-operation diff: **+29 `probed`, +31 `contract`, zero lost on
any axis**. A third, independent confirmation of the "before": the coordinator's
own regeneration on `main` reports the same 141 and 142.

## What stays out of reach, and whose property it is

- **Scaleway `probed`: 3** — `Get`, `Set` and `DeleteServerUserData`. **The
  probe's** property, not the emulator's or a client's: they address a key by
  name, and nothing in a probe pass invents one. Measured rather than reasoned: a
  server the probe creates answers `{"user_data":[]}`, because the only operation
  that can put a key there is the one that demands a name. They earn `contract`
  through client traffic.
- **Exoscale: 8 on `probed`, 9 on `contract`.** Untouched. `list-events` is
  **the contract's** property: its 200 declares an array of a `$ref` the
  extraction cannot name, and it stays `unchecked`, correctly.
- **Outscale: 100 % / 100 %, unchanged.**

**Nothing is declared at a route.** The remaining cause is a property of the
probe, not of the emulator, so it has no place in a route-level declaration —
which in any case only accepts `behaviour` and `negative`.

## None of the brief's three gates detects this lot

Measured, not assumed: `mise run conformance` **exited 0 on the base**, and so
did `prepush` and `corpus:check`. They are `main`'s gates, and `main` is green.

The only criteria that detect it are **axis counts over named sets** —
`scaleway/contract == 173/173`, `scaleway/probed == 170/173`, and the set
equality *"the 31 that gain are the 31 whose document declares an empty
answer"* — all false on the unfixed code, and the falsification spec.

## Falsified

`tools/falsify/specs/declared-empty-answer.json`: **8 mutations, 8 red**, replayed
after amendment.

**One was green at the first attempt**, and it was vacuous: the scenario it drove
left `noteProbe` through the ordinary JSON path, so the guard it neutralised was
never on its route. Fixed by adding a case that actually reaches the branch — an
empty answer carrying a status the document does not name.

Witnesses planted against vacuity: three tests hold the half that must **not**
move, and a living witness sits in the artefact — `vpcgw/v2.DeleteGateway` is a
Scaleway DELETE whose document *does* declare a body and whose pack answers one,
so the check discriminates instead of blessing every DELETE. Four of the 56
DELETEs are in that case, and 12 of the 64 entries are not DELETEs at all.

## Two of this repository's own guards bit on the author

`TestEveryCitedTestExists` caught five citations written before their tests, and
`TestNoDocumentInThisRepositoryStatesAnAxisPercentage` caught a first CHANGELOG
draft stating percentages by hand — the guard #406 installed, working on the
lot that would have re-broken its rule.

## Gates

`prepush` 0 · `corpus --check` 0 · `conformance` 0 · legs `probe` 0 and `fields`
0 · falsification 0. Exit codes captured before any pipe.
`coverage/evidence.json` deliberately untouched.

## Related

Closes #429
