### PR TITLE
fix(machine): the sweep stops trapping the host it cleans, and a station already trapped has a way out (#455)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -17,6 +17,61 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ## [Unreleased]
 
+### Corrigé
+
+- **Un balayage ne piège plus l'hôte qu'il nettoie, et `feint clean --force`
+  libère un hôte déjà piégé** (#455). Quinze stacks tierces rejouées sous
+  `--vm incus-ovn` ont laissé deux réseaux OVN, deux jeux de règles et l'uplink
+  sur une station où **aucune commande `incus` ne pouvait en retirer un seul**,
+  et le fossoyeur était le balayage, pas le run suivant.
+
+  La cause amont est le schéma d'Incus lui-même : des trois références que porte
+  `networks_peers`, seule `target_network_id` n'a pas de cascade. Supprimer la
+  cible d'un peering laisse donc la ligne derrière, tenant un identifiant qui ne
+  résout plus rien. Toute opération sur le réseau survivant échoue alors sur
+  `Failed loading target network: Network not found`, y compris la suppression
+  de peering qui la réparerait. `incus network peer edit` rend 0 et ne persiste
+  rien ; la 7.3 n'y change rien. Reproduit sur cette station, refus par refus,
+  dans `docs/limits.md`.
+
+  Trois comportements de cet émulateur transformaient cela en état permanent, et
+  les trois sont désormais prévenus plutôt que réparés : `Prune` retirait les
+  `ipv4.routes` de `feint-uplink` au passage, parce que l'uplink porte la même
+  étiquette que le reste, et toute voie de gestion des réseaux qui en dépendent
+  échouait ensuite à la validation ; rien ne détachait `security.acls` avant de
+  supprimer un réseau que le jeu de règles retient et qui retient le jeu de
+  règles ; rien ne supprimait la moitié qu'un peering laisse sur sa **cible
+  survivante**, ce qui fabrique l'identifiant mort. L'uplink quitte maintenant
+  le chemin ordinaire et part en dernier, routes intactes ; un jeu de règles est
+  détaché avant la suppression et remis en place si la suppression refuse
+  toujours ; les deux moitiés de chaque peering partent avant le réseau.
+
+  Pour une station qui porte déjà l'état, **`feint clean --force`** retire la
+  ligne par `incus admin sql`, le mécanisme supporté d'Incus et non une édition
+  dans le dos du démon, après l'avoir imprimée entière pour qu'elle soit
+  réinsérable. Elle n'est retirée **que si le réseau auquel elle appartient
+  porte l'étiquette que cet émulateur a lui-même posée** : la ligne pendante
+  d'un tiers est la même table, la même forme et la même cible morte, et un
+  `--force` capable de l'atteindre serait un défaut pire que celui qu'il répare.
+  `TestForceLeavesAThirdPartysDanglingPeerAlone` en est le témoin, et
+  `tools/falsify/specs/trapped-station.json` prouve que les gardes mordent :
+  quinze mutations, toutes rouges. La paire a aussi été jouée une fois contre
+  le vrai runtime, où la ligne plantée sur un pont nommé `fnt-lab` était encore
+  là ensuite.
+
+- **`feint clean --check` rapporte les états qu'aucun balayage ne peut quitter,
+  et sort en 1 dessus** (#455). Il répondait 0 en silence pendant toute la durée
+  du blocage ci-dessus, parce que sans `--doorstep` il n'interrogeait que les
+  services DHCP orphelins. Il nomme désormais une ligne de peering dont la cible
+  ne résout plus, un réseau de l'émulateur dont l'uplink ne porte plus le bloc,
+  et un jeu de règles attaché à un réseau déjà piégé par l'un des deux.
+
+  Ce troisième état n'est délibérément pas la forme nue « un jeu de règles est
+  attaché à un réseau » : `IsolateNetwork` en attache un à chaque réseau OVN
+  ayant un voisin à tenir dehors, donc la forme nue refuserait tout run sain.
+  C'est ainsi que le pas de la porte de #426 s'était mis à se déclencher sur des
+  hôtes où rien n'allait échouer, et c'est ainsi qu'un contrôle finit désarmé.
+
 ### Ajouté
 
 - **La stack Exoscale a une suite qui la pilote**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,58 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Fixed
 
+- **A sweep no longer traps the host it is cleaning, and `feint clean --force`
+  frees a host already trapped** (#455). Fifteen third-party stacks replayed
+  under `--vm incus-ovn` left two OVN networks, two rule sets and the uplink on
+  a station where **no `incus` command could remove any of them**, and the
+  eraser was the sweep rather than the next run.
+
+  The upstream cause is Incus' own schema: of the three references
+  `networks_peers` carries, only `target_network_id` has no cascade, so deleting
+  a peering's *target* leaves the row behind holding an id that resolves to
+  nothing. Every operation on the surviving network then fails on
+  `Failed loading target network: Network not found` — the peer delete that
+  would repair it included. `incus network peer edit` returns 0 and persists
+  nothing; 7.3 changes none of it. Reproduced on this station, refusal by
+  refusal, in `docs/limits.md`.
+
+  Three things this emulator did turned that into permanence, and all three are
+  now prevented rather than repaired: `Prune` stripped `feint-uplink`'s
+  `ipv4.routes` on its way past, because the uplink carries the same label as
+  everything else, and every management path of the networks drawing from it
+  then failed validation; nothing detached `security.acls` before deleting a
+  network the rule set holds and that holds the rule set; and nothing removed
+  the half a peering leaves on its **surviving target**, which is what
+  manufactures the dead id. The uplink now leaves the ordinary path and goes
+  last with its routes intact, a rule set is detached before the delete and put
+  back if the delete still refuses, and both halves of every peering go before
+  the network does.
+
+  For a station already carrying the state, **`feint clean --force`** removes
+  such a row through `incus admin sql` — Incus' own supported mechanism, not an
+  edit behind the daemon's back — after printing it whole so it can be put back.
+  It removes a row **only when the network it belongs to carries the label this
+  emulator wrote**: an operator's dangling row is the same table, the same shape
+  and the same dead target, and a `--force` able to reach it would be a worse
+  defect than the one it repairs.
+  `TestForceLeavesAThirdPartysDanglingPeerAlone` is the witness, and
+  `tools/falsify/specs/trapped-station.json` proves the guards bite — fifteen
+  mutations, all red — and the pair was driven once against the real runtime,
+  where the row planted on a bridge named `fnt-lab` was still there afterwards.
+
+- **`feint clean --check` reports the states no sweep can leave, and exits 1 on
+  them** (#455). It answered 0 in silence for the whole duration of the block
+  above, because without `--doorstep` it only ever asked about orphaned DHCP
+  services. It now names a peering row whose target no longer resolves, a
+  network of the emulator's whose block the uplink no longer carries, and a rule
+  set attached to a network already trapped by either.
+
+  That third one is deliberately not the bare "a rule set is attached to a
+  network": `IsolateNetwork` attaches one to every OVN network with a neighbour
+  to keep out, so the bare form would refuse every healthy run — which is how
+  #426's doorstep once fired on hosts nothing was going to fail on, and how a
+  check gets disarmed.
+
 - **`scw instance security-group list-default-rules` reaches a rule set instead
   of a 404, a rule answers `dest_ip_range`, and a private NIC answers the date
   it last changed** (#431, #432, #436). Three shapes a real `fr-par` account

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -1018,6 +1018,112 @@ emulator that is running. Asked at both, it failed a leg for owning what it had
 just created — measured, and now held by
 `TestOnlyTheDoorstepAsksWhatAnEarlierRunLeft`.
 
+### The third producer, and the only one that reaches Incus' database (#455)
+
+The two above leave objects a sweep can still remove. This one leaves objects
+**nothing can remove**, and the sweep was what made them permanent.
+
+The upstream cause is three lines of Incus' own schema. `networks_peers` carries
+three references, and only one of the three lacks a cascade:
+
+```sql
+network_id INTEGER NOT NULL,
+  FOREIGN KEY (network_id) REFERENCES "networks" (id) ON DELETE CASCADE
+target_network_integration_id INTEGER ... REFERENCES networks_integrations (id) ON DELETE CASCADE
+target_network_id INTEGER NULL,        -- no foreign key, no cascade
+```
+
+The schema above is read from `sqlite_master` on the station, Incus 7.2, not
+quoted from anywhere: `network_id` cascades, `target_network_integration_id`
+cascades, and `target_network_id` carries no foreign key at all.
+
+Delete the **source** network and the peering row goes with it. Delete the
+**target** and the row survives, holding an id that resolves to nothing, with
+`target_network_project` and `target_network_name` both NULL. From that moment
+the source network cannot be removed by anything, and the command that would
+remove the row fails on the same missing target. Reproduced on 2026-08-25 by
+planting one row against a network this emulator had just created, so that the
+premise of this section is measured rather than inherited:
+
+```
+$ incus network peer delete fnt-387f1e8daa2 fnt-gonetarget
+Error: Failed deleting peer: Failed loading target network: Network not found
+$ incus network delete fnt-387f1e8daa2
+Error: The network is currently in use
+```
+
+`incus network peer show` still lists the peering, with no target field left to
+read, and `incus network peer edit` does not repair it: it returns 0 and
+persists nothing, the target fields being immutable after creation. Incus 7.3
+carries nothing that touches peer rows. **The asymmetric cascade appears to be
+unreported upstream.**
+
+Two further refusals belong to the same trap and are quoted from the
+maintainer's station in #455 rather than from the reproduction above, because
+they need a rule set to be attached and the two-subnet Net used here attaches
+none: `incus network unset <net> security.acls` answers `Failed applying router
+security policy: Failed loading target network: Network not found`, and
+`incus network acl delete iso-<net>` answers `Cannot delete an ACL that is in
+use`. That is the full cycle — the network cannot go because the rule set holds
+it, the rule set cannot go because the network holds it, and the detach that
+breaks the cycle is refused by the dangling row.
+
+**Three things this emulator was doing made it permanent, and all three are
+prevention rather than repair:**
+
+1. `Prune` treated `feint-uplink` as an ordinary network — it carries the same
+   `user.feint.provider` label as everything else — and unset its `ipv4.routes`
+   before a delete that then failed on the orphans still attached. From that
+   instant every management path of those orphans failed validation with
+   `Uplink network doesn't contain 10.2.4.0/24 in its routes`, which is the
+   detach they needed in order to go. The uplink now leaves the ordinary path,
+   is deleted last, and its routes are never unset.
+2. Neither `Prune` nor `RemoveNetwork` detached `security.acls` before deleting
+   a network, and the two hold each other: the rule set is "in use" by the
+   network, the network is "in use" by the rule set. Both now detach first —
+   and put the attachment back when the delete still refuses, because a network
+   that survives with its rule set silently off is a firewall disarmed rather
+   than a subnet swept.
+3. Neither removed the half a peering leaves on its **surviving target**. Both
+   now do, before the delete rather than after a refusal, since a delete that
+   succeeds is exactly what leaves the neighbour holding a dead id.
+
+**The repair, for a station already carrying the state, is `feint clean
+--force`.** It removes such a row through `incus admin sql`, which is Incus'
+own supported mechanism for it rather than an edit of a file behind the
+daemon's back, and it removes a row **only when the network that row belongs to
+carries the label this emulator wrote**. That scope is the point and not a
+detail: a dangling row of an operator's own is the same table, the same shape
+and the same dead target, and a `--force` able to reach it would be a worse
+defect than the one it repairs. The witness is
+`TestForceLeavesAThirdPartysDanglingPeerAlone`, and
+`tools/falsify/specs/trapped-station.json` proves it bites — fifteen mutations,
+all red.
+
+It was also driven once against the real runtime, on 2026-08-25: two dangling
+rows planted, one on a network the emulator had labelled and one on a bridge
+created for the purpose and deliberately named `fnt-lab`, so it carried the very
+prefix a name check would accept. `clean --check` exited 1 naming only the first,
+`clean --force` removed only the first and printed it whole, and the row on
+`fnt-lab` was still there afterwards. The same reasoning governs the sweep one
+level up: the half of a peering living on the far end is removed only when that
+network carries the label too, since `fnt-` is a prefix anybody may type.
+
+`feint clean --check` reports three states, and each is one no healthy run ever
+produces: a peering row whose target no longer resolves, a network of the
+emulator's whose block the uplink no longer carries, and a rule set attached to
+a network already trapped by either. That last one is deliberately **not** the
+bare form: `IsolateNetwork` ends by attaching a rule set to every OVN network
+with a neighbour to keep out, so reporting "a rule set is attached" would refuse
+every healthy run — the same way #426's doorstep once fired on hosts nothing was
+going to fail on, which is how a check gets disarmed.
+
+What remains a limit: **a dangling row whose source network is not this
+emulator's is left alone and named nowhere**, deliberately. If an operator's own
+tooling produces one, the repair is theirs to run, and `incus admin sql global
+"DELETE FROM networks_peers WHERE id=<id>"` is the statement — after reading the
+row, because nothing here will read it for them.
+
 ## Authentication is accepted, never verified
 
 No signature is checked, on any provider. Credentials must merely be well-formed,

--- a/internal/cli/clean.go
+++ b/internal/cli/clean.go
@@ -26,11 +26,19 @@ func clean(args []string, stdout io.Writer) error {
 	check := fs.Bool("check", false, "report what this user cannot remove and remove nothing; exit 1 if anything is stuck")
 	format := fs.String("format", "text", "output format: text, or json for one aggregatable line per object found")
 	doorstep := fs.Bool("doorstep", false, "also refuse a machine or network of an earlier run; only true before a run starts, because a run in flight owns both")
+	force := fs.Bool("force", false, "also clear what no ordinary command of the runtime reaches: the peering rows a deleted network left behind, named one by one before they go")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 	if *format != "text" && *format != "json" {
 		return fmt.Errorf("unknown format %q: text or json", *format)
+	}
+	// Two flags that mean opposite things, and a caller who typed both wants
+	// something neither does. Refused rather than resolved in one direction:
+	// guessing here would either remove a database row somebody meant to be
+	// shown, or silently not remove one somebody meant to go.
+	if *check && *force {
+		return fmt.Errorf("--check removes nothing and --force removes what nothing else can: ask for one of the two")
 	}
 	led := newLedger(stdout, *format == "json", time.Now())
 	if *check {
@@ -55,6 +63,18 @@ func clean(args []string, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
+
+	// Before the sweep, deliberately: what --force clears is exactly what makes
+	// the sweep below fail. A peering row whose target network is gone refuses
+	// every operation on the network holding it — the detach, the peer delete
+	// and the delete itself — so sweeping first would report the same five
+	// objects the issue's reproduction reports and change nothing (#455).
+	if *force {
+		if err := clearRuntimeTraps(stdout, led, driver); err != nil {
+			return err
+		}
+	}
+
 	pruner, ok := driver.(machine.Pruner)
 	if !ok {
 		// --vm off has no runtime, so there is nothing to sweep and that is not a
@@ -219,10 +239,45 @@ func reportStuckLeftovers(stdout io.Writer, led *ledger, vm string, doorstep boo
 	//
 	// TestTheDoorstepRefusesAHostHoldingAPreviousRunsNetwork and
 	// TestTheLeftoverCheckMidRunIgnoresTheRunsOwnObjects fail without this.
+	// The runtime is resolved once, here, and handed to both questions below.
+	// It used to be resolved inside the doorstep alone, which is why a check
+	// without --doorstep never touched the runtime at all — and why it answered
+	// 0 in silence on the station of #455.
+	//
+	// A runtime that will not resolve is not a clean host and the caller must
+	// not read it as one, so this fails rather than skipping: the same position
+	// refuseRuntimeLeftovers already took for the doorstep.
+	driver, err := resolveDriver(vm, stdout)
+	if err != nil {
+		led.record(leftoverRecord{Kind: "survey", Name: vm, Attribution: "none",
+			Stage: stageDoorstep, Why: whyUnreadable, Action: actionNone})
+		return fmt.Errorf("could not ask the %s runtime what a previous run left: %w", vm, err)
+	}
+
 	if doorstep {
-		if err := refuseRuntimeLeftovers(stdout, led, vm); err != nil {
+		if err := refuseRuntimeLeftovers(stdout, led, vm, driver); err != nil {
 			return err
 		}
+	}
+
+	// And the states no sweep can leave, asked at every check rather than only
+	// at the doorstep (#455).
+	//
+	// The distinction that makes this safe mid-run is not the flag, it is the
+	// question: every state named here is one no healthy run ever produces. A
+	// rule set attached to a network is *not* one of them — IsolateNetwork
+	// attaches one to every OVN network with a neighbour to keep out, so a check
+	// that refused on it would fail every healthy run, which is precisely how
+	// #426's doorstep learned to fire on hosts nothing was going to fail on.
+	// What is reported is the rule set held by a network that is itself trapped.
+	//
+	// TestCleanCheckReportsADanglingPeerRow, TestCleanCheckReportsAStrippedUplink
+	// and TestCleanCheckReportsARuleSetHeldByATrappedNetwork fail without it;
+	// TestCleanCheckStaysQuietOnARuntimeNothingHoldsBeyondItsSweep is the
+	// accepting half, and it is the one that keeps this usable mid-run.
+	trapped, err := reportRuntimeTraps(stdout, led, driver)
+	if err != nil {
+		return err
 	}
 
 	leftovers, err := findLeftoverDHCP()
@@ -231,7 +286,7 @@ func reportStuckLeftovers(stdout io.Writer, led *ledger, vm string, doorstep boo
 	}
 	if len(leftovers) == 0 {
 		led.prose("no DHCP service of this emulator's outlives its network on this host\n")
-		return nil
+		return trapFailure(trapped, vm)
 	}
 	var stuck []machine.DHCPLeftover
 	for _, leftover := range leftovers {
@@ -252,7 +307,7 @@ func reportStuckLeftovers(stdout io.Writer, led *ledger, vm string, doorstep boo
 	}
 	if len(stuck) == 0 {
 		led.prose("  → feint clean --vm %s ends them\n", vm)
-		return nil
+		return trapFailure(trapped, vm)
 	}
 	for _, leftover := range stuck {
 		if leftover.InterfaceAlive {
@@ -331,4 +386,19 @@ func sweepLeftoverDHCP(stdout io.Writer, led *ledger, vm string) error {
 			len(stuck), strings.Join(stuck, "; "), vm)
 	}
 	return nil
+}
+
+// trapFailure turns the trap count into this command's verdict, and it is
+// separate so the DHCP half keeps its own three verdicts unchanged.
+//
+// Non-zero, always, and that is the whole of #455's third point: `feint clean
+// --check` answered 0 in silence on a station carrying two networks and two rule
+// sets that no command could remove. A check whose "all clear" does not cover
+// the objects the sweep handles reads as proof and is not one.
+func trapFailure(trapped int, vm string) error {
+	if trapped == 0 {
+		return nil
+	}
+	return fmt.Errorf("%d state(s) on this runtime are beyond an ordinary command and were named above; "+
+		"`feint clean --force --vm %s` clears what it can, after naming every row it removes", trapped, vm)
 }

--- a/internal/cli/clean_ledger.go
+++ b/internal/cli/clean_ledger.go
@@ -62,6 +62,12 @@ type leftoverRecord struct {
 	Why string `json:"why"`
 	// Action is what this run did about it.
 	Action string `json:"action"`
+	// Row is the runtime's own record of an object, verbatim, and it appears
+	// only where a repair reaches past the runtime's commands to remove one
+	// (#455). Printing it is what makes the removal reversible by the operator
+	// rather than by trust, so it belongs on the line that records the removal
+	// and nowhere else.
+	Row string `json:"row,omitempty"`
 }
 
 // The vocabulary, closed on purpose: a free-text field cannot be grouped, and a
@@ -219,15 +225,10 @@ func (l *ledger) recordAll(left machine.Leftovers, stage, why, action string) {
 // so refusing on one by itself would fire on a host nothing was going to fail
 // on — which is how a doorstep gets disarmed, and is the lesson mutation 7 of
 // unkillable-dhcp-orphan.json holds.
-func refuseRuntimeLeftovers(out io.Writer, led *ledger, vm string) error {
-	driver, err := resolveDriver(vm, out)
-	if err != nil {
-		// A runtime that will not resolve is not a clean host, and the caller
-		// must not read this as one.
-		led.record(leftoverRecord{Kind: "survey", Name: vm, Attribution: "none",
-			Stage: stageDoorstep, Why: whyUnreadable, Action: actionNone})
-		return fmt.Errorf("could not ask the %s runtime what a previous run left: %w", vm, err)
-	}
+// The driver is resolved by the caller and passed in, since the check now asks
+// this runtime two questions rather than one and resolving it twice would let
+// them disagree about which host they are talking about.
+func refuseRuntimeLeftovers(out io.Writer, led *ledger, vm string, driver machine.Driver) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 

--- a/internal/cli/clean_ledger_test.go
+++ b/internal/cli/clean_ledger_test.go
@@ -69,6 +69,19 @@ func withDriver(t *testing.T, d machine.Driver) {
 	t.Cleanup(func() { surveyRuntime = previousSurvey })
 }
 
+// noRuntime points the check at a runtime that answers no question at all.
+//
+// It exists because `feint clean --check` now resolves the runtime on every
+// call, not only at the doorstep (#455): a test that left the real resolver in
+// place would read the tester's own host, pass on a clean station and fail on a
+// dirty one, which is the "never assert an absolute on shared state" rule the
+// measurement-integrity skill states. Naming the runtime is how a test about
+// DHCP services says it is not about runtime objects.
+func noRuntime(t *testing.T) {
+	t.Helper()
+	withDriver(t, machine.Noop{})
+}
+
 // quietDHCP silences the real /proc scan: these tests are about runtime
 // objects, and a leftover on the tester's own station would fail them for the
 // station's reasons.

--- a/internal/cli/clean_traps.go
+++ b/internal/cli/clean_traps.go
@@ -1,0 +1,156 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/machine"
+)
+
+// The half of a sweep that is not a sweep (#455).
+//
+// Everything else this command does is removable by an ordinary command of the
+// runtime, and the whole argument of `feint clean` is that the operator never
+// has to reach past one. A state measured on the maintainer's station in August
+// 2026 broke that: an OVN network whose peering named a network that had been
+// deleted refused *every* management path, the peer delete that would repair it
+// included, so the network, the rule set attached to it and the uplink they sat
+// on were permanent by every means a user has. Two hours of hand work on the
+// runtime's own database is what cleared it.
+//
+// Three consequences shape this file:
+//
+//   - The prevention is elsewhere and it is the real fix (internal/core/machine:
+//     Prune and RemoveNetwork now drop the surviving half of a peering before
+//     they delete a network, detach a rule set before deleting the network that
+//     holds it, and never strip the uplink's routes). What is here is for the
+//     stations already carrying the state.
+//   - The report is unconditional. `feint clean --check` answered 0 in silence
+//     for the whole duration of the block, because without --doorstep it only
+//     asked about orphaned DHCP services. A check whose "all clear" does not
+//     cover the objects the sweep handles reads as proof and is not one.
+//   - The repair is not. It is behind `--force`, it names every row before it
+//     removes one, and it removes a row only when the network that row belongs
+//     to carries the label this emulator wrote. That last clause is the whole
+//     of it: a --force able to reach a third party's peering row would be a
+//     worse defect than the one it repairs.
+
+// whyTrapped is the ledger's word for the third family, beside a leftover that
+// was refused and one that survived a successful delete: an object no ordinary
+// command of the runtime can remove at all. It is what makes "how often does
+// this happen" answerable, which is the whole point of the ledger.
+const whyTrapped = "beyond-an-ordinary-command"
+
+// reportRuntimeTraps names what holds the runtime, and removes nothing. It
+// returns how many it found, so the caller decides the exit code: this is a
+// read, and a read must not choose what a command means.
+//
+// Distinguishes three outcomes rather than two, like every other reader here: a
+// runtime that cannot be asked is not a clean one, and it says so instead of
+// answering zero.
+func reportRuntimeTraps(out io.Writer, led *ledger, driver machine.Driver) (int, error) {
+	repairer, ok := driver.(machine.Repairer)
+	if !ok {
+		led.prose("the %s runtime cannot be asked what holds it, so nothing was asked\n", driver.Name())
+		return 0, nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	traps, err := repairer.Traps(ctx)
+	if err != nil {
+		led.record(leftoverRecord{Kind: "survey", Name: driver.Name(), Attribution: "none",
+			Stage: stageDoorstep, Why: whyUnreadable, Action: actionNone})
+		return 0, fmt.Errorf("could not look at what holds the %s runtime, so this host cannot be called clean: %w",
+			driver.Name(), err)
+	}
+	if len(traps) == 0 {
+		led.prose("nothing on this runtime is beyond an ordinary sweep\n")
+		return 0, nil
+	}
+	for _, trap := range traps {
+		led.record(trapRecord(trap, stageDoorstep, actionReported))
+		led.prose("%s %s: %s\n", trap.Kind, trap.Name, trap.Why)
+	}
+	if !led.asJSON {
+		fmt.Fprintf(out, "\nNone of the above goes with an ordinary `incus` command, and the sweep cannot\n"+
+			"reach it either. `feint clean --force` clears what it can, naming every row it\n"+
+			"removes first; the rest is cleared by the sweep now that it knows the order.\n")
+	}
+	return len(traps), nil
+}
+
+// clearRuntimeTraps is `--force`: it says what it will remove, removes it, and
+// says what went.
+//
+// The announcement is not politeness. What this touches is the runtime's own
+// database, so the row is printed whole before it goes and again as it goes,
+// and an operator who disagrees has everything needed to put it back.
+func clearRuntimeTraps(out io.Writer, led *ledger, driver machine.Driver) error {
+	repairer, ok := driver.(machine.Repairer)
+	if !ok {
+		return fmt.Errorf("--force has nothing to reach on the %s runtime: it cannot be asked what holds it",
+			driver.Name())
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	traps, err := repairer.Traps(ctx)
+	if err != nil {
+		led.record(leftoverRecord{Kind: "survey", Name: driver.Name(), Attribution: "none",
+			Stage: stageSweep, Why: whyUnreadable, Action: actionNone})
+		return fmt.Errorf("could not look at what holds the %s runtime, so nothing was forced: %w",
+			driver.Name(), err)
+	}
+	var repairable []machine.Trap
+	for _, trap := range traps {
+		if trap.Repairable {
+			repairable = append(repairable, trap)
+		}
+	}
+	if len(repairable) == 0 {
+		led.prose("nothing on this runtime needs more than the sweep, so --force removed nothing\n")
+		return nil
+	}
+
+	if !led.asJSON {
+		fmt.Fprintf(out, "\n--force will remove %d row(s) from the runtime's own database, through\n"+
+			"`incus admin sql`, which is Incus' supported mechanism for exactly this.\n"+
+			"Each row is printed whole so it can be put back:\n\n", len(repairable))
+	}
+	for _, trap := range repairable {
+		led.record(trapRecord(trap, stageSweep, actionReported))
+		led.prose("  %s %s: %s\n    %s\n", trap.Kind, trap.Name, trap.Why, trap.Row)
+	}
+
+	cleared, repairErr := repairer.Repair(ctx)
+	for _, trap := range cleared {
+		led.record(trapRecord(trap, stageSweep, actionRemoved))
+		led.prose("removed %s %s\n", trap.Kind, trap.Name)
+	}
+	if repairErr != nil {
+		return repairErr
+	}
+	led.prose("--force removed %d row(s) no ordinary command could reach\n", len(cleared))
+	return nil
+}
+
+// trapRecord turns a trap into a ledger line.
+//
+// Its attribution is the label and never a name, because that is what entitled
+// this process to act: the row was reached through the network it belongs to,
+// and that network carries the mark EnsureNetwork wrote. A ledger line saying
+// "name-prefix" here would record a permission nobody actually asked for.
+func trapRecord(trap machine.Trap, stage, action string) leftoverRecord {
+	return leftoverRecord{
+		Kind:        trap.Kind,
+		Name:        trap.Name,
+		Attribution: "label:" + machine.LabelKey,
+		Stage:       stage,
+		Why:         whyTrapped,
+		Action:      action,
+		Row:         trap.Row,
+	}
+}

--- a/internal/cli/clean_traps_test.go
+++ b/internal/cli/clean_traps_test.go
@@ -1,0 +1,203 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/machine"
+)
+
+// `feint clean --check` and the three states it answered 0 on (#455).
+//
+// The measurement it is held to: on a station carrying two OVN networks and two
+// rule sets that no `incus` command could remove, this command exited 0 and
+// said nothing about any of them, because without --doorstep it only ever asked
+// about orphaned DHCP services. A check whose "all clear" does not cover the
+// objects the sweep handles reads as proof and is not one.
+
+// trappedDriver is a runtime holding states no ordinary command can clear. It
+// is a Repairer and nothing else: the sweep half is covered by sweptDriver, and
+// mixing the two would let a test pass on the wrong question.
+type trappedDriver struct {
+	machine.Noop
+	traps []machine.Trap
+	// blind makes the survey fail, which must never read as a clean host.
+	blind bool
+	// repaired records what Repair was asked to clear, so the announce-then-act
+	// order can be asserted.
+	repaired int
+}
+
+func (d *trappedDriver) Name() string { return "trapped" }
+
+func (d *trappedDriver) Traps(context.Context) ([]machine.Trap, error) {
+	if d.blind {
+		return nil, errors.New("the daemon did not answer")
+	}
+	return d.traps, nil
+}
+
+func (d *trappedDriver) Repair(context.Context) ([]machine.Trap, error) {
+	var cleared []machine.Trap
+	for _, trap := range d.traps {
+		if trap.Repairable {
+			cleared = append(cleared, trap)
+		}
+	}
+	d.repaired = len(cleared)
+	return cleared, nil
+}
+
+// checkAgainst runs `feint clean --check` against a runtime a test controls.
+func checkAgainst(t *testing.T, driver machine.Driver) (string, error) {
+	t.Helper()
+	quietDHCP(t)
+	withDriver(t, driver)
+
+	var out bytes.Buffer
+	err := reportStuckLeftovers(&out, newLedger(&out, false, time.Now()), "incus", false)
+	return out.String(), err
+}
+
+// The three states, one test each, and each of them exits non-zero today only
+// because this reports them: before the fix all three answered 0.
+
+func TestCleanCheckReportsADanglingPeerRow(t *testing.T) {
+	report, err := checkAgainst(t, &trappedDriver{traps: []machine.Trap{{
+		Kind:       machine.TrapDanglingPeer,
+		Name:       "fnt-c10fedc7f6c/fnt-e41278b8c3a",
+		Why:        "its peering names network 2617, which no longer exists",
+		Repairable: true,
+		Row:        `{"id":401}`,
+	}}})
+	if err == nil {
+		t.Fatal("a host holding a peering row no command can remove was reported as ready")
+	}
+	if !strings.Contains(report, "fnt-c10fedc7f6c") {
+		t.Errorf("the report never named the network it found:\n%s", report)
+	}
+	// And the remedy, as one command with nothing to retype — the shape #375
+	// measured the cost of getting wrong.
+	if !strings.Contains(err.Error()+report, "clean --force") {
+		t.Errorf("the refusal named no runnable remedy:\n%s\n%v", report, err)
+	}
+}
+
+func TestCleanCheckReportsAStrippedUplink(t *testing.T) {
+	report, err := checkAgainst(t, &trappedDriver{traps: []machine.Trap{{
+		Kind: machine.TrapStrippedUplink,
+		Name: "fnt-ad48c26e025",
+		Why:  "its block 10.2.2.0/24 is no longer delegated to the uplink feint-uplink",
+	}}})
+	if err == nil {
+		t.Fatal("a host whose uplink lost the block of a network still standing was reported as ready")
+	}
+	if !strings.Contains(report, "10.2.2.0/24") {
+		t.Errorf("the report never named the block that is missing:\n%s", report)
+	}
+}
+
+func TestCleanCheckReportsARuleSetHeldByATrappedNetwork(t *testing.T) {
+	report, err := checkAgainst(t, &trappedDriver{traps: []machine.Trap{{
+		Kind: machine.TrapHeldFirewall,
+		Name: "iso-fnt-c10fedc7f6c",
+		Why:  "it is attached to fnt-c10fedc7f6c, which is trapped",
+	}}})
+	if err == nil {
+		t.Fatal("a rule set neither the network nor the sweep can release was reported as ready")
+	}
+	if !strings.Contains(report, "iso-fnt-c10fedc7f6c") {
+		t.Errorf("the report never named the rule set:\n%s", report)
+	}
+}
+
+// TestCleanCheckStaysQuietOnARuntimeNothingHoldsBeyondItsSweep is the accepting
+// half, and it is the one that decides whether this check survives contact with
+// a run.
+//
+// This command is called mid-run by three network suites. A check that refused
+// on a healthy runtime would fail every one of them, and the reflex it would
+// teach is the reflex `--no-verify` teaches. So the same code path is driven
+// against a runtime holding nothing beyond its sweep, and it must accept — and
+// say so out loud, because "checked and fine" and "never looked" must not read
+// the same.
+func TestCleanCheckStaysQuietOnARuntimeNothingHoldsBeyondItsSweep(t *testing.T) {
+	report, err := checkAgainst(t, &trappedDriver{})
+	if err != nil {
+		t.Fatalf("a runtime holding nothing beyond its sweep was refused: %v\n%s", err, report)
+	}
+	if !strings.Contains(report, "beyond an ordinary sweep") {
+		t.Errorf("the check passed in silence:\n%s", report)
+	}
+}
+
+// A runtime that cannot be asked is not an empty one. Three outcomes, never two.
+func TestCleanCheckRefusesARuntimeItCannotAsk(t *testing.T) {
+	report, err := checkAgainst(t, &trappedDriver{blind: true})
+	if err == nil {
+		t.Fatalf("a runtime that answered nothing was reported as a clean host:\n%s", report)
+	}
+}
+
+// TestForceNamesEveryRowBeforeItRemovesIt is the operator's half of a repair
+// that reaches the runtime's own database: what is about to go is printed
+// whole, so the person who runs it can put it back.
+func TestForceNamesEveryRowBeforeItRemovesIt(t *testing.T) {
+	quietDHCP(t)
+	driver := &trappedDriver{traps: []machine.Trap{
+		{
+			Kind: machine.TrapDanglingPeer, Name: "fnt-c10fedc7f6c/fnt-e41278b8c3a",
+			Why: "its target network 2617 no longer exists", Repairable: true,
+			Row: `{"id":401,"network_id":2616,"target_network_id":2617}`,
+		},
+		{
+			Kind: machine.TrapStrippedUplink, Name: "fnt-ad48c26e025",
+			Why: "its block is no longer delegated",
+		},
+	}}
+	withDriver(t, driver)
+
+	var out bytes.Buffer
+	if err := clearRuntimeTraps(&out, newLedger(&out, false, time.Now()), driver); err != nil {
+		t.Fatalf("--force: %v\n%s", err, out.String())
+	}
+	report := out.String()
+	if !strings.Contains(report, `"target_network_id":2617`) {
+		t.Errorf("the row was removed without being printed, so nothing can put it back:\n%s", report)
+	}
+	// Announced before it went, not after: the sentence naming the row must come
+	// before the sentence saying it is gone.
+	named := strings.Index(report, `"target_network_id":2617`)
+	removed := strings.Index(report, "removed dangling-peer")
+	if removed >= 0 && named > removed {
+		t.Errorf("the row was announced only after it had gone:\n%s", report)
+	}
+	if driver.repaired != 1 {
+		t.Errorf("--force cleared %d row(s), want the one that needs it", driver.repaired)
+	}
+	// The state the ordinary sweep repairs must not be dragged into the
+	// privileged path: a --force that also does what the sweep does is a --force
+	// people start typing by default.
+	if strings.Contains(report, "fnt-ad48c26e025") {
+		t.Errorf("--force claimed a state the sweep repairs on its own:\n%s", report)
+	}
+}
+
+// --check and --force mean opposite things and a caller who typed both wants
+// neither. Refused rather than resolved in one direction, because guessing here
+// either removes a database row somebody meant to be shown or fails to remove
+// one somebody meant to go.
+func TestCleanRefusesCheckAndForceTogether(t *testing.T) {
+	var out bytes.Buffer
+	err := clean([]string{"--check", "--force"}, &out)
+	if err == nil {
+		t.Fatal("--check and --force were accepted together")
+	}
+	if !strings.Contains(err.Error(), "--force") {
+		t.Errorf("the refusal does not say which flags disagree: %v", err)
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -172,11 +172,27 @@ const (
 // before one starts — mid-run, the machines and networks it names belong to
 // the emulator that is running.
 //
+// Version 17 adds `clean --force` (#455): the one repair that reaches past the
+// runtime's own commands, because a peering row whose target network was
+// deleted survives — the runtime's schema cascades two of that table's three
+// references and not the third — and from then on every operation on the
+// network holding it fails loading a target that resolves to nothing. The
+// network, the rule set attached to it and the uplink they draw from become
+// permanent by every means a user has. `--force` removes such a row through
+// `incus admin sql`, which is Incus' own supported mechanism for it, and only
+// when the network the row belongs to carries the label this emulator wrote:
+// a repair able to reach a third party's row would be a worse defect than the
+// one it repairs. It names every row whole before removing it. In the same
+// change `clean --check` gained the report of those states, so its exit code
+// covers the objects the sweep handles rather than DHCP orphans alone.
+// An addition to one existing verb; nothing was removed, no exit code moved,
+// and a pipeline keyed on version 16 keeps working.
+//
 // The surface itself is frozen in testdata/frozen/cli.json, compared by
 // TestTheFrozenSurfacesStillMatchTheirFixture, and a fixture regenerated
 // without bumping this constant fails TestASurfaceChangeDemandsItsVersionBump.
 // The procedure for a deliberate change is in RELEASING.md ("Frozen surfaces").
-const cliSurfaceVersion = 16
+const cliSurfaceVersion = 17
 
 // Run executes one command and returns the process exit code.
 func Run(args []string, stdout, stderr io.Writer) int {
@@ -505,13 +521,21 @@ Usage:
   feint catalog    [--format json]
                     Print the emulated inventory a client reads before creating.
 
-  feint clean      [--vm incus|incus-vm|incus-ovn] [--check] [--doorstep] [--format text|json]
+  feint clean      [--vm incus|incus-vm|incus-ovn] [--check] [--doorstep] [--force]
+                   [--format text|json]
                     Remove every machine, network and rule set the emulator
                     created. Labelled resources only; nothing else is touched.
                     --check removes nothing: it names what a run left behind
                     holding an address block, and which of it this user may not
                     end, exiting 1 in that case so a suite can refuse on the
-                    doorstep instead of dying on the block minutes in.
+                    doorstep instead of dying on the block minutes in. It also
+                    names the states no ordinary command of the runtime can
+                    leave, and exits 1 on those.
+                    --force clears those states, which today means the peering
+                    rows a deleted network left behind. It reaches the runtime's
+                    own database through "incus admin sql", touches only rows
+                    belonging to a network this emulator labelled, and prints
+                    every row whole before it removes it.
 
   feint version    [--check]
                     Print the version. --check asks GitHub whether a newer

--- a/internal/cli/dhcp_leftover_test.go
+++ b/internal/cli/dhcp_leftover_test.go
@@ -200,6 +200,7 @@ func swapProbeSeam(t *testing.T, can func(machine.DHCPLeftover) error) {
 // anything would be a check with a side effect, and the side effect in question
 // is a signal to a process this run did not start.
 func TestCleanCheckRefusesAHostWhoseLeftoverThisUserCannotEnd(t *testing.T) {
+	noRuntime(t)
 	survivor := machine.DHCPLeftover{
 		PID:            612421,
 		Interface:      "fnt-99109f524b2",
@@ -234,6 +235,7 @@ func TestCleanCheckRefusesAHostWhoseLeftoverThisUserCannotEnd(t *testing.T) {
 // A doorstep that fired on a host nothing was going to fail on is a doorstep
 // somebody disarms, which is the failure mode this whole issue is about.
 func TestCleanCheckPassesWhenTheSweepItselfWouldClearThem(t *testing.T) {
+	noRuntime(t)
 	swapLeftoverSeams(t,
 		func() ([]machine.DHCPLeftover, error) { return []machine.DHCPLeftover{aLeftover}, nil },
 		func(machine.DHCPLeftover) error { t.Fatal("a check signalled a process"); return nil })
@@ -256,6 +258,7 @@ func TestCleanCheckPassesWhenTheSweepItselfWouldClearThem(t *testing.T) {
 // fine" and "never looked" must not read the same, and the caller of this one
 // is a shell guard whose only alternative to reading it is assuming.
 func TestCleanCheckSaysSoOnAHostWithNothingLeftBehind(t *testing.T) {
+	noRuntime(t)
 	swapLeftoverSeams(t,
 		func() ([]machine.DHCPLeftover, error) { return nil, nil },
 		func(machine.DHCPLeftover) error { t.Fatal("a check signalled a process"); return nil })

--- a/internal/cli/testdata/frozen/cli.json
+++ b/internal/cli/testdata/frozen/cli.json
@@ -2590,6 +2590,195 @@
           ]
         }
       }
+    },
+    {
+      "schema_version": 17,
+      "content": {
+        "exit_codes": {
+          "drift": 2,
+          "error": 1,
+          "ok": 0
+        },
+        "verbs": {
+          "catalog": [
+            "--format"
+          ],
+          "clean": [
+            "--check",
+            "--doorstep",
+            "--force",
+            "--format",
+            "--vm"
+          ],
+          "corpus": [
+            "--accepted",
+            "--against-cloud",
+            "--bind",
+            "--check",
+            "--credential",
+            "--dir",
+            "--dry-run",
+            "--endpoint",
+            "--file",
+            "--format",
+            "--mark-stale",
+            "--timeout"
+          ],
+          "coverage": [
+            "--artefact",
+            "--axis",
+            "--baseline",
+            "--contract",
+            "--evidence",
+            "--fail-on-unknown",
+            "--format",
+            "--gaps",
+            "--observed",
+            "--products",
+            "--provider",
+            "--sdk",
+            "--write-baseline"
+          ],
+          "docs": [
+            "--check",
+            "--client-pins",
+            "--confidence",
+            "--contracts",
+            "--coverage",
+            "--file",
+            "--install",
+            "--limits",
+            "--proved",
+            "--routes",
+            "--screenshots",
+            "--ui-manifest",
+            "--workflow"
+          ],
+          "doctor": [
+            "--addr",
+            "--vm"
+          ],
+          "env": [
+            "--client",
+            "--endpoint",
+            "--shell",
+            "--unset"
+          ],
+          "evidence": [
+            "--allow-narrowing",
+            "--contracts",
+            "--endpoint",
+            "--join",
+            "--out",
+            "--reshape",
+            "--shapes",
+            "--suites"
+          ],
+          "images": [
+            "--check",
+            "--only",
+            "--vm"
+          ],
+          "logs": [
+            "--addr",
+            "-f",
+            "-n"
+          ],
+          "probe": [
+            "--contracts",
+            "--endpoint",
+            "--provider"
+          ],
+          "proxy": [
+            "--addr",
+            "--expose-to-network",
+            "--forward",
+            "--intercept",
+            "--max-body",
+            "--provider",
+            "--queue",
+            "--record",
+            "--upstream"
+          ],
+          "replay": [
+            "--endpoint",
+            "--format",
+            "--refusals-only",
+            "--timeout"
+          ],
+          "restart": [
+            "--addr",
+            "--timeout"
+          ],
+          "serve": [
+            "--addr",
+            "--cleanup",
+            "--contracts",
+            "--coverage",
+            "--expose-to-network",
+            "--log-level",
+            "--shapes",
+            "--state",
+            "--vm"
+          ],
+          "shapes": [
+            "--check",
+            "--dir",
+            "--dry-run",
+            "--profile",
+            "--provider",
+            "--record"
+          ],
+          "snapshot list": [
+            "--format"
+          ],
+          "snapshot load": [
+            "--addr"
+          ],
+          "snapshot save": [
+            "--addr",
+            "--force"
+          ],
+          "start": [
+            "--addr",
+            "--cleanup",
+            "--contracts",
+            "--detach",
+            "--foreground",
+            "--log-level",
+            "--state",
+            "--timeout",
+            "--vm"
+          ],
+          "status": [
+            "--addr",
+            "--coverage",
+            "--format"
+          ],
+          "stop": [
+            "--addr",
+            "--timeout"
+          ],
+          "transcript": [
+            "--against",
+            "--contract",
+            "--format",
+            "--sanitise",
+            "--shape"
+          ],
+          "ui": [
+            "--addr",
+            "--print"
+          ],
+          "version": [
+            "--check"
+          ],
+          "wait": [
+            "--addr",
+            "--timeout"
+          ]
+        }
+      }
     }
   ]
 }

--- a/internal/core/machine/incus.go
+++ b/internal/core/machine/incus.go
@@ -1235,9 +1235,14 @@ func leftoverHolds(leftover DHCPLeftover, block netip.Prefix) bool {
 //
 // A peering counts as "in use" too, and that one is not the client's business:
 // the emulator created it, so it goes first, and only then is a remaining
-// refusal a real dependency. The retry is deliberate — dropping the peers of a
-// network whose machines block the delete anyway would still be undone by the
-// next reconciliation, so nothing is lost by trying.
+// refusal a real dependency. Dropping the peers of a network whose machines
+// block the delete anyway would still be undone by the next reconciliation, so
+// nothing is lost by doing it up front — and doing it up front is what stops
+// this path from manufacturing the trap of #455 on the operator's station.
+//
+// A rule set counts as "in use" too, in both directions at once, and that cycle
+// has exactly one exit: detach, delete, and put the attachment back if the
+// delete still refuses.
 func (d *Incus) RemoveNetwork(ctx context.Context, name string) error {
 	// Ours, or nothing happens. This path had no check at all, not even safeName,
 	// and a restored state names the network it deletes.
@@ -1266,19 +1271,41 @@ func (d *Incus) RemoveNetwork(ctx context.Context, name string) error {
 			block = prefix.Masked().String()
 		}
 	}
+	// Both halves of every peering, and *before* the delete rather than on the
+	// refusal it may or may not produce. The half on the surviving target is the
+	// one that matters: the runtime's schema cascades a peer row's reference to
+	// its source network and not the one to its target, so a delete that
+	// succeeds while a neighbour still holds a half pointing here leaves that
+	// neighbour holding an id which resolves to nothing — and from then on the
+	// neighbour refuses every management path, the peer delete that would repair
+	// it included (#455). Doing it only on the "in use" retry would bet the
+	// station on peerings always making a network undeletable.
+	//
+	// Nothing is lost when the delete then fails on a machine still running: the
+	// reconciliation PeerNetworks performs restores the halves of a network that
+	// stays, which is the same reason the retry below was already allowed to
+	// drop them.
+	// TestRemoveNetworkDeletesTheSurvivingHalfOfItsPeerings fails without it.
+	if d.OVN {
+		d.dropPeerings(ctx, name)
+	}
 	if _, err := d.run(ctx, "network", "delete", name); err != nil {
 		if isNotFound(err) {
 			return d.afterNetworkDelete(ctx, name, block)
 		}
-		if d.OVN && strings.Contains(strings.ToLower(err.Error()), "in use") {
-			if peers, peersErr := d.networkPeers(ctx, name); peersErr == nil && len(peers) > 0 {
-				for _, peer := range peers {
-					_, _ = d.run(ctx, "network", "peer", "delete", name, peer.Name)
-				}
-				if _, err := d.run(ctx, "network", "delete", name); err == nil || isNotFound(err) {
-					return d.afterNetworkDelete(ctx, name, block)
-				}
+		if strings.Contains(strings.ToLower(err.Error()), "in use") {
+			// The rule set attached to the network holds it, and the network
+			// holds the rule set: "The network is currently in use" one way,
+			// "Cannot delete an ACL that is in use" the other, and detaching is
+			// the only order Incus accepts. Put back if the delete still fails,
+			// so a network that survives is never left with its isolation
+			// silently off.
+			// TestRemoveNetworkDetachesTheRuleSetThatHoldsIt fails without it.
+			reattach := d.detachRuleSets(ctx, name)
+			if _, retry := d.run(ctx, "network", "delete", name); retry == nil || isNotFound(retry) {
+				return d.afterNetworkDelete(ctx, name, block)
 			}
+			reattach(ctx)
 		}
 		return fmt.Errorf("delete network %s: %w", name, err)
 	}

--- a/internal/core/machine/incus_ovn.go
+++ b/internal/core/machine/incus_ovn.go
@@ -198,32 +198,36 @@ func (d *Incus) adoptUplink(ctx context.Context, config map[string]string) error
 
 // liveDelegations lists the blocks that must stay delegated to the uplink: the
 // block of every labelled OVN network still attached to it.
+//
+// It shares its reading with ovnNetworksOnUplink (incus_traps.go), which needs
+// the same list with the names kept. Two readings of "which of our networks
+// draw from this uplink" would drift apart, and the sweep now depends on the
+// two agreeing: it restores what the adopt would have kept.
 func (d *Incus) liveDelegations(ctx context.Context) ([]string, error) {
-	out, err := d.run(ctx, "query", "/1.0/networks?recursion=1")
+	views, err := d.networkViews(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("list networks to adopt uplink %s: %w", d.uplinkName(), err)
+		return nil, fmt.Errorf("adopt uplink %s: %w", d.uplinkName(), err)
 	}
-	var items []struct {
-		Name   string            `json:"name"`
-		Type   string            `json:"type"`
-		Config map[string]string `json:"config"`
+	networks := d.ovnNetworksOnUplink(views)
+	kept := make([]string, 0, len(networks))
+	for _, network := range networks {
+		kept = append(kept, network.Block)
 	}
-	if err := json.Unmarshal(out, &items); err != nil {
-		return nil, fmt.Errorf("decode networks to adopt uplink %s: %w", d.uplinkName(), err)
-	}
-	var kept []string
-	for _, item := range items {
-		if item.Type != "ovn" || item.Config["user."+LabelKey] == "" ||
-			item.Config["network"] != d.uplinkName() {
-			continue
-		}
-		prefix, err := netip.ParsePrefix(item.Config["ipv4.address"])
-		if err != nil {
-			continue
-		}
-		kept = append(kept, prefix.Masked().String())
+	if len(kept) == 0 {
+		return nil, nil
 	}
 	return kept, nil
+}
+
+// maskedBlock renders an address with its prefix length as the block it sits
+// in, which is the form the uplink's ipv4.routes carries: 10.2.4.1/24 is the
+// gateway of 10.2.4.0/24, and it is the block that must be delegated.
+func maskedBlock(address string) (string, error) {
+	prefix, err := netip.ParsePrefix(address)
+	if err != nil {
+		return "", err
+	}
+	return prefix.Masked().String(), nil
 }
 
 // holderIsAlive reports that the pid recorded on the uplink still belongs to a

--- a/internal/core/machine/incus_peering_test.go
+++ b/internal/core/machine/incus_peering_test.go
@@ -1,0 +1,335 @@
+package machine
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// The ordering discipline that stops a sweep from trapping its own host (#455).
+//
+// What was measured. Fifteen third-party stacks replayed under --vm incus-ovn
+// left two OVN networks, two rule sets and the uplink on the maintainer's
+// station, and *no* incus command could remove any of them. The eraser was not
+// the next run: it was the sweep, three times over.
+//
+//  1. Prune treated feint-uplink as an ordinary network — it carries the same
+//     label — and unset its ipv4.routes before a delete that then failed. From
+//     that instant every management path of the OVN networks drawing from it
+//     answered "Uplink network doesn't contain 10.2.4.0/24 in its routes".
+//  2. Nothing detached security.acls before deleting a network, so the rule set
+//     and the network held each other with no exit.
+//  3. Nothing removed the half a peering leaves on its surviving target, so a
+//     network deleted while a neighbour still pointed at it left that neighbour
+//     holding an id resolving to nothing — permanently unmanageable, because the
+//     runtime's schema cascades two of that table's three references and not
+//     the one to the target.
+
+// peeredWorld is one OVN network of the emulator's, peered with another of its
+// own and with a network an operator created, sitting on the uplink.
+func peeredWorld() map[string]string {
+	world := pruneWorld()
+	world["/1.0/networks?recursion=1"] = `[
+	  {"name": "fnt-aaaa", "project": "default", "type": "ovn",
+	   "config": {"user.feint.provider": "scaleway", "network": "feint-uplink",
+	              "ipv4.address": "10.2.4.1/24", "security.acls": "iso-fnt-aaaa"}},
+	  {"name": "feint-uplink", "project": "default", "type": "bridge",
+	   "config": {"user.feint.provider": "feint", "ipv4.routes": "10.2.4.0/24"}},
+	  {"name": "incusbr0", "project": "default", "type": "bridge", "config": {}}
+	]`
+	world["/1.0/networks/fnt-aaaa/peers?recursion=1"] = `[
+	  {"name": "fnt-bbbb", "target_network": "fnt-bbbb"},
+	  {"name": "incusbr0", "target_network": "incusbr0"}
+	]`
+	world["network get feint-uplink ipv4.routes"] = "10.2.4.0/24\n"
+	world["network get fnt-aaaa security.acls"] = "iso-fnt-aaaa\n"
+	// The label on the far end of the peering. Stated rather than defaulted,
+	// because whether the target carries it is the whole question ownsPeerTarget
+	// asks, and a fixture that answered "ours" for every name would make the
+	// refusal below unmeasurable.
+	world["network get fnt-bbbb user."] = "scaleway\n"
+	return world
+}
+
+// TestPruneNeverStripsTheUplinkRoutesWhileItsNetworksStand is the first of the
+// three, and the one that made the residue permanent rather than merely untidy.
+//
+// The fixture is the measured shape: an OVN network that refuses to go, and the
+// uplink it draws from. Before the fix the sweep unset the uplink's routes on
+// its way past, the delete of the uplink then failed on "in use", and the
+// orphan could no longer be edited by anything at all.
+func TestPruneNeverStripsTheUplinkRoutesWhileItsNetworksStand(t *testing.T) {
+	f := &fakeRuntime{answers: peeredWorld(), fail: map[string]error{
+		"network delete fnt-aaaa": errors.New("Error: The network is currently in use"),
+	}}
+	d := ovnDriver(f)
+
+	if _, err := d.Prune(context.Background()); err == nil {
+		t.Fatal("a network the runtime refused to delete was reported as swept")
+	}
+	for _, cmd := range f.commands() {
+		if strings.Contains(cmd, "unset feint-uplink ipv4.routes") {
+			t.Errorf("the sweep stripped the uplink's routes: %q\n"+
+				"every management path of the networks still drawing from it now fails validation", cmd)
+		}
+	}
+	// And the accepting half: a rule set detached on the way to a delete that
+	// then failed must go back on, or the sweep has disarmed a firewall on a
+	// network which is still standing.
+	if len(f.matching("network set fnt-aaaa security.acls iso-fnt-aaaa")) == 0 {
+		t.Errorf("the rule set was detached and never put back after the delete failed; the driver ran:\n%s",
+			strings.Join(f.commands(), "\n"))
+	}
+}
+
+// The other direction: with nothing left drawing from it, the uplink is swept
+// like everything else. A sweep that spared it would leave a bridge holding a
+// block on every station that ever ran --vm incus-ovn.
+func TestPruneStillRemovesTheUplinkOnceItsNetworksAreGone(t *testing.T) {
+	f := &fakeRuntime{answers: peeredWorld()}
+	d := ovnDriver(f)
+
+	pruned, err := d.Prune(context.Background())
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if len(f.matching("network delete feint-uplink")) != 1 {
+		t.Fatalf("the uplink was never removed; the driver ran:\n%s", strings.Join(f.commands(), "\n"))
+	}
+	if pruned.Networks != 2 {
+		t.Errorf("swept %d network(s), want the OVN network and the uplink", pruned.Networks)
+	}
+	// Last, after the network drawing from it: the other order is the one Incus
+	// refuses, and it is what put the sweep in the state above.
+	commands := f.commands()
+	var deletedNetwork, deletedUplink int
+	for i, cmd := range commands {
+		switch {
+		case strings.Contains(cmd, "network delete fnt-aaaa"):
+			deletedNetwork = i
+		case strings.Contains(cmd, "network delete feint-uplink"):
+			deletedUplink = i
+		}
+	}
+	if deletedUplink < deletedNetwork {
+		t.Errorf("the uplink went before the network drawing from it:\n%s", strings.Join(commands, "\n"))
+	}
+}
+
+// TestPruneDropsTheSurvivingHalfOfEveryPeering is the third lock, and the one
+// that manufactures the state nothing can repair.
+func TestPruneDropsTheSurvivingHalfOfEveryPeering(t *testing.T) {
+	f := &fakeRuntime{answers: peeredWorld()}
+	d := ovnDriver(f)
+
+	if _, err := d.Prune(context.Background()); err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if len(f.matching("network peer delete fnt-bbbb fnt-aaaa")) == 0 {
+		t.Fatalf("the half of the peering living on the surviving target was left behind; the driver ran:\n%s\n"+
+			"that row holds an id, so recreating the network under the same name does not satisfy it",
+			strings.Join(f.commands(), "\n"))
+	}
+}
+
+// TestPruneRefusesToTouchAPeeringHalfOnAForeignNetwork is the guard on the new
+// command, and it is needed because the target's name comes out of the runtime
+// and becomes an argument aimed at *another* network.
+//
+// `incusbr0` is well formed, and that was the whole problem the last time this
+// distinction was missed: an audit obtained `incus network delete incusbr0`
+// from a name that passed every syntactic check there was.
+func TestPruneRefusesToTouchAPeeringHalfOnAForeignNetwork(t *testing.T) {
+	f := &fakeRuntime{answers: peeredWorld()}
+	d := ovnDriver(f)
+
+	if _, err := d.Prune(context.Background()); err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	for _, cmd := range f.commands() {
+		if strings.Contains(cmd, "peer delete incusbr0") {
+			t.Errorf("the sweep reached into a peering on the host's own bridge: %q", cmd)
+		}
+	}
+}
+
+// The rule set and its network hold each other, and detaching is the only order
+// Incus accepts. Before this, the sweep just retried `acl delete` twice and
+// reported both stuck.
+func TestPruneDetachesTheRuleSetHoldingANetwork(t *testing.T) {
+	f := &fakeRuntime{answers: peeredWorld()}
+	d := ovnDriver(f)
+
+	if _, err := d.Prune(context.Background()); err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	detach := -1
+	remove := -1
+	for i, cmd := range f.commands() {
+		switch {
+		case strings.Contains(cmd, "network unset fnt-aaaa security.acls"):
+			detach = i
+		case strings.Contains(cmd, "network delete fnt-aaaa"):
+			remove = i
+		}
+	}
+	if detach < 0 {
+		t.Fatalf("the rule set was never detached; the driver ran:\n%s", strings.Join(f.commands(), "\n"))
+	}
+	if remove < detach {
+		t.Errorf("the delete came before the detach, which is the order Incus refuses:\n%s",
+			strings.Join(f.commands(), "\n"))
+	}
+}
+
+// A host a previous sweep already stripped is repaired by the next one, with no
+// privilege at all: the block goes back on the uplink before anything is asked
+// of the network carrying it. This is the manual step that measurably freed one
+// of the two stuck rule sets on the maintainer's station.
+func TestPruneRestoresABlockTheUplinkLost(t *testing.T) {
+	world := peeredWorld()
+	world["network get feint-uplink ipv4.routes"] = "\n"
+	f := &fakeRuntime{answers: world}
+	d := ovnDriver(f)
+
+	if _, err := d.Prune(context.Background()); err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	restore := -1
+	detach := -1
+	for i, cmd := range f.commands() {
+		switch {
+		case strings.Contains(cmd, "network set feint-uplink ipv4.routes=10.2.4.0/24"):
+			restore = i
+		case strings.Contains(cmd, "network unset fnt-aaaa security.acls"):
+			detach = i
+		}
+	}
+	if restore < 0 {
+		t.Fatalf("the sweep never put the missing block back, so every edit of fnt-aaaa still fails:\n%s",
+			strings.Join(f.commands(), "\n"))
+	}
+	if detach >= 0 && detach < restore {
+		t.Errorf("the detach was attempted before the block came back, which is the call that fails:\n%s",
+			strings.Join(f.commands(), "\n"))
+	}
+}
+
+// TestRemoveNetworkDeletesTheSurvivingHalfOfItsPeerings is the same third lock
+// on the ordinary teardown path, where the client asks for the delete.
+//
+// Before the delete rather than after a refusal: a delete that *succeeds* while
+// a neighbour still points here is exactly what leaves the neighbour holding an
+// id that resolves to nothing.
+func TestRemoveNetworkDeletesTheSurvivingHalfOfItsPeerings(t *testing.T) {
+	f := &fakeRuntime{answers: map[string]string{
+		"/1.0/networks/fnt-aaaa/peers?recursion=1": `[
+		  {"name": "fnt-bbbb", "target_network": "fnt-bbbb"},
+		  {"name": "incusbr0", "target_network": "incusbr0"}
+		]`,
+		"network get fnt-aaaa ipv4.address": "10.2.4.1/24\n",
+		"network get fnt-bbbb user.":        "scaleway\n",
+	}}
+	d := ovnDriver(f)
+
+	if err := d.RemoveNetwork(context.Background(), "fnt-aaaa"); err != nil {
+		t.Fatalf("remove network: %v", err)
+	}
+	drop := -1
+	remove := -1
+	for i, cmd := range f.commands() {
+		switch {
+		case strings.Contains(cmd, "network peer delete fnt-bbbb fnt-aaaa"):
+			drop = i
+		case strings.Contains(cmd, "network delete fnt-aaaa"):
+			remove = i
+		}
+	}
+	if drop < 0 {
+		t.Fatalf("the half on the surviving target was left holding an id that no longer resolves:\n%s",
+			strings.Join(f.commands(), "\n"))
+	}
+	if remove < drop {
+		t.Errorf("the network went before the half pointing at it, which is what makes the row dangle:\n%s",
+			strings.Join(f.commands(), "\n"))
+	}
+	// The same guard as the sweep: an operator's bridge on the far end of a
+	// peering is not this code's to reconfigure.
+	for _, cmd := range f.commands() {
+		if strings.Contains(cmd, "peer delete incusbr0") {
+			t.Errorf("the teardown reached into a peering on the host's own bridge: %q", cmd)
+		}
+	}
+}
+
+// And the rule set half of the same path, with the restore that keeps a network
+// which survives from losing its isolation in silence.
+func TestRemoveNetworkDetachesTheRuleSetThatHoldsIt(t *testing.T) {
+	f := &fakeRuntime{
+		answers: map[string]string{
+			"network get fnt-aaaa security.acls": "iso-fnt-aaaa\n",
+			"network get fnt-aaaa ipv4.address":  "10.2.4.1/24\n",
+		},
+		fail: map[string]error{
+			"network delete fnt-aaaa": errors.New("Error: The network is currently in use"),
+		},
+	}
+	d := newFakeDriver(f)
+
+	if err := d.RemoveNetwork(context.Background(), "fnt-aaaa"); err == nil {
+		t.Fatal("a network the runtime refuses to delete was reported as removed")
+	}
+	if len(f.matching("network unset fnt-aaaa security.acls")) == 0 {
+		t.Fatalf("the rule set holding the network was never detached; the driver ran:\n%s",
+			strings.Join(f.commands(), "\n"))
+	}
+	// The accepting half, and the one that matters most here: the delete still
+	// failed, so the network is standing, and a standing network whose rule set
+	// this code silently took off is a firewall disarmed.
+	if len(f.matching("network set fnt-aaaa security.acls iso-fnt-aaaa")) == 0 {
+		t.Errorf("a network that survived the delete was left with its isolation off:\n%s",
+			strings.Join(f.commands(), "\n"))
+	}
+}
+
+// TestPruneRefusesAPeeringHalfOnAStrangersNetworkNamedLikeOurs is the guard one
+// level below the one above, and it is the one a name check cannot answer.
+//
+// `incusbr0` is refused by the prefix. `fnt-lab` is not: it is well formed, it
+// carries the prefix NetworkName writes, and it belongs to somebody else — an
+// operator who created an OVN network under that name and peered it with one of
+// ours by hand. "fnt-" is a prefix anybody may type, which is the maintainer's
+// own sentence about the database repair of #455, and this reach is of the same
+// family: a destructive command aimed at a network that is not the one being
+// removed.
+//
+// So the label EnsureNetwork wrote decides, and nothing else can.
+func TestPruneRefusesAPeeringHalfOnAStrangersNetworkNamedLikeOurs(t *testing.T) {
+	world := peeredWorld()
+	world["/1.0/networks/fnt-aaaa/peers?recursion=1"] = `[
+	  {"name": "fnt-lab", "target_network": "fnt-lab"}
+	]`
+	// The stranger's network answers the ownership probe with nothing: it was
+	// never created by this emulator, so it carries no label of ours.
+	world["network get fnt-lab user."] = ""
+	f := &fakeRuntime{answers: world}
+	d := ovnDriver(f)
+
+	if _, err := d.Prune(context.Background()); err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	for _, cmd := range f.commands() {
+		if strings.Contains(cmd, "peer delete fnt-lab") {
+			t.Errorf("the sweep reconfigured a peering on a network nobody here created: %q\n"+
+				"the name carries our prefix and the network is not ours; only the label says so", cmd)
+		}
+	}
+	// The accepting half stays measured in the same run: our own side of that
+	// peering is still withdrawn, or a network of ours would keep a half nothing
+	// ever removes.
+	if len(f.matching("network peer delete fnt-aaaa fnt-lab")) == 0 {
+		t.Errorf("our own half of the peering was left behind; the driver ran:\n%s",
+			strings.Join(f.commands(), "\n"))
+	}
+}

--- a/internal/core/machine/incus_prune.go
+++ b/internal/core/machine/incus_prune.go
@@ -35,26 +35,70 @@ func (d *Incus) Prune(ctx context.Context) (Pruned, error) {
 	if err != nil {
 		return pruned, err
 	}
-	// Two passes rather than a dependency order: an OVN network must go before
-	// the uplink it draws from, and the list carries no such order. The first
-	// pass removes everything removable, the second retries what was only
-	// blocked by a neighbour still standing in the first.
-	remaining := networks
+	// The uplink is not an ordinary network, and treating it as one is what made
+	// #455 permanent. It carries the label like everything else, so it was in
+	// this list, and the loop below unset its ipv4.routes before a delete that
+	// then failed because the orphans were still attached. From that instant
+	// every management path of those orphans fails validation — "Uplink network
+	// doesn't contain 10.2.4.0/24 in its routes" — which is the detach they
+	// needed in order to go. The sweep was the eraser, not the next run.
+	//
+	// So it leaves the ordinary path entirely, its routes are never unset, and
+	// it is deleted last, when the networks drawing from it are gone and its
+	// routes go with the object.
+	// TestPruneNeverStripsTheUplinkRoutesWhileItsNetworksStand fails without it.
+	uplink := d.uplinkName()
+	ordinary := make([]string, 0, len(networks))
+	uplinkPresent := false
+	for _, name := range networks {
+		if name == uplink {
+			uplinkPresent = true
+			continue
+		}
+		ordinary = append(ordinary, name)
+	}
+
+	// And the repair of a host a previous sweep already stripped, which needs no
+	// privilege: a network whose block the uplink no longer carries refuses
+	// every update, so the block goes back before anything is asked of it. This
+	// is the manual step that measurably freed one of the two stuck rule sets on
+	// the maintainer's station, automated.
+	//
+	// Not gated on d.OVN: the issue's own reproduction sweeps the trapped host
+	// with `feint clean --vm incus`, and whether the uplink is stripped is a
+	// fact about the host rather than about the mode this process runs in.
+	if uplinkPresent {
+		if err := d.restoreDelegations(ctx); err != nil {
+			failures = append(failures, fmt.Sprintf("uplink %s: %v", uplink, err))
+		}
+	}
+
+	// Two passes rather than a dependency order: a network peered with another
+	// may still be held when its turn comes, and the list carries no such order.
+	// The first pass removes everything removable, the second retries what was
+	// only blocked by a neighbour still standing in the first.
+	remaining := ordinary
 	for pass := 0; pass < 2 && len(remaining) > 0; pass++ {
 		var blocked []string
 		for _, name := range remaining {
-			// Routed addresses, forwards and peerings keep a network alive;
-			// all three are the emulator's own doing, so they go with it.
+			// Peerings, rule sets, routed addresses and forwards all keep a
+			// network alive; all four are the emulator's own doing, so they go
+			// with it — and the order below is the only one Incus accepts.
+			d.dropPeerings(ctx, name)
+			// The rule set and its network hold each other: the rule set is "in
+			// use" by the network and the network is "in use" by the rule set,
+			// and deleting in either order is refused. Detaching first is the
+			// escape, and nothing did it — the ACL loop below just retried the
+			// delete twice and reported it stuck. Put back when the delete then
+			// fails, because a network that survives with its rule set detached
+			// is a firewall disarmed rather than a subnet swept.
+			reattach := d.detachRuleSets(ctx, name)
 			_, _ = d.run(ctx, "network", "unset", name, "ipv4.routes")
 			for _, listen := range d.forwardsOf(ctx, name) {
 				_, _ = d.run(ctx, "network", "forward", "delete", name, listen)
 			}
-			if peers, err := d.networkPeers(ctx, name); err == nil {
-				for _, peer := range peers {
-					_, _ = d.run(ctx, "network", "peer", "delete", name, peer.Name)
-				}
-			}
 			if _, err := d.run(ctx, "network", "delete", name); err != nil && !isNotFound(err) {
+				reattach(ctx)
 				if pass == 0 {
 					blocked = append(blocked, name)
 				} else {
@@ -65,6 +109,17 @@ func (d *Incus) Prune(ctx context.Context) (Pruned, error) {
 			pruned.Networks++
 		}
 		remaining = blocked
+	}
+
+	if uplinkPresent {
+		for _, listen := range d.forwardsOf(ctx, uplink) {
+			_, _ = d.run(ctx, "network", "forward", "delete", uplink, listen)
+		}
+		if _, err := d.run(ctx, "network", "delete", uplink); err != nil && !isNotFound(err) {
+			failures = append(failures, fmt.Sprintf("network %s: %v", uplink, err))
+		} else {
+			pruned.Networks++
+		}
 	}
 
 	// Rule sets carry no config of their own, so they are recognised by the
@@ -187,4 +242,115 @@ func (d *Incus) ownedACLs(ctx context.Context) []string {
 		}
 	}
 	return names
+}
+
+// dropPeerings removes both halves of every peering a network holds.
+//
+// The second half is the whole point, and nothing did it before #455. Peer rows
+// name their target by *id*, and the runtime's schema cascades the reference to
+// the source network but not the one to the target: delete network B and the
+// row on A survives, holding an id that resolves to nothing. A then refuses
+// every management path — including the peer delete that would remove the row —
+// so A, the rule set attached to it and the uplink they sit on are permanent by
+// every means a user has. Recreating B under the same name does not satisfy it
+// either, which is what proves the reference is an id.
+//
+// The target-side half is named after this network, because ensurePeerHalf
+// declares each half under the name of its target.
+//
+// The target's name comes from the runtime and becomes the argument of a
+// destructive command aimed at *another* network, so it answers both questions
+// before it is used: well formed, and one of the emulator's own. A peering an
+// operator made by hand between one of our networks and one of theirs would
+// otherwise have this delete a peering on theirs.
+// TestPruneRefusesToTouchAPeeringHalfOnAForeignNetwork fails without the check.
+func (d *Incus) dropPeerings(ctx context.Context, network string) {
+	peers, err := d.networkPeers(ctx, network)
+	if err != nil {
+		return
+	}
+	for _, peer := range peers {
+		if d.ownsPeerTarget(ctx, peer.Target) {
+			_, _ = d.run(ctx, "network", "peer", "delete", peer.Target, network)
+		}
+		_, _ = d.run(ctx, "network", "peer", "delete", network, peer.Name)
+	}
+}
+
+// ownsPeerTarget decides whether the network on the far end of a peering may be
+// reconfigured by this sweep, and it asks the label rather than stopping at the
+// name.
+//
+// The prefix is necessary and it is not the answer. `fnt-` is a prefix anybody
+// may type, which is the maintainer's own sentence about the database repair in
+// #455 — and the reach here is of the same family, a destructive command aimed
+// at a network that is *not* the one being removed. An operator whose own OVN
+// network happens to be called `fnt-lab` and who peered it with one of ours by
+// hand would otherwise have this delete a peering on theirs, from a check that
+// looked thorough because it had three clauses.
+//
+// So the cheap questions come first and refuse without a round trip — form, then
+// the prefix NetworkName writes — and mustOwn reads the label EnsureNetwork
+// wrote, which is the only one of the three that cannot be typed by somebody
+// else. A target that has already gone answers no, which is right: there is no
+// half left on a network that no longer exists.
+// TestPruneRefusesAPeeringHalfOnAStrangersNetworkNamedLikeOurs fails without
+// the label, and TestPruneDropsTheSurvivingHalfOfEveryPeering fails if it
+// refuses our own.
+func (d *Incus) ownsPeerTarget(ctx context.Context, target string) bool {
+	if target == "" || !safeName.MatchString(target) || !ownedNetwork(target) {
+		return false
+	}
+	return d.mustOwn(ctx, target) == nil
+}
+
+// detachRuleSets takes a network's rule sets off it and returns what puts them
+// back. An empty attachment, or a read that fails, gives a no-op: this exists to
+// break a deadlock, not to reconfigure anything on the way past.
+//
+// The restore matters as much as the detach. `network unset <net> security.acls`
+// is the primitive an audit used to disarm a firewall rather than isolate a
+// subnet, and a delete that then fails would leave exactly that state on a
+// network which is still standing.
+func (d *Incus) detachRuleSets(ctx context.Context, network string) func(context.Context) {
+	nothing := func(context.Context) {}
+	out, err := d.run(ctx, "network", "get", network, "security.acls")
+	if err != nil {
+		return nothing
+	}
+	attached := strings.TrimSpace(string(out))
+	if attached == "" {
+		return nothing
+	}
+	if _, err := d.run(ctx, "network", "unset", network, "security.acls"); err != nil {
+		return nothing
+	}
+	return func(ctx context.Context) {
+		_, _ = d.run(ctx, "network", "set", network, "security.acls", attached)
+	}
+}
+
+// restoreDelegations puts back the block of every labelled OVN network still
+// drawing from the uplink.
+//
+// It is the automated form of the one manual step that measurably freed a
+// trapped station (#455): with the block absent from the uplink's ipv4.routes,
+// the runtime refuses every update of the network carrying it, so nothing can
+// detach its rule set, remove its peerings or delete it. Idempotent — a block
+// already delegated is left alone, and every write to the uplink makes the
+// runtime rebuild its firewall chains.
+func (d *Incus) restoreDelegations(ctx context.Context) error {
+	d.uplinkMu.Lock()
+	defer d.uplinkMu.Unlock()
+
+	kept, err := d.liveDelegations(ctx)
+	if err != nil {
+		return err
+	}
+	for _, block := range kept {
+		if err := d.addUplinkRoute(ctx, block); err != nil {
+			return fmt.Errorf("restore %s on uplink %s: %w", block, d.uplinkName(), err)
+		}
+	}
+	return nil
 }

--- a/internal/core/machine/incus_traps.go
+++ b/internal/core/machine/incus_traps.go
@@ -1,0 +1,475 @@
+package machine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// What holds an Incus host that this emulator's own sweep cannot get out of,
+// and the single repair that needs more than an ordinary command. The neutral
+// contract is in prune.go.
+//
+// The measurement is #455, and the cause is three lines of the runtime's own
+// schema. `networks_peers` carries three references; two cascade and one does
+// not:
+//
+//	network_id INTEGER NOT NULL,
+//	  FOREIGN KEY (network_id) REFERENCES "networks" (id) ON DELETE CASCADE
+//	target_network_integration_id INTEGER ... ON DELETE CASCADE
+//	target_network_id INTEGER NULL          -- no foreign key, no cascade
+//
+// Delete the source network and the row goes with it. Delete the *target* and
+// the row survives, holding a `target_network_id` that resolves to nothing and
+// a `target_network_name` that is NULL. From that moment every operation on the
+// source network fails on "Failed loading target network: Network not found" —
+// `peer delete`, `network unset security.acls`, `acl delete`, `network delete`.
+// `incus network peer edit` cannot repair it either: it returns 0 and persists
+// nothing, the target fields being immutable after creation. Verified on Incus
+// 7.2, and 7.3's changelog carries nothing that touches peer rows.
+//
+// So the row is beyond every command the runtime offers, and the only supported
+// way to reach it is `incus admin sql`, which is the runtime's own mechanism
+// for exactly this and not an edit of a file behind its back.
+//
+// Prevention is elsewhere and it is the real fix: RemoveNetwork and Prune now
+// drop the half a peering leaves on its surviving target *before* deleting a
+// network, which is what manufactures the dangling row. This file is for the
+// stations already carrying one.
+
+// sqlSelect runs one read against the runtime's global database and returns the
+// rows positionally, in the order the SELECT names its columns.
+//
+// Positional rather than by column name: two columns of the same name collapse
+// in the answer's `columns` array, and a reader keyed on names would silently
+// take the wrong one. Every query in this file is a constant with no
+// interpolation at all, so there is nothing for a name to be smuggled through.
+func (d *Incus) sqlSelect(ctx context.Context, query string) ([][]any, error) {
+	out, err := d.run(ctx, "admin", "sql", "global", query, "--format", "json")
+	if err != nil {
+		return nil, fmt.Errorf("read the runtime database: %w", err)
+	}
+	var answer struct {
+		Type string  `json:"type"`
+		Rows [][]any `json:"rows"`
+	}
+	if err := json.Unmarshal(out, &answer); err != nil {
+		return nil, fmt.Errorf("decode the runtime database answer: %w", err)
+	}
+	return answer.Rows, nil
+}
+
+// The three reads a dangling-peer survey needs. Constants, because a query
+// built from a value is the one shape this repository refuses to write.
+const (
+	// Every peering row, whatever project it belongs to and whoever made it.
+	// Ownership is decided afterwards, against the label the emulator wrote,
+	// never here: a WHERE clause on a name would be the "well-formed is not
+	// authorised" mistake with a database behind it.
+	peerRowsSQL = "SELECT id, network_id, name, target_network_id, " +
+		"target_network_project, target_network_name, description, type FROM networks_peers"
+	// The id of every network that still exists, in every project: a target
+	// living in another project is a target that still resolves, so the row is
+	// not dangling and is none of this code's business.
+	networkIDsSQL = "SELECT id FROM networks"
+	// The name and project of every network, so a row's network_id can be
+	// matched against the labelled networks the API names.
+	networkNamesSQL = "SELECT networks.id, projects.name, networks.name " +
+		"FROM networks, projects WHERE projects.id = networks.project_id"
+)
+
+// networkRef is a network as both halves of this file can name it: the API
+// answers a project and a name, the database answers an id and the same pair.
+type networkRef struct {
+	Project string
+	Name    string
+}
+
+// peerRowDB is one row of networks_peers, and whether the emulator may touch it.
+type peerRowDB struct {
+	ID        int64
+	NetworkID int64
+	Name      string
+	TargetID  int64
+	HasTarget bool
+	Source    networkRef
+	// Ours is the answer to the only question that entitles anything here to
+	// act: does the row's *source* network carry the label this emulator wrote
+	// on the networks it created. It is never inferred from a name.
+	Ours bool
+	// Dangling says the target no longer resolves to a network.
+	Dangling bool
+	// Row is the whole row, so a repair can print what it removes.
+	Row string
+}
+
+// networkView is one network as the API describes it, and it is read once per
+// survey: this file asks three questions of the same listing, and three reads
+// could answer them about three different moments of the host.
+type networkView struct {
+	Name    string            `json:"name"`
+	Project string            `json:"project"`
+	Type    string            `json:"type"`
+	Config  map[string]string `json:"config"`
+}
+
+func (d *Incus) networkViews(ctx context.Context) ([]networkView, error) {
+	out, err := d.run(ctx, "query", "/1.0/networks?recursion=1")
+	if err != nil {
+		return nil, fmt.Errorf("list networks: %w", err)
+	}
+	var items []networkView
+	if err := json.Unmarshal(out, &items); err != nil {
+		return nil, fmt.Errorf("decode the network list: %w", err)
+	}
+	return items, nil
+}
+
+// labelledNetworkRefs answers which networks carry the emulator's own label,
+// read through the API rather than the database: it is the same question
+// mustOwn asks, against the same mark EnsureNetwork writes, and reading it
+// where the driver already reads it keeps one answer rather than two.
+func labelledNetworkRefs(views []networkView) map[networkRef]bool {
+	ours := map[networkRef]bool{}
+	for _, item := range views {
+		if item.Config["user."+LabelKey] == "" {
+			continue
+		}
+		project := item.Project
+		if project == "" {
+			project = "default"
+		}
+		ours[networkRef{Project: project, Name: item.Name}] = true
+	}
+	return ours
+}
+
+// peerRows reads every peering row and decides two things about each: whether
+// its target still resolves, and whether its source network is one the emulator
+// labelled.
+//
+// The second is the authorisation, and it is deliberately computed here, once,
+// rather than at each use: TestForceLeavesAThirdPartysDanglingPeerAlone plants
+// a dangling row on an unlabelled network and fails the moment this stops
+// discriminating.
+func (d *Incus) peerRows(ctx context.Context, views []networkView) ([]peerRowDB, error) {
+	rows, err := d.sqlSelect(ctx, peerRowsSQL)
+	if err != nil {
+		return nil, err
+	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	idRows, err := d.sqlSelect(ctx, networkIDsSQL)
+	if err != nil {
+		return nil, err
+	}
+	exists := make(map[int64]bool, len(idRows))
+	for _, row := range idRows {
+		if id, ok := sqlInt(row, 0); ok {
+			exists[id] = true
+		}
+	}
+	nameRows, err := d.sqlSelect(ctx, networkNamesSQL)
+	if err != nil {
+		return nil, err
+	}
+	named := make(map[int64]networkRef, len(nameRows))
+	for _, row := range nameRows {
+		id, ok := sqlInt(row, 0)
+		if !ok {
+			continue
+		}
+		named[id] = networkRef{Project: sqlText(row, 1), Name: sqlText(row, 2)}
+	}
+	ours := labelledNetworkRefs(views)
+
+	out := make([]peerRowDB, 0, len(rows))
+	for _, row := range rows {
+		id, ok := sqlInt(row, 0)
+		if !ok {
+			continue
+		}
+		networkID, ok := sqlInt(row, 1)
+		if !ok {
+			continue
+		}
+		target, hasTarget := sqlInt(row, 3)
+		source := named[networkID]
+		encoded, err := json.Marshal(map[string]any{
+			"id": id, "network_id": networkID, "name": sqlText(row, 2),
+			"target_network_id": sqlAny(row, 3), "target_network_project": sqlAny(row, 4),
+			"target_network_name": sqlAny(row, 5), "description": sqlAny(row, 6),
+			"type": sqlAny(row, 7),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("encode peering row %d: %w", id, err)
+		}
+		out = append(out, peerRowDB{
+			ID:        id,
+			NetworkID: networkID,
+			Name:      sqlText(row, 2),
+			TargetID:  target,
+			HasTarget: hasTarget,
+			Source:    source,
+			Ours:      ours[source],
+			Dangling:  hasTarget && !exists[target],
+			Row:       string(encoded),
+		})
+	}
+	return out, nil
+}
+
+// sqlInt reads one column as an integer. A JSON number arrives as a float64, a
+// NULL as nil, and the second return distinguishes "there is no value" from
+// "the value is zero" — the difference between a peering that names no target
+// and one that names network 0.
+func sqlInt(row []any, at int) (int64, bool) {
+	if at >= len(row) {
+		return 0, false
+	}
+	number, ok := row[at].(float64)
+	if !ok {
+		return 0, false
+	}
+	return int64(number), true
+}
+
+func sqlText(row []any, at int) string {
+	if at >= len(row) {
+		return ""
+	}
+	text, ok := row[at].(string)
+	if !ok {
+		return ""
+	}
+	return text
+}
+
+// sqlAny reads one column verbatim, for the copy of the row a repair prints so
+// an operator can put it back. Out of range gives nil, which encodes as null.
+//
+// Bounded for the same reason sqlInt and sqlText are, and it was not: this row
+// is the answer of another process, decoded from JSON. A shorter answer than
+// the SELECT names — another Incus, a table this one does not have — indexed a
+// slice past its end and panicked, in the one command an operator runs to get
+// a station out of trouble. Nothing else in this file trusts the length, and
+// the repair path is the last place that should.
+// TestAShortDatabaseAnswerIsInertRatherThanFatal fails without it.
+func sqlAny(row []any, at int) any {
+	if at >= len(row) {
+		return nil
+	}
+	return row[at]
+}
+
+// Traps implements Repairer.
+//
+// Three states, and each of them is one no healthy run ever produces. That
+// property is the whole design of this check and is worth stating, because the
+// obvious fourth candidate fails it: a rule set attached to a network is the
+// *normal* state of every isolated OVN network — IsolateNetwork ends by running
+// `network set <network> security.acls <name>` on every network with a
+// neighbour to keep out. Reporting that as stuck would fail every healthy run,
+// which is exactly how #426's doorstep learned to fire on hosts nothing was
+// going to fail on. So the rule set is reported only when the network holding
+// it is itself trapped, which is when the detach is genuinely refused.
+func (d *Incus) Traps(ctx context.Context) ([]Trap, error) {
+	var traps []Trap
+
+	views, err := d.networkViews(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := d.peerRows(ctx, views)
+	if err != nil {
+		return nil, err
+	}
+	trapped := map[string]bool{}
+	for _, row := range rows {
+		if !row.Dangling || !row.Ours {
+			continue
+		}
+		trapped[row.Source.Name] = true
+		traps = append(traps, Trap{
+			Kind: TrapDanglingPeer,
+			Name: row.Source.Name + "/" + row.Name,
+			Why: fmt.Sprintf("its peering names network %d, which no longer exists, so every operation on %s "+
+				"fails loading a target that resolves to nothing", row.TargetID, row.Source.Name),
+			Repairable: true,
+			Row:        row.Row,
+		})
+	}
+
+	stripped, err := d.strippedDelegations(ctx, views)
+	if err != nil {
+		return nil, err
+	}
+	for _, network := range stripped {
+		trapped[network.Name] = true
+		traps = append(traps, Trap{
+			Kind: TrapStrippedUplink,
+			Name: network.Name,
+			Why: fmt.Sprintf("its block %s is no longer delegated to the uplink %s, so the runtime refuses "+
+				"every update of it, the detach that would free it included", network.Block, d.uplinkName()),
+		})
+	}
+
+	traps = append(traps, ruleSetsHeldBy(views, trapped)...)
+
+	sort.Slice(traps, func(i, j int) bool {
+		if traps[i].Kind != traps[j].Kind {
+			return traps[i].Kind < traps[j].Kind
+		}
+		return traps[i].Name < traps[j].Name
+	})
+	return traps, nil
+}
+
+// strippedNetwork is one of the emulator's OVN networks whose block the uplink
+// no longer carries.
+type strippedNetwork struct {
+	Name  string
+	Block string
+}
+
+// strippedDelegations names the labelled OVN networks attached to the uplink
+// whose block is absent from its ipv4.routes.
+//
+// It is not gated on d.OVN, and that is deliberate: the issue's own
+// reproduction sweeps the trapped host with `feint clean --vm incus`. Whether
+// the uplink is stripped is a fact about the host, not about the mode this
+// process happens to run in, and a check that answered "nothing" because of the
+// flag it was given would be the instrument lying.
+func (d *Incus) strippedDelegations(ctx context.Context, views []networkView) ([]strippedNetwork, error) {
+	networks := d.ovnNetworksOnUplink(views)
+	if len(networks) == 0 {
+		return nil, nil
+	}
+	out, err := d.run(ctx, "network", "get", d.uplinkName(), "ipv4.routes")
+	if err != nil {
+		if isNotFound(err) {
+			// No uplink, and networks that name it: they are already beyond
+			// repair by any route edit, and the peering half below is what will
+			// name them. Nothing to report here rather than a route list of one
+			// object that does not exist.
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read routes of uplink %s: %w", d.uplinkName(), err)
+	}
+	routes := strings.TrimSpace(string(out))
+	var stripped []strippedNetwork
+	for _, network := range networks {
+		if !routeListContains(routes, network.Block) {
+			stripped = append(stripped, network)
+		}
+	}
+	return stripped, nil
+}
+
+// ovnNetworksOnUplink lists the labelled OVN networks drawing from the uplink,
+// with the block each one carries. It is liveDelegations' reading with the
+// names kept: the adopt path only needs the blocks, a report needs to say which
+// network each belongs to.
+func (d *Incus) ovnNetworksOnUplink(views []networkView) []strippedNetwork {
+	var networks []strippedNetwork
+	for _, item := range views {
+		if item.Type != "ovn" || item.Config["user."+LabelKey] == "" ||
+			item.Config["network"] != d.uplinkName() {
+			continue
+		}
+		block, err := maskedBlock(item.Config["ipv4.address"])
+		if err != nil {
+			continue
+		}
+		networks = append(networks, strippedNetwork{Name: item.Name, Block: block})
+	}
+	return networks
+}
+
+// ruleSetsHeldBy names the emulator's own rule sets attached to a network that
+// is itself trapped. See Traps for why the bare "attached" form is not a trap.
+//
+// There is deliberately no early return on an empty trapped set, tempting as it
+// is: the loop below would then be skipped on exactly the healthy host this
+// distinction exists for, and the condition inside it — the only thing keeping
+// a normal attachment from being reported — would never be exercised. A guard a
+// fast path walks around is a guard no falsification can reach, which is what
+// the first replay of this spec measured: the mutation that turns every
+// attached rule set into a trap left TestTrapsAreSilentOnAHealthyOVNRun green.
+func ruleSetsHeldBy(views []networkView, trapped map[string]bool) []Trap {
+	var traps []Trap
+	for _, item := range views {
+		if !trapped[item.Name] || item.Config["user."+LabelKey] == "" {
+			continue
+		}
+		for _, name := range strings.Split(item.Config["security.acls"], ",") {
+			name = strings.TrimSpace(name)
+			if name == "" {
+				continue
+			}
+			traps = append(traps, Trap{
+				Kind: TrapHeldFirewall,
+				Name: name,
+				Why: fmt.Sprintf("it is attached to %s, which is trapped: the rule set is in use by the network, "+
+					"the network is in use by the rule set, and the detach that breaks the cycle is refused",
+					item.Name),
+			})
+		}
+	}
+	return traps
+}
+
+// Repair implements Repairer: it removes the peering rows whose target resolves
+// to no network, and nothing else.
+//
+// The scope is the point. A row is removed only when its *source* network
+// carries the label this emulator wrote — the same question mustOwn asks of a
+// network before the driver touches it, asked of a database row. Never a name
+// pattern: a `--force` able to reach a third party's peering row would be a
+// worse defect than the one it repairs, and "fnt-" is a prefix anybody may type.
+//
+// TestForceLeavesAThirdPartysDanglingPeerAlone fails without the Ours filter,
+// and TestForceRemovesADanglingPeerOfOurOwn fails if it refuses everything.
+func (d *Incus) Repair(ctx context.Context) ([]Trap, error) {
+	// Re-read rather than act on what Traps returned: the caller printed that
+	// list, a human read it, and neither the reading nor the printing is a
+	// permission. Ownership is derived again here, from the host as it is now.
+	views, err := d.networkViews(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := d.peerRows(ctx, views)
+	if err != nil {
+		return nil, err
+	}
+	var cleared []Trap
+	var failures []string
+	for _, row := range rows {
+		if !row.Dangling || !row.Ours {
+			continue
+		}
+		// The id is an integer decoded from the runtime's own answer, so the
+		// statement carries no text from anywhere. Nothing else in this file
+		// builds SQL from a value, and nothing else should.
+		if _, err := d.run(ctx, "admin", "sql", "global",
+			fmt.Sprintf("DELETE FROM networks_peers WHERE id=%d", row.ID)); err != nil {
+			failures = append(failures, fmt.Sprintf("peering row %d of %s: %v", row.ID, row.Source.Name, err))
+			continue
+		}
+		cleared = append(cleared, Trap{
+			Kind:       TrapDanglingPeer,
+			Name:       row.Source.Name + "/" + row.Name,
+			Why:        fmt.Sprintf("its target network %d no longer exists", row.TargetID),
+			Repairable: true,
+			Row:        row.Row,
+		})
+	}
+	if len(failures) > 0 {
+		return cleared, fmt.Errorf("could not clear %d peering row(s): %s",
+			len(failures), strings.Join(failures, "; "))
+	}
+	return cleared, nil
+}

--- a/internal/core/machine/incus_traps_test.go
+++ b/internal/core/machine/incus_traps_test.go
@@ -1,0 +1,325 @@
+package machine
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// The states a sweep cannot get out of, and the one repair that reaches past
+// the runtime's own commands (#455).
+//
+// Every assertion here is about an argument the driver emits or refuses to
+// emit, which is the only level at which "it will not touch somebody else's
+// peering row" can be checked without a runtime — and it is the level that
+// matters, because what this repair reaches is Incus' own database.
+
+// trapWorld is a host holding one network of the emulator's and one of a third
+// party's, each with a peering row whose target no longer exists.
+//
+// The two are indistinguishable by shape and by state: same table, same kind of
+// row, same dangling target. The *only* thing that tells them apart is the
+// label the emulator wrote on the network the row belongs to — which is exactly
+// the discrimination this feature stands or falls on.
+func trapWorld() map[string]string {
+	return map[string]string{
+		"/1.0/networks?recursion=1": `[
+		  {"name": "fnt-c10fedc7f6c", "project": "default", "type": "ovn",
+		   "config": {"user.feint.provider": "outscale", "network": "feint-uplink",
+		              "ipv4.address": "10.2.4.1/24", "security.acls": "iso-fnt-c10fedc7f6c"}},
+		  {"name": "feint-uplink", "project": "default", "type": "bridge",
+		   "config": {"user.feint.provider": "feint", "ipv4.routes": "10.2.4.0/24"}},
+		  {"name": "hp-test-net", "project": "default", "type": "ovn",
+		   "config": {"ipv4.address": "192.168.40.1/24"}}
+		]`,
+		"network get feint-uplink ipv4.routes": "10.2.4.0/24\n",
+		// The peering rows, as `incus admin sql global --format json` answers
+		// them: numbers as numbers, an unresolved target as a plain id, and the
+		// name and project of a target that is gone as null.
+		"SELECT id, network_id": `{"type":"select",
+		  "columns":["id","network_id","name","target_network_id","target_network_project","target_network_name","description","type"],
+		  "rows":[[401,2616,"fnt-e41278b8c3a",2617,null,null,"",0],
+		          [777,284,"hp-peer",2618,null,null,"",0]],
+		  "rows_affected":0}`,
+		// 2617 and 2618 are absent: both rows dangle.
+		"SELECT id FROM networks": `{"type":"select","columns":["id"],
+		  "rows":[[2616],[284],[1]],"rows_affected":0}`,
+		"FROM networks, projects": `{"type":"select","columns":["id","name","name"],
+		  "rows":[[2616,"default","fnt-c10fedc7f6c"],[284,"default","hp-test-net"],[1,"default","incusbr0"]],
+		  "rows_affected":0}`,
+	}
+}
+
+// TestForceLeavesAThirdPartysDanglingPeerAlone is the test this whole feature
+// hangs on, and it is the one to read first.
+//
+// A dangling peering row is not rare and not the emulator's speciality: any
+// tool that deletes an OVN network out from under a peering leaves one, and an
+// operator's own row looks exactly like ours. "Well formed is not authorised" —
+// the row belonging to hp-test-net is as dangling as ours and as reachable by
+// the same statement, and the only thing that may stop the delete is the label.
+//
+// Without the ownership filter this is `rm -rf` with a friendly name.
+func TestForceLeavesAThirdPartysDanglingPeerAlone(t *testing.T) {
+	f := &fakeRuntime{answers: trapWorld()}
+	d := ovnDriver(f)
+
+	cleared, err := d.Repair(context.Background())
+	if err != nil {
+		t.Fatalf("repair: %v", err)
+	}
+	for _, cmd := range f.commands() {
+		if strings.Contains(cmd, "id=777") {
+			t.Errorf("the repair removed a peering row of a network nobody here created: %q", cmd)
+		}
+	}
+	for _, trap := range cleared {
+		if strings.Contains(trap.Name, "hp-") {
+			t.Errorf("the repair reported clearing a third party's row: %+v", trap)
+		}
+	}
+	// And the accepting half in the same fixture, so a repair that refuses
+	// everything cannot pass this test: ours must have gone.
+	if len(cleared) != 1 {
+		t.Fatalf("cleared %d row(s), want exactly ours", len(cleared))
+	}
+}
+
+// TestForceRemovesADanglingPeerOfOurOwn is the other half: a guard that refuses
+// everything passes every attack test and ships nothing.
+func TestForceRemovesADanglingPeerOfOurOwn(t *testing.T) {
+	f := &fakeRuntime{answers: trapWorld()}
+	d := ovnDriver(f)
+
+	cleared, err := d.Repair(context.Background())
+	if err != nil {
+		t.Fatalf("repair: %v", err)
+	}
+	if len(f.matching("DELETE FROM networks_peers WHERE id=401")) != 1 {
+		t.Fatalf("the dangling row of our own network was not removed; the driver ran:\n%s",
+			strings.Join(f.commands(), "\n"))
+	}
+	if len(cleared) != 1 || cleared[0].Kind != TrapDanglingPeer {
+		t.Fatalf("cleared %+v, want one dangling peer", cleared)
+	}
+	// The row is printed whole, so an operator can put it back. A repair on the
+	// runtime's own database that cannot be reversed by the person who ran it is
+	// not a repair, it is a bet.
+	if !strings.Contains(cleared[0].Row, "2617") {
+		t.Errorf("the removed row does not carry what it held: %q", cleared[0].Row)
+	}
+}
+
+// A repair reaches Incus' database, so it goes through `incus admin sql`, which
+// is the runtime's own supported mechanism for it — never a file under
+// /var/lib/incus, which would be an edit behind the daemon's back.
+func TestTheRepairGoesThroughTheRuntimesOwnMechanism(t *testing.T) {
+	f := &fakeRuntime{answers: trapWorld()}
+	d := ovnDriver(f)
+
+	if _, err := d.Repair(context.Background()); err != nil {
+		t.Fatalf("repair: %v", err)
+	}
+	for _, call := range f.calls {
+		if len(call) > 0 && strings.Contains(strings.Join(call, " "), "DELETE FROM") {
+			if call[0] != "admin" || call[1] != "sql" || call[2] != "global" {
+				t.Errorf("the repair wrote to the database by another route: %v", call)
+			}
+		}
+	}
+}
+
+// Traps names the dangling row of our own network and says what it blocks.
+func TestTrapsNameADanglingPeerRowOfOurOwn(t *testing.T) {
+	f := &fakeRuntime{answers: trapWorld()}
+	d := ovnDriver(f)
+
+	traps, err := d.Traps(context.Background())
+	if err != nil {
+		t.Fatalf("traps: %v", err)
+	}
+	var found bool
+	for _, trap := range traps {
+		if trap.Kind == TrapDanglingPeer {
+			found = true
+			if !strings.Contains(trap.Name, "fnt-c10fedc7f6c") {
+				t.Errorf("the trap does not name the network it holds: %+v", trap)
+			}
+			if !trap.Repairable {
+				t.Errorf("a dangling row was reported as beyond repair: %+v", trap)
+			}
+		}
+		if strings.Contains(trap.Name, "hp-") {
+			t.Errorf("a third party's row was reported as this emulator's trap: %+v", trap)
+		}
+	}
+	if !found {
+		t.Fatalf("no dangling peering row reported, got %+v", traps)
+	}
+	// And it must have issued no mutating command: naming is the whole contract
+	// of a check, exactly as it is for Survey.
+	for _, call := range f.calls {
+		switch call[0] {
+		case "query", "network", "admin":
+			if call[0] == "network" && call[1] != "get" {
+				t.Errorf("the trap survey issued a mutating command: %v", call)
+			}
+			if call[0] == "admin" && strings.Contains(strings.Join(call, " "), "DELETE") {
+				t.Errorf("the trap survey wrote to the database: %v", call)
+			}
+		default:
+			t.Errorf("the trap survey issued an unexpected command: %v", call)
+		}
+	}
+}
+
+// A network of the emulator's whose block the uplink no longer carries: the
+// state a sweep used to create itself, and the one that makes every management
+// path of that network fail validation.
+func TestTrapsNameAStrippedUplink(t *testing.T) {
+	world := trapWorld()
+	// The uplink after the sweep unset its routes.
+	world["network get feint-uplink ipv4.routes"] = "\n"
+	f := &fakeRuntime{answers: world}
+	d := ovnDriver(f)
+
+	traps, err := d.Traps(context.Background())
+	if err != nil {
+		t.Fatalf("traps: %v", err)
+	}
+	var stripped *Trap
+	for i := range traps {
+		if traps[i].Kind == TrapStrippedUplink {
+			stripped = &traps[i]
+		}
+	}
+	if stripped == nil {
+		t.Fatalf("a network whose block the uplink lost was not reported: %+v", traps)
+	}
+	if !strings.Contains(stripped.Why, "10.2.4.0/24") {
+		t.Errorf("the report does not name the block that is missing: %+v", stripped)
+	}
+	if stripped.Repairable {
+		t.Errorf("the stripped uplink is repaired by the ordinary sweep and must not ask for --force: %+v", stripped)
+	}
+}
+
+// The rule set that cannot be detached because the network holding it is
+// trapped. Reported only in that case — see the accepting half below, which is
+// what stops this from firing on every healthy run.
+func TestTrapsNameARuleSetHeldByATrappedNetwork(t *testing.T) {
+	f := &fakeRuntime{answers: trapWorld()}
+	d := ovnDriver(f)
+
+	traps, err := d.Traps(context.Background())
+	if err != nil {
+		t.Fatalf("traps: %v", err)
+	}
+	for _, trap := range traps {
+		if trap.Kind == TrapHeldFirewall && trap.Name == "iso-fnt-c10fedc7f6c" {
+			return
+		}
+	}
+	t.Fatalf("the rule set held by a trapped network was not reported: %+v", traps)
+}
+
+// TestTrapsAreSilentOnAHealthyOVNRun is the accepting half, and it is the half
+// that decides whether this check survives contact with a run.
+//
+// The obvious formulation of the third state — "a rule set is attached to a
+// network" — is the *normal* state of every isolated OVN network: IsolateNetwork
+// ends by running `network set <network> security.acls <name>` on every network
+// with a neighbour to keep out. A check that reported that would refuse every
+// healthy run, which is precisely how #426's doorstep learned to fire on hosts
+// nothing was going to fail on, and how a doorstep gets disarmed.
+//
+// So the fixture here is a run in mid-flight: two peered networks, both with
+// their rule set attached, both blocks delegated, no dangling row. Nothing is
+// reported.
+func TestTrapsAreSilentOnAHealthyOVNRun(t *testing.T) {
+	f := &fakeRuntime{answers: map[string]string{
+		"/1.0/networks?recursion=1": `[
+		  {"name": "fnt-aaaa", "project": "default", "type": "ovn",
+		   "config": {"user.feint.provider": "scaleway", "network": "feint-uplink",
+		              "ipv4.address": "10.2.4.1/24", "security.acls": "iso-fnt-aaaa"}},
+		  {"name": "fnt-bbbb", "project": "default", "type": "ovn",
+		   "config": {"user.feint.provider": "scaleway", "network": "feint-uplink",
+		              "ipv4.address": "10.2.5.1/24", "security.acls": "iso-fnt-bbbb"}},
+		  {"name": "feint-uplink", "project": "default", "type": "bridge",
+		   "config": {"user.feint.provider": "feint", "ipv4.routes": "10.2.4.0/24,10.2.5.0/24"}}
+		]`,
+		"network get feint-uplink ipv4.routes": "10.2.4.0/24,10.2.5.0/24\n",
+		"SELECT id, network_id": `{"type":"select",
+		  "columns":["id","network_id","name","target_network_id","target_network_project","target_network_name","description","type"],
+		  "rows":[[10,100,"fnt-bbbb",101,"default","fnt-bbbb","",0],
+		          [11,101,"fnt-aaaa",100,"default","fnt-aaaa","",0]],
+		  "rows_affected":0}`,
+		"SELECT id FROM networks": `{"type":"select","columns":["id"],"rows":[[100],[101],[1]],"rows_affected":0}`,
+		"FROM networks, projects": `{"type":"select","columns":["id","name","name"],
+		  "rows":[[100,"default","fnt-aaaa"],[101,"default","fnt-bbbb"]],"rows_affected":0}`,
+	}}
+	d := ovnDriver(f)
+
+	traps, err := d.Traps(context.Background())
+	if err != nil {
+		t.Fatalf("traps: %v", err)
+	}
+	if len(traps) != 0 {
+		t.Fatalf("a healthy run was reported as trapped, which fails every run that follows: %+v", traps)
+	}
+}
+
+// A database that cannot be read is not an empty one. "I could not look" and
+// "there is nothing" are different facts, and reporting the first as the second
+// is how an inventory once called a live account empty.
+func TestATrapSurveyThatCannotReadSaysSo(t *testing.T) {
+	f := &fakeRuntime{answers: trapWorld(), fail: map[string]error{
+		"SELECT id, network_id": errors.New("Error: not authorised"),
+	}}
+	d := ovnDriver(f)
+
+	if _, err := d.Traps(context.Background()); err == nil {
+		t.Fatal("a database this process may not read was reported as a host holding nothing")
+	}
+}
+
+// TestAShortDatabaseAnswerIsInertRatherThanFatal holds the bound on the row the
+// repair prints.
+//
+// Every other reader in this file asks the length before it indexes; the copy
+// of the row kept for the operator did not, and reached row[7] directly. The
+// answer it indexes comes from another process over JSON — another Incus, a
+// column renamed, a table this one does not carry — so a shorter row than the
+// SELECT names panicked the one command somebody runs to get a station out of
+// trouble. Inert is the right answer: a row whose target cannot even be read
+// names nothing that resolves to nothing, so there is nothing to remove.
+func TestAShortDatabaseAnswerIsInertRatherThanFatal(t *testing.T) {
+	world := trapWorld()
+	world["SELECT id, network_id"] = `{"type":"select","columns":["id","network_id"],
+	  "rows":[[401,2616],[777,284]],"rows_affected":0}`
+	f := &fakeRuntime{answers: world}
+	d := ovnDriver(f)
+
+	traps, err := d.Traps(context.Background())
+	if err != nil {
+		t.Fatalf("traps: %v", err)
+	}
+	for _, trap := range traps {
+		if trap.Kind == TrapDanglingPeer {
+			t.Errorf("a row whose target could not be read was called dangling: %+v", trap)
+		}
+	}
+	cleared, err := d.Repair(context.Background())
+	if err != nil {
+		t.Fatalf("repair: %v", err)
+	}
+	if len(cleared) != 0 {
+		t.Errorf("the repair removed %d row(s) it could not even read: %+v", len(cleared), cleared)
+	}
+	for _, cmd := range f.commands() {
+		if strings.Contains(cmd, "DELETE FROM") {
+			t.Errorf("the repair wrote to the database on an answer it could not read: %q", cmd)
+		}
+	}
+}

--- a/internal/core/machine/prune.go
+++ b/internal/core/machine/prune.go
@@ -58,3 +58,68 @@ type Surveyor interface {
 	// contract, TestSurveyFindsOnlyTheEmulatorsWorkAndTouchesNothing holds it.
 	Survey(ctx context.Context) (Leftovers, error)
 }
+
+// A leftover the sweep can still remove is untidy. A leftover no ordinary
+// command of the runtime can remove any more is something else, and #455
+// measured it: an OVN network whose peering points at a network that no longer
+// exists refuses every management path, including the one that would remove the
+// peering, so the network, the rule set attached to it and the uplink they sit
+// on are permanent by every means a user has.
+//
+// A Trap is that second family. It is named apart from Leftovers because the
+// remedy is different in kind: a leftover is swept, a trap is either prevented
+// or repaired by a step the operator asks for by name.
+
+// Trap kinds, closed on purpose so a report can group them.
+const (
+	// TrapDanglingPeer is a peering row whose target network is gone. The
+	// runtime's own schema is what makes it possible: the reference to the
+	// target carries no cascade, so deleting the target leaves the row, and
+	// from then on every operation on the *source* network fails loading a
+	// target that resolves to nothing.
+	TrapDanglingPeer = "dangling-peer"
+	// TrapStrippedUplink is a network of the emulator's whose block is no
+	// longer delegated to the uplink it draws from. The runtime then refuses
+	// every update of that network — including the detach that would free it —
+	// with a message that names the block rather than the uplink.
+	TrapStrippedUplink = "stripped-uplink"
+	// TrapHeldFirewall is a rule set of the emulator's attached to a network
+	// that is itself trapped: neither can go, because the rule set is "in use"
+	// by the network and the network is "in use" by the rule set, and the
+	// detach that breaks the cycle is one of the operations the trap refuses.
+	TrapHeldFirewall = "held-firewall"
+)
+
+// Trap is one such state, named so a check can report it and an operator can
+// decide.
+type Trap struct {
+	// Kind is one of the constants above.
+	Kind string
+	// Name is the object in the runtime's own terms.
+	Name string
+	// Why says what is stuck and what it blocks, in one sentence.
+	Why string
+	// Repairable says whether Repair can clear this one. False means the
+	// ordinary sweep clears it now that it knows how, so nothing privileged is
+	// needed and nothing here should offer any.
+	Repairable bool
+	// Row is what a repair would remove, verbatim and complete, so an operator
+	// can put it back. Empty for a trap Repair does not touch.
+	Row string
+}
+
+// Repairer is the optional half of a Driver that can name the states its own
+// sweep cannot get out of, and clear the ones no ordinary command reaches.
+//
+// The split matters. Traps is a read and is always safe to run; Repair reaches
+// past the runtime's own commands and is therefore only ever run when an
+// operator asks for it by name.
+type Repairer interface {
+	// Traps names what holds this runtime. It must issue no mutating command,
+	// for the same reason Survey must not.
+	Traps(ctx context.Context) ([]Trap, error)
+	// Repair clears the traps that Repair can clear, and returns those it
+	// cleared. It re-derives ownership itself and never trusts a Trap it was
+	// handed: a name that made a round trip is an input, not a permission.
+	Repair(ctx context.Context) ([]Trap, error)
+}

--- a/tools/falsify/specs/run-leaves-nothing.json
+++ b/tools/falsify/specs/run-leaves-nothing.json
@@ -44,8 +44,8 @@
     {
       "label": "the doorstep finds the previous run's networks and lets the run start anyway, which is the state that fails thirty steps later on a message naming only the block",
       "file": "internal/cli/clean.go",
-      "find": "\tif err := refuseRuntimeLeftovers(stdout, led, vm); err != nil {",
-      "replace": "\tif err := refuseRuntimeLeftovers(stdout, led, vm); err != nil && false {",
+      "find": "\tif err := refuseRuntimeLeftovers(stdout, led, vm, driver); err != nil {",
+      "replace": "\tif err := refuseRuntimeLeftovers(stdout, led, vm, driver); err != nil && false {",
       "test": "TestTheDoorstepRefusesAHostHoldingAPreviousRunsNetwork",
       "package": "./internal/cli/"
     },
@@ -76,8 +76,8 @@
     {
       "label": "the doorstep question is asked at every moment, so a run is refused for owning the machines and networks it just created",
       "file": "internal/cli/clean.go",
-      "find": "\tif doorstep {\n\t\tif err := refuseRuntimeLeftovers(stdout, led, vm); err != nil {",
-      "replace": "\tif doorstep || true {\n\t\tif err := refuseRuntimeLeftovers(stdout, led, vm); err != nil {",
+      "find": "\tif doorstep {\n\t\tif err := refuseRuntimeLeftovers(stdout, led, vm, driver); err != nil {",
+      "replace": "\tif doorstep || true {\n\t\tif err := refuseRuntimeLeftovers(stdout, led, vm, driver); err != nil {",
       "test": "TestTheLeftoverCheckMidRunIgnoresTheRunsOwnObjects",
       "package": "./internal/cli/"
     },

--- a/tools/falsify/specs/trapped-station.json
+++ b/tools/falsify/specs/trapped-station.json
@@ -1,0 +1,113 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "the repair stops asking whose network a peering row belongs to, and a third party's row is as reachable as ours",
+      "file": "internal/core/machine/incus_traps.go",
+      "find": "\tvar cleared []Trap\n\tvar failures []string\n\tfor _, row := range rows {\n\t\tif !row.Dangling || !row.Ours {",
+      "replace": "\tvar cleared []Trap\n\tvar failures []string\n\tfor _, row := range rows {\n\t\tif !row.Dangling || (!row.Ours && false) {",
+      "test": "TestForceLeavesAThirdPartysDanglingPeerAlone"
+    },
+    {
+      "label": "the survey stops asking it too, so a check names rows nobody here made and an operator is told to force them away",
+      "file": "internal/core/machine/incus_traps.go",
+      "find": "\ttrapped := map[string]bool{}\n\tfor _, row := range rows {\n\t\tif !row.Dangling || !row.Ours {",
+      "replace": "\ttrapped := map[string]bool{}\n\tfor _, row := range rows {\n\t\tif !row.Dangling || (!row.Ours && false) {",
+      "test": "TestTrapsNameADanglingPeerRowOfOurOwn"
+    },
+    {
+      "label": "the uplink goes back into the ordinary network path, which is the line that made the residue of #455 permanent",
+      "file": "internal/core/machine/incus_prune.go",
+      "find": "\tfor _, name := range networks {\n\t\tif name == uplink {\n\t\t\tuplinkPresent = true\n\t\t\tcontinue\n\t\t}",
+      "replace": "\tfor _, name := range networks {\n\t\tif name == uplink && false {\n\t\t\tuplinkPresent = true\n\t\t\tcontinue\n\t\t}",
+      "test": "TestPruneNeverStripsTheUplinkRoutesWhileItsNetworksStand"
+    },
+    {
+      "label": "the sweep stops removing the half a peering leaves on its surviving target, which is what manufactures the row nothing can repair",
+      "file": "internal/core/machine/incus_prune.go",
+      "find": "\t\tif d.ownsPeerTarget(ctx, peer.Target) {",
+      "replace": "\t\tif d.ownsPeerTarget(ctx, peer.Target) && false {",
+      "test": "TestPruneDropsTheSurvivingHalfOfEveryPeering"
+    },
+    {
+      "label": "the same withdrawal seen from the teardown a client drives, where a delete that succeeds is what leaves the neighbour holding a dead id",
+      "file": "internal/core/machine/incus_prune.go",
+      "find": "\t\tif d.ownsPeerTarget(ctx, peer.Target) {",
+      "replace": "\t\tif d.ownsPeerTarget(ctx, peer.Target) && false {",
+      "test": "TestRemoveNetworkDeletesTheSurvivingHalfOfItsPeerings"
+    },
+    {
+      "label": "the peering half is deleted on any target the runtime names, well formed being taken for authorised again",
+      "file": "internal/core/machine/incus_prune.go",
+      "find": "\t\tif d.ownsPeerTarget(ctx, peer.Target) {",
+      "replace": "\t\tif d.ownsPeerTarget(ctx, peer.Target) || true {",
+      "test": "TestPruneRefusesToTouchAPeeringHalfOnAForeignNetwork"
+    },
+    {
+      "label": "the far end of a peering is judged by its name alone, so a stranger's network called fnt-lab is reconfigured by a check that looked thorough because it had three clauses",
+      "file": "internal/core/machine/incus_prune.go",
+      "find": "\treturn d.mustOwn(ctx, target) == nil\n}",
+      "replace": "\treturn d.mustOwn(ctx, target) == nil || true\n}",
+      "test": "TestPruneRefusesAPeeringHalfOnAStrangersNetworkNamedLikeOurs"
+    },
+    {
+      "label": "nothing detaches the rule set before the delete, so the rule set and its network hold each other with no exit",
+      "file": "internal/core/machine/incus_prune.go",
+      "find": "\tattached := strings.TrimSpace(string(out))\n\tif attached == \"\" {\n\t\treturn nothing\n\t}",
+      "replace": "\tattached := strings.TrimSpace(string(out))\n\tif attached == \"\" || attached != \"\" {\n\t\treturn nothing\n\t}",
+      "test": "TestPruneDetachesTheRuleSetHoldingANetwork"
+    },
+    {
+      "label": "the sweep detaches a rule set and leaves it off when the delete then fails, which is a firewall disarmed on a network still standing",
+      "file": "internal/core/machine/incus_prune.go",
+      "find": "\t\t\tif _, err := d.run(ctx, \"network\", \"delete\", name); err != nil && !isNotFound(err) {\n\t\t\t\treattach(ctx)",
+      "replace": "\t\t\tif _, err := d.run(ctx, \"network\", \"delete\", name); err != nil && !isNotFound(err) {\n\t\t\t\tif false {\n\t\t\t\t\treattach(ctx)\n\t\t\t\t}",
+      "test": "TestPruneNeverStripsTheUplinkRoutesWhileItsNetworksStand"
+    },
+    {
+      "label": "the same on the teardown path, where the network that survives is the one a client still has machines on",
+      "file": "internal/core/machine/incus.go",
+      "find": "\t\t\t\treturn d.afterNetworkDelete(ctx, name, block)\n\t\t\t}\n\t\t\treattach(ctx)",
+      "replace": "\t\t\t\treturn d.afterNetworkDelete(ctx, name, block)\n\t\t\t}\n\t\t\tif false {\n\t\t\t\treattach(ctx)\n\t\t\t}",
+      "test": "TestRemoveNetworkDetachesTheRuleSetThatHoldsIt"
+    },
+    {
+      "label": "the sweep no longer puts back a block the uplink lost, so a station a previous sweep stripped stays beyond every command",
+      "file": "internal/core/machine/incus_prune.go",
+      "find": "\tif uplinkPresent {\n\t\tif err := d.restoreDelegations(ctx); err != nil {",
+      "replace": "\tif uplinkPresent && false {\n\t\tif err := d.restoreDelegations(ctx); err != nil {",
+      "test": "TestPruneRestoresABlockTheUplinkLost"
+    },
+    {
+      "label": "every attached rule set becomes a trap, which is the formulation that would refuse every healthy run and get this check disarmed",
+      "file": "internal/core/machine/incus_traps.go",
+      "find": "\t\tif !trapped[item.Name] || item.Config[\"user.\"+LabelKey] == \"\" {",
+      "replace": "\t\tif (!trapped[item.Name] && false) || item.Config[\"user.\"+LabelKey] == \"\" {",
+      "test": "TestTrapsAreSilentOnAHealthyOVNRun"
+    },
+    {
+      "label": "the copy of the row a repair prints stops asking how long the answer is, and the one command that gets a station out of trouble panics on a database that answered differently",
+      "file": "internal/core/machine/incus_traps.go",
+      "find": "func sqlAny(row []any, at int) any {\n\tif at >= len(row) {",
+      "replace": "func sqlAny(row []any, at int) any {\n\tif at >= len(row) && false {",
+      "test": "TestAShortDatabaseAnswerIsInertRatherThanFatal"
+    },
+    {
+      "label": "the check finds the trap and still exits 0, which is the state the whole issue was reported from",
+      "file": "internal/cli/clean.go",
+      "find": "func trapFailure(trapped int, vm string) error {\n\tif trapped == 0 {\n\t\treturn nil\n\t}",
+      "replace": "func trapFailure(trapped int, vm string) error {\n\tif trapped == 0 || trapped > 0 {\n\t\treturn nil\n\t}",
+      "test": "TestCleanCheckReportsADanglingPeerRow",
+      "package": "./internal/cli/"
+    },
+    {
+      "label": "the check stops asking the runtime what holds it, the exact shape it was in when it answered 0 on a station nothing could clean",
+      "file": "internal/cli/clean.go",
+      "find": "\ttrapped, err := reportRuntimeTraps(stdout, led, driver)\n\tif err != nil {\n\t\treturn err\n\t}",
+      "replace": "\ttrapped, err := reportRuntimeTraps(stdout, led, driver)\n\ttrapped = 0\n\tif err != nil {\n\t\treturn err\n\t}",
+      "test": "TestCleanCheckReportsAStrippedUplink",
+      "package": "./internal/cli/"
+    }
+  ],
+  "note": "The subject is #455. Fifteen third-party stacks replayed under --vm incus-ovn left two OVN networks, two rule sets and the uplink on the maintainer's station, and no incus command could remove any of them; the repair took two hours by hand and one statement against the runtime's own database. Three mechanisms lock together and each has its mutation here: the sweep stripped the uplink's routes because feint-uplink carries the same label as everything else (3), nothing detached security.acls before a delete Incus refuses in both directions (8), and nothing removed the half a peering leaves on its surviving target (4, 5) — that last one binds a network *id*, so recreating the target under the same name does not satisfy it and the source network is unmanageable for ever.\n\nMutations 1 and 2 are the ones to read twice. `clean --force` reaches past every command Incus offers, into networks_peers, and a dangling row of an operator's own looks exactly like ours: same table, same shape, same dead target. The only thing that separates them is the label this emulator wrote on the network the row belongs to, which is mustOwn applied to a database. Without that filter the feature is rm -rf with a friendly name, and mutation 1 is what says so out loud.\n\nMutations 6, 7, 9, 10 and 12 are the false-positive half, and they matter as much as the rest. 6 and 7 are `well-formed is not authorised` on a name that arrives from the runtime and becomes an argument aimed at another network: 6 is the syntax and the prefix, which refuse incusbr0 — the name an audit obtained `incus network delete incusbr0` from the last time — and 7 is the label, which is the only clause a stranger cannot satisfy by choosing a name, since `fnt-` is a prefix anybody may type. 9 and 10 hold the restore: a detach whose delete then fails must be undone, or the sweep has disarmed the isolation of a network that is still standing. 12 is the anti-noise property: `a rule set is attached to a network` is the normal state of every isolated OVN network, since IsolateNetwork ends by attaching one, so reporting the bare form would refuse every healthy run — which is exactly how #426's doorstep learned to fire on hosts nothing was going to fail on.\n\nMutation 13 is the smallest and the least glamorous: the copy of the database row a repair prints indexed a decoded JSON array past its end. The answer comes from another process, so its length is not this code's to assume, and a panic in the one command an operator runs to get a station out of trouble is the worst place for one."
+}


### PR DESCRIPTION
Fifteen third-party stacks replayed under --vm incus-ovn left two OVN networks,
two rule sets and the uplink on a station where no incus command could remove
any of them. The eraser was not the next run: it was the sweep.

The upstream cause is read from Incus' own schema on this station, not quoted:
of the three references networks_peers carries, network_id cascades,
target_network_integration_id cascades, and target_network_id has no foreign
key at all. Delete a peering's target and the row survives holding an id that
resolves to nothing, and from then on every operation on the source network
fails loading a target that is not there, the peer delete that would repair it
included. Reproduced here by planting one row against a network the emulator
had just created: `network delete` answers "The network is currently in use"
and `network peer delete` answers "Failed loading target network".

Three behaviours turned that residue into permanence, and all three are now
prevented rather than repaired:

  - Prune treated feint-uplink as an ordinary network, because it carries the
    same label as everything else, and unset its ipv4.routes before a delete
    that then failed. Every management path of the networks still drawing from
    it failed validation from that instant. The uplink now leaves the ordinary
    path and goes last, routes intact.
  - Nothing detached security.acls before deleting a network the rule set holds
    and that holds the rule set. Both paths detach first now, and put the
    attachment back when the delete still refuses, because a network that
    survives with its isolation silently off is a firewall disarmed rather than
    a subnet swept.
  - Nothing removed the half a peering leaves on its surviving target, which is
    what manufactures the dead id. Both halves now go before the network does,
    and before the delete rather than after a refusal, since a delete that
    succeeds is exactly what strands the neighbour.

For a station already carrying the state, `feint clean --force` removes such a
row through `incus admin sql` after printing it whole so it can be put back. It
removes a row only when the network that row belongs to carries the label this
emulator wrote: an operator's dangling row is the same table, the same shape and
the same dead target, and a --force able to reach it would be a worse defect
than the one it repairs. `feint clean --check` now reports the three states no
healthy run produces and exits 1 on them, where it answered 0 in silence for the
whole duration of the block.

## Gates

`go build` 0 · `go test` 0 · `mise run prepush` 0 · `mise run falsify -- trapped-station.json` 0 (15 mutations, 15 red) · 7 neighbouring specs 0.

**`mise run conformance` was deliberately not played on this branch** — several issues are handled in series and it runs once over the assembled set. Instead, the fix was exercised against the real runtime (Incus 7.2, OVN): dangling row planted and refused on a stranger's network named `fnt-lab`, removed on a labelled one; station delta empty on networks, ACLs, instances and `networks_peers`.

Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)