### PR TITLE
feat(firewall): the three packs hand their groups to the host, and a boot publishes what it produced (#475, #484)

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -28,7 +28,7 @@
 >
 > **Prouvé** : 348 des 371 opérations montées sont pilotées par un vrai client, à chaque pull request. `scw`, `octl`, `exo`, Terraform et OpenTofu tournent contre l'émulateur en CI, et les machines démarrent réellement : connexion ssh sur le compte par défaut de chaque provider, subnets isolés, pare-feu qui filtre. La chaîne complète est décrite dans [docs/conformance.md](docs/conformance.md).
 >
-> **Pas prouvé** : quotas, prix, capacité réelle, validation des identifiants, authentification, cohérence à terme. Les 43 sections de [docs/limits.md](docs/limits.md) disent chacune ce qu'elle coûte. Un émulateur avec un seul compte implicite et aucune grille tarifaire devrait inventer ces chiffres, et quelqu'un agirait dessus.
+> **Pas prouvé** : quotas, prix, capacité réelle, validation des identifiants, authentification, cohérence à terme. Les 42 sections de [docs/limits.md](docs/limits.md) disent chacune ce qu'elle coûte. Un émulateur avec un seul compte implicite et aucune grille tarifaire devrait inventer ces chiffres, et quelqu'un agirait dessus.
 >
 > **Inconnu** : 23 opérations sont montées et n'ont jamais été pilotées par un client. Chacune dit pourquoi aucun client officiel ne l'atteint, à la route et dans [docs/routes.md](docs/routes.md). Elles sont comptées plutôt qu'escamotées, une par une, dans [coverage/evidence.json](coverage/evidence.json).
 >

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 >
 > **Proven**: 348 of the 371 mounted operations are driven by a real client, on every pull request. `scw`, `octl`, `exo`, Terraform and OpenTofu run against the emulator in CI, and machines really boot: an ssh login on each provider's own default account, isolated subnets, a firewall that filters. The whole chain is described in [docs/conformance.md](docs/conformance.md).
 >
-> **Not proven**: quotas, prices, real capacity, identifier validation, authentication, eventual consistency. The 43 sections of [docs/limits.md](docs/limits.md) each say what one costs. An emulator with a single implicit account and no price list would have to invent those figures, and somebody would act on them.
+> **Not proven**: quotas, prices, real capacity, identifier validation, authentication, eventual consistency. The 42 sections of [docs/limits.md](docs/limits.md) each say what one costs. An emulator with a single implicit account and no price list would have to invent those figures, and somebody would act on them.
 >
 > **Unknown**: 23 operations are mounted and have never been driven by a client. Every one of them states why no official client reaches it, at the route and in [docs/routes.md](docs/routes.md). They are counted rather than glossed, one by one, in [coverage/evidence.json](coverage/evidence.json).
 >
@@ -638,14 +638,16 @@ by the install play yet.
 
 This is what separates Feint from a mock server, and it is measured rather than
 claimed: the block a client asks for is the block it gets, the address the API
-publishes is the address the machine carries, **a Scaleway** security group's
-default policy closes a port for real, and authorising it afterwards opens it
-without restarting anything.
+publishes is the address the machine carries, a security group's rules become
+a rule set the host actually holds — for the three packs since #475 — and
+authorising a port afterwards opens it without restarting anything.
 
-That provider name is load-bearing. Only Scaleway hands its rules to the
-runtime; an Outscale or Exoscale security group is served, echoed back and
-enforced on nothing (#180). `/_feint/health` answers which packs deliver it, so
-a program can ask rather than assume:
+Two measured bounds stand, and docs/limits.md carries both with their
+measurements: an interface the runtime declares unenforceable (a routed NIC,
+`capabilities.firewall_public_only: false`) stays unenforceable, and on a run
+with two or more subnets in OVN mode the isolation rule set still defeats a
+group's default-deny (#491). `/_feint/health` answers which packs deliver the
+handoff, so a program can ask rather than assume:
 
 ```bash
 curl -s localhost:4599/_feint/health | jq '{capabilities, enforced}'

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -1357,6 +1357,15 @@ network ACL attached to every interface of the machine. A port no rule opens
 refuses the connection, authorising one opens it without a restart, and revoking
 it closes it again. All four are checked end to end against a live daemon.
 
+**The bound a second subnet adds (#491).** The "port no rule opens refuses"
+half holds only while the machine's network carries no isolation rule set. On
+an OVN run with two or more emulated subnets, the isolation set's catch-all
+allow (rule priority 300) outranks the NIC's default action (100/111), and the
+closed port answers. Measured on 2026-08-26 with one variable: the same
+forbidden port flips from OPEN to CLOSED when the isolation set is detached
+from the network. The rules a group *does* state keep being enforced either
+way; it is the default-deny that #491 tracks.
+
 **What this requires.** `security.acls` on a bridged NIC exists from Incus
 **6.0.4** onwards. On 6.0.0, which Ubuntu 24.04 ships and will not move past, the
 option is rejected outright and nothing is enforced. An ACL attached to a
@@ -2955,28 +2964,36 @@ use it to test whether a packet is dropped. The day a rule is worth programming
 for real it arrives as a declared driver capability, measured under OVN, not as
 a silent upgrade of these records.
 
-## Only Scaleway hands a security group to the runtime
+## The three packs hand their security groups to the runtime, within two measured bounds
 
-`internal/providers/scaleway/firewall.go` is the only file in any pack that
-references `machine.Firewaller`. An **Outscale** or **Exoscale** security group
-is served as a control plane, echoed back, and reconciled onto nothing: with a
-runtime configured, every port of the machine stays open whatever the group
-says, and the API answers success on every rule.
+Until #475 was fixed, `internal/providers/scaleway/firewall.go` was the only
+file in any pack that referenced `machine.Firewaller`: an **Outscale** or
+**Exoscale** security group was served as a control plane, echoed back, and
+reconciled onto nothing — with a runtime configured, every port of the machine
+stayed open whatever the group said, and the API answered success on every
+rule. All three packs now hand their rules over through the shared layer
+(`machine.Binding`), and the witness is observable on the host: `incus network
+acl list` carries `scw-*`, `osc-*` and `exo-*` sets marked `feint security
+group`, attached to the machines that wear the groups (measured 2026-08-26 on
+`examples/stacks/scaleway` — three `scw-*` sets, six interfaces between them —
+`examples/stacks/outscale` and `examples/stacks/exoscale`, each under
+`feint up --runtime incus-ovn`).
 
-That was published as the opposite until #180. `(*Incus).Capabilities()`
-declares `firewall: true` in every mode, one set for the whole process, and this
-repository tells a consumer to key on the capability rather than on a mode name.
-Following that advice, a user probed a port a deny-default group should have
-closed and found it answering.
+The history matters because the claim drifted once before. That gap was
+published as the opposite until #180: `(*Incus).Capabilities()` declares
+`firewall: true` in every mode, one set for the whole process, and this
+repository tells a consumer to key on the capability rather than on a mode
+name. Following that advice, a user probed a port a deny-default group should
+have closed and found it answering.
 
-`/_feint/health` now carries both halves, and the honest check is their
+`/_feint/health` carries both halves, and the honest check is their
 conjunction:
 
 ```console
 $ curl -s localhost:4599/_feint/health | jq '{capabilities: .capabilities.firewall, enforced: .enforced.firewall}'
 {
   "capabilities": true,
-  "enforced": ["scaleway"]
+  "enforced": ["exoscale", "outscale", "scaleway"]
 }
 ```
 
@@ -2985,21 +3002,21 @@ asks it to. A pack absent from that list either does not wire it or has not
 said, and a consumer cannot tell those apart — which is intended, because both
 mean the same thing to whoever is about to open a socket.
 
-## Whether a Scaleway security group filters is not measured under every mode
-
-The security-group family — `CreateSecurityGroup`, its rules, and the groups a
-machine and its interfaces wear — is served as a control plane by all three
-packs. For Scaleway the rules reach the runtime; whether they are *enforced* on
-traffic under `FEINT_VM=incus-ovn` has **not been measured**, and this section
-says so rather than claiming a limit.
-
-The distinction is the one the firewall section above makes for Scaleway, where
-enforcement is measured within stated bounds. Nothing equivalent has been run
-for Outscale groups. The open question named in the roadmap is a rule sourced by
-*group* rather than by CIDR, which needs an OVN selector; the emulator's own
-`machine.Capabilities` is where an answer would be declared, and it declares
-nothing here today.
-
-Until somebody runs it: assume the groups this pack serves describe a policy and
-apply none of it, and do not use the emulator to check that a rule blocks
-anything.
+**The two bounds, both measured.** First, an interface the runtime declares
+unenforceable stays unenforceable: a routed NIC accepts no security option
+(#337, `capabilities.firewall_public_only: false`), and that is the *primary*
+interface of every Exoscale instance and of every Scaleway server whose only
+address is public — the pack hands the set over, the driver refuses with the
+typed error, and the log names the declaring capability instead of crying
+wolf. Second, on any run where at least two emulated subnets exist in OVN
+mode, the emulator's own isolation rule set defeats every NIC-level default
+deny: its catch-all allow sits at rule priority 300 where the NIC default sits
+at 100/111, so a port no rule opens **answers anyway** on machines whose
+network carries an isolation set. Measured both ways on 2026-08-26 — the
+forbidden port flips from OPEN to CLOSED the moment the isolation set is
+detached from the network, nothing else changed — and filed as #491 with the
+upstream constants. Until #491 lands: a group's *allows* are enforced, and its
+default-deny holds only on networks without the emulator's isolation set.
+Group-sourced rules (the tiering statement, "tier 2 accepts tier 1") are
+expanded into the member machines' addresses, since the runtime has no group
+selector, and re-expanded whenever a member boots or gains an interface.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -957,13 +957,16 @@ empty and destroying (OSC-3), and the storage chain (OSC-4). The parity bar
 this item named — that `net_vm` apply — is met, and [limits.md](limits.md)
 records what the served topology does and does not move.
 
-What remains is load balancing (OSC-5, #16) and one warning that belongs here
-because it is an architecture decision rather than pack work: a security-group
-rule sourced by *group* rather than by CIDR needs an OVN selector, not a
-static rule set, and that network-model question must be answered before any
-batch promises Outscale group **enforcement** — which
-[limits.md](limits.md) states is served as a control plane and not measured on
-traffic today.
+What remains is load balancing (OSC-5, #16). The warning this paragraph used
+to carry — that a rule sourced by *group* rather than by CIDR needs an OVN
+selector before any batch promises Outscale group **enforcement** — was
+answered by #475 the way the driver's own contract suggests: the runtime has
+no group selector, so the member reference is expanded into the addresses the
+member machines answer on, and re-expanded whenever a member boots or gains an
+interface. Outscale and Exoscale hand their groups to the runtime now, within
+the two measured bounds [limits.md](limits.md) states (a routed NIC enforces
+nothing by declaration, and #491 tracks the isolation set defeating a group's
+default-deny on multi-subnet OVN runs).
 
 **Evidence:** for what landed, the conformance suite as it runs now; for the
 remainder, the LB apply named in OSC-5.

--- a/internal/core/machine/firewall_binding.go
+++ b/internal/core/machine/firewall_binding.go
@@ -1,0 +1,155 @@
+package machine
+
+import (
+	"context"
+	"errors"
+)
+
+// The reconciliation of a rule set onto machines, shared by every pack.
+//
+// The translation of a security group into a FirewallSpec is each provider's
+// own vocabulary and stays in its pack. Everything after the translation — a
+// permissive set attaches nothing, the defaults ride the binding, a refusal
+// the runtime declares is a Warn where anything else is an Error — is the same
+// behaviour three times over, and it was written once: only Scaleway handed
+// its groups to the runtime, and an Outscale Vm and three Exoscale machines
+// ran with zero ACLs on the host while their API described a closed port
+// (#475). A sequence written per pack is a sequence two packs never wrote.
+
+// EnforcesNothing reports whether a rule set restricts any traffic at all:
+// permissive in both directions, with no rule that denies anything.
+//
+// A group that enforces nothing attaches nothing, on every runtime. This is
+// not an optimisation, and each runtime family contributed its own measured
+// reason:
+//
+//   - OVN: the pipeline evaluates the sender's egress rules before the
+//     receiver's ingress default (the priority constants in acl_ovn.go at
+//     v7.2.0: NIC ingress default 100, NIC egress default 111, rule-level
+//     allow 300), so any allow carried by the sender's rule set opens a port
+//     the receiver's default-deny closes — measured with the Scaleway suite's
+//     own probe machine.
+//   - routed NICs (#337): a default group — pure accept, filtering nothing
+//     upstream — rides onto a server whose one interface accepts no rule set
+//     at all. Attaching the empty policy there was an ERROR log the control
+//     plane answered over as if the group were enforced.
+//
+// TestAPermissiveGroupBindsNothingOnEveryRuntime fails without the
+// unconditional half.
+func (s FirewallSpec) EnforcesNothing() bool {
+	if s.DefaultIngress != "allow" || s.DefaultEgress != "allow" {
+		return false
+	}
+	for _, rule := range s.Rules {
+		if rule.Action == "drop" || rule.Action == "reject" {
+			return false
+		}
+	}
+	return true
+}
+
+// WithPermissiveCatchAll writes a permissive default policy into the rule set
+// itself, as a catch-all in last position of the runtime's precedence: allow
+// loses to any drop or reject the set states, which is exactly what a default
+// is. The binding's default actions say the same thing on bridged NICs, but an
+// OVN NIC cannot take those keys without being re-plugged (and losing its
+// address), so the rule set is the one place the policy can live everywhere.
+//
+// allow is the pack's own permissive verb — "allow" for a stateful group,
+// "allow-stateless" where the provider declares statelessness — because
+// silently turning a stateless group's openness back into a stateful one is a
+// difference a client can measure.
+func (s FirewallSpec) WithPermissiveCatchAll(allow string) FirewallSpec {
+	if s.DefaultIngress == "allow" {
+		s.Rules = append(s.Rules, FirewallRule{Direction: "ingress", Action: allow})
+	}
+	if s.DefaultEgress == "allow" {
+		s.Rules = append(s.Rules, FirewallRule{Direction: "egress", Action: allow})
+	}
+	return s
+}
+
+// SyncRuleSet writes one rule set to the runtime, and reports whether it can
+// now be applied. A failure is logged and never fails the control plane: the
+// API still serves the group, which is the honest degraded state, and this log
+// is the only place an operator learns the rules exist nowhere.
+func (b Binding) SyncRuleSet(ctx context.Context, fw Firewaller, spec FirewallSpec) bool {
+	if fw == nil {
+		return false
+	}
+	if err := fw.EnsureFirewall(ctx, spec); err != nil {
+		b.logger().Error("could not write the firewall rules",
+			"provider", b.Provider, "firewall", spec.Name, "error", err)
+		return false
+	}
+	return true
+}
+
+// ApplyRuleSets attaches rule sets to one machine's interfaces — every set the
+// machine's server carries, in one call, because the runtime replaces the
+// attachment list rather than merging it. Sets that enforce nothing are left
+// out (EnforcesNothing says why), and a machine whose every set is permissive
+// is explicitly detached rather than skipped, so a group emptied of its rules
+// really releases the machine.
+//
+// The combined default is deny-dominant: one set that drops what no rule
+// matches keeps dropping it whatever a more permissive neighbour says, which
+// is the semantics every provider here documents for stacked groups.
+func (b Binding) ApplyRuleSets(ctx context.Context, fw Firewaller, machine string, specs ...FirewallSpec) {
+	if fw == nil || machine == "" {
+		return
+	}
+	binding := FirewallBinding{DefaultIngress: "allow", DefaultEgress: "allow"}
+	for _, spec := range specs {
+		if spec.EnforcesNothing() {
+			continue
+		}
+		binding.Names = append(binding.Names, spec.Name)
+		if spec.DefaultIngress != "allow" {
+			binding.DefaultIngress = "drop"
+		}
+		if spec.DefaultEgress != "allow" {
+			binding.DefaultEgress = "drop"
+		}
+	}
+	if len(binding.Names) == 0 {
+		binding = FirewallBinding{}
+	}
+	if err := fw.ApplyFirewall(ctx, machine, binding); err != nil {
+		b.reportFirewall(err, "machine", machine)
+	}
+}
+
+// reportFirewall logs a failed application at the level it deserves. A rule
+// set the runtime has no mechanism for — a routed NIC, the interface of a
+// server with only a public address (#337) — is a declared limit, not an
+// operational failure: /_feint/health publishes it as
+// capabilities.firewall_public_only=false and docs/limits.md carries the
+// measurement, so the warning names the declaration instead of crying wolf.
+// Anything else stays an error, because nothing declared it.
+// TestAnUnenforceableGroupIsReportedAsTheDeclaredLimit fails without the
+// distinction.
+func (b Binding) reportFirewall(err error, keyvals ...any) {
+	keyvals = append(keyvals, "provider", b.Provider, "error", err)
+	if errors.Is(err, ErrFirewallUnenforceable) {
+		b.logger().Warn("the security group is not enforced on this machine's public-only interface, "+
+			"which the runtime declares (capabilities.firewall_public_only=false, docs/limits.md)",
+			keyvals...)
+		return
+	}
+	b.logger().Error("could not apply the firewall to a machine", keyvals...)
+}
+
+// DropRuleSet removes a rule set whose group is going. Failure is logged
+// rather than fatal: the group is already gone from the control plane, and
+// refusing the delete afterwards would leave the client with a resource it
+// cannot remove.
+func (b Binding) DropRuleSet(ctx context.Context, fw Firewaller, name string) {
+	if fw == nil {
+		return
+	}
+	if err := fw.RemoveFirewall(ctx, name); err != nil {
+		b.logger().Error("could not remove the firewall rules",
+			"provider", b.Provider, "firewall", name, "error", err)
+	}
+}

--- a/internal/core/machine/firewall_binding_test.go
+++ b/internal/core/machine/firewall_binding_test.go
@@ -1,0 +1,141 @@
+package machine
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// fakeFirewaller records what the shared layer hands the runtime, so a test
+// asserts on the argument rather than on a green return (#475: the defect was
+// precisely that nothing was handed over while everything answered 200).
+type fakeFirewaller struct {
+	ensured  []FirewallSpec
+	applied  []FirewallBinding
+	removed  []string
+	applyErr error
+}
+
+func (f *fakeFirewaller) EnsureFirewall(_ context.Context, spec FirewallSpec) error {
+	f.ensured = append(f.ensured, spec)
+	return nil
+}
+
+func (f *fakeFirewaller) ApplyFirewall(_ context.Context, _ string, binding FirewallBinding) error {
+	f.applied = append(f.applied, binding)
+	return f.applyErr
+}
+
+func (f *fakeFirewaller) RemoveFirewall(_ context.Context, name string) error {
+	f.removed = append(f.removed, name)
+	return nil
+}
+
+func firewallBinding(buf *bytes.Buffer) Binding {
+	return Binding{
+		Provider: "test",
+		Prefix:   "feint-test-",
+		Log:      slog.New(slog.NewTextHandler(buf, nil)),
+	}
+}
+
+// TestAPermissiveGroupBindsNothingOnEveryRuntime holds the unconditional half
+// of the shared attach (#337, moved here by #475). The empty binding used to
+// be OVN's alone, for the pipeline-priority reason EnforcesNothing keeps; but
+// a default group — pure accept, filtering nothing upstream — rides every
+// server create, including onto a machine whose only interface is a routed
+// NIC that accepts no rule set at all. On the bridge runtime that attach was
+// an ERROR log the control plane answered over as if the group were enforced.
+// The only faithful translation of "filters nothing" is absence, on every
+// runtime and now for every pack.
+func TestAPermissiveGroupBindsNothingOnEveryRuntime(t *testing.T) {
+	permissive := FirewallSpec{
+		Name:           "sg-permissive",
+		DefaultIngress: "allow",
+		DefaultEgress:  "allow",
+		Rules: []FirewallRule{
+			{Direction: "ingress", Action: "allow"},
+			{Direction: "egress", Action: "allow"},
+		},
+	}
+	restrictive := permissive
+	restrictive.Name = "sg-restrictive"
+	restrictive.DefaultIngress = "drop"
+
+	var buf bytes.Buffer
+	fw := &fakeFirewaller{}
+	b := firewallBinding(&buf)
+
+	b.ApplyRuleSets(context.Background(), fw, "feint-test-a", permissive)
+	if len(fw.applied) != 1 || len(fw.applied[0].Names) != 0 {
+		t.Fatalf("a group that filters nothing must attach nothing, got %+v", fw.applied)
+	}
+
+	// The accepting half: a group that restricts something still attaches, and
+	// its defaults ride the binding.
+	fw.applied = nil
+	b.ApplyRuleSets(context.Background(), fw, "feint-test-a", restrictive)
+	if len(fw.applied) != 1 {
+		t.Fatalf("%d applications, want 1", len(fw.applied))
+	}
+	got := fw.applied[0]
+	if len(got.Names) != 1 || got.Names[0] != "sg-restrictive" || got.DefaultIngress != "drop" {
+		t.Fatalf("a restricting group must still bind with its defaults, got %+v", got)
+	}
+
+	// And stacked sets combine deny-dominant: one restricting neighbour keeps
+	// the default closed whatever a permissive one says, while the permissive
+	// one still attaches nothing.
+	fw.applied = nil
+	b.ApplyRuleSets(context.Background(), fw, "feint-test-a", permissive, restrictive)
+	got = fw.applied[0]
+	if len(got.Names) != 1 || got.DefaultIngress != "drop" {
+		t.Fatalf("stacked sets must combine deny-dominant, got %+v", got)
+	}
+}
+
+// TestAnUnenforceableGroupIsReportedAsTheDeclaredLimit separates the two
+// meanings one ERROR line used to conflate (#337, moved here by #475). A rule
+// set the runtime has no mechanism for — ErrFirewallUnenforceable, the routed
+// NIC — is a declared limit, published as
+// capabilities.firewall_public_only=false, and is reported as a warning that
+// names the declaration. A failure nothing declared stays an error.
+func TestAnUnenforceableGroupIsReportedAsTheDeclaredLimit(t *testing.T) {
+	restrictive := FirewallSpec{Name: "sg-r", DefaultIngress: "drop", DefaultEgress: "allow"}
+
+	var buf bytes.Buffer
+	fw := &fakeFirewaller{applyErr: fmt.Errorf("apply firewall to m/eth0: %w", ErrFirewallUnenforceable)}
+	b := firewallBinding(&buf)
+
+	b.ApplyRuleSets(context.Background(), fw, "feint-test-a", restrictive)
+	declared := buf.String()
+	if !strings.Contains(declared, "level=WARN") {
+		t.Fatalf("a declared limit must be a warning, got %q", declared)
+	}
+	if !strings.Contains(declared, "firewall_public_only") {
+		t.Fatalf("the warning must name the declaring capability, got %q", declared)
+	}
+
+	buf.Reset()
+	fw.applyErr = errors.New("the daemon went away")
+	b.ApplyRuleSets(context.Background(), fw, "feint-test-a", restrictive)
+	if failure := buf.String(); !strings.Contains(failure, "level=ERROR") {
+		t.Fatalf("an undeclared failure must stay an error, got %q", failure)
+	}
+}
+
+// TestDropRuleSetHandsTheNameToTheRuntime is the accepting half of the removal
+// path: the set of a deleted group really reaches RemoveFirewall, whose own
+// ownership check is what protects the host.
+func TestDropRuleSetHandsTheNameToTheRuntime(t *testing.T) {
+	var buf bytes.Buffer
+	fw := &fakeFirewaller{}
+	firewallBinding(&buf).DropRuleSet(context.Background(), fw, "scw-abc")
+	if len(fw.removed) != 1 || fw.removed[0] != "scw-abc" {
+		t.Fatalf("removed %v, want [scw-abc]", fw.removed)
+	}
+}

--- a/internal/providers/exoscale/firewall.go
+++ b/internal/providers/exoscale/firewall.go
@@ -1,0 +1,290 @@
+package exoscale
+
+import (
+	"context"
+	"strings"
+
+	"github.com/stephrobert/feint/internal/core/machine"
+	"github.com/stephrobert/feint/internal/core/resource"
+)
+
+// This is where an Exoscale security group stops being documentation.
+//
+// The pack served the whole product and reconciled none of it: three machines
+// of the register's best stack ran with zero ACLs on the host while the API
+// described groups whose rules open exactly two ports (#475). The mechanics —
+// a permissive set attaches nothing, deny-dominant defaults, Warn-or-Error —
+// live in machine.Binding, shared with the two other packs; this file holds
+// only the Exoscale vocabulary.
+//
+// The semantics are upstream's own, from their security-group overview: "all
+// incoming traffic is forbidden" until a rule allows it, "all outgoing traffic
+// is allowed" — and "as soon as you define an outbound rule, outbound traffic
+// is only allowed for the defined outbound rules". Rules are allow-only.
+
+// enforcer returns the runtime's firewall half, or nil when it has none.
+func (p *Pack) enforcer() machine.Firewaller {
+	fw, _ := p.env.Machines.(machine.Firewaller)
+	return fw
+}
+
+// firewallSpecOf translates a group and its rules for the runtime.
+func (p *Pack) firewallSpecOf(group *resource.Resource) machine.FirewallSpec {
+	spec := machine.FirewallSpec{
+		Name:           machine.FirewallName("exo", group.ID),
+		DefaultIngress: "drop",
+		DefaultEgress:  "allow",
+	}
+	rules, _ := group.Attrs["rules"].([]any)
+	for _, entry := range rules {
+		rule, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		// One egress rule is what flips the egress default, upstream's own
+		// sentence — quoted in the file header.
+		if direction := ruleDirection(rule); direction == "egress" {
+			spec.DefaultEgress = "drop"
+		}
+		spec.Rules = append(spec.Rules, p.firewallRulesOf(rule)...)
+	}
+	// The permissive egress of a group with no egress rule is written into the
+	// set itself — WithPermissiveCatchAll says why an OVN NIC needs it there.
+	return spec.WithPermissiveCatchAll("allow")
+}
+
+func ruleDirection(rule map[string]any) string {
+	direction := strings.ToLower(stringAttr(rule["flow-direction"]))
+	if direction != "egress" {
+		return "ingress"
+	}
+	return direction
+}
+
+// firewallRulesOf converts one stored rule, expanded when it names a group
+// rather than a block: bridge-backed runtimes have no group selector, so
+// "traffic from that group" becomes one /32 per address its member machines
+// answer on, refreshed whenever a machine starts (syncFirewallAfterBoot).
+//
+// A rule carrying an icmp type/code is dropped rather than approximated — the
+// runtime's rule shape has no field for them, and family-wide ICMP would be
+// broader than what the API describes; the log says so, because visibly
+// absent is the honest state.
+func (p *Pack) firewallRulesOf(rule map[string]any) []machine.FirewallRule {
+	if _, precise := rule["icmp"]; precise {
+		p.logger().Warn("an ICMP rule with a type and code is not expressible by this runtime "+
+			"and was left out of the rule set; the API still describes it",
+			"rule", stringAttr(rule["id"]))
+		return nil
+	}
+	base := machine.FirewallRule{
+		Direction: ruleDirection(rule),
+		Action:    "allow",
+		Protocol:  strings.ToLower(stringAttr(rule["protocol"])),
+	}
+	if from := int(numOf(rule["start-port"])); from > 0 {
+		base.PortFrom = from
+	}
+	if to := int(numOf(rule["end-port"])); to > 0 {
+		base.PortTo = to
+	}
+
+	blocks := make([]string, 0, 2)
+	if network := stringAttr(rule["network"]); network != "" {
+		blocks = append(blocks, network)
+	}
+	memberRef := false
+	if target, ok := rule["security-group"].(map[string]any); ok {
+		memberRef = true
+		blocks = append(blocks, p.memberBlocks(stringAttr(target["id"]))...)
+	}
+	// Neither a network nor a group means "from anywhere", which an empty
+	// source already says. A group that expands to nothing emits nothing: no
+	// member has an address yet, and the next boot re-expands it.
+	if len(blocks) == 0 {
+		if memberRef {
+			return nil
+		}
+		return []machine.FirewallRule{base}
+	}
+	out := make([]machine.FirewallRule, 0, len(blocks))
+	for _, block := range blocks {
+		converted := base
+		if converted.Direction == "egress" {
+			converted.Destination = block
+		} else {
+			converted.Source = block
+		}
+		out = append(out, converted)
+	}
+	return out
+}
+
+// numOf reads a number that may be an int fresh from a handler or a float64
+// restored from a JSON snapshot.
+func numOf(v any) float64 {
+	switch n := v.(type) {
+	case int:
+		return float64(n)
+	case int64:
+		return float64(n)
+	case float64:
+		return n
+	default:
+		return 0
+	}
+}
+
+func stringAttr(v any) string {
+	s, _ := v.(string)
+	return s
+}
+
+// memberBlocks is what "traffic from the members of that group" means on a
+// runtime with no group selector: one /32 per address a member machine
+// answers on — its public address and its private-network leases — plus the
+// group's external sources, which upstream defines as extending exactly this
+// membership.
+func (p *Pack) memberBlocks(groupID string) []string {
+	if groupID == "" {
+		return nil
+	}
+	out := make([]string, 0, 4)
+	for _, inst := range p.instancesWearing(groupID) {
+		if ip, _ := inst.Attrs["public-ip"].(string); ip != "" {
+			out = append(out, ip+"/32")
+		}
+		for _, att := range instanceAttachmentsOf(inst) {
+			if att.IP != "" {
+				out = append(out, att.IP+"/32")
+			}
+		}
+	}
+	if group, found := p.env.Store.Get(Name, kindSecurityGroup, groupID); found {
+		out = append(out, stringList(group.Attrs["external-sources"])...)
+	}
+	return out
+}
+
+// instancesWearing lists the instances carrying a group — named at creation,
+// attached later, or inherited from their pool.
+func (p *Pack) instancesWearing(groupID string) []*resource.Resource {
+	all := p.env.Store.List(kindInstance, resource.Tenant{Provider: Name})
+	out := make([]*resource.Resource, 0, len(all))
+	for _, inst := range all {
+		for _, id := range stringList(inst.Attrs[attrSecurityGroupIDs]) {
+			if id == groupID {
+				out = append(out, inst)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// syncSecurityGroup pushes a group's rule set and replays it onto every
+// instance wearing it. Called after any change to the group or to its rules.
+func (p *Pack) syncSecurityGroup(ctx context.Context, group *resource.Resource) {
+	fw := p.enforcer()
+	if fw == nil {
+		return
+	}
+	b := p.binding()
+	if !b.SyncRuleSet(ctx, fw, p.firewallSpecOf(group)) {
+		return
+	}
+	for _, inst := range p.instancesWearing(group.ID) {
+		p.applyInstanceRuleSets(ctx, inst)
+	}
+}
+
+// applyInstanceRuleSets attaches everything one instance wears to its machine,
+// in one call, because the runtime replaces the attachment list rather than
+// merging it. Every set is written first, so an attach cannot name a set the
+// runtime has never seen.
+func (p *Pack) applyInstanceRuleSets(ctx context.Context, inst *resource.Resource) {
+	fw := p.enforcer()
+	if fw == nil {
+		return
+	}
+	name := inst.Runtime[p.binding().RuntimeKey]
+	if name == "" {
+		return
+	}
+	b := p.binding()
+	specs := make([]machine.FirewallSpec, 0, 2)
+	for _, id := range stringList(inst.Attrs[attrSecurityGroupIDs]) {
+		group, found := p.env.Store.Get(Name, kindSecurityGroup, id)
+		if !found {
+			continue
+		}
+		spec := p.firewallSpecOf(group)
+		if !b.SyncRuleSet(ctx, fw, spec) {
+			continue
+		}
+		specs = append(specs, spec)
+	}
+	b.ApplyRuleSets(ctx, fw, name, specs...)
+}
+
+// syncFirewallAfterBoot runs once a machine exists: its own sets attach, and
+// every group whose rules point at a group this instance wears is re-expanded,
+// because this machine's addresses are now part of what those groups mean.
+// Without the second half, "the application tier accepts the web tier and
+// nobody else" — the sentence examples/stacks/exoscale writes — never contains
+// the web machines it talks about.
+func (p *Pack) syncFirewallAfterBoot(ctx context.Context, inst *resource.Resource) {
+	if p.enforcer() == nil {
+		return
+	}
+	p.applyInstanceRuleSets(ctx, inst)
+	p.syncGroupsReferencing(ctx, stringList(inst.Attrs[attrSecurityGroupIDs]))
+}
+
+// syncGroupsReferencing re-syncs every group one of whose rules names one of
+// the given groups as a member source.
+func (p *Pack) syncGroupsReferencing(ctx context.Context, groupIDs []string) {
+	if len(groupIDs) == 0 || p.enforcer() == nil {
+		return
+	}
+	named := make(map[string]bool, len(groupIDs))
+	for _, id := range groupIDs {
+		named[id] = true
+	}
+	for _, group := range p.env.Store.List(kindSecurityGroup, resource.Tenant{Provider: Name}) {
+		if groupReferencesAny(group, named) {
+			p.syncSecurityGroup(ctx, group)
+		}
+	}
+}
+
+// groupReferencesAny reports whether any rule of the group names one of the
+// given groups as its source.
+func groupReferencesAny(group *resource.Resource, named map[string]bool) bool {
+	rules, _ := group.Attrs["rules"].([]any)
+	for _, entry := range rules {
+		rule, _ := entry.(map[string]any)
+		if target, ok := rule["security-group"].(map[string]any); ok {
+			if named[stringAttr(target["id"])] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// removeFirewall drops the runtime rule set of a group being deleted.
+func (p *Pack) removeFirewall(ctx context.Context, group *resource.Resource) {
+	p.binding().DropRuleSet(ctx, p.enforcer(), machine.FirewallName("exo", group.ID))
+}
+
+// EnforcesFirewall implements emulator.FirewallEnforcer: this pack reconciles
+// a security group onto the machines that wear it, so a runtime able to
+// enforce rules is handed them (#475).
+//
+// It answers about the pack and not about the process — the reasoning the
+// Scaleway pack's declaration carries in full. The day this pack stops handing
+// rules over, this line is what has to change, and
+// internal/cli's TestEveryPackThatWiresTheFirewallSaysSo is what notices if
+// it does not.
+func (p *Pack) EnforcesFirewall() bool { return true }

--- a/internal/providers/exoscale/firewall_internal_test.go
+++ b/internal/providers/exoscale/firewall_internal_test.go
@@ -1,0 +1,281 @@
+package exoscale
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/machine"
+	"github.com/stephrobert/feint/internal/core/resource"
+)
+
+// The witnesses of #475 for this pack: three machines of the register's best
+// stack ran with zero ACLs while the API described two groups and four rules.
+// Every assertion here is on what reaches the runtime, through a recording
+// Firewaller — the green apply is exactly what hid the defect.
+
+// firewallDriver is recordingDriver plus the Firewaller half.
+type firewallDriver struct {
+	recordingDriver
+
+	mu      sync.Mutex
+	ensured map[string]machine.FirewallSpec
+	applied map[string]machine.FirewallBinding
+}
+
+func newFirewallDriver() *firewallDriver {
+	return &firewallDriver{
+		ensured: map[string]machine.FirewallSpec{},
+		applied: map[string]machine.FirewallBinding{},
+	}
+}
+
+func (d *firewallDriver) EnsureFirewall(_ context.Context, spec machine.FirewallSpec) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.ensured[spec.Name] = spec
+	return nil
+}
+
+func (d *firewallDriver) ApplyFirewall(_ context.Context, machineName string, binding machine.FirewallBinding) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.applied[machineName] = binding
+	return nil
+}
+
+func (d *firewallDriver) RemoveFirewall(_ context.Context, name string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	delete(d.ensured, name)
+	return nil
+}
+
+func storedSecurityGroup(p *Pack, name string, rules []any) *resource.Resource {
+	now := p.env.Now()
+	res := resource.New(p.env.NewID(), kindSecurityGroup, resource.Tenant{Provider: Name}, "present", now)
+	res.Attrs = map[string]any{"name": name, "description": name}
+	if len(rules) > 0 {
+		res.Attrs["rules"] = rules
+	}
+	p.env.Store.Put(res)
+	return res
+}
+
+func storedInstance(p *Pack, publicIP string, groupIDs ...any) *resource.Resource {
+	now := p.env.Now()
+	res := resource.New(p.env.NewID(), kindInstance, resource.Tenant{Provider: Name}, stoppedState, now)
+	res.Attrs = map[string]any{
+		"name":                 "witness",
+		"template":             map[string]any{"id": "11111111-1111-4111-8111-111111111111"},
+		"public-ip-assignment": "inet4",
+	}
+	if publicIP != "" {
+		res.Attrs["public-ip"] = publicIP
+	}
+	if len(groupIDs) > 0 {
+		res.Attrs[attrSecurityGroupIDs] = groupIDs
+	}
+	p.env.Store.Put(res)
+	return res
+}
+
+// TestAnExoscaleGroupReachesTheHostWhenAnInstanceBoots is the wiring itself:
+// the group an instance wears becomes a rule set the runtime holds, attached
+// to the instance's machine, with upstream's own defaults — incoming
+// forbidden until a rule allows it.
+func TestAnExoscaleGroupReachesTheHostWhenAnInstanceBoots(t *testing.T) {
+	driver := newFirewallDriver()
+	p := sequencedPack(driver)
+	group := storedSecurityGroup(p, "platform-web", []any{map[string]any{
+		"id": "r1", "flow-direction": "ingress", "protocol": "tcp",
+		"network": "0.0.0.0/0", "start-port": 443, "end-port": 443,
+	}})
+	inst := storedInstance(p, "192.0.2.7", group.ID)
+
+	p.start(context.Background(), inst)
+
+	setName := machine.FirewallName("exo", group.ID)
+	spec, held := driver.ensured[setName]
+	if !held {
+		t.Fatalf("the runtime holds no rule set %s: the group stayed documentation, which is #475", setName)
+	}
+	if spec.DefaultIngress != "drop" {
+		t.Fatalf("ingress default %q, want drop: upstream forbids all incoming traffic by default", spec.DefaultIngress)
+	}
+	binding, attached := driver.applied[inst.Runtime[p.binding().RuntimeKey]]
+	if !attached || len(binding.Names) != 1 || binding.Names[0] != setName {
+		t.Fatalf("the machine's interfaces carry %+v, want [%s]", binding.Names, setName)
+	}
+}
+
+// TestAnEgressRuleFlipsTheEgressDefault holds upstream's sentence: all
+// outgoing traffic is allowed — written into the set as a catch-all, since an
+// OVN NIC's own default is deny — until the group defines one outbound rule,
+// after which only the defined outbound rules pass.
+func TestAnEgressRuleFlipsTheEgressDefault(t *testing.T) {
+	p := sequencedPack(&recordingDriver{})
+	open := storedSecurityGroup(p, "no-egress", []any{map[string]any{
+		"id": "r1", "flow-direction": "ingress", "protocol": "tcp",
+		"network": "0.0.0.0/0", "start-port": 22, "end-port": 22,
+	}})
+
+	spec := p.firewallSpecOf(open)
+	if spec.DefaultEgress != "allow" {
+		t.Fatalf("egress default %q, want allow while no egress rule exists", spec.DefaultEgress)
+	}
+	catchAll := false
+	for _, rule := range spec.Rules {
+		if rule.Direction == "egress" && rule.Action == "allow" && rule.Destination == "" {
+			catchAll = true
+		}
+	}
+	if !catchAll {
+		t.Fatal("the permissive egress must be written into the set as a catch-all, or an OVN NIC's own default closes it")
+	}
+
+	restricted := storedSecurityGroup(p, "one-egress", []any{map[string]any{
+		"id": "r2", "flow-direction": "egress", "protocol": "tcp",
+		"network": "10.0.0.0/8", "start-port": 443, "end-port": 443,
+	}})
+	spec = p.firewallSpecOf(restricted)
+	if spec.DefaultEgress != "drop" {
+		t.Fatalf("egress default %q, want drop: one outbound rule restricts outbound to the defined rules", spec.DefaultEgress)
+	}
+	for _, rule := range spec.Rules {
+		if rule.Direction == "egress" && rule.Destination == "" {
+			t.Fatalf("a restricted group must carry no egress catch-all, got %+v", rule)
+		}
+	}
+}
+
+// TestAGroupSourcedRuleExpandsToTheMembersAddresses holds the sentence
+// examples/stacks/exoscale writes: the application tier accepts the web tier
+// and nobody else. The runtime has no group selector, so the reference must
+// arrive expanded into the member machines' addresses — and the group's
+// external sources, which upstream defines as extending that membership.
+func TestAGroupSourcedRuleExpandsToTheMembersAddresses(t *testing.T) {
+	p := sequencedPack(&recordingDriver{})
+	web := storedSecurityGroup(p, "web", nil)
+	_ = p.env.Store.Update(Name, kindSecurityGroup, web.ID, func(stored *resource.Resource) error {
+		stored.Attrs["external-sources"] = []any{"203.0.113.0/24"}
+		return nil
+	})
+	storedInstance(p, "192.0.2.7", web.ID)
+	app := storedSecurityGroup(p, "app", []any{map[string]any{
+		"id": "r1", "flow-direction": "ingress", "protocol": "tcp",
+		"security-group": map[string]any{"id": web.ID},
+		"start-port":     8080, "end-port": 8080,
+	}})
+
+	spec := p.firewallSpecOf(app)
+	sources := map[string]bool{}
+	for _, rule := range spec.Rules {
+		if rule.PortFrom == 8080 {
+			sources[rule.Source] = true
+		}
+	}
+	if !sources["192.0.2.7/32"] {
+		t.Fatalf("the member machine's address never reached the expansion, got %v", sources)
+	}
+	if !sources["203.0.113.0/24"] {
+		t.Fatalf("the group's external sources must extend the membership, got %v", sources)
+	}
+}
+
+// TestAPoolMemberWearsItsPoolsGroups is the half of #475 that lands on the
+// stacks: the app tier's whole firewall rides the pool's security-groups, so a
+// member that does not inherit them is a machine the group never reaches.
+func TestAPoolMemberWearsItsPoolsGroups(t *testing.T) {
+	driver := newFirewallDriver()
+	p := sequencedPack(driver)
+	group := storedSecurityGroup(p, "platform-app", []any{map[string]any{
+		"id": "r1", "flow-direction": "ingress", "protocol": "tcp",
+		"network": "0.0.0.0/0", "start-port": 8080, "end-port": 8080,
+	}})
+
+	body := `{"name":"app","size":1,` +
+		`"template":{"id":"11111111-1111-4111-8111-111111111111"},` +
+		`"instance-type":{"id":"71004023-bb72-4a97-b1e9-bc66dfce9470"},` +
+		`"security-groups":[{"id":"` + group.ID + `"}]}`
+	r := httptest.NewRequest("POST", "/v2/instance-pool", strings.NewReader(body))
+	p.createInstancePool(httptest.NewRecorder(), r)
+
+	members := p.poolMembersOfOnlyPool(t)
+	member := members[0]
+	worn := stringList(member.Attrs[attrSecurityGroupIDs])
+	if len(worn) != 1 || worn[0] != group.ID {
+		t.Fatalf("the member wears %v, want [%s]", worn, group.ID)
+	}
+	setName := machine.FirewallName("exo", group.ID)
+	binding, attached := driver.applied[member.Runtime["machine"]]
+	if !attached || !containsName(binding.Names, setName) {
+		t.Fatalf("the member's machine carries %+v, want %s attached", binding.Names, setName)
+	}
+}
+
+func containsName(names []string, want string) bool {
+	for _, name := range names {
+		if name == want {
+			return true
+		}
+	}
+	return false
+}
+
+// poolMembersOfOnlyPool reads the single pool's members back from the store.
+func (p *Pack) poolMembersOfOnlyPool(t *testing.T) []*resource.Resource {
+	t.Helper()
+	pools := p.env.Store.List(kindPool, resource.Tenant{Provider: Name})
+	if len(pools) != 1 {
+		t.Fatalf("%d pools, want 1", len(pools))
+	}
+	members := p.poolMembers(pools[0].ID)
+	if len(members) == 0 {
+		t.Fatal("the pool has no members")
+	}
+	return members
+}
+
+// TestALateNetworkAttachCarriesTheRuleSets covers the interface born after the
+// boot: the Terraform provider attaches private networks once the create has
+// answered, and a rule set applied at boot never reaches a NIC that does not
+// exist yet. The attach path must re-apply — idempotently, since ApplyFirewall
+// covers every NIC of the machine.
+func TestALateNetworkAttachCarriesTheRuleSets(t *testing.T) {
+	driver := newFirewallDriver()
+	p := sequencedPack(driver)
+	group := storedSecurityGroup(p, "web", []any{map[string]any{
+		"id": "r1", "flow-direction": "ingress", "protocol": "tcp",
+		"network": "0.0.0.0/0", "start-port": 443, "end-port": 443,
+	}})
+	inst := storedInstance(p, "192.0.2.7", group.ID)
+	p.start(context.Background(), inst)
+	p.env.Store.Put(inst)
+	machineName := inst.Runtime["machine"]
+
+	r := httptest.NewRequest("POST", "/v2/private-network",
+		strings.NewReader(`{"name":"back","start-ip":"10.90.2.20","end-ip":"10.90.2.200","netmask":"255.255.255.0"}`))
+	p.createPrivateNetwork(httptest.NewRecorder(), r)
+	pns := p.env.Store.List(kindPrivateNetwork, resource.Tenant{Provider: Name})
+	if len(pns) != 1 {
+		t.Fatalf("%d private networks, want 1", len(pns))
+	}
+
+	// The boot's own application is not what this test measures.
+	driver.mu.Lock()
+	driver.applied = map[string]machine.FirewallBinding{}
+	driver.mu.Unlock()
+
+	ar := httptest.NewRequest("POST", "/v2/private-network/"+pns[0].ID+":attach",
+		strings.NewReader(`{"instance":{"id":"`+inst.ID+`"}}`))
+	ar.SetPathValue("id", pns[0].ID)
+	p.attachInstanceToPrivateNetwork(httptest.NewRecorder(), ar)
+
+	binding, applied := driver.applied[machineName]
+	if !applied || len(binding.Names) == 0 {
+		t.Fatalf("the attach left the new interface without the instance's rule sets (applied=%v %+v)", applied, binding)
+	}
+}

--- a/internal/providers/exoscale/machines.go
+++ b/internal/providers/exoscale/machines.go
@@ -179,6 +179,11 @@ func (p *Pack) start(ctx context.Context, res *resource.Resource) {
 	// way a Boot.Attachment would. Attach is idempotent by network, so a
 	// machine that kept its devices across a stop is repaired, not doubled.
 	p.reattachPrivateNetworks(ctx, res)
+	// The groups this instance wears reach its interfaces, and the groups
+	// that name those groups as sources are re-expanded now that this machine
+	// has addresses (#475). After the networks, so the expansion sees every
+	// interface.
+	p.syncFirewallAfterBoot(ctx, res)
 }
 
 // reattachPrivateNetworks puts a freshly booted machine back on every private

--- a/internal/providers/exoscale/pack.go
+++ b/internal/providers/exoscale/pack.go
@@ -1061,26 +1061,6 @@ func (p *Pack) createInstance(w http.ResponseWriter, r *http.Request) {
 	if req.UserData != "" {
 		res.Attrs["user-data"] = req.UserData
 	}
-	// A public address, assigned at creation, because that is what the real
-	// cloud does: an instance created with nothing but a type and a template
-	// answers `ip_address` on the first read — measured on a real account,
-	// 151.145.198.51, with no private network and no elastic IP.
-	//
-	// The pack recorded the intent above and never honoured it, so an emulated
-	// instance published nothing and the machine took whatever the runtime's
-	// default profile gave it, on the operator's own bridge. A machine carries
-	// the addresses its provider's API publishes and no others (#202), and
-	// "none published" was not the honest half of that rule, it was the pack
-	// failing to be its own cloud.
-	//
-	// TestAnInstanceIsGivenAPublicAddressAtCreation fails without this.
-	if assignment, _ := res.Attrs["public-ip-assignment"].(string); assignment != "none" {
-		unlock := p.lockAddresses()
-		if ip, ok := p.freeAddress(); ok {
-			res.Attrs["public-ip"] = ip
-		}
-		unlock()
-	}
 	if ids := refIDs(req.AntiAffinityGroups); len(ids) > 0 {
 		res.Attrs[attrAntiAffinityGroupIDs] = ids
 	}
@@ -1092,11 +1072,43 @@ func (p *Pack) createInstance(w http.ResponseWriter, r *http.Request) {
 	} else {
 		res.Attrs[attrSecurityGroupIDs] = []any{defaultSecurityGroupID}
 	}
-	// The address comes from the machine that starts, not from a constant. It
-	// used to be a fixed 203.0.113.10 on every instance: two of them reported
-	// the same address and nothing answered on either.
-	p.start(r.Context(), res)
+	// A public address, assigned at creation, because that is what the real
+	// cloud does: an instance created with nothing but a type and a template
+	// answers `ip_address` on the first read — measured on a real account,
+	// 151.145.198.51, with no private network and no elastic IP.
+	// TestAnInstanceIsGivenAPublicAddressAtCreation fails without the
+	// allocation.
+	//
+	// The Put happens under the same hold of the lock as the choice, because
+	// freeAddress chooses from what the store holds: an allocated address the
+	// store cannot see yet is an address the next caller is handed again. This
+	// path used to allocate here and only store the instance after the boot —
+	// seconds, with a runtime — and an instance pool created inside that window
+	// took the same address (#484): the host refused the second machine's
+	// route, and the API kept calling that instance running. Outscale's
+	// allocateVms already stores under its address lock for exactly this
+	// reason; this is the same motif, not a new one.
+	// TestAPoolMemberAndAStandaloneInstanceNeverShareAnAddress fails without
+	// the Put inside the lock.
+	unlock := p.lockAddresses()
+	if assignment, _ := res.Attrs["public-ip-assignment"].(string); assignment != "none" {
+		if ip, ok := p.freeAddress(); ok {
+			res.Attrs["public-ip"] = ip
+		}
+	}
 	p.env.Store.Put(res)
+	unlock()
+
+	// The boot runs outside every lock — a launch takes seconds where the lock
+	// takes microseconds — and its result is written back conditionally,
+	// through the shared Transition: a delete landing mid-boot wins, and the
+	// state published is the one the effect produced. The address comes from
+	// the machine that starts, not from a constant: it used to be a fixed
+	// 203.0.113.10 on every instance — two of them reported the same address
+	// and nothing answered on either.
+	_ = p.binding().Transition(p.env.Store, p.env.Now, kindInstance, res.ID, func(stored *resource.Resource) {
+		p.start(r.Context(), stored)
+	})
 
 	p.writeOperation(w, p.operationReferring(nounInstance, res.ID))
 }

--- a/internal/providers/exoscale/pools.go
+++ b/internal/providers/exoscale/pools.go
@@ -224,9 +224,10 @@ func (p *Pack) createInstancePool(w http.ResponseWriter, r *http.Request) {
 
 	// Started after the lock is released, and after every member exists: a
 	// client that reads the pool while the machines boot sees the size it asked
-	// for, which is what the control plane really promises.
+	// for, which is what the control plane really promises. Each boot commits
+	// its own result — startPoolMember says why.
 	for _, member := range created {
-		p.start(r.Context(), member)
+		p.startPoolMember(r.Context(), member.ID)
 	}
 
 	p.writeOperation(w, p.operationReferring(nounPool, pool.ID))
@@ -322,18 +323,50 @@ func (p *Pack) growPool(_ context.Context, pool *resource.Resource, target int64
 	existing := int64(len(p.poolMembers(pool.ID)))
 	created := make([]*resource.Resource, 0)
 	for i := existing; i < target; i++ {
+		// The member's address is chosen and the member stored under one hold
+		// of the address lock: freeAddress chooses from what the store holds,
+		// so a member allocated but not yet stored is a member whose address
+		// the next caller is handed again (#484). Per member rather than
+		// around the loop, so a pool of fifty does not hold every other
+		// allocation of the pack behind it.
+		unlock := p.lockAddresses()
 		member := p.newPoolMember(pool, i)
 		p.env.Store.Put(member)
+		unlock()
 		created = append(created, member)
 	}
 	return created
 }
 
+// startPoolMember boots one member and commits what the boot produced — the
+// machine name, the address, and the state the effect reached, "error"
+// included. The members used to be started on the caller's local copy and
+// never written back: the store kept the running state they were created
+// with, `running` stood over a member whose launch the host had refused, and
+// a member that did start showed "no machine" in its runtime for its whole
+// life (#484). Through Transition, so the write-back is conditional and a
+// delete landing mid-boot wins.
+//
+// TestAFailedPoolMemberStartIsPublishedAsError and
+// TestAPoolMemberStartIsRecordedInTheStore fail without this.
+func (p *Pack) startPoolMember(ctx context.Context, id string) {
+	_ = p.binding().Transition(p.env.Store, p.env.Now, kindInstance, id, func(res *resource.Resource) {
+		p.start(ctx, res)
+	})
+}
+
 // newPoolMember builds one member: an ordinary instance, carrying the pool's
 // declared shape and a manager reference back to it.
+// Called under p.lockAddresses(), held by growPool across the choice and the
+// Put: the address below must be in the store before the lock is released.
+//
+// The member is born stopped, not running: the state a client reads is the one
+// the boot produced, and startPoolMember commits that once the machine is up —
+// or failed. Born running, a member whose launch the host refused kept reading
+// `running` forever, with no machine behind it (#484).
 func (p *Pack) newPoolMember(pool *resource.Resource, index int64) *resource.Resource {
 	now := p.env.Now()
-	member := resource.New(p.env.NewID(), kindInstance, resource.Tenant{Provider: Name}, runningState, now)
+	member := resource.New(p.env.NewID(), kindInstance, resource.Tenant{Provider: Name}, stoppedState, now)
 	prefix, _ := pool.Attrs["instance-prefix"].(string)
 	poolName, _ := pool.Attrs["name"].(string)
 	if prefix == "pool" && poolName != "" {
@@ -366,15 +399,43 @@ func (p *Pack) newPoolMember(pool *resource.Resource, index int64) *resource.Res
 	// one since #202 and said why in a comment this path never read.
 	//
 	// TestAPoolMemberCarriesThePublicAddressItsPoolDeclares fails without it.
+	// No lock of its own: the caller already holds p.lockAddresses() across
+	// this choice and the Put that makes it visible (#484).
 	if assignment, _ := pool.Attrs["public-ip-assignment"].(string); assignment != "none" {
-		unlock := p.lockAddresses()
 		if ip, ok := p.freeAddress(); ok {
 			member.Attrs["public-ip"] = ip
 		}
-		unlock()
+	}
+	// The pool's declared shape the members inherit and upstream publishes on
+	// the instance itself: the security groups they wear — the app tier of
+	// examples/stacks/exoscale carries its whole firewall this way — and the
+	// keys their machines boot with. A member with no group wears the default
+	// one, exactly like an instance created directly.
+	if ids := poolRefIDs(pool.Attrs["security-groups"]); len(ids) > 0 {
+		member.Attrs[attrSecurityGroupIDs] = ids
+	} else {
+		p.ensureDefaultSecurityGroup()
+		member.Attrs[attrSecurityGroupIDs] = []any{defaultSecurityGroupID}
+	}
+	if keys, ok := pool.Attrs["ssh-keys"]; ok {
+		member.Attrs["ssh-keys"] = keys
 	}
 	member.Runtime = map[string]string{runtimePoolKey: pool.ID}
 	return member
+}
+
+// poolRefIDs reads the ids out of a stored list of {id: …} references,
+// tolerating the []any a snapshot restore produces.
+func poolRefIDs(v any) []any {
+	list, _ := v.([]any)
+	out := make([]any, 0, len(list))
+	for _, entry := range list {
+		ref, _ := entry.(map[string]any)
+		if id, _ := ref["id"].(string); id != "" {
+			out = append(out, id)
+		}
+	}
+	return out
 }
 
 func (p *Pack) listInstancePools(w http.ResponseWriter, _ *http.Request) {
@@ -528,9 +589,10 @@ func (p *Pack) scaleInstancePool(w http.ResponseWriter, r *http.Request) {
 	unlock()
 
 	// Outside the lock, because both directions touch the runtime and take
-	// seconds: starting a container, and terminating one.
+	// seconds: starting a container, and terminating one. Each boot commits
+	// its own result — startPoolMember says why.
 	for _, member := range created {
-		p.start(r.Context(), member)
+		p.startPoolMember(r.Context(), member.ID)
 	}
 	for _, member := range removed {
 		p.destroy(r.Context(), member)

--- a/internal/providers/exoscale/pools_machines_internal_test.go
+++ b/internal/providers/exoscale/pools_machines_internal_test.go
@@ -1,0 +1,228 @@
+package exoscale
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/machine"
+	"github.com/stephrobert/feint/internal/core/resource"
+	"github.com/stephrobert/feint/internal/core/store"
+)
+
+// The two halves of #484, reproduced at the level where they live.
+//
+// Measured on examples/stacks/exoscale under --vm incus-ovn: the standalone
+// instance and the pool's first member were both handed 192.0.2.3, the host
+// refused the second machine's route, and the API kept calling that instance
+// running with no machine behind it. Two defects, two witnesses below.
+
+// gatedDriver blocks every Start until the gate is released, which is what
+// holds the allocation window of a slow boot open deterministically: the real
+// case is a container launch taking seconds while another create allocates.
+type gatedDriver struct {
+	gate    chan struct{}
+	started chan string
+
+	mu    sync.Mutex
+	specs []machine.Spec
+}
+
+func (d *gatedDriver) Name() string                   { return "gated" }
+func (d *gatedDriver) Available(context.Context) bool { return true }
+func (d *gatedDriver) Start(_ context.Context, spec machine.Spec) (machine.Machine, error) {
+	d.started <- spec.Name
+	<-d.gate
+	d.mu.Lock()
+	d.specs = append(d.specs, spec)
+	d.mu.Unlock()
+	return machine.Machine{Name: spec.Name, IP: "10.42.0.9", Running: true}, nil
+}
+func (d *gatedDriver) Stop(context.Context, string) error   { return nil }
+func (d *gatedDriver) Remove(context.Context, string) error { return nil }
+func (d *gatedDriver) Inspect(_ context.Context, name string) (machine.Machine, bool, error) {
+	return machine.Machine{Name: name}, false, nil
+}
+func (d *gatedDriver) EnsureNetwork(context.Context, machine.NetworkSpec) error { return nil }
+func (d *gatedDriver) Attach(context.Context, string, machine.Attachment) error { return nil }
+func (d *gatedDriver) Detach(context.Context, string, string) error             { return nil }
+func (d *gatedDriver) RemoveNetwork(context.Context, string) error              { return nil }
+
+// failingDriver refuses every Start, the way the host refused the duplicate
+// route: "Failed adding host route … file exists".
+type failingDriver struct{ recordingDriver }
+
+func (d *failingDriver) Start(context.Context, machine.Spec) (machine.Machine, error) {
+	return machine.Machine{}, fmt.Errorf("incus start: Failed to start device \"eth0\"")
+}
+
+// sequencedPack is runtimePack with unique identifiers, which address
+// allocation needs: two resources under one constant id are one resource.
+func sequencedPack(driver machine.Driver) *Pack {
+	n := 0
+	var mu sync.Mutex
+	return New(&emulator.Env{
+		Store:    store.New(),
+		Machines: driver,
+		Now:      func() time.Time { return time.Unix(1700000000, 0).UTC() },
+		NewID: func() string {
+			mu.Lock()
+			defer mu.Unlock()
+			n++
+			// The prefix differs from defaultSecurityGroupID's on purpose: the
+			// first identifier this counter minted used to BE the default
+			// group's, and a test asserting "the member wears the pool's group"
+			// passed against the default-group fallback — a witness planted on
+			// its own control value. The falsification harness caught it:
+			// the pool-inheritance mutation stayed green.
+			return fmt.Sprintf("0000000f-0000-4000-8000-%012d", n)
+		},
+		Log: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+}
+
+// createOneInstance drives the real handler, which is where the allocation
+// window was.
+func createOneInstance(p *Pack, name string) {
+	body := `{"name":"` + name + `","disk-size":10,` +
+		`"template":{"id":"11111111-1111-4111-8111-111111111111"},` +
+		`"instance-type":{"id":"71004023-bb72-4a97-b1e9-bc66dfce9470"}}`
+	r := httptest.NewRequest("POST", "/v2/instance", strings.NewReader(body))
+	p.createInstance(httptest.NewRecorder(), r)
+}
+
+func createOnePool(p *Pack, size int) {
+	body := fmt.Sprintf(`{"name":"app","size":%d,`+
+		`"template":{"id":"11111111-1111-4111-8111-111111111111"},`+
+		`"instance-type":{"id":"71004023-bb72-4a97-b1e9-bc66dfce9470"}}`, size)
+	r := httptest.NewRequest("POST", "/v2/instance-pool", strings.NewReader(body))
+	p.createInstancePool(httptest.NewRecorder(), r)
+}
+
+// publicIPs reads every instance's public address off the store, keyed by the
+// address so a duplicate collapses the map.
+func publicIPs(p *Pack) (byAddress map[string][]string, total int) {
+	byAddress = map[string][]string{}
+	for _, res := range p.env.Store.List(kindInstance, resource.Tenant{Provider: Name}) {
+		if ip, _ := res.Attrs["public-ip"].(string); ip != "" {
+			byAddress[ip] = append(byAddress[ip], res.ID)
+			total++
+		}
+	}
+	return byAddress, total
+}
+
+// TestAPoolMemberAndAStandaloneInstanceNeverShareAnAddress holds the exact
+// window of #484 open: a standalone create whose boot is still running when a
+// pool allocates its members. The address the instance chose must already be
+// visible to the pool's allocation, which is what the Put inside the lock
+// delivers; without it the pool re-hands the instance's address and two
+// machines carry one /32.
+func TestAPoolMemberAndAStandaloneInstanceNeverShareAnAddress(t *testing.T) {
+	driver := &gatedDriver{gate: make(chan struct{}), started: make(chan string, 8)}
+	p := sequencedPack(driver)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		createOneInstance(p, "platform-web")
+	}()
+
+	// The instance's boot is now in flight: its address is chosen, its machine
+	// is starting, and the create has not answered.
+	select {
+	case <-driver.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the standalone create never reached the driver")
+	}
+
+	// The pool allocates its two members inside that window. Its member boots
+	// will block on the same gate, so drive it from a goroutine and only wait
+	// for the allocations, which happen before any start.
+	poolDone := make(chan struct{})
+	go func() {
+		defer close(poolDone)
+		createOnePool(p, 2)
+	}()
+	deadline := time.After(5 * time.Second)
+	for {
+		if _, total := publicIPs(p); total >= 3 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("the pool never allocated its two members")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	close(driver.gate)
+	<-done
+	<-poolDone
+
+	byAddress, total := publicIPs(p)
+	if total != 3 {
+		t.Fatalf("%d addressed instances, want 3", total)
+	}
+	for ip, holders := range byAddress {
+		if len(holders) > 1 {
+			t.Errorf("%s was handed to %v: two machines carrying one /32 is what the host "+
+				"refuses with \"file exists\", and what a real account never does (#484)", ip, holders)
+		}
+	}
+}
+
+// TestAFailedPoolMemberStartIsPublishedAsError is the second half of #484: the
+// state a client reads is the one the effect produced. A member whose launch
+// the runtime refused must answer "error" — the state Exoscale's own
+// instance-state enum declares — and record no machine, because none exists.
+func TestAFailedPoolMemberStartIsPublishedAsError(t *testing.T) {
+	p := sequencedPack(&failingDriver{})
+	createOnePool(p, 1)
+
+	members := p.env.Store.List(kindInstance, resource.Tenant{Provider: Name})
+	if len(members) != 1 {
+		t.Fatalf("%d members, want 1", len(members))
+	}
+	member := members[0]
+	if member.State != "error" {
+		t.Fatalf("state %q, want error: `running` over a machine the host refused is the "+
+			"lie this project exists to avoid (#484)", member.State)
+	}
+	if name := member.Runtime["machine"]; name != "" {
+		t.Fatalf("runtime names machine %q where nothing started", name)
+	}
+}
+
+// TestAPoolMemberStartIsRecordedInTheStore is the accepting half: a member
+// whose machine did start publishes running, and its runtime carries the
+// machine's name and address — which is what every later stop, destroy and
+// refresh keys on. Before the fix the start mutated a local copy and the store
+// kept "no machine" for the member's whole life.
+func TestAPoolMemberStartIsRecordedInTheStore(t *testing.T) {
+	driver := &recordingDriver{}
+	p := sequencedPack(driver)
+	createOnePool(p, 1)
+
+	members := p.env.Store.List(kindInstance, resource.Tenant{Provider: Name})
+	if len(members) != 1 {
+		t.Fatalf("%d members, want 1", len(members))
+	}
+	member := members[0]
+	if member.State != runningState {
+		t.Fatalf("state %q, want running", member.State)
+	}
+	if got, want := member.Runtime["machine"], "feint-exo-"+member.ID; got != want {
+		t.Fatalf("runtime machine %q, want %q", got, want)
+	}
+	if got := member.Runtime["address"]; got != "10.42.0.9" {
+		t.Fatalf("runtime address %q, want the one the driver reported", got)
+	}
+}

--- a/internal/providers/exoscale/privatenetworks.go
+++ b/internal/providers/exoscale/privatenetworks.go
@@ -659,6 +659,12 @@ func (p *Pack) attachInstanceToPrivateNetwork(w http.ResponseWriter, r *http.Req
 		return
 	}
 	p.attachMachineToPrivateNetwork(r.Context(), inst, pn, leaseIP)
+	// The interface this attach just created carries the instance's rule sets
+	// like every other one: the Terraform provider attaches networks after the
+	// create returns, and a set applied at boot never reaches an interface
+	// born later (#475). ApplyFirewall covers every NIC of the machine, so
+	// re-applying here is idempotent for the older ones.
+	p.applyInstanceRuleSets(r.Context(), inst)
 	p.writeOperation(w, p.operationReferring(nounPrivateNetwork, id))
 }
 

--- a/internal/providers/exoscale/securitygroups.go
+++ b/internal/providers/exoscale/securitygroups.go
@@ -152,7 +152,13 @@ func (p *Pack) deleteSecurityGroup(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+	res, _ := p.env.Store.Get(Name, kindSecurityGroup, id)
 	p.env.Store.Delete(Name, kindSecurityGroup, id)
+	// The runtime rule set goes with the group, once nothing wears it — the
+	// refusal above guarantees that (#475).
+	if res != nil {
+		p.removeFirewall(r.Context(), res)
+	}
 	p.writeOperation(w, p.operationReferring(nounSecurityGroup, id))
 }
 
@@ -217,6 +223,12 @@ func (p *Pack) addRuleToSecurityGroup(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "resource not found")
 		return
 	}
+	// The rule the client just added reaches the machines wearing the group:
+	// a client adds a rule after the instance is running and expects it to
+	// take effect (#475).
+	if group, found := p.env.Store.Get(Name, kindSecurityGroup, id); found {
+		p.syncSecurityGroup(r.Context(), group)
+	}
 	p.writeOperation(w, p.operationReferring(nounSecurityGroup, id))
 }
 
@@ -246,6 +258,11 @@ func (p *Pack) deleteRuleFromSecurityGroup(w http.ResponseWriter, r *http.Reques
 		writeError(w, http.StatusNotFound, "resource not found")
 		return
 	}
+	// A revoked rule really disappears from the machines: replaying the set
+	// is what closes the port the client just closed (#475).
+	if group, ok := p.env.Store.Get(Name, kindSecurityGroup, id); ok {
+		p.syncSecurityGroup(r.Context(), group)
+	}
 	p.writeOperation(w, p.operationReferring(nounSecurityGroup, id))
 }
 
@@ -264,11 +281,31 @@ type instanceTarget struct {
 }
 
 func (p *Pack) attachInstanceToSecurityGroup(w http.ResponseWriter, r *http.Request) {
-	p.changeInstanceMembership(w, r, kindSecurityGroup, nounSecurityGroup, attrSecurityGroupIDs, true)
+	instanceID, ok := p.changeInstanceMembership(w, r, kindSecurityGroup, nounSecurityGroup, attrSecurityGroupIDs, true)
+	if ok {
+		p.moveInstanceFirewall(r, instanceID)
+	}
 }
 
 func (p *Pack) detachInstanceFromSecurityGroup(w http.ResponseWriter, r *http.Request) {
-	p.changeInstanceMembership(w, r, kindSecurityGroup, nounSecurityGroup, attrSecurityGroupIDs, false)
+	instanceID, ok := p.changeInstanceMembership(w, r, kindSecurityGroup, nounSecurityGroup, attrSecurityGroupIDs, false)
+	if ok {
+		p.moveInstanceFirewall(r, instanceID)
+	}
+}
+
+// moveInstanceFirewall follows a membership change onto the runtime: the
+// instance's machine wears what the store now says, and every group whose
+// rules name the group that just gained or lost this member is re-expanded
+// (#475).
+func (p *Pack) moveInstanceFirewall(r *http.Request, instanceID string) {
+	if p.enforcer() == nil {
+		return
+	}
+	if inst, found := p.env.Store.Get(Name, kindInstance, instanceID); found {
+		p.applyInstanceRuleSets(r.Context(), inst)
+	}
+	p.syncGroupsReferencing(r.Context(), []string{r.PathValue("id")})
 }
 
 // changeInstanceMembership adds or removes one group-like resource on one
@@ -369,6 +406,9 @@ func (p *Pack) changeExternalSources(w http.ResponseWriter, r *http.Request, add
 		writeError(w, http.StatusNotFound, "resource not found")
 		return
 	}
+	// External sources extend the group's membership, so what changed is the
+	// expansion of every rule that names this group as a source (#475).
+	p.syncGroupsReferencing(r.Context(), []string{id})
 	p.writeOperation(w, p.operationReferring(nounSecurityGroup, id))
 }
 

--- a/internal/providers/outscale/firewall.go
+++ b/internal/providers/outscale/firewall.go
@@ -1,0 +1,307 @@
+package outscale
+
+import (
+	"context"
+	"strings"
+
+	"github.com/stephrobert/feint/internal/core/machine"
+	"github.com/stephrobert/feint/internal/core/resource"
+)
+
+// This is where an Outscale security group stops being documentation.
+//
+// The pack served the whole product and reconciled none of it: not one file
+// here touched the runtime's firewall half, so a Vm wearing a group whose only
+// rule opens tcp/22 answered on every port the group forbids — measured in
+// #475 with a listener proved up from inside the machine first. The Scaleway
+// pack had the sequence all along; the mechanics now live in machine.Binding
+// (SyncRuleSet, ApplyRuleSets, DropRuleSet), and what this file holds is only
+// what is Outscale's: its rule vocabulary, and who wears what.
+//
+// The semantics are the measured ones. A group is an allow-list in both
+// directions — traffic no rule matches is dropped — and a fresh group carries
+// its permissive outbound explicitly, as the allow-all OutboundRules entry the
+// create stores (securitygroups.go quotes the recording). So the spec's
+// defaults are drop/drop and the stored rules are the whole story, including
+// the default group's "everything from myself" inbound rule, which expands
+// below like any other member reference.
+
+// enforcer returns the runtime's firewall half, or nil when it has none.
+func (p *Pack) enforcer() machine.Firewaller {
+	fw, _ := p.env.Machines.(machine.Firewaller)
+	return fw
+}
+
+// firewallSpecOf translates a group and its rules for the runtime.
+//
+// fresh, when set, is the resource a transition is still working on: the boot
+// that triggers a re-expansion runs before its own commit, so the store's copy
+// of that Vm does not yet carry the address the expansion is being run FOR.
+// Reading the store alone here silently missed the very machine that booted.
+// TestAMemberSourcedRuleExpandsToTheMembersAddresses fails without it.
+func (p *Pack) firewallSpecOf(group *resource.Resource, fresh *resource.Resource) machine.FirewallSpec {
+	spec := machine.FirewallSpec{
+		Name:           machine.FirewallName("osc", group.ID),
+		DefaultIngress: "drop",
+		DefaultEgress:  "drop",
+	}
+	spec.Rules = append(spec.Rules, p.firewallRulesOf(group, "InboundRules", "ingress", fresh)...)
+	spec.Rules = append(spec.Rules, p.firewallRulesOf(group, "OutboundRules", "egress", fresh)...)
+	return spec
+}
+
+// firewallRulesOf converts one side of a group. A rule that names members
+// rather than blocks is expanded here into the addresses those members'
+// machines answer on, because bridge-backed runtimes have no group selector —
+// firewall.go in the machine package says so — and the expansion is refreshed
+// whenever a machine starts or publishes an address (syncFirewallAfterBoot).
+func (p *Pack) firewallRulesOf(group *resource.Resource, side, direction string, fresh *resource.Resource) []machine.FirewallRule {
+	raw, _ := group.Attrs[side].([]any)
+	out := make([]machine.FirewallRule, 0, len(raw))
+	for _, entry := range raw {
+		rule, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		base := machine.FirewallRule{
+			Direction: direction,
+			Action:    "allow",
+			Protocol:  protocolOf(rule["IpProtocol"]),
+		}
+		if from := int(numOf(rule["FromPortRange"])); from > 0 {
+			base.PortFrom = from
+		}
+		if to := int(numOf(rule["ToPortRange"])); to > 0 {
+			base.PortTo = to
+		}
+
+		blocks := make([]string, 0, 2)
+		for _, r := range stringsOf(rule["IpRanges"]) {
+			if r != "" {
+				blocks = append(blocks, r)
+			}
+		}
+		if members, ok := rule["SecurityGroupsMembers"].([]any); ok {
+			for _, m := range members {
+				member, _ := m.(map[string]any)
+				blocks = append(blocks, p.memberBlocks(stringOf(member["SecurityGroupId"]), fresh)...)
+			}
+		}
+		// A rule with neither ranges nor members means "from anywhere", which
+		// an empty Source already says. A member list that expands to nothing
+		// emits nothing: no machine of that group has an address yet, so there
+		// is nothing to allow, and the next boot re-expands it.
+		if len(blocks) == 0 {
+			if _, membersOnly := rule["SecurityGroupsMembers"]; !membersOnly {
+				out = append(out, base)
+			}
+			continue
+		}
+		for _, block := range blocks {
+			converted := base
+			if direction == "egress" {
+				converted.Destination = block
+			} else {
+				converted.Source = block
+			}
+			out = append(out, converted)
+		}
+	}
+	return out
+}
+
+// protocolOf maps the stored IpProtocol onto the runtime's spelling: "-1" is
+// Outscale's "every protocol", which the runtime writes as an empty one.
+func protocolOf(v any) string {
+	proto := strings.ToLower(stringOf(v))
+	if proto == "-1" {
+		return ""
+	}
+	return proto
+}
+
+// memberBlocks is what "traffic from the members of that group" means on a
+// runtime with no group selector: one /32 per address a member machine
+// answers on — its private address, and every public one linked to it.
+func (p *Pack) memberBlocks(groupID string, fresh *resource.Resource) []string {
+	if groupID == "" {
+		return nil
+	}
+	out := make([]string, 0, 4)
+	for _, vm := range p.vmsWearing(groupID) {
+		// The transition's own copy wins over the store's: the store has not
+		// been committed yet when a boot re-expands the groups naming it.
+		if fresh != nil && vm.ID == fresh.ID {
+			vm = fresh
+		}
+		if ip := stringOf(vm.Attrs["PrivateIp"]); ip != "" {
+			out = append(out, ip+"/32")
+		}
+		for _, ip := range p.publicBootAddresses(vm.ID) {
+			out = append(out, ip+"/32")
+		}
+	}
+	return out
+}
+
+// vmsWearing lists the Vms carrying a group — asked for, or inherited as
+// their Net's default — terminated ones excepted.
+func (p *Pack) vmsWearing(groupID string) []*resource.Resource {
+	all := p.env.Store.List(kindVM, resource.Tenant{Provider: Name})
+	out := make([]*resource.Resource, 0, len(all))
+	for _, vm := range all {
+		if vm.State == stateTerminated {
+			continue
+		}
+		for _, ref := range p.effectiveSecurityGroups(vm) {
+			summary, _ := ref.(map[string]any)
+			if stringOf(summary["SecurityGroupId"]) == groupID {
+				out = append(out, vm)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// syncSecurityGroup pushes a group's rule set and replays it onto every Vm
+// wearing it. Called after any change to the group or to its rules.
+func (p *Pack) syncSecurityGroup(ctx context.Context, group *resource.Resource) {
+	fw := p.enforcer()
+	if fw == nil {
+		return
+	}
+	p.syncSecurityGroupSeen(ctx, group, nil)
+}
+
+// syncSecurityGroupSeen is syncSecurityGroup with the transition's own copy of
+// a booting Vm, which the expansion must see — firewallSpecOf says why.
+func (p *Pack) syncSecurityGroupSeen(ctx context.Context, group, fresh *resource.Resource) {
+	fw := p.enforcer()
+	if fw == nil {
+		return
+	}
+	b := p.binding()
+	if !b.SyncRuleSet(ctx, fw, p.firewallSpecOf(group, fresh)) {
+		return
+	}
+	for _, vm := range p.vmsWearing(group.ID) {
+		if fresh != nil && vm.ID == fresh.ID {
+			vm = fresh
+		}
+		p.applyVMRuleSets(ctx, vm)
+	}
+}
+
+// applyVMRuleSets attaches everything one Vm wears to its machine, in one
+// call, because the runtime replaces the attachment list rather than merging
+// it. Every set is written first, so an attach cannot name a set the runtime
+// has never seen.
+func (p *Pack) applyVMRuleSets(ctx context.Context, vm *resource.Resource) {
+	fw := p.enforcer()
+	if fw == nil {
+		return
+	}
+	name := vm.Runtime[p.binding().RuntimeKey]
+	if name == "" {
+		return
+	}
+	b := p.binding()
+	specs := make([]machine.FirewallSpec, 0, 2)
+	for _, ref := range p.effectiveSecurityGroups(vm) {
+		summary, _ := ref.(map[string]any)
+		group, found := p.env.Store.Get(Name, kindSecurityGroup, stringOf(summary["SecurityGroupId"]))
+		if !found {
+			continue
+		}
+		spec := p.firewallSpecOf(group, vm)
+		if !b.SyncRuleSet(ctx, fw, spec) {
+			continue
+		}
+		specs = append(specs, spec)
+	}
+	b.ApplyRuleSets(ctx, fw, name, specs...)
+}
+
+// syncFirewallAfterBoot runs once a machine exists or first publishes an
+// address: its own sets attach, and every group whose rules point at a group
+// this Vm wears is re-expanded, because this Vm's addresses are now part of
+// what those groups mean. Without the second half, the three-tier statement a
+// stack writes — tier 2 accepts tier 1 and nobody else — never contains the
+// machines it talks about.
+func (p *Pack) syncFirewallAfterBoot(ctx context.Context, vm *resource.Resource) {
+	if p.enforcer() == nil {
+		return
+	}
+	p.applyVMRuleSets(ctx, vm)
+	p.syncGroupsReferencingSeen(ctx, p.wornGroupIDs(vm), vm)
+}
+
+// wornGroupIDs is the identifiers of the groups one Vm wears.
+func (p *Pack) wornGroupIDs(vm *resource.Resource) []string {
+	refs := p.effectiveSecurityGroups(vm)
+	out := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		summary, _ := ref.(map[string]any)
+		if id := stringOf(summary["SecurityGroupId"]); id != "" {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+// syncGroupsReferencing re-syncs every group one of whose rules names one of
+// the given groups as a member source.
+func (p *Pack) syncGroupsReferencing(ctx context.Context, groupIDs []string) {
+	p.syncGroupsReferencingSeen(ctx, groupIDs, nil)
+}
+
+func (p *Pack) syncGroupsReferencingSeen(ctx context.Context, groupIDs []string, fresh *resource.Resource) {
+	if len(groupIDs) == 0 {
+		return
+	}
+	named := make(map[string]bool, len(groupIDs))
+	for _, id := range groupIDs {
+		named[id] = true
+	}
+	for _, group := range p.env.Store.List(kindSecurityGroup, resource.Tenant{Provider: Name}) {
+		if groupReferencesAny(group, named) {
+			p.syncSecurityGroupSeen(ctx, group, fresh)
+		}
+	}
+}
+
+// groupReferencesAny reports whether any rule of the group names one of the
+// given groups in its members.
+func groupReferencesAny(group *resource.Resource, named map[string]bool) bool {
+	for _, side := range []string{"InboundRules", "OutboundRules"} {
+		rules, _ := group.Attrs[side].([]any)
+		for _, entry := range rules {
+			rule, _ := entry.(map[string]any)
+			members, _ := rule["SecurityGroupsMembers"].([]any)
+			for _, m := range members {
+				member, _ := m.(map[string]any)
+				if named[stringOf(member["SecurityGroupId"])] {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// removeFirewall drops the runtime rule set of a group being deleted.
+func (p *Pack) removeFirewall(ctx context.Context, group *resource.Resource) {
+	p.binding().DropRuleSet(ctx, p.enforcer(), machine.FirewallName("osc", group.ID))
+}
+
+// EnforcesFirewall implements emulator.FirewallEnforcer: this pack reconciles
+// a security group onto the machines that wear it, so a runtime able to
+// enforce rules is handed them (#475).
+//
+// It answers about the pack and not about the process — the reasoning the
+// Scaleway pack's declaration carries in full. The day this pack stops handing
+// rules over, this line is what has to change, and
+// internal/cli's TestEveryPackThatWiresTheFirewallSaysSo is what notices if
+// it does not.
+func (p *Pack) EnforcesFirewall() bool { return true }

--- a/internal/providers/outscale/firewall_internal_test.go
+++ b/internal/providers/outscale/firewall_internal_test.go
@@ -1,0 +1,217 @@
+package outscale
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/machine"
+	"github.com/stephrobert/feint/internal/core/resource"
+	"github.com/stephrobert/feint/internal/core/store"
+)
+
+// The witnesses of #475 for this pack. What lied was not a rule's shape but
+// its absence: ten acknowledged security-group calls, six OVN networks, five
+// running containers, zero rule sets on the host. So every test here asserts
+// on what was handed to the runtime, through a recording Firewaller — a green
+// HTTP answer proves nothing about the host.
+
+// firewallDriver is recordingDriver plus the Firewaller half, recording what
+// reaches the runtime.
+type firewallDriver struct {
+	recordingDriver
+
+	mu      sync.Mutex
+	ensured map[string]machine.FirewallSpec
+	applied map[string]machine.FirewallBinding
+}
+
+func newFirewallDriver() *firewallDriver {
+	return &firewallDriver{
+		ensured: map[string]machine.FirewallSpec{},
+		applied: map[string]machine.FirewallBinding{},
+	}
+}
+
+func (d *firewallDriver) EnsureFirewall(_ context.Context, spec machine.FirewallSpec) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.ensured[spec.Name] = spec
+	return nil
+}
+
+func (d *firewallDriver) ApplyFirewall(_ context.Context, machineName string, binding machine.FirewallBinding) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.applied[machineName] = binding
+	return nil
+}
+
+func (d *firewallDriver) RemoveFirewall(_ context.Context, name string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	delete(d.ensured, name)
+	return nil
+}
+
+// firewallPack is runtimePack with unique identifiers, which several stored
+// groups need.
+func firewallPack(driver machine.Driver) *Pack {
+	n := 0
+	return New(&emulator.Env{
+		Store:    store.New(),
+		Machines: driver,
+		Now:      func() time.Time { return time.Unix(1700000000, 0).UTC() },
+		NewID: func() string {
+			n++
+			return fmt.Sprintf("%08d", n)
+		},
+		Log: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+}
+
+func storedGroup(p *Pack, name string, inbound []any) *resource.Resource {
+	now := p.env.Now()
+	res := resource.New(newID("sg", p.env.NewID()), kindSecurityGroup, resource.Tenant{Provider: Name}, "available", now)
+	res.Attrs = map[string]any{
+		"SecurityGroupName": name,
+		"Description":       name,
+		"InboundRules":      inbound,
+		"OutboundRules": []any{map[string]any{
+			"FromPortRange": -1, "ToPortRange": -1, "IpProtocol": "-1",
+			"IpRanges": []any{"0.0.0.0/0"},
+		}},
+		"Tags": []any{},
+	}
+	p.env.Store.Put(res)
+	return res
+}
+
+func storedVM(p *Pack, groupIDs ...string) *resource.Resource {
+	now := p.env.Now()
+	res := resource.New(newVMID(p.env.NewID()), kindVM, resource.Tenant{Provider: Name}, stateStopped, now)
+	res.Attrs = map[string]any{
+		"ImageId":          "ami-00000001",
+		"VmType":           defaultVMType,
+		"SecurityGroupIds": groupIDs,
+	}
+	p.env.Store.Put(res)
+	return res
+}
+
+// TestAnOutscaleGroupReachesTheHostWhenItsVmBoots is the wiring itself: the
+// group a Vm wears becomes a rule set the runtime holds, attached to the Vm's
+// machine with the allow-list defaults — drop what no rule matches, in both
+// directions, which is what the API describes and the host never received.
+func TestAnOutscaleGroupReachesTheHostWhenItsVmBoots(t *testing.T) {
+	driver := newFirewallDriver()
+	p := firewallPack(driver)
+	group := storedGroup(p, "witness-osc", []any{map[string]any{
+		"FromPortRange": 22, "ToPortRange": 22, "IpProtocol": "tcp",
+		"IpRanges": []any{"0.0.0.0/0"},
+	}})
+	vm := storedVM(p, group.ID)
+
+	p.powerOn(context.Background(), vm)
+
+	setName := machine.FirewallName("osc", group.ID)
+	spec, held := driver.ensured[setName]
+	if !held {
+		t.Fatalf("the runtime holds no rule set %s: the group stayed documentation, which is #475", setName)
+	}
+	if spec.DefaultIngress != "drop" || spec.DefaultEgress != "drop" {
+		t.Fatalf("defaults %s/%s, want drop/drop: a security group is an allow-list both ways",
+			spec.DefaultIngress, spec.DefaultEgress)
+	}
+	binding, attached := driver.applied[vm.Runtime[p.binding().RuntimeKey]]
+	if !attached || len(binding.Names) != 1 || binding.Names[0] != setName {
+		t.Fatalf("the machine's interfaces carry %+v, want [%s]", binding.Names, setName)
+	}
+}
+
+// TestAMemberSourcedRuleExpandsToTheMembersAddresses holds the tiering rule
+// the stacks write — the data tier accepts the web tier and nobody else. The
+// runtime has no group selector, so the member reference must arrive expanded
+// into the addresses the member machines answer on, and re-expanded when a
+// member boots.
+func TestAMemberSourcedRuleExpandsToTheMembersAddresses(t *testing.T) {
+	driver := newFirewallDriver()
+	p := firewallPack(driver)
+	web := storedGroup(p, "web", nil)
+	data := storedGroup(p, "data", []any{map[string]any{
+		"FromPortRange": 5432, "ToPortRange": 5432, "IpProtocol": "tcp",
+		"SecurityGroupsMembers": []any{map[string]any{"SecurityGroupId": web.ID}},
+	}})
+	dataVM := storedVM(p, data.ID)
+	p.powerOn(context.Background(), dataVM)
+
+	// Before any web machine runs, the expansion is honestly empty.
+	spec := driver.ensured[machine.FirewallName("osc", data.ID)]
+	for _, rule := range spec.Rules {
+		if rule.PortFrom == 5432 {
+			t.Fatalf("the member rule expanded to %q before any member had an address", rule.Source)
+		}
+	}
+
+	// A web machine boots: the data group's set must now allow its address.
+	webVM := storedVM(p, web.ID)
+	p.powerOn(context.Background(), webVM)
+
+	spec = driver.ensured[machine.FirewallName("osc", data.ID)]
+	found := false
+	for _, rule := range spec.Rules {
+		if rule.PortFrom == 5432 && rule.Source == "10.42.0.9/32" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("the data tier's set never learned the web machine's address; rules: %+v", spec.Rules)
+	}
+}
+
+// TestARevokedRuleLeavesTheRuleSet drives the real handler: deleting a rule
+// replays the whole set, which is what makes a revoked port actually close —
+// EnsureFirewall replaces, so the assertion is on the set the runtime now
+// holds.
+func TestARevokedRuleLeavesTheRuleSet(t *testing.T) {
+	driver := newFirewallDriver()
+	p := firewallPack(driver)
+	group := storedGroup(p, "witness-osc", []any{map[string]any{
+		"FromPortRange": 22, "ToPortRange": 22, "IpProtocol": "tcp",
+		"IpRanges": []any{"0.0.0.0/0"}, "SecurityGroupRuleId": "sgr-1",
+	}})
+	vm := storedVM(p, group.ID)
+	p.powerOn(context.Background(), vm)
+
+	p.syncSecurityGroup(context.Background(), group)
+	setName := machine.FirewallName("osc", group.ID)
+	before := driver.ensured[setName]
+	hasPort := func(spec machine.FirewallSpec, port int) bool {
+		for _, rule := range spec.Rules {
+			if rule.PortFrom == port {
+				return true
+			}
+		}
+		return false
+	}
+	if !hasPort(before, 22) {
+		t.Fatalf("the set never held the rule it was meant to lose: %+v", before.Rules)
+	}
+
+	// The revocation, through the store the way the handler writes it.
+	_ = p.env.Store.Update(Name, kindSecurityGroup, group.ID, func(stored *resource.Resource) error {
+		stored.Attrs["InboundRules"] = []any{}
+		return nil
+	})
+	after, _ := p.env.Store.Get(Name, kindSecurityGroup, group.ID)
+	p.syncSecurityGroup(context.Background(), after)
+
+	if hasPort(driver.ensured[setName], 22) {
+		t.Fatalf("the revoked rule survived in the runtime's set: %+v", driver.ensured[setName].Rules)
+	}
+}

--- a/internal/providers/outscale/machines.go
+++ b/internal/providers/outscale/machines.go
@@ -132,6 +132,10 @@ func (p *Pack) powerOn(ctx context.Context, res *resource.Resource) {
 	for _, address := range p.publicBootAddresses(res.ID) {
 		p.routeLinkedIP(ctx, address, res)
 	}
+	// The groups this Vm wears reach its interfaces, and the groups that name
+	// those groups as members are re-expanded now that this machine has
+	// addresses (#475). After the routes, so the expansion sees them.
+	p.syncFirewallAfterBoot(ctx, res)
 }
 
 // rememberAddress keeps the private address on the resource, not only on the
@@ -170,8 +174,11 @@ func (p *Pack) refreshMachine(ctx context.Context, res *resource.Resource) bool 
 	changed := p.binding().RefreshIfRunning(ctx, res)
 	if changed {
 		// A virtual machine gets its address tens of seconds after it starts,
-		// so this is where it first becomes known for one.
+		// so this is where it first becomes known for one — and where every
+		// group naming this Vm's groups as members first has an address to
+		// expand to (#475).
 		p.rememberAddress(res)
+		p.syncGroupsReferencing(ctx, p.wornGroupIDs(res))
 	}
 	return changed
 }

--- a/internal/providers/outscale/securitygroups.go
+++ b/internal/providers/outscale/securitygroups.go
@@ -267,6 +267,9 @@ func (p *Pack) deleteSecurityGroup(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	p.env.Store.Delete(Name, kindSecurityGroup, res.ID)
+	// The runtime rule set goes with the group, once nothing wears it — the
+	// refusals above guarantee that (#475).
+	p.removeFirewall(r.Context(), res)
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{"ResponseContext": p.context()})
 }
 
@@ -463,6 +466,10 @@ func (p *Pack) createSecurityGroupRule(w http.ResponseWriter, r *http.Request) {
 		p.notFound(w, "security group", res.ID)
 		return
 	}
+	// The rule the client just authorised reaches the machines wearing the
+	// group: a client authorises a rule after the Vm is running and expects it
+	// to take effect (#475).
+	p.syncSecurityGroup(r.Context(), final)
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
 		"SecurityGroup":   securityGroupView(final),
 		"ResponseContext": p.context(),
@@ -522,6 +529,9 @@ func (p *Pack) deleteSecurityGroupRule(w http.ResponseWriter, r *http.Request) {
 		p.notFound(w, "security group", res.ID)
 		return
 	}
+	// A revoked rule really disappears from the machines: replaying the set is
+	// what closes the port the client just closed (#475).
+	p.syncSecurityGroup(r.Context(), final)
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
 		"SecurityGroup":   securityGroupView(final),
 		"ResponseContext": p.context(),

--- a/internal/providers/outscale/vms.go
+++ b/internal/providers/outscale/vms.go
@@ -620,6 +620,11 @@ func (p *Pack) updateVm(w http.ResponseWriter, r *http.Request) {
 		p.notFound(w, "Vm", req.VMID)
 		return
 	}
+	// A changed group list reaches the machine's interfaces: the sets it now
+	// wears attach, the ones it dropped detach with them (#475).
+	if len(req.SecurityGroupIDs) > 0 {
+		p.applyVMRuleSets(r.Context(), updated)
+	}
 
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
 		"Vm":              p.vmView(updated),

--- a/internal/providers/scaleway/firewall.go
+++ b/internal/providers/scaleway/firewall.go
@@ -2,7 +2,6 @@ package scaleway
 
 import (
 	"context"
-	"errors"
 	"strings"
 
 	"github.com/stephrobert/feint/internal/core/machine"
@@ -29,48 +28,26 @@ func (p *Pack) enforcer() machine.Firewaller {
 
 // syncSecurityGroup pushes a group and replays it onto every server using it.
 // Called after any change to the group or to its rules.
+//
+// The mechanics — a permissive set attaches nothing, the deny-dominant
+// defaults, the Warn-or-Error report — are machine.Binding's, shared with the
+// two other packs since #475: written here alone, the same sequence was one
+// Outscale and Exoscale never wrote, and their machines ran with zero ACLs
+// while the API described a closed port. What stays in this file is only the
+// Scaleway vocabulary.
 func (p *Pack) syncSecurityGroup(ctx context.Context, group *resource.Resource) {
 	fw := p.enforcer()
 	if fw == nil {
 		return
 	}
-
+	b := p.binding()
 	spec := p.firewallSpecOf(group)
-	if err := fw.EnsureFirewall(ctx, spec); err != nil {
-		p.logger().Error("could not write the firewall rules",
-			"security_group", group.ID, "error", err)
+	if !b.SyncRuleSet(ctx, fw, spec) {
 		return
 	}
-
-	binding := p.bindingOf(spec)
 	for _, server := range p.serverResourcesUsing(group) {
-		name := server.Runtime[runtimeMachineKey]
-		if name == "" {
-			continue
-		}
-		if err := fw.ApplyFirewall(ctx, name, binding); err != nil {
-			p.reportFirewall(err, "security_group", group.ID, "server", server.ID)
-		}
+		b.ApplyRuleSets(ctx, fw, server.Runtime[runtimeMachineKey], spec)
 	}
-}
-
-// reportFirewall logs a failed application at the level it deserves. A rule
-// set the runtime has no mechanism for — a routed NIC, the interface of a
-// server with only a public address (#337) — is a declared limit, not an
-// operational failure: /_feint/health publishes it as
-// capabilities.firewall_public_only=false and docs/limits.md carries the
-// measurement, so the warning names the declaration instead of crying wolf.
-// Anything else stays an error, because nothing declared it.
-// TestAnUnenforceableGroupIsReportedAsTheDeclaredLimit fails without the
-// distinction.
-func (p *Pack) reportFirewall(err error, keyvals ...any) {
-	if errors.Is(err, machine.ErrFirewallUnenforceable) {
-		p.logger().Warn("the security group is not enforced on this machine's public-only interface, "+
-			"which the runtime declares (capabilities.firewall_public_only=false, docs/limits.md)",
-			append(keyvals, "error", err)...)
-		return
-	}
-	p.logger().Error("could not apply the firewall to a machine", append(keyvals, "error", err)...)
 }
 
 // applyServerFirewall binds the group a server carries to its machine. Called
@@ -90,69 +67,12 @@ func (p *Pack) applyServerFirewall(ctx context.Context, server *resource.Resourc
 		return
 	}
 
+	b := p.binding()
 	spec := p.firewallSpecOf(group)
-	if err := fw.EnsureFirewall(ctx, spec); err != nil {
-		p.logger().Error("could not write the firewall rules",
-			"security_group", groupID, "server", server.ID, "error", err)
+	if !b.SyncRuleSet(ctx, fw, spec) {
 		return
 	}
-	name := server.Runtime[runtimeMachineKey]
-	if name == "" {
-		return
-	}
-	if err := fw.ApplyFirewall(ctx, name, p.bindingOf(spec)); err != nil {
-		p.reportFirewall(err, "server", server.ID, "machine", name)
-	}
-}
-
-// bindingOf turns a rule set into what the machine's interfaces enforce.
-//
-// A group that enforces nothing attaches nothing, on every runtime. This is
-// not an optimisation, and each runtime family contributed its own measured
-// reason:
-//
-//   - OVN: the pipeline evaluates the sender's egress rules before the
-//     receiver's ingress default (the priority constants in acl_ovn.go at
-//     v7.2.0: NIC ingress default 100, NIC egress default 111, rule-level
-//     allow 300), so any allow carried by the sender's rule set opens a port
-//     the receiver's default-deny closes — measured here with the suite's own
-//     probe machine.
-//   - routed NICs (#337): the default security group — pure accept, filtering
-//     nothing upstream — rides every `scw instance server create`, including
-//     onto a server with no emulated network under it, whose one interface
-//     accepts no rule set at all. Attaching the empty policy there was an
-//     ERROR log the control plane answered over as if the group were
-//     enforced.
-//
-// The default security group filters nothing upstream, and the only faithful
-// translation of "filters nothing" is absence. A group that does restrict
-// something still attaches, and the residual gap between two such groups on
-// one OVN subnet is recorded in docs/limits.md.
-// TestAPermissiveGroupBindsNothingOnEveryRuntime fails without the
-// unconditional half.
-func (p *Pack) bindingOf(spec machine.FirewallSpec) machine.FirewallBinding {
-	if enforcesNothing(spec) {
-		return machine.FirewallBinding{}
-	}
-	return machine.FirewallBinding{
-		Names:          []string{spec.Name},
-		DefaultIngress: spec.DefaultIngress,
-		DefaultEgress:  spec.DefaultEgress,
-	}
-}
-
-// enforcesNothing reports whether a rule set restricts any traffic at all:
-// permissive in both directions, with no rule that denies anything.
-func enforcesNothing(spec machine.FirewallSpec) bool {
-	if spec.DefaultIngress != "allow" || spec.DefaultEgress != "allow" {
-		return false
-	}
-	for _, rule := range spec.Rules {
-		if rule.Action == "drop" || rule.Action == "reject" {
-			return false
-		}
-	}
-	return true
+	b.ApplyRuleSets(ctx, fw, server.Runtime[runtimeMachineKey], spec)
 }
 
 // firewallSpecOf translates a group and its rules.
@@ -206,19 +126,10 @@ func (p *Pack) firewallSpecOf(group *resource.Resource) machine.FirewallSpec {
 		spec.Rules = append(spec.Rules, converted)
 	}
 
-	// A permissive default policy is also written into the rule set itself, as a
-	// catch-all in last position of the runtime's precedence: allow loses to any
-	// drop or reject the group states, which is exactly what a default is. The
-	// binding's default actions say the same thing on bridged NICs, but an OVN
-	// NIC cannot take those keys without being re-plugged (and losing its
-	// address), so the rule set is the one place the policy can live everywhere.
-	if spec.DefaultIngress == "allow" {
-		spec.Rules = append(spec.Rules, machine.FirewallRule{Direction: "ingress", Action: allow})
-	}
-	if spec.DefaultEgress == "allow" {
-		spec.Rules = append(spec.Rules, machine.FirewallRule{Direction: "egress", Action: allow})
-	}
-	return spec
+	// A permissive default policy is also written into the rule set itself —
+	// WithPermissiveCatchAll says why, and carries the pack's own allow verb so
+	// a stateless group's openness stays stateless.
+	return spec.WithPermissiveCatchAll(allow)
 }
 
 // nativeIsolation reports whether the runtime keeps its networks apart by
@@ -350,14 +261,7 @@ func (p *Pack) serverResourcesUsing(group *resource.Resource) []*resource.Resour
 // and refusing the delete afterwards would leave the client with a resource it
 // cannot remove.
 func (p *Pack) removeFirewall(ctx context.Context, group *resource.Resource) {
-	fw := p.enforcer()
-	if fw == nil {
-		return
-	}
-	if err := fw.RemoveFirewall(ctx, machine.FirewallName("scw", group.ID)); err != nil {
-		p.logger().Error("could not remove the firewall rules",
-			"security_group", group.ID, "error", err)
-	}
+	p.binding().DropRuleSet(ctx, p.enforcer(), machine.FirewallName("scw", group.ID))
 }
 
 // EnforcesFirewall implements emulator.FirewallEnforcer: this pack reconciles a

--- a/internal/providers/scaleway/firewall_internal_test.go
+++ b/internal/providers/scaleway/firewall_internal_test.go
@@ -1,11 +1,6 @@
 package scaleway
 
 import (
-	"bytes"
-	"errors"
-	"fmt"
-	"log/slog"
-	"strings"
 	"testing"
 
 	"github.com/stephrobert/feint/internal/core/emulator"
@@ -58,66 +53,9 @@ func TestFirewallSpecWritesPermissiveDefaultsAsCatchAlls(t *testing.T) {
 	}
 }
 
-// TestAPermissiveGroupBindsNothingOnEveryRuntime holds the unconditional half
-// of bindingOf (#337). The empty binding used to be OVN's alone, for the
-// pipeline-priority reason its comment keeps; but the default security group —
-// pure accept, filtering nothing upstream — rides every `scw instance server
-// create`, including onto a server whose only interface is a routed NIC that
-// accepts no rule set at all. On the bridge runtime that attach was an ERROR
-// log the control plane answered over as if the group were enforced. The only
-// faithful translation of "filters nothing" is absence, on every runtime.
-func TestAPermissiveGroupBindsNothingOnEveryRuntime(t *testing.T) {
-	p := New(emulator.DefaultEnv())
-	if p.nativeIsolation() {
-		t.Fatal("the default env must not isolate natively, or this test measures the OVN branch")
-	}
-
-	permissive := machine.FirewallSpec{
-		Name:           "sg-permissive",
-		DefaultIngress: "allow",
-		DefaultEgress:  "allow",
-		Rules: []machine.FirewallRule{
-			{Direction: "ingress", Action: "allow"},
-			{Direction: "egress", Action: "allow"},
-		},
-	}
-	if got := p.bindingOf(permissive); len(got.Names) != 0 {
-		t.Fatalf("a group that filters nothing must attach nothing, got %v", got.Names)
-	}
-
-	// The accepting half: a group that restricts something still attaches.
-	restrictive := permissive
-	restrictive.DefaultIngress = "drop"
-	if got := p.bindingOf(restrictive); len(got.Names) != 1 || got.DefaultIngress != "drop" {
-		t.Fatalf("a restricting group must still bind, got %+v", got)
-	}
-}
-
-// TestAnUnenforceableGroupIsReportedAsTheDeclaredLimit separates the two
-// meanings one ERROR line used to conflate (#337). A rule set the runtime has
-// no mechanism for — machine.ErrFirewallUnenforceable, the routed NIC — is a
-// declared limit, published as capabilities.firewall_public_only=false, and is
-// reported as a warning that names the declaration. A failure nothing declared
-// stays an error.
-func TestAnUnenforceableGroupIsReportedAsTheDeclaredLimit(t *testing.T) {
-	var buf bytes.Buffer
-	env := emulator.DefaultEnv()
-	env.Log = slog.New(slog.NewTextHandler(&buf, nil))
-	p := New(env)
-
-	p.reportFirewall(fmt.Errorf("apply firewall to m/eth0: %w", machine.ErrFirewallUnenforceable),
-		"server", "srv-1")
-	declared := buf.String()
-	if !strings.Contains(declared, "level=WARN") {
-		t.Fatalf("a declared limit must be a warning, got %q", declared)
-	}
-	if !strings.Contains(declared, "firewall_public_only") {
-		t.Fatalf("the warning must name the declaring capability, got %q", declared)
-	}
-
-	buf.Reset()
-	p.reportFirewall(errors.New("the daemon went away"), "server", "srv-1")
-	if failure := buf.String(); !strings.Contains(failure, "level=ERROR") {
-		t.Fatalf("an undeclared failure must stay an error, got %q", failure)
-	}
-}
+// The permissive-set-binds-nothing rule and the Warn-or-Error report moved to
+// the shared layer with #475 — machine.Binding.ApplyRuleSets — and their tests
+// went with them: TestAPermissiveGroupBindsNothingOnEveryRuntime and
+// TestAnUnenforceableGroupIsReportedAsTheDeclaredLimit now live in
+// internal/core/machine/firewall_binding_test.go, holding the behaviour once
+// for the three packs.

--- a/tools/falsify/specs/enforcement.json
+++ b/tools/falsify/specs/enforcement.json
@@ -22,6 +22,22 @@
       "replace": "func (p *Pack) EnforcesFirewall() bool { return false }",
       "test": "TestEveryPackThatWiresTheFirewallSaysSo",
       "package": "./internal/cli/"
+    },
+    {
+      "label": "the Outscale pack drops its declaration while still wiring the firewall (#475)",
+      "file": "internal/providers/outscale/firewall.go",
+      "find": "func (p *Pack) EnforcesFirewall() bool { return true }",
+      "replace": "func (p *Pack) EnforcesFirewall() bool { return false }",
+      "test": "TestEveryPackThatWiresTheFirewallSaysSo",
+      "package": "./internal/cli/"
+    },
+    {
+      "label": "the Exoscale pack drops its declaration while still wiring the firewall (#475)",
+      "file": "internal/providers/exoscale/firewall.go",
+      "find": "func (p *Pack) EnforcesFirewall() bool { return true }",
+      "replace": "func (p *Pack) EnforcesFirewall() bool { return false }",
+      "test": "TestEveryPackThatWiresTheFirewallSaysSo",
+      "package": "./internal/cli/"
     }
   ]
 }

--- a/tools/falsify/specs/exoscale-allocation-window.json
+++ b/tools/falsify/specs/exoscale-allocation-window.json
@@ -1,0 +1,26 @@
+{
+  "package": "./internal/providers/exoscale/",
+  "mutations": [
+    {
+      "label": "the instance is stored after its boot again, so a pool allocating during the launch is handed the same address (#484)",
+      "file": "internal/providers/exoscale/pack.go",
+      "find": "\tp.env.Store.Put(res)\n\tunlock()",
+      "replace": "\tunlock()\n\tp.start(r.Context(), res)\n\tp.env.Store.Put(res)",
+      "test": "TestAPoolMemberAndAStandaloneInstanceNeverShareAnAddress"
+    },
+    {
+      "label": "a pool member's boot lands on a copy nobody can commit, so a refused launch stays published as the state the member was born with (#484)",
+      "file": "internal/providers/exoscale/pools.go",
+      "find": "\t_ = p.binding().Transition(p.env.Store, p.env.Now, kindInstance, id, func(res *resource.Resource) {\n\t\tp.start(ctx, res)\n\t})",
+      "replace": "\tif res, ok := p.env.Store.Get(Name, kindInstance, id); ok {\n\t\tp.start(ctx, res)\n\t}\n\t_ = p.binding().Transition\n\t_ = p.env.Now\n\t_ = func(res *resource.Resource) { p.start(ctx, res) }",
+      "test": "TestAFailedPoolMemberStartIsPublishedAsError"
+    },
+    {
+      "label": "the same discarded write-back, read from the accepting half: a started member records no machine",
+      "file": "internal/providers/exoscale/pools.go",
+      "find": "\t_ = p.binding().Transition(p.env.Store, p.env.Now, kindInstance, id, func(res *resource.Resource) {\n\t\tp.start(ctx, res)\n\t})",
+      "replace": "\tif res, ok := p.env.Store.Get(Name, kindInstance, id); ok {\n\t\tp.start(ctx, res)\n\t}\n\t_ = p.binding().Transition\n\t_ = p.env.Now\n\t_ = func(res *resource.Resource) { p.start(ctx, res) }",
+      "test": "TestAPoolMemberStartIsRecordedInTheStore"
+    }
+  ]
+}

--- a/tools/falsify/specs/pack-firewall-handoff.json
+++ b/tools/falsify/specs/pack-firewall-handoff.json
@@ -1,0 +1,51 @@
+{
+  "package": "./internal/providers/outscale/",
+  "mutations": [
+    {
+      "label": "the Outscale boot stops handing the worn groups to the runtime, which is the whole of #475",
+      "file": "internal/providers/outscale/machines.go",
+      "find": "\tp.syncFirewallAfterBoot(ctx, res)\n}",
+      "replace": "\tif false {\n\t\tp.syncFirewallAfterBoot(ctx, res)\n\t}\n}",
+      "test": "TestAnOutscaleGroupReachesTheHostWhenItsVmBoots"
+    },
+    {
+      "label": "a member-sourced rule stops expanding, so the tiering statement contains nobody",
+      "file": "internal/providers/outscale/firewall.go",
+      "find": "\t\tif members, ok := rule[\"SecurityGroupsMembers\"].([]any); ok {",
+      "replace": "\t\tif members, ok := rule[\"SecurityGroupsMembers\"].([]any); ok && false {",
+      "test": "TestAMemberSourcedRuleExpandsToTheMembersAddresses"
+    },
+    {
+      "label": "the Exoscale boot stops handing the worn groups to the runtime",
+      "package": "./internal/providers/exoscale/",
+      "file": "internal/providers/exoscale/machines.go",
+      "find": "\tp.syncFirewallAfterBoot(ctx, res)\n}",
+      "replace": "\tif false {\n\t\tp.syncFirewallAfterBoot(ctx, res)\n\t}\n}",
+      "test": "TestAnExoscaleGroupReachesTheHostWhenAnInstanceBoots"
+    },
+    {
+      "label": "an egress rule no longer restricts the egress default, opening what upstream closes",
+      "package": "./internal/providers/exoscale/",
+      "file": "internal/providers/exoscale/firewall.go",
+      "find": "\t\tif direction := ruleDirection(rule); direction == \"egress\" {\n\t\t\tspec.DefaultEgress = \"drop\"\n\t\t}",
+      "replace": "\t\tif direction := ruleDirection(rule); direction == \"egress\" && false {\n\t\t\tspec.DefaultEgress = \"drop\"\n\t\t}",
+      "test": "TestAnEgressRuleFlipsTheEgressDefault"
+    },
+    {
+      "label": "a network attached after the boot leaves its interface without the instance's rule sets",
+      "package": "./internal/providers/exoscale/",
+      "file": "internal/providers/exoscale/privatenetworks.go",
+      "find": "\tp.applyInstanceRuleSets(r.Context(), inst)",
+      "replace": "\tif false {\n\t\tp.applyInstanceRuleSets(r.Context(), inst)\n\t}",
+      "test": "TestALateNetworkAttachCarriesTheRuleSets"
+    },
+    {
+      "label": "a pool member stops inheriting its pool's groups, so the app tier's firewall reaches no machine",
+      "package": "./internal/providers/exoscale/",
+      "file": "internal/providers/exoscale/pools.go",
+      "find": "\tif ids := poolRefIDs(pool.Attrs[\"security-groups\"]); len(ids) > 0 {",
+      "replace": "\tif ids := poolRefIDs(pool.Attrs[\"security-groups\"]); len(ids) > 0 && false {",
+      "test": "TestAPoolMemberWearsItsPoolsGroups"
+    }
+  ]
+}

--- a/tools/falsify/specs/routed-nic.json
+++ b/tools/falsify/specs/routed-nic.json
@@ -59,18 +59,16 @@
     },
     {
       "label": "a group that filters nothing goes back to binding on non-OVN runtimes",
-      "package": "./internal/providers/scaleway/",
-      "file": "internal/providers/scaleway/firewall.go",
-      "find": "\tif enforcesNothing(spec) {\n\t\treturn machine.FirewallBinding{}\n\t}",
-      "replace": "\tif p.nativeIsolation() && enforcesNothing(spec) {\n\t\treturn machine.FirewallBinding{}\n\t}",
+      "file": "internal/core/machine/firewall_binding.go",
+      "find": "\t\tif spec.EnforcesNothing() {\n\t\t\tcontinue\n\t\t}",
+      "replace": "\t\tif spec.EnforcesNothing() && false {\n\t\t\tcontinue\n\t\t}",
       "test": "TestAPermissiveGroupBindsNothingOnEveryRuntime"
     },
     {
       "label": "a declared limit is reported as an operational failure again",
-      "package": "./internal/providers/scaleway/",
-      "file": "internal/providers/scaleway/firewall.go",
-      "find": "\tif errors.Is(err, machine.ErrFirewallUnenforceable) {",
-      "replace": "\tif errors.Is(err, machine.ErrFirewallUnenforceable) && false {",
+      "file": "internal/core/machine/firewall_binding.go",
+      "find": "\tif errors.Is(err, ErrFirewallUnenforceable) {",
+      "replace": "\tif errors.Is(err, ErrFirewallUnenforceable) && false {",
       "test": "TestAnUnenforceableGroupIsReportedAsTheDeclaredLimit"
     }
   ]


### PR DESCRIPTION
Closes #475. Closes #484.

Two issues found by hand, by driving the three example stacks under
`--vm incus-ovn` and then reading the host. Both are the same failure wearing
two costumes: **the API described something the runtime did not hold**, and
every run was green while it did.

## #484 — a boot that never wrote down what it produced

Two Exoscale machines were handed the same public address, and the API kept
calling the second one `running` after it failed to start.

`createInstance` allocated under `lockAddresses` but did not `Put` the resource
until after `p.start` — seconds later. During that window `freeAddress` scanned
the store and could not see the address already handed out. `growPool` carried
the same gap. The second defect needed no race at all: `pools.go` started its
members and **never wrote back** the result of `PowerOn`, so a refused start
stayed published as `running`.

Allocation and `Put` now share a single hold of `lockAddresses` — the shape
`allocateVms` already used on Outscale — and every boot, standalone instance
and pool member alike, goes through `Binding.Transition`, which commits **the
state the effect produced**: a refused start publishes `error`, a successful
one records the machine and its address.

## #475 — two packs of three served a firewall and enforced nothing

`internal/providers/scaleway/firewall.go` was the only file in any pack that
referenced `machine.Firewaller`. An Outscale or Exoscale security group was
served, echoed back, and reconciled onto nothing: with a runtime configured,
every port stayed open whatever the group said.

The reconciliation now lives once, in a provider-neutral
`internal/core/machine/firewall_binding.go`: a permissive set attaches nothing,
defaults are deny-dominant, a pack that declared the capability gets an error
where a silent one gets a warning, and an OVN NIC keeps its permissive
catch-all. Each pack keeps only what it alone knows — its rule vocabulary, who
wears what, and the expansion of group-sourced rules into their members' /32,
re-expanded when a member boots or gains an interface late. `scaleway/firewall.go`
**loses 132 lines** moving onto the shared layer.

`enforced.firewall` now publishes all three packs, and
`TestEveryPackThatWiresTheFirewallSaysSo` holds that declaration against the
source rather than against a comment.

## The five proofs, per stack

Measured 2026-08-26, `feint up --runtime incus-ovn`, twelve machines. Every
listener is proven **from inside the machine** (`/proc/net/tcp`, hex port,
state `0A`) before anything is attempted from the station — `ss` is absent from
Alpine, and its absence has already been misread as "nothing listening" in this
repository.

| proof | scaleway (6) | outscale (3) | exoscale (3) |
|---|---|---|---|
| answers (cloud-init done, sshd, :22) | 6/6 | 3/3 | 3/3 |
| the stack's own cloud-init ran | fail2ban | feint template | nginx |
| published address is carried inside; no duplicate | ok | ok | ok, 0 duplicates |
| firewall handed to the host | `scw-*` attached, used_by 1/3/2 | `osc-*` attached, web→app:8080 open by group expansion | web set on the OVN eth1 |
| state equals effect (`running` ⇒ container Running) | 6/6 | 3/3 | 3/3 |

**What did not pass, and why it is not a defect of these packs.** The other half
of the firewall proof — a forbidden port *refusing* from the station — does not
hold, bounded by two declared or filed things: #337 (a routed NIC accepts no
security option, `capabilities.firewall_public_only: false`) and #491 below.
`docs/limits.md` and both READMEs are rewritten to those measured bounds, and no
further.

## Gates

`go build` · `go test ./...` · `mise run check` · `mise run prepush` ·
`mise run docs:check` — all 0. Falsification on every spec naming a file this
branch touches: `exoscale-allocation-window` 3/3, `pack-firewall-handoff` 6/6,
`enforcement` 5/5, `routed-nic` 10/10 — every mutation bites. The harness also
caught a planted witness colliding with `defaultSecurityGroupID` on its own
control value, which is the harness doing its job on itself.

Station delta is nil: 0 instances, 0 `fnt-` networks, the operator's own ACL
alone, the ten `feint/*` images intact.

## Filed rather than fixed here

Three findings, all at the 0.11.0 milestone, none in this branch's scope:

- **#491** — the isolation rule set's catch-all allow (priority 300) outranks
  the NIC-level deny default (100/111) on any multi-subnet OVN run. Pre-existing,
  and it applies to Scaleway too — so this branch does not get to claim what
  #180 already cost once. Proven by a one-variable experiment: the forbidden
  port flips OPEN→CLOSED the moment the isolation set is detached, nothing else
  changed.
- **#492** — an Exoscale pool member never joins the pool's private networks,
  so the app tier's rule set attaches to nothing.
- **#493** — a parallel destroy can leave a running machine, its network and its
  rule set behind a `Destroy complete!`, with the emulator's own journal
  carrying the chain.

Each is an instance of #486: a green run whose claim had no witness check
behind it.
