### PR TITLE
fix(machine): a balancer's backends are held to its own subnet, and the ordinary Terraform order stops failing (#457)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -109,6 +109,70 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Corrigé
 
+- **Un répartiteur de charge devant des machines d'un autre sous-réseau cesse de
+  revendiquer un plan de données qu'il n'a pas, et l'ordre Terraform ordinaire
+  cesse d'échouer** (#457). Le rejeu des quinze stacks tierces de
+  `examples/stacks/surveyed.md` sous `--vm incus-ovn` l'a trouvé, sur le
+  `two-tier-architecture` de `chimere-eu/ztiac` : un balanceur public devant des
+  machines privées est la forme ordinaire, et **les deux** balanceurs de cette
+  stack tombaient dessus. L'`apply` réussissait sur 54 ressources alors que
+  l'hôte ne portait aucun balanceur, et seul le journal de l'émulateur le
+  savait — la même famille que #454.
+
+  **La cause était un garde posé sur une extrémité seulement.** `EnsureBalancer`
+  contrôlait l'adresse d'*écoute* contre le bloc du réseau (le garde de #315) et
+  se contentait de `netip.ParseAddr` sur chaque *cible*, si bien qu'un backend
+  sur un autre sous-réseau passait tous les refus et mourait dans le runtime, au
+  milieu de l'écriture, laissant le balanceur debout sur les backends qu'il
+  avait déjà.
+
+  **La question de savoir si OVN pouvait servir cette forme a été mesurée avant
+  d'être tranchée**, sur Incus 7.2 avec OVN le 2026-08-25, sur deux réseaux
+  créés par l'émulateur. Un backend hors du réseau du balanceur est refusé,
+  `Target address is not within the network subnet` ; appairer les deux réseaux
+  — les deux moitiés `CREATED` — ne relâche rien, le refus est le même mot pour
+  mot ; poser le balanceur sur le réseau des *cibles*, ce qui est le placement
+  qui servirait la forme, est refusé à l'autre bout, `Load balancer listen
+  address "10.181.0.5/32" overlaps with another network or NIC` ; et il n'existe
+  aucune clé pour déclarer l'adresse, un réseau OVN répondant `Invalid option
+  for network ... option "ipv4.routes"`, parce que seule une NIC porte
+  `ipv4.routes.external` et qu'une VIP n'a pas de NIC. Le seul placement que le
+  runtime accepte réclame une adresse d'écoute n'appartenant à aucun bloc émulé
+  — exactement la classe d'adresses que #315 a mesurée devenant muette en trois
+  minutes, et ce n'est pas non plus l'adresse que l'API a publiée.
+
+  **C'est donc la limite qui bouge, pas le plan de données.** Le pilote refuse la
+  forme par son nom, entière, avant toute écriture ; le pack la rapporte en WARN
+  en nommant ce que l'API continue de décrire, parce qu'une limite qui tient
+  toute la vie d'une stack rapportée en ERREUR est la façon dont un journal
+  apprend à ignorer ses erreurs ; et `capabilities.balancing` énonce désormais
+  ses deux bornes — l'adresse du balanceur *et* ses backends sur son propre
+  réseau. `docs/limits.md` porte les quatre mesures. Le `200` reste, comme celui
+  du vrai cloud.
+
+  **Et l'ordre Terraform ordinaire cesse d'échouer.** Un balanceur créé avant ses
+  machines était écrit avec un port ne nommant aucun backend, ce que le runtime
+  refuse (`Missing VIP target(s)`), avant de se réparer au register suivant. Le
+  même corps **sans port** est accepté — mesuré, avec la vidange : un `PUT` ne
+  portant ni backend ni port arrête la distribution, donc un balanceur qui perd
+  sa dernière machine cesse réellement de recevoir. L'erreur est supprimée
+  plutôt que journalisée plus discrètement.
+
+  **Une limite bouge aussi sur `/_feint/health`** : `capabilities.balancing` peut
+  désormais passer à faux en cours d'exécution, selon la règle que #454 a écrite
+  pour le pare-feu — à sens unique, et seul un refus *de l'hôte* compte, jamais
+  un refus que ce pilote a prononcé lui-même.
+
+  Éprouvé contre le vrai runtime, en lisant `incus network load-balancer
+  list`/`show` et non la réponse de l'API : le balanceur apparaît sur l'hôte dès
+  la création avec 0 port, le register inter-sous-réseaux le laisse intact avec
+  un WARN et zéro ERREUR sur toute l'exécution, et — le contrôle positif qui
+  donne un sens à ce vide — un balanceur du même sous-réseau porte bien son
+  backend et son port. Falsifié quatre fois de plus
+  (`tools/falsify/specs/balancer-dataplane.json`, quatorze mutations au total) :
+  garde de cible désarmé, ports rétablis sur un balanceur sans backend, retrait
+  de capacité désarmé, et limite ramenée au niveau ERREUR.
+
 - **Un groupe de sécurité portant une règle ICMP dont la source est en IPv6
   garde son pare-feu, et un jeu de règles que l'hôte refuse cesse de se lire
   comme un succès** (#454). Le rejeu des quinze stacks tierces de

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,66 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Fixed
 
+- **A load balancer in front of machines on another subnet stops claiming a
+  dataplane it does not have, and an ordinary Terraform order stops failing**
+  (#457). Replaying the fifteen third-party stacks of
+  `examples/stacks/surveyed.md` under `--vm incus-ovn` found it, on
+  `chimere-eu/ztiac`'s `two-tier-architecture`: a public balancer in front of
+  private machines is the ordinary shape, and **both** of that stack's balancers
+  hit it. The `apply` succeeded over 54 resources while the host held no
+  balancer at all, and only the emulator's log knew — the same family as #454.
+
+  **The cause was a guard applied to one end only.** `EnsureBalancer` checked
+  the *listen* address against the network's block (the #315 guard) and merely
+  `netip.ParseAddr`-ed each *target*, so a backend on another subnet passed
+  every refusal and died inside the runtime, mid-write, leaving the balancer
+  standing on the backends it already had.
+
+  **Whether OVN could be made to serve the shape was measured before it was
+  answered**, on Incus 7.2 with OVN on 2026-08-25, on two networks of the
+  emulator's own making. A backend outside the balancer's network is refused,
+  `Target address is not within the network subnet`; peering the two networks —
+  both halves `CREATED` — does not relax it, word for word the same refusal;
+  putting the balancer on the *backends'* network instead, which is the
+  placement that would serve the shape, is refused on the other end,
+  `Load balancer listen address "10.181.0.5/32" overlaps with another network or
+  NIC`; and there is no key to declare the address with, an OVN network
+  answering `Invalid option for network ... option "ipv4.routes"` because only a
+  NIC carries `ipv4.routes.external` and a VIP has no NIC. The one placement the
+  runtime accepts needs a listen address in no emulated block at all — exactly
+  the address class #315 measured going dark in three minutes, and not the
+  address the API published either.
+
+  **So the limit moved rather than the dataplane.** The driver refuses the shape
+  by name, whole, before anything is written; the pack reports it at WARN
+  naming what the API still describes, because a limit that holds for the life
+  of a stack reported at ERROR is how a log teaches people to skip its errors;
+  and `capabilities.balancing` now states both of its bounds — the balancer's
+  own address *and* its backends on its own network. `docs/limits.md` carries
+  the four measurements. The `200` stands, as the real cloud's does.
+
+  **And the ordinary Terraform order stops failing at all.** A balancer created
+  before its machines was written with a port naming no backend, which the
+  runtime refuses (`Missing VIP target(s)`), before repairing itself at the next
+  register. The same body with **no port** is accepted — measured, along with
+  the drain: a `PUT` carrying neither backend nor port stops the distribution,
+  so a balancer that loses its last machine really does stop receiving. So the
+  error is removed instead of being logged more quietly.
+
+  **A limit moved on `/_feint/health` too:** `capabilities.balancing` can now go
+  false during a run, on the rule #454 wrote for the firewall — one-way, and
+  only a refusal *by the host* counts, never one this driver made on its own.
+
+  Witnessed against the real runtime, reading `incus network load-balancer
+  list`/`show` rather than the API's answer: the balancer appears on the host at
+  create with 0 ports, the cross-subnet register leaves it untouched with one
+  WARN and zero ERROR in the whole run, and — the positive control that makes
+  the emptiness mean something — a same-subnet balancer does carry its backend
+  and port. Falsified four more ways
+  (`tools/falsify/specs/balancer-dataplane.json`, fourteen mutations in all):
+  the target guard disarmed, the ports restored on a balancer with no backend,
+  the capability withdrawal disarmed, and the limit levelled back to ERROR.
+
 - **A security group carrying an ICMP rule with an IPv6 source keeps its
   firewall, and a rule set the host refuses stops reading as a success** (#454).
   Replaying the fifteen third-party stacks of `examples/stacks/surveyed.md`

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -2585,6 +2585,41 @@ What a `200` from `CreateLoadBalancer` means here, stated rather than implied:
   So `EnsureBalancer` **refuses** a listen address outside the network's own
   block rather than configuring one. A balancer that passes a test and fails
   three minutes later is worse than a balancer that was never claimed.
+- **Backends on another subnet are not distributed, under any `--vm` mode**
+  (#457, measured on Incus 7.2 with OVN on 2026-08-25). This is the ordinary
+  two-tier architecture — a load balancer on the public subnet, the application
+  machines on the private one — and it is served as configuration only: the
+  `200` stands, `ReadLoadBalancers` describes the balancer and its
+  `BackendVmIds`, and nothing forwards for it.
+
+  The four measurements, because the shape is common enough that "it should be
+  possible" deserves an answer rather than an opinion. On two OVN networks of
+  the emulator's own making, `10.181.0.0/24` and `10.181.4.0/24`:
+
+  1. a balancer on the first with a backend in the second is refused outright,
+     `Target address is not within the network subnet for backend "b1-80"`;
+  2. peering the two networks — both halves `CREATED` — does not relax it: the
+     same refusal, word for word;
+  3. putting the balancer on the *backends'* network instead, which is the
+     placement that would serve the shape, is refused on the other end,
+     `Load balancer listen address "10.181.0.5/32" overlaps with another network
+     or NIC`;
+  4. and there is no key to declare the address with: an OVN network answers
+     `Invalid option for network "fnt-mxb" option "ipv4.routes"`, since only a
+     NIC carries `ipv4.routes.external` and a VIP has no NIC.
+
+  The one placement the runtime accepts is a listen address belonging to no
+  emulated block at all, delegated through the uplink — which is exactly the
+  address class of the paragraph above, the one that goes dark in minutes, and
+  not the address the API published either.
+
+  So the driver refuses the shape by name, before writing anything, and the pack
+  reports it at WARN rather than ERROR: it is a limit that holds for the life of
+  the stack, not an incident, and an error that is permanent on a working
+  configuration teaches people to skip errors. `capabilities.balancing` covers
+  the balancer whose backends are on its own network and says nothing about this
+  one; what withdraws the claim entirely is the host refusing a write the driver
+  had accepted.
 - **No backend health exists, and none is invented.** `ReadVmsHealth` stays
   declined, and it stays declined *after* the dataplane landed: `incus network
   load-balancer info` answers "No load-balancer health information available",
@@ -2746,6 +2781,10 @@ this emulator's own making (10.63.7.0/24):
 - and the daemon itself refuses the public address before any guard of ours is
   consulted: *Failed creating load balancer: Uplink network doesn't contain
   `"192.0.2.1/32"` in its routes*.
+
+Those three lines are quoted as they were printed that day. The refusal has
+since gained the sentinel #457 added (`machine.ErrBalancerNotDistributed`), so
+its wording differs; the verdict does not.
 
 So `capabilities.balancing` is irrelevant to this family: the pack never asks
 the runtime at all, because the only call it could make is one whose refusal is

--- a/internal/core/machine/balancer.go
+++ b/internal/core/machine/balancer.go
@@ -1,6 +1,9 @@
 package machine
 
-import "context"
+import (
+	"context"
+	"errors"
+)
 
 // A load balancer that distributes packets, within the one bound that was
 // measured (#315).
@@ -36,6 +39,43 @@ import "context"
 // Hence Capabilities.Balancing, declared by the OVN mode alone, and hence
 // EnsureBalancer refusing a listen address outside the network's own block
 // rather than configuring one that would go dark in minutes.
+//
+// The backends live under the same bound, and that half was measured on
+// 2026-08-25 for #457, because nothing had asked the runtime the question. On
+// Incus 7.2 with OVN, on two networks of this emulator's own making:
+//
+//   - a backend outside the balancer's network is refused outright, "Target
+//     address is not within the network subnet for backend \"b1-80\"";
+//   - peering the two networks — both halves CREATED — does not relax it: the
+//     same refusal, word for word;
+//   - putting the balancer on the *backends'* network instead, which is the
+//     placement that would serve the ordinary two-tier shape, is refused on the
+//     other end: "Load balancer listen address \"10.181.0.5/32\" overlaps with
+//     another network or NIC";
+//   - and there is no external-route key on an OVN network to declare the
+//     address with — "Invalid option for network ... option \"ipv4.routes\"" —
+//     only NICs carry ipv4.routes.external, and a VIP has no NIC.
+//
+// The one placement the runtime does accept is a listen address belonging to no
+// emulated block at all, delegated through the uplink. That is exactly the
+// address class of the paragraph above, the one that goes dark in minutes, and
+// it is not the address the API published either.
+//
+// So a load balancer in front of machines on another subnet is not served here,
+// it is refused by name, and docs/limits.md carries the measurement. Refusing is
+// what makes the refusal reach somebody: the runtime's own refusal arrives in
+// the middle of the write, leaving the balancer standing with the backends it
+// already had.
+
+// ErrBalancerNotDistributed marks a balancer whose shape this runtime does not
+// distribute — a stated limit, not a failure.
+//
+// It exists so a caller can tell the two apart without matching prose. A pack
+// hands a balancer to the runtime after every change to it, and a shape the
+// runtime will never take is not an incident to be reported at ERROR on every
+// register: it is a limit, said once, next to what the API still describes. A
+// runtime that broke is the other thing, and it stays an error.
+var ErrBalancerNotDistributed = errors.New("this runtime does not distribute a balancer of this shape")
 
 // BalancerListener is one port a balancer answers on, and the port it hands the
 // connection to on each backend.
@@ -69,10 +109,13 @@ type BalancerSpec struct {
 	Listen string
 	// Listeners are the ports, at least one.
 	Listeners []BalancerListener
-	// Targets are the addresses of the machines behind it. An empty list is
-	// valid and means exactly what it says: a balancer with no backend, which
-	// is what a stack has between creating one and registering its first
-	// machine.
+	// Targets are the addresses of the machines behind it. They must belong to
+	// Network's own block too, for the reason the package comment measures: the
+	// runtime refuses a backend outside it, peered or not.
+	//
+	// An empty list is valid and means exactly what it says: a balancer with no
+	// backend, which is what a stack has between creating one and registering
+	// its first machine.
 	Targets []string
 }
 

--- a/internal/core/machine/capabilities.go
+++ b/internal/core/machine/capabilities.go
@@ -50,17 +50,34 @@ type Capabilities struct {
 	// kernel modules or the boot path measures something.
 	OwnKernel bool `json:"own_kernel"`
 	// Balancing: a load balancer distributes real connections across its
-	// backends, for clients inside the network it sits in.
+	// backends, for clients inside the network it sits in — and across backends
+	// of that same network.
 	//
-	// The bound is in the name of the thing measured and it is not a hedge
-	// (#315, internal/core/machine/balancer.go). An address of the network's
-	// own block — which is what an *internal* load balancer's address is —
-	// balanced 6/6 connections across two machines at t0, t+60s and t+180s. An
-	// address outside it, delegated through the uplink, answered for two
-	// minutes and went dark for ever, because the runtime announces such an
-	// address once at creation and never again. So this claim covers the
-	// internal form and says nothing about the internet-facing one, whose
-	// public address stays a TEST-NET address routed nowhere on purpose.
+	// Both bounds name the thing measured and neither is a hedge
+	// (#315, #457, internal/core/machine/balancer.go).
+	//
+	// The address. One of the network's own block — which is what an *internal*
+	// load balancer's address is — balanced 6/6 connections across two machines
+	// at t0, t+60s and t+180s. An address outside it, delegated through the
+	// uplink, answered for two minutes and went dark for ever, because the
+	// runtime announces such an address once at creation and never again. So
+	// this claim covers the internal form and says nothing about the
+	// internet-facing one, whose public address stays a TEST-NET address routed
+	// nowhere on purpose.
+	//
+	// The backends. Same block, and the second half was measured on 2026-08-25
+	// rather than assumed: the runtime refuses a backend outside the balancer's
+	// own subnet, peering the two networks does not relax it, and the placement
+	// that would serve the ordinary two-tier shape — a public balancer in front
+	// of private machines — is refused on its listen address instead. So this
+	// claim says nothing about a balancer whose machines are on another subnet:
+	// EnsureBalancer refuses that shape by name and docs/limits.md carries the
+	// measurements.
+	//
+	// A true here is therefore a claim about a shape, not about every balancer
+	// the API will accept. What withdraws it entirely is the host refusing a
+	// write this driver had accepted — balancerRefused, the twin of the rule
+	// #454 wrote for the firewall.
 	Balancing bool `json:"balancing"`
 	// PrivateFromHost: an address inside an emulated subnet answers from the
 	// host that runs the emulator, not only from the other machines.
@@ -151,6 +168,14 @@ func (d *Incus) Capabilities() Capabilities {
 	if d.firewallDenied.Load() {
 		caps.Firewall = false
 		caps.FirewallPublicOnly = false
+	}
+	// And the same rule for the balancer (#457). A load balancer the daemon
+	// rejected after this driver had accepted it is the host saying this process
+	// does not distribute what its API describes; balancing=true afterwards is
+	// the same lying 200, one plane over.
+	// TestABalancerWriteTheHostRefusesWithdrawsTheCapability fails without this.
+	if d.balancerDenied.Load() {
+		caps.Balancing = false
 	}
 	return caps
 }

--- a/internal/core/machine/incus.go
+++ b/internal/core/machine/incus.go
@@ -111,6 +111,13 @@ type Incus struct {
 	// the retraction is one-way.
 	firewallDenied atomic.Bool
 
+	// balancerDenied is the same fact one plane over (#457): the host refused a
+	// load balancer this driver had accepted, so Capabilities answers
+	// balancing=false from then on. Written from EnsureBalancer's two writes,
+	// read by every `/_feint/health`; see balancerRefused for why the
+	// retraction is one-way and why only the host's refusal sets it.
+	balancerDenied atomic.Bool
+
 	// Interface allocation is serialised per machine, by serialise.Lock in
 	// Attach — there is no field here on purpose.
 	//

--- a/internal/core/machine/incus_balancer.go
+++ b/internal/core/machine/incus_balancer.go
@@ -84,8 +84,18 @@ var balancerProtocols = map[string]bool{"tcp": true, "udp": true}
 //     balancer answers for a minute or two and then goes dark for ever
 //     (#315, measured 2026-08-19). Refusing beats configuring a balancer whose
 //     failure arrives three minutes after the test that proved it worked.
+//   - a *backend* outside that same block, which is the fourth and was missing
+//     (#457). The listen address was checked and each target was only parsed,
+//     so a load balancer in front of machines on another subnet passed every
+//     guard here and died inside the runtime — after the write had begun, with
+//     the balancer left standing on its previous backends and nothing but a log
+//     line saying so. The measurement that settles it is in balancer.go: OVN
+//     refuses such a backend, peering the two networks does not relax it, and
+//     the placement that would serve the shape is refused on the listen address
+//     instead. So it is refused here, whole, before anything is written.
 //
-// TestABalancerOutsideTheNetworksBlockIsRefused fails without the third.
+// TestABalancerOutsideTheNetworksBlockIsRefused fails without the third,
+// TestABalancerWithATargetOutsideTheNetworkIsRefused without the fourth.
 func (d *Incus) EnsureBalancer(ctx context.Context, spec BalancerSpec) error {
 	if !d.OVN {
 		return fmt.Errorf("balancing %s needs the OVN mode: a managed bridge has no load balancer", spec.Name)
@@ -105,14 +115,30 @@ func (d *Incus) EnsureBalancer(ctx context.Context, spec BalancerSpec) error {
 		return err
 	}
 	if !block.Contains(listen) {
-		return fmt.Errorf("balancer %s listens on %s, which is outside %s's own block %s: "+
+		return fmt.Errorf("%w: balancer %s listens on %s, which is outside %s's own block %s — "+
 			"an address the runtime has to announce goes dark within minutes (#315)",
-			spec.Name, spec.Listen, spec.Network, block.Masked())
+			ErrBalancerNotDistributed, spec.Name, spec.Listen, spec.Network, block.Masked())
 	}
 
 	for _, target := range spec.Targets {
-		if _, err := netip.ParseAddr(target); err != nil {
+		address, err := netip.ParseAddr(target)
+		if err != nil {
 			return fmt.Errorf("balancer %s: parse the backend address %q: %w", spec.Name, target, err)
+		}
+		// The guard #457 was missing. Parsing a target says it is an address;
+		// it says nothing about whether the runtime will take it, and the
+		// runtime takes only its own subnet's — measured on Incus 7.2 on
+		// 2026-08-25, peered networks included (balancer.go carries the four
+		// measurements). Refused here rather than in the middle of the write,
+		// because the write that fails is an update: it leaves the balancer
+		// standing with the backends it had, which is a dataplane nobody
+		// described.
+		if !block.Contains(address) {
+			return fmt.Errorf("%w: balancer %s on %s has the backend %s, which is outside "+
+				"that network's own block %s — the runtime answers \"Target address is not within "+
+				"the network subnet\", peered or not, so a balancer in front of machines on another "+
+				"subnet is not distributed here (#457)",
+				ErrBalancerNotDistributed, spec.Name, spec.Network, target, block.Masked())
 		}
 	}
 	for _, listener := range spec.Listeners {
@@ -123,29 +149,49 @@ func (d *Incus) EnsureBalancer(ctx context.Context, spec BalancerSpec) error {
 		}
 	}
 
+	if len(spec.Listeners) == 0 {
+		return fmt.Errorf("balancer %s carries no listener the runtime can distribute", spec.Name)
+	}
+
 	body := lbBody{
 		Description: balancerDescription + " " + spec.Name,
 		Config:      map[string]string{},
 		Backends:    expandBackends(spec),
 		Ports:       []lbPort{},
 	}
-	// Every listener, with no skip: the loop above already refused anything
-	// this runtime cannot distribute, so a `continue` here would be a second
-	// filter with nothing left to filter and one more place for a listener to
-	// disappear quietly.
-	for _, listener := range spec.Listeners {
-		port := lbPort{
-			Protocol:      strings.ToLower(listener.Protocol),
-			ListenPort:    strconv.Itoa(listener.Listen),
-			TargetBackend: []string{},
+	// No target, no port — and this is a measurement, not tidiness.
+	//
+	// A port that names no backend is refused by the runtime: "Failed applying
+	// OVN load balancer: Missing VIP target(s)" (Incus 7.2, 2026-08-25). That is
+	// the ordinary Terraform order, a balancer created before the machines it
+	// will carry, and it was failing at ERROR on every stack that builds one —
+	// then repairing itself at the next register. The same body with no port at
+	// all is accepted: the host holds the balancer, distributes nothing, which
+	// is exactly true of a balancer with no backend, and the register that
+	// follows PUTs the ports in. An ordinary order stops producing an error
+	// instead of producing a quieter one.
+	//
+	// The drain is the same shape and was measured with it: a PUT carrying
+	// neither backend nor port is accepted and stops the distribution, so a
+	// balancer that loses its last machine really does stop receiving.
+	//
+	// TestABalancerWithNoBackendIsWrittenWithoutPorts fails without this.
+	if len(spec.Targets) > 0 {
+		// Every listener, with no skip: the loop above already refused anything
+		// this runtime cannot distribute, so a `continue` here would be a second
+		// filter with nothing left to filter and one more place for a listener to
+		// disappear quietly.
+		for _, listener := range spec.Listeners {
+			port := lbPort{
+				Protocol:      strings.ToLower(listener.Protocol),
+				ListenPort:    strconv.Itoa(listener.Listen),
+				TargetBackend: []string{},
+			}
+			for i := range spec.Targets {
+				port.TargetBackend = append(port.TargetBackend, backendName(i, listener))
+			}
+			body.Ports = append(body.Ports, port)
 		}
-		for i := range spec.Targets {
-			port.TargetBackend = append(port.TargetBackend, backendName(i, listener))
-		}
-		body.Ports = append(body.Ports, port)
-	}
-	if len(body.Ports) == 0 {
-		return fmt.Errorf("balancer %s carries no listener the runtime can distribute", spec.Name)
 	}
 
 	path := "/1.0/networks/" + spec.Network + "/load-balancers"
@@ -162,14 +208,44 @@ func (d *Incus) EnsureBalancer(ctx context.Context, spec BalancerSpec) error {
 	}
 	if exists {
 		if _, err := d.run(ctx, "query", "-X", "PUT", "--data", string(encoded), path+"/"+spec.Listen); err != nil {
-			return fmt.Errorf("write balancer %s: %w", spec.Name, err)
+			return d.balancerRefused(fmt.Errorf("write balancer %s: %w", spec.Name, err))
 		}
 		return nil
 	}
 	if _, err := d.run(ctx, "query", "-X", "POST", "--data", string(encoded), path); err != nil {
-		return fmt.Errorf("create balancer %s: %w", spec.Name, err)
+		return d.balancerRefused(fmt.Errorf("create balancer %s: %w", spec.Name, err))
 	}
 	return nil
+}
+
+// balancerRefused records that the host refused a balancer this driver had
+// already accepted, and returns the error unchanged so no caller has to know.
+//
+// firewallRefused's twin, and the same argument one plane over (#454, #181):
+// `capabilities.balancing` says "a load balancer distributes real connections
+// across its backends", a write the daemon rejected is the host answering that
+// this one does not, and a false capability is strictly worse than none —
+// because this project tells every consumer to key on the capability rather
+// than on a mode name. The claim goes and does not come back.
+//
+// Only a refusal *by the host* counts, for the reason firewallRefused states: a
+// shape this driver refused itself never reached the daemon, and the values it
+// refuses on arrive from a restorable snapshot, so letting one flip a published
+// claim would hand that switch to a crafted state file.
+//
+// Narrower than its twin on one point, deliberately: it is wired to the two
+// writes and not to the read that precedes them. Failing to *list* a collection
+// is not the host refusing a balancer, and treating it as one would give a
+// transient daemon hiccup a permanent switch on a published claim.
+//
+// TestABalancerWriteTheHostRefusesWithdrawsTheCapability fails without this.
+func (d *Incus) balancerRefused(err error) error {
+	if d.balancerDenied.CompareAndSwap(false, true) {
+		d.logger().Warn("the runtime refused a load balancer, so this process no longer claims "+
+			"to distribute connections (capabilities.balancing is now false)",
+			"error", err)
+	}
+	return err
 }
 
 // balancerExists asks the collection rather than reading a refusal.

--- a/internal/core/machine/incus_balancer_test.go
+++ b/internal/core/machine/incus_balancer_test.go
@@ -1,8 +1,11 @@
 package machine
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"log/slog"
 	"strings"
 	"testing"
 )
@@ -330,4 +333,185 @@ func payloadOf(t *testing.T, f *fakeRuntime, substr string) string {
 	}
 	t.Fatalf("no call matching %q carried a payload: %v", substr, f.commands())
 	return ""
+}
+
+// A backend outside the balancer's own network is refused, whole.
+//
+// #457, and it is the ordinary two-tier architecture rather than an exotic
+// shape: a load balancer on the public subnet, the machines on the private one.
+// Before this guard the listen address was checked and each target was only
+// parsed, so the specification passed every refusal here and died inside the
+// runtime — in the middle of an update, which leaves the balancer standing on
+// the backends it already had while the API describes the new set.
+//
+// The measurements that make refusing the honest answer rather than laziness
+// are in balancer.go: the runtime refuses such a backend, peering the two
+// networks does not relax it, and the placement that would serve the shape is
+// refused on its listen address instead.
+//
+// The commands are asserted, not only the error: a refusal that has already
+// written the object is not a refusal.
+func TestABalancerWithATargetOutsideTheNetworkIsRefused(t *testing.T) {
+	f := &fakeRuntime{answers: map[string]string{
+		"network get fnt-a ipv4.address": "10.61.1.1/24\n",
+		"network get fnt-a user.":        "outscale\n",
+	}, hook: answerExactly(map[string]string{emptyCollection: "[]"})}
+	d := ovnDriver(f)
+
+	err := d.EnsureBalancer(context.Background(), BalancerSpec{
+		Name:      "lbu-public",
+		Network:   "fnt-a",
+		Listen:    "10.61.1.5",
+		Listeners: []BalancerListener{{Protocol: "tcp", Listen: 80, Backend: 8080}},
+		// One backend the network holds and one it does not: the guard has to
+		// look at every target, not at the first.
+		Targets: []string{"10.61.1.10", "10.61.5.10"},
+	})
+	if err == nil {
+		t.Fatalf("a backend on another subnet was accepted; commands: %v", f.commands())
+	}
+	if !errors.Is(err, ErrBalancerNotDistributed) {
+		t.Errorf("a shape this runtime never distributes must be tellable from a runtime failure, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "10.61.5.10") {
+		t.Errorf("the refusal must name the backend it could not take, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "10.61.1.0/24") {
+		t.Errorf("the refusal must name the block the backend had to be in, got %v", err)
+	}
+	if wrote := f.matching("load-balancers"); len(wrote) != 0 {
+		t.Errorf("the refusal still wrote to the runtime: %v", wrote)
+	}
+	// The accepting half of the same guard, and it is the half that keeps the
+	// product: nothing here withdrew the claim, because nothing reached the
+	// host to refuse it.
+	if !d.Capabilities().Balancing {
+		t.Error("this driver's own refusal withdrew a published claim; only the host's refusal may")
+	}
+	if err := d.EnsureBalancer(context.Background(), BalancerSpec{
+		Name:      "lbu-internal",
+		Network:   "fnt-a",
+		Listen:    "10.61.1.5",
+		Listeners: []BalancerListener{{Protocol: "tcp", Listen: 80, Backend: 8080}},
+		Targets:   []string{"10.61.1.10", "10.61.1.11"},
+	}); err != nil {
+		t.Fatalf("backends of the network's own block must still be served: %v", err)
+	}
+}
+
+// A balancer with no backend yet is written without a port.
+//
+// The ordinary Terraform order — the balancer created, its machines registered
+// afterwards — and it was failing on every stack that builds one. A port that
+// names no backend is refused by the runtime, "Failed applying OVN load
+// balancer: Missing VIP target(s)" (Incus 7.2, measured 2026-08-25); the same
+// body with no port at all is accepted, and the register that follows PUTs the
+// ports in. So the error is removed rather than logged more quietly.
+//
+// Both halves are asserted: no port while there is nothing to send to it, and
+// the ports back the moment there is.
+func TestABalancerWithNoBackendIsWrittenWithoutPorts(t *testing.T) {
+	f := &fakeRuntime{answers: map[string]string{
+		"network get fnt-a ipv4.address": "10.61.1.1/24\n",
+		"network get fnt-a user.":        "outscale\n",
+	}, hook: answerExactly(map[string]string{emptyCollection: "[]"})}
+	d := ovnDriver(f)
+
+	if err := d.EnsureBalancer(context.Background(), BalancerSpec{
+		Name: "lbu-x", Network: "fnt-a", Listen: "10.61.1.240",
+		Listeners: []BalancerListener{{Protocol: "tcp", Listen: 80, Backend: 8080}},
+	}); err != nil {
+		t.Fatalf("a balancer with no backend must still reach the runtime: %v", err)
+	}
+	var created lbBody
+	if err := json.Unmarshal([]byte(payloadOf(t, f, "-X POST")), &created); err != nil {
+		t.Fatalf("decode the payload: %v", err)
+	}
+	if len(created.Ports) != 0 {
+		t.Errorf("a port naming no backend is refused by the runtime (\"Missing VIP target(s)\"), got %+v", created.Ports)
+	}
+	if len(created.Backends) != 0 {
+		t.Errorf("a balancer with no target carries no backend, got %+v", created.Backends)
+	}
+
+	// And the register that follows brings the listener back, on a balancer the
+	// collection now holds.
+	second := &fakeRuntime{answers: map[string]string{
+		"network get fnt-a ipv4.address": "10.61.1.1/24\n",
+		"network get fnt-a user.":        "outscale\n",
+	}, hook: answerExactly(map[string]string{
+		emptyCollection: `["/1.0/networks/fnt-a/load-balancers/10.61.1.240"]`,
+	})}
+	d = ovnDriver(second)
+	if err := d.EnsureBalancer(context.Background(), BalancerSpec{
+		Name: "lbu-x", Network: "fnt-a", Listen: "10.61.1.240",
+		Listeners: []BalancerListener{{Protocol: "tcp", Listen: 80, Backend: 8080}},
+		Targets:   []string{"10.61.1.10"},
+	}); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	var registered lbBody
+	if err := json.Unmarshal([]byte(payloadOf(t, second, "-X PUT")), &registered); err != nil {
+		t.Fatalf("decode the payload: %v", err)
+	}
+	if len(registered.Ports) != 1 || len(registered.Ports[0].TargetBackend) != 1 {
+		t.Fatalf("the first backend must bring the listener with it, got %+v", registered.Ports)
+	}
+}
+
+// A write the host refuses withdraws the claim that this process balances.
+//
+// firewallRefused's twin (#454, #181), and the same argument one plane over:
+// `/_feint/health` telling a suite `capabilities.balancing: true` while the
+// daemon holds no balancer is the lying 200 this project exists to refuse, and
+// this repository tells every consumer to key on the capability rather than on
+// a mode name.
+//
+// The accepting half is asserted first, and it matters: a driver that published
+// balancing=false from the start would pass the withdrawal assertion and claim
+// nothing at all. And the last half is the #454 rule itself — a shape this
+// driver refused on its own never reached the daemon, and it arrives from a
+// restorable snapshot, so it must not be a switch on a published claim.
+func TestABalancerWriteTheHostRefusesWithdrawsTheCapability(t *testing.T) {
+	f := &fakeRuntime{answers: map[string]string{
+		"network get fnt-a ipv4.address": "10.61.1.1/24\n",
+		"network get fnt-a user.":        "outscale\n",
+	}, fail: map[string]error{
+		"-X POST": errors.New("incus query: Error: Failed creating load balancer: something new"),
+	}, hook: answerExactly(map[string]string{emptyCollection: "[]"})}
+	var log bytes.Buffer
+	d := ovnDriver(f)
+	d.Log = slog.New(slog.NewTextHandler(&log, nil))
+
+	if !d.Capabilities().Balancing {
+		t.Fatal("an OVN-backed driver must claim balancing before anything refuses it")
+	}
+	if err := d.EnsureBalancer(context.Background(), BalancerSpec{
+		Name: "lbu-x", Network: "fnt-a", Listen: "10.61.1.240",
+		Listeners: []BalancerListener{{Protocol: "tcp", Listen: 80}},
+		Targets:   []string{"10.61.1.10"},
+	}); err == nil {
+		t.Fatal("the refusal must reach the caller")
+	}
+	if d.Capabilities().Balancing {
+		t.Error("the host refused a load balancer and the process still claims to distribute connections")
+	}
+	if !strings.Contains(log.String(), "capabilities.balancing") {
+		t.Errorf("the withdrawal must be said, not only published, got %q", log.String())
+	}
+
+	clean := ovnDriver(&fakeRuntime{answers: map[string]string{
+		"network get fnt-a ipv4.address": "10.61.1.1/24\n",
+		"network get fnt-a user.":        "outscale\n",
+	}, hook: answerExactly(map[string]string{emptyCollection: "[]"})})
+	if err := clean.EnsureBalancer(context.Background(), BalancerSpec{
+		Name: "lbu-x", Network: "fnt-a", Listen: "10.61.1.240",
+		Listeners: []BalancerListener{{Protocol: "tcp", Listen: 80}},
+		Targets:   []string{"10.62.9.10"},
+	}); err == nil {
+		t.Fatal("a backend outside the network must still be refused")
+	}
+	if !clean.Capabilities().Balancing {
+		t.Error("a refusal by this driver's own guard must not withdraw the host's capability")
+	}
 }

--- a/internal/providers/exoscale/loadbalancers.go
+++ b/internal/providers/exoscale/loadbalancers.go
@@ -75,6 +75,10 @@ import (
 //	  Failed creating load balancer: Uplink network doesn't contain
 //	  "192.0.2.1/32" in its routes
 //
+// Those three lines are what was printed that day and are left as printed; the
+// refusal's wording has since gained the sentinel #457 added
+// (machine.ErrBalancerNotDistributed), and the verdict is unchanged.
+//
 // So the interface is not the obstacle — an in-block address is accepted and
 // created — and neither is a provider-shaped gap in it: the runtime refuses
 // this pack's address on its own, before any guard of ours is consulted. What

--- a/internal/providers/outscale/loadbalancer_dataplane.go
+++ b/internal/providers/outscale/loadbalancer_dataplane.go
@@ -2,6 +2,7 @@ package outscale
 
 import (
 	"context"
+	"errors"
 
 	"github.com/stephrobert/feint/internal/core/machine"
 	"github.com/stephrobert/feint/internal/core/resource"
@@ -94,6 +95,28 @@ func (p *Pack) syncBalancer(ctx context.Context, name string) {
 		return
 	}
 	if err := b.EnsureBalancer(ctx, spec); err != nil {
+		// A limit is not an incident, and levelling the two the same is how a
+		// log teaches people to skip its errors (#457).
+		//
+		// The shape this runtime does not distribute — a balancer in front of
+		// machines on another subnet, which is the ordinary two-tier
+		// architecture — is refused by name at the driver, on every register,
+		// for as long as the stack lives. Reported at ERROR it would be a
+		// permanent error on a working configuration; reported at WARN, with
+		// what the API still describes, it is what it is: this emulator records
+		// that balancer and does not distribute for it. docs/limits.md carries
+		// the measurement, and `capabilities.balancing` says which shape it
+		// covers.
+		//
+		// Anything else is the runtime failing at something it had accepted,
+		// which stays an error.
+		// TestAnUndistributableShapeIsNotLoggedAsAnError fails without this.
+		if errors.Is(err, machine.ErrBalancerNotDistributed) {
+			p.logger().Warn("this runtime does not distribute a load balancer of this shape; "+
+				"the API goes on describing it and its backends",
+				"load_balancer", res.ID, "listen", spec.Listen, "error", err)
+			return
+		}
 		p.logger().Error("could not hand the load balancer to the runtime",
 			"load_balancer", res.ID, "listen", spec.Listen, "error", err)
 	}

--- a/internal/providers/outscale/loadbalancer_dataplane_test.go
+++ b/internal/providers/outscale/loadbalancer_dataplane_test.go
@@ -1,13 +1,20 @@
 package outscale_test
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
+	"github.com/stephrobert/feint/internal/core/emulator"
 	"github.com/stephrobert/feint/internal/core/machine"
+	"github.com/stephrobert/feint/internal/providers/outscale"
 )
 
 // The pack half of the load-balancer dataplane (#315).
@@ -248,4 +255,81 @@ func TestEmptyingTheListenersRemovesTheBalancerFromTheRuntime(t *testing.T) {
 
 func containsAddress(line, address string) bool {
 	return len(line) >= len(address) && line[len(line)-len(address):] == address
+}
+
+// refusingBalancer is a runtime that declares balancing and refuses one shape,
+// the way the Incus driver refuses a balancer in front of machines on another
+// subnet (#457).
+type refusingBalancer struct {
+	*recordingBalancer
+	err error
+}
+
+func (r *refusingBalancer) EnsureBalancer(ctx context.Context, spec machine.BalancerSpec) error {
+	_ = r.recordingBalancer.EnsureBalancer(ctx, spec)
+	return r.err
+}
+
+// newLoggedRuntimeServer is newRuntimeServer with somewhere to read the log,
+// because the level a line carries is the subject here.
+func newLoggedRuntimeServer(t *testing.T, drv machine.Driver, log *bytes.Buffer) *httptest.Server {
+	t.Helper()
+	env := emulator.DefaultEnv()
+	env.Machines = drv
+	env.Log = slog.New(slog.NewTextHandler(log, nil))
+	srv, err := emulator.NewServer(env, outscale.New(env))
+	if err != nil {
+		t.Fatalf("build emulator: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// A shape this runtime does not distribute is a limit, not an incident.
+//
+// The two-tier architecture — a load balancer in front of machines on another
+// subnet — is refused by the driver on every register, for as long as the stack
+// lives, and #457 measured why it cannot be served here. Reported at ERROR that
+// is a permanent error on a working configuration, and a log whose errors are
+// permanent is a log whose errors get skipped, which costs the next real one.
+//
+// So the level is the assertion, and both halves of it: no ERROR for the limit,
+// and an ERROR still there for a runtime that broke.
+func TestAnUndistributableShapeIsNotLoggedAsAnError(t *testing.T) {
+	var log bytes.Buffer
+	runtime := &refusingBalancer{
+		recordingBalancer: newRecordingBalancer(true),
+		err: fmt.Errorf("%w: balancer lbu-data on fnt-a has the backend 10.188.9.4, which is "+
+			"outside that network's own block 10.188.3.0/24", machine.ErrBalancerNotDistributed),
+	}
+	close(runtime.release)
+	ts := newLoggedRuntimeServer(t, runtime, &log)
+
+	aBalancedStack(t, ts)
+	if len(runtime.specs()) == 0 {
+		t.Fatal("the balancer never reached the runtime, so this test measures nothing")
+	}
+	if strings.Contains(log.String(), "level=ERROR") {
+		t.Errorf("a shape this runtime never distributes was reported as an error: %q", log.String())
+	}
+	if !strings.Contains(log.String(), "level=WARN") {
+		t.Errorf("the limit must still be said, and it was not: %q", log.String())
+	}
+	if !strings.Contains(log.String(), "goes on describing it") {
+		t.Errorf("the line must say what the API keeps describing, got %q", log.String())
+	}
+
+	// The other half: a runtime that failed at something it had accepted is not
+	// a limit, and a WARN there would hide a real outage.
+	var broken bytes.Buffer
+	failing := &refusingBalancer{
+		recordingBalancer: newRecordingBalancer(true),
+		err:               errors.New("incus query: Error: Failed creating load balancer: something new"),
+	}
+	close(failing.release)
+	aBalancedStack(t, newLoggedRuntimeServer(t, failing, &broken))
+	if !strings.Contains(broken.String(), "level=ERROR") {
+		t.Errorf("a runtime failure must stay an error: %q", broken.String())
+	}
 }

--- a/tools/falsify/specs/balancer-dataplane.json
+++ b/tools/falsify/specs/balancer-dataplane.json
@@ -73,6 +73,35 @@
       "replace": "\tif false {\n\t\tp.removeBalancer(r.Context(), res)\n\t}",
       "test": "TestUnlinkingAndDeletingReachTheRuntime",
       "package": "./internal/providers/outscale/"
+    },
+    {
+      "label": "a backend on another subnet passes the guard and dies inside the runtime, mid-write (#457)",
+      "file": "internal/core/machine/incus_balancer.go",
+      "find": "\t\tif !block.Contains(address) {",
+      "replace": "\t\tif !block.Contains(address) && false {",
+      "test": "TestABalancerWithATargetOutsideTheNetworkIsRefused"
+    },
+    {
+      "label": "a balancer with no backend is written with a port naming nothing, which the runtime refuses with \"Missing VIP target(s)\"",
+      "file": "internal/core/machine/incus_balancer.go",
+      "find": "\tif len(spec.Targets) > 0 {",
+      "replace": "\tif len(spec.Targets) > 0 || true {",
+      "test": "TestABalancerWithNoBackendIsWrittenWithoutPorts"
+    },
+    {
+      "label": "a load balancer the host refused leaves capabilities.balancing true, so a suite keys on a claim the host denied",
+      "file": "internal/core/machine/capabilities.go",
+      "find": "\tif d.balancerDenied.Load() {",
+      "replace": "\tif d.balancerDenied.Load() && false {",
+      "test": "TestABalancerWriteTheHostRefusesWithdrawsTheCapability"
+    },
+    {
+      "label": "a shape this runtime never distributes is reported at ERROR on every register, which teaches people to skip errors",
+      "file": "internal/providers/outscale/loadbalancer_dataplane.go",
+      "find": "\t\tif errors.Is(err, machine.ErrBalancerNotDistributed) {",
+      "replace": "\t\tif errors.Is(err, machine.ErrBalancerNotDistributed) && false {",
+      "test": "TestAnUndistributableShapeIsNotLoggedAsAnError",
+      "package": "./internal/providers/outscale/"
     }
   ]
 }


### PR DESCRIPTION
`EnsureBalancer` checked the **listen** address against the network's block and only *parsed* the targets, so a backend on another subnet passed every guard and died inside the runtime on `Target address is not within the network subnet`. A public balancer in front of private machines is the ordinary shape, so this was not an exotic case.

## The audit proposed serving it. OVN refuses that — measured, not assumed

Bench on the real runtime (Incus 7.2 + OVN), two networks of the emulator's own making, every object trapped and removed:

| | asked | rc | the host's answer |
|---|---|---|---|
| M0 witness | LB on A, listen in A, target in A | 0 | created, `load-balancer list` carries it |
| M1 the defect | + a target in B | 1 | `Target address is not within the network subnet for backend "b1-80"` |
| **M2 — the audit's candidate** | LB on B (the targets' network), listen in A's block | **1** | `Load balancer listen address "10.181.0.5/32" overlaps with another network or NIC` |
| M3 | `network set fnt-mxb ipv4.routes=…` | 1 | `Invalid option … "ipv4.routes"` — an OVN network has no such key; only a NIC has `ipv4.routes.external`, and a VIP has no NIC |
| M3b | LB on B, listen outside every emulated block | 0 | accepted — but that is #315's address class, dark in three minutes, and not the address the API published |
| M4 | peer A↔B (both halves `CREATED`), retry M1 | 1 | **same refusal, word for word** |

So the fallback applies: a **named refusal** at the guard, the four measurements written into `docs/limits.md`, and `capabilities.balancing` qualified.

Following #454's motif exactly: the driver's own refusal does **not** withdraw the capability — a crafted snapshot must not flip a published claim — and what withdraws it is a write the *host* refuses, wired to the two writes and deliberately not to the read before them.

## The minor defect, measured and fixed rather than re-levelled

`syncBalancer` logged at ERROR on the ordinary Terraform order — a balancer created before its backends fails with `Missing VIP target(s)` and then self-heals. An ERROR on a normal sequence teaches people to ignore ERRORs.

The measurement says the fix is not the log level: **the same body with no port at all is accepted** (rc=0), and a later `PUT` installs the ports; a drain `PUT` is accepted too and stops the distribution. So the ports are now omitted when there is no target, and the ordinary order **stops failing** instead of failing more quietly. The WARN/ERROR split stays for the shape that genuinely is a permanent limit.

## Witness on the real runtime, read off the host

`feint serve --vm incus-ovn`, one Net, public 10.182.0.0/24 and private 10.182.4.0/24, machine in the private one, everything read with `incus network load-balancer list`/`show` rather than from the API's answer:

- **W1** create in the public subnet → the host carries `10.182.0.4`, 0 ports (before: a failed write).
- **W2** register the private machine → host unchanged (`backends: []`, `ports: []`), the API still describes `BackendVmIds: [i-c6314c9f]`, one WARN naming the limit, and **`grep -c level=ERROR` = 0** over the whole run.
- **W3 positive control** — the half that makes W2's emptiness mean anything: a same-subnet balancer *does* carry `target_address: 10.182.4.4` and its tcp/80 port on the host.

## Gates

`go build` 0 · `go test ./...` 0 · `mise run prepush` 0 (re-run after the docs, after the changelog, and after the punctuation rewrite) · `falsify balancer-dataplane.json` 0 — **14 mutations all red**, including the four added: target guard disarmed, ports restored on a backend-less balancer, capability withdrawal disarmed, limit levelled back to ERROR · the eight other specs naming a touched file, 0 each.

`mise run conformance` was not played on this branch — issues are handled in series and it runs once over the assembled set.

## Station delta: zero

Before = after. No `fnt-`/`feint-` network, ACLs `['acltest']` only, no instance, 20 images with the 10 `feint/*` aliases intact.

A bench note worth keeping: the first run collided on `10.191.0.0/24`, which this station already carries on `hp-test-net` — the exact collision `networkCreateError` documents.

Closes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)
