### PR TITLE
docs(stacks): the fifteen stacks are replayed twice, and a declared image turns four regressions into four convergences

### DIFF
--- a/examples/stacks/exoscale/main.tf
+++ b/examples/stacks/exoscale/main.tf
@@ -1,5 +1,6 @@
 # A platform on Exoscale: two private networks, a pool that scales, block
-# storage, and an elastic IP in front.
+# storage, an elastic IP in front, a load balancer over the pool — and the
+# per-id reads no published client makes, driven here through data sources.
 #
 # ---------------------------------------------------------------------------
 # READ THIS BEFORE RUNNING IT — this stack needs a patched provider
@@ -285,8 +286,52 @@ resource "exoscale_nlb_service" "app" {
   }
 }
 
+# ---------------------------------------------------------------------------
+# Three reads no published client ever makes. GET /v2/load-balancer/{id},
+# /v2/instance-pool/{id} and /v2/elastic-ip/{id} are served and probed, but
+# `exo` resolves each of them by listing and filtering client-side, so the
+# per-id read has no caller — docs/routes.md carries each reason. The
+# provider's data sources look up by id, which makes this stack those routes'
+# first client-shaped reader: an id, a field or a state the emulator invents
+# on the per-id door and not on the list door surfaces as a diff between
+# these reads and the resources above.
+#
+# Honest limit, the same one the whole stack carries: this runs through the
+# patched fork, which is not the official client, so the `driven` axis of
+# coverage/evidence.json does not move. The reads still exercise the routes.
+# ---------------------------------------------------------------------------
+
+data "exoscale_nlb" "front" {
+  zone = var.zone
+  id   = exoscale_nlb.front.id
+}
+
+data "exoscale_instance_pool" "app" {
+  zone = var.zone
+  id   = exoscale_instance_pool.app.id
+}
+
+data "exoscale_elastic_ip" "ingress" {
+  zone = var.zone
+  id   = exoscale_elastic_ip.ingress.id
+}
+
 output "ingress_address" {
   value = exoscale_elastic_ip.ingress.ip_address
+}
+
+# The per-id doors, read back beside the resources that created them: the two
+# spellings must agree, or one of the two doors is answering an invention.
+output "front_by_id" {
+  value = data.exoscale_nlb.front.name
+}
+
+output "pool_size_by_id" {
+  value = data.exoscale_instance_pool.app.size
+}
+
+output "ingress_address_by_id" {
+  value = data.exoscale_elastic_ip.ingress.ip_address
 }
 
 output "pool_instances" {

--- a/examples/stacks/outscale/main.tf
+++ b/examples/stacks/outscale/main.tf
@@ -8,16 +8,19 @@
 # spread over two subregions the way kasten-on-outscale places its workers, an
 # internet service and a route table serve the public side, a NAT service and
 # its own route table serve the private side, a peering carries the route
-# between the two Nets, and tags ride on almost every call because the
-# provider sends them on almost every call. Each of those motifs is lifted
-# from a stack in examples/stacks/surveyed.md written by someone who never saw
-# this repository.
+# between the two Nets, a load balancer fronts the web tier the way three of
+# the five surveyed stacks front theirs, the Net wears a DHCP options set of
+# its own, the app machine carries a second interface attached explicitly,
+# and tags ride on almost every call because the provider sends them on
+# almost every call. Each of those motifs is lifted from a stack in
+# examples/stacks/surveyed.md written by someone who never saw this
+# repository.
 
 terraform {
   required_version = ">= 1.7.0"
   required_providers {
     outscale = {
-      source  = "outscale/outscale"
+      source = "outscale/outscale"
       # The floor is 1.7, the same one the conformance fixture pins: the 1.7+
       # generation reads its endpoint path from the value (OSC_ENDPOINT_API
       # carries /api/v1), where 1.1.x appends the path itself — the boundary is
@@ -101,6 +104,35 @@ module "services" {
   }
 }
 
+# ---------------------------------------------------------------------------
+# The workload Net's DHCP options. On `outscale_net` itself the set is
+# computed-only, so this pair is UpdateNet's one client-reachable shape: the
+# dedicated set, and the attributes resource that points the Net at it. The
+# proof is that a *different* set than the Net's default is retained and read
+# back — pointing a Net at its own default proves only that the call decodes.
+# ---------------------------------------------------------------------------
+
+resource "outscale_dhcp_option" "workload" {
+  domain_name         = "platform.internal"
+  domain_name_servers = ["192.0.2.53", "192.0.2.54"]
+  ntp_servers         = ["192.0.2.123"]
+
+  tags {
+    key   = "Name"
+    value = "platform-dopt"
+  }
+
+  # Destroy order, pinned: the provider first re-points every Net wearing this
+  # set at the `default` keyword (ReadNets filtered on the set, then UpdateNet),
+  # and only then deletes it — so the Net must still be alive when that runs.
+  depends_on = [module.workload]
+}
+
+resource "outscale_net_attributes" "workload" {
+  net_id              = module.workload.net_id
+  dhcp_options_set_id = outscale_dhcp_option.workload.dhcp_options_set_id
+}
+
 resource "outscale_net_peering" "workload_to_services" {
   accepter_net_id = module.services.net_id
   source_net_id   = module.workload.net_id
@@ -153,6 +185,18 @@ resource "outscale_route_table_link" "public" {
 
   route_table_id = outscale_route_table.public.route_table_id
   subnet_id      = module.workload.subnet_ids[each.key]
+}
+
+# The Net's *main* route table, re-pointed at the public table: a subnet added
+# tomorrow without an explicit link then routes like the public tier, which is
+# what "default route table" means in practice. It is also the one resource
+# that sends UpdateRouteTableLink — `outscale_route_table_link` never does,
+# both its attributes force a replacement — and its destroy drives the same
+# operation a second time when the provider moves the main link back onto the
+# default table.
+resource "outscale_main_route_table_link" "workload" {
+  net_id         = module.workload.net_id
+  route_table_id = outscale_route_table.public.route_table_id
 }
 
 # ---------------------------------------------------------------------------
@@ -209,6 +253,18 @@ resource "outscale_security_group_rule" "web_https" {
   security_group_id = outscale_security_group.web.security_group_id
   from_port_range   = 443
   to_port_range     = 443
+  ip_protocol       = "tcp"
+  ip_range          = "0.0.0.0/0"
+}
+
+# Port 80 for the load balancer below: its listener and its health check both
+# speak HTTP, and a group that only opened 443 would document a balancer no
+# packet could reach.
+resource "outscale_security_group_rule" "web_http" {
+  flow              = "Inbound"
+  security_group_id = outscale_security_group.web.security_group_id
+  from_port_range   = 80
+  to_port_range     = 80
   ip_protocol       = "tcp"
   ip_range          = "0.0.0.0/0"
 }
@@ -315,6 +371,70 @@ resource "outscale_public_ip_link" "web" {
   public_ip = outscale_public_ip.web[each.key].public_ip
 }
 
+# ---------------------------------------------------------------------------
+# The LBU in front of the web tier — the family three of the five surveyed
+# stacks carry, and the one this stack lacked. The trio is the shape the
+# provider models: the balancer with its listeners inline, the backend Vms as
+# their own attachment, the health check as an attributes resource.
+#
+# The pack holds the delete algebra under it: a subnet or a security group
+# under a standing balancer refuses to go, so the destroy order this graph
+# implies is itself part of what an apply-destroy cycle proves.
+#
+# The backends here span the two public subnets on purpose — the exact ztiac
+# shape that found #457. Under `--vm incus-ovn` the host serves a dataplane
+# only for a balancer whose backends share its own subnet (four measurements,
+# docs/limits.md): this configuration is recorded, described and WARNed about,
+# and the runtime declines its dataplane by name rather than half-serving it.
+# With machines off it is a record that round-trips. Both are honest, and the
+# stack keeps the shape so the next run keeps checking the refusal.
+# ---------------------------------------------------------------------------
+
+resource "outscale_load_balancer" "front" {
+  load_balancer_name = "platform-front"
+  load_balancer_type = "internet-facing"
+  subnets            = [module.workload.subnet_ids["public-a"]]
+  security_groups    = [outscale_security_group.web.security_group_id]
+
+  listeners {
+    backend_port           = 80
+    backend_protocol       = "HTTP"
+    load_balancer_protocol = "HTTP"
+    load_balancer_port     = 80
+  }
+
+  tags {
+    key   = "Name"
+    value = "platform-front"
+  }
+
+  # A balancer belongs in a subnet that already routes to an internet service —
+  # the same ordering the NAT service states above.
+  depends_on = [outscale_route_table_link.public]
+}
+
+resource "outscale_load_balancer_vms" "front" {
+  load_balancer_name = outscale_load_balancer.front.load_balancer_name
+  backend_vm_ids     = [for vm in outscale_vm.web : vm.vm_id]
+}
+
+resource "outscale_load_balancer_attributes" "front" {
+  load_balancer_name = outscale_load_balancer.front.load_balancer_name
+
+  # Settings only: they must round-trip because the provider plans on them.
+  # No health *state* exists until something probes a backend, and with
+  # machines off nothing does.
+  health_check {
+    healthy_threshold   = 2
+    unhealthy_threshold = 5
+    check_interval      = 30
+    port                = 80
+    protocol            = "HTTP"
+    path                = "/healthz"
+    timeout             = 5
+  }
+}
+
 resource "outscale_vm" "app" {
   # The catalogue image, not outscale_image.golden above. Same measurement as
   # the Scaleway stack's web tier: this emulator keeps records, not disk
@@ -354,6 +474,36 @@ resource "outscale_nic" "app_services" {
   }
 }
 
+# A second interface for the app Vm, in its own subnet, attached explicitly:
+# LinkNic and UnlinkNic are only ever driven by an interface created apart
+# from its machine, since the one a Vm is born with never travels through
+# them. Device 1, because device 0 is the machine's own.
+resource "outscale_nic" "app_data_plane" {
+  subnet_id          = module.workload.subnet_ids["private"]
+  security_group_ids = [outscale_security_group.app.security_group_id]
+  description        = "platform app data plane"
+
+  tags {
+    key   = "Name"
+    value = "platform-app-nic"
+  }
+}
+
+resource "outscale_nic_link" "app_data_plane" {
+  device_number = "1"
+  vm_id         = outscale_vm.app.vm_id
+  nic_id        = outscale_nic.app_data_plane.nic_id
+}
+
+# Secondary addresses on that interface — the LinkPrivateIps door, which no
+# other resource of this stack or of the conformance fixtures opens from
+# Terraform. High in the /24 on purpose, clear of anything the subnet hands
+# out on its own.
+resource "outscale_nic_private_ip" "app_data_plane" {
+  nic_id      = outscale_nic.app_data_plane.nic_id
+  private_ips = ["10.50.2.200", "10.50.2.201"]
+}
+
 resource "outscale_volume" "app_data" {
   subregion_name = local.az_a
   size           = 20
@@ -381,6 +531,12 @@ output "web_subregions" {
 
 output "nat_public_ip" {
   value = outscale_public_ip.nat.public_ip
+}
+
+# What the surveyed stacks feed to templatefile() and local_file: it must be a
+# stable, well-formed name, or the second plan drifts.
+output "front_dns_name" {
+  value = outscale_load_balancer.front.dns_name
 }
 
 output "machines" {

--- a/examples/stacks/scaleway/main.tf
+++ b/examples/stacks/scaleway/main.tf
@@ -1,10 +1,13 @@
 # A three-tier platform on Scaleway, with a separate management VPC.
 #
 # Written the way a real project is written rather than the way a test fixture
-# is: two VPCs that do not share a network, a bastion that is the only public
-# door, web and application tiers with their own security groups, data disks,
-# a golden image cut from a snapshot, block-storage volumes with their own
-# snapshots, and addresses booked from IPAM before anything carries them.
+# is: two VPCs that do not share a network, a network ACL on the workload one,
+# a bastion that is the only public door, web and application tiers with their
+# own security groups, a load balancer in front of the web tier, a public
+# gateway carrying the app tier's way out, a placement group spreading the
+# workers, data disks, a golden image cut from a snapshot, block-storage
+# volumes with their own snapshots, an IAM SSH key, and addresses booked from
+# IPAM before anything carries them.
 #
 # It exists to be run against Feint with no cloud account. Everything here is
 # ordinary Terraform: if it applies, re-plans empty and destroys, the emulator
@@ -62,6 +65,19 @@ provider "scaleway" {
 }
 
 # ---------------------------------------------------------------------------
+# The SSH key the project holds. IAM is its own product with its own API
+# (iam/v1alpha1), and the key family is the one part of it the emulator serves:
+# a registered key reaches the cloud-init of every machine the project starts,
+# which is what `mise run conformance:ssh` logs into. The scw CLI drives this
+# family in conformance; this resource is its Terraform reader.
+# ---------------------------------------------------------------------------
+
+resource "scaleway_iam_ssh_key" "platform" {
+  name       = "platform"
+  public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIr6pEFlAFO3YU0DNW/r8SkpjdbptN9ockkO2BtIolSD platform@example"
+}
+
+# ---------------------------------------------------------------------------
 # Two VPCs. The workload one and the management one, which is the shape most
 # platforms end up with and the one that makes isolation a real question.
 # ---------------------------------------------------------------------------
@@ -107,6 +123,65 @@ resource "scaleway_vpc_route" "to_management" {
   description                = "management range"
   destination                = "10.40.0.0/16"
   nexthop_private_network_id = scaleway_vpc_private_network.app.id
+}
+
+# The workload VPC's network ACL. Two operations behind one path — SetACL is a
+# PUT, GetACL the read-back — so the only place a defect can show is a second
+# plan that is not empty: a rule the emulator reorders, retypes or drops
+# surfaces as a permanent diff and nowhere else. The conformance fixture makes
+# the same argument; this instance holds it in the stack a reader copies.
+resource "scaleway_vpc_acl" "workload" {
+  vpc_id         = scaleway_vpc.workload.id
+  is_ipv6        = false
+  default_policy = "accept"
+
+  rules {
+    protocol      = "TCP"
+    source        = "0.0.0.0/0"
+    src_port_low  = 0
+    src_port_high = 0
+    destination   = "10.30.2.0/24"
+    dst_port_low  = 8080
+    dst_port_high = 8080
+    action        = "drop"
+    description   = "the app tier is reached through the web tier, never directly"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# The way out for machines that carry no address of their own: a public
+# gateway on the app network, masquerading, with the default route pushed
+# through an IPAM-booked address. terraform-talos and Scaleway's own VPC
+# module walk exactly this chain, and the app tier below is the tier that
+# needs it. The emulator records the gateway and refuses the wrong destroy
+# order; it NATs nothing and its address is TEST-NET-1 on purpose —
+# docs/limits.md states both halves.
+# ---------------------------------------------------------------------------
+
+resource "scaleway_vpc_public_gateway_ip" "egress" {}
+
+resource "scaleway_ipam_ip" "gateway" {
+  source {
+    private_network_id = scaleway_vpc_private_network.app.id
+  }
+}
+
+resource "scaleway_vpc_public_gateway" "egress" {
+  name  = "platform-egress"
+  type  = "VPC-GW-S"
+  ip_id = scaleway_vpc_public_gateway_ip.egress.id
+  tags  = ["platform", "egress"]
+}
+
+resource "scaleway_vpc_gateway_network" "egress" {
+  gateway_id         = scaleway_vpc_public_gateway.egress.id
+  private_network_id = scaleway_vpc_private_network.app.id
+  enable_masquerade  = true
+
+  ipam_config {
+    push_default_route = true
+    ipam_ip_id         = scaleway_ipam_ip.gateway.id
+  }
 }
 
 # ---------------------------------------------------------------------------
@@ -207,6 +282,17 @@ resource "scaleway_instance_private_nic" "bastion" {
   private_network_id = scaleway_vpc_private_network.admin.id
 }
 
+# A user-data key beside cloud-init. The server's own `cloud_init` argument
+# writes the reserved `cloud-init` key; this resource writes a named key of
+# its own, which is a different door — SetServerUserData and GetServerUserData
+# take the value as a raw body, not JSON, and a stack is the only client that
+# reads a key back after writing it.
+resource "scaleway_instance_user_data" "bastion_motd" {
+  server_id = scaleway_instance_server.bastion.id
+  key       = "motd"
+  value     = "platform bastion - access is logged"
+}
+
 # ---------------------------------------------------------------------------
 # The web tier: addresses booked from IPAM before the NICs carry them, which is
 # what a platform does when it wants stable addresses rather than whatever the
@@ -279,6 +365,83 @@ resource "scaleway_instance_private_nic" "web" {
 }
 
 # ---------------------------------------------------------------------------
+# The load balancer in front of the web tier. What each piece exercises is
+# stated, because each is a distinct API family: the standalone address
+# (CreateIP), the balancer joined to the web network (AttachPrivateNetwork),
+# the backend whose pool travels through SetBackendServers, the frontend
+# carrying an inline ACL (CreateACL), and a route that splits by SNI — the
+# one lb resource no conformance fixture declares.
+#
+# What a green apply proves, honestly: the configuration round-trips, field
+# for field. Nothing probes a backend and no packet is forwarded — the
+# balancer's address is TEST-NET-2, and the stats operations are declined
+# rather than invented (docs/limits.md, "A Scaleway load balancer and public
+# gateway record their configuration").
+# ---------------------------------------------------------------------------
+
+resource "scaleway_lb_ip" "front" {}
+
+resource "scaleway_lb" "front" {
+  name   = "platform-front"
+  type   = "LB-S" # from the emulated offer table; an unknown type fails client-side
+  ip_ids = [scaleway_lb_ip.front.id]
+  tags   = ["platform", "web"]
+
+  private_network {
+    private_network_id = scaleway_vpc_private_network.web.id
+  }
+}
+
+resource "scaleway_lb_backend" "web" {
+  lb_id            = scaleway_lb.front.id
+  name             = "platform-web"
+  forward_protocol = "tcp"
+  forward_port     = 443
+
+  # The IPAM-booked addresses of the web tier: the pool is reconciled through
+  # SetBackendServers alone (the provider never edits it incrementally), so an
+  # emulator that stored the list without answering it back would re-plan here
+  # for ever.
+  server_ips = [for ip in scaleway_ipam_ip.web : ip.address]
+
+  health_check_timeout = "5s"
+  health_check_delay   = "30s"
+  health_check_https {
+    uri  = "/healthz"
+    code = 200
+  }
+}
+
+resource "scaleway_lb_frontend" "https" {
+  lb_id        = scaleway_lb.front.id
+  backend_id   = scaleway_lb_backend.web.id
+  name         = "platform-https"
+  inbound_port = 443
+
+  # An inline ACL, the way the provider models one: reconciled rule by rule
+  # (CreateACL, ListACLs, UpdateACL, DeleteACL) — the bulk SetACLs call has no
+  # client and the emulator declines it for exactly that reason.
+  acl {
+    name = "drop-documentation-range"
+    action {
+      type = "deny"
+    }
+    match {
+      ip_subnet = ["192.0.2.0/24"]
+    }
+  }
+}
+
+# The SNI split, on the lb family's own route resource. It is here because no
+# conformance fixture declares one: the route operations are driven by the CLI
+# suite, and this is their first Terraform reader in the repository.
+resource "scaleway_lb_route" "admin" {
+  frontend_id = scaleway_lb_frontend.https.id
+  backend_id  = scaleway_lb_backend.web.id
+  match_sni   = "admin.platform.example"
+}
+
+# ---------------------------------------------------------------------------
 # The application tier: no public address at all, and block-storage volumes
 # rather than instance ones, which is the other volume product and a different
 # API entirely.
@@ -299,6 +462,19 @@ resource "scaleway_block_snapshot" "app_data" {
   tags      = ["platform", "app"]
 }
 
+# Spread the workers apart. At provider pin 2.81.0 this one resource walks two
+# API doors on the same ID — CRUD through instance/v2alpha1, policy_mode
+# through instance/v1 — so it exercises the mixed-halves path that broke the
+# NIC family the day 2.81.0 released. The record is honest about its effect:
+# nothing schedules hosts here, so the policy round-trips and places nothing
+# (docs/limits.md, #285).
+resource "scaleway_instance_placement_group" "app" {
+  name        = "platform-app"
+  policy_type = "max_availability"
+  policy_mode = "enforced"
+  tags        = ["platform", "app"]
+}
+
 resource "scaleway_instance_server" "app" {
   for_each = var.app_servers
 
@@ -307,6 +483,11 @@ resource "scaleway_instance_server" "app" {
   image             = "ubuntu_jammy"
   security_group_id = scaleway_instance_security_group.app.id
   tags              = ["platform", "app"]
+
+  # The membership travels on the server (CreateServer's placement_group), and
+  # the read-back is an embedded object: a server view without it would detach
+  # the group at every refresh.
+  placement_group_id = scaleway_instance_placement_group.app.id
 
   # No ip_id at all: this tier is unreachable from outside, which is the point.
 }
@@ -324,6 +505,18 @@ resource "scaleway_instance_private_nic" "app" {
 
 output "bastion_ip" {
   value = scaleway_instance_ip.bastion.address
+}
+
+# TEST-NET-2, and routed nowhere on purpose: see docs/limits.md. It is read
+# here so the apply proves the balancer publishes an address at all.
+output "front_address" {
+  value = scaleway_lb_ip.front.ip_address
+}
+
+# TEST-NET-1, same argument, on the other product's address block: no two
+# products of this emulator ever publish the same address.
+output "egress_address" {
+  value = scaleway_vpc_public_gateway_ip.egress.address
 }
 
 output "web_addresses" {

--- a/examples/stacks/surveyed.md
+++ b/examples/stacks/surveyed.md
@@ -1078,3 +1078,211 @@ The ghost also leaves a fact that belongs to the register rather than to the
 harness: for those four hours the station carried **two OVN networks and no
 emulator and no machine**. Those networks are #455's, and their surviving an
 emulator's death by hours is the same defect seen from a third angle.
+
+## Replayed under `--vm incus-ovn` on `main@72d861d` (2026-08-25), in two passes
+
+**Runtime: `--vm incus-ovn`**, named here because the register requires it of
+any replay. Same harness as the 2026-08-24 section above — one emulator per
+stack, an `incus monitor --type=lifecycle` started *before* it, a health probe
+that compares `instance.pid` and the declared runtime, a `timeout` on every
+`apply`, `plan` and `destroy`, and `feint clean --vm incus` with a host read-back
+between entries. Same fifteen repositories at the same commits (verified 15 of
+15), same recorded edits, same seeded prerequisites.
+
+Every figure below was measured against a binary built from `72d861d`. `main`
+moved once while the campaign ran, to `a80b4c0`, which touches only
+`examples/stacks/{scaleway,outscale,exoscale}/main.tf` — no Go, no contract, no
+coverage artefact — so it cannot have moved anything measured here; the commit
+named is the one the emulator was built from, which is the datum a replay needs.
+
+Eight fixes landed between the two sections, five of them aimed at what the
+first runtime pass had revealed: [#455] (the sweep no longer traps the host it
+cleans), [#456] (a Net of several subnets peers), [#454] (an ICMP rule reads its
+address family, so a refused rule set stops reading as a success), [#457] (a
+balancer whose backends are elsewhere is refused by name, and its ports are
+omitted when it has no target), [#465] (image recipes derive by family, and an
+opaque identifier is the operator's to declare), plus [#460], [#464], [#466] and
+[#469].
+
+### Why two passes, and why they are never mixed
+
+[#465] shipped a door the previous campaign did not have: an opaque image
+identifier **can be declared** —
+`FEINT_BOOT_IMAGES='<id>=<family>:<version>[@login]'` — and `feint images
+resolve <id>` asks the providers' public listings what to declare. Four of the
+fifteen stacks are blocked by exactly that, so the campaign was run twice:
+
+- **Pass 1, comparable**: no declaration at all. It is the pass that compares to
+  2026-08-24 at identical conditions, and it is the only one that says what the
+  eight fixes changed.
+- **Pass 2, declared**: `FEINT_BOOT_IMAGES` filled in for the four. It says what
+  the mechanism buys, and nothing about the fixes. **A machine that boots
+  because of a declaration is not a machine a fix unblocked**, which is why the
+  figures below never appear in one table.
+
+### Pass 1, the comparable one — the figures with their denominators
+
+| | |
+|---|---|
+| entries replayed | **15 of 15** |
+| conforme | **10** |
+| improved | **1** (talos, in the same sense as 2026-08-24) |
+| regressed | **4** (rke-cluster, ztiac, k3s, kasten) |
+| harness broken, nothing measured | **0 at the end**; one attempt, named below |
+| **machines really started** | **5** — kiwinet 1, ocp_outscale 1, vault 3 |
+| resources created | **379** (`Creation complete` lines) |
+| resources destroyed | **385** |
+| recorded exchanges | **2 388** |
+
+The distribution is the one of 2026-08-24, machine count included. **At equal
+conditions the eight fixes unblocked no machine, and none of them was about
+that.** What they changed is visible entry by entry rather than in the totals,
+and it is ztiac that carries it.
+
+`destroyed` exceeds `created` by six, netting two opposite effects, as in the
+previous pass: tainted resources that are in state and get destroyed without ever
+printing a creation line (rke +1, k3s +1, kasten +5, talos +2), against destroys
+that did not finish (ztiac −1, devbox −2).
+
+| entry | applied | second plan | destroyed | left | machines | exchanges | verdict |
+|---|---|---|---|---|---|---|---|
+| O1 osc-k8s-rke-cluster | 52 | 16 add / 1 destroy | 52 | 0 | 0 | 195 | regressed (image), unchanged |
+| O2 ztiac `advanced-network` | **77** | 18 add | 76 | **1** | 0 | 762 (both templates) | regressed, **new cause** |
+| O2 ztiac `two-tier` | 54 | 0 add / 5 change | 54 | 0 | 0 | | regressed (image), unchanged |
+| O3 ocp_outscale | 30 | `No changes.` | 30 | 0 | **1** | 217 | conforme, machine-backed |
+| O4 terraform-outscale-k3s | 35 | 8 add / 1 destroy | 34 | 0 | 0 | 221 | regressed (image), unchanged |
+| O5 kasten-on-outscale | 29 | 6 add / 5 destroy | 29 | 0 | 0 | 217 | regressed (image), unchanged |
+| E1 openshift4-exoscale | 43 | 42 add / 0 change | 43 | 0 | 0 | 226 | conforme |
+| E2 platform | 20 | 5 add / 0 change | 20 | 0 | 0 | 97 | conforme |
+| E3 terraform-exoscale-vault | 7 | `No changes.` | 7 | 0 | **3** | 48 | conforme, machine-backed |
+| E4 terraform-exoscale-sks | n/a | — | — | — | 0 | 1 | conforme, triggered |
+| E5 eu-data-platform | n/a | — | — | — | 0 | 1 | conforme, triggered |
+| S1 terraform-talos | 25 | 7 add / 2 destroy | 25 | 0 | 0 | 262 | improved, unchanged |
+| S2 scaleway-flatcar-k3s | 9 | 0 to change | 9 | 0 | 0 | 54 | conforme |
+| S3 ephemeral-devbox | 3 | 0 to change | 1 | 2 | 0 | 29 | conforme |
+| S4 kubic | 0 | 15 add | 0 | 0 | 0 | 2 | conforme |
+| S5 kiwinet-infra-cloud | 5 | `No changes.` | 5 | 0 | **1** | 57 | conforme, machine-backed |
+
+**What the fixes held, measured on the stack that revealed them.** ztiac
+`advanced-network` used to leave two OVN networks and two ACLs the host could
+not remove; the station comes back to zero now ([#455]). Its peering applies and
+its fourteen routes through it come back clean, and nothing peering-shaped
+remains in the residual plan ([#456]). ztiac `two-tier` applies **54 of 54** —
+its reference — where the two load balancers used to fail the apply; they are
+refused by name in the log now, and the API goes on describing them ([#457]).
+
+**What replaced it on ztiac `advanced-network` is a different defect, and a
+worse-behaved one** ([#473]): OVN subnet creation is serialised on one lock,
++5.6 s per subnet, so the tenth of fifteen crosses the emulator's 60-second
+write deadline. The connection is cut on a create that then succeeds, the
+client's retry meets its own subnet as a 409 `IpRange 10.2.1.0/24 overlaps the
+subnet on 10.2.1.0/24`, and the destroy fails on a Net holding six subnets
+Terraform never knew it had. 77 of 95, one resource left in state. The curve is
+in every run of the campaign — the first network always costs ~11 s and each one
+after adds ~5.6 s — and ztiac is simply the only surveyed stack with enough
+subnets to reach the cliff.
+
+**The harness attempt that measured nothing.** The first O3 run was killed in
+the middle of its `destroy` by my own tool's timeout: the run had been launched
+with `nohup` from the same shell that then waited on it, so both shared a
+process group. Terraform logged `Stopping operation…` and `Plugin did not
+respond`; nothing about the emulator was measurable from it. Re-run from a clean
+station in its own session (`setsid`), which is the O3 line above. It is listed
+because a killed destroy leaves a plausible-looking log, and the fourth category
+exists so that it is never counted as a regression.
+
+### Pass 2, declared — what [#465]'s door buys
+
+`FEINT_BOOT_IMAGES` filled in for the four entries whose only wall is an opaque
+identifier. Everything else identical.
+
+| entry | declaration | applied | second plan | destroyed | machines |
+|---|---|---|---|---|---|
+| O5 kasten | `ami-538af795=ubuntu:22.04` | **30** | `No changes.` | 30 | **5** |
+| O4 k3s | `ami-47899c77=debian:12` | **41** | `No changes.` | 41 | **3** |
+| O2 `two-tier` | `ami-a3ca408c=ubuntu:22.04` | **54** | `No changes.` | 54 | **5** |
+| O1 rke-cluster | `ami-a3ca408c=ubuntu:22.04` | **53** | 14 add / 0 change | 53 | **1** |
+
+**Four of four reach their `--vm off` reference under a real runtime**, second
+plans included: 30, 41, 54 and 53 are the register's own figures for these
+stacks with no machine runtime at all. **Fourteen machines started where pass 1
+started none**, and the four regressions of pass 1 are, in this pass, four
+convergences. 178 created, 178 destroyed, 1 049 exchanges.
+
+The declared versions are **not** what the identifiers name, and that has to be
+said plainly. `feint images resolve` reports `ami-538af795` as Ubuntu 18.04 and
+`ami-47899c77` as Debian 9, and both are versions the `images:` server has
+withdrawn, so neither can be built. What is above is a substitution the operator
+signs — the nearest buildable version — exactly the gesture [#465] made
+declarable. Measured on the unsubstituted form, kasten declared as printed
+(`ami-538af795=ubuntu:18.04`): **29 applied, 0 machines**, the declaration
+honoured, the build attempted, and the boot refused with `The requested image
+couldn't be found` — the same figures as no declaration at all. That gap is
+[#476].
+
+**O1 is the only one that does not converge, and the reason is the finding.**
+Its apply hit the harness's 900-second cap (`TF_APPLY_TIMED_OUT=900s`,
+`TF_APPLY_EXIT=124`) inside `shell_script.bastion-playbook` — the RKE/ansible
+tail that **no replay in this register has ever run**, because until this pass
+the bastion it depends on had never existed. It ran for 12 min 30 s against a
+live container whose ssh port answers from the station, and did not finish. The
+53 resources and the `14 to add / 0 to change` re-plan are the reference
+figures; only the tail is new, and it is the stack's own local provisioner, not
+this emulator.
+
+### The defects this pass filed
+
+Five, each with its reproduction, none reachable without a machine runtime:
+
+- [#473] fifteen OVN subnets queue on one lock, the tenth create is cut at 60 s,
+  its retry meets its own subnet as a conflict, and ztiac loses a third of itself;
+- [#475] two packs of three never hand a security group to the host — an
+  Outscale Vm and three Exoscale machines run with **no ACL** while the API
+  describes one, and a witness proves the port the group forbids answers;
+- [#476] `feint images resolve` prints a `FEINT_BOOT_IMAGES` line that cannot
+  boot, for two of the three identifiers the surveyed stacks hardcode;
+- [#477] an Exoscale operation feint declines is refused with a bare 404 the
+  official client reads as an ordinary empty answer — three of them inside the
+  register's only fully green stack;
+- [#474] fourteen `ERROR` lines over fifteen replays are all one documented
+  refusal, while the sibling refusal 200 ms later is a `WARN`.
+
+One finding was **not** filed because measurement disproved it: `DeleteSnapshot`
+answers `400` with `type: precondition_failed`, which looked like the wrong
+status until `scw/errors.go`'s `unmarshalStandardError` showed the SDK
+dispatches on the body's `type` and never on the status, and this repository's
+own tests already pin 400 against the real cloud.
+
+### The station, in delta
+
+Zero. No `feint-` instance, no `fnt-`/`iso-fnt-` network, no pack ACL, and the
+uplink swept — before the campaign as after it. Twenty Incus images before, twenty
+after, the same ten `feint/*` aliases (`almalinux/9`, `alpine/3.21`,
+`alpine/3.22`, `debian/12`, `debian/13`, `fedora/44`, `rockylinux/10`,
+`ubuntu/22.04`, `ubuntu/24.04`, `ubuntu/26.04`), read as JSON because the column
+form truncates an alias list to its first entry and `(7 more)`. **No image was
+built along the way**: the declared versions were chosen among those the station
+already held, and the one build the campaign did trigger — `ubuntu/18.04`,
+deliberately — failed at the image server and left nothing behind.
+
+One process on the station is **not** this campaign's and is recorded so that
+the next reader does not attribute it here: `incus monitor --type=lifecycle`,
+pid 121003, started 2026-08-25 at 00:18:53 and still running twenty hours later.
+That is the lifecycle recorder of the 2026-08-24 pass, from the run whose trap
+never fired — the same episode that section describes. Every monitor this
+campaign started exited with its run.
+
+[#454]: https://github.com/stephrobert/feint/issues/454
+[#455]: https://github.com/stephrobert/feint/issues/455
+[#456]: https://github.com/stephrobert/feint/issues/456
+[#457]: https://github.com/stephrobert/feint/issues/457
+[#460]: https://github.com/stephrobert/feint/issues/460
+[#464]: https://github.com/stephrobert/feint/issues/464
+[#465]: https://github.com/stephrobert/feint/issues/465
+[#466]: https://github.com/stephrobert/feint/issues/466
+[#469]: https://github.com/stephrobert/feint/issues/469
+[#473]: https://github.com/stephrobert/feint/issues/473
+[#474]: https://github.com/stephrobert/feint/issues/474
+[#475]: https://github.com/stephrobert/feint/issues/475
+[#476]: https://github.com/stephrobert/feint/issues/476
+[#477]: https://github.com/stephrobert/feint/issues/477


### PR DESCRIPTION
The fifteen third-party stacks were replayed twice on the same evening, under `--vm incus-ovn`, after the eight fixes merged during the day. The register gains a dated section that names its runtime — a rule this register adopted today.

## Pass 1 — comparable, no declaration: identical to the morning

**10 conforme, 1 improved, 4 regressed, 0 harness-broken. Five machines started** (kiwinet 1, ocp_outscale 1, vault 3), 379 created, 385 destroyed, 2 388 exchanges.

Same distribution and the same five machines as the run of 2026-08-24. **At equal conditions the eight fixes unblocked no machine, and none of them aimed at that.** Saying so plainly is the point of running this pass separately.

What they did change is legible on ztiac: the station comes back to zero (#455), the peering and its fourteen routes apply (#456), and 54 of 54 land with the balancers **refused by their name** rather than breaking the run (#457).

## Pass 2 — with the operator's declaration: fourteen machines

`FEINT_BOOT_IMAGES` declared from the image inventory, on the four entries whose hardcoded identifiers name images the upstream withdrew:

| entry | applied | second plan | machines |
|---|---|---|---|
| kasten | 30 | `No changes.` | **5** |
| k3s | 41 | `No changes.` | **3** |
| ztiac two-tier | 54 | `No changes.` | **5** |
| rke | 53 | `14 to add, 0 to change` | **1** |

All four reach their `--vm off` reference under a real runtime — **fourteen machines where pass 1 started none**. Keeping the two passes apart is what makes that number mean something: a machine booted from a declaration is not a machine a fix unblocked.

## The five issues, which are the product of this campaign

- **[#473]** — fifteen OVN subnets queue on one lock: ~11 s for the first network, ~5.6 s added by each one after, the tenth create cut at 60 s by the emulator's `WriteTimeout` **on a create that succeeded**, the retry meeting its own subnet with a 409, and the destroy failing on a Net holding six subnets Terraform never knew about. 77 of 95 for ztiac. The curve repeats over all twelve transcripts.
- **[#475]** — two packs of three never hand a security group to the host: only Scaleway implements `EnforcesFirewall`. A two-provider witness finds the Scaleway ACL and no Outscale ACL; a second witness **opens a port the group forbids** and reaches it from the station. Three Exoscale machines of the register's greenest stack run with zero ACL.
- **[#476]** — `feint images resolve` prints a `FEINT_BOOT_IMAGES` line that cannot boot, with rc=0: two of the three identifiers name versions `images:` withdrew. Measured end to end.
- **[#477]** — a declined Exoscale operation is refused with a bare 404 the official client reads as an ordinary empty answer: three refusals inside a fully green stack, surfaced nowhere.
- **[#474]** — fourteen ERROR lines over fifteen replays are all the same documented refusal, while #457's sibling degradation is a WARN 200 ms later in the same log.

One candidate was **disproved before filing**: `DeleteSnapshot`'s 400 is correct — the SDK dispatches on the body's `type`, never on the status.

## What did not pass, said rather than smoothed

ztiac `advanced-network` (#473). The rke apply capped at 900 s inside the RKE/ansible tail — which no replay of this register had ever executed, for want of a live bastion.

**One harness fell**: the first O3 run, killed mid-`destroy` by the agent's own timeout (`nohup` sharing the process group), replayed under `setsid`. Recorded as the fourth category, never counted as a regression.

## Station delta: zero

0 instance, 0 `fnt-`/`feint-` network, no pack ACL, 20 images and the same 10 `feint/*` aliases. No image built.

One residue that was **not** this campaign's: an `incus monitor` from the previous day whose trap never fired. Named in the register so it is not misattributed; closed since.

`mise run docs:check` rc=0. `mise run conformance` was not played — issues are handled in series and it runs once over the assembled set.

[#473]: https://github.com/stephrobert/feint/issues/473
[#474]: https://github.com/stephrobert/feint/issues/474
[#475]: https://github.com/stephrobert/feint/issues/475
[#476]: https://github.com/stephrobert/feint/issues/476
[#477]: https://github.com/stephrobert/feint/issues/477

🤖 Generated with [Claude Code](https://claude.com/claude-code)
