### PR TITLE
fix(changelog): 0.11.0 absorbs the Unreleased section it was written beside

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -17,6 +17,16 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-08-26
+
+La version où l'émulateur a cessé de se croire sur parole. Quatre défauts
+trouvés à la main en une soirée — un groupe de sécurité servi et appliqué à
+rien, une capacité de répartition que personne ne matérialisait, un répartiteur
+qui ne distribuait rien, deux machines dotées d'une même adresse — étaient tous
+les quatre verts : apply à 0, second plan vide, destruction propre, et trois
+d'entre eux sans une seule ligne ERROR. Rien n'échouait, donc rien ne pouvait
+les attraper sauf quelqu'un qui lisait l'hôte.
+
 ### Ajouté
 
 - **`/_feint/health` répond désormais qui livre la répartition, et plus
@@ -2357,16 +2367,7 @@ change ni l'un ni l'autre a sa place dans `git log`.
   genre d'objet et fausse pour l'autre, est exactement la forme que #389 a coûté
   une release à comprendre.
 
-
-## [0.11.0] - 2026-08-26
-
-La version où l'émulateur a cessé de se croire sur parole. Quatre défauts
-trouvés à la main en une soirée — un groupe de sécurité servi et appliqué à
-rien, une capacité de répartition que personne ne matérialisait, un répartiteur
-qui ne distribuait rien, deux machines dotées d'une même adresse — étaient tous
-les quatre verts : apply à 0, second plan vide, destruction propre, et trois
-d'entre eux sans une seule ligne ERROR. Rien n'échouait, donc rien ne pouvait
-les attraper sauf quelqu'un qui lisait l'hôte.
+<!-- le travail de fin de cycle, écrit à la publication depuis les pull requests fusionnées -->
 
 ### Ajouté
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-08-26
+
+The release where the emulator stopped taking its own word for it. Four defects
+found by hand on one evening — a security group served and enforced on nothing,
+a balancing capability nobody materialised, a load balancer distributing
+nothing, two machines given one address — were all four green: apply exit 0,
+empty second plan, clean destroy, and three of them without a single ERROR
+line. Nothing failed, so nothing could have caught them but a person reading the
+host.
+
 ### Added
 
 - **`/_feint/health` answers who delivers the balancer, not only whether the
@@ -2270,15 +2280,7 @@ what this project is judged on: **a response shape a client can observe**, and
   a closing inventory byte-identical to the opening one across all seven
   resource kinds.
 
-## [0.11.0] - 2026-08-26
-
-The release where the emulator stopped taking its own word for it. Four defects
-found by hand on one evening — a security group served and enforced on nothing,
-a balancing capability nobody materialised, a load balancer distributing
-nothing, two machines given one address — were all four green: apply exit 0,
-empty second plan, clean destroy, and three of them without a single ERROR
-line. Nothing failed, so nothing could have caught them but a person reading the
-host.
+<!-- the late-cycle work, written at release time from the merged pull requests -->
 
 ### Added
 


### PR DESCRIPTION
The 0.11.0 section was written from the merged pull requests and added **beside**
an `[Unreleased]` section that already held this cycle's record.

| | lines | issues |
|---|--:|--:|
| `[Unreleased]` | 2257 | 66 |
| `[0.11.0]` as written | 163 | 32 |
| in both | | 3 |

So the published release body carried 32 issues where the file held 66, and the
sixty-three entries somebody wrote **at the time of their measurement** sat
above the version that shipped them.

`[Unreleased]` is folded into `[0.11.0]`: its body first, since it is the record
written closest to the work, then the release-time narrative and the late-cycle
entries the incremental record could not contain — separated by an HTML comment
so the seam is legible rather than guessed at. An empty `[Unreleased]` is
restored above, which is where the next cycle belongs: the header of this file
says an entry that is not here is an entry nobody downloading a binary will ever
see, and that only works if there is somewhere to write them as they happen.

**The mistake is worth naming rather than quietly fixing.** Writing a release
section without first reading what the file already had is the class of error
this repository documents everywhere else: acting on what one assumes the
artefact contains instead of on what it contains.

`docs:check` and `prepush` pass. The generated blocks still derive 0.11.0, since
the released version is the first numbered section and the empty `[Unreleased]`
carries none.

The published v0.11.0 release body will be updated to the folded section once
this lands.