### PR TITLE
fix(firewall): a port no rule opens refuses even on an isolated network, and pool members join their pool's networks (#491, #492)

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,10 +644,14 @@ authorising a port afterwards opens it without restarting anything.
 
 Two measured bounds stand, and docs/limits.md carries both with their
 measurements: an interface the runtime declares unenforceable (a routed NIC,
-`capabilities.firewall_public_only: false`) stays unenforceable, and on a run
-with two or more subnets in OVN mode the isolation rule set still defeats a
-group's default-deny (#491). `/_feint/health` answers which packs deliver the
-handoff, so a program can ask rather than assume:
+`capabilities.firewall_public_only: false`) stays unenforceable, and between
+two machines of one subnet the sender's permissive egress still wins over the
+receiver's default-deny. The multi-subnet bound that used to sit here — the
+isolation set defeating a group's default-deny (#491) — is gone: a port no
+rule opens refuses from the station on the three example stacks under
+`feint up --runtime incus-ovn`, isolation attached, while two emulated
+networks stay mutually refused. `/_feint/health` answers which packs deliver
+the handoff, so a program can ask rather than assume:
 
 ```bash
 curl -s localhost:4599/_feint/health | jq '{capabilities, enforced}'

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -1357,14 +1357,24 @@ network ACL attached to every interface of the machine. A port no rule opens
 refuses the connection, authorising one opens it without a restart, and revoking
 it closes it again. All four are checked end to end against a live daemon.
 
-**The bound a second subnet adds (#491).** The "port no rule opens refuses"
-half holds only while the machine's network carries no isolation rule set. On
-an OVN run with two or more emulated subnets, the isolation set's catch-all
-allow (rule priority 300) outranks the NIC's default action (100/111), and the
-closed port answers. Measured on 2026-08-26 with one variable: the same
-forbidden port flips from OPEN to CLOSED when the isolation set is detached
-from the network. The rules a group *does* state keep being enforced either
-way; it is the default-deny that #491 tracks.
+**The second subnet no longer defeats the default-deny (#491).** The
+isolation rule set used to end with a catch-all allow in both directions,
+which under OVN sat at rule priority 300 where a NIC's default action sits at
+100/111 — so on any multi-subnet OVN run, a port no rule opens answered
+anyway. The OVN isolation set now carries its foreign-block rejects (400) and
+nothing else: unmatched traffic falls to the NIC default, which is the group's
+default-deny, and the rejects outrank every allow a group can state (300), so
+the two properties hold at once. Measured on the three example stacks under
+`feint up --runtime incus-ovn` on 2026-08-26, listener proved from inside
+before each probe: the forbidden port refuses from the station while an
+allowed port opens in the same pass (Scaleway 443/9999, Outscale 443/9999 over
+the public l2proxy path, Exoscale 443/9999), and a machine of another emulated
+network is refused on a port whose group allows 0.0.0.0/0. A machine whose
+groups enforce nothing wears the shared permissive posture set (`opn-fnt`,
+catch-all allows at 300) on the NICs of an isolated network, so it stays open
+to everything but the foreign subnets; the bridge-mode isolation set keeps its
+catch-all, because there the network ACL filters at the bridge-host boundary
+and would otherwise reject the station itself.
 
 **What this requires.** `security.acls` on a bridged NIC exists from Incus
 **6.0.4** onwards. On 6.0.0, which Ubuntu 24.04 ships and will not move past, the
@@ -3008,15 +3018,17 @@ unenforceable stays unenforceable: a routed NIC accepts no security option
 interface of every Exoscale instance and of every Scaleway server whose only
 address is public — the pack hands the set over, the driver refuses with the
 typed error, and the log names the declaring capability instead of crying
-wolf. Second, on any run where at least two emulated subnets exist in OVN
-mode, the emulator's own isolation rule set defeats every NIC-level default
-deny: its catch-all allow sits at rule priority 300 where the NIC default sits
-at 100/111, so a port no rule opens **answers anyway** on machines whose
-network carries an isolation set. Measured both ways on 2026-08-26 — the
-forbidden port flips from OPEN to CLOSED the moment the isolation set is
-detached from the network, nothing else changed — and filed as #491 with the
-upstream constants. Until #491 lands: a group's *allows* are enforced, and its
-default-deny holds only on networks without the emulator's isolation set.
+wolf. Second, between two machines of one subnet the sender's permissive
+egress still wins over the receiver's ingress default (the single-pipeline
+divergence "Subnet isolation depends on the runtime mode" documents, measured
+again on the Exoscale stack's two pool members on 2026-08-26: a member reaches
+its neighbour's unopened port, the station does not). The bound this paragraph
+used to carry — the isolation set's catch-all allow at 300 defeating every
+NIC-level default deny on multi-subnet OVN runs — was #491, and it is gone:
+the OVN isolation set carries only rejects now, so a group's default-deny
+holds with the isolation attached, measured on the three example stacks under
+`feint up --runtime incus-ovn` (the section "The firewall enforces, within
+stated bounds" carries the runs).
 Group-sourced rules (the tiering statement, "tier 2 accepts tier 1") are
 expanded into the member machines' addresses, since the runtime has no group
 selector, and re-expanded whenever a member boots or gains an interface.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -964,9 +964,11 @@ answered by #475 the way the driver's own contract suggests: the runtime has
 no group selector, so the member reference is expanded into the addresses the
 member machines answer on, and re-expanded whenever a member boots or gains an
 interface. Outscale and Exoscale hand their groups to the runtime now, within
-the two measured bounds [limits.md](limits.md) states (a routed NIC enforces
-nothing by declaration, and #491 tracks the isolation set defeating a group's
-default-deny on multi-subnet OVN runs).
+the measured bounds [limits.md](limits.md) states (a routed NIC enforces
+nothing by declaration, and the same-subnet sender-egress divergence); the
+multi-subnet bound #491 tracked — the isolation set defeating a group's
+default-deny — was closed by removing the OVN isolation set's catch-all
+allow, proved on the three example stacks.
 
 **Evidence:** for what landed, the conformance suite as it runs now; for the
 remainder, the LB apply named in OSC-5.

--- a/internal/core/machine/incus.go
+++ b/internal/core/machine/incus.go
@@ -1367,6 +1367,18 @@ func (d *Incus) afterNetworkDelete(ctx context.Context, name, block string) erro
 	if err := d.RemoveFirewall(ctx, isolationACL(name)); err != nil {
 		return fmt.Errorf("drop the isolation rule set of %s: %w", name, err)
 	}
+	// The permissive posture set belongs to no resource, so no resource's
+	// delete would ever drop it: a run that isolated a network once left
+	// exactly one ACL on the host after a full `feint down` (measured,
+	// 2026-08-26: `opn-fnt` at used_by=0 beside the operator's own acltest).
+	// Dropped opportunistically with each network: "in use" means machines
+	// elsewhere still wear it and is not an error, an absent set is the normal
+	// case, and a later need recreates it on demand.
+	// TestANetworkDeleteTakesTheUnusedPermissiveSetWithIt fails without this.
+	if err := d.RemoveFirewall(ctx, permissiveACL()); err != nil &&
+		!strings.Contains(strings.ToLower(err.Error()), "in use") {
+		return fmt.Errorf("drop the permissive posture set: %w", err)
+	}
 	return d.dropUplinkRouteOVN(ctx, block)
 }
 

--- a/internal/core/machine/incus_firewall.go
+++ b/internal/core/machine/incus_firewall.go
@@ -43,7 +43,7 @@ const aclDescription = "feint security group"
 // A not-found error is returned as-is: whether an absent rule set is a problem is
 // the caller's decision, not this function's.
 func (d *Incus) mustOwnACL(ctx context.Context, name string) error {
-	if isolationOwned(name) {
+	if coreOwnedACL(name) {
 		return nil
 	}
 	out, err := d.run(ctx, "query", "/1.0/network-acls/"+name)
@@ -204,7 +204,8 @@ func (d *Incus) ApplyFirewall(ctx context.Context, machine string, binding Firew
 	}
 
 	joined := strings.Join(binding.Names, ",")
-	networkTypes := map[string]string{}
+	networks := map[string]networkACLInfo{}
+	permissiveEnsured := false
 	var unenforceable error
 	for _, device := range devices {
 		// A routed NIC takes no rule set at all (#337). Measured on Incus 7.2
@@ -242,7 +243,7 @@ func (d *Incus) ApplyFirewall(ctx context.Context, machine string, binding Firew
 		}
 		args := []string{"config", "device", verb, machine, device.name, "security.acls=" + joined}
 		switch {
-		case d.isOVNNetwork(ctx, device.network, networkTypes):
+		case d.isOVNNetwork(ctx, device.network, networks):
 			// Only security.acls: it is the one ACL key an OVN NIC updates in
 			// place (UpdatableFields in nic_ovn.go at v7.2.0). Any other key
 			// makes Incus remove and re-add the device, and the guest loses
@@ -251,6 +252,29 @@ func (d *Incus) ApplyFirewall(ctx context.Context, machine string, binding Firew
 			// the NIC's own default, reject; a permissive group states its
 			// openness as a catch-all allow rule inside the rule set, which
 			// EnsureFirewall replaces live.
+			//
+			// One case takes more than the joined list: no rule set to attach,
+			// on a network that carries the emulator's isolation set. That
+			// network ACL forces the reject default onto every NIC (a network's
+			// security.acls "apply to NICs connected to this network"), so a
+			// bare detach would close a machine whose groups enforce nothing —
+			// the exact opposite of what "enforces nothing" means. The NIC
+			// wears the permissive posture set instead, and the isolation's
+			// rejects at 400 still outrank its catch-all allows at 300, so the
+			// machine stays open to everything but the foreign subnets (#491).
+			//
+			// TestAMachineWithoutAGroupStaysOpenOnAnIsolatedNetwork fails
+			// without this; TestAnEmptyBindingStillClearsANICOnAnUnisolatedNetwork
+			// holds the other half.
+			if joined == "" && networks[device.network].acls != "" {
+				if !permissiveEnsured {
+					if err := d.EnsureFirewall(ctx, permissiveSpec()); err != nil {
+						return fmt.Errorf("apply firewall to %s/%s: %w", machine, device.name, err)
+					}
+					permissiveEnsured = true
+				}
+				args[len(args)-1] = "security.acls=" + permissiveACL()
+			}
 		case joined != "":
 			// The default actions only mean something while a rule set is
 			// attached, and Incus rejects them on a NIC that carries none.
@@ -265,27 +289,36 @@ func (d *Incus) ApplyFirewall(ctx context.Context, machine string, binding Firew
 	return unenforceable
 }
 
+// networkACLInfo is what one network lookup answers ApplyFirewall: its type,
+// and whether the network itself carries rule sets — which under OVN is what
+// decides the posture of a NIC that attaches none of its own.
+type networkACLInfo struct {
+	kind string
+	acls string
+}
+
 // isOVNNetwork reports whether a network is OVN-typed, caching the answer for
 // the duration of one call: a machine's NICs often share a network, and each
 // lookup is a runtime round trip.
-func (d *Incus) isOVNNetwork(ctx context.Context, network string, cache map[string]string) bool {
+func (d *Incus) isOVNNetwork(ctx context.Context, network string, cache map[string]networkACLInfo) bool {
 	if network == "" {
 		return false
 	}
-	kind, known := cache[network]
+	info, known := cache[network]
 	if !known {
 		out, err := d.run(ctx, "query", "/1.0/networks/"+network)
 		if err == nil {
 			var raw struct {
-				Type string `json:"type"`
+				Type   string            `json:"type"`
+				Config map[string]string `json:"config"`
 			}
 			if json.Unmarshal(out, &raw) == nil {
-				kind = raw.Type
+				info = networkACLInfo{kind: raw.Type, acls: raw.Config["security.acls"]}
 			}
 		}
-		cache[network] = kind
+		cache[network] = info
 	}
-	return kind == "ovn"
+	return info.kind == "ovn"
 }
 
 // orDrop keeps the runtime's own default when the caller says nothing, which is

--- a/internal/core/machine/incus_firewall_test.go
+++ b/internal/core/machine/incus_firewall_test.go
@@ -835,3 +835,95 @@ func TestAFirewallWriteTheHostRefusesWithdrawsTheCapability(t *testing.T) {
 		t.Error("a refusal by this driver's own guard must not withdraw the host's capability")
 	}
 }
+
+// A machine whose groups enforce nothing attaches nothing — but on an OVN
+// network that carries the emulator's isolation set, "nothing" is not neutral:
+// the network ACL forces the reject default onto every NIC, so a bare detach
+// closes the machine entirely. The NIC wears the permissive posture set
+// instead, whose catch-all allows at 300 stay under the isolation's rejects at
+// 400: open to the station, closed to the foreign subnets, which is what a
+// group that filters nothing means there (#491).
+func TestAMachineWithoutAGroupStaysOpenOnAnIsolatedNetwork(t *testing.T) {
+	f := &fakeRuntime{answers: map[string]string{
+		"/1.0/instances/srv":     twoNICs,
+		"/1.0/networks/scw-abc":  `{"type": "ovn", "config": {"security.acls": "iso-fnt-abc"}}`,
+		"/1.0/networks/incusbr0": `{"type": "bridge"}`,
+	}}
+	d := newFakeDriver(f)
+	d.OVN = true
+
+	if err := d.ApplyFirewall(context.Background(), "srv", FirewallBinding{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	ovn := f.matching(" eth1 security.acls=")
+	if len(ovn) != 1 || !strings.Contains(ovn[0], "security.acls=opn-fnt") {
+		t.Fatalf("the OVN interface of an isolated network must wear the permissive set, got %v", ovn)
+	}
+	if got := f.matching("/1.0/network-acls/opn-fnt"); len(got) == 0 {
+		t.Error("the permissive set was attached without being written first")
+	}
+	// The bridged interface keeps the plain detach: no network ACL forces a
+	// default onto it.
+	for _, cmd := range f.matching(" eth0 security.acls=") {
+		if strings.Contains(cmd, "opn-fnt") {
+			t.Errorf("a bridged interface has no business wearing the permissive set: %q", cmd)
+		}
+	}
+}
+
+// The other half of the invariant: on an OVN network that carries no ACL, an
+// empty binding still clears the interface, exactly as before — a NIC with no
+// rule set on a bare network filters nothing, and attaching the permissive set
+// there would hand its egress catch-all to the sender's side of the pipeline,
+// opening a restrictive same-subnet neighbour that today filters faithfully.
+func TestAnEmptyBindingStillClearsANICOnAnUnisolatedNetwork(t *testing.T) {
+	f := &fakeRuntime{answers: map[string]string{
+		"/1.0/instances/srv":     twoNICs,
+		"/1.0/networks/scw-abc":  `{"type": "ovn", "config": {}}`,
+		"/1.0/networks/incusbr0": `{"type": "bridge"}`,
+	}}
+	d := newFakeDriver(f)
+	d.OVN = true
+
+	if err := d.ApplyFirewall(context.Background(), "srv", FirewallBinding{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	ovn := f.matching(" eth1 security.acls=")
+	if len(ovn) != 1 || strings.Contains(ovn[0], "opn-fnt") {
+		t.Fatalf("an empty binding on an unisolated network must clear the interface, got %v", ovn)
+	}
+	if got := f.matching("/1.0/network-acls/opn-fnt"); len(got) != 0 {
+		t.Errorf("the permissive set has no business existing here: %v", got)
+	}
+}
+
+// A restrictive binding is never replaced by the permissive set, isolation or
+// not: the groups' own rule sets are what the machine wears, and the reject
+// default the network ACL forces is exactly the group's default-deny.
+func TestARestrictiveBindingKeepsItsGroupsOnAnIsolatedNetwork(t *testing.T) {
+	f := &fakeRuntime{answers: map[string]string{
+		"/1.0/instances/srv":     twoNICs,
+		"/1.0/networks/scw-abc":  `{"type": "ovn", "config": {"security.acls": "iso-fnt-abc"}}`,
+		"/1.0/networks/incusbr0": `{"type": "bridge"}`,
+	}}
+	d := newFakeDriver(f)
+	d.OVN = true
+
+	if err := d.ApplyFirewall(context.Background(), "srv", FirewallBinding{
+		Names:          []string{"sg-one"},
+		DefaultIngress: "drop",
+		DefaultEgress:  "allow",
+	}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	ovn := f.matching(" eth1 security.acls=")
+	if len(ovn) != 1 || !strings.Contains(ovn[0], "security.acls=sg-one") {
+		t.Fatalf("the group must reach the interface unchanged, got %v", ovn)
+	}
+	if got := f.matching("opn-fnt"); len(got) != 0 {
+		t.Errorf("the permissive set has no business near a restrictive binding: %v", got)
+	}
+}

--- a/internal/core/machine/incus_isolate.go
+++ b/internal/core/machine/incus_isolate.go
@@ -45,6 +45,46 @@ func isolationOwned(name string) bool {
 	return strings.HasPrefix(name, "iso-"+NetworkPrefix+"-")
 }
 
+// permissiveACL is the rule set that keeps a machine with no restrictive group
+// open on an OVN network that carries the emulator's isolation set. One per
+// host, because it says the same thing for every such machine: everything
+// passes, in both directions, as catch-all allow rules at the runtime's rule
+// priority (300 in acl_ovn.go at v7.2.0).
+//
+// It exists because attaching any ACL to an OVN network makes the runtime add a
+// default-action rule to every NIC of that network — reject, at priority
+// 100/111 — and the isolation set no longer carries the catch-all allow that
+// used to compensate (that allow, at 300, was #491: it outranked every
+// NIC-level default deny). A machine whose groups enforce nothing attaches
+// nothing, so without this set it would lose all traffic the moment its
+// network gained a second subnet.
+func permissiveACL() string {
+	return "opn-" + NetworkPrefix
+}
+
+// permissiveSpec is the content of that rule set: allow everything, stated as
+// rules rather than as NIC default-action keys, because security.acls is the
+// only ACL key an OVN NIC updates in place (UpdatableFields, nic_ovn.go at
+// v7.2.0) and the keys would cost the guest its addresses on every change.
+func permissiveSpec() FirewallSpec {
+	return FirewallSpec{
+		Name:           permissiveACL(),
+		DefaultIngress: "allow",
+		DefaultEgress:  "allow",
+		Rules: []FirewallRule{
+			{Direction: "ingress", Action: "allow"},
+			{Direction: "egress", Action: "allow"},
+		},
+	}
+}
+
+// coreOwnedACL reports whether a rule set is one this layer names by
+// construction — an isolation set or the permissive posture set — so the
+// ownership checks accept them before their description exists.
+func coreOwnedACL(name string) bool {
+	return isolationOwned(name) || name == permissiveACL()
+}
+
 // IsolateNetwork implements Isolator.
 func (d *Incus) IsolateNetwork(ctx context.Context, network string, foreign []string) error {
 	// This used to return early under OVN, on the grounds that "an OVN network
@@ -96,6 +136,13 @@ func (d *Incus) IsolateNetwork(ctx context.Context, network string, foreign []st
 		if _, err := d.run(ctx, "network", "unset", network, "security.acls"); err != nil {
 			return fmt.Errorf("detach isolation from %s: %w", network, err)
 		}
+		// The permissive posture set was only there because the network carried
+		// an ACL; with the network bare again, a NIC without one filters
+		// nothing, which is the state the set was imitating. After the unset,
+		// so the machines it covered never pass through a closed instant.
+		if d.OVN {
+			d.withdrawPermissive(ctx, network)
+		}
 		return d.RemoveFirewall(ctx, name)
 	}
 
@@ -129,10 +176,30 @@ func (d *Incus) IsolateNetwork(ctx context.Context, network string, foreign []st
 			Source: block,
 		})
 	}
-	// Everything else passes: this rule set exists to keep subnets apart, not to
-	// filter, and the NIC rule sets are what a security group drives.
-	body.Egress = append(body.Egress, aclRule{Action: "allow", State: "enabled"})
-	body.Ingress = append(body.Ingress, aclRule{Action: "allow", State: "enabled"})
+	if !d.OVN {
+		// Everything else passes: on a bridge this rule set exists to keep
+		// subnets apart, not to filter, and it applies at the bridge-host
+		// boundary where the NICs' own rule sets are a separate mechanism.
+		//
+		// Bridge mode only. Under OVN a network ACL applies to every NIC of the
+		// network, in the single pipeline where a rule's priority comes from
+		// its action (acl_ovn.go at v7.2.0: allow 300, reject 400, drop 500,
+		// NIC default action 100/111) — so this catch-all allow at 300
+		// outranked every security group's default deny at 100/111, and a port
+		// no rule opens answered from the station on any multi-subnet run
+		// (#491). Without it, unmatched traffic falls to the NIC default,
+		// reject, which is exactly a group's default-deny; the machines that
+		// deserve openness carry the permissive set instead (spreadPermissive).
+		// The rejects above sit at 400 either way, above every allow a group
+		// can state, which is what keeps two VPCs apart whatever their groups
+		// say — the two halves #491 requires at once.
+		//
+		// TestAnOVNIsolationSetCarriesNoCatchAllAllow fails if the allows come
+		// back under OVN; TestABridgeIsolationSetKeepsItsCatchAll fails if they
+		// leave the bridge path.
+		body.Egress = append(body.Egress, aclRule{Action: "allow", State: "enabled"})
+		body.Ingress = append(body.Ingress, aclRule{Action: "allow", State: "enabled"})
+	}
 
 	encoded, err := json.Marshal(body)
 	if err != nil {
@@ -143,8 +210,139 @@ func (d *Incus) IsolateNetwork(ctx context.Context, network string, foreign []st
 		return fmt.Errorf("write isolation of %s: %w", network, err)
 	}
 
+	// Before the network attach, so a machine with no restrictive group never
+	// sits on an isolated network without its permissive set: the attach is
+	// what makes the runtime add the default-deny to every NIC, and the set
+	// must already be there when that happens.
+	if d.OVN {
+		d.spreadPermissive(ctx, network)
+	}
+
 	if _, err := d.run(ctx, "network", "set", network, "security.acls", name); err != nil {
 		return fmt.Errorf("attach isolation to %s: %w", network, err)
 	}
 	return nil
+}
+
+// networkNIC is one instance interface of the emulator's own machines, as the
+// permissive sweep sees it.
+type networkNIC struct {
+	instance  string
+	device    string
+	inherited bool
+	acls      string
+}
+
+// instanceNICsOn lists the NICs sitting on the named network, restricted to
+// instances the emulator created.
+//
+// The restriction is ownership, not shape: the instance list comes from the
+// host, which also runs the operator's own containers, and the sweep edits
+// network devices. Only instances carrying the label Binding writes at create
+// (user.feint.provider) are listed, so no command this sweep emits can name
+// anybody else's machine. Names are still checked for form before becoming
+// arguments, because well formed and authorised are two different questions.
+func (d *Incus) instanceNICsOn(ctx context.Context, network string) ([]networkNIC, error) {
+	out, err := d.run(ctx, "query", "/1.0/instances?recursion=1")
+	if err != nil {
+		return nil, fmt.Errorf("list instances: %w", err)
+	}
+	var raw []struct {
+		Name            string                       `json:"name"`
+		Config          map[string]string            `json:"config"`
+		ExpandedDevices map[string]map[string]string `json:"expanded_devices"`
+		Devices         map[string]map[string]string `json:"devices"`
+	}
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return nil, fmt.Errorf("decode the instance list: %w", err)
+	}
+	var nics []networkNIC
+	for _, inst := range raw {
+		if inst.Config["user."+LabelKey] == "" || !safeName.MatchString(inst.Name) {
+			continue
+		}
+		for name, device := range inst.ExpandedDevices {
+			if device["type"] != "nic" || device["network"] != network || !safeName.MatchString(name) {
+				continue
+			}
+			_, own := inst.Devices[name]
+			nics = append(nics, networkNIC{
+				instance:  inst.Name,
+				device:    name,
+				inherited: !own,
+				acls:      device["security.acls"],
+			})
+		}
+	}
+	return nics, nil
+}
+
+// spreadPermissive puts the permissive posture set on every rule-set-less NIC
+// of the emulator's machines on the named network, before the network gains an
+// ACL. ApplyFirewall establishes the same invariant when a machine's groups
+// change; this covers the machines that were already applied when the network
+// became isolated. Failures are logged rather than fatal: the isolation itself
+// must still land, and a machine left closed is visible in the log where a
+// silent skip is not.
+//
+// TestIsolatingANetworkSpreadsThePermissiveSetToSetlessNICs fails without it.
+func (d *Incus) spreadPermissive(ctx context.Context, network string) {
+	nics, err := d.instanceNICsOn(ctx, network)
+	if err != nil {
+		d.logger().Error("could not list the network's interfaces before isolating it; "+
+			"machines without a security group may be left closed",
+			"network", network, "error", err)
+		return
+	}
+	ensured := false
+	for _, nic := range nics {
+		if nic.acls != "" {
+			continue
+		}
+		if !ensured {
+			if err := d.EnsureFirewall(ctx, permissiveSpec()); err != nil {
+				d.logger().Error("could not write the permissive posture set",
+					"network", network, "error", err)
+				return
+			}
+			ensured = true
+		}
+		verb := "set"
+		if nic.inherited {
+			verb = "override"
+		}
+		if _, err := d.run(ctx, "config", "device", verb, nic.instance, nic.device,
+			"security.acls="+permissiveACL()); err != nil {
+			d.logger().Error("could not keep a group-less machine open on an isolated network",
+				"network", network, "machine", nic.instance, "device", nic.device, "error", err)
+		}
+	}
+}
+
+// withdrawPermissive is the exact undo, after the network's ACL is gone: a NIC
+// carrying only the permissive set goes back to carrying none, so a later
+// probe of the host reads the same state as before the network was isolated.
+// NICs carrying anything else — a security group, with or without company —
+// are none of this sweep's business.
+func (d *Incus) withdrawPermissive(ctx context.Context, network string) {
+	nics, err := d.instanceNICsOn(ctx, network)
+	if err != nil {
+		d.logger().Error("could not list the network's interfaces after de-isolating it",
+			"network", network, "error", err)
+		return
+	}
+	for _, nic := range nics {
+		if nic.acls != permissiveACL() {
+			continue
+		}
+		verb := "set"
+		if nic.inherited {
+			verb = "override"
+		}
+		if _, err := d.run(ctx, "config", "device", verb, nic.instance, nic.device,
+			"security.acls="); err != nil {
+			d.logger().Error("could not take the permissive posture set off an interface",
+				"network", network, "machine", nic.instance, "device", nic.device, "error", err)
+		}
+	}
 }

--- a/internal/core/machine/incus_ovn_isolate_test.go
+++ b/internal/core/machine/incus_ovn_isolate_test.go
@@ -2,6 +2,7 @@ package machine
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -100,4 +101,220 @@ func TestForeignBlocksKeepsPeersAndTheNetworkItself(t *testing.T) {
 			t.Error("a network was isolated from itself")
 		}
 	}
+}
+
+// The isolation set used to end with a catch-all allow in both directions.
+// Under OVN that allow sat at rule priority 300 in the single pipeline where a
+// NIC's default action sits at 100/111 (acl_ovn.go at v7.2.0), so it outranked
+// every security group's default deny on every NIC of the network: a port no
+// rule opens answered from the station on any multi-subnet run (#491), the
+// forbidden port flipping OPEN→CLOSED the moment the set was detached, nothing
+// else changed. The rejects stay at 400, above every allow a group can state —
+// which is what keeps the two properties at once: the foreign subnets stay out
+// whatever the groups say, and the groups' default deny holds again.
+func TestAnOVNIsolationSetCarriesNoCatchAllAllow(t *testing.T) {
+	f := isolationFake()
+	d := newFakeDriver(f)
+	d.OVN = true
+
+	if err := d.IsolateNetwork(context.Background(), "fnt-aaa", []string{"10.2.0.0/24"}); err != nil {
+		t.Fatalf("isolate: %v", err)
+	}
+
+	body := isolationBody(t, f, "iso-fnt-aaa")
+	for _, direction := range [][]aclRule{body.Ingress, body.Egress} {
+		for _, rule := range direction {
+			if rule.Action == "allow" || rule.Action == "allow-stateless" {
+				t.Fatalf("the OVN isolation set carries an allow rule, which outranks every NIC default deny: %+v", rule)
+			}
+		}
+	}
+	if len(body.Ingress) == 0 || len(body.Egress) == 0 {
+		t.Fatalf("the rejects are gone with the catch-all: %+v", body)
+	}
+	for _, rule := range body.Egress {
+		if rule.Action != "reject" || rule.Destination != "10.2.0.0/24" {
+			t.Errorf("egress rule does not reject the foreign block: %+v", rule)
+		}
+	}
+}
+
+// The bridge half keeps its catch-all: there a network ACL filters at the
+// bridge-host boundary, a separate mechanism from the NIC rule sets, and
+// without the allow the boundary would reject the station itself.
+func TestABridgeIsolationSetKeepsItsCatchAll(t *testing.T) {
+	f := isolationFake()
+	d := newFakeDriver(f)
+
+	if err := d.IsolateNetwork(context.Background(), "fnt-aaa", []string{"10.2.0.0/24"}); err != nil {
+		t.Fatalf("isolate: %v", err)
+	}
+
+	body := isolationBody(t, f, "iso-fnt-aaa")
+	allows := 0
+	for _, direction := range [][]aclRule{body.Ingress, body.Egress} {
+		for _, rule := range direction {
+			if rule.Action == "allow" && rule.Source == "" && rule.Destination == "" {
+				allows++
+			}
+		}
+	}
+	if allows != 2 {
+		t.Fatalf("the bridge isolation set must keep its catch-all allow in both directions, found %d:\n%+v", allows, body)
+	}
+}
+
+// Attaching an ACL to an OVN network is what makes the runtime add the reject
+// default to every NIC of the network. A machine applied before the network
+// became isolated, whose groups enforce nothing, carries no rule set — so the
+// isolation would close it. The sweep puts the permissive posture set on those
+// NICs, before the network attach so no machine passes through a closed
+// instant; it never touches a NIC that carries a rule set, and never an
+// instance the emulator did not create, because the instance list comes from
+// the host and editing a stranger's devices is the audit class ownership
+// checks exist for.
+func TestIsolatingANetworkSpreadsThePermissiveSetToSetlessNICs(t *testing.T) {
+	f := isolationFake()
+	d := newFakeDriver(f)
+	d.OVN = true
+
+	if err := d.IsolateNetwork(context.Background(), "fnt-aaa", []string{"10.2.0.0/24"}); err != nil {
+		t.Fatalf("isolate: %v", err)
+	}
+
+	spread := f.matching("config device set srv-bare eth1 security.acls=opn-fnt")
+	if len(spread) != 1 {
+		t.Fatalf("the set-less NIC did not receive the permissive set:\n%s", strings.Join(f.commands(), "\n"))
+	}
+	if got := f.matching("config device set srv-grouped"); len(got) != 0 {
+		t.Errorf("a NIC already carrying a rule set was edited: %v", got)
+	}
+	for _, cmd := range f.commands() {
+		if strings.Contains(cmd, "production-database") {
+			t.Fatalf("a command names an instance the emulator did not create: %q", cmd)
+		}
+	}
+	if got := f.matching("/1.0/network-acls/opn-fnt"); len(got) == 0 {
+		t.Error("the permissive set was attached without being written first")
+	}
+
+	// Before the network attach: after it, the NIC would already be closed.
+	spreadAt, attachAt := -1, -1
+	for i, cmd := range f.commands() {
+		switch {
+		case strings.Contains(cmd, "security.acls=opn-fnt"):
+			if spreadAt == -1 {
+				spreadAt = i
+			}
+		case strings.HasPrefix(cmd, "network set fnt-aaa security.acls"):
+			attachAt = i
+		}
+	}
+	if attachAt == -1 || spreadAt == -1 || spreadAt > attachAt {
+		t.Errorf("the permissive set must reach the NICs before the network attach (spread at %d, attach at %d)", spreadAt, attachAt)
+	}
+}
+
+// The exact undo: once the network's ACL is gone, a NIC carrying only the
+// permissive set goes back to carrying none, and everything else is left
+// alone.
+func TestDeisolatingANetworkWithdrawsThePermissiveSet(t *testing.T) {
+	f := &fakeRuntime{}
+	f.hook = func(_ int, args []string) ([]byte, error, bool) {
+		if strings.HasPrefix(strings.Join(args, " "), "query /1.0/instances?recursion=1") {
+			return []byte(`[
+				{"name":"srv-bare","config":{"user.feint.provider":"scaleway"},
+				 "expanded_devices":{"eth1":{"type":"nic","network":"fnt-aaa","security.acls":"opn-fnt"}},
+				 "devices":{"eth1":{"type":"nic","network":"fnt-aaa","security.acls":"opn-fnt"}}},
+				{"name":"srv-grouped","config":{"user.feint.provider":"scaleway"},
+				 "expanded_devices":{"eth1":{"type":"nic","network":"fnt-aaa","security.acls":"scw-abc"}},
+				 "devices":{"eth1":{"type":"nic","network":"fnt-aaa","security.acls":"scw-abc"}}}
+			]`), nil, true
+		}
+		return nil, nil, false
+	}
+	d := newFakeDriver(f)
+	d.OVN = true
+
+	if err := d.IsolateNetwork(context.Background(), "fnt-aaa", nil); err != nil {
+		t.Fatalf("de-isolate: %v", err)
+	}
+
+	cleared := f.matching("config device set srv-bare eth1 security.acls=")
+	if len(cleared) != 1 {
+		t.Fatalf("the permissive set was not withdrawn:\n%s", strings.Join(f.commands(), "\n"))
+	}
+	if got := f.matching("config device set srv-grouped"); len(got) != 0 {
+		t.Errorf("a NIC carrying a security group was edited on de-isolation: %v", got)
+	}
+
+	// After the network detach, for the same no-closed-instant reason in
+	// reverse: while the network still carries the ACL, a bare NIC is a closed
+	// NIC.
+	unsetAt, clearAt := -1, -1
+	for i, cmd := range f.commands() {
+		switch {
+		case strings.HasPrefix(cmd, "network unset fnt-aaa security.acls"):
+			unsetAt = i
+		case strings.Contains(cmd, "srv-bare eth1 security.acls="):
+			clearAt = i
+		}
+	}
+	if unsetAt == -1 || clearAt == -1 || clearAt < unsetAt {
+		t.Errorf("the withdrawal must follow the network detach (unset at %d, clear at %d)", unsetAt, clearAt)
+	}
+}
+
+// isolationFake answers what IsolateNetwork asks on the way to writing a rule
+// set: the network exists, no ACL exists yet, and the host runs three
+// instances — one of the emulator's with no rule set, one with a group, and
+// one that is somebody else's.
+func isolationFake() *fakeRuntime {
+	f := &fakeRuntime{}
+	f.hook = func(_ int, args []string) ([]byte, error, bool) {
+		joined := strings.Join(args, " ")
+		switch {
+		case strings.HasPrefix(joined, "network acl show iso-"):
+			return nil, errors.New("Error: Network ACL not found"), true
+		case strings.HasPrefix(joined, "query /1.0/instances?recursion=1"):
+			return []byte(`[
+				{"name":"srv-bare","config":{"user.feint.provider":"scaleway"},
+				 "expanded_devices":{"eth1":{"type":"nic","network":"fnt-aaa"}},
+				 "devices":{"eth1":{"type":"nic","network":"fnt-aaa"}}},
+				{"name":"srv-grouped","config":{"user.feint.provider":"scaleway"},
+				 "expanded_devices":{"eth1":{"type":"nic","network":"fnt-aaa","security.acls":"scw-abc"}},
+				 "devices":{"eth1":{"type":"nic","network":"fnt-aaa","security.acls":"scw-abc"}}},
+				{"name":"production-database","config":{},
+				 "expanded_devices":{"eth0":{"type":"nic","network":"fnt-aaa"}},
+				 "devices":{"eth0":{"type":"nic","network":"fnt-aaa"}}}
+			]`), nil, true
+		}
+		return nil, nil, false
+	}
+	return f
+}
+
+// isolationBody digs the JSON the driver PUT to the named rule set out of the
+// recorded calls.
+func isolationBody(t *testing.T, f *fakeRuntime, name string) aclBody {
+	t.Helper()
+	for _, call := range f.calls {
+		if len(call) < 2 || call[0] != "query" {
+			continue
+		}
+		if call[len(call)-1] != "/1.0/network-acls/"+name {
+			continue
+		}
+		for i, arg := range call {
+			if arg == "--data" && i+1 < len(call) {
+				var body aclBody
+				if err := json.Unmarshal([]byte(call[i+1]), &body); err != nil {
+					t.Fatalf("unreadable rule set body: %v", err)
+				}
+				return body
+			}
+		}
+	}
+	t.Fatalf("no rule set was written for %s:\n%s", name, strings.Join(f.commands(), "\n"))
+	return aclBody{}
 }

--- a/internal/core/machine/incus_peering_test.go
+++ b/internal/core/machine/incus_peering_test.go
@@ -333,3 +333,43 @@ func TestPruneRefusesAPeeringHalfOnAStrangersNetworkNamedLikeOurs(t *testing.T) 
 			strings.Join(f.commands(), "\n"))
 	}
 }
+
+// The permissive posture set belongs to no resource, so nothing's delete ever
+// dropped it: one full `feint up`/`feint down` cycle left `opn-fnt` on the
+// host, used_by=0, beside the operator's own rule sets (measured 2026-08-26).
+// A network delete now drops it opportunistically — and "in use" is not an
+// error, because machines of another network may still wear it.
+func TestANetworkDeleteTakesTheUnusedPermissiveSetWithIt(t *testing.T) {
+	f := &fakeRuntime{
+		answers: map[string]string{
+			"network get fnt-aaaa ipv4.address": "10.2.4.1/24\n",
+		},
+	}
+	d := newFakeDriver(f)
+
+	if err := d.RemoveNetwork(context.Background(), "fnt-aaaa"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if len(f.matching("network acl delete opn-fnt")) == 0 {
+		t.Fatalf("the permissive set was left behind; the driver ran:\n%s",
+			strings.Join(f.commands(), "\n"))
+	}
+}
+
+// The other half: a permissive set still worn by machines of another network
+// must not fail the delete of this one.
+func TestAPermissiveSetStillInUseDoesNotFailANetworkDelete(t *testing.T) {
+	f := &fakeRuntime{
+		answers: map[string]string{
+			"network get fnt-aaaa ipv4.address": "10.2.4.1/24\n",
+		},
+		fail: map[string]error{
+			"network acl delete opn-fnt": errors.New("Error: Cannot delete an ACL that is in use"),
+		},
+	}
+	d := newFakeDriver(f)
+
+	if err := d.RemoveNetwork(context.Background(), "fnt-aaaa"); err != nil {
+		t.Fatalf("a network delete failed on the permissive set another machine still wears: %v", err)
+	}
+}

--- a/internal/core/machine/incus_prune.go
+++ b/internal/core/machine/incus_prune.go
@@ -234,10 +234,10 @@ func (d *Incus) ownedACLs(ctx context.Context) []string {
 		// By description, plus the isolation names, which are the one case that
 		// can exist without one: the description is written by the PUT that
 		// follows the create, so an interrupted run leaves a rule set invisible
-		// to the description check. isolationOwned matches the emulator's own
-		// network prefix rather than a bare iso-, which used to claim an
-		// operator's rule sets too.
-		if strings.HasPrefix(acl.Description, aclDescription) || isolationOwned(acl.Name) {
+		// to the description check. coreOwnedACL matches the emulator's own
+		// network prefix (and the permissive posture set's fixed name) rather
+		// than a bare iso-, which used to claim an operator's rule sets too.
+		if strings.HasPrefix(acl.Description, aclDescription) || coreOwnedACL(acl.Name) {
 			names = append(names, acl.Name)
 		}
 	}

--- a/internal/providers/exoscale/pools.go
+++ b/internal/providers/exoscale/pools.go
@@ -420,8 +420,53 @@ func (p *Pack) newPoolMember(pool *resource.Resource, index int64) *resource.Res
 	if keys, ok := pool.Attrs["ssh-keys"]; ok {
 		member.Attrs["ssh-keys"] = keys
 	}
+	// And the pool's private networks, which every member joins. Upstream this
+	// is what the pool's declaration means — measured on the real API on
+	// 2026-08-26: a member of a pool declaring one network answers
+	// `private-networks: [{id, mac-address}]` on get-instance — and it is what
+	// makes the membership real here: the boot replays these records onto the
+	// machine (reattachPrivateNetworks), and the firewall sync that follows
+	// finds an interface to attach the member's rule sets to. Before this the pool stored its list and nothing turned it
+	// into memberships: one routed NIC per member, and the app tier's rule set
+	// sat at used_by=0 on the host (#492).
+	//
+	// TestAPoolMemberJoinsThePoolsPrivateNetworks fails without it.
+	if atts := p.memberAttachments(pool); len(atts) > 0 {
+		member.Attrs[attrInstancePrivateNetworks] = attachmentsToAttr(atts)
+	}
 	member.Runtime = map[string]string{runtimePoolKey: pool.ID}
 	return member
+}
+
+// memberAttachments builds the memberships one new member takes: one per
+// private network the pool declares, with a lease from the range when the
+// network is managed — chosen exactly the way an instance-side ":attach"
+// chooses one. Called under p.lockAddresses(), held by growPool across the
+// choice and the Put, so two members cannot be handed one address (#484's
+// discipline). A network that no longer exists is skipped the way the
+// instance view drops it: the relation is computed against what is, and a
+// managed range with nothing left is a membership without a lease, logged
+// rather than silently absent.
+func (p *Pack) memberAttachments(pool *resource.Resource) []pnAttachment {
+	ids := poolRefIDs(pool.Attrs["private-networks"])
+	out := make([]pnAttachment, 0, len(ids))
+	for _, ref := range ids {
+		id, _ := ref.(string)
+		pn, found := p.env.Store.Get(Name, kindPrivateNetwork, id)
+		if !found {
+			continue
+		}
+		ip := ""
+		if dhcp, managed := rangeOf(pn); managed {
+			ip = firstFreeLease(dhcp, p.takenLeases(pn.ID))
+			if ip == "" {
+				p.logger().Warn("no address left in the private network's range for a pool member",
+					"pool", pool.ID, "private-network", pn.ID)
+			}
+		}
+		out = append(out, pnAttachment{NetworkID: id, IP: ip})
+	}
+	return out
 }
 
 // poolRefIDs reads the ids out of a stored list of {id: …} references,

--- a/internal/providers/exoscale/pools_machines_internal_test.go
+++ b/internal/providers/exoscale/pools_machines_internal_test.go
@@ -226,3 +226,135 @@ func TestAPoolMemberStartIsRecordedInTheStore(t *testing.T) {
 		t.Fatalf("runtime address %q, want the one the driver reported", got)
 	}
 }
+
+// attachRecordingDriver also records what Attach was called with, so a test
+// can assert a member's machine really joined a network rather than trust the
+// stored record.
+type attachRecordingDriver struct {
+	recordingDriver
+	mu       sync.Mutex
+	attached []string
+}
+
+func (d *attachRecordingDriver) Attach(_ context.Context, name string, att machine.Attachment) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.attached = append(d.attached, name+" "+att.Network+" "+att.Address)
+	return nil
+}
+
+// createManagedNetwork drives the real handler and returns the stored resource.
+func createManagedNetwork(t *testing.T, p *Pack, name string) *resource.Resource {
+	t.Helper()
+	r := httptest.NewRequest("POST", "/v2/private-network",
+		strings.NewReader(`{"name":"`+name+`","start-ip":"10.90.2.20","end-ip":"10.90.2.200","netmask":"255.255.255.0"}`))
+	p.createPrivateNetwork(httptest.NewRecorder(), r)
+	for _, pn := range p.env.Store.List(kindPrivateNetwork, resource.Tenant{Provider: Name}) {
+		if got, _ := pn.Attrs["name"].(string); got == name {
+			return pn
+		}
+	}
+	t.Fatalf("the private network %q was not stored", name)
+	return nil
+}
+
+func createPoolOnNetwork(p *Pack, size int, networkID string) {
+	body := fmt.Sprintf(`{"name":"app","size":%d,`+
+		`"template":{"id":"11111111-1111-4111-8111-111111111111"},`+
+		`"instance-type":{"id":"71004023-bb72-4a97-b1e9-bc66dfce9470"},`+
+		`"private-networks":[{"id":"%s"}]}`, size, networkID)
+	r := httptest.NewRequest("POST", "/v2/instance-pool", strings.NewReader(body))
+	p.createInstancePool(httptest.NewRecorder(), r)
+}
+
+// TestAPoolMemberJoinsThePoolsPrivateNetworks is #492. The pool stored its
+// `private-networks` list and nothing ever turned it into memberships: each
+// member booted with its routed public NIC alone, and the rule set of
+// examples/stacks/exoscale's app tier stayed at used_by=0 on the host —
+// nothing to attach to. Upstream the declaration means membership, measured on
+// the real API on 2026-08-26: a member of a pool declaring one network answers
+// `private-networks: [{id, mac-address}]` on get-instance.
+func TestAPoolMemberJoinsThePoolsPrivateNetworks(t *testing.T) {
+	driver := &attachRecordingDriver{}
+	p := sequencedPack(driver)
+	pn := createManagedNetwork(t, p, "back")
+
+	createPoolOnNetwork(p, 2, pn.ID)
+
+	members := p.env.Store.List(kindInstance, resource.Tenant{Provider: Name})
+	if len(members) != 2 {
+		t.Fatalf("%d members, want 2", len(members))
+	}
+	seen := map[string]bool{}
+	for _, member := range members {
+		atts := instanceAttachmentsOf(member)
+		if len(atts) != 1 || atts[0].NetworkID != pn.ID {
+			t.Fatalf("member %s memberships = %+v, want the pool's network", member.ID, atts)
+		}
+		if atts[0].IP == "" {
+			t.Fatalf("member %s joined the managed network without a lease", member.ID)
+		}
+		if seen[atts[0].IP] {
+			t.Fatalf("two members were handed one lease: %s", atts[0].IP)
+		}
+		seen[atts[0].IP] = true
+
+		// And the machine half: the boot replayed the membership onto the
+		// runtime, on the network the emulator backs the resource with.
+		want := member.Runtime["machine"] + " " + pn.Runtime[runtimeNetworkKey] + " " + atts[0].IP
+		found := false
+		for _, got := range driver.attached {
+			if got == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("no Attach carried %q; attaches: %v", want, driver.attached)
+		}
+	}
+	if leases := p.leasesOf(pn.ID); len(leases) != 2 {
+		t.Fatalf("%d leases on the network, want 2", len(leases))
+	}
+}
+
+// TestAScaleDownReleasesTheMembersLeases is the other half: a member removed
+// by a scale-down releases its lease like an ordinary detach, so the address
+// is free for whoever comes next.
+func TestAScaleDownReleasesTheMembersLeases(t *testing.T) {
+	driver := &attachRecordingDriver{}
+	p := sequencedPack(driver)
+	pn := createManagedNetwork(t, p, "back")
+	createPoolOnNetwork(p, 2, pn.ID)
+
+	pools := p.env.Store.List(kindPool, resource.Tenant{Provider: Name})
+	if len(pools) != 1 {
+		t.Fatalf("%d pools, want 1", len(pools))
+	}
+
+	r := httptest.NewRequest("PUT", "/v2/instance-pool/"+pools[0].ID+":scale",
+		strings.NewReader(`{"size":1}`))
+	r.SetPathValue("id", pools[0].ID)
+	p.scaleInstancePool(httptest.NewRecorder(), r)
+
+	if leases := p.leasesOf(pn.ID); len(leases) != 1 {
+		t.Fatalf("%d leases after the scale-down, want 1", len(leases))
+	}
+
+	// The freed address is genuinely free: growing back re-leases it instead
+	// of walking further into the range.
+	r = httptest.NewRequest("PUT", "/v2/instance-pool/"+pools[0].ID+":scale",
+		strings.NewReader(`{"size":2}`))
+	r.SetPathValue("id", pools[0].ID)
+	p.scaleInstancePool(httptest.NewRecorder(), r)
+
+	leases := p.leasesOf(pn.ID)
+	if len(leases) != 2 {
+		t.Fatalf("%d leases after growing back, want 2", len(leases))
+	}
+	for _, lease := range leases {
+		m, _ := lease.(map[string]any)
+		if ip, _ := m["ip"].(string); ip != "10.90.2.20" && ip != "10.90.2.21" {
+			t.Fatalf("lease %v walked past the freed address", m)
+		}
+	}
+}

--- a/internal/providers/exoscale/privatenetworks.go
+++ b/internal/providers/exoscale/privatenetworks.go
@@ -389,6 +389,39 @@ func (p *Pack) privateNetworkView(res *resource.Resource) map[string]any {
 	return out
 }
 
+// takenLeases is the set of addresses the network's leases already hold, for a
+// chooser that must not hand one out twice. Read under p.lockAddresses(), like
+// every other walk over the leases.
+func (p *Pack) takenLeases(networkID string) map[string]bool {
+	taken := map[string]bool{}
+	for _, lease := range p.leasesOf(networkID) {
+		m, _ := lease.(map[string]any)
+		if ip, _ := m["ip"].(string); ip != "" {
+			taken[ip] = true
+		}
+	}
+	return taken
+}
+
+// gatewayOf is the block's first host address, which belongs to the gateway
+// the backing network answers on, never to a lease.
+func gatewayOf(dhcp managedRange) string {
+	return dhcp.prefix.Masked().Addr().Next().String()
+}
+
+// firstFreeLease picks the lowest address of a managed range that no lease
+// holds and that is not the gateway, or "" when the range is exhausted.
+func firstFreeLease(dhcp managedRange, taken map[string]bool) string {
+	gateway := gatewayOf(dhcp)
+	for addr := dhcp.start; !dhcp.end.Less(addr); addr = addr.Next() {
+		candidate := addr.String()
+		if !taken[candidate] && candidate != gateway {
+			return candidate
+		}
+	}
+	return ""
+}
+
 // leasesOf computes the leases of a managed network from the instances that
 // hold them: {instance-id, ip}, ordered by address so two reads answer the
 // same bytes.
@@ -689,17 +722,7 @@ func (p *Pack) takeLease(w http.ResponseWriter, pn *resource.Resource, instanceI
 			"a static lease needs a managed private network, and this one declares no range")
 		return "", false
 	case managed:
-		taken := map[string]bool{}
-		for _, lease := range p.leasesOf(pn.ID) {
-			m, _ := lease.(map[string]any)
-			if ip, _ := m["ip"].(string); ip != "" {
-				taken[ip] = true
-			}
-		}
-		// The block's first host address belongs to the gateway the backing
-		// network answers on, never to a lease.
-		gateway := dhcp.prefix.Masked().Addr().Next().String()
-
+		taken := p.takenLeases(pn.ID)
 		if requested != "" {
 			addr, err := netip.ParseAddr(requested)
 			if err != nil || !addr.Is4() {
@@ -710,19 +733,13 @@ func (p *Pack) takeLease(w http.ResponseWriter, pn *resource.Resource, instanceI
 				writeError(w, http.StatusBadRequest, "ip is outside the network's range")
 				return "", false
 			}
-			if taken[requested] || requested == gateway {
+			if taken[requested] || requested == gatewayOf(dhcp) {
 				writeError(w, http.StatusBadRequest, "ip is already leased")
 				return "", false
 			}
 			leaseIP = requested
 		} else {
-			for addr := dhcp.start; !dhcp.end.Less(addr); addr = addr.Next() {
-				candidate := addr.String()
-				if !taken[candidate] && candidate != gateway {
-					leaseIP = candidate
-					break
-				}
-			}
+			leaseIP = firstFreeLease(dhcp, taken)
 			if leaseIP == "" {
 				writeError(w, http.StatusBadRequest, "no address left in the network's range")
 				return "", false

--- a/tools/falsify/specs/forbidden-port-refuses.json
+++ b/tools/falsify/specs/forbidden-port-refuses.json
@@ -1,0 +1,92 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "the catch-all allow comes back into the OVN isolation set, outranking every NIC default deny — the whole of #491",
+      "file": "internal/core/machine/incus_isolate.go",
+      "find": "\tif !d.OVN {\n\t\t// Everything else passes:",
+      "replace": "\tif !d.OVN || true {\n\t\t// Everything else passes:",
+      "test": "TestAnOVNIsolationSetCarriesNoCatchAllAllow"
+    },
+    {
+      "label": "the catch-all leaves the bridge path too, and the bridge-host boundary rejects the station",
+      "file": "internal/core/machine/incus_isolate.go",
+      "find": "\tif !d.OVN {\n\t\t// Everything else passes:",
+      "replace": "\tif !d.OVN && false {\n\t\t// Everything else passes:",
+      "test": "TestABridgeIsolationSetKeepsItsCatchAll"
+    },
+    {
+      "label": "the permissive set no longer spreads to the machines already on the network when it becomes isolated, closing every group-less machine",
+      "file": "internal/core/machine/incus_isolate.go",
+      "find": "\tif d.OVN {\n\t\td.spreadPermissive(ctx, network)\n\t}",
+      "replace": "\tif d.OVN && false {\n\t\td.spreadPermissive(ctx, network)\n\t}",
+      "test": "TestIsolatingANetworkSpreadsThePermissiveSetToSetlessNICs"
+    },
+    {
+      "label": "the sweep stops asking whose instance it is, and edits the devices of every container on the host",
+      "file": "internal/core/machine/incus_isolate.go",
+      "find": "\t\tif inst.Config[\"user.\"+LabelKey] == \"\" || !safeName.MatchString(inst.Name) {",
+      "replace": "\t\tif (inst.Config[\"user.\"+LabelKey] == \"\" && false) || !safeName.MatchString(inst.Name) {",
+      "test": "TestIsolatingANetworkSpreadsThePermissiveSetToSetlessNICs"
+    },
+    {
+      "label": "the permissive set is never taken back off, so a de-isolated network keeps a posture nothing explains",
+      "file": "internal/core/machine/incus_isolate.go",
+      "find": "\t\tif d.OVN {\n\t\t\td.withdrawPermissive(ctx, network)\n\t\t}",
+      "replace": "\t\tif d.OVN && false {\n\t\t\td.withdrawPermissive(ctx, network)\n\t\t}",
+      "test": "TestDeisolatingANetworkWithdrawsThePermissiveSet"
+    },
+    {
+      "label": "an empty binding goes back to the bare detach on an isolated network, and the reject default closes the machine entirely",
+      "file": "internal/core/machine/incus_firewall.go",
+      "find": "\t\t\tif joined == \"\" && networks[device.network].acls != \"\" {",
+      "replace": "\t\t\tif joined == \"\" && networks[device.network].acls != \"\" && false {",
+      "test": "TestAMachineWithoutAGroupStaysOpenOnAnIsolatedNetwork"
+    },
+    {
+      "label": "the permissive set attaches to every bare NIC whatever its network carries, handing its egress catch-all to the sender's side of the pipeline",
+      "file": "internal/core/machine/incus_firewall.go",
+      "find": "\t\t\tif joined == \"\" && networks[device.network].acls != \"\" {",
+      "replace": "\t\t\tif joined == \"\" && (networks[device.network].acls != \"\" || true) {",
+      "test": "TestAnEmptyBindingStillClearsANICOnAnUnisolatedNetwork"
+    },
+    {
+      "label": "a pool member stops joining the pool's private networks — the whole of #492",
+      "package": "./internal/providers/exoscale/",
+      "file": "internal/providers/exoscale/pools.go",
+      "find": "\tif atts := p.memberAttachments(pool); len(atts) > 0 {",
+      "replace": "\tif atts := p.memberAttachments(pool); len(atts) < 0 {",
+      "test": "TestAPoolMemberJoinsThePoolsPrivateNetworks"
+    },
+    {
+      "label": "the lease chooser stops reading what is already leased, and two members share one address",
+      "package": "./internal/providers/exoscale/",
+      "file": "internal/providers/exoscale/privatenetworks.go",
+      "find": "\t\tif !taken[candidate] && candidate != gateway {",
+      "replace": "\t\tif (!taken[candidate] || true) && candidate != gateway {",
+      "test": "TestAPoolMemberJoinsThePoolsPrivateNetworks"
+    },
+    {
+      "label": "a scale-down stops deleting the member records, and the leases they hold never free",
+      "package": "./internal/providers/exoscale/",
+      "file": "internal/providers/exoscale/pools.go",
+      "find": "\t\tremoved = members[*req.Size:]\n\t\tfor _, member := range removed {\n\t\t\tp.env.Store.Delete(Name, kindInstance, member.ID)\n\t\t}",
+      "replace": "\t\tremoved = members[*req.Size:]\n\t\tfor _, member := range removed {\n\t\t\tif false {\n\t\t\t\tp.env.Store.Delete(Name, kindInstance, member.ID)\n\t\t\t}\n\t\t}",
+      "test": "TestAScaleDownReleasesTheMembersLeases"
+    },
+    {
+      "label": "a network delete stops dropping the permissive set, and every run leaves one ACL on the host",
+      "file": "internal/core/machine/incus.go",
+      "find": "\tif err := d.RemoveFirewall(ctx, permissiveACL()); err != nil &&\n\t\t!strings.Contains(strings.ToLower(err.Error()), \"in use\") {",
+      "replace": "\tif err := d.RemoveFirewall(ctx, isolationACL(permissiveACL())); err != nil &&\n\t\t!strings.Contains(strings.ToLower(err.Error()), \"in use\") {",
+      "test": "TestANetworkDeleteTakesTheUnusedPermissiveSetWithIt"
+    },
+    {
+      "label": "a permissive set still worn elsewhere fails the network delete",
+      "file": "internal/core/machine/incus.go",
+      "find": "\tif err := d.RemoveFirewall(ctx, permissiveACL()); err != nil &&\n\t\t!strings.Contains(strings.ToLower(err.Error()), \"in use\") {",
+      "replace": "\tif err := d.RemoveFirewall(ctx, permissiveACL()); err != nil &&\n\t\t(!strings.Contains(strings.ToLower(err.Error()), \"in use\") || true) {",
+      "test": "TestAPermissiveSetStillInUseDoesNotFailANetworkDelete"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #491. Closes #492.

#494 made the three packs hand their security groups to the host. This branch
makes those groups **decide**: a port no rule opens now refuses, and it does so
without giving up the isolation between two networks — the property that
separates the OVN mode from the bridge mode, and the argument this project
sells.

## #491 — the isolation set outranked every firewall default

The isolation rule set carried a catch-all `allow`. Read against upstream
`acl_ovn.go` v7.2.0 (downloaded and read, not assumed): allow sits at 300,
reject at 400, the NIC defaults at 100/111, and it is a single to-lport stage.
So on any run with two or more emulated subnets, the catch-all beat the NIC's
deny default and a forbidden port answered — on all three packs, Scaleway
included.

The catch-all is gone. Traffic no rule opens falls through to the NIC's reject
default; the isolation rejects at 400 still dominate any group allow, so the
isolation property is unchanged. A machine wearing no restrictive set gets the
shared permissive `opn-fnt` — laid down by `ApplyFirewall` and by a sweep when
a network is isolated, withdrawn on de-isolation, and carried away by the
network's deletion (measured surviving a full `down` otherwise, which is why
the teardown was hardened and has its own mutations). **The bridge mode keeps
its catch-all**, because it cannot deliver isolation anyway and the honest
thing is to leave its behaviour where it was.

## #492 — pool members never joined the pool's private networks

`pools.go` recorded the pool's `private-networks` list and nothing turned it
into memberships: each member carried exactly one interface, the routed public
NIC, so the app tier's rule set had nothing to attach to and sat at
`used_by=0`.

**The premise was checked against the real cloud first**, since the issue
claimed an upstream behaviour: a real pool of size 1 was created, and its member
publishes `private-networks: [{id, mac-address}]`. Resources removed behind.
One instrument note worth keeping: the CLI's `-O json` view **omits** that
field — only the raw API answers honestly, and a reader trusting the CLI would
have concluded the opposite.

`newPoolMember` now records the membership per member, with its lease taken
under the address lock; the boot replays it and scale-down releases it.

## The proofs, per stack

`--vm incus-ovn`, every listener proven from inside the machine
(`/proc/net/tcp`, hex port, state `0A`) before anything is attempted from the
station.

| stack | positive control | forbidden port (9999) | across networks | #492 |
|---|---|---|---|---|
| Scaleway | web:443 OPEN; web1→web2:443 OPEN (same subnet) | CLOSED (111); :22 CLOSED with sshd alive | app→web:443 CLOSED despite an allow on 0.0.0.0/0 | — |
| Outscale | 198.51.100.2:443 OPEN (l2proxy); web→app:8080 OPEN (peered subnets) | CLOSED; :22 CLOSED | the isolation set rejects only the foreign Net, zero allow | — |
| Exoscale | web:443 OPEN | CLOSED on the web instance **and** on a pool member | member (private source forced) → web:443 CLOSED; segments mutually closed | members on `back`, distinct leases, app SG **used_by=2** (was 0) |

## Gates

`mise run check`, `go test -race`, `mise run prepush`, `mise run docs:check` —
all 0. Falsification: the new `forbidden-port-refuses.json` carries 12
mutations and every one bites; the ten existing specs were replayed green.

**`FEINT_VM=incus-ovn mise run conformance` is green end to end** (1676 s) with
the suite patch of #499 applied — see below. Station delta is nil: 0 instances,
0 `fnt-` networks, the operator's own ACL alone, no leftover route.

## What this branch does not fix, and why

The conformance run first came back red on one assertion — *"an accepted
peering carries traffic"* in the Outscale network suite. It was measured on
**both trees before anything was changed**: it is red on `main` (a344f8d) too,
identically. CI never sees it, because `conformance.yml` runs `FEINT_VM=off`
and the network suite skips itself without a runtime.

The assertion is the thing at fault: it creates two Vms with no explicit group,
so each wears its Net's default group, whose inbound accepts its own members
and nobody else — the real cloud would refuse that ping too, peered or not. It
was green only while no group reached the runtime at all.

Filed as **#499** with both measurements side by side and a suite patch that is
measured to bring the full run green. The patch is deliberately **not** in this
branch: a defect already red on `main` gets filed, not folded into an unrelated
lot.

## Also filed (0.11.0), none of it fixed here

- **#495** — a Port_Group race: a group application lost and never replayed,
  witnessed twice on two stacks. It now fails **closed** rather than open, and
  an API reboot repairs it.
- **#496** — scope-link uplink routes with no ARP answer, the station cut off
  from OVN private addresses; amended after reading `private_from_host=false`.
- **#497** — `routing_enabled` defaults false here and true upstream, measured
  by a real `scw vpc vpc create`.
- **#498** — a non-idempotent public route re-laid at reboot, shouting ERROR
  over a correct final state.
