### PR TITLE
fix: reachability has one writer, and a package step with no route out is said at boot (#507, #508)

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -28,7 +28,7 @@
 >
 > **Prouvé** : 348 des 371 opérations montées sont pilotées par un vrai client, à chaque pull request. `scw`, `octl`, `exo`, Terraform et OpenTofu tournent contre l'émulateur en CI, et les machines démarrent réellement : connexion ssh sur le compte par défaut de chaque provider, subnets isolés, pare-feu qui filtre. La chaîne complète est décrite dans [docs/conformance.md](docs/conformance.md).
 >
-> **Pas prouvé** : quotas, prix, capacité réelle, validation des identifiants, authentification, cohérence à terme. Les 42 sections de [docs/limits.md](docs/limits.md) disent chacune ce qu'elle coûte. Un émulateur avec un seul compte implicite et aucune grille tarifaire devrait inventer ces chiffres, et quelqu'un agirait dessus.
+> **Pas prouvé** : quotas, prix, capacité réelle, validation des identifiants, authentification, cohérence à terme. Les 43 sections de [docs/limits.md](docs/limits.md) disent chacune ce qu'elle coûte. Un émulateur avec un seul compte implicite et aucune grille tarifaire devrait inventer ces chiffres, et quelqu'un agirait dessus.
 >
 > **Inconnu** : 23 opérations sont montées et n'ont jamais été pilotées par un client. Chacune dit pourquoi aucun client officiel ne l'atteint, à la route et dans [docs/routes.md](docs/routes.md). Elles sont comptées plutôt qu'escamotées, une par une, dans [coverage/evidence.json](coverage/evidence.json).
 >

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 >
 > **Proven**: 348 of the 371 mounted operations are driven by a real client, on every pull request. `scw`, `octl`, `exo`, Terraform and OpenTofu run against the emulator in CI, and machines really boot: an ssh login on each provider's own default account, isolated subnets, a firewall that filters. The whole chain is described in [docs/conformance.md](docs/conformance.md).
 >
-> **Not proven**: quotas, prices, real capacity, identifier validation, authentication, eventual consistency. The 42 sections of [docs/limits.md](docs/limits.md) each say what one costs. An emulator with a single implicit account and no price list would have to invent those figures, and somebody would act on them.
+> **Not proven**: quotas, prices, real capacity, identifier validation, authentication, eventual consistency. The 43 sections of [docs/limits.md](docs/limits.md) each say what one costs. An emulator with a single implicit account and no price list would have to invent those figures, and somebody would act on them.
 >
 > **Unknown**: 23 operations are mounted and have never been driven by a client. Every one of them states why no official client reaches it, at the route and in [docs/routes.md](docs/routes.md). They are counted rather than glossed, one by one, in [coverage/evidence.json](coverage/evidence.json).
 >

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -1625,6 +1625,65 @@ Until then `mise run conformance:parity` runs on demand and is deliberately not
 in the `conformance` aggregate: a red suite inside the gate every other change is
 judged by teaches people to skip the gate.
 
+## A machine's route out: which shapes reach a package repository (#507)
+
+Whether an emulated machine can reach the internet is a property of its
+**primary interface's shape**, not of the host it runs on. Measured on
+2026-08-26, one emulator (`incus-ovn`), one station, one minute apart, the same
+`#cloud-config` declaring `package_update: true` and `packages: [nginx]` on
+both:
+
+| shape | outbound | DNS | cloud-init | port 80 |
+|---|---|---|---|---|
+| routed NIC (Scaleway server, public IP, no private network at create) | none | none | `status: error` on `package_update_upgrade_install` | never listens |
+| NAT-backed network (Outscale public-Cloud Vm on `fnt-default`) | yes | yes | `status: done` | listening — nginx installed |
+
+The port-22 positive control was OPEN on both, so the `error` measures the
+machine, not the reader.
+
+Why the routed shape has no route out is #202's decision: a machine carries
+exactly the addresses its provider's API publishes, on a routed NIC with no
+network underneath — and therefore no NAT and no resolver, because the images
+`feint images` builds carry their ssh daemon already (#203) and nothing else
+about the machine needs the internet. The default route inside the guest is
+`via 169.254.0.1`, the routed NIC's link-local next hop, and it wins even when
+a private NIC with a NAT-backed network is attached later, which is the
+ordinary Terraform order on Scaleway and Exoscale (server first, NIC after).
+Outscale's Subnets are NAT-less **on purpose and faithfully**: upstream, a
+Subnet reaches out only through an internet or NAT service, and this emulator
+records those without routing them (see "Outscale's gateways and NAT move
+records, not packets").
+
+This is not a per-environment fact. The runtime-proof runner showed the same
+boundary from both sides: machines whose outbound is routed and NATed through
+the host crossed the Docker `FORWARD` policy (the comment in
+`runtime-proof.yml`), and the routed shape without NAT kept the ssh suite red
+for five consecutive nights until the images stopped needing a repository
+(#335). Two shapes, one boundary, both environments.
+
+Consequences, stated rather than implied:
+
+- **A stack's `packages:` clause cannot complete on a routed-shape machine.**
+  cloud-init runs the user data — the config reaches
+  `/var/lib/cloud/instance/user-data.txt` — and ends in `status: error`, in a
+  journal inside the guest that nobody opens. The example stacks therefore
+  declare none (#507); their user data does what an offline machine can hold
+  (`write_files`, `runcmd`, a python listener — python is guaranteed wherever
+  cloud-init runs).
+- **The emulator says it at boot**: a client cloud-config that declares a
+  package step on a machine booting with no emulated network under it is
+  warned about in the emulator's log, naming this section.
+  `TestAPackageStepWithNoRouteOutIsSaidOutLoud` holds the warning, and its
+  absence on the shapes that can install.
+- **No NAT is added for the routed shape here.** A routed NIC has no network
+  object, so there is no `ipv4.nat` to switch on: feint would have to write
+  masquerade rules on the operator's host outside anything Incus manages, and
+  provide a resolver besides — for an interface that `firewall_public_only`
+  already documents as unfiltered. The real cloud does give such a machine
+  outbound, so this is a divergence, and it is recorded here rather than
+  papered over; widening the machine layer's contract is the boundary work of
+  the architecture audit (#514), not a patch.
+
 ## Subnet isolation depends on the runtime mode
 
 Upstream, two private networks of two different VPCs do not reach each other.

--- a/examples/stacks/exoscale/main.tf
+++ b/examples/stacks/exoscale/main.tf
@@ -218,11 +218,20 @@ resource "exoscale_compute_instance" "web" {
     network_id = exoscale_private_network.front.id
   }
 
+  # No `packages:` here, deliberately (#507). An instance with an elastic IP
+  # boots on a routed NIC with no NAT and no resolver (docs/limits.md, "A
+  # machine's route out"), so a package step cannot complete: under a runtime,
+  # cloud-init would end in `status: error` in a journal nobody opens. The web
+  # tier still gets a real listener on 80 — python3 is guaranteed wherever
+  # cloud-init runs, since cloud-init is python.
   user_data = <<-EOT
     #cloud-config
-    package_update: true
-    packages:
-      - nginx
+    write_files:
+      - path: /var/www/html/index.html
+        content: |
+          <h1>platform web</h1>
+    runcmd:
+      - [systemd-run, --unit=platform-web, --working-directory=/var/www/html, python3, -m, http.server, "80"]
   EOT
 }
 

--- a/examples/stacks/scaleway/main.tf
+++ b/examples/stacks/scaleway/main.tf
@@ -269,11 +269,21 @@ resource "scaleway_instance_server" "bastion" {
   security_group_id = scaleway_instance_security_group.bastion.id
   tags              = ["platform", "bastion"]
 
+  # No `packages:` here, deliberately (#507). A server created with a public IP
+  # boots on a routed NIC with no NAT and no resolver (docs/limits.md, "A
+  # machine's route out"), so a package step cannot complete: under a runtime,
+  # cloud-init ends in `status: error` on every machine that declares one, in a
+  # journal inside the guest that nobody opens. A stack declares what its
+  # environment can hold — this user data exercises the same delivery path,
+  # with steps that succeed offline.
   cloud_init = <<-EOT
     #cloud-config
-    package_update: true
-    packages:
-      - fail2ban
+    write_files:
+      - path: /etc/motd
+        content: |
+          platform bastion — access is logged
+    runcmd:
+      - [sh, -c, "touch /var/lib/platform-bastion-ready"]
   EOT
 }
 
@@ -348,11 +358,18 @@ resource "scaleway_instance_server" "web" {
   additional_volume_ids = [scaleway_instance_volume.web_data[count.index].id]
   tags                  = ["platform", "web"]
 
+  # No `packages:` for the same reason as the bastion (#507): no route out on a
+  # routed NIC, so `nginx` could never install. The web tier still gets a real
+  # listener on 80 — python3 is guaranteed wherever cloud-init runs, since
+  # cloud-init is python.
   cloud_init = <<-EOT
     #cloud-config
-    package_update: true
-    packages:
-      - nginx
+    write_files:
+      - path: /var/www/html/index.html
+        content: |
+          <h1>platform web</h1>
+    runcmd:
+      - [systemd-run, --unit=platform-web, --working-directory=/var/www/html, python3, -m, http.server, "80"]
   EOT
 }
 

--- a/internal/core/machine/binding.go
+++ b/internal/core/machine/binding.go
@@ -276,6 +276,26 @@ func (b Binding) Start(ctx context.Context, boot Boot) Started {
 		userData = rendered
 	}
 
+	// A client cloud-config that declares a package step cannot complete on a
+	// machine booting with no emulated network under it: such a machine
+	// carries only what its provider's API publishes — a routed public
+	// address with no NAT and no resolver, or no interface at all (#202) — so
+	// `packages:` dies on "Temporary failure resolving" and cloud-init
+	// finishes in `status: error`, in a journal inside the guest that nobody
+	// opens (#507). Measured both ways on 2026-08-26: the same cloud-config
+	// ends `error` on a routed machine and `done` — package installed,
+	// listening — on a machine whose network has NAT. Said here, in the shared
+	// layer, so every pack's operator reads it in the emulator's log instead
+	// of diagnosing a healthy-looking machine; the boot itself proceeds,
+	// because everything else about the machine works.
+	// TestAPackageStepWithNoRouteOutIsSaidOutLoud fails without this.
+	if _, metadataOnly := b.Driver.(Noop); !metadataOnly &&
+		boot.CloudInit != "" && len(boot.Attachments) == 0 && declaresPackageStep(boot.CloudInit) {
+		b.logger().Warn("this machine's user data declares a package step it cannot complete",
+			"provider", b.Provider, "resource", boot.ID, "machine", name,
+			"consequence", "the machine boots with no emulated network under it, so it has no route to a package repository and no resolver; cloud-init will finish in `status: error` on package_update_upgrade_install (docs/limits.md, #507)")
+	}
+
 	labels := map[string]string{LabelKey: b.Provider}
 	for k, v := range boot.Labels {
 		labels[k] = v
@@ -507,4 +527,39 @@ func (b Binding) RefreshIfRunning(ctx context.Context, res *resource.Resource) b
 // does not call it at all, when its API declares none.
 func (b Binding) AddressOf(res *resource.Resource) string {
 	return res.Runtime[b.AddressKey]
+}
+
+// declaresPackageStep reports whether a client's user data asks cloud-init for
+// a package install or update — the one step that needs a route out of the
+// machine (#507).
+//
+// Deliberately a line scan, not a YAML parse: the value is untrusted client
+// input, this answer only gates a warning, and a parser here would be a second
+// place that interprets cloud-config (the first being cloud-init itself).
+// Top-level keys only, so a `packages:` nested under `write_files` content
+// does not trigger it; anything that is not a #cloud-config document — a shell
+// script, a MIME archive — answers false, because the packages semantics
+// belong to cloud-config alone.
+func declaresPackageStep(userData string) bool {
+	if !strings.HasPrefix(strings.TrimSpace(userData), "#cloud-config") {
+		return false
+	}
+	for line := range strings.SplitSeq(userData, "\n") {
+		key, value, found := strings.Cut(line, ":")
+		if !found {
+			continue
+		}
+		// The key is compared raw, indentation included: an indented
+		// "packages:" belongs to something nested — a write_files body, a
+		// list item — and must not count as the module's own directive.
+		switch key {
+		case "packages":
+			return true
+		case "package_update", "package_upgrade":
+			if strings.TrimSpace(value) == "true" {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/internal/core/machine/binding_boot_test.go
+++ b/internal/core/machine/binding_boot_test.go
@@ -290,3 +290,81 @@ func TestTheBootRefusalNamesTheGesturesThatUnblock(t *testing.T) {
 		}
 	}
 }
+
+// A client cloud-config that declares a package step cannot complete on a
+// machine booting with no emulated network under it (#507): no NAT, no
+// resolver, no route to a package repository (#202). The guest's own journal
+// is the only place cloud-init reports the resulting `status: error`, and
+// nobody opens it — so the shared layer says it in the emulator's log, once,
+// at boot. Both halves are asserted: the shapes that must warn, and the shapes
+// that must not, because a warning that fires for every machine is one nobody
+// reads either.
+func TestAPackageStepWithNoRouteOutIsSaidOutLoud(t *testing.T) {
+	const packagesConfig = "#cloud-config\npackage_update: true\npackages:\n  - nginx\n"
+	cases := map[string]struct {
+		boot Boot
+		warn bool
+	}{
+		"packages on a routed machine": {
+			boot: Boot{Image: "ubuntu:22.04", Requested: "ubuntu_jammy", CloudInit: packagesConfig,
+				PublicAddresses: []string{"203.0.113.9"}},
+			warn: true,
+		},
+		"package_update alone on a routed machine": {
+			boot: Boot{Image: "ubuntu:22.04", Requested: "ubuntu_jammy",
+				CloudInit: "#cloud-config\npackage_update: true\n"},
+			warn: true,
+		},
+		"packages on a machine with an emulated network": {
+			boot: Boot{Image: "ubuntu:22.04", Requested: "ubuntu_jammy", CloudInit: packagesConfig,
+				Attachments: []Attachment{{Network: "fnt-sub1"}}},
+			warn: false,
+		},
+		"a shell script whose heredoc carries a column-zero packages line": {
+			boot: Boot{Image: "ubuntu:22.04", Requested: "ubuntu_jammy",
+				CloudInit: "#!/bin/sh\ncat > /tmp/x <<'E'\npackages:\n  - nginx\nE\n"},
+			warn: false,
+		},
+		"packages indented inside write_files content": {
+			boot: Boot{Image: "ubuntu:22.04", Requested: "ubuntu_jammy",
+				CloudInit: "#cloud-config\nwrite_files:\n  - path: /etc/x\n    content: |\n      packages:\n"},
+			warn: false,
+		},
+		"package_update declared false": {
+			boot: Boot{Image: "ubuntu:22.04", Requested: "ubuntu_jammy",
+				CloudInit: "#cloud-config\npackage_update: false\n"},
+			warn: false,
+		},
+		"no client user data at all": {
+			boot: Boot{Image: "ubuntu:22.04", Requested: "ubuntu_jammy",
+				AuthorizedKeys: []string{"ssh-ed25519 AAAA test"}},
+			warn: false,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			driver := &recordingDriver{}
+			b := bootBinding(driver)
+			var log bytes.Buffer
+			b.Log = slog.New(slog.NewTextHandler(&log, nil))
+			res := &resource.Resource{ID: "srv-1", State: "stopped"}
+			if !b.PowerOn(context.Background(), res, tc.boot) {
+				t.Fatal("the boot itself must proceed: the limit degrades the guest, not the control plane")
+			}
+			said := strings.Contains(log.String(), "package step it cannot complete")
+			if said != tc.warn {
+				t.Fatalf("warned=%v, want %v; log:\n%s", said, tc.warn, log.String())
+			}
+		})
+	}
+
+	// And never with a metadata-only runtime: nothing boots, so nothing fails.
+	b := bootBinding(Noop{})
+	var log bytes.Buffer
+	b.Log = slog.New(slog.NewTextHandler(&log, nil))
+	res := &resource.Resource{ID: "srv-1", State: "stopped"}
+	b.PowerOn(context.Background(), res, Boot{Requested: "ubuntu_jammy", CloudInit: packagesConfig})
+	if strings.Contains(log.String(), "package step") {
+		t.Fatalf("a metadata-only boot warned about a machine that does not exist; log:\n%s", log.String())
+	}
+}

--- a/internal/providers/outscale/isolate.go
+++ b/internal/providers/outscale/isolate.go
@@ -28,11 +28,49 @@ import (
 //
 // TestSubnetsOfOtherNetsAreForeign fails without this.
 
-// reachableFrom reports whether one subnet may reach another: same Net, and
-// nothing else. Net peerings widen this, and they do it through PeerNetworks
-// rather than here, so a peering that is only pending grants nothing.
-func (p *Pack) reachableFrom(subnet, other *resource.Resource) bool {
-	return stringOf(subnet.Attrs["NetId"]) == stringOf(other.Attrs["NetId"])
+// reachableFrom reports whether one subnet may reach another: same Net, or a
+// Net an *active* peering joins to its own — a peering "works both ways" (SDK
+// doc), whoever requested it, and one that is only pending grants nothing.
+//
+// Both truths live in this one predicate on purpose. An earlier version kept
+// the peering half in a second writer (reconcilePeerings) beside this one, and
+// machine.PeerNetworks reconciles rather than appends: whichever writer ran
+// last erased the other's declaration, so an ordinary CreateSubnet in a peered
+// Net severed the active peering at the runtime and the newborn subnet never
+// joined it (#508). One predicate, one writer, and the last pass is always
+// right because every pass states the whole truth.
+//
+// TestACreateSubnetDoesNotSeverAnActivePeering fails without the peering half.
+func (p *Pack) reachableFrom(subnet, other *resource.Resource, peered netReachability) bool {
+	a := stringOf(subnet.Attrs["NetId"])
+	b := stringOf(other.Attrs["NetId"])
+	return a == b || peered[a][b]
+}
+
+// netReachability says which Nets reach which through active peerings, in both
+// directions. Built once per reconciliation pass rather than queried per pair:
+// the predicate runs O(N²) times over the subnets and must not scan the store
+// each time.
+type netReachability map[string]map[string]bool
+
+func (p *Pack) activePeeringReaches() netReachability {
+	reaches := netReachability{}
+	join := func(a, b string) {
+		if reaches[a] == nil {
+			reaches[a] = map[string]bool{}
+		}
+		reaches[a][b] = true
+	}
+	for _, pcx := range p.env.Store.List(kindNetPeering, resource.Tenant{Provider: Name}) {
+		if pcx.State != statePeeringActive {
+			continue
+		}
+		source := stringOf(pcx.Attrs["SourceNetId"])
+		accepter := stringOf(pcx.Attrs["AccepterNetId"])
+		join(source, accepter)
+		join(accepter, source)
+	}
+	return reaches
 }
 
 // isolateNetworks reconciles what every subnet's backing network may reach.
@@ -64,6 +102,7 @@ func (p *Pack) isolateNetworks(ctx context.Context) {
 // runs. Only the Coalescer calls it.
 func (p *Pack) isolationPass(ctx context.Context) {
 	all := p.env.Store.List(kindSubnet, resource.Tenant{Provider: Name})
+	peered := p.activePeeringReaches()
 	members := make([]machine.IsolationMember, len(all))
 	for i, subnet := range all {
 		members[i] = machine.IsolationMember{
@@ -73,5 +112,5 @@ func (p *Pack) isolationPass(ctx context.Context) {
 		}
 	}
 	machine.ReconcileIsolation(ctx, p.env.Machines, p.logger(), "subnet",
-		members, func(from, to int) bool { return p.reachableFrom(all[from], all[to]) })
+		members, func(from, to int) bool { return p.reachableFrom(all[from], all[to], peered) })
 }

--- a/internal/providers/outscale/isolate_test.go
+++ b/internal/providers/outscale/isolate_test.go
@@ -34,18 +34,30 @@ func TestSubnetsOfOtherNetsAreForeign(t *testing.T) {
 	b := subnet("subnet-2", "vpc-a")
 	c := subnet("subnet-3", "vpc-b")
 
-	if !p.reachableFrom(a, b) {
+	if !p.reachableFrom(a, b, nil) {
 		t.Error("two subnets of one Net were treated as foreign; the real cloud routes between them")
 	}
-	if p.reachableFrom(a, c) {
+	if p.reachableFrom(a, c, nil) {
 		t.Error("a subnet of another Net was treated as reachable, which is the leak this closes")
 	}
 	// A subnet with no Net at all must not be reachable by accident: an absent
 	// value is not a match, and treating two empties as equal would join every
 	// malformed record to every other.
 	empty := subnet("subnet-4", "")
-	if p.reachableFrom(a, empty) {
+	if p.reachableFrom(a, empty, nil) {
 		t.Error("a subnet naming no Net was treated as reachable from one that does")
+	}
+
+	// An active peering is the one thing that widens the answer (#508), and it
+	// widens it in both directions — activePeeringReaches records both — while
+	// leaving every unpeered pair exactly as foreign as before.
+	peered := netReachability{"vpc-a": {"vpc-b": true}, "vpc-b": {"vpc-a": true}}
+	if !p.reachableFrom(a, c, peered) || !p.reachableFrom(c, a, peered) {
+		t.Error("an active peering between the two Nets did not make their subnets reachable")
+	}
+	d := subnet("subnet-5", "vpc-c")
+	if p.reachableFrom(a, d, peered) {
+		t.Error("a peering between vpc-a and vpc-b leaked reachability towards vpc-c")
 	}
 }
 

--- a/internal/providers/outscale/netpeerings.go
+++ b/internal/providers/outscale/netpeerings.go
@@ -1,13 +1,11 @@
 package outscale
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"time"
 
 	"github.com/stephrobert/feint/internal/core/emulator"
-	"github.com/stephrobert/feint/internal/core/machine"
 	"github.com/stephrobert/feint/internal/core/resource"
 )
 
@@ -249,8 +247,11 @@ func (p *Pack) acceptNetPeering(w http.ResponseWriter, r *http.Request) {
 	// The reachability the acceptance granted, on the runtime, outside any
 	// lock: the store already says active, and a failing runtime degrades the
 	// data plane without taking the control plane down (same policy as the
-	// sibling packs' reconcilers, vpc.go and privatenetworks.go).
-	p.reconcilePeerings(r.Context())
+	// sibling packs' reconcilers, vpc.go and privatenetworks.go). The same
+	// reconciliation as a subnet create, because reachability has one writer:
+	// a second one dedicated to peerings erased the subnet writer's truth and
+	// vice versa, whichever ran last (#508).
+	p.isolateNetworks(r.Context())
 
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{
 		"NetPeering":      netPeeringView(res),
@@ -327,8 +328,9 @@ func (p *Pack) deleteNetPeering(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Whatever reachability the peering granted goes with it.
-	p.reconcilePeerings(r.Context())
+	// Whatever reachability the peering granted goes with it — through the one
+	// writer, so nothing else's truth is erased on the way (#508).
+	p.isolateNetworks(r.Context())
 
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{"ResponseContext": p.context()})
 }
@@ -414,68 +416,14 @@ func (p *Pack) activePeeringBetween(sourceID, accepterID string) bool {
 	return false
 }
 
-// reconcilePeerings makes the runtime reachability match the store: every
-// subnet's backing network is peered with the backing networks of every subnet
-// of every Net an *active* peering joins to its own — and with nothing else,
-// because machine.PeerNetworks reconciles rather than appends, so a deleted
-// peering separates the Nets again on the same call.
-//
-// Only a runtime whose networks are born separate has anything to do here. On
-// a Peerer with native isolation (OVN) the peering is what joins two Nets; on
-// bridges nothing was ever separated, which is exactly the bridge-mode limit
-// docs/limits.md records — a suite must gate on `capabilities.isolation`, and
-// no document says "peered" without naming the mode.
-//
-// Errors are logged, not answered: the store is committed by the time this
-// runs, and a runtime failure degrades the data plane without taking the
-// control plane down (the same policy as vpc.go's isolateNetworks).
-func (p *Pack) reconcilePeerings(ctx context.Context) {
-	peerer, ok := p.env.Machines.(machine.Peerer)
-	if !ok || !peerer.NativeIsolation() {
-		return
-	}
-
-	// Which Nets each Net reaches, through active peerings, in both
-	// directions: a peering "works both ways" (SDK doc), whoever requested it.
-	reaches := map[string]map[string]bool{}
-	join := func(a, b string) {
-		if reaches[a] == nil {
-			reaches[a] = map[string]bool{}
-		}
-		reaches[a][b] = true
-	}
-	for _, pcx := range p.env.Store.List(kindNetPeering, resource.Tenant{Provider: Name}) {
-		if pcx.State != statePeeringActive {
-			continue
-		}
-		source := stringOf(pcx.Attrs["SourceNetId"])
-		accepter := stringOf(pcx.Attrs["AccepterNetId"])
-		join(source, accepter)
-		join(accepter, source)
-	}
-
-	// The backing networks per Net, from the runtime name each subnet carries.
-	backing := map[string][]string{}
-	subnets := p.env.Store.List(kindSubnet, resource.Tenant{Provider: Name})
-	for _, subnet := range subnets {
-		if name := subnet.Runtime[runtimeNetworkKey]; name != "" {
-			netID := stringOf(subnet.Attrs["NetId"])
-			backing[netID] = append(backing[netID], name)
-		}
-	}
-
-	for _, subnet := range subnets {
-		name := subnet.Runtime[runtimeNetworkKey]
-		if name == "" {
-			continue
-		}
-		peers := make([]string, 0, 4)
-		for peerNet := range reaches[stringOf(subnet.Attrs["NetId"])] {
-			peers = append(peers, backing[peerNet]...)
-		}
-		if err := peerer.PeerNetworks(ctx, name, peers); err != nil {
-			p.logger().Error("could not reconcile the peering of a subnet's network",
-				"subnet", subnet.ID, "network", name, "error", err)
-		}
-	}
-}
+// The runtime half of a peering transition is isolateNetworks, the same
+// reconciliation a subnet create or delete runs. There used to be a dedicated
+// reconciler here, computing peers from the active peerings alone, while
+// isolateNetworks computed them from Net membership alone — two writers of one
+// runtime state, each stating a partial truth, and machine.PeerNetworks
+// reconciles rather than appends, so whichever ran last erased the other's
+// half: an ordinary CreateSubnet in a peered Net severed the active peering,
+// and the newborn subnet never joined it (#508). The active-peering half now
+// lives in the shared predicate (reachableFrom, isolate.go), which is the
+// widening CLAUDE.md's "Factoriser" section prescribes — the abstraction
+// grows, the pack does not grow a second writer beside it.

--- a/internal/providers/outscale/netpeerings_test.go
+++ b/internal/providers/outscale/netpeerings_test.go
@@ -429,3 +429,80 @@ func TestAnAcceptedPeeringPeersTheBackingNetworks(t *testing.T) {
 		t.Fatalf("after delete, %s still peers with %v", networkB, got)
 	}
 }
+
+// TestACreateSubnetDoesNotSeverAnActivePeering is the audit witness of #508.
+//
+// Two Nets, one subnet each, a peering accepted: both backing networks peer.
+// Then one ordinary CreateSubnet in the source Net. Before the fix, two
+// reconcilers wrote this runtime state with two different truths — the
+// subnet-side pass knew "same Net, and nothing else", the peering-side pass
+// knew "active peering" — and machine.PeerNetworks reconciles rather than
+// appends, so the subnet create's pass severed the active peering of the
+// existing subnet, and the newborn subnet never joined it. Both properties
+// are asserted on the recorder, and the negative control matters as much: a
+// third, unpeered Net goes through the same sequence and stays out of every
+// peer list.
+func TestACreateSubnetDoesNotSeverAnActivePeering(t *testing.T) {
+	env := emulator.DefaultEnv()
+	rt := newPeererRuntime()
+	env.Machines = rt
+	srv, err := emulator.NewServer(env, outscale.New(env))
+	if err != nil {
+		t.Fatalf("build emulator: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	netA, subnetA := netAndSubnet(t, ts, "10.60.0.0/16", "10.60.1.0/24")
+	netB, subnetB := netAndSubnet(t, ts, "10.61.0.0/16", "10.61.1.0/24")
+	_, subnetC := netAndSubnet(t, ts, "10.62.0.0/16", "10.62.1.0/24")
+	networkA := machine.NetworkName(machine.NetworkPrefix, subnetA)
+	networkB := machine.NetworkName(machine.NetworkPrefix, subnetB)
+	networkC := machine.NetworkName(machine.NetworkPrefix, subnetC)
+
+	_, out := post(t, ts, "CreateNetPeering", `{"SourceNetId":"`+netA+`","AccepterNetId":"`+netB+`"}`)
+	id, _ := peeringOf(t, out)["NetPeeringId"].(string)
+
+	// A pass that runs while the peering is only pending must not grant it:
+	// the predicate counts *active* peerings and nothing weaker. The probe
+	// subnet is what forces a pass to run at exactly that moment.
+	post(t, ts, "CreateSubnet", `{"NetId":"`+netA+`","IpRange":"10.60.3.0/24"}`)
+	if got := rt.peersOf(networkA); has(got, networkB) {
+		t.Fatalf("a subnet create while the peering is pending-acceptance granted it: %s peers with %v", networkA, got)
+	}
+
+	post(t, ts, "AcceptNetPeering", `{"NetPeeringId":"`+id+`"}`)
+	if got := rt.peersOf(networkA); !has(got, networkB) {
+		t.Fatalf("after accept, %s peers with %v, want %s; nothing after this measures the subnet create", networkA, got, networkB)
+	}
+
+	// The ordinary create the issue names, in the Net the peering joins.
+	_, out = post(t, ts, "CreateSubnet", `{"NetId":"`+netA+`","IpRange":"10.60.2.0/24"}`)
+	s, _ := out["Subnet"].(map[string]any)
+	newborn, _ := s["SubnetId"].(string)
+	if newborn == "" {
+		t.Fatalf("CreateSubnet answered no SubnetId: %v", out)
+	}
+	networkNew := machine.NetworkName(machine.NetworkPrefix, newborn)
+
+	if got := rt.peersOf(networkA); !has(got, networkB) {
+		t.Fatalf("an ordinary CreateSubnet in %s severed the active peering: %s peers with %v and no longer with %s", netA, networkA, got, networkB)
+	}
+	if got := rt.peersOf(networkNew); !has(got, networkB) {
+		t.Fatalf("the newborn subnet never joined the active peering: %s peers with %v, want %s", networkNew, got, networkB)
+	}
+	if got := rt.peersOf(networkB); !has(got, networkA) || !has(got, networkNew) {
+		t.Fatalf("the far side does not name both subnets of the peered Net: %s peers with %v", networkB, got)
+	}
+
+	// The widening must not leak: the unpeered Net reaches nobody and nobody
+	// reaches it, through the exact same sequence.
+	if got := rt.peersOf(networkC); len(got) != 0 {
+		t.Fatalf("the unpeered Net's subnet gained peers: %s peers with %v", networkC, got)
+	}
+	for _, network := range []string{networkA, networkNew, networkB} {
+		if has(rt.peersOf(network), networkC) {
+			t.Fatalf("%s peers with the unpeered Net's %s", network, networkC)
+		}
+	}
+}

--- a/internal/providers/outscale/nets.go
+++ b/internal/providers/outscale/nets.go
@@ -369,7 +369,11 @@ func (p *Pack) createSubnet(w http.ResponseWriter, r *http.Request) {
 
 	// What each subnet may reach changed, so every rule set is reconciled. That
 	// includes a subnet born into a Net an active peering already joins: it must
-	// reach the peer's subnets from the start, not from the next transition.
+	// reach the peer's subnets from the start, not from the next transition —
+	// and the pass must not sever what the peering granted the Net's other
+	// subnets, which is what happened while a second writer held the peering
+	// half of the truth (#508).
+	// TestACreateSubnetDoesNotSeverAnActivePeering fails without both halves.
 	p.isolateNetworks(r.Context())
 
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{

--- a/tools/conformance/outscale/network.sh
+++ b/tools/conformance/outscale/network.sh
@@ -114,8 +114,10 @@ net_id=""
 sub_id=""
 vm_a=""
 vm_b=""
+born_vm=""
 sub_a=""
 sub_b=""
+born_sub=""
 net_a=""
 net_b=""
 # Delete through the API, which is what removes the backing network. Killing the
@@ -123,10 +125,12 @@ net_b=""
 cleanup() {
   [ -n "$vm_a" ] && osc DeleteVms --VmIds "$vm_a" >/dev/null 2>&1
   [ -n "$vm_b" ] && osc DeleteVms --VmIds "$vm_b" >/dev/null 2>&1
+  [ -n "$born_vm" ] && osc DeleteVms --VmIds "$born_vm" >/dev/null 2>&1
   sleep 2
   [ -n "$sub_id" ] && osc DeleteSubnet --SubnetId "$sub_id" >/dev/null 2>&1
   [ -n "$sub_a" ] && osc DeleteSubnet --SubnetId "$sub_a" >/dev/null 2>&1
   [ -n "$sub_b" ] && osc DeleteSubnet --SubnetId "$sub_b" >/dev/null 2>&1
+  [ -n "$born_sub" ] && osc DeleteSubnet --SubnetId "$born_sub" >/dev/null 2>&1
   [ -n "$net_id" ] && osc DeleteNet --NetId "$net_id" >/dev/null 2>&1
   [ -n "$net_a" ] && osc DeleteNet --NetId "$net_a" >/dev/null 2>&1
   [ -n "$net_b" ] && osc DeleteNet --NetId "$net_b" >/dev/null 2>&1
@@ -320,13 +324,53 @@ sleep 2
 reach || fail "the peering is active and $vm_a still cannot reach $ip_b"
 ok "$vm_a reaches $ip_b through the active peering"
 
+# The regression #508 measured, held in the same pass as the lifecycle above:
+# two reconcilers used to write the runtime's peer state with two different
+# truths — "same Net" on every subnet transition, "active peering" on every
+# peering transition — and the runtime reconciles rather than appends, so an
+# ordinary CreateSubnet in a peered Net severed the active peering, and the
+# newborn subnet never joined it. Both halves are asserted here on packets,
+# and the deleted-peering verdict below now runs after this create, so it is
+# also the negative control: the widening must not leave anything joined once
+# the peering is gone, the newborn included.
+echo "- a Subnet created while the peering is active does not sever it (#508)"
+born_sub="$(osc CreateSubnet --NetId "$net_a" --IpRange "${PEER_BLOCK_A%.0.0/16}.3.0/24" | jq -r '.Subnet.SubnetId')"
+[ -n "$born_sub" ] || fail "CreateSubnet was refused while the peering is active"
+sleep 2
+reach || fail "an ordinary CreateSubnet in $net_a severed the active peering: $vm_a no longer reaches $ip_b (#508)"
+ok "the existing machine still reaches $ip_b after the create"
+
+echo "- a machine born in that Subnet joins the active peering (#508)"
+born_doc="$(osc CreateVms --ImageId ami-00000003 --VmType tinav6.c1r1p2 --SubnetId "$born_sub")" \
+  || fail "CreateVms rejected in $born_sub: $born_doc"
+born_vm="$(printf '%s' "$born_doc" | jq -r '.Vms[0].VmId')"
+born_ip="$(printf '%s' "$born_doc" | jq -r '.Vms[0].PrivateIp // empty')"
+[ -n "$born_ip" ] || fail "the newborn Vm came back without a PrivateIp"
+born_up=""
+for _ in $(seq 1 12); do
+  if machine_carries "feint-osc-$born_vm" "$born_ip"; then born_up="yes"; break; fi
+  sleep 2
+done
+[ -n "$born_up" ] || fail "feint-osc-$born_vm does not carry $born_ip; cannot measure the newborn's reachability"
+sleep 2
+incus exec "feint-osc-$born_vm" -- ping -c 2 -W 3 "$ip_b" >/dev/null 2>&1 \
+  || fail "the newborn Subnet's machine never joined the active peering: $born_vm cannot reach $ip_b (#508)"
+ok "$born_vm reaches $ip_b through the peering it was born into"
+
 echo "- a deleted peering separates them again"
 osc DeleteNetPeering --NetPeeringId "$pcx_id" >/dev/null || fail "DeleteNetPeering rejected"
 sleep 2
 if reach; then
   fail "the peering is deleted and the Nets still reach each other"
 fi
-ok "unreachable again"
+if incus exec "feint-osc-$born_vm" -- ping -c 2 -W 2 "$ip_b" >/dev/null 2>&1; then
+  fail "the peering is deleted and the newborn Subnet's machine still reaches $ip_b"
+fi
+ok "unreachable again, the newborn included"
+
+osc DeleteVms --VmIds "$born_vm" >/dev/null 2>&1 && born_vm=""
+sleep 3
+osc DeleteSubnet --SubnetId "$born_sub" >/dev/null 2>&1 && born_sub=""
 
 # And the accepting half, which the peering lifecycle above does not cover: a
 # rule set that kept everything out would pass every check so far and separate

--- a/tools/falsify/specs/netpeering-states.json
+++ b/tools/falsify/specs/netpeering-states.json
@@ -46,8 +46,8 @@
     {
       "label": "a deleted peering keeps carrying traffic on the runtime",
       "file": "internal/providers/outscale/netpeerings.go",
-      "find": "\t// Whatever reachability the peering granted goes with it.\n\tp.reconcilePeerings(r.Context())",
-      "replace": "\t// Whatever reachability the peering granted goes with it.\n\tif false {\n\t\tp.reconcilePeerings(r.Context())\n\t}",
+      "find": "\t// Whatever reachability the peering granted goes with it — through the one\n\t// writer, so nothing else's truth is erased on the way (#508).\n\tp.isolateNetworks(r.Context())",
+      "replace": "\t// Whatever reachability the peering granted goes with it — through the one\n\t// writer, so nothing else's truth is erased on the way (#508).\n\tif false {\n\t\tp.isolateNetworks(r.Context())\n\t}",
       "test": "TestAnAcceptedPeeringPeersTheBackingNetworks"
     }
   ]

--- a/tools/falsify/specs/one-reachability-writer.json
+++ b/tools/falsify/specs/one-reachability-writer.json
@@ -1,0 +1,26 @@
+{
+  "package": "./internal/providers/outscale/",
+  "mutations": [
+    {
+      "label": "the predicate loses its peering half, so the subnet-side pass severs an active peering and the newborn never joins it (#508)",
+      "file": "internal/providers/outscale/isolate.go",
+      "find": "\treturn a == b || peered[a][b]",
+      "replace": "\treturn a == b || (peered[a][b] && false)",
+      "test": "TestACreateSubnetDoesNotSeverAnActivePeering"
+    },
+    {
+      "label": "a pending peering already grants reachability, so a request joins two Nets nobody accepted (#508)",
+      "file": "internal/providers/outscale/isolate.go",
+      "find": "\t\tif pcx.State != statePeeringActive {\n\t\t\tcontinue\n\t\t}",
+      "replace": "\t\tif pcx.State != statePeeringActive && false {\n\t\t\tcontinue\n\t\t}",
+      "test": "TestACreateSubnetDoesNotSeverAnActivePeering"
+    },
+    {
+      "label": "accepting a peering no longer reconciles the runtime, so the acceptance grants nothing until an unrelated subnet moves (#508)",
+      "file": "internal/providers/outscale/netpeerings.go",
+      "find": "\t// a second one dedicated to peerings erased the subnet writer's truth and\n\t// vice versa, whichever ran last (#508).\n\tp.isolateNetworks(r.Context())",
+      "replace": "\t// a second one dedicated to peerings erased the subnet writer's truth and\n\t// vice versa, whichever ran last (#508).\n\tif false {\n\t\tp.isolateNetworks(r.Context())\n\t}",
+      "test": "TestAnAcceptedPeeringPeersTheBackingNetworks"
+    }
+  ]
+}

--- a/tools/falsify/specs/unroutable-package-step.json
+++ b/tools/falsify/specs/unroutable-package-step.json
@@ -1,0 +1,26 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "the package-step warning never fires, and a stack's packages: dies in a guest journal nobody opens (#507)",
+      "file": "internal/core/machine/binding.go",
+      "find": "\tif _, metadataOnly := b.Driver.(Noop); !metadataOnly &&\n\t\tboot.CloudInit != \"\" && len(boot.Attachments) == 0 && declaresPackageStep(boot.CloudInit) {",
+      "replace": "\tif _, metadataOnly := b.Driver.(Noop); !metadataOnly &&\n\t\tboot.CloudInit != \"\" && len(boot.Attachments) == 0 && declaresPackageStep(boot.CloudInit) && false {",
+      "test": "TestAPackageStepWithNoRouteOutIsSaidOutLoud"
+    },
+    {
+      "label": "the scan warns on user data that is not cloud-config at all, and the warning becomes noise nobody reads (#507)",
+      "file": "internal/core/machine/binding.go",
+      "find": "\tif !strings.HasPrefix(strings.TrimSpace(userData), \"#cloud-config\") {\n\t\treturn false\n\t}",
+      "replace": "\tif !strings.HasPrefix(strings.TrimSpace(userData), \"#cloud-config\") && false {\n\t\treturn false\n\t}",
+      "test": "TestAPackageStepWithNoRouteOutIsSaidOutLoud"
+    },
+    {
+      "label": "an indented key counts as top-level, so a packages: inside a write_files body triggers the warning (#507)",
+      "file": "internal/core/machine/binding.go",
+      "find": "\t\t// The key is compared raw, indentation included: an indented\n\t\t// \"packages:\" belongs to something nested — a write_files body, a\n\t\t// list item — and must not count as the module's own directive.\n\t\tswitch key {",
+      "replace": "\t\t// The key is compared raw, indentation included: an indented\n\t\t// \"packages:\" belongs to something nested — a write_files body, a\n\t\t// list item — and must not count as the module's own directive.\n\t\tswitch strings.TrimSpace(key) {",
+      "test": "TestAPackageStepWithNoRouteOutIsSaidOutLoud"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #507. Closes #508.

Two defects about what is reachable: one where two writers disagreed about a
peering, and one where no machine could reach a package repository and nothing
said so.

## #508 — reachability gets one writer

`isolateNetworks` carried the predicate *"same Net, and nothing else"*, and
`reconcilePeerings` carried *"accepted peering"*. Both called `PeerNetworks`,
which reconciles the **whole** state, so the last writer erased the other's
truth. Measured consequence: after an `AcceptNetPeering`, creating a subnet in
Net A **severed** the existing subnet's peering, and the newborn never joined
it. The comment at `nets.go:370-373` promised exactly the property the code
contradicted.

`reachableFrom` now answers *"same Net **or** active peering, in both
directions"* from a table computed once per pass, and **`reconcilePeerings` is
deleted** — not coordinated with, deleted. Both peering transitions call
`isolateNetworks`, the single writer. A concurrency defect with one of its two
sources removed is fixed; one whose two sources are synchronised comes back.

**The host witness, in one pass of `tools/conformance/outscale/network.sh`
under OVN:**

```
- before any peering, the Nets do not reach each other
- a pending peering grants nothing
- an accepted peering carries traffic       ok: i-7b4665b2 reaches 10.184.1.4
- a Subnet created while the peering is active does not sever it (#508)
- a machine born in that Subnet joins the active peering (#508)
                                            ok: i-265de083 reaches 10.184.1.4
- a deleted peering separates them again    ok: unreachable again, the newborn included
```

The last line is what makes it a measurement: a reachability that cannot be
made to stop proves nothing. Unit witness
`TestACreateSubnetDoesNotSeverAnActivePeering` through the `peererRuntime`
recorder, new spec `one-reachability-writer.json` (3 mutations, all bite), and
`netpeering-states.json` retargeted onto the fragment that moved.

## #507 — the bound is the NIC's shape, and it was measured rather than deduced

The issue reported it as *deduced* from #202. It is now measured, by changing
one variable: same station, same emulator, same cloud-config
(`package_update` + nginx), one minute apart.

| primary NIC | cloud-init | outbound | port 80 |
|---|---|---|---|
| **routed** (Scaleway server with a public IP) | `status: error` | none, no resolver | never listening |
| **NATed network** (Outscale Vm on `fnt-default`) | `status: done` | works, DNS works | **listening, nginx really installed** |

Port 22 was OPEN on the routed machines throughout, as the positive control —
without it, "port 80 closed" would have measured the reader.

**Station and CI runner do not disagree.** Both comments in
`runtime-proof.yml` describe the same frontier from its two sides: NATed traffic
crossing `FORWARD`, and #335's five red nights on the routed form. No CI leg
starts a machine declaring `packages:`. One bound, two shapes, not two verdicts.

### The decision: no NAT for the routed form

It would reverse #202 — a measured and tested decision — and require masquerade
rules outside everything Incus manages, plus a resolver, on an interface
`firewall_public_only` already documents as unfiltered. The boundary that would
make it clean is #514, at the 0.12.0 milestone. Adding plumbing outside the
runtime's own management to work around a declared limit is the bypass this
repository has just spent a day forbidding.

What ships instead, so the failure stops being silent:

- **`Binding.Start` warns in the shared layer** when a client cloud-config
  declares a package step on a machine with no emulated network — so all three
  packs, not one. Seven cases tested, 3 falsification mutations biting, verified
  live in `feint.log`.
- **The three stacks stop declaring `packages:`** — the web tier keeps a real
  listener on :80 through python, so the shape being measured is unchanged.
- **`docs/limits.md` gains "A machine's route out"**, carrying the differential
  table above rather than a claim.

The falsification spec for the warning is worth a line: two of its first three
mutations **did not bite** — a shell case in column zero, and a dead indentation
clause because the switch compared the raw key. The test was hardened, the dead
clause removed, the mutation retargeted. Without the harness, a guard would have
shipped guarding nothing.

## Gates

`check`, `go test ./... -race` (exit read directly, not through a pipe),
`prepush`, `docs:check`, `falsify:lint` (671 mutations / 115 specs) all 0.
`FEINT_VM=incus-ovn mise run conformance` **exit 0**, ten suites.

Stacks under `feint up --runtime incus-ovn`: Scaleway 6 machines all `done`,
three `scw-*` sets over six references; Outscale 3 machines `done`, two `osc-*`
sets, 1+2 — **reference values unchanged**. Empty second plans, clean destroys,
nil station delta. `falsify:all` was not run, deliberately: 655 mutations at one
tree copy each, which `mise.toml` keeps nightly rather than per pull request.

Residue and noise met on the way were matched to open issues rather than filed
again: the uplink leftover is #521, the `scw` balancer panic is #505.
