### PR TITLE
refactor(machine): the packs reach a declared surface, and the driver leaves their vocabulary (#511)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,6 +95,15 @@ fit — Exoscale declares its login *per template*, not per cloud — the
 abstraction widens (`Boot.User`); the pack never invents a value to fit the
 mould.
 
+And what a pack may ask of the runtime is a closed list rather than whatever it
+can reach: `machine.PackSurface()` names eight service families, and
+`internal/cli`'s `TestNoPackReachesPastTheDeclaredDriverSurface` holds the packs'
+own sources against it, naming the pack, the gesture and the line. The strongest
+half is not that test: a pack receives no `machine.Driver` value at all —
+`emulator.Env` keeps it unexported and hands back a finished `Binding` — so the
+call it would have written does not compile. A gesture the list lacks is added
+to it; the pack never works around it.
+
 ## A request, end to end
 
 1. `http.ServeMux` matches the pattern a pack registered, using Go 1.22 routing

--- a/docs/fourth-pack.md
+++ b/docs/fourth-pack.md
@@ -79,6 +79,7 @@ generic loaders:
 | Coverage and baseline | `coverage/<name>-{coverage,baseline}.json`, generic reader/writer |
 | Shapes catalogue | `shapes/<name>.json`, generic `shape.Catalogue` |
 | Machine lifecycle | `machine.Binding` fields; the sequence is shared, the vocabulary is the pack's |
+| What the runtime offers a pack | `machine.PackSurface()` — the closed list, eight service families; a gesture missing from it is a service the driver gains, never a call written around it |
 | Probe | reads the contract, no provider code |
 | Transcript / proxy / trace | provider is a string field in the exchange |
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -936,7 +936,7 @@ func serve(args []string, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
-	env.Machines = driver
+	env.UseMachines(driver)
 	// The operator's own identifier declarations, the door through the boot
 	// refusal (#465). Read here in the composition root like the other
 	// deployment choices (FEINT_OUTSCALE_REGION), and only on the serve path:
@@ -1013,7 +1013,7 @@ func serve(args []string, stdout io.Writer) error {
 		for _, p := range srv.Packs() {
 			fmt.Fprintf(stdout, "  %-9s %d routes\n", p.Name(), len(p.Routes()))
 		}
-		fmt.Fprintf(stdout, "  machines  %s\n", env.Machines.Name())
+		fmt.Fprintf(stdout, "  machines  %s\n", env.RuntimeName())
 		if page {
 			fmt.Fprintf(stdout, "  page      http://%s/_feint/ui\n", *addr)
 		}

--- a/internal/cli/discipline_test.go
+++ b/internal/cli/discipline_test.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/stephrobert/feint/internal/core/machine"
 )
 
 // The shared layer is enforced, not merely offered (#220).
@@ -217,15 +219,21 @@ func barrageCalls(t *testing.T, file string) map[string]int {
 // guard already paid for: the exemption maps above would otherwise let a pack out
 // with an empty string.
 func TestEveryBarrageExemptionSaysWhy(t *testing.T) {
-	for _, exemptions := range []map[string]string{ownExclusion, notInTheBarrage} {
+	for _, exemptions := range []map[string]string{ownExclusion, notInTheBarrage, notInTheDriverSurface} {
 		for key, reason := range exemptions {
-			if len(strings.Fields(reason)) < 5 {
+			if reasonIsThin(reason) {
 				t.Errorf("the exemption for %s says %q, which is not a reason a reviewer can weigh",
 					key, reason)
 			}
 		}
 	}
 }
+
+// reasonIsThin is what "says why" means here, in one place so the detector's
+// own positive control can exercise it: "not yet migrated" and "cannot be" are
+// different reasons and both are too short to be one. Five words is not a
+// quality bar, it is a floor under the empty string.
+func reasonIsThin(reason string) bool { return len(strings.Fields(reason)) < 5 }
 
 // `internal/core` carries no provider-named code, which is the testable half of
 // what adding a provider costs.
@@ -346,5 +354,93 @@ func TestTheDisciplineDetectorsFindWhatTheyLookFor(t *testing.T) {
 	}
 	if strings.Contains(source, "storetest.NoLostUpdate(") {
 		t.Error("the registration scan reports a call that is not there")
+	}
+
+	// The driver-surface detector (#511), against a pack that bypasses it.
+	//
+	// Two shapes, because they fail differently. Naming an implementation of
+	// the driver is the flat one. Calling a low-level Binding verb through a
+	// local variable is the one a scanner reading only `p.binding().Verb(…)`
+	// misses entirely — and that scanner existed, in this file, while the load
+	// balancer's three verbs went unseen. The accepting half is asserted too:
+	// PowerOff, which is in the surface, must not be reported, or a detector
+	// that refuses everything would pass this test and break the packs.
+	pack := filepath.Join(t.TempDir(), "provider")
+	if err := os.MkdirAll(pack, 0o750); err != nil {
+		t.Fatalf("make the fixture pack: %v", err)
+	}
+	bypass := `package provider
+
+import (
+	"context"
+
+	"github.com/stephrobert/feint/internal/core/machine"
+	"github.com/stephrobert/feint/internal/core/resource"
+)
+
+func binding() machine.Binding { return machine.Binding{} }
+
+func act(ctx context.Context, res *resource.Resource) {
+	b := binding()
+	b.PowerOff(ctx, res)
+	b.Stop(ctx, res.ID, "feint-xxx-1")
+	_ = machine.Noop{}
+}
+`
+	if err := os.WriteFile(filepath.Join(pack, "machines.go"), []byte(bypass), 0o600); err != nil {
+		t.Fatalf("write the fixture pack: %v", err)
+	}
+	surface := machine.PackSurface()
+	outside := map[string]bool{}
+	sawAllowed := false
+	for _, r := range driverSurfaceReaches(t, readMachinePackage(t), pack) {
+		if _, allowed := surface[r.key]; allowed {
+			if r.key == "Binding.PowerOff" {
+				sawAllowed = true
+			}
+			continue
+		}
+		outside[r.key] = true
+	}
+	for _, planted := range []string{"Binding.Stop", "Noop"} {
+		if !outside[planted] {
+			t.Errorf("the driver-surface detector did not report the planted %s: a discipline "+
+				"test that finds nothing reads exactly like a disciplined repository", planted)
+		}
+	}
+	if !sawAllowed {
+		t.Error("the driver-surface detector did not even see Binding.PowerOff in the fixture, " +
+			"so its silence about the rest proves nothing")
+	}
+	if len(outside) != 2 {
+		t.Errorf("the driver-surface detector reports %v outside the surface; PowerOff is in it, "+
+			"and a detector that refuses a declared verb would break every pack", outside)
+	}
+
+	// And the scanner's own precondition: it resolves machine.X by that one
+	// name, so it has to notice a file that renames the package rather than
+	// reading it as touching nothing.
+	aliased, err := parser.ParseFile(token.NewFileSet(), filepath.Join(pack, "machines.go"), []byte(
+		"package provider\n\nimport mach \"github.com/stephrobert/feint/internal/core/machine\"\n\nvar _ = mach.Noop{}\n"), 0)
+	if err != nil {
+		t.Fatalf("parse the aliased fixture: %v", err)
+	}
+	if got := aliasedMachineImport(aliased); got != "mach" {
+		t.Errorf("the scanner does not notice an aliased machine import, got %q: it would then "+
+			"read that file as reaching nothing at all", got)
+	}
+	plain, err := parser.ParseFile(token.NewFileSet(), filepath.Join(pack, "machines.go"), []byte(bypass), 0)
+	if err != nil {
+		t.Fatalf("parse the plain fixture: %v", err)
+	}
+	if got := aliasedMachineImport(plain); got != "" {
+		t.Errorf("the scanner calls a plain import an alias (%q), which would fail every pack", got)
+	}
+
+	if !reasonIsThin("not yet migrated") {
+		t.Error("the exemption check accepts a reason nobody can weigh")
+	}
+	if reasonIsThin(notInTheBarrage["exoscale/Orphans"]) {
+		t.Error("the exemption check rejects a reason that says why")
 	}
 }

--- a/internal/cli/driver_surface_test.go
+++ b/internal/cli/driver_surface_test.go
@@ -1,0 +1,786 @@
+package cli
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/machine"
+)
+
+// reach is one place a pack's own source names something of
+// internal/core/machine: a package-level name written machine.X, or a member —
+// method or field — read off a value whose type came from there.
+type reach struct {
+	key   string // "Attachment", or "Binding.PowerOff"
+	pack  string
+	where string // "internal/providers/scaleway/servers.go:445"
+	how   string
+}
+
+// machinePackage is what internal/core/machine offers, read from its own
+// source: the denominator the surface is judged against.
+type machinePackage struct {
+	// names are the exported package-level names, mapped to their kind.
+	names map[string]string
+	// members are the exported methods and fields of exported types, keyed
+	// "Type.Member".
+	members map[string]bool
+	// yields maps a member to the machine type it produces, so a value passed
+	// from one member to the next stays resolvable: the delivery a balancer
+	// hand-off returns is a machine value too, and a scanner that lost it
+	// there would stop watching at the first hop.
+	yields map[string]string
+	// results maps a member to every type it returns, positionally, for the
+	// `a, b := x.M()` form.
+	results map[string][]string
+}
+
+// readMachinePackage parses internal/core/machine and reports what it exports.
+//
+// Derived, never listed by hand, and the reason is written in #511's own
+// history: three successive counts of this same surface were wrong because
+// each started from a list of verbs somebody remembered — test files left in
+// the population, then Attach and Detach missing from the list, then the
+// interface assertions missing altogether. A grep that does not enumerate what
+// it ignores cannot say what it missed. So the denominator is the package's
+// own declarations, and the surface below is checked against them: a name that
+// stops existing, or is renamed, fails here rather than quietly stopping to
+// mean anything.
+func readMachinePackage(t *testing.T) machinePackage {
+	t.Helper()
+	dir := filepath.Join(repoRoot(t), "internal", "core", "machine")
+	files, err := filepath.Glob(filepath.Join(dir, "*.go"))
+	if err != nil {
+		t.Fatalf("list the machine package: %v", err)
+	}
+	pkg := machinePackage{
+		names:   map[string]string{},
+		members: map[string]bool{},
+		yields:  map[string]string{},
+		results: map[string][]string{},
+	}
+	parsed := 0
+	for _, file := range files {
+		if strings.HasSuffix(file, "_test.go") {
+			continue
+		}
+		tree, err := parser.ParseFile(token.NewFileSet(), file, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", file, err)
+		}
+		parsed++
+		for _, decl := range tree.Decls {
+			switch d := decl.(type) {
+			case *ast.FuncDecl:
+				readMachineFunc(pkg, d)
+			case *ast.GenDecl:
+				readMachineGenDecl(pkg, d)
+			}
+		}
+	}
+	if parsed < 10 || len(pkg.names) < 40 {
+		t.Fatalf("read %d files and %d exported names from the machine package: the reader is "+
+			"broken, and a broken reader makes every surface entry look stale", parsed, len(pkg.names))
+	}
+	return pkg
+}
+
+func readMachineFunc(pkg machinePackage, d *ast.FuncDecl) {
+	if !d.Name.IsExported() {
+		return
+	}
+	if d.Recv == nil {
+		pkg.names[d.Name.Name] = "func"
+		pkg.results[d.Name.Name] = machineResults(d.Type)
+		if types := pkg.results[d.Name.Name]; len(types) > 0 {
+			pkg.yields[d.Name.Name] = types[0]
+		}
+		return
+	}
+	recv := receiverName(d.Recv.List[0].Type)
+	if recv == "" || !ast.IsExported(recv) {
+		return
+	}
+	key := recv + "." + d.Name.Name
+	pkg.members[key] = true
+	pkg.results[key] = machineResults(d.Type)
+	if types := pkg.results[key]; len(types) > 0 {
+		pkg.yields[key] = types[0]
+	}
+}
+
+func readMachineGenDecl(pkg machinePackage, d *ast.GenDecl) {
+	for _, spec := range d.Specs {
+		switch s := spec.(type) {
+		case *ast.TypeSpec:
+			if !s.Name.IsExported() {
+				continue
+			}
+			pkg.names[s.Name.Name] = "type"
+			switch t := s.Type.(type) {
+			case *ast.InterfaceType:
+				for _, m := range t.Methods.List {
+					for _, name := range m.Names {
+						key := s.Name.Name + "." + name.Name
+						pkg.members[key] = true
+						if fn, ok := m.Type.(*ast.FuncType); ok {
+							pkg.results[key] = machineResults(fn)
+							if types := pkg.results[key]; len(types) > 0 {
+								pkg.yields[key] = types[0]
+							}
+						}
+					}
+				}
+			case *ast.StructType:
+				for _, f := range t.Fields.List {
+					for _, name := range f.Names {
+						if !name.IsExported() {
+							continue
+						}
+						key := s.Name.Name + "." + name.Name
+						pkg.members[key] = true
+						if local, ok := localType(f.Type); ok {
+							pkg.yields[key] = local
+						}
+					}
+				}
+			}
+		case *ast.ValueSpec:
+			kind := "var"
+			if d.Tok == token.CONST {
+				kind = "const"
+			}
+			for _, name := range s.Names {
+				if name.IsExported() {
+					pkg.names[name.Name] = kind
+				}
+			}
+		}
+	}
+}
+
+func receiverName(e ast.Expr) string {
+	switch t := e.(type) {
+	case *ast.StarExpr:
+		return receiverName(t.X)
+	case *ast.Ident:
+		return t.Name
+	}
+	return ""
+}
+
+// machineResults names, positionally, the machine types a signature returns;
+// "" where a result is something else.
+func machineResults(fn *ast.FuncType) []string {
+	if fn.Results == nil {
+		return nil
+	}
+	var out []string
+	for _, f := range fn.Results.List {
+		name, _ := localType(f.Type)
+		n := len(f.Names)
+		if n == 0 {
+			n = 1
+		}
+		for range n {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// localType names the machine type an expression written *inside* the machine
+// package denotes: "Binding", "[]Attachment", or "" for anything else.
+func localType(e ast.Expr) (string, bool) {
+	switch t := e.(type) {
+	case *ast.StarExpr:
+		return localType(t.X)
+	case *ast.ArrayType:
+		if inner, ok := localType(t.Elt); ok {
+			return "[]" + inner, true
+		}
+	case *ast.Ident:
+		if ast.IsExported(t.Name) {
+			return t.Name, true
+		}
+	}
+	return "", false
+}
+
+// qualifiedType names the machine type an expression written in a *pack*
+// denotes: machine.Binding, []machine.Attachment.
+func qualifiedType(e ast.Expr) (string, bool) {
+	switch t := e.(type) {
+	case *ast.StarExpr:
+		return qualifiedType(t.X)
+	case *ast.ArrayType:
+		if inner, ok := qualifiedType(t.Elt); ok {
+			return "[]" + inner, true
+		}
+	case *ast.SelectorExpr:
+		if id, ok := t.X.(*ast.Ident); ok && id.Name == machinePackageName {
+			return t.Sel.Name, true
+		}
+	}
+	return "", false
+}
+
+// machinePackageName is the identifier the packs import internal/core/machine
+// under. Every scan below resolves `machine.X` by this name, so a file that
+// imported the package as something else would be read as touching nothing —
+// a silent empty scan, which is the exact shape of failure this file exists to
+// refuse. refuseAnAliasedImport asks the question rather than the comment
+// asserting the answer.
+const machinePackageName = "machine"
+
+const machinePackagePath = `"github.com/stephrobert/feint/internal/core/machine"`
+
+// aliasedMachineImport names the alias a file gives the machine package, and is
+// empty when the file imports it plainly or not at all.
+//
+// Widening the scanner to follow an alias would be the other answer, and it is
+// the wrong one here: the alias would have to be threaded through every
+// resolution below, and a scanner that silently coped would let the next
+// reader believe the constant above is a convention rather than a fact. The
+// caller fails on the file that broke it instead — and this is a value rather
+// than a t.Fatalf so the detectors' own positive control can exercise it.
+func aliasedMachineImport(tree *ast.File) string {
+	for _, spec := range tree.Imports {
+		if spec.Path.Value != machinePackagePath {
+			continue
+		}
+		if spec.Name != nil && spec.Name.Name != machinePackageName {
+			return spec.Name.Name
+		}
+	}
+	return ""
+}
+
+// surfaceScanner walks one pack and reports every reach into the machine
+// package.
+type surfaceScanner struct {
+	pkg     machinePackage
+	pack    string
+	root    string
+	results map[string][]string
+	fields  map[string]string // pack struct field name -> machine type
+	locals  map[string]string
+	fset    *token.FileSet
+	rel     string
+	out     []reach
+}
+
+// driverSurfaceReaches reports every reach into the machine package made by
+// the non-test sources of one pack directory.
+//
+// Non-test on purpose, and the reason is the measurement that opened #511: the
+// first count of this surface was taken with `grep -rh … | grep -v _test`,
+// which with -h has no filename to filter on and therefore dropped *lines*
+// containing "_test" while keeping every test file in the population. Test
+// files legitimately build fake drivers — that is how a pack is tested at all
+// — so counting them measures the harness. Here the exclusion is by filename,
+// on the file being opened.
+func driverSurfaceReaches(t *testing.T, pkg machinePackage, dir string) []reach {
+	t.Helper()
+	files, err := filepath.Glob(filepath.Join(dir, "*.go"))
+	if err != nil {
+		t.Fatalf("list %s: %v", dir, err)
+	}
+	sources := make([]string, 0, len(files))
+	for _, file := range files {
+		if !strings.HasSuffix(file, "_test.go") {
+			sources = append(sources, file)
+		}
+	}
+
+	s := &surfaceScanner{
+		pkg:     pkg,
+		pack:    filepath.Base(dir),
+		root:    repoRoot(t),
+		results: map[string][]string{},
+		fields:  map[string]string{},
+	}
+
+	// Two passes: what this pack's own functions and structs carry has to be
+	// known before any body is read, because p.binding() is declared in one
+	// file and called from a dozen others. Resolving per file was the first
+	// version of this scanner and it lost every call outside machines.go.
+	trees := make([]*ast.File, 0, len(sources))
+	fsets := make([]*token.FileSet, 0, len(sources))
+	for _, file := range sources {
+		fset := token.NewFileSet()
+		tree, err := parser.ParseFile(fset, file, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", file, err)
+		}
+		if alias := aliasedMachineImport(tree); alias != "" {
+			t.Fatalf("%s imports the machine package as %q: every scan below resolves machine.X "+
+				"by the name %q, so this file would be read as reaching nothing at all. Drop the "+
+				"alias, or teach the scanner to carry one per file", file, alias, machinePackageName)
+		}
+		s.declare(tree)
+		trees = append(trees, tree)
+		fsets = append(fsets, fset)
+	}
+	for i, tree := range trees {
+		s.fset = fsets[i]
+		rel, err := filepath.Rel(s.root, sources[i])
+		if err != nil {
+			rel = sources[i]
+		}
+		s.rel = rel
+		s.scan(tree)
+	}
+	return s.out
+}
+
+// declare records what this pack's own declarations carry of the machine
+// package: a function returning one, a struct field holding one.
+func (s *surfaceScanner) declare(tree *ast.File) {
+	for _, decl := range tree.Decls {
+		switch d := decl.(type) {
+		case *ast.FuncDecl:
+			results := packResults(d.Type)
+			if len(results) == 0 {
+				continue
+			}
+			s.results[d.Name.Name] = results
+		case *ast.GenDecl:
+			for _, spec := range d.Specs {
+				ts, ok := spec.(*ast.TypeSpec)
+				if !ok {
+					continue
+				}
+				st, ok := ts.Type.(*ast.StructType)
+				if !ok {
+					continue
+				}
+				for _, f := range st.Fields.List {
+					name, ok := qualifiedType(f.Type)
+					if !ok {
+						continue
+					}
+					for _, ident := range f.Names {
+						s.fields[ident.Name] = name
+					}
+				}
+			}
+		}
+	}
+}
+
+func packResults(fn *ast.FuncType) []string {
+	if fn.Results == nil {
+		return nil
+	}
+	var out []string
+	machine := false
+	for _, f := range fn.Results.List {
+		name, _ := qualifiedType(f.Type)
+		if name != "" {
+			machine = true
+		}
+		n := len(f.Names)
+		if n == 0 {
+			n = 1
+		}
+		for range n {
+			out = append(out, name)
+		}
+	}
+	if !machine {
+		return nil
+	}
+	return out
+}
+
+func (s *surfaceScanner) scan(tree *ast.File) {
+	for _, decl := range tree.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			s.walk(decl)
+			continue
+		}
+		s.locals = map[string]string{}
+		s.bindParams(fn.Type)
+		if fn.Recv != nil {
+			s.bindFields(fn.Recv)
+		}
+		s.walk(fn)
+	}
+}
+
+func (s *surfaceScanner) bindParams(fn *ast.FuncType) {
+	if fn.Params == nil {
+		return
+	}
+	for _, f := range fn.Params.List {
+		name, ok := qualifiedType(f.Type)
+		if !ok {
+			continue
+		}
+		for _, ident := range f.Names {
+			s.locals[ident.Name] = name
+		}
+	}
+}
+
+func (s *surfaceScanner) bindFields(recv *ast.FieldList) {
+	for _, f := range recv.List {
+		name, ok := qualifiedType(f.Type)
+		if !ok {
+			continue
+		}
+		for _, ident := range f.Names {
+			s.locals[ident.Name] = name
+		}
+	}
+}
+
+// walk reads a declaration, recording assignments as it meets them so a value
+// stays followed across statements: `b := p.binding()` then `b.Stop(…)` is a
+// reach, and a scanner that only understood `p.binding().Stop(…)` would report
+// a clean pack for a bypass one local variable deep. That variant was measured
+// on this very repository while the scanner was being written — the load
+// balancer's three verbs were invisible until this arrived.
+func (s *surfaceScanner) walk(node ast.Node) {
+	ast.Inspect(node, func(n ast.Node) bool {
+		switch stmt := n.(type) {
+		case *ast.AssignStmt:
+			s.record(stmt)
+		case *ast.DeclStmt:
+			if decl, ok := stmt.Decl.(*ast.GenDecl); ok {
+				for _, spec := range decl.Specs {
+					vs, ok := spec.(*ast.ValueSpec)
+					if !ok {
+						continue
+					}
+					s.recordValueSpec(vs)
+				}
+			}
+		case *ast.RangeStmt:
+			if elem, ok := strings.CutPrefix(s.typeOf(stmt.X), "[]"); ok && elem != "" {
+				if ident, ok := stmt.Value.(*ast.Ident); ok {
+					s.locals[ident.Name] = elem
+				}
+			}
+		case *ast.SelectorExpr:
+			s.reachSelector(stmt)
+		}
+		return true
+	})
+}
+
+func (s *surfaceScanner) record(stmt *ast.AssignStmt) {
+	if len(stmt.Rhs) == len(stmt.Lhs) {
+		for i, lhs := range stmt.Lhs {
+			if ident, ok := lhs.(*ast.Ident); ok {
+				if typ := s.typeOf(stmt.Rhs[i]); typ != "" {
+					s.locals[ident.Name] = typ
+				}
+			}
+		}
+		return
+	}
+	if len(stmt.Rhs) != 1 {
+		return
+	}
+	for i, lhs := range stmt.Lhs {
+		ident, ok := lhs.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		if typ := s.resultAt(stmt.Rhs[0], i); typ != "" {
+			s.locals[ident.Name] = typ
+		}
+	}
+}
+
+func (s *surfaceScanner) recordValueSpec(vs *ast.ValueSpec) {
+	if typ, ok := qualifiedType(vs.Type); ok {
+		for _, ident := range vs.Names {
+			s.locals[ident.Name] = typ
+		}
+		return
+	}
+	if len(vs.Values) != len(vs.Names) {
+		return
+	}
+	for i, ident := range vs.Names {
+		if typ := s.typeOf(vs.Values[i]); typ != "" {
+			s.locals[ident.Name] = typ
+		}
+	}
+}
+
+// typeOf names the machine type an expression in pack code evaluates to, "" for
+// anything else.
+func (s *surfaceScanner) typeOf(e ast.Expr) string {
+	switch t := e.(type) {
+	case *ast.ParenExpr:
+		return s.typeOf(t.X)
+	case *ast.UnaryExpr:
+		return s.typeOf(t.X)
+	case *ast.StarExpr:
+		return s.typeOf(t.X)
+	case *ast.CompositeLit:
+		if name, ok := qualifiedType(t.Type); ok {
+			return name
+		}
+	case *ast.TypeAssertExpr:
+		if t.Type != nil {
+			if name, ok := qualifiedType(t.Type); ok {
+				return name
+			}
+		}
+	case *ast.IndexExpr:
+		if elem, ok := strings.CutPrefix(s.typeOf(t.X), "[]"); ok {
+			return elem
+		}
+	case *ast.CallExpr:
+		return s.resultAt(t, 0)
+	case *ast.SelectorExpr:
+		return s.selectorType(t)
+	case *ast.Ident:
+		return s.locals[t.Name]
+	}
+	return ""
+}
+
+func (s *surfaceScanner) selectorType(t *ast.SelectorExpr) string {
+	if id, ok := t.X.(*ast.Ident); ok && id.Name == machinePackageName {
+		// machine.X used as a value: a var or a const of the package.
+		return s.pkg.yields[t.Sel.Name]
+	}
+	if owner := s.typeOf(t.X); owner != "" {
+		return s.pkg.yields[owner+"."+t.Sel.Name]
+	}
+	return s.fields[t.Sel.Name]
+}
+
+// resultAt names the machine type the i-th result of a call evaluates to.
+func (s *surfaceScanner) resultAt(e ast.Expr, i int) string {
+	call, ok := e.(*ast.CallExpr)
+	if !ok {
+		return ""
+	}
+	at := func(results []string) string {
+		if i < len(results) {
+			return results[i]
+		}
+		return ""
+	}
+	switch fn := call.Fun.(type) {
+	case *ast.Ident:
+		return at(s.results[fn.Name])
+	case *ast.SelectorExpr:
+		if id, ok := fn.X.(*ast.Ident); ok && id.Name == machinePackageName {
+			return at(s.pkg.results[fn.Sel.Name])
+		}
+		if owner := s.typeOf(fn.X); owner != "" {
+			return at(s.pkg.results[owner+"."+fn.Sel.Name])
+		}
+		return at(s.results[fn.Sel.Name])
+	}
+	return ""
+}
+
+// reachSelector records the reach a selector expression is, if it is one.
+func (s *surfaceScanner) reachSelector(sel *ast.SelectorExpr) {
+	if id, ok := sel.X.(*ast.Ident); ok && id.Name == machinePackageName {
+		s.add(sel.Sel.Name, sel, "machine."+sel.Sel.Name)
+		return
+	}
+	owner := s.typeOf(sel.X)
+	if owner == "" || strings.HasPrefix(owner, "[]") {
+		return
+	}
+	s.add(owner+"."+sel.Sel.Name, sel, "a value of type machine."+owner)
+}
+
+func (s *surfaceScanner) add(key string, node ast.Node, how string) {
+	s.out = append(s.out, reach{
+		key:   key,
+		pack:  s.pack,
+		where: fmt.Sprintf("%s:%d", s.rel, s.fset.Position(node.Pos()).Line),
+		how:   how,
+	})
+}
+
+// notInTheDriverSurface lists the reaches a pack keeps outside the declared
+// surface, each with the reason — the discipline Declined() applies to a
+// refusal, applied to an internal boundary, and the shape
+// TestEveryBarrageExemptionSaysWhy already holds for the two maps beside it.
+//
+// Keyed "<pack>/<key>" so an exemption cannot quietly widen to a whole pack,
+// and empty, which is the honest state after this lot: every site the packs
+// held on 0f8b58e either went through a service or gained one. "Not yet
+// migrated" and "cannot be" are different reasons and would be written
+// differently here; there is neither today.
+var notInTheDriverSurface = map[string]string{}
+
+// mustStayOutside names what the declared surface may never admit.
+//
+// It is the answer to the trap #511 names first: a surface that authorises
+// everything a pack reaches today documents the state of affairs instead of
+// constraining it. So what is excluded is asserted, not merely absent — the
+// raw driver and its optional halves, the driver's own argument vocabulary,
+// and the low-level Binding verbs the two orchestrators exist to sequence.
+// Every entry below is exported by internal/core/machine and therefore
+// nameable; none may appear in PackSurface.
+var mustStayOutside = []string{
+	// The runtime itself, and every implementation of it. A pack holding one
+	// calls Start, Remove or RemoveNetwork past Binding.ours and past the
+	// driver's mustOwn — the hole a crafted snapshot walked through.
+	"Driver", "Noop", "Incus", "Recorder",
+	// Its optional halves. Reaching one by assertion bypasses the shared layer
+	// exactly as surely as calling a method does, which is the correction that
+	// took #511's count from eleven sites to twenty-nine.
+	"Router", "Firewaller", "Peerer", "Isolator", "Balancer", "Capable", "Waiter",
+	"ImageBuilder", "ImageLister", "Pruner", "Repairer", "Surveyor", "Watcher",
+	"UplinkReleaser",
+	// The driver's own argument vocabulary: what the shared layer builds from
+	// what a pack declares. A pack assembling one of these is a pack writing
+	// the call the layer exists to write.
+	"Spec", "NetworkSpec", "AddressSpec", "FirewallBinding", "Machine",
+	// Host object names and the capability half, which belong to the driver
+	// and to /_feint/health respectively.
+	"NetworkName", "NetworkPrefix", "LabelKey", "MaxNetworkNameLen",
+	"Capabilities", "CapabilitiesOf", "Declared",
+	// The package-level isolation pass takes a Driver, which is the value no
+	// pack may hold; Binding.ReconcileIsolation is the door.
+	"ReconcileIsolation",
+	// Binding's low-level half. PowerOn is here and Reconciler.PowerOn is in
+	// the surface on purpose: the plan's order — addresses, memberships,
+	// firewall last — is a property of the runtime, and a pack that starts a
+	// machine through the binding skips it.
+	"Binding.Start", "Binding.Stop", "Binding.Remove", "Binding.Address",
+	"Binding.Name", "Binding.PowerOn", "Binding.Refresh", "Binding.ForgetPlacements",
+	"Binding.RouteAddress", "Binding.UnrouteAddress",
+	"Binding.SyncRuleSet", "Binding.ApplyRuleSets", "Binding.DropRuleSet",
+	"Binding.WithDriver",
+	// The firewall step of the boot replay. The Reconciler runs it, last, and
+	// a pack running it itself puts the expansion before the interfaces it is
+	// supposed to see.
+	"GroupSync.AfterBoot",
+}
+
+// The packs reach nothing of internal/core/machine that the contract does not
+// name (#511).
+//
+// The measurement that opened the issue was that three packs reached
+// twenty-nine sites of that package and nothing said which were legitimate.
+// The corridor was opened first — GroupSync (#509), Plan and Reconciler
+// (#510), the shared recorder (#515) — so the remaining question was only
+// which door each gesture goes through. This is the door, and machine.
+// PackSurface is the list of what is behind it.
+//
+// It reports the pack, the gesture and the line, because a discipline failure
+// that only says "a pack reached too far" is a failure somebody has to
+// reproduce before they can act on it.
+//
+// What this holds that the compiler does not: emulator.Env no longer carries a
+// Driver and machine.Binding's driver field is unexported, so a pack cannot
+// obtain a driver value at all — that half is a build error since this lot.
+// What stays for this test is everything reachable *without* a driver value:
+// constructing machine.Noop, naming an optional half in a signature, calling a
+// low-level Binding verb the orchestrators exist to sequence. Typing cannot
+// see those, and they are how the boundary would come back.
+func TestNoPackReachesPastTheDeclaredDriverSurface(t *testing.T) {
+	pkg := readMachinePackage(t)
+	surface := machine.PackSurface()
+
+	var offences []string
+	total := 0
+	for _, dir := range packDirs(t) {
+		reaches := driverSurfaceReaches(t, pkg, dir)
+		total += len(reaches)
+		for _, r := range reaches {
+			if _, allowed := surface[r.key]; allowed {
+				continue
+			}
+			if reason := notInTheDriverSurface[r.pack+"/"+r.key]; reason != "" {
+				continue
+			}
+			offences = append(offences, fmt.Sprintf("%s reaches %s at %s (%s)",
+				r.pack, r.key, r.where, r.how))
+		}
+	}
+
+	// A scan that found nothing looks exactly like a repository where no pack
+	// touches the runtime, and that repository does not exist: three packs
+	// drive machines, networks, addresses, rule sets and a balancer. The floor
+	// is well under today's count and well over zero.
+	if total < 60 {
+		t.Fatalf("only %d reaches into internal/core/machine found across the packs: the scan is "+
+			"broken, and a broken scan reports a disciplined repository", total)
+	}
+
+	sort.Strings(offences)
+	if len(offences) > 0 {
+		t.Errorf("%d reach(es) into internal/core/machine that machine.PackSurface does not name. "+
+			"A gesture the driver does not expose is a service the driver gains, never a call a "+
+			"pack makes around it; if one genuinely cannot go through the layer, add "+
+			"\"<pack>/<key>\" to notInTheDriverSurface with the reason:\n  %s",
+			len(offences), strings.Join(offences, "\n  "))
+	}
+}
+
+// The declared surface says something, and still means what it says.
+//
+// Two halves, and each answers one way the list could become decoration. It
+// must resolve: every entry names something internal/core/machine really
+// exports, so a rename makes this fail instead of silently emptying the
+// contract. And it must exclude: mustStayOutside is asserted absent, because a
+// list that admits everything a pack reaches today is an inventory, not a
+// boundary — #511 names that trap first and this is what answers it.
+func TestTheDeclaredDriverSurfaceIsSmallerThanThePackage(t *testing.T) {
+	pkg := readMachinePackage(t)
+	surface := machine.PackSurface()
+
+	for key, why := range surface {
+		if len(strings.Fields(why)) < 4 {
+			t.Errorf("the surface entry for %s says %q, which does not say what a pack asks it for", key, why)
+		}
+		typ, member, qualified := strings.Cut(key, ".")
+		if !qualified {
+			if _, ok := pkg.names[key]; !ok {
+				t.Errorf("PackSurface admits %q, which internal/core/machine does not export: "+
+					"a contract naming something gone constrains nothing", key)
+			}
+			continue
+		}
+		if _, ok := pkg.names[typ]; !ok {
+			t.Errorf("PackSurface admits %q, whose type is not exported by internal/core/machine", key)
+			continue
+		}
+		if !pkg.members[key] {
+			t.Errorf("PackSurface admits %q, which is not a method or a field of machine.%s", member, typ)
+		}
+	}
+
+	for _, key := range mustStayOutside {
+		if _, admitted := surface[key]; admitted {
+			t.Errorf("PackSurface admits %s, which the contract excludes: a surface that authorises "+
+				"everything the packs reach guarantees nothing, and this is one of the names the "+
+				"boundary exists to keep out", key)
+		}
+		typ, _, qualified := strings.Cut(key, ".")
+		if !qualified {
+			if _, ok := pkg.names[key]; !ok {
+				t.Errorf("mustStayOutside names %q, which internal/core/machine no longer exports: "+
+					"an exclusion nobody can violate is not an exclusion", key)
+			}
+			continue
+		}
+		if !pkg.members[key] {
+			t.Errorf("mustStayOutside names %q, which machine.%s no longer has: same reason", key, typ)
+		}
+	}
+}

--- a/internal/cli/enforcement_test.go
+++ b/internal/cli/enforcement_test.go
@@ -41,13 +41,20 @@ func TestEveryPackThatWiresTheFirewallSaysSo(t *testing.T) {
 
 // The balancer is the same claim one capability over (#481), and it is held by
 // the same instrument because it drifted the same way: `capabilities.balancing`
-// was true under OVN while the Scaleway pack handed nothing to
-// `machine.Balancer`, so a suite told to key on the capability would have
-// asserted a distribution that pack never promised. `enforced.balancing` is
-// the per-pack answer, and this test is what keeps it from becoming a second
-// list somebody forgets.
+// was true under OVN while the Scaleway pack handed nothing to the runtime's
+// balancing half, so a suite told to key on the capability would have asserted
+// a distribution that pack never promised. `enforced.balancing` is the
+// per-pack answer, and this test is what keeps it from becoming a second list
+// somebody forgets.
+//
+// The marker was `machine.Balancer` until #511 took the driver's optional
+// halves out of the packs' vocabulary — the same re-point #509 forced on the
+// firewall's marker. `machine.BalancerSpec` replaces it and says the same
+// thing: the spec exists only to be handed over, Binding.EnsureBalancer being
+// its one consumer, so a pack that builds one wires the dataplane and a pack
+// that does not, does not.
 func TestEveryPackThatWiresTheBalancerSaysSo(t *testing.T) {
-	declarationMatchesSource(t, "machine.Balancer", "EnforcesBalancing",
+	declarationMatchesSource(t, "machine.BalancerSpec", "EnforcesBalancing",
 		func(p emulator.Pack) bool {
 			be, ok := p.(emulator.BalancingEnforcer)
 			return ok && be.EnforcesBalancing()
@@ -115,9 +122,9 @@ func declarationMatchesSource(t *testing.T, marker, method string, declared func
 }
 
 // referencesType reports whether any non-test Go file directly under dir names
-// the marker type — "machine.Firewaller", "machine.Balancer" — in code. Non-test
-// on purpose: a fake in a test file proves the pack can be tested, never that
-// it wires anything.
+// the marker type — "machine.GroupSync", "machine.BalancerSpec" — in code.
+// Non-test on purpose: a fake in a test file proves the pack can be tested,
+// never that it wires anything.
 //
 // The marker is resolved on the AST, exactly as the doc above promises, and not
 // by substring: the Exoscale pack discusses `machine.Balancer` in comments to

--- a/internal/core/emulator/conformance.go
+++ b/internal/core/emulator/conformance.go
@@ -872,8 +872,8 @@ func (s *Server) handleConformance(w http.ResponseWriter, _ *http.Request) {
 	// The dataplane axis reads the driver's own declaration, never a mode
 	// name: Noop names itself "none", and that is the whole comparison.
 	machines := "none"
-	if s.env.Machines != nil {
-		machines = s.env.Machines.Name()
+	if s.env.machines != nil {
+		machines = s.env.machines.Name()
 	}
 	runtimeOn := machines != "none"
 

--- a/internal/core/emulator/emulator.go
+++ b/internal/core/emulator/emulator.go
@@ -30,10 +30,18 @@ type Env struct {
 	Store *store.Store
 	Now   func() time.Time
 	NewID func() string
-	// Machines backs powered-on servers with something that actually runs.
+	// machines backs powered-on servers with something that actually runs.
 	// Defaults to the metadata-only driver, so nothing ever starts unless the
 	// operator asked for it.
-	Machines machine.Driver
+	//
+	// Unexported since #511, and that is the point: it was the one value that
+	// put a machine.Driver in every pack's hand, and a pack holding one can
+	// call any driver verb — Start, Remove, RemoveNetwork — past the ownership
+	// checks and past the shared order. A pack now declares its binding and
+	// receives it back through Bind, and no expression in internal/providers
+	// can name a driver at all. Wiring and tests use UseMachines; readers of
+	// the runtime's identity use RuntimeName.
+	machines machine.Driver
 	// BootImages maps an opaque image identifier onto the operating system the
 	// operator declared it to be (FEINT_BOOT_IMAGES, parsed by
 	// machine.ParseDeclaredImages). Each pack hands it to its Binding, which
@@ -56,6 +64,38 @@ type Env struct {
 	Contracts map[string]*contract.Doc
 }
 
+// Bind completes a pack's machine binding with the runtime this emulator was
+// started with, and is how a pack obtains one (#511).
+//
+// The pack declares what only it knows — its prefix, its login, the key its
+// address is published under, its image table — and the environment supplies
+// the driver. It used to write `Driver: p.env.Machines` itself, which meant
+// every pack held a machine.Driver value and could call any of its verbs,
+// ownership checks and shared order included; machine.Binding's driver field
+// is unexported since, so this is the only way in and there is no way back
+// out. A pack naming this field again does not fail a test — it fails the
+// build, which is the strongest of the three ranks #514 lists; internal/cli's
+// TestNoPackReachesPastTheDeclaredDriverSurface holds what typing cannot,
+// starting with a pack that builds a driver of its own.
+func (e *Env) Bind(b machine.Binding) machine.Binding {
+	return b.WithDriver(e.machines)
+}
+
+// UseMachines points this environment at a machine runtime. It is how the CLI
+// wires the driver the operator asked for, and how a test injects a fake one;
+// nothing hands the value back out.
+func (e *Env) UseMachines(d machine.Driver) { e.machines = d }
+
+// RuntimeName identifies the runtime in logs, in `feint status` and on
+// /_feint/health — the one thing about the driver a caller outside this
+// package may read, because a name is not a handle.
+func (e *Env) RuntimeName() string {
+	if e.machines == nil {
+		return machine.Noop{}.Name()
+	}
+	return e.machines.Name()
+}
+
 // DefaultEnv returns an environment backed by a fresh store, the wall clock,
 // random UUIDs and no machine runtime.
 func DefaultEnv() *Env {
@@ -63,7 +103,7 @@ func DefaultEnv() *Env {
 		Store:    store.New(),
 		Now:      func() time.Time { return time.Now().UTC() },
 		NewID:    NewUUID,
-		Machines: machine.Noop{},
+		machines: machine.Noop{},
 		Log:      slog.Default(),
 	}
 }
@@ -579,12 +619,12 @@ func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
 	}
 	driver := "none"
 	var capabilities *machine.Capabilities
-	if s.env.Machines != nil {
-		driver = s.env.Machines.Name()
+	if s.env.machines != nil {
+		driver = s.env.machines.Name()
 		// Declared rather than CapabilitiesOf: null on the wire when the driver
 		// said nothing, so a reader can tell "no" from "nobody promised". Five
 		// falses cannot.
-		capabilities = machine.Declared(s.env.Machines)
+		capabilities = machine.Declared(s.env.machines)
 	}
 	// The capabilities are published because the difference between the runtime
 	// modes was recorded only in documentation — that is, nowhere at the moment

--- a/internal/core/emulator/evidence_test.go
+++ b/internal/core/emulator/evidence_test.go
@@ -187,7 +187,7 @@ func (namedDriver) Available(context.Context) bool { return true }
 
 func TestEvidenceDataplaneFollowsTheDriversOwnDeclaration(t *testing.T) {
 	env := contractEnv(t)
-	env.Machines = namedDriver{}
+	env.UseMachines(namedDriver{})
 	srv := evidenceServer(t, env, `{"ok": true}`)
 	ts := httptest.NewServer(srv.Handler())
 	defer ts.Close()

--- a/internal/core/emulator/ui_test.go
+++ b/internal/core/emulator/ui_test.go
@@ -419,7 +419,7 @@ func (mute) Name() string { return "mute" }
 func TestAnUndeclaredDriverIsNotTheSameAsOneThatDeclaresNothing(t *testing.T) {
 	read := func(driver machine.Driver) map[string]any {
 		env := emulator.DefaultEnv()
-		env.Machines = driver
+		env.UseMachines(driver)
 		srv, err := emulator.NewServer(env)
 		if err != nil {
 			t.Fatalf("build emulator: %v", err)

--- a/internal/core/machine/balancer.go
+++ b/internal/core/machine/balancer.go
@@ -221,3 +221,56 @@ type Balancer interface {
 	// must refuse a balancer the emulator did not create.
 	RemoveBalancer(ctx context.Context, network, listen string) error
 }
+
+// balancer is the runtime's balancing half, nil when it has none — the
+// assertion the balancing pack wrote for itself, now inside the layer beside
+// Reconciler.router and GroupSync.enforcer (#511).
+//
+// Two questions, both asked, and the second is not redundant: the Incus driver
+// implements Balancer in every mode and can only deliver it under OVN, and
+// Verify clears the claim on a host whose daemon has no northbound connection.
+// Asking only whether the interface is implemented would drive a
+// bridge-backed run into a refusal on every register.
+func (b Binding) balancer() Balancer {
+	if b.driver == nil || !CapabilitiesOf(b.driver).Balancing {
+		return nil
+	}
+	balancer, _ := b.driver.(Balancer)
+	return balancer
+}
+
+// Balances reports whether this runtime both implements and declares
+// balancing, so a pack can leave its load-balancer family a record — which is
+// what it was before #315 — instead of asking the host for something it has
+// said it cannot do.
+func (b Binding) Balances() bool { return b.balancer() != nil }
+
+// EnsureBalancer hands the whole balancer to the runtime and reports what it
+// actually holds. See BalancerSpec for why the spec is whole rather than
+// patched, and BalancerDelivery for why the effect comes back beside it.
+//
+// A runtime that does not balance answers ErrBalancerNotDistributed rather
+// than an empty delivery and a nil error: an empty delivery reads exactly like
+// a balancer with no backend, which is a legitimate state a stack passes
+// through, so the caller would record "nothing distributed" with no reason
+// beside it. Three outcomes, never two.
+func (b Binding) EnsureBalancer(ctx context.Context, spec BalancerSpec) (BalancerDelivery, error) {
+	balancer := b.balancer()
+	if balancer == nil {
+		return BalancerDelivery{}, ErrBalancerNotDistributed
+	}
+	return balancer.EnsureBalancer(ctx, spec)
+}
+
+// RemoveBalancer withdraws it. It succeeds when nothing is there, which is the
+// normal path: a delete runs after an emptied listener set that may never have
+// reached the host. A runtime that does not balance holds nothing to withdraw,
+// so this is a no-op rather than an error — the asymmetry with EnsureBalancer
+// is deliberate, and it is the same one Driver.Remove documents.
+func (b Binding) RemoveBalancer(ctx context.Context, network, listen string) error {
+	balancer := b.balancer()
+	if balancer == nil {
+		return nil
+	}
+	return balancer.RemoveBalancer(ctx, network, listen)
+}

--- a/internal/core/machine/binding.go
+++ b/internal/core/machine/binding.go
@@ -28,9 +28,18 @@ import (
 // the packs, because those must differ — a client must not see the difference
 // from its own cloud, which is the whole point.
 type Binding struct {
-	// Driver is what actually runs machines. Nil means metadata only, which is
+	// driver is what actually runs machines. Nil means metadata only, which is
 	// the default: starting machines is a side effect on the operator's host.
-	Driver Driver
+	//
+	// Unexported, and that is the point of #511: a pack declares the fields
+	// below and receives the driver from the emulator through WithDriver, so
+	// no expression in a provider pack can name a driver method through the
+	// binding. The field was exported until then, and `p.binding().Driver.
+	// EnsureNetwork(…)` was a working sentence — a discipline test can only
+	// report such a line, while an unexported field means it does not compile.
+	// internal/cli's TestNoPackReachesPastTheDeclaredDriverSurface holds what
+	// typing cannot.
+	driver Driver
 	// Provider labels everything this binding creates, so a sweep can find its
 	// own work and an operator's machines are never touched.
 	Provider string
@@ -94,6 +103,18 @@ type Binding struct {
 	// must never break the control plane, which makes this the only place an
 	// operator can learn why nothing is running.
 	Log *slog.Logger
+}
+
+// WithDriver returns the binding bound to a runtime.
+//
+// This is the one door a driver goes through on its way into a binding, and it
+// is deliberately one-way: nothing hands it back out. The emulator calls it
+// (Env.Bind) while mounting a pack, which is why a pack declares the fields
+// above and never the driver — see the driver field for the sentence that used
+// to compile and no longer does.
+func (b Binding) WithDriver(d Driver) Binding {
+	b.driver = d
+	return b
 }
 
 // Name is the runtime name for a resource id.
@@ -189,7 +210,7 @@ type Started struct {
 // than one that only tracks state.
 func (b Binding) Start(ctx context.Context, boot Boot) Started {
 	name := b.Name(boot.ID)
-	if b.Driver == nil {
+	if b.driver == nil {
 		return Started{}
 	}
 	// An identifier no catalogue holds resolves to no image at all, and a real
@@ -208,7 +229,7 @@ func (b Binding) Start(ctx context.Context, boot Boot) Started {
 	//
 	// TestAnUnknownImageFailsTheBootInsteadOfSubstituting and
 	// TestADeclaredIdentifierBootsTheImageTheOperatorNamed fail without this.
-	if _, metadataOnly := b.Driver.(Noop); boot.Image == "" && !metadataOnly {
+	if _, metadataOnly := b.driver.(Noop); boot.Image == "" && !metadataOnly {
 		declared, ok := b.Declared[boot.Requested]
 		if !ok || boot.Requested == "" {
 			b.refuseUnknownImage(boot)
@@ -237,7 +258,7 @@ func (b Binding) Start(ctx context.Context, boot Boot) Started {
 	//
 	// TestAFailedImageBuildRefusesTheBootAndNamesTheSource fails without this.
 	if boot.Image != "" {
-		if _, err := EnsureImage(ctx, b.Driver, boot.Image, b.logger()); err != nil {
+		if _, err := EnsureImage(ctx, b.driver, boot.Image, b.logger()); err != nil {
 			spec, _ := SpecFor(boot.Image)
 			b.logger().Error("refusing to boot: the image this reference derives could not be built",
 				"provider", b.Provider, "resource", boot.ID, "image", boot.Image,
@@ -289,7 +310,7 @@ func (b Binding) Start(ctx context.Context, boot Boot) Started {
 	// of diagnosing a healthy-looking machine; the boot itself proceeds,
 	// because everything else about the machine works.
 	// TestAPackageStepWithNoRouteOutIsSaidOutLoud fails without this.
-	if _, metadataOnly := b.Driver.(Noop); !metadataOnly &&
+	if _, metadataOnly := b.driver.(Noop); !metadataOnly &&
 		boot.CloudInit != "" && len(boot.Attachments) == 0 && declaresPackageStep(boot.CloudInit) {
 		b.logger().Warn("this machine's user data declares a package step it cannot complete",
 			"provider", b.Provider, "resource", boot.ID, "machine", name,
@@ -301,7 +322,7 @@ func (b Binding) Start(ctx context.Context, boot Boot) Started {
 		labels[k] = v
 	}
 
-	m, err := b.Driver.Start(ctx, Spec{
+	m, err := b.driver.Start(ctx, Spec{
 		Name:            name,
 		Image:           boot.Image,
 		Labels:          labels,
@@ -379,11 +400,11 @@ func (b Binding) ours(id, machine string) string {
 // address it published: an address that answers nothing is the defect this
 // project exists to avoid.
 func (b Binding) Stop(ctx context.Context, id, machine string) {
-	if b.Driver == nil || machine == "" {
+	if b.driver == nil || machine == "" {
 		return
 	}
 	machine = b.ours(id, machine)
-	if err := b.Driver.Stop(ctx, machine); err != nil {
+	if err := b.driver.Stop(ctx, machine); err != nil {
 		b.logger().Error("could not stop the backing machine",
 			"provider", b.Provider, "resource", id, "machine", machine, "error", err)
 	}
@@ -393,7 +414,7 @@ func (b Binding) Stop(ctx context.Context, id, machine string) {
 // justified it. The name is derived when the caller has none, which is the case
 // for a resource that never started.
 func (b Binding) Remove(ctx context.Context, id, machine string) {
-	if b.Driver == nil {
+	if b.driver == nil {
 		return
 	}
 	if machine == "" {
@@ -401,7 +422,7 @@ func (b Binding) Remove(ctx context.Context, id, machine string) {
 	} else {
 		machine = b.ours(id, machine)
 	}
-	if err := b.Driver.Remove(ctx, machine); err != nil {
+	if err := b.driver.Remove(ctx, machine); err != nil {
 		b.logger().Error("could not remove the backing machine",
 			"provider", b.Provider, "resource", id, "machine", machine, "error", err)
 	}
@@ -413,13 +434,13 @@ func (b Binding) Remove(ctx context.Context, id, machine string) {
 // seconds later, once it has booted and DHCP has answered. Start therefore never
 // waits, and a pack calls this on the read a client is making anyway.
 func (b Binding) Address(ctx context.Context, id, machine string) (string, bool) {
-	if b.Driver == nil || machine == "" {
+	if b.driver == nil || machine == "" {
 		return "", false
 	}
 	// Read-only, but still checked: inspecting an arbitrary instance of the host
 	// would publish its address as if it were the emulated server's.
 	machine = b.ours(id, machine)
-	m, ok, err := b.Driver.Inspect(ctx, machine)
+	m, ok, err := b.driver.Inspect(ctx, machine)
 	if err != nil {
 		b.logger().Error("could not inspect the backing machine",
 			"provider", b.Provider, "resource", id, "machine", machine, "error", err)
@@ -453,7 +474,7 @@ func (b Binding) PowerOn(ctx context.Context, res *resource.Resource, boot Boot)
 	// mode: the control plane is the whole emulation, and a client driving the
 	// API sees a machine that runs. This is what keeps the conformance suites
 	// runnable in CI, where no runtime exists.
-	if b.Driver == nil {
+	if b.driver == nil {
 		res.State = b.RunningState
 		return true
 	}

--- a/internal/core/machine/binding_boot_test.go
+++ b/internal/core/machine/binding_boot_test.go
@@ -46,7 +46,7 @@ func (d *recordingDriver) RemoveNetwork(context.Context, string) error      { re
 
 func bootBinding(driver Driver) Binding {
 	return Binding{
-		Driver:       driver,
+		driver:       driver,
 		Provider:     "acme",
 		Prefix:       "feint-acme-",
 		User:         "root",

--- a/internal/core/machine/groupsync.go
+++ b/internal/core/machine/groupsync.go
@@ -77,7 +77,7 @@ type GroupSync struct {
 // which is what lets the enforcement test mark a wired pack by this type
 // instead of by machine.Firewaller.
 func (s GroupSync) enforcer() Firewaller {
-	fw, _ := s.Binding.Driver.(Firewaller)
+	fw, _ := s.Binding.driver.(Firewaller)
 	return fw
 }
 
@@ -85,7 +85,7 @@ func (s GroupSync) enforcer() Firewaller {
 // construction, in which case reject rules against foreign subnets are dead
 // weight: the blocks would name subnets the machine cannot reach anyway.
 func (s GroupSync) nativeIsolation() bool {
-	peerer, ok := s.Binding.Driver.(Peerer)
+	peerer, ok := s.Binding.driver.(Peerer)
 	return ok && peerer.NativeIsolation()
 }
 

--- a/internal/core/machine/groupsync_test.go
+++ b/internal/core/machine/groupsync_test.go
@@ -46,7 +46,7 @@ func newGroupSyncBench() *groupSyncBench {
 
 func (b *groupSyncBench) binding() Binding {
 	return Binding{
-		Driver:     b.rec,
+		driver:     b.rec,
 		Provider:   "bench",
 		Prefix:     "feint-bench-",
 		RuntimeKey: "machine",
@@ -358,7 +358,7 @@ func TestARefusedRuleSetDoesNotShrinkTheAttachmentList(t *testing.T) {
 	vm := b.machine("m", "10.42.0.5", "open", "closed")
 
 	s := b.sync()
-	s.Binding.Driver = refusingFirewaller{Recorder: b.rec, refuse: FirewallName("bench", "closed")}
+	s.Binding.driver = refusingFirewaller{Recorder: b.rec, refuse: FirewallName("bench", "closed")}
 	s.ApplyMachine(context.Background(), vm)
 
 	for _, e := range b.rec.Events() {

--- a/internal/core/machine/isolate.go
+++ b/internal/core/machine/isolate.go
@@ -140,6 +140,19 @@ func ReconcileIsolation(ctx context.Context, driver Driver, log *slog.Logger, no
 	return false, true
 }
 
+// ReconcileIsolation is the binding's door onto the pass above, and the only
+// one a provider pack has: the package-level form takes a Driver, which is
+// precisely the value #511 took out of every pack's reach, and it stays
+// exported for the core's own tests and for nothing else.
+//
+// The pack still owns what it alone knows — the noun for the log line, the
+// members, and the reachability predicate. The driver and the logger come from
+// the binding it already declared.
+func (b Binding) ReconcileIsolation(ctx context.Context, noun string,
+	members []IsolationMember, reachable func(from, to int) bool) (native, applied bool) {
+	return ReconcileIsolation(ctx, b.driver, b.logger(), noun, members, reachable)
+}
+
 // report says what a reconciliation could not do, and separates the two reasons
 // it can fail.
 //

--- a/internal/core/machine/ownership_test.go
+++ b/internal/core/machine/ownership_test.go
@@ -23,7 +23,7 @@ import (
 
 func quietBinding(driver Driver) Binding {
 	return Binding{
-		Driver:   driver,
+		driver:   driver,
 		Provider: "scaleway",
 		Prefix:   "feint-scw-",
 		Log:      slog.New(slog.NewTextHandler(io.Discard, nil)),

--- a/internal/core/machine/plan.go
+++ b/internal/core/machine/plan.go
@@ -80,7 +80,7 @@ func (r Reconciler) binding() Binding { return r.Groups.Binding }
 // router is the runtime's routing half, nil when it has none — the assertion
 // every pack wrote for itself, now inside the layer.
 func (r Reconciler) router() Router {
-	router, _ := r.binding().Driver.(Router)
+	router, _ := r.binding().driver.(Router)
 	return router
 }
 
@@ -209,7 +209,7 @@ func (r Reconciler) Join(ctx context.Context, res *resource.Resource, att Attach
 }
 
 func (r Reconciler) attach(ctx context.Context, res *resource.Resource, att Attachment) error {
-	driver := r.binding().Driver
+	driver := r.binding().driver
 	if driver == nil {
 		return nil
 	}
@@ -235,7 +235,7 @@ func (r Reconciler) attach(ctx context.Context, res *resource.Resource, att Atta
 // whose carrier is going next, and adding one belongs to a measured defect,
 // not to a move.
 func (r Reconciler) Leave(ctx context.Context, res *resource.Resource, network string) {
-	driver := r.binding().Driver
+	driver := r.binding().driver
 	if driver == nil {
 		return
 	}
@@ -279,7 +279,7 @@ type BackingNetwork struct {
 // naming a network that does not exist, which the delete path then tries to
 // remove.
 func (b Binding) EnsureBackingNetwork(ctx context.Context, res *resource.Resource, spec BackingNetwork) error {
-	if b.Driver == nil {
+	if b.driver == nil {
 		return nil
 	}
 	name := NetworkName(NetworkPrefix, res.ID)
@@ -295,7 +295,7 @@ func (b Binding) EnsureBackingNetwork(ctx context.Context, res *resource.Resourc
 	if spec.Gateway {
 		network.Gateway = spec.CIDR.Masked().Addr().Next().String()
 	}
-	if err := b.Driver.EnsureNetwork(ctx, network); err != nil {
+	if err := b.driver.EnsureNetwork(ctx, network); err != nil {
 		return err
 	}
 	if res.Runtime == nil {
@@ -312,10 +312,10 @@ func (b Binding) EnsureBackingNetwork(ctx context.Context, res *resource.Resourc
 // client-visible surface, so the layer does not pick for them.
 func (b Binding) RemoveBackingNetwork(ctx context.Context, res *resource.Resource, key string) error {
 	name := res.Runtime[key]
-	if b.Driver == nil || name == "" {
+	if b.driver == nil || name == "" {
 		return nil
 	}
-	if err := b.Driver.RemoveNetwork(ctx, name); err != nil {
+	if err := b.driver.RemoveNetwork(ctx, name); err != nil {
 		return err
 	}
 	delete(res.Runtime, key)

--- a/internal/core/machine/plan_test.go
+++ b/internal/core/machine/plan_test.go
@@ -136,7 +136,7 @@ func TestARefusedAttachStillResyncsTheFirewall(t *testing.T) {
 	b.group("g", "")
 	vm := b.machine("m", "10.0.0.5", "g")
 	r := reconcilerBench(b, Plan{})
-	r.Groups.Binding.Driver = refusingAttacher{b.rec}
+	r.Groups.Binding.driver = refusingAttacher{b.rec}
 
 	if err := r.Join(context.Background(), vm, Attachment{Network: "fnt-bench-net"}); err == nil {
 		t.Fatal("the refusal never reached the caller, so no pack can surface it on its resource")
@@ -193,7 +193,7 @@ func TestEnsureBackingNetworkRecordsOnlyWhatTheDriverAccepted(t *testing.T) {
 	}
 
 	refused := b.machine("net-2", "")
-	binding.Driver = refusingNetworker{b.rec}
+	binding.driver = refusingNetworker{b.rec}
 	if err := binding.EnsureBackingNetwork(context.Background(), refused, BackingNetwork{
 		Key: "network", CIDR: netip.MustParsePrefix("10.62.0.0/24"),
 	}); err == nil {
@@ -229,7 +229,7 @@ func TestRemoveBackingNetworkForgetsTheNameOnSuccessOnly(t *testing.T) {
 
 	held := b.machine("net-2", "")
 	held.Runtime["network"] = "fnt-bench-kept"
-	binding.Driver = refusingRemover{b.rec}
+	binding.driver = refusingRemover{b.rec}
 	if err := binding.RemoveBackingNetwork(context.Background(), held, "network"); err == nil {
 		t.Fatal("the refusal was swallowed")
 	}

--- a/internal/core/machine/surface.go
+++ b/internal/core/machine/surface.go
@@ -1,0 +1,171 @@
+package machine
+
+// The surface a provider pack may reach, declared rather than discovered
+// (#511).
+//
+// Three packs used to reach twenty-nine sites of this package — sixteen direct
+// driver calls and thirteen interface assertions — and nothing said which of
+// them were legitimate. The corridor was opened first: GroupSync took the
+// firewall orchestration (#509), Plan and Reconciler took the interface plan
+// and the hot verbs (#510), EnsureBackingNetwork and RemoveBackingNetwork
+// closed the network family, and the shared recorder gave all three a common
+// witness (#515). What was left was the door, and this is it.
+//
+// # What a pack may ask of the runtime
+//
+// The eight families below, and nothing else. The list is short because the
+// question it answers is narrow: *what does a provider have to ask a host to
+// do that only a host can do?* Boot a machine and stop it. Put it on a
+// network, and take the network away. Make an address reach it. Enforce a rule
+// set. Keep two networks apart. Distribute a balancer. Everything else a pack
+// does — deciding what its API says, which fields carry which value, when a
+// state changes — needs no host at all.
+//
+// # What it excludes, which is the point
+//
+// A surface that admits everything the packs reach today would be an
+// inventory. This one excludes, and internal/cli's
+// TestTheDeclaredDriverSurfaceIsSmallerThanThePackage asserts the exclusions
+// by name rather than leaving them to absence:
+//
+//   - Driver itself and every implementation of it. A pack holding one calls
+//     Start, Remove or RemoveNetwork past Binding.ours and past the driver's
+//     mustOwn — the path a crafted snapshot walked through, and the reason
+//     Resource.Runtime is untrusted input.
+//   - Its optional halves — Router, Firewaller, Peerer, Isolator, Balancer.
+//     Reaching one by type assertion bypasses the shared layer as surely as
+//     calling a method does; that correction is what took the measurement of
+//     this defect from eleven sites to twenty-nine.
+//   - The driver's own argument vocabulary — Spec, NetworkSpec, AddressSpec,
+//     FirewallBinding — which the layer builds from what a pack declares.
+//   - Thirteen of Binding's own verbs, including Start, Stop, RouteAddress and
+//     SyncRuleSet: they are the mechanics the two orchestrators sequence.
+//     Binding.PowerOn is excluded and Reconciler.PowerOn admitted, and the
+//     difference is the whole of #510 — the order addresses, then memberships,
+//     then the firewall is a property of the runtime, and a pack that boots
+//     through the binding skips it.
+//   - GroupSync.AfterBoot, for the same reason one level up: the Reconciler
+//     runs it, last.
+//
+// Measured on 2026-08-26, the day the door closed: this package exports 97
+// package-level names and 297 members of them; the list below admits 17 and 41.
+// Binding alone offers 36 exported members and 14 are in — the other 22 are the
+// mechanics. What the three packs actually reach is 216 sites, every one of them
+// named here and none of them a driver.
+//
+// # The rule when something is missing
+//
+// A gesture this list lacks is added to it — the driver gains a service — and
+// never worked around. That is the maintainer's own wording, and it is why
+// this file grew Binding.ReconcileIsolation and the three balancer verbs in
+// the same change that closed the door: two packs were reaching the isolation
+// pass with a raw driver and one was asserting its way to the balancing half,
+// and the answer to both was a service, not an exemption.
+//
+// # What holds this
+//
+// internal/cli's TestNoPackReachesPastTheDeclaredDriverSurface reads the packs'
+// own sources against this list and names the pack, the gesture and the line.
+// It follows a value across assignments, so a bypass one local variable deep is
+// caught too. Its exemption ledger is empty today, and an exemption without a
+// written reason is refused by TestEveryBarrageExemptionSaysWhy.
+//
+// The compiler holds the rest and holds it harder: emulator.Env carries no
+// Driver a pack can read, and Binding's driver field is unexported behind
+// WithDriver, so `p.binding().Driver.EnsureNetwork(…)` — a sentence that
+// compiled before this change — no longer does.
+
+// PackSurface is the closed list of what a provider pack may name in this
+// package: package-level names as they are written (machine.Attachment), and
+// members of those types as "Type.Member". The value says what a pack asks it
+// for.
+//
+// It is a function rather than a variable so no caller can add to it at
+// runtime, which is the same reason Declined() is one.
+func PackSurface() map[string]string {
+	return map[string]string{
+		// S1 — machine lifecycle. What the pack declares about its machines,
+		// and the four verbs that move one. Serialise and Transition are here
+		// because the store mutation and the slow runtime effect have to be
+		// ordered together: a per-target lock the pack held itself is how two
+		// concurrent poweron left an orphan container.
+		"Binding":                  "the pack's own declaration of its machines: prefix, login, the keys it publishes under",
+		"Binding.Serialise":        "serialise two actions on one target, since the runtime call runs outside the store lock",
+		"Binding.Transition":       "change a stored resource under the shared conditional write-back",
+		"Binding.Observe":          "read a resource back after an effect, with the same write-back discipline",
+		"Binding.PowerOff":         "stop the machine behind a resource",
+		"Binding.Destroy":          "destroy the machine behind a resource",
+		"Binding.RefreshIfRunning": "re-read what the host holds for a machine the store calls running",
+		"Binding.AddressOf":        "the address the boot produced, as this pack publishes it",
+		"Binding.RuntimeKey":       "the pack's own Runtime key, to read the machine name it is about to hand to Unroute",
+		"Boot":                     "what to boot: image, login, keys, user data",
+		"Image":                    "one entry of the pack's image table, the runtime image and the login together",
+		"Image.Ref":                "the image identifier that table resolved to",
+		"Image.User":               "the login that image provisions",
+
+		// S2 — the interface plan. The pack declares the shape; the layer
+		// executes the one order.
+		"Reconciler":           "the orchestrator that executes a declared plan in the runtime's order",
+		"Reconciler.PowerOn":   "start a machine on its plan and replay the post-boot order",
+		"Plan":                 "the machine's declared interface shape",
+		"Plan.Memberships":     "the networks joined after boot, read back from the plan the pack built",
+		"Attachment":           "one interface: a network, an address, the mask, the secondaries",
+		"Attachment.PrefixLen": "the mask of an attachment the pack assembled",
+
+		// S3 — public addresses.
+		"Reconciler.Route":           "make one public address reach the machine, the hot half",
+		"Reconciler.Unroute":         "take the route back, machine gone or not",
+		"Reconciler.ReplayAddresses": "hand a machine its promised addresses again after a boot",
+
+		// S4 — networks. Ensure records the name only once the driver accepted
+		// it, which is the ordering two packs had wrong.
+		"BackingNetwork":               "what an emulated subnet needs from the runtime, in the pack's terms",
+		"Binding.EnsureBackingNetwork": "give an emulated subnet a real network and record its name",
+		"Binding.RemoveBackingNetwork": "take that network away and forget its name",
+		"DefaultMachineNetwork":        "the emulator's own network, the one placement a pack may ask for with no subnet of its own",
+
+		// S5 — membership, the hot attach a cloud performs on a running
+		// machine, which cannot fold into a boot-time plan.
+		"Reconciler.Join":  "put a running machine on one more network, firewall resync included",
+		"Reconciler.Leave": "take it off again",
+
+		// S6 — rule sets. The pack translates; the skeleton sequences.
+		"GroupSync":                           "the firewall orchestrator, built from the pack's own translation of its groups",
+		"GroupSync.SyncGroup":                 "write one group's rule set and replay it onto every wearer",
+		"GroupSync.ApplyMachine":              "write every set one resource wears and attach them in one call",
+		"GroupSync.SyncReferrers":             "re-expand the groups whose rules name the groups this resource wears",
+		"GroupSync.Drop":                      "remove a deleted group's rule set from the runtime",
+		"FirewallSpec":                        "one rule set as the runtime takes it, translated by the pack",
+		"FirewallSpec.Rules":                  "the rules of a set the pack is assembling",
+		"FirewallSpec.DefaultEgress":          "the set's default egress action, which upstream models differ on",
+		"FirewallSpec.WithPermissiveCatchAll": "the shared catch-all a permissive provider needs, rather than a fourth copy",
+		"FirewallRule":                        "one rule, in the neutral shape every runtime takes",
+		"FirewallRule.Direction":              "a rule's direction, read back from what the pack built",
+		"FirewallRule.Action":                 "a rule's action, likewise",
+		"FirewallRule.Source":                 "a rule's source block, likewise",
+		"FirewallRule.Destination":            "a rule's destination block, likewise",
+		"FirewallRule.PortFrom":               "the low port of a rule the pack is assembling",
+		"FirewallRule.PortTo":                 "the high port of a rule the pack is assembling",
+		"FirewallName":                        "the runtime name of a pack's rule set, spelled once for the three",
+
+		// S7 — isolation and peering, with one writer. The pack owns the
+		// predicate — what "may reach" means in its upstream model — and
+		// nothing else.
+		"Binding.ReconcileIsolation": "apply what every member may reach, over the whole set, through the one writer",
+		"IsolationMember":            "one network of this pack in a reconciliation pass",
+
+		// S8 — the balancer, the one family whose delivery is partial often
+		// enough that the effect is reported beside the intent.
+		"Binding.Balances":          "ask whether this runtime both implements and declares balancing",
+		"Binding.EnsureBalancer":    "hand the whole balancer to the runtime",
+		"Binding.RemoveBalancer":    "withdraw a balancer from the runtime",
+		"BalancerSpec":              "a named balancer on one network, described whole",
+		"BalancerSpec.Listen":       "the address a balancer the pack assembled answers on",
+		"BalancerSpec.Listeners":    "the ports a balancer the pack assembled answers on",
+		"BalancerSpec.Targets":      "the backends behind it",
+		"BalancerListener":          "one port a balancer answers on, and the backend port",
+		"BalancerDelivery.Lines":    "the two strings the delivery is recorded as",
+		"RecordBalancerDelivery":    "write what the hand-off produced onto the pack's own resource",
+		"ErrBalancerNotDistributed": "tell a limit from an incident, so a shape this runtime will never take is not an error",
+	}
+}

--- a/internal/providers/exoscale/elasticip_routing_test.go
+++ b/internal/providers/exoscale/elasticip_routing_test.go
@@ -68,7 +68,7 @@ func routedServe(t *testing.T) (http.Handler, *routedRuntime, *emulator.Env) {
 	t.Helper()
 	env := emulator.DefaultEnv()
 	rt := &routedRuntime{}
-	env.Machines = rt
+	env.UseMachines(rt)
 	srv, err := emulator.NewServer(env, exoscale.New(env))
 	if err != nil {
 		t.Fatalf("build the server: %v", err)

--- a/internal/providers/exoscale/entry_test.go
+++ b/internal/providers/exoscale/entry_test.go
@@ -227,7 +227,7 @@ func (r *recordingRuntime) user() string {
 func serveWith(t *testing.T, drv machine.Driver) http.Handler {
 	t.Helper()
 	env := emulator.DefaultEnv()
-	env.Machines = drv
+	env.UseMachines(drv)
 	srv, err := emulator.NewServer(env, exoscale.New(env))
 	if err != nil {
 		t.Fatalf("build the server: %v", err)

--- a/internal/providers/exoscale/machines.go
+++ b/internal/providers/exoscale/machines.go
@@ -22,8 +22,7 @@ import (
 
 // binding is this pack's half of the shared machine lifecycle.
 func (p *Pack) binding() machine.Binding {
-	return machine.Binding{
-		Driver:   p.env.Machines,
+	return p.env.Bind(machine.Binding{
 		Provider: Name,
 		Prefix:   "feint-exo-",
 		// No provider-wide login: Exoscale's template schema carries a
@@ -38,7 +37,7 @@ func (p *Pack) binding() machine.Binding {
 		// an entry matters most here, where the login belongs to the template.
 		Declared: p.env.BootImages,
 		Log:      p.env.Log,
-	}
+	})
 }
 
 // logger returns the environment logger, or the default one when a caller

--- a/internal/providers/exoscale/machines_internal_test.go
+++ b/internal/providers/exoscale/machines_internal_test.go
@@ -42,13 +42,14 @@ func (d *recordingDriver) Detach(_ context.Context, name, network string) error 
 func (d *recordingDriver) RemoveNetwork(context.Context, string) error { return nil }
 
 func runtimePack(driver machine.Driver) *Pack {
-	return New(&emulator.Env{
-		Store:    store.New(),
-		Machines: driver,
-		Now:      func() time.Time { return time.Unix(1700000000, 0).UTC() },
-		NewID:    func() string { return "00000000-0000-4000-8000-000000000001" },
-		Log:      slog.New(slog.NewTextHandler(io.Discard, nil)),
-	})
+	env := &emulator.Env{
+		Store: store.New(),
+		Now:   func() time.Time { return time.Unix(1700000000, 0).UTC() },
+		NewID: func() string { return "00000000-0000-4000-8000-000000000001" },
+		Log:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	env.UseMachines(driver)
+	return New(env)
 }
 
 // One case per row of the template table: the boot and the login the template

--- a/internal/providers/exoscale/pools_machines_internal_test.go
+++ b/internal/providers/exoscale/pools_machines_internal_test.go
@@ -68,10 +68,9 @@ func (d *failingDriver) Start(context.Context, machine.Spec) (machine.Machine, e
 func sequencedPack(driver machine.Driver) *Pack {
 	n := 0
 	var mu sync.Mutex
-	return New(&emulator.Env{
-		Store:    store.New(),
-		Machines: driver,
-		Now:      func() time.Time { return time.Unix(1700000000, 0).UTC() },
+	env := &emulator.Env{
+		Store: store.New(),
+		Now:   func() time.Time { return time.Unix(1700000000, 0).UTC() },
 		NewID: func() string {
 			mu.Lock()
 			defer mu.Unlock()
@@ -85,7 +84,9 @@ func sequencedPack(driver machine.Driver) *Pack {
 			return fmt.Sprintf("0000000f-0000-4000-8000-%012d", n)
 		},
 		Log: slog.New(slog.NewTextHandler(io.Discard, nil)),
-	})
+	}
+	env.UseMachines(driver)
+	return New(env)
 }
 
 // createOneInstance drives the real handler, which is where the allocation

--- a/internal/providers/exoscale/privatenetworks.go
+++ b/internal/providers/exoscale/privatenetworks.go
@@ -338,7 +338,7 @@ func (p *Pack) isolationPass(ctx context.Context) {
 			Block:   block,
 		}
 	}
-	machine.ReconcileIsolation(ctx, p.env.Machines, p.logger(), "private-network",
+	p.binding().ReconcileIsolation(ctx, "private-network",
 		members, func(int, int) bool { return false })
 }
 
@@ -531,7 +531,12 @@ func (p *Pack) updatePrivateNetwork(w http.ResponseWriter, r *http.Request) {
 	// A changed block needs a changed backing network. EnsureNetwork succeeds
 	// on an existing network without reshaping it, so the old one goes first —
 	// safe here because the refusal above proved nothing is attached.
-	if rangeChanged && p.env.Machines != nil {
+	//
+	// No "is a runtime configured" guard: both verbs below degrade to nothing
+	// without one (Binding.RemoveBackingNetwork and EnsureBackingNetwork both
+	// return on a nil driver), and asking the question meant holding the
+	// driver, which is what #511 took away.
+	if rangeChanged {
 		if err := p.binding().RemoveBackingNetwork(r.Context(), res, runtimeNetworkKey); err != nil {
 			p.logger().Error("could not remove the outgrown backing network",
 				"private-network", res.ID, "network", res.Runtime[runtimeNetworkKey], "error", err)

--- a/internal/providers/outscale/audit_test.go
+++ b/internal/providers/outscale/audit_test.go
@@ -482,7 +482,7 @@ func (f *blockingRuntime) running() []string {
 func newRuntimeServer(t *testing.T, drv machine.Driver) *httptest.Server {
 	t.Helper()
 	env := emulator.DefaultEnv()
-	env.Machines = drv
+	env.UseMachines(drv)
 	srv, err := emulator.NewServer(env, outscale.New(env))
 	if err != nil {
 		t.Fatalf("build emulator: %v", err)

--- a/internal/providers/outscale/firewall_internal_test.go
+++ b/internal/providers/outscale/firewall_internal_test.go
@@ -63,16 +63,17 @@ func (d *firewallDriver) RemoveFirewall(_ context.Context, name string) error {
 // groups need.
 func firewallPack(driver machine.Driver) *Pack {
 	n := 0
-	return New(&emulator.Env{
-		Store:    store.New(),
-		Machines: driver,
-		Now:      func() time.Time { return time.Unix(1700000000, 0).UTC() },
+	env := &emulator.Env{
+		Store: store.New(),
+		Now:   func() time.Time { return time.Unix(1700000000, 0).UTC() },
 		NewID: func() string {
 			n++
 			return fmt.Sprintf("%08d", n)
 		},
 		Log: slog.New(slog.NewTextHandler(io.Discard, nil)),
-	})
+	}
+	env.UseMachines(driver)
+	return New(env)
 }
 
 func storedGroup(p *Pack, name string, inbound []any) *resource.Resource {

--- a/internal/providers/outscale/isolate.go
+++ b/internal/providers/outscale/isolate.go
@@ -111,6 +111,6 @@ func (p *Pack) isolationPass(ctx context.Context) {
 			Block:   stringOf(subnet.Attrs["IpRange"]),
 		}
 	}
-	machine.ReconcileIsolation(ctx, p.env.Machines, p.logger(), "subnet",
+	p.binding().ReconcileIsolation(ctx, "subnet",
 		members, func(from, to int) bool { return p.reachableFrom(all[from], all[to], peered) })
 }

--- a/internal/providers/outscale/isolate_pass_internal_test.go
+++ b/internal/providers/outscale/isolate_pass_internal_test.go
@@ -64,7 +64,7 @@ func (f *passIsolator) networksSeen() []string {
 func TestConcurrentSubnetCreatesShareTheirIsolationPasses(t *testing.T) {
 	env := emulator.DefaultEnv()
 	driver := newPassIsolator()
-	env.Machines = driver
+	env.UseMachines(driver)
 	p := New(env)
 
 	subnet := func(id, network, block string) *resource.Resource {

--- a/internal/providers/outscale/loadbalancer_dataplane.go
+++ b/internal/providers/outscale/loadbalancer_dataplane.go
@@ -29,22 +29,11 @@ import (
 // Capabilities.Balancing, the OVN mode alone sets it, `Verify` clears it on a
 // host with no OVN, and a driver that says nothing is read as not balancing —
 // which is what makes the degraded path the default rather than the exception.
-
-// balancer returns the runtime's balancing half, or nil when it has none.
 //
-// Two questions, both asked: does the driver implement the interface, and does
-// it *declare* the capability. The second is not redundant — the Incus driver
-// implements Balancer in every mode and can only deliver it under OVN, and
-// `Verify` clears the claim on a host whose daemon has no northbound
-// connection. Asking only the first would drive a bridge-backed run into a
-// refusal on every register.
-func (p *Pack) balancer() machine.Balancer {
-	if p.env.Machines == nil || !machine.CapabilitiesOf(p.env.Machines).Balancing {
-		return nil
-	}
-	b, _ := p.env.Machines.(machine.Balancer)
-	return b
-}
+// The two questions that decide it — does the runtime implement the balancing
+// half, and does it *declare* the capability — moved into machine.Binding with
+// #511, beside the router and firewall assertions the packs used to write for
+// themselves. This file asks Balances() and knows nothing about a driver.
 
 // syncBalancer hands one balancer's current backend set to the runtime.
 //
@@ -57,8 +46,8 @@ func (p *Pack) balancer() machine.Balancer {
 // container does is worse than one that records the truth and says what it
 // could not do.
 func (p *Pack) syncBalancer(ctx context.Context, name string) {
-	b := p.balancer()
-	if b == nil {
+	b := p.binding()
+	if !b.Balances() {
 		return
 	}
 	res, found := p.env.Store.Get(Name, kindLoadBalancer, name)
@@ -156,8 +145,8 @@ func (p *Pack) EnforcesBalancing() bool { return true }
 
 // removeBalancer undoes it, on the way out.
 func (p *Pack) removeBalancer(ctx context.Context, res *resource.Resource) {
-	b := p.balancer()
-	if b == nil {
+	b := p.binding()
+	if !b.Balances() {
 		return
 	}
 	network, listen := p.balancerPlacement(res)

--- a/internal/providers/outscale/loadbalancer_dataplane_test.go
+++ b/internal/providers/outscale/loadbalancer_dataplane_test.go
@@ -299,7 +299,7 @@ func (r *withholdingBalancer) EnsureBalancer(ctx context.Context, spec machine.B
 func newLoggedRuntimeServer(t *testing.T, drv machine.Driver, log *bytes.Buffer) *httptest.Server {
 	t.Helper()
 	env := emulator.DefaultEnv()
-	env.Machines = drv
+	env.UseMachines(drv)
 	env.Log = slog.New(slog.NewTextHandler(log, nil))
 	srv, err := emulator.NewServer(env, outscale.New(env))
 	if err != nil {

--- a/internal/providers/outscale/machines.go
+++ b/internal/providers/outscale/machines.go
@@ -21,8 +21,7 @@ import (
 // what tells an Outscale machine from a Scaleway one on a shared host, for the
 // sweep and for the event filter alike.
 func (p *Pack) binding() machine.Binding {
-	return machine.Binding{
-		Driver:   p.env.Machines,
+	return p.env.Bind(machine.Binding{
 		Provider: Name,
 		Prefix:   "feint-osc-",
 		User:     DefaultUser,
@@ -36,7 +35,7 @@ func (p *Pack) binding() machine.Binding {
 		// by the binding only when the catalogue above resolved nothing.
 		Declared: p.env.BootImages,
 		Log:      p.env.Log,
-	}
+	})
 }
 
 // DefaultUser is the login Outscale provisions on its images. Their own

--- a/internal/providers/outscale/machines_internal_test.go
+++ b/internal/providers/outscale/machines_internal_test.go
@@ -38,13 +38,14 @@ func (d *recordingDriver) Detach(context.Context, string, string) error         
 func (d *recordingDriver) RemoveNetwork(context.Context, string) error              { return nil }
 
 func runtimePack(driver machine.Driver) *Pack {
-	return New(&emulator.Env{
-		Store:    store.New(),
-		Machines: driver,
-		Now:      func() time.Time { return time.Unix(1700000000, 0).UTC() },
-		NewID:    func() string { return "00000000-0000-4000-8000-000000000001" },
-		Log:      slog.New(slog.NewTextHandler(io.Discard, nil)),
-	})
+	env := &emulator.Env{
+		Store: store.New(),
+		Now:   func() time.Time { return time.Unix(1700000000, 0).UTC() },
+		NewID: func() string { return "00000000-0000-4000-8000-000000000001" },
+		Log:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	env.UseMachines(driver)
+	return New(env)
 }
 
 // One case per row of the OMI table: image and login resolve together, and an

--- a/internal/providers/outscale/netpeerings_test.go
+++ b/internal/providers/outscale/netpeerings_test.go
@@ -392,7 +392,7 @@ func (r *peererRuntime) peersOf(network string) []string {
 func TestAnAcceptedPeeringPeersTheBackingNetworks(t *testing.T) {
 	env := emulator.DefaultEnv()
 	rt := newPeererRuntime()
-	env.Machines = rt
+	env.UseMachines(rt)
 	srv, err := emulator.NewServer(env, outscale.New(env))
 	if err != nil {
 		t.Fatalf("build emulator: %v", err)
@@ -445,7 +445,7 @@ func TestAnAcceptedPeeringPeersTheBackingNetworks(t *testing.T) {
 func TestACreateSubnetDoesNotSeverAnActivePeering(t *testing.T) {
 	env := emulator.DefaultEnv()
 	rt := newPeererRuntime()
-	env.Machines = rt
+	env.UseMachines(rt)
 	srv, err := emulator.NewServer(env, outscale.New(env))
 	if err != nil {
 		t.Fatalf("build emulator: %v", err)

--- a/internal/providers/outscale/privateips.go
+++ b/internal/providers/outscale/privateips.go
@@ -350,10 +350,10 @@ func contains(list []string, want string) bool {
 // address allocation in this pack needs, so one link serialised the pack behind
 // one incus exec — the shape CLAUDE.md documents under *un effet de bord lent ne
 // tient pas dans le verrou*, written into the very function that denied it.
+// No "is a runtime configured" guard at the top since #511: Reconciler.Join
+// degrades to nothing without one, as does the firewall replay behind it, and
+// asking the question meant holding the driver.
 func (p *Pack) carrySecondary(ctx context.Context, nic *resource.Resource) {
-	if p.env.Machines == nil {
-		return
-	}
 	vmID := stringOf(nic.Attrs["LinkVmId"])
 	networkName := ""
 	if subnet, found := p.env.Store.Get(Name, kindSubnet, stringOf(nic.Attrs["SubnetId"])); found {

--- a/internal/providers/outscale/privateips_lock_test.go
+++ b/internal/providers/outscale/privateips_lock_test.go
@@ -88,7 +88,7 @@ func newSlowAttachServer(t *testing.T) (*httptest.Server, *slowAttach) {
 		release:  make(chan struct{}),
 	}
 	env := emulator.DefaultEnv()
-	env.Machines = rt
+	env.UseMachines(rt)
 	srv, err := emulator.NewServer(env, outscale.New(env))
 	if err != nil {
 		t.Fatalf("build emulator: %v", err)

--- a/internal/providers/outscale/publicip_routing_test.go
+++ b/internal/providers/outscale/publicip_routing_test.go
@@ -113,7 +113,7 @@ func newRoutedServer(t *testing.T) (*httptest.Server, *routedRuntime, *emulator.
 	t.Helper()
 	env := emulator.DefaultEnv()
 	rt := newRoutedRuntime()
-	env.Machines = rt
+	env.UseMachines(rt)
 	srv, err := emulator.NewServer(env, outscale.New(env))
 	if err != nil {
 		t.Fatalf("build emulator: %v", err)

--- a/internal/providers/replay_test.go
+++ b/internal/providers/replay_test.go
@@ -116,15 +116,15 @@ func recorderEnv() (*emulator.Env, *machine.Recorder) {
 	rec := machine.NewRecorder()
 	n := 0
 	env := &emulator.Env{
-		Store:    store.New(),
-		Machines: rec,
-		Now:      func() time.Time { return time.Unix(1700000000, 0).UTC() },
+		Store: store.New(),
+		Now:   func() time.Time { return time.Unix(1700000000, 0).UTC() },
 		NewID: func() string {
 			n++
 			return fmt.Sprintf("00000000-0000-4000-8000-%012d", n)
 		},
 		Log: slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
+	env.UseMachines(rec)
 	return env, rec
 }
 

--- a/internal/providers/scaleway/address_routing_test.go
+++ b/internal/providers/scaleway/address_routing_test.go
@@ -93,13 +93,13 @@ func newAddressTestServer(t testing.TB, drv machine.Driver) (*httptest.Server, *
 
 	var seq atomic.Int64
 	env := &emulator.Env{
-		Store:    store.New(),
-		Machines: drv,
-		Now:      func() time.Time { return time.Unix(1700000000, 0).UTC() },
+		Store: store.New(),
+		Now:   func() time.Time { return time.Unix(1700000000, 0).UTC() },
 		NewID: func() string {
 			return fmt.Sprintf("00000000-0000-4000-8000-%012d", seq.Add(1))
 		},
 	}
+	env.UseMachines(drv)
 	srv, err := emulator.NewServer(env, scaleway.New(env))
 	if err != nil {
 		t.Fatalf("build emulator: %v", err)

--- a/internal/providers/scaleway/barrage_test.go
+++ b/internal/providers/scaleway/barrage_test.go
@@ -37,13 +37,13 @@ func newBarrageServer(t *testing.T, drv machine.Driver) (*httptest.Server, *stor
 	seq.Store(1_000_000)
 	st := store.New()
 	env := &emulator.Env{
-		Store:    st,
-		Machines: drv,
-		Now:      func() time.Time { return time.Unix(1700000000, 0).UTC() },
+		Store: st,
+		Now:   func() time.Time { return time.Unix(1700000000, 0).UTC() },
 		NewID: func() string {
 			return fmt.Sprintf("00000000-0000-4000-8000-%012d", seq.Add(1))
 		},
 	}
+	env.UseMachines(drv)
 	srv, err := emulator.NewServer(env, scaleway.New(env))
 	if err != nil {
 		t.Fatalf("build emulator: %v", err)

--- a/internal/providers/scaleway/concurrency_test.go
+++ b/internal/providers/scaleway/concurrency_test.go
@@ -137,13 +137,13 @@ func newRuntimeTestServer(t testing.TB, drv machine.Driver) *httptest.Server {
 
 	var seq atomic.Int64
 	env := &emulator.Env{
-		Store:    store.New(),
-		Machines: drv,
-		Now:      func() time.Time { return time.Unix(1700000000, 0).UTC() },
+		Store: store.New(),
+		Now:   func() time.Time { return time.Unix(1700000000, 0).UTC() },
 		NewID: func() string {
 			return fmt.Sprintf("00000000-0000-4000-8000-%012d", seq.Add(1))
 		},
 	}
+	env.UseMachines(drv)
 	srv, err := emulator.NewServer(env, scaleway.New(env))
 	if err != nil {
 		t.Fatalf("build emulator: %v", err)

--- a/internal/providers/scaleway/firewall_internal_test.go
+++ b/internal/providers/scaleway/firewall_internal_test.go
@@ -72,7 +72,7 @@ func TestBridgeModeRejectsForeignSubnetsThroughTheGroup(t *testing.T) {
 	rec := machine.NewRecorder()
 	rec.Joined = true // the bridge shape: networks reach each other unless rejected
 	env := emulator.DefaultEnv()
-	env.Machines = rec
+	env.UseMachines(rec)
 	p := New(env)
 
 	tenant := resource.Tenant{Provider: Name, Project: defaultProject, Zone: "fr-par-1"}

--- a/internal/providers/scaleway/machines.go
+++ b/internal/providers/scaleway/machines.go
@@ -35,8 +35,7 @@ const DefaultUser = "root"
 
 // binding is this pack's half of the shared machine lifecycle.
 func (p *Pack) binding() machine.Binding {
-	return machine.Binding{
-		Driver:     p.env.Machines,
+	return p.env.Bind(machine.Binding{
 		Provider:   Name,
 		Prefix:     "feint-scw-",
 		User:       DefaultUser,
@@ -53,7 +52,7 @@ func (p *Pack) binding() machine.Binding {
 		// by the binding only when the catalogue resolved nothing.
 		Declared: p.env.BootImages,
 		Log:      p.env.Log,
-	}
+	})
 }
 
 // imageFor resolves a Scaleway image label onto what stands in for it — image

--- a/internal/providers/scaleway/vpc.go
+++ b/internal/providers/scaleway/vpc.go
@@ -803,7 +803,7 @@ func (p *Pack) isolationPass(ctx context.Context) {
 			Block:   block,
 		}
 	}
-	native, applied := machine.ReconcileIsolation(ctx, p.env.Machines, p.logger(), "private_network",
+	native, applied := p.binding().ReconcileIsolation(ctx, "private_network",
 		members, func(from, to int) bool { return p.reachableFrom(all[from], all[to]) })
 	if native || !applied {
 		// No group resync under native isolation: the rule sets carry no

--- a/tools/falsify/specs/balancer-dataplane.json
+++ b/tools/falsify/specs/balancer-dataplane.json
@@ -51,10 +51,10 @@
       "test": "TestVerifyNarrowsBalancingWithIsolation"
     },
     {
-      "label": "the pack asks a runtime that never declared balancing, so every bridge-backed run meets a refusal",
-      "file": "internal/providers/outscale/loadbalancer_dataplane.go",
-      "find": "\tif p.env.Machines == nil || !machine.CapabilitiesOf(p.env.Machines).Balancing {",
-      "replace": "\tif p.env.Machines == nil || !machine.CapabilitiesOf(p.env.Machines).Balancing && false {",
+      "label": "the shared layer asks a runtime that never declared balancing, so every bridge-backed run meets a refusal",
+      "file": "internal/core/machine/balancer.go",
+      "find": "\tif b.driver == nil || !CapabilitiesOf(b.driver).Balancing {",
+      "replace": "\tif b.driver == nil || !CapabilitiesOf(b.driver).Balancing && false {",
       "test": "TestAnUndeclaredBalancingCapabilityIsNeverUsed",
       "package": "./internal/providers/outscale/"
     },

--- a/tools/falsify/specs/driver-surface.json
+++ b/tools/falsify/specs/driver-surface.json
@@ -1,0 +1,54 @@
+{
+  "package": "./internal/cli/",
+  "mutations": [
+    {
+      "label": "a pack reaches past the declared surface: it stops the machine through the binding's low-level verb, skipping the order the Reconciler holds (#511)",
+      "file": "internal/providers/scaleway/machines.go",
+      "find": "// binding is this pack's half of the shared machine lifecycle.",
+      "replace": "// The bypass the declared driver surface exists to refuse.\nfunc (p *Pack) bypassTheDeclaredSurface(ctx context.Context, id string) {\n\tp.binding().Stop(ctx, id, \"feint-scw-\"+id)\n}\n\n// binding is this pack's half of the shared machine lifecycle.",
+      "test": "TestNoPackReachesPastTheDeclaredDriverSurface"
+    },
+    {
+      "label": "the bypass hides one local variable deep, which is the shape a scanner reading only p.binding().Verb() never sees (#511)",
+      "file": "internal/providers/outscale/machines.go",
+      "find": "// DefaultUser is the login Outscale provisions on its images.",
+      "replace": "// The same bypass, through a local variable.\nfunc (p *Pack) bypassTheDeclaredSurface(ctx context.Context, id string) {\n\tb := p.binding()\n\tb.Remove(ctx, id, b.Name(id))\n}\n\n// DefaultUser is the login Outscale provisions on its images.",
+      "test": "TestNoPackReachesPastTheDeclaredDriverSurface"
+    },
+    {
+      "label": "the scanner stops following a value across assignments, so every bypass held in a local variable becomes invisible (#511)",
+      "file": "internal/cli/driver_surface_test.go",
+      "find": "\t\t\tif ident, ok := lhs.(*ast.Ident); ok {\n\t\t\t\tif typ := s.typeOf(stmt.Rhs[i]); typ != \"\" {\n\t\t\t\t\ts.locals[ident.Name] = typ",
+      "replace": "\t\t\tif ident, ok := lhs.(*ast.Ident); ok {\n\t\t\t\tif typ := s.typeOf(stmt.Rhs[i]); typ != \"\" && false {\n\t\t\t\t\ts.locals[ident.Name] = typ",
+      "test": "TestTheDisciplineDetectorsFindWhatTheyLookFor"
+    },
+    {
+      "label": "the declared surface admits the driver itself, which is the list authorising everything it was written to exclude (#511)",
+      "file": "internal/core/machine/surface.go",
+      "find": "\treturn map[string]string{\n\t\t// S1 — machine lifecycle.",
+      "replace": "\treturn map[string]string{\n\t\t\"Driver\": \"the runtime itself, which no pack may ever hold\",\n\t\t// S1 — machine lifecycle.",
+      "test": "TestTheDeclaredDriverSurfaceIsSmallerThanThePackage"
+    },
+    {
+      "label": "the declared surface names a member the package no longer has, so the contract goes on reading as a contract while meaning nothing (#511)",
+      "file": "internal/core/machine/surface.go",
+      "find": "\t\t\"Binding.Serialise\":        \"serialise two actions on one target",
+      "replace": "\t\t\"Binding.SerialiseRenamed\": \"serialise two actions on one target",
+      "test": "TestTheDeclaredDriverSurfaceIsSmallerThanThePackage"
+    },
+    {
+      "label": "a driver-surface exemption is granted with a reason nobody can weigh, the difference between \"not yet migrated\" and \"cannot be\" (#511)",
+      "file": "internal/cli/driver_surface_test.go",
+      "find": "var notInTheDriverSurface = map[string]string{}",
+      "replace": "var notInTheDriverSurface = map[string]string{\"scaleway/Driver\": \"legacy\"}",
+      "test": "TestEveryBarrageExemptionSaysWhy"
+    },
+    {
+      "label": "the scanner stops noticing a renamed import, so a pack that aliases the machine package reads as touching nothing (#511)",
+      "file": "internal/cli/driver_surface_test.go",
+      "find": "\t\tif spec.Name != nil && spec.Name.Name != machinePackageName {\n\t\t\treturn spec.Name.Name",
+      "replace": "\t\tif spec.Name != nil && spec.Name.Name != machinePackageName && false {\n\t\t\treturn spec.Name.Name",
+      "test": "TestTheDisciplineDetectorsFindWhatTheyLookFor"
+    }
+  ]
+}

--- a/tools/falsify/specs/image-derivation.json
+++ b/tools/falsify/specs/image-derivation.json
@@ -11,8 +11,8 @@
     {
       "label": "a failed image build stops refusing the boot, so the runtime is asked to boot the very source the build could not fetch",
       "file": "internal/core/machine/binding.go",
-      "find": "\t\tif _, err := EnsureImage(ctx, b.Driver, boot.Image, b.logger()); err != nil {",
-      "replace": "\t\tif _, err := EnsureImage(ctx, b.Driver, boot.Image, b.logger()); err != nil && false {",
+      "find": "\t\tif _, err := EnsureImage(ctx, b.driver, boot.Image, b.logger()); err != nil {",
+      "replace": "\t\tif _, err := EnsureImage(ctx, b.driver, boot.Image, b.logger()); err != nil && false {",
       "test": "TestAFailedImageBuildRefusesTheBootAndNamesTheSource"
     },
     {

--- a/tools/falsify/specs/interface-plan.json
+++ b/tools/falsify/specs/interface-plan.json
@@ -25,8 +25,8 @@
     {
       "label": "the backing network is recorded before the driver accepted it, the ordering two packs had (#510)",
       "file": "internal/core/machine/plan.go",
-      "find": "\tif err := b.Driver.EnsureNetwork(ctx, network); err != nil {\n\t\treturn err\n\t}\n\tif res.Runtime == nil {\n\t\tres.Runtime = map[string]string{}\n\t}\n\tres.Runtime[spec.Key] = name\n\treturn nil",
-      "replace": "\tif res.Runtime == nil {\n\t\tres.Runtime = map[string]string{}\n\t}\n\tres.Runtime[spec.Key] = name\n\tif err := b.Driver.EnsureNetwork(ctx, network); err != nil {\n\t\treturn err\n\t}\n\treturn nil",
+      "find": "\tif err := b.driver.EnsureNetwork(ctx, network); err != nil {\n\t\treturn err\n\t}\n\tif res.Runtime == nil {\n\t\tres.Runtime = map[string]string{}\n\t}\n\tres.Runtime[spec.Key] = name\n\treturn nil",
+      "replace": "\tif res.Runtime == nil {\n\t\tres.Runtime = map[string]string{}\n\t}\n\tres.Runtime[spec.Key] = name\n\tif err := b.driver.EnsureNetwork(ctx, network); err != nil {\n\t\treturn err\n\t}\n\treturn nil",
       "test": "TestEnsureBackingNetworkRecordsOnlyWhatTheDriverAccepted"
     },
     {

--- a/tools/falsify/specs/unroutable-package-step.json
+++ b/tools/falsify/specs/unroutable-package-step.json
@@ -4,8 +4,8 @@
     {
       "label": "the package-step warning never fires, and a stack's packages: dies in a guest journal nobody opens (#507)",
       "file": "internal/core/machine/binding.go",
-      "find": "\tif _, metadataOnly := b.Driver.(Noop); !metadataOnly &&\n\t\tboot.CloudInit != \"\" && len(boot.Attachments) == 0 && declaresPackageStep(boot.CloudInit) {",
-      "replace": "\tif _, metadataOnly := b.Driver.(Noop); !metadataOnly &&\n\t\tboot.CloudInit != \"\" && len(boot.Attachments) == 0 && declaresPackageStep(boot.CloudInit) && false {",
+      "find": "\tif _, metadataOnly := b.driver.(Noop); !metadataOnly &&\n\t\tboot.CloudInit != \"\" && len(boot.Attachments) == 0 && declaresPackageStep(boot.CloudInit) {",
+      "replace": "\tif _, metadataOnly := b.driver.(Noop); !metadataOnly &&\n\t\tboot.CloudInit != \"\" && len(boot.Attachments) == 0 && declaresPackageStep(boot.CloudInit) && false {",
       "test": "TestAPackageStepWithNoRouteOutIsSaidOutLoud"
     },
     {


### PR DESCRIPTION
Closes #511.

The corridor was opened by #509, #510 and #515; this closes the door behind it.
Nothing forces a pack into the shadows any more, so a bypass can stop being
tolerated and start being refused.

## The surface, and what it excludes

`machine.PackSurface()` declares **58 keys — 17 package-level names and 41
members** — against the **97 names and 297 members** the package exports. What a
pack may ask of the runtime is **23 verbs**, grouped by the eight service
families of #514: lifecycle, interface plan, addresses, networks, membership,
rule sets, isolation, balancer. The rest of the list is data a pack declares and
reads back — `Plan`, `Attachment`, `Boot`, `Image`, `FirewallSpec`,
`BalancerSpec`, `IsolationMember`, `BackingNetwork` — plus one field read.

**What it excludes is the half that matters**, and 46 entries are asserted by
name so the exclusion cannot rot: `Driver`, `Incus`, `Noop`, `Recorder`; every
optional half (`Router`, `Firewaller`, `Peerer`, `Isolator`, `Balancer`,
`Capable`, and nine more); the driver's own argument vocabulary (`Spec`,
`NetworkSpec`, `AddressSpec`, `Machine`); the host naming and capability halves;
and **fourteen `Binding` verbs** — `Start`, `Stop`, `Remove`, `PowerOn`,
`Refresh`, `RouteAddress`, `UnrouteAddress`, `SyncRuleSet`, `ApplyRuleSets`,
`DropRuleSet` among them.

`Binding.PowerOn` **out** and `Reconciler.PowerOn` **in** is the sharp line: it
is #510's order, and admitting the first would have let a pack boot a machine
outside the plan that sequences its addresses, memberships and firewall.
`Binding` offers 36 exported members; 14 are admitted.

A surface that admits everything guarantees nothing — this one admits 58 of 394.

## The count, re-measured rather than inherited

The issue's 29 sites were counted on `46230cc`, before the three merged lots,
and its first count was wrong twice over — a `grep -rh … | grep -v _test` that
filtered *lines* instead of *files*, then a guessed verb list missing `Attach`
and `Detach`. So the inventory here is **derived from what the package exports**
and read with an AST scanner, never from a list of verbs somebody remembered:

| | base `0f8b58e` | after |
|---|--:|--:|
| pack sites naming the raw driver (`p.env.Machines`) | 11 | **0** |
| type assertions to a driver interface | 1 | **0** |
| distinct `machine.*` names reached | 20 | 17 |
| total reach sites | — | 216, all declared |
| **exemptions** | — | **0** |

Where the eleven went: three `Binding` literals to `Env.Bind`; three isolation
passes to a new `Binding.ReconcileIsolation`; one `CapabilitiesOf`, one
`machine.Balancer` assertion and one nil check to new `Binding.Balances` /
`EnsureBalancer` / `RemoveBalancer` — the maintainer's doctrine applied, *the
driver gains a service, the pack never works around*. And **two "is a runtime
configured" guards were deleted**: every verb behind them already degrades to
nothing without one, so the guard was a second opinion about a decision already
taken elsewhere.

**The exemption ledger is empty rather than seeded.** Nothing needed one, and
`notInTheDriverSurface` exists with its refusal of a thin reason, tested, for
the day something does.

## The compiler holds what it can

`emulator.Env.machines` and `machine.Binding.driver` are unexported, behind
`Env.Bind` / `UseMachines` / `RuntimeName` and `Binding.WithDriver`. So
`p.binding().Driver.EnsureNetwork(…)` **no longer compiles** — a bypass is a
build error before it is a test failure, which is the strongest form the
maintainer asked for. The discipline test holds what the type system cannot.

## The red, obtained by planting

A method doing `b := p.binding(); b.Stop(…, b.Name(id)); _ = machine.Noop{}`,
planted in the Scaleway pack:

```
--- FAIL: TestNoPackReachesPastTheDeclaredDriverSurface
    3 reach(es) into internal/core/machine that machine.PackSurface does not name...
      scaleway reaches Binding.Name at internal/providers/scaleway/machines.go:40
      scaleway reaches Binding.Stop at internal/providers/scaleway/machines.go:40
      scaleway reaches Noop         at internal/providers/scaleway/machines.go:41
```

It names the pack, the gesture and the line. The detector joins
`TestTheDisciplineDetectorsFindWhatTheyLookFor`, the positive control of the
five existing discipline tests — a silent detector reads exactly like a healthy
repository.

New spec `driver-surface.json`, **7 mutations, all biting**: a bypass in
Scaleway, the same one held in a local deep in Outscale, the scanner losing
assignment tracking, the surface admitting `Driver`, the surface naming a member
that no longer exists, an exemption with a thin reason, and the scanner losing
its aliased-import check.

## Instrument failures, recorded because they are the lesson

- **A comment claimed "checked rather than assumed" and checked nothing** —
  precisely the defect `CLAUDE.md` names. `aliasedMachineImport` is now a real
  control with its own positive control and mutation.
- A naive `grep -oE 'machine\.[A-Za-z]+'` reports four `machine.PeerNetworks` in
  the packs; **all four are in comments**. The AST scanner sees zero. That is the
  same class of error as the issue's own two wrong counts.
- The first scanner resolved per file and missed every `p.binding().Verb()`
  outside `machines.go`, then missed three balancer verbs held in a local. Both
  are falsification mutations now.
- `git checkout -- <file>` to remove a planted bypass also reverted that file's
  migration, since HEAD was the base. Caught and re-applied.

## Evidence

`mise run check`, `go test ./... -race`, `prepush`, `docs:check` all 0.
`FEINT_VM=incus-ovn mise run conformance` **exit 0**, 1271 s, ten suites passed.
`mise run conformance:witness` exit 0 — Scaleway 6 running with 6 machines all
wearing a rule set, Outscale 3/3 plus one balancer held with a backend and a
port.

Stacks under `feint up --runtime incus-ovn`: **Scaleway three `scw-*` sets over
six references for six machines, Outscale two `osc-*` sets at 1+2 for three** —
both reference values unmoved — empty second plans, clean destroys of 50 and 48
resources, **nil station delta**.

`falsify:lint` over the whole set (714 mutations, 121 specs), and the **34 specs
naming a file this lot touches replayed whole, all green** — including
`interface-plan`, whose mutation still turns
`TestSameIntentSameRuntimeSequenceAcrossPacks` red, and `contract-recorder`,
whose four controls all still bite. #510's acquisition is not lost.

No CHANGELOG entry: no response shape and no limit moved.
