### PR TITLE
refactor(machine): one firewall skeleton, one interface plan, and one intent replays as one sequence (#509, #510)

### DIFF
--- a/internal/cli/enforcement_test.go
+++ b/internal/cli/enforcement_test.go
@@ -22,15 +22,17 @@ import (
 // same reasoning that stopped the README's client matrix being a constant.
 //
 // So the truth is read where it lives: a pack wires the firewall when a
-// non-test file of its own references machine.Firewaller. Nothing else counts,
-// and in particular a comment does not: the marker is the type, which the
-// compiler resolves.
+// non-test file of its own references machine.GroupSync — the shared
+// orchestration a pack builds to hand its groups to the runtime (#509; the
+// marker was machine.Firewaller until that type left the packs' vocabulary
+// with the skeleton). Nothing else counts, and in particular a comment does
+// not: the marker is the type, which the compiler resolves.
 //
 // This is what fails if a pack starts handing rules over and forgets to say so,
 // and equally if a pack says so and hands nothing over. Both directions matter:
 // the first understates and the second is the defect #180 was filed for.
 func TestEveryPackThatWiresTheFirewallSaysSo(t *testing.T) {
-	declarationMatchesSource(t, "machine.Firewaller", "EnforcesFirewall",
+	declarationMatchesSource(t, "machine.GroupSync", "EnforcesFirewall",
 		func(p emulator.Pack) bool {
 			fe, ok := p.(emulator.FirewallEnforcer)
 			return ok && fe.EnforcesFirewall()

--- a/internal/core/machine/groupsync.go
+++ b/internal/core/machine/groupsync.go
@@ -1,0 +1,224 @@
+package machine
+
+import (
+	"context"
+
+	"github.com/stephrobert/feint/internal/core/resource"
+)
+
+// The orchestration of security groups onto machines, written once (#509).
+//
+// #494 moved the per-rule-set mechanics into the shared layer (SyncRuleSet,
+// ApplyRuleSets, DropRuleSet, firewall_binding.go). What stayed in the packs
+// was the skeleton above the mechanics — sync a group then replay it on its
+// wearers, collect one machine's sets and apply them in one call, re-expand
+// the groups referencing a machine's groups once it has addresses — copied two
+// to three times, line-for-line isomorphic. That layer is exactly where #475
+// was born: a sequence written per pack is a sequence two packs never wrote,
+// and a fourth pack would have rediscovered it alone.
+//
+// What stays in a pack is only what that provider knows: how a group and its
+// rules translate into a FirewallSpec, who wears a group, which groups a
+// resource wears, and which groups reference a group as a member source. Each
+// of those is a field below, so no provider name enters this file and
+// internal/cli's TestTheCoreNamesNoProvider remains the judge.
+type GroupSync struct {
+	// Binding is the pack's machine binding: the driver, the runtime key the
+	// machine name lives under, and the rule-set mechanics of #494.
+	Binding Binding
+
+	// SpecOf translates one group and its rules into the runtime's rule set —
+	// the pack's own vocabulary, member expansion included.
+	//
+	// fresh, when non-nil, is the copy a transition is still working on: the
+	// boot that triggers a re-expansion runs before its own commit, so the
+	// store's copy of that resource does not yet carry the address the
+	// expansion is being run FOR. Reading the store alone here silently missed
+	// the very machine that booted — measured on Outscale, unproven but
+	// structurally identical on Exoscale, and now impossible to forget because
+	// the skeleton threads fresh for every pack.
+	// TestAFreshResourceWinsOverItsStaleStoreCopy fails without the threading.
+	SpecOf func(group, fresh *resource.Resource) FirewallSpec
+
+	// ForeignBlocks, optional, lists the CIDR blocks the wearers of this group
+	// must not reach when the runtime cannot keep networks apart by
+	// construction (bridge mode). The rejects ride the group's rule set
+	// because a NIC carrying a rule set no longer obeys the network-level
+	// isolation — the runtime orders rules by action, so a reject here wins
+	// over any allow the group adds. What is foreign is the pack's own routing
+	// model and stays behind this field; where the rejects go is runtime
+	// knowledge and is decided here, once.
+	//
+	// Nil keeps today's behaviour for the packs that never embedded the
+	// defence: bridge mode declares isolation:false for every pack, so their
+	// nil is honest, and wiring their predicates here would change measured
+	// bridge-mode rule sets without a witness asking for it.
+	ForeignBlocks func(group *resource.Resource) []string
+
+	// Wearers enumerates the resources wearing a group, for the replay after
+	// the group or its rules change.
+	Wearers func(group *resource.Resource) []*resource.Resource
+
+	// WornIDs enumerates the identifiers of the groups one resource wears.
+	WornIDs func(res *resource.Resource) []string
+
+	// Group resolves a worn identifier to its stored group.
+	Group func(id string) (*resource.Resource, bool)
+
+	// Referrers, optional, lists the groups one of whose rules names one of
+	// the given groups as a member source. Nil where the provider's rules
+	// cannot name a group at all (Scaleway), in which case the re-expansion
+	// half of AfterBoot is honestly empty rather than emptily looped.
+	Referrers func(named map[string]bool) []*resource.Resource
+}
+
+// enforcer is the runtime's firewall half, nil when it has none — the
+// assertion every pack wrote for itself, now out of their vocabulary entirely,
+// which is what lets the enforcement test mark a wired pack by this type
+// instead of by machine.Firewaller.
+func (s GroupSync) enforcer() Firewaller {
+	fw, _ := s.Binding.Driver.(Firewaller)
+	return fw
+}
+
+// nativeIsolation reports whether the runtime keeps its networks apart by
+// construction, in which case reject rules against foreign subnets are dead
+// weight: the blocks would name subnets the machine cannot reach anyway.
+func (s GroupSync) nativeIsolation() bool {
+	peerer, ok := s.Binding.Driver.(Peerer)
+	return ok && peerer.NativeIsolation()
+}
+
+// spec assembles the rule set of one group: the pack's translation, with the
+// bridge-mode foreign rejects in front. In front and not by precedence — the
+// runtime orders rules by action, not by position — but keeping them first
+// keeps the written set byte-identical to what the packs measured.
+func (s GroupSync) spec(group, fresh *resource.Resource) FirewallSpec {
+	spec := s.SpecOf(group, fresh)
+	if s.ForeignBlocks == nil || s.nativeIsolation() {
+		return spec
+	}
+	blocks := s.ForeignBlocks(group)
+	if len(blocks) == 0 {
+		return spec
+	}
+	rejects := make([]FirewallRule, 0, 2*len(blocks))
+	for _, block := range blocks {
+		rejects = append(rejects,
+			FirewallRule{Direction: "egress", Action: "reject", Destination: block},
+			FirewallRule{Direction: "ingress", Action: "reject", Source: block},
+		)
+	}
+	spec.Rules = append(rejects, spec.Rules...)
+	return spec
+}
+
+// SyncGroup writes one group's rule set to the runtime and replays it onto
+// every wearer. Called after any change to the group or to its rules.
+//
+// fresh, when non-nil, wins over the store's copy of the same resource, in the
+// wearer replay as in the expansion — SpecOf says why.
+func (s GroupSync) SyncGroup(ctx context.Context, group, fresh *resource.Resource) {
+	fw := s.enforcer()
+	if fw == nil {
+		return
+	}
+	if !s.Binding.SyncRuleSet(ctx, fw, s.spec(group, fresh)) {
+		return
+	}
+	for _, wearer := range s.Wearers(group) {
+		if fresh != nil && wearer.ID == fresh.ID {
+			wearer = fresh
+		}
+		s.applyMachine(ctx, wearer, fresh)
+	}
+}
+
+// ApplyMachine writes every set one resource wears and attaches them to its
+// machine in one call, because the runtime replaces the attachment list rather
+// than merging it. Every set is written first, so an attach cannot name a set
+// the runtime has never seen. The resource is its own fresh copy: its groups
+// are being applied because of what it just became.
+//
+// The sets are written even when no machine is running: a rule set lives on
+// the runtime for every wearer at once, and this resource may be the reason
+// its translation changed — a NIC created on a stopped server changes the
+// foreign blocks its group must reject. Only the attach half needs a machine.
+//
+// A set the runtime refused is not applied at all rather than applied minus
+// the refused set: dropping one deny-carrying set from the attachment list
+// would open traffic the API describes as closed, and the refusal is already
+// in the log (SyncRuleSet). Two packs of three attached the remainder; the
+// conservative form is the one that cannot lie in the permissive direction.
+func (s GroupSync) ApplyMachine(ctx context.Context, res *resource.Resource) {
+	s.applyMachine(ctx, res, res)
+}
+
+// applyMachine is ApplyMachine with the pass's fresh copy threaded through.
+//
+// One fresh per orchestration pass, everywhere: when a wearer replay re-writes
+// a set the pass has already written with the booting resource's copy,
+// re-translating it with the wearer's own store copy instead would overwrite
+// the fresh expansion with a stale one — the booting machine's address,
+// written a moment ago, silently erased by the very replay that was meant to
+// deliver it. One pack's copy dodged this by skipping machineless wearers
+// entirely, which hid the overwrite without removing it.
+// TestTheWearerReplayKeepsTheFreshExpansion fails without the threading.
+func (s GroupSync) applyMachine(ctx context.Context, res, fresh *resource.Resource) {
+	fw := s.enforcer()
+	if fw == nil {
+		return
+	}
+	if fresh == nil {
+		fresh = res
+	}
+	specs := make([]FirewallSpec, 0, 2)
+	for _, id := range s.WornIDs(res) {
+		group, found := s.Group(id)
+		if !found {
+			continue
+		}
+		spec := s.spec(group, fresh)
+		if !s.Binding.SyncRuleSet(ctx, fw, spec) {
+			return
+		}
+		specs = append(specs, spec)
+	}
+	s.Binding.ApplyRuleSets(ctx, fw, res.Runtime[s.Binding.RuntimeKey], specs...)
+}
+
+// AfterBoot runs once a machine exists or first publishes an address: its own
+// sets attach, and every group whose rules point at a group this resource
+// wears is re-expanded, because this machine's addresses are now part of what
+// those groups mean. Without the second half, the tiering statement a stack
+// writes — tier 2 accepts tier 1 and nobody else — never contains the machines
+// it talks about (#475).
+func (s GroupSync) AfterBoot(ctx context.Context, res *resource.Resource) {
+	if s.enforcer() == nil {
+		return
+	}
+	s.ApplyMachine(ctx, res)
+	s.SyncReferrers(ctx, s.WornIDs(res), res)
+}
+
+// SyncReferrers re-syncs every group one of whose rules names one of the given
+// groups as a member source. fresh carries the resource whose addresses
+// changed, ahead of its own commit — SpecOf says why the store is not enough.
+func (s GroupSync) SyncReferrers(ctx context.Context, groupIDs []string, fresh *resource.Resource) {
+	if s.Referrers == nil || len(groupIDs) == 0 || s.enforcer() == nil {
+		return
+	}
+	named := make(map[string]bool, len(groupIDs))
+	for _, id := range groupIDs {
+		named[id] = true
+	}
+	for _, group := range s.Referrers(named) {
+		s.SyncGroup(ctx, group, fresh)
+	}
+}
+
+// Drop removes one group's rule set from the runtime, for a group being
+// deleted. Failure is logged rather than fatal — DropRuleSet says why.
+func (s GroupSync) Drop(ctx context.Context, name string) {
+	s.Binding.DropRuleSet(ctx, s.enforcer(), name)
+}

--- a/internal/core/machine/groupsync_test.go
+++ b/internal/core/machine/groupsync_test.go
@@ -1,0 +1,387 @@
+package machine
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/resource"
+)
+
+// The witnesses of #509: the skeleton — sync-then-apply, the wearer replay,
+// the fresh copy, the after-boot re-expansion, the bridge-mode rejects — is
+// asserted here once, against the shared contract recorder, so the discipline
+// holds for every pack at once instead of living in whichever pack happened to
+// write the test. The fresh test transposes internal/providers/outscale's
+// TestAMemberSourcedRuleExpandsToTheMembersAddresses, which held the only copy
+// of that discipline before this file.
+
+// groupSyncBench builds a GroupSync over a recorder and a tiny in-memory
+// world: groups and machines are plain resources, a group's spec expands the
+// addresses of the wearers of the group its one rule names — the shape of
+// every member-sourced rule, without any provider's vocabulary.
+type groupSyncBench struct {
+	rec *Recorder
+	// resources by id: groups and machines alike, standing in for the store.
+	resources map[string]*testResource
+	// wearing maps a machine id to the group ids it wears.
+	wearing map[string][]string
+	// references maps a group id to the group id its one rule names, "" for a
+	// plain rule.
+	references map[string]string
+}
+
+type testResource = resource.Resource
+
+func newGroupSyncBench() *groupSyncBench {
+	return &groupSyncBench{
+		rec:        NewRecorder(),
+		resources:  map[string]*testResource{},
+		wearing:    map[string][]string{},
+		references: map[string]string{},
+	}
+}
+
+func (b *groupSyncBench) binding() Binding {
+	return Binding{
+		Driver:     b.rec,
+		Provider:   "bench",
+		Prefix:     "feint-bench-",
+		RuntimeKey: "machine",
+		AddressKey: "address",
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+}
+
+func (b *groupSyncBench) sync() GroupSync {
+	return GroupSync{
+		Binding: b.binding(),
+		SpecOf: func(group, fresh *testResource) FirewallSpec {
+			spec := FirewallSpec{
+				Name:           FirewallName("bench", group.ID),
+				DefaultIngress: "drop",
+				DefaultEgress:  "drop",
+			}
+			target := b.references[group.ID]
+			if target == "" {
+				spec.Rules = append(spec.Rules, FirewallRule{Direction: "ingress", Action: "allow", PortFrom: 22, PortTo: 22})
+				return spec
+			}
+			// The member expansion: one /32 per address a wearer of the named
+			// group answers on — with the transition's own copy winning over
+			// the store's, which is the whole fresh discipline.
+			for _, wearer := range b.wearersOf(target) {
+				if fresh != nil && wearer.ID == fresh.ID {
+					wearer = fresh
+				}
+				if address, _ := wearer.Attrs["address"].(string); address != "" {
+					spec.Rules = append(spec.Rules, FirewallRule{
+						Direction: "ingress", Action: "allow", Source: address + "/32",
+					})
+				}
+			}
+			return spec
+		},
+		Wearers: func(group *testResource) []*testResource { return b.wearersOf(group.ID) },
+		WornIDs: func(res *testResource) []string { return b.wearing[res.ID] },
+		Group: func(id string) (*testResource, bool) {
+			res, found := b.resources[id]
+			if !found {
+				return nil, false
+			}
+			return res.Clone(), true
+		},
+		Referrers: func(named map[string]bool) []*testResource {
+			var out []*testResource
+			for id, target := range b.references {
+				if named[target] {
+					out = append(out, b.resources[id])
+				}
+			}
+			return out
+		},
+	}
+}
+
+// wearersOf clones, the way the real store does: a resource read here is a
+// copy, and a transition's uncommitted changes are invisible in it — the exact
+// staleness the fresh discipline exists for. A bench handing out live pointers
+// would prove the discipline by accident, on an instrument that cannot see its
+// absence.
+func (b *groupSyncBench) wearersOf(groupID string) []*testResource {
+	var out []*testResource
+	for id, worn := range b.wearing {
+		for _, w := range worn {
+			if w == groupID {
+				out = append(out, b.resources[id].Clone())
+			}
+		}
+	}
+	return out
+}
+
+func (b *groupSyncBench) group(id, references string) *testResource {
+	res := &testResource{ID: id, Attrs: map[string]any{}}
+	b.resources[id] = res
+	b.references[id] = references
+	return res
+}
+
+func (b *groupSyncBench) machine(id, address string, worn ...string) *testResource {
+	res := &testResource{ID: id, Attrs: map[string]any{}, Runtime: map[string]string{}}
+	if address != "" {
+		res.Attrs["address"] = address
+		res.Runtime["machine"] = "feint-bench-" + id
+	}
+	b.resources[id] = res
+	b.wearing[id] = worn
+	return res
+}
+
+func ruleSources(spec FirewallSpec) []string {
+	var out []string
+	for _, rule := range spec.Rules {
+		if rule.Source != "" {
+			out = append(out, rule.Source)
+		}
+	}
+	return out
+}
+
+func ensuredSpec(t *testing.T, rec *Recorder, name string) FirewallSpec {
+	t.Helper()
+	var found *FirewallSpec
+	for _, e := range rec.Events() {
+		if e.Kind == "EnsureFirewall" && e.Resource == name {
+			spec := e.Args.(FirewallSpec)
+			found = &spec // the last write is what the runtime holds
+		}
+	}
+	if found == nil {
+		t.Fatalf("the runtime never received the rule set %s", name)
+	}
+	return *found
+}
+
+// TestAFreshResourceWinsOverItsStaleStoreCopy is the transposition of
+// internal/providers/outscale's
+// TestAMemberSourcedRuleExpandsToTheMembersAddresses to the shared
+// skeleton: a re-expansion triggered by a boot runs before that boot's own
+// commit, so the store's copy of the booting resource carries neither its
+// address nor its machine name yet. The skeleton must hand the transition's
+// own copy to the pack's translation AND substitute it in the wearer replay —
+// reading the store alone silently missed the very machine that booted, in the
+// one pack of three that had guarded against it.
+func TestAFreshResourceWinsOverItsStaleStoreCopy(t *testing.T) {
+	b := newGroupSyncBench()
+	web := b.group("web", "")
+	_ = web
+	data := b.group("data", "web")
+	// The store's copy of the web machine: no address, no runtime name — the
+	// state before the transition commits.
+	b.machine("m-web", "", "web")
+
+	// The transition's own copy: booted, addressed, named.
+	fresh := &testResource{
+		ID:      "m-web",
+		Attrs:   map[string]any{"address": "10.42.0.9"},
+		Runtime: map[string]string{"machine": "feint-bench-m-web"},
+	}
+
+	b.sync().SyncGroup(context.Background(), data, fresh)
+
+	spec := ensuredSpec(t, b.rec, FirewallName("bench", "data"))
+	sources := ruleSources(spec)
+	if len(sources) != 1 || sources[0] != "10.42.0.9/32" {
+		t.Fatalf("the member rule expanded to %v, want the fresh copy's 10.42.0.9/32: the store's stale copy won", sources)
+	}
+}
+
+// TestTheWearerReplaySubstitutesTheFreshCopy is the second half of the fresh
+// discipline: the wearer replay must act on the transition's copy of the
+// booting resource, whose Runtime alone names the machine — the store's copy
+// would apply the sets to nothing.
+func TestTheWearerReplaySubstitutesTheFreshCopy(t *testing.T) {
+	b := newGroupSyncBench()
+	group := b.group("g", "")
+	b.machine("m", "", "g") // store copy: never booted, no machine name
+
+	fresh := &testResource{
+		ID:      "m",
+		Attrs:   map[string]any{"address": "10.42.0.7"},
+		Runtime: map[string]string{"machine": "feint-bench-m"},
+	}
+	b.sync().SyncGroup(context.Background(), group, fresh)
+
+	applied := false
+	for _, e := range b.rec.Events() {
+		if e.Kind == "ApplyFirewall" && e.Resource == "feint-bench-m" {
+			applied = true
+		}
+	}
+	if !applied {
+		t.Fatalf("the wearer replay never reached the booting machine: the store's machineless copy was replayed instead; events: %v", b.rec.Sequence())
+	}
+}
+
+// TestTheWearerReplayKeepsTheFreshExpansion guards the overwrite the wearer
+// replay can commit: after a referrer's set is written with the booting
+// resource's fresh copy, replaying that referrer's wearers re-writes the same
+// set — and re-translating it with each wearer's own store copy would erase
+// the fresh expansion a moment after delivering it. One fresh per pass,
+// threaded into every translation of the pass. Outscale's copy dodged this by
+// skipping machineless wearers, which hid the overwrite without removing it —
+// this test holds the property for a wearer with a machine, where no skip can
+// save it.
+func TestTheWearerReplayKeepsTheFreshExpansion(t *testing.T) {
+	b := newGroupSyncBench()
+	b.group("web", "")
+	data := b.group("data", "web")
+	// The data machine runs, committed long ago: the store copy is complete,
+	// so nothing skips it in the wearer replay.
+	b.machine("m-data", "10.42.0.10", "data")
+	// The web machine's store copy: mid-boot, address not committed yet.
+	b.machine("m-web", "", "web")
+
+	fresh := &testResource{
+		ID:      "m-web",
+		Attrs:   map[string]any{"address": "10.42.0.9"},
+		Runtime: map[string]string{"machine": "feint-bench-m-web"},
+	}
+	b.sync().SyncGroup(context.Background(), data, fresh)
+
+	spec := ensuredSpec(t, b.rec, FirewallName("bench", "data"))
+	sources := ruleSources(spec)
+	if len(sources) != 1 || sources[0] != "10.42.0.9/32" {
+		t.Fatalf("the wearer replay erased the fresh expansion: the set the runtime holds expanded to %v, want 10.42.0.9/32", sources)
+	}
+}
+
+// TestAfterBootAppliesTheMachineBeforeReexpandingItsReferrers holds the order
+// of the two halves: the machine's own sets attach first, then the groups
+// naming its groups re-expand. The re-expansion re-applies wearers, so run
+// first it would attach a set the first half then rewrites — the order is the
+// property, and it lived in per-pack comments before this test.
+func TestAfterBootAppliesTheMachineBeforeReexpandingItsReferrers(t *testing.T) {
+	b := newGroupSyncBench()
+	b.group("web", "")
+	b.group("data", "web")
+	webVM := b.machine("m-web", "10.42.0.9", "web")
+	b.machine("m-data", "10.42.0.10", "data")
+
+	b.sync().AfterBoot(context.Background(), webVM)
+
+	seq := b.rec.Sequence()
+	ownApply := -1
+	referrerSync := -1
+	for i, e := range b.rec.Events() {
+		if e.Kind == "ApplyFirewall" && e.Resource == "feint-bench-m-web" && ownApply == -1 {
+			ownApply = i
+		}
+		if e.Kind == "EnsureFirewall" && e.Resource == FirewallName("bench", "data") && referrerSync == -1 {
+			referrerSync = i
+		}
+	}
+	if ownApply == -1 || referrerSync == -1 {
+		t.Fatalf("AfterBoot skipped one of its two halves; sequence: %v", seq)
+	}
+	if ownApply > referrerSync {
+		t.Fatalf("the referrers re-expanded before the machine's own sets attached; sequence: %v", seq)
+	}
+	spec := ensuredSpec(t, b.rec, FirewallName("bench", "data"))
+	sources := ruleSources(spec)
+	if len(sources) != 1 || sources[0] != "10.42.0.9/32" {
+		t.Fatalf("the re-expansion never learned the booted machine's address: %v", sources)
+	}
+}
+
+// TestForeignRejectsRideTheRuleSetOnlyWhereNetworksAreBornJoined: the
+// bridge-mode defence is a field, applied by the skeleton exactly where it
+// means something. Under native isolation the blocks name subnets the machine
+// cannot reach anyway, and writing them would change every measured OVN rule
+// set for nothing.
+func TestForeignRejectsRideTheRuleSetOnlyWhereNetworksAreBornJoined(t *testing.T) {
+	for _, joined := range []bool{true, false} {
+		b := newGroupSyncBench()
+		b.rec.Joined = joined
+		group := b.group("g", "")
+		b.machine("m", "10.42.0.5", "g")
+
+		s := b.sync()
+		s.ForeignBlocks = func(*testResource) []string { return []string{"10.99.0.0/24"} }
+		s.SyncGroup(context.Background(), group, nil)
+
+		spec := ensuredSpec(t, b.rec, FirewallName("bench", "g"))
+		rejected := false
+		for _, rule := range spec.Rules {
+			if rule.Action == "reject" {
+				rejected = true
+			}
+		}
+		if joined && !rejected {
+			t.Fatalf("networks born joined and no reject in the set: the bridge-mode defence was lost in the move")
+		}
+		if !joined && rejected {
+			t.Fatalf("native isolation and a reject in the set: dead weight the packs never wrote")
+		}
+		if joined && spec.Rules[0].Action != "reject" {
+			t.Fatalf("the rejects must come first, as the packs measured them; rules: %+v", spec.Rules)
+		}
+	}
+}
+
+// refusingFirewaller wraps the recorder and refuses to write one named rule
+// set, for the conservative-application control below.
+type refusingFirewaller struct {
+	*Recorder
+	refuse string
+}
+
+func (r refusingFirewaller) EnsureFirewall(ctx context.Context, spec FirewallSpec) error {
+	if spec.Name == r.refuse {
+		return errors.New("refused on purpose")
+	}
+	return r.Recorder.EnsureFirewall(ctx, spec)
+}
+
+// TestARefusedRuleSetDoesNotShrinkTheAttachmentList: when the runtime refuses
+// one of a machine's sets, nothing is applied at all. Attaching the remainder
+// would silently drop a deny-carrying set from the machine's interfaces —
+// opening traffic the API describes as closed, which is the one direction an
+// emulator must never err in.
+func TestARefusedRuleSetDoesNotShrinkTheAttachmentList(t *testing.T) {
+	b := newGroupSyncBench()
+	b.group("open", "")
+	b.group("closed", "")
+	vm := b.machine("m", "10.42.0.5", "open", "closed")
+
+	s := b.sync()
+	s.Binding.Driver = refusingFirewaller{Recorder: b.rec, refuse: FirewallName("bench", "closed")}
+	s.ApplyMachine(context.Background(), vm)
+
+	for _, e := range b.rec.Events() {
+		if e.Kind == "ApplyFirewall" {
+			t.Fatalf("the machine was attached to a shrunken list after a set was refused: %v", e.Args)
+		}
+	}
+}
+
+// TestASetIsWrittenEvenWithoutAMachine: the rule set lives on the runtime for
+// every wearer at once, and the resource may be the very reason its
+// translation changed — a NIC created on a stopped server changes the foreign
+// blocks its group must reject. So the write half runs without a machine; the
+// attach half, which needs one, waits for it.
+func TestASetIsWrittenEvenWithoutAMachine(t *testing.T) {
+	b := newGroupSyncBench()
+	b.group("g", "")
+	stopped := b.machine("m", "", "g")
+
+	b.sync().ApplyMachine(context.Background(), stopped)
+
+	seq := b.rec.Sequence()
+	if len(seq) != 1 || seq[0] != "EnsureFirewall" {
+		t.Fatalf("want the set written and nothing attached, got %v", seq)
+	}
+}

--- a/internal/core/machine/plan.go
+++ b/internal/core/machine/plan.go
@@ -1,0 +1,323 @@
+package machine
+
+import (
+	"context"
+	"net/netip"
+
+	"github.com/stephrobert/feint/internal/core/resource"
+)
+
+// A machine's interface shape is declared once, not choreographed three times
+// (#510).
+//
+// The three providers produce three interface shapes, and those shapes are
+// right — they reproduce three real upstream models: interfaces that ride the
+// launch, a managed primary fixed at create, a public primary whose private
+// memberships always join after boot. What was wrong is that each pack wrote
+// the *recipe* by hand — route the promised public addresses, join the private
+// networks, resync the firewall, in that order — three spellings, three
+// orders, and the ordering constraints alive only in per-pack comments. The
+// order route → attach → firewall is a property of the runtime, not of a
+// provider, and a comment is not a control.
+//
+// So the pack declares its Plan and the Reconciler executes the one order.
+// What stays in the pack is everything provider-shaped: which stored fields
+// become which attachment, which addresses were promised, and the wire dialect
+// around it all. No provider name enters this file; internal/cli's
+// TestTheCoreNamesNoProvider remains the judge.
+
+// Plan is one machine's declared interface shape.
+type Plan struct {
+	// Boot are the interfaces that ride the launch; the first is the primary.
+	// Carried on the Start rather than attached afterwards because editing a
+	// live OVN NIC re-plugs it and the guest loses its lease — Boot.Attachments
+	// says the rest.
+	Boot []Attachment
+	// Memberships are the networks joined after boot, one Attach each, and
+	// never promoted to the primary the way a Boot attachment would be: on the
+	// provider that declares them, the primary is the public interface.
+	Memberships []Attachment
+	// Publics are the emulated public addresses promised to the machine — the
+	// launch installs their host half, the post-boot replay hands the guest
+	// its routes and repairs a machine that already existed.
+	Publics []string
+	// RouteVia names the network public routes ride, empty to let the driver
+	// pick. One pack routes on the network its server lives on and says so;
+	// the two others let the driver pick, and changing that would change what
+	// the runtime is asked without an upstream difference demanding it.
+	RouteVia string
+}
+
+// Reconciler executes a declared Plan in the one order — addresses, then
+// memberships, the firewall last, so the expansion sees every interface. It is
+// the second orchestrator of the driver contract, beside GroupSync, whose
+// firewall step it consumes.
+type Reconciler struct {
+	// Groups is the firewall step (#509); its Binding is the spine everything
+	// below rides on.
+	Groups GroupSync
+	// PlanOf builds the machine's declared interface shape from the resource —
+	// the pack's own field walks, nothing else.
+	PlanOf func(res *resource.Resource) Plan
+	// Settle, optional, is the pack's bookkeeping between the start and the
+	// replay: what the boot produced, recorded in the pack's own attributes
+	// before the firewall expansion reads them. One pack keeps the machine's
+	// private address in an API field the others do not declare; forcing that
+	// into the shared sequence would invent a field, so it is a hook.
+	Settle func(res *resource.Resource)
+	// PublicBlock is the emulated public range this pack may route. It guards
+	// every address on its way to the driver, routing and unrouting alike: a
+	// stored address is untrusted input — PUT /_feint/state and snapshot load
+	// restore it verbatim — and routing an arbitrary value would send the
+	// host's traffic for that address into a container. On the Reconciler and
+	// not on the Plan, because the unroute of a machine already gone has no
+	// resource left to plan from.
+	PublicBlock netip.Prefix
+}
+
+func (r Reconciler) binding() Binding { return r.Groups.Binding }
+
+// router is the runtime's routing half, nil when it has none — the assertion
+// every pack wrote for itself, now inside the layer.
+func (r Reconciler) router() Router {
+	router, _ := r.binding().Driver.(Router)
+	return router
+}
+
+// PowerOn starts the machine on its declared plan and replays the post-boot
+// order: the promised addresses, the memberships, the firewall last. It
+// reports what PowerOn reported; a machine that did not start is not replayed
+// onto, and the state the pack publishes is the one the effect produced.
+func (r Reconciler) PowerOn(ctx context.Context, res *resource.Resource, boot Boot) bool {
+	plan := r.PlanOf(res)
+	boot.Attachments = plan.Boot
+	boot.PublicAddresses = plan.Publics
+	if !r.binding().PowerOn(ctx, res, boot) {
+		return false
+	}
+	if r.Settle != nil {
+		r.Settle(res)
+	}
+	// The launch installed the host half of every public route; this hands
+	// the guest its addresses, and repairs a machine that already existed.
+	// Idempotent, like everything in the replay.
+	for _, address := range plan.Publics {
+		r.route(ctx, res, plan, address)
+	}
+	// The memberships come back as extra interfaces, after the boot rather
+	// than on it. Attach is idempotent by network, so a machine that kept its
+	// devices across a stop is repaired, not doubled. A refusal is already in
+	// the log and must not stop the replay: the remaining memberships and the
+	// firewall still describe what the store says.
+	for _, m := range plan.Memberships {
+		_ = r.attach(ctx, res, m)
+	}
+	// The firewall last, so the expansion sees every address and every
+	// interface the two loops above delivered. This line is the order the
+	// packs kept in comments; TestTheReplayRoutesThenJoinsThenAppliesTheFirewall
+	// is what holds it now.
+	r.Groups.AfterBoot(ctx, res)
+	return true
+}
+
+// ReplayAddresses re-routes every promised address of a machine that just
+// proved reachable — the late-address door: a virtual machine's agent answers
+// long after poweron returned, and the guest half of its routes can only land
+// then. Idempotent for a machine already served.
+func (r Reconciler) ReplayAddresses(ctx context.Context, res *resource.Resource) {
+	plan := r.PlanOf(res)
+	for _, address := range plan.Publics {
+		r.route(ctx, res, plan, address)
+	}
+}
+
+// Route makes one public address reach the machine, the hot half: an address
+// attached to a running machine. The block guard and the router assertion are
+// the layer's; whether several holders may record the address is the pack's
+// control plane, and the runtime carries it on at most one machine either way
+// (Binding.RouteAddress says why).
+func (r Reconciler) Route(ctx context.Context, res *resource.Resource, address string) {
+	r.route(ctx, res, r.PlanOf(res), address)
+}
+
+func (r Reconciler) route(ctx context.Context, res *resource.Resource, plan Plan, address string) {
+	router := r.router()
+	if router == nil {
+		return
+	}
+	name := res.Runtime[r.binding().RuntimeKey]
+	if name == "" || address == "" {
+		return
+	}
+	if !r.emulated(address) {
+		r.binding().logger().Warn("refusing to route an address outside the emulated public block",
+			"provider", r.binding().Provider, "address", address, "resource", res.ID)
+		return
+	}
+	if err := r.binding().RouteAddress(ctx, router, AddressSpec{
+		Machine: name,
+		Address: address,
+		Network: plan.RouteVia,
+	}); err != nil {
+		r.binding().logger().Error("could not route the public address to the machine",
+			"provider", r.binding().Provider, "address", address, "resource", res.ID, "error", err)
+	}
+}
+
+// Unroute takes a route back. The machine may already be gone — the driver
+// treats that as nothing left to undo, and on OVN it still withdraws the
+// uplink route, which outlives the machine; that is why this takes the machine
+// name rather than a resource.
+func (r Reconciler) Unroute(ctx context.Context, machine, address string) {
+	router := r.router()
+	if router == nil || !r.emulated(address) {
+		return
+	}
+	if err := r.binding().UnrouteAddress(ctx, router, machine, address); err != nil {
+		r.binding().logger().Error("could not stop routing the public address",
+			"provider", r.binding().Provider, "address", address, "error", err)
+	}
+}
+
+// emulated reports whether an address is one this pack can have handed out:
+// inside PublicBlock. Well-formed is not authorised; this is the authorisation
+// half, held once for the three packs.
+func (r Reconciler) emulated(address string) bool {
+	if !r.PublicBlock.IsValid() {
+		return false
+	}
+	addr, err := netip.ParseAddr(address)
+	if err != nil {
+		return false
+	}
+	return r.PublicBlock.Contains(addr)
+}
+
+// Join puts a running machine on one more network — the hot half of a
+// membership: a cloud attaches a NIC to a server that is running, and that
+// cannot fold into a boot-time plan. The interface this attach creates carries
+// the machine's rule sets like every other one, so the firewall step runs
+// last, attach refused or not: the sets and the store moved even when the
+// runtime did not, and the resync is what keeps them one truth.
+//
+// The attach error is returned for the pack that surfaces it on its resource;
+// degrading quietly stays the caller's choice, as everywhere.
+func (r Reconciler) Join(ctx context.Context, res *resource.Resource, att Attachment) error {
+	err := r.attach(ctx, res, att)
+	r.Groups.AfterBoot(ctx, res)
+	return err
+}
+
+func (r Reconciler) attach(ctx context.Context, res *resource.Resource, att Attachment) error {
+	driver := r.binding().Driver
+	if driver == nil {
+		return nil
+	}
+	name := res.Runtime[r.binding().RuntimeKey]
+	if name == "" || att.Network == "" {
+		// No machine, or no backing network: the membership is still true in
+		// the store, and the interface arrives with the next boot's plan.
+		return nil
+	}
+	if err := driver.Attach(ctx, name, att); err != nil {
+		r.binding().logger().Error("could not attach the machine to the network",
+			"provider", r.binding().Provider, "resource", res.ID, "network", att.Network,
+			"address", att.Address, "error", err)
+		return err
+	}
+	return nil
+}
+
+// Leave is the exact undo of Join's attach half. It degrades the same way:
+// with no runtime, or a machine that never started, there is nothing to take
+// off and the membership has already gone from the store. No firewall resync
+// follows, deliberately: no pack ran one here, its callers sit on delete paths
+// whose carrier is going next, and adding one belongs to a measured defect,
+// not to a move.
+func (r Reconciler) Leave(ctx context.Context, res *resource.Resource, network string) {
+	driver := r.binding().Driver
+	if driver == nil {
+		return
+	}
+	name := res.Runtime[r.binding().RuntimeKey]
+	if name == "" || network == "" {
+		return
+	}
+	if err := driver.Detach(ctx, name, network); err != nil {
+		r.binding().logger().Error("could not detach the machine from the network",
+			"provider", r.binding().Provider, "resource", res.ID, "network", network, "error", err)
+	}
+}
+
+// BackingNetwork is what an emulated subnet needs from the runtime, in the
+// pack's terms; EnsureBackingNetwork turns it into the NetworkSpec every pack
+// used to build by hand.
+type BackingNetwork struct {
+	// Key is the Runtime key the network name is recorded under.
+	Key string
+	// CIDR is the block, canonicalised here so no pack forgets to.
+	CIDR netip.Prefix
+	// Gateway reserves the block's first host address as the runtime's own,
+	// for the packs whose allocator accounts for it. False lets the runtime
+	// pick, which the pack must then not publish.
+	Gateway bool
+	// NAT gives machines outbound access through the host. Deliberately per
+	// pack: one provider's subnet reaches the internet only once a gateway
+	// service is attached, and switching NAT on for it would make the
+	// emulator more permissive than the cloud it imitates.
+	NAT bool
+	// Marker is the pack's own label key naming the backed resource, so
+	// orphans can be swept; the provider label rides beside it under LabelKey,
+	// spelled once here instead of three ways.
+	Marker string
+}
+
+// EnsureBackingNetwork asks the driver for a real network carrying the block,
+// and records its name on the resource — after the driver accepted it, which
+// is the one ordering that never records a network the runtime refused. Two
+// packs wrote the key first and would have kept, on failure, a Runtime entry
+// naming a network that does not exist, which the delete path then tries to
+// remove.
+func (b Binding) EnsureBackingNetwork(ctx context.Context, res *resource.Resource, spec BackingNetwork) error {
+	if b.Driver == nil {
+		return nil
+	}
+	name := NetworkName(NetworkPrefix, res.ID)
+	network := NetworkSpec{
+		Name:   name,
+		CIDR:   spec.CIDR.Masked().String(),
+		NAT:    spec.NAT,
+		Labels: map[string]string{LabelKey: b.Provider},
+	}
+	if spec.Marker != "" {
+		network.Labels[spec.Marker] = res.ID
+	}
+	if spec.Gateway {
+		network.Gateway = spec.CIDR.Masked().Addr().Next().String()
+	}
+	if err := b.Driver.EnsureNetwork(ctx, network); err != nil {
+		return err
+	}
+	if res.Runtime == nil {
+		res.Runtime = map[string]string{}
+	}
+	res.Runtime[spec.Key] = name
+	return nil
+}
+
+// RemoveBackingNetwork removes the backing network and forgets its name on
+// success. The error comes back to the pack, which decides its dialect:
+// refusing the delete so nothing is reported gone while the runtime still
+// holds its block, or logging and proceeding — both exist today and both are
+// client-visible surface, so the layer does not pick for them.
+func (b Binding) RemoveBackingNetwork(ctx context.Context, res *resource.Resource, key string) error {
+	name := res.Runtime[key]
+	if b.Driver == nil || name == "" {
+		return nil
+	}
+	if err := b.Driver.RemoveNetwork(ctx, name); err != nil {
+		return err
+	}
+	delete(res.Runtime, key)
+	return nil
+}

--- a/internal/core/machine/plan_test.go
+++ b/internal/core/machine/plan_test.go
@@ -1,0 +1,246 @@
+package machine
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"testing"
+)
+
+// The witnesses of #510: the post-boot order — addresses, then memberships,
+// the firewall last — and the shared guards around it are asserted here once,
+// against the contract recorder, instead of living as three comments in three
+// packs.
+
+// reconcilerBench extends the group-sync bench with a plan, so the whole
+// choreography runs over one recorder.
+func reconcilerBench(b *groupSyncBench, plan Plan) Reconciler {
+	return Reconciler{
+		Groups:      b.sync(),
+		PlanOf:      func(*testResource) Plan { return plan },
+		PublicBlock: netip.MustParsePrefix("203.0.113.0/24"),
+	}
+}
+
+// TestTheReplayRoutesThenJoinsThenAppliesTheFirewall is the order property
+// itself, the sentence three packs kept in comments: route the promised
+// addresses, join the private networks, resync the firewall, in that order —
+// so the expansion sees every address and every interface. Red without the
+// Reconciler for any pack whose comment was the only thing holding it.
+func TestTheReplayRoutesThenJoinsThenAppliesTheFirewall(t *testing.T) {
+	b := newGroupSyncBench()
+	b.group("g", "")
+	vm := b.machine("m", "", "g")
+
+	r := reconcilerBench(b, Plan{
+		Publics:     []string{"203.0.113.9"},
+		Memberships: []Attachment{{Network: "fnt-bench-net"}},
+	})
+	if !r.PowerOn(context.Background(), vm, Boot{Image: "ubuntu:24.04"}) {
+		t.Fatalf("the boot did not start; sequence: %v", b.rec.Sequence())
+	}
+
+	position := map[string]int{}
+	for i, kind := range b.rec.Sequence() {
+		if _, seen := position[kind]; !seen {
+			position[kind] = i
+		}
+	}
+	for _, kind := range []string{"Start", "RouteAddress", "Attach", "EnsureFirewall", "ApplyFirewall"} {
+		if _, seen := position[kind]; !seen {
+			t.Fatalf("the replay never emitted %s; sequence: %v", kind, b.rec.Sequence())
+		}
+	}
+	ordered := position["Start"] < position["RouteAddress"] &&
+		position["RouteAddress"] < position["Attach"] &&
+		position["Attach"] < position["EnsureFirewall"] &&
+		position["EnsureFirewall"] < position["ApplyFirewall"]
+	if !ordered {
+		t.Fatalf("the order is not route, then attach, then firewall: %v", b.rec.Sequence())
+	}
+}
+
+// TestAPoisonedStoredAddressIsNeverRoutedByTheLayer holds the authorisation
+// half once for the three packs: a stored address is untrusted input — a
+// restored snapshot carries it verbatim — and routing an arbitrary value would
+// send the host's traffic for that address into a container. The accepting
+// half is asserted too, because a guard that refuses everything passes every
+// attack test and breaks the product.
+func TestAPoisonedStoredAddressIsNeverRoutedByTheLayer(t *testing.T) {
+	b := newGroupSyncBench()
+	vm := b.machine("m", "10.0.0.5")
+	vm.Runtime["machine"] = "feint-bench-m"
+	r := reconcilerBench(b, Plan{})
+
+	r.Route(context.Background(), vm, "192.168.1.10") // the operator's LAN
+	r.Unroute(context.Background(), "feint-bench-m", "192.168.1.10")
+	for _, e := range b.rec.Events() {
+		if e.Kind == "RouteAddress" || e.Kind == "UnrouteAddress" {
+			t.Fatalf("an address outside the emulated block reached the driver: %v", e)
+		}
+	}
+
+	r.Route(context.Background(), vm, "203.0.113.9")
+	routed := false
+	for _, e := range b.rec.Events() {
+		if e.Kind == "RouteAddress" && e.Resource == "203.0.113.9" {
+			routed = true
+		}
+	}
+	if !routed {
+		t.Fatalf("the guard also refuses the emulated block, so no address can ever be routed; events: %v", b.rec.Sequence())
+	}
+}
+
+// TestJoinRunsTheFirewallAfterTheAttach is the hot half of the order: a NIC
+// attached to a running machine creates an interface the machine's rule sets
+// must cover, so the resync runs after the attach — and still runs when the
+// attach was refused, because the store moved even when the runtime did not.
+func TestJoinRunsTheFirewallAfterTheAttach(t *testing.T) {
+	b := newGroupSyncBench()
+	b.group("g", "")
+	vm := b.machine("m", "10.0.0.5", "g")
+	r := reconcilerBench(b, Plan{})
+
+	if err := r.Join(context.Background(), vm, Attachment{Network: "fnt-bench-net"}); err != nil {
+		t.Fatalf("the attach failed on a recorder that refuses nothing: %v", err)
+	}
+	seq := b.rec.Sequence()
+	attach, firewall := -1, -1
+	for i, kind := range seq {
+		if kind == "Attach" && attach == -1 {
+			attach = i
+		}
+		if kind == "ApplyFirewall" && firewall == -1 {
+			firewall = i
+		}
+	}
+	if attach == -1 || firewall == -1 || attach > firewall {
+		t.Fatalf("want the attach then the firewall, got %v", seq)
+	}
+}
+
+// refusingAttacher wraps the recorder and refuses every attach, for the
+// refused-attach half of the Join contract.
+type refusingAttacher struct{ *Recorder }
+
+func (r refusingAttacher) Attach(context.Context, string, Attachment) error {
+	return errors.New("refused on purpose")
+}
+
+// TestARefusedAttachStillResyncsTheFirewall: the error comes back to the pack
+// — one surfaces it on its NIC's state — and the firewall step runs anyway,
+// exactly what the pack that surfaces the error also does today.
+func TestARefusedAttachStillResyncsTheFirewall(t *testing.T) {
+	b := newGroupSyncBench()
+	b.group("g", "")
+	vm := b.machine("m", "10.0.0.5", "g")
+	r := reconcilerBench(b, Plan{})
+	r.Groups.Binding.Driver = refusingAttacher{b.rec}
+
+	if err := r.Join(context.Background(), vm, Attachment{Network: "fnt-bench-net"}); err == nil {
+		t.Fatal("the refusal never reached the caller, so no pack can surface it on its resource")
+	}
+	applied := false
+	for _, kind := range b.rec.Sequence() {
+		if kind == "ApplyFirewall" {
+			applied = true
+		}
+	}
+	if !applied {
+		t.Fatalf("a refused attach skipped the resync, and the machine's sets no longer match the store: %v", b.rec.Sequence())
+	}
+}
+
+// TestEnsureBackingNetworkRecordsOnlyWhatTheDriverAccepted settles the write
+// ordering the three packs disagreed on: the Runtime key is written after the
+// driver accepted the network — the one ordering that never records a network
+// the runtime refused, which the delete path would then try to remove.
+func TestEnsureBackingNetworkRecordsOnlyWhatTheDriverAccepted(t *testing.T) {
+	b := newGroupSyncBench()
+	res := b.machine("net-1", "")
+	binding := b.binding()
+
+	err := binding.EnsureBackingNetwork(context.Background(), res, BackingNetwork{
+		Key:     "network",
+		CIDR:    netip.MustParsePrefix("10.61.0.0/24"),
+		Gateway: true,
+		NAT:     true,
+		Marker:  "feint.bench-net",
+	})
+	if err != nil {
+		t.Fatalf("the recorder refused a network: %v", err)
+	}
+	if res.Runtime["network"] == "" {
+		t.Fatal("the accepted network was not recorded")
+	}
+	var spec NetworkSpec
+	found := false
+	for _, e := range b.rec.Events() {
+		if e.Kind == "EnsureNetwork" {
+			spec = e.Args.(NetworkSpec)
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("no EnsureNetwork reached the driver: %v", b.rec.Sequence())
+	}
+	if spec.Labels[LabelKey] != "bench" || spec.Labels["feint.bench-net"] != res.ID {
+		t.Fatalf("the labels lost the provider or the marker: %v", spec.Labels)
+	}
+	if spec.Gateway != "10.61.0.1" {
+		t.Fatalf("gateway %q, want the block's first host address", spec.Gateway)
+	}
+
+	refused := b.machine("net-2", "")
+	binding.Driver = refusingNetworker{b.rec}
+	if err := binding.EnsureBackingNetwork(context.Background(), refused, BackingNetwork{
+		Key: "network", CIDR: netip.MustParsePrefix("10.62.0.0/24"),
+	}); err == nil {
+		t.Fatal("the refusal was swallowed")
+	}
+	if refused.Runtime["network"] != "" {
+		t.Fatal("a network the driver refused was recorded anyway — the ordering two packs had")
+	}
+}
+
+// refusingNetworker wraps the recorder and refuses every network.
+type refusingNetworker struct{ *Recorder }
+
+func (r refusingNetworker) EnsureNetwork(context.Context, NetworkSpec) error {
+	return errors.New("refused on purpose")
+}
+
+// TestRemoveBackingNetworkForgetsTheNameOnSuccessOnly: the Runtime entry
+// survives a refused removal, so the pack can refuse its delete instead of
+// reporting gone something that still holds its block.
+func TestRemoveBackingNetworkForgetsTheNameOnSuccessOnly(t *testing.T) {
+	b := newGroupSyncBench()
+	res := b.machine("net-1", "")
+	res.Runtime["network"] = "fnt-bench-net"
+	binding := b.binding()
+
+	if err := binding.RemoveBackingNetwork(context.Background(), res, "network"); err != nil {
+		t.Fatalf("the recorder refused a removal: %v", err)
+	}
+	if res.Runtime["network"] != "" {
+		t.Fatal("the removed network is still recorded")
+	}
+
+	held := b.machine("net-2", "")
+	held.Runtime["network"] = "fnt-bench-kept"
+	binding.Driver = refusingRemover{b.rec}
+	if err := binding.RemoveBackingNetwork(context.Background(), held, "network"); err == nil {
+		t.Fatal("the refusal was swallowed")
+	}
+	if held.Runtime["network"] != "fnt-bench-kept" {
+		t.Fatal("a network the runtime kept was forgotten, and nothing can remove it any more")
+	}
+}
+
+// refusingRemover wraps the recorder and refuses every network removal.
+type refusingRemover struct{ *Recorder }
+
+func (r refusingRemover) RemoveNetwork(context.Context, string) error {
+	return errors.New("refused on purpose")
+}

--- a/internal/providers/exoscale/elasticips.go
+++ b/internal/providers/exoscale/elasticips.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 
 	"github.com/stephrobert/feint/internal/core/emulator"
-	"github.com/stephrobert/feint/internal/core/machine"
 	"github.com/stephrobert/feint/internal/core/resource"
 )
 
@@ -33,6 +32,9 @@ import (
 // elasticIPBlock is the block as a prefix, for the guard below.
 const elasticIPBlock = "192.0.2.0/24"
 
+// elasticIPPrefix is the block parsed once, for the Reconciler's route guard.
+var elasticIPPrefix = netip.MustParsePrefix(elasticIPBlock)
+
 // emulatedElasticIP reports whether an address is one this pack can have
 // handed out: inside elasticIPBlock. A stored address is restored verbatim by
 // PUT /_feint/state and `feint snapshot load`, and routing an arbitrary value
@@ -53,54 +55,31 @@ func emulatedElasticIP(address string) bool {
 // routeElasticIP makes an attached address reach the instance's machine.
 // Degrades quietly, like every runtime call in this pack.
 // TestAttachElasticIPRoutesTheAddress fails without it.
+//
+// Through the shared Reconciler, which holds the block guard and the router
+// assertion once for the three packs (#510) — and, through the binding it
+// rides on, takes the address back from its previous holder before handing it
+// over: this pack lets several instances hold one Elastic IP, which is what
+// the real cloud does, measured on ch-gva-2, where two instances both reported
+// holding 185.19.28.243. The control plane is right to allow it; the runtime
+// cannot honour it, since two containers answering ARP for one /32 make the
+// host pick arbitrarily while the API describes both as holders. So the
+// address goes to the most recent attach; upstream elects by healthcheck,
+// feint has none and does not invent one — docs/limits.md names the rule.
+// TestAnElasticIPReachesOneMachineAtATime fails without this.
 func (p *Pack) routeElasticIP(ctx context.Context, address string, inst *resource.Resource) {
-	router, ok := p.env.Machines.(machine.Router)
-	if !ok {
-		return
-	}
-	name := inst.Runtime[p.binding().RuntimeKey]
-	if name == "" || address == "" {
-		return
-	}
-	if !emulatedElasticIP(address) {
-		p.logger().Warn("refusing to route an address outside the emulated elastic block",
-			"address", address, "instance", inst.ID)
-		return
-	}
-	// Through the binding rather than straight at the router, because this pack
-	// lets several instances hold one Elastic IP — which is what the real cloud
-	// does, measured on ch-gva-2, where two instances both reported holding
-	// 185.19.28.243. The control plane is right to allow it; the runtime cannot
-	// honour it, since two containers answering ARP for one /32 make the host
-	// pick arbitrarily while the API describes both as holders.
-	//
-	// So the address goes to the most recent attach and is taken back from the
-	// previous holder. Upstream elects by healthcheck; feint has none and does
-	// not invent one — docs/limits.md names the rule instead.
-	//
-	// TestAnElasticIPReachesOneMachineAtATime fails without this.
-	if err := p.binding().RouteAddress(ctx, router, machine.AddressSpec{Machine: name, Address: address}); err != nil {
-		p.logger().Error("could not route the elastic IP to the machine",
-			"address", address, "instance", inst.ID, "error", err)
-	}
+	p.reconciler().Route(ctx, inst, address)
 }
 
 // unrouteElasticIP takes the route back. The machine may already be gone; the
 // driver treats that as nothing left to undo, and on OVN it still withdraws
 // the uplink route, which outlives the machine.
 func (p *Pack) unrouteElasticIP(ctx context.Context, address string, inst *resource.Resource) {
-	router, ok := p.env.Machines.(machine.Router)
-	if !ok || !emulatedElasticIP(address) {
-		return
-	}
 	name := ""
 	if inst != nil {
 		name = inst.Runtime[p.binding().RuntimeKey]
 	}
-	if err := p.binding().UnrouteAddress(ctx, router, name, address); err != nil {
-		p.logger().Error("could not stop routing the elastic IP",
-			"address", address, "error", err)
-	}
+	p.reconciler().Unroute(ctx, name, address)
 }
 
 // elasticBootAddresses is what an instance's machine must answer on from its

--- a/internal/providers/exoscale/firewall.go
+++ b/internal/providers/exoscale/firewall.go
@@ -22,14 +22,41 @@ import (
 // is allowed" — and "as soon as you define an outbound rule, outbound traffic
 // is only allowed for the defined outbound rules". Rules are allow-only.
 
-// enforcer returns the runtime's firewall half, or nil when it has none.
-func (p *Pack) enforcer() machine.Firewaller {
-	fw, _ := p.env.Machines.(machine.Firewaller)
-	return fw
+// groupSync is this pack's half of the shared firewall orchestration (#509):
+// the skeleton — sync-then-apply, the wearer replay, the fresh copy, the
+// after-boot re-expansion — lives in machine.GroupSync, written once for every
+// pack; what is declared here is only what Exoscale knows. Referencing
+// machine.GroupSync is also this pack's marker for the enforcement test: a
+// pack wires the firewall when a non-test file of its own builds one of these.
+func (p *Pack) groupSync() machine.GroupSync {
+	return machine.GroupSync{
+		Binding: p.binding(),
+		SpecOf:  p.firewallSpecOf,
+		Wearers: func(group *resource.Resource) []*resource.Resource {
+			return p.instancesWearing(group.ID)
+		},
+		WornIDs: p.wornGroupIDs,
+		Group: func(id string) (*resource.Resource, bool) {
+			return p.env.Store.Get(Name, kindSecurityGroup, id)
+		},
+		Referrers: p.groupsReferencing,
+	}
+}
+
+// wornGroupIDs is the identifiers of the groups one instance wears.
+func (p *Pack) wornGroupIDs(res *resource.Resource) []string {
+	return stringList(res.Attrs[attrSecurityGroupIDs])
 }
 
 // firewallSpecOf translates a group and its rules for the runtime.
-func (p *Pack) firewallSpecOf(group *resource.Resource) machine.FirewallSpec {
+//
+// fresh, when set, is the resource a transition is still working on: the boot
+// that triggers a re-expansion runs before its own commit, so the store's copy
+// of that instance does not yet carry the addresses the expansion is being run
+// FOR. This pack read the store alone until the skeleton threaded fresh for
+// every pack at once — whether its gap was reachable was never established
+// (the audit's open question on #509), and now the question no longer exists.
+func (p *Pack) firewallSpecOf(group, fresh *resource.Resource) machine.FirewallSpec {
 	spec := machine.FirewallSpec{
 		Name:           machine.FirewallName("exo", group.ID),
 		DefaultIngress: "drop",
@@ -46,7 +73,7 @@ func (p *Pack) firewallSpecOf(group *resource.Resource) machine.FirewallSpec {
 		if direction := ruleDirection(rule); direction == "egress" {
 			spec.DefaultEgress = "drop"
 		}
-		spec.Rules = append(spec.Rules, p.firewallRulesOf(rule)...)
+		spec.Rules = append(spec.Rules, p.firewallRulesOf(rule, fresh)...)
 	}
 	// The permissive egress of a group with no egress rule is written into the
 	// set itself — WithPermissiveCatchAll says why an OVN NIC needs it there.
@@ -64,13 +91,13 @@ func ruleDirection(rule map[string]any) string {
 // firewallRulesOf converts one stored rule, expanded when it names a group
 // rather than a block: bridge-backed runtimes have no group selector, so
 // "traffic from that group" becomes one /32 per address its member machines
-// answer on, refreshed whenever a machine starts (syncFirewallAfterBoot).
+// answer on, refreshed whenever a machine starts (GroupSync.AfterBoot).
 //
 // A rule carrying an icmp type/code is dropped rather than approximated — the
 // runtime's rule shape has no field for them, and family-wide ICMP would be
 // broader than what the API describes; the log says so, because visibly
 // absent is the honest state.
-func (p *Pack) firewallRulesOf(rule map[string]any) []machine.FirewallRule {
+func (p *Pack) firewallRulesOf(rule map[string]any, fresh *resource.Resource) []machine.FirewallRule {
 	if _, precise := rule["icmp"]; precise {
 		p.logger().Warn("an ICMP rule with a type and code is not expressible by this runtime "+
 			"and was left out of the rule set; the API still describes it",
@@ -96,7 +123,7 @@ func (p *Pack) firewallRulesOf(rule map[string]any) []machine.FirewallRule {
 	memberRef := false
 	if target, ok := rule["security-group"].(map[string]any); ok {
 		memberRef = true
-		blocks = append(blocks, p.memberBlocks(stringAttr(target["id"]))...)
+		blocks = append(blocks, p.memberBlocks(stringAttr(target["id"]), fresh)...)
 	}
 	// Neither a network nor a group means "from anywhere", which an empty
 	// source already says. A group that expands to nothing emits nothing: no
@@ -144,13 +171,17 @@ func stringAttr(v any) string {
 // runtime with no group selector: one /32 per address a member machine
 // answers on — its public address and its private-network leases — plus the
 // group's external sources, which upstream defines as extending exactly this
-// membership.
-func (p *Pack) memberBlocks(groupID string) []string {
+// membership. The transition's own copy wins over the store's: the store has
+// not been committed yet when a boot re-expands the groups naming it.
+func (p *Pack) memberBlocks(groupID string, fresh *resource.Resource) []string {
 	if groupID == "" {
 		return nil
 	}
 	out := make([]string, 0, 4)
 	for _, inst := range p.instancesWearing(groupID) {
+		if fresh != nil && inst.ID == fresh.ID {
+			inst = fresh
+		}
 		if ip, _ := inst.Attrs["public-ip"].(string); ip != "" {
 			out = append(out, ip+"/32")
 		}
@@ -184,78 +215,22 @@ func (p *Pack) instancesWearing(groupID string) []*resource.Resource {
 
 // syncSecurityGroup pushes a group's rule set and replays it onto every
 // instance wearing it. Called after any change to the group or to its rules.
+// The skeleton is machine.GroupSync's, shared with the two other packs.
 func (p *Pack) syncSecurityGroup(ctx context.Context, group *resource.Resource) {
-	fw := p.enforcer()
-	if fw == nil {
-		return
-	}
-	b := p.binding()
-	if !b.SyncRuleSet(ctx, fw, p.firewallSpecOf(group)) {
-		return
-	}
-	for _, inst := range p.instancesWearing(group.ID) {
-		p.applyInstanceRuleSets(ctx, inst)
-	}
+	p.groupSync().SyncGroup(ctx, group, nil)
 }
 
-// applyInstanceRuleSets attaches everything one instance wears to its machine,
-// in one call, because the runtime replaces the attachment list rather than
-// merging it. Every set is written first, so an attach cannot name a set the
-// runtime has never seen.
-func (p *Pack) applyInstanceRuleSets(ctx context.Context, inst *resource.Resource) {
-	fw := p.enforcer()
-	if fw == nil {
-		return
-	}
-	name := inst.Runtime[p.binding().RuntimeKey]
-	if name == "" {
-		return
-	}
-	b := p.binding()
-	specs := make([]machine.FirewallSpec, 0, 2)
-	for _, id := range stringList(inst.Attrs[attrSecurityGroupIDs]) {
-		group, found := p.env.Store.Get(Name, kindSecurityGroup, id)
-		if !found {
-			continue
-		}
-		spec := p.firewallSpecOf(group)
-		if !b.SyncRuleSet(ctx, fw, spec) {
-			continue
-		}
-		specs = append(specs, spec)
-	}
-	b.ApplyRuleSets(ctx, fw, name, specs...)
-}
-
-// syncFirewallAfterBoot runs once a machine exists: its own sets attach, and
-// every group whose rules point at a group this instance wears is re-expanded,
-// because this machine's addresses are now part of what those groups mean.
-// Without the second half, "the application tier accepts the web tier and
-// nobody else" — the sentence examples/stacks/exoscale writes — never contains
-// the web machines it talks about.
-func (p *Pack) syncFirewallAfterBoot(ctx context.Context, inst *resource.Resource) {
-	if p.enforcer() == nil {
-		return
-	}
-	p.applyInstanceRuleSets(ctx, inst)
-	p.syncGroupsReferencing(ctx, stringList(inst.Attrs[attrSecurityGroupIDs]))
-}
-
-// syncGroupsReferencing re-syncs every group one of whose rules names one of
-// the given groups as a member source.
-func (p *Pack) syncGroupsReferencing(ctx context.Context, groupIDs []string) {
-	if len(groupIDs) == 0 || p.enforcer() == nil {
-		return
-	}
-	named := make(map[string]bool, len(groupIDs))
-	for _, id := range groupIDs {
-		named[id] = true
-	}
+// groupsReferencing lists every group one of whose rules names one of the
+// given groups as its source — the enumeration is Exoscale's (its rule
+// attributes), the re-sync it feeds is the shared skeleton's.
+func (p *Pack) groupsReferencing(named map[string]bool) []*resource.Resource {
+	var out []*resource.Resource
 	for _, group := range p.env.Store.List(kindSecurityGroup, resource.Tenant{Provider: Name}) {
 		if groupReferencesAny(group, named) {
-			p.syncSecurityGroup(ctx, group)
+			out = append(out, group)
 		}
 	}
+	return out
 }
 
 // groupReferencesAny reports whether any rule of the group names one of the
@@ -275,7 +250,7 @@ func groupReferencesAny(group *resource.Resource, named map[string]bool) bool {
 
 // removeFirewall drops the runtime rule set of a group being deleted.
 func (p *Pack) removeFirewall(ctx context.Context, group *resource.Resource) {
-	p.binding().DropRuleSet(ctx, p.enforcer(), machine.FirewallName("exo", group.ID))
+	p.groupSync().Drop(ctx, machine.FirewallName("exo", group.ID))
 }
 
 // EnforcesFirewall implements emulator.FirewallEnforcer: this pack reconciles

--- a/internal/providers/exoscale/firewall_internal_test.go
+++ b/internal/providers/exoscale/firewall_internal_test.go
@@ -122,7 +122,7 @@ func TestAnEgressRuleFlipsTheEgressDefault(t *testing.T) {
 		"network": "0.0.0.0/0", "start-port": 22, "end-port": 22,
 	}})
 
-	spec := p.firewallSpecOf(open)
+	spec := p.firewallSpecOf(open, nil)
 	if spec.DefaultEgress != "allow" {
 		t.Fatalf("egress default %q, want allow while no egress rule exists", spec.DefaultEgress)
 	}
@@ -140,7 +140,7 @@ func TestAnEgressRuleFlipsTheEgressDefault(t *testing.T) {
 		"id": "r2", "flow-direction": "egress", "protocol": "tcp",
 		"network": "10.0.0.0/8", "start-port": 443, "end-port": 443,
 	}})
-	spec = p.firewallSpecOf(restricted)
+	spec = p.firewallSpecOf(restricted, nil)
 	if spec.DefaultEgress != "drop" {
 		t.Fatalf("egress default %q, want drop: one outbound rule restricts outbound to the defined rules", spec.DefaultEgress)
 	}
@@ -170,7 +170,7 @@ func TestAGroupSourcedRuleExpandsToTheMembersAddresses(t *testing.T) {
 		"start-port":     8080, "end-port": 8080,
 	}})
 
-	spec := p.firewallSpecOf(app)
+	spec := p.firewallSpecOf(app, nil)
 	sources := map[string]bool{}
 	for _, rule := range spec.Rules {
 		if rule.PortFrom == 8080 {

--- a/internal/providers/exoscale/machines.go
+++ b/internal/providers/exoscale/machines.go
@@ -141,7 +141,14 @@ func (p *Pack) start(ctx context.Context, res *resource.Resource) {
 	name, _ := res.Attrs["name"].(string)
 	userData, _ := res.Attrs["user-data"].(string)
 
-	p.binding().PowerOn(ctx, res, machine.Boot{
+	// The plan — no interface rides the launch, the elastic addresses do, the
+	// memberships come back as extra interfaces after the boot — is declared
+	// to the shared Reconciler, which executes the one post-boot order:
+	// addresses, then memberships, the firewall last (#510). The rule this
+	// pack used to keep as a comment — a membership must never become the
+	// primary the way a Boot.Attachment would — is the layer's law now:
+	// Plan.Memberships never ride the launch.
+	p.reconciler().PowerOn(ctx, res, machine.Boot{
 		Image:     img.Ref,
 		Requested: templateID,
 		Hostname:  name,
@@ -162,44 +169,40 @@ func (p *Pack) start(ctx context.Context, res *resource.Resource) {
 		// Decoded here, stored encoded: Exoscale documents user-data as base64,
 		// so that is what a read gives back and what cloud-init must not see.
 		CloudInit: cloudinit.Decode(userData),
-		// The elastic IPs already attached, on the launch: a route edited onto
-		// a live OVN NIC re-plugs it and costs the guest its lease.
-		PublicAddresses: p.elasticBootAddresses(res),
-		Labels:          map[string]string{"feint.instance": res.ID},
+		Labels:    map[string]string{"feint.instance": res.ID},
 	})
-	// The boot installed the host half of every route; this hands the guest
-	// its addresses, and repairs a machine that already existed. Idempotent.
-	for _, address := range p.elasticBootAddresses(res) {
-		p.routeElasticIP(ctx, address, res)
-	}
-	// The private networks the instance already joined come back as extra
-	// interfaces, after the boot rather than on it: Exoscale's eth0 is the
-	// public interface — the address this pack publishes as public-ip is the
-	// primary interface's — so a membership must never become the primary the
-	// way a Boot.Attachment would. Attach is idempotent by network, so a
-	// machine that kept its devices across a stop is repaired, not doubled.
-	p.reattachPrivateNetworks(ctx, res)
-	// The groups this instance wears reach its interfaces, and the groups
-	// that name those groups as sources are re-expanded now that this machine
-	// has addresses (#475). After the networks, so the expansion sees every
-	// interface — and the transition's own copy rides as fresh, because the
-	// store has not committed it yet.
-	p.groupSync().AfterBoot(ctx, res)
 }
 
-// reattachPrivateNetworks puts a freshly booted machine back on every private
-// network its memberships name. Attaching to a stopped instance and then
-// starting it is the ordinary order, and without this the machine came up on
-// the default network alone while the API published a membership it had never
-// taken.
-func (p *Pack) reattachPrivateNetworks(ctx context.Context, res *resource.Resource) {
+// reconciler is this pack's half of the shared interface choreography (#510):
+// the plan declares what only Exoscale knows, the layer executes the order.
+func (p *Pack) reconciler() machine.Reconciler {
+	return machine.Reconciler{
+		Groups:      p.groupSync(),
+		PlanOf:      p.machinePlan,
+		PublicBlock: elasticIPPrefix,
+	}
+}
+
+// machinePlan declares an instance's interface shape: nothing rides the
+// launch, because Exoscale's eth0 is the public interface — the address this
+// pack publishes as public-ip is the primary interface's — so a membership
+// must never become the primary the way a Boot attachment would. The elastic
+// IPs already attached ride as promised addresses (a route edited onto a live
+// OVN NIC re-plugs it and costs the guest its lease), and the private
+// networks the instance already joined come back as memberships, after the
+// boot: attaching to a stopped instance and then starting it is the ordinary
+// order, and without the replay the machine came up on the default network
+// alone while the API published a membership it had never taken.
+func (p *Pack) machinePlan(res *resource.Resource) machine.Plan {
+	plan := machine.Plan{Publics: p.elasticBootAddresses(res)}
 	for _, m := range instanceAttachmentsOf(res) {
 		pn, found := p.env.Store.Get(Name, kindPrivateNetwork, m.NetworkID)
 		if !found {
 			continue
 		}
-		p.attachMachineToPrivateNetwork(ctx, res, pn, m.IP)
+		plan.Memberships = append(plan.Memberships, p.membershipAttachment(pn, m.IP))
 	}
+	return plan
 }
 
 // authorizedKeys is the material of the key an instance names, or nothing.

--- a/internal/providers/exoscale/machines.go
+++ b/internal/providers/exoscale/machines.go
@@ -182,8 +182,9 @@ func (p *Pack) start(ctx context.Context, res *resource.Resource) {
 	// The groups this instance wears reach its interfaces, and the groups
 	// that name those groups as sources are re-expanded now that this machine
 	// has addresses (#475). After the networks, so the expansion sees every
-	// interface.
-	p.syncFirewallAfterBoot(ctx, res)
+	// interface — and the transition's own copy rides as fresh, because the
+	// store has not committed it yet.
+	p.groupSync().AfterBoot(ctx, res)
 }
 
 // reattachPrivateNetworks puts a freshly booted machine back on every private

--- a/internal/providers/exoscale/privatenetworks.go
+++ b/internal/providers/exoscale/privatenetworks.go
@@ -289,27 +289,16 @@ func stringOf(v *string) string {
 
 // ensureBackingNetwork asks the machine driver for a real network carrying the
 // managed range. The gateway is the block's first host address, one the lease
-// allocator below never hands out.
+// allocator below never hands out. The mechanics — the derived name, the
+// labels, recording the name only once the driver accepted it — are
+// Binding.EnsureBackingNetwork's, shared with the two other packs (#510).
 func (p *Pack) ensureBackingNetwork(ctx context.Context, res *resource.Resource, prefix netip.Prefix) error {
-	if p.env.Machines == nil {
-		return nil
-	}
-	name := machine.NetworkName(machine.NetworkPrefix, res.ID)
-	if res.Runtime == nil {
-		res.Runtime = map[string]string{}
-	}
-	res.Runtime[runtimeNetworkKey] = name
-
-	gateway := prefix.Masked().Addr().Next()
-	return p.env.Machines.EnsureNetwork(ctx, machine.NetworkSpec{
-		Name:    name,
-		CIDR:    prefix.Masked().String(),
-		Gateway: gateway.String(),
+	return p.binding().EnsureBackingNetwork(ctx, res, machine.BackingNetwork{
+		Key:     runtimeNetworkKey,
+		CIDR:    prefix,
+		Gateway: true,
 		NAT:     true,
-		Labels: map[string]string{
-			"feint.provider":        Name,
-			"feint.private-network": res.ID,
-		},
+		Marker:  "feint.private-network",
 	})
 }
 
@@ -543,11 +532,11 @@ func (p *Pack) updatePrivateNetwork(w http.ResponseWriter, r *http.Request) {
 	// on an existing network without reshaping it, so the old one goes first —
 	// safe here because the refusal above proved nothing is attached.
 	if rangeChanged && p.env.Machines != nil {
-		if name := res.Runtime[runtimeNetworkKey]; name != "" {
-			if err := p.env.Machines.RemoveNetwork(r.Context(), name); err != nil {
-				p.logger().Error("could not remove the outgrown backing network",
-					"private-network", res.ID, "network", name, "error", err)
-			}
+		if err := p.binding().RemoveBackingNetwork(r.Context(), res, runtimeNetworkKey); err != nil {
+			p.logger().Error("could not remove the outgrown backing network",
+				"private-network", res.ID, "network", res.Runtime[runtimeNetworkKey], "error", err)
+			// Forgotten anyway: the re-ensure below derives the same name, and
+			// keeping the record would change nothing about what it finds.
 			delete(res.Runtime, runtimeNetworkKey)
 		}
 		if managed {
@@ -611,11 +600,9 @@ func (p *Pack) deletePrivateNetwork(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
-	if name := res.Runtime[runtimeNetworkKey]; name != "" && p.env.Machines != nil {
-		if err := p.env.Machines.RemoveNetwork(r.Context(), name); err != nil {
-			p.logger().Error("could not remove the backing network",
-				"private-network", res.ID, "network", name, "error", err)
-		}
+	if err := p.binding().RemoveBackingNetwork(r.Context(), res, runtimeNetworkKey); err != nil {
+		p.logger().Error("could not remove the backing network",
+			"private-network", res.ID, "network", res.Runtime[runtimeNetworkKey], "error", err)
 	}
 	p.env.Store.Delete(Name, kindPrivateNetwork, id)
 	p.isolatePrivateNetworks(r.Context())
@@ -704,13 +691,14 @@ func (p *Pack) attachInstanceToPrivateNetwork(w http.ResponseWriter, r *http.Req
 		writeError(w, http.StatusNotFound, "resource not found")
 		return
 	}
-	p.attachMachineToPrivateNetwork(r.Context(), inst, pn, leaseIP)
-	// The interface this attach just created carries the instance's rule sets
-	// like every other one: the Terraform provider attaches networks after the
-	// create returns, and a set applied at boot never reaches an interface
-	// born later (#475). ApplyFirewall covers every NIC of the machine, so
-	// re-applying here is idempotent for the older ones.
-	p.groupSync().ApplyMachine(r.Context(), inst)
+	// Join attaches and then resyncs the firewall: the interface this attach
+	// just created carries the instance's rule sets like every other one — the
+	// Terraform provider attaches networks after the create returns, and a set
+	// applied at boot never reaches an interface born later (#475).
+	// ApplyFirewall covers every NIC of the machine, so re-applying is
+	// idempotent for the older ones; the groups naming this instance's groups
+	// re-expand with it, because the new lease is now part of what they mean.
+	p.joinPrivateNetwork(r.Context(), inst, pn, leaseIP)
 	p.writeOperation(w, p.operationReferring(nounPrivateNetwork, id))
 }
 
@@ -872,7 +860,7 @@ func (p *Pack) updatePrivateNetworkInstanceIP(w http.ResponseWriter, r *http.Req
 		return
 	}
 	if inst, ok := p.env.Store.Get(Name, kindInstance, req.Instance.ID); ok {
-		p.attachMachineToPrivateNetwork(r.Context(), inst, pn, req.IP)
+		p.joinPrivateNetwork(r.Context(), inst, pn, req.IP)
 	}
 	p.writeOperation(w, p.operationReferring(nounPrivateNetwork, id))
 }
@@ -930,37 +918,33 @@ func (p *Pack) moveLease(w http.ResponseWriter, pn *resource.Resource, dhcp mana
 
 // ---- The machine half -------------------------------------------------------
 
-// attachMachineToPrivateNetwork puts the backing machine on the backing
-// network at the address the control plane just published. Degrades quietly,
-// like every runtime call of this pack: with no runtime, or none started yet,
-// the membership is still true and the interface arrives with the next boot.
-func (p *Pack) attachMachineToPrivateNetwork(ctx context.Context, inst, pn *resource.Resource, ip string) {
-	if p.env.Machines == nil {
-		return
-	}
-	networkName := pn.Runtime[runtimeNetworkKey]
-	machineName := inst.Runtime[p.binding().RuntimeKey]
-	if networkName == "" || machineName == "" {
-		return
-	}
-	att := machine.Attachment{Network: networkName, Address: ip}
+// membershipAttachment is what one private-network membership means to the
+// runtime: the backing network, the leased address, and the range's mask when
+// the network is managed — configuring the interface inside the guest needs
+// both halves.
+func (p *Pack) membershipAttachment(pn *resource.Resource, ip string) machine.Attachment {
+	att := machine.Attachment{Network: pn.Runtime[runtimeNetworkKey], Address: ip}
 	if dhcp, managed := rangeOf(pn); managed && ip != "" {
 		att.PrefixLen = dhcp.prefix.Bits()
 	}
-	if err := p.env.Machines.Attach(ctx, machineName, att); err != nil {
-		p.logger().Error("could not attach the machine to the private network",
-			"instance", inst.ID, "private-network", pn.ID, "address", ip, "error", err)
-	}
+	return att
 }
 
-// detachMachineFromPrivateNetwork is the exact undo of
-// attachMachineToPrivateNetwork, and degrades the same way: with no runtime, or
-// a machine that never started, there is nothing to take off and the membership
-// has already gone from the store.
+// joinPrivateNetwork puts the backing machine on the backing network at the
+// address the control plane just published, and resyncs the firewall after it
+// — the hot half of a membership, through the shared Reconciler (#510).
+// Degrades quietly, like every runtime call of this pack: with no runtime, or
+// none started yet, the membership is still true and the interface arrives
+// with the next boot's plan.
+func (p *Pack) joinPrivateNetwork(ctx context.Context, inst, pn *resource.Resource, ip string) {
+	_ = p.reconciler().Join(ctx, inst, p.membershipAttachment(pn, ip))
+}
+
+// detachMachineFromPrivateNetwork is the exact undo of joinPrivateNetwork's
+// attach half, and degrades the same way: with no runtime, or a machine that
+// never started, there is nothing to take off and the membership has already
+// gone from the store.
 func (p *Pack) detachMachineFromPrivateNetwork(ctx context.Context, instanceID, networkID string) {
-	if p.env.Machines == nil {
-		return
-	}
 	inst, found := p.env.Store.Get(Name, kindInstance, instanceID)
 	if !found {
 		return
@@ -969,15 +953,7 @@ func (p *Pack) detachMachineFromPrivateNetwork(ctx context.Context, instanceID, 
 	if !found {
 		return
 	}
-	networkName := pn.Runtime[runtimeNetworkKey]
-	machineName := inst.Runtime[p.binding().RuntimeKey]
-	if networkName == "" || machineName == "" {
-		return
-	}
-	if err := p.env.Machines.Detach(ctx, machineName, networkName); err != nil {
-		p.logger().Error("could not detach the machine from the private network",
-			"instance", instanceID, "private-network", networkID, "error", err)
-	}
+	p.reconciler().Leave(ctx, inst, pn.Runtime[runtimeNetworkKey])
 }
 
 // privateNetworkRefs is the instance-side wire shape: their instance schema

--- a/internal/providers/exoscale/privatenetworks.go
+++ b/internal/providers/exoscale/privatenetworks.go
@@ -710,7 +710,7 @@ func (p *Pack) attachInstanceToPrivateNetwork(w http.ResponseWriter, r *http.Req
 	// create returns, and a set applied at boot never reaches an interface
 	// born later (#475). ApplyFirewall covers every NIC of the machine, so
 	// re-applying here is idempotent for the older ones.
-	p.applyInstanceRuleSets(r.Context(), inst)
+	p.groupSync().ApplyMachine(r.Context(), inst)
 	p.writeOperation(w, p.operationReferring(nounPrivateNetwork, id))
 }
 

--- a/internal/providers/exoscale/securitygroups.go
+++ b/internal/providers/exoscale/securitygroups.go
@@ -299,13 +299,10 @@ func (p *Pack) detachInstanceFromSecurityGroup(w http.ResponseWriter, r *http.Re
 // rules name the group that just gained or lost this member is re-expanded
 // (#475).
 func (p *Pack) moveInstanceFirewall(r *http.Request, instanceID string) {
-	if p.enforcer() == nil {
-		return
-	}
 	if inst, found := p.env.Store.Get(Name, kindInstance, instanceID); found {
-		p.applyInstanceRuleSets(r.Context(), inst)
+		p.groupSync().ApplyMachine(r.Context(), inst)
 	}
-	p.syncGroupsReferencing(r.Context(), []string{r.PathValue("id")})
+	p.groupSync().SyncReferrers(r.Context(), []string{r.PathValue("id")}, nil)
 }
 
 // changeInstanceMembership adds or removes one group-like resource on one
@@ -408,7 +405,7 @@ func (p *Pack) changeExternalSources(w http.ResponseWriter, r *http.Request, add
 	}
 	// External sources extend the group's membership, so what changed is the
 	// expansion of every rule that names this group as a source (#475).
-	p.syncGroupsReferencing(r.Context(), []string{id})
+	p.groupSync().SyncReferrers(r.Context(), []string{id}, nil)
 	p.writeOperation(w, p.operationReferring(nounSecurityGroup, id))
 }
 

--- a/internal/providers/outscale/firewall.go
+++ b/internal/providers/outscale/firewall.go
@@ -26,10 +26,25 @@ import (
 // the default group's "everything from myself" inbound rule, which expands
 // below like any other member reference.
 
-// enforcer returns the runtime's firewall half, or nil when it has none.
-func (p *Pack) enforcer() machine.Firewaller {
-	fw, _ := p.env.Machines.(machine.Firewaller)
-	return fw
+// groupSync is this pack's half of the shared firewall orchestration (#509):
+// the skeleton — sync-then-apply, the wearer replay, the fresh copy, the
+// after-boot re-expansion — lives in machine.GroupSync, written once for every
+// pack; what is declared here is only what Outscale knows. Referencing
+// machine.GroupSync is also this pack's marker for the enforcement test: a
+// pack wires the firewall when a non-test file of its own builds one of these.
+func (p *Pack) groupSync() machine.GroupSync {
+	return machine.GroupSync{
+		Binding: p.binding(),
+		SpecOf:  p.firewallSpecOf,
+		Wearers: func(group *resource.Resource) []*resource.Resource {
+			return p.vmsWearing(group.ID)
+		},
+		WornIDs: p.wornGroupIDs,
+		Group: func(id string) (*resource.Resource, bool) {
+			return p.env.Store.Get(Name, kindSecurityGroup, id)
+		},
+		Referrers: p.groupsReferencing,
+	}
 }
 
 // firewallSpecOf translates a group and its rules for the runtime.
@@ -165,76 +180,10 @@ func (p *Pack) vmsWearing(groupID string) []*resource.Resource {
 }
 
 // syncSecurityGroup pushes a group's rule set and replays it onto every Vm
-// wearing it. Called after any change to the group or to its rules.
+// wearing it. Called after any change to the group or to its rules. The
+// skeleton is machine.GroupSync's, shared with the two other packs.
 func (p *Pack) syncSecurityGroup(ctx context.Context, group *resource.Resource) {
-	fw := p.enforcer()
-	if fw == nil {
-		return
-	}
-	p.syncSecurityGroupSeen(ctx, group, nil)
-}
-
-// syncSecurityGroupSeen is syncSecurityGroup with the transition's own copy of
-// a booting Vm, which the expansion must see — firewallSpecOf says why.
-func (p *Pack) syncSecurityGroupSeen(ctx context.Context, group, fresh *resource.Resource) {
-	fw := p.enforcer()
-	if fw == nil {
-		return
-	}
-	b := p.binding()
-	if !b.SyncRuleSet(ctx, fw, p.firewallSpecOf(group, fresh)) {
-		return
-	}
-	for _, vm := range p.vmsWearing(group.ID) {
-		if fresh != nil && vm.ID == fresh.ID {
-			vm = fresh
-		}
-		p.applyVMRuleSets(ctx, vm)
-	}
-}
-
-// applyVMRuleSets attaches everything one Vm wears to its machine, in one
-// call, because the runtime replaces the attachment list rather than merging
-// it. Every set is written first, so an attach cannot name a set the runtime
-// has never seen.
-func (p *Pack) applyVMRuleSets(ctx context.Context, vm *resource.Resource) {
-	fw := p.enforcer()
-	if fw == nil {
-		return
-	}
-	name := vm.Runtime[p.binding().RuntimeKey]
-	if name == "" {
-		return
-	}
-	b := p.binding()
-	specs := make([]machine.FirewallSpec, 0, 2)
-	for _, ref := range p.effectiveSecurityGroups(vm) {
-		summary, _ := ref.(map[string]any)
-		group, found := p.env.Store.Get(Name, kindSecurityGroup, stringOf(summary["SecurityGroupId"]))
-		if !found {
-			continue
-		}
-		spec := p.firewallSpecOf(group, vm)
-		if !b.SyncRuleSet(ctx, fw, spec) {
-			continue
-		}
-		specs = append(specs, spec)
-	}
-	b.ApplyRuleSets(ctx, fw, name, specs...)
-}
-
-// syncFirewallAfterBoot runs once a machine exists or first publishes an
-// address: its own sets attach, and every group whose rules point at a group
-// this Vm wears is re-expanded, because this Vm's addresses are now part of
-// what those groups mean. Without the second half, the three-tier statement a
-// stack writes — tier 2 accepts tier 1 and nobody else — never contains the
-// machines it talks about.
-func (p *Pack) syncFirewallAfterBoot(ctx context.Context, vm *resource.Resource) {
-	if p.enforcer() == nil {
-		return
-	}
-	p.applyVMRuleSets(ctx, vm)
-	p.syncGroupsReferencingSeen(ctx, p.wornGroupIDs(vm), vm)
+	p.groupSync().SyncGroup(ctx, group, nil)
 }
 
 // wornGroupIDs is the identifiers of the groups one Vm wears.
@@ -250,25 +199,17 @@ func (p *Pack) wornGroupIDs(vm *resource.Resource) []string {
 	return out
 }
 
-// syncGroupsReferencing re-syncs every group one of whose rules names one of
-// the given groups as a member source.
-func (p *Pack) syncGroupsReferencing(ctx context.Context, groupIDs []string) {
-	p.syncGroupsReferencingSeen(ctx, groupIDs, nil)
-}
-
-func (p *Pack) syncGroupsReferencingSeen(ctx context.Context, groupIDs []string, fresh *resource.Resource) {
-	if len(groupIDs) == 0 {
-		return
-	}
-	named := make(map[string]bool, len(groupIDs))
-	for _, id := range groupIDs {
-		named[id] = true
-	}
+// groupsReferencing lists every group one of whose rules names one of the
+// given groups as a member source — the enumeration is Outscale's (its rule
+// attributes), the re-sync it feeds is the shared skeleton's.
+func (p *Pack) groupsReferencing(named map[string]bool) []*resource.Resource {
+	var out []*resource.Resource
 	for _, group := range p.env.Store.List(kindSecurityGroup, resource.Tenant{Provider: Name}) {
 		if groupReferencesAny(group, named) {
-			p.syncSecurityGroupSeen(ctx, group, fresh)
+			out = append(out, group)
 		}
 	}
+	return out
 }
 
 // groupReferencesAny reports whether any rule of the group names one of the
@@ -292,7 +233,7 @@ func groupReferencesAny(group *resource.Resource, named map[string]bool) bool {
 
 // removeFirewall drops the runtime rule set of a group being deleted.
 func (p *Pack) removeFirewall(ctx context.Context, group *resource.Resource) {
-	p.binding().DropRuleSet(ctx, p.enforcer(), machine.FirewallName("osc", group.ID))
+	p.groupSync().Drop(ctx, machine.FirewallName("osc", group.ID))
 }
 
 // EnforcesFirewall implements emulator.FirewallEnforcer: this pack reconciles

--- a/internal/providers/outscale/machines.go
+++ b/internal/providers/outscale/machines.go
@@ -105,38 +105,50 @@ func (p *Pack) powerOn(ctx context.Context, res *resource.Resource) {
 		reason = p.bootRefusalReason(imageID)
 	}
 
-	p.binding().PowerOn(ctx, res, machine.Boot{
+	// The plan — the Subnet attachment riding the launch, the linked public
+	// address, the private address remembered before the expansion reads it —
+	// is declared to the shared Reconciler, which executes the one post-boot
+	// order: addresses, then memberships, the firewall last (#510). Written
+	// here as a comment three ways before that; held by a test now.
+	p.reconciler().PowerOn(ctx, res, machine.Boot{
 		Image:          img.Ref,
 		User:           img.User,
 		Requested:      imageID,
 		Reason:         reason,
 		Hostname:       res.ID,
 		AuthorizedKeys: p.authorizedKeys(keypair),
-		// The Subnet the client asked for, carried onto the machine. Without
-		// this the address published as PrivateIp is a number in a store and
-		// nothing answers on it — which is the defect this project exists to
-		// avoid, not a detail of the API shape.
-		Attachments: p.attachmentOf(res),
 		// Decoded here, stored encoded: Outscale documents UserData as
 		// Base64-encoded, so that is what a read must give back, and what
 		// cloud-init must never receive.
 		CloudInit: cloudinit.Decode(userData),
-		// The public address linked to this Vm, on the launch: a route edited
-		// onto a live OVN NIC re-plugs it and costs the guest its lease.
-		PublicAddresses: p.publicBootAddresses(res.ID),
-		Labels:          map[string]string{"feint.vm": res.ID},
+		Labels:    map[string]string{"feint.vm": res.ID},
 	})
-	p.rememberAddress(res)
-	// The boot installed the host half of the route; this hands the guest its
-	// address, and repairs a machine that already existed. Idempotent.
-	for _, address := range p.publicBootAddresses(res.ID) {
-		p.routeLinkedIP(ctx, address, res)
+}
+
+// reconciler is this pack's half of the shared interface choreography (#510):
+// the plan declares what only Outscale knows, the layer executes the order.
+func (p *Pack) reconciler() machine.Reconciler {
+	return machine.Reconciler{
+		Groups: p.groupSync(),
+		PlanOf: p.machinePlan,
+		// The private address is kept on the resource before the firewall
+		// expansion reads it — rememberAddress says why it lives in Attrs.
+		Settle:      p.rememberAddress,
+		PublicBlock: publicIPPrefix,
 	}
-	// The groups this Vm wears reach its interfaces, and the groups that name
-	// those groups as members are re-expanded now that this machine has
-	// addresses (#475). After the routes, so the expansion sees them. The
-	// transition's own copy rides as fresh: the store has not committed it yet.
-	p.groupSync().AfterBoot(ctx, res)
+}
+
+// machinePlan declares a Vm's interface shape: the Subnet the client asked
+// for rides the launch — without it the address published as PrivateIp is a
+// number in a store and nothing answers on it — and the linked public address
+// rides too, because a route edited onto a live OVN NIC re-plugs it and costs
+// the guest its lease. No membership joins after boot: a Vm is born on its
+// Subnet, which is this provider's model.
+func (p *Pack) machinePlan(res *resource.Resource) machine.Plan {
+	return machine.Plan{
+		Boot:    p.attachmentOf(res),
+		Publics: p.publicBootAddresses(res.ID),
+	}
 }
 
 // rememberAddress keeps the private address on the resource, not only on the

--- a/internal/providers/outscale/machines.go
+++ b/internal/providers/outscale/machines.go
@@ -134,8 +134,9 @@ func (p *Pack) powerOn(ctx context.Context, res *resource.Resource) {
 	}
 	// The groups this Vm wears reach its interfaces, and the groups that name
 	// those groups as members are re-expanded now that this machine has
-	// addresses (#475). After the routes, so the expansion sees them.
-	p.syncFirewallAfterBoot(ctx, res)
+	// addresses (#475). After the routes, so the expansion sees them. The
+	// transition's own copy rides as fresh: the store has not committed it yet.
+	p.groupSync().AfterBoot(ctx, res)
 }
 
 // rememberAddress keeps the private address on the resource, not only on the
@@ -176,9 +177,12 @@ func (p *Pack) refreshMachine(ctx context.Context, res *resource.Resource) bool 
 		// A virtual machine gets its address tens of seconds after it starts,
 		// so this is where it first becomes known for one — and where every
 		// group naming this Vm's groups as members first has an address to
-		// expand to (#475).
+		// expand to (#475). res rides as fresh: rememberAddress wrote the
+		// address into this copy and Observe has not committed it yet, so an
+		// expansion reading the store alone would miss the very address this
+		// refresh just learned — the boot door's gap, one door over.
 		p.rememberAddress(res)
-		p.syncGroupsReferencing(ctx, p.wornGroupIDs(res))
+		p.groupSync().SyncReferrers(ctx, p.wornGroupIDs(res), res)
 	}
 	return changed
 }

--- a/internal/providers/outscale/nets.go
+++ b/internal/providers/outscale/nets.go
@@ -604,35 +604,21 @@ func (p *Pack) subnetSubregion(subnetID string) string {
 const runtimeNetworkKey = "network"
 
 func (p *Pack) ensureBackingNetwork(ctx context.Context, res *resource.Resource, prefix netip.Prefix) error {
-	if p.env.Machines == nil {
-		return nil
-	}
-	name := machine.NetworkName(machine.NetworkPrefix, res.ID)
 	// NAT is deliberately left off. A Subnet reaches the internet only once a
 	// client attaches an internet service or a NAT service, which is Outscale's
 	// model and AWS's before it. Switching NAT on here would make every emulated
 	// Subnet routable and quietly turn a plan that should fail into one that
 	// works — the emulator would be more permissive than the cloud it imitates,
 	// which is the one direction a test environment must never take.
-	if err := p.env.Machines.EnsureNetwork(ctx, machine.NetworkSpec{
-		Name:   name,
-		CIDR:   prefix.String(),
-		Labels: map[string]string{machine.LabelKey: Name, "feint.subnet": res.ID},
-	}); err != nil {
-		return err
-	}
-	if res.Runtime == nil {
-		res.Runtime = map[string]string{}
-	}
-	res.Runtime[runtimeNetworkKey] = name
-	return nil
+	return p.binding().EnsureBackingNetwork(ctx, res, machine.BackingNetwork{
+		Key:    runtimeNetworkKey,
+		CIDR:   prefix,
+		Marker: "feint.subnet",
+	})
 }
 
 func (p *Pack) removeBackingNetwork(ctx context.Context, res *resource.Resource) {
-	if p.env.Machines == nil || res.Runtime[runtimeNetworkKey] == "" {
-		return
-	}
-	if err := p.env.Machines.RemoveNetwork(ctx, res.Runtime[runtimeNetworkKey]); err != nil {
+	if err := p.binding().RemoveBackingNetwork(ctx, res, runtimeNetworkKey); err != nil {
 		p.logger().Error("could not remove the backing network",
 			"subnet", res.ID, "network", res.Runtime[runtimeNetworkKey], "error", err)
 	}

--- a/internal/providers/outscale/privateips.go
+++ b/internal/providers/outscale/privateips.go
@@ -369,7 +369,6 @@ func (p *Pack) carrySecondary(ctx context.Context, nic *resource.Resource) {
 	if !found {
 		return
 	}
-	machineName := p.binding().Name(vm.ID)
 	prefixLen := 0
 	if subnet, ok := p.env.Store.Get(Name, kindSubnet, stringOf(nic.Attrs["SubnetId"])); ok {
 		if prefix, err := prefixOf(subnet, "IpRange"); err == nil {
@@ -382,8 +381,9 @@ func (p *Pack) carrySecondary(ctx context.Context, nic *resource.Resource) {
 		PrefixLen: prefixLen,
 		Secondary: secondaryAddresses(nic),
 	}
-	if err := p.env.Machines.Attach(ctx, machineName, att); err != nil {
-		p.logger().Error("could not carry the secondary addresses",
-			"nic", nic.ID, "machine", machineName, "error", err)
-	}
+	// Through the shared Join, which reads the machine name off Runtime the
+	// way every other runtime path does — this function used to derive it
+	// with binding().Name and would have reconfigured a machine the Vm never
+	// started — and resyncs the firewall after the interface changed shape.
+	_ = p.reconciler().Join(ctx, vm, att)
 }

--- a/internal/providers/outscale/privateips_lock_test.go
+++ b/internal/providers/outscale/privateips_lock_test.go
@@ -115,9 +115,13 @@ func TestAnAddressLinkDoesNotHoldTheAddressLockAcrossTheRuntime(t *testing.T) {
 
 	// A machine, so the NIC has something to be carried on: carrySecondary is a
 	// no-op for a NIC linked to nothing, and a test that measured that would
-	// measure the absence of the call rather than its placement.
+	// measure the absence of the call rather than its placement. A bootable
+	// image, because the runtime path reads the machine name off Runtime now
+	// (#510): with the boot refused, no machine exists, nothing reaches Attach,
+	// and this test would measure the absence of the call again — under the
+	// old derived name it silently reconfigured a machine the Vm never started.
 	status, doc := doAction(t, ts, "CreateVms",
-		`{"ImageId":"ami-12345678","VmType":"tinav4.c1r1p2","SubnetId":"`+subnet+`"}`)
+		`{"ImageId":"ami-00000001","VmType":"tinav4.c1r1p2","SubnetId":"`+subnet+`"}`)
 	if status != http.StatusOK {
 		t.Fatalf("CreateVms answered %d: %v", status, doc)
 	}

--- a/internal/providers/outscale/publicips.go
+++ b/internal/providers/outscale/publicips.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/stephrobert/feint/internal/core/emulator"
-	"github.com/stephrobert/feint/internal/core/machine"
 	"github.com/stephrobert/feint/internal/core/resource"
 )
 
@@ -63,6 +62,9 @@ const publicIPBase = "198.51.100."
 // every suite and fixture in this repository, is two.
 const publicIPBlock = "198.51.100.0/28"
 
+// publicIPPrefix is the block parsed once, for the Reconciler's route guard.
+var publicIPPrefix = netip.MustParsePrefix(publicIPBlock)
+
 // publicIPHosts is how many addresses publicIPBlock holds, derived from the
 // prefix rather than written a second time. A bound that does not follow the
 // prefix is exactly how an allocator and the catalogue it publishes come to
@@ -103,44 +105,22 @@ func emulatedPublicIP(address string) bool {
 // stopped being one. Degrades quietly, like every runtime call in this pack.
 // TestLinkPublicIpRoutesTheAddress fails without it.
 func (p *Pack) routeLinkedIP(ctx context.Context, address string, vm *resource.Resource) {
-	router, ok := p.env.Machines.(machine.Router)
-	if !ok {
-		return
-	}
-	name := vm.Runtime[p.binding().RuntimeKey]
-	if name == "" || address == "" {
-		return
-	}
-	if !emulatedPublicIP(address) {
-		p.logger().Warn("refusing to route an address outside the emulated public block",
-			"address", address, "vm", vm.ID)
-		return
-	}
-	// Through the binding: this pack refuses to move a linked address unless the
-	// request passes AllowRelink, which is the real API's own default, and the
-	// runtime half of that move is the same in all three packs (#213).
-	if err := p.binding().RouteAddress(ctx, router, machine.AddressSpec{Machine: name, Address: address}); err != nil {
-		p.logger().Error("could not route the public IP to the machine",
-			"address", address, "vm", vm.ID, "error", err)
-	}
+	// Through the shared Reconciler, which holds the block guard and the
+	// router assertion once for the three packs (#510). This pack's own half
+	// stays at the control plane: a linked address moves only when the request
+	// passes AllowRelink, the real API's default (#213).
+	p.reconciler().Route(ctx, vm, address)
 }
 
 // unrouteLinkedIP takes the route back. The machine may already be gone; the
 // driver treats that as nothing left to undo, and on OVN it still withdraws
 // the uplink route, which outlives the machine.
 func (p *Pack) unrouteLinkedIP(ctx context.Context, address string, vm *resource.Resource) {
-	router, ok := p.env.Machines.(machine.Router)
-	if !ok || !emulatedPublicIP(address) {
-		return
-	}
 	machineName := ""
 	if vm != nil {
 		machineName = vm.Runtime[p.binding().RuntimeKey]
 	}
-	if err := p.binding().UnrouteAddress(ctx, router, machineName, address); err != nil {
-		p.logger().Error("could not stop routing the public IP",
-			"address", address, "error", err)
-	}
+	p.reconciler().Unroute(ctx, machineName, address)
 }
 
 // publicBootAddresses is what a Vm's machine must answer on from its first

--- a/internal/providers/outscale/vms.go
+++ b/internal/providers/outscale/vms.go
@@ -623,7 +623,7 @@ func (p *Pack) updateVm(w http.ResponseWriter, r *http.Request) {
 	// A changed group list reaches the machine's interfaces: the sets it now
 	// wears attach, the ones it dropped detach with them (#475).
 	if len(req.SecurityGroupIDs) > 0 {
-		p.applyVMRuleSets(r.Context(), updated)
+		p.groupSync().ApplyMachine(r.Context(), updated)
 	}
 
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{

--- a/internal/providers/replay_test.go
+++ b/internal/providers/replay_test.go
@@ -1,12 +1,11 @@
 // Package providers holds the properties that only make sense across packs.
 //
 // Each pack's own tests prove its dialect against its own client; nothing in
-// them can state that two packs agree. This test-only package mounts the three
-// packs one after the other on the shared contract recorder
-// (machine.NewRecorder, #515) and replays the same intent into each, so the
-// cross-pack properties become statable: same intent, same runtime sequence
-// (#510's sentence, red today), and no gesture outside the contract (#514's
-// service list, held dynamically).
+// them can state that two packs agree. This test-only package mounts the packs
+// on the shared contract recorder (machine.NewRecorder, #515) and replays the
+// same intent into each, so the cross-pack properties become statable: same
+// intent, same runtime sequence (#510's sentence, green since the Reconciler),
+// and no gesture outside the contract (#514's service list, held dynamically).
 package providers
 
 import (
@@ -28,17 +27,92 @@ import (
 	"github.com/stephrobert/feint/internal/providers/scaleway"
 )
 
-// The intent every pack can express, the one #515 names: one machine on one
-// private network, wearing one rule-set-bearing group, carrying one public
-// address. Each replay speaks its pack's own dialect — the forms must differ,
-// that is the polar star — but the client steps follow one canonical order:
-// network, group and its rule, address, machine wired to all three, then the
-// attachments the dialect performs after creation. What is compared is never
-// the dialect: it is the sequence of contract gestures the pack asked of the
-// runtime.
+// The equivalence is asserted per expressible intent, never "all sequences are
+// identical": the packs do not express every intent identically, because the
+// clouds do not. Each intent below names the packs that can express it and the
+// written reason the others cannot — a reason must be an upstream difference,
+// not a convenience — and every intent is expressed by at least two packs, or
+// it would compare nothing. What is compared is never the dialect: it is the
+// sequence of contract gestures the pack asked of the runtime.
+
+// packReplay is one pack's expression of an intent, in its own dialect.
+type packReplay struct {
+	pack string
+	run  func(*testing.T) *machine.Recorder
+}
+
+// intent is one thing a user asks of a cloud, with every pack that can say it.
+type intent struct {
+	name string
+	// excluded documents, per absent pack, the upstream difference that keeps
+	// it out. The map is read by the coverage assertion below: an exclusion
+	// without a reason is a restriction nobody argued.
+	excluded map[string]string
+	replays  []packReplay
+}
+
+// intents is the corpus. Two properties are load-bearing and asserted by
+// TestSameIntentSameRuntimeSequenceAcrossPacks itself: every pack appears in
+// at least one intent, and the union of recorded gestures still covers the
+// mutating vocabulary — so no restriction of the statement can silently retire
+// a pack or a gesture from the comparison.
+var intents = []intent{
+	{
+		// The richest common intent: one machine booting with its cloud-given
+		// public address, wearing one rule-bearing group, joining one private
+		// network after boot, gaining one more public address after boot.
+		// Scaleway says it with dynamic_ip_required, a hot private NIC and a
+		// flexible IP; Exoscale with its instance's own public IP, a private
+		// network attach and an elastic IP.
+		name: "the machine boots public, joins its network and gains an address afterwards",
+		excluded: map[string]string{
+			"outscale": "a Vm is born on its Subnet — the membership rides the launch, it cannot be joined " +
+				"after boot — and no Vm carries an emulated public address at boot: LinkPublicIp is " +
+				"post-create by design, so neither half of this intent is expressible",
+		},
+		replays: []packReplay{
+			{"scaleway", replayScalewayJoinsAfterBoot},
+			{"exoscale", replayExoscaleJoinsAfterBoot},
+		},
+	},
+	{
+		// The intent every pack can say: one machine wearing one rule-bearing
+		// group, its one public address linked after boot, no private network.
+		// Outscale's Vm lives outside any Net (its public-cloud shape),
+		// Exoscale declares public-ip-assignment none, Scaleway boots without
+		// dynamic_ip_required.
+		name:     "the machine wears a group and its address is linked after boot",
+		excluded: map[string]string{},
+		replays: []packReplay{
+			{"scaleway", replayScalewayLinkedAfterBoot},
+			{"outscale", replayOutscaleLinkedAfterBoot},
+			{"exoscale", replayExoscaleLinkedAfterBoot},
+		},
+	},
+}
+
+// allReplays flattens the corpus for the properties that hold per replay.
+func allReplays() []packReplay {
+	var out []packReplay
+	for _, in := range intents {
+		out = append(out, in.replays...)
+	}
+	return out
+}
 
 // recorderEnv builds a deterministic Env backed by a fresh contract recorder.
+//
+// The address placements are forgotten first: they live in a package-level map
+// keyed by provider and address — state that must outlive one request cannot
+// live in a per-call Binding — and two replays of one dialect hand out the
+// same deterministic addresses. Without the reset, the second replay's route
+// finds the first replay's machine as the recorded holder and emits an
+// UnrouteAddress the first never did: the determinism property would then be
+// measuring this suite's own residue, not the pack.
 func recorderEnv() (*emulator.Env, *machine.Recorder) {
+	for _, provider := range []string{scaleway.Name, outscale.Name, exoscale.Name} {
+		machine.Binding{Provider: provider}.ForgetPlacements()
+	}
 	rec := machine.NewRecorder()
 	n := 0
 	env := &emulator.Env{
@@ -93,10 +167,11 @@ func id(t *testing.T, out map[string]any, keys ...string) string {
 	return s
 }
 
-// replayScaleway expresses the intent in Scaleway's dialect: the group and the
-// address are wired at create, the private network is joined by a NIC after
-// the boot.
-func replayScaleway(t *testing.T) *machine.Recorder {
+// ---- Intent one: boots public, joins afterwards -----------------------------
+
+// replayScalewayJoinsAfterBoot: the dynamic address rides the boot, the
+// private NIC is attached to the running server, the flexible IP afterwards.
+func replayScalewayJoinsAfterBoot(t *testing.T) *machine.Recorder {
 	t.Helper()
 	env, rec := recorderEnv()
 	srv, err := emulator.NewServer(env, scaleway.New(env))
@@ -110,69 +185,25 @@ func replayScaleway(t *testing.T) *machine.Recorder {
 		`{"name":"intent-net","subnets":["10.61.0.0/24"]}`)
 	pnID := id(t, pn, "id")
 
-	sg := request(t, h, "POST", zone+"/security_groups",
-		`{"name":"intent-group","description":"the intent's one group","inbound_default_policy":"drop"}`)
-	sgID := id(t, sg, "security_group", "id")
-	request(t, h, "POST", zone+"/security_groups/"+sgID+"/rules",
-		`{"protocol":"TCP","direction":"inbound","action":"accept","ip_range":"0.0.0.0/0","dest_port_from":22,"dest_port_to":22}`)
-
-	ip := request(t, h, "POST", zone+"/ips", `{}`)
-	ipID := id(t, ip, "ip", "id")
+	sgID := scalewayGroupWithRule(t, h)
 
 	created := request(t, h, "POST", zone+"/servers",
-		`{"name":"intent-machine","commercial_type":"DEV1-S","image":"ubuntu_jammy","security_group":"`+sgID+`","public_ip":"`+ipID+`"}`)
+		`{"name":"intent-machine","commercial_type":"DEV1-S","image":"ubuntu_jammy","security_group":"`+sgID+`","dynamic_ip_required":true}`)
 	serverID := id(t, created, "server", "id")
-
 	request(t, h, "POST", zone+"/servers/"+serverID+"/action", `{"action":"poweron"}`)
+
 	request(t, h, "POST", zone+"/servers/"+serverID+"/private_nics",
 		`{"private_network_id":"`+pnID+`"}`)
+
+	ip := request(t, h, "POST", zone+"/ips", `{}`)
+	request(t, h, "PATCH", zone+"/ips/"+id(t, ip, "ip", "id"), `{"server":"`+serverID+`"}`)
 	return rec
 }
 
-// replayOutscale expresses the intent in Outscale's dialect: the Vm boots on
-// its Subnet wearing its group, the public address is linked afterwards.
-func replayOutscale(t *testing.T) *machine.Recorder {
-	t.Helper()
-	env, rec := recorderEnv()
-	srv, err := emulator.NewServer(env, outscale.New(env))
-	if err != nil {
-		t.Fatalf("mount outscale: %v", err)
-	}
-	h := srv.Handler()
-	post := func(action, body string) map[string]any {
-		return request(t, h, "POST", "/api/v1/"+action, body)
-	}
-
-	net := post("CreateNet", `{"IpRange":"10.61.0.0/16"}`)
-	netID := id(t, net, "Net", "NetId")
-	subnet := post("CreateSubnet", `{"NetId":"`+netID+`","IpRange":"10.61.1.0/24"}`)
-	subnetID := id(t, subnet, "Subnet", "SubnetId")
-
-	sg := post("CreateSecurityGroup",
-		`{"SecurityGroupName":"intent-group","Description":"the intent's one group","NetId":"`+netID+`"}`)
-	sgID := id(t, sg, "SecurityGroup", "SecurityGroupId")
-	post("CreateSecurityGroupRule",
-		`{"Flow":"Inbound","SecurityGroupId":"`+sgID+`","IpProtocol":"tcp","FromPortRange":22,"ToPortRange":22,"IpRange":"0.0.0.0/0"}`)
-
-	ip := post("CreatePublicIp", `{}`)
-	ipID := id(t, ip, "PublicIp", "PublicIpId")
-
-	vms := post("CreateVms",
-		`{"ImageId":"ami-00000001","VmType":"tinav6.c1r1p2","SubnetId":"`+subnetID+`","SecurityGroupIds":["`+sgID+`"]}`)
-	list, _ := vms["Vms"].([]any)
-	if len(list) != 1 {
-		t.Fatalf("CreateVms answered %d Vms, want 1: %v", len(list), vms)
-	}
-	vmID := id(t, map[string]any{"Vm": list[0]}, "Vm", "VmId")
-
-	post("LinkPublicIp", `{"PublicIpId":"`+ipID+`","VmId":"`+vmID+`"}`)
-	return rec
-}
-
-// replayExoscale expresses the intent in Exoscale's dialect: the instance
-// boots wearing its group, then the private network and the elastic IP are
-// attached to the running machine.
-func replayExoscale(t *testing.T) *machine.Recorder {
+// replayExoscaleJoinsAfterBoot: the instance's own public IP rides the boot —
+// Exoscale's eth0 is the public interface — the private network and the
+// elastic IP are attached to the running machine.
+func replayExoscaleJoinsAfterBoot(t *testing.T) *machine.Recorder {
 	t.Helper()
 	env, rec := recorderEnv()
 	srv, err := emulator.NewServer(env, exoscale.New(env))
@@ -190,20 +221,132 @@ func replayExoscale(t *testing.T) *machine.Recorder {
 	}
 	pnID := id(t, map[string]any{"pn": pns[0]}, "pn", "id")
 
+	sgID := exoscaleGroupWithRule(t, h)
+	instanceID := exoscaleInstance(t, h, sgID, "")
+
+	request(t, h, "PUT", "/v2/private-network/"+pnID+":attach",
+		`{"instance":{"id":"`+instanceID+`"}}`)
+
+	eip := request(t, h, "POST", "/v2/elastic-ip", `{}`)
+	request(t, h, "PUT", "/v2/elastic-ip/"+id(t, eip, "reference", "id")+":attach",
+		`{"instance":{"id":"`+instanceID+`"}}`)
+	return rec
+}
+
+// ---- Intent two: a group, and the address linked after boot -----------------
+
+// replayScalewayLinkedAfterBoot: the server boots wearing its group and
+// nothing else; the flexible IP is attached afterwards.
+func replayScalewayLinkedAfterBoot(t *testing.T) *machine.Recorder {
+	t.Helper()
+	env, rec := recorderEnv()
+	srv, err := emulator.NewServer(env, scaleway.New(env))
+	if err != nil {
+		t.Fatalf("mount scaleway: %v", err)
+	}
+	h := srv.Handler()
+	const zone = "/instance/v1/zones/fr-par-1"
+
+	sgID := scalewayGroupWithRule(t, h)
+	created := request(t, h, "POST", zone+"/servers",
+		`{"name":"intent-machine","commercial_type":"DEV1-S","image":"ubuntu_jammy","security_group":"`+sgID+`"}`)
+	serverID := id(t, created, "server", "id")
+	request(t, h, "POST", zone+"/servers/"+serverID+"/action", `{"action":"poweron"}`)
+
+	ip := request(t, h, "POST", zone+"/ips", `{}`)
+	request(t, h, "PATCH", zone+"/ips/"+id(t, ip, "ip", "id"), `{"server":"`+serverID+`"}`)
+	return rec
+}
+
+// replayOutscaleLinkedAfterBoot: the Vm lives outside any Net — Outscale's
+// public-cloud shape, the one placement where nothing of its network rides the
+// launch — wearing its group; the public IP is linked afterwards, which is the
+// only moment its dialect can link one.
+func replayOutscaleLinkedAfterBoot(t *testing.T) *machine.Recorder {
+	t.Helper()
+	env, rec := recorderEnv()
+	srv, err := emulator.NewServer(env, outscale.New(env))
+	if err != nil {
+		t.Fatalf("mount outscale: %v", err)
+	}
+	h := srv.Handler()
+	post := func(action, body string) map[string]any {
+		return request(t, h, "POST", "/api/v1/"+action, body)
+	}
+
+	sg := post("CreateSecurityGroup",
+		`{"SecurityGroupName":"intent-group","Description":"the intent's one group"}`)
+	sgID := id(t, sg, "SecurityGroup", "SecurityGroupId")
+	post("CreateSecurityGroupRule",
+		`{"Flow":"Inbound","SecurityGroupId":"`+sgID+`","IpProtocol":"tcp","FromPortRange":22,"ToPortRange":22,"IpRange":"0.0.0.0/0"}`)
+
+	ip := post("CreatePublicIp", `{}`)
+	ipID := id(t, ip, "PublicIp", "PublicIpId")
+
+	vms := post("CreateVms",
+		`{"ImageId":"ami-00000001","VmType":"tinav6.c1r1p2","SecurityGroupIds":["`+sgID+`"]}`)
+	list, _ := vms["Vms"].([]any)
+	if len(list) != 1 {
+		t.Fatalf("CreateVms answered %d Vms, want 1: %v", len(list), vms)
+	}
+	vmID := id(t, map[string]any{"Vm": list[0]}, "Vm", "VmId")
+
+	post("LinkPublicIp", `{"PublicIpId":"`+ipID+`","VmId":"`+vmID+`"}`)
+	return rec
+}
+
+// replayExoscaleLinkedAfterBoot: the instance declares public-ip-assignment
+// none — a real upstream setting — so nothing rides the boot but the group;
+// the elastic IP is attached afterwards.
+func replayExoscaleLinkedAfterBoot(t *testing.T) *machine.Recorder {
+	t.Helper()
+	env, rec := recorderEnv()
+	srv, err := emulator.NewServer(env, exoscale.New(env))
+	if err != nil {
+		t.Fatalf("mount exoscale: %v", err)
+	}
+	h := srv.Handler()
+
+	sgID := exoscaleGroupWithRule(t, h)
+	instanceID := exoscaleInstance(t, h, sgID, `"public-ip-assignment":"none",`)
+
+	eip := request(t, h, "POST", "/v2/elastic-ip", `{}`)
+	request(t, h, "PUT", "/v2/elastic-ip/"+id(t, eip, "reference", "id")+":attach",
+		`{"instance":{"id":"`+instanceID+`"}}`)
+	return rec
+}
+
+// ---- Dialect helpers shared by the intents ----------------------------------
+
+func scalewayGroupWithRule(t *testing.T, h http.Handler) string {
+	t.Helper()
+	const zone = "/instance/v1/zones/fr-par-1"
+	sg := request(t, h, "POST", zone+"/security_groups",
+		`{"name":"intent-group","description":"the intent's one group","inbound_default_policy":"drop"}`)
+	sgID := id(t, sg, "security_group", "id")
+	request(t, h, "POST", zone+"/security_groups/"+sgID+"/rules",
+		`{"protocol":"TCP","direction":"inbound","action":"accept","ip_range":"0.0.0.0/0","dest_port_from":22,"dest_port_to":22}`)
+	return sgID
+}
+
+func exoscaleGroupWithRule(t *testing.T, h http.Handler) string {
+	t.Helper()
 	sg := request(t, h, "POST", "/v2/security-group",
 		`{"name":"intent-group","description":"the intent's one group"}`)
 	sgID := id(t, sg, "reference", "id")
 	request(t, h, "POST", "/v2/security-group/"+sgID+"/rules",
 		`{"flow-direction":"ingress","protocol":"tcp","network":"0.0.0.0/0","start-port":22,"end-port":22}`)
+	return sgID
+}
 
-	eip := request(t, h, "POST", "/v2/elastic-ip", `{}`)
-	eipID := id(t, eip, "reference", "id")
-
+func exoscaleInstance(t *testing.T, h http.Handler, sgID, extra string) string {
+	t.Helper()
 	request(t, h, "POST", "/v2/instance", `{
 		"name":"intent-machine",
 		"instance-type":{"id":"21624abb-764e-4def-81d7-9fc54b5957fb"},
 		"template":{"id":"11111111-1111-4111-8111-111111111111"},
 		"disk-size":10,
+		`+extra+`
 		"security-groups":[{"id":"`+sgID+`"}]
 	}`)
 	instances := request(t, h, "GET", "/v2/instance", "")
@@ -211,25 +354,10 @@ func replayExoscale(t *testing.T) *machine.Recorder {
 	if len(list) != 1 {
 		t.Fatalf("%d instances after create, want 1: %v", len(list), instances)
 	}
-	instanceID := id(t, map[string]any{"i": list[0]}, "i", "id")
-
-	request(t, h, "PUT", "/v2/private-network/"+pnID+":attach",
-		`{"instance":{"id":"`+instanceID+`"}}`)
-	request(t, h, "PUT", "/v2/elastic-ip/"+eipID+":attach",
-		`{"instance":{"id":"`+instanceID+`"}}`)
-	return rec
+	return id(t, map[string]any{"i": list[0]}, "i", "id")
 }
 
-// replays runs the three packs' replays and answers their recorders, keyed by
-// pack name, in a fixed iteration order.
-var replays = []struct {
-	pack string
-	run  func(*testing.T) *machine.Recorder
-}{
-	{"scaleway", replayScaleway},
-	{"outscale", replayOutscale},
-	{"exoscale", replayExoscale},
-}
+// ---- The properties ---------------------------------------------------------
 
 // sameSequence is the equivalence the cross-pack property asserts: the same
 // gesture kinds, in the same order. Deliberately nothing weaker — not a set
@@ -254,13 +382,13 @@ func formatSequence(seq []string) string {
 }
 
 // TestNoPackAsksTheRuntimeAGestureOutsideTheContract is property 2 of #515,
-// live: every gesture the three replays asked of the runtime is one the
-// contract vocabulary names. The detector's own positive control is
+// live: every gesture the replays asked of the runtime is one the contract
+// vocabulary names. The detector's own positive control is
 // TestAPlantedUnknownGestureIsReported in the machine package; the vocabulary
 // itself is held against the driver interfaces by
 // TestTheContractNamesEveryGesture there.
 func TestNoPackAsksTheRuntimeAGestureOutsideTheContract(t *testing.T) {
-	for _, replay := range replays {
+	for _, replay := range allReplays() {
 		rec := replay.run(t)
 		if outside := rec.OutsideContract(); len(outside) != 0 {
 			t.Errorf("%s asked the runtime %d gestures the contract cannot name: %v",
@@ -277,7 +405,7 @@ func TestNoPackAsksTheRuntimeAGestureOutsideTheContract(t *testing.T) {
 // rather than packs: an equivalence read on a nondeterministic recording is an
 // instrument that lies in both directions.
 func TestTwoIdenticalReplaysProduceTheSameSequence(t *testing.T) {
-	for _, replay := range replays {
+	for _, replay := range allReplays() {
 		first := replay.run(t).Sequence()
 		second := replay.run(t).Sequence()
 		if !sameSequence(first, second) {
@@ -290,10 +418,10 @@ func TestTwoIdenticalReplaysProduceTheSameSequence(t *testing.T) {
 // TestAShuffledReplayIsToldFromItsOriginal is the positive control of the
 // equivalence assertion: before trusting sameSequence on real replays, prove
 // it fails on a deliberately reordered one. A comparator that cannot see a
-// rotation would read three different orders as one and turn the red property
+// rotation would read three different orders as one and turn the property
 // green by instrument defect — the exact lie this repository exists to avoid.
 func TestAShuffledReplayIsToldFromItsOriginal(t *testing.T) {
-	original := replayScaleway(t).Sequence()
+	original := replayScalewayJoinsAfterBoot(t).Sequence()
 	if len(original) < 2 {
 		t.Fatalf("the replay recorded %d gestures; nothing can be reordered", len(original))
 	}
@@ -314,47 +442,71 @@ func TestAShuffledReplayIsToldFromItsOriginal(t *testing.T) {
 	}
 }
 
-// TestSameIntentSameRuntimeSequenceAcrossPacks is property 1 of #515: for the
-// one intent all three packs can express, the three replays produce the same
-// contract-level sequence — the executable form of #510's sentence, the order
-// is a property of the runtime, not of a provider.
+// TestSameIntentSameRuntimeSequenceAcrossPacks is property 1 of #515: for each
+// intent, every pack that can express it produces the same contract-level
+// sequence — the executable form of #510's sentence, the order is a property
+// of the runtime, not of a provider. It was red from #515 to #510 — three
+// orders, held by three comments — and the Reconciler is what made it green;
+// this assertion is now what guards it.
 //
-// It is red today, and deliberately so: the audit measured three orders held
-// by three comments (scaleway/servers.go, outscale/machines.go,
-// exoscale/machines.go), and this instrument is what makes that divergence a
-// measurement instead of a citation. #510 is what turns it green. Until then
-// the test *runs*, prints the measured divergence, and ends in Skip rather
-// than Fail — a red assertion in prepush would make every branch undeliverable
-// for a defect this branch does not create — and the Skip line carries the
-// full measurement so nobody has to re-derive it. The day the sequences agree,
-// this test passes on its own and the skip below becomes dead code to delete
-// with #510.
-//
-// The assertion is per expressible intent, never "all sequences are
-// identical": the packs do not express every intent identically (Scaleway has
-// no group-sourced rules, Exoscale routes elastic addresses on attach), and a
-// global phrasing would make the test lie.
+// The statement is restricted to the expressible intents, with each
+// restriction written where the intent declares it, and the restriction
+// itself is fenced: an intent compared alone, a pack retired from every
+// intent, a missing reason, or a gesture kind gone from the whole corpus all
+// fail here — the ways a comparison quietly relaxes, each one closed.
 func TestSameIntentSameRuntimeSequenceAcrossPacks(t *testing.T) {
-	sequences := make(map[string][]string, len(replays))
-	for _, replay := range replays {
-		sequences[replay.pack] = replay.run(t).Sequence()
-	}
+	packs := map[string]bool{"scaleway": false, "outscale": false, "exoscale": false}
+	recorded := map[string]bool{}
 
-	reference := sequences[replays[0].pack]
-	diverged := false
-	for _, replay := range replays[1:] {
-		if !sameSequence(reference, sequences[replay.pack]) {
-			diverged = true
+	for _, in := range intents {
+		if len(in.replays) < 2 {
+			t.Fatalf("intent %q is expressed by %d pack(s): it compares nothing", in.name, len(in.replays))
+		}
+		present := map[string]bool{}
+		for _, replay := range in.replays {
+			present[replay.pack] = true
+		}
+		for pack := range packs {
+			if !present[pack] && in.excluded[pack] == "" {
+				t.Fatalf("intent %q leaves %s out without a written reason", in.name, pack)
+			}
+			if present[pack] && in.excluded[pack] != "" {
+				t.Fatalf("intent %q both includes %s and excuses its absence", in.name, pack)
+			}
+		}
+
+		sequences := make(map[string][]string, len(in.replays))
+		for _, replay := range in.replays {
+			seq := replay.run(t).Sequence()
+			sequences[replay.pack] = seq
+			packs[replay.pack] = true
+			for _, kind := range seq {
+				recorded[kind] = true
+			}
+		}
+		reference := sequences[in.replays[0].pack]
+		for _, replay := range in.replays[1:] {
+			if !sameSequence(reference, sequences[replay.pack]) {
+				var lines []string
+				for _, r := range in.replays {
+					lines = append(lines, fmt.Sprintf("  %-8s %s", r.pack, formatSequence(sequences[r.pack])))
+				}
+				t.Fatalf("intent %q produces diverging runtime sequences:\n%s", in.name, strings.Join(lines, "\n"))
+			}
 		}
 	}
-	if !diverged {
-		return // #510 landed: the property holds, and this test now guards it.
-	}
 
-	var lines []string
-	for _, replay := range replays {
-		lines = append(lines, fmt.Sprintf("  %-8s %s", replay.pack, formatSequence(sequences[replay.pack])))
+	for pack, seen := range packs {
+		if !seen {
+			t.Fatalf("%s is compared in no intent: the property no longer says anything about it", pack)
+		}
 	}
-	t.Skipf("red on purpose (#515): the same intent produces three runtime sequences, one per pack — "+
-		"#510 is the corridor that makes them one; measured now:\n%s", strings.Join(lines, "\n"))
+	// The mutating vocabulary the intents must keep exercising: dropping one
+	// of these from every replay would shrink what the equivalence proves,
+	// which is exactly how a comparison relaxes without touching sameSequence.
+	for _, kind := range []string{"EnsureNetwork", "PeerNetworks", "EnsureFirewall", "ApplyFirewall", "Start", "Attach", "RouteAddress"} {
+		if !recorded[kind] {
+			t.Fatalf("no replay of any intent records %s any more: the compared vocabulary shrank", kind)
+		}
+	}
 }

--- a/internal/providers/scaleway/firewall.go
+++ b/internal/providers/scaleway/firewall.go
@@ -20,59 +20,54 @@ import (
 // running and expects it to take effect, so every mutation of a group replays it
 // onto the machines that carry it.
 
-// enforcer returns the runtime's firewall half, or nil when it has none.
-func (p *Pack) enforcer() machine.Firewaller {
-	fw, _ := p.env.Machines.(machine.Firewaller)
-	return fw
+// groupSync is this pack's half of the shared firewall orchestration (#509):
+// the skeleton — sync-then-apply, the wearer replay, the fresh copy, the
+// after-boot re-expansion — lives in machine.GroupSync, written once for every
+// pack; what is declared here is only what Scaleway knows. Referencing
+// machine.GroupSync is also this pack's marker for the enforcement test: a
+// pack wires the firewall when a non-test file of its own builds one of these.
+//
+// Two fields are deliberately narrower than the other packs':
+//
+//   - Referrers is nil, because no Scaleway rule can name a group as a source
+//     — ip_range is the only selector its SDK declares — so the re-expansion
+//     half of AfterBoot is honestly empty rather than emptily looped;
+//   - ForeignBlocks is set, the bridge-mode defence the other two packs never
+//     embedded: what is foreign is this pack's routing model (a VPC routes
+//     between its own private networks), where the rejects go is the
+//     skeleton's, once.
+func (p *Pack) groupSync() machine.GroupSync {
+	return machine.GroupSync{
+		Binding:       p.binding(),
+		SpecOf:        p.firewallSpecOf,
+		ForeignBlocks: p.foreignBlocksFor,
+		Wearers:       p.serverResourcesUsing,
+		WornIDs:       p.wornGroupIDs,
+		Group: func(id string) (*resource.Resource, bool) {
+			return p.env.Store.Get(Name, kindSecurityGroup, id)
+		},
+	}
+}
+
+// wornGroupIDs is the identifier of the one group a server carries — a list,
+// because the skeleton speaks in lists and this provider's servers wear
+// exactly one group.
+func (p *Pack) wornGroupIDs(res *resource.Resource) []string {
+	summary, _ := res.Attrs["security_group"].(map[string]any)
+	groupID, _ := summary["id"].(string)
+	if groupID == "" {
+		return nil
+	}
+	return []string{groupID}
 }
 
 // syncSecurityGroup pushes a group and replays it onto every server using it.
-// Called after any change to the group or to its rules.
-//
-// The mechanics — a permissive set attaches nothing, the deny-dominant
-// defaults, the Warn-or-Error report — are machine.Binding's, shared with the
-// two other packs since #475: written here alone, the same sequence was one
-// Outscale and Exoscale never wrote, and their machines ran with zero ACLs
-// while the API described a closed port. What stays in this file is only the
-// Scaleway vocabulary.
+// Called after any change to the group or to its rules. The skeleton is
+// machine.GroupSync's, shared with the two other packs since #475: written
+// here alone, the same sequence was one Outscale and Exoscale never wrote, and
+// their machines ran with zero ACLs while the API described a closed port.
 func (p *Pack) syncSecurityGroup(ctx context.Context, group *resource.Resource) {
-	fw := p.enforcer()
-	if fw == nil {
-		return
-	}
-	b := p.binding()
-	spec := p.firewallSpecOf(group)
-	if !b.SyncRuleSet(ctx, fw, spec) {
-		return
-	}
-	for _, server := range p.serverResourcesUsing(group) {
-		b.ApplyRuleSets(ctx, fw, server.Runtime[runtimeMachineKey], spec)
-	}
-}
-
-// applyServerFirewall binds the group a server carries to its machine. Called
-// once the machine exists, since a rule set attaches to interfaces.
-func (p *Pack) applyServerFirewall(ctx context.Context, server *resource.Resource) {
-	fw := p.enforcer()
-	if fw == nil {
-		return
-	}
-	summary, _ := server.Attrs["security_group"].(map[string]any)
-	groupID, _ := summary["id"].(string)
-	if groupID == "" {
-		return
-	}
-	group, found := p.env.Store.Get(Name, kindSecurityGroup, groupID)
-	if !found {
-		return
-	}
-
-	b := p.binding()
-	spec := p.firewallSpecOf(group)
-	if !b.SyncRuleSet(ctx, fw, spec) {
-		return
-	}
-	b.ApplyRuleSets(ctx, fw, server.Runtime[runtimeMachineKey], spec)
+	p.groupSync().SyncGroup(ctx, group, nil)
 }
 
 // firewallSpecOf translates a group and its rules.
@@ -81,7 +76,10 @@ func (p *Pack) applyServerFirewall(ctx context.Context, server *resource.Resourc
 // and they are what a rule does not override. Note the mapping of accept onto
 // allow, of inbound onto ingress, and that a rule's ip_range is a source going
 // in and a destination going out.
-func (p *Pack) firewallSpecOf(group *resource.Resource) machine.FirewallSpec {
+//
+// fresh is unused: no Scaleway rule expands other resources' addresses — see
+// the Referrers note on groupSync — so there is no stale copy to win over.
+func (p *Pack) firewallSpecOf(group, _ *resource.Resource) machine.FirewallSpec {
 	inbound, _ := group.Attrs["inbound_default_policy"].(string)
 	outbound, _ := group.Attrs["outbound_default_policy"].(string)
 
@@ -98,21 +96,6 @@ func (p *Pack) firewallSpecOf(group *resource.Resource) machine.FirewallSpec {
 	allow := "allow"
 	if ok && !stateful {
 		allow = "allow-stateless"
-	}
-
-	// Isolation first: the runtime orders rules by action, not by position, so a
-	// reject wins over any allow the group adds. Two private networks that
-	// upstream keeps apart must not reach each other whatever the group says,
-	// because that separation is the subnet's, not the group's. A runtime whose
-	// networks are separate by construction gets none of this: the blocks would
-	// name subnets the machine cannot reach anyway.
-	if !p.nativeIsolation() {
-		for _, block := range p.foreignBlocksFor(group) {
-			spec.Rules = append(spec.Rules,
-				machine.FirewallRule{Direction: "egress", Action: "reject", Destination: block},
-				machine.FirewallRule{Direction: "ingress", Action: "reject", Source: block},
-			)
-		}
 	}
 
 	for _, rule := range p.rulesOf(group.ID) {
@@ -132,17 +115,11 @@ func (p *Pack) firewallSpecOf(group *resource.Resource) machine.FirewallSpec {
 	return spec.WithPermissiveCatchAll(allow)
 }
 
-// nativeIsolation reports whether the runtime keeps its networks apart by
-// construction, in which case reject rules against foreign subnets are dead
-// weight and reachability is granted by peering instead (see isolateNetworks).
-func (p *Pack) nativeIsolation() bool {
-	peerer, ok := p.env.Machines.(machine.Peerer)
-	return ok && peerer.NativeIsolation()
-}
-
 // foreignBlocksFor lists the emulated subnets a server carrying this group must
 // not reach: another project, or another VPC, or a VPC that does not route
-// between its own private networks.
+// between its own private networks. What is foreign is the question this pack
+// answers; where the rejects ride, and on which runtimes, is the skeleton's
+// (GroupSync.ForeignBlocks says both).
 //
 // The group is the carrier rather than the subject: a rule set attaches to
 // interfaces, and this is the only rule set a server's interfaces carry.
@@ -261,7 +238,7 @@ func (p *Pack) serverResourcesUsing(group *resource.Resource) []*resource.Resour
 // and refusing the delete afterwards would leave the client with a resource it
 // cannot remove.
 func (p *Pack) removeFirewall(ctx context.Context, group *resource.Resource) {
-	p.binding().DropRuleSet(ctx, p.enforcer(), machine.FirewallName("scw", group.ID))
+	p.groupSync().Drop(ctx, machine.FirewallName("scw", group.ID))
 }
 
 // EnforcesFirewall implements emulator.FirewallEnforcer: this pack reconciles a

--- a/internal/providers/scaleway/firewall_internal_test.go
+++ b/internal/providers/scaleway/firewall_internal_test.go
@@ -37,17 +37,17 @@ func TestFirewallSpecWritesPermissiveDefaultsAsCatchAlls(t *testing.T) {
 	}
 	p := New(emulator.DefaultEnv())
 
-	spec := p.firewallSpecOf(group(policyDrop, policyAccept, true))
+	spec := p.firewallSpecOf(group(policyDrop, policyAccept, true), nil)
 	if got := catchAlls(spec); got["ingress"] != "" || got["egress"] != "allow" {
 		t.Errorf("drop/accept: catch-alls = %v, want egress allow only", got)
 	}
 
-	spec = p.firewallSpecOf(group(policyAccept, policyAccept, false))
+	spec = p.firewallSpecOf(group(policyAccept, policyAccept, false), nil)
 	if got := catchAlls(spec); got["ingress"] != "allow-stateless" || got["egress"] != "allow-stateless" {
 		t.Errorf("stateless accept/accept: catch-alls = %v, want allow-stateless both ways", got)
 	}
 
-	spec = p.firewallSpecOf(group(policyDrop, policyDrop, true))
+	spec = p.firewallSpecOf(group(policyDrop, policyDrop, true), nil)
 	if got := catchAlls(spec); len(got) != 0 {
 		t.Errorf("drop/drop: catch-alls = %v, want none, or the group would open what it closes", got)
 	}
@@ -59,3 +59,70 @@ func TestFirewallSpecWritesPermissiveDefaultsAsCatchAlls(t *testing.T) {
 // TestAnUnenforceableGroupIsReportedAsTheDeclaredLimit now live in
 // internal/core/machine/firewall_binding_test.go, holding the behaviour once
 // for the three packs.
+
+// TestBridgeModeRejectsForeignSubnetsThroughTheGroup holds this pack's wiring
+// of the bridge-mode defence: on a runtime whose networks are born joined, the
+// subnets a server must not reach ride its group's rule set as rejects,
+// because a NIC carrying a rule set no longer obeys the network-level
+// isolation. The mechanism moved to the shared skeleton with #509; what this
+// asserts is that the pack still declares its foreign blocks to it — losing
+// the GroupSync.ForeignBlocks field would fail here, and nothing else
+// white-box held it.
+func TestBridgeModeRejectsForeignSubnetsThroughTheGroup(t *testing.T) {
+	rec := machine.NewRecorder()
+	rec.Joined = true // the bridge shape: networks reach each other unless rejected
+	env := emulator.DefaultEnv()
+	env.Machines = rec
+	p := New(env)
+
+	tenant := resource.Tenant{Provider: Name, Project: defaultProject, Zone: "fr-par-1"}
+	now := env.Now()
+	pn := func(id, block string) *resource.Resource {
+		res := resource.New(id, kindPrivateNetwork, tenant, "available", now)
+		res.Attrs = map[string]any{"subnet": block}
+		env.Store.Put(res)
+		return res
+	}
+	own := pn("11111111-1111-4111-8111-111111111111", "172.16.4.0/22")
+	pn("22222222-2222-4222-8222-222222222222", "172.16.8.0/22")
+
+	group := resource.New("33333333-3333-4333-8333-333333333333", kindSecurityGroup, tenant, "available", now)
+	group.Attrs = map[string]any{
+		"inbound_default_policy":  policyDrop,
+		"outbound_default_policy": policyAccept,
+		"stateful":                true,
+	}
+	env.Store.Put(group)
+
+	server := resource.New("44444444-4444-4444-8444-444444444444", kindServer, tenant, "running", now)
+	server.Attrs = map[string]any{"security_group": map[string]any{"id": group.ID}}
+	server.Runtime = map[string]string{runtimeMachineKey: "feint-scw-" + server.ID}
+	env.Store.Put(server)
+
+	nic := resource.New("55555555-5555-4555-8555-555555555555", kindPrivateNIC, tenant, "available", now)
+	nic.Runtime = map[string]string{runtimeServerKey: server.ID, runtimePrivateNetworkKey: own.ID}
+	env.Store.Put(nic)
+
+	p.syncSecurityGroup(t.Context(), group)
+
+	setName := machine.FirewallName("scw", group.ID)
+	var spec *machine.FirewallSpec
+	for _, e := range rec.Events() {
+		if e.Kind == "EnsureFirewall" && e.Resource == setName {
+			s := e.Args.(machine.FirewallSpec)
+			spec = &s
+		}
+	}
+	if spec == nil {
+		t.Fatalf("the runtime never received the rule set %s", setName)
+	}
+	rejected := false
+	for _, rule := range spec.Rules {
+		if rule.Action == "reject" && (rule.Source == "172.16.8.0/22" || rule.Destination == "172.16.8.0/22") {
+			rejected = true
+		}
+	}
+	if !rejected {
+		t.Fatalf("the foreign subnet is not rejected by the group's set in bridge mode; rules: %+v", spec.Rules)
+	}
+}

--- a/internal/providers/scaleway/ips.go
+++ b/internal/providers/scaleway/ips.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/stephrobert/feint/internal/core/emulator"
-	"github.com/stephrobert/feint/internal/core/machine"
 	"github.com/stephrobert/feint/internal/core/network"
 	"github.com/stephrobert/feint/internal/core/resource"
 )
@@ -21,6 +20,9 @@ import (
 // these addresses to machines, and doing that on a real public range would
 // capture the host's own traffic towards it.
 const flexibleBlock = "203.0.113.0/24"
+
+// flexiblePrefix is the block parsed once, for the Reconciler's route guard.
+var flexiblePrefix = netip.MustParsePrefix(flexibleBlock)
 
 // kindIP is the store kind for flexible IPs.
 const kindIP = "instance/ip"
@@ -420,58 +422,15 @@ func (p *Pack) attachAddress(ctx context.Context, ip, server *resource.Resource)
 // routeAddress routes one public address — flexible or dynamic — to the
 // server's machine. Idempotent by the Router contract, which is what lets the
 // poweron replay call it on addresses the launch already installed.
+//
+// Through the shared Reconciler, which holds the block guard and the router
+// assertion once for the three packs (#510), takes the address back from its
+// previous holder before handing it over (#213), and routes it on the network
+// the server lives on when it has one — a public address on the runtime's
+// default bridge would sit on an interface the emulated topology says nothing
+// about, which is why machinePlan declares RouteVia.
 func (p *Pack) routeAddress(ctx context.Context, address string, server *resource.Resource) {
-	router, ok := p.env.Machines.(machine.Router)
-	if !ok {
-		return
-	}
-	name := server.Runtime[runtimeMachineKey]
-	if name == "" || address == "" {
-		return
-	}
-	// A stored address is untrusted input: a restored snapshot carries it
-	// verbatim, and routing an arbitrary value would send the host's traffic
-	// for that address into a container. See emulatedAddress.
-	if !emulatedAddress(address) {
-		p.logger().Warn("refusing to route an address outside the emulated public block",
-			"address", address, "server", server.ID)
-		return
-	}
-	// On the network the server lives on, when it has one: a public address on
-	// the runtime's default bridge would answer, and would sit on an interface
-	// the emulated topology says nothing about.
-	// Through the binding, which takes the address back from its previous holder
-	// before handing it over: this pack moves a flexible IP to the server the
-	// client names, and the move used to be written here rather than shared, which
-	// is how a third pack came to be missing it entirely (#213).
-	if err := p.binding().RouteAddress(ctx, router, machine.AddressSpec{
-		Machine: name,
-		Address: address,
-		Network: p.privateNetworkNameOf(server),
-	}); err != nil {
-		p.logger().Error("could not route the public address to the machine",
-			"address", address, "server", server.ID, "error", err)
-	}
-}
-
-// routeServerAddresses (re)routes every public address a server holds.
-//
-// Called after the machine exists: at poweron, and on the read that discovers
-// a late address. The boot itself installs the host half (the route keys ride
-// the launch); this replay is what hands the guest its addresses, and what
-// repairs a machine that already existed with different attachments.
-//
-// It is the missing half of #116: an address attached at create was recorded
-// and never routed, because attachAddress ran while the server had no machine
-// and nothing replayed it once one existed.
-// TestPowerOnRoutesAnAddressAttachedBeforeBoot fails without it.
-func (p *Pack) routeServerAddresses(ctx context.Context, res *resource.Resource) {
-	for _, ip := range p.attachedIPsOf(res.ID, res.Tenant.Zone) {
-		p.attachAddress(ctx, ip, res)
-	}
-	if address := res.Runtime[runtimeDynamicIPKey]; address != "" {
-		p.routeAddress(ctx, address, res)
-	}
+	p.reconciler().Route(ctx, server, address)
 }
 
 // privateNetworkNameOf returns the runtime network of the server's first
@@ -487,10 +446,6 @@ func (p *Pack) privateNetworkNameOf(server *resource.Resource) string {
 }
 
 func (p *Pack) detachAddress(ctx context.Context, ip *resource.Resource) {
-	router, ok := p.env.Machines.(machine.Router)
-	if !ok {
-		return
-	}
 	address, _ := ip.Attrs["address"].(string)
 	if address == "" {
 		return
@@ -504,10 +459,7 @@ func (p *Pack) detachAddress(ctx context.Context, ip *resource.Resource) {
 			}
 		}
 	}
-	if err := p.binding().UnrouteAddress(ctx, router, holder, address); err != nil {
-		p.logger().Error("could not stop routing the flexible IP",
-			"ip", ip.ID, "address", address, "error", err)
-	}
+	p.reconciler().Unroute(ctx, holder, address)
 }
 
 func (p *Pack) deleteIP(w http.ResponseWriter, r *http.Request) {
@@ -634,12 +586,5 @@ func (p *Pack) releaseDynamicAddress(ctx context.Context, res *resource.Resource
 	}
 	delete(res.Runtime, runtimeDynamicIPKey)
 	delete(res.Runtime, runtimeDynamicIPIDKey)
-	router, ok := p.env.Machines.(machine.Router)
-	if !ok || !emulatedAddress(address) {
-		return
-	}
-	if err := p.binding().UnrouteAddress(ctx, router, res.Runtime[runtimeMachineKey], address); err != nil {
-		p.logger().Error("could not stop routing the dynamic address",
-			"address", address, "server", res.ID, "error", err)
-	}
+	p.reconciler().Unroute(ctx, res.Runtime[runtimeMachineKey], address)
 }

--- a/internal/providers/scaleway/machines.go
+++ b/internal/providers/scaleway/machines.go
@@ -98,8 +98,8 @@ func requestedImageOf(res *resource.Resource, label string) string {
 	return id
 }
 
-// startMachine powers the server on. It returns the address to publish, empty
-// when nothing is actually running.
+// startMachine powers the server on: the boot, the address replay and the
+// firewall, in the shared Reconciler's one order.
 func (p *Pack) startMachine(ctx context.Context, res *resource.Resource) {
 	label, _ := res.Attrs["image_label"].(string)
 	hostname, _ := res.Attrs["hostname"].(string)
@@ -109,29 +109,50 @@ func (p *Pack) startMachine(ctx context.Context, res *resource.Resource) {
 	// hands the "cloud-init" user data key to cloud-init at boot. The
 	// consequence is stated in docs/limits.md: with a custom cloud-init, the
 	// project's SSH keys are only installed if the script installs them.
-	p.binding().PowerOn(ctx, res, machine.Boot{
+	p.reconciler().PowerOn(ctx, res, machine.Boot{
 		Image:          img.Ref,
 		User:           img.User,
 		Requested:      requestedImageOf(res, label),
 		Hostname:       hostname,
 		AuthorizedKeys: p.authorizedKeys(res.Tenant.Project),
 		CloudInit:      userDataOf(res, CloudInitKey),
-		// The NICs the server already owns travel with the boot. Attaching a NIC
-		// to a stopped server then powering it on is the ordinary Terraform
-		// order, and without this the machine came up on the runtime's default
-		// bridge alone while the API published an address on a private network
-		// it had never joined.
-		Attachments: p.attachmentsOf(res),
-		// So do the public addresses it was promised — flexible IPs attached
-		// before the boot, and the dynamic one when the flag asked for it. On
-		// the launch, not routed afterwards: editing a live OVN NIC re-plugs it
-		// and the guest loses its DHCP lease (#116).
-		PublicAddresses: p.publicAddressesOf(res),
 		Labels: map[string]string{
 			"feint.server": res.ID,
 			"feint.zone":   res.Tenant.Zone,
 		},
 	})
+}
+
+// reconciler is this pack's half of the shared interface choreography (#510):
+// the plan declares what only Scaleway knows, the layer executes the one
+// post-boot order — addresses, then memberships, the firewall last.
+func (p *Pack) reconciler() machine.Reconciler {
+	return machine.Reconciler{
+		Groups:      p.groupSync(),
+		PlanOf:      p.machinePlan,
+		PublicBlock: flexiblePrefix,
+	}
+}
+
+// machinePlan declares a server's interface shape.
+//
+// The NICs the server already owns ride the launch: attaching a NIC to a
+// stopped server then powering it on is the ordinary Terraform order, and
+// without this the machine came up on the runtime's default bridge alone while
+// the API published an address on a private network it had never joined. So do
+// the public addresses it was promised — flexible IPs attached before the
+// boot, and the dynamic one when the flag asked for it: editing a live OVN NIC
+// re-plugs it and the guest loses its DHCP lease (#116). No membership joins
+// after boot here — a NIC created on a running server is the hot path,
+// Reconciler.Join. Routes ride the network the server lives on, when it has
+// one: a public address on the runtime's default bridge would sit on an
+// interface the emulated topology says nothing about.
+func (p *Pack) machinePlan(res *resource.Resource) machine.Plan {
+	return machine.Plan{
+		Boot:     p.attachmentsOf(res),
+		Publics:  p.publicAddressesOf(res),
+		RouteVia: p.privateNetworkNameOf(res),
+	}
 }
 
 // attachmentsOf turns the NICs a server already owns into the attachments its

--- a/internal/providers/scaleway/privatenics.go
+++ b/internal/providers/scaleway/privatenics.go
@@ -340,8 +340,10 @@ func (p *Pack) attachNIC(w http.ResponseWriter, r *http.Request, serverID string
 	// The rule set binds to interfaces, so a NIC created after the server was
 	// powered on carries none until this runs. Without it the security group
 	// applies to the first interface and not to the private one, which is
-	// exactly the interface the group is about.
-	p.applyServerFirewall(r.Context(), server)
+	// exactly the interface the group is about. On a stopped server this still
+	// re-writes the set: the new NIC changed the foreign blocks its group must
+	// reject, and the set lives on the runtime for every wearer at once.
+	p.groupSync().AfterBoot(r.Context(), server)
 
 	return res, true
 }

--- a/internal/providers/scaleway/privatenics.go
+++ b/internal/providers/scaleway/privatenics.go
@@ -325,7 +325,15 @@ func (p *Pack) attachNIC(w http.ResponseWriter, r *http.Request, serverID string
 	// not carry — the one thing this project exists to avoid.
 	//
 	// TestARefusedAttachmentIsVisibleOnTheNIC fails without this.
-	if err := p.attachMachineToNetwork(r.Context(), server, pn, address); err != nil {
+	// Join attaches and then resyncs the firewall, in that order: the rule set
+	// binds to interfaces, so a NIC created after the server was powered on
+	// carries none until the resync runs — and without it the security group
+	// applies to the first interface and not to the private one, which is
+	// exactly the interface the group is about. On a stopped server the attach
+	// waits for the boot plan but the set is still re-written: the new NIC
+	// changed the foreign blocks its group must reject, and the set lives on
+	// the runtime for every wearer at once.
+	if err := p.joinNetwork(r.Context(), server, pn, address); err != nil {
 		// Inside the store lock, and only the state: Put re-inserted a NIC
 		// deleted during the seconds the attachment took, and wrote the whole
 		// stale clone over anything else that landed meanwhile (#295).
@@ -336,14 +344,6 @@ func (p *Pack) attachNIC(w http.ResponseWriter, r *http.Request, serverID string
 		})
 		res.State = "syncing_error"
 	}
-
-	// The rule set binds to interfaces, so a NIC created after the server was
-	// powered on carries none until this runs. Without it the security group
-	// applies to the first interface and not to the private one, which is
-	// exactly the interface the group is about. On a stopped server this still
-	// re-writes the set: the new NIC changed the foreign blocks its group must
-	// reject, and the set lives on the runtime for every wearer at once.
-	p.groupSync().AfterBoot(r.Context(), server)
 
 	return res, true
 }
@@ -497,23 +497,15 @@ func hexPair(b byte) string {
 	return string([]byte{digits[b>>4], digits[b&0x0f]})
 }
 
-// attachMachineToNetwork puts the backing machine on the backing network at the
-// address the control plane just published.
+// joinNetwork puts the backing machine on the backing network at the address
+// the control plane just published, and resyncs the firewall after it — the
+// hot half of a membership, through the shared Reconciler (#510).
 //
 // Everything here degrades quietly, as elsewhere in the pack: with no runtime,
 // or with one that refuses, the control plane still answers and the NIC still
-// exists. The log is then the only way to learn why nothing is attached.
-func (p *Pack) attachMachineToNetwork(ctx context.Context, server, pn *resource.Resource, address netip.Addr) error {
-	// No runtime, or nothing started yet: there is no machine to refuse, so the
-	// NIC is not in error. The address is applied when the machine boots.
-	if p.env.Machines == nil {
-		return nil
-	}
-	networkName := pn.Runtime[runtimeNetworkKey]
-	machineName := server.Runtime[runtimeMachineKey]
-	if networkName == "" || machineName == "" {
-		return nil
-	}
+// exists. The log is then the only way to learn why nothing is attached, and
+// the error comes back so the NIC can say syncing_error.
+func (p *Pack) joinNetwork(ctx context.Context, server, pn *resource.Resource, address netip.Addr) error {
 	// The mask travels with the address: reserving it on the bridge is not the
 	// same as the guest carrying it, and configuring the interface needs both.
 	prefix, err := prefixOf(pn)
@@ -522,20 +514,15 @@ func (p *Pack) attachMachineToNetwork(ctx context.Context, server, pn *resource.
 			"private_network", pn.ID, "error", err)
 		return err
 	}
-	if err := p.env.Machines.Attach(ctx, machineName, machine.Attachment{
-		Network:   networkName,
+	return p.reconciler().Join(ctx, server, machine.Attachment{
+		Network:   pn.Runtime[runtimeNetworkKey],
 		Address:   address.String(),
 		PrefixLen: prefix.Bits(),
-	}); err != nil {
-		p.logger().Error("could not attach the machine to the private network",
-			"server", server.ID, "private_network", pn.ID, "address", address, "error", err)
-		return err
-	}
-	return nil
+	})
 }
 
 // detachMachineFromNetwork takes the backing machine off the backing network,
-// the exact undo of attachMachineToNetwork.
+// the exact undo of joinNetwork's attach half.
 //
 // It degrades quietly for the same reason the attach does: with no runtime, or
 // with a machine that never started, there is nothing to detach and the NIC
@@ -543,9 +530,6 @@ func (p *Pack) attachMachineToNetwork(ctx context.Context, server, pn *resource.
 // plane has already decided the NIC is gone; what must not happen is the
 // silence this replaced, where nothing was even attempted.
 func (p *Pack) detachMachineFromNetwork(ctx context.Context, nic *resource.Resource) {
-	if p.env.Machines == nil {
-		return
-	}
 	server, ok := p.env.Store.Get(Name, kindServer, nic.Runtime[runtimeServerKey])
 	if !ok {
 		return
@@ -554,15 +538,7 @@ func (p *Pack) detachMachineFromNetwork(ctx context.Context, nic *resource.Resou
 	if !ok {
 		return
 	}
-	machineName := server.Runtime[runtimeMachineKey]
-	networkName := pn.Runtime[runtimeNetworkKey]
-	if machineName == "" || networkName == "" {
-		return
-	}
-	if err := p.env.Machines.Detach(ctx, machineName, networkName); err != nil {
-		p.logger().Error("could not detach the machine from the private network",
-			"private_nic", nic.ID, "server", server.ID, "private_network", pn.ID, "error", err)
-	}
+	p.reconciler().Leave(ctx, server, pn.Runtime[runtimeNetworkKey])
 }
 
 // privateNICView is the wire shape, and it carries no address on purpose:

--- a/internal/providers/scaleway/servers.go
+++ b/internal/providers/scaleway/servers.go
@@ -772,7 +772,7 @@ func (p *Pack) serverAction(w http.ResponseWriter, r *http.Request) {
 			// attaches to interfaces. A server powered on before its group was
 			// edited still gets the current rules, because every group mutation
 			// replays onto the machines carrying it.
-			p.applyServerFirewall(r.Context(), res)
+			p.groupSync().AfterBoot(r.Context(), res)
 			// The launch installed the host half of every public route; this
 			// hands the guest its addresses, and repairs a machine that already
 			// existed. Without it, an address attached at create was published

--- a/internal/providers/scaleway/servers.go
+++ b/internal/providers/scaleway/servers.go
@@ -455,7 +455,7 @@ func (p *Pack) getServer(w http.ResponseWriter, r *http.Request) {
 		// The machine just proved reachable, so the guest half of its public
 		// addresses can finally land — a virtual machine's agent answers long
 		// after poweron returned. Idempotent for a machine already served.
-		p.routeServerAddresses(r.Context(), res)
+		p.reconciler().ReplayAddresses(r.Context(), res)
 	}
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{"server": p.view(res)})
 }
@@ -701,53 +701,70 @@ func (p *Pack) serverAction(w http.ResponseWriter, r *http.Request) {
 	}
 	id := r.PathValue("id")
 
-	// One action at a time on one server, held past the write-back below.
-	//
-	// The runtime call runs outside the store lock on purpose, and Commit only
-	// refuses to resurrect a deleted resource: it does not order two writers.
-	// Two concurrent poweron each launched a container, the second failed on the
-	// name the first had taken, and the API then described as "stopped" a
-	// machine that was running. TestConcurrentPowerOnStartsTheMachineOnce fails
-	// without this line.
-	unlock := p.binding().Serialise(id)
-	defer unlock()
-
-	res, found := p.env.Store.Get(Name, kindServer, id)
-	if !found || res.Tenant.Zone != zone {
-		writeNotFound(w, "server", id)
-		return
-	}
-	// The base of the write-back at the bottom: the action owns the state, the
-	// allowed actions and the machine's runtime entries, and nothing else — a
-	// tag or a user-data key acknowledged while the machine boots survives it
-	// (#295). TestConcurrentServerUpdateAndActionKeepBothWrites fails without
-	// it.
-	base := res.Clone()
-
 	var req serverActionRequest
 	if err := emulator.DecodeJSON(r, &req); err != nil {
 		writeInvalidArguments(w, ArgumentError{ArgumentName: "body", Reason: "format", HelpMessage: err.Error()})
 		return
 	}
 
-	// The protection flag was stored at create and at update, published on every
-	// read, and consulted nowhere (#212). A field that round-trips perfectly and
-	// governs nothing reads as a feature, which is the *un commentaire n'est pas
-	// un contrôle* family arriving through data rather than prose.
+	now := p.env.Now()
+
+	// The transactional half — one action at a time on one server, the
+	// existence check inside the hold, the runtime work outside the store lock,
+	// the conditional write-back scoped to what the action owns — is
+	// Binding.Observe, shared with the two other packs' lifecycles instead of
+	// staying this pack's inline copy (#510). What it holds is measured
+	// history: two concurrent poweron each launched a container and the API
+	// described as "stopped" a machine that was running
+	// (TestConcurrentPowerOnStartsTheMachineOnce), and a tag acknowledged
+	// while the machine boots must survive the action's write-back (#295,
+	// TestConcurrentServerUpdateAndActionKeepBothWrites).
 	//
-	// Which door it closes was measured on fr-par-1, and the measurement reversed
-	// the issue: DELETE removes a protected server with 204, twice over. It is the
-	// action endpoint that refuses, for every action that stops or destroys the
-	// machine. Implementing the intuition would have made this emulator diverge
-	// from the cloud it imitates.
-	//
-	// TestProtectionRefusesEveryStoppingAction fails without this.
-	if stopsTheMachine(req.Action) && protectedServer(res) {
-		writePreconditionFailed(w, "protected_resource", "server is protected")
+	// The reply is decided under the hold and written after it: what to answer
+	// depends on state read under the lock, and writing it there would hold
+	// the target across the client's read of the response.
+	var reply func()
+	_, err := p.binding().Observe(p.env.Store, p.env.Now, kindServer, id, func(res *resource.Resource) bool {
+		if res.Tenant.Zone != zone {
+			reply = func() { writeNotFound(w, "server", id) }
+			return false
+		}
+
+		// The protection flag was stored at create and at update, published on
+		// every read, and consulted nowhere (#212). A field that round-trips
+		// perfectly and governs nothing reads as a feature, which is the *un
+		// commentaire n'est pas un contrôle* family arriving through data
+		// rather than prose.
+		//
+		// Which door it closes was measured on fr-par-1, and the measurement
+		// reversed the issue: DELETE removes a protected server with 204, twice
+		// over. It is the action endpoint that refuses, for every action that
+		// stops or destroys the machine. Implementing the intuition would have
+		// made this emulator diverge from the cloud it imitates.
+		//
+		// TestProtectionRefusesEveryStoppingAction fails without this.
+		if stopsTheMachine(req.Action) && protectedServer(res) {
+			reply = func() { writePreconditionFailed(w, "protected_resource", "server is protected") }
+			return false
+		}
+
+		reply = func() {
+			emulator.WriteJSON(w, http.StatusAccepted, map[string]any{"task": task(p.env.NewID(), "server_"+req.Action, now)})
+		}
+		return p.applyServerAction(w, r, req, res, id, zone, now, &reply)
+	})
+	if err != nil {
+		writeNotFound(w, "server", id)
 		return
 	}
+	reply()
+}
 
-	now := p.env.Now()
+// applyServerAction runs one lifecycle action on the held server and reports
+// whether the change must be written back. It rewrites reply when the action
+// answers something other than the accepted task.
+func (p *Pack) applyServerAction(w http.ResponseWriter, r *http.Request, req serverActionRequest,
+	res *resource.Resource, id, zone string, now time.Time, reply *func()) bool {
 	switch req.Action {
 	case "poweron", "reboot":
 		// A poweron on a server that is already running is not a second launch.
@@ -767,17 +784,12 @@ func (p *Pack) serverAction(w http.ResponseWriter, r *http.Request) {
 			// degraded mode; with a runtime that failed to start the machine it
 			// stays stopped, because a server reported running while nothing
 			// exists is the defect this project is built to avoid.
+			//
+			// The whole post-boot order rides inside: the promised addresses
+			// (an address attached at create was once published and never
+			// routed, #116), then the firewall, replayed by the shared
+			// Reconciler in the one order every pack follows (#510).
 			p.startMachine(r.Context(), res)
-			// The security group binds once the machine exists, since a rule set
-			// attaches to interfaces. A server powered on before its group was
-			// edited still gets the current rules, because every group mutation
-			// replays onto the machines carrying it.
-			p.groupSync().AfterBoot(r.Context(), res)
-			// The launch installed the host half of every public route; this
-			// hands the guest its addresses, and repairs a machine that already
-			// existed. Without it, an address attached at create was published
-			// and never routed (#116).
-			p.routeServerAddresses(r.Context(), res)
 		}
 		res.Attrs["allowed_actions"] = allowedActions(res.State, protectedServer(res))
 	case "poweroff", "stop_in_place":
@@ -819,28 +831,29 @@ func (p *Pack) serverAction(w http.ResponseWriter, r *http.Request) {
 		// lifecycle expected the root volume to vanish here and was wrong; the
 		// SDK is what settled it.
 		p.releaseServerResources(r.Context(), id, zone)
-		emulator.WriteJSON(w, http.StatusAccepted, map[string]any{"task": task(p.env.NewID(), "server_terminate", now)})
-		return
+		// The server is gone: nothing to write back, and the accepted task is
+		// the whole answer.
+		*reply = func() {
+			emulator.WriteJSON(w, http.StatusAccepted, map[string]any{"task": task(p.env.NewID(), "server_terminate", now)})
+		}
+		return false
 	case "backup":
 		// Accepted and ignored: backups need an image catalogue the emulator
 		// does not have. Declared here so the action does not 400 in a script.
 	default:
-		writeInvalidArguments(w, ArgumentError{
-			ArgumentName: "action",
-			Reason:       "constraint",
-			HelpMessage:  "unknown action " + req.Action,
-		})
-		return
+		*reply = func() {
+			writeInvalidArguments(w, ArgumentError{
+				ArgumentName: "action",
+				Reason:       "constraint",
+				HelpMessage:  "unknown action " + req.Action,
+			})
+		}
+		return false
 	}
-
-	// Starting a machine takes tens of seconds and runs outside the lock. A
-	// terminate that landed meanwhile must stay landed: Put would bring the
-	// server back, address and all.
-	if !p.env.Store.Commit(base, res, now) {
-		writeNotFound(w, "server", id)
-		return
-	}
-	emulator.WriteJSON(w, http.StatusAccepted, map[string]any{"task": task(p.env.NewID(), "server_"+req.Action, now)})
+	// Starting a machine takes tens of seconds and runs outside the lock; the
+	// conditional write-back is Observe's, so a terminate that landed meanwhile
+	// stays landed — Put would bring the server back, address and all.
+	return true
 }
 
 // stopsTheMachine names the actions protection refuses.

--- a/internal/providers/scaleway/vpc.go
+++ b/internal/providers/scaleway/vpc.go
@@ -547,15 +547,13 @@ func (p *Pack) deletePrivateNetwork(w http.ResponseWriter, r *http.Request) {
 	// says it must refuse rather than cut off.
 	//
 	// TestAPrivateNetworkTheRuntimeKeptIsNotReportedDeleted fails without this.
-	if name := res.Runtime[runtimeNetworkKey]; name != "" && p.env.Machines != nil {
-		if err := p.env.Machines.RemoveNetwork(r.Context(), name); err != nil {
-			p.logger().Error("could not remove the backing network",
-				"private_network", res.ID, "network", name, "error", err)
-			writePrecondition(w, "private_network", res.ID,
-				"the machine runtime still holds the network backing this private network, "+
-					"so deleting it here would report gone something that still holds its block: "+err.Error())
-			return
-		}
+	if err := p.binding().RemoveBackingNetwork(r.Context(), res, runtimeNetworkKey); err != nil {
+		p.logger().Error("could not remove the backing network",
+			"private_network", res.ID, "network", res.Runtime[runtimeNetworkKey], "error", err)
+		writePrecondition(w, "private_network", res.ID,
+			"the machine runtime still holds the network backing this private network, "+
+				"so deleting it here would report gone something that still holds its block: "+err.Error())
+		return
 	}
 	p.env.Store.Delete(Name, kindPrivateNetwork, res.ID)
 	p.isolateNetworks(r.Context())
@@ -995,27 +993,17 @@ func (p *Pack) allocatorFor(res *resource.Resource) (*network.Allocator, error) 
 
 // ensureBackingNetwork asks the machine driver for a real network carrying the
 // block. Failure is logged, never fatal: the control plane must keep answering
-// when no runtime is available, which is the default configuration.
+// when no runtime is available, which is the default configuration. The
+// mechanics — the derived name, the labels, recording the name only once the
+// driver accepted it — are Binding.EnsureBackingNetwork's, shared with the two
+// other packs (#510).
 func (p *Pack) ensureBackingNetwork(ctx context.Context, res *resource.Resource, prefix netip.Prefix) error {
-	if p.env.Machines == nil {
-		return nil
-	}
-	name := machine.NetworkName(machine.NetworkPrefix, res.ID)
-	if res.Runtime == nil {
-		res.Runtime = map[string]string{}
-	}
-	res.Runtime[runtimeNetworkKey] = name
-
-	gateway := prefix.Masked().Addr().Next()
-	return p.env.Machines.EnsureNetwork(ctx, machine.NetworkSpec{
-		Name:    name,
-		CIDR:    prefix.String(),
-		Gateway: gateway.String(),
+	return p.binding().EnsureBackingNetwork(ctx, res, machine.BackingNetwork{
+		Key:     runtimeNetworkKey,
+		CIDR:    prefix,
+		Gateway: true,
 		NAT:     true,
-		Labels: map[string]string{
-			"feint.provider":        Name,
-			"feint.private-network": res.ID,
-		},
+		Marker:  "feint.private-network",
 	})
 }
 

--- a/tools/falsify/specs/interface-plan.json
+++ b/tools/falsify/specs/interface-plan.json
@@ -1,0 +1,41 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "the boot replay applies the firewall before joining the memberships, the order three packs kept only in comments (#510)",
+      "file": "internal/core/machine/plan.go",
+      "find": "\tfor _, m := range plan.Memberships {\n\t\t_ = r.attach(ctx, res, m)\n\t}\n\t// The firewall last, so the expansion sees every address and every\n\t// interface the two loops above delivered. This line is the order the\n\t// packs kept in comments; TestTheReplayRoutesThenJoinsThenAppliesTheFirewall\n\t// is what holds it now.\n\tr.Groups.AfterBoot(ctx, res)",
+      "replace": "\t// The firewall last, so the expansion sees every address and every\n\t// interface the two loops above delivered. This line is the order the\n\t// packs kept in comments; TestTheReplayRoutesThenJoinsThenAppliesTheFirewall\n\t// is what holds it now.\n\tr.Groups.AfterBoot(ctx, res)\n\tfor _, m := range plan.Memberships {\n\t\t_ = r.attach(ctx, res, m)\n\t}",
+      "test": "TestTheReplayRoutesThenJoinsThenAppliesTheFirewall"
+    },
+    {
+      "label": "a hot join resyncs the firewall before the interface it must cover exists (#510)",
+      "file": "internal/core/machine/plan.go",
+      "find": "\terr := r.attach(ctx, res, att)\n\tr.Groups.AfterBoot(ctx, res)\n\treturn err",
+      "replace": "\tr.Groups.AfterBoot(ctx, res)\n\terr := r.attach(ctx, res, att)\n\treturn err",
+      "test": "TestJoinRunsTheFirewallAfterTheAttach"
+    },
+    {
+      "label": "the shared block guard stops firing, and a poisoned stored address reaches the driver (#510)",
+      "file": "internal/core/machine/plan.go",
+      "find": "\tif !r.emulated(address) {\n\t\tr.binding().logger().Warn(\"refusing to route an address outside the emulated public block\",",
+      "replace": "\tif !r.emulated(address) && false {\n\t\tr.binding().logger().Warn(\"refusing to route an address outside the emulated public block\",",
+      "test": "TestAPoisonedStoredAddressIsNeverRoutedByTheLayer"
+    },
+    {
+      "label": "the backing network is recorded before the driver accepted it, the ordering two packs had (#510)",
+      "file": "internal/core/machine/plan.go",
+      "find": "\tif err := b.Driver.EnsureNetwork(ctx, network); err != nil {\n\t\treturn err\n\t}\n\tif res.Runtime == nil {\n\t\tres.Runtime = map[string]string{}\n\t}\n\tres.Runtime[spec.Key] = name\n\treturn nil",
+      "replace": "\tif res.Runtime == nil {\n\t\tres.Runtime = map[string]string{}\n\t}\n\tres.Runtime[spec.Key] = name\n\tif err := b.Driver.EnsureNetwork(ctx, network); err != nil {\n\t\treturn err\n\t}\n\treturn nil",
+      "test": "TestEnsureBackingNetworkRecordsOnlyWhatTheDriverAccepted"
+    },
+    {
+      "label": "one pack stops declaring its promised addresses, and the cross-pack equivalence names the divergence (#510, #515)",
+      "package": "./internal/providers/",
+      "file": "internal/providers/scaleway/machines.go",
+      "find": "\treturn machine.Plan{\n\t\tBoot:     p.attachmentsOf(res),\n\t\tPublics:  p.publicAddressesOf(res),\n\t\tRouteVia: p.privateNetworkNameOf(res),\n\t}",
+      "replace": "\treturn machine.Plan{\n\t\tBoot:     p.attachmentsOf(res),\n\t\tPublics:  p.publicAddressesOf(res)[:0],\n\t\tRouteVia: p.privateNetworkNameOf(res),\n\t}",
+      "test": "TestSameIntentSameRuntimeSequenceAcrossPacks"
+    }
+  ]
+}

--- a/tools/falsify/specs/one-machine-per-address.json
+++ b/tools/falsify/specs/one-machine-per-address.json
@@ -39,9 +39,9 @@
     {
       "label": "the Exoscale attach routes the address without moving it off the previous instance",
       "package": "./internal/providers/exoscale/",
-      "file": "internal/providers/exoscale/elasticips.go",
-      "find": "\tif err := p.binding().RouteAddress(ctx, router, machine.AddressSpec{Machine: name, Address: address}); err != nil {",
-      "replace": "\t_ = p.binding()\n\tif err := router.RouteAddress(ctx, machine.AddressSpec{Machine: name, Address: address}); err != nil {",
+      "file": "internal/core/machine/plan.go",
+      "find": "\tif err := r.binding().RouteAddress(ctx, router, AddressSpec{\n\t\tMachine: name,\n\t\tAddress: address,\n\t\tNetwork: plan.RouteVia,\n\t}); err != nil {",
+      "replace": "\t_ = r.binding()\n\tif err := router.RouteAddress(ctx, AddressSpec{\n\t\tMachine: name,\n\t\tAddress: address,\n\t\tNetwork: plan.RouteVia,\n\t}); err != nil {",
       "test": "TestAnElasticIPReachesOneMachineAtATime"
     }
   ]

--- a/tools/falsify/specs/pack-firewall-handoff.json
+++ b/tools/falsify/specs/pack-firewall-handoff.json
@@ -4,8 +4,8 @@
     {
       "label": "the Outscale boot stops handing the worn groups to the runtime, which is the whole of #475",
       "file": "internal/providers/outscale/machines.go",
-      "find": "\tp.syncFirewallAfterBoot(ctx, res)\n}",
-      "replace": "\tif false {\n\t\tp.syncFirewallAfterBoot(ctx, res)\n\t}\n}",
+      "find": "\tp.groupSync().AfterBoot(ctx, res)\n}",
+      "replace": "\tif false {\n\t\tp.groupSync().AfterBoot(ctx, res)\n\t}\n}",
       "test": "TestAnOutscaleGroupReachesTheHostWhenItsVmBoots"
     },
     {
@@ -19,8 +19,8 @@
       "label": "the Exoscale boot stops handing the worn groups to the runtime",
       "package": "./internal/providers/exoscale/",
       "file": "internal/providers/exoscale/machines.go",
-      "find": "\tp.syncFirewallAfterBoot(ctx, res)\n}",
-      "replace": "\tif false {\n\t\tp.syncFirewallAfterBoot(ctx, res)\n\t}\n}",
+      "find": "\tp.groupSync().AfterBoot(ctx, res)\n}",
+      "replace": "\tif false {\n\t\tp.groupSync().AfterBoot(ctx, res)\n\t}\n}",
       "test": "TestAnExoscaleGroupReachesTheHostWhenAnInstanceBoots"
     },
     {
@@ -35,8 +35,8 @@
       "label": "a network attached after the boot leaves its interface without the instance's rule sets",
       "package": "./internal/providers/exoscale/",
       "file": "internal/providers/exoscale/privatenetworks.go",
-      "find": "\tp.applyInstanceRuleSets(r.Context(), inst)",
-      "replace": "\tif false {\n\t\tp.applyInstanceRuleSets(r.Context(), inst)\n\t}",
+      "find": "\tp.groupSync().ApplyMachine(r.Context(), inst)",
+      "replace": "\tif false {\n\t\tp.groupSync().ApplyMachine(r.Context(), inst)\n\t}",
       "test": "TestALateNetworkAttachCarriesTheRuleSets"
     },
     {
@@ -46,6 +46,30 @@
       "find": "\tif ids := poolRefIDs(pool.Attrs[\"security-groups\"]); len(ids) > 0 {",
       "replace": "\tif ids := poolRefIDs(pool.Attrs[\"security-groups\"]); len(ids) > 0 && false {",
       "test": "TestAPoolMemberWearsItsPoolsGroups"
+    },
+    {
+      "label": "the skeleton hands the pack's translation the store's stale copy instead of the transition's fresh one (#509)",
+      "package": "./internal/core/machine/",
+      "file": "internal/core/machine/groupsync.go",
+      "find": "\tspec := s.SpecOf(group, fresh)",
+      "replace": "\tif fresh != nil {\n\t\tfresh = nil\n\t}\n\tspec := s.SpecOf(group, fresh)",
+      "test": "TestAFreshResourceWinsOverItsStaleStoreCopy"
+    },
+    {
+      "label": "the wearer replay re-translates with each wearer's stale store copy, erasing the fresh expansion it just delivered (#509)",
+      "package": "./internal/core/machine/",
+      "file": "internal/core/machine/groupsync.go",
+      "find": "\t\ts.applyMachine(ctx, wearer, fresh)",
+      "replace": "\t\tif fresh != nil {\n\t\t\tfresh = wearer\n\t\t}\n\t\ts.applyMachine(ctx, wearer, fresh)",
+      "test": "TestTheWearerReplayKeepsTheFreshExpansion"
+    },
+    {
+      "label": "the bridge-mode rejects stop riding the group's rule set, re-opening what the subnets keep apart (#509)",
+      "package": "./internal/core/machine/",
+      "file": "internal/core/machine/groupsync.go",
+      "find": "\tif s.ForeignBlocks == nil || s.nativeIsolation() {",
+      "replace": "\tif true || s.ForeignBlocks == nil || s.nativeIsolation() {",
+      "test": "TestForeignRejectsRideTheRuleSetOnlyWhereNetworksAreBornJoined"
     }
   ]
 }

--- a/tools/falsify/specs/pack-firewall-handoff.json
+++ b/tools/falsify/specs/pack-firewall-handoff.json
@@ -3,9 +3,9 @@
   "mutations": [
     {
       "label": "the Outscale boot stops handing the worn groups to the runtime, which is the whole of #475",
-      "file": "internal/providers/outscale/machines.go",
-      "find": "\tp.groupSync().AfterBoot(ctx, res)\n}",
-      "replace": "\tif false {\n\t\tp.groupSync().AfterBoot(ctx, res)\n\t}\n}",
+      "file": "internal/core/machine/plan.go",
+      "find": "\tr.Groups.AfterBoot(ctx, res)\n\treturn true",
+      "replace": "\tif false {\n\t\tr.Groups.AfterBoot(ctx, res)\n\t}\n\treturn true",
       "test": "TestAnOutscaleGroupReachesTheHostWhenItsVmBoots"
     },
     {
@@ -18,9 +18,9 @@
     {
       "label": "the Exoscale boot stops handing the worn groups to the runtime",
       "package": "./internal/providers/exoscale/",
-      "file": "internal/providers/exoscale/machines.go",
-      "find": "\tp.groupSync().AfterBoot(ctx, res)\n}",
-      "replace": "\tif false {\n\t\tp.groupSync().AfterBoot(ctx, res)\n\t}\n}",
+      "file": "internal/core/machine/plan.go",
+      "find": "\tr.Groups.AfterBoot(ctx, res)\n\treturn true",
+      "replace": "\tif false {\n\t\tr.Groups.AfterBoot(ctx, res)\n\t}\n\treturn true",
       "test": "TestAnExoscaleGroupReachesTheHostWhenAnInstanceBoots"
     },
     {
@@ -34,9 +34,9 @@
     {
       "label": "a network attached after the boot leaves its interface without the instance's rule sets",
       "package": "./internal/providers/exoscale/",
-      "file": "internal/providers/exoscale/privatenetworks.go",
-      "find": "\tp.groupSync().ApplyMachine(r.Context(), inst)",
-      "replace": "\tif false {\n\t\tp.groupSync().ApplyMachine(r.Context(), inst)\n\t}",
+      "file": "internal/core/machine/plan.go",
+      "find": "\terr := r.attach(ctx, res, att)\n\tr.Groups.AfterBoot(ctx, res)\n\treturn err",
+      "replace": "\terr := r.attach(ctx, res, att)\n\tif false {\n\t\tr.Groups.AfterBoot(ctx, res)\n\t}\n\treturn err",
       "test": "TestALateNetworkAttachCarriesTheRuleSets"
     },
     {

--- a/tools/falsify/specs/run-leaves-nothing.json
+++ b/tools/falsify/specs/run-leaves-nothing.json
@@ -12,8 +12,8 @@
     {
       "label": "the network delete goes back to logging its failure and answering 204, so the API reports gone a network whose bridge still holds the block",
       "file": "internal/providers/scaleway/vpc.go",
-      "find": "\t\tif err := p.env.Machines.RemoveNetwork(r.Context(), name); err != nil {",
-      "replace": "\t\tif err := p.env.Machines.RemoveNetwork(r.Context(), name); err != nil && false {",
+      "find": "\tif err := p.binding().RemoveBackingNetwork(r.Context(), res, runtimeNetworkKey); err != nil {",
+      "replace": "\tif err := p.binding().RemoveBackingNetwork(r.Context(), res, runtimeNetworkKey); err != nil && false {",
       "test": "TestAPrivateNetworkTheRuntimeKeptIsNotReportedDeleted",
       "package": "./internal/providers/scaleway/"
     },


### PR DESCRIPTION
Closes #509. Closes #510.

The instrument #515 shipped printed three sequences for one intent. This turns
it green — and the acceptance criterion is that single line.

## The criterion, and the interdiction that makes it honest

`TestSameIntentSameRuntimeSequenceAcrossPacks` **passes**, because the sequences
converged and **not** because the comparison loosened: `sameSequence` is
unchanged — strict, ordered equality — and `TestAShuffledReplayIsToldFromItsOriginal`
still refuses a one-step rotation, replayed after the fix. A pack-level
falsification (Scaleway stops declaring its promised addresses) is caught and
named by the cross-pack property itself. The comparator still discriminates.

The statement is **per expressible intent**, and the restriction is closed on
itself. Two intents, each over at least two packs, exclusions carrying their
written reason — Outscale is out of intent 1 because its Vm is born on its
Subnet, the membership rides the launch, and no Vm carries an emulated public
address at boot since `LinkPublicIp` is post-create by construction. The test
**fails** if an intent is compared alone, if a pack is dropped from every
intent, if an exclusion loses its reason, or if a gesture disappears from the
compared vocabulary. Those are the four ways to make it lie, and each is
guarded.

## The boundary: the recipe moves up, the semantics stay

`machine.GroupSync` (#509) holds the skeleton — sync-then-apply, replay on the
wearers, the fresh copy, the post-boot re-expansion — parameterised by `SpecOf`,
`Wearers`, `WornIDs`, `Group`, `Referrers`, `ForeignBlocks`. `machine.Plan` and
`machine.Reconciler` (#510) execute the single order — addresses, then
memberships, then the firewall last so the expansion sees every interface — and
`Join`/`Leave`/`Route`/`Unroute` plus `EnsureBackingNetwork`/`RemoveBackingNetwork`
close the hot-attach families the boot-time plan could not hold.

**What did not move**: Scaleway's VPC routing predicates, Outscale's peering
semantics, Exoscale's group references. `TestTheCoreNamesNoProvider` is green.
The audit warned about the opposite mistake as loudly as about duplication, and
a zealous refactor breaks rule 5 as surely as a lazy copy.

## Two defects the factoring exposed

Neither was being looked for; both surfaced from putting three copies side by
side.

- **The wearer replay re-translated from the stale wearer copy**, overwriting the
  fresh expansion one second after delivering it — masked on Outscale by an
  early return on a wearer with no machine. Fixed by one `fresh` per pass, held
  by `TestTheWearerReplayKeepsTheFreshExpansion` and its mutation.
- **`carrySecondary` derived the machine name instead of reading `Runtime`**, and
  reconfigured a machine the Vm had never started. A test leaned on that ghost;
  it now starts a real machine.

## The two asymmetries, decided rather than copied

- **`fresh`** is threaded by the skeleton for all three packs, so Exoscale
  **gains** it: the question of whether its hole was reachable is closed rather
  than answered, which is the point of a shared skeleton — the question stops
  existing.
- **Foreign-block rejects**, Scaleway's alone, become the field `ForeignBlocks`:
  the predicate (what counts as foreign — its VPC routing model) stays in the
  pack, the mechanism moves to the skeleton. The other two stay `nil` with the
  reason written: bridge mode declares `isolation: false` for all three, nothing
  lies, and wiring their predicates would change measured rule sets with no
  witness asking for it. `TestBridgeModeRejectsForeignSubnetsThroughTheGroup`
  fails if the field is lost.

## Left undone, on purpose

`Route` still performs no firewall resync — today's behaviour on all three
packs. The staleness that leaves on Outscale is measured and filed as **#531**,
because fixing it changes behaviour and deserves its own red test first. A
move-the-code batch must not smuggle that in.

## Gates

`mise run check`, `go test ./... -race`, `mise run prepush`, `mise run docs:check`
all 0. **The 29 specs naming a touched file replayed in full, every mutation
biting**; `pack-firewall-handoff` (9) and the new `interface-plan` (5) replayed
again on the final tree; four specs re-pointed, including the
`enforcement_test.go` marker onto `machine.GroupSync` as #509's comment required.
`falsify:lint`: 694 mutations over 119 specs, none dead.

`FEINT_VM=incus-ovn mise run conformance` green end to end (exit 0, 21 min,
score 350/373). Stacks under `feint up --runtime incus-ovn`: Scaleway 6 machines
with three `scw-*` sets over six references, Outscale 3 machines with two
`osc-*` sets over three — **the reference values did not move** — empty second
plans, clean destroys, nil station delta.

Three instrument failures are recorded in the branch's progress file, including
one that mattered: **global address placements let two replays of one dialect
see each other**, so the determinism property was measuring the suite's residue
rather than the replay. `ForgetPlacements` per replay, with the reason in a
comment.

No CHANGELOG entry: this changes no response shape and no limit, which the
file's own header says belongs in `git log`.
