### PR TITLE
docs(stacks): the fifteen stranger stacks meet a machine runtime, and five servers actually boot

### DIFF
--- a/docs/limits.md
+++ b/docs/limits.md
@@ -636,6 +636,25 @@ log says which of the two it was. If the emulator ever captures disk contents
 (the runtime could: `incus publish` exists), that refusal is the line to
 replace.
 
+**What that decision costs, measured 2026-08-24.** The fifteen third-party stacks
+of `examples/stacks/surveyed.md` were replayed under `--vm incus-ovn` for the
+first time, and **four machines started across all fifteen**. Not because the
+runtime failed — it started every machine it was asked for — but because
+thirteen of the fifteen name an image the emulated catalogues do not hold:
+`ami-a3ca408c`, `ami-538af795`, `ami-47899c77`, a talos image registered through
+volume → snapshot → `CreateImage`, an RHCOS template registered by name. The two
+that boot are the two that name a *catalogue* identifier rather than a
+production one: kiwinet's `debian_bookworm` label, and
+terraform-exoscale-vault's `template_id` read from the served template list.
+
+So the rule of thumb, for anyone deciding whether `--vm` will do anything for
+them: **a configuration that hardcodes a real image id keeps applying and starts
+nothing.** That is the deliberate half of the decision above working exactly as
+written — under `--vm off` the same configuration reports `running` and the
+difference never shows. It is recorded here rather than filed as a defect,
+because it is the documented behaviour meeting a population nobody had measured
+it against.
+
 Two details follow from the same decision. The Scaleway marketplace answers one
 fixed UUID **per label**, so Terraform — which resolves a label into a UUID and
 sends the UUID back — still names the distribution it chose; a single shared

--- a/examples/stacks/surveyed.md
+++ b/examples/stacks/surveyed.md
@@ -824,18 +824,29 @@ apart. Where that was not possible, the entry says so.
 ### Per-entry
 
 **Outscale 1 — outscale/osc-k8s-rke-cluster** (`7427b98`): **regressed, runtime.**
-52 applied against the reference's 53, re-plan `16 to add / 1 to destroy`, 52
-destroyed, **0 machines**. `outscale_vm.bastion` is tainted: `ami-a3ca408c`, the
-OMI the vendor's own archived example hardcodes, is in no emulated catalogue, so
-the boot is refused by name and the provider reports `expected state running but
-found stopped`. The RKE/ansible tail that every earlier replay recorded as
-"times out against the fictional bastion" **never ran at all** here, because the
-bastion it depends on never existed — the one thing this campaign hoped a real
-runtime might unblock, and the image wall is upstream of it. *Separation: not
-completed, and the reason is named — the `--vm off` re-run does not terminate,
-because the stack's own `ansible.cfg` sets `retries=999` with a 60-second
-timeout against an unroutable address. Attribution rests on the mechanism, which
-is identical to the four stacks below whose separation did complete.*
+Measured **twice** under `--vm incus-ovn`, the second time deliberately, from a
+clean station and with a hard per-command cap: **52 then 51 applied** against the
+reference's 53, re-plan `16 to add / 1 to destroy` then `17 to add / 1 to
+destroy`, 52 then 51 destroyed, **0 machines both times**. The one-resource
+spread between two runs of the same stack is ordering: the apply aborts on the
+tainted bastion, and which of its independent siblings had finished by then
+varies. Both runs agree on everything that matters.
+
+`outscale_vm.bastion` is tainted because `ami-a3ca408c`, the OMI the vendor's own
+archived example hardcodes, is in no emulated catalogue: the boot is refused by
+name and the provider reports `expected state running but found stopped`. The
+RKE/ansible tail that every earlier replay recorded as "times out against the
+fictional bastion" **never ran at all** here, because the bastion it depends on
+never existed — the one thing this campaign hoped a real runtime might unblock,
+and the image wall sits upstream of it.
+
+*Separation: abandoned, and the reason is named.* The `--vm off` re-run does not
+terminate: the stack's own `ansible.cfg` sets `retries=999` with a 60-second
+timeout against an unroutable address. The first attempt to stop it is worth
+recording, because it produced a four-hour ghost — see the harness note at the
+end of this section. Attribution therefore rests on the mechanism, identical to
+the four entries below whose separation did complete, and is stated as an
+inference rather than a measurement.
 
 **Outscale 2 — chimere-eu/ztiac** (`093330c`), `advanced-network`: **regressed,
 runtime, and this is the pass's worst result.** 80 applied against 95, re-plan
@@ -998,9 +1009,9 @@ included, with `cloud-init status` answering inside it. It boots because
 | regressed | 5 (rke-cluster, ztiac ×2 counted as one entry, k3s, kasten — and ztiac's two templates both) |
 | harness broken, nothing measured | 0 at the end; 4 attempts along the way, all re-run (§ below) |
 | **machines really started** | **5** — kiwinet 1, ocp_outscale 1, vault 3 |
-| resources created, summed over the fifteen `--vm incus-ovn` runs | **382** (`Creation complete` lines) |
-| resources destroyed | **387** — larger on purpose, see below |
-| recorded exchanges over those fifteen runs | **2 402** |
+| resources created, summed over the fifteen `--vm incus-ovn` runs | **381** (`Creation complete` lines) |
+| resources destroyed | **386** — larger on purpose, see below |
+| recorded exchanges over those fifteen runs | **2 396** |
 
 `destroyed` exceeds `created` by five because a server that was created and then
 failed to reach `running` is **tainted**: it is in state and gets destroyed, but
@@ -1022,14 +1033,35 @@ proxy started without `--record`, caught by the run's own guard; `ssh_key` passe
 as a name where openshift4 wants key material; and E5's `init` run at the repo
 root, where there is no backend block, so it passed and proved nothing.
 
-The fifth is the one worth repeating outside this repository. A run was killed
+Two more are worth repeating outside this repository, because both are about a
+control that was green while being wrong.
+
+**A health probe that could not say whose emulator answered.** A run was killed
 harshly, its trap never fired, and its `--vm off` emulator kept port 4610. The
 next two runs' health checks — `curl -sf /_feint/health` — **passed against that
 stale emulator**, which was holding another stack's resources in the wrong
 runtime mode, while feint's own log said `refusing to serve on 127.0.0.1:4610: it
 is already served by another emulator (pid 121004)`. Two entries were measured
 against the wrong runtime and discarded. The probe now compares `instance.pid`
-and the declared runtime with what it started, and refuses a non-empty emulator;
-a witness proves it refuses a squatter. **A health probe that cannot say whose
-emulator answered is not a health probe**, and this one had been green all
-evening.
+and the declared runtime against what it started and refuses a non-empty
+emulator, and a witness proves it refuses a squatter.
+
+**A sweep that killed itself, and a cap that died with its parent.** The command
+meant to stop the non-terminating O1 separation was
+`pkill -f campaign-outscale.sh; …; pkill -f "run-O1.sh"; …; pkill -f "terraform
+apply"`. `pkill -f` matches the **whole command line**, and the shell running
+that very command contains those strings, so the sweep killed itself before
+reaching its last clause. The emulator died; `terraform` did not. Its ansible
+tail then ran **3 h 57** against an address nothing carried any more, on a host
+with no emulator and no machine at all, and it was the maintainer who noticed at
+04:15 and sent it TERM — not any control of mine. The `timeout 3600` that should
+have bounded it was on the wrapper I had killed: **a cap that lives in the parent
+is not a cap.** Both are fixed: every `apply`, `plan` and `destroy` now carries
+its own `timeout`, and the sweeper's patterns are anchored (`^…`) so they cannot
+match the shell that runs them. O1 was then re-measured under `--vm incus-ovn`
+from a clean station, which is the second of the two runs in its entry above.
+
+The ghost also leaves a fact that belongs to the register rather than to the
+harness: for those four hours the station carried **two OVN networks and no
+emulator and no machine**. Those networks are #455's, and their surviving an
+emulator's death by hours is the same defect seen from a third angle.

--- a/examples/stacks/surveyed.md
+++ b/examples/stacks/surveyed.md
@@ -1007,17 +1007,25 @@ included, with `cloud-init status` answering inside it. It boots because
 | conforme | **10** |
 | improved | **1** (talos) |
 | regressed | **4** (rke-cluster, ztiac, k3s, kasten) — ztiac is one entry whose *two* templates both regressed |
-| harness broken, nothing measured | 0 at the end; 4 attempts along the way, all re-run (§ below) |
+| harness broken, nothing measured | **0 at the end**; **7 attempts** along the way, every one re-run (§ below) |
 | **machines really started** | **5** — kiwinet 1, ocp_outscale 1, vault 3 |
 | resources created, summed over the fifteen `--vm incus-ovn` runs | **381** (`Creation complete` lines) |
 | resources destroyed | **386** — larger on purpose, see below |
 | recorded exchanges over those fifteen runs | **2 396** |
 
-`destroyed` exceeds `created` by five because a server that was created and then
-failed to reach `running` is **tainted**: it is in state and gets destroyed, but
-it never printed a `Creation complete` line. The gap is therefore the count of
-machines the runtime refused to boot, arrived at from the opposite direction —
-which is why both numbers are given instead of one.
+`destroyed` exceeds `created` by five, and the gap is a **net of two opposite
+effects** rather than one number:
+
+- **destroyed more than created**, entry by entry: a server that was created and
+  then failed to reach `running` is *tainted* — it is in state and gets
+  destroyed, but it never printed a `Creation complete` line. rke-cluster +1,
+  k3s +1, kasten +5, talos +2.
+- **created more than destroyed**, where a destroy did not finish: ztiac −2
+  (#456) and devbox −2 (its own snapshot rotation, as recorded).
+
+1 − 2 + 1 + 5 + 2 − 2 = 5. Both numbers are given precisely because neither alone
+says what happened, and the tidier sentence — "the gap is the machines refused" —
+would have been wrong.
 
 Every regression was separated by a `--vm off` re-run except O1's, and **every
 separation that ran reproduced its reference exactly**: ztiac 95 and 54,
@@ -1026,12 +1034,16 @@ code did not move under any of them.
 
 ### What went wrong in the harness, since it reads like findings otherwise
 
-Four attempts measured this replay's harness rather than the emulator, and all
-four were re-run. They are listed because each one produced a plausible number:
-an invented SSH key the Scaleway SDK rightly refused (kiwinet 4 of 5); a TLS
-proxy started without `--record`, caught by the run's own guard; `ssh_key` passed
-as a name where openshift4 wants key material; and E5's `init` run at the repo
-root, where there is no backend block, so it passed and proved nothing.
+Seven attempts measured this replay's harness rather than the emulator, and every
+one was re-run. They are listed because each produced a plausible number: an
+invented SSH key the Scaleway SDK rightly refused (kiwinet 4 of 5); a pin patcher
+that treated "already pinned" as "matched nothing" and silently emptied two
+separation runs; a TLS proxy started without `--record`, caught by the run's own
+guard; a resource counter that counted data sources, inflating talos by exactly
+its three; `ssh_key` passed as a name where openshift4 wants key material; E5's
+`init` run at the repo root, where there is no backend block, so it passed and
+proved nothing, and E4 planned without providers or variables so it died on the
+wrong error; and the two below.
 
 Two more are worth repeating outside this repository, because both are about a
 control that was green while being wrong.

--- a/examples/stacks/surveyed.md
+++ b/examples/stacks/surveyed.md
@@ -55,6 +55,18 @@ FEINT_EXOSCALE_ALLOW_TERRAFORM=1 ./feint serve --addr 127.0.0.1:4610 --contracts
 ./feint proxy --addr 127.0.0.1:4611 --upstream http://127.0.0.1:4610 --record /tmp/rec.jsonl
 ```
 
+**Name the runtime, always.** The command above carries no `--vm`, which means
+`off`: the measurements of 2026-08-17 and of 2026-08-18 ran with **no machine
+runtime at all**, and every server in them was a record. #262's delivery comment
+says `--vm off` in as many words, but this register did not, and the silence was
+later read as evidence that no runtime had been asked for — an empty cell is
+information about the report, not about what was ordered. The 2026-08-24 section
+at the end of this file is the first pass on a real one, `--vm incus-ovn`.
+
+**So the runtime is a required datum of any replay, exactly like the commit and
+the recorded edits: a replay that does not name its `--vm` is not reproducible,
+and its silence will one day be re-read as a fact.**
+
 Per provider, everything rides the environment — no stack needs an endpoint
 edit **except** where the table below says so:
 
@@ -739,3 +751,285 @@ dead registry namespace, and one provider whose S3 calls ignore the
 redirect entirely. **Six of fifteen stacks needed no edit at all; five
 needed exactly one recorded edit whose cause was the provider ecosystem,
 not this emulator.**
+
+## Replayed under `--vm incus-ovn` on `main@104a6d4` (2026-08-24)
+
+**This is the first pass of this register on a machine runtime.** Every figure
+above was measured with `--vm off`, where a server is a record and nothing boots.
+Every figure here was measured with `--vm incus-ovn`, where a server is an Incus
+instance on an OVN network, with a real address and a real firewall. That single
+change moves the subject of the measurement, so these are not a before-and-after
+of the emulator's quality — they are two different questions, and the older
+answers stand unedited above as the photograph of before.
+
+**What it can therefore conclude**: whether the control plane still answers the
+same way when its answers have consequences, and what the runtime does with what
+the packs hand it. **What it cannot**: anything about products the emulator does
+not serve. A machine runtime does not make a route appear, and no wall below moved
+because of it.
+
+### The pass in one paragraph
+
+Fifteen entries, all replayed. **Nine are unchanged from their reference, three of
+them now backed by something real**: kiwinet applies its 5 with a container that
+carries the address the API published and holds the stack's own cloud-init;
+terraform-exoscale-vault applies its 7 with **three running machines** and is
+still the only entirely green stack of the fifteen; ocp_outscale applies its 30
+with a real bastion. openshift4, platform, flatcar-k3s, devbox, kubic and the two
+recorded-inapplicable entries answer exactly as recorded. **One improved, and it
+is the one this register demanded**: `terraform-talos` had its two walls removed
+on separate branches, and the register refused to record the inference — measured
+together on `main` at last, it applies **30 of 33** with `0 to change` and
+destroys clean, the only wall left being `vpc-gw/v1`, declined by name. **Five
+regressed, and every one of them for the same single cause**: the emulated image
+catalogues hold a handful of identifiers, every stranger's stack hardcodes a real
+one, and under a machine runtime an unbootable image is no longer harmless — the
+emulator honestly answers `stopped` where `--vm off` answered `running`. That is
+`docs/limits.md`'s decision working exactly as written, and its class-level price
+had never been measured. **Across the fifteen, five machines actually started**,
+and that number is the finding: kiwinet's one, ocp_outscale's one and
+terraform-exoscale-vault's three — the only three entries whose image or template
+identifier comes from the served catalogue rather than from a production cloud.
+
+Four defects came out of it, none of them reachable without a runtime, and all
+four are the same shape — the API describes something the host does not have:
+[#454] (a security group with an IPv6 ICMP rule loses its whole firewall),
+[#455] (an orphaned OVN network becomes permanently unremovable and
+`clean --check` does not see it), [#456] (a Net with several subnets fails to
+peer, and its destroy fails), [#457] (a load balancer whose backends are on
+another subnet is accepted and never built). Two more findings were **not** filed
+because measurement disproved them: the refusal to boot a registered image is
+documented and deliberate, and the `Missing VIP target(s)` error self-heals when
+the backends arrive — proven by a witness that registered one and watched the
+balancer appear.
+
+[#454]: https://github.com/stephrobert/feint/issues/454
+[#455]: https://github.com/stephrobert/feint/issues/455
+[#456]: https://github.com/stephrobert/feint/issues/456
+[#457]: https://github.com/stephrobert/feint/issues/457
+
+### How the runtime pass differs from the harness above
+
+Same commits, same recorded edits, same seeded prerequisites. Three additions:
+the emulator runs `--vm incus-ovn --cleanup`; an `incus monitor --type=lifecycle`
+starts **before** it, so no launch can precede the recorder; and the health probe
+compares `instance.pid` and the declared runtime with what it started — a probe
+that only asked "does the port answer" passed against a stale `--vm off` emulator
+and voided two entries before it was fixed.
+
+Every entry whose verdict differs from its reference was re-run **alone under
+`--vm off`, everything else identical**, so that code and runtime could be told
+apart. Where that was not possible, the entry says so.
+
+### Per-entry
+
+**Outscale 1 — outscale/osc-k8s-rke-cluster** (`7427b98`): **regressed, runtime.**
+52 applied against the reference's 53, re-plan `16 to add / 1 to destroy`, 52
+destroyed, **0 machines**. `outscale_vm.bastion` is tainted: `ami-a3ca408c`, the
+OMI the vendor's own archived example hardcodes, is in no emulated catalogue, so
+the boot is refused by name and the provider reports `expected state running but
+found stopped`. The RKE/ansible tail that every earlier replay recorded as
+"times out against the fictional bastion" **never ran at all** here, because the
+bastion it depends on never existed — the one thing this campaign hoped a real
+runtime might unblock, and the image wall is upstream of it. *Separation: not
+completed, and the reason is named — the `--vm off` re-run does not terminate,
+because the stack's own `ansible.cfg` sets `retries=999` with a 60-second
+timeout against an unroutable address. Attribution rests on the mechanism, which
+is identical to the four stacks below whose separation did complete.*
+
+**Outscale 2 — chimere-eu/ztiac** (`093330c`), `advanced-network`: **regressed,
+runtime, and this is the pass's worst result.** 80 applied against 95, re-plan
+`15 to add`, and **the destroy fails**, leaving 2 resources in state and two OVN
+networks plus two ACLs on the host that nothing can remove. The cause is [#456]:
+a Net with several subnets fails to peer (`More than one matching network peer
+was found`), the subnets' backing networks cannot then be deleted, and
+`DeleteNet` refuses with its own correct 409 (`the Net vpc-… still holds 2
+subnet(s)`). The register's only fully converging stranger stack, and the #249
+shape it was famous for, is what breaks first on a machine runtime.
+
+`two-tier-architecture`: **regressed, runtime.** 54 applied — the reference
+figure exactly — and 54 destroyed, but the second plan is `0 to add, 5 to change`
+where it was `No changes.`: all five changes are `state = "stopped" -> "running"`
+on the five Vms, whose `ami-a3ca408c` the catalogue does not hold. Both of its
+load balancers also failed to reach the host, and that is [#457]: their backends
+are on the private subnet while they listen on the public one, which OVN refuses
+and the API never mentions.
+
+**Outscale 3 — davmartini/ocp_outscale** (`1c7fd7b`): **conforme, and machine-backed
+— and it is the campaign's natural experiment.** 30 applied, `No changes.`,
+30 destroyed, identical to the reference, **with 1 machine started**:
+`outscale_vm.vm-pub-aza` came up as a real container in 21 seconds.
+
+It boots for one reason, and the reason has to be declared because it is a
+harness choice rather than a recorded one: the register names "nine TF_VARs
+(keys, region, vm type, image id, keypair name, three DNS IPs)" **without naming
+the image id**, so this replay supplied `ami-00000001`, an OMI the emulated
+catalogue holds. Same pack, same runtime, same evening as the four Outscale
+entries that started nothing on `ami-a3ca408c` / `ami-538af795` / `ami-47899c77`.
+The only variable that differs is whether the identifier is in the catalogue, and
+it decides the whole outcome. Same recorded edit (0.5.3's `endpoints` block) and
+the same TLS intercept on 4612, whose locally-minted CA the run trusts through
+`SSL_CERT_FILE`.
+
+**Outscale 4 — pli01/terraform-outscale-k3s** (`e68aa43`): **regressed,
+runtime — separated.** Under `--vm incus-ovn`: 35 applied, re-plan `8 to add /
+1 to destroy`, 34 destroyed, 0 machines, `ami-47899c77` refused by name. Under
+`--vm off`, everything else identical: **41 applied, `No changes.`** — the
+reference exactly. The difference is the runtime alone.
+
+**Outscale 5 — michaelcourcy/kasten-on-outscale** (`f1fcc87`): **regressed,
+runtime — separated.** Under `--vm incus-ovn`: 29 applied, re-plan `6 to add /
+5 to destroy`, 29 destroyed, 0 machines; all five Vms tainted on `ami-538af795`.
+Under `--vm off`: **30 applied, `No changes.`, 30 destroyed** — the reference
+exactly, and #268's convergence still holds. The runtime alone.
+
+**Exoscale 1 — appuio/terraform-openshift4-exoscale** (`46016ea`): **conforme.**
+43 applied, `0 to change`, 43 destroyed — the reference to the resource. The only
+failure is the unserved DNS branch, and it now refuses with #284's explicit
+sentence rather than a zone-lookup error: "this deployment serves zone ch-dk-2,
+and the client resolved zone ch-gva-2 from GET /v2/zone … Restart with
+FEINT_EXOSCALE_ZONE=ch-gva-2". The re-plan is `42 to add, 0 to change`, and all
+42 are that branch and what sits behind it — the lb module, whose
+`data.exoscale_domain.cluster` cannot resolve, and `module.infra`'s four compute
+instances. 0 machines: everything that would boot is downstream of the DNS
+branch, so none was ever attempted. Both registered templates resolve, and
+`visibility=private` still answers exactly the two of them (#271 holds).
+
+**Exoscale 2 — PhilippeChepy/platform** (`84791e3`), `terraform-base` against a
+`de-fra-1` emulator: **conforme.** 20 created, re-plan `5 to add / 0 to change`,
+20 destroyed — the 2026-08-21 reference to the resource. Its only failures are
+the two SOS buckets at the real `sos-de-muc-1.exo.io` on fake credentials, which
+is the documented external gap; the emulator logged nothing. 0 machines: the
+instance pools name templates the served catalogue does not hold.
+
+**Exoscale 3 — PhilippeChepy/terraform-exoscale-vault** (`62d27ee`):
+**conforme, and machine-backed.** 7 applied, `No changes.`, 7 destroyed — and
+**3 machines really started**, the Vault cluster's instance pool at its default
+size of three. Still the only third-party stack of the fifteen that is entirely
+green end to end, and now green with something running. It boots because its
+`template_id` is taken from the served catalogue rather than hardcoded, which is
+the whole difference between this entry and the eight that started nothing.
+
+**Exoscale 4 — camptocamp/terraform-exoscale-sks** (`2f61075`): **conforme, and
+the reason was triggered rather than restated.** With its providers installed and
+its four variables supplied, so that nothing else could be the cause:
+`terraform validate` and `terraform plan` both exit 1 on
+`Error: Invalid resource type … "exoscale_affinity"` at `main.tf` line 7. One
+exchange reached the recorder — the harness's own health probe — so nothing of
+this stack ever addressed the emulator, exactly as recorded. SKS remains unserved
+and the plan never got near it.
+
+**Exoscale 5 — datamindedbe/eu-data-platform** (`119712a`): **conforme, and the
+reason was triggered rather than restated.** Pointed at
+`infra/exoscale-platform/app`, which is where the backend actually lives:
+`terraform init` exits 1 with `Error: Variables not allowed` on both
+`bucket = var.bucket_name` and
+`endpoint = "https://sos-${local.zone}.exo.io"`. Nothing reached any endpoint.
+
+One detail measured while triggering it, which confirms the register's
+parenthetical rather than contradicting it: **OpenTofu 1.11.4 accepts the
+syntax** — it gets past the parse and stops at `backend.s3 depends on
+var.bucket_name which is not available`, i.e. a missing input, not a forbidden
+interpolation. So "OpenTofu ≥ 1.8 syntax, plain Terraform refuses at init" is
+right, and the tofu half now has a measurement behind it too.
+
+**Scaleway 1 — sergelogvinov/terraform-talos** (`1edaa02`, `scaleway/`):
+**improved — and this is the line the register demanded.** #285 (placement
+groups) and #282 (LB and gateway) fell on separate branches, each naming as its
+remaining wall exactly what the other had removed, and the register refused to
+record the inference: "the next replay on a `main` carrying both is what will
+say, and it is what this line exists to demand." Measured, on `main@104a6d4`,
+with `type_lb = "LB-S"` and `controlplane = {count=2, type="DEV1-L"}`:
+
+- under `--vm off`, **30 of 33 applied**, re-plan `3 to add, 0 to change`, 30
+  destroyed clean. The three are `scaleway_vpc_public_gateway_ip`,
+  `scaleway_vpc_public_gateway` and `scaleway_vpc_gateway_network` — the
+  `vpc-gw/v1` wall the register itself records as declined **by name**, because
+  the portal withdrew the v1 document and the stack pins `~> 2.43.0`, which
+  speaks v1. Every other wall is gone: placement groups, LB, IPv6 subnet,
+  address order, the catalogue.
+- under `--vm incus-ovn`, **25 applied**, re-plan `7 to add / 2 to destroy`, 25
+  destroyed. The delta is the two controlplane servers, tainted: their image is a
+  *registered* image, built by the register's own prerequisite recipe
+  (volume → snapshot → `CreateImage`), and `docs/limits.md` refuses to boot one
+  deliberately — "this emulator keeps records, not disk contents, so there are no
+  bytes to boot".
+
+So: the improvement is the **code**, present in both modes; the shortfall is the
+**runtime**, present only under `ovn`.
+
+**Scaleway 2 — ioandev/scaleway-flatcar-k3s** (`85cb05d`): **conforme.** 9
+applied, `0 to change`, 9 destroyed — the reference exactly. `CreateBucket` still
+leaves for the real `s3.fr-par.scw.cloud` whatever `SCW_API_URL` says, and
+Cloudflare still fails on token-shaped fakes; both are external and neither
+touched the emulator.
+
+**Scaleway 3 — HealsCodes/ephemeral-devbox** (`cb43927`): **conforme.** 3 applied
+from the re-seeded block snapshot, and the destroy still trips on the stack's own
+snapshot rotation meeting feint's correct `resource is still in use` refusal,
+leaving 2 — which is what the reference records, down to the shape of the
+failure. Tailscale still walls the server on fake credentials, so no machine was
+ever asked for.
+
+**Scaleway 4 — CentraleSupelec/kubic** (`c326f47`): **conforme.** Run rather than
+recorded, with the same two harness inputs (the S3 backend overridden to local,
+21 dummy helm/argocd variables). 0 applied: the apply reaches the emulator and
+dies on its first resource, `scaleway_k8s_cluster` → `/k8s/v1/regions/fr-par/clusters`,
+a named 501. Kapsule is the next wall by name, exactly as recorded.
+
+**Scaleway 5 — Rookain-Kiwi/kiwinet-infra-cloud** (`78c97c9`): **conforme, and
+machine-backed.** 5 applied, `No changes.`, 5 destroyed — identical to the
+`feat/279` reference — with **1 machine really started**. Read back between apply
+and destroy, which is what only this pass could do: `feint-scw-a041c7de-…`
+RUNNING with `203.0.113.2` on `eth0`, the API publishing `public_ip=203.0.113.2`
+— **the same address the machine carries**, not a plausible-looking number — and
+the container holding the stack's own `cloud-init.yml`, French comment box
+included, with `cloud-init status` answering inside it. It boots because
+`debian_bookworm` is a catalogue label rather than a hardcoded id.
+
+### The figures, with their denominators
+
+| | |
+|---|---|
+| entries replayed | **15 of 15** (the sixteenth, OpenAether/#327, is out of scope by the register's own decision) |
+| entries abandoned | **0** — one *separation* run was abandoned, O1's, named in its entry |
+| conforme | 9 |
+| improved | 1 (talos) |
+| regressed | 5 (rke-cluster, ztiac ×2 counted as one entry, k3s, kasten — and ztiac's two templates both) |
+| harness broken, nothing measured | 0 at the end; 4 attempts along the way, all re-run (§ below) |
+| **machines really started** | **5** — kiwinet 1, ocp_outscale 1, vault 3 |
+| resources created, summed over the fifteen `--vm incus-ovn` runs | **382** (`Creation complete` lines) |
+| resources destroyed | **387** — larger on purpose, see below |
+| recorded exchanges over those fifteen runs | **2 402** |
+
+`destroyed` exceeds `created` by five because a server that was created and then
+failed to reach `running` is **tainted**: it is in state and gets destroyed, but
+it never printed a `Creation complete` line. The gap is therefore the count of
+machines the runtime refused to boot, arrived at from the opposite direction —
+which is why both numbers are given instead of one.
+
+Every regression was separated by a `--vm off` re-run except O1's, and **every
+separation that ran reproduced its reference exactly**: ztiac 95 and 54,
+k3s 41, kasten 30, talos 30. So the five regressions are the runtime, and the
+code did not move under any of them.
+
+### What went wrong in the harness, since it reads like findings otherwise
+
+Four attempts measured this replay's harness rather than the emulator, and all
+four were re-run. They are listed because each one produced a plausible number:
+an invented SSH key the Scaleway SDK rightly refused (kiwinet 4 of 5); a TLS
+proxy started without `--record`, caught by the run's own guard; `ssh_key` passed
+as a name where openshift4 wants key material; and E5's `init` run at the repo
+root, where there is no backend block, so it passed and proved nothing.
+
+The fifth is the one worth repeating outside this repository. A run was killed
+harshly, its trap never fired, and its `--vm off` emulator kept port 4610. The
+next two runs' health checks — `curl -sf /_feint/health` — **passed against that
+stale emulator**, which was holding another stack's resources in the wrong
+runtime mode, while feint's own log said `refusing to serve on 127.0.0.1:4610: it
+is already served by another emulator (pid 121004)`. Two entries were measured
+against the wrong runtime and discarded. The probe now compares `instance.pid`
+and the declared runtime with what it started, and refuses a non-empty emulator;
+a witness proves it refuses a squatter. **A health probe that cannot say whose
+emulator answered is not a health probe**, and this one had been green all
+evening.

--- a/examples/stacks/surveyed.md
+++ b/examples/stacks/surveyed.md
@@ -770,7 +770,7 @@ because of it.
 
 ### The pass in one paragraph
 
-Fifteen entries, all replayed. **Nine are unchanged from their reference, three of
+Fifteen entries, all replayed. **Ten are unchanged from their reference, three of
 them now backed by something real**: kiwinet applies its 5 with a container that
 carries the address the API published and holds the stack's own cloud-init;
 terraform-exoscale-vault applies its 7 with **three running machines** and is
@@ -780,7 +780,7 @@ recorded-inapplicable entries answer exactly as recorded. **One improved, and it
 is the one this register demanded**: `terraform-talos` had its two walls removed
 on separate branches, and the register refused to record the inference — measured
 together on `main` at last, it applies **30 of 33** with `0 to change` and
-destroys clean, the only wall left being `vpc-gw/v1`, declined by name. **Five
+destroys clean, the only wall left being `vpc-gw/v1`, declined by name. **Four
 regressed, and every one of them for the same single cause**: the emulated image
 catalogues hold a handful of identifiers, every stranger's stack hardcodes a real
 one, and under a machine runtime an unbootable image is no longer harmless — the
@@ -1004,9 +1004,9 @@ included, with `cloud-init status` answering inside it. It boots because
 |---|---|
 | entries replayed | **15 of 15** (the sixteenth, OpenAether/#327, is out of scope by the register's own decision) |
 | entries abandoned | **0** — one *separation* run was abandoned, O1's, named in its entry |
-| conforme | 9 |
-| improved | 1 (talos) |
-| regressed | 5 (rke-cluster, ztiac ×2 counted as one entry, k3s, kasten — and ztiac's two templates both) |
+| conforme | **10** |
+| improved | **1** (talos) |
+| regressed | **4** (rke-cluster, ztiac, k3s, kasten) — ztiac is one entry whose *two* templates both regressed |
 | harness broken, nothing measured | 0 at the end; 4 attempts along the way, all re-run (§ below) |
 | **machines really started** | **5** — kiwinet 1, ocp_outscale 1, vault 3 |
 | resources created, summed over the fifteen `--vm incus-ovn` runs | **381** (`Creation complete` lines) |
@@ -1021,7 +1021,7 @@ which is why both numbers are given instead of one.
 
 Every regression was separated by a `--vm off` re-run except O1's, and **every
 separation that ran reproduced its reference exactly**: ztiac 95 and 54,
-k3s 41, kasten 30, talos 30. So the five regressions are the runtime, and the
+k3s 41, kasten 30, talos 30. So the four regressions are the runtime, and the
 code did not move under any of them.
 
 ### What went wrong in the harness, since it reads like findings otherwise


### PR DESCRIPTION
# Summary

The register of fifteen third-party stacks has now been replayed on a **machine
runtime** for the first time: `--vm incus-ovn`, on `main@104a6d4`.

It also closes a gap that had already caused a wrong conclusion. The register was
written on 2026-08-17 and replayed on 2026-08-18, **both times with `--vm off`**,
and it never said so — the word `incus` appears nowhere in its 741 lines and its
harness block prints `feint serve` with no flag. That silence was later read as
evidence that no runtime had ever been asked for. The harness block now names the
runtime of both earlier passes and states the rule: **a replay that does not name
its `--vm` is not reproducible**, and its silence will one day be re-read as a
fact.

**The pass, in figures with denominators.** Fifteen entries of fifteen, none
abandoned: **10 conforme, 1 improved, 4 regressed** (ztiac is one entry whose two
templates both regressed). 381 resources created, 386
destroyed (the gap is exactly the tainted servers), 2 396 exchanges recorded, and
**5 machines really started**.

**The improvement is the one the register demanded of itself.** #285 (placement
groups) and #282 (LB and gateway) fell on separate branches, each naming as its
remaining wall exactly what the other had removed, and the register refused to
record the inference: *"the next replay on a `main` carrying both is what will
say, and it is what this line exists to demand."* Measured: `terraform-talos`
applies **30 of 33** with `0 to change` and destroys clean, the one wall left
being `vpc-gw/v1`, declined by name.

**The five regressions have one cause, and it is a decision rather than a
defect.** Strangers hardcode real image identifiers; the emulated catalogues hold
a handful; and under a machine runtime an unbootable image stops being harmless,
because the emulator answers `stopped` — which is what actually happened.
`docs/limits.md` had already decided this and said why; what it lacked was the
measured price, added here. `ocp_outscale` is the control that proves the
mechanism: same pack, same runtime, same evening, a *catalogue* OMI, and its
bastion booted in 21 seconds.

**Every regression was separated**, by re-running that stack alone under
`--vm off` with everything else identical, and **every separation that ran
reproduced its reference exactly** — ztiac 95 and 54, k3s 41, kasten 30,
talos 30. So the code moved under none of them. One separation was abandoned and
is named in its entry: `osc-k8s-rke-cluster`'s own `ansible.cfg` sets
`retries=999` with a 60-second timeout against an unroutable address, so the
`--vm off` run does not terminate; its attribution is stated as an inference from
the mechanism, not as a measurement.

**One harness defect of mine is recorded in the register rather than quietly
fixed**, because it generalises past this repository. The command meant to stop
that non-terminating run was `pkill -f campaign-outscale.sh; …; pkill -f
"run-O1.sh"; …`, and `pkill -f` matches the whole command line — so the shell
executing that very command matched its own pattern and **the sweep killed
itself** before its last clause. The emulator died, terraform did not, and its
ansible tail ran 3 h 57 against an address nothing carried; the maintainer
stopped it, no control of mine did. The `timeout 3600` that should have bounded
it lived on the wrapper that had just been killed: **a cap that lives in the
parent is not a cap.** Both halves are now fixed in the harness — every `apply`,
`plan` and `destroy` carries its own `timeout` and reports a hit as a result, and
the sweeper's patterns are anchored so they cannot match their own shell — and
O1 was re-measured from a clean station afterwards, which is the second of the
two runs its entry now carries.

**What the runtime bought, concretely.** kiwinet's own `cloud-init.yml` — French
comment box included — was read back out of a running container, with
`cloud-init status` answering inside it, and the address the API published
(`203.0.113.2`) is the address `eth0` carries. Until now the register could only
say the API accepted a `user_data` key.

## Type of change

- [ ] A route added or changed
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes — via `mise run prepush`, whose exit code was
      captured **before** any pipe: **0**
- [x] No new external Go dependency — no Go code changes at all
- [x] `internal/core` still knows no provider — no code changes
- [x] Nothing in the diff could be written identically for another provider — the
      diff is two documentation files

### When a model wrote a substantive part of this

- [x] `Assisted-by:` trailer present
- [ ] I ran `mise run conformance` myself — **N/A and deliberately so.** This
      change adds no route and no response shape; what it reports is a run of the
      *real third-party clients*, which is a stronger instrument than the
      conformance suite and is what the whole diff documents. The fifteen stacks
      were driven with Terraform 1.15.4, OpenTofu 1.11.4 and the pinned Exoscale
      fork, against `--vm incus-ovn`.
- [x] Every field name in the diff comes from a run of a real client — every
      figure is extracted from the run logs by `totals.py` / `consolidate.py`,
      not transcribed, and every quoted error string is copied from a transcript

### When a route is added or changed

N/A — no route added or changed.

### When behaviour a client can observe changes

- [x] `docs/limits.md` updated: the registered/hardcoded-image refusal already
      documented there now carries its measured consequence
- [ ] README generated tables — N/A, no coverage artefact moved

### When `.github/workflows/` is touched

N/A.

### When a machine runtime is involved

- [x] Tested with a machine runtime — that is the entire point: `--vm incus-ovn`
      for all fifteen, plus `--vm off` separation runs
- [x] Nothing the emulator did not create was touched. The station's pre-existing
      `incusbr0`, `incusbr-1000`, `hp-test-net` and the unrelated `acltest` ACL
      were left alone throughout
- [ ] **The run leaves nothing behind — checked, and it does not hold.** Two OVN
      networks and one ACL are still on the station and **cannot be removed by
      any `incus` command**. That is not an oversight in this pull request: it is
      #455, reproduced by an ordinary finished run rather than a killed one, and
      the manual repair attempt is recorded in a comment there. Stated here
      rather than ticked, because ticking it would be false.

## Related issues

Filed by this replay, each with its reproduction:

- #454 — a security group carrying an ICMP rule with an IPv6 source loses its
  whole firewall under `--vm`; the API describes rules the host does not enforce
- #455 — an orphaned OVN network becomes permanently unremovable, and
  `feint clean --check` does not see it
- #456 — a Net with several subnets fails to peer under OVN, and its destroy
  fails; this is what costs ztiac the register's flagship result
- #457 — a load balancer whose backends are on another subnet is accepted by the
  API and refused by OVN

Answers the demand recorded in the talos entry (#285 / #282 measured together).

Two findings were **not** filed because measurement disproved them, and both are
recorded in the register so nobody re-files them: the refusal to boot a
registered image is documented and deliberate, and `Missing VIP target(s)`
self-heals once the backends arrive — proven by a witness that registered one and
watched the OVN balancer appear.

Assisted-by: Claude Code (Claude Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
