### PR TITLE
chore(evidence): the record follows the divergence and queue lots, and a task owns the death of what it starts

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -960,6 +960,14 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Modifié
 
+- **Le registre suit les lots de divergences et de file** (#431, #445), et
+  `mise run conformance:exoscale-terraform` arme son `trap` avant l'émulateur
+  qu'elle démarre. En trois étapes elle en laissait un derrière elle quand le
+  script échouait, jusqu'à ce qu'`evidence:update` refuse de démarrer à côté :
+  le pas de la porte ajouté par #426, appliqué à la tâche qui venait d'être
+  écrite. Une tâche qui démarre un processus possède sa mort sur tous les
+  chemins, pas seulement sur le chemin heureux.
+
 - **Le registre suit le correctif de la réponse vide** (#429) : `contract` passe
   de 330 à **361 sur 370** et `probed` de 330 à **359**. Le `contract` de
   Scaleway atteint **173 sur 173** et son `probed` 170. **Aucune opération n'a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1209,6 +1209,13 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Changed
 
+- **The record follows the divergence and queue lots** (#431, #445), and
+  `mise run conformance:exoscale-terraform` arms its trap before the emulator it
+  starts. As three steps it left one behind on a failing run, until
+  `evidence:update` refused to start beside it — the doorstep #426 added, working
+  on the task that had just been written. A task that starts a process owns its
+  death on every path, not on the happy one.
+
 - **The record follows the empty-answer fix** (#429): `contract` goes 330 to
   **361 of 370** and `probed` 330 to **359**. Scaleway's own `contract` reaches
   **173 of 173** and its `probed` 170. **No operation lost anything on any

--- a/coverage/evidence.json
+++ b/coverage/evidence.json
@@ -8,7 +8,7 @@
   "generated_from": {
     "contracts": "888ba9fc893edbcf",
     "shapes": "cac046c206cc9fc8",
-    "suites": "7284cb9442785799"
+    "suites": "68c2428f794babb9"
   },
   "operations": {
     "block/v1/API.CreateSnapshot": {
@@ -1482,7 +1482,7 @@
       "driven": true,
       "probed": "response",
       "contract": "clean",
-      "dataplane": false,
+      "dataplane": true,
       "shape": "unobserved",
       "behaviour": false,
       "negative": false
@@ -1885,7 +1885,7 @@
     },
     "lb/v1/ZonedAPI.AttachPrivateNetwork": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1894,7 +1894,7 @@
     },
     "lb/v1/ZonedAPI.CreateACL": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "observed",
@@ -1903,7 +1903,7 @@
     },
     "lb/v1/ZonedAPI.CreateBackend": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "observed",
@@ -1912,7 +1912,7 @@
     },
     "lb/v1/ZonedAPI.CreateFrontend": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "observed",
@@ -1939,7 +1939,7 @@
     },
     "lb/v1/ZonedAPI.CreateRoute": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "observed",
@@ -1948,7 +1948,7 @@
     },
     "lb/v1/ZonedAPI.DeleteACL": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1975,7 +1975,7 @@
     },
     "lb/v1/ZonedAPI.DeleteLB": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1984,7 +1984,7 @@
     },
     "lb/v1/ZonedAPI.DeleteRoute": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -1993,7 +1993,7 @@
     },
     "lb/v1/ZonedAPI.DetachPrivateNetwork": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -2002,7 +2002,7 @@
     },
     "lb/v1/ZonedAPI.GetACL": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "observed",
@@ -2011,7 +2011,7 @@
     },
     "lb/v1/ZonedAPI.GetBackend": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "observed",
@@ -2020,7 +2020,7 @@
     },
     "lb/v1/ZonedAPI.GetFrontend": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "observed",
@@ -2038,7 +2038,7 @@
     },
     "lb/v1/ZonedAPI.GetLB": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "observed",
@@ -2047,7 +2047,7 @@
     },
     "lb/v1/ZonedAPI.GetRoute": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "observed",
@@ -2056,7 +2056,7 @@
     },
     "lb/v1/ZonedAPI.ListACLs": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "observed",
@@ -2065,7 +2065,7 @@
     },
     "lb/v1/ZonedAPI.ListBackends": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "observed",
@@ -2074,7 +2074,7 @@
     },
     "lb/v1/ZonedAPI.ListFrontends": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "observed",
@@ -2092,7 +2092,7 @@
     },
     "lb/v1/ZonedAPI.ListLBPrivateNetworks": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "observed",
@@ -2128,7 +2128,7 @@
     },
     "lb/v1/ZonedAPI.SetBackendServers": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "observed",
@@ -2137,7 +2137,7 @@
     },
     "lb/v1/ZonedAPI.UpdateACL": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "observed",
@@ -2146,7 +2146,7 @@
     },
     "lb/v1/ZonedAPI.UpdateBackend": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "observed",
@@ -2155,7 +2155,7 @@
     },
     "lb/v1/ZonedAPI.UpdateFrontend": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "observed",
@@ -2164,7 +2164,7 @@
     },
     "lb/v1/ZonedAPI.UpdateHealthCheck": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "unobserved",
@@ -2182,7 +2182,7 @@
     },
     "lb/v1/ZonedAPI.UpdateLB": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "observed",
@@ -2191,7 +2191,7 @@
     },
     "lb/v1/ZonedAPI.UpdateRoute": {
       "driven": true,
-      "probed": "refusal",
+      "probed": "response",
       "contract": "clean",
       "dataplane": true,
       "shape": "observed",

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -43,8 +43,8 @@ a workflow. None of them opens a socket.
 |---|---|---|---|---|---|---|---|---|
 | Exoscale | 104 | 83 % (86) | 92 % (96) | 91 % (95) | 83 % (86) | 32 % (33) | 75 % (78) | 17 % (18) |
 | Outscale | 93 | 100 % (93) | 100 % (93) | 100 % (93) | 100 % (93) | 100 % (93) | 87 % (81) | 97 % (90) |
-| Scaleway | 174 | 97 % (169) | 98 % (171) | 100 % (174) | 97 % (168) | 57 % (99) | 93 % (161) | 80 % (139) |
-| **All three** | 371 | 94 % (348) | 97 % (360) | 98 % (362) | 94 % (347) | 61 % (225) | 86 % (320) | 67 % (247) |
+| Scaleway | 174 | 97 % (169) | 98 % (171) | 100 % (174) | 97 % (169) | 57 % (99) | 93 % (161) | 80 % (139) |
+| **All three** | 371 | 94 % (348) | 97 % (360) | 98 % (362) | 94 % (348) | 61 % (225) | 86 % (320) | 67 % (247) |
 
 What each axis says, one line each. They are independent and are never added
 into one number: none of them implies another, and an operation can be driven
@@ -207,7 +207,7 @@ disappears from the suite.
 | `GET` | `/instance/v1/zones/{zone}/placement_groups/{id}` | `instance/v1/API.GetPlacementGroup` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `GET` | `/instance/v1/zones/{zone}/placement_groups` | `instance/v1/API.ListPlacementGroups` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `GET` | `/instance/v1/zones/{zone}/products/servers` | `instance/v1/API.ListServersTypes` | `client` `contract` `shape` `runtime` `probe` `negative` |
-| `GET` | `/instance/v1/zones/{zone}/security_groups/default/rules` | `instance/v1/API.ListDefaultSecurityGroupRules` | `client` `contract` `probe` |
+| `GET` | `/instance/v1/zones/{zone}/security_groups/default/rules` | `instance/v1/API.ListDefaultSecurityGroupRules` | `client` `contract` `runtime` `probe` |
 | `GET` | `/instance/v1/zones/{zone}/security_groups/{id}/rules/{ruleID}` | `instance/v1/API.GetSecurityGroupRule` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `GET` | `/instance/v1/zones/{zone}/security_groups/{id}/rules` | `instance/v1/API.ListSecurityGroupRules` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `GET` | `/instance/v1/zones/{zone}/security_groups/{id}` | `instance/v1/API.GetSecurityGroup` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
@@ -274,43 +274,43 @@ disappears from the suite.
 
 | Method | Path | Upstream operation | Proven by |
 |---|---|---|---|
-| `DELETE` | `/lb/v1/zones/{zone}/acls/{aclID}` | `lb/v1/ZonedAPI.DeleteACL` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
+| `DELETE` | `/lb/v1/zones/{zone}/acls/{aclID}` | `lb/v1/ZonedAPI.DeleteACL` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 | `DELETE` | `/lb/v1/zones/{zone}/backends/{backendID}` | `lb/v1/ZonedAPI.DeleteBackend` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
 | `DELETE` | `/lb/v1/zones/{zone}/frontends/{frontendID}` | `lb/v1/ZonedAPI.DeleteFrontend` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
 | `DELETE` | `/lb/v1/zones/{zone}/ips/{ipID}` | `lb/v1/ZonedAPI.ReleaseIP` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
-| `DELETE` | `/lb/v1/zones/{zone}/lbs/{lbID}` | `lb/v1/ZonedAPI.DeleteLB` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `DELETE` | `/lb/v1/zones/{zone}/routes/{routeID}` | `lb/v1/ZonedAPI.DeleteRoute` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
-| `GET` | `/lb/v1/zones/{zone}/acls/{aclID}` | `lb/v1/ZonedAPI.GetACL` | `client` `contract` `shape` `runtime` `probe-refusal` `behaviour` `negative` |
-| `GET` | `/lb/v1/zones/{zone}/backends/{backendID}` | `lb/v1/ZonedAPI.GetBackend` | `client` `contract` `shape` `runtime` `probe-refusal` `behaviour` `negative` |
-| `GET` | `/lb/v1/zones/{zone}/frontends/{frontendID}/acls` | `lb/v1/ZonedAPI.ListACLs` | `client` `contract` `shape` `runtime` `probe-refusal` `behaviour` `negative` |
-| `GET` | `/lb/v1/zones/{zone}/frontends/{frontendID}` | `lb/v1/ZonedAPI.GetFrontend` | `client` `contract` `shape` `runtime` `probe-refusal` `behaviour` `negative` |
+| `DELETE` | `/lb/v1/zones/{zone}/lbs/{lbID}` | `lb/v1/ZonedAPI.DeleteLB` | `client` `contract` `runtime` `probe` `behaviour` |
+| `DELETE` | `/lb/v1/zones/{zone}/routes/{routeID}` | `lb/v1/ZonedAPI.DeleteRoute` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `GET` | `/lb/v1/zones/{zone}/acls/{aclID}` | `lb/v1/ZonedAPI.GetACL` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
+| `GET` | `/lb/v1/zones/{zone}/backends/{backendID}` | `lb/v1/ZonedAPI.GetBackend` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
+| `GET` | `/lb/v1/zones/{zone}/frontends/{frontendID}/acls` | `lb/v1/ZonedAPI.ListACLs` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
+| `GET` | `/lb/v1/zones/{zone}/frontends/{frontendID}` | `lb/v1/ZonedAPI.GetFrontend` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `GET` | `/lb/v1/zones/{zone}/ips/{ipID}` | `lb/v1/ZonedAPI.GetIP` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `GET` | `/lb/v1/zones/{zone}/ips` | `lb/v1/ZonedAPI.ListIPs` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
-| `GET` | `/lb/v1/zones/{zone}/lbs/{lbID}/backends` | `lb/v1/ZonedAPI.ListBackends` | `client` `contract` `shape` `runtime` `probe-refusal` `behaviour` `negative` |
-| `GET` | `/lb/v1/zones/{zone}/lbs/{lbID}/frontends` | `lb/v1/ZonedAPI.ListFrontends` | `client` `contract` `shape` `runtime` `probe-refusal` `behaviour` `negative` |
-| `GET` | `/lb/v1/zones/{zone}/lbs/{lbID}/private-networks` | `lb/v1/ZonedAPI.ListLBPrivateNetworks` | `client` `contract` `shape` `runtime` `probe-refusal` `behaviour` `negative` |
-| `GET` | `/lb/v1/zones/{zone}/lbs/{lbID}` | `lb/v1/ZonedAPI.GetLB` | `client` `contract` `shape` `runtime` `probe-refusal` `behaviour` `negative` |
+| `GET` | `/lb/v1/zones/{zone}/lbs/{lbID}/backends` | `lb/v1/ZonedAPI.ListBackends` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
+| `GET` | `/lb/v1/zones/{zone}/lbs/{lbID}/frontends` | `lb/v1/ZonedAPI.ListFrontends` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
+| `GET` | `/lb/v1/zones/{zone}/lbs/{lbID}/private-networks` | `lb/v1/ZonedAPI.ListLBPrivateNetworks` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
+| `GET` | `/lb/v1/zones/{zone}/lbs/{lbID}` | `lb/v1/ZonedAPI.GetLB` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `GET` | `/lb/v1/zones/{zone}/lbs` | `lb/v1/ZonedAPI.ListLBs` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
-| `GET` | `/lb/v1/zones/{zone}/routes/{routeID}` | `lb/v1/ZonedAPI.GetRoute` | `client` `contract` `shape` `runtime` `probe-refusal` `behaviour` `negative` |
+| `GET` | `/lb/v1/zones/{zone}/routes/{routeID}` | `lb/v1/ZonedAPI.GetRoute` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `GET` | `/lb/v1/zones/{zone}/routes` | `lb/v1/ZonedAPI.ListRoutes` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `PATCH` | `/lb/v1/zones/{zone}/ips/{ipID}` | `lb/v1/ZonedAPI.UpdateIP` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
-| `POST` | `/lb/v1/zones/{zone}/frontends/{frontendID}/acls` | `lb/v1/ZonedAPI.CreateACL` | `client` `contract` `shape` `runtime` `probe-refusal` `behaviour` `negative` |
+| `POST` | `/lb/v1/zones/{zone}/frontends/{frontendID}/acls` | `lb/v1/ZonedAPI.CreateACL` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 | `POST` | `/lb/v1/zones/{zone}/ips` | `lb/v1/ZonedAPI.CreateIP` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
-| `POST` | `/lb/v1/zones/{zone}/lbs/{lbID}/attach-private-network` | `lb/v1/ZonedAPI.AttachPrivateNetwork` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
-| `POST` | `/lb/v1/zones/{zone}/lbs/{lbID}/backends` | `lb/v1/ZonedAPI.CreateBackend` | `client` `contract` `shape` `runtime` `probe-refusal` `behaviour` `negative` |
-| `POST` | `/lb/v1/zones/{zone}/lbs/{lbID}/detach-private-network` | `lb/v1/ZonedAPI.DetachPrivateNetwork` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
-| `POST` | `/lb/v1/zones/{zone}/lbs/{lbID}/frontends` | `lb/v1/ZonedAPI.CreateFrontend` | `client` `contract` `shape` `runtime` `probe-refusal` `behaviour` `negative` |
-| `POST` | `/lb/v1/zones/{zone}/lbs/{lbID}/private-networks/{pnID}/attach` | `lb/v1/ZonedAPI.AttachPrivateNetwork` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
-| `POST` | `/lb/v1/zones/{zone}/lbs/{lbID}/private-networks/{pnID}/detach` | `lb/v1/ZonedAPI.DetachPrivateNetwork` | `client` `contract` `runtime` `probe-refusal` `behaviour` `negative` |
+| `POST` | `/lb/v1/zones/{zone}/lbs/{lbID}/attach-private-network` | `lb/v1/ZonedAPI.AttachPrivateNetwork` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/lb/v1/zones/{zone}/lbs/{lbID}/backends` | `lb/v1/ZonedAPI.CreateBackend` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/lb/v1/zones/{zone}/lbs/{lbID}/detach-private-network` | `lb/v1/ZonedAPI.DetachPrivateNetwork` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/lb/v1/zones/{zone}/lbs/{lbID}/frontends` | `lb/v1/ZonedAPI.CreateFrontend` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/lb/v1/zones/{zone}/lbs/{lbID}/private-networks/{pnID}/attach` | `lb/v1/ZonedAPI.AttachPrivateNetwork` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
+| `POST` | `/lb/v1/zones/{zone}/lbs/{lbID}/private-networks/{pnID}/detach` | `lb/v1/ZonedAPI.DetachPrivateNetwork` | `client` `contract` `runtime` `probe` `behaviour` `negative` |
 | `POST` | `/lb/v1/zones/{zone}/lbs` | `lb/v1/ZonedAPI.CreateLB` | `client` `contract` `shape` `runtime` `probe-refusal` `behaviour` `negative` |
-| `POST` | `/lb/v1/zones/{zone}/routes` | `lb/v1/ZonedAPI.CreateRoute` | `client` `contract` `shape` `runtime` `probe-refusal` `behaviour` `negative` |
-| `PUT` | `/lb/v1/zones/{zone}/acls/{aclID}` | `lb/v1/ZonedAPI.UpdateACL` | `client` `contract` `shape` `runtime` `probe-refusal` `behaviour` `negative` |
-| `PUT` | `/lb/v1/zones/{zone}/backends/{backendID}/healthcheck` | `lb/v1/ZonedAPI.UpdateHealthCheck` | `client` `contract` `runtime` `probe-refusal` `behaviour` |
-| `PUT` | `/lb/v1/zones/{zone}/backends/{backendID}/servers` | `lb/v1/ZonedAPI.SetBackendServers` | `client` `contract` `shape` `runtime` `probe-refusal` `behaviour` `negative` |
-| `PUT` | `/lb/v1/zones/{zone}/backends/{backendID}` | `lb/v1/ZonedAPI.UpdateBackend` | `client` `contract` `shape` `runtime` `probe-refusal` `behaviour` `negative` |
-| `PUT` | `/lb/v1/zones/{zone}/frontends/{frontendID}` | `lb/v1/ZonedAPI.UpdateFrontend` | `client` `contract` `shape` `runtime` `probe-refusal` `behaviour` `negative` |
-| `PUT` | `/lb/v1/zones/{zone}/lbs/{lbID}` | `lb/v1/ZonedAPI.UpdateLB` | `client` `contract` `shape` `runtime` `probe-refusal` `behaviour` |
-| `PUT` | `/lb/v1/zones/{zone}/routes/{routeID}` | `lb/v1/ZonedAPI.UpdateRoute` | `client` `contract` `shape` `runtime` `probe-refusal` `behaviour` `negative` |
+| `POST` | `/lb/v1/zones/{zone}/routes` | `lb/v1/ZonedAPI.CreateRoute` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
+| `PUT` | `/lb/v1/zones/{zone}/acls/{aclID}` | `lb/v1/ZonedAPI.UpdateACL` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
+| `PUT` | `/lb/v1/zones/{zone}/backends/{backendID}/healthcheck` | `lb/v1/ZonedAPI.UpdateHealthCheck` | `client` `contract` `runtime` `probe` `behaviour` |
+| `PUT` | `/lb/v1/zones/{zone}/backends/{backendID}/servers` | `lb/v1/ZonedAPI.SetBackendServers` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
+| `PUT` | `/lb/v1/zones/{zone}/backends/{backendID}` | `lb/v1/ZonedAPI.UpdateBackend` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
+| `PUT` | `/lb/v1/zones/{zone}/frontends/{frontendID}` | `lb/v1/ZonedAPI.UpdateFrontend` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
+| `PUT` | `/lb/v1/zones/{zone}/lbs/{lbID}` | `lb/v1/ZonedAPI.UpdateLB` | `client` `contract` `shape` `runtime` `probe` `behaviour` |
+| `PUT` | `/lb/v1/zones/{zone}/routes/{routeID}` | `lb/v1/ZonedAPI.UpdateRoute` | `client` `contract` `shape` `runtime` `probe` `behaviour` `negative` |
 
 ### `marketplace`
 

--- a/mise.toml
+++ b/mise.toml
@@ -269,11 +269,22 @@ description = "Apply the Exoscale stack through the patched provider fork. Needs
 #
 # FEINT_EXOSCALE_ALLOW_TERRAFORM lifts the refusal, named rather than hidden: a
 # guard with no way past it gets worked around by copying the emulator.
-run = [
-  "./feint start --addr $FEINT_ADDR --contracts contracts --timeout 60s",
-  "tools/conformance/exoscale/terraform.sh http://$FEINT_ADDR",
-  "./feint stop --addr $FEINT_ADDR",
-]
+#
+# One `run` string with a trap, not three steps. Measured the hard way on
+# 2026-08-24: as three steps, the script failed and mise stopped the chain, so
+# `feint stop` never ran and an emulator sat on the port for twenty-seven
+# minutes — until `evidence:update` refused to start beside it, which is the
+# doorstep #426 added doing its job on the person who wrote this task.
+#
+# The aggregate `conformance` task has armed a trap for exactly this reason
+# since it was written. A task that starts a process must own its death on
+# every path, not on the happy one.
+run = """
+set -o errexit
+./feint start --addr $FEINT_ADDR --contracts contracts --timeout 60s
+trap './feint stop --addr $FEINT_ADDR >/dev/null 2>&1 || true' EXIT
+tools/conformance/exoscale/terraform.sh http://$FEINT_ADDR
+"""
 depends = ["build"]
 env = { FEINT_ADDR = "127.0.0.1:4599", FEINT_EXOSCALE_ALLOW_TERRAFORM = "1" }
 


### PR DESCRIPTION
The register is regenerated on `main` after #449, #450 and #451.

| cloud | driven | probed | contract | dataplane | shape | behaviour | negative |
|---|---|---|---|---|---|---|---|
| **Outscale** | **100 %** | **100 %** | **100 %** | **100 %** | **100 %** | 87 % | 97 % |
| Scaleway | 97 % | 98 % | **100 %** | 97 % | 57 % | 93 % | 80 % |
| Exoscale | 83 % | 92 % | 91 % | 83 % | 32 % | 75 % | 17 % |

**No operation lost anything on any axis** — checked operation by operation against the replaced record, not by comparing totals.

## A task that starts a process owns its death

`conformance:exoscale-terraform` shipped in #451 as three mise steps: start, script, stop. The script fails today on #448, so mise stopped the chain **before** `feint stop`, and an emulator held port 4599 for twenty-seven minutes.

It was caught by `evidence:update` refusing to start beside it — **the doorstep #426 added, working on the task that had just been written**, hours later.

It now runs as one shell with the trap armed immediately after the start, which is what the aggregate `conformance` task has done since it was written. Verified: the task still fails on #448, and leaves nothing.

## Related

Follows #449, #450, #451. Refs #426, #448.