### PR TITLE
feat(conformance): the Exoscale stack is driven by a suite, and the doorstep prints the whole remedy (#448)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -19,6 +19,26 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Ajouté
 
+- **La stack Exoscale a une suite qui la pilote**
+  (`mise run conformance:exoscale-terraform`, `tools/conformance/exoscale/terraform.sh`).
+  Elle applique `examples/stacks/exoscale` par le fork corrigé épinglé dans
+  `docs/limits.md`, exige un second plan vide et une destruction propre, et
+  **refuse sur le pas de la porte** quand le fork n'est pas construit, en
+  imprimant le remède entier, du clone à la compilation, pour qu'un lecteur n'ait
+  jamais à ouvrir la documentation pour passer cette ligne.
+
+  **Elle est hors de `mise run conformance` délibérément**, aux mêmes conditions
+  que `conformance:ssh` : aucune porte de ce dépôt ne clone un dépôt tiers, ce
+  qui mettrait la disponibilité de quelqu'un d'autre dans ce pipeline, et un
+  client que ce projet a patché n'est pas le client officiel, donc il ne pourrait
+  pas compter pour la conformance. Jusqu'ici la procédure n'existait qu'en prose
+  dans `main.tf` et sous forme d'une exécution à la main notée dans
+  `docs/clients.md`.
+
+  Lancée aujourd'hui, elle échoue sur une cause nommée plutôt que sur du
+  folklore : le fork corrige le client v2 et la stack utilise désormais des
+  ressources v3 (#448).
+
 - **Tout identifiant qu'une réponse Outscale publie désigne désormais un objet
   qu'une lecture retrouve** (#389, #383, #378). Une seule chaîne plutôt que
   trois rustines : le catalogue d'images est adossé à des snapshots que

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,6 +255,24 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Added
 
+- **The Exoscale stack has a suite that drives it**
+  (`mise run conformance:exoscale-terraform`, `tools/conformance/exoscale/terraform.sh`).
+  It applies `examples/stacks/exoscale` through the patched provider fork
+  pinned in `docs/limits.md`, asserts an empty second plan and a clean destroy,
+  and refuses **at the doorstep** when the fork is not built — printing the whole
+  remedy, clone through build, so a reader never has to open the documentation to
+  get past that line.
+
+  **It is outside `mise run conformance` on purpose**, on the same terms as
+  `conformance:ssh`: no gate here clones a third-party repository, which would
+  put somebody else's availability in this pipeline, and a client this project
+  patched is not the official client, so it could not count towards conformance
+  anyway. Until now the procedure existed only as prose in `main.tf` and a
+  hand-run noted in `docs/clients.md`.
+
+  Run today, it fails on a named cause rather than on folklore: the fork corrects
+  the v2 client and the stack now uses v3 resources (#448).
+
 - **`feint clean --format json` records what a sweep found, one line per
   object** (#426). #316, #342, #375 and #386 each fixed one symptom of one
   family, and nobody could see the family because every sighting lived in the

--- a/mise.toml
+++ b/mise.toml
@@ -251,6 +251,32 @@ run = [
   "tools/conformance/outscale/balancer.sh http://$FEINT_ADDR",
 ]
 
+[tasks."conformance:exoscale-terraform"]
+description = "Apply the Exoscale stack through the patched provider fork. Needs the fork built — the script says how"
+# Outside `conformance` on purpose, on the same terms as conformance:ssh.
+#
+# The published Exoscale provider builds two clients and only one honours
+# EXOSCALE_API_ENDPOINT, so an apply splits between this emulator and a paying
+# account. The emulator refuses it by user agent; the four-line fix lives on the
+# fork pinned in docs/limits.md at 2e78b42.
+#
+# Two reasons this is never a gate, and both are decisions rather than gaps:
+# no task here clones a third-party repository, which would put somebody else's
+# availability in this pipeline; and a client this project patched is not the
+# official client, so it could not count towards conformance anyway. What it is
+# worth is the other half — it drives the Exoscale pack through the client a
+# user actually reaches for, which no other suite does.
+#
+# FEINT_EXOSCALE_ALLOW_TERRAFORM lifts the refusal, named rather than hidden: a
+# guard with no way past it gets worked around by copying the emulator.
+run = [
+  "./feint start --addr $FEINT_ADDR --contracts contracts --timeout 60s",
+  "tools/conformance/exoscale/terraform.sh http://$FEINT_ADDR",
+  "./feint stop --addr $FEINT_ADDR",
+]
+depends = ["build"]
+env = { FEINT_ADDR = "127.0.0.1:4599", FEINT_EXOSCALE_ALLOW_TERRAFORM = "1" }
+
 [tasks."conformance:ssh"]
 description = "Register a key, boot a server, log into it — on every provider. Needs FEINT_VM=incus or incus-vm"
 # Three providers, three logins, one chain each: the login is a per-pack fact

--- a/tools/conformance/exoscale/terraform.sh
+++ b/tools/conformance/exoscale/terraform.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# The Exoscale stack, driven by the patched provider.
+#
+# WHY THIS IS A TASK OF ITS OWN AND NOT PART OF `mise run conformance`
+#
+# The published Exoscale provider builds two clients and only one honours
+# EXOSCALE_API_ENDPOINT, so an apply does not fail — it *splits*, half against
+# this emulator and half against a paying account with whatever credentials the
+# environment holds. The emulator refuses that client by its user agent rather
+# than serving half of it (docs/limits.md, upstream #573).
+#
+# The fix is four lines per site and lives on a fork, pinned in docs/limits.md
+# to commit 2e78b42. Two consequences, both deliberate and both stated in
+# CLAUDE.md:
+#
+#   1. No gate here clones a third-party repository. That would put someone
+#      else's availability in this project's CI, and a client this project
+#      patched is not the official client, so it could not count towards
+#      conformance anyway. This script is therefore never called by
+#      `mise run conformance` — it is `mise run conformance:exoscale-terraform`,
+#      on the same terms as `conformance:ssh`.
+#   2. The refusal is named rather than hidden. A guard with no way past it gets
+#      worked around by copying the emulator, which teaches nobody anything, so
+#      FEINT_EXOSCALE_ALLOW_TERRAFORM=1 exists and this script sets it.
+#
+# What it is worth in spite of that: it exercises the Exoscale pack through the
+# client a user would actually reach for. Applied by hand on 2026-08-18 —
+# 13 resources, empty second plan, clean destroy — and this script is that
+# procedure, so the next reader does not have to reconstruct it.
+set -euo pipefail
+
+ENDPOINT="${1:?usage: terraform.sh <emulator-url>}"
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+STACK="$ROOT/examples/stacks/exoscale"
+PROVIDER_DIR="${FEINT_EXOSCALE_PROVIDER_DIR:-/tmp/tfp}"
+BIN="$PROVIDER_DIR/terraform-provider-exoscale"
+PINNED_COMMIT=2e78b42
+
+fail() { printf '\nFAIL: %s\n' "$*" >&2; exit 1; }
+ok()   { printf '  ok: %s\n' "$*"; }
+
+# The doorstep. Asked at second zero rather than thirty steps in, on the model
+# #375 established: the answer has not changed since the script started, so
+# there is no reason to discover it after an apply has already run.
+#
+# It names the remedy in full. A reader who has never built the fork must not
+# have to open docs/limits.md to get past this line — that is what turns a
+# guard into something people route around.
+if [ ! -x "$BIN" ]; then
+  cat >&2 <<MSG
+
+FAIL: the patched Exoscale provider is not built at $BIN
+
+  The published provider cannot drive this emulator: it builds two clients and
+  only one honours EXOSCALE_API_ENDPOINT, so an apply splits between the
+  emulator and a paying account. The emulator refuses it by user agent.
+
+  Build the pinned fork (docs/limits.md, "The patched provider, while upstream
+  decides"), or set FEINT_EXOSCALE_PROVIDER_DIR at a directory that holds it:
+
+    git clone -b fix/v2-client-honours-api-endpoint \\
+      https://github.com/stephrobert/terraform-provider-exoscale
+    cd terraform-provider-exoscale && git checkout $PINNED_COMMIT
+    go build -o $PROVIDER_DIR/terraform-provider-exoscale .
+
+  No gate in this repository clones that repository for you, deliberately:
+  it would put somebody else's availability in this pipeline.
+
+MSG
+  exit 1
+fi
+ok "the patched provider is built at $BIN"
+
+command -v terraform >/dev/null 2>&1 || fail "terraform is not installed"
+
+WORK="$(mktemp -d)"
+CLEAN=1
+cleanup() {
+  # Destruction first, and its verdict is reported rather than swallowed: a
+  # teardown that fails silently leaves the next run to meet the leftovers.
+  if [ "$CLEAN" = 1 ] && [ -f "$WORK/terraform.tfstate" ]; then
+    TF_CLI_CONFIG_FILE="$WORK/dev.tfrc" terraform -chdir="$WORK" destroy -auto-approve \
+      >/dev/null 2>&1 || printf 'WARN: destroy failed, %s kept for inspection\n' "$WORK" >&2
+  fi
+  rm -rf "$WORK"
+}
+trap cleanup EXIT INT TERM
+
+cp "$STACK"/*.tf "$WORK/"
+cat > "$WORK/dev.tfrc" <<RC
+provider_installation {
+  dev_overrides { "exoscale/exoscale" = "$PROVIDER_DIR" }
+  direct {}
+}
+RC
+
+# The credentials are the repository's public placeholders, in the one file that
+# holds them. Never inline: CLAUDE.md rule 8, and a value written into a script
+# is a value somebody eventually believes is real.
+set -a
+# shellcheck source=/dev/null
+. "$ROOT/tools/conformance/exoscale/fake-credentials.env"
+set +a
+
+export TF_CLI_CONFIG_FILE="$WORK/dev.tfrc"
+export EXOSCALE_API_ENDPOINT="$ENDPOINT"
+
+echo "- the Exoscale stack applies through the patched provider"
+terraform -chdir="$WORK" apply -auto-approve -input=false >"$WORK/apply.log" 2>&1 \
+  || { tail -30 "$WORK/apply.log" >&2; fail "apply rejected"; }
+applied="$(terraform -chdir="$WORK" state list | wc -l)"
+[ "$applied" -gt 0 ] || fail "the apply created no resource, so nothing below measures anything"
+ok "$applied resources"
+
+# The second plan is the assertion that matters. An apply that succeeds proves
+# the emulator accepted the writes; an empty second plan proves it answers back
+# what the provider wrote, which is the property a stack actually depends on.
+echo "- a second plan is empty"
+if ! terraform -chdir="$WORK" plan -detailed-exitcode -input=false >"$WORK/plan.log" 2>&1; then
+  case $? in
+    2) tail -40 "$WORK/plan.log" >&2
+       fail "the second plan is not empty: the emulator does not read back what the stack sent" ;;
+    *) tail -30 "$WORK/plan.log" >&2; fail "plan rejected" ;;
+  esac
+fi
+ok "no drift"
+
+echo "- destroy leaves nothing"
+terraform -chdir="$WORK" destroy -auto-approve -input=false >"$WORK/destroy.log" 2>&1 \
+  || { tail -30 "$WORK/destroy.log" >&2; fail "destroy rejected"; }
+left="$(terraform -chdir="$WORK" state list | wc -l)"
+[ "$left" = 0 ] || fail "$left resource(s) survived the destroy"
+CLEAN=0
+ok "state is empty"
+
+printf '\nexoscale terraform: %s resources applied, empty second plan, clean destroy\n' "$applied"


### PR DESCRIPTION
The Exoscale stack's procedure existed only as **prose** in `main.tf` and a hand-run noted in `docs/clients.md` for 2026-08-18. It is now one command: `mise run conformance:exoscale-terraform`.

It applies the stack through the patched provider fork pinned in `docs/limits.md`, asserts an **empty second plan** and a **clean destroy**, and reports its teardown verdict rather than swallowing it.

## The doorstep prints the whole remedy

When the fork is not built it refuses at second zero — on the model #375 established — and prints clone, checkout and build in full. **A guard a reader must leave the script to get past is a guard that gets routed around**, which is the argument `main.tf` already makes for `FEINT_EXOSCALE_ALLOW_TERRAFORM` existing at all.

## Outside `conformance` on purpose

Same terms as `conformance:ssh`. No gate here clones a third-party repository — that would put somebody else's availability in this pipeline — and a client this project patched is not the official client, so it could not count towards conformance anyway. That decision is recorded in `main.tf`, in `docs/clients.md` and now in `CLAUDE.md`.

## Run today, it fails on a named cause

The pinned fork corrects the **v2** client; the stack now uses **v3** resources (`block_storage`, `private_network` import `egoscale/v3`). Filed as **#448** with the measurement.

Worth noting: **the emulator's own error message made that diagnosable in one run.** It names the path, says the route is served under `/v2/`, and points at `feint env` and `/_feint/routes`.

## Related

Refs #448