### PR TITLE
fix(conformance): the ssh suites name what they lack, and the peering check measures what it claims (#499, #501)

### DIFF
--- a/tools/conformance/exoscale/ssh.sh
+++ b/tools/conformance/exoscale/ssh.sh
@@ -28,6 +28,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # account. That is not hypothetical — it happened, to this repository.
 # shellcheck source=/dev/null
 . "$SCRIPT_DIR/../guard.sh"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/../sshlogin.sh"
 guard_local "$ENDPOINT"
 # The images this suite boots have to exist before it registers a key and
 # promises an address; without them nothing answers on port 22 (#335).
@@ -148,11 +150,9 @@ for _ in $(seq 1 45); do
 done
 [ "$logged_in" = true ] \
   || fail "no ssh daemon answered for $user@$eip although the $MACHINES runtime is on: the published address is a promise nobody keeps"
-remote="$(ssh -F /dev/null -i "$WORK/id" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-            -o BatchMode=yes "$user@$eip" 'id -un; grep -c feint-sshconf ~/.ssh/authorized_keys')"
-[ "$(printf '%s' "$remote" | head -1)" = "$user" ] \
-  || fail "logged in as '$(printf '%s' "$remote" | head -1)', not as the template's declared $user"
-ok "logged in: $(echo "$remote" | tr '\n' ' ')"
+# The assertions live in sshlogin.sh, shared by the three ssh suites: every
+# one carries its message, and no grep ever decides an exit status (#501).
+assert_login "$user@$eip" "$WORK/id" "$user" "$WORK/id.pub"
 
 echo "- clean up"
 exo -Q compute instance delete "$instance_id" --force >/dev/null || fail "instance delete rejected"

--- a/tools/conformance/outscale/network.sh
+++ b/tools/conformance/outscale/network.sh
@@ -275,6 +275,24 @@ sleep 2
 # the binding's, prefix feint-osc-.
 reach() { incus exec "feint-osc-$vm_a" -- ping -c 2 -W 2 "$ip_b" >/dev/null 2>&1; }
 
+# The rule a real user would write, posed BEFORE the negative checks (#499).
+# Both Vms carry the default group of their own Net, whose inbound accepts the
+# group's own members and nobody else — measured on a real account, and the
+# head comment of internal/providers/outscale/securitygroups.go. So without an
+# explicit allow, the accepted peering below would still not carry this ping,
+# on the real cloud exactly as here; the check was only ever green while no
+# group reached the runtime (before #494). Placing the allow first also makes
+# the refusals stronger: an explicit allow that still does not cross an
+# unpeered or pending Net is the strongest form of those refusals, because the
+# isolation rejects at 400 dominate any allow at 300.
+sg_b="$(osc ReadSecurityGroups --Filters.NetIds "$net_b" --Filters.SecurityGroupNames default \
+        | jq -r '.SecurityGroups[0].SecurityGroupId // empty')"
+[ -n "$sg_b" ] || fail "the default group of $net_b was not found"
+osc CreateSecurityGroupRule --Flow Inbound --SecurityGroupId "$sg_b" \
+    --IpProtocol icmp --IpRange "$PEER_BLOCK_A" >/dev/null \
+  || fail "CreateSecurityGroupRule rejected on $sg_b"
+sleep 2
+
 # The positive control, before four negative verdicts in a row: the target answers
 # on its own address. A machine whose stack never came up refuses a ping exactly
 # as an unpeered Net does, and this suite draws its strongest conclusion from that

--- a/tools/conformance/outscale/ssh.sh
+++ b/tools/conformance/outscale/ssh.sh
@@ -27,6 +27,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # account. That is not hypothetical — it happened, to this repository.
 # shellcheck source=/dev/null
 . "$SCRIPT_DIR/../guard.sh"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/../sshlogin.sh"
 guard_local "$ENDPOINT"
 # The images this suite boots have to exist before it registers a key and
 # promises an address; without them nothing answers on port 22 (#335).
@@ -145,11 +147,9 @@ for _ in $(seq 1 45); do
 done
 [ "$logged_in" = true ] \
   || fail "no ssh daemon answered for outscale@$public although the $MACHINES runtime is on: the published address is a promise nobody keeps"
-remote="$(ssh -F /dev/null -i "$WORK/id" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-            -o BatchMode=yes "outscale@$public" 'id -un; grep -c feint-sshconf ~/.ssh/authorized_keys')"
-[ "$(printf '%s' "$remote" | head -1)" = "outscale" ] \
-  || fail "logged in as '$(printf '%s' "$remote" | head -1)', not as the login Outscale provisions"
-ok "logged in: $(echo "$remote" | tr '\n' ' ')"
+# The assertions live in sshlogin.sh, shared by the three ssh suites: every
+# one carries its message, and no grep ever decides an exit status (#501).
+assert_login "outscale@$public" "$WORK/id" outscale "$WORK/id.pub"
 
 echo "- clean up"
 osc DeleteVms --VmIds "$vm_id" >/dev/null || fail "DeleteVms rejected"

--- a/tools/conformance/scaleway/ssh.sh
+++ b/tools/conformance/scaleway/ssh.sh
@@ -21,6 +21,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # account. That is not hypothetical — it happened, to this repository.
 # shellcheck source=/dev/null
 . "$SCRIPT_DIR/../guard.sh"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/../sshlogin.sh"
 guard_local "$ENDPOINT"
 # The images this suite boots have to exist before it registers a key and
 # promises an address; without them nothing answers on port 22 (#335).
@@ -102,9 +104,12 @@ for _ in $(seq 1 45); do
 done
 
 if [ "$logged_in" = true ]; then
-  remote="$(ssh -F /dev/null -i "$WORK/id" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              -o BatchMode=yes "root@$ip" 'hostname; id -un; grep -c feint-conformance ~/.ssh/authorized_keys')"
-  ok "logged in: $(echo "$remote" | tr '\n' ' ')"
+  # The assertions live in sshlogin.sh, shared by the three ssh suites, and
+  # every one of them names what it did not get. This block used to be a
+  # single unguarded ssh whose last sub-command was `grep -c`, which exits 1
+  # when the count is zero: under `set -euo pipefail` the script died right
+  # here without a word, five scheduled nights in a row (#501).
+  assert_login "root@$ip" "$WORK/id" root "$WORK/id.pub"
 elif [ "$MACHINES" = "none" ]; then
   echo "  SKIP: no ssh daemon answered on $ip (expected with --vm off; use --vm incus)" >&2
 else

--- a/tools/conformance/sshlogin.sh
+++ b/tools/conformance/sshlogin.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# The login assertions the three ssh suites share (#501).
+#
+# Sourced, not executed. The caller defines fail() and ok(), the way guard.sh
+# is consumed.
+#
+# Why this file exists. Each suite used to end its login step with one
+# unguarded command substitution whose remote command ended in `grep -c`:
+#
+#   remote="$(ssh … 'hostname; id -un; grep -c feint-conformance ~/.ssh/authorized_keys')"
+#
+# Two defects in one line, and together they cost runtime-proof.yml five
+# scheduled nights (2026-08-22 to 2026-08-26), silently:
+#
+#   - `grep -c` exits 1 when the count is zero, a perfectly ordinary case, and
+#     the line had no `|| fail`: under `set -euo pipefail` the script died right
+#     there without a word. "The key lost its comment", "the default account
+#     moved" and "ssh dropped" were indistinguishable.
+#   - the count was taken on the key COMMENT, which is not a property any
+#     provider promises: Scaleway's real cloud keeps the algorithm and the
+#     material and drops the comment (measured 2026-08-21 on a real fr-par
+#     account; the pack emulates it in sshkeys.go, held by
+#     TestASSHKeyIsPublishedWithoutItsComment, merged in b71d085 on
+#     2026-08-21 at 17:10 — after that night's 02:51 scheduled run, which is
+#     why 08-21 is green and every night after it is red).
+#
+# So the red was DESERVED, and merely unreadable: #363 made the emulator more
+# faithful to upstream, and this assertion was the thing lagging behind. The
+# five red nights before those (08-16 to 08-20) were a different cause
+# entirely — missing images, #335, fixed by #338 on 08-20 — so the suite went
+# red, was repaired, held one night, and went red again for an unrelated
+# reason with nobody told. Two successive causes, one green night between
+# them: that is the argument of #502, and of every message below.
+#
+# So the rules this file encodes, for all three suites at once — a block
+# written three times is a fix that survives in two of them:
+#
+#   - every assertion carries its own message, and no grep ever decides an
+#     exit status;
+#   - the key assertion bears on the MATERIAL, never the comment.
+#
+# tools/conformance/sshlogin_test.go drives assert_login against a stub ssh,
+# and tools/falsify/specs/ssh-login-names-what-it-lacks.json replays those
+# tests with each guard neutralised.
+
+# assert_login <user@host> <identity-file> <expected-user> <public-key-file>
+#
+# Logs in and asserts, one message each: the shell answers, the account is the
+# one the provider provisions, authorized_keys is readable, and the registered
+# key's material is in it.
+assert_login() {
+  local target="$1" identity="$2" want_user="$3" pubkey="$4"
+  local remote_host remote_user authorized key_material
+
+  ssh_login() {
+    ssh -F /dev/null -i "$identity" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+      -o BatchMode=yes "$target" "$@"
+  }
+
+  remote_host="$(ssh_login 'hostname')" \
+    || fail "hostname failed over ssh for $target: the session opens but the machine cannot say its name"
+  remote_user="$(ssh_login 'id -un')" \
+    || fail "id -un failed over ssh for $target: the session opens but the shell does not answer"
+  [ "$remote_user" = "$want_user" ] \
+    || fail "logged in as '$remote_user', not '$want_user': the provider's default login moved"
+  authorized="$(ssh_login 'cat ~/.ssh/authorized_keys')" \
+    || fail "authorized_keys is not readable in $want_user's home for $target: the login worked, so sshd honoured a key this file does not show"
+  key_material="$(cut -d' ' -f2 <"$pubkey")"
+  grep -qF "$key_material" <<<"$authorized" \
+    || fail "the registered key's material is missing from authorized_keys for $target ($(wc -l <<<"$authorized") line(s) present): sshd honoured the key, so it lives somewhere this file is not"
+  ok "logged in: $remote_host $remote_user, registered key present in authorized_keys"
+}

--- a/tools/conformance/sshlogin_test.go
+++ b/tools/conformance/sshlogin_test.go
@@ -1,0 +1,204 @@
+package conformance
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The login assertions the three ssh suites share (#501).
+//
+// runtime-proof.yml was red on the "Scaleway ssh suite" step for five
+// consecutive scheduled nights (2026-08-22 to 2026-08-26) and the step's log
+// ended on nothing: no FAIL line, no emulator ERROR, exit 1. The block died in
+// a single unguarded command substitution whose remote command ended in
+// `grep -c`, which exits 1 when the count is zero — and the count WAS zero,
+// legitimately, because it counted the key's comment and the real cloud drops
+// the comment (sshkeys.go, held by internal/providers/scaleway's
+// TestASSHKeyIsPublishedWithoutItsComment, merged the day the red nights
+// started).
+//
+// These tests drive assert_login itself, against a stub ssh, under the same
+// `set -euo pipefail` the suites run under. What they hold is the repair's two
+// halves: the assertion bears on the key MATERIAL, never the comment, and every
+// way the login can disappoint produces a FAIL line that names it.
+// tools/falsify/specs/ssh-login-names-what-it-lacks.json replays them with each
+// guard neutralised.
+
+// The accepting half first: a machine whose authorized_keys holds the key the
+// way the real cloud publishes it — material without comment — passes. This is
+// the exact input the old block died on.
+func TestASuccessfulLoginReportsTheKeyByItsMaterial(t *testing.T) {
+	code, output := runLogin(t, loginStub{
+		user:       "root",
+		authorized: "ssh-ed25519 " + stubMaterial + "\n",
+	}, "root")
+	if code != 0 {
+		t.Errorf("a login whose key lost its comment failed (exit %d); the comment is not a property any provider promises:\n%s", code, output)
+	}
+	if !strings.Contains(output, "registered key present") {
+		t.Errorf("the success does not say the key was found:\n%s", output)
+	}
+}
+
+// The core of #501: deprived of its key in authorized_keys, the suite fails
+// NAMING authorized_keys — not by exiting 1 without a word.
+func TestALoginMissingItsKeyFailsNamingAuthorizedKeys(t *testing.T) {
+	code, output := runLogin(t, loginStub{
+		user:       "root",
+		authorized: "ssh-ed25519 AAAAsomebodyElsesKey other-host\n",
+	}, "root")
+	if code == 0 {
+		t.Errorf("the login passed while authorized_keys does not hold the registered key:\n%s", output)
+	}
+	if !strings.Contains(output, "FAIL:") || !strings.Contains(output, "authorized_keys") {
+		t.Errorf("the failure does not name authorized_keys; a suite that exits 1 without a word is not fixed, it is displaced:\n%s", output)
+	}
+}
+
+// A default account that moved is named, with the account it found.
+func TestALoginAsTheWrongUserFailsNamingTheAccount(t *testing.T) {
+	code, output := runLogin(t, loginStub{
+		user:       "alpine",
+		authorized: "ssh-ed25519 " + stubMaterial + "\n",
+	}, "root")
+	if code == 0 {
+		t.Errorf("the login passed as 'alpine' where the provider provisions root:\n%s", output)
+	}
+	if !strings.Contains(output, "FAIL:") || !strings.Contains(output, "'alpine'") {
+		t.Errorf("the failure does not name the account it got:\n%s", output)
+	}
+}
+
+// An unreadable file is not an absent key: the two get different sentences,
+// because "the shape is unknown" must never be reported as "not found".
+func TestAnUnreadableAuthorizedKeysFailsSayingSo(t *testing.T) {
+	code, output := runLogin(t, loginStub{
+		user:       "root",
+		catFails:   true,
+		authorized: "unused",
+	}, "root")
+	if code == 0 {
+		t.Errorf("the login passed while authorized_keys cannot be read:\n%s", output)
+	}
+	if !strings.Contains(output, "FAIL:") || !strings.Contains(output, "not readable") {
+		t.Errorf("the failure does not say the file was unreadable, so an io error reads as a missing key:\n%s", output)
+	}
+}
+
+// The call sites, on the same terms as TestEverySuiteThatLogsInAsksForItsImages:
+// a shared block nobody calls repairs nothing, and the three suites carried the
+// same defect precisely because the block was written three times.
+func TestEverySshSuiteAssertsItsLoginThroughTheSharedBlock(t *testing.T) {
+	suites := []string{
+		filepath.Join("scaleway", "ssh.sh"),
+		filepath.Join("outscale", "ssh.sh"),
+		filepath.Join("exoscale", "ssh.sh"),
+	}
+	for _, suite := range suites {
+		body, err := os.ReadFile(suite) //nolint:gosec // a fixed path in this directory
+		if err != nil {
+			t.Fatalf("read %s: %v", suite, err)
+		}
+		called := false
+		for _, line := range strings.Split(string(body), "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), `assert_login "`) {
+				called = true
+				break
+			}
+		}
+		if !called {
+			t.Errorf("%s never calls assert_login on a line of its own: its login step is not held by the shared assertions", suite)
+		}
+		if strings.Contains(string(body), "grep -c ") {
+			t.Errorf("%s still lets a grep -c near its verdict; grep -c exits 1 on a count of zero, which is the silent death of #501", suite)
+		}
+	}
+}
+
+const stubMaterial = "AAAAC3NzaC1lZDI1NTE5AAAAIFeintConformanceStubMaterial"
+
+type loginStub struct {
+	user       string
+	authorized string
+	catFails   bool
+}
+
+// runLogin sources the real sshlogin.sh and calls assert_login under
+// `set -euo pipefail` — the exact regime the suites run under, and the one
+// that made the unguarded block die silently — with a stub ssh first in PATH
+// standing for the machine.
+func runLogin(t *testing.T, stub loginStub, wantUser string) (int, string) {
+	t.Helper()
+	requireTool(t, "bash")
+
+	dir := t.TempDir()
+
+	// The machine, as far as assert_login can see one.
+	stubSSH := `#!/usr/bin/env bash
+cmd="${!#}"
+case "$cmd" in
+  hostname) echo stub-machine ;;
+  'id -un') echo "$STUB_USER" ;;
+  'cat ~/.ssh/authorized_keys')
+    if [ -n "${STUB_CAT_FAILS:-}" ]; then
+      echo "cat: can't open '/root/.ssh/authorized_keys'" >&2
+      exit 1
+    fi
+    printf '%s' "$STUB_AUTHORIZED" ;;
+  *) echo "stub ssh: unexpected remote command: $cmd" >&2; exit 99 ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(dir, "ssh"), []byte(stubSSH), 0o755); err != nil { //nolint:gosec // an executable stub
+		t.Fatalf("write the ssh stub: %v", err)
+	}
+
+	// The key pair the suite registered: the public file carries a comment,
+	// the way ssh-keygen -C writes it, and the machine's authorized_keys may
+	// or may not — that difference is the whole subject.
+	identity := filepath.Join(dir, "id")
+	pubkey := identity + ".pub"
+	if err := os.WriteFile(identity, []byte("stub private key\n"), 0o600); err != nil {
+		t.Fatalf("write the identity stub: %v", err)
+	}
+	if err := os.WriteFile(pubkey, []byte("ssh-ed25519 "+stubMaterial+" feint-conformance\n"), 0o644); err != nil { //nolint:gosec // a public key
+		t.Fatalf("write the public key stub: %v", err)
+	}
+
+	script, err := filepath.Abs("sshlogin.sh")
+	if err != nil {
+		t.Fatalf("locate sshlogin.sh: %v", err)
+	}
+	if _, err := os.Stat(script); err != nil {
+		t.Fatalf("sshlogin.sh is not where this test looks (%s): %v", script, err)
+	}
+
+	cmd := exec.Command("bash", "-c", //nolint:gosec // fixed script, test-controlled arguments
+		`set -euo pipefail
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ok() { echo "  ok: $*"; }
+. "$1"
+assert_login "$2" "$3" "$4" "$5"`,
+		"bash", script, "root@203.0.113.9", identity, wantUser, pubkey)
+	cmd.Env = append(os.Environ(),
+		"PATH="+dir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"STUB_USER="+stub.user,
+		"STUB_AUTHORIZED="+stub.authorized,
+	)
+	if stub.catFails {
+		cmd.Env = append(cmd.Env, "STUB_CAT_FAILS=1")
+	}
+	out, err := cmd.CombinedOutput()
+	code := 0
+	if err != nil {
+		var exit *exec.ExitError
+		if !errors.As(err, &exit) {
+			t.Fatalf("run assert_login: %v\n%s", err, out)
+		}
+		code = exit.ExitCode()
+	}
+	return code, string(out)
+}

--- a/tools/falsify/specs/ssh-login-names-what-it-lacks.json
+++ b/tools/falsify/specs/ssh-login-names-what-it-lacks.json
@@ -1,0 +1,34 @@
+{
+  "package": "./tools/conformance/",
+  "mutations": [
+    {
+      "label": "the key-material assertion never fails, so a machine provisioned without the registered key logs a success — the suite is silent about the one thing it exists to say",
+      "file": "tools/conformance/sshlogin.sh",
+      "find": "  grep -qF \"$key_material\" <<<\"$authorized\" \\",
+      "replace": "  grep -qF \"$key_material\" <<<\"$authorized\" || true \\",
+      "test": "TestALoginMissingItsKeyFailsNamingAuthorizedKeys"
+    },
+    {
+      "label": "the account assertion never fails, so a default login that moved goes unreported",
+      "file": "tools/conformance/sshlogin.sh",
+      "find": "  [ \"$remote_user\" = \"$want_user\" ] \\",
+      "replace": "  [ \"$remote_user\" = \"$want_user\" ] || true \\",
+      "test": "TestALoginAsTheWrongUserFailsNamingTheAccount"
+    },
+    {
+      "label": "the readability guard never fails, so an io error on authorized_keys is reported as a missing key — 'the shape is unknown' collapsed into 'not found'",
+      "file": "tools/conformance/sshlogin.sh",
+      "find": "  authorized=\"$(ssh_login 'cat ~/.ssh/authorized_keys')\" \\",
+      "replace": "  authorized=\"$(ssh_login 'cat ~/.ssh/authorized_keys')\" || true \\",
+      "test": "TestAnUnreadableAuthorizedKeysFailsSayingSo"
+    },
+    {
+      "label": "the Scaleway suite stops calling the shared assertions, which is the shape the defect had: one block written three times, fixed in one",
+      "file": "tools/conformance/scaleway/ssh.sh",
+      "find": "  assert_login \"root@$ip\" \"$WORK/id\" root \"$WORK/id.pub\"",
+      "replace": "  true || assert_login \"root@$ip\" \"$WORK/id\" root \"$WORK/id.pub\"",
+      "test": "TestEverySshSuiteAssertsItsLoginThroughTheSharedBlock"
+    }
+  ],
+  "note": "The subject is #501. runtime-proof.yml was red on the 'Scaleway ssh suite' step for five consecutive scheduled nights (2026-08-22 to 2026-08-26) with no FAIL line and no emulator ERROR: the login block was one unguarded command substitution whose remote command ended in `grep -c`, which exits 1 when the count is zero — and the count was legitimately zero, because it counted the key's COMMENT and the real cloud drops the comment (measured on a real fr-par account 2026-08-21; the pack emulates it in sshkeys.go, held by TestASSHKeyIsPublishedWithoutItsComment, merged in b71d085 the very day the red nights began). Reproduced on the author's station 2026-08-26 under FEINT_VM=incus: once given its voice, the suite failed on 'the registered key (comment feint-conformance) is missing from authorized_keys (1 line(s) present)', and reading that one line inside the machine showed the material present and the comment gone. The repair asserts the material, never the comment, one guarded message per assertion, in a block shared by the three suites — the previous block was written three times and the silent death lived in all three."
+}


### PR DESCRIPTION
Closes #499. Closes #501.

The only gate that boots real machines has been red on ten of the last twelve
scheduled nights, and the failure said nothing. This branch makes it speak, and
fixes the assertion that was measuring the wrong thing.

## #501 — a suite that failed without a word

`Scaleway ssh suite` ended `exit 1` with no `FAIL:` line and no ERROR from the
emulator. The retry loop had succeeded — sshd was up and accepting the key — and
the next line died: an assertion with no `|| fail`, one of whose three
sub-commands was `grep -c`, which returns 1 when the count is **zero**. Under
`set -euo pipefail` the script died there, silently. "The key comment is
missing", "the default account moved" and "ssh broke" were indistinguishable.

**The real defect, once the suite could speak:** the assertion counted the key's
*comment* in `authorized_keys` — a property the real cloud does not promise
(`key.Comment = ""` since b71d085, #363, measured on a real fr-par account). So
**the red was deserved**: the emulator had just become more faithful and the
assertion was behind. It was only illegible.

**The timeline has two causes, not one** — and it is measured, not inferred:

```
08-15 green
08-16 → 08-20  red      ← cause A
08-20 17:10    #335 closed by #338 ("an ssh suite that asks for its images first")
08-21 green              ← the fix held for exactly one night
08-21 17:10    b71d085 lands: key.Comment = ""
08-22 → 08-26  red      ← cause B, this one
```

Five nights each. The suite was red, repaired, and red again the next day for an
entirely different reason, and nobody learned — which is the argument for #502,
stronger with two causes than with one.

The guard now lives once in `tools/conformance/sshlogin.sh`, shared by the three
suites; the trap was written three times. What it says now, measured rather than
promised:

- `FAIL: the registered key's material is missing from authorized_keys for root@… (1 line(s) present)`
- `FAIL: logged in as 'alpine', not 'root': the provider's default login moved`
- an unreadable file gets its own sentence — **"unknown" never collapses into
  "absent"**, which is the distinction #501 exists to restore.

## #499 — an assertion that was green because of a defect

`an accepted peering carries traffic` went red the night after #494 landed. It
was measured on **both trees before anything was changed**: red on `main`
(a344f8d) identically, and the scheduled runner reproduced it a third time with
a third Vm id. Never seen in CI, because `conformance.yml` runs `FEINT_VM=off`
and the network suite skips itself without a runtime.

The assertion was at fault. It created two Vms with no explicit group, so each
wore its Net's default group, whose inbound accepts its own members and nobody
else — the real cloud would refuse that ping too, peered or not. It was green
only while no group reached the runtime at all.

The suite now writes the rule a real user would write — an inbound ICMP allow
from Net A's block on Net B's default group — **before** the negative checks. An
explicit allow that still does not cross an unpeered Net is the strongest form
of those refusals, and it is what the accepted peering then answers through.

## Proofs

- `conformance:ssh` green under `incus` **and** `incus-ovn`, on the three
  providers;
- `FEINT_VM=incus-ovn mise run conformance` **green end to end, 1144 s, zero
  FAIL**, the peering assertion included;
- the three example stacks under `feint up --runtime incus-ovn`: 12 machines
  measured (published state equals the runtime, address carried, groups attached
  per managed NIC, `/proc/net/tcp` reader positively controlled on 22), empty
  second plans on scw and osc, clean destroys **on these three passes** —
  a measurement, not a guarantee, #493 being the counter-example;
- gates: `check`, `go test -race`, `prepush`, `docs:check` all 0;
- falsification: `ssh-login-names-what-it-lacks.json`, **4 mutations, all bite**.

## Filed rather than fixed here

**#505** — `scw lb acl delete` panics (recovered, rc=0) on every success: an
upstream CLI bug bisected to a wrong type assertion (`custom_acl.go:83`).
Nothing to fix in the emulator. **#506** — the Exoscale stack's second plan
exits 2 on two output-only additions. **#507** — under a runtime, the stacks'
`packages:` clauses can never install: no outbound route, no resolver.
