### PR TITLE
fix(coverage): each axis declares what earns it, and a probe-side zero stops saying nobody can act (#445)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -1178,6 +1178,44 @@ change ni l'un ni l'autre a sa place dans `git log`.
   les trois opérations d'écriture étaient déjà déclinées — un filtre qu'aucun
   client ne peut modifier et que rien n'applique n'est pas un filtre.
 
+- **Un zéro que la sonde peut fermer n'est plus classé comme une décision sur
+  laquelle personne ne peut agir** (#445). `feint coverage --evidence <registre>
+  --gaps` classait un zéro en `declared` (« pas du travail : aucun chemin
+  n'existe pour fermer ce zéro ») dès que le registre disait qu'aucun client
+  n'avait piloté l'opération, sur les sept axes à la fois, en affichant à côté de
+  chacun la raison `Route.Undriven` de la route.
+
+  Cette raison est une phrase sur les clients : « `exo limits` lit la liste
+  entière des quotas, donc la lecture par nom n'a aucun chemin client ». Elle
+  explique un zéro sur `driven`, `dataplane`, `behaviour` et `negative`, qu'aucun
+  échange synthétique ne peut déplacer. Elle n'explique rien sur `probed`, que la
+  sonde gagne sans le moindre client ; rien sur `contract`, que gagne toute
+  réponse validée, y compris celle de la sonde ; et rien sur `shape`, résolu hors
+  ligne depuis le catalogue d'enregistrements, qu'aucun trafic ne déplace dans un
+  sens ni dans l'autre.
+
+  Chaque axe déclare désormais ce qui le gagne, et deux témoins indépendants
+  tiennent cette déclaration : l'un pilote un échange marqué et un échange nu
+  contre un émulateur vivant puis relit les axes, l'autre refuse une déclaration
+  que le registre commité contredit. Le registre porte **16 opérations qu'aucun
+  client n'a pilotées et qui ont gagné `probed`, 14 qui ont gagné `contract` et
+  une qui a gagné `shape`** : la preuve, par l'artefact lui-même, que « aucun
+  client ne l'atteint » n'est pas ce qui tient ces trois axes à zéro.
+
+  Mesuré sur `coverage/evidence.json` tel qu'il est commité, sans qu'un seul axe
+  bouge et sans qu'une opération entre dans la file ou en sorte : **38 lignes sur
+  22 opérations cessent de dire que personne ne peut agir**, et 64 autres cessent
+  de dire « le registre n'explique pas ». Une sixième nature, `unvalidated`,
+  nomme ce que ces zéros sont : une réponse tenue à la description d'API du
+  fournisseur, qui ne demande ni compte cloud ni binaire client. #429 est la
+  mesure derrière : 31 opérations Scaleway ont gagné `contract` et 29 ont gagné
+  `probed` grâce à un seul correctif de l'extraction du contrat, sans toucher un
+  client ni une ligne de pack, et si elles avaient porté une raison `Undriven`,
+  cette file aurait déclaré les soixante « pas du travail ».
+
+  `classifyGap` rend désormais la raison sur laquelle il a classé, de sorte
+  qu'une ligne `declared` ne peut plus afficher une phrase que le classificateur
+  n'a pas employée.
 
 - **Outscale est prouvé sur chaque opération qu'il sert : `shape` atteint 93 sur
   93** (#427). Les quatre dernières étaient la famille de l'appairage de Nets,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,41 @@ what this project is judged on: **a response shape a client can observe**, and
   operations were already declined — a filter no client can edit and nothing
   enforces is not a filter.
 
+- **A zero the contract-driven probe can close is no longer filed as a decision
+  nobody can act on** (#445). `feint coverage --evidence <record> --gaps` filed a
+  zero as `declared` — "not work: no path exists to close this zero" — as soon as
+  the record said no client drove the operation, on all seven axes at once, and
+  printed the route's `Route.Undriven` reason beside every one of them.
+
+  That reason is a sentence about clients: "`exo limits` reads the whole quota
+  list, so the per-name read has no client path". It explains a zero on `driven`,
+  `dataplane`, `behaviour` and `negative`, which no synthetic exchange can move.
+  It explains nothing on `probed`, which the probe earns with no client
+  whatsoever; nothing on `contract`, which any validated answer earns, the
+  probe's included; and nothing on `shape`, which is resolved offline from the
+  recordings catalogue and which no traffic moves either way.
+
+  Each axis now declares what earns it, and two independent witnesses hold the
+  declaration to it: one drives a marked and an unmarked exchange against a live
+  emulator and reads the axes back, the other refuses a declaration the committed
+  record contradicts. The record holds **16 operations no client drove that
+  earned `probed`, 14 that earned `contract` and one that earned `shape`** —
+  proof, from the artefact itself, that "no client reaches it" is not what keeps
+  those three at zero.
+
+  Measured on `coverage/evidence.json` as committed, with no axis moved and not
+  one operation added to or removed from the queue: **38 lines across 22
+  operations stop saying nobody can act**, and 64 more stop saying "the record
+  does not say why". A sixth kind, `unvalidated`, names what those zeros are —
+  an answer held to the provider's own API description, which needs neither a
+  cloud account nor a client binary. #429 is the measurement behind it: 31
+  Scaleway operations earned `contract` and 29 earned `probed` from a single fix
+  to the contract extraction, no client and no pack code touched, and had they
+  carried an `Undriven` reason this queue would have called all sixty "not work".
+
+  `classifyGap` now returns the reason it classified on, so a `declared` line
+  cannot print a sentence the classifier did not use.
+
 - **An operation whose API description says it answers no body is now checked
   against exactly that, and thirty-one Scaleway operations stop reading
   "nobody looked"** (#429). Scaleway writes `204: {description: ''}` on 64 of

--- a/internal/cli/evidence_axes.go
+++ b/internal/cli/evidence_axes.go
@@ -55,6 +55,10 @@ import (
 type evidenceAxis struct {
 	// Name is the key the record uses and the value --axis takes.
 	Name string
+	// earner says what can put a mark on this axis, and it is what decides
+	// whether a Route.Undriven reason — a sentence about clients — is allowed to
+	// explain a zero here. See axisEarner.
+	earner axisEarner
 	// Meaning is the single line docs/routes.md prints for this axis. The long
 	// form is evidenceLegend, in docs_routes.go; this is the row of the summary
 	// table, and a reader who skips the legend must still not misread a score.
@@ -69,6 +73,60 @@ type evidenceAxis struct {
 	verdict func(emulator.Evidence) string
 }
 
+// axisEarner names what can put a mark on an axis. It exists because a reason
+// only explains a zero on an axis its own subject can reach, and this file had
+// no way to say which axis that was: `--gaps` filed every zero of an undriven
+// operation as "declared, no path exists" and printed the route's Undriven
+// reason beside it, on all seven axes at once (#445).
+//
+// That reason is a sentence about clients — "`exo limits` reads the whole quota
+// list, so the per-name read has no client path". It is a complete explanation
+// for an axis only a client can earn, and it explains nothing at all about an
+// axis a client never touches.
+//
+// The split is not a reading of the axes' names. The observer keeps a synthetic
+// exchange apart from a client one at the source (emulator.ProbeHeader), and
+// each axis reads one side or the other:
+//
+//   - driven counts non-synthetic calls, dataplane is driven with a runtime on,
+//     and behaviour and negative are attributed inside assertion spans that skip
+//     every synthetic flight (assert.go). No probe run moves any of the four.
+//   - probed is the synthetic side and nothing else: a client cannot earn it.
+//   - contract is earned by any answer validated against the provider's own
+//     description, and the probe produces such answers with no client present.
+//   - shape is not earned by a run at all. It is resolved offline from the
+//     shapes catalogue, so no traffic of any kind moves it.
+//
+// Two witnesses hold the declaration to that, and neither reads this comment:
+// TestOnlyAClientEarnsAClientBorneAxis drives one synthetic and one real
+// exchange against a live emulator and reads the axes back, and
+// TestNoClientBorneAxisIsEarnedWithoutAClient refuses a declaration the
+// committed record contradicts — the record holds 16 operations no client drove
+// that earned `probed`, 14 that earned `contract` and one that earned `shape`.
+type axisEarner int
+
+const (
+	// earnedByAClient: only a real client driving this emulator marks it, so
+	// "no official client reaches this operation" is a complete explanation for
+	// a zero, and Route.Undriven is allowed to retire one.
+	earnedByAClient axisEarner = iota
+	// earnedByValidation: an answer held to the provider's own API description
+	// marks it, and the contract-driven probe produces those without any client.
+	// A zero here has its cause on the probe's side — its plan, its seeding, or
+	// the extraction that built the document — and #429 is the measurement: 31
+	// Scaleway operations went from `unchecked` to `clean`, and 29 from no probe
+	// verdict to one, with not a line of client or pack code moved. Had they
+	// carried an Undriven reason, this queue would have called all sixty of them
+	// "not work".
+	earnedByValidation
+	// earnedByARecording: a recorded real-cloud answer marks it, and nothing a
+	// run does moves it either way. The recorder reads the cloud directly rather
+	// than through an official client (tools/shapes/record.sh), which is why a
+	// sentence about what `exo` or `scw` cannot compose says nothing about it.
+	earnedByARecording
+)
+
+// evidenceAxisList is the seven axes in the order emulator.Evidence declares
 // evidenceAxisList is the seven axes in the order emulator.Evidence declares
 // them. The order is fixed for diff stability and is not a ranking — the record
 // publishes independent axes and never adds them into a score, which is the
@@ -78,12 +136,14 @@ func evidenceAxisList() []evidenceAxis {
 	return []evidenceAxis{
 		{
 			Name:    "driven",
+			earner:  earnedByAClient,
 			Meaning: "a real client reached it in the recorded run; it proves what the suite asserted, nothing more",
 			earned:  func(e emulator.Evidence) bool { return e.Driven },
 			verdict: noVerdict,
 		},
 		{
 			Name:    "probed",
+			earner:  earnedByValidation,
 			Meaning: "the contract-driven probe validated an answer here against the operation's own schema, a success (`response`) or a refusal (`refusal`)",
 			// Named positively, and that is the point. Written as `!= ProbeNone`
 			// it counted a record carrying no verdict at all — an empty string,
@@ -98,30 +158,35 @@ func evidenceAxisList() []evidenceAxis {
 		},
 		{
 			Name:    "contract",
+			earner:  earnedByValidation,
 			Meaning: "at least one answer was validated against the provider's own API description and none violated it (`unchecked`: none was ever validated, which is not the same as no violation)",
 			earned:  func(e emulator.Evidence) bool { return e.Contract == emulator.ContractClean },
 			verdict: func(e emulator.Evidence) string { return e.Contract },
 		},
 		{
 			Name:    "dataplane",
+			earner:  earnedByAClient,
 			Meaning: "it was driven in a run whose machines were real, so the control plane ran with its side effects on",
 			earned:  func(e emulator.Evidence) bool { return e.Dataplane },
 			verdict: noVerdict,
 		},
 		{
 			Name:    "shape",
+			earner:  earnedByARecording,
 			Meaning: "a recorded real-cloud answer covers it, from `shapes/` — which `mise run shapes:fold` also fills from the committed corpora; it says the answer has been held against a real one, not that the offline gate re-issues the call",
 			earned:  func(e emulator.Evidence) bool { return e.Shape == emulator.ShapeObserved },
 			verdict: func(e emulator.Evidence) string { return e.Shape },
 		},
 		{
 			Name:    "behaviour",
+			earner:  earnedByAClient,
 			Meaning: "it took part in a create-to-destroy sequence the emulator's own store observed, inside a span a suite declared",
 			earned:  func(e emulator.Evidence) bool { return e.Behaviour },
 			verdict: noVerdict,
 		},
 		{
 			Name:    "negative",
+			earner:  earnedByAClient,
 			Meaning: "it really answered 4xx to a real client inside a span where a suite demanded a refusal; **an injected fault never earns it**, so arming faults cannot move this number",
 			earned:  func(e emulator.Evidence) bool { return e.Negative },
 			verdict: noVerdict,

--- a/internal/cli/evidence_earner_test.go
+++ b/internal/cli/evidence_earner_test.go
@@ -1,0 +1,330 @@
+package cli
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+)
+
+// The controls behind evidenceAxis.earner, which decides whether a reason about
+// clients is allowed to explain a zero.
+//
+// It is the same hazard Route.Unearnable carries and the same answer: a
+// declaration that removes work from a queue is measured, and the prose only
+// explains it. Until #445 there was no such declaration at all — every zero of
+// an undriven operation was filed "declared, no path exists" with the route's
+// client-shaped reason printed beside it, on all seven axes at once, including
+// the one the contract-driven probe earns with no client whatsoever.
+//
+// Two independent witnesses, and neither is sufficient alone:
+//
+//   - the mechanism (TestOnlyAClientEarnsAClientBorneAxis) drives one synthetic
+//     and one real exchange against a live emulator and reads the axes back. It
+//     measures what the observer actually does, whatever the record happens to
+//     hold today.
+//   - the record (TestNoClientBorneAxisIsEarnedWithoutAClient) refuses a
+//     declaration the committed artefact contradicts. It is what makes the
+//     declaration expire on its own the day an axis changes hands.
+
+// probedAxisName is the axis the probe alone earns, named once so a rename
+// breaks the tests rather than silently emptying them.
+const probedAxisName = "probed"
+
+// A synthetic exchange earns nothing a client is supposed to earn — measured
+// against a running emulator, not read off the axis names.
+//
+// Both halves are required. "The probe earned no client axis" is equally true
+// of a probe that never ran, which is the vacuous pass this repository has paid
+// for more than once, so the test also requires the synthetic exchange to have
+// earned something. And the real client call is there to prove the same server,
+// in the same run, does move the client axes: without it, a server that recorded
+// nothing at all would pass.
+func TestOnlyAClientEarnsAClientBorneAxis(t *testing.T) {
+	docs, err := loadContracts(filepath.Join("..", "..", "contracts"))
+	if err != nil {
+		t.Fatalf("load the contracts: %v", err)
+	}
+	srv, _, err := newServer(docs)
+	if err != nil {
+		t.Fatalf("build the emulator: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	const (
+		probeOp  = "instance/v1/API.ListServers"
+		clientOp = "instance/v1/API.ListIPs"
+	)
+	mounted := map[string]string{}
+	for _, r := range srv.AllRoutes() {
+		mounted[r.Operation] = r.Path
+	}
+	for _, op := range []string{probeOp, clientOp} {
+		if mounted[op] == "" {
+			t.Fatalf("%s is not mounted, so this test would measure nothing", op)
+		}
+	}
+
+	// One synthetic exchange, marked exactly the way the contract-driven probe
+	// marks its own, and one exchange with no marking at all.
+	// The page size is asked for on purpose: a paged operation earns `probed`
+	// only through the call that carried it (noteProbe), so without it the
+	// synthetic exchange earns `contract` alone and this witness never exercises
+	// the axis a client can never reach.
+	get(t, ts.URL+"/instance/v1/zones/fr-par-1/servers?per_page=1", true)
+	get(t, ts.URL+"/instance/v1/zones/fr-par-1/ips", false)
+
+	var view emulator.ConformanceView
+	body := get(t, ts.URL+"/_feint/conformance", false)
+	if err := json.Unmarshal(body, &view); err != nil {
+		t.Fatalf("decode the conformance view: %v", err)
+	}
+	probed, ok := view.Evidence[probeOp]
+	if !ok {
+		t.Fatalf("the view holds no evidence for %s", probeOp)
+	}
+	driven, ok := view.Evidence[clientOp]
+	if !ok {
+		t.Fatalf("the view holds no evidence for %s", clientOp)
+	}
+
+	// The witness: the synthetic call was measured. Without it, every assertion
+	// below is true of an exchange that never happened.
+	var earnedByTheProbe []string
+	for _, a := range evidenceAxisList() {
+		if a.earned(probed) {
+			earnedByTheProbe = append(earnedByTheProbe, a.Name)
+		}
+	}
+	if len(earnedByTheProbe) == 0 {
+		t.Fatalf("the synthetic exchange on %s earned no axis at all, so this test proves "+
+			"nothing about which axes it cannot earn", probeOp)
+	}
+	// And it earned the one axis no client can reach. Asserted by name rather
+	// than left to the count above: an exchange that earned `contract` alone
+	// would satisfy the witness and say nothing about `probed`, which is the
+	// axis #445 is about.
+	if !namedAxis(t, probedAxisName).earned(probed) {
+		t.Fatalf("the synthetic exchange on %s did not earn `%s`, so nothing here shows a "+
+			"client-less exchange reaching it", probeOp, probedAxisName)
+	}
+
+	for _, a := range evidenceAxisList() {
+		if a.earner != earnedByAClient {
+			continue
+		}
+		if a.earned(probed) {
+			t.Errorf("%s is declared earned by a client alone, and a synthetic exchange earned it "+
+				"on %s: the declaration is what lets a client-shaped reason retire a zero there",
+				a.Name, probeOp)
+		}
+	}
+
+	// The other side of the same server: a real client does move the client
+	// axes, and does not move the probe's.
+	if !driven.Driven {
+		t.Fatalf("a plain request to %s left it undriven, so the comparison above measures "+
+			"a broken observer rather than a boundary", clientOp)
+	}
+	for _, a := range evidenceAxisList() {
+		if a.Name == probedAxisName && a.earned(driven) {
+			t.Errorf("a client with no probe marking earned `%s` on %s", a.Name, clientOp)
+		}
+		if a.earner == earnedByARecording && (a.earned(driven) || a.earned(probed)) {
+			t.Errorf("%s is declared earned by a recording, and traffic earned it", a.Name)
+		}
+	}
+	sort.Strings(earnedByTheProbe)
+	t.Logf("the synthetic exchange on %s earned: %s", probeOp, strings.Join(earnedByTheProbe, ", "))
+}
+
+// The committed record must not contradict the declaration.
+//
+// This is the half that makes the declaration expire on its own. An axis
+// declared earnable by a client alone, that an operation no client drove has
+// earned, is a declaration the record disproves — and it is the declaration
+// that lets `--gaps` file a zero as "not work" with a sentence about `exo` or
+// `scw` beside it.
+//
+// The converse is asserted too, and it is not decoration: without it a
+// declaration marking every axis as probe-borne would pass, which is a control
+// that has stopped measuring while staying green. The record holds 16
+// operations no client drove that earned `probed`, 14 that earned `contract`
+// and one — exoscale/v2.get-operation — that earned `shape`.
+func TestNoClientBorneAxisIsEarnedWithoutAClient(t *testing.T) {
+	art, err := loadEvidenceArtefact(filepath.Join("..", "..", "coverage", "evidence.json"))
+	if err != nil {
+		t.Fatalf("read the evidence artefact: %v", err)
+	}
+	if art == nil || len(art.Operations) == 0 {
+		t.Fatal("the evidence artefact is empty, so this test would pass while measuring nothing")
+	}
+	var undriven []string
+	for op, ev := range art.Operations {
+		if !ev.Driven {
+			undriven = append(undriven, op)
+		}
+	}
+	if len(undriven) == 0 {
+		t.Fatal("the record holds no undriven operation, so it can neither confirm nor " +
+			"contradict any declaration and this test would pass on any code")
+	}
+	sort.Strings(undriven)
+
+	earnedWithoutAClient := map[string][]string{}
+	for _, a := range evidenceAxisList() {
+		for _, op := range undriven {
+			if a.earned(art.Operations[op]) {
+				earnedWithoutAClient[a.Name] = append(earnedWithoutAClient[a.Name], op)
+			}
+		}
+	}
+
+	witnessed := 0
+	for _, a := range evidenceAxisList() {
+		got := earnedWithoutAClient[a.Name]
+		if a.earner == earnedByAClient {
+			if len(got) > 0 {
+				t.Errorf("`%s` is declared earned by a client alone, and %d operation(s) no client "+
+					"drove have earned it: %s\nA zero on that axis is then retired by a reason about "+
+					"clients, and the record says clients are not what earns it.",
+					a.Name, len(got), strings.Join(got, ", "))
+			}
+			continue
+		}
+		witnessed += len(got)
+	}
+	if witnessed == 0 {
+		t.Fatal("no axis declared earnable without a client was earned by any undriven operation, " +
+			"so a declaration marking every axis client-borne would pass this test unchanged")
+	}
+}
+
+// No zero the probe can close is filed as a decision nobody can act on.
+//
+// The defect, measured on the committed record before the fix: seven Exoscale
+// operations sat at zero on `probed` and nine on `contract`, every one of them
+// filed `declared` — "not work: no path exists to close this zero" — with a
+// sentence about the `exo` CLI printed beside it. The probe needs no CLI. #429
+// then proved the point from the other side: 31 Scaleway operations earned
+// `contract` and 29 earned `probed` from a single fix to the contract
+// extraction, with no client and no pack code touched at all — and had those
+// carried an Undriven reason, this queue would have called all sixty "not work".
+//
+// The assertion is over the committed record rather than a fixture, because the
+// misfiled population is a property of the packs and the record together, and a
+// fixture would have let the two drift apart. The non-vacuity guard is what
+// stops it passing on a record where nobody is in that state.
+func TestAClientShapedReasonNeverExplainsAProbeSideZero(t *testing.T) {
+	art, err := loadEvidenceArtefact(filepath.Join("..", "..", "coverage", "evidence.json"))
+	if err != nil {
+		t.Fatalf("read the evidence artefact: %v", err)
+	}
+	if art == nil || len(art.Operations) == 0 {
+		t.Fatal("the evidence artefact is empty, so this test would pass while measuring nothing")
+	}
+	owners, providers, err := operationOwners()
+	if err != nil {
+		t.Fatal(err)
+	}
+	reasons, err := undrivenReasons()
+	if err != nil {
+		t.Fatal(err)
+	}
+	unearnable, err := unearnableReasons()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The population the defect lived in, derived from the two inputs and never
+	// from the report under test: undriven, carrying a client-shaped reason, and
+	// at zero on an axis no client earns.
+	exposed := map[string][]string{}
+	for op, ev := range art.Operations {
+		if _, owned := owners[op]; !owned || ev.Driven || reasons[op] == "" {
+			continue
+		}
+		for _, a := range evidenceAxisList() {
+			if a.earner == earnedByAClient || a.earned(ev) || unearnable[op][a.Name] != "" {
+				continue
+			}
+			exposed[a.Name] = append(exposed[a.Name], op)
+		}
+	}
+	if len(exposed) == 0 {
+		t.Fatal("no operation is undriven, declared, and at zero on an axis a client does not " +
+			"earn, so the state this test describes is unreachable on this record and it would " +
+			"pass on any code")
+	}
+
+	report, err := buildGaps("coverage/evidence.json", art, owners, reasons, unearnable, providers, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	filed := map[string]map[string]gapEntry{}
+	for _, g := range report.Groups {
+		for _, e := range g.Entries {
+			if filed[e.Axis] == nil {
+				filed[e.Axis] = map[string]gapEntry{}
+			}
+			filed[e.Axis][e.Operation] = e
+		}
+	}
+
+	seen := 0
+	for axis, ops := range exposed {
+		sort.Strings(ops)
+		for _, op := range ops {
+			e, queued := filed[axis][op]
+			if !queued {
+				t.Errorf("%s is at zero on `%s` and the queue does not name it", op, axis)
+				continue
+			}
+			seen++
+			if e.Kind == gapKindNames[gapDeclared] {
+				t.Errorf("%s is filed `declared` on `%s` and the only reason anybody wrote for it "+
+					"is about clients:\n    %s\nA client is not what earns `%s`.", op, axis, e.Reason, axis)
+			}
+			if e.Reason != "" {
+				t.Errorf("%s is filed `%s` on `%s` and still prints a reason: %s",
+					op, e.Kind, axis, e.Reason)
+			}
+		}
+	}
+	if seen == 0 {
+		t.Fatal("no entry of the exposed population was examined, so this test measured nothing")
+	}
+}
+
+// get issues one request and returns the body, marking it synthetic the way the
+// contract-driven probe does when asked.
+func get(t *testing.T, url string, synthetic bool) []byte {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("build the request: %v", err)
+	}
+	if synthetic {
+		req.Header.Set(emulator.ProbeHeader, "1")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read %s: %v", url, err)
+	}
+	if resp.StatusCode >= 300 {
+		t.Fatalf("GET %s answered %d: %s", url, resp.StatusCode, body)
+	}
+	return body
+}

--- a/internal/cli/evidence_gaps.go
+++ b/internal/cli/evidence_gaps.go
@@ -35,14 +35,37 @@ const (
 	// axis rather than never reaching it. It is served, it is reached, and it
 	// is wrong: nothing else in this queue is a defect.
 	gapViolating gapKind = iota
-	// gapUnrecorded: the operation is driven by a real client, and the axis is
-	// still missing. For `shape` that is exactly "no recording of the real
-	// cloud's answer exists" — one recording session away from earned, which
-	// is why it outranks the two below.
+	// gapUnvalidated: no answer of this operation was ever held to the
+	// provider's own API description — the record says `probed: none` or
+	// `contract: unchecked`. The contract-driven probe is what earns those two
+	// axes and it needs no client at all, so the cause is on the probe's side:
+	// its plan, its seeding pool, or the extraction that built the document.
+	//
+	// It says that and no more. Which of the three it is, the record does not
+	// carry, and this queue does not guess — the whole defect it was split out
+	// of (#445) was a line claiming a cause the record could not verify.
+	//
+	// It outranks the recording below because it is the one entry of this queue
+	// that needs neither a cloud account nor a client binary: everything it
+	// asks for is in this repository. #429 is the measurement — a single fix to
+	// the extraction, which had recorded "the document declares an empty answer"
+	// and "no schema" the same way, retired 31 Scaleway zeros on `contract` and
+	// 29 on `probed` at once, and every one of the thirty-one operations turned
+	// out to have been correct all along.
+	gapUnvalidated
+	// gapUnrecorded: no recorded real-cloud answer covers this operation. It is
+	// the whole story of a `shape` zero, and one recording session from earned.
+	//
+	// It says nothing about clients, and that is deliberate since #445: the
+	// recorder reads the cloud directly rather than through an official client
+	// (tools/shapes/record.sh), so a sentence about what `exo` or `scw` cannot
+	// compose does not explain a missing recording. The committed record agrees
+	// — exoscale/v2.get-operation carries an observed shape and no client has
+	// ever driven it.
 	gapUnrecorded
-	// gapUndriven: no real client reaches this operation, and no route says
-	// why. Most axes cannot be earned without a client, so this is the upstream
-	// job: a conformance suite, not a pack change.
+	// gapUndriven: no real client reaches this operation, no route says why, and
+	// the axis is one only a client can earn (axisEarner). So this is the
+	// upstream job: a conformance suite, not a pack change.
 	//
 	// It reads zero on a green repository, and that is the design rather than a
 	// dead branch: TestEveryUndrivenOperationSaysWhy already refuses an undriven
@@ -56,8 +79,9 @@ const (
 	// because a bucket that absorbs the unexplained is how a queue starts
 	// lying.
 	//
-	// It is the largest bucket, and 172 of its 264 zeros are the `negative`
-	// axis. A tempting reading — measured and rejected on 2026-08-24 — is that
+	// It is the largest bucket, and 98 of its 113 zeros are the `negative` axis
+	// (measured 2026-08-24, after #445 moved the probe's and the recorder's
+	// zeros to the kinds that name them). A tempting reading — measured and rejected on 2026-08-24 — is that
 	// those are recordings like `shape`, and should be reclassified as such.
 	// They are not. `shape` is earned by a recorded real-cloud answer and by
 	// nothing else, so "no recording exists" is its whole story; `negative` is
@@ -80,7 +104,7 @@ const (
 	// of the thirteen resisted an attempt to earn them before they were
 	// declared, which is the order this kind of entry has to be written in.
 	//
-	// It exists because the four kinds above could not tell "nobody has written
+	// It exists because the kinds above could not tell "nobody has written
 	// the suite yet" from "no client path exists to write one with", and the
 	// queue told both to go and write a suite. Measured on 2026-08-24: all
 	// twenty-five operations the record left undriven already carried a reason
@@ -98,65 +122,89 @@ const (
 // gapKindNames are what the output prints, and the keys --format json uses.
 // Short, lowercase, stable: they are a vocabulary consumers will match on.
 var gapKindNames = map[gapKind]string{
-	gapViolating:  "violating",
-	gapUnrecorded: "unrecorded",
-	gapUndriven:   "undriven",
-	gapUnproven:   "unproven",
-	gapDeclared:   "declared",
+	gapViolating:   "violating",
+	gapUnvalidated: "unvalidated",
+	gapUnrecorded:  "unrecorded",
+	gapUndriven:    "undriven",
+	gapUnproven:    "unproven",
+	gapDeclared:    "declared",
 }
 
 // gapKindWork is the sentence the text output prints once per group. It names
 // the job, not the state, because the reader of this queue is deciding what to
 // pick up.
 var gapKindWork = map[gapKind]string{
-	gapViolating:  "a defect: the operation is served and reached, and the record says it broke this axis",
-	gapUnrecorded: "a recording: a real client already drives it, and no answer of the real cloud has been kept",
-	gapUndriven:   "a conformance suite: no real client reaches this operation, so most axes cannot be earned",
+	gapViolating: "a defect: the operation is served and reached, and the record says it broke this axis",
+	gapUnvalidated: "the probe: this axis is earned by an answer held to the provider's own API description, " +
+		"which the contract-driven probe produces with no client at all, and the record says none was ever held here",
+	gapUnrecorded: "a recording: no answer of the real cloud has been kept for this operation",
+	gapUndriven:   "a conformance suite: no real client reaches this operation, and only a client can earn this axis",
 	gapUnproven:   "unexplained: driven, not violating, still not earned — the record does not say why",
 	gapDeclared:   "not work: no path exists to close this zero, and the route says which — the reason is printed with each line",
 }
 
-// classifyGap decides which of the five a zero is, from the record and from
-// what the pack declares at the route — never from the operation's name.
+// classifyGap decides which of the six a zero is, from the record and from what
+// the pack declares at the route — never from the operation's name.
+//
+// It returns the reason it classified on, so that a `declared` line cannot
+// print a sentence the classifier did not use. That is not tidiness: the defect
+// this function carried until #445 was exactly a printed reason and a branch
+// that had nothing to do with each other, and a second copy of the branch
+// conditions in the caller is how the two drifted apart in the first place.
 //
 // The order of the tests is the classification: a violation outranks everything
-// because it is the only defect here, and "undriven" is asked before the
+// because it is the only defect here, and the declarations are asked before the
 // catch-all so that the unexplained bucket stays as small as the record allows.
 //
-// `reason` is Route.Undriven for this operation, empty when the route declares
-// none. It is only ever consulted for an operation the record says no client
-// drove: a reason on a driven operation is a stale excuse, and
-// TestEveryUndrivenOperationSaysWhy is the control that refuses one — this
-// function must not quietly honour what that test exists to reject.
+// `undriven` is Route.Undriven for this operation, empty when the route
+// declares none. Two conditions gate it, and each answers a different question:
 //
-// TestAGapIsClassifiedFromTheRecordRatherThanTheName and
-// TestADeclaredReasonSplitsTheUndrivenQueue fail without this.
-func classifyGap(ev emulator.Evidence, axis evidenceAxis, undriven, unearnable string) gapKind {
+//   - the record must say no client drove the operation. A reason on a driven
+//     operation is a stale excuse, and TestEveryUndrivenOperationSaysWhy is the
+//     control that refuses one — this function must not quietly honour what
+//     that test exists to reject.
+//   - the axis must be one a client alone can earn (axisEarner). "No official
+//     client reaches this operation" is a fact about client traffic, and it
+//     explains a zero only where client traffic is what earns the axis. Applied
+//     to `probed` — which the probe earns with no client whatsoever — it filed
+//     doable work as "not work" and printed a sentence about `exo` beside it
+//     (#445). The committed record shows the same reason sitting on operations
+//     that earned `probed` anyway.
+//
+// TestAGapIsClassifiedFromTheRecordRatherThanTheName,
+// TestADeclaredReasonSplitsTheUndrivenQueue and
+// TestAClientShapedReasonNeverExplainsAProbeSideZero fail without this.
+func classifyGap(ev emulator.Evidence, axis evidenceAxis, undriven, unearnable string) (gapKind, string) {
 	if v := axis.verdict(ev); v == "violating" {
-		return gapViolating
+		return gapViolating, ""
 	}
-	if !ev.Driven {
+	if axis.earner == earnedByAClient && !ev.Driven {
 		if undriven != "" {
-			return gapDeclared
+			return gapDeclared, undriven
 		}
-		return gapUndriven
+		return gapUndriven, ""
 	}
-	// Driven, and the route says this axis can never be earned here. Asked
-	// before the catch-all for the same reason "undriven" is: the unexplained
+	// The route says this axis can never be earned here. Asked before the
+	// catch-alls for the same reason the client reason is: the unexplained
 	// bucket must stay as small as the declarations allow, and a zero no work
 	// can close is not work.
 	//
-	// It is asked AFTER the driven test on purpose: an operation nothing drives
-	// is Undriven's business, and letting an axis declaration answer for it
-	// would hide a missing suite behind a true statement about a different
-	// thing.
+	// It is asked AFTER the branch above on purpose: an operation nothing drives
+	// is Undriven's business on the axes a client earns, and letting an axis
+	// declaration answer for it would hide a missing suite behind a true
+	// statement about a different thing. Unlike Route.Undriven it is keyed by
+	// axis, so its subject already matches what it excuses, and it is honoured
+	// on every axis a route names.
 	if unearnable != "" {
-		return gapDeclared
+		return gapDeclared, unearnable
 	}
-	if axis.Name == "shape" {
-		return gapUnrecorded
+	switch axis.earner {
+	case earnedByValidation:
+		return gapUnvalidated, ""
+	case earnedByARecording:
+		return gapUnrecorded, ""
 	}
-	return gapUnproven
+	return gapUnproven, ""
 }
 
 // gapEntry is one operation of the queue, with the work it names.
@@ -167,9 +215,11 @@ type gapEntry struct {
 	// Verdict carries the record's own word for a non-boolean axis, so a
 	// consumer never has to re-derive it from Kind.
 	Verdict string `json:"verdict,omitempty"`
-	// Reason is Route.Undriven, carried on the "declared" lines only. Published
-	// rather than left for the reader to go and find in a pack file: a decision
-	// a report names but does not state is a decision nobody re-examines.
+	// Reason is the declaration the classifier retired this zero on —
+	// Route.Undriven or the Route.Unearnable entry for this axis — carried on
+	// the "declared" lines only. Published rather than left for the reader to go
+	// and find in a pack file: a decision a report names but does not state is a
+	// decision nobody re-examines.
 	Reason string `json:"reason,omitempty"`
 }
 
@@ -243,21 +293,18 @@ func buildGaps(record string, art *evidenceArtefact, owners map[string]string,
 				if a.earned(ev) {
 					continue
 				}
-				unearned := unearnable[op][a.Name]
-				kind := classifyGap(ev, a, reasons[op], unearned)
-				entry := gapEntry{
+				kind, why := classifyGap(ev, a, reasons[op], unearnable[op][a.Name])
+				group.Entries = append(group.Entries, gapEntry{
 					Operation: op,
 					Axis:      a.Name,
 					Kind:      gapKindNames[kind],
 					Verdict:   a.verdict(ev),
-				}
-				if kind == gapDeclared {
-					entry.Reason = reasons[op]
-					if unearned != "" && ev.Driven {
-						entry.Reason = unearned
-					}
-				}
-				group.Entries = append(group.Entries, entry)
+					// The reason the classifier used, never one this loop went
+					// and fetched again: the two readings drifting apart is the
+					// defect #445 measured, and a single return value is what
+					// makes them one reading.
+					Reason: why,
+				})
 			}
 			if len(group.Entries) == 0 {
 				continue
@@ -279,9 +326,10 @@ func buildGaps(record string, art *evidenceArtefact, owners map[string]string,
 	return report, nil
 }
 
-// kindRank orders the four. Violations first because they are the only defect;
-// then the recording, which is one session from earned; then the suite, which
-// is upstream of most axes; then what nothing explains.
+// kindRank orders the six. Violations first because they are the only defect;
+// then the probe, which asks for nothing outside this repository; then the
+// recording, which needs a real account; then the suite, which needs a client;
+// then what nothing explains, and last what nothing can close.
 func kindRank(name string) int {
 	for k, n := range gapKindNames {
 		if n == name {

--- a/internal/cli/evidence_gaps_test.go
+++ b/internal/cli/evidence_gaps_test.go
@@ -12,15 +12,16 @@ import (
 
 // A gap's kind comes from the record, never from the operation's name.
 //
-// The whole value of this queue is that four zeros name four different jobs. If
-// a kind could be inferred from a name, a renamed operation would change the
+// The whole value of this queue is that a zero names one of six different jobs.
+// If a kind could be inferred from a name, a renamed operation would change the
 // work it names, and the queue would be a convention rather than a measurement.
 //
-// Each case below is a state the record can really hold, and the four are the
-// four branches of classifyGap in order.
+// Each case below is a state the record can really hold, and they are the
+// branches of classifyGap in order.
 func TestAGapIsClassifiedFromTheRecordRatherThanTheName(t *testing.T) {
 	shape := namedAxis(t, "shape")
 	negative := namedAxis(t, "negative")
+	probed := namedAxis(t, "probed")
 
 	cases := []struct {
 		name string
@@ -36,28 +37,41 @@ func TestAGapIsClassifiedFromTheRecordRatherThanTheName(t *testing.T) {
 		{"a violating verdict outranks everything",
 			emulator.Evidence{Driven: true, Shape: "violating"}, shape, "", "", gapViolating},
 		{"undriven and nothing says why is a suite to write",
-			emulator.Evidence{Driven: false, Shape: "unobserved"}, shape, "", "", gapUndriven},
-		{"driven and unobserved is a recording",
+			emulator.Evidence{Driven: false}, negative, "", "", gapUndriven},
+		{"unobserved is a recording, whoever drove it",
 			emulator.Evidence{Driven: true, Shape: "unobserved"}, shape, "", "", gapUnrecorded},
+		{"no probe verdict is the probe's side",
+			emulator.Evidence{Driven: true, Probed: "none"}, probed, "", "", gapUnvalidated},
 		{"driven, not violating, another axis: unexplained rather than guessed",
 			emulator.Evidence{Driven: true}, negative, "", "", gapUnproven},
 		// The two that separate "no suite yet" from "no client to write one
 		// with". Same record, same axis, different answer — so the reason is
 		// what decides, and it is read from the route rather than from the name.
 		{"undriven with a declared reason is not work",
-			emulator.Evidence{Driven: false, Shape: "unobserved"}, shape,
+			emulator.Evidence{Driven: false}, negative,
 			"no official client calls it: the CLI has no attach subcommand", "", gapDeclared},
 		// A reason must never rescue a driven operation from its zero. The
 		// stale half of TestEveryUndrivenOperationSaysWhy exists to reject such
 		// a reason, and this asserts the queue does not honour it meanwhile:
 		// otherwise a stale excuse would empty a real recording queue.
 		{"a reason on a driven operation changes nothing",
-			emulator.Evidence{Driven: true, Shape: "unobserved"}, shape,
+			emulator.Evidence{Driven: true}, negative,
+			"no official client calls it: the CLI has no attach subcommand", "", gapUnproven},
+		// The half #445 added, and the one this file could not state before it.
+		// Same record and same reason as the case two rows up, on an axis the
+		// probe earns with no client at all: the sentence is about `exo`, the
+		// zero is not, and filing it "declared" told a reader nobody could act
+		// on work #429 has since shown to be both doable and already done.
+		{"a client reason does not explain a zero the probe earns",
+			emulator.Evidence{Driven: false, Probed: "none"}, probed,
+			"no official client calls it: the CLI has no attach subcommand", "", gapUnvalidated},
+		{"a client reason does not explain a missing recording either",
+			emulator.Evidence{Driven: false, Shape: "unobserved"}, shape,
 			"no official client calls it: the CLI has no attach subcommand", "", gapUnrecorded},
 		// The axis declaration, which answers a different question from the one
 		// above: the operation IS driven, and the axis is still out of reach.
-		// Without the third branch of classifyGap this is "unproven", which
-		// sends a reader to write a case that cannot exist.
+		// Without that branch of classifyGap this is "unproven", which sends a
+		// reader to write a case that cannot exist.
 		{"driven, and the route says the axis is out of reach: not work",
 			emulator.Evidence{Driven: true}, negative, "",
 			"no supported client can compose a request it must refuse", gapDeclared},
@@ -70,8 +84,18 @@ func TestAGapIsClassifiedFromTheRecordRatherThanTheName(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := classifyGap(c.ev, c.axis, c.reason, c.unearnable); got != c.want {
+			got, why := classifyGap(c.ev, c.axis, c.reason, c.unearnable)
+			if got != c.want {
 				t.Fatalf("classified as %s, want %s", gapKindNames[got], gapKindNames[c.want])
+			}
+			// The reason travels with the branch, or a `declared` line prints a
+			// sentence that decided nothing — which is the shape of the defect
+			// this queue was corrected for.
+			if got == gapDeclared && why == "" {
+				t.Fatal("classified as declared and returned no reason to print")
+			}
+			if got != gapDeclared && why != "" {
+				t.Fatalf("classified as %s and returned the reason %q", gapKindNames[got], why)
 			}
 		})
 	}

--- a/tools/falsify/specs/evidence-gaps.json
+++ b/tools/falsify/specs/evidence-gaps.json
@@ -4,19 +4,19 @@
   "mutations": [
     {
       "file": "internal/cli/evidence_gaps.go",
-      "find": "\tif v := axis.verdict(ev); v == \"violating\" {\n\t\treturn gapViolating\n\t}",
-      "replace": "\tif v := axis.verdict(ev); v == \"violating\" && false {\n\t\treturn gapViolating\n\t}",
+      "find": "\tif v := axis.verdict(ev); v == \"violating\" {\n\t\treturn gapViolating, \"\"\n\t}",
+      "replace": "\tif v := axis.verdict(ev); v == \"violating\" && false {\n\t\treturn gapViolating, \"\"\n\t}",
       "expect": "a defect stops outranking the rest, so an operation the record says broke its own contract is queued among the ones nobody ever drove",
       "test": "TestAGapIsClassifiedFromTheRecordRatherThanTheName",
       "label": "a defect no longer outranks the rest"
     },
     {
       "file": "internal/cli/evidence_gaps.go",
-      "find": "\tif !ev.Driven {\n\t\tif undriven != \"\" {\n\t\t\treturn gapDeclared\n\t\t}\n\t\treturn gapUndriven\n\t}",
-      "replace": "\tif !ev.Driven && false {\n\t\tif undriven != \"\" {\n\t\t\treturn gapDeclared\n\t\t}\n\t\treturn gapUndriven\n\t}",
-      "expect": "an operation no client reaches is filed as a recording session, so somebody records a cloud answer for a route nothing calls",
+      "find": "\tif axis.earner == earnedByAClient && !ev.Driven {\n\t\tif undriven != \"\" {\n\t\t\treturn gapDeclared, undriven\n\t\t}\n\t\treturn gapUndriven, \"\"\n\t}",
+      "replace": "\tif axis.earner == earnedByAClient && !ev.Driven && false {\n\t\tif undriven != \"\" {\n\t\t\treturn gapDeclared, undriven\n\t\t}\n\t\treturn gapUndriven, \"\"\n\t}",
+      "expect": "an operation no client reaches stops asking for the conformance suite that would close it, and lands in the bucket the record cannot explain",
       "test": "TestAGapIsClassifiedFromTheRecordRatherThanTheName",
-      "label": "an undriven operation is filed as a recording"
+      "label": "an operation no client reaches is filed as unexplained"
     },
     {
       "file": "internal/cli/evidence_gaps.go",
@@ -52,24 +52,24 @@
     },
     {
       "file": "internal/cli/evidence_gaps.go",
-      "find": "\t\tif undriven != \"\" {\n\t\t\treturn gapDeclared\n\t\t}\n\t\treturn gapUndriven",
-      "replace": "\t\tif undriven != \"\" && false {\n\t\t\treturn gapDeclared\n\t\t}\n\t\treturn gapUndriven",
+      "find": "\t\tif undriven != \"\" {\n\t\t\treturn gapDeclared, undriven\n\t\t}\n\t\treturn gapUndriven, \"\"",
+      "replace": "\t\tif undriven != \"\" && false {\n\t\t\treturn gapDeclared, undriven\n\t\t}\n\t\treturn gapUndriven, \"\"",
       "expect": "the reason a pack wrote at the route stops retiring its zero, so all 141 of them go back to asking for a conformance suite that no client exists to write",
       "test": "TestADeclaredReasonSplitsTheUndrivenQueue",
       "label": "a declared reason stops retiring its zero"
     },
     {
       "file": "internal/cli/evidence_gaps.go",
-      "find": "\tif !ev.Driven {\n\t\tif undriven != \"\" {\n\t\t\treturn gapDeclared\n\t\t}\n\t\treturn gapUndriven\n\t}\n\t// Driven, and the route says",
-      "replace": "\tif !ev.Driven || true {\n\t\tif undriven != \"\" {\n\t\t\treturn gapDeclared\n\t\t}\n\t\treturn gapUndriven\n\t}\n\t// Driven, and the route says",
+      "find": "\tif axis.earner == earnedByAClient && !ev.Driven {\n\t\tif undriven != \"\" {\n\t\t\treturn gapDeclared, undriven\n\t\t}\n\t\treturn gapUndriven, \"\"\n\t}\n\t// The route says",
+      "replace": "\tif axis.earner == earnedByAClient && (!ev.Driven || true) {\n\t\tif undriven != \"\" {\n\t\t\treturn gapDeclared, undriven\n\t\t}\n\t\treturn gapUndriven, \"\"\n\t}\n\t// The route says",
       "expect": "a reason is honoured on an operation a client does drive, so a stale excuse \u2014 the exact thing TestEveryUndrivenOperationSaysWhy exists to reject \u2014 empties a real recording queue",
       "test": "TestAGapIsClassifiedFromTheRecordRatherThanTheName",
       "label": "a stale reason excuses an operation a client drives"
     },
     {
       "file": "internal/cli/evidence_gaps.go",
-      "find": "\t\t\t\tif kind == gapDeclared {\n\t\t\t\t\tentry.Reason = reasons[op]",
-      "replace": "\t\t\t\tif kind == gapDeclared && false {\n\t\t\t\t\tentry.Reason = reasons[op]",
+      "find": "\t\t\t\t\tReason: why,",
+      "replace": "\t\t\t\t\tReason: why[:0],",
       "expect": "the queue calls an operation declared and never says on what grounds, so a decision it names is one no reader can re-examine without opening three pack files",
       "test": "TestADeclaredReasonSplitsTheUndrivenQueue",
       "label": "a declared line stops carrying its reason"
@@ -83,5 +83,5 @@
       "label": "the reasons are never read from the packs"
     }
   ],
-  "note": " Retargeted on 2026-08-24: classifyGap gained a third branch for Route.Unearnable and its first reason parameter was renamed `undriven`, so four fragments here stopped matching. falsify:lint is what caught it, which is the whole reason that gate refuses a spec whose fragment has moved rather than reporting it green."
+  "note": " Retargeted on 2026-08-24: classifyGap gained a third branch for Route.Unearnable and its first reason parameter was renamed `undriven`, so four fragments here stopped matching. falsify:lint is what caught it, which is the whole reason that gate refuses a spec whose fragment has moved rather than reporting it green. Retargeted a second time on 2026-08-24 for #445: classifyGap returns the reason it classified on, its first branch now asks which axis it is looking at, and the caller no longer re-derives the reason. Five fragments moved; falsify:lint is what named them."
 }

--- a/tools/falsify/specs/probe-side-zeros.json
+++ b/tools/falsify/specs/probe-side-zeros.json
@@ -1,0 +1,56 @@
+{
+  "package": "./internal/cli/",
+  "subject": "which axis a reason is allowed to explain, in the work queue (#445)",
+  "why": "`--gaps` filed a zero as `declared` \u2014 \"not work: no path exists to close this zero\" \u2014 as soon as the record said no client drove the operation, on all seven axes at once, and printed the route's Route.Undriven reason beside it. That reason is a sentence about clients. The contract-driven probe needs no client, so on `probed` and `contract` it explained nothing, and on `shape` \u2014 resolved offline from the recordings catalogue \u2014 it explained nothing either. Measured on the committed record: 38 queue lines across 22 operations said nobody could act, and #429 had just shown from the other side that 31 Scaleway operations earn `contract` and 29 earn `probed` from a single fix to the contract extraction, with no client and no pack code touched. Each mutation below puts one of those 38 lines back, or takes away a witness that keeps them out.",
+  "mutations": [
+    {
+      "file": "internal/cli/evidence_gaps.go",
+      "find": "\tif axis.earner == earnedByAClient && !ev.Driven {",
+      "replace": "\tif (axis.earner == earnedByAClient || true) && !ev.Driven {",
+      "expect": "the axis stops being asked, so a zero on `probed` is retired again by a sentence about what the `exo` CLI cannot compose \u2014 and the queue tells a reader that work #429 has already done twice is work nobody can do",
+      "test": "TestAClientShapedReasonNeverExplainsAProbeSideZero",
+      "label": "a client reason explains a probe-side zero again"
+    },
+    {
+      "file": "internal/cli/evidence_axes.go",
+      "find": "\t\t\tName:    \"probed\",\n\t\t\tearner:  earnedByValidation,",
+      "replace": "\t\t\tName:    \"probed\",\n\t\t\tearner:  earnedByAClient + earnedByValidation - earnedByValidation,",
+      "expect": "the axis only the probe can earn is declared earnable by a client alone, which the committed record contradicts sixteen times over",
+      "test": "TestNoClientBorneAxisIsEarnedWithoutAClient",
+      "label": "the probe's own axis is declared client-borne"
+    },
+    {
+      "file": "internal/cli/evidence_axes.go",
+      "find": "\t\t\tName:    \"shape\",\n\t\t\tearner:  earnedByARecording,",
+      "replace": "\t\t\tName:    \"shape\",\n\t\t\tearner:  earnedByAClient + earnedByARecording - earnedByARecording,",
+      "expect": "a missing recording of the real cloud is declared to be a client's business, and exoscale/v2.get-operation \u2014 observed, and driven by nobody \u2014 says it is not",
+      "test": "TestNoClientBorneAxisIsEarnedWithoutAClient",
+      "label": "a missing recording is declared client-borne"
+    },
+    {
+      "file": "internal/cli/evidence_gaps.go",
+      "find": "\tswitch axis.earner {\n\tcase earnedByValidation:\n\t\treturn gapUnvalidated, \"\"\n\tcase earnedByARecording:\n\t\treturn gapUnrecorded, \"\"\n\t}",
+      "replace": "\tswitch axis.earner {\n\tcase earnedByValidation, earnedByARecording:\n\t\tif false {\n\t\t\treturn gapUnvalidated, \"\"\n\t\t}\n\t\treturn gapUnrecorded, \"\"\n\t}",
+      "expect": "a zero the probe can close is filed as a recording, so a reader is sent to a real cloud account for work that needs nothing outside this repository",
+      "test": "TestAGapIsClassifiedFromTheRecordRatherThanTheName",
+      "label": "a probe-side zero is filed as a recording session"
+    },
+    {
+      "file": "internal/cli/evidence_gaps.go",
+      "find": "\t\t\t\t\tReason: why,",
+      "replace": "\t\t\t\t\tReason: reasons[op] + why[:0],",
+      "expect": "the printed reason is fetched again instead of coming from the branch that used it, so a line the classifier did not retire on a client reason prints one anyway \u2014 the exact decoupling the defect lived in",
+      "test": "TestAClientShapedReasonNeverExplainsAProbeSideZero",
+      "label": "the printed reason stops coming from the branch that used it"
+    },
+    {
+      "file": "internal/core/emulator/conformance.go",
+      "find": "\t\tsynthetic := req.Header.Get(ProbeHeader) != \"\"",
+      "replace": "\t\tsynthetic := req.Header.Get(ProbeHeader) != \"\" && false",
+      "expect": "the observer stops telling a probe's request from a client's, so the boundary the whole split rests on is gone and the witness that measures it must say so",
+      "test": "TestOnlyAClientEarnsAClientBorneAxis",
+      "label": "the observer stops telling a probe from a client"
+    }
+  ],
+  "note": "The sixth mutation runs against internal/core/emulator, not because the declaration lives there but because the fact it declares does: the observer is what keeps a synthetic exchange apart from a client's, and every axis reads one side or the other. A declaration whose subject nobody drives is a comment, which is why TestOnlyAClientEarnsAClientBorneAxis issues one marked request and one plain one against a live emulator rather than reading the axis table back to itself. The second and third mutations are the other witness \u2014 the committed record \u2014 and they are kept separate on purpose: the mechanical one cannot see a mis-declaration of an axis the two exchanges happen not to move, and the record one cannot see a boundary that has stopped existing. The sixth mutation edits a file of internal/core/emulator and deliberately does NOT carry a `package` of its own: the test that reads it lives in internal/cli, and the first draft pointed the run at the emulator package, where `-run` matched nothing and the mutation came back green with no test having run at all. The harness refused the spec rather than certifying it, which is the behaviour to rely on \u2014 a mutation whose test never executes reads exactly like a guard that does not bite."
+}

--- a/tools/falsify/specs/unearnable-axes.json
+++ b/tools/falsify/specs/unearnable-axes.json
@@ -4,8 +4,8 @@
     {
       "label": "the queue stops separating an axis nothing can earn from one nobody has proven, and thirteen impossible entries come back as work",
       "file": "internal/cli/evidence_gaps.go",
-      "find": "\tif unearnable != \"\" {\n\t\treturn gapDeclared\n\t}",
-      "replace": "\tif unearnable != \"\" && false {\n\t\treturn gapDeclared\n\t}",
+      "find": "\tif unearnable != \"\" {\n\t\treturn gapDeclared, unearnable\n\t}",
+      "replace": "\tif unearnable != \"\" && false {\n\t\treturn gapDeclared, unearnable\n\t}",
       "test": "TestAGapIsClassifiedFromTheRecordRatherThanTheName"
     },
     {
@@ -38,5 +38,5 @@
       "test": "TestATerminatedVmAndADeletedPeeringAreKeptRatherThanRemoved"
     }
   ],
-  "note": "Route.Unearnable removes work from a queue by declaring an axis out of reach, which makes it the most dangerous kind of entry in this repository: it reads like a decision and the sentence itself is not checkable. Every mutation here moves a pack declaration or the classifier, never the test that reads them \u2014 the lesson undriven-says-why.json paid for, where neutralising the branches inside the test file left everything green because a test whose detection is switched off passes by construction. The five cover the two independent halves: the classifier and the staleness guard make the mechanism expire on its own, and the three cause checks make each reason a measurement. The last one runs in the pack, where the delete can actually be driven, and is the one that matters most: it is what stops 'a terminated Vm is kept' from being a comment."
+  "note": "Route.Unearnable removes work from a queue by declaring an axis out of reach, which makes it the most dangerous kind of entry in this repository: it reads like a decision and the sentence itself is not checkable. Every mutation here moves a pack declaration or the classifier, never the test that reads them \u2014 the lesson undriven-says-why.json paid for, where neutralising the branches inside the test file left everything green because a test whose detection is switched off passes by construction. The five cover the two independent halves: the classifier and the staleness guard make the mechanism expire on its own, and the three cause checks make each reason a measurement. The last one runs in the pack, where the delete can actually be driven, and is the one that matters most: it is what stops 'a terminated Vm is kept' from being a comment. Retargeted on 2026-08-24 for #445: classifyGap now returns the reason it classified on, so the fragment gained a second return value."
 }


### PR DESCRIPTION
The work queue could say **"nobody can act on this"** about work that is not
only doable but already done. This stops it.

## The decision: each axis declares what earns it

`evidenceAxis.earner` states, per axis, whether client traffic is what earns it.
A `Route.Undriven` reason — a sentence about clients — is honoured only there.

**The split is mechanical, not a reading of names.** The observer already
separates a synthetic exchange from a client's at the source
(`emulator.ProbeHeader`), so: `driven`, `dataplane`, `behaviour` and `negative`
read the client side alone; `probed` reads the synthetic side alone; `contract`
reads either; and `shape` reads neither, since it is resolved offline from
`shapes/`.

A **sixth kind, `unvalidated`**, takes the zeros the probe can close. It states
only what the record carries — no answer of this operation was ever held to the
provider's API description — and **claims no cause**.

Three alternatives were rejected with reasons:

- *Fold into `unproven`* would bury 80 entries of offline, no-account work among
  113 zeros that are overwhelmingly `negative`.
- *A probe-shaped reason* cannot be verified: `probed: none` cannot tell "the
  probe never arrived" from "it arrived and nothing validated". A plan-level skip
  is derivable offline, a call-time skip is not, so the reason would be a
  measurement for some operations and prose for the rest.
- *Deriving the earner from the record at runtime* would flip silently the day a
  run holds no undriven-and-probed operation.

`classifyGap` now **returns the reason it classified on**, so a line cannot print
a sentence the classifier did not use. The caller re-deriving it is exactly how
the two drifted apart.

## Measured

Same 444 queue entries before and after, same set, **no axis moved**. 102 change
kind:

| | before | after |
|---|--:|--:|
| `declared` | 144 | **106** |
| `unproven` | 177 | 113 |
| `unrecorded` | 123 | 145 |
| `unvalidated` | 0 | **80** |

**38 lines across 22 operations stop saying nobody can act.** They are the 18
undriven Exoscale operations plus `block/v1/API.ListVolumeTypes`,
`ipam/v1/API.{AttachIP,DetachIP,MoveIP}` and `vpc/v2/API.ListSubnets`.

## Premises the measurement contradicted

1. **"The eight Exoscale operations filed `declared` on `probed`" — seven are.**
   The eighth was `unproven`. Eight is the count of Exoscale zeros on `probed`,
   not of misfiled ones.
2. **The fix does not stop at `probed` and `contract`.** `shape` is in the same
   class, and the record proves it rather than an argument: `get-operation` is
   undriven and carries an observed shape, and the shape recorder reads the cloud
   directly rather than through an official client. **22 of the 38 undeclared
   lines are `shape`** — beyond what the issue asked, and forced by the witness.
3. **"Zero probe arrivals" — confirmed** by a real probe run, offline, no
   account, torn down. All eight have zero; eleven operations do in total, the
   other three being the `ServerUserData` trio that #429's changelog already
   called probe-side. **Zero operations had arrivals without a verdict.**

## Both of the brief's criteria pass on the uncorrected code

`go test ./internal/cli/` is green in the unfixed checkout, and the defect
shipped in #408 under `prepush` and `corpus:check`. Only the three new tests
discriminate, and the falsification is the demonstration.

## Falsified

`tools/falsify/specs/probe-side-zeros.json`, **six mutations, six red**,
including the one this issue mandates: restore the client reason on a probe-side
zero and `TestAClientShapedReasonNeverExplainsAProbeSideZero` goes red. Six
fragments in two neighbouring specs had moved; `falsify:lint` named them and both
replayed green.

**Witnesses.** `TestOnlyAClientEarnsAClientBorneAxis` drives one marked and one
unmarked exchange against a live emulator, and **must earn `probed` by name or
fail as vacuous**. `TestNoClientBorneAxisIsEarnedWithoutAClient` refuses a
declaration the record contradicts **in both directions** — without the converse,
declaring every axis probe-borne would pass.

**One mutation stayed green at the first attempt**, and the harness caught
itself: it carried its own package override, where `-run` matched no test at
all, so the mutation ran and nothing executed. The harness reported it and
**refused the spec rather than certifying it**. Removing the override made it
bite. Recorded in the spec's note.

## Not done, deliberately

`--gaps` could name a probe *skip* reason for the plan-level cases, derivable
offline from the contract document — but not for the call-time ones. It would be
a measurement for some operations and prose for the rest, which is an issue to
file rather than a line to add here.

`coverage/evidence.json` untouched.

## Related

Closes #445
Refs #408, #429
