### PR TITLE
perf(outscale): the emulated public block is a /28, and the suite stops spending four minutes releasing addresses

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -19,6 +19,31 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Modifié
 
+- **Le bloc public Outscale émulé est un `/28`, plus un `/24`, et la suite de
+  conformance a cessé de passer quatre minutes à libérer des adresses.** Ce que
+  ce bloc doit tenir — l'allocation refuse au-delà de la dernière adresse avec
+  un `9029` typé, une adresse libérée revient au pool — ne dépend pas de leur
+  nombre, et le pic réellement détenu simultanément par l'ensemble des suites,
+  fixtures et stacks d'exemple de ce dépôt est de **deux**. Épuiser un `/24`
+  coûtait 254 appels `DeletePublicIp` à ~700 ms de démarrage de client chacun.
+  Mesuré sur cette station : jambe `octl` **368 s → 142 s**, jambe `fields`
+  **435 s → 209 s**, les deux toujours vertes avec le gate d'omission armé.
+
+  La borne de l'allocateur se déduit désormais du préfixe au lieu d'être écrite
+  une seconde fois, `ReadPublicIpRanges` publie cette même constante, et
+  `TestTheAllocatorStopsWhereTheCatalogueSaysItDoes` parcourt la plage publiée
+  jusqu'au bout puis exige que le refus tombe sur l'adresse suivante — éditer
+  un seul des deux côtés le fait donc échouer. Falsifié trois fois : publier
+  une autre plage, désolidariser la borne du préfixe, laisser le pool
+  distribuer deux fois la même adresse ; les trois rougissent.
+
+  Trouvé en chemin : `TestAnOutscaleBarrageLeavesTheStoreCoherent` prétendait en
+  commentaire attraper un pool distribuant une adresse à deux appelants, et
+  jetait l'adresse qu'on venait de lui donner (`_ = ip`). Il enregistre
+  maintenant chaque adresse et vérifie les doublons, et traite l'épuisement pour
+  ce qu'il est : la réponse attendue.
+
+
 - **La suite Outscale pilote `octl`, et le client qu'elle pilotait est archivé**
   (#460). `outscale/oapi-cli` et `outscale/osc-cli` sont tous deux
   `archived: true` sur l'API GitHub, en lecture seule, avec « Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,30 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Changed
 
+- **The emulated Outscale public block is a `/28`, not a `/24`, and the
+  conformance suite stopped spending four minutes releasing addresses.** The
+  property the block holds — allocation refuses past the last address with a
+  typed `9029`, a released address returns to the pool — does not depend on how
+  many addresses there are, and the measured peak held at once across every
+  suite, fixture and example stack here is two. Exhausting a `/24` cost 254
+  `DeletePublicIp` calls at roughly 700 ms of client startup each. Measured on
+  this station: the `octl` leg **368 s → 142 s**, the `fields` leg **435 s →
+  209 s**, both still green with the omission gate armed.
+
+  The allocator's bound is now derived from the prefix instead of written a
+  second time, `ReadPublicIpRanges` publishes that same constant, and
+  `TestTheAllocatorStopsWhereTheCatalogueSaysItDoes` walks the published range
+  to its end and asserts the refusal lands on the address after it — so editing
+  either side alone fails. Falsified three ways: publishing a different range,
+  unpinning the bound from the prefix, and letting the pool hand one address
+  twice; all three go red.
+
+  Found on the way: `TestAnOutscaleBarrageLeavesTheStoreCoherent` claimed in a
+  comment to catch a pool handing one address to two callers, and discarded the
+  address it had just been given (`_ = ip`). It now records every address and
+  checks for duplicates, and treats exhaustion as the expected answer it is.
+
+
 - **The Outscale suite drives `octl`, and the client it drove for a year is
   archived** (#460). `outscale/oapi-cli` and `outscale/osc-cli` are both
   `archived: true` on the GitHub API, read-only, with "Deprecated Outscale CLI"

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -2400,9 +2400,23 @@ The rest is structural rather than unbuilt, and the difference matters because
 everything around it was buildable and got built. The emulator has no data
 plane beyond that host: a NAT service is a managed appliance in a facility
 this machine is not in. A public address allocated here comes from
-`198.51.100.0/24` — TEST-NET-2, reserved by RFC 5737 and routed nowhere on
+`198.51.100.0/28` — TEST-NET-2, reserved by RFC 5737 and routed nowhere on
 purpose, so beyond this host an address goes visibly nowhere rather than
 quietly somewhere.
+
+**Fourteen addresses, and that is a measurement rather than a limit of the
+model.** The block was a `/24` until 2026-08-25. What the emulated pool has to
+hold is that allocation refuses past the last address with a typed `9029` and
+that a released address returns to it — neither claim depends on how many
+addresses there are. Exhausting a `/24` cost the Outscale conformance suite 254
+`DeletePublicIp` calls, and at roughly 700 ms of client process startup each
+that was the larger half of an eleven-minute workflow. Measured across every
+suite, fixture and example stack in this repository, the peak of addresses held
+at once is two. `ReadPublicIpRanges` publishes the block the allocator serves,
+derived from the same constant rather than written twice, and
+`TestTheAllocatorStopsWhereTheCatalogueSaysItDoes` fails if either side is
+edited alone. A project that needs more can widen the prefix in
+`publicips.go`; nothing else has to move with it.
 
 What *is* real is the resource algebra, and it is what a plan actually depends
 on: an address a NAT service holds refuses to be released, a gateway refuses to

--- a/internal/providers/outscale/barrage_test.go
+++ b/internal/providers/outscale/barrage_test.go
@@ -58,6 +58,10 @@ func TestAnOutscaleBarrageLeavesTheStoreCoherent(t *testing.T) {
 
 	var wg sync.WaitGroup
 	problems := make(chan string, outscaleBarrageWorkers*8)
+	// Every address the pool hands out, to prove after the fact that it never
+	// handed the same one twice — the property this barrage's comment claimed
+	// and nothing checked.
+	handed := make(chan string, outscaleBarrageWorkers*2)
 
 	for w := range outscaleBarrageWorkers {
 		wg.Add(1)
@@ -82,13 +86,26 @@ func TestAnOutscaleBarrageLeavesTheStoreCoherent(t *testing.T) {
 
 			// Two addresses and two machines per worker: enough interleaving for
 			// a shared pool to hand one out twice if nothing serialises it.
+			//
+			// The address used to be discarded here (`_ = ip`) while this
+			// comment claimed to catch a double hand-out, which is a comment
+			// and not a control. Every address is now recorded and checked for
+			// duplicates after the barrage.
+			//
+			// Exhaustion is an expected answer, not a problem to report: the
+			// emulated block is a /28 since 2026-08-25, and eight workers
+			// asking for two addresses each want sixteen of the fourteen there
+			// are. What must never happen is the same address twice.
 			for i := range 2 {
 				status, ip := postRaw(ts, "CreatePublicIp", `{}`)
+				if status == http.StatusConflict {
+					continue
+				}
 				if status != http.StatusOK {
 					problems <- fmt.Sprintf("%s: CreatePublicIp answered %d", tag, status)
 					continue
 				}
-				_ = ip
+				handed <- nestedID(ip, "PublicIp", "PublicIp")
 
 				status, vm := postRaw(ts, "CreateVms",
 					fmt.Sprintf(`{"ImageId":"ami-00000001","SubnetId":%q}`, subnetID))
@@ -109,6 +126,27 @@ func TestAnOutscaleBarrageLeavesTheStoreCoherent(t *testing.T) {
 	}
 	wg.Wait()
 	close(problems)
+	close(handed)
+
+	// The barrage's own claim, now measured. A pool that hands one address to
+	// two callers is the defect a concurrent create is here to surface, and it
+	// would otherwise pass silently.
+	seen := map[string]int{}
+	total := 0
+	for addr := range handed {
+		seen[addr]++
+		total++
+	}
+	for addr, times := range seen {
+		if times > 1 {
+			t.Errorf("the pool handed %s to %d callers at once", addr, times)
+		}
+	}
+	// And the run must have allocated something: a barrage where every
+	// CreatePublicIp was refused would satisfy the loop above vacuously.
+	if total == 0 {
+		t.Fatalf("no address was allocated at all, so nothing above was measured")
+	}
 
 	var refused []string
 	for p := range problems {

--- a/internal/providers/outscale/catalog.go
+++ b/internal/providers/outscale/catalog.go
@@ -589,7 +589,7 @@ func (p *Pack) readPublicIPRanges(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
-		"PublicIps":       []any{publicIPBase + "0/24"},
+		"PublicIps":       []any{publicIPBlock},
 		"ResponseContext": p.context(),
 	})
 }

--- a/internal/providers/outscale/netresources_test.go
+++ b/internal/providers/outscale/netresources_test.go
@@ -2,6 +2,7 @@ package outscale_test
 
 import (
 	"net/http"
+	"net/netip"
 	"testing"
 )
 
@@ -34,10 +35,27 @@ func TestAPublicIpIsAllocatedListedAndReleased(t *testing.T) {
 		t.Fatalf("second allocation = %v, want 198.51.100.2", ip2["PublicIp"])
 	}
 
-	// The catalogue and the allocator answer from the same block.
+	// The catalogue and the allocator answer from the same block. Asserted by
+	// containment rather than against a literal: the block's size is a tuning
+	// decision (it shrank from /24 to /28 on 2026-08-25 to stop the conformance
+	// suite spending four minutes releasing addresses), and a literal here made
+	// that one-line change fail a test that has nothing to say about size.
+	// What must hold is that the published range contains what was handed out —
+	// TestTheAllocatorStopsWhereTheCatalogueSaysItDoes holds the far end.
 	ranges := call(t, ts, doc, "ReadPublicIpRanges", `{}`)
-	if list, _ := ranges["PublicIps"].([]any); len(list) != 1 || list[0] != "198.51.100.0/24" {
-		t.Fatalf("ReadPublicIpRanges does not publish the allocator's block: %v", ranges["PublicIps"])
+	list, _ := ranges["PublicIps"].([]any)
+	if len(list) != 1 {
+		t.Fatalf("ReadPublicIpRanges publishes %d ranges, want exactly one: %v", len(list), ranges["PublicIps"])
+	}
+	text, _ := list[0].(string)
+	prefix, err := netip.ParsePrefix(text)
+	if err != nil {
+		t.Fatalf("the published range %q is not a prefix: %v", text, err)
+	}
+	for _, handed := range []string{"198.51.100.1", "198.51.100.2"} {
+		if addr, _ := netip.ParseAddr(handed); !prefix.Contains(addr) {
+			t.Fatalf("the allocator handed out %s, outside the published %v", handed, prefix)
+		}
 	}
 
 	// Deleting by address value, which the API accepts alongside the id.
@@ -217,4 +235,77 @@ func TestTheNetCataloguesAreFixedAndFilterable(t *testing.T) {
 	if one["ServiceId"] != "pl-00000001" {
 		t.Fatalf("the api service is not the fixed one: %v", one)
 	}
+}
+
+// TestTheAllocatorStopsWhereTheCatalogueSaysItDoes walks the published range to
+// its last address and asserts the refusal lands on the one after it.
+//
+// It exists because the allocator's bound and the range ReadPublicIpRanges
+// publishes are two statements about one block, and this repository has already
+// paid for two statements edited apart. Whichever side moves alone, the other
+// starts lying — handing out an address the catalogue does not list, or
+// refusing one it does — and nothing else here would fail. So the test reads
+// the range from the catalogue rather than from a literal, and derives the
+// count the same way the allocator does.
+func TestTheAllocatorStopsWhereTheCatalogueSaysItDoes(t *testing.T) {
+	ts := newServer(t)
+	doc := contractDoc(t)
+
+	published := call(t, ts, doc, "ReadPublicIpRanges", `{}`)
+	ranges, _ := published["PublicIps"].([]any)
+	if len(ranges) != 1 {
+		t.Fatalf("the catalogue publishes %d ranges, want exactly one: %v", len(ranges), published)
+	}
+	text, _ := ranges[0].(string)
+	prefix, err := netip.ParsePrefix(text)
+	if err != nil {
+		t.Fatalf("the published range %q is not a prefix: %v", text, err)
+	}
+	// Minus the network and broadcast addresses, as the allocator does.
+	want := 1<<(32-prefix.Bits()) - 2
+
+	got := 0
+	for {
+		status, body := post(t, ts, "CreatePublicIp", `{}`)
+		if status != http.StatusOK {
+			// The refusal has to be the typed exhaustion, not any failure: a
+			// 500 would end this loop too and would prove nothing.
+			if status != http.StatusConflict {
+				t.Fatalf("allocation %d answered %d, want 409: %v", got+1, status, body)
+			}
+			if code := errorCodeOf(body); code != "9029" {
+				t.Fatalf("the refusal is coded %q, want the exhaustion code 9029: %v", code, body)
+			}
+			break
+		}
+		got++
+		if got > want+1 {
+			t.Fatalf("the allocator handed out %d addresses, past the %d the catalogue publishes", got, want)
+		}
+		ip, _ := body["PublicIp"].(map[string]any)
+		text, _ := ip["PublicIp"].(string)
+		addr, err := netip.ParseAddr(text)
+		if err != nil {
+			t.Fatalf("allocation %d handed out %q, which is not an address", got, text)
+		}
+		if !prefix.Contains(addr) {
+			t.Fatalf("allocation %d handed out %v, outside the published %v", got, addr, prefix)
+		}
+	}
+	if got != want {
+		t.Fatalf("the allocator stopped after %d addresses, the catalogue publishes %d", got, want)
+	}
+}
+
+// errorCodeOf reads the Code of the first error, the way errorTypeOf reads its
+// Type. Both exist because an untyped assertion on a refusal passes for any
+// failure at all.
+func errorCodeOf(body map[string]any) string {
+	errs, _ := body["Errors"].([]any)
+	if len(errs) == 0 {
+		return ""
+	}
+	first, _ := errs[0].(map[string]any)
+	code, _ := first["Code"].(string)
+	return code
 }

--- a/internal/providers/outscale/publicips.go
+++ b/internal/providers/outscale/publicips.go
@@ -50,8 +50,33 @@ const kindPublicIP = "publicip"
 // sequentially from .1: deterministic, so a test can pin the first address.
 const publicIPBase = "198.51.100."
 
-// publicIPBlock is the same block as a prefix, for the guard below.
-const publicIPBlock = "198.51.100.0/24"
+// publicIPBlock is the same block as a prefix, for the guard below and for the
+// bound of the allocator's sweep.
+//
+// It is a /28 — fourteen addresses — and not the /24 it was until 2026-08-25.
+// The assertion this block exists to hold is that allocation refuses past the
+// last address with a typed 9029, and that a released address returns to the
+// pool; neither depends on how many addresses there are. Exhausting a /24 cost
+// the Outscale conformance suite 254 `DeletePublicIp` calls, and at ~730 ms of
+// client startup each that was 64% of the suite and the larger half of an
+// eleven-minute workflow. The measured peak of addresses held at once, across
+// every suite and fixture in this repository, is two.
+const publicIPBlock = "198.51.100.0/28"
+
+// publicIPHosts is how many addresses publicIPBlock holds, derived from the
+// prefix rather than written a second time. A bound that does not follow the
+// prefix is exactly how an allocator and the catalogue it publishes come to
+// disagree — which is why TestTheAllocatorStopsWhereTheCatalogueSaysItDoes
+// walks the published range to its end and asserts the refusal lands on the
+// address after it, and fails if either side is edited alone.
+var publicIPHosts = func() int {
+	prefix, err := netip.ParsePrefix(publicIPBlock)
+	if err != nil {
+		panic("publicIPBlock is not a prefix: " + err.Error())
+	}
+	// Minus the network and broadcast addresses, which nobody is handed.
+	return 1<<(32-prefix.Bits()) - 2
+}()
 
 // emulatedPublicIP reports whether an address is one this pack can have handed
 // out: inside publicIPBlock. It is the authorisation half on the way to the
@@ -159,7 +184,7 @@ func (p *Pack) createPublicIP(w http.ResponseWriter, r *http.Request) {
 		taken[stringOf(res.Attrs["PublicIp"])] = true
 	}
 	address := ""
-	for host := 1; host < 255; host++ {
+	for host := 1; host <= publicIPHosts; host++ {
 		candidate := fmt.Sprintf("%s%d", publicIPBase, host)
 		if !taken[candidate] {
 			address = candidate
@@ -168,7 +193,7 @@ func (p *Pack) createPublicIP(w http.ResponseWriter, r *http.Request) {
 	}
 	if address == "" {
 		unlock()
-		p.conflict(w, "the emulated public block "+publicIPBase+"0/24 is exhausted; release an address first")
+		p.conflict(w, "the emulated public block "+publicIPBlock+" is exhausted; release an address first")
 		return
 	}
 	now := p.env.Now()


### PR DESCRIPTION
The conformance workflow went from **4m24 to 11m04** when the Outscale suite migrated to `octl` (#460), which pays ~700 ms of process startup per invocation. The dominant cost is not the client but what the suite asks of it: exhausting a `/24` means allocating and then releasing **254 addresses, one process each**.

## Measured, both legs still green with the omission gate armed

| leg | before | after |
|---|---|---|
| `conformance:leg -- octl` | 368 s | **142 s** |
| `conformance:leg -- fields` | 435 s | **209 s** |

## Why a /28 loses nothing

What the emulated pool has to hold is that allocation **refuses past the last address with a typed 9029**, and that a **released address returns to the pool**. Neither claim depends on how many addresses there are.

The measured peak of addresses held at once, across every suite, fixture and example stack in this repository, is **two**.

## The bound and the published range no longer say the same thing twice

The allocator derives its sweep from the prefix, `ReadPublicIpRanges` publishes that same constant, and **`TestTheAllocatorStopsWhereTheCatalogueSaysItDoes`** walks the published range to its end and asserts the refusal lands on the address after it.

Editing either side alone now fails — which is the failure this pair could not previously produce. The old assertion compared the catalogue to a **literal**, so a one-line size change broke a test that has nothing to say about size.

**Falsified three ways, all red:** publishing a range the allocator does not serve, unpinning the bound from the prefix, and letting the pool hand one address to two callers.

## Found on the way, and it is the defect this repository names most often

`TestAnOutscaleBarrageLeavesTheStoreCoherent` said in a comment that two addresses per worker gave *"enough interleaving for a shared pool to hand one out twice if nothing serialises it"* — and the next line was `_ = ip`. **The address was discarded and no duplicate was ever checked.**

It now records every address handed out, fails on a duplicate, refuses a vacuous pass where nothing was allocated, and treats exhaustion as the expected answer it is rather than a problem to report.

## Gates

`go build` 0 · `go test ./...` 0 · `mise run prepush` 0 · `conformance:leg -- octl` 0 · `conformance:leg -- fields` 0.

**`mise run conformance` was not played on this branch** — issues are handled in series and it runs once over the assembled set — but both legs this change touches were, with the timings above.

## Related

The residual ~700 ms of `octl` startup per invocation is reported upstream as [outscale/octl#313](https://github.com/outscale/octl/issues/313); it is the only path below ~4 min, and it is theirs to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)