### PR TITLE
feat(ci): a red scheduled night opens one issue, and a green one closes it (#502)

### DIFF
--- a/.github/workflows/night-report.yml
+++ b/.github/workflows/night-report.yml
@@ -1,0 +1,78 @@
+# A red scheduled night opens or updates one issue; a green one closes it (#502).
+#
+# runtime-proof.yml was red ten scheduled nights out of twelve (#501) and the
+# only trace was a job log, plus a streak counter written to a job summary —
+# the two places nobody opens without already knowing there is a problem. This
+# workflow is the mechanism drift.yml's "Open the drift issue" job already
+# carries, generalised: one issue per calling workflow, updated, never a new
+# one per night, closed by the first green night. An issue per night teaches
+# everyone to close them unread, which is the failure mode the whole mechanism
+# exists to avoid.
+#
+# Why a reusable workflow rather than a block in each scheduled caller: a
+# control copied into every caller is a control one caller forgets (CLAUDE.md
+# states it, and #335/#502 are both that story). runtime-proof.yml consumes it
+# first; falsify.yml, conformance.yml and corpus-cloud.yml can adopt it with a
+# six-line job when their turn comes.
+#
+# Why the decisions live in tools/ci/night-report.sh rather than in a run:
+# block here: a run: block only executes on GitHub's runners, and this
+# repository has three audited cases of CI fixes that existed only as comments
+# ("Un commentaire n'est pas un contrôle"). The script is the same one a human
+# runs, read-only, against any past run. The controls on it:
+# tools/ci/night_report_test.go drives it with a stubbed `gh` over
+# field-trimmed payloads of real runs (a red night, a green one, a
+# cancellation), and tools/falsify/specs/a-red-night-opens-an-issue.json
+# replays those tests with each decision neutralised.
+name: Night report
+
+on:
+  workflow_call:
+    inputs:
+      streak-target:
+        description: >-
+          Consecutive green scheduled nights the caller is aiming for
+          (runtime-proof passes 14, the promotion criterion of #125). Empty
+          hides the target from the issue rather than inventing one.
+        type: string
+        required: false
+        default: ''
+
+permissions: {}
+
+jobs:
+  report:
+    name: Open, update or close the red-night issue
+    # The caller's event, not this file's: a workflow_call job runs under the
+    # calling run's context. Dispatches and pushes are a human asking a
+    # question and watching the answer; the issue reports nights, and counting
+    # anything else would let it shout about runs somebody is already reading.
+    # The guard sits here, in the shared layer, so a caller that forgets its
+    # own `if:` still cannot turn the mechanism into noise.
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read # checkout, for the script below
+      actions: read # this run's jobs, and the scheduled history for the streak
+      issues: write # the issue itself
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # The script inspects the very run it is part of: the measuring jobs are
+      # completed (the caller gates on needs:), its own job is in_progress and
+      # therefore outside its own verdict.
+      - name: Open, update or close the issue for this night
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.run_id }}
+          NIGHT_STREAK_TARGET: ${{ inputs.streak-target }}
+        run: tools/ci/night-report.sh --apply "${RUN_ID}"

--- a/.github/workflows/runtime-proof.yml
+++ b/.github/workflows/runtime-proof.yml
@@ -428,3 +428,33 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
           echo "streak=${streak}/${TARGET}"
+
+  # A red night tells somebody (#502). Ten scheduled reds in twelve nights
+  # (#501) left no trace outside job logs and the summary above — the two
+  # places nobody opens without already knowing there is a problem. This job
+  # opens or updates one issue on a red scheduled night, naming the failing
+  # step and its job (mode) plus the streak, and closes it on the first green
+  # one; a run where no step failed is written as the run's own infrastructure,
+  # never blamed on a suite.
+  #
+  # The mechanism is drift.yml's report job — one issue, updated, never a new
+  # one per night — as a reusable workflow, because a block copied into each
+  # scheduled caller is a control one caller forgets. Its decisions live in
+  # tools/ci/night-report.sh, not in a run: block, so they are provable off
+  # GitHub Actions: tools/ci/night_report_test.go drives the script over
+  # field-trimmed payloads of real runs of this workflow, and
+  # tools/falsify/specs/a-red-night-opens-an-issue.json replays those tests
+  # with each decision neutralised.
+  report:
+    name: A red night opens the issue, a green one closes it
+    needs: runtime
+    if: always() && github.event_name == 'schedule'
+    permissions:
+      contents: read
+      actions: read
+      issues: write
+    uses: ./.github/workflows/night-report.yml
+    with:
+      # The promotion criterion of #125, the number the `streak` job above
+      # publishes; the issue carries it so nobody has to open a summary.
+      streak-target: '14'

--- a/tools/ci/night-report.sh
+++ b/tools/ci/night-report.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# A red scheduled night opens or updates one issue; a green one closes it (#502).
+#
+# runtime-proof.yml was red ten scheduled nights out of twelve (#501) and the
+# only trace was a job log — the one place nobody opens without already knowing
+# there is a problem. This script turns a scheduled run's outcome into the one
+# notification a maintainer actually triages, following the rule drift.yml's
+# report job already carries: one issue, updated, never a new one per night. An
+# issue per night teaches everyone to close them unread, and the silence comes
+# back in another shape.
+#
+# The logic lives here, not in a run: block, because a run: block cannot be
+# executed outside GitHub Actions and this repository has already paid for CI
+# fixes described in comments and never executed (CLAUDE.md, "Un commentaire
+# n'est pas un contrôle"). The controls on this file:
+#
+#   - tools/ci/night_report_test.go drives it with a stubbed `gh` over
+#     field-trimmed payloads of real runs of runtime-proof.yml — a red night
+#     (32924409224), a green one (32441329459) and a cancellation with no
+#     failing step (31716251612);
+#   - tools/falsify/specs/a-red-night-opens-an-issue.json replays those tests
+#     with each decision neutralised, so a mutation that silences the report
+#     makes a named test fail.
+#
+# Usage: night-report.sh [--apply] <run-id>
+#
+# Without --apply it prints what it would do — verdict, plan, title, body — and
+# writes nothing. With --apply it also performs the gh writes. The reusable
+# workflow .github/workflows/night-report.yml is the only caller that passes
+# --apply; a human proving the script points it at any past run and reads.
+#
+# Environment: GITHUB_REPOSITORY (owner/repo, required), GH_TOKEN (for gh),
+# NIGHT_STREAK_TARGET (optional; empty hides the target sentence).
+set -euo pipefail
+
+usage() {
+  echo "usage: night-report.sh [--apply] <run-id>" >&2
+  exit 64
+}
+
+apply=0
+if [ "${1:-}" = "--apply" ]; then
+  apply=1
+  shift
+fi
+[ "$#" -eq 1 ] || usage
+run_id="$1"
+
+repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must hold owner/repo}"
+target="${NIGHT_STREAK_TARGET:-}"
+label="scheduled-red"
+
+run_json="$(gh api "repos/${repo}/actions/runs/${run_id}")"
+wf_name="$(jq -r '.name' <<<"${run_json}")"
+wf_file="$(jq -r '.path | split("/") | last' <<<"${run_json}")"
+run_url="$(jq -r '.html_url' <<<"${run_json}")"
+run_created="$(jq -r '.created_at' <<<"${run_json}")"
+run_event="$(jq -r '.event' <<<"${run_json}")"
+run_date="${run_created%%T*}"
+
+# The run's jobs, completed ones only: when this runs inside the run it judges
+# (needs: on the measuring jobs), its own job is still in_progress and must not
+# sit in its own verdict.
+jobs_json="$(gh api --paginate "repos/${repo}/actions/runs/${run_id}/jobs?per_page=100" \
+  | jq -s '[.[].jobs[] | select(.status == "completed")]')"
+
+# Three outcomes, never two (measurement-integrity): a run with no completed
+# job is not green and not red — it is a run this script cannot judge, and
+# saying so beats inventing a verdict.
+if [ "$(jq 'length' <<<"${jobs_json}")" -eq 0 ]; then
+  echo "FAIL: run ${run_id} has no completed job; nothing to judge." >&2
+  exit 1
+fi
+
+# One finding per job that did not succeed. The first failing step of a job
+# carries the cause: the steps after it run under if: always() and fail
+# downstream of it (measured on 31716251612, where "Report what was exercised"
+# failed because the cancellation had killed the emulator it reads). A job with
+# no failing step at all — cancelled, timed out, runner lost — is the run's own
+# infrastructure, and naming a suite for it would invent a cause.
+findings="$(jq '
+  def failed_steps: [.steps[] | select(.conclusion == "failure")];
+  [.[]
+   | select(.conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral")
+   | if .conclusion == "failure" and (failed_steps | length) > 0
+     then {kind: "measured", job: .name, step: (failed_steps | first).name}
+     else {kind: "infra", job: .name, conclusion: .conclusion}
+     end
+  ]' <<<"${jobs_json}")"
+
+verdict=green
+if [ "$(jq 'length' <<<"${findings}")" -gt 0 ]; then
+  verdict=red
+fi
+
+# The scheduled history strictly before this run, newest first (the API's own
+# order). Scheduled runs only, twice: the query says so, and the filter says it
+# again so a caller (or a test fixture) that hands back more than asked cannot
+# widen the population — the streak counts nights, not button presses, which is
+# the rule runtime-proof.yml's streak job states.
+history="$(gh api --paginate "repos/${repo}/actions/workflows/${wf_file}/runs?event=schedule&per_page=100" \
+  | jq -s --arg id "${run_id}" --arg created "${run_created}" '
+      [.[].workflow_runs[]
+       | select(.status == "completed")
+       | select(.event == "schedule")
+       | select((.id | tostring) != $id)
+       | select(.created_at < $created)
+       | .conclusion]')"
+prior_reds="$(jq '[.[] | . != "success"] | (index(false) // length)' <<<"${history}")"
+prior_greens="$(jq '[.[] | . == "success"] | (index(false) // length)' <<<"${history}")"
+streak_before="$(jq --argjson n "${prior_reds}" \
+  '.[$n:] | [.[] | . == "success"] | (index(false) // length)' <<<"${history}")"
+
+target_note=""
+if [ -n "${target}" ]; then
+  target_note=" (target: ${target})"
+fi
+
+title="Red scheduled night: ${wf_name}"
+body_file="$(mktemp)"
+
+if [ "${verdict}" = "red" ]; then
+  reds_total="$((prior_reds + 1))"
+  measured_lines="$(jq -r '.[] | select(.kind == "measured")
+    | "- step `\(.step)` — job `\(.job)`"' <<<"${findings}")"
+  infra_lines="$(jq -r '.[] | select(.kind == "infra")
+    | "- job `\(.job)` ended `\(.conclusion)` with no failing step"' <<<"${findings}")"
+  {
+    echo "The scheduled run of ${run_date} is red: ${run_url}"
+    echo
+    if [ -n "${measured_lines}" ]; then
+      echo "What failed — the first failing step of a job carries the cause; later"
+      echo "failures run under \`if: always()\` and are downstream of it:"
+      echo
+      echo "${measured_lines}"
+      echo
+    fi
+    if [ -n "${infra_lines}" ]; then
+      echo "Where no step carries the failure:"
+      echo
+      echo "${infra_lines}"
+      echo
+      echo "A red with no failing step is the run's own infrastructure — a lost runner,"
+      echo "a cancellation, an unreachable dependency — not a measured verdict on any"
+      echo "suite. No suite is named for it because none failed."
+      echo
+    fi
+    echo "Consecutive red scheduled nights, this one included: **${reds_total}**."
+    echo "The green streak before this series was **${streak_before}**; it is now 0${target_note}."
+  } > "${body_file}"
+else
+  new_streak="$((prior_greens + 1))"
+  {
+    echo "The scheduled night of ${run_date} is green: ${run_url}"
+    echo
+    echo "The streak restarts at **${new_streak}** consecutive green scheduled night(s)${target_note}."
+  } > "${body_file}"
+fi
+
+# One issue per workflow, found by label plus exact title — the same lookup
+# drift.yml performs, made workflow-specific so several scheduled workflows can
+# share the mechanism without sharing an issue.
+existing="$(gh issue list --repo "${repo}" --state open --label "${label}" --json number,title \
+  | jq -r --arg t "${title}" '[.[] | select(.title == $t)] | first | .number // empty')"
+
+plan="nothing to do (green night, no open issue)"
+if [ "${verdict}" = "red" ]; then
+  if [ -n "${existing}" ]; then
+    plan="comment on issue #${existing}"
+  else
+    plan="create the issue"
+  fi
+elif [ -n "${existing}" ]; then
+  plan="close issue #${existing}"
+fi
+
+echo "run ${run_id} — ${wf_name}, event ${run_event}, created ${run_created}"
+echo "verdict: ${verdict}"
+echo "plan: ${plan}"
+echo "title: ${title}"
+echo "--- body ---"
+cat "${body_file}"
+echo "--- end ---"
+
+if [ "${apply}" -ne 1 ]; then
+  exit 0
+fi
+
+if [ "${verdict}" = "red" ]; then
+  if [ -n "${existing}" ]; then
+    gh issue comment "${existing}" --repo "${repo}" --body-file "${body_file}"
+  else
+    # The label may not exist on a fresh repository; create it once, exactly as
+    # drift.yml does for its own.
+    gh label create "${label}" --repo "${repo}" --color D93F0B \
+      --description "A scheduled run is red and this issue is how somebody learns it" \
+      2>/dev/null || true
+    gh issue create --repo "${repo}" --title "${title}" --label "${label}" \
+      --body-file "${body_file}"
+  fi
+elif [ -n "${existing}" ]; then
+  gh issue close "${existing}" --repo "${repo}" --comment "$(cat "${body_file}")"
+fi

--- a/tools/ci/night_report_test.go
+++ b/tools/ci/night_report_test.go
@@ -1,0 +1,256 @@
+// Package ci holds the tests of the shell this repository's workflows call.
+// The workflows themselves only run on GitHub's runners; the decisions they
+// delegate to versioned scripts do not, and those are exactly the part that
+// has to be provable before a push — a run: block is untestable by
+// construction, which is why the logic does not live in one.
+package ci
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// night-report.sh (#502) turns a scheduled run's outcome into one issue,
+// updated and eventually closed, never a new one per night. These tests drive
+// the real script with a stubbed `gh` that replays field-trimmed payloads of
+// real runs of runtime-proof.yml, captured on 2026-08-26:
+//
+//	testdata/red-night        run 32924409224 — schedule, failure; the incus
+//	                          job failed on "Scaleway ssh suite", the
+//	                          incus-ovn job on "Outscale network suite"
+//	testdata/green-night      run 32441329459 — schedule, success
+//	testdata/cancelled-night  run 31716251612 — cancelled, and its one step
+//	                          with conclusion "failure" is "Report what was
+//	                          exercised", an if: always() step that failed
+//	                          downstream of the cancellation, not a cause
+//	testdata/history.json     every completed scheduled run of the workflow
+//
+// The writes land in a log instead of on GitHub, so the create/update/close
+// branching is asserted without opening a test issue on the repository.
+// tools/falsify/specs/a-red-night-opens-an-issue.json replays these tests
+// with each decision neutralised.
+
+// The stub dispatches on the subcommand, never on the whole argument line: a
+// close comment carries the run's URL, so a pattern like *"/actions/runs/"*
+// matched against "$*" catches the write and answers it with run.json — a
+// harness lying before its subject, caught on this stub's first run.
+const ghStub = `#!/usr/bin/env bash
+set -eu
+case "$1" in
+  api)
+    case "$*" in
+      *"/actions/runs/"*"/jobs"*) cat "${GH_STUB_DIR}/jobs.json" ;;
+      *"/actions/workflows/"*"/runs"*) cat "${GH_STUB_HISTORY}" ;;
+      *"/actions/runs/"*) cat "${GH_STUB_DIR}/run.json" ;;
+      *)
+        echo "unexpected gh api call: $*" >&2
+        exit 64
+        ;;
+    esac
+    ;;
+  issue)
+    if [ "$2" = "list" ]; then
+      cat "${GH_STUB_ISSUES}"
+      exit 0
+    fi
+    printf '%s\n' "$*" >>"${GH_STUB_LOG}"
+    prev=""
+    for a in "$@"; do
+      if [ "${prev}" = "--body-file" ]; then
+        cat "${a}" >>"${GH_STUB_LOG}"
+      fi
+      prev="${a}"
+    done
+    ;;
+  label)
+    printf '%s\n' "$*" >>"${GH_STUB_LOG}"
+    ;;
+  *)
+    echo "unexpected gh call: $*" >&2
+    exit 64
+    ;;
+esac
+`
+
+// runReport executes night-report.sh against the fixtures of one night and
+// returns its exit code, its stdout+stderr, and the log of every gh write the
+// stub received. openIssues is a JSON array in `gh issue list --json
+// number,title` shape: what the repository's open scheduled-red issues look
+// like at that moment.
+func runReport(t *testing.T, night, runID, openIssues string, apply bool) (int, string, string) {
+	t.Helper()
+
+	stubDir := t.TempDir()
+	stub := filepath.Join(stubDir, "gh")
+	if err := os.WriteFile(stub, []byte(ghStub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	issues := filepath.Join(stubDir, "issues.json")
+	if err := os.WriteFile(issues, []byte(openIssues), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	log := filepath.Join(stubDir, "calls.log")
+
+	fixtures, err := filepath.Abs(filepath.Join("testdata", night))
+	if err != nil {
+		t.Fatal(err)
+	}
+	history, err := filepath.Abs(filepath.Join("testdata", "history.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	args := []string{"night-report.sh"}
+	if apply {
+		args = append(args, "--apply")
+	}
+	args = append(args, runID)
+
+	cmd := exec.Command("bash", args...)
+	cmd.Env = append(os.Environ(),
+		"PATH="+stubDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"GH_STUB_DIR="+fixtures,
+		"GH_STUB_HISTORY="+history,
+		"GH_STUB_ISSUES="+issues,
+		"GH_STUB_LOG="+log,
+		"GITHUB_REPOSITORY=stephrobert/feint",
+		"NIGHT_STREAK_TARGET=14",
+	)
+	out, err := cmd.CombinedOutput()
+	code := 0
+	if err != nil {
+		var exit *exec.ExitError
+		if !errors.As(err, &exit) {
+			t.Fatalf("running night-report.sh: %v\n%s", err, out)
+		}
+		code = exit.ExitCode()
+	}
+	calls, readErr := os.ReadFile(log)
+	if readErr != nil && !os.IsNotExist(readErr) {
+		t.Fatal(readErr)
+	}
+	return code, string(out), string(calls)
+}
+
+const noOpenIssue = `[]`
+
+// oneOpenIssue is what `gh issue list` answers once a first red night has
+// opened the issue: number 600, the exact title the script composes.
+const oneOpenIssue = `[{"number": 600, "title": "Red scheduled night: Runtime proof"}]`
+
+// A red night names the step and the job that failed, and carries the streak —
+// not "the workflow failed", which is the noise #502 exists to replace. The
+// numbers are the real ones: the fifth consecutive red night, after a green
+// streak of one.
+func TestARedNightNamesTheStepTheJobAndTheStreak(t *testing.T) {
+	code, out, _ := runReport(t, "red-night", "32924409224", noOpenIssue, false)
+	if code != 0 {
+		t.Fatalf("the script failed on a real red run (exit %d):\n%s", code, out)
+	}
+	for _, want := range []string{
+		"verdict: red",
+		"plan: create the issue",
+		"title: Red scheduled night: Runtime proof",
+		"- step `Scaleway ssh suite` — job `incus`",
+		"- step `Outscale network suite` — job `incus-ovn`",
+		"Consecutive red scheduled nights, this one included: **5**.",
+		"The green streak before this series was **1**",
+		"(target: 14)",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the report never says %q; a notification that does not name "+
+				"the step, the job and the streak is a constat, not an alert:\n%s", want, out)
+		}
+	}
+}
+
+// The first red night creates the issue; without --apply nothing is written at
+// all. Both halves matter: the second is what lets the script be pointed at
+// any real run to be read.
+func TestAFirstRedNightOpensTheIssue(t *testing.T) {
+	_, _, calls := runReport(t, "red-night", "32924409224", noOpenIssue, false)
+	if calls != "" {
+		t.Errorf("a dry run performed writes:\n%s", calls)
+	}
+
+	code, out, calls := runReport(t, "red-night", "32924409224", noOpenIssue, true)
+	if code != 0 {
+		t.Fatalf("exit %d:\n%s", code, out)
+	}
+	if !strings.Contains(calls, "issue create") ||
+		!strings.Contains(calls, "--title Red scheduled night: Runtime proof") ||
+		!strings.Contains(calls, "--label scheduled-red") {
+		t.Errorf("the first red night did not create the labelled issue:\n%s", calls)
+	}
+	if strings.Contains(calls, "issue comment") {
+		t.Errorf("commented with no issue to comment on:\n%s", calls)
+	}
+}
+
+// The second red night updates the same issue instead of opening a second one.
+// drift.yml states the rule this repeats: an issue per night teaches everyone
+// to close them unread, which is the failure mode the mechanism exists to
+// avoid.
+func TestASecondRedNightUpdatesTheIssue(t *testing.T) {
+	code, out, calls := runReport(t, "red-night", "32924409224", oneOpenIssue, true)
+	if code != 0 {
+		t.Fatalf("exit %d:\n%s", code, out)
+	}
+	if !strings.Contains(calls, "issue comment 600") {
+		t.Errorf("the second red night never commented on the open issue:\n%s", calls)
+	}
+	if strings.Contains(calls, "issue create") {
+		t.Errorf("a second issue was created; one per night is worse than none:\n%s", calls)
+	}
+}
+
+// A green night closes the issue and says where the streak restarts; a green
+// night with nothing open writes nothing, because a notification mechanism
+// that speaks when all is well becomes noise of its own.
+func TestAGreenNightClosesTheIssue(t *testing.T) {
+	code, out, calls := runReport(t, "green-night", "32441329459", oneOpenIssue, true)
+	if code != 0 {
+		t.Fatalf("exit %d:\n%s", code, out)
+	}
+	if !strings.Contains(calls, "issue close 600") {
+		t.Errorf("the green night left the issue open:\n%s", calls)
+	}
+	if !strings.Contains(out, "The streak restarts at **1**") {
+		t.Errorf("the closing note does not carry the restarted streak:\n%s", out)
+	}
+
+	code, out, calls = runReport(t, "green-night", "32441329459", noOpenIssue, true)
+	if code != 0 {
+		t.Fatalf("exit %d:\n%s", code, out)
+	}
+	if calls != "" {
+		t.Errorf("a green night with no open issue still wrote something:\n%s", calls)
+	}
+}
+
+// A red run where no step failed is an infrastructure failure and must say so
+// instead of inventing a cause. The fixture is the sharpest real case on
+// record: both jobs of run 31716251612 were cancelled, and each carries one
+// step with conclusion "failure" — "Report what was exercised", an
+// if: always() step that failed because the cancellation had killed the
+// emulator it reads. Naming it would blame the reporter for the outage.
+func TestARedWithNoFailingStepBlamesTheRunNotASuite(t *testing.T) {
+	code, out, _ := runReport(t, "cancelled-night", "31716251612", noOpenIssue, false)
+	if code != 0 {
+		t.Fatalf("exit %d:\n%s", code, out)
+	}
+	if !strings.Contains(out, "no failing step") ||
+		!strings.Contains(out, "not a measured verdict") {
+		t.Errorf("the infrastructure failure is not written as one:\n%s", out)
+	}
+	for _, invented := range []string{"Report what was exercised", "ssh suite", "network suite"} {
+		if strings.Contains(out, invented) {
+			t.Errorf("the report names %q for a run where no suite failed; "+
+				"a cause was invented:\n%s", invented, out)
+		}
+	}
+}

--- a/tools/ci/testdata/cancelled-night/jobs.json
+++ b/tools/ci/testdata/cancelled-night/jobs.json
@@ -1,0 +1,330 @@
+{
+  "jobs": [
+    {
+      "name": "incus",
+      "status": "completed",
+      "conclusion": "cancelled",
+      "steps": [
+        {
+          "name": "Set up job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 1
+        },
+        {
+          "name": "Pre Harden the runner",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 2
+        },
+        {
+          "name": "Harden the runner",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 3
+        },
+        {
+          "name": "Checkout",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 4
+        },
+        {
+          "name": "Setup Go",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 5
+        },
+        {
+          "name": "Install Incus (Zabbly stable, key fingerprint pinned)",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 6
+        },
+        {
+          "name": "Install and wire OVN",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 7
+        },
+        {
+          "name": "Initialise Incus",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 8
+        },
+        {
+          "name": "Build feint and diagnose the runtime",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "number": 9
+        },
+        {
+          "name": "Install the Scaleway CLI",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 10
+        },
+        {
+          "name": "Install the Outscale CLI",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 11
+        },
+        {
+          "name": "Install the Exoscale CLI",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 12
+        },
+        {
+          "name": "Start the emulator with real machines",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 13
+        },
+        {
+          "name": "The runtime the health endpoint declares",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 14
+        },
+        {
+          "name": "Scaleway network suite",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 15
+        },
+        {
+          "name": "Outscale network suite",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 16
+        },
+        {
+          "name": "Scaleway ssh suite",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 17
+        },
+        {
+          "name": "Outscale ssh suite",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 18
+        },
+        {
+          "name": "Exoscale ssh suite",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 19
+        },
+        {
+          "name": "Report what was exercised",
+          "status": "completed",
+          "conclusion": "failure",
+          "number": 20
+        },
+        {
+          "name": "The emulator's log and the runtime's state",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 21
+        },
+        {
+          "name": "Stop the emulator",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 22
+        },
+        {
+          "name": "Post Setup Go",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 42
+        },
+        {
+          "name": "Post Checkout",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 43
+        },
+        {
+          "name": "Post Harden the runner",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 44
+        },
+        {
+          "name": "Complete job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 45
+        }
+      ]
+    },
+    {
+      "name": "incus-ovn",
+      "status": "completed",
+      "conclusion": "cancelled",
+      "steps": [
+        {
+          "name": "Set up job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 1
+        },
+        {
+          "name": "Pre Harden the runner",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 2
+        },
+        {
+          "name": "Harden the runner",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 3
+        },
+        {
+          "name": "Checkout",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 4
+        },
+        {
+          "name": "Setup Go",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 5
+        },
+        {
+          "name": "Install Incus (Zabbly stable, key fingerprint pinned)",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 6
+        },
+        {
+          "name": "Install and wire OVN",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 7
+        },
+        {
+          "name": "Initialise Incus",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 8
+        },
+        {
+          "name": "Build feint and diagnose the runtime",
+          "status": "completed",
+          "conclusion": "cancelled",
+          "number": 9
+        },
+        {
+          "name": "Install the Scaleway CLI",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 10
+        },
+        {
+          "name": "Install the Outscale CLI",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 11
+        },
+        {
+          "name": "Install the Exoscale CLI",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 12
+        },
+        {
+          "name": "Start the emulator with real machines",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 13
+        },
+        {
+          "name": "The runtime the health endpoint declares",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 14
+        },
+        {
+          "name": "Scaleway network suite",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 15
+        },
+        {
+          "name": "Outscale network suite",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 16
+        },
+        {
+          "name": "Scaleway ssh suite",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 17
+        },
+        {
+          "name": "Outscale ssh suite",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 18
+        },
+        {
+          "name": "Exoscale ssh suite",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 19
+        },
+        {
+          "name": "Report what was exercised",
+          "status": "completed",
+          "conclusion": "failure",
+          "number": 20
+        },
+        {
+          "name": "The emulator's log and the runtime's state",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 21
+        },
+        {
+          "name": "Stop the emulator",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 22
+        },
+        {
+          "name": "Post Setup Go",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 42
+        },
+        {
+          "name": "Post Checkout",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 43
+        },
+        {
+          "name": "Post Harden the runner",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 44
+        },
+        {
+          "name": "Complete job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 45
+        }
+      ]
+    }
+  ]
+}

--- a/tools/ci/testdata/cancelled-night/run.json
+++ b/tools/ci/testdata/cancelled-night/run.json
@@ -1,0 +1,10 @@
+{
+  "id": 31716251612,
+  "name": "Runtime proof",
+  "path": ".github/workflows/runtime-proof.yml",
+  "event": "push",
+  "status": "completed",
+  "conclusion": "cancelled",
+  "created_at": "2026-08-13T15:35:52Z",
+  "html_url": "https://github.com/stephrobert/feint/actions/runs/31716251612"
+}

--- a/tools/ci/testdata/green-night/jobs.json
+++ b/tools/ci/testdata/green-night/jobs.json
@@ -1,0 +1,409 @@
+{
+  "jobs": [
+    {
+      "name": "incus-ovn",
+      "status": "completed",
+      "conclusion": "success",
+      "steps": [
+        {
+          "name": "Set up job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 1
+        },
+        {
+          "name": "Pre Harden the runner",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 2
+        },
+        {
+          "name": "Harden the runner",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 3
+        },
+        {
+          "name": "Checkout",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 4
+        },
+        {
+          "name": "Setup Go",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 5
+        },
+        {
+          "name": "Install Incus (Zabbly stable, key fingerprint pinned)",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 6
+        },
+        {
+          "name": "Install and wire OVN",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 7
+        },
+        {
+          "name": "Initialise Incus",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 8
+        },
+        {
+          "name": "Keep the runner's Docker firewall out of the verdict",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 9
+        },
+        {
+          "name": "Build feint and diagnose the runtime",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 10
+        },
+        {
+          "name": "Build the machine images the suites boot",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 11
+        },
+        {
+          "name": "Install the Scaleway CLI",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 12
+        },
+        {
+          "name": "Install the Outscale CLI",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 13
+        },
+        {
+          "name": "Install the Exoscale CLI",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 14
+        },
+        {
+          "name": "Start the emulator with real machines",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 15
+        },
+        {
+          "name": "The runtime the health endpoint declares",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 16
+        },
+        {
+          "name": "Scaleway network suite",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 17
+        },
+        {
+          "name": "Outscale network suite",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 18
+        },
+        {
+          "name": "Scaleway ssh suite",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 19
+        },
+        {
+          "name": "Outscale ssh suite",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 20
+        },
+        {
+          "name": "Exoscale ssh suite",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 21
+        },
+        {
+          "name": "Report what was exercised",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 22
+        },
+        {
+          "name": "The emulator's log and the runtime's state",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 23
+        },
+        {
+          "name": "Stop the emulator",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 24
+        },
+        {
+          "name": "Crash proof — what survives a kill",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 25
+        },
+        {
+          "name": "Post Setup Go",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 48
+        },
+        {
+          "name": "Post Checkout",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 49
+        },
+        {
+          "name": "Post Harden the runner",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 50
+        },
+        {
+          "name": "Complete job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 51
+        }
+      ]
+    },
+    {
+      "name": "incus",
+      "status": "completed",
+      "conclusion": "success",
+      "steps": [
+        {
+          "name": "Set up job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 1
+        },
+        {
+          "name": "Pre Harden the runner",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 2
+        },
+        {
+          "name": "Harden the runner",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 3
+        },
+        {
+          "name": "Checkout",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 4
+        },
+        {
+          "name": "Setup Go",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 5
+        },
+        {
+          "name": "Install Incus (Zabbly stable, key fingerprint pinned)",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 6
+        },
+        {
+          "name": "Install and wire OVN",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 7
+        },
+        {
+          "name": "Initialise Incus",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 8
+        },
+        {
+          "name": "Keep the runner's Docker firewall out of the verdict",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 9
+        },
+        {
+          "name": "Build feint and diagnose the runtime",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 10
+        },
+        {
+          "name": "Build the machine images the suites boot",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 11
+        },
+        {
+          "name": "Install the Scaleway CLI",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 12
+        },
+        {
+          "name": "Install the Outscale CLI",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 13
+        },
+        {
+          "name": "Install the Exoscale CLI",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 14
+        },
+        {
+          "name": "Start the emulator with real machines",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 15
+        },
+        {
+          "name": "The runtime the health endpoint declares",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 16
+        },
+        {
+          "name": "Scaleway network suite",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 17
+        },
+        {
+          "name": "Outscale network suite",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 18
+        },
+        {
+          "name": "Scaleway ssh suite",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 19
+        },
+        {
+          "name": "Outscale ssh suite",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 20
+        },
+        {
+          "name": "Exoscale ssh suite",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 21
+        },
+        {
+          "name": "Report what was exercised",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 22
+        },
+        {
+          "name": "The emulator's log and the runtime's state",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 23
+        },
+        {
+          "name": "Stop the emulator",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 24
+        },
+        {
+          "name": "Crash proof — what survives a kill",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 25
+        },
+        {
+          "name": "Post Setup Go",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 48
+        },
+        {
+          "name": "Post Checkout",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 49
+        },
+        {
+          "name": "Post Harden the runner",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 50
+        },
+        {
+          "name": "Complete job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 51
+        }
+      ]
+    },
+    {
+      "name": "Consecutive green scheduled runs",
+      "status": "completed",
+      "conclusion": "success",
+      "steps": [
+        {
+          "name": "Set up job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 1
+        },
+        {
+          "name": "Pre Harden the runner",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 2
+        },
+        {
+          "name": "Harden the runner",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 3
+        },
+        {
+          "name": "Count the streak, from the Actions history",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 4
+        },
+        {
+          "name": "Post Harden the runner",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 8
+        },
+        {
+          "name": "Complete job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 9
+        }
+      ]
+    }
+  ]
+}

--- a/tools/ci/testdata/green-night/run.json
+++ b/tools/ci/testdata/green-night/run.json
@@ -1,0 +1,10 @@
+{
+  "id": 32441329459,
+  "name": "Runtime proof",
+  "path": ".github/workflows/runtime-proof.yml",
+  "event": "schedule",
+  "status": "completed",
+  "conclusion": "success",
+  "created_at": "2026-08-21T02:52:02Z",
+  "html_url": "https://github.com/stephrobert/feint/actions/runs/32441329459"
+}

--- a/tools/ci/testdata/history.json
+++ b/tools/ci/testdata/history.json
@@ -1,0 +1,95 @@
+{
+  "workflow_runs": [
+    {
+      "id": 32924409224,
+      "event": "schedule",
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-08-26T02:53:45Z"
+    },
+    {
+      "id": 32802961270,
+      "event": "schedule",
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-08-25T02:51:17Z"
+    },
+    {
+      "id": 32684474067,
+      "event": "schedule",
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-08-24T02:52:12Z"
+    },
+    {
+      "id": 32613916950,
+      "event": "schedule",
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-08-23T02:52:11Z"
+    },
+    {
+      "id": 32547323257,
+      "event": "schedule",
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-08-22T02:50:04Z"
+    },
+    {
+      "id": 32441329459,
+      "event": "schedule",
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-08-21T02:52:02Z"
+    },
+    {
+      "id": 32326096236,
+      "event": "schedule",
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-08-20T02:50:54Z"
+    },
+    {
+      "id": 32210026563,
+      "event": "schedule",
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-08-19T02:51:03Z"
+    },
+    {
+      "id": 32093284751,
+      "event": "schedule",
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-08-18T02:50:24Z"
+    },
+    {
+      "id": 31989269977,
+      "event": "schedule",
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-08-17T02:51:16Z"
+    },
+    {
+      "id": 31922866928,
+      "event": "schedule",
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-08-16T02:51:37Z"
+    },
+    {
+      "id": 31860194621,
+      "event": "schedule",
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-08-15T02:49:29Z"
+    },
+    {
+      "id": 31766516879,
+      "event": "schedule",
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-08-14T03:20:37Z"
+    }
+  ]
+}

--- a/tools/ci/testdata/red-night/jobs.json
+++ b/tools/ci/testdata/red-night/jobs.json
@@ -1,0 +1,409 @@
+{
+  "jobs": [
+    {
+      "name": "incus",
+      "status": "completed",
+      "conclusion": "failure",
+      "steps": [
+        {
+          "name": "Set up job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 1
+        },
+        {
+          "name": "Pre Harden the runner",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 2
+        },
+        {
+          "name": "Harden the runner",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 3
+        },
+        {
+          "name": "Checkout",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 4
+        },
+        {
+          "name": "Setup Go",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 5
+        },
+        {
+          "name": "Install Incus (Zabbly stable, key fingerprint pinned)",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 6
+        },
+        {
+          "name": "Install and wire OVN",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 7
+        },
+        {
+          "name": "Initialise Incus",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 8
+        },
+        {
+          "name": "Keep the runner's Docker firewall out of the verdict",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 9
+        },
+        {
+          "name": "Build feint and diagnose the runtime",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 10
+        },
+        {
+          "name": "Build the machine images the suites boot",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 11
+        },
+        {
+          "name": "Install the Scaleway CLI",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 12
+        },
+        {
+          "name": "Install the Outscale CLI",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 13
+        },
+        {
+          "name": "Install the Exoscale CLI",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 14
+        },
+        {
+          "name": "Start the emulator with real machines",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 15
+        },
+        {
+          "name": "The runtime the health endpoint declares",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 16
+        },
+        {
+          "name": "Scaleway network suite",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 17
+        },
+        {
+          "name": "Outscale network suite",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 18
+        },
+        {
+          "name": "Scaleway ssh suite",
+          "status": "completed",
+          "conclusion": "failure",
+          "number": 19
+        },
+        {
+          "name": "Outscale ssh suite",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 20
+        },
+        {
+          "name": "Exoscale ssh suite",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 21
+        },
+        {
+          "name": "Report what was exercised",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 22
+        },
+        {
+          "name": "The emulator's log and the runtime's state",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 23
+        },
+        {
+          "name": "Stop the emulator",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 24
+        },
+        {
+          "name": "Crash proof — what survives a kill",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 25
+        },
+        {
+          "name": "Post Setup Go",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 48
+        },
+        {
+          "name": "Post Checkout",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 49
+        },
+        {
+          "name": "Post Harden the runner",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 50
+        },
+        {
+          "name": "Complete job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 51
+        }
+      ]
+    },
+    {
+      "name": "incus-ovn",
+      "status": "completed",
+      "conclusion": "failure",
+      "steps": [
+        {
+          "name": "Set up job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 1
+        },
+        {
+          "name": "Pre Harden the runner",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 2
+        },
+        {
+          "name": "Harden the runner",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 3
+        },
+        {
+          "name": "Checkout",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 4
+        },
+        {
+          "name": "Setup Go",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 5
+        },
+        {
+          "name": "Install Incus (Zabbly stable, key fingerprint pinned)",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 6
+        },
+        {
+          "name": "Install and wire OVN",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 7
+        },
+        {
+          "name": "Initialise Incus",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 8
+        },
+        {
+          "name": "Keep the runner's Docker firewall out of the verdict",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 9
+        },
+        {
+          "name": "Build feint and diagnose the runtime",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 10
+        },
+        {
+          "name": "Build the machine images the suites boot",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 11
+        },
+        {
+          "name": "Install the Scaleway CLI",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 12
+        },
+        {
+          "name": "Install the Outscale CLI",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 13
+        },
+        {
+          "name": "Install the Exoscale CLI",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 14
+        },
+        {
+          "name": "Start the emulator with real machines",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 15
+        },
+        {
+          "name": "The runtime the health endpoint declares",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 16
+        },
+        {
+          "name": "Scaleway network suite",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 17
+        },
+        {
+          "name": "Outscale network suite",
+          "status": "completed",
+          "conclusion": "failure",
+          "number": 18
+        },
+        {
+          "name": "Scaleway ssh suite",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 19
+        },
+        {
+          "name": "Outscale ssh suite",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 20
+        },
+        {
+          "name": "Exoscale ssh suite",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 21
+        },
+        {
+          "name": "Report what was exercised",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 22
+        },
+        {
+          "name": "The emulator's log and the runtime's state",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 23
+        },
+        {
+          "name": "Stop the emulator",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 24
+        },
+        {
+          "name": "Crash proof — what survives a kill",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 25
+        },
+        {
+          "name": "Post Setup Go",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 48
+        },
+        {
+          "name": "Post Checkout",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 49
+        },
+        {
+          "name": "Post Harden the runner",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 50
+        },
+        {
+          "name": "Complete job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 51
+        }
+      ]
+    },
+    {
+      "name": "Consecutive green scheduled runs",
+      "status": "completed",
+      "conclusion": "success",
+      "steps": [
+        {
+          "name": "Set up job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 1
+        },
+        {
+          "name": "Pre Harden the runner",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 2
+        },
+        {
+          "name": "Harden the runner",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 3
+        },
+        {
+          "name": "Count the streak, from the Actions history",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 4
+        },
+        {
+          "name": "Post Harden the runner",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 8
+        },
+        {
+          "name": "Complete job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 9
+        }
+      ]
+    }
+  ]
+}

--- a/tools/ci/testdata/red-night/run.json
+++ b/tools/ci/testdata/red-night/run.json
@@ -1,0 +1,10 @@
+{
+  "id": 32924409224,
+  "name": "Runtime proof",
+  "path": ".github/workflows/runtime-proof.yml",
+  "event": "schedule",
+  "status": "completed",
+  "conclusion": "failure",
+  "created_at": "2026-08-26T02:53:45Z",
+  "html_url": "https://github.com/stephrobert/feint/actions/runs/32924409224"
+}

--- a/tools/falsify/specs/a-red-night-opens-an-issue.json
+++ b/tools/falsify/specs/a-red-night-opens-an-issue.json
@@ -1,0 +1,34 @@
+{
+  "package": "./tools/ci/",
+  "mutations": [
+    {
+      "label": "a red run reads as green, so no night — however red — ever opens or updates the issue; this is the exact state runtime-proof.yml was in for ten of twelve nights",
+      "file": "tools/ci/night-report.sh",
+      "find": "if [ \"$(jq 'length' <<<\"${findings}\")\" -gt 0 ]; then\n  verdict=red\nfi",
+      "replace": "if [ \"$(jq 'length' <<<\"${findings}\")\" -gt 0 ] && false; then\n  verdict=red\nfi",
+      "test": "TestAFirstRedNightOpensTheIssue"
+    },
+    {
+      "label": "the open issue is never found on the write path, so every red night creates a fresh one — the failure mode drift.yml's comment names: issues nobody reads before closing",
+      "file": "tools/ci/night-report.sh",
+      "find": "if [ \"${verdict}\" = \"red\" ]; then\n  if [ -n \"${existing}\" ]; then\n    gh issue comment \"${existing}\" --repo \"${repo}\" --body-file \"${body_file}\"",
+      "replace": "if [ \"${verdict}\" = \"red\" ]; then\n  if [ -n \"${existing}\" ] && false; then\n    gh issue comment \"${existing}\" --repo \"${repo}\" --body-file \"${body_file}\"",
+      "test": "TestASecondRedNightUpdatesTheIssue"
+    },
+    {
+      "label": "a green night no longer closes the issue, so a permanently red issue becomes scenery within three weeks and the silence returns in another shape",
+      "file": "tools/ci/night-report.sh",
+      "find": "elif [ -n \"${existing}\" ]; then\n  gh issue close \"${existing}\" --repo \"${repo}\" --comment \"$(cat \"${body_file}\")\"\nfi",
+      "replace": "elif [ -n \"${existing}\" ] && false; then\n  gh issue close \"${existing}\" --repo \"${repo}\" --comment \"$(cat \"${body_file}\")\"\nfi",
+      "test": "TestAGreenNightClosesTheIssue"
+    },
+    {
+      "label": "the measured/infrastructure distinction collapses: any failing step counts, so a cancelled run gets blamed on its if: always() reporting step and the issue invents a cause",
+      "file": "tools/ci/night-report.sh",
+      "find": "   | if .conclusion == \"failure\" and (failed_steps | length) > 0",
+      "replace": "   | if (.conclusion == \"failure\" or true) and (failed_steps | length) > 0",
+      "test": "TestARedWithNoFailingStepBlamesTheRunNotASuite"
+    }
+  ],
+  "note": "The subject is #502. runtime-proof.yml was red ten scheduled nights out of twelve (#501) and the only trace was a job log plus a streak counter written to a job summary — the two places nobody opens without already knowing there is a problem. The mechanism repeats drift.yml's report job (one issue, updated, never one per night) but its decisions live in tools/ci/night-report.sh rather than in a run: block, precisely so these mutations have something to bite: a run: block cannot be executed outside GitHub Actions, and this repository has three audited cases of CI fixes that existed only as comments. The tests drive the script over field-trimmed payloads of real runs, including the cancellation 31716251612 whose only step with conclusion 'failure' is 'Report what was exercised' — an if: always() collateral that mutation 4 makes the script accuse."
+}


### PR DESCRIPTION
Closes #502.

`runtime-proof.yml` is the only gate in this repository that boots real
machines. It was red on ten of the last twelve scheduled nights (#501) and the
only trace was a job log — the one place nobody opens without already knowing
there is a problem. The `streak` job even computes the number that matters (the
consecutive-green count #125 waits on, target 14, currently 0) and writes it to
a job summary.

A red scheduled night now opens or updates one issue; a green one closes it.

## The design decision, and its reason

**A reusable brick, in two layers.** A `workflow_call` workflow
(`.github/workflows/night-report.yml`) that `runtime-proof.yml` consumes alone
in this batch — six lines plus its comment — and **every decision in a versioned
script**, `tools/ci/night-report.sh`.

One reason per layer. A block copied into each scheduled workflow is a control
one caller forgets, which is the repository's own rule and the story of both
#335 and #502. And a thirty-line `run:` block can only be executed on a GitHub
runner, so it cannot be proven before a push — the defect this repository has
paid for three times, described in comments and never executed.

The `if: github.event_name == 'schedule'` guard lives **in the brick**, not only
in the caller, so a caller that forgets its own `if` cannot turn the mechanism
into noise.

Without `--apply` the script prints verdict, plan, title and body and writes
nothing. That is its proof surface, and it is how the output below was obtained
against the live API.

## What it prints on real runs

**A real red night (32924409224):**

```
verdict: red
plan: create the issue
title: Red scheduled night: Runtime proof

What failed — the first failing step of a job carries the cause; later
failures run under `if: always()` and are downstream of it:

- step `Scaleway ssh suite` — job `incus`
- step `Outscale network suite` — job `incus-ovn`

Consecutive red scheduled nights, this one included: **5**.
The green streak before this series was **1**; it is now 0.
```

It names the failing step and its mode, and recovers the two-cause timeline on
its own.

**A real green night (32441329459)** — `plan: nothing to do`, with the closing
body ready. **A cancelled run (31716251612)** — it writes "no failing step …
not a measured verdict on any suite" and names **no** suite, not even the
`if: always()` step that is genuinely in collateral `failure`. A measurement
failure and an infrastructure failure are different things, and saying otherwise
would wear out trust in the mechanism as surely as the silence did.

## Controls

Five Go tests (`tools/ci/night_report_test.go`) drive the real script with a
stubbed `gh` replaying field-trimmed payloads of those same real runs: a second
red night **comments** rather than creating a second issue, a green night
closes, a green night with no open issue stays silent. The falsification spec
`tools/falsify/specs/a-red-night-opens-an-issue.json` neutralises each of the
four decisions: **all four mutations bite**, baseline and restoration green.

`mise run prepush` 0 — measured on `mise`'s own exit code, the first reading
having gone through a zsh pipe, which is exactly the lying instrument this
repository documents. `actionlint` clean, `zizmor --offline` 0 findings,
`poutine analyze_local` 0 failures, `plumber analyze` 100/100, `shellcheck
--severity=style` 0.

**No test issue was opened on the repository.**

## What this proof does not cover

Only the first real scheduled run will prove the `workflow_call` wiring itself —
permission propagation, the issue write by `GITHUB_TOKEN` — and the population
seen from inside a live run (the exclusion of its own `in_progress` job is coded,
never observed). One structural limit, accepted: a cancellation of the whole run
kills the `report` job too, so that night goes unreported.
