### PR TITLE
feat(environment): a repository declares the cloud to develop against, and one verb reads it (#189, #190)

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -426,6 +426,17 @@ jobs:
         if: matrix.client == 'fields'
         run: FEINT_BIN=/tmp/feint tools/conformance/refusals.sh http://127.0.0.1:4599
 
+      # `feint up` and `feint down` on the fixture declaration (#190), with
+      # --vm off, which is the whole of this matrix. It runs on `probe` because
+      # that leg needs no client binary and this suite needs none either: what
+      # it drives is the binary's own lifecycle. Its emulator is its own, on its
+      # own port, for the reason the fault suite's is.
+      - name: Bring a declared environment up and down
+        if: matrix.client == 'probe'
+        run: |
+          go build -o /tmp/feint ./cmd/feint
+          FEINT_BIN=/tmp/feint tools/conformance/environment/up.sh 127.0.0.1:4598
+
       # No client at all: every route driven from its provider's own API
       # description, which is the half of conformance that needs nothing
       # installed. It proves the protocol and never touches the score.

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -17,6 +17,54 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ## [Unreleased]
 
+### Ajouté
+
+- **`feint.yaml`, et les deux verbes qui le lisent : `feint up` et `feint down`
+  (#189, #190).** Les drapeaux qui décident de ce que l'émulateur d'un collègue
+  sait faire — quel runtime, quel provider, quels contrats, quel état de départ
+  — vivaient dans un historique de shell et dans un paragraphe de README, et un
+  dépôt qui en exigeait un précis n'avait aucun moyen de le dire. Une
+  déclaration à la racine le dit désormais, et `feint up` la lit : il contrôle
+  que l'hôte peut livrer le runtime nommé et **refuse avant que rien ne
+  démarre** plutôt que de dégrader, démarre l'émulateur avec l'état et les
+  contrats déclarés, exporte l'environnement client du pack lui-même, lance le
+  moteur dans le répertoire déclaré en laissant passer sa sortie telle quelle,
+  attend chaque condition `ready:` à voix haute et avec une échéance, puis
+  imprime les points d'entrée. `feint down` détruit puis arrête, en disant ce
+  qu'il jette.
+
+  Le schéma est fermé : **une clé qu'il ne nomme pas est refusée par son nom au
+  chargement**, avec la liste de celles que ce bloc accepte, de sorte qu'un
+  fichier mal tapé échoue au chargement et non au premier comportement
+  surprenant. Ce que ce fichier ne porte délibérément pas est refusé avec sa
+  raison plutôt qu'en clé inconnue — `emulator.coverage`, `emulator.shapes`,
+  `emulator.expose_to_network` et `proxy` disent chacun où vit réellement ce que
+  le lecteur cherchait. Et une clé que le schéma connaît et qu'aucun verbe ne lit
+  encore est annoncée au chargement : un fichier qui accepte tout et n'applique
+  qu'une partie est le mensonge exact que ce projet existe pour éviter.
+
+  `up` compose le cycle de vie au lieu de le remplacer : il rend la déclaration
+  dans les drapeaux que `feint start` accepte déjà, si bien que `status`, `logs`
+  et `stop` connaissent l'instance qu'il a montée. La surface CLI passe en
+  version 18 pour les deux verbes ; rien n'a été retiré, aucun code de sortie
+  n'a bougé.
+
+  Quatre pièges disparaissent, chacun payé à la main le 2026-08-24 en appliquant
+  les trois stacks d'exemple : un module local qu'une copie des `*.tf` laisse
+  derrière (le moteur tourne dans le répertoire déclaré, en place) ; une variable
+  `endpoint` dont le défaut vise un port où rien n'écoute (`iac.vars`, avec
+  `${feint.endpoint}` pour seule substitution) ; un endpoint dont le chemin `/v2`
+  appartient à la valeur chez un provider et pas chez les autres (il vient de
+  l'`Env` du pack, jamais d'un champ) ; et `FEINT_EXOSCALE_ALLOW_TERRAFORM`, lu
+  côté serveur, donc inopérant s'il est exporté après le démarrage
+  (`emulator.env`, posé avant le spawn).
+
+  Chaque stack d'exemple porte sa déclaration, et
+  `tools/conformance/environment/` pilote les deux verbes sur un dépôt fixture
+  en `--vm off`. [docs/environment.md](docs/environment.md) décrit le chemin de
+  `git clone` à un `terraform apply` qui passe, et sa référence de champs est
+  générée depuis le schéma, sur le rail de `feint docs --check`.
+
 ### Modifié
 
 - **Le bloc public Outscale émulé est un `/28`, plus un `/24`, et la suite de

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -59,6 +59,19 @@ change ni l'un ni l'autre a sa place dans `git log`.
   côté serveur, donc inopérant s'il est exporté après le démarrage
   (`emulator.env`, posé avant le spawn).
 
+  Éprouvé sous un vrai runtime de machines, et pas seulement en plan de
+  contrôle : la même déclaration Scaleway avec `--runtime incus-ovn` a appliqué
+  50 ressources, replanifié vide et détruit, et l'hôte portait ce que l'API
+  décrivait — six conteneurs en marche, trois réseaux OVN sur les blocs que la
+  stack déclare, trois jeux de règles marqués `feint security group` répartis sur
+  six interfaces, une ACL d'isolation par réseau, et rien après `feint down`.
+  `runtime.images` est contrôlé sur la station avant que rien ne démarre et
+  n'est jamais construit, avec trois réponses plutôt que deux : présente,
+  absente du jeu de préchauffage et refusée avec `feint images --only <nom>`, ou
+  hors de ce jeu et annoncée comme un premier démarrage qui en dérivera une. Un
+  runtime que l'hôte ne peut pas livrer est refusé avant tout démarrage, en
+  nommant la moitié manquante et les trois portes qui restent.
+
   Chaque stack d'exemple porte sa déclaration, et
   `tools/conformance/environment/` pilote les deux verbes sur un dépôt fixture
   en `--vm off`. [docs/environment.md](docs/environment.md) décrit le chemin de

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,52 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ## [Unreleased]
 
+### Added
+
+- **`feint.yaml`, and the two verbs that read it: `feint up` and `feint down`
+  (#189, #190).** The flags that decide what a colleague's emulator can do —
+  which runtime, which provider, which contracts, which state to start from —
+  lived in shell history and in a README paragraph, and a repository that needed
+  a particular one had no way to say so. One declaration at the repository root
+  now says it, and `feint up` reads it: it checks the host can deliver the
+  runtime the file names and **refuses before anything starts** rather than
+  downgrading, starts the emulator with the state and contracts it names,
+  exports the pack's own client environment, runs the engine in the directory it
+  names with its output passed straight through, waits for each `ready:`
+  condition out loud and with a deadline, then prints the endpoints. `feint down`
+  destroys and then stops, saying what it discards.
+
+  The schema is closed: **a key it does not name is refused by name at load**,
+  with the list of the keys that block does take, so a mistyped file fails at
+  load rather than at the first surprising behaviour. What this file
+  deliberately does not carry is refused with its reason rather than as an
+  unknown key — `emulator.coverage`, `emulator.shapes`,
+  `emulator.expose_to_network` and `proxy` each say where the thing a reader
+  wanted actually lives. And a key the schema knows that no verb reads yet is
+  said out loud at load, because a file that accepts everything and applies half
+  of it is the lie this project exists to avoid.
+
+  `up` composes the lifecycle rather than replacing it: it renders the
+  declaration into the flags `feint start` already takes, so `status`, `logs`
+  and `stop` know the instance it brought up. The CLI surface moves to version
+  18 for the two verbs; nothing was removed and no exit code moved.
+
+  Four traps this removes, each paid for by hand on 2026-08-24 applying the
+  three example stacks: a local module that a copy of `*.tf` leaves behind (the
+  engine runs in the declared directory, in place); an `endpoint` variable whose
+  default points at a port nothing listens on (`iac.vars`, with
+  `${feint.endpoint}` as the one substitution); an endpoint whose `/v2` path
+  belongs inside the value for one provider and not the others (it comes from
+  the pack's own `Env`, never from a field); and `FEINT_EXOSCALE_ALLOW_TERRAFORM`,
+  which is read server-side so exporting it after the start does nothing
+  (`emulator.env`, set before the spawn).
+
+  Each example stack ships its declaration, and `tools/conformance/environment/`
+  drives both verbs on a fixture repository with `--vm off`.
+  [docs/environment.md](docs/environment.md) is the path from `git clone` to a
+  `terraform apply` that passes, and its field reference is generated from the
+  schema on the `feint docs --check` rail.
+
 ### Changed
 
 - **The emulated Outscale public block is a `/28`, not a `/24`, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,18 @@ what this project is judged on: **a response shape a client can observe**, and
   which is read server-side so exporting it after the start does nothing
   (`emulator.env`, set before the spawn).
 
+  Proved under a real machine runtime, not only as a control plane: the same
+  Scaleway declaration with `--runtime incus-ovn` applied 50 resources, re-planned
+  empty and destroyed, and the host carried what the API described — six running
+  containers, three OVN networks on the blocks the stack declares, three rule sets
+  marked `feint security group` across six interfaces, one isolation ACL per
+  network, and nothing left after `feint down`. `runtime.images` is checked against
+  the station before anything starts and never built, with three answers rather
+  than two: present, absent from the warm-up set and refused with
+  `feint images --only <name>`, or outside that set and announced as a first boot
+  that will derive one. A runtime the host cannot deliver is refused before
+  anything is started, naming the missing half and the three ways past it.
+
   Each example stack ships its declaration, and `tools/conformance/environment/`
   drives both verbs on a fixture repository with `--vm off`.
   [docs/environment.md](docs/environment.md) is the path from `git clone` to a

--- a/README.fr.md
+++ b/README.fr.md
@@ -248,6 +248,26 @@ mise tasks                     # tout le reste
 
 ## S'en servir
 
+### Ou déclarez l'environnement entier, une fois, dans le dépôt
+
+Les drapeaux qui décident de ce que l'émulateur d'un collègue sait faire — quel
+runtime, quel provider, quels contrats, quel état de départ — vivent sinon dans
+un historique de shell. `feint.yaml` le dit une fois, et `feint up` le lit :
+
+```bash
+cd examples/stacks/scaleway    # un feint.yaml est posé à côté de main.tf
+feint up                       # contrôle l'hôte, démarre, exporte, applique, attend, imprime
+feint down                     # détruit, puis arrête en disant ce qu'il jette
+```
+
+`up` refuse **avant de démarrer quoi que ce soit** quand l'hôte ne peut pas
+livrer le runtime déclaré, et il ne dégrade jamais en silence ; le schéma est
+fermé, donc une clé mal tapée échoue au chargement, avec la liste de celles que
+ce bloc accepte. [docs/environment.md](docs/environment.md) décrit le chemin de
+`git clone` à un `terraform apply` qui passe, et la référence de champs générée.
+
+### Ou pilotez-le à la main
+
 Démarrez l'émulateur une fois. Tout ce qui suit parle au même processus.
 
 ```bash
@@ -468,6 +488,8 @@ c'est arrivé à dix d'entre eux avant qu'un test compare les deux listes.
 | commande | ce qu'elle fait |
 | --- | --- |
 | `feint serve` | les trois clouds émulés sur un port, au premier plan |
+| `feint up` | lit `feint.yaml` et monte l'environnement entier : il contrôle l'hôte, démarre l'émulateur, exporte l'environnement client, lance le moteur, attend les conditions déclarées |
+| `feint down` | détruit ce que la déclaration a bâti, puis arrête l'émulateur en disant ce qu'il jette |
 | `feint start` | le même, détaché : il enregistre l'instance, attend qu'elle réponde, dit où est le journal |
 | `feint stop` | SIGTERM, puis SIGKILL s'il le faut, en disant lequel — jamais un pid qui a cessé d'être feint |
 | `feint restart` | arrête, puis redémarre avec les drapeaux enregistrés |

--- a/README.md
+++ b/README.md
@@ -311,6 +311,26 @@ mise tasks                     # everything else
 
 ## Use it
 
+### Or declare the whole environment once, in the repository
+
+The flags that decide what a colleague's emulator can do — which runtime, which
+provider, which contracts, which state to start from — otherwise live in shell
+history. `feint.yaml` says it once, and `feint up` reads it:
+
+```bash
+cd examples/stacks/scaleway    # a feint.yaml sits beside main.tf
+feint up                       # check the host, start, export, apply, wait, print
+feint down                     # destroy, then stop, saying what it discards
+```
+
+`up` refuses **before it starts anything** when the host cannot deliver the
+runtime the file names — it never downgrades in silence — and the schema is
+closed, so a mistyped key fails at load with the list of the keys that block
+takes. [docs/environment.md](docs/environment.md) is the path from `git clone`
+to a `terraform apply` that passes, and the generated field reference.
+
+### Or drive it by hand
+
 Start the emulator once. Everything below talks to the same process.
 
 ```bash
@@ -871,6 +891,8 @@ rather than assumed.
 
 | Command | What it does |
 |---|---|
+| `feint up` | read `feint.yaml` and bring the whole environment up: check the host, start the emulator, export the client environment, run the engine, wait for the ready conditions |
+| `feint down` | destroy what the declaration built, then stop the emulator, saying what it discards |
 | `feint start` | run it in the background: it records the instance, waits until it answers, and says where the log is |
 | `feint stop` | SIGTERM, then SIGKILL if it has to, and say which — never a pid that stopped being feint |
 | `feint restart` | stop, then start again with the flags that were recorded |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,6 +23,8 @@ internal/contract/          API descriptions, and the check that answers match t
 internal/corpus/            turns a recording of a real cloud into an artefact this repository
                             may commit: values synthetic, statuses and order kept
 internal/drift/             the upstream surface scan, coverage, baselines
+internal/environment/       feint.yaml: what one environment is, and the schema that
+                            refuses by name what it does not carry
 internal/probe/             drives every mounted route from its API description
 internal/replay/            reissues a recorded exchange here and grades the answer
 internal/proxy/             records what a real client and a real cloud say to each other

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -139,17 +139,80 @@ script.
    after the emulator started leaves the guard armed. `emulator.env` sets it
    before the spawn.
 
+## Machines, and the refusal that comes before them
+
+`runtime.mode` is the `--vm` values and nothing else. It defaults to `off`,
+because starting machines is a side effect this project asks for rather than
+assumes — and the three example stacks ship with `off`, which is what lets them
+run on a CI runner with nothing installed.
+
+Flipping it is the whole difference between a control plane and a cloud. The
+same Scaleway declaration, on a station with Incus and OVN, measured on
+2026-08-25:
+
+```bash
+$ feint up --runtime incus-ovn
+examples/stacks/scaleway/feint.yaml: scaleway, runtime off, terraform in .
+  runtime off, overridden to incus-ovn by --runtime
+  runtime.images: 1 of 1 present on this station
+...
+Apply complete! Resources: 50 added
+  ok: resource:instance/server:6
+```
+
+and on the host, while it was up: six running containers, three OVN networks
+carrying the blocks the stack declares (`10.30.1.0/24`, `10.30.2.0/24`,
+`10.40.1.0/24`), three rule sets marked `feint security group` used by six
+interfaces between them, and one isolation ACL per network. After `feint down`,
+nothing of it remains.
+
+**`up` never downgrades on its own.** A declaration naming a runtime the host
+cannot deliver is refused *before anything is started*, naming the missing half
+— a developer who believes their subnets are separate and finds out otherwise in
+production is the exact failure this project exists to prevent:
+
+```text
+feint: --vm incus-ovn requested but this host cannot deliver it:
+  isolation: the daemon did not answer for network.ovn.northbound
+
+Nothing was started. Three ways on, in the order they cost:
+  feint doctor --vm incus-ovn        the whole diagnosis, including what to install
+  feint up --runtime off              run this environment without machines, and say so
+  feint.yaml                          change runtime.mode to what this host delivers
+```
+
+A guard with no way past it gets worked around by copying the emulator, which is
+why the refusal carries the doors rather than only the wall.
+
+### `runtime.images`, and the three answers it gives
+
+The declaration names the images this environment boots. `up` checks the station
+before anything starts and never builds one — a build launches a container and
+takes minutes, which is a side effect of its own. Three answers, and the third
+is the one a two-way check would get wrong:
+
+- **present** — `runtime.images: 1 of 1 present on this station`;
+- **in the warm-up set and absent** — refused, with `feint images --only <name>`;
+- **outside the warm-up set** — announced, never refused: the boot path derives
+  an image on demand for a family and version `feint images` does not build, so
+  refusing it would refuse something the runtime can do. The line says the first
+  boot will cost minutes.
+
+Under `mode: off` nothing boots, and the check says it is skipping for that
+reason rather than passing quietly.
+
 ## Asking for less on purpose
 
 ```bash
 feint up                      # what the file asks for
 feint up --runtime off        # deliberately less, and it says so
+feint up --no-iac             # the control plane only
 ```
 
-`up` never downgrades on its own. A declaration naming a runtime the host cannot
-deliver is refused, because a developer who believes their subnets are separate
-and finds out otherwise in production is the exact failure this project exists
-to prevent. Asking for less is a flag, and the run prints the override.
+Asking for something other than what the file declares is a flag, and the run
+prints the override. `--no-iac` skips the engine, and therefore skips the ready
+conditions that describe what the engine builds — out loud, and the summary then
+says `proved: nothing` rather than listing conditions nothing evaluated.
 
 ## The field reference
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -1,0 +1,210 @@
+# `feint.yaml`: one environment, declared once
+
+`feint serve --vm incus-ovn --contracts contracts` is a command somebody types,
+remembers, and types differently next week. The flags that decide what a
+colleague's emulator can do — which runtime, which provider, which contracts,
+which state to start from — live in shell history and in a README paragraph, and
+a repository that needs a particular one has no way to say so.
+
+`feint.yaml` is that way. `feint up` reads it and brings the environment up;
+`feint down` takes it back down. A declaration nothing reads is a comment, which
+is why the two arrived together.
+
+## From `git clone` to a `terraform apply` that passes
+
+This is the whole path, and it is the one the three stacks under
+[`examples/stacks/`](../examples/stacks/) are checked against.
+
+```bash
+git clone https://github.com/stephrobert/feint && cd feint
+mise run build                       # or: go install github.com/stephrobert/feint/cmd/feint@latest
+
+cd examples/stacks/scaleway          # a feint.yaml sits beside main.tf
+../../../feint up
+```
+
+That single command does six things, in order, and says each one out loud:
+
+1. **checks what the host can deliver, and refuses before anything starts.** A
+   declaration naming `incus-ovn` on a host with no OVN wiring is refused here,
+   naming the missing half — not four minutes later, half-applied;
+2. **starts the emulator** with the address, the state and the contracts the
+   file names. It is an ordinary `feint start`, so `feint status`, `feint logs`
+   and `feint stop` all know about it;
+3. **exports the client environment** from the pack itself — the same variables
+   `feint env <provider>` prints, endpoint form included;
+4. **runs the engine** in the directory the file names, in place, with its
+   output passed straight through;
+5. **waits for each `ready:` condition**, each with a deadline and each named
+   while it waits;
+6. **prints the endpoints** and what proved them.
+
+Then, when you are done:
+
+```bash
+../../../feint down
+```
+
+which destroys what the declaration built and stops the emulator, saying what it
+discards.
+
+### The Exoscale stack needs two more things, and they are not optional
+
+The published Exoscale Terraform provider cannot be pointed at a local emulator:
+it builds two clients and only one of them honours `EXOSCALE_API_ENDPOINT`, so
+an apply **splits** between the emulator and a paying account. Feint refuses
+that client by its user agent rather than serving half of it. The whole
+measurement, the pinned fork and the `dev_overrides` recipe are in
+[limits.md](limits.md#the-exoscale-terraform-provider-is-refused-and-why).
+
+So, for that stack only:
+
+```bash
+export TF_CLI_CONFIG_FILE=/path/to/dev.tfrc     # the dev_overrides from limits.md
+cd examples/stacks/exoscale && feint up
+```
+
+`FEINT_EXOSCALE_ALLOW_TERRAFORM=1` is **not** something to export by hand: it is
+read inside the emulator's own process, so exporting it after the start does
+nothing at all, and that is one of the traps this file exists to remove. It sits
+in the stack's `feint.yaml`, under `emulator.env`, where `feint up` sets it
+before the emulator is spawned.
+
+`TF_CLI_CONFIG_FILE` stays in the shell, and deliberately: it names a file
+outside this repository, on your machine, so a declaration that carried it would
+be a declaration that only works on the machine it was written on.
+
+## What the file is, and what it is not
+
+| what | says | where it lives |
+|---|---|---|
+| `feint.yaml` | how to bring the environment up | this project |
+| Terraform / OpenTofu | what the infrastructure is | your repository |
+| a snapshot | what the state currently is | an artefact |
+
+The day this file grows a block describing a subnet, this project has started
+rewriting Terraform badly. The day it grows a `packages:` list, it has started
+rewriting Devbox badly. Both refusals are structural rather than advisory: the
+schema is a closed table, and **a key it does not name is refused by name at
+load** — with the list of the keys that block does take.
+
+Two consequences worth stating before the reference:
+
+- **Nothing is accepted and then ignored.** A key this schema knows and no verb
+  reads yet is said out loud at load. A file that accepts everything and applies
+  half of it is the exact lie this project exists to avoid.
+- **Nothing here describes what a provider can do.** The catalogue, the image
+  table and the login of a machine live in the packs. A second place describing
+  them would be a second place to keep in agreement.
+
+## The shortest one that works
+
+```yaml
+version: 1
+
+cloud:
+  provider: scaleway
+
+iac:
+  engine: terraform
+  directory: .
+  vars:
+    endpoint: ${feint.endpoint}
+```
+
+Everything else has a default, and `runtime.mode` defaults to `off` because
+starting machines is a side effect this project asks for rather than assumes.
+
+## The four traps this replaces
+
+Every one of these was paid for by hand, on 2026-08-24, applying these same
+three stacks. Each was a parameter somebody had to reconstitute by reading a
+script.
+
+1. **`examples/stacks/outscale` carries a local module**, so copying `*.tf` on
+   their own does not run. The engine runs in the declared directory, in place.
+2. **Scaleway and Outscale declare an `endpoint` variable** whose default is
+   `127.0.0.1:4599`. Pointed at a port nothing listens on, Terraform blocks to
+   its own ceiling, the plugin dies, and the message blames the provider.
+   `iac.vars` carries it, with `${feint.endpoint}` — the one substitution this
+   file has, so the address is written once.
+3. **Exoscale declares no such variable**: its endpoint travels in
+   `EXOSCALE_API_ENDPOINT`, and the `/v2` path belongs to the value. That comes
+   from the pack's own `Env`, never from a field here, so no reader has to learn
+   which provider wants its path inside the value and which does not. The
+   mechanism is `TF_VAR_`, not `-var`, and the difference is measured: an
+   undeclared `TF_VAR_` is ignored, where `-var endpoint=…` fails outright on a
+   stack that declares no such variable.
+4. **`FEINT_EXOSCALE_ALLOW_TERRAFORM` is read server-side**, so exporting it
+   after the emulator started leaves the guard armed. `emulator.env` sets it
+   before the spawn.
+
+## Asking for less on purpose
+
+```bash
+feint up                      # what the file asks for
+feint up --runtime off        # deliberately less, and it says so
+```
+
+`up` never downgrades on its own. A declaration naming a runtime the host cannot
+deliver is refused, because a developer who believes their subnets are separate
+and finds out otherwise in production is the exact failure this project exists
+to prevent. Asking for less is a flag, and the run prints the override.
+
+## The field reference
+
+Generated from the schema itself, on the `feint docs --check` rail: a field
+added to `internal/environment` and a page that never learned about it fails the
+gate. The sentence a field carries lives on the field.
+
+<!-- environment:start -->
+<!-- Generated by `mise run docs:coverage`. Do not edit by hand. -->
+
+| field | takes | default | read by | what it says |
+|---|---|---|---|---|
+| `version` | a number | — | `feint up`, `feint down` | The schema version. Only 1 is read; another is refused naming both. |
+| `cloud.provider` | a provider name | — | `feint up`, `feint down` | The pack whose client environment `up` exports before running the engine — the same variables `feint env <provider>` prints, including the endpoint form that provider's clients want. Refused when the binary mounts no such pack. |
+| `emulator.addr` | a listen address | `127.0.0.1:4599` | `feint up`, `feint down` | Where the emulator listens: `serve --addr`. |
+| `emulator.state` | a path | — | `feint up` | The JSON file the store is loaded from and persisted to: `serve --state`. Relative to the declaration's own directory. |
+| `emulator.contracts` | a directory | — | `feint up` | The API descriptions every response is checked against: `serve --contracts`. Relative to the declaration's own directory. |
+| `emulator.log_level` | error, warn, info or debug | `info` | `feint up` | `serve --log-level`, which is what `feint logs` then shows. |
+| `emulator.cleanup` | true or false | `false` | `feint up` | Remove the machines and networks the run created before exiting: `serve --cleanup`. |
+| `emulator.env` | a block of FEINT_* variables | — | `feint up` | The environment the emulator's own process starts with. This is where the per-provider declarations that travelled in a chat paragraph belong — FEINT_EXOSCALE_ALLOW_TERRAFORM, which is read server-side and so cannot be exported after the start, and FEINT_BOOT_IMAGES. FEINT_* only: a declaration that could set any variable of a process it spawns would be a different kind of file. |
+| `runtime.mode` | off, incus, incus-vm, incus-ovn, auto | `off` | `feint up` | What backs a powered-on server: the `--vm` values and nothing else. Absent means `off`, because starting machines is a side effect this project asks for rather than assumes. `up` checks the host can deliver the named mode before it starts anything, and refuses rather than downgrading. |
+| `runtime.images` | a list of family/version | — | `feint up` | The machine images this environment needs present. `up` checks them and refuses naming what is missing and the `feint images` command that builds it; it never builds them itself, because a build takes minutes. Ignored when `runtime.mode` is `off`, where nothing boots. |
+| `snapshot.load` | a snapshot name | — | `feint up` | A snapshot loaded once the emulator answers, so this environment starts from a known state rather than from nothing: `feint snapshot load <name>`. The name, never a path — snapshots live where `feint snapshot list` says they live. |
+| `iac.engine` | terraform or opentofu | — | `feint up`, `feint down` | The engine `up` runs and `down` destroys with. Absent means this environment declares no infrastructure, and `up` brings the control plane up and stops there. |
+| `iac.directory` | a directory | `.` | `feint up`, `feint down` | Where the engine runs, relative to the declaration's own directory. The engine runs there in place — a copy of `*.tf` would leave a local module behind, which is one of the four things this file exists to make impossible. |
+| `iac.vars` | a block of variables | — | `feint up`, `feint down` | Engine variables, exported as `TF_VAR_<name>`. The value `${feint.endpoint}` is replaced by the emulator's endpoint, and it is the only substitution this file has: a stack that takes its endpoint through a variable then carries the address once, here. |
+| `ready` | a list of conditions | — | `feint up` | What `up` waits for before it says the environment is up, each with a deadline and each said out loud while it waits. Three forms: `http:<path>` (the emulator answers below 400), `tcp:<host>:<port>` (a connection is accepted), and `resource:<kind>[:<count>]` (the emulator's own inventory holds at least that many). Every one is asserted against the emulator, never against the engine's state file. |
+
+### What this file deliberately does not carry
+
+| field | why not |
+|---|---|
+| `emulator.coverage` | `--coverage` is a flag of `feint serve` alone, which `feint start` refuses and `feint up` composes; run `feint coverage` against the running emulator instead |
+| `emulator.expose_to_network` | putting an emulator that accepts every credential on the network is a decision the person at the keyboard makes, never one a file they cloned makes for them; type `feint serve --expose-to-network` and read SECURITY.md first |
+| `emulator.shapes` | `--shapes` is a flag of `feint serve` alone, which `feint start` refuses and `feint up` composes; run `feint shapes --check` against the running emulator instead |
+| `proxy` | a recorder needs a real cloud endpoint and real credentials, which is the one thing this file must never carry; run `feint proxy --upstream … --record …` beside the emulator |
+
+### The ready conditions
+
+- `http:<path>`
+- `tcp:<host>:<port>`
+- `resource:<kind>[:<count>]`
+
+A condition that is not one of those forms is refused at load, with the list.
+<!-- environment:end -->
+
+## What is not here yet
+
+- **A transmissible bundle** ([#191]): `feint env export` / `import`, so an
+  environment attaches to a bug report as one file. The declaration is the half
+  that was missing; the bundle wraps it around a snapshot.
+- **Assertions that skip out loud** ([#192]): a suite that cannot prove
+  isolation because the host has no OVN should say which assertions it therefore
+  skipped, keyed on the capability the runtime declares rather than on a mode
+  name. `--runtime` is the half of it that exists today.
+
+[#191]: https://github.com/stephrobert/feint/issues/191
+[#192]: https://github.com/stephrobert/feint/issues/192

--- a/examples/stacks/exoscale/feint.yaml
+++ b/examples/stacks/exoscale/feint.yaml
@@ -1,0 +1,38 @@
+# The environment this stack needs, declared once. See docs/environment.md.
+#
+# Two things about this one, and neither is optional:
+#
+#   1. FEINT_EXOSCALE_ALLOW_TERRAFORM is read inside the emulator's process, so
+#      exporting it after the start does nothing at all. It sits under
+#      emulator.env, where `feint up` sets it before the emulator is spawned.
+#      What it lifts, and why the guard exists, is in docs/limits.md.
+#   2. The provider has to be the patched fork, resolved through dev_overrides.
+#      TF_CLI_CONFIG_FILE stays in your shell: it names a file on your machine,
+#      so a declaration carrying it would only work on the machine that wrote it.
+#
+# There is no `endpoint` variable here, and that is not an omission: the Exoscale
+# provider has no such attribute. It reads EXOSCALE_API_ENDPOINT — with the /v2
+# path inside the value — which comes from the pack's own environment, the same
+# one `feint env exoscale` prints.
+version: 1
+
+cloud:
+  provider: exoscale
+
+emulator:
+  addr: 127.0.0.1:4599
+  env:
+    FEINT_EXOSCALE_ALLOW_TERRAFORM: "1"
+
+runtime:
+  mode: off
+
+iac:
+  engine: terraform
+  directory: .
+
+ready:
+  - http:/v2/instance
+  - resource:compute-instance:1
+  - resource:private-network:2
+  - resource:instance-pool:1

--- a/examples/stacks/exoscale/feint.yaml
+++ b/examples/stacks/exoscale/feint.yaml
@@ -26,6 +26,10 @@ emulator:
 
 runtime:
   mode: off
+  # The template this stack resolves ("Linux Ubuntu 24.04 LTS 64-bit") maps to
+  # ubuntu:24.04. Checked before anything starts, once the mode is not `off`.
+  images:
+    - ubuntu/24.04
 
 iac:
   engine: terraform

--- a/examples/stacks/outscale/feint.yaml
+++ b/examples/stacks/outscale/feint.yaml
@@ -1,0 +1,31 @@
+# The environment this stack needs, declared once. See docs/environment.md.
+#
+# This stack carries a local module under modules/net, which is why `feint up`
+# runs the engine in this directory in place: copying *.tf alone leaves the
+# module behind, and that was one of four harness errors measured by hand before
+# this file existed.
+version: 1
+
+cloud:
+  provider: outscale
+
+emulator:
+  addr: 127.0.0.1:4599
+
+runtime:
+  mode: off
+
+iac:
+  engine: terraform
+  directory: .
+  vars:
+    endpoint: ${feint.endpoint}
+
+# The Outscale API answers POST on /api/v1/<Action>, so the emulator's own
+# health is what an http condition can read here; the resource counts do the
+# rest, and they are read from the store rather than from the engine.
+ready:
+  - http:/_feint/health
+  - resource:vm:2
+  - resource:net:2
+  - resource:loadbalancer:1

--- a/examples/stacks/outscale/feint.yaml
+++ b/examples/stacks/outscale/feint.yaml
@@ -14,6 +14,10 @@ emulator:
 
 runtime:
   mode: off
+  # ami-00000001, which the catalogue maps to ubuntu:24.04: what every Vm here
+  # boots once the mode above is not `off`. Checked before anything starts.
+  images:
+    - ubuntu/24.04
 
 iac:
   engine: terraform

--- a/examples/stacks/scaleway/feint.yaml
+++ b/examples/stacks/scaleway/feint.yaml
@@ -1,0 +1,39 @@
+# The environment this stack needs, declared once.
+#
+# `feint up` reads this file and does the whole of it: it checks the host, starts
+# the emulator, exports what the Scaleway clients need, runs Terraform here, and
+# waits for the conditions below against the emulator's own API. `feint down`
+# takes it back down.
+#
+# docs/environment.md is the field reference and the reason each line is here.
+version: 1
+
+cloud:
+  provider: scaleway
+
+emulator:
+  addr: 127.0.0.1:4599
+
+# Nothing here boots a machine: the stack asserts the control plane. Set this to
+# incus, incus-vm or incus-ovn — and `feint up` refuses if the host cannot
+# deliver it, rather than downgrading in silence.
+runtime:
+  mode: off
+
+iac:
+  engine: terraform
+  directory: .
+  vars:
+    # The stack declares a variable `endpoint` whose default is 127.0.0.1:4599.
+    # Left to that default against an emulator on another port, Terraform blocks
+    # to its own ceiling and the message blames the provider. Written once, here.
+    endpoint: ${feint.endpoint}
+
+# Asserted against the emulator, never against Terraform's state file: six
+# machines, two VPCs and the load balancer the stack puts in front of the web
+# tier.
+ready:
+  - http:/instance/v1/zones/fr-par-1/servers
+  - resource:instance/server:6
+  - resource:vpc/vpc:2
+  - resource:lb/lb:1

--- a/examples/stacks/scaleway/feint.yaml
+++ b/examples/stacks/scaleway/feint.yaml
@@ -19,6 +19,13 @@ emulator:
 # deliver it, rather than downgrading in silence.
 runtime:
   mode: off
+  # What this stack boots when the mode above is not `off`: every server here
+  # asks for `ubuntu_jammy`, which the catalogue maps to ubuntu:22.04. Declared
+  # rather than discovered — `feint up` checks the station holds it and names
+  # `feint images --only ubuntu/22.04` when it does not, before anything starts.
+  # Under `off` nothing boots, and the check says it is skipping for that reason.
+  images:
+    - ubuntu/22.04
 
 iac:
   engine: terraform

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -188,11 +188,22 @@ const (
 // An addition to one existing verb; nothing was removed, no exit code moved,
 // and a pipeline keyed on version 16 keeps working.
 //
+// Version 18 adds `feint up` and `feint down` (#189, #190): the environment
+// declaration had no verb reading it, and a declaration nothing reads is a
+// comment. `up` composes the lifecycle rather than replacing it — it renders
+// feint.yaml into the flags `start` already takes, so `status`, `logs` and
+// `stop` know the instance it brought up — and its own flags are the four a
+// declaration cannot carry: which file, a deliberate runtime override, the
+// deadline the ready conditions share, and whether to run the engine at all.
+// `down` is `stop` with the engine's destroy in front of it, because destroying
+// needs the API that is about to stop. Two verbs added; nothing was removed, no
+// exit code moved, and a pipeline keyed on version 17 keeps working.
+//
 // The surface itself is frozen in testdata/frozen/cli.json, compared by
 // TestTheFrozenSurfacesStillMatchTheirFixture, and a fixture regenerated
 // without bumping this constant fails TestASurfaceChangeDemandsItsVersionBump.
 // The procedure for a deliberate change is in RELEASING.md ("Frozen surfaces").
-const cliSurfaceVersion = 17
+const cliSurfaceVersion = 18
 
 // Run executes one command and returns the process exit code.
 func Run(args []string, stdout, stderr io.Writer) int {
@@ -231,6 +242,10 @@ func Run(args []string, stdout, stderr io.Writer) int {
 		return evidence(args[2:], stdout, stderr)
 	case "docs":
 		return docs(args[2:], stdout, stderr)
+	case "up":
+		return up(args[2:], stdout, stderr)
+	case "down":
+		return down(args[2:], stdout, stderr)
 	case "start":
 		return start(args[2:], stdout, stderr)
 	case "stop":
@@ -292,6 +307,24 @@ Usage:
                     loopback, and it disarms the anti-rebinding guard: this
                     emulator accepts every credential and, under --vm, starts
                     containers with your privileges. Read SECURITY.md first.
+
+  feint up         [--file feint.yaml] [--runtime off|incus|incus-vm|incus-ovn|auto]
+                    [--timeout 2m] [--no-iac]
+                    Read the environment declaration and bring it up: check the
+                    host can deliver the runtime it names and refuse before
+                    anything starts, start the emulator with the state and the
+                    contracts it names, export the pack's own client
+                    environment, run the engine in the directory it names, wait
+                    for each ready condition out loud, then print the
+                    endpoints. --runtime asks for less than the file does, on
+                    purpose and out loud; it never downgrades on its own.
+                    --no-iac brings the control plane up and stops there.
+                    docs/environment.md is the field reference.
+
+  feint down       [--file feint.yaml] [--keep-emulator]
+                    Destroy what the declaration built, then stop the emulator,
+                    saying what it discards. The engine runs first: destroying
+                    needs the API that is about to stop.
 
   feint start      [--addr :4599] [--state <file>] [--vm off|incus|incus-vm|incus-ovn|auto]
                     [--cleanup] [--contracts <dir>] [--log-level info|debug]

--- a/internal/cli/docs.go
+++ b/internal/cli/docs.go
@@ -283,6 +283,16 @@ func docs(args []string, stdout, stderr io.Writer) int {
 		return exitError
 	}
 
+	// The feint.yaml reference, rendered from the schema itself: a field added
+	// to internal/environment and a page that never learned about it is the
+	// drift this rail exists to catch, and the reason the sentence lives on the
+	// field rather than on the page.
+	environmentChanged, environmentErr := spliceEnvironment(filepath.Dir(*target))
+	if environmentErr != nil {
+		fmt.Fprintf(stderr, "feint: %v\n", environmentErr)
+		return exitError
+	}
+
 	installChanged, installErr := splicePrereq(*installDoc, goModPath)
 	if installErr != nil {
 		fmt.Fprintf(stderr, "feint: %v\n", installErr)
@@ -377,6 +387,10 @@ func docs(args []string, stdout, stderr io.Writer) int {
 			fmt.Fprintf(stderr, "feint: the route banner in the translated README is out of date; run `feint docs`\n")
 			return exitDrift
 		}
+		if environmentChanged {
+			fmt.Fprintf(stderr, "feint: the feint.yaml reference in %s is behind the schema; run `feint docs`\n", environmentDoc)
+			return exitDrift
+		}
 		if installChanged || commandsChanged || containerChanged {
 			fmt.Fprintf(stderr, "feint: %s is out of date; run `mise run docs:coverage`\n", *installDoc)
 			return exitDrift
@@ -452,6 +466,13 @@ func docs(args []string, stdout, stderr io.Writer) int {
 			return exitError
 		}
 		fmt.Fprintln(stdout, "the route banner in the translated README updated")
+	}
+	if environmentChanged {
+		if err := writeSplicedEnvironment(filepath.Dir(*target)); err != nil {
+			fmt.Fprintf(stderr, "feint: %v\n", err)
+			return exitError
+		}
+		fmt.Fprintf(stdout, "the feint.yaml reference in %s updated\n", environmentDoc)
 	}
 	if installChanged {
 		if err := writeSplicedPrereq(*installDoc, goModPath); err != nil {

--- a/internal/cli/docs_environment.go
+++ b/internal/cli/docs_environment.go
@@ -1,0 +1,124 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/stephrobert/feint/internal/environment"
+)
+
+// The field reference for feint.yaml, rendered from the schema itself (#189).
+//
+// Written by hand it would be a second description of the same table, and this
+// repository has measured twice what those cost: a page and a schema drift, the
+// page reads as the promise, and the difference surfaces as a field somebody
+// declared that nothing reads. So the sentence a field carries lives on the
+// field, `feint docs` renders it, and `feint docs --check` fails when the page
+// is behind — the same rail every other generated block rides.
+//
+// TestTheEnvironmentReferenceIsGeneratedFromTheSchema fails when a field is
+// added to the schema and the page is not regenerated.
+
+const (
+	environmentStartMarker = "<!-- environment:start -->"
+	environmentEndMarker   = "<!-- environment:end -->"
+	// environmentDoc is where the reference lives. Named here rather than
+	// taken as a flag: the page belongs to this repository, and a flag would
+	// invite a second copy of it somewhere else.
+	environmentDoc = "docs/environment.md"
+)
+
+// renderEnvironmentReference writes the two tables: what the file takes, and
+// what it deliberately does not carry. The second is not a courtesy — a reader
+// who writes `expose_to_network:` has a model of what this file is for, and a
+// page that only lists the accepted fields leaves that model intact.
+func renderEnvironmentReference() string {
+	var b strings.Builder
+	b.WriteString(docsGenerated + "\n\n")
+	b.WriteString("| field | takes | default | read by | what it says |\n")
+	b.WriteString("|---|---|---|---|---|\n")
+	for _, fd := range environment.Fields() {
+		read := "nothing yet"
+		if len(fd.ReadBy) > 0 {
+			verbs := make([]string, 0, len(fd.ReadBy))
+			for _, verb := range fd.ReadBy {
+				verbs = append(verbs, "`feint "+verb+"`")
+			}
+			read = strings.Join(verbs, ", ")
+		}
+		def := "—"
+		if fd.Default != "" {
+			def = "`" + fd.Default + "`"
+		}
+		fmt.Fprintf(&b, "| `%s` | %s | %s | %s | %s |\n",
+			fd.Path, fd.Takes, def, read, cell(fd.Doc))
+	}
+
+	b.WriteString("\n### What this file deliberately does not carry\n\n")
+	b.WriteString("| field | why not |\n")
+	b.WriteString("|---|---|\n")
+	for _, fd := range environment.NotCarried() {
+		fmt.Fprintf(&b, "| `%s` | %s |\n", fd.Path, cell(fd.Doc))
+	}
+
+	b.WriteString("\n### The ready conditions\n\n")
+	for _, form := range environment.ConditionKinds {
+		fmt.Fprintf(&b, "- `%s`\n", form)
+	}
+	b.WriteString("\nA condition that is not one of those forms is refused at load, with the list.\n")
+	return b.String()
+}
+
+// cell folds a sentence onto one line of a Markdown table. A pipe inside it
+// would end the cell, so it is escaped rather than dropped: a sentence that
+// loses half of itself to the renderer reads as a sentence somebody wrote badly.
+func cell(doc string) string {
+	one := strings.Join(strings.Fields(doc), " ")
+	return strings.ReplaceAll(one, "|", `\|`)
+}
+
+// spliceEnvironment answers whether the reference page is behind the schema.
+// Absent page: no complaint, on the same terms as every other optional
+// document — a user who installed the binary has no docs/ directory.
+func spliceEnvironment(root string) (bool, error) {
+	path := filepath.Join(root, environmentDoc)
+	current, err := os.ReadFile(path) //nolint:gosec // a path this repository owns
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if !strings.Contains(string(current), environmentStartMarker) {
+		return false, nil
+	}
+	updated, err := spliceSection(string(current), environmentStartMarker, environmentEndMarker,
+		renderEnvironmentReference())
+	if err != nil {
+		return false, err
+	}
+	return updated != string(current), nil
+}
+
+// writeSplicedEnvironment writes it.
+func writeSplicedEnvironment(root string) error {
+	path := filepath.Join(root, environmentDoc)
+	current, err := os.ReadFile(path) //nolint:gosec // a path this repository owns
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(string(current), environmentStartMarker) {
+		return nil
+	}
+	updated, err := spliceSection(string(current), environmentStartMarker, environmentEndMarker,
+		renderEnvironmentReference())
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(updated), 0o600)
+}

--- a/internal/cli/docs_status.go
+++ b/internal/cli/docs_status.go
@@ -61,6 +61,10 @@ var clientOf = map[string]string{
 	"network": "",
 	"ssh":     "",
 	"crash":   "",
+	// `feint up` and `feint down` on a fixture declaration (#190). No client at
+	// all: what it drives is this binary's own lifecycle, so crediting a
+	// provider with it would credit a client nobody ran.
+	"up": "",
 }
 
 // providerRow is what the table prints for one provider, beyond the clients.

--- a/internal/cli/testdata/frozen/cli.json
+++ b/internal/cli/testdata/frozen/cli.json
@@ -2779,6 +2779,205 @@
           ]
         }
       }
+    },
+    {
+      "schema_version": 18,
+      "content": {
+        "exit_codes": {
+          "drift": 2,
+          "error": 1,
+          "ok": 0
+        },
+        "verbs": {
+          "catalog": [
+            "--format"
+          ],
+          "clean": [
+            "--check",
+            "--doorstep",
+            "--force",
+            "--format",
+            "--vm"
+          ],
+          "corpus": [
+            "--accepted",
+            "--against-cloud",
+            "--bind",
+            "--check",
+            "--credential",
+            "--dir",
+            "--dry-run",
+            "--endpoint",
+            "--file",
+            "--format",
+            "--mark-stale",
+            "--timeout"
+          ],
+          "coverage": [
+            "--artefact",
+            "--axis",
+            "--baseline",
+            "--contract",
+            "--evidence",
+            "--fail-on-unknown",
+            "--format",
+            "--gaps",
+            "--observed",
+            "--products",
+            "--provider",
+            "--sdk",
+            "--write-baseline"
+          ],
+          "docs": [
+            "--check",
+            "--client-pins",
+            "--confidence",
+            "--contracts",
+            "--coverage",
+            "--file",
+            "--install",
+            "--limits",
+            "--proved",
+            "--routes",
+            "--screenshots",
+            "--ui-manifest",
+            "--workflow"
+          ],
+          "doctor": [
+            "--addr",
+            "--vm"
+          ],
+          "down": [
+            "--file",
+            "--keep-emulator"
+          ],
+          "env": [
+            "--client",
+            "--endpoint",
+            "--shell",
+            "--unset"
+          ],
+          "evidence": [
+            "--allow-narrowing",
+            "--contracts",
+            "--endpoint",
+            "--join",
+            "--out",
+            "--reshape",
+            "--shapes",
+            "--suites"
+          ],
+          "images": [
+            "--check",
+            "--only",
+            "--vm"
+          ],
+          "logs": [
+            "--addr",
+            "-f",
+            "-n"
+          ],
+          "probe": [
+            "--contracts",
+            "--endpoint",
+            "--provider"
+          ],
+          "proxy": [
+            "--addr",
+            "--expose-to-network",
+            "--forward",
+            "--intercept",
+            "--max-body",
+            "--provider",
+            "--queue",
+            "--record",
+            "--upstream"
+          ],
+          "replay": [
+            "--endpoint",
+            "--format",
+            "--refusals-only",
+            "--timeout"
+          ],
+          "restart": [
+            "--addr",
+            "--timeout"
+          ],
+          "serve": [
+            "--addr",
+            "--cleanup",
+            "--contracts",
+            "--coverage",
+            "--expose-to-network",
+            "--log-level",
+            "--shapes",
+            "--state",
+            "--vm"
+          ],
+          "shapes": [
+            "--check",
+            "--dir",
+            "--dry-run",
+            "--profile",
+            "--provider",
+            "--record"
+          ],
+          "snapshot list": [
+            "--format"
+          ],
+          "snapshot load": [
+            "--addr"
+          ],
+          "snapshot save": [
+            "--addr",
+            "--force"
+          ],
+          "start": [
+            "--addr",
+            "--cleanup",
+            "--contracts",
+            "--detach",
+            "--foreground",
+            "--log-level",
+            "--state",
+            "--timeout",
+            "--vm"
+          ],
+          "status": [
+            "--addr",
+            "--coverage",
+            "--format"
+          ],
+          "stop": [
+            "--addr",
+            "--timeout"
+          ],
+          "transcript": [
+            "--against",
+            "--contract",
+            "--format",
+            "--sanitise",
+            "--shape"
+          ],
+          "ui": [
+            "--addr",
+            "--print"
+          ],
+          "up": [
+            "--file",
+            "--no-iac",
+            "--runtime",
+            "--timeout"
+          ],
+          "version": [
+            "--check"
+          ],
+          "wait": [
+            "--addr",
+            "--timeout"
+          ]
+        }
+      }
     }
   ]
 }

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -1,0 +1,554 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/machine"
+	"github.com/stephrobert/feint/internal/environment"
+)
+
+// `feint up` and `feint down`: the verbs that read feint.yaml (#190).
+//
+// A declaration nothing reads is a comment, so this is the reading. What it is
+// not is a second lifecycle: `start`, `stop`, `status` and `wait` exist and are
+// a frozen surface, and this composes them rather than growing its own flags and
+// its own bugs. Every emulator these verbs bring up is one `feint stop`,
+// `feint logs` and `feint status` know about, because it *is* one of theirs.
+//
+// The order is #190's, and the first step is the one that matters most:
+//
+//  1. check what the host can deliver, and refuse before anything is started;
+//  2. start the control plane with the contracts and the state the file names;
+//  3. configure the client from the pack's own Env — `feint env` already
+//     answers it, so nothing new is invented here;
+//  4. run the IaC engine the file names, in the directory it names;
+//  5. wait for the ready conditions, each with a deadline and each said out
+//     loud while it waits;
+//  6. print the endpoints, and what proved them.
+//
+// Four traps this replaces, each measured by hand on 2026-08-24 against the
+// example stacks, each of them a parameter somebody had to reconstitute by
+// reading a script:
+//
+//   - `examples/stacks/outscale` carries a local module, so copying `*.tf`
+//     alone does not run. The engine runs in the declared directory, in place.
+//   - Scaleway and Outscale declare an `endpoint` variable whose default is
+//     127.0.0.1:4599. Pointed at a port nothing listens on, Terraform blocks to
+//     its own ceiling and blames the provider. `iac.vars` carries it, with the
+//     one substitution this file has.
+//   - Exoscale declares no such variable and takes its endpoint from
+//     EXOSCALE_API_ENDPOINT, path included. That value comes from the pack's own
+//     Env, never from a field, so no reader has to learn which provider wants
+//     its path inside the value.
+//   - FEINT_EXOSCALE_ALLOW_TERRAFORM is read inside the emulator's process, so
+//     exporting it afterwards does nothing. `emulator.env` is set before the
+//     spawn.
+
+// upTimeout bounds the whole of step 5. Every condition is also announced
+// before it is waited on, because a wait with no output is indistinguishable
+// from a broken emulator.
+const defaultReadyTimeout = 2 * time.Minute
+
+func up(args []string, stdout, stderr io.Writer) int {
+	fs := newFlagSet("up")
+	file := fs.String("file", environment.DefaultFile, "the environment declaration to read")
+	runtimeMode := fs.String("runtime", "", "override the declared runtime mode, deliberately and out loud")
+	timeout := fs.Duration("timeout", defaultReadyTimeout, "how long the ready conditions have, together")
+	skipIaC := fs.Bool("no-iac", false, "bring the control plane up and do not run the engine")
+	if err := fs.Parse(args); err != nil {
+		return exitError
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintf(stderr, "feint: unexpected argument %q; up takes flags only\n", fs.Arg(0))
+		return exitError
+	}
+
+	decl, code := readDeclaration(*file, *runtimeMode, stdout, stderr)
+	if decl == nil {
+		return code
+	}
+
+	// Step 1. Everything that can be refused is refused here, before a process
+	// is spawned or a container is started. A run that dies four minutes in on
+	// a missing binary has spent those minutes teaching nothing.
+	if err := preflight(decl, *skipIaC, stdout); err != nil {
+		fmt.Fprintf(stderr, "feint: %v\n", err)
+		return exitError
+	}
+
+	// The emulator's own knobs, set before the spawn because the child inherits
+	// this process's environment and some of them are read server-side.
+	for name, value := range decl.Emulator.Env {
+		if err := os.Setenv(name, value); err != nil {
+			fmt.Fprintf(stderr, "feint: %v\n", err)
+			return exitError
+		}
+		fmt.Fprintf(stdout, "  %s=%s (the emulator's own environment)\n", name, value)
+	}
+
+	// Step 2: the existing verb, with the flags the file names. Not a second
+	// way to run an emulator — the same one, given a written-down command line.
+	if code := start(startArgs(decl), stdout, stderr); code != exitOK {
+		return code
+	}
+
+	if decl.Snapshot.Load != "" {
+		fmt.Fprintf(stdout, "- loading the snapshot %q\n", decl.Snapshot.Load)
+		if code := snapshotLoad([]string{decl.Snapshot.Load, "--addr", decl.Emulator.Addr}, stdout, stderr); code != exitOK {
+			return code
+		}
+	}
+
+	// Steps 3 and 4.
+	if decl.IaC.Engine != "" && !*skipIaC {
+		if err := runEngine(decl, "apply", stdout, stderr); err != nil {
+			fmt.Fprintf(stderr, "feint: %v\n", err)
+			return exitError
+		}
+	}
+
+	// Step 5.
+	if err := waitReady(decl, *timeout, stdout); err != nil {
+		fmt.Fprintf(stderr, "feint: %v\n", err)
+		return exitError
+	}
+
+	// Step 6.
+	printEndpoints(decl, stdout)
+	return exitOK
+}
+
+func down(args []string, stdout, stderr io.Writer) int {
+	fs := newFlagSet("down")
+	file := fs.String("file", environment.DefaultFile, "the environment declaration to read")
+	keep := fs.Bool("keep-emulator", false, "destroy the infrastructure and leave the emulator running")
+	if err := fs.Parse(args); err != nil {
+		return exitError
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintf(stderr, "feint: unexpected argument %q; down takes flags only\n", fs.Arg(0))
+		return exitError
+	}
+
+	decl, code := readDeclaration(*file, "", stdout, stderr)
+	if decl == nil {
+		return code
+	}
+
+	// The engine first: destroying the infrastructure needs the API that is
+	// about to be stopped. A `down` that stopped the emulator first would leave
+	// a state file describing resources nothing can reach.
+	failed := exitOK
+	if decl.IaC.Engine != "" {
+		if err := runEngine(decl, "destroy", stdout, stderr); err != nil {
+			// Reported and carried on: leaving the emulator running because the
+			// engine failed would leave the operator with both problems.
+			fmt.Fprintf(stderr, "feint: %v\n", err)
+			failed = exitError
+		}
+	}
+	if *keep {
+		return failed
+	}
+	// `stop` says what it discards when no state file was recorded (#182), and
+	// this inherits that rather than reimplementing it.
+	if code := stop([]string{"--addr", decl.Emulator.Addr}, stdout, stderr); code != exitOK {
+		return code
+	}
+	return failed
+}
+
+// readDeclaration loads the file and applies the one deliberate override.
+//
+// A nil file means the caller returns the code beside it: the two-value return
+// keeps the refusal and its exit code in one place, where a bool would have
+// each caller invent one.
+func readDeclaration(path, override string, stdout, stderr io.Writer) (*environment.File, int) {
+	decl, err := environment.Load(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Fprintf(stderr, "feint: no %s here. It is the declaration of one environment — "+
+				"which provider, which runtime, which engine — and `docs/environment.md` "+
+				"has the shortest one that works.\n", path)
+			return nil, exitError
+		}
+		fmt.Fprintf(stderr, "feint: %v\n", err)
+		return nil, exitError
+	}
+	fmt.Fprintf(stdout, "%s: %s, runtime %s", path, describeCloud(decl), decl.Runtime.Mode)
+	if decl.IaC.Engine != "" {
+		fmt.Fprintf(stdout, ", %s in %s", decl.IaC.Engine, decl.IaC.Directory)
+	}
+	fmt.Fprintln(stdout)
+
+	// A field the schema knows and no verb reads yet is said out loud. Accepting
+	// it in silence and applying half the file is the exact lie this project
+	// exists to avoid, and a warning is the honest form of "declared, not read".
+	for _, path := range decl.Unread() {
+		fmt.Fprintf(stderr, "warning: `%s` is declared and no verb reads it yet\n", path)
+	}
+
+	if override != "" {
+		if override != decl.Runtime.Mode {
+			// Out loud, and only ever downward from what the file asked: this is
+			// the deliberate difference #192 asks to be declared rather than
+			// discovered. A silent downgrade is what `up` refuses.
+			fmt.Fprintf(stdout, "  runtime %s, overridden to %s by --runtime\n", decl.Runtime.Mode, override)
+		}
+		decl.Runtime.Mode = override
+	}
+	return decl, exitOK
+}
+
+func describeCloud(decl *environment.File) string {
+	if decl.Cloud.Provider == "" {
+		return "no provider named"
+	}
+	return decl.Cloud.Provider
+}
+
+// preflight is step 1, and the only step allowed to be slow is the one that
+// asks the host about its runtime.
+//
+// Everything here answers the same question — can this host deliver what the
+// file declares — and every answer names both what is missing and how to get
+// it. A guard with no way past it gets worked around by copying the emulator,
+// which teaches nobody anything; that is why FEINT_BOOT_IMAGES exists and it is
+// why each refusal below carries its command.
+func preflight(decl *environment.File, skipIaC bool, stdout io.Writer) error {
+	if decl.Cloud.Provider != "" {
+		srv, _, err := newServer(nil)
+		if err != nil {
+			return err
+		}
+		names := make([]string, 0, len(srv.Packs()))
+		found := false
+		for _, p := range srv.Packs() {
+			names = append(names, p.Name())
+			if p.Name() == decl.Cloud.Provider {
+				found = true
+			}
+		}
+		sort.Strings(names)
+		if !found {
+			return fmt.Errorf("`cloud.provider: %s`, and this binary serves %s",
+				decl.Cloud.Provider, strings.Join(names, ", "))
+		}
+	}
+
+	if decl.IaC.Engine != "" && !skipIaC {
+		dir := decl.Resolve(decl.IaC.Directory)
+		info, err := os.Stat(dir)
+		if err != nil || !info.IsDir() {
+			return fmt.Errorf("`iac.directory: %s` resolves to %s, which is not a directory",
+				decl.IaC.Directory, dir)
+		}
+		if _, err := exec.LookPath(decl.IaC.Engine); err != nil {
+			return fmt.Errorf("`iac.engine: %s` and no %s on PATH; install it, or name the other one "+
+				"(%s)", decl.IaC.Engine, decl.IaC.Engine, strings.Join(environment.Engines, ", "))
+		}
+	}
+
+	// The runtime, asked of the host rather than deduced from the mode's name.
+	// This is the same check `serve` makes at startup (#181) — a mode the host
+	// cannot deliver is refused naming the missing half — moved ahead of
+	// everything so that nothing has started when it fires.
+	driver, err := machineDriver(decl.Runtime.Mode, stdout)
+	if err != nil {
+		return err
+	}
+	if len(decl.Runtime.Images) == 0 {
+		return nil
+	}
+	if _, isNoop := driver.(machine.Noop); isNoop {
+		fmt.Fprintf(stdout, "  runtime.images: not checked, nothing boots under `%s`\n", decl.Runtime.Mode)
+		return nil
+	}
+	return checkDeclaredImages(decl, driver, stdout)
+}
+
+// checkDeclaredImages holds the declaration to what the station actually has.
+//
+// It never builds: a build launches a container and takes minutes, which is a
+// side effect this project asks for rather than performs on the way past. So it
+// names what is missing and the command that makes it, which is the difference
+// between a refusal and a dead end.
+func checkDeclaredImages(decl *environment.File, driver machine.Driver, stdout io.Writer) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	inventory, err := machine.ImageInventory(ctx, driver)
+	if err != nil {
+		return fmt.Errorf("reading the machine images: %w", err)
+	}
+	held := map[string]bool{}
+	known := make([]string, 0, len(inventory))
+	for _, status := range inventory {
+		known = append(known, status.Spec.Name)
+		if status.Present() {
+			held[status.Spec.Name] = true
+		}
+	}
+	var missing, unknown []string
+	for _, name := range decl.Runtime.Images {
+		switch {
+		case held[name]:
+		case contains(known, name):
+			missing = append(missing, name)
+		default:
+			unknown = append(unknown, name)
+		}
+	}
+	if len(unknown) > 0 {
+		return fmt.Errorf("`runtime.images` names %s, and this binary builds %s",
+			strings.Join(unknown, ", "), strings.Join(known, ", "))
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("`runtime.images` needs %s, which this station does not hold.\n"+
+			"  Build it: feint images --only %s", strings.Join(missing, ", "), missing[0])
+	}
+	fmt.Fprintf(stdout, "  runtime.images: %s present\n", strings.Join(decl.Runtime.Images, ", "))
+	return nil
+}
+
+func contains(list []string, want string) bool {
+	for _, item := range list {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}
+
+// startArgs renders the declaration into the command line `feint start` takes.
+//
+// One direction only, and that is the point: the flags stay the CLI's, the file
+// only says which values they carry. A field here that named no flag would be a
+// second source for something the binary already decides.
+func startArgs(decl *environment.File) []string {
+	args := []string{
+		"--addr", decl.Emulator.Addr,
+		"--vm", decl.Runtime.Mode,
+		"--log-level", decl.Emulator.LogLevel,
+	}
+	if decl.Emulator.State != "" {
+		args = append(args, "--state", decl.Resolve(decl.Emulator.State))
+	}
+	if decl.Emulator.Contracts != "" {
+		args = append(args, "--contracts", decl.Resolve(decl.Emulator.Contracts))
+	}
+	if decl.Emulator.Cleanup {
+		args = append(args, "--cleanup")
+	}
+	return args
+}
+
+// runEngine is steps 3 and 4: the client's environment, then the engine.
+//
+// The engine's own output goes straight through, never a summary of it. When
+// `terraform apply` fails, its error is what the developer needs, and a wrapper
+// that reformats it has thrown away the only useful thing in the run.
+func runEngine(decl *environment.File, action string, stdout, stderr io.Writer) error {
+	dir := decl.Resolve(decl.IaC.Directory)
+	env, err := engineEnvironment(decl)
+	if err != nil {
+		return err
+	}
+
+	steps := [][]string{{"init", "-input=false"}}
+	switch action {
+	case "apply":
+		steps = append(steps, []string{"apply", "-input=false", "-auto-approve"})
+	case "destroy":
+		steps = append(steps, []string{"destroy", "-input=false", "-auto-approve"})
+	}
+	for _, step := range steps {
+		fmt.Fprintf(stdout, "- %s %s in %s\n", decl.IaC.Engine, step[0], dir)
+		cmd := exec.Command(decl.IaC.Engine, step...) //nolint:gosec // the engine is one of two names the schema accepts
+		cmd.Dir = dir
+		cmd.Env = env
+		cmd.Stdout = stdout
+		cmd.Stderr = stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("%s %s: %w", decl.IaC.Engine, step[0], err)
+		}
+	}
+	return nil
+}
+
+// engineEnvironment is step 3: what a real client of this provider needs, taken
+// from the pack itself.
+//
+// Nothing here names a provider. `feint env` prints these same variables from
+// Pack.Env, and this reads the same method rather than a copy of its output —
+// which is what keeps the endpoint form (Exoscale carries its /v2 path inside
+// the value; Scaleway does not) a fact with one owner.
+func engineEnvironment(decl *environment.File) ([]string, error) {
+	out := os.Environ()
+	// TF_IN_AUTOMATION and TF_INPUT are what tell the engine no human is
+	// watching. Without them a missing value opens a prompt on a stdin that is
+	// not a terminal, and the run hangs rather than failing.
+	out = append(out, "TF_IN_AUTOMATION=1", "TF_INPUT=0")
+
+	if decl.Cloud.Provider != "" {
+		srv, _, err := newServer(nil)
+		if err != nil {
+			return nil, err
+		}
+		for _, p := range srv.Packs() {
+			if p.Name() != decl.Cloud.Provider {
+				continue
+			}
+			env := p.Env(decl.Endpoint())
+			names := make([]string, 0, len(env.Vars))
+			for name := range env.Vars {
+				names = append(names, name)
+			}
+			sort.Strings(names)
+			for _, name := range names {
+				out = append(out, name+"="+env.Vars[name])
+			}
+		}
+	}
+	// TF_VAR_ rather than -var, and the difference is measured: an undeclared
+	// TF_VAR_ is ignored, where `-var endpoint=…` fails outright on a stack that
+	// declares no such variable. Exoscale's is exactly that stack, and one
+	// mechanism has to serve all three.
+	for name, value := range decl.EngineVars() {
+		out = append(out, "TF_VAR_"+name+"="+value)
+	}
+	return out, nil
+}
+
+// waitReady is step 5. Every condition is announced before it is waited on and
+// named when its deadline passes: a hang with no output is indistinguishable
+// from a broken emulator, and this repository has already paid for that.
+func waitReady(decl *environment.File, timeout time.Duration, stdout io.Writer) error {
+	conditions := decl.Conditions()
+	if len(conditions) == 0 {
+		return nil
+	}
+	deadline := time.Now().Add(timeout)
+	for _, condition := range conditions {
+		fmt.Fprintf(stdout, "- waiting: %s\n", condition.Describe())
+		if err := awaitCondition(decl, condition, deadline); err != nil {
+			return err
+		}
+		fmt.Fprintf(stdout, "  ok: %s\n", condition.Raw)
+	}
+	return nil
+}
+
+func awaitCondition(decl *environment.File, condition environment.Condition, deadline time.Time) error {
+	var last string
+	for {
+		met, why := conditionMet(decl, condition)
+		if met {
+			return nil
+		}
+		last = why
+		if time.Now().After(deadline) {
+			return fmt.Errorf("the ready condition %q was never met: %s (waiting for %s)",
+				condition.Raw, last, condition.Describe())
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+}
+
+// conditionMet answers one condition, and answers *why not* when it is not met.
+//
+// Three outcomes, never two: met, not met with a reason, and unreadable with a
+// reason. A reader that mapped a failed call to "not met" would report a broken
+// emulator as a resource that has not appeared yet, which is the family of
+// defect measurement-integrity names first.
+func conditionMet(decl *environment.File, condition environment.Condition) (bool, string) {
+	switch condition.Kind {
+	case environment.HTTPCondition:
+		client := &http.Client{Timeout: 3 * time.Second}
+		res, err := client.Get(decl.Endpoint() + condition.Path)
+		if err != nil {
+			return false, err.Error()
+		}
+		defer func() { _ = res.Body.Close() }()
+		if res.StatusCode >= 400 {
+			return false, fmt.Sprintf("the emulator answered %d", res.StatusCode)
+		}
+		return true, ""
+	case environment.TCPCondition:
+		conn, err := net.DialTimeout("tcp", condition.Address, 3*time.Second)
+		if err != nil {
+			return false, err.Error()
+		}
+		_ = conn.Close()
+		return true, ""
+	case environment.ResourceCondition:
+		held, err := countKindInInventory(decl.Endpoint(), condition.Resource)
+		if err != nil {
+			return false, err.Error()
+		}
+		if held < condition.Count {
+			return false, fmt.Sprintf("the emulator holds %d", held)
+		}
+		return true, ""
+	default:
+		return false, "no reader for this condition"
+	}
+}
+
+// countKindInInventory reads the emulator's own inventory, which is
+// provider-neutral by construction: the store holds resources whose kind is a
+// value, so this counts a pack nobody has written yet.
+func countKindInInventory(endpoint, kind string) (int, error) {
+	client := &http.Client{Timeout: 5 * time.Second}
+	res, err := client.Get(endpoint + "/_feint/resources")
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("the inventory answered %d", res.StatusCode)
+	}
+	// The shape is the emulator's own, and it is decoded strictly: a body this
+	// does not understand is an error rather than a zero, because a silent zero
+	// reads exactly like an emulator nobody has used yet.
+	var body struct {
+		Resources []struct {
+			Kind string `json:"kind"`
+		} `json:"resources"`
+	}
+	decoder := json.NewDecoder(io.LimitReader(res.Body, maxStateBody))
+	if err := decoder.Decode(&body); err != nil {
+		return 0, fmt.Errorf("reading the inventory: %w", err)
+	}
+	count := 0
+	for _, r := range body.Resources {
+		if r.Kind == kind {
+			count++
+		}
+	}
+	return count, nil
+}
+
+// printEndpoints is step 6: where the environment is, and what proved it.
+func printEndpoints(decl *environment.File, stdout io.Writer) {
+	fmt.Fprintf(stdout, "\nup: %s\n", decl.Endpoint())
+	if decl.Cloud.Provider != "" {
+		fmt.Fprintf(stdout, "  clients:  eval \"$(feint env %s)\"\n", decl.Cloud.Provider)
+	}
+	fmt.Fprintf(stdout, "  page:     %s/_feint/ui\n", decl.Endpoint())
+	fmt.Fprintf(stdout, "  logs:     feint logs --addr %s\n", decl.Emulator.Addr)
+	fmt.Fprintf(stdout, "  state:    feint status --addr %s\n", decl.Emulator.Addr)
+	if len(decl.Ready) > 0 {
+		fmt.Fprintf(stdout, "  proved:   %s\n", strings.Join(decl.Ready, ", "))
+	}
+	fmt.Fprintf(stdout, "  down:     feint down\n")
+}

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -117,14 +117,26 @@ func up(args []string, stdout, stderr io.Writer) int {
 		}
 	}
 
-	// Step 5.
-	if err := waitReady(decl, *timeout, stdout); err != nil {
-		fmt.Fprintf(stderr, "feint: %v\n", err)
-		return exitError
+	// Step 5. Skipped, out loud, when the engine that builds what the conditions
+	// describe was skipped: waiting for resources nobody asked to create would
+	// fail every time, and a flag whose only outcome is a failure is a flag
+	// nobody uses. Said rather than silent — that is the whole difference
+	// between a skip and a lie.
+	proved := true
+	switch {
+	case *skipIaC && decl.IaC.Engine != "" && len(decl.Ready) > 0:
+		proved = false
+		fmt.Fprintf(stdout, "- not waiting: --no-iac skipped %s, and the ready conditions describe what it builds (%s)\n",
+			decl.IaC.Engine, strings.Join(decl.Ready, ", "))
+	default:
+		if err := waitReady(decl, *timeout, stdout); err != nil {
+			fmt.Fprintf(stderr, "feint: %v\n", err)
+			return exitError
+		}
 	}
 
 	// Step 6.
-	printEndpoints(decl, stdout)
+	printEndpoints(decl, proved, stdout)
 	return exitOK
 }
 
@@ -263,9 +275,14 @@ func preflight(decl *environment.File, skipIaC bool, stdout io.Writer) error {
 	// This is the same check `serve` makes at startup (#181) — a mode the host
 	// cannot deliver is refused naming the missing half — moved ahead of
 	// everything so that nothing has started when it fires.
-	driver, err := machineDriver(decl.Runtime.Mode, stdout)
+	driver, err := resolveRuntime(decl.Runtime.Mode, stdout)
 	if err != nil {
-		return err
+		// A guard with no way past it gets worked around by copying the
+		// emulator, which teaches nobody anything — the reasoning that named
+		// FEINT_BOOT_IMAGES rather than hiding it. So the refusal carries the
+		// three doors: read the whole diagnosis, run this environment with less
+		// on purpose, or change what it asks for.
+		return fmt.Errorf("%w\n\n%s", err, waysPastTheRuntimeRefusal(decl))
 	}
 	if len(decl.Runtime.Images) == 0 {
 		return nil
@@ -277,12 +294,51 @@ func preflight(decl *environment.File, skipIaC bool, stdout io.Writer) error {
 	return checkDeclaredImages(decl, driver, stdout)
 }
 
+// resolveRuntime is machineDriver, behind a name a test can replace.
+//
+// The seam exists because the refusal it guards is host-dependent in the one
+// direction that matters: on a station with OVN wired, no mode is refused, and
+// a test asserting the refusal there would measure the station rather than the
+// verb. What the refusal *says* is machineDriver's and is proved next door
+// (machine.TestVerifyNarrowsWhatTheHostCannotDeliver); what this seam lets a
+// test assert is that `up` asks before it starts anything, and that the answer
+// carries a way through.
+var resolveRuntime = machineDriver
+
+// waysPastTheRuntimeRefusal is the door beside the wall.
+//
+// Every line of it is a command or an edit the reader can make now. A refusal
+// that only states the problem is one people route around by copying the
+// emulator and deleting the check, and this repository has written that
+// reasoning down once already.
+func waysPastTheRuntimeRefusal(decl *environment.File) string {
+	where := decl.Path
+	if where == "" {
+		where = environment.DefaultFile
+	}
+	return fmt.Sprintf(`Nothing was started. Three ways on, in the order they cost:
+  feint doctor --vm %s        the whole diagnosis, including what to install
+  feint up --runtime off              run this environment without machines, and say so
+  %s                          change runtime.mode to what this host delivers (%s)`,
+		decl.Runtime.Mode, where, strings.Join(environment.RuntimeModes, ", "))
+}
+
 // checkDeclaredImages holds the declaration to what the station actually has.
 //
 // It never builds: a build launches a container and takes minutes, which is a
 // side effect this project asks for rather than performs on the way past. So it
 // names what is missing and the command that makes it, which is the difference
 // between a refusal and a dead end.
+//
+// Three outcomes, never two, and the third is the one a two-way reader would get
+// wrong. The warm-up set (`feint images`) is enumerated; the boot path also
+// *derives* an image on demand for a family and version outside it (#465). So a
+// name the warm-up set does not carry is not an error — it is a first boot that
+// will cost minutes — and saying that is worth more than refusing something the
+// runtime can do.
+//
+// TestADeclaredImageTheStationLacksIsRefusedWithTheCommandThatBuildsIt fails
+// without the refusal, and its sibling holds the accepting half.
 func checkDeclaredImages(decl *environment.File, driver machine.Driver, stdout io.Writer) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -290,33 +346,47 @@ func checkDeclaredImages(decl *environment.File, driver machine.Driver, stdout i
 	if err != nil {
 		return fmt.Errorf("reading the machine images: %w", err)
 	}
+	derived, err := machine.DerivedImages(ctx, driver)
+	if err != nil {
+		return fmt.Errorf("reading the images this station derived: %w", err)
+	}
+
 	held := map[string]bool{}
-	known := make([]string, 0, len(inventory))
+	buildable := make([]string, 0, len(inventory))
 	for _, status := range inventory {
-		known = append(known, status.Spec.Name)
+		buildable = append(buildable, status.Spec.Name)
 		if status.Present() {
 			held[status.Spec.Name] = true
 		}
 	}
-	var missing, unknown []string
+	for _, status := range derived {
+		held[status.Spec.Name] = true
+	}
+
+	var missing, onDemand []string
 	for _, name := range decl.Runtime.Images {
 		switch {
 		case held[name]:
-		case contains(known, name):
+		case contains(buildable, name):
 			missing = append(missing, name)
 		default:
-			unknown = append(unknown, name)
+			onDemand = append(onDemand, name)
 		}
-	}
-	if len(unknown) > 0 {
-		return fmt.Errorf("`runtime.images` names %s, and this binary builds %s",
-			strings.Join(unknown, ", "), strings.Join(known, ", "))
 	}
 	if len(missing) > 0 {
 		return fmt.Errorf("`runtime.images` needs %s, which this station does not hold.\n"+
-			"  Build it: feint images --only %s", strings.Join(missing, ", "), missing[0])
+			"  Build it:  feint images --only %s\n"+
+			"  Or drop the line, and the first boot that needs it derives one, which costs minutes",
+			strings.Join(missing, ", "), missing[0])
 	}
-	fmt.Fprintf(stdout, "  runtime.images: %s present\n", strings.Join(decl.Runtime.Images, ", "))
+	for _, name := range onDemand {
+		fmt.Fprintf(stdout, "  runtime.images: %s is outside the warm-up set; "+
+			"the first boot that needs it derives one, which costs minutes\n", name)
+	}
+	if held := len(decl.Runtime.Images) - len(onDemand); held > 0 {
+		fmt.Fprintf(stdout, "  runtime.images: %d of %d present on this station\n",
+			held, len(decl.Runtime.Images))
+	}
 	return nil
 }
 
@@ -539,7 +609,7 @@ func countKindInInventory(endpoint, kind string) (int, error) {
 }
 
 // printEndpoints is step 6: where the environment is, and what proved it.
-func printEndpoints(decl *environment.File, stdout io.Writer) {
+func printEndpoints(decl *environment.File, proved bool, stdout io.Writer) {
 	fmt.Fprintf(stdout, "\nup: %s\n", decl.Endpoint())
 	if decl.Cloud.Provider != "" {
 		fmt.Fprintf(stdout, "  clients:  eval \"$(feint env %s)\"\n", decl.Cloud.Provider)
@@ -547,8 +617,15 @@ func printEndpoints(decl *environment.File, stdout io.Writer) {
 	fmt.Fprintf(stdout, "  page:     %s/_feint/ui\n", decl.Endpoint())
 	fmt.Fprintf(stdout, "  logs:     feint logs --addr %s\n", decl.Emulator.Addr)
 	fmt.Fprintf(stdout, "  state:    feint status --addr %s\n", decl.Emulator.Addr)
-	if len(decl.Ready) > 0 {
+	// What proved it, and never what would have. A summary that lists a
+	// condition nothing evaluated is the shape of every green verdict this
+	// project exists to distrust.
+	switch {
+	case len(decl.Ready) == 0:
+	case proved:
 		fmt.Fprintf(stdout, "  proved:   %s\n", strings.Join(decl.Ready, ", "))
+	default:
+		fmt.Fprintf(stdout, "  proved:   nothing — the ready conditions were skipped with the engine\n")
 	}
 	fmt.Fprintf(stdout, "  down:     feint down\n")
 }

--- a/internal/cli/up_test.go
+++ b/internal/cli/up_test.go
@@ -1,0 +1,137 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/environment"
+)
+
+// What `feint up` refuses, driven through the dispatcher, so that what is
+// measured is the binary's behaviour rather than a helper's.
+//
+// The refusal that has to arrive *before anything starts* lives in
+// up_wait_test.go instead, in the package: proving it needs to see that no
+// emulator was spawned, and the way to see that is the instance directory.
+
+// A declaration this binary cannot read is refused at load, and the message
+// says where the field reference is. A refusal with no way forward gets worked
+// around by copying the emulator.
+func TestUpRefusesAMistypedDeclarationNamingTheField(t *testing.T) {
+	dir := t.TempDir()
+	// The mistake a reader actually makes: the CLI flag is --log-level and the
+	// field is log_level. Refused by name, with the list of what the block takes.
+	write(t, dir, environment.DefaultFile, "version: 1\nemulator:\n  log-level: debug\n")
+	t.Chdir(dir)
+
+	code, _, errOut := run("up")
+	if code != 1 {
+		t.Fatalf("exited %d, want 1", code)
+	}
+	if !strings.Contains(errOut, "emulator.log-level") {
+		t.Errorf("the refusal never names the field: %q", errOut)
+	}
+}
+
+// The three stacks this repository ships each carry a declaration, and each one
+// has to load. A stack whose feint.yaml stopped parsing would be found by a
+// reader rather than by a gate, which is the class of defect the repository has
+// paid for most often.
+func TestEveryExampleStackCarriesADeclarationThatLoads(t *testing.T) {
+	root := filepath.Join("..", "..", "examples", "stacks")
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatalf("read %s: %v", root, err)
+	}
+	found := 0
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(root, entry.Name(), environment.DefaultFile)
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("%s ships no %s, so a reader has to reconstitute the environment by hand",
+				entry.Name(), environment.DefaultFile)
+			continue
+		}
+		decl, err := environment.Load(path)
+		if err != nil {
+			t.Errorf("%s: %v", path, err)
+			continue
+		}
+		if decl.Cloud.Provider != entry.Name() {
+			t.Errorf("%s declares provider %q, and it sits in %s", path, decl.Cloud.Provider, entry.Name())
+		}
+		if len(decl.Unread()) != 0 {
+			t.Errorf("%s declares %v, which no verb reads", path, decl.Unread())
+		}
+		found++
+	}
+	// The witness: a scan that found no stack would pass every assertion above.
+	if found < 3 {
+		t.Fatalf("only %d stacks carry a declaration; the scan is broken, not the stacks", found)
+	}
+}
+
+// The vocabulary the schema documents is the vocabulary the binary takes. The
+// list lives in internal/environment because a schema that discovers its own
+// words at run time cannot document them, and this is what stops the two from
+// drifting apart.
+func TestEveryDeclaredRuntimeModeIsAModeTheBinaryTakes(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	for _, mode := range environment.RuntimeModes {
+		if mode != "off" && mode != "auto" {
+			// Every other mode needs a runtime this station may not have, and
+			// asserting on it would measure the station. `off` and `auto` are
+			// the two that answer everywhere.
+			continue
+		}
+		write(t, dir, environment.DefaultFile, "version: 1\nemulator:\n  addr: 127.0.0.1:1\nruntime:\n  mode: "+mode+"\n")
+		// --no-iac and an address nothing can bind would still start; what is
+		// read here is only whether the mode itself was refused.
+		_, _, errOut := run("up", "--no-iac", "--timeout", "1s")
+		if strings.Contains(errOut, "unknown --vm mode") {
+			t.Errorf("the schema documents the mode %q and the binary answers %q", mode, errOut)
+		}
+	}
+	// The witness, without which the loop above would pass while measuring
+	// nothing: a mode the schema does not carry is refused, and by the schema.
+	write(t, dir, environment.DefaultFile, "version: 1\nruntime:\n  mode: podman\n")
+	if code, _, errOut := run("up"); code == 0 {
+		t.Errorf("`mode: podman` was accepted: %q", errOut)
+	}
+}
+
+// The reference page is rendered from the schema, so a field added to the
+// schema and a page that never learned about it is a gate failure rather than a
+// reader's discovery.
+func TestTheEnvironmentReferenceIsGeneratedFromTheSchema(t *testing.T) {
+	page, err := os.ReadFile(filepath.Join("..", "..", "docs", "environment.md"))
+	if err != nil {
+		t.Fatalf("read the reference: %v", err)
+	}
+	body := string(page)
+	if len(environment.Fields()) < 10 {
+		t.Fatalf("only %d fields in the schema: the table is not being read", len(environment.Fields()))
+	}
+	for _, fd := range environment.Fields() {
+		if !strings.Contains(body, "`"+fd.Path+"`") {
+			t.Errorf("the reference never names `%s`; run `feint docs`", fd.Path)
+		}
+	}
+	for _, fd := range environment.NotCarried() {
+		if !strings.Contains(body, "`"+fd.Path+"`") {
+			t.Errorf("the reference never names `%s`, so a reader who writes it learns nothing", fd.Path)
+		}
+	}
+}
+
+func write(t *testing.T, dir, name, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/cli/up_wait_test.go
+++ b/internal/cli/up_wait_test.go
@@ -2,6 +2,9 @@ package cli
 
 import (
 	"bytes"
+	"context"
+	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stephrobert/feint/internal/core/machine"
 	"github.com/stephrobert/feint/internal/environment"
 )
 
@@ -265,5 +269,193 @@ func TestPreflightPassesADeclarationThisHostCanDeliver(t *testing.T) {
 	var out bytes.Buffer
 	if err := preflight(decl, true, &out); err != nil {
 		t.Fatalf("preflight refused a declaration nothing is wrong with: %v", err)
+	}
+}
+
+// The refusal the Scaleway declaration's own comment promises: a runtime the
+// host cannot deliver is refused **before anything starts**, naming the missing
+// half — and carrying a way through, because a guard with no door gets worked
+// around by copying the emulator.
+//
+// The seam is resolveRuntime, and the reason it exists is that this refusal is
+// host-dependent in the one direction that matters: this project's station has
+// OVN wired, so machineDriver refuses nothing here and a test written against
+// it would measure the station. What the refusal *says* is proved next door
+// (machine.TestVerifyNarrowsWhatTheHostCannotDeliver); the message stubbed below
+// is the one machineDriver builds from Verify's own unmet lines.
+//
+// TestUpRefusesADeclaredRuntimeTheHostCannotDeliver fails without the preflight
+// call, and its message assertions fail without waysPastTheRuntimeRefusal.
+func TestUpRefusesADeclaredRuntimeTheHostCannotDeliver(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("find a free port: %v", err)
+	}
+	addr := listener.Addr().String()
+	if err := listener.Close(); err != nil {
+		t.Fatalf("release the port: %v", err)
+	}
+	dir, err := instanceDir(addr)
+	if err != nil {
+		t.Fatalf("instance directory: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(dir)
+		var discard strings.Builder
+		stop([]string{"--addr", addr}, &discard, &discard)
+	})
+
+	asked := ""
+	restore := resolveRuntime
+	resolveRuntime = func(mode string, _ io.Writer) (machine.Driver, error) {
+		asked = mode
+		if mode == "off" {
+			return machine.Noop{}, nil
+		}
+		return nil, fmt.Errorf("--vm %s requested but this host cannot deliver it:\n"+
+			"  isolation: the daemon did not answer for network.ovn.northbound", mode)
+	}
+	t.Cleanup(func() { resolveRuntime = restore })
+
+	work := t.TempDir()
+	declaration := "version: 1\nemulator:\n  addr: " + addr + "\nruntime:\n  mode: incus-ovn\n"
+	if err := os.WriteFile(filepath.Join(work, environment.DefaultFile), []byte(declaration), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(work)
+
+	var out, errOut bytes.Buffer
+	if code := Run([]string{"feint", "up"}, &out, &errOut); code != exitError {
+		t.Fatalf("exited %d, want %d: a runtime the host cannot deliver must be refused, never downgraded",
+			code, exitError)
+	}
+	if asked != "incus-ovn" {
+		t.Fatalf("preflight asked the host about %q, and the declaration says incus-ovn", asked)
+	}
+	said := errOut.String()
+	// The missing half, by name. "This host cannot deliver it" alone sends the
+	// reader to a search engine.
+	if !strings.Contains(said, "isolation:") || !strings.Contains(said, "northbound") {
+		t.Errorf("the refusal does not name what is missing: %q", said)
+	}
+	// The doors. Each is a command or an edit the reader can make now.
+	for _, door := range []string{"feint doctor --vm incus-ovn", "feint up --runtime off", "runtime.mode"} {
+		if !strings.Contains(said, door) {
+			t.Errorf("the refusal offers no way past it: %q is missing from %q", door, said)
+		}
+	}
+	// And nothing was started, which is what makes it a refusal rather than a
+	// message printed on the way to starting one anyway.
+	if _, err := os.Stat(filepath.Join(dir, "feint.log")); err == nil {
+		t.Errorf("up spawned an emulator on %s before refusing the runtime it could not deliver", addr)
+	}
+}
+
+// The accepting half of the same guard, without which a preflight that refused
+// every mode would pass the test above and serve nobody.
+func TestUpAcceptsARuntimeTheHostDoesDeliver(t *testing.T) {
+	restore := resolveRuntime
+	resolveRuntime = func(_ string, _ io.Writer) (machine.Driver, error) { return machine.Noop{}, nil }
+	t.Cleanup(func() { resolveRuntime = restore })
+
+	decl, err := environment.Parse("version: 1\nruntime:\n  mode: incus-ovn\n")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var out bytes.Buffer
+	if err := preflight(decl, true, &out); err != nil {
+		t.Fatalf("preflight refused a runtime the host answers for: %v", err)
+	}
+}
+
+// runtime.images is checked against the station and never built: a build costs
+// minutes, and this project asks before those rather than after. The refusal
+// carries the command that makes the image — a guard with no door is a guard
+// people route around.
+func TestADeclaredImageTheStationLacksIsRefusedWithTheCommandThatBuildsIt(t *testing.T) {
+	// A warm-up name the fake station does not hold. Taken from the runtime's
+	// own list rather than invented, so this cannot pass by naming something
+	// that was never buildable in the first place.
+	required := machine.RequiredImages()
+	if len(required) == 0 {
+		t.Fatal("the runtime declares no warm-up image: the list is not being read")
+	}
+	want := required[0].Name
+
+	decl, err := environment.Parse("version: 1\nruntime:\n  mode: incus\n  images:\n    - " + want + "\n")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var buf bytes.Buffer
+	err = checkDeclaredImages(decl, emptyStation{}, &buf)
+	if err == nil {
+		t.Fatalf("a station holding no image accepted a declaration that needs %s", want)
+	}
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("the refusal does not name the image: %v", err)
+	}
+	if !strings.Contains(err.Error(), "feint images --only "+want) {
+		t.Errorf("the refusal offers no way to obtain it: %v", err)
+	}
+}
+
+// The three-outcome half. A name outside the warm-up set is not an error: the
+// boot path derives one on demand (#465). Reporting it as missing would refuse
+// something the runtime can do, and reporting nothing would hide minutes.
+func TestAnImageOutsideTheWarmUpSetIsAnnouncedAndNeverRefused(t *testing.T) {
+	decl, err := environment.Parse("version: 1\nruntime:\n  mode: incus\n  images:\n    - nixos/25.05\n")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var out bytes.Buffer
+	if err := checkDeclaredImages(decl, emptyStation{}, &out); err != nil {
+		t.Fatalf("an image the boot path can derive was refused: %v", err)
+	}
+	if !strings.Contains(out.String(), "nixos/25.05") || !strings.Contains(out.String(), "derives one") {
+		t.Errorf("the run says nothing about the minutes the first boot will cost: %q", out.String())
+	}
+}
+
+// emptyStation is a runtime that answers for the image questions and holds
+// nothing, which is the state of a machine that has never run `feint images`.
+type emptyStation struct{ machine.Noop }
+
+func (emptyStation) LocalImages(context.Context) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
+// The summary claims nothing it did not prove.
+//
+// When the engine was skipped, the ready conditions describing what it builds
+// are skipped too, and the endpoints block must say so rather than list them.
+// A summary that credited a condition nothing evaluated would be the shape of
+// every green verdict this project exists to distrust: the words of a proof with
+// none of the measurement.
+//
+// Only the decision is tested, for the reason the whole of this file documents:
+// `up` starts the emulator by re-execing the binary. The line that announces the
+// skip is driven by tools/conformance/environment/up.sh.
+func TestTheSummaryClaimsNothingItDidNotProve(t *testing.T) {
+	decl, err := environment.Parse("version: 1\nemulator:\n  addr: 127.0.0.1:4612\n" +
+		"iac:\n  engine: terraform\nready:\n  - resource:instance/server:6\n")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	var skipped bytes.Buffer
+	printEndpoints(decl, false, &skipped)
+	if strings.Contains(skipped.String(), "resource:instance/server:6") {
+		t.Errorf("a condition nothing evaluated is listed as what proved the environment:\n%s", skipped.String())
+	}
+	if !strings.Contains(skipped.String(), "proved:   nothing") {
+		t.Errorf("the summary does not say the conditions were skipped:\n%s", skipped.String())
+	}
+
+	// The accepting half: when the wait did run, its conditions are exactly what
+	// the summary credits.
+	var proved bytes.Buffer
+	printEndpoints(decl, true, &proved)
+	if !strings.Contains(proved.String(), "resource:instance/server:6") {
+		t.Errorf("a condition that was met is not credited:\n%s", proved.String())
 	}
 }

--- a/internal/cli/up_wait_test.go
+++ b/internal/cli/up_wait_test.go
@@ -1,0 +1,269 @@
+package cli
+
+import (
+	"bytes"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stephrobert/feint/internal/environment"
+)
+
+// The decision, tested apart from the act.
+//
+// `up`'s waiting half cannot be driven through Run: spawning the emulator is a
+// re-exec of this binary, and in a test that binary is the test binary. The
+// lesson is the one go-production-engineer records — separate the decision from
+// the act and test the decision — so what is measured here is `waitReady`
+// against a server that answers exactly what a real one would, and the whole
+// verb is proved end to end by tools/conformance/environment/up.sh and by the
+// three example stacks.
+
+// declFor builds a declaration pointed at a test server.
+func declFor(t *testing.T, addr string, ready ...string) *environment.File {
+	t.Helper()
+	src := "version: 1\nemulator:\n  addr: " + addr + "\nready:\n"
+	for _, item := range ready {
+		src += "  - " + item + "\n"
+	}
+	decl, err := environment.Parse(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return decl
+}
+
+// A condition that is met is said out loud both ways: announced before the wait
+// and confirmed after it. A silent wait is indistinguishable from a hang.
+func TestAReadyConditionThatIsMetIsSaidOutLoudBothWays(t *testing.T) {
+	inventory := `{"count":2,"resources":[{"kind":"instance/server"},{"kind":"instance/server"}]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/_feint/resources" {
+			_, _ = w.Write([]byte(inventory))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	decl := declFor(t, strings.TrimPrefix(srv.URL, "http://"),
+		"http:/instance/v1/zones/fr-par-1/servers", "resource:instance/server:2")
+	var out bytes.Buffer
+	if err := waitReady(decl, 5*time.Second, &out); err != nil {
+		t.Fatalf("conditions the server satisfies were not met: %v\n%s", err, out.String())
+	}
+	for _, want := range []string{"waiting:", "ok: http:/instance", "ok: resource:instance/server:2"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("the wait never printed %q:\n%s", want, out.String())
+		}
+	}
+}
+
+// The other direction, and the one #190 asks for by name: a condition that
+// cannot be met fails **within its deadline**, naming what it was waiting for.
+// It must not hang, because a hang with no output reads as a broken emulator
+// and blocks everything behind it.
+func TestAReadyConditionThatCannotBeMetFailsWithinItsDeadlineNamingIt(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/_feint/resources" {
+			_, _ = w.Write([]byte(`{"count":0,"resources":[]}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	decl := declFor(t, strings.TrimPrefix(srv.URL, "http://"), "resource:instance/server:1")
+	var out bytes.Buffer
+	started := time.Now()
+	err := waitReady(decl, 300*time.Millisecond, &out)
+	if err == nil {
+		t.Fatal("a condition nothing satisfies was reported met")
+	}
+	if elapsed := time.Since(started); elapsed > 5*time.Second {
+		t.Errorf("the wait took %s for a 300ms deadline: it is hanging, not failing", elapsed)
+	}
+	if !strings.Contains(err.Error(), "resource:instance/server:1") {
+		t.Errorf("the failure never names the condition: %v", err)
+	}
+	// And it says how far it got, which is the difference between "not yet" and
+	// "the emulator is broken".
+	if !strings.Contains(err.Error(), "the emulator holds 0") {
+		t.Errorf("the failure never says what it saw: %v", err)
+	}
+}
+
+// Three outcomes, never two. An inventory that cannot be read is a failure with
+// a reason, never a count of zero: a silent zero reads exactly like an emulator
+// nobody has used yet, which is the family measurement-integrity names first.
+func TestAnUnreadableInventoryIsAnErrorAndNeverAZero(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("this is not JSON"))
+	}))
+	defer srv.Close()
+
+	_, err := countKindInInventory(srv.URL, "instance/server")
+	if err == nil {
+		t.Fatal("an unreadable inventory was read as a count, and a wrong count reads exactly like a right one")
+	}
+	// The witness: the same reader finds what is there when the body is good.
+	good := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"count":1,"resources":[{"kind":"instance/server"}]}`))
+	}))
+	defer good.Close()
+	held, err := countKindInInventory(good.URL, "instance/server")
+	if err != nil || held != 1 {
+		t.Fatalf("the reader found %d, %v on an inventory holding one", held, err)
+	}
+}
+
+// The declaration renders into the flags `start` already takes, one direction
+// only: a field that named no flag would be a second source for something the
+// binary already decides.
+func TestTheDeclarationRendersIntoTheFlagsStartAlreadyTakes(t *testing.T) {
+	decl, err := environment.Parse("version: 1\nemulator:\n  addr: 127.0.0.1:4610\n" +
+		"  state: state.json\n  contracts: contracts\n  log_level: debug\n  cleanup: true\n" +
+		"runtime:\n  mode: incus\n")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got := strings.Join(startArgs(decl), " ")
+	for _, want := range []string{
+		"--addr 127.0.0.1:4610", "--vm incus", "--log-level debug",
+		"--state state.json", "--contracts contracts", "--cleanup",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("start would not receive %q: %s", want, got)
+		}
+	}
+	// The flags `start` refuses are never rendered, because the schema refuses
+	// them at load and there is nothing here that could invent one.
+	for _, never := range []string{"--coverage", "--shapes", "--expose-to-network"} {
+		if strings.Contains(got, never) {
+			t.Errorf("start refuses %s and up rendered it: %s", never, got)
+		}
+	}
+}
+
+// The engine's environment comes from the pack rather than from a field, which
+// is what keeps the endpoint form — Exoscale carries its /v2 path inside the
+// value, Scaleway does not — a fact with one owner.
+func TestTheEngineGetsThePacksOwnEnvironmentAndTheDeclaredVariables(t *testing.T) {
+	for _, tc := range []struct {
+		provider string
+		wants    string
+	}{
+		{"scaleway", "SCW_API_URL="},
+		{"exoscale", "EXOSCALE_API_ENDPOINT="},
+	} {
+		t.Run(tc.provider, func(t *testing.T) {
+			decl, err := environment.Parse("version: 1\ncloud:\n  provider: " + tc.provider +
+				"\nemulator:\n  addr: 127.0.0.1:4611\niac:\n  engine: terraform\n  vars:\n    endpoint: ${feint.endpoint}\n")
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			env, err := engineEnvironment(decl)
+			if err != nil {
+				t.Fatalf("engineEnvironment: %v", err)
+			}
+			joined := strings.Join(env, "\n")
+			if !strings.Contains(joined, tc.wants) {
+				t.Errorf("the engine never receives %s: the pack's own exports are missing", tc.wants)
+			}
+			// TF_VAR_ rather than -var, and the value carries the endpoint the
+			// declaration wrote once.
+			if !strings.Contains(joined, "TF_VAR_endpoint=http://127.0.0.1:4611") {
+				t.Errorf("the endpoint variable never reached the engine:\n%s", joined)
+			}
+			if !strings.Contains(joined, "TF_INPUT=0") {
+				t.Error("the engine could open a prompt on a stdin nothing is watching")
+			}
+		})
+	}
+}
+
+// The refusal that costs the most when it comes late, and the property that
+// makes it a refusal rather than a message: **nothing was started**.
+//
+// That distinction is not theoretical. The first version of this test named a
+// runtime mode instead of a provider, and it stayed green with the preflight
+// call removed — twice over. The schema refuses an unknown mode at load, so
+// preflight never saw it; and even where it did, `start` spawned a child, the
+// child died on the same mode, and the refusal arrived from the wrong side
+// looking identical. Two different ways of measuring the wrong subject, both
+// found by the falsification run rather than by reading.
+//
+// So the subject here is a provider this binary does not serve — a preflight
+// question, host-independent, at the same call site as the runtime check — and
+// the evidence is the log file a spawn creates before its child can even fail.
+// The runtime check is proven by the same mutation, because it is the same call.
+//
+// TestUpRefusesBeforeStartingAnything fails when the preflight call is removed
+// from up.
+func TestUpRefusesBeforeStartingAnything(t *testing.T) {
+	// A free port, so the instance directory read below belongs to this run and
+	// to no other: an assertion about a shared path is only as good as the
+	// guarantee that nobody else is using it.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("find a free port: %v", err)
+	}
+	addr := listener.Addr().String()
+	if err := listener.Close(); err != nil {
+		t.Fatalf("release the port: %v", err)
+	}
+	dir, err := instanceDir(addr)
+	if err != nil {
+		t.Fatalf("instance directory: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(dir)
+		// Under the mutation this verb really does start something, and a child
+		// left holding a port is how one test starts reporting another's
+		// timing.
+		var discard strings.Builder
+		stop([]string{"--addr", addr}, &discard, &discard)
+	})
+
+	work := t.TempDir()
+	declaration := "version: 1\ncloud:\n  provider: azure\nemulator:\n  addr: " + addr + "\n"
+	if err := os.WriteFile(filepath.Join(work, environment.DefaultFile), []byte(declaration), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(work)
+
+	var out, errOut bytes.Buffer
+	if code := Run([]string{"feint", "up"}, &out, &errOut); code != exitError {
+		t.Fatalf("exited %d, want %d: a provider this binary does not serve must be refused", code, exitError)
+	}
+	// Named, and with the list: a refusal that does not say what is available
+	// leaves the reader guessing.
+	if !strings.Contains(errOut.String(), "azure") || !strings.Contains(errOut.String(), "scaleway") {
+		t.Errorf("the refusal names neither the provider asked for nor the ones served: %q", errOut.String())
+	}
+	// The property. `spawn` creates the instance directory and its log before
+	// the child can fail, so the log's absence is the evidence that the refusal
+	// came first.
+	if _, err := os.Stat(filepath.Join(dir, "feint.log")); err == nil {
+		t.Errorf("up spawned an emulator on %s before refusing what it could see beforehand", addr)
+	}
+}
+
+// The accepting half, without which a preflight that refused everything would
+// pass the test above and serve nobody: a declaration this host can deliver
+// gets past every check preflight makes.
+func TestPreflightPassesADeclarationThisHostCanDeliver(t *testing.T) {
+	decl, err := environment.Parse("version: 1\ncloud:\n  provider: scaleway\nruntime:\n  mode: off\n")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var out bytes.Buffer
+	if err := preflight(decl, true, &out); err != nil {
+		t.Fatalf("preflight refused a declaration nothing is wrong with: %v", err)
+	}
+}

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -1,0 +1,678 @@
+// Package environment reads feint.yaml: the declaration of one emulated
+// environment, and the single source the `up` and `down` verbs act on.
+//
+// The boundary is the whole design (#189):
+//
+//	feint.yaml            how to bring the environment up   this project
+//	Terraform / OpenTofu  what the infrastructure is        the user's repository
+//	a snapshot            what the state currently is       an artefact
+//
+// The day this file grows a block describing a subnet, this project has started
+// rewriting Terraform badly; the day it grows a package list, it has started
+// rewriting Devbox badly. Both refusals are structural here rather than
+// advisory: the schema is a closed table, and a key it does not name is refused
+// by name at load.
+//
+// Two properties matter more than any field:
+//
+//   - **Nothing is accepted and then ignored.** A key this schema knows but no
+//     verb reads yet is declared as such and said out loud at load (Fields
+//     carries ReadBy, and an empty ReadBy is a warning, never silence). A file
+//     that accepts everything and applies half of it is the exact lie this
+//     project exists to avoid.
+//   - **Nothing here describes what a provider can do.** The catalogue, the
+//     image table and the login of a machine live in the packs. A second place
+//     describing them would be a second place to keep in agreement, and this
+//     repository has paid for that more than once.
+package environment
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// DefaultFile is the name read from the repository root when none is named.
+const DefaultFile = "feint.yaml"
+
+// Version is the only schema version this binary reads. A file naming another
+// is refused with both numbers, the way a snapshot from the future already is.
+const Version = 1
+
+// File is one environment declaration, after loading and validation.
+//
+// Every field maps to a flag or a verb that exists. There is no field here that
+// means something only this struct knows: that is the rule that keeps the file
+// from becoming a second source for what the CLI already decides.
+type File struct {
+	// Path is where this declaration was read from, for messages that can be
+	// acted on. Empty for a declaration parsed from bytes.
+	Path string
+
+	Version int
+
+	Cloud struct {
+		// Provider names the pack whose client environment `up` exports before
+		// running the engine. Validated against the packs the binary mounts,
+		// by the caller: which packs exist is not this package's knowledge.
+		Provider string
+	}
+
+	Emulator struct {
+		Addr      string
+		State     string
+		Contracts string
+		LogLevel  string
+		Cleanup   bool
+		// Env is the environment the emulator's own process is started with.
+		// FEINT_* only — see checkEnvName for why, and for the refusal.
+		Env map[string]string
+	}
+
+	Runtime struct {
+		// Mode is a --vm value. Absent means "off": starting machines is a side
+		// effect on the operator's host, and it is asked for rather than
+		// assumed.
+		Mode string
+		// Images are the machine images this environment needs present before
+		// it starts. `up` checks them and refuses naming what is missing and
+		// the command that builds it; it never builds them itself, because a
+		// build takes minutes and is a side effect of its own.
+		Images []string
+	}
+
+	Snapshot struct {
+		// Load is the name of a snapshot loaded once the emulator answers, so a
+		// fixture starts from a known state rather than from nothing.
+		Load string
+	}
+
+	IaC struct {
+		Engine    string
+		Directory string
+		// Vars are engine variables, exported as TF_VAR_<name>. The value
+		// ${feint.endpoint} is substituted with the emulator's endpoint — the
+		// one substitution this file has, so a stack that takes its endpoint
+		// through a variable never carries the address twice.
+		Vars map[string]string
+	}
+
+	// Ready are the conditions `up` waits for, each with a deadline and each
+	// said out loud while it waits.
+	Ready []string
+
+	// declared records which known fields the file actually wrote, so the
+	// loader can name the ones no verb reads yet.
+	declared map[string]bool
+}
+
+// Engines are the infrastructure-as-code engines `up` runs. Both are the same
+// language; which binary answers is the user's decision, not this project's.
+var Engines = []string{"terraform", "opentofu"}
+
+// RuntimeModes are the --vm values, and this list is the one the declaration is
+// checked against.
+//
+// It is declared here rather than parsed out of the CLI because a schema that
+// discovers its own vocabulary at run time cannot document it. What binds the
+// two is a test, not a comment: TestEveryDeclaredRuntimeModeIsAModeTheBinaryTakes
+// in internal/cli drives machineDriver with every name below and fails on one it
+// rejects — and with a name that is not below, to prove it can tell the
+// difference.
+var RuntimeModes = []string{"off", "incus", "incus-vm", "incus-ovn", "auto"}
+
+// LogLevels are the --log-level values.
+var LogLevels = []string{"error", "warn", "info", "debug"}
+
+// EndpointToken is the one substitution an iac.vars value may carry.
+const EndpointToken = "${feint.endpoint}" //nolint:gosec // a substitution token, not a credential
+
+// Load reads and validates a declaration from disk.
+func Load(path string) (*File, error) {
+	raw, err := os.ReadFile(path) //nolint:gosec // the operator's own declaration, named on the command line
+	if err != nil {
+		return nil, err
+	}
+	file, err := Parse(string(raw))
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	file.Path = path
+	return file, nil
+}
+
+// Parse reads and validates a declaration from its text.
+func Parse(src string) (*File, error) {
+	root, err := parseYAML(src)
+	if err != nil {
+		return nil, err
+	}
+	out := &File{declared: map[string]bool{}}
+	out.Emulator.Addr = "127.0.0.1:4599"
+	out.Emulator.LogLevel = "info"
+	out.Runtime.Mode = "off"
+	out.IaC.Directory = "."
+
+	if err := walk(out, root, ""); err != nil {
+		return nil, err
+	}
+	if out.Version == 0 {
+		return nil, fmt.Errorf("no `version:` field; this binary reads version %d", Version)
+	}
+	if out.Version != Version {
+		return nil, fmt.Errorf("version %d, and this binary reads version %d", out.Version, Version)
+	}
+	if err := out.check(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Declared answers whether the file itself wrote this field, as opposed to it
+// holding the default. `up` uses it to say what it is honouring.
+func (f *File) Declared(path string) bool { return f.declared[path] }
+
+// Unread names the fields this file declares that no verb reads yet, so a load
+// can say so out loud. A field declared and not read is acceptable only when it
+// is named as such; one read halfway is not acceptable at all.
+func (f *File) Unread() []string {
+	var out []string
+	for _, fd := range Fields() {
+		if len(fd.ReadBy) == 0 && f.declared[fd.Path] {
+			out = append(out, fd.Path)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Endpoint renders the emulator's address as a URL a client can use.
+func (f *File) Endpoint() string {
+	addr := f.Emulator.Addr
+	if strings.HasPrefix(addr, ":") {
+		addr = "127.0.0.1" + addr
+	}
+	return "http://" + addr
+}
+
+// Dir answers the directory the declaration sits in, which is what every
+// relative path in it is relative to. A declaration that resolved paths against
+// the caller's working directory would mean the same file did two things
+// depending on where it was run from, which is the property #192 exists to
+// remove.
+func (f *File) Dir() string {
+	if f.Path == "" {
+		return "."
+	}
+	return filepath.Dir(f.Path)
+}
+
+// Resolve makes one of the declaration's paths absolute against Dir.
+func (f *File) Resolve(path string) string {
+	if path == "" || filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(f.Dir(), path)
+}
+
+// EngineVars renders iac.vars with the endpoint substituted.
+func (f *File) EngineVars() map[string]string {
+	out := make(map[string]string, len(f.IaC.Vars))
+	for name, value := range f.IaC.Vars {
+		out[name] = strings.ReplaceAll(value, EndpointToken, f.Endpoint())
+	}
+	return out
+}
+
+// walk assigns every key of a block, refusing the ones this schema does not
+// name. The refusal carries the reason when the key is one this project
+// deliberately does not carry, and the list of siblings otherwise: "unknown
+// key" alone tells a reader they made a mistake without telling them which.
+func walk(out *File, block node, prefix string) error {
+	for _, key := range block.order {
+		path := key
+		if prefix != "" {
+			path = prefix + "." + key
+		}
+		child := block.mapping[key]
+		if reason, refused := notCarried[path]; refused {
+			return fmt.Errorf("line %d: `%s` is not carried by this file: %s", child.line, path, reason)
+		}
+		fd, known := fieldsByPath[path]
+		if !known {
+			if isBranch(path) {
+				if child.kind != kindMapping {
+					return fmt.Errorf("line %d: `%s` takes a block of fields, not %s", child.line, path, child.kind)
+				}
+				if err := walk(out, child, path); err != nil {
+					return err
+				}
+				continue
+			}
+			return fmt.Errorf("line %d: unknown field `%s`; %s", child.line, path, siblings(prefix))
+		}
+		if err := fd.assign(out, child); err != nil {
+			return fmt.Errorf("line %d: `%s`: %w", child.line, path, err)
+		}
+		out.declared[path] = true
+	}
+	return nil
+}
+
+// siblings names what a block does take, for the refusal above.
+func siblings(prefix string) string {
+	var names []string
+	for _, fd := range Fields() {
+		parent, leaf := split(fd.Path)
+		if parent == prefix {
+			names = append(names, leaf)
+		}
+	}
+	for path := range branches {
+		parent, leaf := split(path)
+		if parent == prefix {
+			names = append(names, leaf)
+		}
+	}
+	sort.Strings(names)
+	if prefix == "" {
+		return "this file takes: " + strings.Join(names, ", ")
+	}
+	return "`" + prefix + "` takes: " + strings.Join(names, ", ")
+}
+
+func split(path string) (parent, leaf string) {
+	i := strings.LastIndex(path, ".")
+	if i < 0 {
+		return "", path
+	}
+	return path[:i], path[i+1:]
+}
+
+func isBranch(path string) bool { return branches[path] }
+
+// branches are the blocks of the schema. Listed rather than derived from the
+// field paths so that a typo in a block name — `runtimes:` for `runtime:` — is
+// refused as an unknown field instead of walked into and reported one level
+// deeper, where the reader has to work out which line was wrong.
+var branches = map[string]bool{
+	"cloud":    true,
+	"emulator": true,
+	"runtime":  true,
+	"snapshot": true,
+	"iac":      true,
+}
+
+// notCarried names what this file deliberately does not carry, with the reason.
+//
+// Refusing by name is the point. A reader who writes `expose_to_network: true`
+// into a declaration has a model of what this file is for, and an "unknown
+// field" answer leaves that model intact. These four answers correct it.
+var notCarried = map[string]string{
+	"emulator.coverage": "`--coverage` is a flag of `feint serve` alone, which `feint start` refuses and " +
+		"`feint up` composes; run `feint coverage` against the running emulator instead",
+	"emulator.shapes": "`--shapes` is a flag of `feint serve` alone, which `feint start` refuses and " +
+		"`feint up` composes; run `feint shapes --check` against the running emulator instead",
+	"emulator.expose_to_network": "putting an emulator that accepts every credential on the network is a " +
+		"decision the person at the keyboard makes, never one a file they cloned makes for them; " +
+		"type `feint serve --expose-to-network` and read SECURITY.md first",
+	"proxy": "a recorder needs a real cloud endpoint and real credentials, which is the one thing this " +
+		"file must never carry; run `feint proxy --upstream … --record …` beside the emulator",
+}
+
+// Field is one key of the schema, and the only description of it there is.
+//
+// The reference page is rendered from this table (`feint docs`), so a field
+// added without a sentence is a field the page shows without one — visible
+// rather than missing. ReadBy names the verbs that act on the field today; an
+// empty ReadBy is a field declared and not yet read, which the loader says out
+// loud.
+type Field struct {
+	Path    string
+	Takes   string
+	Default string
+	Doc     string
+	ReadBy  []string
+	assign  func(*File, node) error
+}
+
+// Fields is the schema, in the order the reference presents it.
+func Fields() []Field { return fields }
+
+var fields = []Field{
+	{
+		Path: "version", Takes: "a number", Default: "",
+		Doc:    "The schema version. Only " + strconv.Itoa(Version) + " is read; another is refused naming both.",
+		ReadBy: []string{"up", "down"},
+		assign: func(f *File, n node) error {
+			v, err := scalarInt(n)
+			if err != nil {
+				return err
+			}
+			f.Version = v
+			return nil
+		},
+	},
+	{
+		Path: "cloud.provider", Takes: "a provider name", Default: "",
+		Doc: "The pack whose client environment `up` exports before running the engine — the same " +
+			"variables `feint env <provider>` prints, including the endpoint form that provider's " +
+			"clients want. Refused when the binary mounts no such pack.",
+		ReadBy: []string{"up", "down"},
+		assign: func(f *File, n node) error { return scalarInto(n, &f.Cloud.Provider) },
+	},
+	{
+		Path: "emulator.addr", Takes: "a listen address", Default: "127.0.0.1:4599",
+		Doc:    "Where the emulator listens: `serve --addr`.",
+		ReadBy: []string{"up", "down"},
+		assign: func(f *File, n node) error { return scalarInto(n, &f.Emulator.Addr) },
+	},
+	{
+		Path: "emulator.state", Takes: "a path", Default: "",
+		Doc: "The JSON file the store is loaded from and persisted to: `serve --state`. " +
+			"Relative to the declaration's own directory.",
+		ReadBy: []string{"up"},
+		assign: func(f *File, n node) error { return scalarInto(n, &f.Emulator.State) },
+	},
+	{
+		Path: "emulator.contracts", Takes: "a directory", Default: "",
+		Doc: "The API descriptions every response is checked against: `serve --contracts`. " +
+			"Relative to the declaration's own directory.",
+		ReadBy: []string{"up"},
+		assign: func(f *File, n node) error { return scalarInto(n, &f.Emulator.Contracts) },
+	},
+	{
+		Path: "emulator.log_level", Takes: "error, warn, info or debug", Default: "info",
+		Doc:    "`serve --log-level`, which is what `feint logs` then shows.",
+		ReadBy: []string{"up"},
+		assign: func(f *File, n node) error { return scalarInto(n, &f.Emulator.LogLevel) },
+	},
+	{
+		Path: "emulator.cleanup", Takes: "true or false", Default: "false",
+		Doc:    "Remove the machines and networks the run created before exiting: `serve --cleanup`.",
+		ReadBy: []string{"up"},
+		assign: func(f *File, n node) error { return scalarBool(n, &f.Emulator.Cleanup) },
+	},
+	{
+		Path: "emulator.env", Takes: "a block of FEINT_* variables", Default: "",
+		Doc: "The environment the emulator's own process starts with. This is where the per-provider " +
+			"declarations that travelled in a chat paragraph belong — FEINT_EXOSCALE_ALLOW_TERRAFORM, " +
+			"which is read server-side and so cannot be exported after the start, and FEINT_BOOT_IMAGES. " +
+			"FEINT_* only: a declaration that could set any variable of a process it spawns would be a " +
+			"different kind of file.",
+		ReadBy: []string{"up"},
+		assign: func(f *File, n node) error {
+			m, err := scalarMap(n, checkEnvName)
+			if err != nil {
+				return err
+			}
+			f.Emulator.Env = m
+			return nil
+		},
+	},
+	{
+		Path: "runtime.mode", Takes: strings.Join(RuntimeModes, ", "), Default: "off",
+		Doc: "What backs a powered-on server: the `--vm` values and nothing else. Absent means `off`, " +
+			"because starting machines is a side effect this project asks for rather than assumes. " +
+			"`up` checks the host can deliver the named mode before it starts anything, and refuses " +
+			"rather than downgrading.",
+		ReadBy: []string{"up"},
+		assign: func(f *File, n node) error {
+			return scalarOneOf(n, RuntimeModes, &f.Runtime.Mode)
+		},
+	},
+	{
+		Path: "runtime.images", Takes: "a list of family/version", Default: "",
+		Doc: "The machine images this environment needs present. `up` checks them and refuses naming " +
+			"what is missing and the `feint images` command that builds it; it never builds them " +
+			"itself, because a build takes minutes. Ignored when `runtime.mode` is `off`, where " +
+			"nothing boots.",
+		ReadBy: []string{"up"},
+		assign: func(f *File, n node) error {
+			list, err := scalarList(n)
+			if err != nil {
+				return err
+			}
+			for _, name := range list {
+				if strings.Count(name, "/") == 0 {
+					return fmt.Errorf("%q is not a family/version image name", name)
+				}
+			}
+			f.Runtime.Images = list
+			return nil
+		},
+	},
+	{
+		Path: "snapshot.load", Takes: "a snapshot name", Default: "",
+		Doc: "A snapshot loaded once the emulator answers, so this environment starts from a known " +
+			"state rather than from nothing: `feint snapshot load <name>`. The name, never a path — " +
+			"snapshots live where `feint snapshot list` says they live.",
+		ReadBy: []string{"up"},
+		assign: func(f *File, n node) error { return scalarInto(n, &f.Snapshot.Load) },
+	},
+	{
+		Path: "iac.engine", Takes: strings.Join(Engines, " or "), Default: "",
+		Doc: "The engine `up` runs and `down` destroys with. Absent means this environment declares no " +
+			"infrastructure, and `up` brings the control plane up and stops there.",
+		ReadBy: []string{"up", "down"},
+		assign: func(f *File, n node) error { return scalarOneOf(n, Engines, &f.IaC.Engine) },
+	},
+	{
+		Path: "iac.directory", Takes: "a directory", Default: ".",
+		Doc: "Where the engine runs, relative to the declaration's own directory. The engine runs " +
+			"there in place — a copy of `*.tf` would leave a local module behind, which is one of the " +
+			"four things this file exists to make impossible.",
+		ReadBy: []string{"up", "down"},
+		assign: func(f *File, n node) error { return scalarInto(n, &f.IaC.Directory) },
+	},
+	{
+		Path: "iac.vars", Takes: "a block of variables", Default: "",
+		Doc: "Engine variables, exported as `TF_VAR_<name>`. The value `" + EndpointToken + "` is " +
+			"replaced by the emulator's endpoint, and it is the only substitution this file has: a " +
+			"stack that takes its endpoint through a variable then carries the address once, here.",
+		ReadBy: []string{"up", "down"},
+		assign: func(f *File, n node) error {
+			m, err := scalarMap(n, checkVarName)
+			if err != nil {
+				return err
+			}
+			f.IaC.Vars = m
+			return nil
+		},
+	},
+	{
+		Path: "ready", Takes: "a list of conditions", Default: "",
+		Doc: "What `up` waits for before it says the environment is up, each with a deadline and each " +
+			"said out loud while it waits. Three forms: `http:<path>` (the emulator answers below " +
+			"400), `tcp:<host>:<port>` (a connection is accepted), and `resource:<kind>[:<count>]` " +
+			"(the emulator's own inventory holds at least that many). Every one is asserted against " +
+			"the emulator, never against the engine's state file.",
+		ReadBy: []string{"up"},
+		assign: func(f *File, n node) error {
+			list, err := scalarList(n)
+			if err != nil {
+				return err
+			}
+			for _, item := range list {
+				if _, err := ParseCondition(item); err != nil {
+					return err
+				}
+			}
+			f.Ready = list
+			return nil
+		},
+	},
+}
+
+// NotCarried answers what the file deliberately does not carry, with the
+// reason, for the generated reference. Sorted, so the page is stable.
+func NotCarried() []Field {
+	out := make([]Field, 0, len(notCarried))
+	for path, why := range notCarried {
+		out = append(out, Field{Path: path, Doc: why})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
+	return out
+}
+
+var fieldsByPath = func() map[string]Field {
+	out := make(map[string]Field, len(fields))
+	for _, fd := range fields {
+		out[fd.Path] = fd
+	}
+	return out
+}()
+
+// check holds the cross-field rules, which are the ones a per-field assign
+// cannot see.
+func (f *File) check() error {
+	if f.IaC.Engine == "" && (f.declared["iac.directory"] || f.declared["iac.vars"]) {
+		return fmt.Errorf("`iac` declares a directory or variables and no `engine`; name one of %s",
+			strings.Join(Engines, ", "))
+	}
+	if !contains(LogLevels, f.Emulator.LogLevel) {
+		return fmt.Errorf("`emulator.log_level`: %q is not one of %s",
+			f.Emulator.LogLevel, strings.Join(LogLevels, ", "))
+	}
+	if f.Snapshot.Load != "" && strings.ContainsAny(f.Snapshot.Load, "/\\") {
+		return fmt.Errorf("`snapshot.load`: %q is a path, and this field takes a snapshot name; "+
+			"`feint snapshot list` names them", f.Snapshot.Load)
+	}
+	return nil
+}
+
+// checkEnvName holds emulator.env to this project's own knobs.
+//
+// The field exists so that FEINT_EXOSCALE_ALLOW_TERRAFORM — read inside the
+// emulator's process, so exporting it after the start does nothing — travels
+// with the declaration instead of in a chat paragraph. That need is met by
+// FEINT_* alone, and a declaration able to set any variable of a process it
+// spawns is a different and much larger thing. Refusing names both facts.
+//
+// TestAnEnvironmentVariableOutsideTheProjectsOwnIsRefused fails without this.
+func checkEnvName(name string) error {
+	if !strings.HasPrefix(name, "FEINT_") {
+		return fmt.Errorf("%q: this block sets the emulator's own knobs, so a name has to start with "+
+			"FEINT_; export anything else in the shell that runs `feint up`", name)
+	}
+	for _, c := range name {
+		if (c < 'A' || c > 'Z') && (c < '0' || c > '9') && c != '_' {
+			return fmt.Errorf("%q: an environment variable name here is FEINT_ and then capitals, "+
+				"digits and underscores", name)
+		}
+	}
+	return nil
+}
+
+// checkVarName refuses a variable name Terraform could not take, which is the
+// cheapest way to turn a typo into a refusal rather than into an engine
+// variable nothing reads.
+func checkVarName(name string) error {
+	if name == "" {
+		return errNamelessVariable
+	}
+	for i, c := range name {
+		letter := (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_'
+		digit := c >= '0' && c <= '9'
+		if i == 0 && !letter {
+			return fmt.Errorf("%q: an engine variable name starts with a letter or an underscore", name)
+		}
+		if !letter && !digit && c != '-' {
+			return fmt.Errorf("%q: an engine variable name is letters, digits, dashes and underscores", name)
+		}
+	}
+	return nil
+}
+
+// errNamelessVariable is the one refusal with no value to name.
+var errNamelessVariable = errors.New("a variable with no name")
+
+func contains(list []string, want string) bool {
+	for _, item := range list {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}
+
+func scalarInto(n node, dst *string) error {
+	if n.kind != kindScalar {
+		return fmt.Errorf("takes a value, not %s", n.kind)
+	}
+	if n.scalar == "" {
+		return fmt.Errorf("is empty; give it a value or remove the line")
+	}
+	*dst = n.scalar
+	return nil
+}
+
+func scalarInt(n node) (int, error) {
+	if n.kind != kindScalar {
+		return 0, fmt.Errorf("takes a number, not %s", n.kind)
+	}
+	v, err := strconv.Atoi(n.scalar)
+	if err != nil {
+		return 0, fmt.Errorf("%q is not a number", n.scalar)
+	}
+	return v, nil
+}
+
+func scalarBool(n node, dst *bool) error {
+	if n.kind != kindScalar {
+		return fmt.Errorf("takes true or false, not %s", n.kind)
+	}
+	switch n.scalar {
+	case "true":
+		*dst = true
+	case "false":
+		*dst = false
+	default:
+		return fmt.Errorf("%q is not true or false", n.scalar)
+	}
+	return nil
+}
+
+func scalarOneOf(n node, allowed []string, dst *string) error {
+	if n.kind != kindScalar {
+		return fmt.Errorf("takes one of %s, not %s", strings.Join(allowed, ", "), n.kind)
+	}
+	if !contains(allowed, n.scalar) {
+		return fmt.Errorf("%q is not one of %s", n.scalar, strings.Join(allowed, ", "))
+	}
+	*dst = n.scalar
+	return nil
+}
+
+func scalarList(n node) ([]string, error) {
+	if n.kind != kindSeq {
+		return nil, fmt.Errorf("takes a list of values, not %s", n.kind)
+	}
+	out := make([]string, 0, len(n.seq))
+	for _, item := range n.seq {
+		out = append(out, item.scalar)
+	}
+	return out, nil
+}
+
+func scalarMap(n node, checkName func(string) error) (map[string]string, error) {
+	if n.kind != kindMapping {
+		return nil, fmt.Errorf("takes a block of `name: value` lines, not %s", n.kind)
+	}
+	out := make(map[string]string, len(n.mapping))
+	for _, name := range n.order {
+		child := n.mapping[name]
+		if child.kind != kindScalar {
+			return nil, fmt.Errorf("%q takes a value, not %s", name, child.kind)
+		}
+		if err := checkName(name); err != nil {
+			return nil, err
+		}
+		out[name] = child.scalar
+	}
+	return out, nil
+}

--- a/internal/environment/environment_test.go
+++ b/internal/environment/environment_test.go
@@ -1,0 +1,367 @@
+package environment
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// The declaration this repository's own example stacks carry, used wherever a
+// test needs a valid file. It is the shape a reader meets, not one invented for
+// the test: the same fields examples/stacks/scaleway/feint.yaml declares.
+const validDeclaration = `version: 1
+
+cloud:
+  provider: scaleway
+
+emulator:
+  addr: 127.0.0.1:4599
+  log_level: info
+
+runtime:
+  mode: off
+
+iac:
+  engine: terraform
+  directory: .
+  vars:
+    endpoint: ${feint.endpoint}
+
+ready:
+  - http:/instance/v1/zones/fr-par-1/servers
+  - resource:instance:6
+`
+
+func TestAValidDeclarationLoads(t *testing.T) {
+	file, err := Parse(validDeclaration)
+	if err != nil {
+		t.Fatalf("a valid declaration was refused: %v", err)
+	}
+	if file.Cloud.Provider != "scaleway" {
+		t.Errorf("cloud.provider = %q, want scaleway", file.Cloud.Provider)
+	}
+	if file.Runtime.Mode != "off" {
+		t.Errorf("runtime.mode = %q, want off", file.Runtime.Mode)
+	}
+	if got := file.EngineVars()["endpoint"]; got != "http://127.0.0.1:4599" {
+		t.Errorf("the endpoint substitution produced %q, want the emulator's endpoint", got)
+	}
+	if len(file.Conditions()) != 2 {
+		t.Errorf("%d ready conditions parsed, want 2", len(file.Conditions()))
+	}
+}
+
+// The round trip #189 asks for, and the reason Render is not a courtesy: a
+// field added to File and forgotten in Render makes this go red, because the
+// rendered copy no longer carries it.
+func TestAValidDeclarationSurvivesARoundTrip(t *testing.T) {
+	first, err := Parse(validDeclaration)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	rendered := Render(first)
+	second, err := Parse(rendered)
+	if err != nil {
+		t.Fatalf("the rendered copy of a valid declaration was refused: %v\n%s", err, rendered)
+	}
+	first.Path, second.Path = "", ""
+	if !reflect.DeepEqual(first, second) {
+		t.Errorf("the round trip changed the declaration:\n  first:  %+v\n  second: %+v\n  rendered:\n%s",
+			first, second, rendered)
+	}
+	// And the render is stable, so a diff of two renders means something moved.
+	if again := Render(second); again != rendered {
+		t.Errorf("two renders of one declaration differ:\n%s\n---\n%s", rendered, again)
+	}
+}
+
+// The refusal #189 names first: a file somebody mistyped must fail at load, not
+// at the first surprising behaviour. Every case below names the field.
+func TestAMistypedFieldIsRefusedByName(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "a flag name where a field name belongs",
+			src:  "version: 1\nemulator:\n  log-level: debug\n",
+			want: "emulator.log-level",
+		},
+		{
+			name: "a misspelled block",
+			src:  "version: 1\nruntimes:\n  mode: off\n",
+			want: "runtimes",
+		},
+		{
+			name: "a block borrowed from Terraform",
+			src:  "version: 1\nnetwork:\n  subnet: 10.0.0.0/24\n",
+			want: "network",
+		},
+		{
+			name: "a package list borrowed from Devbox",
+			src:  "version: 1\npackages:\n  - terraform\n",
+			want: "packages",
+		},
+		{
+			name: "a value where a block belongs",
+			src:  "version: 1\nemulator: 127.0.0.1:4599\n",
+			want: "emulator",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Parse(tc.src)
+			if err == nil {
+				t.Fatalf("accepted, and the field would then be discovered later")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("the refusal never names %q: %v", tc.want, err)
+			}
+		})
+	}
+}
+
+// The other half of every refusal test: the case that must still work. A schema
+// that refuses everything passes every test above and serves nobody.
+func TestEveryFieldOfTheSchemaIsAccepted(t *testing.T) {
+	src := `version: 1
+cloud:
+  provider: scaleway
+emulator:
+  addr: 127.0.0.1:4699
+  state: state.json
+  contracts: contracts
+  log_level: debug
+  cleanup: true
+  env:
+    FEINT_EXOSCALE_ALLOW_TERRAFORM: "1"
+runtime:
+  mode: incus
+  images:
+    - ubuntu/24.04
+snapshot:
+  load: fixture
+iac:
+  engine: opentofu
+  directory: terraform
+  vars:
+    endpoint: ${feint.endpoint}
+ready:
+  - http:/_feint/health
+  - tcp:127.0.0.1:4699
+  - resource:instance
+`
+	file, err := Parse(src)
+	if err != nil {
+		t.Fatalf("a declaration using every field was refused: %v", err)
+	}
+	for _, fd := range Fields() {
+		if !file.Declared(fd.Path) {
+			t.Errorf("`%s` is in the schema and this declaration writes it, and the loader did not record it", fd.Path)
+		}
+	}
+	if len(file.Unread()) != 0 {
+		t.Errorf("fields declared and read by nothing: %v — either a verb reads them or the reference says so",
+			file.Unread())
+	}
+}
+
+// What this file deliberately does not carry is refused with the reason, never
+// as a plain unknown key: a reader who writes it has a model of what the file
+// is for, and "unknown field" leaves that model intact.
+func TestWhatIsNotCarriedIsRefusedWithItsReason(t *testing.T) {
+	for _, fd := range NotCarried() {
+		t.Run(fd.Path, func(t *testing.T) {
+			parent, leaf := split(fd.Path)
+			src := "version: 1\n"
+			if parent == "" {
+				src += leaf + ":\n  upstream: https://api.example\n"
+			} else {
+				src += parent + ":\n  " + leaf + ": true\n"
+			}
+			_, err := Parse(src)
+			if err == nil {
+				t.Fatalf("accepted, so the file carries a field nothing acts on")
+			}
+			if !strings.Contains(err.Error(), fd.Path) {
+				t.Errorf("the refusal never names the field: %v", err)
+			}
+			// The reason, not only the name: this is what tells a reader where
+			// the thing they wanted actually lives.
+			if !strings.Contains(err.Error(), "is not carried by this file") {
+				t.Errorf("the refusal gives no reason: %v", err)
+			}
+		})
+	}
+}
+
+// runtime.mode is the --vm values and nothing else, and a name that is not one
+// of them is refused **with the list** rather than accepted and discovered when
+// the emulator starts.
+func TestAnUnknownRuntimeModeIsRefusedWithTheList(t *testing.T) {
+	_, err := Parse("version: 1\nruntime:\n  mode: docker\n")
+	if err == nil {
+		t.Fatal("`mode: docker` was accepted; the Docker driver was removed and this would surface at startup")
+	}
+	for _, mode := range RuntimeModes {
+		if !strings.Contains(err.Error(), mode) {
+			t.Errorf("the refusal does not name the mode %q, so a reader cannot fix it: %v", mode, err)
+		}
+	}
+}
+
+// emulator.env sets the emulator's own knobs and nothing else. A declaration
+// able to set any variable of a process it spawns is a different and much
+// larger thing, and the refusal says both halves.
+func TestAnEnvironmentVariableOutsideTheProjectsOwnIsRefused(t *testing.T) {
+	for _, name := range []string{"LD_PRELOAD", "PATH", "AWS_SECRET_ACCESS_KEY", "SCW_SECRET_KEY"} {
+		t.Run(name, func(t *testing.T) {
+			_, err := Parse("version: 1\nemulator:\n  env:\n    " + name + ": x\n")
+			if err == nil {
+				t.Fatalf("a declaration set %s on the process it spawns", name)
+			}
+			if !strings.Contains(err.Error(), name) {
+				t.Errorf("the refusal never names the variable: %v", err)
+			}
+		})
+	}
+	// The accepting half, without which a guard that refuses everything would
+	// pass every case above.
+	file, err := Parse("version: 1\nemulator:\n  env:\n    FEINT_EXOSCALE_ALLOW_TERRAFORM: \"1\"\n")
+	if err != nil {
+		t.Fatalf("the project's own knob was refused: %v", err)
+	}
+	if file.Emulator.Env["FEINT_EXOSCALE_ALLOW_TERRAFORM"] != "1" {
+		t.Errorf("emulator.env = %v, want the declared knob", file.Emulator.Env)
+	}
+}
+
+func TestAReadyConditionNobodyServesIsRefusedWithTheForms(t *testing.T) {
+	for _, raw := range []string{"ssh:web-01", "ping:10.0.0.1", "http:no-leading-slash", "tcp:host", "resource:instance:0"} {
+		t.Run(raw, func(t *testing.T) {
+			_, err := Parse("version: 1\nready:\n  - " + raw + "\n")
+			if err == nil {
+				t.Fatalf("accepted, so `up` would wait for a condition nothing evaluates")
+			}
+		})
+	}
+	// And the forms that must still work.
+	file, err := Parse("version: 1\nready:\n  - http:/_feint/health\n  - tcp:127.0.0.1:4599\n  - resource:instance:3\n")
+	if err != nil {
+		t.Fatalf("the three forms were refused: %v", err)
+	}
+	got := file.Conditions()
+	if len(got) != 3 {
+		t.Fatalf("%d conditions, want 3", len(got))
+	}
+	if got[2].Count != 3 || got[2].Resource != "instance" {
+		t.Errorf("resource:instance:3 parsed as %+v", got[2])
+	}
+}
+
+func TestAVersionThisBinaryDoesNotReadIsRefusedNamingBoth(t *testing.T) {
+	_, err := Parse("version: 2\ncloud:\n  provider: scaleway\n")
+	if err == nil {
+		t.Fatal("a declaration from the future was accepted")
+	}
+	if !strings.Contains(err.Error(), "2") || !strings.Contains(err.Error(), "1") {
+		t.Errorf("the refusal names only one of the two versions: %v", err)
+	}
+	if _, err := Parse("cloud:\n  provider: scaleway\n"); err == nil {
+		t.Error("a declaration with no version was accepted")
+	}
+}
+
+// A key written twice would otherwise have one of the two win in silence, which
+// is the class of defect this whole file exists to make impossible.
+func TestADuplicateKeyIsRefused(t *testing.T) {
+	_, err := Parse("version: 1\nruntime:\n  mode: off\n  mode: incus\n")
+	if err == nil {
+		t.Fatal("a duplicated key was accepted, and one of the two values won in silence")
+	}
+	if !strings.Contains(err.Error(), "twice") {
+		t.Errorf("the refusal does not say what happened: %v", err)
+	}
+}
+
+// The YAML this reader does not implement is refused by name rather than
+// mis-parsed. A subset that fails on a construct without saying which one
+// teaches a reader that the file is broken, not that the reader is.
+func TestTheYAMLThisReaderDoesNotImplementIsRefusedByName(t *testing.T) {
+	cases := map[string]string{
+		"a tab":          "version: 1\nruntime:\n\tmode: off\n",
+		"flow style":     "version: 1\nruntime: {mode: off}\n",
+		"an anchor":      "version: 1\ncloud:\n  provider: &p scaleway\n",
+		"a block scalar": "version: 1\ncloud:\n  provider: |\n    scaleway\n",
+		"two documents":  "version: 1\n---\nversion: 1\n",
+		"an open quote":  "version: 1\ncloud:\n  provider: \"scaleway\n",
+	}
+	for name, src := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := Parse(src); err == nil {
+				t.Fatalf("accepted; the reader would then act on something nobody wrote")
+			}
+		})
+	}
+}
+
+// Comments and quoted hashes, because a reader annotates their declaration and
+// a reader who quotes a value containing a hash must get the hash.
+func TestCommentsAreStrippedAndQuotedHashesAreNot(t *testing.T) {
+	file, err := Parse("# what this environment is\nversion: 1 # the schema\ncloud:\n  provider: \"scale#way\"\n")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if file.Cloud.Provider != "scale#way" {
+		t.Errorf("provider = %q; a quoted hash is data, not a comment", file.Cloud.Provider)
+	}
+}
+
+// Every relative path is relative to the declaration, never to the working
+// directory: the same file has to do the same thing wherever it is run from,
+// which is the property #192 exists to protect.
+func TestPathsResolveAgainstTheDeclarationNotTheCaller(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, DefaultFile)
+	if err := os.WriteFile(path, []byte("version: 1\nemulator:\n  state: state.json\niac:\n  engine: terraform\n  directory: tf\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	file, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got, want := file.Resolve(file.Emulator.State), filepath.Join(dir, "state.json"); got != want {
+		t.Errorf("state resolved to %q, want %q", got, want)
+	}
+	if got, want := file.Resolve(file.IaC.Directory), filepath.Join(dir, "tf"); got != want {
+		t.Errorf("directory resolved to %q, want %q", got, want)
+	}
+}
+
+// Every field of the schema carries the sentence the reference renders. A field
+// added without one would show on the page as a blank cell, which is worse than
+// visible: it reads as "nothing to say about this".
+func TestEveryFieldOfTheSchemaIsDocumented(t *testing.T) {
+	if len(Fields()) < 10 {
+		t.Fatalf("only %d fields found: the schema table is not being read", len(Fields()))
+	}
+	for _, fd := range Fields() {
+		if fd.Doc == "" {
+			t.Errorf("`%s` has no sentence, so the generated reference shows it blank", fd.Path)
+		}
+		if fd.Takes == "" {
+			t.Errorf("`%s` does not say what it takes", fd.Path)
+		}
+		if fd.assign == nil {
+			t.Errorf("`%s` is documented and nothing reads it", fd.Path)
+		}
+	}
+	for _, fd := range NotCarried() {
+		if fd.Doc == "" {
+			t.Errorf("`%s` is refused with no reason", fd.Path)
+		}
+	}
+}

--- a/internal/environment/ready.go
+++ b/internal/environment/ready.go
@@ -1,0 +1,132 @@
+package environment
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// The ready conditions, parsed once at load so a file naming a form nobody
+// serves is refused before anything is started rather than at the end of a wait
+// (#190). Each carries a deadline and a description said out loud while it is
+// waited on: a hang with no output is indistinguishable from a broken emulator,
+// and this repository has already paid for that.
+//
+// Three forms, and every one of them is asserted against the emulator rather
+// than against the engine's state file. That is #190's own rule, and it is what
+// makes a green `up` mean the API answers rather than that Terraform wrote a
+// file.
+
+// ConditionKind is one of the forms a ready condition takes.
+type ConditionKind string
+
+const (
+	// HTTPCondition waits for the emulator to answer a path below 400.
+	HTTPCondition ConditionKind = "http"
+	// TCPCondition waits for a connection to be accepted.
+	TCPCondition ConditionKind = "tcp"
+	// ResourceCondition waits for the emulator's own inventory to hold at least
+	// Count resources of a kind. Provider-neutral by construction: the store
+	// holds resource.Resource, whose kind is a value rather than a type.
+	ResourceCondition ConditionKind = "resource"
+)
+
+// ConditionKinds names every form, for the refusal. A name that is not one of
+// these is refused with this list, never accepted and discovered later.
+var ConditionKinds = []string{
+	"http:<path>",
+	"tcp:<host>:<port>",
+	"resource:<kind>[:<count>]",
+}
+
+// Condition is one parsed ready condition.
+type Condition struct {
+	Kind ConditionKind
+	// Raw is what the file wrote, for the message said while waiting and for
+	// the one printed when the deadline passes.
+	Raw string
+	// Path is set for HTTPCondition.
+	Path string
+	// Address is set for TCPCondition.
+	Address string
+	// Resource and Count are set for ResourceCondition.
+	Resource string
+	Count    int
+}
+
+// ParseCondition reads one condition and refuses everything else by name.
+func ParseCondition(raw string) (Condition, error) {
+	kind, rest, ok := strings.Cut(raw, ":")
+	if !ok || rest == "" {
+		return Condition{}, fmt.Errorf("%q is not a ready condition; the forms are %s",
+			raw, strings.Join(ConditionKinds, ", "))
+	}
+	switch ConditionKind(kind) {
+	case HTTPCondition:
+		if !strings.HasPrefix(rest, "/") {
+			return Condition{}, fmt.Errorf("%q: an http condition takes a path on the emulator, "+
+				"starting with a slash", raw)
+		}
+		return Condition{Kind: HTTPCondition, Raw: raw, Path: rest}, nil
+	case TCPCondition:
+		host, port, split := strings.Cut(rest, ":")
+		if !split || host == "" || port == "" {
+			return Condition{}, fmt.Errorf("%q: a tcp condition takes host:port", raw)
+		}
+		if _, err := strconv.Atoi(port); err != nil {
+			return Condition{}, fmt.Errorf("%q: %q is not a port number", raw, port)
+		}
+		return Condition{Kind: TCPCondition, Raw: raw, Address: rest}, nil
+	case ResourceCondition:
+		name, count, split := strings.Cut(rest, ":")
+		if name == "" {
+			return Condition{}, fmt.Errorf("%q: a resource condition takes the kind the emulator "+
+				"stores, as `feint status` and the page name it", raw)
+		}
+		want := 1
+		if split {
+			n, err := strconv.Atoi(count)
+			if err != nil || n < 1 {
+				return Condition{}, fmt.Errorf("%q: %q is not a count of at least one", raw, count)
+			}
+			want = n
+		}
+		return Condition{Kind: ResourceCondition, Raw: raw, Resource: name, Count: want}, nil
+	default:
+		return Condition{}, fmt.Errorf("%q: %q is not a ready condition; the forms are %s",
+			raw, kind, strings.Join(ConditionKinds, ", "))
+	}
+}
+
+// Conditions parses every ready condition of the file. It cannot fail: Parse
+// already refused a file carrying one that does not read, which is what makes
+// the refusal early rather than at the end of a wait.
+func (f *File) Conditions() []Condition {
+	out := make([]Condition, 0, len(f.Ready))
+	for _, raw := range f.Ready {
+		c, err := ParseCondition(raw)
+		if err != nil {
+			continue
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+// Describe answers what this condition is waiting for, in a sentence a reader
+// can act on when the deadline passes.
+func (c Condition) Describe() string {
+	switch c.Kind {
+	case HTTPCondition:
+		return "the emulator answers " + c.Path
+	case TCPCondition:
+		return c.Address + " accepts a connection"
+	case ResourceCondition:
+		if c.Count == 1 {
+			return "the emulator holds a " + c.Resource
+		}
+		return fmt.Sprintf("the emulator holds %d %s resources", c.Count, c.Resource)
+	default:
+		return c.Raw
+	}
+}

--- a/internal/environment/render.go
+++ b/internal/environment/render.go
@@ -1,0 +1,113 @@
+package environment
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Render writes the declaration back out, in the schema's own order.
+//
+// It exists for the round trip #189 asks for — a valid file loads and renders —
+// and that round trip is a test rather than a promise: a field added to the
+// struct and forgotten here makes TestAValidDeclarationSurvivesARoundTrip go
+// red, because the rendered copy no longer carries it.
+//
+// Only what the file declared is written. Rendering the defaults too would make
+// every round trip grow the document, and a reader diffing their own file
+// against the rendered one would be shown decisions they never made.
+func Render(f *File) string {
+	var b strings.Builder
+	b.WriteString("version: " + strconv.Itoa(f.Version) + "\n")
+
+	block := func(name string, body func(*strings.Builder)) {
+		var inner strings.Builder
+		body(&inner)
+		if inner.Len() == 0 {
+			return
+		}
+		b.WriteString("\n" + name + ":\n")
+		b.WriteString(inner.String())
+	}
+	scalar := func(w *strings.Builder, path, key, value string) {
+		if !f.declared[path] {
+			return
+		}
+		fmt.Fprintf(w, "  %s: %s\n", key, quote(value))
+	}
+
+	block("cloud", func(w *strings.Builder) {
+		scalar(w, "cloud.provider", "provider", f.Cloud.Provider)
+	})
+	block("emulator", func(w *strings.Builder) {
+		scalar(w, "emulator.addr", "addr", f.Emulator.Addr)
+		scalar(w, "emulator.state", "state", f.Emulator.State)
+		scalar(w, "emulator.contracts", "contracts", f.Emulator.Contracts)
+		scalar(w, "emulator.log_level", "log_level", f.Emulator.LogLevel)
+		if f.declared["emulator.cleanup"] {
+			fmt.Fprintf(w, "  cleanup: %t\n", f.Emulator.Cleanup)
+		}
+		renderMap(w, f.declared["emulator.env"], "env", f.Emulator.Env)
+	})
+	block("runtime", func(w *strings.Builder) {
+		scalar(w, "runtime.mode", "mode", f.Runtime.Mode)
+		renderList(w, f.declared["runtime.images"], "images", f.Runtime.Images)
+	})
+	block("snapshot", func(w *strings.Builder) {
+		scalar(w, "snapshot.load", "load", f.Snapshot.Load)
+	})
+	block("iac", func(w *strings.Builder) {
+		scalar(w, "iac.engine", "engine", f.IaC.Engine)
+		scalar(w, "iac.directory", "directory", f.IaC.Directory)
+		renderMap(w, f.declared["iac.vars"], "vars", f.IaC.Vars)
+	})
+	if f.declared["ready"] {
+		b.WriteString("\nready:\n")
+		for _, item := range f.Ready {
+			b.WriteString("  - " + quote(item) + "\n")
+		}
+	}
+	return b.String()
+}
+
+func renderMap(w *strings.Builder, declared bool, key string, values map[string]string) {
+	if !declared {
+		return
+	}
+	names := make([]string, 0, len(values))
+	for name := range values {
+		names = append(names, name)
+	}
+	// Sorted, so two renders of one file are the same bytes and a diff means
+	// something moved rather than that a map iterated differently.
+	sort.Strings(names)
+	fmt.Fprintf(w, "  %s:\n", key)
+	for _, name := range names {
+		fmt.Fprintf(w, "    %s: %s\n", name, quote(values[name]))
+	}
+}
+
+func renderList(w *strings.Builder, declared bool, key string, values []string) {
+	if !declared {
+		return
+	}
+	fmt.Fprintf(w, "  %s:\n", key)
+	for _, value := range values {
+		fmt.Fprintf(w, "    - %s\n", quote(value))
+	}
+}
+
+// quote wraps a value the reader would otherwise read as something else — a
+// comment, an empty value, or a line whose leading space this parser trims.
+// Everything else is written bare, because a document where every value carries
+// quotes is a document nobody edits by hand.
+func quote(value string) string {
+	if value == "" {
+		return `""`
+	}
+	if strings.ContainsAny(value, "#:\"'") || strings.TrimSpace(value) != value {
+		return strconv.Quote(value)
+	}
+	return value
+}

--- a/internal/environment/yaml.go
+++ b/internal/environment/yaml.go
@@ -1,0 +1,271 @@
+package environment
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// A YAML reader that refuses everything it cannot account for.
+//
+// The declaration is a nested mapping of scalars, plus one sequence of scalars.
+// That is the whole language it needs, and writing those hundred lines is
+// cheaper than the first external dependency this repository would take (rule 6
+// of CLAUDE.md). The cost of a subset is that a reader can write valid YAML this
+// does not accept — so every refusal names the construct and the line, rather
+// than reporting a value nobody wrote.
+//
+// What it refuses, by name: tabs, flow style ({} and []), anchors and aliases,
+// block scalars (| and >), multiple documents, and a duplicate key. Refusing is
+// the whole point: a file somebody mistyped must fail at load, never at the
+// first surprising behaviour (#189).
+
+// node is one parsed value: exactly one of the three is set.
+//
+// scalar and seq are leaves; mapping is the branch. A node whose kind is
+// mapping never carries a scalar, which is what lets the schema walk answer
+// "this field wanted a value and got a block" with the line to look at.
+type node struct {
+	kind kind
+	// line is where this node was written, for a refusal that can be acted on.
+	line int
+	// scalar holds the value for kindScalar.
+	scalar string
+	// seq holds the items for kindSeq, each of them a scalar node.
+	seq []node
+	// mapping holds the children for kindMapping, and order preserves the
+	// file's own so a refusal reports the first mistake rather than a random
+	// one.
+	mapping map[string]node
+	order   []string
+}
+
+type kind int
+
+const (
+	kindScalar kind = iota
+	kindSeq
+	kindMapping
+)
+
+func (k kind) String() string {
+	switch k {
+	case kindSeq:
+		return "a list"
+	case kindMapping:
+		return "a block"
+	default:
+		return "a value"
+	}
+}
+
+// line is one physical line, already stripped of its comment.
+type line struct {
+	number int
+	indent int
+	text   string
+}
+
+// parseYAML reads the subset. The returned node is always a mapping; an empty
+// document is an empty mapping, which the schema walk then reports as missing
+// fields rather than as a parse error.
+func parseYAML(src string) (node, error) {
+	lines, err := scanLines(src)
+	if err != nil {
+		return node{}, err
+	}
+	pos := 0
+	root, err := parseBlock(lines, &pos, 0)
+	if err != nil {
+		return node{}, err
+	}
+	if pos < len(lines) {
+		return node{}, fmt.Errorf("line %d: %q is indented less than the block it is in", lines[pos].number, lines[pos].text)
+	}
+	if root.kind != kindMapping {
+		return node{}, fmt.Errorf("the document must be a block of fields, not %s", root.kind)
+	}
+	return root, nil
+}
+
+// scanLines drops blank lines and comments and records each remaining line's
+// indentation. A tab anywhere in the indentation is refused by name: YAML
+// forbids it, and the failure it produces otherwise is a mis-nested block that
+// reads as a schema error.
+func scanLines(src string) ([]line, error) {
+	var out []line
+	for i, raw := range strings.Split(src, "\n") {
+		number := i + 1
+		if strings.HasPrefix(raw, "---") || strings.HasPrefix(raw, "...") {
+			return nil, fmt.Errorf("line %d: this reader takes one document; %q starts another", number, strings.TrimSpace(raw))
+		}
+		text := stripComment(raw)
+		trimmed := strings.TrimRight(text, " ")
+		if strings.TrimSpace(trimmed) == "" {
+			continue
+		}
+		indent := 0
+		for indent < len(trimmed) && trimmed[indent] == ' ' {
+			indent++
+		}
+		if strings.Contains(trimmed[:indent], "\t") || strings.HasPrefix(strings.TrimLeft(trimmed, " "), "\t") {
+			return nil, fmt.Errorf("line %d: indent with spaces, not tabs", number)
+		}
+		out = append(out, line{number: number, indent: indent, text: strings.TrimSpace(trimmed)})
+	}
+	return out, nil
+}
+
+// stripComment removes a # comment, honouring quotes so a # inside a value is
+// data. Same reasoning as stripHCLComments in internal/cli: a reader who quotes
+// a value containing a hash must get the hash.
+func stripComment(s string) string {
+	var quote byte
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case quote != 0:
+			if c == quote {
+				quote = 0
+			}
+		case c == '\'' || c == '"':
+			quote = c
+		case c == '#' && (i == 0 || s[i-1] == ' ' || s[i-1] == '\t'):
+			return s[:i]
+		}
+	}
+	return s
+}
+
+// parseBlock reads every line at exactly `indent` and their children.
+func parseBlock(lines []line, pos *int, indent int) (node, error) {
+	if *pos >= len(lines) {
+		return node{kind: kindMapping, mapping: map[string]node{}}, nil
+	}
+	if lines[*pos].text[0] == '-' {
+		return parseSeq(lines, pos, indent)
+	}
+	out := node{kind: kindMapping, line: lines[*pos].number, mapping: map[string]node{}}
+	for *pos < len(lines) {
+		cur := lines[*pos]
+		if cur.indent < indent {
+			break
+		}
+		if cur.indent > indent {
+			return node{}, fmt.Errorf("line %d: %q is indented further than the field above it, which takes a value", cur.number, cur.text)
+		}
+		key, rest, ok := strings.Cut(cur.text, ":")
+		if !ok {
+			return node{}, fmt.Errorf("line %d: %q is not a `key: value` line", cur.number, cur.text)
+		}
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return node{}, fmt.Errorf("line %d: a field with no name", cur.number)
+		}
+		if _, dup := out.mapping[key]; dup {
+			return node{}, fmt.Errorf("line %d: %q is declared twice; one of the two would win in silence", cur.number, key)
+		}
+		rest = strings.TrimSpace(rest)
+		*pos++
+		if rest != "" {
+			value, err := scalarNode(rest, cur.number)
+			if err != nil {
+				return node{}, err
+			}
+			out.mapping[key] = value
+			out.order = append(out.order, key)
+			continue
+		}
+		// A bare `key:` opens a block or a list, unless nothing is indented
+		// under it — in which case it is an empty value, which the schema walk
+		// reports against the field rather than here.
+		if *pos >= len(lines) || lines[*pos].indent <= indent {
+			out.mapping[key] = node{kind: kindScalar, line: cur.number}
+			out.order = append(out.order, key)
+			continue
+		}
+		child, err := parseBlock(lines, pos, lines[*pos].indent)
+		if err != nil {
+			return node{}, err
+		}
+		out.mapping[key] = child
+		out.order = append(out.order, key)
+	}
+	return out, nil
+}
+
+// parseSeq reads a list of scalars. A list of blocks is refused by name: no
+// field of this schema takes one, and accepting it would mean the reader
+// carries a shape nothing reads.
+func parseSeq(lines []line, pos *int, indent int) (node, error) {
+	out := node{kind: kindSeq, line: lines[*pos].number}
+	for *pos < len(lines) {
+		cur := lines[*pos]
+		if cur.indent < indent {
+			break
+		}
+		if cur.indent > indent || cur.text[0] != '-' {
+			return node{}, fmt.Errorf("line %d: %q is not a `- value` item of the list above it", cur.number, cur.text)
+		}
+		item := strings.TrimSpace(strings.TrimPrefix(cur.text, "-"))
+		if item == "" {
+			return node{}, fmt.Errorf("line %d: an empty list item", cur.number)
+		}
+		if strings.Contains(item, ":") && !strings.Contains(item, "://") {
+			// `- key: value` is a list of blocks. Refused by name so the reader
+			// is told what this schema takes, rather than being handed a
+			// silently ignored item.
+			if _, rest, ok := strings.Cut(item, ":"); ok && (rest == "" || strings.HasPrefix(rest, " ")) {
+				return node{}, fmt.Errorf("line %d: %q is a list of blocks; every list in this file is a list of values", cur.number, item)
+			}
+		}
+		value, err := scalarNode(item, cur.number)
+		if err != nil {
+			return node{}, err
+		}
+		out.seq = append(out.seq, value)
+		*pos++
+	}
+	return out, nil
+}
+
+// scalarNode reads one scalar and refuses the constructs this subset does not
+// implement. Each refusal names the construct: a reader who wrote an anchor
+// gets told anchors are not read, not that their value is malformed.
+func scalarNode(raw string, number int) (node, error) {
+	switch {
+	case strings.HasPrefix(raw, "&") || strings.HasPrefix(raw, "*"):
+		return node{}, fmt.Errorf("line %d: anchors and aliases are not read; write the value out", number)
+	case strings.HasPrefix(raw, "|") || strings.HasPrefix(raw, ">"):
+		return node{}, fmt.Errorf("line %d: block scalars (| and >) are not read; this file holds no multi-line value", number)
+	case strings.HasPrefix(raw, "{") || strings.HasPrefix(raw, "["):
+		return node{}, fmt.Errorf("line %d: flow style ({…} and […]) is not read; write the block out on its own lines", number)
+	case strings.HasPrefix(raw, "!"):
+		return node{}, fmt.Errorf("line %d: tags (!…) are not read", number)
+	}
+	value, err := unquote(raw, number)
+	if err != nil {
+		return node{}, err
+	}
+	return node{kind: kindScalar, line: number, scalar: value}, nil
+}
+
+// unquote strips one layer of quotes. A double-quoted value goes through
+// strconv.Unquote so an escape means what YAML says it means; a single-quoted
+// one is literal but for the doubled quote.
+func unquote(raw string, number int) (string, error) {
+	if len(raw) >= 2 && raw[0] == '"' && raw[len(raw)-1] == '"' {
+		out, err := strconv.Unquote(raw)
+		if err != nil {
+			return "", fmt.Errorf("line %d: %s is not a readable double-quoted value: %w", number, raw, err)
+		}
+		return out, nil
+	}
+	if len(raw) >= 2 && raw[0] == '\'' && raw[len(raw)-1] == '\'' {
+		return strings.ReplaceAll(raw[1:len(raw)-1], "''", "'"), nil
+	}
+	if strings.HasPrefix(raw, "\"") || strings.HasPrefix(raw, "'") {
+		return "", fmt.Errorf("line %d: %s opens a quote it never closes", number, raw)
+	}
+	return raw, nil
+}

--- a/mise.toml
+++ b/mise.toml
@@ -235,6 +235,14 @@ run = [
 description = "Apply the example stacks — realistic platform configurations, not fixtures"
 run = "tools/conformance/stacks.sh http://$FEINT_ADDR"
 
+[tasks."conformance:environment"]
+description = "Prove `feint up` and `feint down` on a fixture declaration, with the real binary"
+depends = ["build"]
+# On a port of its own, because this suite starts and stops an emulator of its
+# own: pointed at the shared address, its cleanup would stop the process every
+# other suite is measuring. Same reasoning as faults.sh and zones.sh.
+run = "tools/conformance/environment/up.sh 127.0.0.1:4598"
+
 [tasks."conformance:terraform:outscale"]
 description = "Run the real Outscale Terraform provider against the running emulator"
 run = "tools/conformance/outscale/terraform.sh http://$FEINT_ADDR"
@@ -521,6 +529,11 @@ tools/conformance/faults.sh
 # --refusals-only` reads the whole file before it sends anything rather than
 # taking that on trust.
 tools/conformance/refusals.sh "http://$FEINT_ADDR"
+# `feint up` and `feint down` on a fixture declaration (#190). On an emulator
+# and a port of its own, for the reason faults.sh has one: this suite's whole
+# subject is starting and stopping an emulator, and it would otherwise stop the
+# one every other line here is measuring.
+tools/conformance/environment/up.sh 127.0.0.1:4598
 # Every route driven from its provider's API description. Skipped when a machine
 # runtime is on: a synthetic walk of every Create* would start a container each.
 if [ "${FEINT_VM:-off}" = "off" ]; then ./feint probe --endpoint "http://$FEINT_ADDR" --contracts contracts; fi

--- a/tools/conformance/environment/fixture/feint.yaml
+++ b/tools/conformance/environment/fixture/feint.yaml
@@ -1,0 +1,22 @@
+# The fixture repository #190 asks for: one declaration, driven by `feint up`
+# and `feint down` on every pull request, with --vm off.
+#
+# It declares no infrastructure on purpose. What is under test is the verb, not
+# a provider: the ready conditions are the emulator's own answers, so this runs
+# on a runner with nothing installed but the binary itself.
+version: 1
+
+cloud:
+  provider: scaleway
+
+emulator:
+  addr: 127.0.0.1:4599
+  log_level: info
+
+runtime:
+  mode: off
+
+ready:
+  - http:/_feint/health
+  - http:/instance/v1/zones/fr-par-1/servers
+  - tcp:127.0.0.1:4599

--- a/tools/conformance/environment/up.sh
+++ b/tools/conformance/environment/up.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# `feint up` and `feint down` on a fixture repository, with the real binary.
+#
+# #190 asks for exactly this, and the reason is that the verbs cannot be proved
+# in a Go test: `up` starts the emulator by re-execing the binary, and in a test
+# that binary is the test binary. So internal/cli tests the decisions — the
+# refusals, the wait, the flags rendered — and this proves the act.
+#
+# What it asserts, and the last one is the one that finds things:
+#
+#   1. `feint up` reaches a state where the emulator answers and every ready
+#      condition passed, asserted against the emulator;
+#   2. the instance it started is one the existing lifecycle verbs know about,
+#      because `up` composes `start` rather than growing a second lifecycle;
+#   3. `feint down` leaves nothing: no process, and nothing answering the port.
+#
+# Usage: tools/conformance/environment/up.sh [addr]
+set -uo pipefail
+
+# Its own port, never the shared one: this suite starts and stops an emulator of
+# its own, and pointing it at the address the rest of the run shares would have
+# its cleanup stop somebody else's process.
+ADDR="${1:-127.0.0.1:4598}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+FEINT="${FEINT_BIN:-$ROOT/feint}"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ok() { echo "  ok: $*"; }
+
+WORK=""
+cleanup() {
+  # The emulator goes even when an assertion failed: a leftover process holds
+  # the port and the next run then measures it instead of the code under test.
+  "$FEINT" stop --addr "$ADDR" >/dev/null 2>&1
+  [ -n "$WORK" ] && rm -rf "$WORK"
+}
+trap cleanup EXIT INT TERM
+
+[ -x "$FEINT" ] || fail "no feint binary at $FEINT; run \`mise run build\` first"
+
+echo "conformance: feint up and feint down on $ADDR"
+
+# A copy, so the repository nobody asked to dirty stays clean: `up` records an
+# instance and the engine, when one is declared, writes state beside the file.
+WORK="$(mktemp -d)"
+cp "$SCRIPT_DIR/fixture/feint.yaml" "$WORK/"
+sed -i "s|addr: 127.0.0.1:4599|addr: $ADDR|g; s|tcp:127.0.0.1:4599|tcp:$ADDR|g" "$WORK/feint.yaml"
+cd "$WORK" || fail "cannot enter the work directory"
+
+echo "- feint up"
+UP_OUT="$WORK/up.log"
+"$FEINT" up --timeout 60s >"$UP_OUT" 2>&1
+UP=$?
+[ "$UP" -eq 0 ] || { cat "$UP_OUT"; fail "up exited $UP"; }
+ok "up exited 0"
+
+# Every declared condition was named while it was waited on, and confirmed. A
+# green run that printed nothing would be indistinguishable from one that
+# skipped the wait.
+for condition in "http:/_feint/health" "http:/instance/v1/zones/fr-par-1/servers" "tcp:$ADDR"; do
+  grep -qF "ok: $condition" "$UP_OUT" || { cat "$UP_OUT"; fail "the ready condition $condition was never confirmed"; }
+done
+ok "every ready condition was said out loud and confirmed"
+
+# Asserted against the emulator rather than against up's own output.
+curl -sf "http://$ADDR/_feint/health" >/dev/null || fail "the emulator up brought up does not answer"
+ok "the emulator answers"
+
+# The instance is one the existing verbs know about: `up` composes `start`, and
+# a second lifecycle would show up exactly here.
+"$FEINT" status --addr "$ADDR" >/dev/null 2>&1 || fail "status does not know the instance up started"
+"$FEINT" logs --addr "$ADDR" -n 1 >/dev/null 2>&1 || fail "logs does not know the instance up started"
+ok "status and logs know the instance, so up composed start rather than replacing it"
+
+echo "- feint down"
+"$FEINT" down >"$WORK/down.log" 2>&1
+DOWN=$?
+[ "$DOWN" -eq 0 ] || { cat "$WORK/down.log"; fail "down exited $DOWN"; }
+ok "down exited 0"
+
+# Checked, not assumed.
+if curl -sf --max-time 2 "http://$ADDR/_feint/health" >/dev/null 2>&1; then
+  fail "down returned and something still answers on $ADDR"
+fi
+ok "nothing answers on $ADDR"
+
+echo "conformance: the environment declaration was brought up and taken down"

--- a/tools/falsify/specs/environment-declaration.json
+++ b/tools/falsify/specs/environment-declaration.json
@@ -65,6 +65,38 @@
       "replace": "\tif err := preflight(decl, *skipIaC, stdout); err != nil && false {",
       "test": "TestUpRefusesBeforeStartingAnything",
       "package": "./internal/cli/"
+    },
+    {
+      "label": "the runtime refusal states the wall and not the door, so a reader routes around it by copying the emulator",
+      "file": "internal/cli/up.go",
+      "find": "\t\treturn fmt.Errorf(\"%w\\n\\n%s\", err, waysPastTheRuntimeRefusal(decl))",
+      "replace": "\t\tif false {\n\t\t\treturn fmt.Errorf(\"%w\\n\\n%s\", err, waysPastTheRuntimeRefusal(decl))\n\t\t}\n\t\treturn err",
+      "test": "TestUpRefusesADeclaredRuntimeTheHostCannotDeliver",
+      "package": "./internal/cli/"
+    },
+    {
+      "label": "a declared image the station does not hold is accepted, and the run dies minutes later on a boot instead of at once",
+      "file": "internal/cli/up.go",
+      "find": "\tif len(missing) > 0 {",
+      "replace": "\tif len(missing) > 0 && false {",
+      "test": "TestADeclaredImageTheStationLacksIsRefusedWithTheCommandThatBuildsIt",
+      "package": "./internal/cli/"
+    },
+    {
+      "label": "an image outside the warm-up set is refused as missing, so a declaration is refused for something the boot path can derive",
+      "file": "internal/cli/up.go",
+      "find": "\t\tcase contains(buildable, name):\n\t\t\tmissing = append(missing, name)\n\t\tdefault:\n\t\t\tonDemand = append(onDemand, name)",
+      "replace": "\t\tcase contains(buildable, name):\n\t\t\tmissing = append(missing, name)\n\t\tdefault:\n\t\t\tonDemand = append(onDemand, name)\n\t\t\tmissing = append(missing, name)",
+      "test": "TestAnImageOutsideTheWarmUpSetIsAnnouncedAndNeverRefused",
+      "package": "./internal/cli/"
+    },
+    {
+      "label": "the summary lists ready conditions nothing evaluated as what proved the environment",
+      "file": "internal/cli/up.go",
+      "find": "\tdefault:\n\t\tfmt.Fprintf(stdout, \"  proved:   nothing — the ready conditions were skipped with the engine\\n\")\n\t}",
+      "replace": "\tdefault:\n\t\tfmt.Fprintf(stdout, \"  proved:   %s\\n\", strings.Join(decl.Ready, \", \"))\n\t}",
+      "test": "TestTheSummaryClaimsNothingItDidNotProve",
+      "package": "./internal/cli/"
     }
   ],
   "note": "The declaration (#189) and the verbs that read it (#190). Every mutation removes a refusal rather than a computation, which is the shape this schema is made of: a file that accepts anything is the whole defect. Each one neutralises a condition rather than deleting a term, so no name is orphaned and a red verdict cannot be a compile failure wearing a guard's clothes. The last two live in internal/cli, because the two halves of the same rule sit either side of that boundary: the schema refuses what it cannot account for, and `up` refuses what the host cannot deliver."

--- a/tools/falsify/specs/environment-declaration.json
+++ b/tools/falsify/specs/environment-declaration.json
@@ -1,0 +1,71 @@
+{
+  "package": "./internal/environment/",
+  "mutations": [
+    {
+      "label": "the schema accepts a key it does not name, and a mistyped file is discovered at the first surprising behaviour instead of at load",
+      "file": "internal/environment/environment.go",
+      "find": "\t\t\treturn fmt.Errorf(\"line %d: unknown field `%s`; %s\", child.line, path, siblings(prefix))",
+      "replace": "\t\t\tif false {\n\t\t\t\treturn fmt.Errorf(\"line %d: unknown field `%s`; %s\", child.line, path, siblings(prefix))\n\t\t\t}\n\t\t\tcontinue",
+      "test": "TestAMistypedFieldIsRefusedByName"
+    },
+    {
+      "label": "what this file deliberately does not carry is accepted, so a reader who writes expose_to_network gets no answer about where it belongs",
+      "file": "internal/environment/environment.go",
+      "find": "\t\tif reason, refused := notCarried[path]; refused {",
+      "replace": "\t\tif reason, refused := notCarried[path]; refused && false {",
+      "test": "TestWhatIsNotCarriedIsRefusedWithItsReason"
+    },
+    {
+      "label": "emulator.env sets any variable of the process it spawns, not this project's own knobs",
+      "file": "internal/environment/environment.go",
+      "find": "\tif !strings.HasPrefix(name, \"FEINT_\") {",
+      "replace": "\tif !strings.HasPrefix(name, \"FEINT_\") && false {",
+      "test": "TestAnEnvironmentVariableOutsideTheProjectsOwnIsRefused"
+    },
+    {
+      "label": "a runtime mode the binary does not know is accepted, and surfaces when the emulator starts rather than when the file is read",
+      "file": "internal/environment/environment.go",
+      "find": "\tif !contains(allowed, n.scalar) {",
+      "replace": "\tif !contains(allowed, n.scalar) && false {",
+      "test": "TestAnUnknownRuntimeModeIsRefusedWithTheList"
+    },
+    {
+      "label": "a ready condition nobody serves is accepted, so up waits out its deadline on a form nothing evaluates",
+      "file": "internal/environment/ready.go",
+      "find": "\tdefault:\n\t\treturn Condition{}, fmt.Errorf(\"%q: %q is not a ready condition; the forms are %s\",\n\t\t\traw, kind, strings.Join(ConditionKinds, \", \"))",
+      "replace": "\tdefault:\n\t\tif false {\n\t\t\treturn Condition{}, fmt.Errorf(\"%q: %q is not a ready condition; the forms are %s\",\n\t\t\t\traw, kind, strings.Join(ConditionKinds, \", \"))\n\t\t}\n\t\treturn Condition{Kind: ConditionKind(kind), Raw: raw}, nil",
+      "test": "TestAReadyConditionNobodyServesIsRefusedWithTheForms"
+    },
+    {
+      "label": "a key written twice is accepted, and one of the two values wins in silence",
+      "file": "internal/environment/yaml.go",
+      "find": "\t\tif _, dup := out.mapping[key]; dup {",
+      "replace": "\t\tif _, dup := out.mapping[key]; dup && false {",
+      "test": "TestADuplicateKeyIsRefused"
+    },
+    {
+      "label": "a declaration from the future is read as if this binary knew its schema",
+      "file": "internal/environment/environment.go",
+      "find": "\tif out.Version != Version {",
+      "replace": "\tif out.Version != Version && false {",
+      "test": "TestAVersionThisBinaryDoesNotReadIsRefusedNamingBoth"
+    },
+    {
+      "label": "an unreadable inventory is read as a count of zero, so a broken emulator is indistinguishable from one nobody has used",
+      "file": "internal/cli/up.go",
+      "find": "\tif err := decoder.Decode(&body); err != nil {",
+      "replace": "\tif err := decoder.Decode(&body); err != nil && false {",
+      "test": "TestAnUnreadableInventoryIsAnErrorAndNeverAZero",
+      "package": "./internal/cli/"
+    },
+    {
+      "label": "up starts the emulator before asking the questions it could answer beforehand: which provider, which runtime, which engine",
+      "file": "internal/cli/up.go",
+      "find": "\tif err := preflight(decl, *skipIaC, stdout); err != nil {",
+      "replace": "\tif err := preflight(decl, *skipIaC, stdout); err != nil && false {",
+      "test": "TestUpRefusesBeforeStartingAnything",
+      "package": "./internal/cli/"
+    }
+  ],
+  "note": "The declaration (#189) and the verbs that read it (#190). Every mutation removes a refusal rather than a computation, which is the shape this schema is made of: a file that accepts anything is the whole defect. Each one neutralises a condition rather than deleting a term, so no name is orphaned and a red verdict cannot be a compile failure wearing a guard's clothes. The last two live in internal/cli, because the two halves of the same rule sit either side of that boundary: the schema refuses what it cannot account for, and `up` refuses what the host cannot deliver."
+}


### PR DESCRIPTION
Two developers on one repository did not get the same cloud, and nothing in the tree said what either should be. `feint.yaml` is that declaration, and `feint up` / `feint down` are the verbs that read it — because a declaration nothing reads is a comment.

## What it covers

Read today: `version`, `cloud.provider`, `emulator.{addr,state,contracts,log_level,cleanup,env}`, `runtime.{mode,images}`, `snapshot.load`, `iac.{engine,directory,vars}`, `ready`.

**Nothing is declared-but-unread.** `Unread()` reports any such field out loud at load, and a test asserts the three shipped declarations have none.

**Refused by name with the reason**, never swallowed as an unknown key: `emulator.coverage`, `emulator.shapes` and `emulator.expose_to_network` (all three are `serve`-only, `start` refuses them, and `up` composes `start` — the third is also a decision that must be typed rather than cloned), and `proxy` (it needs a real cloud endpoint and credentials).

`emulator.env` accepts `FEINT_*` only, which is how `FEINT_EXOSCALE_ALLOW_TERRAFORM` — **read inside the emulator's process, so useless if exported after the start** — and `FEINT_BOOT_IMAGES` now travel with the declaration instead of in a paragraph.

## What the three declarations absorb, measured the hard way

The three example stacks were played by hand the same evening, and cost four harness errors in one hour. Each one is now a line in a file:

- `iac.vars.endpoint` — Scaleway and Outscale declare a variable whose default is `127.0.0.1:4599`; left to it against an emulator on another port, Terraform blocks to its own ceiling and **the message blames the provider**.
- Exoscale declares no such variable, and the file says so rather than leaving the asymmetry to be discovered: that provider has no endpoint attribute and reads `EXOSCALE_API_ENDPOINT` with the `/v2` path inside the value.
- `TF_CLI_CONFIG_FILE` stays out on purpose — it names a file on the operator's machine, so a declaration carrying it would only work on the machine that wrote it. That is #191's boundary, drawn here.

## Proved, not asserted

**`feint up --runtime incus-ovn` carried the Scaleway stack to the end three times.** The host read directly rather than through the API, while it was up: **6 containers** matching 6 `instance/server`, **3 OVN networks** carrying exactly the declared blocks, **3 rule sets** whose `used_by` totals the six interfaces, and `capabilities` reporting machines, addresses, firewall, isolation and balancing. After `feint down`: nothing left.

The three stacks replayed in `off` with the final binary: **50 / 48 / 15**, plans empty / empty / two outputs, destroys clean.

**One instrument lied and was caught before it filed anything.** The first ACL reader filtered on the *network* prefix and reported `0 ACLs` on a run carrying six — a rule set is named by the pack (`scw-<digest>`) and marked by its description. Filed as written, that would have been a false #475 against Scaleway.

## Guards, with their doors

`--runtime` refuses a mode the host cannot deliver **before starting anything**, and names the way through (`feint doctor --vm <mode>`, `feint up --runtime off`, editing `runtime.mode`) — a guard with no way past it gets worked around by copying the emulator.

`runtime.images` answers **three ways, never two**: present; in the warm-up set and absent → refused, naming `feint images --only <name>`; outside that set → *announced, not refused*, because the boot path derives one on demand (#465) and refusing would refuse something the runtime can do.

**A defect found while measuring**: `--no-iac` waited for ready conditions describing what the engine it had just skipped would build, so it failed every time. It now skips them out loud, and the summary prints `proved: nothing` instead of crediting conditions nothing evaluated.

## Gates

`go build` 0 · `go test ./...` 0 · `mise run prepush` 0 · `falsify environment-declaration.json` 0 — **13 mutations, 13 red** · `feint docs --check` 0 · `tools/conformance/environment/up.sh` 0 (new, wired into the `probe` leg on a port of its own so its cleanup cannot stop the shared emulator).

CLI surface frozen: `cliSurfaceVersion` 17→18, `frozen:update` run.

**`up` cannot be proved end to end in a Go test** — it starts the emulator by re-execing the binary, which in a test is the test binary. So `internal/cli` tests the decisions and the shell script proves the act, and that split is written where a reader meets it.

## Filed while measuring, not smoothed over

**#481**, **#483** and **#484** came out of driving the real runtime, and all three are the same family: the API describes something the host does not do, and nothing fails.

## Not delivered

**#191** needs an envelope wrapping the declaration, the store snapshot and the runtime it was made under, plus a capability check at import and a stated decision about what a bundle carries when the state holds an SSH key. **#192** needs assertions keyed on `capabilities.*` that skip *with a message* and keep exit 0 — `--runtime` ships and prints its override, nothing else of it does.

Closes #189
Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)
