### PR TITLE
fix(replay): list elements are paired by rebound identifier, and the account's own objects stop being findings (#469)

### DIFF
--- a/corpus/accepted.json
+++ b/corpus/accepted.json
@@ -1024,14 +1024,6 @@
       "file": "scaleway/scw-free-shapes.jsonl"
     },
     {
-      "file": "exoscale/exo-free-shapes.jsonl",
-      "operation": "exoscale/v2.list-security-groups",
-      "kind": "absent",
-      "path": "security-groups[].description",
-      "reason": "THIS IS THE COMPARISON, NOT THE PACK, and the recording proves it in its own body. The replay walks two arrays by position, and the two arrays do not hold the same groups: the recorded list answers THREE security groups -- two the ch-gva-2 account already had, then the one the run created -- and this emulator's answers two, the `default` group it ships and the one the run created. So element 1 is a pre-existing group of a real account on one side and a freshly created group on the other. The cloud's OWN created group, element 2 of the recording, carries no `description` key at all, which is exactly what this emulator answers for a group created without one; element 0, `default`, carries a description on both sides. Nothing here is a field the pack fails to serve, and no contract entry on the model of tools/contract/exoscale-recorded-fields.yaml would be honest, because the field is already declared and already served. It goes when the replay matches list elements by the identifier it has already rebound instead of by position, or when a recording is taken on an account holding no group of its own. Recorded 2026-08-24 (#427).",
-      "issue": "https://github.com/stephrobert/feint/issues/436"
-    },
-    {
       "file": "scaleway/scw-billed-shapes.jsonl",
       "operation": "instance/v1/API.GetImage",
       "kind": "type",

--- a/internal/replay/replay.go
+++ b/internal/replay/replay.go
@@ -48,6 +48,14 @@
 // against a *fresh* one with zero divergences, which it cannot do without
 // rebinding, because the recording's own identifiers no longer exist anywhere.
 //
+// That rebinding is also what pairs the elements of a list. A recording made
+// against an account that already holds resources lists somebody else's objects
+// beside the one the run created, so walking two lists by index grades one
+// object against another and reports every field they do not share.
+// [compareElements] carries the rule, the two halves of "no counterpart" it has
+// to keep apart, and what re-running the corpus said about the count an audit
+// had estimated for it.
+//
 // # Nothing from the recording reaches the output
 //
 // A transcript is redacted of credentials and is not anonymous: docs/proxy.md
@@ -526,7 +534,7 @@ func compare(x *trace.Exchange, status int, got any, operation string, b *bindin
 			Got:  strconv.Itoa(status),
 		})
 	}
-	out = append(out, compareShape("", x.Res.Body, got, operation, opt)...)
+	out = append(out, compareShape("", x.Res.Body, got, operation, b, opt)...)
 	invariants, evaluated := compareInvariants(x.Res.Body, got, operation, b, opt)
 	out = append(out, invariants...)
 	sort.SliceStable(out, func(i, j int) bool {
@@ -551,7 +559,7 @@ func compare(x *trace.Exchange, status int, got any, operation string, b *bindin
 // the recording lacks is not a finding here: internal/contract already refuses
 // a field the provider's own description does not define, and a recording made
 // against a sparse account legitimately carries less than a full one.
-func compareShape(path string, want, got any, operation string, opt Options) []Finding {
+func compareShape(path string, want, got any, operation string, b *bindings, opt Options) []Finding {
 	switch w := want.(type) {
 	case map[string]any:
 		g, ok := got.(map[string]any)
@@ -591,7 +599,7 @@ func compareShape(path string, want, got any, operation string, opt Options) []F
 				out = append(out, absentOrExcused(child, jsonType(w[k]), operation, opt))
 				continue
 			}
-			out = append(out, compareShape(child, w[k], nested, operation, opt)...)
+			out = append(out, compareShape(child, w[k], nested, operation, b, opt)...)
 		}
 		return out
 	case []any:
@@ -606,14 +614,7 @@ func compareShape(path string, want, got any, operation string, opt Options) []F
 			// shape underneath was not observed, it was not omitted.
 			return []Finding{absentOrExcused(element, "array element", operation, opt)}
 		}
-		var out []Finding
-		for i := range w {
-			if i >= len(g) {
-				break
-			}
-			out = append(out, compareShape(element, w[i], g[i], operation, opt)...)
-		}
-		return out
+		return compareElements(element, w, g, operation, b, opt)
 	default:
 		if proxy.IsPlaceholder(want) {
 			// The recorder replaced this value, so its type is erased rather
@@ -638,6 +639,350 @@ func compareShape(path string, want, got any, operation string, opt Options) []F
 		}
 		return nil
 	}
+}
+
+// compareElements walks two lists together, pairing each recorded element with
+// the answered element that carries the same identifier rather than with the
+// one that happens to sit at its index.
+//
+// # Why position is not an answer
+//
+// A recording taken against an account that already holds resources lists the
+// objects that were there beside the one the run created. Compared by index,
+// element 0 of the recording — somebody else's volume, minted months ago with
+// its own set of optional fields populated — is graded against element 0 here,
+// which is the volume this run just created, and every field the two do not
+// share is reported as a divergence. Nothing in that is a fact about this
+// emulator, and #427 would have recorded 212 more operations through it (#469).
+//
+// # What the re-run said, against what the audit had estimated
+//
+// The audit of 2026-08-25 attributed 26 of the 59 findings of #433 and more
+// than 20 of the 92 of #434 to this defect, by reading the recordings. That
+// attribution does not survive re-running them. `corpus/scaleway/scw-billed-shapes.jsonl`
+// is the recording both issues measure, and it produces the *same 169 findings*
+// through this comparison and through the positional one it replaced — nothing
+// moved, because its findings sit on single objects (GetVolume, GetSnapshot,
+// GetLB, GetServer) and not on the members of a list.
+//
+// What the re-run did find is one manufactured finding, in another file, and
+// its own acceptance entry had already named the cure verbatim: "It goes when
+// the replay matches list elements by the identifier it has already rebound
+// instead of by position" (#436, exoscale/v2.list-security-groups). The defect
+// is real and the fix is right; the number attached to it was an estimate, and
+// this paragraph is here so that nobody re-derives 26 and 20 from a comment.
+//
+// # What identifies an element, and why no field name is written here
+//
+// The replay already rebinds identifiers — that is how it follows a resource
+// across a run — so where a recorded value has a binding, the object it names
+// and the one this emulator minted for it are already known to be the same. An
+// element is therefore named by the minted values it carries, mapped through
+// the bindings, and a value names an element only where it names *exactly one*
+// on each side: project_id is carried by every element of a list and identifies
+// none of them, an id is carried by one. Uniqueness is what tells those apart,
+// which is why no field name is hard-coded — a rule written on names would have
+// to learn Scaleway's id, Outscale's VmId, Exoscale's id, and whatever a fourth
+// pack mints.
+//
+// # The two halves of "no counterpart", and only one of them is a finding
+//
+// This is the half a first version gets wrong in the other direction, and it
+// was measured here before it was written down: reporting every unpaired
+// recorded element produced 64 findings over the committed corpus, 57 of them
+// saying that a real account has twelve Exoscale zones where this emulator
+// serves one.
+//
+// The distinction is whether the replay knows what the counterpart should have
+// been. An element whose identifier an earlier exchange *bound* has a
+// counterpart in this run by construction — this run created it — so its
+// absence from a list is a fact about this emulator and is reported. An element
+// nothing ever bound is an object of the recorded account that this run never
+// asked for: a zone, a public template, a security group that was already
+// there. It has no counterpart by construction, and calling it absent would
+// accuse this emulator of omitting something nobody asked it to make, which is
+// as false as comparing it by index.
+//
+// # The fallback
+//
+// Where no recorded element pairs with any answered one, the two lists are not
+// in the same namespace and identity says nothing at all — the marketplace
+// catalogue is the measured case, 90 images recorded against 18 served and not
+// one of the 90 identifiers ever minted here. The walk then falls back to
+// position, which is what it did before and no worse.
+//
+// TestListElementsAreMatchedByReboundIdentifier and
+// TestAnElementThisRunCreatedAndTheListOmitsIsOneFinding fail without this;
+// TestAListWithNothingToIdentifyItsElementsIsStillComparedByPosition holds the
+// fallback and TestAnAccountsOwnObjectIsNotReportedAsAbsent holds the half
+// above.
+func compareElements(element string, want, got []any, operation string, b *bindings, opt Options) []Finding {
+	matched, byIdentity, blanked := matchElements(want, got, b)
+
+	var out []Finding
+	if blanked {
+		// Named once, and never folded into "this element carries no
+		// identifier". Those are two different sentences: one says the element
+		// has nothing to be known by, the other says it has something and the
+		// recorder replaced it before writing. Reported for the reason an
+		// excused field is reported — what a comparison subtracts has to stay
+		// visible — and as [KindRedacted], which is not a divergence, because
+		// the proxy's own hygiene is not a defect of this emulator.
+		//
+		// TestAnElementWhoseIdentifierIsRedactedIsNotFiledAsUnidentified fails
+		// without this.
+		out = append(out, Finding{Kind: KindRedacted, Path: element, Want: "identifier"})
+	}
+	if !byIdentity {
+		for i := range want {
+			if i >= len(got) {
+				break
+			}
+			out = append(out, compareShape(element, want[i], got[i], operation, b, opt)...)
+		}
+		return out
+	}
+
+	taken := make([]bool, len(got))
+	for _, m := range matched {
+		if m.at >= 0 {
+			taken[m.at] = true
+		}
+	}
+	next := 0
+	spare := func() int {
+		for next < len(got) {
+			j := next
+			next++
+			if !taken[j] {
+				taken[j] = true
+				return j
+			}
+		}
+		return -1
+	}
+
+	orphan := false
+	for i := range want {
+		j := matched[i].at
+		if j < 0 {
+			switch {
+			case matched[i].outcome == identityRedacted:
+				// Not placed by position, and that is the whole point: an
+				// element nobody could read is not an element that belongs
+				// where the index puts it. The line above already named it.
+				continue
+			case matched[i].outcome == identityNone:
+				// Nothing identifies it, so position is all there is for it —
+				// the same answer the whole list falls back to, applied to the
+				// one element that needs it.
+				j = spare()
+			case matched[i].known:
+				// An object this run created, and this list does not carry it.
+				orphan = true
+				continue
+			default:
+				// The recorded account's own object. See the doc comment.
+				continue
+			}
+		}
+		if j < 0 {
+			continue
+		}
+		out = append(out, compareShape(element, want[i], got[j], operation, b, opt)...)
+	}
+	if orphan {
+		// One finding for the list, never one per element: the statement is
+		// "the recording carries elements this emulator does not answer", and
+		// it is the same statement the empty-list branch makes. Saying it once
+		// per element is how nine operations turned into several hundred lines
+		// the first time a list was graded here.
+		out = append(out, absentOrExcused(element, "array element", operation, opt))
+	}
+	return out
+}
+
+// identityOutcome is what reading one list element's identifier came to.
+//
+// Three and never two, which is rule 2 of the measurement-integrity skill: a
+// reader that maps its input to "identified" / "not identified" files
+// *unreadable* under *not identified*, and the element whose identifier the
+// recorder replaced would then be paired by position in silence — which is the
+// defect this file is fixing, arriving through the door the proxy's redaction
+// has already opened once (the first row of that skill's own table).
+type identityOutcome int
+
+const (
+	// identityNone: the element carries nothing a cloud mints. Position is all
+	// there is for it, and saying so is honest.
+	identityNone identityOutcome = iota
+	// identityFound: the element carries at least one minted value, mapped
+	// through the bindings into this emulator's namespace.
+	identityFound
+	// identityRedacted: the element carries a value the recorder replaced
+	// before writing it. Something was there and it cannot be read, so this
+	// walk refuses to assert the element has no identity — it cannot tell
+	// whether what was blanked was one.
+	identityRedacted
+)
+
+// identityKey is one name a list element answers to, in this emulator's
+// namespace.
+type identityKey struct {
+	// key is "<field>\x00<value>". The field name is part of it because one
+	// recorded value under two names is two different things here — the
+	// project_id and organization_id of [bindings] — and a bare value would
+	// merge them.
+	key string
+	// rebound reports that an earlier exchange actually bound this value, so
+	// the object it names is one this run created rather than one the recorded
+	// account already held. It is what separates the two halves of "no
+	// counterpart" in [compareElements].
+	rebound bool
+}
+
+// elementIdentity is what one list element is known by, with which of the three
+// outcomes reading it came to.
+type elementIdentity struct {
+	// keys are sorted by field name, so two runs over the same document pair
+	// the same way. Determinism first: a gate that answers differently on two
+	// identical inputs is a gate that gets disarmed the first time it seems to
+	// lie.
+	keys    []identityKey
+	outcome identityOutcome
+}
+
+// identifyElement reads the identifiers one list element carries.
+//
+// rebind is true for the recorded side, where a value has to be mapped into
+// this emulator's namespace before it can name anything here, and false for
+// what the endpoint answered, which is already in it.
+//
+// Only the element's own top-level string fields, deliberately: an identifier a
+// cloud hands out sits there, and walking deeper would let a nested project_id
+// — the same on every element — offer a pairing that [matchElements] then has
+// to undo by uniqueness anyway.
+func identifyElement(el any, b *bindings, rebind bool) elementIdentity {
+	var (
+		keys    []identityKey
+		blanked bool
+	)
+	consider := func(field, value string) {
+		if proxy.IsPlaceholder(value) {
+			blanked = true
+			return
+		}
+		if !looksMinted(value) {
+			return
+		}
+		bound := false
+		if rebind {
+			if to, ok := b.resolve(field, value); ok {
+				value, bound = to, true
+			}
+		}
+		keys = append(keys, identityKey{key: field + "\x00" + value, rebound: bound})
+	}
+	switch e := el.(type) {
+	case map[string]any:
+		names := make([]string, 0, len(e))
+		for k := range e {
+			names = append(names, k)
+		}
+		sort.Strings(names)
+		for _, k := range names {
+			if text, isText := e[k].(string); isText {
+				consider(k, text)
+			}
+		}
+	case string:
+		// A list of bare identifiers, which is how a body names the addresses
+		// of a server. No field to scope it by, which is the case
+		// [bindings.resolve] falls back to for a path segment.
+		consider("", e)
+	}
+	switch {
+	case len(keys) > 0:
+		return elementIdentity{keys: keys, outcome: identityFound}
+	case blanked:
+		return elementIdentity{outcome: identityRedacted}
+	default:
+		return elementIdentity{outcome: identityNone}
+	}
+}
+
+// match is what became of one recorded element.
+type match struct {
+	// at is the index in the answered list this element names, or -1.
+	at int
+	// known reports that at least one identifier naming this element, and
+	// naming only it, was bound by an earlier exchange — so this run created
+	// its counterpart and a list without it is a finding.
+	known   bool
+	outcome identityOutcome
+}
+
+// matchElements pairs recorded elements with answered ones by identifier.
+//
+// byIdentity reports whether any pair was made at all: it is what tells "these
+// two lists describe the same objects" from "these two lists have nothing in
+// common", and only the first justifies reading anything into an element that
+// did not pair. blanked reports whether any recorded element's identifier was
+// unreadable.
+func matchElements(want, got []any, b *bindings) (matched []match, byIdentity, blanked bool) {
+	matched = make([]match, len(want))
+	identities := make([]elementIdentity, len(want))
+	seen := map[string]int{}
+	for i := range want {
+		identities[i] = identifyElement(want[i], b, true)
+		matched[i] = match{at: -1, outcome: identities[i].outcome}
+		if identities[i].outcome == identityRedacted {
+			blanked = true
+		}
+		for _, k := range identities[i].keys {
+			seen[k.key]++
+		}
+	}
+
+	// A key that names two answered elements names neither: -1 rather than the
+	// last one walked, so a repeated value cannot decide a pairing by the order
+	// the list happened to arrive in.
+	at := map[string]int{}
+	for j := range got {
+		for _, k := range identifyElement(got[j], b, false).keys {
+			if _, twice := at[k.key]; twice {
+				at[k.key] = -1
+				continue
+			}
+			at[k.key] = j
+		}
+	}
+
+	taken := make([]bool, len(got))
+	for i := range identities {
+		for _, k := range identities[i].keys {
+			// Only a key that names one recorded element says anything about
+			// which element this is; a project_id every element carries says
+			// only which account the recording was made on.
+			if seen[k.key] != 1 {
+				continue
+			}
+			if k.rebound {
+				matched[i].known = true
+			}
+			if matched[i].at >= 0 {
+				continue
+			}
+			j, ok := at[k.key]
+			if !ok || j < 0 || taken[j] {
+				continue
+			}
+			matched[i].at = j
+			taken[j] = true
+			byIdentity = true
+		}
+	}
+	return matched, byIdentity, blanked
 }
 
 // absentOrExcused turns a missing field into a finding, or into the pack's own

--- a/internal/replay/replay_test.go
+++ b/internal/replay/replay_test.go
@@ -592,3 +592,200 @@ func TestAnInventoryKeyTheRecordingHasIsNotAMissingField(t *testing.T) {
 			"finding: %+v", gap.Results[0].Findings)
 	}
 }
+
+// #469, and the whole of it: two elements the recording tells apart by a field
+// only one of them carries, answered here in the opposite order.
+//
+// A comparison that walks the two lists by index grades the recording's first
+// element against this emulator's second, and reports both distinguishing
+// fields as missing. Neither statement is true — both elements are here, both
+// carry what the recording says they carry — and that is the shape the audit of
+// 2026-08-25 attributed 26 of the 59 findings of #433 and more than 20 of the
+// 92 of #434 to.
+//
+// The prelude is what makes the identifiers mean anything: two POST /ips bind
+// the recorded identifiers and the recorded addresses to the ones this emulator
+// minted, exactly as #320's own fixture does, so by the time the list is
+// compared the two sides are in one namespace.
+func TestListElementsAreMatchedByReboundIdentifier(t *testing.T) {
+	ts := answers(t, ipsThenServer(freshDistinctIPsReversed))
+	rep := run(t, distinctIPsRecording(), ts.URL)
+	if rep.Divergent != 0 {
+		t.Fatalf("a list answered in the opposite order reported %d divergent exchange(s); "+
+			"the elements are the same two objects and neither is missing a field: %+v",
+			rep.Divergent, findingsOf(rep))
+	}
+	if rep.Matched != 3 {
+		t.Fatalf("matched %d exchange(s), want 3", rep.Matched)
+	}
+}
+
+// The witness that keeps the one above honest.
+//
+// Without it, a comparison that stopped reporting anything at all would pass
+// for a fix — which is the failure this repository catches most often, and it
+// would be particularly easy here, since "report nothing" and "pair correctly"
+// look identical from the outside on a clean fixture.
+//
+// One element this run created, absent from the answer, has to be exactly one
+// finding: the composition genuinely differs, that difference is the finding,
+// and it is named once at the element rather than once per field underneath it.
+func TestAnElementThisRunCreatedAndTheListOmitsIsOneFinding(t *testing.T) {
+	short := `{"server":{"id":"` + freshID + `","name":"web-1","commercial_type":"DEV1-S",` +
+		`"public_ips":[{"id":"` + freshIPOne + `","address":"10.0.0.1","provisioning_mode":"dhcp"}]}}`
+	ts := answers(t, ipsThenServer(short))
+	rep := run(t, distinctIPsRecording(), ts.URL)
+
+	found := findingsOf(rep)
+	if len(found) != 1 {
+		t.Fatalf("%d finding(s) for one missing element, want exactly 1: %+v", len(found), found)
+	}
+	if found[0].Kind != replay.KindAbsent || found[0].Path != "server.public_ips[]" {
+		t.Fatalf("the missing element is reported as %+v, want an absent finding at server.public_ips[]", found[0])
+	}
+	if rep.Divergent != 1 {
+		t.Fatalf("divergent %d, want 1", rep.Divergent)
+	}
+}
+
+// The other half of the same rule, and the one a first version gets wrong in
+// the opposite direction.
+//
+// A recording is made against an account that already holds things. An element
+// no exchange of the run ever bound is one of those: a zone, a public template,
+// an address somebody reserved last year. It has no counterpart here by
+// construction, and calling it absent accuses this emulator of omitting
+// something nobody asked it to make.
+//
+// This was measured before it was written: reporting every unpaired element
+// produced 64 findings over the committed corpus, 57 of them saying that a real
+// Exoscale account has twelve zones where this emulator serves one.
+//
+// The fixture is the one above with the *second* reservation removed, so the
+// second recorded address is one the account already had — and nothing else
+// changes. The two tests are therefore the two answers to one question.
+func TestAnAccountsOwnObjectIsNotReportedAsAbsent(t *testing.T) {
+	short := `{"server":{"id":"` + freshID + `","name":"web-1","commercial_type":"DEV1-S",` +
+		`"public_ips":[{"id":"` + freshIPOne + `","address":"10.0.0.1","provisioning_mode":"dhcp"}]}}`
+	ts := answers(t, ipsThenServer(short))
+	full := distinctIPsRecording()
+	rep := run(t, []trace.Exchange{full[0], full[2]}, ts.URL)
+
+	if found := findingsOf(rep); len(found) != 0 {
+		t.Fatalf("%d finding(s) about an object the recorded account already held and this run "+
+			"never created: %+v", len(found), found)
+	}
+}
+
+// Nothing identifies these elements, so position is all there is — and the walk
+// still compares them.
+//
+// The fallback is not a detail: the marketplace catalogue is 90 recorded images
+// against 18 served, not one of the 90 identifiers ever minted here, and two
+// lists with no identifier in common are not evidence of anything. But a
+// fallback that quietly stopped comparing would be the same defect wearing the
+// other coat, so the assertion is that the missing field is still named.
+func TestAListWithNothingToIdentifyItsElementsIsStillComparedByPosition(t *testing.T) {
+	recorded := `{"server":{"id":"` + recordedID + `","name":"web-1","commercial_type":"DEV1-S",` +
+		`"labels":[{"name":"a","value":"x"},{"name":"b","value":"y"}]}}`
+	ts := answers(t, func(*http.Request) (int, string) {
+		return 201, `{"server":{"id":"` + freshID + `","name":"web-1","commercial_type":"DEV1-S",` +
+			`"labels":[{"name":"a","value":"x"},{"name":"b"}]}}`
+	})
+	rep := run(t, []trace.Exchange{exchange(t, createLine(recorded))}, ts.URL)
+	if !namesFinding(rep, replay.KindAbsent, "server.labels[].value") {
+		t.Fatalf("a field missing from an element of a list nothing identifies stopped being a "+
+			"finding: %+v", findingsOf(rep))
+	}
+}
+
+// Three outcomes, never two: identified, nothing to identify it, and unreadable.
+//
+// A reader that only knows "identified" and "not identified" files the third
+// under the second, and an element whose identifier the recorder replaced is
+// then paired by position in silence — which is the defect this file exists to
+// fix, arriving through the door the redaction has already opened once (the
+// account inventory of the measurement-integrity skill).
+//
+// It is not hypothetical here: `carriers` matches the substring "key", so an
+// Outscale tag's own `Key` reaches every transcript as a placeholder, and 25
+// elements of the committed corpus are in exactly this state.
+//
+// Both halves are asserted. The element whose identifier was blanked is named,
+// and it is not a divergence — the proxy's hygiene is not a defect of this
+// emulator. The element that simply has nothing to be known by is *not* named,
+// or the distinction would be decoration.
+func TestAnElementWhoseIdentifierIsRedactedIsNotFiledAsUnidentified(t *testing.T) {
+	recorded := `{"server":{"id":"` + recordedID + `","name":"web-1","commercial_type":"DEV1-S",` +
+		`"keys":[{"key_id":"REDACTED-0123abcd","name":"first"}],` +
+		`"labels":[{"name":"a","value":"x"}]}}`
+	ts := answers(t, func(*http.Request) (int, string) {
+		return 201, `{"server":{"id":"` + freshID + `","name":"web-1","commercial_type":"DEV1-S",` +
+			`"keys":[{"key_id":"` + freshIPOne + `","name":"first"}],` +
+			`"labels":[{"name":"a","value":"x"}]}}`
+	})
+	rep := run(t, []trace.Exchange{exchange(t, createLine(recorded))}, ts.URL)
+
+	if !namesFinding(rep, replay.KindRedacted, "server.keys[]") {
+		t.Fatalf("an element whose identifier the recorder replaced was filed with the elements "+
+			"that have none, and nothing said so: %+v", findingsOf(rep))
+	}
+	if namesFinding(rep, replay.KindRedacted, "server.labels[]") {
+		t.Fatalf("an element that simply carries no identifier was reported as unreadable, which "+
+			"makes the three outcomes two again: %+v", findingsOf(rep))
+	}
+	if rep.Divergent != 0 {
+		t.Fatalf("an unreadable identifier reddened the run; the recorder's hygiene is not a "+
+			"defect of this emulator: %+v", findingsOf(rep))
+	}
+	if rep.Redacted == 0 {
+		t.Fatalf("nothing was counted: a comparison that skips in silence reports \"all matched\" " +
+			"over a recording it half read")
+	}
+}
+
+// distinctIPsRecording is the #469 fixture: two reservations, then a create
+// whose two addresses are told apart by a field only one of them carries.
+//
+// Every value is invented, and the addresses are TEST-NET-3, for the reason the
+// rest of this file states.
+func distinctIPsRecording() []trace.Exchange {
+	lines := []string{
+		`{"method":"POST","path":"` + ipPath + `","operation":"instance/v1/API.CreateIP","status":201,` +
+			`"mounted":true,"req":{"body":{"type":"routed_ipv4"}},` +
+			`"res":{"body":{"ip":{"id":"` + recordedIPOne + `","address":"203.0.113.1"}}}}`,
+		`{"method":"POST","path":"` + ipPath + `","operation":"instance/v1/API.CreateIP","status":201,` +
+			`"mounted":true,"req":{"body":{"type":"routed_ipv4"}},` +
+			`"res":{"body":{"ip":{"id":"` + recordedIPTwo + `","address":"203.0.113.2"}}}}`,
+		`{"method":"POST","path":"` + serverPath + `","operation":"instance/v1/API.CreateServer","status":201,` +
+			`"mounted":true,"req":{"headers":{"Content-Type":"application/json"},` +
+			`"body":{"name":"web-1","commercial_type":"DEV1-S"}},` +
+			`"res":{"body":{"server":{"id":"` + recordedID + `","name":"web-1","commercial_type":"DEV1-S",` +
+			`"public_ips":[` +
+			`{"id":"` + recordedIPOne + `","address":"203.0.113.1","provisioning_mode":"dhcp"},` +
+			`{"id":"` + recordedIPTwo + `","address":"203.0.113.2","state":"attached"}]}}}}`,
+	}
+	out := make([]trace.Exchange, 0, len(lines))
+	for _, line := range lines {
+		out = append(out, mustExchange(line))
+	}
+	return out
+}
+
+// freshDistinctIPsReversed is what this emulator answers: the same two
+// addresses, its own identifiers, and the two elements the other way round.
+const freshDistinctIPsReversed = `{"server":{"id":"` + freshID + `","name":"web-1","commercial_type":"DEV1-S",` +
+	`"public_ips":[` +
+	`{"id":"` + freshIPTwo + `","address":"10.0.0.2","state":"attached"},` +
+	`{"id":"` + freshIPOne + `","address":"10.0.0.1","provisioning_mode":"dhcp"}]}}`
+
+// findingsOf flattens a report, so a test can assert on how many findings there
+// were and not only on whether one of them was named. The count is the half
+// that catches a fix which reports nothing at all.
+func findingsOf(rep replay.Report) []replay.Finding {
+	var out []replay.Finding
+	for _, r := range rep.Results {
+		out = append(out, r.Findings...)
+	}
+	return out
+}

--- a/tools/falsify/specs/replay-compares.json
+++ b/tools/falsify/specs/replay-compares.json
@@ -86,6 +86,41 @@
       "find": "\t\tif proxy.IsPlaceholder(want) {",
       "replace": "\t\tif proxy.IsPlaceholder(want) && false {",
       "test": "TestARedactedValueIsNotComparedAndIsCounted"
+    },
+    {
+      "label": "list elements are compared by position again, so a recording taken on an account that already holds resources grades one object against another and reports every field they do not share",
+      "file": "internal/replay/replay.go",
+      "find": "\tmatched, byIdentity, blanked := matchElements(want, got, b)",
+      "replace": "\tmatched, byIdentity, blanked := matchElements(want, got, b)\n\tbyIdentity = false",
+      "test": "TestListElementsAreMatchedByReboundIdentifier"
+    },
+    {
+      "label": "an element this run created and the list omits stops being a finding, so pairing by identifier becomes a way to report nothing at all",
+      "file": "internal/replay/replay.go",
+      "find": "\t\t\tcase matched[i].known:",
+      "replace": "\t\t\tcase matched[i].known && false:",
+      "test": "TestAnElementThisRunCreatedAndTheListOmitsIsOneFinding"
+    },
+    {
+      "label": "THE SECOND DIRECTION: every unpaired element is called absent, which accuses this emulator of omitting the twelve zones and ninety templates of the account the recording was made on — 64 findings, measured over the committed corpus",
+      "file": "internal/replay/replay.go",
+      "find": "\t\t\tdefault:\n\t\t\t\t// The recorded account's own object. See the doc comment.\n\t\t\t\tcontinue",
+      "replace": "\t\t\tdefault:\n\t\t\t\t// The recorded account's own object. See the doc comment.\n\t\t\t\torphan = true\n\t\t\t\tcontinue",
+      "test": "TestAnAccountsOwnObjectIsNotReportedAsAbsent"
+    },
+    {
+      "label": "THE SECOND DIRECTION: two lists with no identifier in common stop being compared at all, so a fallback that had to keep comparing becomes the same silence wearing the other coat",
+      "file": "internal/replay/replay.go",
+      "find": "\tif !byIdentity {\n\t\tfor i := range want {",
+      "replace": "\tif !byIdentity {\n\t\tfor i := range want[:0] {",
+      "test": "TestAListWithNothingToIdentifyItsElementsIsStillComparedByPosition"
+    },
+    {
+      "label": "the three outcomes become two: an element whose identifier the recorder replaced is filed with the ones that have none, and is paired by position in silence",
+      "file": "internal/replay/replay.go",
+      "find": "\t\tif identities[i].outcome == identityRedacted {\n\t\t\tblanked = true\n\t\t}",
+      "replace": "\t\tif identities[i].outcome == identityRedacted && false {\n\t\t\tblanked = true\n\t\t}",
+      "test": "TestAnElementWhoseIdentifierIsRedactedIsNotFiledAsUnidentified"
     }
   ]
 }


### PR DESCRIPTION
The list branch of `compareShape` walked two lists by index, so a recording taken against an account that already holds resources lined element *n* up with element *n* whatever they were, and reported every field of two unrelated objects as a divergence.

Elements are now paired by the identifier the replay has **already rebound**. A value names an element only where it names exactly one *on each side* — which is what tells `project_id`, carried by every element and identifying none, from `id`, carried by one. No provider field name is hard-coded.

## Read this first: the count attached to this issue does not survive the re-run

This issue says the defect explains **26 of the 59 findings of #433** and 20+ of the 92 of #434. Both measure `corpus/scaleway/scw-billed-shapes.jsonl`, which is committed — so it was re-run through both instruments.

**Same 169 findings, verdict for verdict, key for key, before and after. Zero moved.**

Those findings sit on single objects (`GetVolume` 39+3, `GetSnapshot` 12+1, `GetLB` 19+1, `GetServer` 12+9), not on members of a list; only 23 of the 169 name a list path at all, and none of those changed. The defect is real and the fix is right, but the number was an estimate made by reading and it did not hold. **#433 and #434 keep their full finding sets to triage; this removes none of them.**

The disproof is written into the `compareElements` doc comment, so the next reader meets it instead of re-deriving "26 and 20" from the issue.

## What actually moves, over all 14 committed corpora

714 findings → 739, and **exactly four lines change**:

- `exoscale/v2.list-security-groups absent security-groups[].description` **1 → 0** — a manufactured finding. Its own acceptance entry named the cure verbatim: *"It goes when the replay matches list elements by the identifier it has already rebound instead of by position"* (#436). The entry is removed, which the staleness rule makes compulsory: `accepted.json` 208 → 207.
- `instance/v1/API.ListSecurityGroupRules absent rules[]` **1 → 2** — the same true divergence (#432's six account-wide default rules) is now seen at seq 24 as well as seq 18. Coverage gained, not lost.
- `ReadVms redacted Vms[].Tags[]` **0 → 24** and `ReadNets redacted Nets[].Tags[]` **0 → 1** — the third outcome saying so.

## Three outcomes on identity, and the third is real here

`identityFound`, `identityNone`, `identityRedacted`. The third is not defensive programming: the redaction carrier list matches the substring `key`, so an Outscale tag's own `Key` reaches every transcript as a placeholder. It is now named at the element as a `KindRedacted` finding — counted, printed, never a divergence — instead of being filed silently among "carries no identifier".

## The direction found only by measuring

Reporting *every* unpaired recorded element produced **64 new findings**, 57 of them saying a real Exoscale account has twelve zones where this emulator serves one.

So "no counterpart" is raised only where an earlier exchange actually **bound** the element — i.e. this run created its counterpart. An element nothing ever bound is the recorded account's own property, and calling it absent accuses the emulator of omitting what nobody asked for. Where nothing pairs at all, the walk falls back to position, unchanged.

## Gates

`go build` 0 · `go test ./...` 0 · `mise run prepush` 0 (all 13 subtasks ran) · **`mise run corpus:check` 0** — 1066 exchanges, 0 unaccepted divergent findings, 497 accepted, 15 value and 13 order comparisons ran · `falsify replay-compares.json` 0 — **17 mutations, all red**, green after restoration · `corpus-findings`, `corpus-gate`, `corpus-cloud`, `refusal-corpus` 0 each · `falsify:lint` 0 over 103 specs.

The Go pre-commit hooks were checked explicitly (`gofmt`, `go vet`, `golangci-lint` on `--files`): during the commit they printed "no files to check", which reads exactly like a hook that never ran.

`mise run conformance` was not played on this branch — issues are handled in series and it runs once over the assembled set.

## Why this one had to come first

#427 asks for 212 operations to be recorded against real accounts. Recording them through an instrument that pairs by position means delivering 212 operations' worth of findings nobody can trust, and triaging a poisoned finding costs the same as triaging a real one — so the waste is paid twice.

Closes #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)
