### PR TITLE
chore(scaleway): the five S3 endpoint operations follow their upstream rename

### DIFF
--- a/coverage/scaleway-coverage.json
+++ b/coverage/scaleway-coverage.json
@@ -2778,7 +2778,7 @@
       "status": "declined"
     },
     {
-      "operation": "vpc/v2/API.AddPrivateNetworkS3Endpoint",
+      "operation": "vpc/v2/API.AddPrivateNetworkObjectStoragePrivateAccess",
       "product": "vpc",
       "reason": "they attach a private network to Object Storage, which is not emulated because the Terraform provider builds that endpoint in code, measured in docs/limits.md",
       "version": "v2",
@@ -2830,7 +2830,7 @@
       "status": "implemented"
     },
     {
-      "operation": "vpc/v2/API.DeletePrivateNetworkS3Endpoint",
+      "operation": "vpc/v2/API.DeletePrivateNetworkObjectStoragePrivateAccess",
       "product": "vpc",
       "reason": "they attach a private network to Object Storage, which is not emulated because the Terraform provider builds that endpoint in code, measured in docs/limits.md",
       "version": "v2",
@@ -2856,7 +2856,7 @@
       "status": "declined"
     },
     {
-      "operation": "vpc/v2/API.DisableS3Endpoint",
+      "operation": "vpc/v2/API.DisableObjectStoragePrivateAccess",
       "product": "vpc",
       "reason": "they attach a private network to Object Storage, which is not emulated because the Terraform provider builds that endpoint in code, measured in docs/limits.md",
       "version": "v2",
@@ -2876,17 +2876,17 @@
       "status": "implemented"
     },
     {
-      "operation": "vpc/v2/API.EnableRouting",
-      "product": "vpc",
-      "version": "v2",
-      "status": "implemented"
-    },
-    {
-      "operation": "vpc/v2/API.EnableS3Endpoint",
+      "operation": "vpc/v2/API.EnableObjectStoragePrivateAccess",
       "product": "vpc",
       "reason": "they attach a private network to Object Storage, which is not emulated because the Terraform provider builds that endpoint in code, measured in docs/limits.md",
       "version": "v2",
       "status": "declined"
+    },
+    {
+      "operation": "vpc/v2/API.EnableRouting",
+      "product": "vpc",
+      "version": "v2",
+      "status": "implemented"
     },
     {
       "operation": "vpc/v2/API.GetACL",
@@ -2972,7 +2972,7 @@
       "status": "implemented"
     },
     {
-      "operation": "vpc/v2/API.SetPrivateNetworksS3Endpoint",
+      "operation": "vpc/v2/API.SetPrivateNetworksObjectStoragePrivateAccess",
       "product": "vpc",
       "reason": "they attach a private network to Object Storage, which is not emulated because the Terraform provider builds that endpoint in code, measured in docs/limits.md",
       "version": "v2",

--- a/internal/providers/scaleway/pack.go
+++ b/internal/providers/scaleway/pack.go
@@ -1064,17 +1064,27 @@ func (p *Pack) Declined() []emulator.Decline {
 			"vpcgw/v1/API.UpdatePATRule",
 			"vpcgw/v1/API.UpgradeGateway"),
 
-		// The five S3 endpoints vpc/v2 grew since the last scan. They attach a
-		// private network to Object Storage, and Object Storage is refused here
+		// The five Object Storage private-access operations of vpc/v2. They attach
+		// a private network to Object Storage, and Object Storage is refused here
 		// for a reason docs/limits.md measured: the Terraform provider builds the
 		// S3 endpoint from the region in code, so serving it needs DNS
 		// interception and a certificate the client accepts.
+		//
+		// Renamed upstream on 2026-08-25, *S3Endpoint -> *ObjectStoragePrivateAccess.
+		// The decision did not change and the reason did not either; only the
+		// spelling did. `drift:check` reported them as five new untriaged
+		// operations, which is what a rename looks like from one side — and
+		// `drift:update` named the other side, five orphan routes matching nothing
+		// upstream. Reading only the first half would have declined a second time
+		// what was already declined, and left the old names behind as a decline
+		// nothing upstream answers to. That pair of reports is why the scan reads
+		// both directions.
 		emulator.Because("they attach a private network to Object Storage, which is not emulated because the Terraform provider builds that endpoint in code, measured in docs/limits.md",
-			"vpc/v2/API.AddPrivateNetworkS3Endpoint",
-			"vpc/v2/API.DeletePrivateNetworkS3Endpoint",
-			"vpc/v2/API.DisableS3Endpoint",
-			"vpc/v2/API.EnableS3Endpoint",
-			"vpc/v2/API.SetPrivateNetworksS3Endpoint"),
+			"vpc/v2/API.AddPrivateNetworkObjectStoragePrivateAccess",
+			"vpc/v2/API.DeletePrivateNetworkObjectStoragePrivateAccess",
+			"vpc/v2/API.DisableObjectStoragePrivateAccess",
+			"vpc/v2/API.EnableObjectStoragePrivateAccess",
+			"vpc/v2/API.SetPrivateNetworksObjectStoragePrivateAccess"),
 
 		// ipam/v1alpha1 is the superseded draft of ipam/v1, which is served.
 		emulator.Because("ipam/v1alpha1 is the superseded draft of ipam/v1, which is served",


### PR DESCRIPTION
`drift:check` went red on 2026-08-25 with five new untriaged Scaleway
operations, and it stayed red for every branch, blocking the pre-push hook:

    vpc/v2/API.AddPrivateNetworkObjectStoragePrivateAccess
    vpc/v2/API.DeletePrivateNetworkObjectStoragePrivateAccess
    vpc/v2/API.DisableObjectStoragePrivateAccess
    vpc/v2/API.EnableObjectStoragePrivateAccess
    vpc/v2/API.SetPrivateNetworksObjectStoragePrivateAccess

They are not new. They are the five `*S3Endpoint` operations this pack already
declines, renamed upstream. `drift:update` is what said so, and it said it from
the other side: five orphan routes matching nothing upstream, spelled
`AddPrivateNetworkS3Endpoint` and its four siblings.

So the decision does not change and the reason does not either — Object Storage
is not emulated, because the Terraform provider builds the S3 endpoint from the
region in code and serving it would take DNS interception and a certificate the
client accepts (docs/limits.md). Only the spelling changes.

Worth recording, because the first fix here was wrong and the tool caught it:
reading only "five new operations" leads to declining a second time what is
already declined, and leaving the old names behind as a decline that nothing
upstream answers to. A rename looks like an addition from one side and a
deletion from the other, and the scan reports both halves precisely so the pair
can be recognised. This commit is the pair read together.

`drift:check` 0, `drift:update` 0, `mise run prepush` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)