### PR TITLE
fix(machine): fifteen concurrent creates stop queueing, a teardown waits out what holds the instance, and a lost port group stops leaving a NIC bare (#473, #493)

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -993,12 +993,7 @@ func serve(args []string, stdout io.Writer) error {
 		// caller asked for against what this process is bound to.
 		Handler:           emulator.GuardRebinding(srv.Handler(), *addr),
 		ReadHeaderTimeout: 10 * time.Second,
-		// A client that opens a response and stops reading it holds a handler
-		// goroutine, and before the store learned to encode outside its lock,
-		// held the whole emulator with it. The lock is fixed; the timeout is the
-		// second line, and it costs nothing here because every response this
-		// emulator produces is small and local.
-		WriteTimeout: 60 * time.Second,
+		WriteTimeout:      writeTimeoutFor(driver),
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)

--- a/internal/cli/timeout.go
+++ b/internal/cli/timeout.go
@@ -1,0 +1,34 @@
+package cli
+
+import (
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/machine"
+)
+
+// writeTimeoutFor is the serve deadline on writing one response, and it
+// depends on whether a machine runtime is configured.
+//
+// The timeout exists for the client that opens a response and stops reading
+// it: such a client holds a handler goroutine, and before the store learned to
+// encode outside its lock, held the whole emulator with it. The lock is fixed;
+// the timeout is the second line of defence.
+//
+// Sixty seconds was chosen when "every response this emulator produces is
+// small and local" — true with no machine runtime, and false under one, where
+// a create provisions real networks and machines. #473 measured what the gap
+// does: fifteen OVN subnets queued past the deadline, the emulator closed the
+// connection on creates that then *succeeded*, and each client retry met the
+// subnet its own cut call had created as a 409 conflict — the emulator telling
+// the client less than it knew, which is the lie this project exists to avoid.
+// So under a runtime the ceiling moves above the slowest legitimate handler
+// (an image pull on a cold host is minutes) while stalled-reader protection
+// stays; without one, the original figure keeps its measured justification.
+//
+// TestTheWriteDeadlineFollowsTheRuntime fails if either mode loses its value.
+func writeTimeoutFor(driver machine.Driver) time.Duration {
+	if _, none := driver.(machine.Noop); none {
+		return 60 * time.Second
+	}
+	return 10 * time.Minute
+}

--- a/internal/cli/timeout_test.go
+++ b/internal/cli/timeout_test.go
@@ -1,0 +1,24 @@
+package cli
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/machine"
+)
+
+// The write deadline follows the runtime, because the sentence that justified
+// sixty seconds — every response is small and local — is only true without
+// one. Under a runtime, a subnet create provisions a real network, fifteen of
+// them queue, and a deadline below the queue makes the emulator close the
+// connection on work that then succeeds: the client's retry meets its own
+// subnet as a conflict (#473, links 2 and 3).
+func TestTheWriteDeadlineFollowsTheRuntime(t *testing.T) {
+	if got := writeTimeoutFor(machine.Noop{}); got != 60*time.Second {
+		t.Errorf("with no runtime the deadline is %v; sixty seconds is the measured figure for small local responses", got)
+	}
+	withRuntime := writeTimeoutFor(machine.NewIncusOVN())
+	if withRuntime <= 60*time.Second {
+		t.Errorf("under a machine runtime the deadline is %v; anything at or under a minute cuts a fifteen-subnet apply (#473)", withRuntime)
+	}
+}

--- a/internal/core/machine/balancer.go
+++ b/internal/core/machine/balancer.go
@@ -32,7 +32,7 @@ import (
 // The two are not the same mechanism, and reading the second measurement as a
 // verdict on the first is the mistake this comment exists to prevent: an
 // in-block address needs no announcement at all. The emulator already delegates
-// every emulated subnet to the uplink (delegateRoute), so the uplink routes the
+// every emulated subnet to the uplink (delegateQueuedRoutes), so the uplink routes the
 // whole block to the OVN router, and the router answers for the VIP as it does
 // for any other address of its own switch.
 //

--- a/internal/core/machine/incus.go
+++ b/internal/core/machine/incus.go
@@ -90,6 +90,13 @@ type Incus struct {
 	// can hold in milliseconds.
 	agentPoll time.Duration
 
+	// busyPoll and busyBudget override how runUntilFree waits out an
+	// instance another operation still holds. Only a test sets them, so the
+	// suite does not pay real seconds for a property it can hold in
+	// milliseconds; zero means the defaults in runUntilFree.
+	busyPoll   time.Duration
+	busyBudget time.Duration
+
 	// leftoverScan replaces the host process scan behind networkCreateError,
 	// and is only ever set by a test: which processes a diagnostic may name is
 	// an argument-level fact, and the real scan reads the tester's own /proc.
@@ -1431,10 +1438,83 @@ func (d *Incus) Stop(ctx context.Context, name string) error {
 	if _, ok, err := d.Inspect(ctx, name); err != nil || !ok {
 		return err
 	}
-	if _, err := d.run(ctx, "stop", "--force", name); err != nil {
+	if _, err := d.runUntilFree(ctx, "stop", "--force", name); err != nil {
 		return fmt.Errorf("stop instance %s: %w", name, err)
 	}
 	return nil
+}
+
+// isBusy reads "another operation still holds this instance" out of a failed
+// command — `Error: Instance is busy running a "update" operation` is the
+// wording Incus 7.2 uses. Busy is a promise of later, not a verdict: the
+// operation holding the instance ends, and a teardown that gives up on the
+// first refusal leaves a running machine the control plane no longer
+// describes, which is #493's tail.
+func isBusy(err error) bool {
+	return err != nil && strings.Contains(strings.ToLower(err.Error()), "instance is busy")
+}
+
+// isTransientConflict reads "another edit crossed this one" out of a failed
+// command: the three shapes measured on Incus 7.2 during parallel applies and
+// destroys, every one of which succeeds when simply asked again.
+//
+//   - "Instance is busy running a … operation": another operation holds the
+//     instance (isBusy, #493);
+//   - "ETag doesn't match": the daemon's own optimistic concurrency check —
+//     a concurrent edit changed the instance between this edit's read and its
+//     write (measured on two Outscale eth0 applies of one run);
+//   - `Transaction causes multiple rows in "Port_Group" table`: two device
+//     edits referencing one rule set both asked OVN to create the set's port
+//     group, and the loser died on the OVSDB uniqueness constraint — measured
+//     on the two machines of one Scaleway group, applied concurrently, which
+//     left one NIC with no rule set at all while the API said applied.
+//
+// The retry is the remedy because each conflict is transient by construction:
+// the operation ends, the re-read sees the new ETag, the port group exists on
+// the second look. A wording outside these three is not retried — notably
+// "Cannot find security ACL ID", which is an ordering defect the network lock
+// closes, not a conflict that resolves itself.
+func isTransientConflict(err error) bool {
+	if err == nil {
+		return false
+	}
+	said := strings.ToLower(err.Error())
+	return isBusy(err) ||
+		strings.Contains(said, "etag doesn't match") ||
+		strings.Contains(said, "transaction causes multiple rows")
+}
+
+// runUntilFree runs one command, waiting out "Instance is busy" refusals until
+// the budget is spent. Any other outcome — success, or a different error —
+// returns at once.
+//
+// It exists for the stop and delete of a teardown (#493): a failed device
+// update elsewhere in a parallel destroy holds the instance for seconds, both
+// paths used to try exactly once, and `feint down` then exited 0 over a
+// machine still running. The wait is per call and bounded: an instance still
+// busy after the budget is reported, never silently abandoned.
+// TestRemoveWaitsOutABusyInstance fails without the waiting.
+func (d *Incus) runUntilFree(ctx context.Context, args ...string) ([]byte, error) {
+	interval := d.busyPoll
+	if interval == 0 {
+		interval = 500 * time.Millisecond
+	}
+	budget := d.busyBudget
+	if budget == 0 {
+		budget = 15 * time.Second
+	}
+	deadline := time.Now().Add(budget)
+	for {
+		out, err := d.run(ctx, args...)
+		if !isTransientConflict(err) || time.Now().After(deadline) {
+			return out, err
+		}
+		select {
+		case <-ctx.Done():
+			return out, err
+		case <-time.After(interval):
+		}
+	}
 }
 
 // Remove implements Driver.
@@ -1455,12 +1535,12 @@ func (d *Incus) Remove(ctx context.Context, name string) error {
 	if !safeName.MatchString(name) {
 		return fmt.Errorf("refusing to remove %q: not a name this emulator creates", name)
 	}
-	if _, err := d.run(ctx, "stop", "--force", name); err != nil && !isNotFound(err) {
+	if _, err := d.runUntilFree(ctx, "stop", "--force", name); err != nil && !isNotFound(err) {
 		// Not fatal: an instance that refuses to stop must still be deletable,
 		// which is what --force below is for.
 		_ = err
 	}
-	if _, err := d.run(ctx, "delete", "--force", name); err != nil {
+	if _, err := d.runUntilFree(ctx, "delete", "--force", name); err != nil {
 		// Asked, not guessed: a delete can fail for reasons whose message also
 		// contains "not found" ("Storage pool not found" was one), and treating
 		// those as success left the instance running while the caller believed

--- a/internal/core/machine/incus.go
+++ b/internal/core/machine/incus.go
@@ -150,13 +150,19 @@ type Incus struct {
 	// lock in the daemon — so of two concurrent rebuilds, the loser dies on
 	// `Failed deleting nftables chain "fwd.feint-uplink" ... No such file or
 	// directory` (#341, measured on Incus 7.2 with the daemon's debug log: a
-	// PUT from delegateRoute interleaved with the POST creating fnt-default).
+	// PUT from a route delegation interleaved with the POST creating fnt-default).
 	// TestConcurrentSubnetAndMachineNetworkCreatesSerialiseOnTheUplink fails
 	// without this serialisation.
 	uplinkMu sync.Mutex
 	// uplinkAdopt runs once per process, at the first reuse of an uplink a
 	// previous emulator left behind: see adoptUplink.
 	uplinkAdopt sync.Once
+	// uplinkQueue collects the blocks whose delegation is waiting for
+	// uplinkMu, so the holder of the lock delegates the whole queue in one
+	// uplink write instead of one write each; see delegateQueuedRoutes for the
+	// measurement (#473).
+	uplinkQueueMu sync.Mutex
+	uplinkQueue   map[string]bool
 	// holderProbe answers whether a pid recorded on the uplink is a live feint
 	// process. A test seam; nil means reading /proc.
 	holderProbe func(pid int) bool
@@ -1159,6 +1165,10 @@ func (d *Incus) EnsureNetwork(ctx context.Context, spec NetworkSpec) error {
 		// lock": the uplink is the single named target whose reconfigurations
 		// must be exclusive, and a network create costs seconds, not the tens
 		// of seconds of a machine launch.
+		// Queued before the lock, so whoever holds it can delegate this block
+		// along with its own in a single uplink write; see
+		// delegateQueuedRoutes for the measurement (#473).
+		d.queueUplinkRoute(spec.CIDR)
 		d.uplinkMu.Lock()
 		defer d.uplinkMu.Unlock()
 		// The uplink is what an OVN network draws its router address from;
@@ -1168,7 +1178,7 @@ func (d *Incus) EnsureNetwork(ctx context.Context, spec NetworkSpec) error {
 		}
 		// The block has to be delegated before the network that carries it: an
 		// OVN network outside its uplink's routes is refused outright.
-		if err := d.delegateRoute(ctx, spec.CIDR); err != nil {
+		if err := d.delegateQueuedRoutes(ctx, spec.CIDR); err != nil {
 			return err
 		}
 		args = append(args, "--type=ovn", "network="+d.uplinkName())

--- a/internal/core/machine/incus_apply_conflict_test.go
+++ b/internal/core/machine/incus_apply_conflict_test.go
@@ -1,0 +1,131 @@
+package machine
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// The apply-side sibling of #493's retry, measured on the Scaleway example
+// stack under --vm incus-ovn: the two machines of one security group are
+// applied concurrently, both device edits make the daemon ensure the group's
+// rule set in OVN, both ask for its port group, and the loser dies on the
+// OVSDB uniqueness constraint:
+//
+//	Failed creating port group "incus_acl2597_all" for referenced security
+//	ACL "scw-…" setup: constraint violation: Transaction causes multiple
+//	rows in "Port_Group" table to have identical values
+//
+// Nothing retried, so one NIC ended with no rule set at all — used_by one
+// short of the group's members — while the API reported the group applied.
+// The same run also measured the daemon's own optimistic-concurrency refusal
+// ("ETag doesn't match") on two concurrent Outscale applies. Both conflicts
+// are transient by construction: the port group exists on the second look,
+// the re-read sees the new ETag. The edit rides them out.
+func TestApplyFirewallRidesOutADuplicatePortGroupRace(t *testing.T) {
+	const machineName = "feint-scw-conflict1"
+	const network = "fnt-c0ffee00001"
+
+	var mu sync.Mutex
+	attempts := 0
+	applied := ""
+	runner := func(_ context.Context, args ...string) ([]byte, error) {
+		key := strings.Join(args, " ")
+		switch {
+		case key == "config get "+machineName+" user."+LabelKey:
+			return []byte("scaleway\n"), nil
+		case key == "query /1.0/instances/"+machineName:
+			devices := `{"eth0":{"type":"nic","network":"` + network + `"}}`
+			return []byte(`{"name":"` + machineName + `","devices":` + devices +
+				`,"expanded_devices":` + devices + `}`), nil
+		case key == "query /1.0/networks/"+network:
+			return []byte(`{"type":"ovn","config":{}}`), nil
+		case strings.HasPrefix(key, "config device set "+machineName+" eth0 security.acls="):
+			mu.Lock()
+			defer mu.Unlock()
+			attempts++
+			switch attempts {
+			case 1:
+				return nil, &textError{`incus config: Error: Failed to update device "eth0": ` +
+					`Failed creating port group "incus_acl2597_all" for referenced security ACL "scw-x" setup: ` +
+					`constraint violation: Transaction causes multiple rows in "Port_Group" table ` +
+					`to have identical values (incus_acl2597_all) for index on column "name".`}
+			case 2:
+				return nil, &textError{"incus config: Error: ETag doesn't match: aaaa vs bbbb"}
+			}
+			applied = strings.TrimPrefix(key, "config device set "+machineName+" eth0 ")
+			return nil, nil
+		}
+		return nil, nil
+	}
+
+	d := NewIncusOVN()
+	d.runner = runner
+	d.busyPoll = time.Millisecond
+
+	err := d.ApplyFirewall(context.Background(), machineName, FirewallBinding{Names: []string{"scw-x"}})
+	if err != nil {
+		t.Fatalf("the apply gave up on a transient conflict: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if attempts != 3 {
+		t.Fatalf("expected the edit to be asked again through both conflicts, got %d attempt(s)", attempts)
+	}
+	if !strings.Contains(applied, "security.acls=scw-x") {
+		t.Fatalf("the rule set never landed on the NIC: %q", applied)
+	}
+}
+
+// The predicate is the guard's edge: a wording outside the three measured
+// transient shapes is not retried. "Cannot find security ACL ID" is the
+// ordering defect the network lock closes — retrying it would paper over a
+// deleted rule set — and it must come back as the error it is, first try.
+func TestANonTransientFailureIsNotRetried(t *testing.T) {
+	const machineName = "feint-scw-conflict2"
+	const network = "fnt-c0ffee00002"
+
+	var mu sync.Mutex
+	attempts := 0
+	runner := func(_ context.Context, args ...string) ([]byte, error) {
+		key := strings.Join(args, " ")
+		switch {
+		case key == "config get "+machineName+" user."+LabelKey:
+			return []byte("scaleway\n"), nil
+		case key == "query /1.0/instances/"+machineName:
+			devices := `{"eth0":{"type":"nic","network":"` + network + `"}}`
+			return []byte(`{"name":"` + machineName + `","devices":` + devices +
+				`,"expanded_devices":` + devices + `}`), nil
+		case key == "query /1.0/networks/"+network:
+			return []byte(`{"type":"ovn","config":{}}`), nil
+		case strings.HasPrefix(key, "config device set "+machineName+" eth0 security.acls="):
+			mu.Lock()
+			defer mu.Unlock()
+			attempts++
+			return nil, &textError{`incus config: Error: Failed setting up OVN port: ` +
+				`Cannot find security ACL ID for "iso-fnt-c0ffee00002"`}
+		}
+		return nil, nil
+	}
+
+	d := NewIncusOVN()
+	d.runner = runner
+	d.busyPoll = time.Millisecond
+
+	err := d.ApplyFirewall(context.Background(), machineName, FirewallBinding{Names: []string{"scw-x"}})
+	if err == nil {
+		t.Fatal("a vanished rule set was reported applied")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if attempts != 1 {
+		t.Fatalf("a non-transient failure was retried %d times; it should come back first try", attempts)
+	}
+}
+
+// textError keeps the fake's wording exactly as the daemon produced it.
+type textError struct{ s string }
+
+func (e *textError) Error() string { return e.s }

--- a/internal/core/machine/incus_firewall.go
+++ b/internal/core/machine/incus_firewall.go
@@ -282,7 +282,16 @@ func (d *Incus) ApplyFirewall(ctx context.Context, machine string, binding Firew
 				"security.acls.default.ingress.action="+orDrop(binding.DefaultIngress),
 				"security.acls.default.egress.action="+orDrop(binding.DefaultEgress))
 		}
-		if _, err := d.run(ctx, args...); err != nil {
+		// runUntilFree, not run: this edit makes the daemon re-ensure every
+		// rule set the NIC references in OVN, and two such edits crossing —
+		// the two machines of one group applied concurrently, or an address
+		// route holding the instance — fail in one of the transient shapes
+		// isTransientConflict names. Measured: an OVSDB port-group collision
+		// left one NIC with no rule set at all while the API said applied,
+		// which is a machine open (or closed) against everything the control
+		// plane claims. TestApplyFirewallRidesOutADuplicatePortGroupRace
+		// fails without the retry.
+		if _, err := d.runUntilFree(ctx, args...); err != nil {
 			return fmt.Errorf("apply firewall to %s/%s: %w", machine, device.name, err)
 		}
 	}

--- a/internal/core/machine/incus_ovn.go
+++ b/internal/core/machine/incus_ovn.go
@@ -699,6 +699,18 @@ func (d *Incus) routeAddressOVN(ctx context.Context, spec AddressSpec) error {
 	if err := d.mustOwn(ctx, network); err != nil {
 		return err
 	}
+	// Exclusive on the NIC's network for the whole edit. The route keys are
+	// not live-updatable on an OVN NIC, so the set below re-plugs the device,
+	// and the daemon then re-ensures every rule set the network references —
+	// resolving names to IDs with no lock shared with its own ACL paths. An
+	// isolation detach running concurrently (IsolateNetwork holds this same
+	// lock) deletes the referenced set between the two steps, and the edit
+	// dies on `Cannot find security ACL ID for "iso-fnt-…"` with the failed
+	// update operation holding the instance busy — the first link of #493's
+	// chain. Same lock, so the edit and the detach take turns.
+	// TestARouteAddressEditAndAnIsolationDetachTakeTurns fails without it.
+	release := d.networkLock(network)
+	defer release()
 	devices, err := d.instanceDevices(ctx, spec.Machine)
 	if err != nil {
 		return fmt.Errorf("inspect %s: %w", spec.Machine, err)
@@ -766,19 +778,53 @@ func (d *Incus) unrouteAddressOVN(ctx context.Context, machine, address string) 
 			if !routeListContains(cfg["ipv4.routes.external"], route) {
 				continue
 			}
-			kept := removeRoute(cfg["ipv4.routes.external"], route)
-			if _, err := d.run(ctx, "config", "device", "set", machine, device,
-				"ipv4.routes.external="+kept); err != nil {
-				return fmt.Errorf("unroute %s from %s/%s: %w", address, machine, device, err)
-			}
-			// The re-plug already dropped every guest address, including the
-			// public one; the repair puts back only what stays.
-			if err := d.repairGuestInterface(ctx, machine, cfg["network"], device); err != nil {
+			if err := d.unrouteOVNDevice(ctx, machine, device, cfg["network"], address); err != nil {
 				return err
 			}
 		}
 	}
 	return d.setUplinkRoute(ctx, address, false)
+}
+
+// unrouteOVNDevice takes one public address off one OVN NIC, holding the
+// network's lock across the edit and its repair.
+//
+// The lock is the ordering half of #493: the set below re-plugs the device,
+// the daemon re-ensures every rule set the NIC's network references while
+// setting the OVN port back up, and an isolation detach landing between the
+// two steps leaves it resolving a rule set that no longer exists — `Cannot
+// find security ACL ID for "iso-fnt-…"`, with the failed update operation
+// holding the instance busy against the stop and remove that follow. The
+// detach holds this same lock (IsolateNetwork), so the two take turns; taken
+// per device, because the loop above walks NICs that may sit on different
+// networks and each edit only needs its own.
+// TestAPublicAddressEditAndAnIsolationDetachTakeTurns fails without it.
+func (d *Incus) unrouteOVNDevice(ctx context.Context, machine, device, network, address string) error {
+	if network != "" {
+		release := d.networkLock(network)
+		defer release()
+	}
+	devices, err := d.instanceDevices(ctx, machine)
+	if err != nil {
+		if isNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("inspect %s: %w", machine, err)
+	}
+	cfg := devices.own[device]
+	route := address + "/32"
+	if !routeListContains(cfg["ipv4.routes.external"], route) {
+		// Withdrawn while this call waited for the lock: nothing left to undo.
+		return nil
+	}
+	kept := removeRoute(cfg["ipv4.routes.external"], route)
+	if _, err := d.run(ctx, "config", "device", "set", machine, device,
+		"ipv4.routes.external="+kept); err != nil {
+		return fmt.Errorf("unroute %s from %s/%s: %w", address, machine, device, err)
+	}
+	// The re-plug already dropped every guest address, including the
+	// public one; the repair puts back only what stays.
+	return d.repairGuestInterface(ctx, machine, network, device)
 }
 
 // repairGuestInterface restores what a device re-plug cost the guest: the

--- a/internal/core/machine/incus_ovn.go
+++ b/internal/core/machine/incus_ovn.go
@@ -46,7 +46,20 @@ const (
 	DefaultUplinkCIDR = "10.209.83.0/24"
 )
 
-// delegateRoute adds one block to the uplink's ipv4.routes. The caller holds
+// queueUplinkRoute registers one block as waiting for delegation. Called
+// before uplinkMu is taken, so the current holder of the lock can drain the
+// queue into its own write; delegateQueuedRoutes is the other half.
+func (d *Incus) queueUplinkRoute(block string) {
+	d.uplinkQueueMu.Lock()
+	if d.uplinkQueue == nil {
+		d.uplinkQueue = map[string]bool{}
+	}
+	d.uplinkQueue[block] = true
+	d.uplinkQueueMu.Unlock()
+}
+
+// delegateQueuedRoutes adds the caller's block, and every block queued behind
+// the lock, to the uplink's ipv4.routes in a single write. The caller holds
 // uplinkMu — see the field's comment for the measured reason there is no safe
 // unserialised edit of the uplink.
 //
@@ -56,17 +69,39 @@ const (
 // it is never the uplink's own /24, the block has to be delegated as the network
 // is created.
 //
-// One block at a time, never a blanket range. Delegating 10.0.0.0/8 up front
-// looks tidier and fails: Incus turns each route into a real route on the host,
-// and a /8 collides with whatever already lives in that space — measured on a
-// machine whose own bridge sat at 10.108.0.0/24, where the whole uplink then
-// refused to come up.
+// The whole queue at once, because every write to the uplink makes the daemon
+// clear and rebuild its firewall — measured at ~1 s per write on Incus 7.2 —
+// and a terraform apply issues its subnet creates concurrently: one write per
+// create put fifteen rebuilds in a serial queue, which is a third of the
+// straight line of #473. Draining the queue is an optimisation, never the
+// guarantee: a caller's own block is always ensured under its own turn of the
+// lock, so a failed batched write costs the others nothing but a retry at
+// their turn, where addUplinkRoutes finds the block still missing.
+// TestConcurrentOVNCreatesShareTheirUplinkWrites fails without the draining.
+//
+// Still one block per network, never a blanket range. Delegating 10.0.0.0/8 up
+// front looks tidier and fails: Incus turns each route into a real route on the
+// host, and a /8 collides with whatever already lives in that space — measured
+// on a machine whose own bridge sat at 10.108.0.0/24, where the whole uplink
+// then refused to come up.
 //
 // Idempotent by construction: a block already delegated is left alone, so
 // creating the same network twice does not grow the list.
-func (d *Incus) delegateRoute(ctx context.Context, block string) error {
-	if err := d.addUplinkRoute(ctx, block); err != nil {
-		return fmt.Errorf("delegate %s to uplink %s: %w", block, d.uplinkName(), err)
+func (d *Incus) delegateQueuedRoutes(ctx context.Context, own string) error {
+	d.uplinkQueueMu.Lock()
+	blocks := make([]string, 0, len(d.uplinkQueue)+1)
+	for block := range d.uplinkQueue {
+		blocks = append(blocks, block)
+	}
+	d.uplinkQueue = nil
+	d.uplinkQueueMu.Unlock()
+	if !slices.Contains(blocks, own) {
+		blocks = append(blocks, own)
+	}
+	// Sorted so two runs write the same value and a log diff means something.
+	slices.Sort(blocks)
+	if err := d.addUplinkRoutes(ctx, blocks); err != nil {
+		return fmt.Errorf("delegate %s to uplink %s: %w", own, d.uplinkName(), err)
 	}
 	return nil
 }
@@ -895,16 +930,32 @@ func (d *Incus) setUplinkRoute(ctx context.Context, address string, add bool) er
 // alone; an entry already present is left as it is, so nothing is rebuilt for
 // nothing. The caller holds uplinkMu.
 func (d *Incus) addUplinkRoute(ctx context.Context, route string) error {
+	return d.addUplinkRoutes(ctx, []string{route})
+}
+
+// addUplinkRoutes is addUplinkRoute for a set: one read, and at most one
+// write, whatever the set's size — a write is what makes the daemon rebuild
+// the uplink's firewall, so entries already present cause none. The caller
+// holds uplinkMu.
+func (d *Incus) addUplinkRoutes(ctx context.Context, routes []string) error {
 	name := d.uplinkName()
 	out, err := d.run(ctx, "network", "get", name, "ipv4.routes")
 	if err != nil {
 		return fmt.Errorf("read routes on uplink %s: %w", name, err)
 	}
-	current := strings.TrimSpace(string(out))
-	if routeListContains(current, route) {
+	merged := strings.TrimSpace(string(out))
+	changed := false
+	for _, route := range routes {
+		if routeListContains(merged, route) {
+			continue
+		}
+		merged = appendRoute(merged, route)
+		changed = true
+	}
+	if !changed {
 		return nil
 	}
-	if _, err := d.run(ctx, "network", "set", name, "ipv4.routes="+appendRoute(current, route)); err != nil {
+	if _, err := d.run(ctx, "network", "set", name, "ipv4.routes="+merged); err != nil {
 		return err
 	}
 	return nil

--- a/internal/core/machine/incus_unroute_race_test.go
+++ b/internal/core/machine/incus_unroute_race_test.go
@@ -1,0 +1,367 @@
+package machine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// The teardown race of #493, staged rather than bet on.
+//
+// A parallel destroy left a running machine, its network and its attached rule
+// set on the host while `terraform destroy` said complete and `feint down`
+// exited 0 — reproduced twice, and both times the survivor was the machine
+// carrying a public address, the one whose teardown withdraws that address
+// through a *device edit* on its OVN NIC. The emulator's own journal carries
+// the chain:
+//
+//	unroute … from feint-osc-…/eth0: … Failed setting up OVN port: …
+//	Cannot find security ACL ID for "iso-fnt-8b667bd77cd"
+//	stop instance …: Error: Instance is busy running a "update" operation
+//
+// The daemon re-ensures every rule set the NIC's network references while it
+// re-plugs the device, resolving names to IDs with no lock shared with its own
+// ACL paths; a neighbouring subnet teardown deletes the isolation set between
+// the two steps, the failed update operation holds the instance busy, and the
+// stop and remove that follow gave up on the first refusal.
+//
+// fakeOVNd below is that behaviour as it was observed, not a line-by-line
+// replay: a device edit snapshots the ACLs its network references when it
+// begins, resolves them when it commits, and a delete landing in between fails
+// the edit and leaves the instance busy for a while. The channels are what
+// make the interleaving a fact rather than a probability, exactly as in
+// fakeNetd one file over.
+type fakeOVNd struct {
+	mu sync.Mutex
+	// networkACLs is what network fnt-… references in security.acls.
+	networkACLs string
+	networkGone bool
+	acls        map[string]bool
+	instance    struct {
+		exists    bool
+		busyUntil time.Time
+	}
+	deviceRoutes string // eth0's ipv4.routes.external
+	uplinkRoutes string
+	calls        []string
+	editFailures []string
+
+	// landed closes when the ACL delete has been applied, so an edit in
+	// flight can meet it instead of hoping to.
+	landed chan struct{}
+	// editStarted closes when the racing device edit has begun: the signal
+	// for the concurrent detach to start, with the ordering guard in place
+	// and with it removed.
+	editStarted chan struct{}
+	landOnce    sync.Once
+	startOnce   sync.Once
+	// beat is how long an edit waits for a delete to cross it: long enough
+	// that a racing delete is inside rather than merely likely to be.
+	beat time.Duration
+	// busyFor is how long the failed update operation holds the instance.
+	busyFor time.Duration
+}
+
+const (
+	racedNetwork = "fnt-a1b2c3d4e5f"
+	racedMachine = "feint-osc-i-1"
+	racedAddress = "198.51.100.3"
+)
+
+func newFakeOVNd() *fakeOVNd {
+	f := &fakeOVNd{
+		networkACLs:  isolationACL(racedNetwork),
+		acls:         map[string]bool{isolationACL(racedNetwork): true},
+		deviceRoutes: racedAddress + "/32",
+		uplinkRoutes: racedAddress + "/32",
+		landed:       make(chan struct{}),
+		editStarted:  make(chan struct{}),
+		beat:         200 * time.Millisecond,
+		busyFor:      100 * time.Millisecond,
+	}
+	f.instance.exists = true
+	return f
+}
+
+func (f *fakeOVNd) instanceJSON() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	devices := fmt.Sprintf(`{"eth0":{"type":"nic","network":%q,"ipv4.routes.external":%q}}`,
+		racedNetwork, f.deviceRoutes)
+	return fmt.Sprintf(`{"name":%q,"config":{%q:"outscale"},"devices":%s,"expanded_devices":%s}`,
+		racedMachine, "user."+LabelKey, devices, devices)
+}
+
+func (f *fakeOVNd) run(_ context.Context, args ...string) ([]byte, error) {
+	key := strings.Join(args, " ")
+	f.mu.Lock()
+	f.calls = append(f.calls, key)
+	f.mu.Unlock()
+
+	switch {
+	case key == "config get "+racedMachine+" user."+LabelKey:
+		return []byte("outscale\n"), nil
+
+	case key == "network get "+racedNetwork+" user."+LabelKey:
+		return []byte("outscale\n"), nil
+
+	case key == "query /1.0/instances/"+racedMachine:
+		f.mu.Lock()
+		exists := f.instance.exists
+		f.mu.Unlock()
+		if !exists {
+			return nil, errors.New("Error: Instance not found")
+		}
+		return []byte(f.instanceJSON()), nil
+
+	case key == "query /1.0/instances?recursion=1":
+		f.mu.Lock()
+		exists := f.instance.exists
+		f.mu.Unlock()
+		if !exists {
+			return []byte("[]"), nil
+		}
+		return []byte("[" + f.instanceJSON() + "]"), nil
+
+	case key == "query /1.0/networks/"+racedNetwork:
+		f.mu.Lock()
+		gone := f.networkGone
+		f.mu.Unlock()
+		if gone {
+			return nil, errors.New("Error: Network not found")
+		}
+		return []byte(`{"type":"ovn","config":{"ipv4.address":"10.0.1.1/24","user.` + LabelKey + `":"outscale"}}`), nil
+
+	case key == "network unset "+racedNetwork+" security.acls":
+		f.mu.Lock()
+		f.networkACLs = ""
+		f.mu.Unlock()
+		return nil, nil
+
+	case strings.HasPrefix(key, "network acl delete "):
+		name := strings.TrimPrefix(key, "network acl delete ")
+		f.mu.Lock()
+		if f.networkACLs == name {
+			f.mu.Unlock()
+			return nil, errors.New("Error: Cannot delete an ACL that is in use")
+		}
+		delete(f.acls, name)
+		f.mu.Unlock()
+		f.landOnce.Do(func() { close(f.landed) })
+		return nil, nil
+
+	case strings.HasPrefix(key, "config device set "+racedMachine+" eth0 ipv4.routes.external="):
+		return f.deviceEdit(key)
+
+	case strings.HasPrefix(key, "stop --force ") || strings.HasPrefix(key, "delete --force "):
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		if !f.instance.exists {
+			return nil, errors.New("Error: Instance not found")
+		}
+		if time.Now().Before(f.instance.busyUntil) {
+			return nil, errors.New(`Error: Instance is busy running a "update" operation`)
+		}
+		if strings.HasPrefix(key, "delete --force ") {
+			f.instance.exists = false
+		}
+		return nil, nil
+
+	case key == "network get feint-uplink ipv4.routes":
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		return []byte(f.uplinkRoutes + "\n"), nil
+
+	case strings.HasPrefix(key, "network set feint-uplink ipv4.routes="):
+		f.mu.Lock()
+		f.uplinkRoutes = strings.TrimPrefix(key, "network set feint-uplink ipv4.routes=")
+		f.mu.Unlock()
+		return nil, nil
+
+	case strings.HasPrefix(key, "config get "+racedMachine+" volatile."):
+		// The interface never carried a recorded address: the repair then has
+		// nothing to put back, which keeps the model to the racing edit.
+		return []byte("\n"), nil
+	}
+	return nil, nil
+}
+
+// deviceEdit is the daemon's OVN NIC re-plug as observed: the referenced rule
+// sets are read when the edit begins and resolved when the port is set back
+// up, and a delete landing between the two fails the edit — with the failed
+// update operation holding the instance.
+func (f *fakeOVNd) deviceEdit(key string) ([]byte, error) {
+	f.mu.Lock()
+	snapshot := f.networkACLs
+	f.mu.Unlock()
+	f.startOnce.Do(func() { close(f.editStarted) })
+
+	select {
+	case <-f.landed:
+	case <-time.After(f.beat):
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if snapshot != "" && !f.acls[snapshot] {
+		failure := fmt.Sprintf(
+			`Failed to start device "eth0": Failed setting up OVN port: Cannot find security ACL ID for %q`,
+			snapshot)
+		f.editFailures = append(f.editFailures, failure)
+		f.instance.busyUntil = time.Now().Add(f.busyFor)
+		return nil, errors.New("Error: " + failure)
+	}
+	f.deviceRoutes = strings.TrimPrefix(key, "config device set "+racedMachine+" eth0 ipv4.routes.external=")
+	return nil, nil
+}
+
+func (f *fakeOVNd) failures() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.editFailures...)
+}
+
+func (f *fakeOVNd) machineExists() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.instance.exists
+}
+
+// The reproduction of #493's first link. A public-address withdrawal (a device
+// edit on the machine's OVN NIC) and the isolation detach of the machine's
+// network, issued concurrently the way a parallel destroy issues them, must
+// take turns: the edit must never resolve a rule set the detach deleted inside
+// it, and the machine must be removable afterwards.
+//
+// The interleaving is staged: the detach starts at the exact moment the device
+// edit begins, and the edit waits long enough for the detach's ACL delete to
+// land inside it if nothing orders the two. With the ordering in place the
+// detach waits its turn instead, and both orders of the two winners are
+// acceptable — what must never happen is the third order, the delete inside
+// the edit.
+func TestAPublicAddressEditAndAnIsolationDetachTakeTurns(t *testing.T) {
+	f := newFakeOVNd()
+	d := NewIncusOVN()
+	d.runner = f.run
+	d.busyPoll = 5 * time.Millisecond
+
+	var wg sync.WaitGroup
+	var unrouteErr, detachErr error
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		unrouteErr = d.UnrouteAddress(context.Background(), racedMachine, racedAddress)
+	}()
+	go func() {
+		defer wg.Done()
+		<-f.editStarted
+		detachErr = d.IsolateNetwork(context.Background(), racedNetwork, nil)
+	}()
+	wg.Wait()
+
+	if failures := f.failures(); len(failures) != 0 {
+		t.Fatalf("the isolation detach landed inside the device edit (#493):\n%s\nunroute: %v\ndetach: %v",
+			strings.Join(failures, "\n"), unrouteErr, detachErr)
+	}
+	if unrouteErr != nil {
+		t.Fatalf("the address withdrawal failed: %v", unrouteErr)
+	}
+	if detachErr != nil && !errors.Is(detachErr, ErrNetworkGone) {
+		t.Fatalf("the detach failed for a reason other than the network being gone: %v", detachErr)
+	}
+
+	// And the teardown completes: the machine the control plane will stop
+	// describing must actually be removable.
+	if err := d.Remove(context.Background(), racedMachine); err != nil {
+		t.Fatalf("remove after the race: %v", err)
+	}
+	if f.machineExists() {
+		t.Fatal("the machine survived its own teardown (#493's tail)")
+	}
+}
+
+// The same turn-taking, on the granting side: routing a public address onto
+// the NIC is the same re-plugging device edit, issued by LinkPublicIp while a
+// neighbouring teardown may be detaching the network's isolation set. The
+// staging is identical; the edit must never resolve a rule set deleted inside
+// it.
+func TestARouteAddressEditAndAnIsolationDetachTakeTurns(t *testing.T) {
+	f := newFakeOVNd()
+	d := NewIncusOVN()
+	d.runner = f.run
+
+	const granted = "198.51.100.4"
+	var wg sync.WaitGroup
+	var routeErr, detachErr error
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		routeErr = d.RouteAddress(context.Background(), AddressSpec{Machine: racedMachine, Address: granted})
+	}()
+	go func() {
+		defer wg.Done()
+		<-f.editStarted
+		detachErr = d.IsolateNetwork(context.Background(), racedNetwork, nil)
+	}()
+	wg.Wait()
+
+	if failures := f.failures(); len(failures) != 0 {
+		t.Fatalf("the isolation detach landed inside the route edit (#493):\n%s\nroute: %v\ndetach: %v",
+			strings.Join(failures, "\n"), routeErr, detachErr)
+	}
+	if routeErr != nil {
+		t.Fatalf("the address grant failed: %v", routeErr)
+	}
+	if detachErr != nil && !errors.Is(detachErr, ErrNetworkGone) {
+		t.Fatalf("the detach failed for a reason other than the network being gone: %v", detachErr)
+	}
+}
+
+// The second link of #493 on its own: an instance still held by another
+// operation refuses its stop and its delete with "Instance is busy", the hold
+// ends, and the teardown must wait it out rather than give up on the first
+// refusal — one try each is exactly what left a running machine behind a
+// `feint down` that exited 0.
+func TestRemoveWaitsOutABusyInstance(t *testing.T) {
+	f := newFakeOVNd()
+	f.mu.Lock()
+	f.instance.busyUntil = time.Now().Add(60 * time.Millisecond)
+	f.mu.Unlock()
+
+	d := NewIncusOVN()
+	d.runner = f.run
+	d.busyPoll = 5 * time.Millisecond
+
+	if err := d.Remove(context.Background(), racedMachine); err != nil {
+		t.Fatalf("remove gave up on a busy instance: %v", err)
+	}
+	if f.machineExists() {
+		t.Fatal("the instance survived: the delete was never retried past the busy window")
+	}
+}
+
+// The budget is a budget: an instance that stays busy is reported, never
+// waited on for ever and never silently dropped.
+func TestABusyInstanceBeyondTheBudgetIsReported(t *testing.T) {
+	f := newFakeOVNd()
+	f.mu.Lock()
+	f.instance.busyUntil = time.Now().Add(time.Hour)
+	f.mu.Unlock()
+
+	d := NewIncusOVN()
+	d.runner = f.run
+	d.busyPoll = 2 * time.Millisecond
+	d.busyBudget = 30 * time.Millisecond
+
+	err := d.Remove(context.Background(), racedMachine)
+	if err == nil {
+		t.Fatal("a permanently busy instance was reported removed")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "instance is busy") {
+		t.Fatalf("the report does not name the hold: %v", err)
+	}
+}

--- a/internal/core/machine/incus_uplink_batch_test.go
+++ b/internal/core/machine/incus_uplink_batch_test.go
@@ -1,0 +1,98 @@
+package machine
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestConcurrentOVNCreatesShareTheirUplinkWrites holds the batching half of
+// #473. Every write to the uplink's ipv4.routes makes the daemon clear and
+// rebuild its firewall — ~1 s measured on Incus 7.2 — and the writes are
+// serialised under uplinkMu on purpose (#341). One write per subnet create
+// therefore queued fifteen rebuilds behind each other on a fifteen-subnet
+// apply; delegating the queue in one write is what removes the queue without
+// touching the serialisation.
+//
+// The burst is staged rather than bet on: the first uplink write sleeps long
+// enough that every other create has queued its block before the write
+// returns, so the fixed driver needs at most two writes. The property the
+// count refuses is exact in the other direction: without draining, eight
+// distinct blocks cost eight writes, whatever the timing.
+func TestConcurrentOVNCreatesShareTheirUplinkWrites(t *testing.T) {
+	self := strconv.Itoa(os.Getpid())
+
+	var mu sync.Mutex
+	routes := ""
+	writes := 0
+	runner := func(_ context.Context, args ...string) ([]byte, error) {
+		key := strings.Join(args, " ")
+		switch {
+		case strings.HasPrefix(key, "query /1.0/networks/feint-uplink"):
+			mu.Lock()
+			out := ourUplinkJSON(self, routes)
+			mu.Unlock()
+			return []byte(out), nil
+		case strings.HasPrefix(key, "query /1.0/networks?recursion=1"):
+			return []byte("[]"), nil
+		case strings.HasPrefix(key, "query /1.0/networks/"):
+			return nil, errors.New("Network not found")
+		case key == "network get feint-uplink ipv4.routes":
+			mu.Lock()
+			out := routes + "\n"
+			mu.Unlock()
+			return []byte(out), nil
+		case strings.HasPrefix(key, "network set feint-uplink ipv4.routes="):
+			mu.Lock()
+			routes = strings.TrimPrefix(key, "network set feint-uplink ipv4.routes=")
+			writes++
+			mu.Unlock()
+			// The rebuild the write costs, long enough for the whole burst to
+			// have queued behind uplinkMu before this returns.
+			time.Sleep(50 * time.Millisecond)
+			return nil, nil
+		}
+		return nil, nil
+	}
+
+	d := NewIncus()
+	d.runner = runner
+	d.OVN = true
+
+	const creates = 8
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < creates; i++ {
+		spec := NetworkSpec{
+			Name: "fnt-batch" + strconv.Itoa(i),
+			CIDR: "10.71." + strconv.Itoa(i+1) + ".0/24",
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if err := d.EnsureNetwork(context.Background(), spec); err != nil {
+				t.Errorf("create %s: %v", spec.Name, err)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	for i := 0; i < creates; i++ {
+		block := "10.71." + strconv.Itoa(i+1) + ".0/24"
+		if !routeListContains(routes, block) {
+			t.Errorf("%s was never delegated; the uplink carries %q", block, routes)
+		}
+	}
+	if writes >= creates {
+		t.Fatalf("%d creates cost %d uplink writes: nothing was batched, and each write is a serial firewall rebuild (#473)", creates, writes)
+	}
+}

--- a/internal/core/serialise/coalesce.go
+++ b/internal/core/serialise/coalesce.go
@@ -1,0 +1,70 @@
+package serialise
+
+import "sync"
+
+// Coalescer collapses concurrent demands for the same full-set pass into as
+// few executions as the demands allow, while keeping each caller's guarantee:
+// Run returns only once a pass that *began after the call* has completed.
+//
+// It exists for the reconciliations that are written against the whole current
+// state rather than against one change — an isolation pass reads every subnet
+// of the store and applies what each may reach. Run one such pass per change
+// under load and the work is O(N) per request, serialised on the runtime's own
+// locks: fifteen concurrent subnet creates each paid a full pass over all
+// fifteen networks, which is the straight line of #473 (a flat ~6 s per
+// create, cut at the emulator's write deadline from the tenth on). Any pass
+// that starts after a change already covers it, so a burst of fifteen needs at
+// most the pass in flight plus one more — never fifteen.
+//
+// The guarantee is the reason this is not a plain "skip if running" debounce:
+// a caller whose change landed while a pass was already reading would return
+// with its change possibly unseen, and the pack would answer the client before
+// the state it just wrote was reconciled. TestRunWaitsForAPassThatSawTheCall
+// fails against that shortcut.
+//
+// The zero value is ready to use. Like Lock, the domain of one Coalescer is
+// whatever its owner says it is — one per pack's reconciliation, never one for
+// the whole emulator.
+type Coalescer struct {
+	mu      sync.Mutex
+	cond    *sync.Cond
+	running bool
+	// begun and done number the passes: begun is bumped when a pass starts,
+	// done records the highest finished one. A caller is satisfied by any pass
+	// numbered strictly above the value begun had when it arrived.
+	begun uint64
+	done  uint64
+}
+
+// Run executes pass, or waits for an execution that covers this call.
+//
+// The pass function must read the state it reconciles itself, at the moment it
+// runs: a pass replays no argument from the callers it covers, which is what
+// makes covering them sound.
+func (c *Coalescer) Run(pass func()) {
+	c.mu.Lock()
+	if c.cond == nil {
+		c.cond = sync.NewCond(&c.mu)
+	}
+	// Any pass that begins from now on reads state that includes this
+	// caller's change; the one currently running (begun-th) may not.
+	target := c.begun + 1
+	for c.done < target {
+		if c.running {
+			c.cond.Wait()
+			continue
+		}
+		c.running = true
+		c.begun++
+		mine := c.begun
+		c.mu.Unlock()
+		pass()
+		c.mu.Lock()
+		c.running = false
+		if c.done < mine {
+			c.done = mine
+		}
+		c.cond.Broadcast()
+	}
+	c.mu.Unlock()
+}

--- a/internal/core/serialise/coalesce_test.go
+++ b/internal/core/serialise/coalesce_test.go
@@ -1,0 +1,119 @@
+package serialise
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// A caller whose change lands while a pass is already reading must not be
+// satisfied by that pass: it returns only once a pass that began after its
+// call has completed. This is the guarantee that separates the coalescer from
+// a debounce, and the test stages it rather than betting on timing: the first
+// pass is held open on a channel while the second caller arrives.
+func TestRunWaitsForAPassThatSawTheCall(t *testing.T) {
+	var c Coalescer
+
+	// The state a pass reads, as a pack's pass reads the store.
+	var mu sync.Mutex
+	state := []string{}
+	var seen [][]string
+
+	release := make(chan struct{})
+	firstStarted := make(chan struct{})
+	pass := func() {
+		mu.Lock()
+		snapshot := append([]string(nil), state...)
+		seen = append(seen, snapshot)
+		mu.Unlock()
+		select {
+		case <-firstStarted:
+		default:
+			close(firstStarted)
+			<-release // hold the first pass open so the second caller arrives inside it
+		}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		c.Run(pass)
+	}()
+	<-firstStarted
+
+	// The second caller writes its change, then asks. The running pass has
+	// already taken its snapshot and cannot have seen it.
+	mu.Lock()
+	state = append(state, "late-change")
+	mu.Unlock()
+
+	secondDone := make(chan struct{})
+	go func() {
+		c.Run(pass)
+		close(secondDone)
+	}()
+
+	select {
+	case <-secondDone:
+		t.Fatal("the second caller returned while the only completed pass predates its change")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release)
+	<-secondDone
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	last := seen[len(seen)-1]
+	if len(last) != 1 || last[0] != "late-change" {
+		t.Fatalf("the pass that satisfied the second caller did not read its change: %v", seen)
+	}
+}
+
+// A burst of callers is served by a bounded number of passes, not one each.
+// Every goroutine is released at once and the pass is slow enough that the
+// whole burst arrives while the first pass runs; the fixed code then needs at
+// most the running pass plus one more, and the unfixed shape — one pass per
+// caller — is what the count refuses.
+func TestABurstOfCallersSharesItsPasses(t *testing.T) {
+	var c Coalescer
+	var passes atomic.Int64
+	pass := func() {
+		passes.Add(1)
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	const callers = 24
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			c.Run(pass)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := passes.Load(); got >= callers {
+		t.Fatalf("%d callers ran %d passes: nothing was coalesced", callers, got)
+	}
+	if got := passes.Load(); got > 4 {
+		t.Fatalf("%d callers needed %d passes; a burst arriving inside one pass needs at most that pass plus one", callers, got)
+	}
+}
+
+// An idle coalescer runs the pass immediately and synchronously.
+func TestAnIdleCoalescerRunsAtOnce(t *testing.T) {
+	var c Coalescer
+	ran := false
+	c.Run(func() { ran = true })
+	if !ran {
+		t.Fatal("the pass did not run")
+	}
+}

--- a/internal/providers/exoscale/pack.go
+++ b/internal/providers/exoscale/pack.go
@@ -73,6 +73,10 @@ type Pack struct {
 	// #269 invariant, this pack's turn.
 	templates     []map[string]any
 	instanceTypes []map[string]any
+	// isolation coalesces the full-set reconciliation passes of
+	// isolatePrivateNetworks; the measurement is on the Outscale pack's
+	// isolateNetworks (#473).
+	isolation serialise.Coalescer
 }
 
 // lockAddresses serializes elastic IP and lease allocation, which is

--- a/internal/providers/exoscale/privatenetworks.go
+++ b/internal/providers/exoscale/privatenetworks.go
@@ -322,7 +322,20 @@ func (p *Pack) ensureBackingNetwork(ctx context.Context, res *resource.Resource,
 // this batch, and the predicate below says exactly that. The reconciliation —
 // empty peer lists under native isolation, every managed block to keep out
 // otherwise — is machine.ReconcileIsolation, shared with the two other packs.
+//
+// Coalesced like the Outscale pack's (#473, the measurement and the guarantee
+// are on isolateNetworks there): a burst of concurrent creates shares its
+// passes instead of each request paying a full O(N) one. The pass re-reads
+// the store when it runs, and every caller returns only once a pass that read
+// its own change has completed.
 func (p *Pack) isolatePrivateNetworks(ctx context.Context) {
+	ctx = context.WithoutCancel(ctx)
+	p.isolation.Run(func() { p.isolationPass(ctx) })
+}
+
+// isolationPass is one full reconciliation, reading the store at the moment it
+// runs. Only the Coalescer calls it.
+func (p *Pack) isolationPass(ctx context.Context) {
 	all := p.env.Store.List(kindPrivateNetwork, resource.Tenant{Provider: Name})
 	members := make([]machine.IsolationMember, len(all))
 	for i, pn := range all {

--- a/internal/providers/outscale/isolate.go
+++ b/internal/providers/outscale/isolate.go
@@ -42,7 +42,27 @@ func (p *Pack) reachableFrom(subnet, other *resource.Resource) bool {
 // machine.ReconcileIsolation, shared with the two other packs — this pack is
 // the one that had no isolation wiring at all until #201 — and only the
 // Outscale question above stays here, as the predicate.
+//
+// Coalesced, because the pass is O(N) over every subnet and a terraform apply
+// issues its creates concurrently: fifteen subnets each paying a full pass,
+// serialised on the runtime's locks, is the straight line of #473 — a flat
+// ~6 s per create, cut at the emulator's write deadline from the tenth on.
+// Any pass that starts after a change covers it, so the coalescer runs at
+// most the pass in flight plus one for a whole burst, and every caller still
+// returns only once a pass that read its own change has completed. The pass
+// re-reads the store when it runs (isolationPass), which is what makes
+// covering a burst sound. Detached from the request's cancellation because
+// one pass serves many requests, and the first client hanging up must not
+// abort the reconciliation the others are waiting on.
+// TestConcurrentSubnetCreatesShareTheirIsolationPasses fails without this.
 func (p *Pack) isolateNetworks(ctx context.Context) {
+	ctx = context.WithoutCancel(ctx)
+	p.isolation.Run(func() { p.isolationPass(ctx) })
+}
+
+// isolationPass is one full reconciliation, reading the store at the moment it
+// runs. Only the Coalescer calls it.
+func (p *Pack) isolationPass(ctx context.Context) {
 	all := p.env.Store.List(kindSubnet, resource.Tenant{Provider: Name})
 	members := make([]machine.IsolationMember, len(all))
 	for i, subnet := range all {

--- a/internal/providers/outscale/isolate_pass_internal_test.go
+++ b/internal/providers/outscale/isolate_pass_internal_test.go
@@ -1,0 +1,132 @@
+package outscale
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/machine"
+	"github.com/stephrobert/feint/internal/core/resource"
+)
+
+// passIsolator is a driver whose first isolation call can be held open, so a
+// test can put a whole burst of callers *inside* the first reconciliation pass
+// instead of hoping to land there. It records which networks each
+// IsolateNetwork call named, which is how the test reads both what a pass saw
+// and how many passes ran.
+type passIsolator struct {
+	machine.Noop
+	mu    sync.Mutex
+	calls []string
+
+	firstStarted chan struct{}
+	release      chan struct{}
+	firstOnce    sync.Once
+}
+
+func newPassIsolator() *passIsolator {
+	return &passIsolator{
+		firstStarted: make(chan struct{}),
+		release:      make(chan struct{}),
+	}
+}
+
+func (f *passIsolator) IsolateNetwork(_ context.Context, network string, _ []string) error {
+	f.mu.Lock()
+	f.calls = append(f.calls, network)
+	f.mu.Unlock()
+	f.firstOnce.Do(func() {
+		close(f.firstStarted)
+		<-f.release // hold the first pass open so the burst arrives inside it
+	})
+	return nil
+}
+
+func (f *passIsolator) networksSeen() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.calls...)
+}
+
+// The isolation passes of a burst of subnet creates are shared: a burst that
+// arrives while a pass is already reading is served by that pass plus one
+// more, never by one pass per caller — one pass per caller is the O(N) per
+// request that #473's straight line is made of. And sharing stays sound
+// because the pass re-reads the store when it runs: the covering pass below
+// names subnets stored after the first pass began.
+//
+// The collapse arithmetic of the coalescer is held by the serialise tests;
+// what only this level can assert is the wiring — that isolateNetworks routes
+// through the coalescer at all, and computes its members inside the coalesced
+// pass rather than before Run.
+func TestConcurrentSubnetCreatesShareTheirIsolationPasses(t *testing.T) {
+	env := emulator.DefaultEnv()
+	driver := newPassIsolator()
+	env.Machines = driver
+	p := New(env)
+
+	subnet := func(id, network, block string) *resource.Resource {
+		res := resource.New(id, kindSubnet, resource.Tenant{Provider: Name}, "available", time.Now())
+		res.Attrs = map[string]any{"NetId": "vpc-1", "IpRange": block}
+		res.Runtime = map[string]string{runtimeNetworkKey: network}
+		return res
+	}
+
+	// First change, first pass: it starts, and stays open on the driver.
+	env.Store.Put(subnet("subnet-0", "fnt-first", "10.0.1.0/24"))
+	firstDone := make(chan struct{})
+	go func() {
+		p.isolateNetworks(context.Background())
+		close(firstDone)
+	}()
+	<-driver.firstStarted
+
+	// The burst lands while the first pass is reading: five more subnets, five
+	// more callers. None may be satisfied by the pass in flight.
+	const burst = 5
+	var wg sync.WaitGroup
+	burstDone := make(chan struct{})
+	for i := 0; i < burst; i++ {
+		env.Store.Put(subnet("subnet-"+string(rune('1'+i)), "fnt-late"+string(rune('1'+i)), "10.0."+string(rune('2'+i))+".0/24"))
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			p.isolateNetworks(context.Background())
+		}()
+	}
+	go func() { wg.Wait(); close(burstDone) }()
+
+	// Long enough for every burst caller to have reached the coalescer while
+	// the first pass is still held open — which is what makes the pass count
+	// below a staged fact rather than a bet.
+	select {
+	case <-burstDone:
+		t.Fatal("a burst caller returned while the only pass in flight predates its subnet")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(driver.release)
+	<-firstDone
+	<-burstDone
+
+	seen := driver.networksSeen()
+	passes := 0
+	coveredLast := false
+	for _, network := range seen {
+		if network == "fnt-first" {
+			passes++ // fnt-first is in the store throughout, so every pass names it once
+		}
+		if network == "fnt-late5" {
+			coveredLast = true
+		}
+	}
+	if !coveredLast {
+		t.Fatalf("no pass named the last subnet of the burst; the members were computed before the pass ran: %v", seen)
+	}
+	if passes > 2 {
+		t.Fatalf("a burst of %d callers inside one pass cost %d passes; sharing means the pass in flight plus one, and one per caller is #473's slope (calls: %v)",
+			burst, passes, seen)
+	}
+}

--- a/internal/providers/outscale/pack.go
+++ b/internal/providers/outscale/pack.go
@@ -59,6 +59,9 @@ type Pack struct {
 	// subregion — the API's own behaviour for a create outside a Net. The
 	// region's first zone, which is the "<region>a" every region publishes.
 	defaultSubregion string
+	// isolation coalesces the full-set reconciliation passes of
+	// isolateNetworks; see that function for the measurement (#473).
+	isolation serialise.Coalescer
 }
 
 // lockAddresses serialises the choice of a block or an address, which is

--- a/internal/providers/scaleway/pack.go
+++ b/internal/providers/scaleway/pack.go
@@ -25,6 +25,9 @@ const Name = "scaleway"
 // Pack implements emulator.Pack for Scaleway.
 type Pack struct {
 	env *emulator.Env
+	// isolation coalesces the full-set reconciliation passes of
+	// isolateNetworks; the measurement is on the Outscale pack's (#473).
+	isolation serialise.Coalescer
 }
 
 // lockAddresses serialises address allocation, which is read-modify-write over

--- a/internal/providers/scaleway/vpc.go
+++ b/internal/providers/scaleway/vpc.go
@@ -780,7 +780,21 @@ func (p *Pack) newVPC(region, project, name string, isDefault bool) *resource.Re
 // neighbours must keep out — is machine.ReconcileIsolation, shared with the
 // two other packs rather than copied a third time (#201 measured what the
 // copies cost).
+//
+// Coalesced like the Outscale pack's (#473, the measurement and the guarantee
+// are on isolateNetworks there): the pass is O(N) over every network and a
+// client creates its networks concurrently, so a burst shares its passes
+// instead of each request paying a full one. The pass re-reads the store when
+// it runs, and every caller returns only once a pass that read its own change
+// has completed.
 func (p *Pack) isolateNetworks(ctx context.Context) {
+	ctx = context.WithoutCancel(ctx)
+	p.isolation.Run(func() { p.isolationPass(ctx) })
+}
+
+// isolationPass is one full reconciliation, reading the store at the moment it
+// runs. Only the Coalescer calls it.
+func (p *Pack) isolationPass(ctx context.Context) {
 	all := p.env.Store.List(kindPrivateNetwork, resource.Tenant{Provider: Name})
 	members := make([]machine.IsolationMember, len(all))
 	for i, pn := range all {

--- a/tools/falsify/specs/ovn-create-concurrency.json
+++ b/tools/falsify/specs/ovn-create-concurrency.json
@@ -1,0 +1,36 @@
+{
+  "package": "./internal/core/serialise/",
+  "mutations": [
+    {
+      "label": "the coalescer satisfies a caller with the pass that was already reading when it arrived, so a change landing mid-pass is answered before anything reconciled it (#473)",
+      "file": "internal/core/serialise/coalesce.go",
+      "find": "\ttarget := c.begun + 1",
+      "replace": "\ttarget := c.begun",
+      "test": "TestRunWaitsForAPassThatSawTheCall"
+    },
+    {
+      "label": "the pack runs its own full pass per request again instead of sharing, which is the O(N) per create the straight line of #473 is made of",
+      "file": "internal/providers/outscale/isolate.go",
+      "find": "\tp.isolation.Run(func() { p.isolationPass(ctx) })",
+      "replace": "\tp.isolation.Run(func() {})\n\tp.isolationPass(ctx)",
+      "test": "TestConcurrentSubnetCreatesShareTheirIsolationPasses",
+      "package": "./internal/providers/outscale/"
+    },
+    {
+      "label": "the uplink queue is no longer drained, so every concurrent create pays its own uplink write and firewall rebuild again (#473)",
+      "file": "internal/core/machine/incus_ovn.go",
+      "find": "\tfor block := range d.uplinkQueue {\n\t\tblocks = append(blocks, block)\n\t}",
+      "replace": "\tfor block := range d.uplinkQueue {\n\t\t_ = append(blocks, block)\n\t}",
+      "test": "TestConcurrentOVNCreatesShareTheirUplinkWrites",
+      "package": "./internal/core/machine/"
+    },
+    {
+      "label": "the write deadline goes back to sixty seconds under a machine runtime, the figure that cut six completed creates on the ztiac replay (#473)",
+      "file": "internal/cli/timeout.go",
+      "find": "\treturn 10 * time.Minute",
+      "replace": "\treturn 60 * time.Second",
+      "test": "TestTheWriteDeadlineFollowsTheRuntime",
+      "package": "./internal/cli/"
+    }
+  ]
+}

--- a/tools/falsify/specs/ovn-teardown-ordering.json
+++ b/tools/falsify/specs/ovn-teardown-ordering.json
@@ -1,0 +1,40 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "the address withdrawal edits the OVN NIC without the network's lock again, so an isolation detach can delete the referenced rule set inside the edit (#493)",
+      "file": "internal/core/machine/incus_ovn.go",
+      "find": "\tif network != \"\" {\n\t\trelease := d.networkLock(network)\n\t\tdefer release()\n\t}",
+      "replace": "\tif network != \"\" {\n\t\trelease := d.networkLock(network)\n\t\trelease()\n\t}",
+      "test": "TestAPublicAddressEditAndAnIsolationDetachTakeTurns"
+    },
+    {
+      "label": "the address grant edits the OVN NIC without the network's lock again, same hazard on the granting side (#493)",
+      "file": "internal/core/machine/incus_ovn.go",
+      "find": "\t// TestARouteAddressEditAndAnIsolationDetachTakeTurns fails without it.\n\trelease := d.networkLock(network)\n\tdefer release()",
+      "replace": "\t// TestARouteAddressEditAndAnIsolationDetachTakeTurns fails without it.\n\trelease := d.networkLock(network)\n\trelease()",
+      "test": "TestARouteAddressEditAndAnIsolationDetachTakeTurns"
+    },
+    {
+      "label": "the stop and delete of a teardown give up on the first \"Instance is busy\" again, which is what left a running machine behind a feint down that exited 0 (#493)",
+      "file": "internal/core/machine/incus.go",
+      "find": "\t\tif !isTransientConflict(err) || time.Now().After(deadline) {\n\t\t\treturn out, err\n\t\t}",
+      "replace": "\t\tif !isTransientConflict(err) || !time.Now().After(deadline) {\n\t\t\treturn out, err\n\t\t}",
+      "test": "TestRemoveWaitsOutABusyInstance"
+    },
+    {
+      "label": "the transient-conflict predicate stops recognising the ETag and port-group shapes, so a crossed apply gives up first try and a NIC loses its rule set (#493)",
+      "file": "internal/core/machine/incus.go",
+      "find": "\treturn isBusy(err) ||\n\t\tstrings.Contains(said, \"etag doesn't match\") ||\n\t\tstrings.Contains(said, \"transaction causes multiple rows\")",
+      "replace": "\treturn isBusy(err) ||\n\t\t(false && strings.Contains(said, \"etag doesn't match\")) ||\n\t\t(false && strings.Contains(said, \"transaction causes multiple rows\"))",
+      "test": "TestApplyFirewallRidesOutADuplicatePortGroupRace"
+    },
+    {
+      "label": "the predicate widens to every error, so an ordering defect like a vanished rule set is retried into silence instead of reported (#493)",
+      "file": "internal/core/machine/incus.go",
+      "find": "\treturn isBusy(err) ||\n\t\tstrings.Contains(said, \"etag doesn't match\") ||\n\t\tstrings.Contains(said, \"transaction causes multiple rows\")",
+      "replace": "\treturn (err != nil) || isBusy(err) ||\n\t\tstrings.Contains(said, \"etag doesn't match\") ||\n\t\tstrings.Contains(said, \"transaction causes multiple rows\")",
+      "test": "TestANonTransientFailureIsNotRetried"
+    }
+  ]
+}

--- a/tools/falsify/specs/uplink-serialisation.json
+++ b/tools/falsify/specs/uplink-serialisation.json
@@ -4,8 +4,8 @@
     {
       "label": "the uplink rebuilds stop being serialised, so a subnet delegation and a machine-network create race in the daemon's firewall clear (#341)",
       "file": "internal/core/machine/incus.go",
-      "find": "\t\t// of seconds of a machine launch.\n\t\td.uplinkMu.Lock()\n\t\tdefer d.uplinkMu.Unlock()",
-      "replace": "\t\t// of seconds of a machine launch.\n\t\tif false {\n\t\t\td.uplinkMu.Lock()\n\t\t\tdefer d.uplinkMu.Unlock()\n\t\t}",
+      "find": "\t\td.queueUplinkRoute(spec.CIDR)\n\t\td.uplinkMu.Lock()\n\t\tdefer d.uplinkMu.Unlock()",
+      "replace": "\t\td.queueUplinkRoute(spec.CIDR)\n\t\tif false {\n\t\t\td.uplinkMu.Lock()\n\t\t\tdefer d.uplinkMu.Unlock()\n\t\t}",
       "test": "TestConcurrentSubnetAndMachineNetworkCreatesSerialiseOnTheUplink"
     },
     {


### PR DESCRIPTION
Closes #473. Closes #493.

Two defects of one family: a slow side effect held inside a lock that was too
wide, and two slow side effects that never took turns. `CLAUDE.md` already
carries the doctrine — *un effet de bord lent ne tient pas dans le verrou* — and
these are the two shapes it warns about, measured.

## The harness comes first, and it is the proof

A race that fires once in three runs cannot be fixed, only observed. So both
defects got a harness that makes them bite **on demand, before any fix**, and
the same harness is what says they no longer do.

**#473 — two stages.** A real replay of fifteen concurrent `CreateSubnet`
against the emulator under `--vm incus-ovn`, and deterministic Go tests driven
**by channels, never by hoped-for timing**: the coalescer holds one caller until
no pass later than its write has finished (the first pass is held open on a
channel while the second caller arrives *inside* it), and the uplink write batch
is counted through the injected runner (8 creates → fewer than 8 writes).

Baseline on `46230cc`, the shape the issue described:

```
2.3s  4.6s  6.9s  …  35.5s     strictly linear
```

After: min 2.4 s, **max 11.6 s, twelve of the fifteen finishing together**. The
second caller's latency no longer contains the first's.

**#493 — the fake daemon puts the ACL delete inside the device edit.** The edit
photographs the ACLs the network references on entry, waits on channels for the
concurrent delete to land *inside* it, then fails with `Cannot find security ACL
ID` and holds the instance busy — the exact chain from the issue's journal,
replayable at will. Three guards, each with a test that bites: the network lock
over re-plugging edits (route and unroute), `runUntilFree` on stop and delete,
and a budget that reports instead of giving up.

## A third defect of the same family, caught by the reference numbers

The Scaleway replay came back with rule-set `used_by` **3+1+1 where the branch
brief demanded 1+3+2**. Instrumented hunt, HIT on cycle 2 of 8, journal in hand:

**two concurrent `ApplyFirewall` calls for two machines of one group each create
the ACL's OVN port group; the loser dies on the OVSDB constraint, and a NIC is
left wearing no rule set at all while the API reports it applied.** Plus two
"ETag doesn't match" on Outscale. That is #475's family for the third time, and
nothing else was red.

Fixed by retrying genuinely transient conflicts (busy, ETag, port-group), with
`ApplyFirewall` routed through the retry — **and a test proving a
non-transient failure is never retried**, which is the half that gets forgotten.
Before: 2 occurrences over 9 cycles. After: **0 over 8**, plus the replays.

## What it was replayed on

- Outscale, #493's victim: **five** `feint up --runtime incus-ovn` / `feint down`
  cycles, clean destroy and nil station delta every time.
- Scaleway: two full replays plus the 8 hunt cycles, rule-set references
  3+2+1 = 6 for six machines. Exoscale: apply, destroy, nil delta.
- `go test ./... -race`, with `-count=3` on every race test; `check`, `prepush`,
  `docs:check` all 0.
- **Falsification: 14/14 mutations bite** (4 for #473, 5 for #493, 5 from #341's
  spec retargeted after a fragment moved), `falsify:lint` green on 112 specs.
- `FEINT_VM=incus-ovn mise run conformance` **green end to end, twice** — once as
  a baseline, once on the committed code (1190 s, 350/373 routes).

## The `clean` anomaly was an instrument, not a defect

A review comment on #493 reported `clean` counting two networks where `incus
network list` showed one. Both counts were right: `clean` counts **feint-uplink**
among its networks, and "feint" does not contain the substring `fnt`, which the
observation's grep filtered on. Sixteen networks on both sides. Refutation filed
on the issue rather than left standing.

## Filed rather than fixed here

- **#519** — the destroy side still pays one serialised uplink rewrite per
  network, a flat +1.3 s each. The symmetric half of #473, not corrected here.
- **#520** — the Exoscale stack's second plan is no longer empty: the two per-id
  outputs (#478) read back null at apply time. **Proven identical with a binary
  built from `main@46230cc`**, so it predates this branch.
- **#521** — a green conformance run leaves the uplink and a detached `osc-*`
  rule set behind, which its own doorstep then refuses at the next launch.
  Measured twice.
