### PR TITLE
feat(machine): one shared contract recorder names every runtime gesture, and one intent replays as three sequences instead of one (#515)

### DIFF
--- a/internal/core/machine/recorder.go
+++ b/internal/core/machine/recorder.go
@@ -1,0 +1,316 @@
+package machine
+
+import (
+	"context"
+	"sync"
+)
+
+// The shared contract recorder (#515).
+//
+// The repository proves argv-level facts through the injectable Incus runner,
+// and contract-level facts through per-suite, unexported fakes — fifteen-plus
+// of them, each seeing one suite's slice of the driver. None of them can state
+// a property across packs, and it was one of those homemade recorders that
+// found #508's severed peering, which is the measure of what recording the
+// sequence is worth. This file is that recorder written once, in the machine
+// package's own vocabulary, so a property like "the same intent produces the
+// same runtime sequence whatever the pack" becomes statable at all.
+//
+// Two disciplines, both held by tests rather than by this comment:
+//
+//   - the vocabulary below is closed, and TestTheContractNamesEveryGesture
+//     holds it against the driver interfaces in both directions: a gesture the
+//     contract cannot name is a violation, and a name the interfaces no longer
+//     carry is fiction;
+//   - the detector for a gesture outside the vocabulary is proven able to find
+//     one — TestAPlantedUnknownGestureIsReported plants one — because a control
+//     that looks for absence and never found anything is indistinguishable
+//     from a control that looked nowhere.
+
+// Gesture is one contract-level call a pack asked of the runtime. (Event was
+// the natural name and is already taken by the watcher's type in watch.go;
+// gesture is the word #514 uses for exactly this.)
+type Gesture struct {
+	// Kind names the gesture: the Driver (or optional-half) method that was
+	// called. It must be a key of the contract vocabulary.
+	Kind string
+	// Resource is what the gesture acted on — the machine, network, rule set
+	// or balancer it names, or the address for the routing pair.
+	Resource string
+	// Args carries the full argument, for the assertions that need more than
+	// the name: the boot Spec, the NetworkSpec, the FirewallSpec, and so on.
+	Args any
+}
+
+// contractGestures is the closed vocabulary of the driver contract: every
+// method of Driver and its optional halves (Router, Firewaller, Peerer,
+// Isolator, Balancer, Capable), and nothing else. The value says whether the
+// gesture changes the host: true is a gesture the Recorder records, false is a
+// read, deliberately left out of the recording — a read changes nothing on the
+// host, and packs legitimately differ in how often they look.
+//
+// This list is the service list of #514 §1 at driver level. A method added to
+// an interface without a row here fails TestTheContractNamesEveryGesture; a
+// row without a method fails it the other way.
+var contractGestures = map[string]bool{
+	// Driver.
+	"Name":          false,
+	"Available":     false,
+	"Start":         true,
+	"Stop":          true,
+	"Remove":        true,
+	"Inspect":       false,
+	"EnsureNetwork": true,
+	"Attach":        true,
+	"Detach":        true,
+	"RemoveNetwork": true,
+	// Router.
+	"RouteAddress":   true,
+	"UnrouteAddress": true,
+	// Firewaller.
+	"EnsureFirewall": true,
+	"ApplyFirewall":  true,
+	"RemoveFirewall": true,
+	// Peerer.
+	"NativeIsolation": false,
+	"PeerNetworks":    true,
+	// Isolator.
+	"IsolateNetwork": true,
+	// Balancer.
+	"EnsureBalancer": true,
+	"RemoveBalancer": true,
+	// Capable.
+	"Capabilities": false,
+}
+
+// KnownGesture reports whether the contract can name this gesture. An event
+// whose Kind it refuses is what Recorder.OutsideContract returns.
+func KnownGesture(kind string) bool {
+	_, known := contractGestures[kind]
+	return known
+}
+
+// Recorder is the shared fake runtime: it implements Driver and every optional
+// half, runs machines instantly, and records each host-changing gesture as a
+// typed Gesture, in call order.
+//
+// It exists for the properties no per-suite fake can state — the same intent
+// produces the same runtime sequence in every pack, and no pack asks the
+// runtime a gesture outside the contract. A suite asserting a driver-internal
+// fact keeps its own fake; nothing forces a migration.
+//
+// Safe for concurrent use, like the contract it implements.
+type Recorder struct {
+	// Joined declares the runtime's networks born joined, the bridge shape:
+	// NativeIsolation answers false and packs take their Isolator path. The
+	// zero value is the OVN shape — networks born separate, joined by peering —
+	// because that is the mode the stack replays run under and the only one
+	// that delivers isolation.
+	Joined bool
+
+	mu       sync.Mutex
+	events   []Gesture
+	machines map[string]recordedMachine
+}
+
+// recordedMachine is what the Recorder holds for one started machine.
+type recordedMachine struct {
+	ip      string
+	running bool
+}
+
+// NewRecorder returns a Recorder ready to stand behind an emulator.Env.
+func NewRecorder() *Recorder {
+	return &Recorder{machines: map[string]recordedMachine{}}
+}
+
+// Record appends one gesture. It is the seam every gesture below goes through,
+// and it is exported on purpose: a positive control plants a gesture the
+// vocabulary cannot name and requires OutsideContract to report it, because an
+// unknown-gesture detector that never found one proves nothing.
+func (r *Recorder) Record(g Gesture) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, g)
+}
+
+// Events returns every recorded gesture, in call order.
+func (r *Recorder) Events() []Gesture {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]Gesture(nil), r.events...)
+}
+
+// Sequence returns the recorded gesture kinds, in call order. It is the value
+// the cross-pack equivalence property compares: same intent, same sequence.
+func (r *Recorder) Sequence() []string {
+	events := r.Events()
+	kinds := make([]string, 0, len(events))
+	for _, e := range events {
+		kinds = append(kinds, e.Kind)
+	}
+	return kinds
+}
+
+// OutsideContract returns the recorded gestures whose Kind the contract cannot
+// name. A non-empty answer is a contract violation: a gesture reached the
+// runtime that the service list of #514 does not know.
+func (r *Recorder) OutsideContract() []Gesture {
+	var out []Gesture
+	for _, e := range r.Events() {
+		if _, known := contractGestures[e.Kind]; !known {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// Name implements Driver.
+func (r *Recorder) Name() string { return "recorder" }
+
+// Available implements Driver.
+func (r *Recorder) Available(context.Context) bool { return true }
+
+// Start implements Driver: the machine runs at once, on the address its first
+// attachment fixes, or on a stable placeholder when the pack fixed none.
+func (r *Recorder) Start(_ context.Context, spec Spec) (Machine, error) {
+	ip := "10.230.0.10"
+	if len(spec.Attachments) > 0 && spec.Attachments[0].Address != "" {
+		ip = spec.Attachments[0].Address
+	}
+	r.mu.Lock()
+	r.machines[spec.Name] = recordedMachine{ip: ip, running: true}
+	r.mu.Unlock()
+	r.Record(Gesture{Kind: "Start", Resource: spec.Name, Args: spec})
+	return Machine{Name: spec.Name, IP: ip, Running: true}, nil
+}
+
+// Stop implements Driver.
+func (r *Recorder) Stop(_ context.Context, name string) error {
+	r.mu.Lock()
+	if m, found := r.machines[name]; found {
+		m.running = false
+		r.machines[name] = m
+	}
+	r.mu.Unlock()
+	r.Record(Gesture{Kind: "Stop", Resource: name})
+	return nil
+}
+
+// Remove implements Driver. It succeeds when nothing is there, as the contract
+// requires.
+func (r *Recorder) Remove(_ context.Context, name string) error {
+	r.mu.Lock()
+	delete(r.machines, name)
+	r.mu.Unlock()
+	r.Record(Gesture{Kind: "Remove", Resource: name})
+	return nil
+}
+
+// Inspect implements Driver. A read, so it is not recorded.
+func (r *Recorder) Inspect(_ context.Context, name string) (Machine, bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	m, found := r.machines[name]
+	if !found {
+		return Machine{}, false, nil
+	}
+	return Machine{Name: name, IP: m.ip, Running: m.running}, true, nil
+}
+
+// EnsureNetwork implements Driver.
+func (r *Recorder) EnsureNetwork(_ context.Context, spec NetworkSpec) error {
+	r.Record(Gesture{Kind: "EnsureNetwork", Resource: spec.Name, Args: spec})
+	return nil
+}
+
+// Attach implements Driver.
+func (r *Recorder) Attach(_ context.Context, name string, att Attachment) error {
+	r.Record(Gesture{Kind: "Attach", Resource: name, Args: att})
+	return nil
+}
+
+// Detach implements Driver.
+func (r *Recorder) Detach(_ context.Context, name, network string) error {
+	r.Record(Gesture{Kind: "Detach", Resource: name, Args: network})
+	return nil
+}
+
+// RemoveNetwork implements Driver.
+func (r *Recorder) RemoveNetwork(_ context.Context, name string) error {
+	r.Record(Gesture{Kind: "RemoveNetwork", Resource: name})
+	return nil
+}
+
+// RouteAddress implements Router.
+func (r *Recorder) RouteAddress(_ context.Context, spec AddressSpec) error {
+	r.Record(Gesture{Kind: "RouteAddress", Resource: spec.Address, Args: spec})
+	return nil
+}
+
+// UnrouteAddress implements Router.
+func (r *Recorder) UnrouteAddress(_ context.Context, machine, address string) error {
+	r.Record(Gesture{Kind: "UnrouteAddress", Resource: address, Args: machine})
+	return nil
+}
+
+// EnsureFirewall implements Firewaller.
+func (r *Recorder) EnsureFirewall(_ context.Context, spec FirewallSpec) error {
+	r.Record(Gesture{Kind: "EnsureFirewall", Resource: spec.Name, Args: spec})
+	return nil
+}
+
+// ApplyFirewall implements Firewaller.
+func (r *Recorder) ApplyFirewall(_ context.Context, machine string, binding FirewallBinding) error {
+	r.Record(Gesture{Kind: "ApplyFirewall", Resource: machine, Args: binding})
+	return nil
+}
+
+// RemoveFirewall implements Firewaller.
+func (r *Recorder) RemoveFirewall(_ context.Context, name string) error {
+	r.Record(Gesture{Kind: "RemoveFirewall", Resource: name})
+	return nil
+}
+
+// NativeIsolation implements Peerer. A read, so it is not recorded.
+func (r *Recorder) NativeIsolation() bool { return !r.Joined }
+
+// PeerNetworks implements Peerer.
+func (r *Recorder) PeerNetworks(_ context.Context, network string, peers []string) error {
+	r.Record(Gesture{Kind: "PeerNetworks", Resource: network, Args: append([]string(nil), peers...)})
+	return nil
+}
+
+// IsolateNetwork implements Isolator, for a Recorder declared Joined.
+func (r *Recorder) IsolateNetwork(_ context.Context, network string, foreign []string) error {
+	r.Record(Gesture{Kind: "IsolateNetwork", Resource: network, Args: append([]string(nil), foreign...)})
+	return nil
+}
+
+// EnsureBalancer implements Balancer: the spec is taken whole.
+func (r *Recorder) EnsureBalancer(_ context.Context, spec BalancerSpec) (BalancerDelivery, error) {
+	r.Record(Gesture{Kind: "EnsureBalancer", Resource: spec.Listen, Args: spec})
+	return BalancerDelivery{Distributed: append([]string(nil), spec.Targets...)}, nil
+}
+
+// RemoveBalancer implements Balancer.
+func (r *Recorder) RemoveBalancer(_ context.Context, network, listen string) error {
+	r.Record(Gesture{Kind: "RemoveBalancer", Resource: listen, Args: network})
+	return nil
+}
+
+// Capabilities implements Capable: the Recorder claims everything, so every
+// enforced path a pack has is taken and recorded. A read, so it is not
+// recorded.
+func (r *Recorder) Capabilities() Capabilities {
+	return Capabilities{
+		Machines:           true,
+		Addresses:          true,
+		Firewall:           true,
+		FirewallPublicOnly: true,
+		Isolation:          true,
+		OwnKernel:          true,
+		Balancing:          true,
+		PrivateFromHost:    true,
+	}
+}

--- a/internal/core/machine/recorder_test.go
+++ b/internal/core/machine/recorder_test.go
@@ -1,0 +1,115 @@
+package machine
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+// The recorder is an instrument, and an instrument that lies reads exactly
+// like proof. So this file holds the instrument itself: the vocabulary against
+// the interfaces it claims to cover, the unknown-gesture detector against a
+// planted unknown, and the recording against a known lifecycle — the accepting
+// half, because a detector that refuses everything passes every planted test
+// and measures nothing.
+
+// contractInterfaces is the surface the vocabulary must cover: Driver and its
+// optional halves, exactly the set NewRecorder implements.
+var contractInterfaces = map[string]reflect.Type{
+	"Driver":     reflect.TypeOf((*Driver)(nil)).Elem(),
+	"Router":     reflect.TypeOf((*Router)(nil)).Elem(),
+	"Firewaller": reflect.TypeOf((*Firewaller)(nil)).Elem(),
+	"Peerer":     reflect.TypeOf((*Peerer)(nil)).Elem(),
+	"Isolator":   reflect.TypeOf((*Isolator)(nil)).Elem(),
+	"Balancer":   reflect.TypeOf((*Balancer)(nil)).Elem(),
+	"Capable":    reflect.TypeOf((*Capable)(nil)).Elem(),
+}
+
+// TestTheContractNamesEveryGesture holds the vocabulary against the driver
+// interfaces, in both directions. A method added to Driver or an optional half
+// without a vocabulary row is a gesture the contract cannot name — the exact
+// hole property 2 of #515 exists to close — and a row naming no method is
+// fiction that would let a planted event of that name pass as legitimate.
+func TestTheContractNamesEveryGesture(t *testing.T) {
+	methods := map[string]bool{}
+	for name, iface := range contractInterfaces {
+		for i := 0; i < iface.NumMethod(); i++ {
+			method := iface.Method(i).Name
+			methods[method] = true
+			if !KnownGesture(method) {
+				t.Errorf("%s.%s is a gesture the contract cannot name: add it to contractGestures, with its class", name, method)
+			}
+		}
+	}
+	for kind := range contractGestures {
+		if !methods[kind] {
+			t.Errorf("the vocabulary names %q and no driver interface carries it: a planted event of that name would pass as legitimate", kind)
+		}
+	}
+}
+
+// TestAPlantedUnknownGestureIsReported is the positive control of the
+// unknown-gesture detector. A control that looks for absence must first prove
+// it can find: without this plant, OutsideContract returning nothing is
+// indistinguishable from OutsideContract looking nowhere.
+func TestAPlantedUnknownGestureIsReported(t *testing.T) {
+	r := NewRecorder()
+	if _, err := r.Start(context.Background(), Spec{Name: "feint-x-1"}); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if outside := r.OutsideContract(); len(outside) != 0 {
+		t.Fatalf("a contract gesture was reported as outside it: %v", outside)
+	}
+
+	r.Record(Gesture{Kind: "FormatDisk", Resource: "feint-x-1"})
+
+	outside := r.OutsideContract()
+	if len(outside) != 1 || outside[0].Kind != "FormatDisk" {
+		t.Fatalf("the planted unknown gesture was not reported: got %v, want the FormatDisk event", outside)
+	}
+}
+
+// TestARecorderReplaysTheLifecycleInCallOrder is the accepting half: the
+// recorder behaves as a working runtime for the ordinary lifecycle, and its
+// sequence is the calls, in order, host-changing gestures only. Reads are
+// deliberately absent — packs legitimately differ in how often they look, and
+// a sequence polluted by Inspect would make the cross-pack equivalence lie.
+func TestARecorderReplaysTheLifecycleInCallOrder(t *testing.T) {
+	r := NewRecorder()
+	ctx := context.Background()
+
+	if err := r.EnsureNetwork(ctx, NetworkSpec{Name: "feint-net-1", CIDR: "10.230.0.0/24"}); err != nil {
+		t.Fatalf("ensure network: %v", err)
+	}
+	m, err := r.Start(ctx, Spec{Name: "feint-x-1", Attachments: []Attachment{{Network: "feint-net-1", Address: "10.230.0.7"}}})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if m.IP != "10.230.0.7" {
+		t.Fatalf("the machine does not carry its attachment's address: %q", m.IP)
+	}
+	if got, found, _ := r.Inspect(ctx, "feint-x-1"); !found || !got.Running {
+		t.Fatalf("a started machine inspects as %+v, found=%v", got, found)
+	}
+	if err := r.Stop(ctx, "feint-x-1"); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	if got, found, _ := r.Inspect(ctx, "feint-x-1"); !found || got.Running {
+		t.Fatalf("a stopped machine inspects as %+v, found=%v", got, found)
+	}
+	if err := r.Remove(ctx, "feint-x-1"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if _, found, _ := r.Inspect(ctx, "feint-x-1"); found {
+		t.Fatal("a removed machine is still there")
+	}
+	// Removing what is already gone succeeds, as the contract requires.
+	if err := r.Remove(ctx, "feint-x-1"); err != nil {
+		t.Fatalf("second remove: %v", err)
+	}
+
+	want := []string{"EnsureNetwork", "Start", "Stop", "Remove", "Remove"}
+	if got := r.Sequence(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("sequence %v, want %v: the recording is not the calls in order, and every property built on it would lie", got, want)
+	}
+}

--- a/internal/providers/replay_test.go
+++ b/internal/providers/replay_test.go
@@ -1,0 +1,360 @@
+// Package providers holds the properties that only make sense across packs.
+//
+// Each pack's own tests prove its dialect against its own client; nothing in
+// them can state that two packs agree. This test-only package mounts the three
+// packs one after the other on the shared contract recorder
+// (machine.NewRecorder, #515) and replays the same intent into each, so the
+// cross-pack properties become statable: same intent, same runtime sequence
+// (#510's sentence, red today), and no gesture outside the contract (#514's
+// service list, held dynamically).
+package providers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/machine"
+	"github.com/stephrobert/feint/internal/core/store"
+	"github.com/stephrobert/feint/internal/providers/exoscale"
+	"github.com/stephrobert/feint/internal/providers/outscale"
+	"github.com/stephrobert/feint/internal/providers/scaleway"
+)
+
+// The intent every pack can express, the one #515 names: one machine on one
+// private network, wearing one rule-set-bearing group, carrying one public
+// address. Each replay speaks its pack's own dialect — the forms must differ,
+// that is the polar star — but the client steps follow one canonical order:
+// network, group and its rule, address, machine wired to all three, then the
+// attachments the dialect performs after creation. What is compared is never
+// the dialect: it is the sequence of contract gestures the pack asked of the
+// runtime.
+
+// recorderEnv builds a deterministic Env backed by a fresh contract recorder.
+func recorderEnv() (*emulator.Env, *machine.Recorder) {
+	rec := machine.NewRecorder()
+	n := 0
+	env := &emulator.Env{
+		Store:    store.New(),
+		Machines: rec,
+		Now:      func() time.Time { return time.Unix(1700000000, 0).UTC() },
+		NewID: func() string {
+			n++
+			return fmt.Sprintf("00000000-0000-4000-8000-%012d", n)
+		},
+		Log: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	return env, rec
+}
+
+// request drives one client step and fails the replay on any error status: a
+// sequence recorded after a refused step would measure the refusal, not the
+// pack, and an empty sequence compares equal to another empty one — the exact
+// way an instrument passes by vacuity.
+func request(t *testing.T, h http.Handler, method, path, body string) map[string]any {
+	t.Helper()
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code >= http.StatusBadRequest {
+		t.Fatalf("%s %s answered %d: %s", method, path, rec.Code, rec.Body.String())
+	}
+	out := map[string]any{}
+	if rec.Body.Len() > 0 {
+		if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+			t.Fatalf("%s %s answered something that is not a JSON object: %s", method, path, rec.Body.String())
+		}
+	}
+	return out
+}
+
+func id(t *testing.T, out map[string]any, keys ...string) string {
+	t.Helper()
+	var current any = out
+	for _, key := range keys {
+		obj, ok := current.(map[string]any)
+		if !ok {
+			t.Fatalf("no %v in %v", keys, out)
+		}
+		current = obj[key]
+	}
+	s, _ := current.(string)
+	if s == "" {
+		t.Fatalf("empty %v in %v", keys, out)
+	}
+	return s
+}
+
+// replayScaleway expresses the intent in Scaleway's dialect: the group and the
+// address are wired at create, the private network is joined by a NIC after
+// the boot.
+func replayScaleway(t *testing.T) *machine.Recorder {
+	t.Helper()
+	env, rec := recorderEnv()
+	srv, err := emulator.NewServer(env, scaleway.New(env))
+	if err != nil {
+		t.Fatalf("mount scaleway: %v", err)
+	}
+	h := srv.Handler()
+	const zone = "/instance/v1/zones/fr-par-1"
+
+	pn := request(t, h, "POST", "/vpc/v2/regions/fr-par/private-networks",
+		`{"name":"intent-net","subnets":["10.61.0.0/24"]}`)
+	pnID := id(t, pn, "id")
+
+	sg := request(t, h, "POST", zone+"/security_groups",
+		`{"name":"intent-group","description":"the intent's one group","inbound_default_policy":"drop"}`)
+	sgID := id(t, sg, "security_group", "id")
+	request(t, h, "POST", zone+"/security_groups/"+sgID+"/rules",
+		`{"protocol":"TCP","direction":"inbound","action":"accept","ip_range":"0.0.0.0/0","dest_port_from":22,"dest_port_to":22}`)
+
+	ip := request(t, h, "POST", zone+"/ips", `{}`)
+	ipID := id(t, ip, "ip", "id")
+
+	created := request(t, h, "POST", zone+"/servers",
+		`{"name":"intent-machine","commercial_type":"DEV1-S","image":"ubuntu_jammy","security_group":"`+sgID+`","public_ip":"`+ipID+`"}`)
+	serverID := id(t, created, "server", "id")
+
+	request(t, h, "POST", zone+"/servers/"+serverID+"/action", `{"action":"poweron"}`)
+	request(t, h, "POST", zone+"/servers/"+serverID+"/private_nics",
+		`{"private_network_id":"`+pnID+`"}`)
+	return rec
+}
+
+// replayOutscale expresses the intent in Outscale's dialect: the Vm boots on
+// its Subnet wearing its group, the public address is linked afterwards.
+func replayOutscale(t *testing.T) *machine.Recorder {
+	t.Helper()
+	env, rec := recorderEnv()
+	srv, err := emulator.NewServer(env, outscale.New(env))
+	if err != nil {
+		t.Fatalf("mount outscale: %v", err)
+	}
+	h := srv.Handler()
+	post := func(action, body string) map[string]any {
+		return request(t, h, "POST", "/api/v1/"+action, body)
+	}
+
+	net := post("CreateNet", `{"IpRange":"10.61.0.0/16"}`)
+	netID := id(t, net, "Net", "NetId")
+	subnet := post("CreateSubnet", `{"NetId":"`+netID+`","IpRange":"10.61.1.0/24"}`)
+	subnetID := id(t, subnet, "Subnet", "SubnetId")
+
+	sg := post("CreateSecurityGroup",
+		`{"SecurityGroupName":"intent-group","Description":"the intent's one group","NetId":"`+netID+`"}`)
+	sgID := id(t, sg, "SecurityGroup", "SecurityGroupId")
+	post("CreateSecurityGroupRule",
+		`{"Flow":"Inbound","SecurityGroupId":"`+sgID+`","IpProtocol":"tcp","FromPortRange":22,"ToPortRange":22,"IpRange":"0.0.0.0/0"}`)
+
+	ip := post("CreatePublicIp", `{}`)
+	ipID := id(t, ip, "PublicIp", "PublicIpId")
+
+	vms := post("CreateVms",
+		`{"ImageId":"ami-00000001","VmType":"tinav6.c1r1p2","SubnetId":"`+subnetID+`","SecurityGroupIds":["`+sgID+`"]}`)
+	list, _ := vms["Vms"].([]any)
+	if len(list) != 1 {
+		t.Fatalf("CreateVms answered %d Vms, want 1: %v", len(list), vms)
+	}
+	vmID := id(t, map[string]any{"Vm": list[0]}, "Vm", "VmId")
+
+	post("LinkPublicIp", `{"PublicIpId":"`+ipID+`","VmId":"`+vmID+`"}`)
+	return rec
+}
+
+// replayExoscale expresses the intent in Exoscale's dialect: the instance
+// boots wearing its group, then the private network and the elastic IP are
+// attached to the running machine.
+func replayExoscale(t *testing.T) *machine.Recorder {
+	t.Helper()
+	env, rec := recorderEnv()
+	srv, err := emulator.NewServer(env, exoscale.New(env))
+	if err != nil {
+		t.Fatalf("mount exoscale: %v", err)
+	}
+	h := srv.Handler()
+
+	request(t, h, "POST", "/v2/private-network",
+		`{"name":"intent-net","start-ip":"10.61.0.20","end-ip":"10.61.0.200","netmask":"255.255.255.0"}`)
+	listed := request(t, h, "GET", "/v2/private-network", "")
+	pns, _ := listed["private-networks"].([]any)
+	if len(pns) != 1 {
+		t.Fatalf("%d private networks after create, want 1: %v", len(pns), listed)
+	}
+	pnID := id(t, map[string]any{"pn": pns[0]}, "pn", "id")
+
+	sg := request(t, h, "POST", "/v2/security-group",
+		`{"name":"intent-group","description":"the intent's one group"}`)
+	sgID := id(t, sg, "reference", "id")
+	request(t, h, "POST", "/v2/security-group/"+sgID+"/rules",
+		`{"flow-direction":"ingress","protocol":"tcp","network":"0.0.0.0/0","start-port":22,"end-port":22}`)
+
+	eip := request(t, h, "POST", "/v2/elastic-ip", `{}`)
+	eipID := id(t, eip, "reference", "id")
+
+	request(t, h, "POST", "/v2/instance", `{
+		"name":"intent-machine",
+		"instance-type":{"id":"21624abb-764e-4def-81d7-9fc54b5957fb"},
+		"template":{"id":"11111111-1111-4111-8111-111111111111"},
+		"disk-size":10,
+		"security-groups":[{"id":"`+sgID+`"}]
+	}`)
+	instances := request(t, h, "GET", "/v2/instance", "")
+	list, _ := instances["instances"].([]any)
+	if len(list) != 1 {
+		t.Fatalf("%d instances after create, want 1: %v", len(list), instances)
+	}
+	instanceID := id(t, map[string]any{"i": list[0]}, "i", "id")
+
+	request(t, h, "PUT", "/v2/private-network/"+pnID+":attach",
+		`{"instance":{"id":"`+instanceID+`"}}`)
+	request(t, h, "PUT", "/v2/elastic-ip/"+eipID+":attach",
+		`{"instance":{"id":"`+instanceID+`"}}`)
+	return rec
+}
+
+// replays runs the three packs' replays and answers their recorders, keyed by
+// pack name, in a fixed iteration order.
+var replays = []struct {
+	pack string
+	run  func(*testing.T) *machine.Recorder
+}{
+	{"scaleway", replayScaleway},
+	{"outscale", replayOutscale},
+	{"exoscale", replayExoscale},
+}
+
+// sameSequence is the equivalence the cross-pack property asserts: the same
+// gesture kinds, in the same order. Deliberately nothing weaker — not a set
+// comparison, not a subsequence — because the order is the property (#510).
+func sameSequence(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func formatSequence(seq []string) string {
+	if len(seq) == 0 {
+		return "(empty)"
+	}
+	return strings.Join(seq, " → ")
+}
+
+// TestNoPackAsksTheRuntimeAGestureOutsideTheContract is property 2 of #515,
+// live: every gesture the three replays asked of the runtime is one the
+// contract vocabulary names. The detector's own positive control is
+// TestAPlantedUnknownGestureIsReported in the machine package; the vocabulary
+// itself is held against the driver interfaces by
+// TestTheContractNamesEveryGesture there.
+func TestNoPackAsksTheRuntimeAGestureOutsideTheContract(t *testing.T) {
+	for _, replay := range replays {
+		rec := replay.run(t)
+		if outside := rec.OutsideContract(); len(outside) != 0 {
+			t.Errorf("%s asked the runtime %d gestures the contract cannot name: %v",
+				replay.pack, len(outside), outside)
+		}
+		if len(rec.Events()) == 0 {
+			t.Errorf("%s recorded nothing: a replay that never reached the runtime holds this property by vacuity", replay.pack)
+		}
+	}
+}
+
+// TestTwoIdenticalReplaysProduceTheSameSequence proves the instrument's
+// determinism, without which the cross-pack verdict would measure scheduling
+// rather than packs: an equivalence read on a nondeterministic recording is an
+// instrument that lies in both directions.
+func TestTwoIdenticalReplaysProduceTheSameSequence(t *testing.T) {
+	for _, replay := range replays {
+		first := replay.run(t).Sequence()
+		second := replay.run(t).Sequence()
+		if !sameSequence(first, second) {
+			t.Errorf("%s replayed twice produced two sequences:\n  %s\n  %s",
+				replay.pack, formatSequence(first), formatSequence(second))
+		}
+	}
+}
+
+// TestAShuffledReplayIsToldFromItsOriginal is the positive control of the
+// equivalence assertion: before trusting sameSequence on real replays, prove
+// it fails on a deliberately reordered one. A comparator that cannot see a
+// rotation would read three different orders as one and turn the red property
+// green by instrument defect — the exact lie this repository exists to avoid.
+func TestAShuffledReplayIsToldFromItsOriginal(t *testing.T) {
+	original := replayScaleway(t).Sequence()
+	if len(original) < 2 {
+		t.Fatalf("the replay recorded %d gestures; nothing can be reordered", len(original))
+	}
+	shuffled := append([]string(nil), original[1:]...)
+	shuffled = append(shuffled, original[0])
+	if sameSequence(original, shuffled) {
+		t.Fatalf("a rotated sequence compares equal to its original:\n  %s\n  %s",
+			formatSequence(original), formatSequence(shuffled))
+	}
+	// The rotation must be a real reordering for the control to mean anything:
+	// a sequence of one repeated kind rotates onto itself.
+	distinct := map[string]bool{}
+	for _, kind := range original {
+		distinct[kind] = true
+	}
+	if len(distinct) < 2 {
+		t.Fatalf("the replay's %d gestures are all %q: the rotation control compared nothing", len(original), original[0])
+	}
+}
+
+// TestSameIntentSameRuntimeSequenceAcrossPacks is property 1 of #515: for the
+// one intent all three packs can express, the three replays produce the same
+// contract-level sequence — the executable form of #510's sentence, the order
+// is a property of the runtime, not of a provider.
+//
+// It is red today, and deliberately so: the audit measured three orders held
+// by three comments (scaleway/servers.go, outscale/machines.go,
+// exoscale/machines.go), and this instrument is what makes that divergence a
+// measurement instead of a citation. #510 is what turns it green. Until then
+// the test *runs*, prints the measured divergence, and ends in Skip rather
+// than Fail — a red assertion in prepush would make every branch undeliverable
+// for a defect this branch does not create — and the Skip line carries the
+// full measurement so nobody has to re-derive it. The day the sequences agree,
+// this test passes on its own and the skip below becomes dead code to delete
+// with #510.
+//
+// The assertion is per expressible intent, never "all sequences are
+// identical": the packs do not express every intent identically (Scaleway has
+// no group-sourced rules, Exoscale routes elastic addresses on attach), and a
+// global phrasing would make the test lie.
+func TestSameIntentSameRuntimeSequenceAcrossPacks(t *testing.T) {
+	sequences := make(map[string][]string, len(replays))
+	for _, replay := range replays {
+		sequences[replay.pack] = replay.run(t).Sequence()
+	}
+
+	reference := sequences[replays[0].pack]
+	diverged := false
+	for _, replay := range replays[1:] {
+		if !sameSequence(reference, sequences[replay.pack]) {
+			diverged = true
+		}
+	}
+	if !diverged {
+		return // #510 landed: the property holds, and this test now guards it.
+	}
+
+	var lines []string
+	for _, replay := range replays {
+		lines = append(lines, fmt.Sprintf("  %-8s %s", replay.pack, formatSequence(sequences[replay.pack])))
+	}
+	t.Skipf("red on purpose (#515): the same intent produces three runtime sequences, one per pack — "+
+		"#510 is the corridor that makes them one; measured now:\n%s", strings.Join(lines, "\n"))
+}

--- a/tools/falsify/specs/contract-recorder.json
+++ b/tools/falsify/specs/contract-recorder.json
@@ -1,0 +1,35 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "the unknown-gesture detector reports nothing, so a gesture outside the contract passes as legitimate",
+      "file": "internal/core/machine/recorder.go",
+      "find": "\t\tif _, known := contractGestures[e.Kind]; !known {",
+      "replace": "\t\tif _, known := contractGestures[e.Kind]; !known && false {",
+      "test": "TestAPlantedUnknownGestureIsReported"
+    },
+    {
+      "label": "the vocabulary misnames a gesture, so the contract no longer covers the driver surface it claims to",
+      "file": "internal/core/machine/recorder.go",
+      "find": "\t\"PeerNetworks\":    true,",
+      "replace": "\t\"PeerNetworksX\":    true,",
+      "test": "TestTheContractNamesEveryGesture"
+    },
+    {
+      "label": "the recorder records nothing, so every sequence is empty and every property built on it holds by vacuity",
+      "file": "internal/core/machine/recorder.go",
+      "find": "\tr.events = append(r.events, g)",
+      "replace": "\tif false {\n\t\tr.events = append(r.events, g)\n\t}",
+      "test": "TestARecorderReplaysTheLifecycleInCallOrder"
+    },
+    {
+      "label": "the sequence comparator reads every pair as equal, so three divergent orders would report as one",
+      "file": "internal/providers/replay_test.go",
+      "find": "\tif len(a) != len(b) {\n\t\treturn false\n\t}\n\tfor i := range a {\n\t\tif a[i] != b[i] {\n\t\t\treturn false\n\t\t}\n\t}\n\treturn true",
+      "replace": "\tif len(a) != len(b) && false {\n\t\treturn false\n\t}\n\tfor i := range a {\n\t\tif a[i] != b[i] && false {\n\t\t\treturn false\n\t\t}\n\t}\n\treturn true",
+      "test": "TestAShuffledReplayIsToldFromItsOriginal",
+      "package": "./internal/providers/"
+    }
+  ],
+  "note": "The instrument of #515 falsified on itself: the recorder and its two assertions are what the 0.12.0 corridor's proofs replay against, so a defect here reads exactly like proof. The first mutation blinds the outside-contract detector against its planted witness; the second breaks the both-ways hold between the vocabulary and the driver interfaces; the third silences the recording, which turns every sequence property vacuous; the fourth blinds the equivalence comparator that must tell a shuffled replay from its original before the red cross-pack divergence (three boot orders, measured 2026-08-26) can be believed."
+}


### PR DESCRIPTION
First of the 0.12.0 milestone, and the instrument the others' proofs replay
against (#514 orders it first).

## What it measures that nothing measured

This repository proves argv-level facts through the injectable `Incus.runner`,
and contract-level facts through **fifteen unexported per-suite fakes**. Each
sees one suite's slice of the driver; none can state a property **across packs**
— and it was one of those homemade recorders that found #508's severed peering,
which is the measure of what recording a sequence is worth.

`machine.NewRecorder()` implements `Driver` and its six optional halves,
recording typed gestures in call order. The type is `Gesture`, not `Event`, for
a named reason: `machine.Event` already belongs to the watcher (`watch.go:19`),
and "gesture" is #514's own word.

## The vocabulary, and why it is held in both directions

Exactly the 21 methods of `Driver` plus the six halves — the service list of
#514 §1 at driver level — and each carries a class. Host-changing gestures are
recorded; reads (`Name`, `Available`, `Inspect`, `NativeIsolation`,
`Capabilities`) are named but not, because packs legitimately differ in how
often they look and a sequence polluted with `Inspect` would make the
equivalence lie.

`TestTheContractNamesEveryGesture` holds it against the interfaces by reflection
**in both directions**: a method with no entry is a gesture the contract cannot
name, and an entry with no method is a fiction that would legitimise a planted
event. The second direction is the one that gets forgotten, and it is what keeps
the detector from being fooled by its own table.

## The instrument is proven before it is trusted

One that lies reads exactly like proof, so both assertions were made to fail on
demand before being believed:

- a deliberately shuffled replay is refused, with both sequences printed;
- a planted `FormatDisk` is reported by `OutsideContract`.

`contract-recorder.json` holds them afterwards: blind the comparator and
`TestAShuffledReplayIsToldFromItsOriginal` goes red; blind the detector and
`TestAPlantedUnknownGestureIsReported` goes red. Four mutations, all biting.

## One assertion ships red, deliberately

`TestSameIntentSameRuntimeSequenceAcrossPacks` runs every pass and **skips with
its measurement printed**, naming #515 and #510. This branch ships the
instrument, not the fix — #510 is what turns it green, which makes this the test
#510 cites as failing without it.

What it measures today:

```
scaleway  … Start → EnsureFirewall → ApplyFirewall → RouteAddress → Attach …
outscale  … Start → EnsureFirewall → ApplyFirewall → RouteAddress
exoscale  … Start → RouteAddress → EnsureFirewall → ApplyFirewall → Attach …
```

Three orders, held by three comments, exactly as the 0.12.0 audit measured.

The form was chosen against two worse ones: a skip declared up front would hide
the measurement and never notice #510 landing, and a pinned divergence file
would fail every batch that moves a choreography without fixing it — teaching
"update the golden". The property is stated **per expressible intent**, never as
"all sequences are identical", which is the phrasing that would make the test
lie: Scaleway has no group-sourced rules and Exoscale routes elastic addresses
on attach.

## Not done, on purpose

None of the fifteen homemade fakes was migrated. Only cross-pack properties
*need* the shared recorder; a suite asserting a driver-internal fact keeps its
own, and churning tests for no property gained is a cost without a measurement.

## Gates

`mise run check`, `go test ./... -race`, `mise run prepush`, `mise run docs:check`
all 0 — re-verified after rebasing onto `main` at v0.11.0. `falsify:lint` 686
mutations over 118 specs. No station used: nothing required it.
