### PR TITLE
feat(machine): the image recipe derives by family, and an opaque identifier is the operator's to declare (#465)

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,22 @@ FEINT_VM=auto      mise run serve   # the most capable runtime that answers
 mise run conformance:ssh            # register a key, boot a server, log in over ssh
 ```
 
+The machine images build themselves: the recipe derives from the OS family
+(ubuntu, debian, alpine, almalinux, rockylinux, centos, fedora), so a known
+family at any version is built on first boot, announced, and `feint images`
+warms a station ahead of a run. A configuration that hardcodes a real cloud's
+image id still applies and starts nothing — no catalogue here can know what
+`ami-a3ca408c` is — but the refusal now says what to do, and both gestures need
+no cloud account:
+
+```bash
+feint images resolve ami-a3ca408c        # asks the providers' public listings
+FEINT_BOOT_IMAGES='ami-a3ca408c=ubuntu:22.04' feint serve --vm incus-ovn
+```
+
+[docs/limits.md](docs/limits.md) carries the measured details, including why the
+emulator never guesses an OS and never fetches anything on the boot path.
+
 That mode needs Incus and OVN, and how to install them differs enough per
 distribution to be worth measuring: **[docs/install.md](docs/install.md)** carries
 the commands, measured on a fresh virtual machine of Debian 12 and 13, Ubuntu 24.04

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -655,6 +655,100 @@ difference never shows. It is recorded here rather than filed as a defect,
 because it is the documented behaviour meeting a population nobody had measured
 it against.
 
+### The recipe derives by family, and the identifier is the operator's to declare (#465)
+
+Two moves close most of that gap without weakening the refusal, and neither
+guesses anything.
+
+**The image recipe derives from the family, so any version builds on the fly.**
+The build table used to enumerate five family/version rows, and the Scaleway
+catalogue promised one it did not hold: `debian_trixie` maps on `debian:13`,
+no `debian/13` was ever built, and a client using the label the emulator itself
+publishes got a machine without ssh. The irregular part of the recipe is per
+**family**, never per version — the source is always
+`images:<family>/<version>/cloud`, and only the ssh package name, the service
+name and the package manager change — so `machine.SpecFor` now derives the
+recipe from the ref: ubuntu, debian (apt), alpine (apk), almalinux, rockylinux,
+centos and fedora (dnf). A known family at a version the station lacks is built
+at first boot, announced when it starts and when it ends, through the same seam
+`feint images` drives — one recipe, one per-image lock, and a builder container
+named for its image *and* its process, because a Go lock cannot span two
+processes and the pair that actually collided was a `feint serve` and a `feint
+images` in another terminal. `feint images` still exists for what it is
+genuinely for: warming a station ahead of a run, so no `terraform apply` pays a
+build. A family with no recipe (`plan9:4`, talos) still degrades exactly as
+above, and a version the upstream image server has withdrawn — `images:` no
+longer publishes ubuntu 18.04, debian 9 or debian 10, all named by surveyed
+stacks — fails the boot with the ref and the source in the log instead of a raw
+driver error.
+
+**An opaque identifier is the operator's to declare, and the refusal says how.**
+No table can name the OS behind `ami-a3ca408c`, and guessing one was refused in
+#392: a stack that asked for an AlmaLinux and got an Ubuntu boots, then fails at
+its first `dnf`. What replaces the guess is a declaration the operator signs:
+
+```bash
+FEINT_BOOT_IMAGES='ami-a3ca408c=ubuntu:22.04,ami-538af795=ubuntu:22.04' \
+  feint serve --vm incus-ovn
+```
+
+Each entry maps one identifier onto `family:version`, with an optional `@login`
+for the cloud where the login belongs to the template. The declaration is
+consulted only when the pack's own catalogue resolved nothing, so no entry can
+shadow a catalogue label; a malformed entry or an unknown family refuses to
+start, naming the entry and the families a recipe exists for, because a typo
+that surfaced hours later as a refused boot would be blamed on the stack. The
+boot refusal itself names the identifier it got, the reason, and both gestures:
+the declaration above, and the lookup below.
+
+**`feint images resolve <id>...` asks the providers' public listings what an
+identifier is** — network, but no account, and never on the boot path: a create
+that waits on a third party's availability is the failure mode that cost the
+Exoscale Terraform provider a fork. Measured on 2026-08-25, without
+credentials: Outscale's [Official OMIs
+Reference](https://docs.outscale.com/en/userguide/Official-OMIs-Reference.html)
+page is **historical** — it named all three withdrawn identifiers the surveyed
+stacks hardcode (`ami-a3ca408c` = Ubuntu-22.04-2023.12.04-0, `ami-538af795` =
+Ubuntu-18.04-2021.02.04-0, `ami-47899c77` = Debian-9-2019.11.29-0) while the
+live API answers zero images for them to a valid account, and 401 without one.
+Scaleway's marketplace (`api.scaleway.com/marketplace/v2/…`) and Exoscale's
+template listing (`api-<zone>.exoscale.com/v2/template`) answer JSON with
+identifier, name and — for Exoscale — family, version and default user. The
+command prints what each listing calls the identifier and the exact
+`FEINT_BOOT_IMAGES` line to paste; an identifier in no listing exits 2 and says
+what remains (the stack's own docs, or whoever created the image), and a
+listing that cannot be asked exits 1 and is never reported as an absence. What
+it deliberately does not do is feed the emulator directly: the lookup fetches,
+the operator declares, the emulator works offline afterwards — the same shape
+as `upstream:sync` feeding the drift scan, and for the same reason a list baked
+into the binary was refused: it ages into one more lie.
+
+**A derived image is a cache, and it is visible and individually removable.**
+Derivation splits two questions the enumerated table kept fused: what the
+warm-up set requires (`feint images --check` grades that, exit 2 on a miss)
+and what this emulator has put on the station — which now includes images no
+list names. Both commands therefore print derived images as their own rows,
+because an image an inventory cannot name is a silent residue on somebody
+else's machine. `feint clean` deliberately removes no image, warm-up or
+derived alike: clean removes what a killed run left half-alive, and an image
+is the cache that spares the next run its minutes of build — the conformance
+suite runs clean, and sweeping images there would rebuild the set on every
+pass. Removal is explicit and targeted instead: `feint images remove
+fedora/44` says the alias and fingerprint it is about to delete, refuses a
+name the emulator never published, and can only ever spell aliases under the
+`feint/` prefix — an operator's own images cannot even be named through it.
+
+**A first boot that builds can outlive the answer to the call that caused it.**
+Measured on 2026-08-25: `CreateVms` on a declared `fedora:44` built the image in
+52 seconds and the machine reached `running` with its address published — while
+the HTTP answer to that one call died on the server's 60-second write timeout
+(curl: empty reply). The state converges and is honest; the response of the
+call that paid the build is what may be lost, and a client that retries a
+create it believes failed will make a second machine. The exposure predates
+derivation — any boot longer than a minute had it — but a cold build makes it
+ordinary, which is why the warm-up set exists and why `debian/13` is in it:
+`feint images` ahead of a run keeps every production path under the timeout.
+
 Two details follow from the same decision. The Scaleway marketplace answers one
 fixed UUID **per label**, so Terraform — which resolves a label into a UUID and
 sends the UUID back — still names the distribution it chose; a single shared

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -904,6 +904,18 @@ func serve(args []string, stdout io.Writer) error {
 		return err
 	}
 	env.Machines = driver
+	// The operator's own identifier declarations, the door through the boot
+	// refusal (#465). Read here in the composition root like the other
+	// deployment choices (FEINT_OUTSCALE_REGION), and only on the serve path:
+	// the docs and evidence entry points that share newServer must not depend
+	// on the environment. A bad entry refuses to start rather than surfacing
+	// hours later as a refused boot blamed on the stack.
+	if declared, err := machine.ParseDeclaredImages(os.Getenv("FEINT_BOOT_IMAGES")); err != nil {
+		return fmt.Errorf("FEINT_BOOT_IMAGES: %w", err)
+	} else if declared != nil {
+		env.BootImages = declared
+		fmt.Fprintf(stdout, "boot images declared by the operator: %d\n", len(declared))
+	}
 	// Set after newServer, which cannot know the flag. At debug the runtime's
 	// own lifecycle events come through, which is what makes a machine that
 	// will not start explainable without leaving the emulator's log.

--- a/internal/cli/images.go
+++ b/internal/cli/images.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/stephrobert/feint/internal/core/machine"
 )
@@ -26,6 +27,23 @@ import (
 // launches a container and takes minutes, which is a side effect on the
 // operator's station, and this project asks before those rather than after.
 func images(args []string, stdout, stderr io.Writer) int {
+	// `feint images resolve <id>...` is the lookup half of the boot refusal
+	// (#465): it asks the providers' public listings what an opaque identifier
+	// names, and prints the FEINT_BOOT_IMAGES declaration to make of it. A
+	// subcommand rather than a flag because it takes identifiers, not specs,
+	// and shares nothing with the build loop below but the family table.
+	if len(args) > 0 && args[0] == "resolve" {
+		return imagesResolve(args[1:], stdout, stderr)
+	}
+	// `feint images remove <family/version>...` is the explicit, targeted
+	// removal that `feint clean` deliberately is not: an image is the cache
+	// that spares the next run its minutes of build, never the leftover of a
+	// killed run, so it goes only when somebody names it. The driver refuses
+	// anything the emulator did not publish — the alias is spelled from the
+	// prefix, so an operator's image cannot even be named here.
+	if len(args) > 0 && args[0] == "remove" {
+		return imagesRemove(args[1:], stdout, stderr)
+	}
 	fs := newFlagSet("images")
 	fs.SetOutput(stderr)
 	vm := fs.String("vm", "auto", "machine runtime to build with: auto, incus, incus-vm, incus-ovn")
@@ -52,15 +70,25 @@ func images(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "feint: %v\n", err)
 		return 1
 	}
-
-	if *checkOnly {
-		return reportImages(inventory, *only, stdout)
+	// The station question beside the warm-up question (#465): a boot that
+	// derived an image put it under the prefix without any warm-up row naming
+	// it, and an inventory that only answered the list would leave it
+	// invisible on the operator's own machine.
+	derived, err := machine.DerivedImages(ctx, driver)
+	if err != nil {
+		fmt.Fprintf(stderr, "feint: %v\n", err)
+		return 1
 	}
 
-	builder, ok := driver.(interface {
-		BuildImage(context.Context, machine.ImageSpec, io.Writer) error
-	})
-	if !ok {
+	if *checkOnly {
+		return reportImages(inventory, derived, *only, stdout)
+	}
+
+	// Asked once, up front, so a runtime that cannot build says so before the
+	// first image rather than in the middle of the set. The build itself goes
+	// through machine.BuildIfMissing below, which is the seam the boot
+	// path (machine.EnsureImage) drives too.
+	if _, ok := driver.(machine.ImageBuilder); !ok {
 		fmt.Fprintln(stderr, "feint: this runtime cannot build images")
 		return 1
 	}
@@ -76,25 +104,68 @@ func images(args []string, stdout, stderr io.Writer) int {
 			continue
 		}
 		fmt.Fprintf(stdout, "== %s\n", status.Spec.Alias())
-		if err := builder.BuildImage(ctx, status.Spec, stdout); err != nil {
+		// Through the shared seam rather than straight at the driver: it holds
+		// the per-image exclusion and the second look, so this command and a boot
+		// building on the fly (#465) cannot build the same image at once — two
+		// callers, one lock, written once. Measured on 2026-08-25: two builds
+		// that met on the old fixed-name builder killed each other, one on
+		// `apt-get update … 137`, the other on a publish whose rootfs moved.
+		made, err := machine.BuildIfMissing(ctx, driver, status.Spec, stdout)
+		if err != nil {
 			fmt.Fprintf(stderr, "feint: %s: %v\n", status.Spec.Name, err)
 			return 1
+		}
+		if !made {
+			// Another run built it while this one waited. Said rather than
+			// counted as a build: the operator asked and something else
+			// answered.
+			fmt.Fprintf(stdout, "  built by another run while this one waited\n")
+			skipped++
+			continue
 		}
 		built++
 	}
 
 	if built == 0 && skipped == 0 {
-		fmt.Fprintf(stderr, "feint: no image is called %q\n", *only)
-		return 1
+		// Outside the warm-up set the recipe can still derive it (#465):
+		// `feint images --only fedora/44` builds the row the set does not
+		// carry, which is also what the boot-failure log tells an operator to
+		// run. A name no family covers is refused with the families that are.
+		spec, ok := machine.SpecFor(strings.Replace(*only, "/", ":", 1))
+		if !ok {
+			fmt.Fprintf(stderr, "feint: no recipe derives %q (families: %s)\n",
+				*only, strings.Join(machine.Families(), ", "))
+			return 1
+		}
+		fmt.Fprintf(stdout, "== %s (outside the warm-up set, derived from the family table)\n", spec.Alias())
+		made, err := machine.BuildIfMissing(ctx, driver, spec, stdout)
+		if err != nil {
+			fmt.Fprintf(stderr, "feint: %s: %v\n", spec.Name, err)
+			return 1
+		}
+		if made {
+			built++
+		} else {
+			fmt.Fprintf(stdout, "  already on the station\n")
+			skipped++
+		}
 	}
 	fmt.Fprintf(stdout, "\n%d built, %d already present\n", built, skipped)
+	reportDerived(derived, stdout)
 	return 0
 }
 
 // reportImages prints the inventory and answers 2 when something is missing, the
 // exit code every other gate in this project uses for "the world moved and
 // nobody triaged it".
-func reportImages(inventory []machine.ImageStatus, only string, stdout io.Writer) int {
+//
+// Two questions, kept apart on purpose (#465): what the warm-up set requires
+// and lacks — that is what the exit code grades — and what this emulator has
+// put on this station, which includes the images a boot derived. A derived
+// image is neither missing nor wrong, so it never moves the exit code; it is
+// named, because an image an inventory cannot name is a silent residue on
+// somebody else's machine.
+func reportImages(inventory, derived []machine.ImageStatus, only string, stdout io.Writer) int {
 	missing := 0
 	for _, status := range inventory {
 		if only != "" && only != status.Spec.Name {
@@ -107,11 +178,82 @@ func reportImages(inventory []machine.ImageStatus, only string, stdout io.Writer
 		fmt.Fprintf(stdout, "  missing  %-16s from %s\n", status.Spec.Name, status.Spec.Source)
 		missing++
 	}
+	if only == "" {
+		reportDerived(derived, stdout)
+	}
 	if missing > 0 {
 		fmt.Fprintf(stdout, "\n%d missing; `feint images` builds them\n", missing)
 		return 2
 	}
 	fmt.Fprintln(stdout, "\nevery machine image is present")
+	return 0
+}
+
+// reportDerived names what the station holds under the prefix beyond the
+// warm-up set, with the removal gesture: `feint clean` deliberately removes no
+// image — an image is the asset that spares the next run its minutes of build,
+// not the leftover of a killed run — so this line is the only place a derived
+// image is ever seen.
+func reportDerived(derived []machine.ImageStatus, stdout io.Writer) {
+	for _, status := range derived {
+		fmt.Fprintf(stdout, "  derived  %-16s %s (built on demand; `incus image delete %s` removes it)\n",
+			status.Spec.Name, short(status.Fingerprint), machine.ImagePrefix+"/"+status.Spec.Name)
+	}
+}
+
+// imagesRemove deletes images this emulator published, each named by its
+// family/version half. It says what it is about to remove — alias and
+// fingerprint — before removing it, and refuses a name the station does not
+// hold under the prefix rather than silently ignoring it.
+func imagesRemove(args []string, stdout, stderr io.Writer) int {
+	fs := newFlagSet("images remove")
+	fs.SetOutput(stderr)
+	vm := fs.String("vm", "auto", "machine runtime holding the images: auto, incus, incus-vm, incus-ovn")
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+	names := fs.Args()
+	if len(names) == 0 {
+		fmt.Fprintln(stderr, "usage: feint images remove <family/version>...")
+		fmt.Fprintln(stderr, "  removes an image this emulator published; `feint images --check` lists them")
+		return 1
+	}
+
+	driver, err := machineDriver(*vm, stderr)
+	if err != nil {
+		fmt.Fprintf(stderr, "feint: %v\n", err)
+		return 1
+	}
+	remover, ok := driver.(interface {
+		RemoveImage(context.Context, string) error
+	})
+	if !ok {
+		fmt.Fprintln(stderr, "feint: this runtime holds no images to remove")
+		return 1
+	}
+	ctx := context.Background()
+	held := map[string]string{}
+	if lister, canAsk := driver.(machine.ImageLister); canAsk {
+		if listed, err := lister.LocalImages(ctx); err == nil {
+			held = listed
+		}
+	}
+
+	for _, name := range names {
+		alias := machine.ImagePrefix + "/" + name
+		fingerprint, present := held[alias]
+		if !present {
+			// Refused out loud, never skipped: a removal that ignores an
+			// unknown name teaches the operator nothing about their typo.
+			fmt.Fprintf(stderr, "feint: this emulator published no image called %q; `feint images --check` lists what it did\n", name)
+			return 1
+		}
+		fmt.Fprintf(stdout, "removing %s (%s)\n", alias, short(fingerprint))
+		if err := remover.RemoveImage(ctx, name); err != nil {
+			fmt.Fprintf(stderr, "feint: %v\n", err)
+			return 1
+		}
+	}
 	return 0
 }
 

--- a/internal/cli/images_resolve.go
+++ b/internal/cli/images_resolve.go
@@ -1,0 +1,378 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/stephrobert/feint/internal/core/machine"
+)
+
+// `feint images resolve <identifier>...` asks the providers' public listings
+// what an opaque image identifier names, and prints the FEINT_BOOT_IMAGES
+// declaration that makes it bootable here.
+//
+// It exists because a hardcoded image id in a published Terraform configuration
+// is undecipherable to anyone without an account in the right region — and
+// sometimes to them too: measured on 2026-08-25, the real Outscale answers zero
+// images for ami-a3ca408c, ami-538af795 and ami-47899c77 to a valid account
+// that sees 609 others. The public listings below answered all three, without
+// credentials, because Outscale's reference page is historical.
+//
+// The lookups are deliberately here, in an explicit command, and never on the
+// boot path: a create that waited on a third party's availability is the
+// failure mode that cost the Exoscale Terraform provider a fork (an apply that
+// splits between the emulator and a paid account). This command fetches, the
+// operator declares, and the emulator works offline afterwards — the same
+// shape as `mise run upstream:sync` feeding the drift scan.
+//
+// Sources, each measured without credentials on 2026-08-25:
+//   - Outscale: the "Official OMIs Reference" documentation page (HTML, http
+//     200, no auth). Historical — it lists withdrawn OMIs with their name and
+//     deprecation date back to at least 2019, so it resolves identifiers the
+//     live API no longer serves.
+//   - Scaleway: the public marketplace API (JSON, http 200, no auth; an
+//     unknown id answers a clean 404).
+//   - Exoscale: the public template listing (JSON, http 200, no auth).
+//     Private templates never appear there, and nothing public ever could
+//     resolve them.
+const (
+	outscaleOMIsURL     = "https://docs.outscale.com/en/userguide/Official-OMIs-Reference.html"
+	scalewayLocalImages = "https://api.scaleway.com/marketplace/v2/local-images/"
+	scalewayImagesURL   = "https://api.scaleway.com/marketplace/v2/images?page_size=100"
+	exoscaleTemplates   = "https://api-ch-gva-2.exoscale.com/v2/template"
+)
+
+// fetchListing is the network seam, injectable so the parsers are tested on
+// fixtures and no test ever depends on a third party answering.
+var fetchListing = func(url string) (status int, body []byte, err error) {
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	// The reference page weighs ~540 KiB today; 8 MiB is well past every
+	// listing and still refuses a runaway body.
+	body, err = io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+	if err != nil {
+		return 0, nil, err
+	}
+	return resp.StatusCode, body, nil
+}
+
+// resolvedImage is what one lookup learned.
+type resolvedImage struct {
+	id     string
+	name   string // what the listing calls it, verbatim
+	source string // which listing answered
+	ref    string // family:version derived from the name, "" when none derives
+	login  string // the login the listing declares, when it declares one
+}
+
+// imagesResolve drives one lookup per identifier and prints what to declare.
+//
+// Three outcomes per identifier, kept distinct on purpose: found (the listing
+// names it), absent (the listing answered and does not hold it), and failed
+// (the listing could not be asked — which must never read as absent). Exit
+// codes follow the repository's convention: 0 when every identifier resolved,
+// 1 when a listing could not be asked, 2 when one is in no listing — the same
+// "the world needs triage" the other gates use.
+func imagesResolve(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "usage: feint images resolve <identifier>...")
+		fmt.Fprintln(stderr, "  looks each identifier up in the providers' public listings (network, no account)")
+		fmt.Fprintln(stderr, "  and prints the FEINT_BOOT_IMAGES declaration that makes it bootable here")
+		return 1
+	}
+
+	cache := map[string][]byte{}
+	fetch := func(url string) (int, []byte, error) {
+		if body, ok := cache[url]; ok {
+			return http.StatusOK, body, nil
+		}
+		status, body, err := fetchListing(url)
+		if err == nil && status == http.StatusOK {
+			cache[url] = body
+		}
+		return status, body, err
+	}
+
+	failed, absent := false, false
+	var declarations []string
+	for _, id := range args {
+		res, found, err := resolveOne(id, fetch)
+		fmt.Fprintf(stdout, "%s\n", id)
+		if err != nil {
+			// A listing that could not be asked is not a listing that lacks the
+			// id: said as a failure, never counted as an absence.
+			fmt.Fprintf(stdout, "  could not ask the public listings: %v\n", err)
+			failed = true
+			continue
+		}
+		if !found {
+			absent = true
+			fmt.Fprintf(stdout, "  in none of the public listings consulted (%s)\n", strings.Join(sourcesFor(id), "; "))
+			fmt.Fprintln(stdout, "  what remains: the stack's own docs, or whoever created the image;")
+			fmt.Fprintf(stdout, "  once known, declare it: FEINT_BOOT_IMAGES='%s=<family>:<version>' (families: %s)\n",
+				id, strings.Join(machine.Families(), ", "))
+			continue
+		}
+		fmt.Fprintf(stdout, "  %s: %s\n", res.source, res.name)
+		if res.ref == "" {
+			fmt.Fprintln(stdout, "  the name yields no family:version this emulator could build")
+			continue
+		}
+		if _, buildable := machine.SpecFor(res.ref); !buildable {
+			fmt.Fprintf(stdout, "  → %s — no recipe for this family here (families: %s)\n",
+				res.ref, strings.Join(machine.Families(), ", "))
+			continue
+		}
+		entry := id + "=" + res.ref
+		if res.login != "" {
+			entry += "@" + res.login
+		}
+		fmt.Fprintf(stdout, "  → %s\n", res.ref)
+		declarations = append(declarations, entry)
+	}
+
+	if len(declarations) > 0 {
+		fmt.Fprintf(stdout, "\ndeclare and restart:\n  FEINT_BOOT_IMAGES='%s' feint serve ...\n",
+			strings.Join(declarations, ","))
+	}
+	switch {
+	case failed:
+		return 1
+	case absent:
+		return 2
+	}
+	return 0
+}
+
+// resolveOne picks the listings an identifier's shape can appear in. An OMI id
+// is Outscale vocabulary; a UUID could be a Scaleway local image or an Exoscale
+// template, so both are asked; anything else has no public listing wired.
+func resolveOne(id string, fetch func(string) (int, []byte, error)) (resolvedImage, bool, error) {
+	switch {
+	case looksLikeOMI(id):
+		return resolveOutscaleOMI(id, fetch)
+	case looksLikeImageUUID(id):
+		res, found, err := resolveScalewayImage(id, fetch)
+		if err != nil || found {
+			return res, found, err
+		}
+		return resolveExoscaleTemplate(id, fetch)
+	}
+	return resolvedImage{}, false, nil
+}
+
+// sourcesFor names, for the not-found message, which listings were consulted.
+func sourcesFor(id string) []string {
+	switch {
+	case looksLikeOMI(id):
+		return []string{"Outscale official OMIs reference, which lists withdrawn OMIs too — this one never was one, or predates the page"}
+	case looksLikeImageUUID(id):
+		return []string{"Scaleway marketplace", "Exoscale public templates — a private template never appears there"}
+	}
+	return []string{"no public listing is wired for this identifier's shape"}
+}
+
+func looksLikeOMI(id string) bool {
+	if len(id) != 12 || !strings.HasPrefix(id, "ami-") {
+		return false
+	}
+	for _, c := range id[4:] {
+		if !unicode.Is(unicode.ASCII_Hex_Digit, c) {
+			return false
+		}
+	}
+	return true
+}
+
+func looksLikeImageUUID(id string) bool { return len(id) == 36 && strings.Count(id, "-") == 4 }
+
+// resolveOutscaleOMI reads the reference page: rows of (id, name, published,
+// replacement, deprecated) per region. The name is the cell right after the id
+// when the id opens a row; the same id in a replacement cell is followed by a
+// date, which is how the two positions are told apart.
+func resolveOutscaleOMI(id string, fetch func(string) (int, []byte, error)) (resolvedImage, bool, error) {
+	status, body, err := fetch(outscaleOMIsURL)
+	if err != nil {
+		return resolvedImage{}, false, err
+	}
+	if status != http.StatusOK {
+		return resolvedImage{}, false, fmt.Errorf("the Outscale reference page answered %d", status)
+	}
+	name, found := outscaleNameFor(string(body), id)
+	if !found {
+		return resolvedImage{}, false, nil
+	}
+	return resolvedImage{
+		id: id, name: name,
+		source: "Outscale official OMIs reference",
+		ref:    refFromDashedName(name),
+	}, true, nil
+}
+
+// outscaleNameFor scans the page's cell text for the row the id opens.
+//
+// The page is HTML and this is a parser of last resort — Outscale publishes no
+// machine-readable equivalent (the API answers 401 without credentials,
+// measured). It anchors on content, not markup: a token equal to the id,
+// followed by a token that starts with a letter, is the (id, name) pair; the
+// id in a replacement cell is followed by a date and never matches.
+func outscaleNameFor(page, id string) (string, bool) {
+	tokens := cellTokens(page)
+	for i, token := range tokens {
+		if token != id || i+1 >= len(tokens) {
+			continue
+		}
+		next := tokens[i+1]
+		if next == "" || !unicode.IsLetter(rune(next[0])) {
+			continue
+		}
+		return next, true
+	}
+	return "", false
+}
+
+// cellTokens strips markup and returns the visible cell texts.
+func cellTokens(page string) []string {
+	var tokens []string
+	var cell strings.Builder
+	inTag := false
+	flush := func() {
+		if text := strings.TrimSpace(cell.String()); text != "" {
+			tokens = append(tokens, text)
+		}
+		cell.Reset()
+	}
+	for _, r := range page {
+		switch {
+		case r == '<':
+			inTag = true
+			flush()
+		case r == '>':
+			inTag = false
+		case !inTag:
+			cell.WriteRune(r)
+		}
+	}
+	flush()
+	return tokens
+}
+
+// refFromDashedName turns an Outscale OMI name into a family:version ref:
+// "Ubuntu-22.04-2023.12.04-0" yields ubuntu:22.04, "Debian-9-2019.11.29-0"
+// yields debian:9. A name whose second segment is not a version — or that has
+// none — yields nothing, and the caller says so instead of inventing one.
+func refFromDashedName(name string) string {
+	parts := strings.Split(name, "-")
+	if len(parts) < 2 || parts[1] == "" || !unicode.IsDigit(rune(parts[1][0])) {
+		return ""
+	}
+	return strings.ToLower(parts[0]) + ":" + parts[1]
+}
+
+// resolveScalewayImage asks the public marketplace: the local image for the
+// UUID (a clean 404 when unknown), then the image list for the label's human
+// name, which carries family and version ("Ubuntu 24.04 Noble Numbat").
+func resolveScalewayImage(id string, fetch func(string) (int, []byte, error)) (resolvedImage, bool, error) {
+	status, body, err := fetch(scalewayLocalImages + id)
+	if err != nil {
+		return resolvedImage{}, false, err
+	}
+	if status == http.StatusNotFound {
+		return resolvedImage{}, false, nil
+	}
+	if status != http.StatusOK {
+		return resolvedImage{}, false, fmt.Errorf("the Scaleway marketplace answered %d", status)
+	}
+	var local struct {
+		Label string `json:"label"`
+	}
+	if err := json.Unmarshal(body, &local); err != nil {
+		return resolvedImage{}, false, fmt.Errorf("unreadable Scaleway local-image answer: %w", err)
+	}
+	if local.Label == "" {
+		return resolvedImage{}, false, errors.New("the Scaleway local-image answer carries no label")
+	}
+
+	name := local.Label
+	if status, body, err := fetch(scalewayImagesURL); err == nil && status == http.StatusOK {
+		var list struct {
+			Images []struct {
+				Label string `json:"label"`
+				Name  string `json:"name"`
+			} `json:"images"`
+		}
+		if json.Unmarshal(body, &list) == nil {
+			for _, img := range list.Images {
+				if img.Label == local.Label && img.Name != "" {
+					name = img.Name
+					break
+				}
+			}
+		}
+	}
+	return resolvedImage{
+		id: id, name: name,
+		source: "Scaleway marketplace (label " + local.Label + ")",
+		ref:    refFromSpacedName(name),
+	}, true, nil
+}
+
+// refFromSpacedName reads "Family Version …" marketplace names:
+// "Debian 13 (Trixie)" yields debian:13. Same contract as refFromDashedName.
+func refFromSpacedName(name string) string {
+	parts := strings.Fields(name)
+	if len(parts) < 2 || !unicode.IsDigit(rune(parts[1][0])) {
+		return ""
+	}
+	return strings.ToLower(parts[0]) + ":" + parts[1]
+}
+
+// resolveExoscaleTemplate reads the public template listing, which carries
+// family, version and the template's own default user — the login rides the
+// declaration as @login, because at Exoscale it belongs to the template.
+func resolveExoscaleTemplate(id string, fetch func(string) (int, []byte, error)) (resolvedImage, bool, error) {
+	status, body, err := fetch(exoscaleTemplates)
+	if err != nil {
+		return resolvedImage{}, false, err
+	}
+	if status != http.StatusOK {
+		return resolvedImage{}, false, fmt.Errorf("the Exoscale template listing answered %d", status)
+	}
+	var list struct {
+		Templates []struct {
+			ID      string `json:"id"`
+			Name    string `json:"name"`
+			Family  string `json:"family"`
+			Version string `json:"version"`
+			User    string `json:"default-user"`
+		} `json:"templates"`
+	}
+	if err := json.Unmarshal(body, &list); err != nil {
+		return resolvedImage{}, false, fmt.Errorf("unreadable Exoscale template answer: %w", err)
+	}
+	for _, t := range list.Templates {
+		if t.ID != id {
+			continue
+		}
+		ref := ""
+		if t.Family != "" && t.Version != "" {
+			ref = strings.ToLower(t.Family) + ":" + t.Version
+		}
+		return resolvedImage{
+			id: id, name: t.Name,
+			source: "Exoscale public templates",
+			ref:    ref, login: t.User,
+		}, true, nil
+	}
+	return resolvedImage{}, false, nil
+}

--- a/internal/cli/images_resolve_test.go
+++ b/internal/cli/images_resolve_test.go
@@ -1,0 +1,173 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// The fixtures mirror the shapes measured on 2026-08-25, without which these
+// parsers would be tested against a page nobody serves. The Outscale excerpt
+// keeps the trait the parser must survive: an id can appear in the replacement
+// cell of an older row — followed by a date — before the row it opens.
+const outscaleFixture = `
+<tr>
+<td class="tableblock"><p class="tableblock"><strong>ami-cd8d714e</strong></p></td>
+<td class="tableblock"><p class="tableblock">Ubuntu-22.04-2023.02.21-0</p></td>
+<td class="tableblock"><p class="tableblock">2023-02-21</p></td>
+<td class="tableblock"><p class="tableblock">ami-a3ca408c</p></td>
+<td class="tableblock"><p class="tableblock">2024-01-04</p></td>
+</tr>
+<tr>
+<td class="tableblock"><p class="tableblock"><strong>ami-a3ca408c</strong></p></td>
+<td class="tableblock"><p class="tableblock">Ubuntu-22.04-2023.12.04-0</p></td>
+<td class="tableblock"><p class="tableblock">2024-01-04</p></td>
+<td class="tableblock"><p class="tableblock">ami-70f5d073</p></td>
+<td class="tableblock"><p class="tableblock">2025-04-16</p></td>
+</tr>
+<tr>
+<td class="tableblock"><p class="tableblock"><strong>ami-47899c77</strong></p></td>
+<td class="tableblock"><p class="tableblock">Debian-9-2019.11.29-0</p></td>
+<td class="tableblock"><p class="tableblock">2019-11-29</p></td>
+</tr>
+<tr>
+<td class="tableblock"><p class="tableblock"><strong>ami-69129fc8</strong></p></td>
+<td class="tableblock"><p class="tableblock">RHEL-9-2023.11.17-0</p></td>
+<td class="tableblock"><p class="tableblock">2024-01-04</p></td>
+</tr>`
+
+const exoscaleFixture = `{"templates":[
+  {"id":"d4296d2e-3722-4b2e-ba4a-2a59918b9395","name":"Linux Ubuntu 22.04 LTS 64-bit",
+   "family":"ubuntu","version":"22.04","default-user":"ubuntu"}]}`
+
+const scalewayLocalFixture = `{"id":"08176977-2d0e-4db0-a604-f81daa390f81","zone":"fr-par-1","label":"ubuntu_noble"}`
+const scalewayImagesFixture = `{"images":[{"label":"ubuntu_noble","name":"Ubuntu 24.04 Noble Numbat"}]}`
+
+// withListings replaces the network seam for one test, mapping URL prefixes to
+// canned answers. A URL outside the map answers 404, the clean absence the real
+// Scaleway marketplace was measured to give.
+func withListings(t *testing.T, answers map[string]string) {
+	t.Helper()
+	previous := fetchListing
+	t.Cleanup(func() { fetchListing = previous })
+	fetchListing = func(url string) (int, []byte, error) {
+		for prefix, body := range answers {
+			if strings.HasPrefix(url, prefix) {
+				return http.StatusOK, []byte(body), nil
+			}
+		}
+		return http.StatusNotFound, []byte(`{"type":"not_found"}`), nil
+	}
+}
+
+func TestResolveReadsTheOutscaleReferencePage(t *testing.T) {
+	withListings(t, map[string]string{outscaleOMIsURL: outscaleFixture})
+	var out, errOut bytes.Buffer
+
+	// The planted witnesses come first: a control that will later report an
+	// absence has to prove it can find, and these three are the identifiers the
+	// live Outscale API no longer serves (measured: rc=0, zero images).
+	code := imagesResolve([]string{"ami-a3ca408c", "ami-47899c77", "ami-69129fc8"}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("exit %d, want 0 when every identifier resolves\n%s%s", code, out.String(), errOut.String())
+	}
+	for _, needle := range []string{
+		// The id that also sits in an older row's replacement cell must take
+		// its name from the row it opens, not a date from the cell it fills.
+		"Ubuntu-22.04-2023.12.04-0",
+		"Debian-9-2019.11.29-0",
+		// A withdrawn version still resolves; making it bootable is the build's
+		// business, and its failure names the source.
+		"debian:9",
+		// A family without a recipe is said, with the families that have one.
+		"rhel:9",
+		"no recipe",
+		// The final line is the exact declaration to paste.
+		"FEINT_BOOT_IMAGES='ami-a3ca408c=ubuntu:22.04,ami-47899c77=debian:9'",
+	} {
+		if !strings.Contains(out.String(), needle) {
+			t.Errorf("output does not carry %q\n%s", needle, out.String())
+		}
+	}
+}
+
+func TestResolveDistinguishesAbsentFromUnaskable(t *testing.T) {
+	t.Run("an identifier no listing holds is absent, exit 2", func(t *testing.T) {
+		withListings(t, map[string]string{outscaleOMIsURL: outscaleFixture})
+		var out, errOut bytes.Buffer
+		if code := imagesResolve([]string{"ami-00c0ffee"}, &out, &errOut); code != 2 {
+			t.Fatalf("exit %d, want 2 for an identifier in no listing\n%s", code, out.String())
+		}
+		if !strings.Contains(out.String(), "FEINT_BOOT_IMAGES='ami-00c0ffee=<family>:<version>'") {
+			t.Errorf("the absence does not say what to do next\n%s", out.String())
+		}
+	})
+
+	t.Run("a listing that cannot be asked is a failure, exit 1, never an absence", func(t *testing.T) {
+		previous := fetchListing
+		t.Cleanup(func() { fetchListing = previous })
+		fetchListing = func(string) (int, []byte, error) {
+			return 0, nil, errors.New("dial tcp: no route to host")
+		}
+		var out, errOut bytes.Buffer
+		if code := imagesResolve([]string{"ami-a3ca408c"}, &out, &errOut); code != 1 {
+			t.Fatalf("exit %d, want 1 when the listing could not be asked\n%s", code, out.String())
+		}
+		if strings.Contains(out.String(), "in none of the public listings") {
+			t.Errorf("a network failure was reported as an absence\n%s", out.String())
+		}
+	})
+}
+
+func TestResolveReadsTheScalewayAndExoscaleListings(t *testing.T) {
+	withListings(t, map[string]string{
+		scalewayLocalImages + "08176977": scalewayLocalFixture,
+		scalewayImagesURL:                scalewayImagesFixture,
+		exoscaleTemplates:                exoscaleFixture,
+	})
+	var out, errOut bytes.Buffer
+
+	code := imagesResolve([]string{
+		"08176977-2d0e-4db0-a604-f81daa390f81", // Scaleway local image (witness measured 2026-08-25)
+		"d4296d2e-3722-4b2e-ba4a-2a59918b9395", // Exoscale public template: the marketplace 404s, the template list answers
+	}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("exit %d, want 0\n%s%s", code, out.String(), errOut.String())
+	}
+	for _, needle := range []string{
+		"Ubuntu 24.04 Noble Numbat",
+		"Linux Ubuntu 22.04 LTS 64-bit",
+		// The Exoscale login rides the declaration: at Exoscale it belongs to
+		// the template, and dropping it hands out a machine nobody can enter.
+		"d4296d2e-3722-4b2e-ba4a-2a59918b9395=ubuntu:22.04@ubuntu",
+		"08176977-2d0e-4db0-a604-f81daa390f81=ubuntu:24.04",
+	} {
+		if !strings.Contains(out.String(), needle) {
+			t.Errorf("output does not carry %q\n%s", needle, out.String())
+		}
+	}
+}
+
+func TestResolveWithoutIdentifiersExplainsItself(t *testing.T) {
+	var out, errOut bytes.Buffer
+	if code := imagesResolve(nil, &out, &errOut); code != 1 {
+		t.Fatalf("exit %d, want a usage refusal", code)
+	}
+	if !strings.Contains(errOut.String(), "feint images resolve") {
+		t.Errorf("the usage does not name the command: %s", errOut.String())
+	}
+}
+
+// A guard against the trap the harness memo records: an instrument that
+// under-reports. The tokeniser is what every lookup stands on, so it is pinned
+// on the exact cell layout the real page serves.
+func TestCellTokensSurviveTheReferenceMarkup(t *testing.T) {
+	got := cellTokens(`<td><p><strong>ami-cd8d714e</strong></p></td>` + "\n" + `<td><p>Ubuntu-22.04</p></td>`)
+	want := fmt.Sprintf("%v", []string{"ami-cd8d714e", "Ubuntu-22.04"})
+	if fmt.Sprintf("%v", got) != want {
+		t.Fatalf("tokens %v, want %s", got, want)
+	}
+}

--- a/internal/core/emulator/emulator.go
+++ b/internal/core/emulator/emulator.go
@@ -34,6 +34,13 @@ type Env struct {
 	// Defaults to the metadata-only driver, so nothing ever starts unless the
 	// operator asked for it.
 	Machines machine.Driver
+	// BootImages maps an opaque image identifier onto the operating system the
+	// operator declared it to be (FEINT_BOOT_IMAGES, parsed by
+	// machine.ParseDeclaredImages). Each pack hands it to its Binding, which
+	// consults it only when the pack's own catalogue resolved nothing. The keys
+	// are opaque strings the operator chose; nothing here knows any provider's
+	// vocabulary, which is what keeps this field in the neutral core.
+	BootImages map[string]machine.Image
 	// Log is where packs report what they could not do. A machine runtime that
 	// fails must never break the control plane, which makes the log the only
 	// place the operator can learn why nothing started.

--- a/internal/core/machine/binding.go
+++ b/internal/core/machine/binding.go
@@ -78,6 +78,18 @@ type Binding struct {
 	// state for a machine at all, so a start that failed is "stopped" there —
 	// which is true, and inventing a word their clients would not parse is worse.
 	FailedState string
+	// Declared maps an opaque image identifier onto the operating system the
+	// operator says it is — FEINT_BOOT_IMAGES, parsed once at startup by
+	// ParseDeclaredImages. Consulted only when the pack's own catalogue resolved
+	// nothing, so a catalogue entry always wins over a declaration.
+	//
+	// It is the door through the boot refusal below, and it is a declaration
+	// rather than a guess: #392's generic substitution was refused because a
+	// stack that asked for an AlmaLinux and got an Ubuntu boots and then fails
+	// at the first dnf. Here the operator names the OS, signs the mapping, and
+	// the log records that the declaration — not the emulator — chose the image.
+	// The keys are opaque strings; this stays as provider-neutral as the rest.
+	Declared map[string]Image
 	// Log is where a runtime failure is reported. A machine that will not start
 	// must never break the control plane, which makes this the only place an
 	// operator can learn why nothing is running.
@@ -189,15 +201,51 @@ func (b Binding) Start(ctx context.Context, boot Boot) Started {
 	// control plane must stay usable without a runtime — hardcoded production
 	// identifiers included, as docs/limits.md promises.
 	//
-	// TestAnUnknownImageFailsTheBootInsteadOfSubstituting fails without this.
+	// The operator's declaration is the one way past it (#465): consulted here,
+	// in the shared layer, so the three packs get the same door and a fourth
+	// could not forget it — and only after the pack's own catalogue resolved
+	// nothing, so no declaration can shadow a catalogue entry.
+	//
+	// TestAnUnknownImageFailsTheBootInsteadOfSubstituting and
+	// TestADeclaredIdentifierBootsTheImageTheOperatorNamed fail without this.
 	if _, metadataOnly := b.Driver.(Noop); boot.Image == "" && !metadataOnly {
-		reason := boot.Reason
-		if reason == "" {
-			reason = "the identifier is in no catalogue"
+		declared, ok := b.Declared[boot.Requested]
+		if !ok || boot.Requested == "" {
+			b.refuseUnknownImage(boot)
+			return Started{}
 		}
-		b.logger().Error("refusing to boot: the image identifier resolves to nothing this emulator can run",
-			"provider", b.Provider, "resource", boot.ID, "image", boot.Requested, "reason", reason)
-		return Started{}
+		b.logger().Info("booting the image the operator declared for this identifier",
+			"provider", b.Provider, "resource", boot.ID, "image", boot.Requested,
+			"declared", declared.Ref, "via", "FEINT_BOOT_IMAGES")
+		boot.Image = declared.Ref
+		// The login rides the image here as everywhere else: on the cloud where
+		// the login belongs to the template rather than to the provider, a
+		// declaration that dropped it would boot a machine nobody can enter.
+		if boot.User == "" {
+			boot.User = declared.User
+		}
+	}
+
+	// Build what the ref derives when the station lacks it (#465): the recipe
+	// is per family, the version travels through, and the first boot pays the
+	// build once, announced. A build that fails refuses the boot instead of
+	// falling back — for a derived ref the upstream image is the very source
+	// the build could not fetch, so the fallback would re-fail with a raw
+	// driver error where this refusal names the ref and the source. The state
+	// the caller publishes is FailedState: the machine did not start, and
+	// saying so is the one thing this project cannot compromise on.
+	//
+	// TestAFailedImageBuildRefusesTheBootAndNamesTheSource fails without this.
+	if boot.Image != "" {
+		if _, err := EnsureImage(ctx, b.Driver, boot.Image, b.logger()); err != nil {
+			spec, _ := SpecFor(boot.Image)
+			b.logger().Error("refusing to boot: the image this reference derives could not be built",
+				"provider", b.Provider, "resource", boot.ID, "image", boot.Image,
+				"requested", boot.Requested, "source", spec.Source, "error", err,
+				"fix", "`feint images --only "+spec.Name+"` reproduces the build by hand; "+
+					"a version the upstream image server no longer publishes cannot be built — name one it does")
+			return Started{}
+		}
 	}
 	user := b.User
 	if boot.User != "" {
@@ -252,6 +300,32 @@ func (b Binding) Start(ctx context.Context, boot Boot) Started {
 		return Started{}
 	}
 	return Started{Machine: name, Address: m.IP}
+}
+
+// refuseUnknownImage is the actionable half of the boot refusal: it names the
+// identifier the client sent, why nothing here can run it, and the two gestures
+// that lead through — asking the providers' public listings what the identifier
+// is (`feint images resolve`, no account needed), then declaring the answer
+// (FEINT_BOOT_IMAGES). A refusal without a way through gets worked around by
+// copying the emulator, which teaches nobody anything; a guess would teach
+// worse, a machine that boots and then fails at its first package install —
+// the reason #392's generic substitution was refused.
+//
+// TestTheBootRefusalNamesTheGesturesThatUnblock fails without the gestures.
+func (b Binding) refuseUnknownImage(boot Boot) {
+	reason := boot.Reason
+	if reason == "" {
+		reason = "the identifier is in no catalogue"
+	}
+	id := boot.Requested
+	if id == "" {
+		id = "<empty>"
+	}
+	b.logger().Error("refusing to boot: nothing says which operating system this image identifier names",
+		"provider", b.Provider, "resource", boot.ID, "image", id, "reason", reason,
+		"consequence", "the machine stays "+b.FailedState+"; guessing an OS would boot a machine that fails at its first package install",
+		"ask", "`feint images resolve "+id+"` looks it up in the providers' public listings, no account needed",
+		"fix", "declare what it is, then restart: FEINT_BOOT_IMAGES='"+id+"=<family>:<version>' with a family among "+strings.Join(Families(), ", "))
 }
 
 // ours refuses a backing-machine name the emulator could not have produced.

--- a/internal/core/machine/binding_boot_test.go
+++ b/internal/core/machine/binding_boot_test.go
@@ -1,9 +1,12 @@
 package machine
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/stephrobert/feint/internal/core/resource"
@@ -123,5 +126,167 @@ func TestAnImageWithoutItsOwnLoginKeepsTheProviderWideOne(t *testing.T) {
 	})
 	if len(driver.specs) != 1 || driver.specs[0].User != "root" {
 		t.Fatalf("specs=%v, want one boot as the binding's own login", driver.specs)
+	}
+}
+
+// buildingDriver is a recordingDriver that can also be asked what it holds and
+// told to build — the two optional halves EnsureImage drives. It fails on
+// demand, so the refusal path is testable without a runtime.
+type buildingDriver struct {
+	recordingDriver
+	held  map[string]string
+	built []ImageSpec
+	fail  error
+}
+
+func (d *buildingDriver) LocalImages(context.Context) (map[string]string, error) {
+	return d.held, nil
+}
+
+func (d *buildingDriver) BuildImage(_ context.Context, spec ImageSpec, _ io.Writer) error {
+	if d.fail != nil {
+		return d.fail
+	}
+	d.built = append(d.built, spec)
+	if d.held == nil {
+		d.held = map[string]string{}
+	}
+	d.held[spec.Alias()] = "made-by-test"
+	return nil
+}
+
+func TestABootDerivesAndBuildsTheImageItNames(t *testing.T) {
+	t.Run("a version the station lacks is built on the boot path", func(t *testing.T) {
+		driver := &buildingDriver{}
+		b := bootBinding(driver)
+		res := &resource.Resource{ID: "srv-1", State: "stopped"}
+
+		// debian:13 is the measured hole of #465: the Scaleway catalogue serves
+		// debian_trixie mapped on it, and the fixed table never built it.
+		ok := b.PowerOn(context.Background(), res, Boot{
+			Image: "debian:13", Requested: "debian_trixie",
+			AuthorizedKeys: []string{"ssh-ed25519 AAAA test"},
+		})
+		if !ok || res.State != "running" {
+			t.Fatalf("ok=%v state=%q, want a machine that runs", ok, res.State)
+		}
+		if len(driver.built) != 1 || driver.built[0].Alias() != "feint/debian/13" {
+			t.Fatalf("built %v, want exactly feint/debian/13 derived from the ref", driver.built)
+		}
+		if len(driver.specs) != 1 || driver.specs[0].Image != "debian:13" {
+			t.Fatalf("booted %v, want one boot of the derived ref", driver.specs)
+		}
+	})
+
+	t.Run("an image the station holds is not rebuilt", func(t *testing.T) {
+		driver := &buildingDriver{held: map[string]string{"feint/debian/13": "already"}}
+		b := bootBinding(driver)
+		res := &resource.Resource{ID: "srv-1", State: "stopped"}
+
+		b.PowerOn(context.Background(), res, Boot{
+			Image: "debian:13", Requested: "debian_trixie",
+			AuthorizedKeys: []string{"ssh-ed25519 AAAA test"},
+		})
+		if len(driver.built) != 0 {
+			t.Fatalf("built %v for an image the station already holds", driver.built)
+		}
+	})
+
+	t.Run("an unknown family keeps the announced fallback", func(t *testing.T) {
+		driver := &buildingDriver{}
+		b := bootBinding(driver)
+		res := &resource.Resource{ID: "srv-1", State: "stopped"}
+
+		// plan9:4 derives nothing; the boot must go on to the driver, whose own
+		// resolveImage announces the upstream fallback. Building here would be
+		// "build anything", the guard #465 says must hold.
+		ok := b.PowerOn(context.Background(), res, Boot{
+			Image: "plan9:4", Requested: "plan9",
+			AuthorizedKeys: []string{"ssh-ed25519 AAAA test"},
+		})
+		if !ok || len(driver.built) != 0 || len(driver.specs) != 1 {
+			t.Fatalf("ok=%v built=%v specs=%d, want a boot with nothing built", ok, driver.built, len(driver.specs))
+		}
+	})
+}
+
+func TestAFailedImageBuildRefusesTheBootAndNamesTheSource(t *testing.T) {
+	driver := &buildingDriver{fail: errors.New("Failed getting remote image info")}
+	var log bytes.Buffer
+	b := bootBinding(driver)
+	b.Log = slog.New(slog.NewTextHandler(&log, nil))
+	res := &resource.Resource{ID: "srv-1", State: "stopped"}
+
+	// debian:9 is a real witness, not a hypothesis: images: withdrew it, and
+	// two of the surveyed stacks still hardcode identifiers that name it.
+	ok := b.PowerOn(context.Background(), res, Boot{
+		Image: "debian:9", Requested: "ami-47899c77",
+		AuthorizedKeys: []string{"ssh-ed25519 AAAA test"},
+	})
+	if ok || res.State != "failed" {
+		t.Fatalf("ok=%v state=%q, want a refused boot in the failed state", ok, res.State)
+	}
+	if len(driver.specs) != 0 {
+		t.Fatal("the runtime was asked to boot an image whose build had just failed")
+	}
+	for _, needle := range []string{"images:debian/9/cloud", "debian:9", "ami-47899c77"} {
+		if !strings.Contains(log.String(), needle) {
+			t.Errorf("the refusal does not name %q; a reader cannot act on it\nlog: %s", needle, log.String())
+		}
+	}
+}
+
+func TestADeclaredIdentifierBootsTheImageTheOperatorNamed(t *testing.T) {
+	t.Run("the declaration resolves what no catalogue holds", func(t *testing.T) {
+		driver := &recordingDriver{}
+		b := bootBinding(driver)
+		b.Declared = map[string]Image{"ami-a3ca408c": {Ref: "ubuntu:22.04", User: "ubuntu"}}
+		res := &resource.Resource{ID: "srv-1", State: "stopped"}
+
+		ok := b.PowerOn(context.Background(), res, Boot{
+			Requested:      "ami-a3ca408c",
+			AuthorizedKeys: []string{"ssh-ed25519 AAAA test"},
+		})
+		if !ok || res.State != "running" {
+			t.Fatalf("ok=%v state=%q, want the declared image to boot", ok, res.State)
+		}
+		if len(driver.specs) != 1 || driver.specs[0].Image != "ubuntu:22.04" || driver.specs[0].User != "ubuntu" {
+			t.Fatalf("booted %+v, want the ref and login the operator declared", driver.specs)
+		}
+	})
+
+	t.Run("a catalogue entry always wins over a declaration", func(t *testing.T) {
+		driver := &recordingDriver{}
+		b := bootBinding(driver)
+		b.Declared = map[string]Image{"alpine_3.21": {Ref: "ubuntu:22.04"}}
+		res := &resource.Resource{ID: "srv-1", State: "stopped"}
+
+		b.PowerOn(context.Background(), res, Boot{
+			Image: "alpine:3.21", Requested: "alpine_3.21",
+			AuthorizedKeys: []string{"ssh-ed25519 AAAA test"},
+		})
+		if len(driver.specs) != 1 || driver.specs[0].Image != "alpine:3.21" {
+			t.Fatalf("booted %+v, want the catalogue's resolution untouched", driver.specs)
+		}
+	})
+}
+
+func TestTheBootRefusalNamesTheGesturesThatUnblock(t *testing.T) {
+	driver := &recordingDriver{}
+	var log bytes.Buffer
+	b := bootBinding(driver)
+	b.Log = slog.New(slog.NewTextHandler(&log, nil))
+	res := &resource.Resource{ID: "srv-1", State: "stopped"}
+
+	if b.PowerOn(context.Background(), res, Boot{Requested: "ami-deadf00d"}) {
+		t.Fatal("an undeclared unknown identifier booted")
+	}
+	// The refusal is only actionable if a reader can apply it without opening
+	// the code: the identifier received, the lookup that needs no account, and
+	// the declaration that unblocks — each named verbatim.
+	for _, needle := range []string{"ami-deadf00d", "feint images resolve", "FEINT_BOOT_IMAGES", "ubuntu"} {
+		if !strings.Contains(log.String(), needle) {
+			t.Errorf("the refusal does not carry %q\nlog: %s", needle, log.String())
+		}
 	}
 }

--- a/internal/core/machine/images.go
+++ b/internal/core/machine/images.go
@@ -3,8 +3,12 @@ package machine
 import (
 	"context"
 	"fmt"
+	"io"
+	"log/slog"
 	"sort"
 	"strings"
+	"sync"
+	"time"
 )
 
 // The machine images feint boots, and why it builds its own (#203).
@@ -56,20 +60,389 @@ type ImageSpec struct {
 // Alias is the local image alias this spec publishes to.
 func (s ImageSpec) Alias() string { return ImagePrefix + "/" + s.Name }
 
-// RequiredImages is the set feint needs to boot machines.
+// ImageFamily is what every version of one operating-system family shares: the
+// package that carries the ssh daemon, the service that enables it at boot, and
+// the package manager that installs it. The version is deliberately absent — it
+// is the part that varies per boot, and SpecFor passes it through untouched.
+type ImageFamily struct {
+	Package string
+	Service string
+	Manager string
+}
+
+// imageFamilies is the recipe table, keyed by the family half of a Ref (#465).
+//
+// The irregular part of the recipe is per family, never per version: the source
+// is always images:<family>/<version>/cloud, and the triplet below is the whole
+// difference between building a Debian and building an Alpine. Enumerating
+// versions here was the defect #465 names — the Scaleway catalogue served
+// debian_trixie mapped on debian:13 while the table stopped at debian/12, so
+// the label the emulator itself publishes booted a machine without ssh.
+//
+// Every triplet is verified by execution, not assumed: ubuntu/debian/alpine/
+// almalinux by the existing builds, debian/13 and fedora/44 by rehearsals on
+// 2026-08-25 (each command rc=0, `images-inventaire.md` §3). rockylinux and
+// centos publish on images: and carry the dnf family's packaging; their first
+// build is their proof, and a failure there is loud, not silent.
+//
+// A family absent from this table derives nothing, on purpose: deriving a spec
+// for plan9:4 would produce a build that cannot work. The guard keeps the
+// announced fallback of resolveImage for unknown families, and
+// TestSpecForRefusesWhatNoRecipeCovers fails without it.
+func imageFamilies() map[string]ImageFamily {
+	apt := ImageFamily{Package: "openssh-server", Service: "ssh", Manager: "apt"}
+	dnf := ImageFamily{Package: "openssh-server", Service: "sshd", Manager: "dnf"}
+	return map[string]ImageFamily{
+		"ubuntu":     apt,
+		"debian":     apt,
+		"alpine":     {Package: "openssh", Service: "sshd", Manager: "apk"},
+		"almalinux":  dnf,
+		"rockylinux": dnf,
+		"centos":     dnf,
+		"fedora":     dnf,
+	}
+}
+
+// Families lists the family keys a recipe exists for, sorted so the refusal
+// message that quotes them reads the same on every run.
+func Families() []string {
+	out := make([]string, 0, len(imageFamilies()))
+	for family := range imageFamilies() {
+		out = append(out, family)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// splitRef takes a runtime-agnostic Ref apart and answers false for anything
+// that is not a well-formed family:version pair. An explicit runtime reference
+// ("images:debian/13/cloud") is the caller naming an image of their own, and
+// this emulator neither builds nor touches those.
+//
+// Both halves are checked against a closed charset because both become an argv
+// and an alias: the version travels into `incus launch images:<f>/<v>/cloud`
+// and into the published alias, and a Ref can arrive through FEINT_BOOT_IMAGES
+// or a restored snapshot — an input from outside, whatever it looks like. This
+// is the syntax half only; whether a recipe exists is SpecFor's question, and
+// keeping the two apart is the "well formed is not authorised" rule.
+func splitRef(ref string) (family, version string, ok bool) {
+	if strings.Contains(ref, "/") {
+		return "", "", false
+	}
+	family, version, found := strings.Cut(ref, ":")
+	if !found || !refToken(family) || !refToken(version) {
+		return "", "", false
+	}
+	return family, version, true
+}
+
+// refToken accepts the characters a family or version may carry. The first rune
+// must be alphanumeric so no token can ever reach a command line looking like a
+// flag, the same reason safeName exists.
+func refToken(s string) bool {
+	if s == "" || len(s) > 64 {
+		return false
+	}
+	for i, c := range s {
+		alnum := c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9'
+		if i == 0 && !alnum {
+			return false
+		}
+		if !alnum && c != '.' && c != '_' && c != '-' {
+			return false
+		}
+	}
+	return true
+}
+
+// ImageAlias is the local alias a runtime-agnostic Ref publishes to:
+// "ubuntu:24.04" is held as "feint/ubuntu/24.04".
+//
+// Named once and used twice on purpose: the driver resolves a boot through it
+// (resolveImage) and SpecFor derives what to build through it. Two spellings
+// of the same mapping is how one of them ends up looking for an alias nothing
+// publishes.
+func ImageAlias(ref string) (string, bool) {
+	family, version, ok := splitRef(ref)
+	if !ok {
+		return "", false
+	}
+	return ImagePrefix + "/" + family + "/" + version, true
+}
+
+// SpecFor derives the image to build from a Ref: the family selects the
+// package, service and manager, the version travels through (#465).
+//
+// Enumerating was the previous shape, and it made the struct's own comment a
+// lie — "a fifth family is a row and not a code change" was true for a family
+// and false for a version, so debian:13 silently derived nothing and the boot
+// fell back to an upstream image with no ssh daemon. A known family at any
+// version now yields a buildable spec; an unknown family still yields nothing,
+// which keeps the announced fallback for what genuinely has no recipe.
+//
+// TestSpecForDerivesEveryVersionOfAKnownFamily and
+// TestSpecForRefusesWhatNoRecipeCovers fail without this.
+func SpecFor(ref string) (ImageSpec, bool) {
+	family, version, ok := splitRef(ref)
+	if !ok {
+		return ImageSpec{}, false
+	}
+	recipe, known := imageFamilies()[family]
+	if !known {
+		return ImageSpec{}, false
+	}
+	return ImageSpec{
+		Name:    family + "/" + version,
+		Source:  "images:" + family + "/" + version + "/cloud",
+		Package: recipe.Package,
+		Service: recipe.Service,
+		Manager: recipe.Manager,
+	}, true
+}
+
+// RequiredImages is the set `feint images` builds ahead of time, so an operator
+// can warm a station before a run. Derivation serves the boot path; this list
+// serves the warm-up — two questions, one recipe, which is why every row is
+// derived through SpecFor rather than spelled out beside it.
 //
 // One row per cloud-init template family, and that is not a coincidence: an
 // image set narrower than internal/core/cloudinit/templates/ makes the templates
-// lie about distributions nobody can actually boot.
+// lie about distributions nobody can actually boot. debian:13 is here because
+// the Scaleway catalogue promises debian_trixie today (#465); fedora stays
+// derive-on-demand, with one demander in the surveyed stacks and a recipe that
+// costs nothing to hold.
 func RequiredImages() []ImageSpec {
-	return []ImageSpec{
-		{Name: "ubuntu/24.04", Source: "images:ubuntu/24.04/cloud", Package: "openssh-server", Service: "ssh", Manager: "apt"},
-		{Name: "ubuntu/22.04", Source: "images:ubuntu/22.04/cloud", Package: "openssh-server", Service: "ssh", Manager: "apt"},
-		{Name: "debian/12", Source: "images:debian/12/cloud", Package: "openssh-server", Service: "ssh", Manager: "apt"},
-		{Name: "alpine/3.21", Source: "images:alpine/3.21/cloud", Package: "openssh", Service: "sshd", Manager: "apk"},
-		{Name: "almalinux/9", Source: "images:almalinux/9/cloud", Package: "openssh-server", Service: "sshd", Manager: "dnf"},
+	refs := []string{
+		"ubuntu:24.04",
+		"ubuntu:22.04",
+		"debian:12",
+		"debian:13",
+		"alpine:3.21",
+		"almalinux:9",
 	}
+	out := make([]ImageSpec, 0, len(refs))
+	for _, ref := range refs {
+		spec, ok := SpecFor(ref)
+		if !ok {
+			// A warm-up ref outside the family table is a defect of this file;
+			// TestRequiredImagesDeriveFromTheFamilyTable is what fails first.
+			continue
+		}
+		out = append(out, spec)
+	}
+	return out
 }
+
+// DeclaredImageSyntax is the shape one FEINT_BOOT_IMAGES entry takes, quoted by
+// the refusal message and the parse errors so the reader never has to open the
+// code to learn it.
+const DeclaredImageSyntax = "<identifier>=<family>:<version>[@login]"
+
+// ParseDeclaredImages reads the operator's own identifier declarations, the
+// form FEINT_BOOT_IMAGES carries: comma-separated entries, each mapping one
+// opaque identifier onto the operating system the operator knows it to be —
+// "ami-a3ca408c=ubuntu:22.04", with an optional @login for the clouds where the
+// login belongs to the image.
+//
+// This is the door through the boot refusal, and it is the operator's own
+// assertion rather than the emulator guessing: a substitution nobody asked for
+// was refused in #392, and what replaces it is a declaration somebody signs.
+// The keys are opaque strings; nothing here knows any provider's vocabulary.
+//
+// Every entry is validated here, at the entry, and a bad one refuses the whole
+// set: a typo that silently dropped an entry would resurface hours later as a
+// refused boot, blamed on the stack. Unknown family, malformed ref, duplicate
+// identifier — each error names the entry and the families a recipe exists for.
+//
+// TestParseDeclaredImagesRefusesWhatItCannotBuild fails without the checks.
+func ParseDeclaredImages(s string) (map[string]Image, error) {
+	if strings.TrimSpace(s) == "" {
+		return nil, nil
+	}
+	out := map[string]Image{}
+	for _, entry := range strings.Split(s, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		id, spec, found := strings.Cut(entry, "=")
+		id, spec = strings.TrimSpace(id), strings.TrimSpace(spec)
+		if !found || id == "" || spec == "" {
+			return nil, fmt.Errorf("entry %q: want %s", entry, DeclaredImageSyntax)
+		}
+		ref, login, _ := strings.Cut(spec, "@")
+		if _, ok := SpecFor(ref); !ok {
+			return nil, fmt.Errorf("entry %q: %q is not a ref this emulator can build; want %s with a family among %s",
+				entry, ref, DeclaredImageSyntax, strings.Join(Families(), ", "))
+		}
+		if _, dup := out[id]; dup {
+			return nil, fmt.Errorf("entry %q: %s is declared twice", entry, id)
+		}
+		out[id] = Image{Ref: ref, User: login}
+	}
+	return out, nil
+}
+
+// ImageBuilder is the optional half of a Driver that can build the images
+// RequiredImages names.
+//
+// It is the seam `feint images` drives, named here so EnsureImage can drive the
+// same one. Two builders would be two recipes, and a defect fixed in one would
+// survive in the other — the shape CLAUDE.md names as the most expensive
+// mistake made in this repository.
+type ImageBuilder interface {
+	BuildImage(ctx context.Context, spec ImageSpec, progress io.Writer) error
+}
+
+// imageBuilds serialises builds by alias.
+//
+// Two servers powered on at once against a station that holds neither image
+// would otherwise each build it: minutes spent twice, and two containers
+// working on one alias. A lock per alias rather than one global lock, for the
+// reason the store lock already taught here — a global one would queue every
+// boot behind one download, while two different images have no reason to wait
+// for each other.
+//
+// It is taken in exactly one place, BuildIfMissing, and that is the point: a
+// control every caller has to remember is a control one caller will forget.
+// `feint images` and the boot path (EnsureImage) are the two callers today, and
+// neither takes it itself.
+//
+// What it cannot do is span processes, and the pair that actually collided on
+// 2026-08-25 was a `feint serve` and a `feint images` in another terminal. That
+// half is closed by the builder's name rather than by a lock: see builderName.
+var imageBuilds sync.Map // alias -> *sync.Mutex
+
+func imageBuildLock(alias string) *sync.Mutex {
+	mu, _ := imageBuilds.LoadOrStore(alias, &sync.Mutex{})
+	return mu.(*sync.Mutex)
+}
+
+// BuildIfMissing builds one image unless the station already holds it, and
+// reports whether it built anything.
+//
+// The one seam every build goes through: `feint images` for the warm-up set,
+// and EnsureImage for the image a boot derives. Both get the exclusion and the
+// second look for free, which is why neither writes them.
+//
+// The second look is not belt and braces. A caller checks the inventory, waits
+// for whoever holds the lock, and by the time it gets in the image it wanted
+// exists — building it again would cost minutes for nothing and republish an
+// alias somebody may be booting from.
+//
+// TestOneBuilderPerImageAndPerProcess fails without this.
+func BuildIfMissing(ctx context.Context, driver Driver, spec ImageSpec, progress io.Writer) (bool, error) {
+	builder, canBuild := driver.(ImageBuilder)
+	if !canBuild {
+		return false, fmt.Errorf("the %s runtime cannot build images", driver.Name())
+	}
+	mu := imageBuildLock(spec.Alias())
+	mu.Lock()
+	defer mu.Unlock()
+
+	if lister, canAsk := driver.(ImageLister); canAsk {
+		held, err := lister.LocalImages(ctx)
+		// A station that cannot be asked is not a station that holds nothing:
+		// the build goes ahead, because the caller asked for this image and
+		// refusing on a failed question would be worse than building twice.
+		if err == nil {
+			if _, present := held[spec.Alias()]; present {
+				return false, nil
+			}
+		}
+	}
+	if err := builder.BuildImage(ctx, spec, progress); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// EnsureImage makes sure the station holds the image behind ref, building it at
+// boot when the family table derives a recipe and the station lacks the result
+// (#465). It reports whether it built one.
+//
+// "On the fly" is the decision this implements: a station that has never run
+// `feint images` still boots debian:13 with an ssh daemon, at the price of one
+// announced build on the first boot. Building is a slow side effect on
+// somebody's machine, so it is announced when it starts and when it ends, with
+// the image and how long it took: a treatment that says nothing is
+// indistinguishable from one that is stuck.
+//
+// A ref outside the family table is not an error — it returns (false, nil) and
+// the boot keeps resolveImage's announced fallback, because "no recipe" and
+// "the recipe failed" must not read the same. A build that does fail is an
+// error, and the caller refuses the boot with it rather than falling back: for
+// a derived ref the upstream image is the very source the build could not
+// fetch, so the fallback would re-fail with a raw driver error where a refusal
+// can name the ref and the source.
+//
+// TestAFailedImageBuildRefusesTheBootAndNamesTheSource and
+// TestABootDerivesAndBuildsTheImageItNames fail without this.
+func EnsureImage(ctx context.Context, driver Driver, ref string, log *slog.Logger) (bool, error) {
+	if log == nil {
+		log = slog.Default()
+	}
+	spec, ours := SpecFor(ref)
+	if !ours {
+		return false, nil
+	}
+	lister, canAsk := driver.(ImageLister)
+	_, canBuild := driver.(ImageBuilder)
+	if !canAsk || !canBuild {
+		// An undeclared capability counts as absent, so this says "nobody could
+		// look" rather than "the image is there": the boot goes on, and the
+		// driver's own fallback warning is what the operator reads next.
+		log.Debug("this runtime cannot be asked about base images, so none is built",
+			"image", ref, "runtime", driver.Name())
+		return false, nil
+	}
+	held, err := lister.LocalImages(ctx)
+	if err != nil {
+		log.Warn("could not ask the station which base images it holds, so none is built",
+			"image", ref, "error", err)
+		return false, nil
+	}
+	if _, present := held[spec.Alias()]; present {
+		return false, nil
+	}
+
+	log.Warn("building an image this station does not hold yet, so the boot has something to run",
+		"image", ref, "alias", spec.Alias(), "source", spec.Source,
+		"consequence", "minutes on this first boot, and outbound network to fetch it",
+		"fix", "`feint images` builds the warm-up set ahead of time, `feint images --check` says what is missing")
+	// Detached from the caller's context on purpose. A client that gives up on
+	// its request — Terraform's timeout, a Ctrl-C — would otherwise kill the
+	// build halfway and leave the builder instance on the station, which is the
+	// leftover this project sweeps rather than creates. The build finishes, the
+	// next boot finds the image, and the cap is there so a wedged download
+	// cannot hold the lock for ever.
+	buildCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), imageBuildTimeout)
+	defer cancel()
+	started := time.Now()
+	built, err := BuildIfMissing(buildCtx, driver, spec, nil)
+	if err != nil {
+		// Said here with the duration; the caller owns the refusal and its
+		// message, because only it knows the resource and the provider.
+		log.Error("could not build the image this boot derived",
+			"image", ref, "alias", spec.Alias(), "source", spec.Source,
+			"after", time.Since(started).Round(time.Second).String(), "error", err)
+		return false, err
+	}
+	if !built {
+		log.Warn("another run had already built this image, and the boot goes on",
+			"image", ref, "alias", spec.Alias())
+		return false, nil
+	}
+	log.Warn("the image is built and the boot goes on",
+		"image", ref, "alias", spec.Alias(), "in", time.Since(started).Round(time.Second).String())
+	return true, nil
+}
+
+// imageBuildTimeout caps one build. Three minutes go to waiting for the builder
+// to answer (waitForBuilder), the rest to a package install over whatever
+// network the station has; twenty minutes is well past both and still short of
+// forever.
+const imageBuildTimeout = 20 * time.Minute
 
 // ImageStatus is what the host holds for one required image.
 type ImageStatus struct {
@@ -119,6 +492,57 @@ func ImageInventory(ctx context.Context, driver Driver) ([]ImageStatus, error) {
 	for _, spec := range specs {
 		out = append(out, ImageStatus{Spec: spec, Fingerprint: held[spec.Alias()]})
 	}
+	return out, nil
+}
+
+// DerivedImages answers the images the station holds under the emulator's
+// prefix that no warm-up row names — the ones a boot derived on demand (#465),
+// and anything published under the prefix by hand.
+//
+// The two questions used to coincide: while the recipe table was enumerated,
+// what the station could hold under the prefix was exactly what the fixed list
+// named, and an inventory of the list was an inventory of the station.
+// Derivation splits them — a boot builds feint/fedora/44 without the warm-up
+// set ever naming it — and an image the inventory cannot name is the silent
+// residue this project hunts.
+//
+// A derived image is neither missing nor wrong, and `feint clean` deliberately
+// removes no image, warm-up or derived alike: clean removes what a killed run
+// left half-alive, and an image is the asset that spares the next run its
+// minutes of build — the conformance suite runs clean, and sweeping images
+// there would rebuild the set on every pass. Visibility is therefore the whole
+// control, and the report names the removal gesture beside each derived row.
+//
+// TestDerivedImagesAreNamedBesideTheWarmupSet fails without this.
+func DerivedImages(ctx context.Context, driver Driver) ([]ImageStatus, error) {
+	lister, ok := driver.(ImageLister)
+	if !ok {
+		return nil, nil
+	}
+	held, err := lister.LocalImages(ctx)
+	if err != nil {
+		return nil, err
+	}
+	named := map[string]bool{}
+	for _, spec := range RequiredImages() {
+		named[spec.Alias()] = true
+	}
+	var out []ImageStatus
+	for alias, fingerprint := range held {
+		if named[alias] || !strings.HasPrefix(alias, ImagePrefix+"/") {
+			continue
+		}
+		name := strings.TrimPrefix(alias, ImagePrefix+"/")
+		spec, known := SpecFor(strings.Replace(name, "/", ":", 1))
+		if !known {
+			// Under the prefix and outside every recipe: named all the same. A
+			// family the table lost would otherwise vanish from the inventory
+			// while staying on the station.
+			spec = ImageSpec{Name: name}
+		}
+		out = append(out, ImageStatus{Spec: spec, Fingerprint: fingerprint})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Spec.Name < out[j].Spec.Name })
 	return out, nil
 }
 

--- a/internal/core/machine/images_test.go
+++ b/internal/core/machine/images_test.go
@@ -82,7 +82,7 @@ func TestAnImageTheHostHoldsIsReportedPresent(t *testing.T) {
 	d := NewIncus()
 	d.runner = func(_ context.Context, args ...string) ([]byte, error) {
 		if strings.HasPrefix(strings.Join(args, " "), "image list") {
-			return []byte(held.Alias() + ",abc123def456\n"), nil
+			return []byte(`[{"fingerprint":"abc123def456","aliases":[{"name":"` + held.Alias() + `"}]}]`), nil
 		}
 		return nil, nil
 	}
@@ -120,7 +120,8 @@ func TestAnOperatorsOwnImagesAreNotReported(t *testing.T) {
 	d := NewIncus()
 	d.runner = func(_ context.Context, args ...string) ([]byte, error) {
 		if strings.HasPrefix(strings.Join(args, " "), "image list") {
-			return []byte("production-base,deadbeef00\n" + ImagePrefix + "/ubuntu/24.04,cafebabe11\n"), nil
+			return []byte(`[{"fingerprint":"deadbeef00","aliases":[{"name":"production-base"}]},` +
+				`{"fingerprint":"cafebabe11","aliases":[{"name":"` + ImagePrefix + `/ubuntu/24.04"}]}]`), nil
 		}
 		return nil, nil
 	}
@@ -170,9 +171,14 @@ func TestTheBuiltImageIsPreferredWhenTheHostHoldsIt(t *testing.T) {
 		d.runner = func(_ context.Context, args ...string) ([]byte, error) {
 			if strings.HasPrefix(strings.Join(args, " "), "image list") {
 				var out strings.Builder
-				for _, alias := range aliases {
-					out.WriteString(alias + ",fingerprint\n")
+				out.WriteString("[")
+				for i, alias := range aliases {
+					if i > 0 {
+						out.WriteString(",")
+					}
+					out.WriteString(`{"fingerprint":"fingerprint","aliases":[{"name":"` + alias + `"}]}`)
 				}
+				out.WriteString("]")
 				return []byte(out.String()), nil
 			}
 			return nil, nil
@@ -198,5 +204,186 @@ func TestTheBuiltImageIsPreferredWhenTheHostHoldsIt(t *testing.T) {
 	// An explicit Incus reference is the caller naming an image; it is honoured.
 	if got := withImages(ours).resolveImage(context.Background(), "images:debian/13"); got != "images:debian/13" {
 		t.Errorf("an explicit reference was rewritten to %s", got)
+	}
+}
+
+func TestSpecForDerivesEveryVersionOfAKnownFamily(t *testing.T) {
+	cases := []struct {
+		ref     string
+		name    string
+		source  string
+		manager string
+		service string
+	}{
+		// The measured hole of #465: the catalogue promises debian_trixie.
+		{"debian:13", "debian/13", "images:debian/13/cloud", "apt", "ssh"},
+		// A family the fixed table never carried; triplet rehearsed 2026-08-25.
+		{"fedora:44", "fedora/44", "images:fedora/44/cloud", "dnf", "sshd"},
+		// The version half must travel verbatim, capitals included.
+		{"centos:9-Stream", "centos/9-Stream", "images:centos/9-Stream/cloud", "dnf", "sshd"},
+		{"alpine:3.22", "alpine/3.22", "images:alpine/3.22/cloud", "apk", "sshd"},
+		{"ubuntu:26.04", "ubuntu/26.04", "images:ubuntu/26.04/cloud", "apt", "ssh"},
+		{"rockylinux:9", "rockylinux/9", "images:rockylinux/9/cloud", "dnf", "sshd"},
+	}
+	for _, c := range cases {
+		spec, ok := SpecFor(c.ref)
+		if !ok {
+			t.Errorf("SpecFor(%q) derived nothing for a family the table holds", c.ref)
+			continue
+		}
+		if spec.Name != c.name || spec.Source != c.source || spec.Manager != c.manager || spec.Service != c.service {
+			t.Errorf("SpecFor(%q) = %+v, want name=%s source=%s manager=%s service=%s",
+				c.ref, spec, c.name, c.source, c.manager, c.service)
+		}
+		if spec.Package == "" {
+			t.Errorf("SpecFor(%q) carries no ssh package, so the build would produce the very image it replaces", c.ref)
+		}
+	}
+}
+
+func TestSpecForRefusesWhatNoRecipeCovers(t *testing.T) {
+	refused := []string{
+		"plan9:4",                // no recipe for the family: the guard of #465
+		"talos:1.7",              // no ssh package to install; outside the form
+		"",                       //
+		"debian",                 // no version at all
+		"debian:",                // empty version
+		":13",                    // empty family
+		"images:debian/13/cloud", // an explicit runtime ref is the caller's own image
+		"debian:-13",             // a version that would reach argv looking like a flag
+		"debian:13 evil",         // charset: whitespace never travels into a command
+		"debian:13;true",         //
+		"Debian:13",              // families are table keys, exactly
+	}
+	for _, ref := range refused {
+		if spec, ok := SpecFor(ref); ok {
+			t.Errorf("SpecFor(%q) = %+v, want a refusal", ref, spec)
+		}
+	}
+}
+
+func TestRequiredImagesDeriveFromTheFamilyTable(t *testing.T) {
+	specs := RequiredImages()
+	if len(specs) != 6 {
+		t.Fatalf("%d warm-up rows, want 6: a ref outside the family table was silently dropped", len(specs))
+	}
+	seen := map[string]bool{}
+	for _, spec := range specs {
+		seen[spec.Name] = true
+		ref := strings.Replace(spec.Name, "/", ":", 1)
+		derived, ok := SpecFor(ref)
+		if !ok || derived != spec {
+			t.Errorf("warm-up row %s does not derive from the family table (got %+v, ok=%v): two spellings of one recipe", spec.Name, derived, ok)
+		}
+	}
+	// The user-visible half of #465: the Scaleway catalogue serves
+	// debian_trixie mapped on debian:13, so the warm-up set must hold it.
+	if !seen["debian/13"] {
+		t.Error("debian/13 is not in the warm-up set while the catalogue promises debian_trixie")
+	}
+}
+
+func TestParseDeclaredImagesRefusesWhatItCannotBuild(t *testing.T) {
+	t.Run("a valid declaration parses, login included", func(t *testing.T) {
+		got, err := ParseDeclaredImages(" ami-a3ca408c=ubuntu:22.04, tmpl-1=fedora:44@fedora ,")
+		if err != nil {
+			t.Fatalf("refused a valid declaration: %v", err)
+		}
+		want := map[string]Image{
+			"ami-a3ca408c": {Ref: "ubuntu:22.04"},
+			"tmpl-1":       {Ref: "fedora:44", User: "fedora"},
+		}
+		if len(got) != len(want) || got["ami-a3ca408c"] != want["ami-a3ca408c"] || got["tmpl-1"] != want["tmpl-1"] {
+			t.Fatalf("parsed %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("nothing declared is nil, not empty", func(t *testing.T) {
+		if got, err := ParseDeclaredImages("  "); err != nil || got != nil {
+			t.Fatalf("got %v, %v for an empty declaration", got, err)
+		}
+	})
+
+	t.Run("a bad entry refuses the whole set and says how to fix it", func(t *testing.T) {
+		cases := map[string]string{
+			"ami-x=plan9:4":                   "ubuntu", // the fix names the families a recipe exists for
+			"garbage":                         "family", // the fix quotes the syntax
+			"ami-x=debian:13,ami-x=debian:12": "twice",  // a duplicate is a typo, not a choice
+			"=debian:12":                      "family", //
+			"ami-x=debian:-13":                "family", // the ref guard holds here too
+		}
+		for entry, needle := range cases {
+			got, err := ParseDeclaredImages(entry)
+			if err == nil {
+				t.Errorf("ParseDeclaredImages(%q) = %v, want a refusal", entry, got)
+				continue
+			}
+			if !strings.Contains(err.Error(), needle) {
+				t.Errorf("ParseDeclaredImages(%q) error %q does not carry %q, so the reader cannot act on it", entry, err, needle)
+			}
+		}
+	})
+}
+
+func TestDerivedImagesAreNamedBesideTheWarmupSet(t *testing.T) {
+	driver := &buildingDriver{held: map[string]string{
+		"feint/ubuntu/24.04": "warmup-row",   // named by the set: not derived
+		"feint/fedora/44":    "derived-here", // a boot derived it (#465)
+		"feint/plan9/4":      "lost-family",  // under the prefix, no recipe: still named
+		"operator/own":       "not-ours",     // outside the prefix: none of our business
+	}}
+
+	derived, err := DerivedImages(context.Background(), driver)
+	if err != nil {
+		t.Fatalf("DerivedImages: %v", err)
+	}
+	if len(derived) != 2 || derived[0].Spec.Name != "fedora/44" || derived[1].Spec.Name != "plan9/4" {
+		t.Fatalf("derived %+v, want exactly fedora/44 and plan9/4: a warm-up row is not derived, an operator's image is not ours, and a prefix image with no recipe must not vanish", derived)
+	}
+	if derived[0].Spec.Source == "" || derived[0].Spec.Manager != "dnf" {
+		t.Errorf("fedora/44 lost its derived recipe: %+v", derived[0].Spec)
+	}
+	if !derived[1].Present() {
+		t.Error("a held image reports absent")
+	}
+
+	// A driver that cannot be asked holds nothing to report — never an error,
+	// the same rule CapabilitiesOf applies.
+	if got, err := DerivedImages(context.Background(), &recordingDriver{}); err != nil || got != nil {
+		t.Fatalf("got %v, %v from a driver with no lister", got, err)
+	}
+}
+
+// The instrument before the subject: `incus image list -c l` truncates a second
+// alias into "feint/debian/12 (1 more)", csv included, and the csv parser
+// turned that into a name nothing publishes while the real aliases vanished —
+// `feint images --check` called a present image missing. Caught on 2026-08-25
+// by planting a second alias on a held image; the fix is asking for JSON,
+// which carries every alias whole.
+func TestLocalImagesSurviveASecondAlias(t *testing.T) {
+	var asked []string
+	d := NewIncus()
+	d.runner = func(_ context.Context, args ...string) ([]byte, error) {
+		asked = append(asked, strings.Join(args, " "))
+		return []byte(`[{"fingerprint":"7bf813f9e3ea","aliases":[` +
+			`{"name":"` + ImagePrefix + `/debian/12"},{"name":"` + ImagePrefix + `/fedora/44"}]}]`), nil
+	}
+
+	held, err := d.LocalImages(context.Background())
+	if err != nil {
+		t.Fatalf("LocalImages: %v", err)
+	}
+	for _, alias := range []string{ImagePrefix + "/debian/12", ImagePrefix + "/fedora/44"} {
+		if held[alias] != "7bf813f9e3ea" {
+			t.Errorf("alias %s vanished from the listing: %v", alias, held)
+		}
+	}
+	for alias := range held {
+		if strings.Contains(alias, " ") {
+			t.Errorf("held a truncation artefact as an alias: %q", alias)
+		}
+	}
+	if len(asked) == 0 || !strings.Contains(asked[0], "--format json") {
+		t.Fatalf("the listing did not ask for JSON, so a second alias will truncate: %v", asked)
 	}
 }

--- a/internal/core/machine/incus.go
+++ b/internal/core/machine/incus.go
@@ -242,14 +242,13 @@ func (d *Incus) imageRef(image string) string {
 func (d *Incus) resolveImage(ctx context.Context, image string) string {
 	upstream := d.imageRef(image)
 	// An explicit Incus reference is the caller naming an image; honour it.
-	if strings.Contains(image, "/") {
+	// ImageAlias answers false for that case, and for anything that is not a
+	// family:version pair — it is the one spelling of this mapping, shared with
+	// EnsureImage so a build and a boot cannot look for different aliases.
+	alias, ours := ImageAlias(image)
+	if !ours {
 		return upstream
 	}
-	name, version, found := strings.Cut(image, ":")
-	if !found {
-		return upstream
-	}
-	alias := ImagePrefix + "/" + name + "/" + version
 
 	held, err := d.LocalImages(ctx)
 	if err != nil {

--- a/internal/core/machine/incus_imagebuild_test.go
+++ b/internal/core/machine/incus_imagebuild_test.go
@@ -1,0 +1,211 @@
+package machine
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Two builds must never work in one container, and the proof has to be at the
+// level of the commands: the failure it prevents is invisible above argv.
+//
+// Measured on 2026-08-25, when #392 put a second caller on this recipe: a
+// `feint serve --vm incus-ovn` building ubuntu/24.04 on the boot path and a
+// `feint images` in another terminal, both on the fixed-name builder. One died
+// on `apt-get update … exit status 137` — its container removed under the exec
+// — and the other on `incus publish: lstat …/libsmartcols.so.1.1.0: no such
+// file or directory`, a file deleted under the publish.
+//
+// Two halves, because they close two different cases: the lock covers one
+// process (BuildIfMissing), and the name covers two.
+
+// buildRecorder is an injected runner: it records argv, answers the calls
+// BuildImage makes, and can hold the first build open so a second one has to
+// meet it.
+type buildRecorder struct {
+	mu    sync.Mutex
+	calls [][]string
+	// published is the alias store the recorded `image list` answers from, so a
+	// second caller sees what the first one built.
+	published map[string]bool
+	// entered is signalled when a launch is seen; release holds that launch
+	// until the test lets go.
+	entered chan string
+	release chan struct{}
+}
+
+func newBuildRecorder() *buildRecorder {
+	return &buildRecorder{
+		published: map[string]bool{},
+		entered:   make(chan string, 8),
+		release:   make(chan struct{}),
+	}
+}
+
+func (r *buildRecorder) run(_ context.Context, args ...string) ([]byte, error) {
+	r.mu.Lock()
+	r.calls = append(r.calls, append([]string(nil), args...))
+	published := make([]string, 0, len(r.published))
+	for alias := range r.published {
+		published = append(published, alias)
+	}
+	r.mu.Unlock()
+
+	switch {
+	case len(args) > 1 && args[0] == "image" && args[1] == "list":
+		out := "["
+		for i, alias := range published {
+			if i > 0 {
+				out += ","
+			}
+			out += `{"fingerprint":"fingerprint","aliases":[{"name":"` + alias + `"}]}`
+		}
+		return []byte(out + "]"), nil
+	case args[0] == "launch":
+		r.entered <- args[2]
+		<-r.release
+		return nil, nil
+	case args[0] == "publish":
+		r.mu.Lock()
+		r.published[args[len(args)-1]] = true
+		r.mu.Unlock()
+		return nil, nil
+	}
+	return nil, nil
+}
+
+func (r *buildRecorder) launched() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []string
+	for _, call := range r.calls {
+		if call[0] == "launch" {
+			out = append(out, call[2])
+		}
+	}
+	return out
+}
+
+func TestOneBuilderPerImageAndPerProcess(t *testing.T) {
+	t.Run("one build at a time per image", func(t *testing.T) {
+		rec := newBuildRecorder()
+		d := &Incus{runner: rec.run}
+		spec := RequiredImages()[0]
+
+		done := make(chan bool, 2)
+		build := func() {
+			made, err := BuildIfMissing(context.Background(), d, spec, nil)
+			if err != nil {
+				t.Errorf("build: %v", err)
+			}
+			done <- made
+		}
+		go build()
+		<-rec.entered // the first caller holds the container
+		go build()
+
+		// The witness, and it has to be this shape. Releasing the first caller
+		// as soon as the second is launched proves nothing: the second would
+		// then find the image published and skip, lock or no lock, and the
+		// falsification said so — the mutation that removes the lock left this
+		// test green on its first form. So the assertion is about what reaches
+		// argv **while the first caller is still inside the recipe**: with the
+		// lock, the second emits nothing at all; without it, a second builder
+		// is launched within microseconds.
+		for i := 0; i < 60; i++ {
+			if len(rec.launched()) > 1 {
+				break
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		if names := rec.launched(); len(names) != 1 {
+			t.Fatalf("launched %v while the first build was still running, want the second caller queued", names)
+		}
+		close(rec.release)
+
+		built := 0
+		for i := 0; i < 2; i++ {
+			if <-done {
+				built++
+			}
+		}
+		if built != 1 {
+			t.Fatalf("%d of the two callers built the image, want exactly 1", built)
+		}
+		if names := rec.launched(); len(names) != 1 {
+			t.Fatalf("launched %v, want one builder for two concurrent callers", names)
+		}
+	})
+
+	t.Run("the container is named for its image and its process", func(t *testing.T) {
+		// The accepting half, and the cross-process one: two different images
+		// build in two different containers by decision, and another process
+		// building the same image never lands on this one's name.
+		first, second := builderName(RequiredImages()[0]), builderName(RequiredImages()[1])
+		if first == second {
+			t.Fatalf("two images share the builder %q, so they cannot build side by side", first)
+		}
+		for _, name := range []string{first, second} {
+			if !strings.HasPrefix(name, builderPrefix+"-") {
+				t.Errorf("%q is outside the sweep's prefix, so a leftover would be nobody's", name)
+			}
+			if !strings.HasSuffix(name, "-"+strconv.Itoa(os.Getpid())) {
+				t.Errorf("%q does not name this process, so two runs share one container", name)
+			}
+			if strings.ContainsAny(name, "/:. ") {
+				t.Errorf("%q is not a name a runtime will take", name)
+			}
+		}
+	})
+
+	t.Run("an image the station already holds is not rebuilt", func(t *testing.T) {
+		rec := newBuildRecorder()
+		close(rec.release)
+		spec := RequiredImages()[0]
+		rec.published[spec.Alias()] = true
+		d := &Incus{runner: rec.run}
+
+		made, err := BuildIfMissing(context.Background(), d, spec, nil)
+		if err != nil || made {
+			t.Fatalf("made=%v err=%v, want no build for an image that is already there", made, err)
+		}
+		if names := rec.launched(); len(names) != 0 {
+			t.Fatalf("launched %v for an image the station holds", names)
+		}
+	})
+}
+
+// The destructive half of the image lifecycle answers both questions at its
+// own choke point: a name outside <family>/<version> shape never reaches argv,
+// and the alias is always built from the emulator's own prefix, so an
+// operator's image cannot even be spelled. Asserted at the argv level with the
+// injected runner, because that is where the damage would happen.
+func TestImageRemovalStaysInsideThePrefix(t *testing.T) {
+	rec := newBuildRecorder()
+	close(rec.release)
+	d := &Incus{runner: rec.run}
+
+	// The refusing half: not one of these may emit a command.
+	for _, name := range []string{"", "fedora", "a/b/c", "../etc", "-rf/whatever", "fedora/44 x", "fedora/-44"} {
+		if err := d.RemoveImage(context.Background(), name); err == nil {
+			t.Errorf("RemoveImage(%q) did not refuse", name)
+		}
+	}
+	for _, call := range rec.calls {
+		t.Errorf("a refused name still reached the runtime: %v", call)
+	}
+
+	// The accepting half: the emulator's own image is removable, and the argv
+	// names the prefixed alias and nothing else.
+	if err := d.RemoveImage(context.Background(), "fedora/44"); err != nil {
+		t.Fatalf("RemoveImage(fedora/44): %v", err)
+	}
+	want := []string{"image", "delete", ImagePrefix + "/fedora/44"}
+	if len(rec.calls) != 1 || strings.Join(rec.calls[0], " ") != strings.Join(want, " ") {
+		t.Fatalf("argv %v, want exactly %v", rec.calls, want)
+	}
+}

--- a/internal/core/machine/incus_images.go
+++ b/internal/core/machine/incus_images.go
@@ -2,51 +2,83 @@ package machine
 
 import (
 	"context"
-	"encoding/csv"
+	"encoding/json"
 	"fmt"
 	"io"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 )
 
-// builderName is the instance an image build runs in.
+// builderPrefix marks the instance an image build runs in.
 //
 // Under the emulator's own machine prefix on purpose: a build interrupted
 // halfway leaves it behind, and `feint clean` sweeps what carries the prefix, so
 // the leftover is removed by the tool the operator already runs rather than by
 // remembering it exists.
-const builderName = "feint-imagebuild"
+const builderPrefix = "feint-imagebuild"
+
+// builderName is the instance one build runs in: the prefix, the image it is
+// building, and the process building it.
+//
+// It used to be the single constant "feint-imagebuild", for every image and
+// every process, and that made the builder a shared object with no owner.
+// BuildImage force-deletes the builder on the way in and on the way out, so two
+// builds meeting on that name delete and publish each other's container.
+//
+// Measured on 2026-08-25, both halves in the same minute: `feint serve --vm
+// incus-ovn` building ubuntu/24.04 on the boot path (#392 put a second caller
+// on this recipe) and a `feint images` started by hand in another terminal.
+// The first died on `apt-get update … exit status 137` — SIGKILL, the container
+// removed from under the exec — and the second on `incus publish: lstat
+// …/rootfs/usr/lib/x86_64-linux-gnu/libsmartcols.so.1.1.0: no such file or
+// directory`, a file that had just been deleted under the publish. Neither run
+// could have told you what hit it.
+//
+// A Go lock closes the case inside one process (BuildIfMissing) and cannot
+// close it across two, which is exactly the pair that failed. The name does:
+// two processes now build in two containers, and two different images build in
+// parallel by decision rather than by accident of a shared name.
+//
+// TestOneBuilderPerImageAndPerProcess fails without this.
+func builderName(spec ImageSpec) string {
+	slug := strings.NewReplacer("/", "-", ".", "-", ":", "-").Replace(spec.Name)
+	return builderPrefix + "-" + slug + "-" + strconv.Itoa(os.Getpid())
+}
 
 // LocalImages implements ImageLister.
 //
 // Only aliases under the emulator's own prefix are reported. An operator's own
 // images are none of this code's business, and reporting them would be the first
 // step towards deleting one.
+//
+// JSON and not the csv column, and that is a measurement, not a taste: `incus
+// image list -c l` truncates a second alias into "feint/debian/12 (1 more)",
+// csv format included. Parsed from that column, an image carrying two aliases
+// reported a name nothing publishes, its real aliases vanished, and `feint
+// images --check` called a present image missing — the instrument lying before
+// its subject, caught on 2026-08-25 by planting a second alias on a held
+// image. TestLocalImagesSurviveASecondAlias fails against the csv version.
 func (d *Incus) LocalImages(ctx context.Context) (map[string]string, error) {
-	out, err := d.run(ctx, "image", "list", ImagePrefix+"/", "-f", "csv", "-c", "lf")
+	out, err := d.run(ctx, "image", "list", ImagePrefix+"/", "--format", "json")
 	if err != nil {
 		return nil, fmt.Errorf("list local images: %w", err)
 	}
+	var images []struct {
+		Fingerprint string `json:"fingerprint"`
+		Aliases     []struct {
+			Name string `json:"name"`
+		} `json:"aliases"`
+	}
+	if err := json.Unmarshal(out, &images); err != nil {
+		return nil, fmt.Errorf("read the image list: %w", err)
+	}
 	held := map[string]string{}
-	reader := csv.NewReader(strings.NewReader(string(out)))
-	reader.FieldsPerRecord = -1
-	for {
-		row, err := reader.Read()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return nil, fmt.Errorf("read the image list: %w", err)
-		}
-		if len(row) < 2 {
-			continue
-		}
-		// One image can carry several aliases; the column is comma-joined
-		// inside a quoted field, so each is taken on its own.
-		for _, alias := range strings.Split(row[0], ",") {
-			alias = strings.TrimSpace(alias)
-			if strings.HasPrefix(alias, ImagePrefix+"/") {
-				held[alias] = strings.TrimSpace(row[1])
+	for _, image := range images {
+		for _, alias := range image.Aliases {
+			if strings.HasPrefix(alias.Name, ImagePrefix+"/") {
+				held[alias.Name] = image.Fingerprint
 			}
 		}
 	}
@@ -70,19 +102,20 @@ func (d *Incus) BuildImage(ctx context.Context, spec ImageSpec, progress io.Writ
 		}
 	}
 
-	_ = d.removeBuilder(ctx)
-	defer func() { _ = d.removeBuilder(ctx) }()
+	builder := builderName(spec)
+	_ = d.removeBuilder(ctx, builder)
+	defer func() { _ = d.removeBuilder(ctx, builder) }()
 
 	say("launching %s", spec.Source)
 	// Labelled like every other object this driver creates, so `feint clean`
 	// sweeps a builder an interrupted run left behind. An unlabelled leftover is
 	// one this emulator would refuse to touch, which is the right rule applied
 	// to the wrong object.
-	if _, err := d.run(ctx, "launch", spec.Source, builderName,
+	if _, err := d.run(ctx, "launch", spec.Source, builder,
 		"--config", "user."+LabelKey+"=imagebuild"); err != nil {
 		return fmt.Errorf("launch %s: %w", spec.Source, err)
 	}
-	if err := d.waitForBuilder(ctx); err != nil {
+	if err := d.waitForBuilder(ctx, builder); err != nil {
 		return err
 	}
 
@@ -92,7 +125,7 @@ func (d *Incus) BuildImage(ctx context.Context, spec ImageSpec, progress io.Writ
 		return err
 	}
 	for _, command := range commands {
-		if err := d.execInBuilder(ctx, command); err != nil {
+		if err := d.execInBuilder(ctx, builder, command); err != nil {
 			return err
 		}
 	}
@@ -102,11 +135,11 @@ func (d *Incus) BuildImage(ctx context.Context, spec ImageSpec, progress io.Writ
 		// Best effort: a distribution without dbus has no dbus machine id to
 		// remove, and failing there would refuse an image for a file that was
 		// never supposed to exist.
-		_ = d.execInBuilder(ctx, command)
+		_ = d.execInBuilder(ctx, builder, command)
 	}
 
 	say("publishing %s", spec.Alias())
-	if _, err := d.run(ctx, "stop", builderName); err != nil {
+	if _, err := d.run(ctx, "stop", builder); err != nil {
 		return fmt.Errorf("stop the builder: %w", err)
 	}
 	// A previous alias would make `publish` fail rather than replace, and a
@@ -121,7 +154,7 @@ func (d *Incus) BuildImage(ctx context.Context, spec ImageSpec, progress io.Writ
 	// lives here, where it is scoped to one call whose failure cannot hide
 	// anything: a genuine conflict surfaces at publish, loudly.
 	_, _ = d.run(ctx, "image", "delete", spec.Alias())
-	if _, err := d.run(ctx, "publish", builderName, "--alias", spec.Alias()); err != nil {
+	if _, err := d.run(ctx, "publish", builder, "--alias", spec.Alias()); err != nil {
 		return fmt.Errorf("publish %s: %w", spec.Alias(), err)
 	}
 	return nil
@@ -130,12 +163,12 @@ func (d *Incus) BuildImage(ctx context.Context, spec ImageSpec, progress io.Writ
 // waitForBuilder blocks until the builder answers and cloud-init has finished,
 // because installing a package while cloud-init is still holding the package
 // manager is a race that fails intermittently — the worst kind.
-func (d *Incus) waitForBuilder(ctx context.Context) error {
+func (d *Incus) waitForBuilder(ctx context.Context, builder string) error {
 	deadline := time.Now().Add(3 * time.Minute)
 	for time.Now().Before(deadline) {
-		if _, err := d.run(ctx, "exec", builderName, "--", "true"); err == nil {
+		if _, err := d.run(ctx, "exec", builder, "--", "true"); err == nil {
 			// cloud-init is absent on some images and that is not an error.
-			_, _ = d.run(ctx, "exec", builderName, "--", "cloud-init", "status", "--wait")
+			_, _ = d.run(ctx, "exec", builder, "--", "cloud-init", "status", "--wait")
 			return nil
 		}
 		select {
@@ -147,18 +180,45 @@ func (d *Incus) waitForBuilder(ctx context.Context) error {
 	return fmt.Errorf("the build instance never answered")
 }
 
-func (d *Incus) execInBuilder(ctx context.Context, command []string) error {
-	args := append([]string{"exec", builderName, "--"}, command...)
+func (d *Incus) execInBuilder(ctx context.Context, builder string, command []string) error {
+	args := append([]string{"exec", builder, "--"}, command...)
 	if _, err := d.run(ctx, args...); err != nil {
 		return fmt.Errorf("%s in the build instance: %w", strings.Join(command, " "), err)
 	}
 	return nil
 }
 
-func (d *Incus) removeBuilder(ctx context.Context) error {
-	_, err := d.run(ctx, "delete", "--force", builderName)
+func (d *Incus) removeBuilder(ctx context.Context, builder string) error {
+	_, err := d.run(ctx, "delete", "--force", builder)
 	if err != nil && !isNotFound(err) {
 		return err
+	}
+	return nil
+}
+
+// RemoveImage deletes one image this emulator published, named by its
+// family/version half ("fedora/44") — the explicit, asked-for removal that
+// `feint clean` deliberately is not: clean removes what a killed run left
+// half-alive, an image is the cache that spares the next run its minutes of
+// build, and a sweep that deleted it would punish whoever runs clean between
+// two tries.
+//
+// Two questions, both answered here at the destructive choke point. Ownership:
+// the alias is built from ImagePrefix, the mark BuildImage itself writes, so
+// an operator's image cannot even be spelled through this call — the same rule
+// Binding.ours and mustOwn apply to machines and networks. Syntax: each half
+// obeys the same charset a ref does, so no name reaches argv as a flag or a
+// path. A name that fails either is refused out loud, never skipped.
+//
+// TestImageRemovalStaysInsideThePrefix fails without the guards.
+func (d *Incus) RemoveImage(ctx context.Context, name string) error {
+	family, version, found := strings.Cut(name, "/")
+	if !found || !refToken(family) || !refToken(version) || strings.Contains(version, "/") {
+		return fmt.Errorf("%q does not name an image of this emulator: want <family>/<version>", name)
+	}
+	alias := ImagePrefix + "/" + name
+	if _, err := d.run(ctx, "image", "delete", alias); err != nil {
+		return fmt.Errorf("remove %s: %w", alias, err)
 	}
 	return nil
 }

--- a/internal/providers/exoscale/machines.go
+++ b/internal/providers/exoscale/machines.go
@@ -33,7 +33,11 @@ func (p *Pack) binding() machine.Binding {
 		RunningState: "running",
 		// Declared in their instance-state enum.
 		FailedState: "error",
-		Log:         p.env.Log,
+		// The operator's identifier declarations (FEINT_BOOT_IMAGES), consulted
+		// by the binding only when no template resolved. The optional @login of
+		// an entry matters most here, where the login belongs to the template.
+		Declared: p.env.BootImages,
+		Log:      p.env.Log,
 	}
 }
 

--- a/internal/providers/outscale/machines.go
+++ b/internal/providers/outscale/machines.go
@@ -32,7 +32,10 @@ func (p *Pack) binding() machine.Binding {
 		RunningState: stateRunning,
 		// Outscale declares no error state for a Vm; stopped is the true one.
 		FailedState: stateStopped,
-		Log:         p.env.Log,
+		// The operator's identifier declarations (FEINT_BOOT_IMAGES), consulted
+		// by the binding only when the catalogue above resolved nothing.
+		Declared: p.env.BootImages,
+		Log:      p.env.Log,
 	}
 }
 

--- a/internal/providers/scaleway/machines.go
+++ b/internal/providers/scaleway/machines.go
@@ -49,7 +49,10 @@ func (p *Pack) binding() machine.Binding {
 		RunningState: "running",
 		// Scaleway declares no error state for a server either.
 		FailedState: "stopped",
-		Log:         p.env.Log,
+		// The operator's identifier declarations (FEINT_BOOT_IMAGES), consulted
+		// by the binding only when the catalogue resolved nothing.
+		Declared: p.env.BootImages,
+		Log:      p.env.Log,
 	}
 }
 

--- a/tools/falsify/specs/image-derivation.json
+++ b/tools/falsify/specs/image-derivation.json
@@ -1,0 +1,41 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "the family table stops being an authorization, so any family:version derives a build — plan9:4 included",
+      "file": "internal/core/machine/images.go",
+      "find": "\trecipe, known := imageFamilies()[family]\n\tif !known {\n\t\treturn ImageSpec{}, false\n\t}",
+      "replace": "\trecipe, known := imageFamilies()[family]\n\tif false && !known {\n\t\treturn ImageSpec{}, false\n\t}",
+      "test": "TestSpecForRefusesWhatNoRecipeCovers"
+    },
+    {
+      "label": "a failed image build stops refusing the boot, so the runtime is asked to boot the very source the build could not fetch",
+      "file": "internal/core/machine/binding.go",
+      "find": "\t\tif _, err := EnsureImage(ctx, b.Driver, boot.Image, b.logger()); err != nil {",
+      "replace": "\t\tif _, err := EnsureImage(ctx, b.Driver, boot.Image, b.logger()); err != nil && false {",
+      "test": "TestAFailedImageBuildRefusesTheBootAndNamesTheSource"
+    },
+    {
+      "label": "the operator's declaration is never consulted, so the door through the refusal is painted on",
+      "file": "internal/core/machine/binding.go",
+      "find": "\t\tdeclared, ok := b.Declared[boot.Requested]\n\t\tif !ok || boot.Requested == \"\" {",
+      "replace": "\t\tdeclared, ok := b.Declared[boot.Requested]\n\t\tif true || !ok || boot.Requested == \"\" {",
+      "test": "TestADeclaredIdentifierBootsTheImageTheOperatorNamed"
+    },
+    {
+      "label": "the refusal loses its gestures: the lookup command and the declaration vanish from the message, families and identifier kept evaluated",
+      "file": "internal/core/machine/binding.go",
+      "find": "\t\t\"ask\", \"`feint images resolve \"+id+\"` looks it up in the providers' public listings, no account needed\",\n\t\t\"fix\", \"declare what it is, then restart: FEINT_BOOT_IMAGES='\"+id+\"=<family>:<version>' with a family among \"+strings.Join(Families(), \", \"))",
+      "replace": "\t\t\"ask\", \"unresolved \"+id,\n\t\t\"fix\", strings.Join(Families(), \"/\"))",
+      "test": "TestTheBootRefusalNamesTheGesturesThatUnblock"
+    },
+    {
+      "label": "the removal guard stops refusing, so any string reaches `incus image delete` as long as the prefix is glued on",
+      "file": "internal/core/machine/incus_images.go",
+      "find": "\tfamily, version, found := strings.Cut(name, \"/\")\n\tif !found || !refToken(family) || !refToken(version) || strings.Contains(version, \"/\") {",
+      "replace": "\tfamily, version, found := strings.Cut(name, \"/\")\n\tif (!found || !refToken(family) || !refToken(version) || strings.Contains(version, \"/\")) && false {",
+      "test": "TestImageRemovalStaysInsideThePrefix"
+    }
+  ],
+  "note": "The guards of #465, each with the test its comment cites. The first is the line between deriving any version of a known family and building anything at all; the second is what keeps a withdrawn upstream version (debian:9 — a real witness, two surveyed stacks hardcode identifiers naming it) from reaching the runtime as a raw driver error; the third and fourth are the two halves of the actionable refusal — the door must exist, and the message must point at it. Every mutation still compiles: err and declared stay referenced, and the trailing arguments keep the call well formed."
+}


### PR DESCRIPTION
`RequiredImages()` was a fixed table of five rows, and `SpecFor(ref)` returned `ours=false` for anything else — so nothing was built and the boot fell back to the upstream image **with no ssh daemon, no regenerated machine id and no cleared cloud-init state**.

That is correct for an unknown family. It was wrong for a **known family at another version**, and the emulator already promised one: the Scaleway catalogue serves `debian_trixie` mapped to `Ref: "debian:13"`, and no `debian/13` was ever built. A client using the label this emulator publishes got a machine without ssh.

## The recipe derives by family, because that is where it varies

Seven families, three triplets: `ubuntu`/`debian` → apt·`openssh-server`·`ssh`, `alpine` → apk·`openssh`·`sshd`, `almalinux`/`rockylinux`/`centos`/`fedora` → dnf·`openssh-server`·`sshd`. The version travels through. `debian:13` is now in the ahead-of-time set — the hole above.

**Four distributions built on this station today, none of them written anywhere in the code:**

| built | family | inside, probed via `incus exec` |
|---|---|---|
| `fedora/44` | RHEL | active, enabled, listening, 3 host keys, cloud-init `done` |
| `ubuntu/26.04` | Debian | active, enabled, 2 sockets on :22, 3 host keys, cloud-init `done` |
| `alpine/3.22` | Alpine | sshd running, port `0016` LISTEN in `/proc/net/tcp` |
| `rockylinux/10` | RHEL | `Rocky Linux 10.2`, active, enabled, 2 sockets, 3 host keys |

Bracketing witnesses each time: `images:ubuntu/99.04/cloud`, `images:alpine/9.99/cloud` and `images:rockylinux/42/cloud` answer rc=1, so the availability probe can tell present from absent.

## An opaque identifier is the operator's to declare, and it is never substituted

An `ami-a3ca408c` names no OS, so no recipe can derive one. **The boot stops, and the state stays `stopped` — never `running`.** The ERROR names the identifier, the pack's reason, the consequence, and **two ways through**: `feint images resolve <id>`, and `FEINT_BOOT_IMAGES='<id>=<family>:<version>[@login]'`, which is the operator's signed assertion rather than a guess.

A guard with no way past it gets worked around by copying the emulator, so the door is named. And it is not the substitution of #392, which the maintainer refused: booting an Ubuntu where the stack asked for an AlmaLinux is a machine that starts and then fails on its first `dnf`.

## The public listings, measured

- **Outscale** — `Official-OMIs-Reference.html`, http 200 without credentials, and **historical**: the three identifiers the live API no longer knows are named there (`ami-a3ca408c`=Ubuntu-22.04, `ami-538af795`=Ubuntu-18.04, `ami-47899c77`=Debian-9). The API itself without auth: **401**, measured.
- **Scaleway** — `marketplace/v2/images`, 200 JSON, no auth, clean 404 on an invented uuid (witness planted first).
- **Exoscale** — `/v2/template`, 200 JSON, no auth, carries id, name, family, version and default user.

`feint images resolve` reads those three, prints the exact declaration to paste, and the emulator works offline afterwards. **No network call on the create or boot path** — that is the failure mode that cost this project a fork of the Exoscale Terraform provider, where an apply *splits* between the emulator and a paying account.

## Derived images are visible, and they survive

`feint images` and `--check` report a third category, `derived`, distinct from the ahead-of-time set, naming the removal gesture. **`feint clean` does not touch images**: an image is a cache, not a residue — removing it on every sweep would make a command an operator runs between two runs punish its user. Explicit removal is `feint images remove <family/version>`, which spells the alias from the prefix, so an operator's own image is *unspellable*.

Proven on `fedora/44`: **same fingerprint after `feint stop`, `feint clean` and `feint start`.**

## Gates

`go build` 0 · `go test ./...` 0 · `mise run check` 0 · `docs:check` 0 · `mise run prepush` **0** (after #466 landed the upstream rename that had it red on every branch) · `falsify image-derivation.json` 0 — 5 mutations, 5 red · the 9 existing specs naming these files, 0 each.

`mise run conformance` was not played on this branch — issues are handled in series and it runs once over the assembled set.

## Two instruments caught lying, both recorded

- `incus image list` in csv **truncates a second alias** to "(1 more)", which read a present `debian/12` as missing. `LocalImages` now uses `--format json`; `TestLocalImagesSurviveASecondAlias` holds it.
- A passive banner probe reads nothing against **OpenSSH 10**, which does not speak until the client does. The "FAILED" of an e2e script was the instrument, proven by a witness on a known-good image and a real ssh client.

## Left open, documented rather than claimed away

The first trixie boot converges slowly (~3 min 30) — the networkd unit cloud-init renders loses the netplan `on-link`, and the route arrives on retry — and a create that builds an image outlives the 60 s write timeout while the state converges honestly. Both are in `docs/limits.md` as candidates for their own issues.

Closes #465

🤖 Generated with [Claude Code](https://claude.com/claude-code)
