### PR TITLE
fix(exoscale): the endpoint carries its path, and sixteen resources apply through the fork (#448)

### DIFF
--- a/docs/limits.md
+++ b/docs/limits.md
@@ -1587,6 +1587,20 @@ an IP literal*. The fork is therefore honoured end to end for
 rewritten back to `*.exoscale.com`. Closing that half is a change in `egoscale`,
 not in the provider.
 
+**The v3 resources are not out of reach, and a measurement said otherwise for
+a day.** `tools/conformance/exoscale/terraform.sh` first read the whole stack as
+blocked at `block_storage` on `list zones: ListZones: Not Found: no route matches
+this path, but it is served under /v2/`, and #448 recorded the cause as "the fork
+corrects the v2 client, and the stack now uses v3". That was wrong. The script
+was exporting `EXOSCALE_API_ENDPOINT` as a bare host, and the v3 client resolves
+its zone endpoint against exactly what it is given — the path belongs in the
+value, which is why `feint env exoscale` prints one and why
+`examples/stacks/surveyed.md` records one. With the path restored, the same
+stack applies **sixteen** resources through the same pinned commit, block storage
+and private networking included, plans empty and destroys clean (2026-08-24).
+The error is worth keeping written down: the message named the fix in as many
+words, and it was read as a statement about the fork.
+
 **It does not count towards conformance, and must not.** The north star of this
 project is that *the official client cannot tell the difference*; a client this
 project patched is no longer the official client. What the fork proves is real

--- a/tools/conformance/exoscale/terraform.sh
+++ b/tools/conformance/exoscale/terraform.sh
@@ -25,8 +25,9 @@
 #
 # What it is worth in spite of that: it exercises the Exoscale pack through the
 # client a user would actually reach for. Applied by hand on 2026-08-18 —
-# 13 resources, empty second plan, clean destroy — and this script is that
-# procedure, so the next reader does not have to reconstruct it.
+# 13 resources — and re-measured by this script on 2026-08-24 at 16 resources,
+# block storage and private networking included, so this is the procedure and
+# the next reader does not have to reconstruct it.
 set -euo pipefail
 
 ENDPOINT="${1:?usage: terraform.sh <emulator-url>}"
@@ -103,7 +104,19 @@ set -a
 set +a
 
 export TF_CLI_CONFIG_FILE="$WORK/dev.tfrc"
-export EXOSCALE_API_ENDPOINT="$ENDPOINT"
+# The path belongs in the value. `feint env exoscale` prints
+# EXOSCALE_API_ENDPOINT='http://127.0.0.1:4599/v2', examples/stacks/surveyed.md
+# records the same form for the surveyed Exoscale stack, and this script was
+# passing the bare host instead.
+#
+# The run that fails without this line is this script: with a bare host it stops
+# on the first block_storage resource with `list zones: ListZones: Not Found: no
+# route matches this path, but it is served under /v2/`, because the v3 client
+# resolves its zone endpoint against whatever it was given. With the path it
+# applies sixteen resources, plans empty, and destroys clean. That reading —
+# recorded in #448 as "the fork corrects v2 and the stack now needs v3" — was
+# wrong about the cause: the fork drives v3 resources here perfectly well.
+export EXOSCALE_API_ENDPOINT="${ENDPOINT%/}/v2"
 
 echo "- the Exoscale stack applies through the patched provider"
 terraform -chdir="$WORK" apply -auto-approve -input=false >"$WORK/apply.log" 2>&1 \


### PR DESCRIPTION
#448 read the Exoscale stack as blocked at the first `block_storage` resource
and recorded the cause as "the pinned fork corrects the v2 client, and the
stack now uses v3". That was wrong, and the error is the interesting part: the
failure message named the fix in as many words — `no route matches this path,
but it is served under /v2/: the endpoint is probably missing that prefix` —
and it was read as a statement about the fork's reach.

The path belongs in the value. `feint env exoscale` prints
EXOSCALE_API_ENDPOINT='http://127.0.0.1:4599/v2', examples/stacks/surveyed.md
records the same form for the surveyed Exoscale stack, and docs/limits.md
quotes it too. tools/conformance/exoscale/terraform.sh was the only place
passing a bare host, because it built the value itself from its argument.

Measured with the path restored, same pinned commit 2e78b42, same stack:
sixteen resources applied, second plan empty, destroy clean.

Falsified rather than asserted: with the path removed, the suite stops at rc=1
on `served under /v2/`; with it, sixteen resources. The comment on the line
cites that run, per "un commentaire n'est pas un contrôle".

docs/limits.md carries the disproof where the next reader meets it, beside the
one limit the fork genuinely does not lift.

Closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)