### PR TITLE
fix(machine): a Net of three subnets peers under OVN, and the two runtime rules that stopped it are held (#456)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -84,6 +84,64 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Corrigé
 
+- **Un Net à trois subnets ou plus s'appaire sous OVN, et un hôte qui porte déjà
+  l'état qui l'en empêchait est réconcilié** (#456). Le rejeu des quinze stacks
+  tierces sous `--vm incus-ovn` a coûté au registre son résultat vedette :
+  `chimere-eu/ztiac` appliquait 80 de ses 95 ressources, en réclamait 15 au
+  second plan, et son `destroy` échouait. Douze lignes de
+  `Failed creating peer: More than one matching network peer was found` dans un
+  seul apply, nommant six subnets, et l'émulateur continuait en ERROR : l'API
+  décrivait donc un Net dont les subnets se routent entre eux alors que le
+  runtime ne portait aucun peering entre eux.
+
+  **La cause est en amont, et ce ne sont pas deux déclarations de la même
+  paire.** Incus consomme un peering en cherchant une moitié *pendante* qui vise
+  le réseau sur lequel la création atterrit, et cette recherche ne filtre que sur
+  le réseau cible : aucune clause ne dit quel réseau porte la ligne (v7.2.0,
+  `driver_ovn.go`, `PeerCreate`). Deux moitiés pendantes visant un même réseau
+  font donc échouer **toute** création sur lui, quelles que soient les paires
+  auxquelles elles appartiennent. Mesuré sur la station avec trois vrais réseaux
+  OVN et rien de concurrent : `peer create A B B` rend pendant,
+  `peer create C B B` rend pendant, `peer create B A A` rend l'erreur ci-dessus.
+  `(A,B)` et `(C,B)` sont deux paires différentes, ce qui explique qu'un verrou à
+  clé de paire n'aurait rien fermé, et qu'il faille trois subnets à un Net pour
+  déclencher le défaut là où les fixtures à deux subnets ne l'ont jamais fait. Le
+  pilote exclut désormais les deux **bouts** d'une paire, un verrou par réseau
+  pris dans l'ordre trié : deux subnets d'un même Net ne peuvent plus déclarer en
+  même temps deux moitiés visant le même réseau, et deux paires sans réseau
+  commun continuent de s'exécuter en parallèle, ce qu'un verrou global aurait
+  coûté.
+
+  **Une seconde règle du runtime a été mesurée au passage, et elle est corrigée
+  avec.** Supprimer un peer efface la cible de toutes les lignes qui visent le
+  réseau sur lequel la suppression s'exécute, quelle que soit leur paire : sur
+  une maille de trois réseaux, `peer delete B C` a laissé **A** tenant
+  `{"name":"B","target_network":null,"status":"Errored"}`, et redéclarer cette
+  moitié rend `A peer for that name already exists`, que ce pilote tolérait comme
+  un succès. Le peering était donc rapporté appliqué et n'existait pas. Une paire
+  dont le runtime n'appelle pas les deux moitiés `Created` est maintenant
+  reconstruite des deux côtés, et toute suppression sur ce chemin demande
+  l'étiquette écrite par `EnsureNetwork` avant de toucher un réseau, jamais le
+  préfixe `fnt-` que n'importe qui peut taper.
+
+  **Et « More than one matching network peer was found » est réconcilié plutôt
+  que rapporté** : les moitiés pendantes qui visent ce réseau sont retirées, sur
+  les seuls réseaux portant l'étiquette de cet émulateur, puis la création est
+  réémise une fois, parce qu'un hôte laissé dans cet état par un run interrompu
+  n'est réparé par rien de ce qu'un utilisateur peut taper.
+
+  Mesuré de bout en bout contre Incus 7.2 avec OVN, le 2026-08-25 : un Net dont
+  les trois subnets sont créés en parallèle donne trois réseaux OVN, six lignes
+  de peering, six `Created`, et aucun échec dans le journal ; un hôte cassé à la
+  main dans exactement l'état ci-dessus puis doté d'un quatrième subnet est
+  revenu à **12 lignes sur 12 en `Created`**, puis 20 sur 20 et 30 sur 30 à
+  mesure que deux subnets s'ajoutaient ; les six subnets et le Net se sont
+  ensuite supprimés sans aucun 409, ne laissant aucun réseau et une table
+  `networks_peers` vide. `tools/falsify/specs/peering-pairs.json` prouve que les
+  gardes mordent (quatre mutations, quatre tests rouges), et `docs/limits.md`
+  porte les deux règles du runtime avec les commandes qui les ont produites, y
+  compris le cas qui n'est toujours pas garanti en une seule passe.
+
 - **Un balayage ne piège plus l'hôte qu'il nettoie, et `feint clean --force`
   libère un hôte déjà piégé** (#455). Quinze stacks tierces rejouées sous
   `--vm incus-ovn` ont laissé deux réseaux OVN, deux jeux de règles et l'uplink

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,59 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Fixed
 
+- **A Net with three subnets or more peers under OVN, and a host already
+  carrying the state that stopped it is reconciled** (#456). Replaying the
+  fifteen third-party stacks under `--vm incus-ovn` cost the register its
+  flagship result: `chimere-eu/ztiac` applied 80 of its 95 resources, wanted 15
+  back on the second plan, and its `destroy` failed. Twelve lines of
+  `Failed creating peer: More than one matching network peer was found` in one
+  apply, naming six subnets, and the emulator carried on at ERROR — so the API
+  kept describing a Net whose subnets route to each other while the runtime held
+  no peering between them at all.
+
+  **The cause is upstream, and it is not two declarations of the same pair.**
+  Incus completes a peering by looking for a *pending* half aiming at the network
+  the create lands on, and that lookup filters on the target network alone: there
+  is no clause on which network holds the row (v7.2.0, `driver_ovn.go`,
+  `PeerCreate`). Two pending halves aiming at one network therefore make **every**
+  create on it fail, whichever pairs they belong to. Measured on the station with
+  three real OVN networks and nothing concurrent: `peer create A B B` → pending,
+  `peer create C B B` → pending, `peer create B A A` → the error above. `(A,B)`
+  and `(C,B)` are different pairs, which is why a lock keyed by the pair would
+  not have closed this, and why a Net needs three subnets to trip it while the
+  two-subnet fixtures never did. The driver now excludes both **ends** of a pair,
+  one lock per network taken in sorted order: two subnets of one Net can no
+  longer declare halves aiming at the same network at once, and two pairs sharing
+  no network still run in parallel, which a global lock would have cost.
+
+  **A second upstream rule was measured on the way, and is fixed with it.**
+  Deleting one peer blanks the target of every row aiming at the network the
+  delete runs on, whatever pair it belongs to: on a three-network mesh,
+  `peer delete B C` left **A** holding
+  `{"name":"B","target_network":null,"status":"Errored"}`, and redeclaring that
+  half answers `A peer for that name already exists` — which this driver
+  tolerated as success, so a peering was reported applied and did not exist. A
+  pair whose halves the runtime does not both call `Created` is now rebuilt from
+  both ends, and every delete on that path asks the label `EnsureNetwork` wrote
+  before touching a network, never the `fnt-` prefix anybody may type.
+
+  **And "More than one matching network peer was found" is reconciled rather than
+  reported**: the pending halves aiming at that network are cleared, only on
+  networks carrying this emulator's label, and the create is re-issued once —
+  because a host left in that state by a crashed run is repaired by nothing a
+  user can type.
+
+  Measured end to end against Incus 7.2 with OVN, on 2026-08-25: a Net whose
+  three subnets are created concurrently gives three OVN networks, six peer rows,
+  six `Created`, and no failure in the log; a host then broken by hand into
+  exactly the state above and given a fourth subnet came back **12 rows of 12
+  `Created`**, then 20 of 20 and 30 of 30 as two more subnets arrived; the six
+  subnets and the Net then deleted with no 409, leaving no network and an empty
+  `networks_peers`. `tools/falsify/specs/peering-pairs.json` proves the guards
+  bite — four mutations, four red tests — and `docs/limits.md` carries both
+  runtime rules with the commands that produced them, including the one case
+  that is still not guaranteed in a single pass.
+
 - **A sweep no longer traps the host it is cleaning, and `feint clean --force`
   frees a host already trapped** (#455). Fifteen third-party stacks replayed
   under `--vm incus-ovn` left two OVN networks, two rule sets and the uplink on

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -1124,6 +1124,73 @@ tooling produces one, the repair is theirs to run, and `incus admin sql global
 "DELETE FROM networks_peers WHERE id=<id>"` is the statement — after reading the
 row, because nothing here will read it for them.
 
+### Two more of Incus' peering rules, and why a Net of three subnets found them (#456)
+
+The section above is about a row nothing can remove. This one is about the two
+rules that produce such rows in the first place, and both were read from the
+Incus source at v7.2.0 and then measured on the station, sequentially, with
+nothing concurrent.
+
+**A create is completed by any pending half aiming at the network, and by
+exactly one.** `PeerCreate` in `internal/server/network/driver_ovn.go` looks for
+the half to consummate with `GetNetworkPeers(TargetNetworkProject,
+TargetNetworkName)` — the target network, and no clause on which network holds
+the row — and answers `More than one matching network peer was found` when the
+filter matches twice. So two pending halves aiming at one network make *every*
+create on it fail, whichever pairs they belong to:
+
+```
+$ incus network peer create fnt-lab1 fnt-lab2 fnt-lab2
+Network peer fnt-lab2 pending (please complete mutual peering on peer network)
+$ incus network peer create fnt-lab3 fnt-lab2 fnt-lab2
+Network peer fnt-lab2 pending (please complete mutual peering on peer network)
+$ incus network peer create fnt-lab2 fnt-lab1 fnt-lab1
+Error: Failed creating peer: More than one matching network peer was found
+```
+
+`(lab1, lab2)` and `(lab3, lab2)` are two different pairs, which is the whole
+shape of #456: a Net of N subnets declares N(N-1) halves as its subnets appear,
+and only a Net with three or more can have two of them aiming at one network at
+once. That is why a stranger's three-subnet Net tripped it and the two-subnet
+conformance fixtures never did — and why the emulator excludes both *ends* of a
+pair rather than the pair, one lock per network taken in sorted order
+(`peerLock`, `internal/core/machine/incus_ovn.go`).
+
+**A peer delete blanks every row aiming at the network it runs on.** `PeerDelete`
+clears `target_network_id` for every row whose target is that network, in the
+same transaction, whatever pair the row belongs to. On a three-network mesh:
+
+```
+$ incus network peer delete fnt-lab2 fnt-lab3
+Network peer fnt-lab3 deleted
+$ incus query /1.0/networks/fnt-lab1/peers?recursion=1
+  {"name":"fnt-lab2","target_network":null,"status":"Errored"}
+$ incus network peer create fnt-lab1 fnt-lab2 fnt-lab2
+Error: Failed creating peer: A peer for that name already exists
+```
+
+The delete named lab2 and lab3, and it is **lab1**'s half that came back
+`Errored`. Redeclaring that half is then refused for the name, which this driver
+used to tolerate as the peering already being there — so a peering was reported
+applied and did not exist. A pair whose two halves the runtime does not both
+call `Created` is now rebuilt from both ends instead, and every delete on that
+path asks the label `EnsureNetwork` wrote before touching a network, never the
+`fnt-` prefix.
+
+**What remains a limit.** Because a delete invalidates every inbound half of a
+network, repairing one pair of a mesh can damage its neighbours', so a mesh
+*already* wrecked on the host is not guaranteed to come back complete in a single
+reconciliation. Measured both ways on 2026-08-25, same shape both times: one run
+of a three-subnet Net broken by hand and then given a fourth subnet came back
+with twelve rows of which four were `Created`; the next, with the passes carried
+on, came back **12 of 12, then 20 of 20, then 30 of 30** as subnets five and six
+arrived, with no `More than one matching network peer was found` and no
+`could not peer` in the log at all. A Net whose subnets are merely *created* is
+the case that matters and it is exact: three subnets give three networks, six
+rows, six `Created`. Nothing here is a reason to hand-repair a host — the next
+subnet event reconciles, and `feint clean --force` is what frees a station that
+carries the older, unremovable form.
+
 ## Authentication is accepted, never verified
 
 No signature is checked, on any provider. Credentials must merely be well-formed,

--- a/internal/core/machine/incus.go
+++ b/internal/core/machine/incus.go
@@ -1045,10 +1045,12 @@ func freeInterface(devices map[string]map[string]string) string {
 // network — and keeps its own mutex; a caller that needs both takes this one
 // first, which is the order EnsureNetwork and RemoveNetwork both use.
 //
-// PeerNetworks deliberately does not take it. It names two networks, and a lock
-// on each would let two peerings of the same pair deadlock on opposite halves;
-// it also calls IsolateNetwork, which takes this lock itself, and serialise.Lock
-// is not reentrant.
+// PeerNetworks does not take this one: it calls IsolateNetwork, which takes it
+// itself, and serialise.Lock is not reentrant. It has its own domain instead
+// (peerLock, incus_ovn.go), one lock per network of the pair, and the deadlock
+// this paragraph used to warn about — two peerings of one pair each holding the
+// other's half — is closed there by taking the set in sorted order rather than
+// by going without.
 //
 // TestAnIsolationDetachDoesNotOrphanTheNetworkBeingDeleted fails without it.
 func (d *Incus) networkLock(name string) func() {

--- a/internal/core/machine/incus_ovn.go
+++ b/internal/core/machine/incus_ovn.go
@@ -8,8 +8,11 @@ import (
 	"net/netip"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
+
+	"github.com/stephrobert/feint/internal/core/serialise"
 )
 
 // OVN is the mode where emulated subnets are separate by construction.
@@ -275,13 +278,67 @@ func uplinkRanges(prefix netip.Prefix) (dhcp, ovn string, err error) {
 // NativeIsolation implements Peerer.
 func (d *Incus) NativeIsolation() bool { return d.OVN }
 
+// peerLock excludes every other peering this driver declares on the networks it
+// names, until the returned function is called. One lock per network, taken in
+// sorted order — which is what makes a set of them deadlock-free — so a pair
+// excludes exactly the work that could disturb it and two disjoint pairs still
+// run at once.
+//
+// A lock keyed by the *pair* is not enough, and the reason is in the runtime
+// rather than in this driver. Incus completes a peering by looking for a pending
+// half aiming at the network the create lands on, and that lookup filters on the
+// target network alone — there is no clause on which network holds the row
+// (v7.2.0, internal/server/network/driver_ovn.go, PeerCreate: GetNetworkPeers
+// with TargetNetworkProject and TargetNetworkName, then "More than one matching
+// network peer was found" when it matches twice). So two pending halves aiming
+// at one network are fatal to every create on it, whichever pairs they belong
+// to. Measured on Incus 7.2, three real OVN networks, nothing concurrent:
+//
+//	incus network peer create A B B  -> pending                        rc=0
+//	incus network peer create C B B  -> pending                        rc=0
+//	incus network peer create B A A  -> Error: Failed creating peer:
+//	                                    More than one matching network
+//	                                    peer was found                 rc=1
+//
+// (A,B) and (C,B) are two different pairs, so a per-pair key would have let
+// precisely that through; a lock on each end lets neither in while the other
+// works. That is the shape of #456: a Net of N subnets declares N(N-1) halves
+// as its subnets appear, and only a Net with three or more can have two of them
+// aiming at one network at once — which is why the two-subnet fixtures never
+// tripped it and a stranger's three-subnet Net did.
+//
+// Never one global lock: a Net's subnets are created in parallel on purpose,
+// and serialise.go's rule is that the exclusion is named, not widened.
+//
+// Its domain is deliberately not networkLock's: PeerNetworks ends in
+// IsolateNetwork, which takes that one, and serialise.Lock is not reentrant.
+// TestConcurrentPairsOfOneNetDoNotCollideOnAPendingHalf fails without this.
+func (d *Incus) peerLock(names ...string) func() {
+	ordered := make([]string, 0, len(names))
+	for _, name := range names {
+		if name == "" || slices.Contains(ordered, name) {
+			continue
+		}
+		ordered = append(ordered, name)
+	}
+	slices.Sort(ordered)
+	releases := make([]func(), 0, len(ordered))
+	for _, name := range ordered {
+		releases = append(releases, serialise.Lock("incus.peering."+name))
+	}
+	return func() {
+		for i := len(releases) - 1; i >= 0; i-- {
+			releases[i]()
+		}
+	}
+}
+
 // PeerNetworks implements Peerer.
 //
 // Reconciled, not appended: peers the caller no longer names are removed, so
 // a VPC that stops routing between its subnets actually separates them again.
-// A peering only carries traffic once both networks declare it, so both
-// halves are created here; the second call for the same pair finds its work
-// done and does nothing.
+// A peering only carries traffic once both networks declare it, so both halves
+// are declared here, as one operation under the pair's locks.
 func (d *Incus) PeerNetworks(ctx context.Context, network string, peers []string) error {
 	if !d.OVN {
 		// Bridges on one host are routed together already; there is nothing to
@@ -317,15 +374,12 @@ func (d *Incus) PeerNetworks(ctx context.Context, network string, peers []string
 		if row.Target != "" && desired[row.Target] {
 			continue
 		}
-		if _, err := d.run(ctx, "network", "peer", "delete", network, row.Name); err != nil && !isNotFound(err) {
-			return fmt.Errorf("remove stale peering %s of %s: %w", row.Name, network, err)
+		if err := d.removePeerRow(ctx, network, row); err != nil {
+			return err
 		}
 	}
 	for _, peer := range peers {
-		if err := d.ensurePeerHalf(ctx, network, peer); err != nil {
-			return err
-		}
-		if err := d.ensurePeerHalf(ctx, peer, network); err != nil {
+		if err := d.ensurePeering(ctx, network, peer); err != nil {
 			return err
 		}
 	}
@@ -337,9 +391,226 @@ func (d *Incus) PeerNetworks(ctx context.Context, network string, peers []string
 	return d.isolateOVN(ctx, network, peers)
 }
 
+// peerCreated is the runtime's own word for a peering both ends have declared;
+// it is the only status under which one carries traffic. Pending and Errored
+// are the two ways a row can be there and mean nothing, and telling them apart
+// from Created is what stops this driver reporting a peering it did not make.
+const peerCreated = "Created"
+
+// ensurePeering makes two networks peer each other, the pair being the unit
+// rather than each half on its own.
+//
+// A half is only worth keeping when the runtime calls it Created. A half whose
+// other end has gone is left behind as a row with no target at all, and the
+// runtime then answers "A peer for that name already exists" to every attempt
+// to declare that half again — which the code before #456 tolerated as success,
+// so the peering was reported applied and did not exist. Measured on Incus 7.2,
+// on a three-network mesh, with nothing concurrent:
+//
+//	incus network peer delete B C                                      rc=0
+//	incus query /1.0/networks/A/peers  -> {"name":"B","target_network":null,
+//	                                       "status":"Errored"}
+//	incus network peer create A B B    -> Error: Failed creating peer:
+//	                                       A peer for that name already exists
+//
+// Note which pair broke: the delete named B and C, and it is A's half that was
+// wrecked. PeerDelete clears the target of *every* row aiming at the network it
+// runs on, so removing one subnet from a Net damages the halves of its
+// neighbours too. That is why a pair that is not established at both ends is
+// rebuilt rather than patched: the row that looks wrong and the row that looks
+// right are the same peering.
+//
+// The ordinary path costs two reads and nothing else: a pair being declared for
+// the first time has no rows to take down, so an apply performs no delete and
+// leaves no wreck behind.
+// TestAWreckedHalfIsRebuiltRatherThanReportedApplied fails without this.
+func (d *Incus) ensurePeering(ctx context.Context, network, peer string) error {
+	release := d.peerLock(network, peer)
+	defer release()
+
+	near, err := d.networkPeers(ctx, network)
+	if err != nil {
+		return err
+	}
+	far, err := d.networkPeers(ctx, peer)
+	if err != nil {
+		return err
+	}
+	if peeringEstablished(near, peer) && peeringEstablished(far, network) {
+		return nil
+	}
+	if err := d.dropPeerHalf(ctx, network, near, peer); err != nil {
+		return err
+	}
+	if err := d.dropPeerHalf(ctx, peer, far, network); err != nil {
+		return err
+	}
+	if err := d.declarePeerHalf(ctx, network, peer); err != nil {
+		return err
+	}
+	return d.declarePeerHalf(ctx, peer, network)
+}
+
+// peeringEstablished reports that this end of the pair carries traffic: a row
+// aiming at the other network which the runtime itself calls Created.
+//
+// A pending half is not established — it grants nothing, which the network
+// conformance suite asserts against the real runtime — and neither is a wreck.
+// An empty status is read as established, because a runtime that does not say
+// must not have this driver tear a working mesh down on every pass; that is the
+// same rule as an undeclared capability counting as absent, pointed the way that
+// refuses to act.
+func peeringEstablished(rows []peerRow, other string) bool {
+	for _, row := range rows {
+		if row.Target == other && (row.Status == peerCreated || row.Status == "") {
+			return true
+		}
+	}
+	return false
+}
+
+// dropPeerHalf takes this end's half of one pair down, whatever state it is in:
+// the row aiming at the other network, and the row holding that network's name
+// with no target left, which are the same half seen before and after the runtime
+// blanked it.
+//
+// The ownership question is asked here and not at each caller, because this is
+// the only place a peering is deleted on the way to declaring one. It is asked
+// against the label EnsureNetwork wrote, never the name: `fnt-` is a prefix
+// anybody may type, and an operator's own OVN network called `fnt-lab`, peered
+// with one of ours by hand, would otherwise have this reach into theirs. That is
+// the guard #455 had to add to the sweep, and it belongs on every path that
+// deletes a peering.
+// TestPeeringRefusesToRebuildOnAStrangersNetworkNamedLikeOurs fails without it.
+func (d *Incus) dropPeerHalf(ctx context.Context, network string, rows []peerRow, other string) error {
+	doomed := make([]peerRow, 0, 2)
+	for _, row := range rows {
+		if row.Name == other || row.Target == other {
+			doomed = append(doomed, row)
+		}
+	}
+	if len(doomed) == 0 {
+		return nil
+	}
+	if !d.ownsPeerTarget(ctx, network) {
+		return fmt.Errorf("refusing to rebuild the peering between %s and %s: %s is not a network the emulator created",
+			network, other, network)
+	}
+	for _, row := range doomed {
+		if _, err := d.run(ctx, "network", "peer", "delete", network, row.Name); err != nil && !isNotFound(err) {
+			return fmt.Errorf("take down the %s half of the peering with %s: %w", network, other, err)
+		}
+	}
+	return nil
+}
+
+// removePeerRow deletes one row of a network's own peer list, under the locks of
+// both ends so it cannot cross a declaration of the same pair.
+func (d *Incus) removePeerRow(ctx context.Context, network string, row peerRow) error {
+	release := d.peerLock(network, row.Target, row.Name)
+	defer release()
+	if _, err := d.run(ctx, "network", "peer", "delete", network, row.Name); err != nil && !isNotFound(err) {
+		return fmt.Errorf("remove stale peering %s of %s: %w", row.Name, network, err)
+	}
+	return nil
+}
+
+// declarePeerHalf declares one direction of a peering, under the target's name
+// so the pair is recognisable from either side.
+//
+// Two answers are not failures. "Already exists" is another declaration of the
+// same half arriving first — the pair's locks exclude every other goroutine
+// here, so it is a second process, and its work is this call's work. "More than
+// one matching network peer was found" is the runtime refusing to guess between
+// several pending halves aiming at this network (see peerLock for the source and
+// the measurement): the locks stop this process from making that state, but a
+// crashed run, or a run of a version without them, leaves it on the host, and
+// nothing a user can type repairs it. So it is reconciled and the create is
+// re-issued once.
+// TestASecondPendingHalfIsReconciledRatherThanReported fails without the branch.
+func (d *Incus) declarePeerHalf(ctx context.Context, from, to string) error {
+	_, err := d.run(ctx, "network", "peer", "create", from, to, to)
+	if err == nil {
+		return nil
+	}
+	said := strings.ToLower(err.Error())
+	if strings.Contains(said, "already exists") {
+		return nil
+	}
+	if !strings.Contains(said, "more than one matching network peer") {
+		return fmt.Errorf("peer %s with %s: %w", from, to, err)
+	}
+	dropped, rivalErr := d.clearRivalPendingHalves(ctx, from, to)
+	if rivalErr != nil {
+		return fmt.Errorf("peer %s with %s: %w (the pending halves aiming at %s could not be read: %w)",
+			from, to, err, from, rivalErr)
+	}
+	if dropped == 0 {
+		return fmt.Errorf("peer %s with %s: %w (several pending halves aim at %s and none of them is the emulator's to remove)",
+			from, to, err, from)
+	}
+	if _, err := d.run(ctx, "network", "peer", "create", from, to, to); err != nil &&
+		!strings.Contains(strings.ToLower(err.Error()), "already exists") {
+		return fmt.Errorf("peer %s with %s, after clearing %d pending half(s) aiming at %s: %w",
+			from, to, dropped, from, err)
+	}
+	return nil
+}
+
+// clearRivalPendingHalves removes the pending halves aiming at one network that
+// come from anywhere except the peer being declared, and answers how many went.
+//
+// Only the emulator's own OVN networks are read, and each one is asked for the
+// label before anything is deleted on it: a pending half on a network somebody
+// else created is somebody else's, and leaving the create to fail is the honest
+// outcome. A half taken down here carried no traffic — pending grants nothing —
+// and the reconciliation that owns it is level-based, so it is declared again on
+// the next pass.
+func (d *Incus) clearRivalPendingHalves(ctx context.Context, aimedAt, keep string) (int, error) {
+	subnets, err := d.ourOVNSubnets(ctx)
+	if err != nil {
+		return 0, err
+	}
+	names := make([]string, 0, len(subnets))
+	for name := range subnets {
+		if name == aimedAt || name == keep {
+			continue
+		}
+		names = append(names, name)
+	}
+	// Sorted, so two runs of the same repair emit the same commands.
+	slices.Sort(names)
+
+	dropped := 0
+	for _, name := range names {
+		rows, err := d.networkPeers(ctx, name)
+		if err != nil {
+			// A network that went while this was being read holds no half.
+			continue
+		}
+		for _, row := range rows {
+			if row.Target != aimedAt || row.Status == peerCreated {
+				continue
+			}
+			if !d.ownsPeerTarget(ctx, name) {
+				break
+			}
+			if _, err := d.run(ctx, "network", "peer", "delete", name, row.Name); err != nil && !isNotFound(err) {
+				return dropped, fmt.Errorf("clear the pending half %s of %s: %w", row.Name, name, err)
+			}
+			dropped++
+		}
+	}
+	return dropped, nil
+}
+
 type peerRow struct {
-	Name   string
+	Name string
+	// Target is the network on the far end. The runtime blanks it when that
+	// network's peer list is edited, which is what a wreck looks like.
 	Target string
+	// Status is the runtime's own verdict: Created, Pending, or Errored.
+	Status string
 }
 
 func (d *Incus) networkPeers(ctx context.Context, network string) ([]peerRow, error) {
@@ -350,35 +621,16 @@ func (d *Incus) networkPeers(ctx context.Context, network string) ([]peerRow, er
 	var raw []struct {
 		Name          string `json:"name"`
 		TargetNetwork string `json:"target_network"`
+		Status        string `json:"status"`
 	}
 	if err := json.Unmarshal(out, &raw); err != nil {
 		return nil, fmt.Errorf("decode peers of %s: %w", network, err)
 	}
 	rows := make([]peerRow, 0, len(raw))
 	for _, r := range raw {
-		rows = append(rows, peerRow{Name: r.Name, Target: r.TargetNetwork})
+		rows = append(rows, peerRow{Name: r.Name, Target: r.TargetNetwork, Status: r.Status})
 	}
 	return rows, nil
-}
-
-// ensurePeerHalf declares one direction of a peering, under the target's name
-// so the pair is recognisable from either side. Racing another declaration of
-// the same half is the success case arriving first.
-func (d *Incus) ensurePeerHalf(ctx context.Context, from, to string) error {
-	rows, err := d.networkPeers(ctx, from)
-	if err != nil {
-		return err
-	}
-	for _, row := range rows {
-		if row.Target == to {
-			return nil
-		}
-	}
-	if _, err := d.run(ctx, "network", "peer", "create", from, to, to); err != nil &&
-		!strings.Contains(strings.ToLower(err.Error()), "already exists") {
-		return fmt.Errorf("peer %s with %s: %w", from, to, err)
-	}
-	return nil
 }
 
 // ---- Public addresses -------------------------------------------------------

--- a/internal/core/machine/incus_ovn_peering_test.go
+++ b/internal/core/machine/incus_ovn_peering_test.go
@@ -1,0 +1,522 @@
+package machine
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// The peering half of #456, staged against a daemon that answers the way the
+// real one was measured to answer.
+//
+// Two facts of Incus 7.2 drive everything here, and both were measured on this
+// station with three real OVN networks and nothing concurrent, before a line of
+// this file existed. They are stated in the fake below because a model that got
+// either wrong would make these tests agree with a driver that cannot work.
+//
+//  1. A create completes a peering by looking for a *pending* half aiming at the
+//     network the create lands on, and the lookup names only that target — not
+//     which network holds the row (v7.2.0, driver_ovn.go, PeerCreate). So:
+//
+//     incus network peer create A B B  -> pending                        rc=0
+//     incus network peer create C B B  -> pending                        rc=0
+//     incus network peer create B A A  -> Error: Failed creating peer:
+//     More than one matching network peer was found                      rc=1
+//
+//     (A,B) and (C,B) are different pairs. A lock keyed by the pair would have
+//     allowed exactly this, which is why the driver locks each end.
+//
+//  2. Deleting one peer clears the target of every row aiming at the network the
+//     delete runs on, whatever pair it belongs to. In a three-network mesh,
+//     `incus network peer delete B C` left A holding
+//     {"name":"B","target_network":null,"status":"Errored"} — and the runtime
+//     then answers "A peer for that name already exists" to any attempt to
+//     declare that half again, which the code before #456 read as success.
+
+const (
+	peerPending = "Pending"
+	peerErrored = "Errored"
+)
+
+// peerRecord is one row of the daemon's networks_peers table, in the two states
+// the API distinguishes plus the wreck a delete leaves.
+type peerRecord struct {
+	name   string
+	target string // the target's name while pending; blanked when the row is wrecked
+	status string
+}
+
+// fakePeerd is the peering half of the daemon.
+type fakePeerd struct {
+	mu       sync.Mutex
+	rows     map[string][]peerRecord
+	networks []string
+	// unlabelled names the networks that carry no label of this emulator's: an
+	// operator's own, which happen to be spelled like ours.
+	unlabelled map[string]bool
+	calls      []string
+
+	// beat is how long a create that only left a pending half takes to answer.
+	// It is the window a second declaration has to arrive in.
+	beat time.Duration
+	// gate makes that window deterministic: a pending create waits for a second
+	// one instead of hoping to meet it. With the driver's locks in place no
+	// second one can arrive for a network already being paired, so the wait
+	// costs the beat; without them the two meet, and the state the runtime
+	// refuses is reached every time rather than sometimes.
+	gate    bool
+	waiters []chan struct{}
+}
+
+func newFakePeerd(networks ...string) *fakePeerd {
+	f := &fakePeerd{
+		rows:       map[string][]peerRecord{},
+		networks:   networks,
+		unlabelled: map[string]bool{},
+		beat:       100 * time.Millisecond,
+	}
+	return f
+}
+
+func peerDriver(f *fakePeerd) *Incus {
+	d := NewIncus()
+	d.runner = f.run
+	d.OVN = true
+	return d
+}
+
+func (f *fakePeerd) run(_ context.Context, args ...string) ([]byte, error) {
+	joined := strings.Join(args, " ")
+	f.mu.Lock()
+	f.calls = append(f.calls, joined)
+	f.mu.Unlock()
+
+	switch {
+	case joined == "query /1.0/networks?recursion=1":
+		return f.networkList()
+	case strings.HasPrefix(joined, "query /1.0/networks/") && strings.HasSuffix(joined, "/peers?recursion=1"):
+		name := strings.TrimSuffix(strings.TrimPrefix(joined, "query /1.0/networks/"), "/peers?recursion=1")
+		return f.peerList(name)
+	case strings.HasPrefix(joined, "query /1.0/networks/"):
+		// The existence probe IsolateNetwork makes before it edits anything.
+		return []byte(`{"type": "ovn"}`), nil
+	case strings.HasPrefix(joined, "network peer create "):
+		return f.peerCreate(args[3], args[4], args[5])
+	case strings.HasPrefix(joined, "network peer delete "):
+		return f.peerDelete(args[3], args[4])
+	case strings.HasPrefix(joined, "network get ") && strings.Contains(joined, "user."+LabelKey):
+		if f.unlabelled[args[2]] {
+			return []byte("\n"), nil
+		}
+		return []byte("outscale\n"), nil
+	case strings.HasPrefix(joined, "network acl show "), strings.HasPrefix(joined, "network acl delete "):
+		// No rule set stands in these fixtures: the isolation half is measured
+		// in incus_ovn_isolate_test.go, and an absent one is what both the
+		// create path and RemoveFirewall are written for.
+		return nil, errors.New("Error: Network ACL not found")
+	}
+	return []byte("{}"), nil
+}
+
+func (f *fakePeerd) networkList() ([]byte, error) {
+	type wire struct {
+		Name   string            `json:"name"`
+		Type   string            `json:"type"`
+		Config map[string]string `json:"config"`
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]wire, 0, len(f.networks))
+	for i, name := range f.networks {
+		out = append(out, wire{Name: name, Type: "ovn", Config: map[string]string{
+			"ipv4.address": fmt.Sprintf("10.185.%d.1/24", i+1),
+		}})
+	}
+	return json.Marshal(out)
+}
+
+func (f *fakePeerd) peerList(network string) ([]byte, error) {
+	type wire struct {
+		Name   string  `json:"name"`
+		Target *string `json:"target_network"`
+		Status string  `json:"status"`
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	rows := f.rows[network]
+	out := make([]wire, 0, len(rows))
+	for _, row := range rows {
+		item := wire{Name: row.name, Status: row.status}
+		if row.target != "" {
+			target := row.target
+			item.Target = &target
+		}
+		out = append(out, item)
+	}
+	return json.Marshal(out)
+}
+
+// peerCreate is fact 1 above, in code.
+func (f *fakePeerd) peerCreate(from, to, name string) ([]byte, error) {
+	f.mu.Lock()
+	for _, row := range f.rows[from] {
+		if row.name == name {
+			f.mu.Unlock()
+			return nil, errors.New("Error: Failed creating peer: A peer for that name already exists")
+		}
+		if row.target == to {
+			f.mu.Unlock()
+			return nil, errors.New("Error: Failed creating peer: A peer for that target network already exists")
+		}
+	}
+	// Every pending half aiming at the network this create lands on, wherever it
+	// lives. This is the filter with no clause on the row's own network.
+	matches := 0
+	holder, at := "", -1
+	for network, rows := range f.rows {
+		for i, row := range rows {
+			if row.status == peerPending && row.target == from {
+				matches++
+				holder, at = network, i
+			}
+		}
+	}
+	if matches > 1 {
+		f.mu.Unlock()
+		return nil, errors.New("Error: Failed creating peer: More than one matching network peer was found")
+	}
+	if matches == 1 {
+		f.rows[holder][at].status = peerCreated
+		f.rows[from] = append(f.rows[from], peerRecord{name: name, target: to, status: peerCreated})
+		f.mu.Unlock()
+		return []byte("created"), nil
+	}
+	f.rows[from] = append(f.rows[from], peerRecord{name: name, target: to, status: peerPending})
+	wait := f.pendingWindowLocked()
+	f.mu.Unlock()
+	wait()
+	return []byte("pending"), nil
+}
+
+// pendingWindowLocked returns the wait a create that left a pending half takes
+// before it answers. The caller holds the lock; the wait runs without it.
+func (f *fakePeerd) pendingWindowLocked() func() {
+	if !f.gate {
+		beat := f.beat
+		return func() { time.Sleep(beat) }
+	}
+	mine := make(chan struct{})
+	f.waiters = append(f.waiters, mine)
+	if len(f.waiters) > 1 {
+		for _, waiter := range f.waiters {
+			close(waiter)
+		}
+		f.waiters = nil
+	}
+	beat := f.beat
+	return func() {
+		select {
+		case <-mine:
+		case <-time.After(beat):
+		}
+	}
+}
+
+// peerDelete is fact 2 above, in code: the row goes, and every row aiming at
+// this network loses its target.
+func (f *fakePeerd) peerDelete(network, name string) ([]byte, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	rows := f.rows[network]
+	at := -1
+	for i, row := range rows {
+		if row.name == name {
+			at = i
+			break
+		}
+	}
+	if at < 0 {
+		return nil, errors.New("Error: Network peer not found")
+	}
+	f.rows[network] = append(rows[:at:at], rows[at+1:]...)
+	for _, other := range f.rows {
+		for i := range other {
+			if other[i].status == peerCreated && other[i].target == network {
+				other[i].target = ""
+				other[i].status = peerErrored
+			}
+		}
+	}
+	return []byte("deleted"), nil
+}
+
+// established is what the driver claims when PeerNetworks returns: both ends
+// hold a row aiming at the other, and the daemon calls both Created.
+func (f *fakePeerd) established(a, b string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.halfLocked(a, b) && f.halfLocked(b, a)
+}
+
+func (f *fakePeerd) halfLocked(from, to string) bool {
+	for _, row := range f.rows[from] {
+		if row.target == to && row.status == peerCreated {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *fakePeerd) commands() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.calls))
+	copy(out, f.calls)
+	return out
+}
+
+func (f *fakePeerd) table() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var b strings.Builder
+	for _, network := range f.networks {
+		for _, row := range f.rows[network] {
+			fmt.Fprintf(&b, "  on %s: name=%s target=%q %s\n", network, row.name, row.target, row.status)
+		}
+	}
+	if b.Len() == 0 {
+		return "  (no peering at all)\n"
+	}
+	return b.String()
+}
+
+// mesh drives what ReconcileIsolation drives: every member of one Net declares
+// every other as its peer, and the members appear at once because a stack
+// creates its subnets in parallel.
+func mesh(t *testing.T, d *Incus, members []string) []error {
+	t.Helper()
+	var wg sync.WaitGroup
+	failures := make(chan error, len(members))
+	for i, member := range members {
+		wg.Add(1)
+		go func(i int, member string) {
+			defer wg.Done()
+			peers := make([]string, 0, len(members)-1)
+			for j, other := range members {
+				if i != j {
+					peers = append(peers, other)
+				}
+			}
+			if err := d.PeerNetworks(context.Background(), member, peers); err != nil {
+				failures <- fmt.Errorf("PeerNetworks(%s, %v): %w", member, peers, err)
+			}
+		}(i, member)
+	}
+	wg.Wait()
+	close(failures)
+	var errs []error
+	for err := range failures {
+		errs = append(errs, err)
+	}
+	return errs
+}
+
+// TestConcurrentPairsOfOneNetDoNotCollideOnAPendingHalf is #456 itself: a Net
+// with three subnets, whose networks are declared at once.
+//
+// Twelve of these lines were logged in one apply of a stranger's stack, naming
+// six subnets, and the emulator carried on at ERROR — so the API kept describing
+// a Net whose subnets route to each other while the runtime had no peering at
+// all between them.
+//
+// Two subnets never showed it, and that is the shape of the defect rather than
+// luck: one pair has one pending half at a time, and it takes two of them aiming
+// at one network to make a create fail. The gate in the fake makes the meeting
+// certain instead of likely.
+func TestConcurrentPairsOfOneNetDoNotCollideOnAPendingHalf(t *testing.T) {
+	members := []string{"fnt-aaa", "fnt-bbb", "fnt-ccc"}
+	f := newFakePeerd(members...)
+	f.gate = true
+	d := peerDriver(f)
+
+	for _, err := range mesh(t, d, members) {
+		t.Errorf("a subnet of the Net could not be peered: %v", err)
+	}
+
+	for i, a := range members {
+		for _, b := range members[i+1:] {
+			if !f.established(a, b) {
+				t.Errorf("%s and %s are not peered at both ends; the Net's subnets do not reach each other:\n%s",
+					a, b, f.table())
+			}
+		}
+	}
+}
+
+// The accepting half, and the reason the exclusion is per network rather than
+// one lock over all peering: a Net's subnets are created in parallel on purpose.
+//
+// Two pairs that share no network must not wait for each other. Serialised, the
+// pair below costs two creates each, one after the other; per network, it costs
+// one round. This is the bound #348 was measured against, one layer along.
+func TestPeeringTwoDisjointPairsDoesNotQueue(t *testing.T) {
+	f := newFakePeerd("fnt-aaa", "fnt-bbb", "fnt-ccc", "fnt-ddd")
+	f.beat = 300 * time.Millisecond
+	d := peerDriver(f)
+
+	var wg sync.WaitGroup
+	start := time.Now()
+	for _, pair := range [][2]string{{"fnt-aaa", "fnt-bbb"}, {"fnt-ccc", "fnt-ddd"}} {
+		wg.Add(1)
+		go func(pair [2]string) {
+			defer wg.Done()
+			if err := d.PeerNetworks(context.Background(), pair[0], []string{pair[1]}); err != nil {
+				t.Errorf("peer %s with %s: %v", pair[0], pair[1], err)
+			}
+		}(pair)
+	}
+	wg.Wait()
+	elapsed := time.Since(start)
+
+	if limit := f.beat * 3 / 2; elapsed > limit {
+		t.Fatalf("two peerings sharing no network took %v, over %v: they queued behind one lock, "+
+			"which is the global lock serialise.go refuses — a Net's subnets are declared in parallel", elapsed, limit)
+	}
+	if !f.established("fnt-aaa", "fnt-bbb") || !f.established("fnt-ccc", "fnt-ddd") {
+		t.Errorf("the pairs were fast and not peered:\n%s", f.table())
+	}
+}
+
+// TestAWreckedHalfIsRebuiltRatherThanReportedApplied holds the second measured
+// fact: a half whose target the runtime blanked cannot be declared again under
+// its own name, and the answer it gives says "already exists", which the driver
+// used to accept as the work being done.
+//
+// The fixture is what a station holds after one subnet of a Net is deleted: the
+// pair that was not named in the delete, with one end still Created and the
+// other wrecked.
+func TestAWreckedHalfIsRebuiltRatherThanReportedApplied(t *testing.T) {
+	f := newFakePeerd("fnt-aaa", "fnt-bbb")
+	f.rows["fnt-aaa"] = []peerRecord{{name: "fnt-bbb", target: "", status: peerErrored}}
+	f.rows["fnt-bbb"] = []peerRecord{{name: "fnt-aaa", target: "fnt-aaa", status: peerCreated}}
+	d := peerDriver(f)
+
+	if err := d.PeerNetworks(context.Background(), "fnt-aaa", []string{"fnt-bbb"}); err != nil {
+		t.Fatalf("peer: %v", err)
+	}
+	if !f.established("fnt-aaa", "fnt-bbb") {
+		t.Fatalf("the peering was reported applied and is not there:\n%s\nthe driver ran:\n%s",
+			f.table(), strings.Join(f.commands(), "\n"))
+	}
+}
+
+// TestASecondPendingHalfIsReconciledRatherThanReported is the belt the lock does
+// not replace: a pending half left on the host by a crashed run, or by a version
+// of this driver without the locks, makes every create on the network it aims at
+// fail — and nothing a user can type repairs it, because the runtime refuses the
+// create that would.
+func TestASecondPendingHalfIsReconciledRatherThanReported(t *testing.T) {
+	f := newFakePeerd("fnt-aaa", "fnt-bbb", "fnt-ccc")
+	// The residue: fnt-ccc declared a half aiming at fnt-bbb and nothing ever
+	// completed it.
+	f.rows["fnt-ccc"] = []peerRecord{{name: "fnt-bbb", target: "fnt-bbb", status: peerPending}}
+	d := peerDriver(f)
+
+	if err := d.PeerNetworks(context.Background(), "fnt-aaa", []string{"fnt-bbb"}); err != nil {
+		t.Fatalf("peer: %v", err)
+	}
+	if !f.established("fnt-aaa", "fnt-bbb") {
+		t.Fatalf("the pair was not peered:\n%s\nthe driver ran:\n%s",
+			f.table(), strings.Join(f.commands(), "\n"))
+	}
+	// And the half that was cleared is one that carried nothing: pending grants
+	// no traffic, and the reconciliation that owns it declares it again.
+	for _, row := range f.rows["fnt-ccc"] {
+		if row.status == peerPending && row.target == "fnt-bbb" {
+			t.Errorf("the pending half that blocked the create is still there:\n%s", f.table())
+		}
+	}
+}
+
+// TestPeeringRefusesToRebuildOnAStrangersNetworkNamedLikeOurs is the guard on
+// the destructive half of the repair, and it is the one a name cannot answer.
+//
+// `fnt-` is a prefix anybody may type. An operator with an OVN network of their
+// own under that name, peered with one of ours by hand, must not have this
+// driver delete peerings on theirs to rebuild ours — which is the guard #455
+// added to the sweep, on a path of exactly this family.
+func TestPeeringRefusesToRebuildOnAStrangersNetworkNamedLikeOurs(t *testing.T) {
+	f := newFakePeerd("fnt-aaa", "fnt-lab")
+	f.unlabelled["fnt-lab"] = true
+	// Both ends carry a half that must be rebuilt: ours is a wreck, theirs holds
+	// the name the rebuild needs.
+	f.rows["fnt-aaa"] = []peerRecord{{name: "fnt-lab", target: "", status: peerErrored}}
+	f.rows["fnt-lab"] = []peerRecord{{name: "fnt-aaa", target: "fnt-aaa", status: peerCreated}}
+	d := peerDriver(f)
+
+	err := d.PeerNetworks(context.Background(), "fnt-aaa", []string{"fnt-lab"})
+	if err == nil {
+		t.Error("a peering the driver could not make was reported as made")
+	}
+	for _, cmd := range f.commands() {
+		if strings.HasPrefix(cmd, "network peer delete fnt-lab") {
+			t.Errorf("the driver deleted a peering on a network nobody here created: %q\n"+
+				"the name carries our prefix and the network is not ours; only the label says so", cmd)
+		}
+	}
+}
+
+// The accepting half of the same guard, in the same run: a network that does
+// carry the label is rebuilt, or the refusal above would be indistinguishable
+// from a driver that repairs nothing.
+func TestPeeringRebuildsOnOurOwnNetwork(t *testing.T) {
+	f := newFakePeerd("fnt-aaa", "fnt-bbb")
+	f.rows["fnt-aaa"] = []peerRecord{{name: "fnt-bbb", target: "", status: peerErrored}}
+	f.rows["fnt-bbb"] = []peerRecord{{name: "fnt-aaa", target: "fnt-aaa", status: peerCreated}}
+	d := peerDriver(f)
+
+	if err := d.PeerNetworks(context.Background(), "fnt-aaa", []string{"fnt-bbb"}); err != nil {
+		t.Fatalf("peer: %v", err)
+	}
+	if len(matchingIn(f.commands(), "network peer delete fnt-bbb fnt-aaa")) == 0 {
+		t.Errorf("the far half was never taken down, so the rebuild had nothing to declare:\n%s",
+			strings.Join(f.commands(), "\n"))
+	}
+	if !f.established("fnt-aaa", "fnt-bbb") {
+		t.Errorf("the pair was not rebuilt:\n%s", f.table())
+	}
+}
+
+// A pair both ends already call Created costs two reads and no command at all.
+// Without this, every reconciliation pass would tear a working mesh down and
+// build it again, which is a peering that flaps for as long as the Net lives.
+func TestAnEstablishedPeeringIsLeftAlone(t *testing.T) {
+	f := newFakePeerd("fnt-aaa", "fnt-bbb")
+	f.rows["fnt-aaa"] = []peerRecord{{name: "fnt-bbb", target: "fnt-bbb", status: peerCreated}}
+	f.rows["fnt-bbb"] = []peerRecord{{name: "fnt-aaa", target: "fnt-aaa", status: peerCreated}}
+	d := peerDriver(f)
+
+	if err := d.PeerNetworks(context.Background(), "fnt-aaa", []string{"fnt-bbb"}); err != nil {
+		t.Fatalf("peer: %v", err)
+	}
+	for _, cmd := range f.commands() {
+		if strings.HasPrefix(cmd, "network peer delete") || strings.HasPrefix(cmd, "network peer create") {
+			t.Errorf("an established peering was rebuilt: %q", cmd)
+		}
+	}
+}
+
+func matchingIn(commands []string, substr string) []string {
+	var out []string
+	for _, cmd := range commands {
+		if strings.Contains(cmd, substr) {
+			out = append(out, cmd)
+		}
+	}
+	return out
+}

--- a/tools/falsify/specs/peering-pairs.json
+++ b/tools/falsify/specs/peering-pairs.json
@@ -1,0 +1,33 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "the peering of a pair stops excluding the networks it names, so two pairs of one Net leave two pending halves aiming at the same network and the runtime refuses every create on it (#456)",
+      "file": "internal/core/machine/incus_ovn.go",
+      "find": "\tslices.Sort(ordered)\n\treleases := make([]func(), 0, len(ordered))",
+      "replace": "\tslices.Sort(ordered)\n\tordered = ordered[:0]\n\treleases := make([]func(), 0, len(ordered))",
+      "test": "TestConcurrentPairsOfOneNetDoNotCollideOnAPendingHalf"
+    },
+    {
+      "label": "the rebuild ignores the half holding the target's name with no target left, so the create answers \"a peer for that name already exists\" and the peering is reported applied without existing (#456)",
+      "file": "internal/core/machine/incus_ovn.go",
+      "find": "\t\tif row.Name == other || row.Target == other {",
+      "replace": "\t\tif row.Target == other {",
+      "test": "TestAWreckedHalfIsRebuiltRatherThanReportedApplied"
+    },
+    {
+      "label": "a second pending half aiming at the network is reported instead of reconciled, which leaves a host nothing a user can type repairs (#456)",
+      "file": "internal/core/machine/incus_ovn.go",
+      "find": "\tif !strings.Contains(said, \"more than one matching network peer\") {",
+      "replace": "\tif !strings.Contains(said, \"more than one matching network peer of a wording no runtime uses\") {",
+      "test": "TestASecondPendingHalfIsReconciledRatherThanReported"
+    },
+    {
+      "label": "the rebuild deletes peerings on the far network without asking whether the emulator created it, so an operator's own fnt-* network is reconfigured (#456, the guard #455 added to the sweep)",
+      "file": "internal/core/machine/incus_ovn.go",
+      "find": "\tif !d.ownsPeerTarget(ctx, network) {\n\t\treturn fmt.Errorf(\"refusing to rebuild the peering between %s and %s: %s is not a network the emulator created\",",
+      "replace": "\tif false && !d.ownsPeerTarget(ctx, network) {\n\t\treturn fmt.Errorf(\"refusing to rebuild the peering between %s and %s: %s is not a network the emulator created\",",
+      "test": "TestPeeringRefusesToRebuildOnAStrangersNetworkNamedLikeOurs"
+    }
+  ]
+}


### PR DESCRIPTION
A Net with several subnets failed to peer under OVN (`More than one matching network peer was found`), which left its subnets undeletable, made `DeleteNet` refuse with its own correct 409, and failed `terraform destroy`. It is what manufactured the dangling halves #455 taught the sweep to clean; this closes the factory.

## The audit's diagnosis was half right, and the measurement changed the fix

The audit said the collision is two declarations of the *same pair*, and prescribed a lock keyed `min(a,b)|max(a,b)`. **That lock would not have closed it.** Incus v7.2.0 (`driver_ovn.go`, `PeerCreate`) filters the lookup that completes a peering on `TargetNetworkName` **alone**, with no clause on which network holds the row. Two pending halves aiming at one network therefore break *every* create on it, whichever pairs they belong to — and `(A,B)` and `(C,B)` are two distinct keys, so a pair lock lets them run in parallel.

Measured on three real OVN networks, sequentially, nothing concurrent:

```
incus network peer create A B B  -> pending                             rc=0
incus network peer create C B B  -> pending                             rc=0
incus network peer create B A A  -> More than one matching network peer rc=1
incus network peer delete C B    -> deleted                             rc=0
incus network peer create B A A  -> created                             rc=0
```

The exclusion is **one lock per network, on both ends, taken in sorted order** — still per-pair (disjoint pairs run in parallel, asserted by a timing test), never global, deadlock-free by the ordering.

## A second rule, found on the way, and worse

**A peer delete blanks the target of every row aiming at the network it runs on.** On a three-network mesh, `peer delete B C` left **A** holding `{"target_network":null,"status":"Errored"}`, and redeclaring that half answers `A peer for that name already exists` — **which the driver tolerated as success**. A peering was reported applied and did not exist.

A pair the runtime does not call `Created` at both ends is now rebuilt from both ends, and every delete on that path asks the label `EnsureNetwork` wrote, never the `fnt-` prefix.

## Against the real runtime (Incus 7.2 + OVN)

- Net with 3 subnets created concurrently → 3 OVN networks, **6 rows, 6 `Created`**, zero `More than one matching`.
- Host broken by hand into the exact defect state, then a 4th subnet → **12 of 12 `Created`**; 20/20 and 30/30 at subnets 5 and 6.
- Teardown: 6 × `DeleteSubnet` rc=0, `DeleteNet` rc=0, **no 409**, no `fnt-*` network, `networks_peers` **empty**.

**Station delta: zero.** Baseline and final `incus network list` diff empty, 0 instances, 0 peer rows.

## What is not closed, stated rather than claimed away

**Repairing a mesh that is *already* wrecked is not guaranteed in one reconciliation** — an earlier run returned 4 `Created` of 12 — because every peer delete invalidates all inbound halves of its network. Written into `docs/limits.md` with the cause. The case this issue is about, subnets being *created*, converges exactly.

## Gates

`go build` 0 · `go test ./...` 0 (26 packages) · `mise run prepush` 0 · `falsify peering-pairs.json` 0 (4 mutations, 4 red) · the two existing specs naming `incus_ovn.go` 0, 0.

**`mise run conformance` was deliberately not played on this branch** — several issues are handled in series and it runs once over the assembled set.

Closes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)