### PR TITLE
fix(machine): an ICMP rule reads its address family, and a refused rule set stops reading as a success (#454)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -109,6 +109,68 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Corrigé
 
+- **Un groupe de sécurité portant une règle ICMP dont la source est en IPv6
+  garde son pare-feu, et un jeu de règles que l'hôte refuse cesse de se lire
+  comme un succès** (#454). Le rejeu des quinze stacks tierces de
+  `examples/stacks/surveyed.md` sous `--vm incus-ovn` l'a trouvé ;
+  `sergelogvinov/terraform-talos` livre
+  `whitelist_admins = ["0.0.0.0/0", "::/0"]`, donc une liste blanche
+  d'administration en double pile est ce qu'une stack apporte, pas un cas
+  exotique.
+
+  **Mesuré sur cette station, Incus 7.2 avec OVN, sur le témoin réduit de la
+  campagne : deux groupes identiques à une règle près.** Avant, le groupe A
+  décrivait une règle et en appliquait une ; le groupe B en décrivait deux et
+  en appliquait **une**, sa règle ICMP purement absente, avec trois refus
+  `Cannot use IPv6 source addresses with "icmp4" protocol` dans le journal de
+  l'émulateur et `capabilities.firewall: true` publié pendant tout ce temps.
+  Pire que le compte : la machine portant le groupe B ne portait **aucun jeu de
+  règles** sur son interface, parce que le pack retourne avant d'attacher quand
+  l'écriture échoue, si bien qu'un groupe en refus par défaut laissait sa
+  machine sans filtre. Après, A fait 1/1 et B fait 2/2, la seconde règle écrite
+  `protocol: icmp6, source: ::/0`, les deux machines portant leur jeu de règles,
+  et aucun échec dans le journal.
+
+  **La cause tient en une ligne, et dans l'écriture tout ou rien à côté
+  d'elle.** `toACLRule` choisissait le protocole de l'ACL sur le seul nom de la
+  règle (`case "icmp", "icmp4"`) sans jamais lire la famille d'adresses, tandis
+  qu'`EnsureFirewall` écrit tout le jeu en un seul PUT, délibérément, pour
+  qu'une règle révoquée disparaisse. Une règle inexprimable coûtait donc toutes
+  les règles de son groupe, et l'API continuait de les décrire toutes : le
+  commentaire de la fonction promettait l'inverse (« reports false for a rule
+  the runtime cannot express, which the caller drops rather than
+  approximating »), ce qui est le motif « un commentaire n'est pas un contrôle »
+  de ce dépôt, dans la couche qui agit sur la machine de l'opérateur.
+
+  La famille vient désormais des adresses de la règle : une source ou une
+  destination IPv6 donne `icmp6`, une IPv4 donne `icmp4`, et les orthographes
+  `icmp6`, `icmpv6` et `ipv6-icmp` sont comprises. `icmp` et `icmp4` restent
+  tous deux agnostiques, volontairement : `icmp4` est le nom de fil du runtime,
+  pas une revendication d'un pack, et la seule valeur de Scaleway est `ICMP`.
+  Une règle qui ne fixe aucune famille devient donc **deux** règles, une par
+  famille, parce que c'est ce que « ICMP depuis n'importe où » veut dire. Une
+  règle qu'aucun protocole n'exprime (deux familles dans une règle, un nom qui
+  contredit ses adresses, une adresse illisible) est laissée tomber **seule** et
+  rapportée en WARN, en nommant le jeu et la règle, ce que « visiblement
+  absente » était censé signifier.
+
+  **Et une limite a bougé, observable sur `/_feint/health` :
+  `capabilities.firewall` peut désormais passer à faux en cours d'exécution.**
+  Un jeu de règles que l'hôte refuse, c'est l'hôte qui répond que ce processus
+  n'applique pas ce que son API décrit ; la revendication est donc retirée, et
+  dite dans le journal. Le retrait est à sens unique, et seul un refus **de
+  l'hôte** compte : un nom que ce pilote refuse lui-même n'a jamais atteint le
+  démon et provient d'un instantané restaurable, ce qui donnerait sinon à un
+  fichier d'état fabriqué un interrupteur sur une revendication publiée.
+
+  Falsifié de neuf façons (`tools/falsify/specs/icmp-family.json`), dont le
+  choix sur le nom seul rétabli, le jumelage des deux familles retiré, le
+  retrait désarmé, et le refus de la garde interne compté comme celui de
+  l'hôte ; les neuf passent au rouge. Le témoin unitaire pilote `EnsureFirewall`
+  par le `runner` injectable contre un faux démon qui reproduit le refus
+  d'Incus, de sorte que le test mesure si l'écriture est *acceptée* plutôt que
+  la façon dont elle est orthographiée.
+
 - **Un Net à trois subnets ou plus s'appaire sous OVN, et un hôte qui porte déjà
   l'état qui l'en empêchait est réconcilié** (#456). Le rejeu des quinze stacks
   tierces sous `--vm incus-ovn` a coûté au registre son résultat vedette :

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,62 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Fixed
 
+- **A security group carrying an ICMP rule with an IPv6 source keeps its
+  firewall, and a rule set the host refuses stops reading as a success** (#454).
+  Replaying the fifteen third-party stacks of `examples/stacks/surveyed.md`
+  under `--vm incus-ovn` found it; `sergelogvinov/terraform-talos` ships
+  `whitelist_admins = ["0.0.0.0/0", "::/0"]`, so a dual-stack admin whitelist is
+  what a stack brings rather than an edge case.
+
+  **Measured on this station, Incus 7.2 with OVN, on the campaign's own reduced
+  witness: two groups identical but for one rule.** Before, group A described
+  one rule and enforced one; group B described two and enforced **one**, its
+  ICMP rule simply absent, with three
+  `Cannot use IPv6 source addresses with "icmp4" protocol` refusals in the
+  emulator's log and `capabilities.firewall: true` published the whole time.
+  Worse than the count: the machine carrying group B held **no rule set at all**
+  on its interface, because the pack returns before attaching when the write
+  fails, so a deny-default group left its machine unfiltered. After, A is 1/1
+  and B is 2/2, the second rule written `protocol: icmp6, source: ::/0`, both
+  machines carrying their rule set, and no failure in the log.
+
+  **The cause is one line and the all-or-nothing write beside it.**
+  `toACLRule` chose the ACL protocol from the rule's own name
+  (`case "icmp", "icmp4"`) and never read the address family, while
+  `EnsureFirewall` writes the whole set in one PUT — deliberately, so a revoked
+  rule disappears. One inexpressible rule therefore cost every rule of its
+  group, and the API went on describing all of them: the function's own comment
+  promised the opposite ("reports false for a rule the runtime cannot express,
+  which the caller drops rather than approximating"), which is this
+  repository's "a comment is not a control" pattern in the layer that acts on
+  the operator's host.
+
+  The family now comes from the rule's addresses: an IPv6 source or destination
+  yields `icmp6`, an IPv4 one `icmp4`, and the `icmp6` / `icmpv6` / `ipv6-icmp`
+  spellings are understood. `icmp` and `icmp4` both stay family-agnostic on
+  purpose — `icmp4` is the runtime's wire name, not a claim any pack makes, and
+  Scaleway's only value is `ICMP` — so a rule that fixes no family at all
+  becomes **two** rules, one per family, because that is what "ICMP from
+  anywhere" means. A rule no protocol expresses (both families in one rule, a
+  name contradicting its addresses, an address that cannot be read) is dropped
+  **alone** and reported at WARN naming the rule set and the rule, which is what
+  "visibly absent" was supposed to mean.
+
+  **And a limit moved, observable on `/_feint/health`:
+  `capabilities.firewall` can now go false during a run.** A rule set the host
+  refuses is the host answering that this process does not enforce what its API
+  describes, so the claim is withdrawn and said in the log. It is one-way, and
+  only a refusal *by the host* counts: a name this driver refuses itself never
+  reached the daemon and arrives from a restorable snapshot, which would
+  otherwise hand a crafted state file a switch on a published claim.
+
+  Falsified nine ways (`tools/falsify/specs/icmp-family.json`), including the
+  name-only mapping restored, the twin expansion removed, the withdrawal
+  disarmed, and the own-guard refusal made to count as the host's; all nine go
+  red. The unit witness drives `EnsureFirewall` through the injectable `runner`
+  against a fake daemon that reproduces Incus's own refusal, so the test
+  measures whether the write is *accepted* rather than how it is spelled.
+
 - **A Net with three subnets or more peers under OVN, and a host already
   carrying the state that stopped it is reconciled** (#456). Replaying the
   fifteen third-party stacks under `--vm incus-ovn` cost the register its

--- a/internal/core/machine/capabilities.go
+++ b/internal/core/machine/capabilities.go
@@ -140,6 +140,24 @@ func (Noop) Capabilities() Capabilities { return Capabilities{} }
 // managed bridge has no load balancer primitive at all, so there is nothing to
 // measure there rather than something that half works.
 func (d *Incus) Capabilities() Capabilities {
+	caps := d.declaredCapabilities()
+	// And what the host *refused* wins over both (#454). A rule set the daemon
+	// rejected is the host saying, in the plainest way it has, that this
+	// process does not enforce what its API describes; going on publishing
+	// firewall=true afterwards is the lying 200 the whole project exists to
+	// refuse, one layer down. See firewallRefused for why it is one-way and why
+	// only a refusal by the host counts.
+	// TestAFirewallWriteTheHostRefusesWithdrawsTheCapability fails without this.
+	if d.firewallDenied.Load() {
+		caps.Firewall = false
+		caps.FirewallPublicOnly = false
+	}
+	return caps
+}
+
+// declaredCapabilities is what the flags promise, narrowed by what the host
+// answered at startup.
+func (d *Incus) declaredCapabilities() Capabilities {
 	// What the host answered wins over what the flag promised (#181). Verify
 	// narrows this set once at startup; before that, and in a test that builds a
 	// driver directly, the declaration below is what there is.

--- a/internal/core/machine/firewall.go
+++ b/internal/core/machine/firewall.go
@@ -41,7 +41,16 @@ type FirewallRule struct {
 	Direction string
 	// Action is "allow", "drop" or "reject". Drop is silent, reject answers.
 	Action string
-	// Protocol is "tcp", "udp", "icmp4", or empty for any.
+	// Protocol is "tcp", "udp", an ICMP spelling, or empty for any.
+	//
+	// ICMP does not name an address family here, and a driver must not read one
+	// into it: "icmp" and "icmp4" are both the family-agnostic spelling, because
+	// "icmp4" is the runtime's wire name for the IPv4 protocol rather than a
+	// claim any pack makes — Scaleway's only value is "ICMP". A driver picks the
+	// family from Source and Destination, and the explicit v6 spellings
+	// ("icmp6", "icmpv6", "ipv6-icmp") are the ones that fix it. Reading the
+	// name alone is #454: an ICMP rule sourced from an IPv6 block was written as
+	// the IPv4 protocol and the daemon refused the group's whole rule set.
 	Protocol string
 	// Source is the block traffic comes from, for an ingress rule.
 	Source string

--- a/internal/core/machine/incus.go
+++ b/internal/core/machine/incus.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/stephrobert/feint/internal/core/serialise"
@@ -54,6 +55,15 @@ type Incus struct {
 	// UplinkCIDR is the block the uplink carries. Empty means
 	// DefaultUplinkCIDR.
 	UplinkCIDR string
+	// Log is where this driver says what it could not do. Nil means the
+	// default logger, which is what the CLI configures.
+	//
+	// A field rather than slog.Default() at the call site, for the reason
+	// Binding.Log is one: the two things this driver has to say — a rule it
+	// left out of a rule set, and a claim it is withdrawing — are assertions a
+	// test must be able to read, and swapping the process-wide default to read
+	// them would make one test's assertion depend on every other test's timing.
+	Log *slog.Logger
 
 	// runner replaces the CLI call, and is only ever set by a test. It exists
 	// because a handful of decisions in this driver are invisible to the
@@ -90,6 +100,16 @@ type Incus struct {
 	// the case in a test that builds a driver directly: the declared set is then
 	// the honest answer, because no host was consulted to contradict it.
 	verified *Capabilities
+
+	// firewallDenied is set once the host has refused a rule set (#454), and
+	// makes Capabilities answer firewall=false from then on.
+	//
+	// Atomic rather than guarded by the field above: `verified` is written once
+	// at startup by Verify and only read afterwards, while this one is written
+	// from EnsureFirewall — mid-run, from whichever request is reconciling a
+	// group — and read by every `/_feint/health`. See firewallRefused for why
+	// the retraction is one-way.
+	firewallDenied atomic.Bool
 
 	// Interface allocation is serialised per machine, by serialise.Lock in
 	// Attach — there is no field here on purpose.
@@ -157,6 +177,15 @@ func NewIncusOVN() *Incus {
 	d := NewIncus()
 	d.OVN = true
 	return d
+}
+
+// logger answers where this driver reports what it could not do, defaulting to
+// the process logger the way Binding.logger does.
+func (d *Incus) logger() *slog.Logger {
+	if d.Log != nil {
+		return d.Log
+	}
+	return slog.Default()
 }
 
 // Name implements Driver.
@@ -258,7 +287,7 @@ func (d *Incus) resolveImage(ctx context.Context, image string) string {
 	if _, ok := held[alias]; ok {
 		return alias
 	}
-	slog.Default().Warn("no image of ours for this system, booting the upstream one",
+	d.logger().Warn("no image of ours for this system, booting the upstream one",
 		"image", image, "wanted", alias, "using", upstream,
 		"consequence", "no upstream image carries an ssh daemon, and this machine has no route to a package repository, so nothing will answer on port 22",
 		"fix", "feint images")

--- a/internal/core/machine/incus_firewall.go
+++ b/internal/core/machine/incus_firewall.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/netip"
 	"strconv"
 	"strings"
 )
@@ -85,6 +86,12 @@ type aclBody struct {
 // security group is edited by replacing its list (Scaleway's own
 // SetSecurityGroupRules does exactly that), and replacing here is what makes a
 // revoked rule actually disappear.
+//
+// All-or-nothing is what makes the two halves below load-bearing (#454). A rule
+// the daemon refuses does not fail alone: it fails the PUT, and every rule of
+// the group with it, while the API keeps describing all of them. So a rule this
+// driver cannot express is dropped here and *said*, and a write the host still
+// refuses withdraws the claim that this runtime enforces anything.
 func (d *Incus) EnsureFirewall(ctx context.Context, spec FirewallSpec) error {
 	if !safeName.MatchString(spec.Name) {
 		return fmt.Errorf("invalid firewall name %q", spec.Name)
@@ -92,10 +99,10 @@ func (d *Incus) EnsureFirewall(ctx context.Context, spec FirewallSpec) error {
 
 	if _, err := d.run(ctx, "network", "acl", "show", spec.Name); err != nil {
 		if !isNotFound(err) {
-			return fmt.Errorf("inspect firewall %s: %w", spec.Name, err)
+			return d.firewallRefused(fmt.Errorf("inspect firewall %s: %w", spec.Name, err))
 		}
 		if _, err := d.run(ctx, "network", "acl", "create", spec.Name); err != nil {
-			return fmt.Errorf("create firewall %s: %w", spec.Name, err)
+			return d.firewallRefused(fmt.Errorf("create firewall %s: %w", spec.Name, err))
 		}
 	}
 
@@ -105,16 +112,27 @@ func (d *Incus) EnsureFirewall(ctx context.Context, spec FirewallSpec) error {
 		Egress:      []aclRule{},
 		Config:      map[string]string{},
 	}
+	var dropped []string
 	for _, rule := range spec.Rules {
-		converted, ok := toACLRule(rule)
-		if !ok {
+		converted := toACLRules(rule)
+		if len(converted) == 0 {
+			dropped = append(dropped, describeRule(rule))
 			continue
 		}
 		if rule.Direction == "egress" {
-			body.Egress = append(body.Egress, converted)
+			body.Egress = append(body.Egress, converted...)
 		} else {
-			body.Ingress = append(body.Ingress, converted)
+			body.Ingress = append(body.Ingress, converted...)
 		}
+	}
+	if len(dropped) > 0 {
+		// "Visibly absent" was the word the contract used, and nothing was
+		// saying it: a rule the runtime cannot express left no trace at all,
+		// while the API went on serving it. TestADroppedRuleIsReported fails
+		// without this line.
+		d.logger().Warn("some rules of a security group are not expressible by this runtime "+
+			"and were left out of the rule set; the API still describes them",
+			"firewall", spec.Name, "rules", strings.Join(dropped, "; "))
 	}
 
 	encoded, err := json.Marshal(body)
@@ -123,9 +141,34 @@ func (d *Incus) EnsureFirewall(ctx context.Context, spec FirewallSpec) error {
 	}
 	if _, err := d.run(ctx, "query", "-X", "PUT", "--data", string(encoded),
 		"/1.0/network-acls/"+spec.Name); err != nil {
-		return fmt.Errorf("write firewall %s: %w", spec.Name, err)
+		return d.firewallRefused(fmt.Errorf("write firewall %s: %w", spec.Name, err))
 	}
 	return nil
+}
+
+// firewallRefused records that the host refused a rule set this driver had
+// already accepted, and returns the error unchanged so no caller has to know.
+//
+// The claim goes and does not come back. `capabilities.firewall` says "a
+// security group's rules are enforced on the machine's interface", and a refused
+// write is the host answering that they are not — for that group, now, and for
+// any group whose rules meet the same refusal. #181 settled the direction for
+// this exact question: what the host answered wins over what the flag promised,
+// and a false capability is strictly worse than none, because this project tells
+// every consumer to key on the capability rather than on a mode name.
+//
+// Only a refusal *by the host* counts. A name this driver refused itself never
+// reached the daemon, and it arrives from a restorable snapshot — letting it
+// flip a published claim would hand that switch to a crafted state file.
+//
+// TestAFirewallWriteTheHostRefusesWithdrawsTheCapability fails without this.
+func (d *Incus) firewallRefused(err error) error {
+	if d.firewallDenied.CompareAndSwap(false, true) {
+		d.logger().Warn("the runtime refused a security group's rule set, so this process no "+
+			"longer claims to enforce firewalls (capabilities.firewall is now false)",
+			"error", err)
+	}
+	return err
 }
 
 // ApplyFirewall implements Firewaller. It sets the rule sets, and the default
@@ -337,42 +380,201 @@ func (d *Incus) networkDevices(ctx context.Context, machine string) ([]nicDevice
 	return devices, nil
 }
 
-// toACLRule converts one emulated rule. It reports false for a rule the runtime
-// cannot express, which the caller drops rather than approximating: a rule
-// enforced differently from what the API describes is worse than one visibly
-// absent.
-func toACLRule(rule FirewallRule) (aclRule, bool) {
-	out := aclRule{Action: rule.Action, State: "enabled"}
+// toACLRules converts one emulated rule into the rules the runtime can express.
+//
+// It returns nothing for a rule the runtime cannot express, which the caller
+// drops — and says so — rather than approximating: a rule enforced differently
+// from what the API describes is worse than one visibly absent. Dropping *that
+// rule* is the whole point. EnsureFirewall writes the set in one PUT, so a rule
+// this function let through and the daemon then refused cost every rule beside
+// it: a group whose API described two rules enforced one (#454).
+//
+// It can also return two, because the runtime has no single ICMP protocol.
+// icmp4 and icmp6 are separate protocols there, each refusing the other
+// family's addresses, so a rule that names no address at all means both.
+func toACLRules(rule FirewallRule) []aclRule {
 	switch rule.Action {
 	// allow-stateless is a real runtime action, and the translation of a
 	// stateless security group: dropping it here would silently turn the
 	// group's rules back into stateful ones.
 	case "allow", "allow-stateless", "drop", "reject":
 	default:
-		return aclRule{}, false
+		return nil
 	}
 
-	switch strings.ToLower(rule.Protocol) {
+	protocols, ok := aclProtocols(rule)
+	if !ok {
+		return nil
+	}
+
+	out := make([]aclRule, 0, len(protocols))
+	for _, protocol := range protocols {
+		converted := aclRule{
+			Action:      rule.Action,
+			State:       "enabled",
+			Protocol:    protocol,
+			Source:      rule.Source,
+			Destination: rule.Destination,
+		}
+		// Ports only exist for TCP and UDP; Incus rejects the field otherwise.
+		if protocol == "tcp" || protocol == "udp" {
+			converted.DestinationPort = portRange(rule.PortFrom, rule.PortTo)
+		}
+		out = append(out, converted)
+	}
+	return out
+}
+
+// aclProtocols reports the runtime protocols one rule becomes, and false when
+// no protocol expresses it.
+//
+// The ICMP half is where #454 lived: the protocol used to be chosen from the
+// rule's own name — `case "icmp", "icmp4"` — and the address family was never
+// read, so an ICMP rule sourced from an IPv6 block was written as icmp4 and the
+// daemon refused the whole PUT with `Cannot use IPv6 source addresses with
+// "icmp4" protocol`. The family of the addresses is the fact that decides here;
+// the name only decides when the addresses fix nothing.
+// TestAnICMPRuleWithAnIPv6SourceKeepsItsGroup fails without this.
+func aclProtocols(rule FirewallRule) ([]string, bool) {
+	switch name := strings.ToLower(strings.TrimSpace(rule.Protocol)); name {
 	case "", "any":
-		out.Protocol = ""
-	case "tcp":
-		out.Protocol = "tcp"
-	case "udp":
-		out.Protocol = "udp"
-	case "icmp", "icmp4":
-		out.Protocol = "icmp4"
+		// The empty protocol is "every protocol" on the wire, and it takes no
+		// family: an "any" rule carries whatever addresses it was given.
+		return []string{""}, true
+	case "tcp", "udp":
+		return []string{name}, true
 	default:
-		return aclRule{}, false
+		named, isICMP := icmpFamilyOfName(name)
+		if !isICMP {
+			return nil, false
+		}
+		return icmpProtocols(named, rule.Source, rule.Destination)
+	}
+}
+
+// icmpFamilyOfName reports the address family an ICMP spelling fixes — 4, 6, or
+// 0 for a spelling that fixes none — and false for a name that is not ICMP.
+//
+// "icmp4" fixes nothing, which reads odd and is deliberate: it is this package's
+// own documented spelling for ICMP (see FirewallRule.Protocol), taken from the
+// runtime's wire name rather than written as an assertion about a family, and
+// the only ICMP value Scaleway has is the family-agnostic "ICMP". Reading it as
+// a claim about IPv4 would drop exactly the rules #454 is about. The v6
+// spellings do fix one: a caller that writes icmpv6 has named the family, and
+// three vocabularies spell it three ways.
+func icmpFamilyOfName(name string) (int, bool) {
+	switch name {
+	case "icmp", "icmp4", "icmpv4":
+		return 0, true
+	case "icmp6", "icmpv6", "ipv6-icmp":
+		return 6, true
+	}
+	return 0, false
+}
+
+// icmpProtocols picks between the runtime's two ICMP protocols from the family
+// of the rule's own addresses, falling back to the family its name fixed.
+func icmpProtocols(named int, source, destination string) ([]string, bool) {
+	sourceV4, sourceV6, sourceRead := addressFamilies(source)
+	destinationV4, destinationV6, destinationRead := addressFamilies(destination)
+	if !sourceRead || !destinationRead {
+		// An address this cannot read is not an address that is absent. Picking
+		// a family for it would send the daemon a value it is about to refuse,
+		// and the refusal costs the whole group.
+		return nil, false
 	}
 
-	out.Source = rule.Source
-	out.Destination = rule.Destination
-
-	// Ports only exist for TCP and UDP; Incus rejects the field otherwise.
-	if out.Protocol == "tcp" || out.Protocol == "udp" {
-		out.DestinationPort = portRange(rule.PortFrom, rule.PortTo)
+	v4 := sourceV4 || destinationV4
+	v6 := sourceV6 || destinationV6
+	switch {
+	case v4 && v6:
+		// One rule, both families, and no ICMP protocol covers both.
+		return nil, false
+	case v4:
+		if named == 6 {
+			// The name says one family and the addresses say the other. Never
+			// approximated: the rule goes, alone and named in the log.
+			return nil, false
+		}
+		return []string{"icmp4"}, true
+	case v6:
+		if named == 4 {
+			return nil, false
+		}
+		return []string{"icmp6"}, true
+	case named == 4:
+		return []string{"icmp4"}, true
+	case named == 6:
+		return []string{"icmp6"}, true
+	default:
+		// Nothing fixes a family: "ICMP from anywhere" means both of them, and
+		// half of it enforced silently is the same defect one size smaller.
+		return []string{"icmp4", "icmp6"}, true
 	}
-	return out, true
+}
+
+// addressFamilies reports the families an ACL address field names, and whether
+// it could be read at all.
+//
+// Incus accepts a comma-separated list of CIDR blocks, bare addresses and
+// dash-separated ranges in `source` and `destination`, so each member is read on
+// its own. The third result is the third outcome a reader owes its caller: an
+// unreadable address is not an absent one, and mapping it onto "no family" would
+// silently pick a protocol for a value the daemon will reject.
+func addressFamilies(field string) (v4, v6, readable bool) {
+	if strings.TrimSpace(field) == "" {
+		return false, false, true
+	}
+	for _, member := range strings.Split(field, ",") {
+		member = strings.TrimSpace(member)
+		if member == "" {
+			return false, false, false
+		}
+		for _, bound := range strings.SplitN(member, "-", 2) {
+			addr, ok := parseAddressOrPrefix(strings.TrimSpace(bound))
+			if !ok {
+				return false, false, false
+			}
+			if addr.Is4() || addr.Is4In6() {
+				v4 = true
+			} else {
+				v6 = true
+			}
+		}
+	}
+	return v4, v6, true
+}
+
+// parseAddressOrPrefix reads one member of an address field: "10.0.0.0/8",
+// "::/0" or a bare address.
+func parseAddressOrPrefix(s string) (netip.Addr, bool) {
+	if prefix, err := netip.ParsePrefix(s); err == nil {
+		return prefix.Addr(), true
+	}
+	addr, err := netip.ParseAddr(s)
+	if err != nil {
+		return netip.Addr{}, false
+	}
+	return addr, true
+}
+
+// describeRule renders a rule for the line that reports it was dropped. A rule
+// the API still serves is only "visibly absent" if something is saying so.
+func describeRule(rule FirewallRule) string {
+	parts := []string{rule.Direction, rule.Action}
+	if rule.Protocol != "" {
+		parts = append(parts, rule.Protocol)
+	}
+	if rule.Source != "" {
+		parts = append(parts, "from "+rule.Source)
+	}
+	if rule.Destination != "" {
+		parts = append(parts, "to "+rule.Destination)
+	}
+	if ports := portRange(rule.PortFrom, rule.PortTo); ports != "" {
+		parts = append(parts, "port "+ports)
+	}
+	return strings.Join(parts, " ")
 }
 
 func portRange(from, to int) string {

--- a/internal/core/machine/incus_firewall_test.go
+++ b/internal/core/machine/incus_firewall_test.go
@@ -1,8 +1,13 @@
 package machine
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"log/slog"
+	"net/netip"
 	"strings"
 	"testing"
 )
@@ -262,72 +267,141 @@ func TestRemoveFirewallIsIdempotent(t *testing.T) {
 	}
 }
 
-func TestToACLRule(t *testing.T) {
+// TestToACLRules holds the translation table, and its ICMP rows are #454.
+//
+// The protocol used to be chosen from the rule's own name alone, so an ICMP rule
+// sourced from an IPv6 block was written as icmp4; the daemon answered `Cannot
+// use IPv6 source addresses with "icmp4" protocol`, and because the set is
+// written in one PUT the refusal cost every rule of that group. The family of
+// the addresses decides now, and a rule no protocol expresses is dropped alone.
+func TestToACLRules(t *testing.T) {
 	cases := []struct {
 		name string
 		in   FirewallRule
-		want aclRule
-		ok   bool
+		want []aclRule
 	}{
 		{
 			name: "an ingress rule keeps its source and its port range",
 			in:   FirewallRule{Direction: "ingress", Action: "allow", Protocol: "TCP", Source: "10.0.0.0/8", PortFrom: 80, PortTo: 90},
-			want: aclRule{Action: "allow", State: "enabled", Protocol: "tcp", Source: "10.0.0.0/8", DestinationPort: "80-90"},
-			ok:   true,
+			want: []aclRule{{Action: "allow", State: "enabled", Protocol: "tcp", Source: "10.0.0.0/8", DestinationPort: "80-90"}},
 		},
 		{
 			name: "a single port is not written as a range",
 			in:   FirewallRule{Direction: "ingress", Action: "allow", Protocol: "tcp", PortFrom: 22, PortTo: 22},
-			want: aclRule{Action: "allow", State: "enabled", Protocol: "tcp", DestinationPort: "22"},
-			ok:   true,
+			want: []aclRule{{Action: "allow", State: "enabled", Protocol: "tcp", DestinationPort: "22"}},
 		},
 		{
 			name: "no port means every port, not port zero",
 			in:   FirewallRule{Direction: "ingress", Action: "allow", Protocol: "tcp"},
-			want: aclRule{Action: "allow", State: "enabled", Protocol: "tcp"},
-			ok:   true,
+			want: []aclRule{{Action: "allow", State: "enabled", Protocol: "tcp"}},
 		},
 		{
-			name: "icmp carries no port, which the runtime rejects on it",
-			in:   FirewallRule{Direction: "ingress", Action: "allow", Protocol: "ICMP", PortFrom: 22},
-			want: aclRule{Action: "allow", State: "enabled", Protocol: "icmp4"},
-			ok:   true,
+			name: "icmp from an IPv4 block carries no port, which the runtime rejects on it",
+			in:   FirewallRule{Direction: "ingress", Action: "allow", Protocol: "ICMP", Source: "0.0.0.0/0", PortFrom: 22},
+			want: []aclRule{{Action: "allow", State: "enabled", Protocol: "icmp4", Source: "0.0.0.0/0"}},
+		},
+		{
+			// The defect. The name says nothing about a family; ::/0 does.
+			name: "icmp from an IPv6 block becomes the IPv6 protocol",
+			in:   FirewallRule{Direction: "ingress", Action: "allow", Protocol: "ICMP", Source: "::/0"},
+			want: []aclRule{{Action: "allow", State: "enabled", Protocol: "icmp6", Source: "::/0"}},
+		},
+		{
+			// "icmp4" is this package's own spelling for ICMP, not a claim about
+			// IPv4. Reading it as one would drop exactly the rules #454 is about.
+			name: "the icmp4 spelling is family-agnostic too",
+			in:   FirewallRule{Direction: "ingress", Action: "allow", Protocol: "icmp4", Source: "2001:db8::/32"},
+			want: []aclRule{{Action: "allow", State: "enabled", Protocol: "icmp6", Source: "2001:db8::/32"}},
+		},
+		{
+			name: "an egress icmp rule reads its destination",
+			in:   FirewallRule{Direction: "egress", Action: "drop", Protocol: "icmp", Destination: "fd00::/8"},
+			want: []aclRule{{Action: "drop", State: "enabled", Protocol: "icmp6", Destination: "fd00::/8"}},
+		},
+		{
+			name: "a bare address fixes a family as well as a block does",
+			in:   FirewallRule{Direction: "ingress", Action: "allow", Protocol: "icmp", Source: "2001:db8::1"},
+			want: []aclRule{{Action: "allow", State: "enabled", Protocol: "icmp6", Source: "2001:db8::1"}},
+		},
+		{
+			name: "an address range fixes a family through both of its bounds",
+			in:   FirewallRule{Direction: "ingress", Action: "allow", Protocol: "icmp", Source: "10.0.0.1-10.0.0.9"},
+			want: []aclRule{{Action: "allow", State: "enabled", Protocol: "icmp4", Source: "10.0.0.1-10.0.0.9"}},
+		},
+		{
+			// "ICMP from anywhere" means both families. Half of it enforced
+			// silently is the same defect one size smaller.
+			name: "icmp with no address at all becomes both protocols",
+			in:   FirewallRule{Direction: "ingress", Action: "allow", Protocol: "icmp"},
+			want: []aclRule{
+				{Action: "allow", State: "enabled", Protocol: "icmp4"},
+				{Action: "allow", State: "enabled", Protocol: "icmp6"},
+			},
+		},
+		{
+			name: "an explicit v6 spelling with no address stays v6, and gains no v4 twin",
+			in:   FirewallRule{Direction: "ingress", Action: "allow", Protocol: "ipv6-icmp"},
+			want: []aclRule{{Action: "allow", State: "enabled", Protocol: "icmp6"}},
+		},
+		{
+			name: "the icmpv6 spelling is understood rather than dropped",
+			in:   FirewallRule{Direction: "ingress", Action: "allow", Protocol: "ICMPv6", Source: "::/0"},
+			want: []aclRule{{Action: "allow", State: "enabled", Protocol: "icmp6", Source: "::/0"}},
 		},
 		{
 			name: "an empty protocol means any, and takes no port either",
 			in:   FirewallRule{Direction: "egress", Action: "drop", Destination: "0.0.0.0/0", PortFrom: 53},
-			want: aclRule{Action: "drop", State: "enabled", Destination: "0.0.0.0/0"},
-			ok:   true,
+			want: []aclRule{{Action: "drop", State: "enabled", Destination: "0.0.0.0/0"}},
+		},
+		{
+			// An "any" rule carries whatever addresses it was given: the empty
+			// protocol has no family, so an IPv6 block is not its business.
+			name: "an any rule with an IPv6 block is untouched by the family question",
+			in:   FirewallRule{Direction: "ingress", Action: "allow", Source: "::/0"},
+			want: []aclRule{{Action: "allow", State: "enabled", Source: "::/0"}},
 		},
 		{
 			name: "a stateless allow survives translation rather than becoming stateful",
 			in:   FirewallRule{Direction: "ingress", Action: "allow-stateless", Protocol: "udp", PortFrom: 53},
-			want: aclRule{Action: "allow-stateless", State: "enabled", Protocol: "udp", DestinationPort: "53"},
-			ok:   true,
+			want: []aclRule{{Action: "allow-stateless", State: "enabled", Protocol: "udp", DestinationPort: "53"}},
 		},
 		{
 			name: "an action the runtime does not know is dropped, not approximated",
 			in:   FirewallRule{Direction: "ingress", Action: "log", Protocol: "tcp"},
-			ok:   false,
 		},
 		{
 			name: "a protocol the runtime does not know is dropped too",
 			in:   FirewallRule{Direction: "ingress", Action: "allow", Protocol: "sctp"},
-			ok:   false,
+		},
+		{
+			// No ICMP protocol covers both families, and approximating with one
+			// of them would enforce something the API does not describe.
+			name: "an icmp rule naming both families is dropped rather than halved",
+			in:   FirewallRule{Direction: "ingress", Action: "allow", Protocol: "icmp", Source: "10.0.0.0/8,::/0"},
+		},
+		{
+			name: "an explicit v6 spelling beside an IPv4 block is a contradiction, not a v4 rule",
+			in:   FirewallRule{Direction: "ingress", Action: "allow", Protocol: "icmpv6", Source: "10.0.0.0/8"},
+		},
+		{
+			// Three outcomes, never two: an address this cannot read is not an
+			// address that is absent, and guessing a family for it sends the
+			// daemon a value it refuses — which costs the whole group.
+			name: "an unreadable source is dropped rather than read as no address",
+			in:   FirewallRule{Direction: "ingress", Action: "allow", Protocol: "icmp", Source: "not-an-address"},
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, ok := toACLRule(tc.in)
-			if ok != tc.ok {
-				t.Fatalf("acceptance: got %v, want %v", ok, tc.ok)
+			got := toACLRules(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d rules %+v, want %d %+v", len(got), got, len(tc.want), tc.want)
 			}
-			if !ok {
-				return
-			}
-			if got != tc.want {
-				t.Fatalf("got  %+v\nwant %+v", got, tc.want)
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("rule %d:\ngot  %+v\nwant %+v", i, got[i], tc.want[i])
+				}
 			}
 		})
 	}
@@ -505,5 +579,259 @@ func TestApplyFirewallStillWorksOnOurOwnInstance(t *testing.T) {
 	}
 	if !applied {
 		t.Errorf("no rule set was applied:\n%s", strings.Join(f.commands(), "\n"))
+	}
+}
+
+// The rest of this file is #454: a security group that carried one ICMP rule
+// with an IPv6 source lost its *whole* firewall, because the protocol was
+// chosen from the rule's name alone and the daemon refuses icmp4 beside an IPv6
+// address — and the rule set is written in one PUT.
+
+// aclDaemon is a runtime that validates a rule set the way incusd does, so a
+// test measures whether the write is *accepted* rather than how it is spelled.
+//
+// This is the planted witness rule 1 of measurement-integrity asks for: without
+// it, a test asserting "the body holds two rules" would pass on a body the real
+// daemon rejects, which is exactly the state this defect shipped in. The one
+// refusal reproduced here is the one the issue recorded verbatim:
+//
+//	Invalid ingress rule 1: Cannot use IPv6 source addresses with "icmp4" protocol
+type aclDaemon struct {
+	fakeRuntime
+	// written holds the last body each rule set was written with.
+	written map[string]aclBody
+}
+
+func newACLDaemon() *aclDaemon {
+	d := &aclDaemon{written: map[string]aclBody{}}
+	d.hook = d.answer
+	return d
+}
+
+func (a *aclDaemon) answer(_ int, args []string) ([]byte, error, bool) {
+	if len(args) < 6 || args[0] != "query" || args[2] != "PUT" {
+		return nil, nil, false
+	}
+	name := strings.TrimPrefix(args[5], "/1.0/network-acls/")
+	var body aclBody
+	if err := json.Unmarshal([]byte(args[4]), &body); err != nil {
+		return nil, errors.New("incus query: Error: not JSON"), true
+	}
+	for direction, rules := range map[string][]aclRule{"ingress": body.Ingress, "egress": body.Egress} {
+		for i, rule := range rules {
+			if err := validateLikeIncus(direction, i, rule); err != nil {
+				return nil, err, true
+			}
+		}
+	}
+	a.written[name] = body
+	return []byte("{}"), nil, true
+}
+
+// validateLikeIncus refuses what the daemon refuses: an ICMP protocol beside an
+// address of the other family. Quoted shape, not invented — see the issue.
+func validateLikeIncus(direction string, index int, rule aclRule) error {
+	want := map[string]bool{"icmp4": true, "icmp6": false}
+	wantV4, isICMP := want[rule.Protocol]
+	if !isICMP {
+		return nil
+	}
+	for field, value := range map[string]string{"source": rule.Source, "destination": rule.Destination} {
+		for _, member := range strings.Split(value, ",") {
+			member = strings.TrimSpace(member)
+			if member == "" {
+				continue
+			}
+			prefix, err := netip.ParsePrefix(member)
+			if err != nil {
+				addr, addrErr := netip.ParseAddr(member)
+				if addrErr != nil {
+					return fmt.Errorf("incus query: Error: Invalid %s rule %d: Invalid %s %q",
+						direction, index, field, member)
+				}
+				prefix = netip.PrefixFrom(addr, addr.BitLen())
+			}
+			if prefix.Addr().Is4() != wantV4 {
+				return fmt.Errorf("incus query: Error: Invalid %s rule %d: Cannot use %s %s addresses with %q protocol",
+					direction, index, familyOf(prefix), field, rule.Protocol)
+			}
+		}
+	}
+	return nil
+}
+
+func familyOf(prefix netip.Prefix) string {
+	if prefix.Addr().Is4() {
+		return "IPv4"
+	}
+	return "IPv6"
+}
+
+// witnessGroup is the reduced witness of the replay campaign: a group holding
+// TCP/22 from anywhere, optionally plus one ICMP rule from the block given.
+func witnessGroup(name, icmpFrom string) FirewallSpec {
+	spec := FirewallSpec{
+		Name:           name,
+		DefaultIngress: "drop",
+		DefaultEgress:  "allow",
+		Rules: []FirewallRule{
+			{Direction: "ingress", Action: "allow", Protocol: "tcp", Source: "0.0.0.0/0", PortFrom: 22, PortTo: 22},
+		},
+	}
+	if icmpFrom != "" {
+		spec.Rules = append(spec.Rules,
+			FirewallRule{Direction: "ingress", Action: "allow", Protocol: "icmp", Source: icmpFrom})
+	}
+	return spec
+}
+
+// TestAnICMPRuleWithAnIPv6SourceKeepsItsGroup is the test the issue asked for.
+//
+// Red before the fix: the body carried icmp4 beside ::/0, the daemon refused the
+// PUT, and the TCP rule standing next to the ICMP one was lost with it — the API
+// went on describing two rules while the host enforced one.
+func TestAnICMPRuleWithAnIPv6SourceKeepsItsGroup(t *testing.T) {
+	daemon := newACLDaemon()
+	d := newFakeDriver(&daemon.fakeRuntime)
+
+	if err := d.EnsureFirewall(context.Background(), witnessGroup("scw-dual", "::/0")); err != nil {
+		t.Fatalf("the daemon refused the rule set: %v", err)
+	}
+
+	body, written := daemon.written["scw-dual"]
+	if !written {
+		t.Fatal("no rule set reached the daemon")
+	}
+	if len(body.Ingress) != 2 {
+		t.Fatalf("the group must keep both of its rules, got %d: %+v", len(body.Ingress), body.Ingress)
+	}
+	if got := body.Ingress[0]; got.Protocol != "tcp" || got.DestinationPort != "22" {
+		t.Errorf("the TCP rule beside the ICMP one was altered: %+v", got)
+	}
+	if got := body.Ingress[1]; got.Protocol != "icmp6" || got.Source != "::/0" {
+		t.Errorf("an ICMP rule from an IPv6 block must be written as icmp6, got %+v", got)
+	}
+}
+
+// TestTwoGroupsDifferingByOneRuleEachEnforceWhatTheyDescribe reproduces the
+// campaign's own reduced witness, at the layer that has a seam for it.
+//
+// Two groups, identical but for one rule, so the difference names the cause and
+// nothing else. Measured under --vm incus-ovn before the fix: the API described
+// 1 rule and 2 rules, the host enforced 1 and 1.
+func TestTwoGroupsDifferingByOneRuleEachEnforceWhatTheyDescribe(t *testing.T) {
+	daemon := newACLDaemon()
+	d := newFakeDriver(&daemon.fakeRuntime)
+
+	control := witnessGroup("scw-control", "")
+	dual := witnessGroup("scw-dual", "::/0")
+	for _, spec := range []FirewallSpec{control, dual} {
+		if err := d.EnsureFirewall(context.Background(), spec); err != nil {
+			t.Fatalf("%s: the daemon refused the rule set: %v", spec.Name, err)
+		}
+	}
+
+	for _, spec := range []FirewallSpec{control, dual} {
+		body, written := daemon.written[spec.Name]
+		if !written {
+			t.Fatalf("%s: nothing reached the daemon", spec.Name)
+		}
+		// What the API describes is len(spec.Rules); what the host enforces is
+		// what the accepted body holds. Every rule must be represented — the
+		// count can be higher, since a family-agnostic ICMP rule becomes two.
+		if len(body.Ingress) < len(spec.Rules) {
+			t.Errorf("%s: the API describes %d rules and the host holds %d: %+v",
+				spec.Name, len(spec.Rules), len(body.Ingress), body.Ingress)
+		}
+	}
+
+	// And the difference between the two groups is exactly one rule, which is
+	// what makes this witness name a cause rather than a symptom.
+	if got := len(daemon.written["scw-dual"].Ingress) - len(daemon.written["scw-control"].Ingress); got != 1 {
+		t.Fatalf("the two groups must differ by exactly one enforced rule, got %d", got)
+	}
+}
+
+// TestADroppedRuleIsReported holds the backstop's second half. Dropping a rule
+// the runtime cannot express is right; dropping it in silence is what let the
+// contract's own promise — "visibly absent" — go unkept for as long as it did.
+func TestADroppedRuleIsReported(t *testing.T) {
+	var log bytes.Buffer
+	daemon := newACLDaemon()
+	d := newFakeDriver(&daemon.fakeRuntime)
+	d.Log = slog.New(slog.NewTextHandler(&log, nil))
+
+	spec := witnessGroup("scw-mixed", "")
+	spec.Rules = append(spec.Rules,
+		// Both families in one rule: no ICMP protocol covers it.
+		FirewallRule{Direction: "ingress", Action: "allow", Protocol: "icmp", Source: "10.0.0.0/8,::/0"})
+	if err := d.EnsureFirewall(context.Background(), spec); err != nil {
+		t.Fatalf("one inexpressible rule must not cost the write: %v", err)
+	}
+
+	if got := len(daemon.written["scw-mixed"].Ingress); got != 1 {
+		t.Fatalf("the expressible rule must survive alone, got %d rules", got)
+	}
+	line := log.String()
+	if !strings.Contains(line, "level=WARN") {
+		t.Fatalf("a dropped rule must be reported, got %q", line)
+	}
+	if !strings.Contains(line, "scw-mixed") || !strings.Contains(line, "10.0.0.0/8,::/0") {
+		t.Fatalf("the report must name the rule set and the rule, got %q", line)
+	}
+
+	// The accepting half: a group whose rules are all expressible says nothing.
+	log.Reset()
+	if err := d.EnsureFirewall(context.Background(), witnessGroup("scw-plain", "::/0")); err != nil {
+		t.Fatalf("plain group: %v", err)
+	}
+	if strings.Contains(log.String(), "level=WARN") {
+		t.Fatalf("a group with nothing dropped must stay quiet, got %q", log.String())
+	}
+}
+
+// TestAFirewallWriteTheHostRefusesWithdrawsTheCapability is the half that holds
+// whatever the translation did not foresee.
+//
+// A refused write used to leave `/_feint/health` publishing
+// `capabilities.firewall: true` while the host enforced nothing of that group —
+// a lying 200 in the security plane, and the thing this project exists to
+// refuse. What the host answered wins over what the flag promised (#181), and a
+// refusal is the host answering.
+func TestAFirewallWriteTheHostRefusesWithdrawsTheCapability(t *testing.T) {
+	f := &fakeRuntime{fail: map[string]error{
+		"-X PUT": errors.New(`incus query: Error: Invalid ingress rule 1: something new`),
+	}}
+	var log bytes.Buffer
+	d := newFakeDriver(f)
+	d.Log = slog.New(slog.NewTextHandler(&log, nil))
+
+	// The accepting half first, and it matters: a driver that published
+	// firewall=false from the start would pass the assertion below and claim
+	// nothing at all.
+	if !d.Capabilities().Firewall {
+		t.Fatal("the Incus driver must claim the firewall before anything refuses it")
+	}
+
+	if err := d.EnsureFirewall(context.Background(), witnessGroup("scw-refused", "")); err == nil {
+		t.Fatal("the refusal must reach the caller")
+	}
+	if d.Capabilities().Firewall {
+		t.Error("the host refused a rule set and the process still claims to enforce firewalls")
+	}
+	if !strings.Contains(log.String(), "capabilities.firewall") {
+		t.Errorf("the withdrawal must be said, not only published, got %q", log.String())
+	}
+
+	// A name this driver refused itself never reached the daemon, so it is not
+	// the host denying anything — and the name comes from a restorable snapshot,
+	// which would otherwise hand a crafted state file a switch on a published
+	// claim.
+	clean := newFakeDriver(&fakeRuntime{})
+	if err := clean.EnsureFirewall(context.Background(), FirewallSpec{Name: "-oops"}); err == nil {
+		t.Fatal("an unsafe rule-set name must still be refused")
+	}
+	if !clean.Capabilities().Firewall {
+		t.Error("a refusal by this driver's own guard must not withdraw the host's capability")
 	}
 }

--- a/internal/core/machine/verify.go
+++ b/internal/core/machine/verify.go
@@ -80,7 +80,11 @@ var serverVersion = regexp.MustCompile(`^(\d+)\.(\d+)(?:\.(\d+))?`)
 // Both calls are reads. Neither creates a network, touches the uplink, or
 // leaves a trace.
 func (d *Incus) Verify(ctx context.Context) (Capabilities, []string) {
-	declared := d.Capabilities()
+	// The declaration, not Capabilities(): what this stores is what the *host*
+	// answered at startup, and a firewall claim withdrawn later by a refused
+	// write is a separate fact, applied on top by Capabilities (#454). Folding
+	// the two here would make a startup probe record a mid-run refusal.
+	declared := d.declaredCapabilities()
 	verified := declared
 	var unmet []string
 

--- a/tools/falsify/specs/icmp-family.json
+++ b/tools/falsify/specs/icmp-family.json
@@ -1,0 +1,68 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "the ICMP protocol is chosen from the rule's name again, which is how #454 shipped",
+      "file": "internal/core/machine/incus_firewall.go",
+      "find": "\t\treturn icmpProtocols(named, rule.Source, rule.Destination)",
+      "replace": "\t\tif named == 0 {\n\t\t\treturn []string{\"icmp4\"}, true\n\t\t}\n\t\treturn icmpProtocols(named, rule.Source, rule.Destination)",
+      "test": "TestAnICMPRuleWithAnIPv6SourceKeepsItsGroup"
+    },
+    {
+      "label": "the same defect, read through the campaign's own two-group witness",
+      "file": "internal/core/machine/incus_firewall.go",
+      "find": "\tcase v6:\n\t\tif named == 4 {\n\t\t\treturn nil, false\n\t\t}\n\t\treturn []string{\"icmp6\"}, true",
+      "replace": "\tcase v6:\n\t\tif named == 4 {\n\t\t\treturn nil, false\n\t\t}\n\t\treturn []string{\"icmp4\"}, true",
+      "test": "TestTwoGroupsDifferingByOneRuleEachEnforceWhatTheyDescribe"
+    },
+    {
+      "label": "a rule naming both families is approximated to one of them instead of dropped",
+      "file": "internal/core/machine/incus_firewall.go",
+      "find": "\tcase v4 && v6:",
+      "replace": "\tcase v4 && v6 && false:",
+      "test": "TestADroppedRuleIsReported"
+    },
+    {
+      "label": "an address this cannot read is read as no address at all, and a family is guessed for it",
+      "file": "internal/core/machine/incus_firewall.go",
+      "find": "\tif !sourceRead || !destinationRead {",
+      "replace": "\tif (!sourceRead || !destinationRead) && false {",
+      "test": "TestToACLRules"
+    },
+    {
+      "label": "ICMP from anywhere covers one family only, and the other half is enforced by nobody",
+      "file": "internal/core/machine/incus_firewall.go",
+      "find": "\t\treturn []string{\"icmp4\", \"icmp6\"}, true",
+      "replace": "\t\treturn []string{\"icmp4\"}, true",
+      "test": "TestToACLRules"
+    },
+    {
+      "label": "a rule left out of the rule set goes back to leaving no trace",
+      "file": "internal/core/machine/incus_firewall.go",
+      "find": "\tif len(dropped) > 0 {",
+      "replace": "\tif len(dropped) > 0 && false {",
+      "test": "TestADroppedRuleIsReported"
+    },
+    {
+      "label": "a write the host refused no longer withdraws the firewall claim",
+      "file": "internal/core/machine/capabilities.go",
+      "find": "\tif d.firewallDenied.Load() {",
+      "replace": "\tif d.firewallDenied.Load() && false {",
+      "test": "TestAFirewallWriteTheHostRefusesWithdrawsTheCapability"
+    },
+    {
+      "label": "the withdrawal is published but never said, so only a reader of /_feint/health learns it",
+      "file": "internal/core/machine/incus_firewall.go",
+      "find": "\tif d.firewallDenied.CompareAndSwap(false, true) {",
+      "replace": "\tif d.firewallDenied.CompareAndSwap(false, true) && false {",
+      "test": "TestAFirewallWriteTheHostRefusesWithdrawsTheCapability"
+    },
+    {
+      "label": "this driver's own refusal of a name counts as the host denying the capability, so a crafted snapshot flips a published claim",
+      "file": "internal/core/machine/incus_firewall.go",
+      "find": "\t\treturn fmt.Errorf(\"invalid firewall name %q\", spec.Name)",
+      "replace": "\t\treturn d.firewallRefused(fmt.Errorf(\"invalid firewall name %q\", spec.Name))",
+      "test": "TestAFirewallWriteTheHostRefusesWithdrawsTheCapability"
+    }
+  ]
+}


### PR DESCRIPTION
`toACLRule` chose the ICMP flavour from the **protocol name alone**, so a rule whose source is an IPv6 address asked the runtime for `icmp4` with a `::/0` source. Incus refuses that pairing, the ACL write is all-or-nothing, and the whole rule set was therefore never posted — while the API kept describing rules the host did not enforce and `/_feint/health` kept publishing `capabilities.firewall: true`.

## Worse than the issue described

Two binaries, same scenario, same station: `feint-before` built from `HEAD` via `git archive`, `feint-after` from this branch. The campaign's reduced witness — two groups differing by exactly one rule, one server booted and attached per group.

| group | API describes | host enforced (before) | host enforces (after) |
|---|---|---|---|
| A — TCP 22 from `0.0.0.0/0` | 1 | 1 | 1 |
| B — same + ICMP from `::/0` | 2 | **1** | **2** |

The count is not the worst of it. **The machine carrying group B held no `security.acls` at all on its NIC**, because the pack returns before attaching when the write fails — so a deny-default group left its machine entirely unfiltered. Before: three `Cannot use IPv6 source addresses with "icmp4" protocol` ERROR lines with `firewall: true` published throughout. After: `incus network acl show` renders the second rule as `protocol: icmp6, source: ::/0`, both machines carry their rule set, zero write failures.

## Two decisions, named in the code rather than left implicit

**A rule that fixes no address family becomes two rules, one per family.** "ICMP from anywhere" means both, and enforcing half of it silently is the same defect one size smaller. `icmp`/`icmp4`/`icmpv4` stay family-agnostic deliberately — `icmp4` is the runtime's wire name, not a claim a pack makes, and Scaleway's only value is `ICMP`.

**A write the host refuses withdraws `capabilities.firewall`**, one way, and logs it. Only a *host* refusal counts: a name the driver refuses itself never reached the daemon and can come from a restored snapshot, which would otherwise hand a crafted state file a switch on a published capability.

A rule naming both families, a name contradicting its addresses, or an unparseable address is dropped **alone** and reported at WARN naming the rule set and the rule. `addressFamilies` answers three outcomes, never two — unreadable is not absent.

## Gates

`go build` 0 · `go test ./...` 0 · `mise run prepush` 0 (run twice, before and after the changelog) · `falsify icmp-family.json` 0 — **9 new mutations, all nine bite** · the 5 existing specs naming these files (29 mutations) 0 each · `falsify --lint` 0 over 104 specs and 593 mutations.

The unit witnesses drive `EnsureFirewall` through the injectable `runner` against a fake daemon reproducing Incus's own refusal, so they measure whether the write is **accepted**, not how it is spelled.

`mise run conformance` was not played on this branch — issues are handled in series and it runs once over the assembled set.

## Station delta: strictly zero

`diff` of the before/after survey empty, `feint clean --check` reports nothing stuck, the pre-existing `acltest` ACL and all ten `feint/*` images intact.

Closes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)
