### PR TITLE
test(contract): the fourth provider exists as code, and the sequence it asks of the runtime is the other three's (#517)

### DIFF
--- a/docs/fourth-pack.md
+++ b/docs/fourth-pack.md
@@ -266,3 +266,99 @@ new audit: the eleven-file, forty-three-line figure for the shared surface. It
 requires judging, file by file, whether a fourth pack would have to edit it, and
 the answer moved when `packsFor`, the shapes gate and the docs banner started
 deriving their lists from the mounted packs. Re-measure it before quoting it.
+
+## The fourth pack now compiles
+
+Added **2026-08-27** (#517). Everything above is paper, and this document says
+so about itself in two places: the walkthrough of what a fourth pack provides,
+and the honest note that no fourth signature has ever been measured. Paper
+rots. What changed is that the *dataplane* half of the walkthrough no longer
+can.
+
+`internal/cli/testdata/provider-four/` is a fourth provider that does not
+exist — an imaginary minimal cloud with nodes, segments, barriers, anchors and
+spreaders — which drives the whole runtime dataplane through the shared
+contract alone: it boots a machine, declares a network and joins it at boot and
+after boot, publishes and withdraws a public address, hands a rule set over and
+re-expands it, asks for a balancer, and keeps two subnets apart. It names no
+runtime, and it could not name `machine.Driver` if it tried: since #511
+`emulator.Env` hands out no driver value.
+
+Three things it is deliberately not:
+
+- **Not OVHcloud.** OVH is the intended fourth pack and nothing of its API has
+  been measured in this repository, so a fake shaped like OVH would be
+  measuring a belief. This one depends on no trait of any real cloud; when the
+  OVH pack starts, this is the recipe it reads and never the model it copies.
+- **Not a served pack.** It has no routes and no wire dialect, is never
+  mounted, and proves the contract's shape rather than wire fidelity. The polar
+  star stays with `scw`, the `exo` CLI and Terraform.
+- **Not counted by any instrument.** It lives under `testdata/`, which Go's
+  `./...` patterns skip — measured, not assumed: `go build ./...` does not
+  build it and `go list ./...` does not name it, so no coverage, evidence or
+  drift artefact can ever carry a fourth provider that has no upstream SDK.
+  An explicit import still resolves, which is how it compiles at all.
+
+**What it is judged by, with no exemption of its own:**
+`TestNoPackReachesPastTheDeclaredDriverSurface` (#511) and
+`TestNoPackKnowsWhichRuntimeIsBehindTheDriver` (#516) read it beside the three
+real packs, and `TestSameIntentSameRuntimeSequenceAcrossPacks` (#510, #515)
+compares the sequence it asks of the runtime against theirs, on both intents of
+the corpus — identical. That comparison is the one worth the lot: the three
+real packs were *migrated* onto the shared order, so each of them knows what it
+used to write by hand; Provider Four never wrote one, and still produces the
+same sequence.
+
+**What it had to supply**, and therefore what a real fourth pack will: its
+binding fields, its plan, its firewall translation and the four enumerators
+around it, its isolation predicate, its balancer's shape, its own address
+planning — the runtime contract has no opinion on that last one at all — and
+every call site, because the contract can refuse a gesture and never require
+one.
+
+**What it received without writing a line:** the machine's host-side name and
+the ownership check on it, the boot order (addresses, then memberships, the
+firewall last), the published state being the one the effect produced, the
+refusal to route an address outside its own block, the conditional write-back a
+delete racing a launch cannot lose, the re-expansion of every rule set a booted
+machine's groups are named by, the network name recorded only once the runtime
+accepted it, and the report of what a balancer hand-off actually delivered.
+
+**What it can still forget**, stated rather than hidden — and each held by a
+named test with a planted red in `tools/falsify/specs/provider-four.json`
+rather than by this paragraph:
+
+| forgettable | why nothing can force it | held by |
+|---|---|---|
+| handing a changed rule set to the host (#475) | only the pack knows its rules changed | `TestTheFourthPacksRuleChangeReachesTheRuntime` |
+| re-expanding the rule sets that named a deleted machine | only the pack knows a machine's groups are gone | `TestTheFourthPacksDeleteReExpandsTheBarriersThatNameIt` |
+| declaring a public block wide enough to cover the host's own network | the guard enforces the block the pack declared | `TestTheFourthPackRefusesToRouteAnAddressOutsideItsOwnBlock` |
+| a wrong isolation predicate | what "may reach" means is upstream knowledge | `TestTheFourthPacksSegmentsReachEachOtherOnlyInTheSameRealm` |
+| copying a nested `Attrs` value before writing it | `resource.Clone` shares it with the store | `TestTheFourthPacksNestedAttributesAreNeverWrittenThroughTheStore` |
+| reading a stored number back with a plain `.(int)` | `Attrs` is `map[string]any`, so a restore yields `float64` | `TestTheFourthPacksSpreaderKeepsItsPortAcrossASnapshot` |
+
+The first two are #514's named residue, and they are the honest answer to the
+milestone's own question: forgetting is not made impossible, it is made visible
+in more than one place.
+
+**The last row is the one the list did not predict, and it is the most useful
+thing the exercise produced**, because the fake pack did not merely risk it —
+it committed it. `res.Attrs["port"].(int)` is what anybody writes, and after a
+`feint snapshot load` it yields zero: a balancer listening on port 0 while the
+API still describes 443. It is a *re*discovery. `exoscale/privatenetworks.go`
+carries `intOf` with the sentence "tolerating the float64 a snapshot restore
+produces", and the two other real packs do not — `outscale/volumes.go` and
+`outscale/snapshots.go` read `Attrs["Size"].(int)` at three sites, where it
+costs a shrink refusal that no longer fires, a volume that publishes no size,
+and a snapshot recording `VolumeSize: 0` (#542). A lesson living in one pack of
+three is a lesson a fourth pack cannot inherit, which is #475's shape one
+storey below the runtime contract.
+
+A second one came out the same way: a pack that declares `GroupSync` without
+wiring its fields panics on the first boot, and only under a runtime — so
+`--vm off`, which is the default and the whole CI matrix, is exactly the mode
+that cannot see it (#543).
+
+The rest of this document — the surface, the wire vocabulary, the drift reader
+and the versioned baseline a fourth provider also owes — is untouched by #517
+and stays paper.

--- a/internal/cli/driver_surface_test.go
+++ b/internal/cli/driver_surface_test.go
@@ -698,7 +698,13 @@ func TestNoPackReachesPastTheDeclaredDriverSurface(t *testing.T) {
 
 	var offences []string
 	total := 0
-	for _, dir := range packDirs(t) {
+	// The fourth pack is in the population, not beside it (#517). The three
+	// real packs were migrated onto this boundary, so each of them knows what
+	// it used to do by hand; testdata/provider-four never did, and it is the
+	// only member of this scan that can answer whether the declared surface
+	// suffices rather than whether three authors remembered it. It carries no
+	// exemption of its own, which is the whole claim.
+	for _, dir := range disciplinedPackDirs(t) {
 		reaches := driverSurfaceReaches(t, pkg, dir)
 		total += len(reaches)
 		for _, r := range reaches {

--- a/internal/cli/provider_four_test.go
+++ b/internal/cli/provider_four_test.go
@@ -1,0 +1,955 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	providerfour "github.com/stephrobert/feint/internal/cli/testdata/provider-four"
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/machine"
+	"github.com/stephrobert/feint/internal/core/store"
+)
+
+// The fourth provider, exercised as code (#517).
+//
+// #509, #510 and #511 prove the three real packs *can stop* reaching past the
+// contract. None of them proves the contract *suffices* for a pack that never
+// had the old habits: every one of the three was migrated onto it, so each one
+// knows what it used to do by hand. testdata/provider-four is the pack that
+// does not — an imaginary minimal cloud, written from the dataplane #517 asks
+// for and from no cloud at all — and these are the tests that say what it had
+// to supply, what it received without writing a line, and what it could still
+// forget.
+//
+// Why the green here is worth less than the red: a fake pack written by
+// reading the contract until everything compiles demonstrates that somebody
+// can write a conforming pack, never that a stranger could. So every property
+// below was planted before it was trusted, and
+// tools/falsify/specs/provider-four.json keeps all thirteen plantable — twelve
+// of them for the tests here, one for the population they are read in.
+//
+// The two that matter most are the ones a pack can still get wrong whatever
+// the contract does, because only the pack knows they happened: the rule
+// change that never reaches the host (#475) and the delete that leaves a
+// tiering statement naming a machine that is gone. And one was not planted but
+// committed — this pack read a stored port with a plain int assertion on its
+// first draft, which a snapshot restore turns into zero; see
+// TestTheFourthPacksSpreaderKeepsItsPortAcrossASnapshot and #542.
+
+// fourthPackDir is where the fake fourth pack lives.
+//
+// Under testdata/, which is not an accident and not a hiding place: Go's
+// ./... patterns skip it, so `go build ./...` never builds it and
+// `go list ./...` never names it — measured on 2026-08-27, which is what #517
+// asks for in place of an assumption — and therefore no coverage, evidence or
+// drift artefact can ever count a fourth provider that has no upstream SDK.
+// An explicit import still resolves, which is how it compiles at all.
+//
+// It fails rather than skipping when the directory is gone: the two discipline
+// detectors below judge a population this function returns, and a population
+// that silently lost a member is exactly the shape of an instrument that
+// reports a disciplined repository because it looked nowhere.
+func fourthPackDir(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(repoRoot(t), "internal", "cli", "testdata", "provider-four")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read the fourth pack: %v — the discipline detectors judge it beside the three "+
+			"real packs, and a missing fourth pack makes them pass by looking at one less thing", err)
+	}
+	sources := 0
+	for _, entry := range entries {
+		if strings.HasSuffix(entry.Name(), ".go") && !strings.HasSuffix(entry.Name(), "_test.go") {
+			sources++
+		}
+	}
+	if sources == 0 {
+		t.Fatalf("%s holds no Go source: the fourth pack is the positive control of both "+
+			"discipline detectors, and an empty one controls nothing", dir)
+	}
+	return dir
+}
+
+// disciplinedPackDirs is the population the two discipline detectors of #511
+// and #516 judge: the three packs the emulator serves, and the fourth that
+// nothing serves.
+//
+// Separate from packDirs on purpose. packDirs answers "which packs does this
+// emulator mount", which is what the barrage, the declines and the core's
+// no-provider rule are about — and a fake pack has no routes, no Declined()
+// and no barrage to run. This answers "which packs must obey the driver
+// boundary", and the fourth belongs there precisely because it is the one that
+// never had the habits the boundary was written to remove.
+func disciplinedPackDirs(t *testing.T) []string {
+	t.Helper()
+	return append(packDirs(t), fourthPackDir(t))
+}
+
+// ---- The population, which is the thing that can quietly stop being true ----
+
+// Both discipline detectors really read the fourth pack.
+//
+// The reason this exists rather than being obvious: dropping the fourth pack
+// from disciplinedPackDirs makes every other test in this file go on passing,
+// and both detectors go on passing too — with a population one member smaller
+// and nothing saying so. That is the exact shape measurement-integrity calls
+// an instrument reporting a disciplined repository because it looked nowhere,
+// and the repository has paid for it seven times in a day.
+//
+// So the membership is asserted, and so is the fact that each scanner sees
+// something there: a fourth pack the surface scanner resolves nothing in would
+// be in the population and still measure nothing. The floors are well under
+// what the pack holds today — 69 reaches, 2 files, 113 literals on 2026-08-27
+// — and well over zero.
+func TestTheDisciplineDetectorsReadTheFourthPack(t *testing.T) {
+	dir := fourthPackDir(t)
+	found := false
+	for _, candidate := range disciplinedPackDirs(t) {
+		if candidate == dir {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("%s is not in the population the two discipline detectors judge: they would "+
+			"pass on three packs that were cleaned up, which is the question #517 exists to stop "+
+			"answering", dir)
+	}
+
+	pkg := readMachinePackage(t)
+	if reaches := driverSurfaceReaches(t, pkg, dir); len(reaches) < 40 {
+		t.Errorf("the surface scanner resolves %d reach(es) in the fourth pack: a pack it reads "+
+			"as touching nothing is a pack the boundary does not constrain", len(reaches))
+	}
+
+	impls := driverImplementations(t, pkg)
+	named := map[string]bool{}
+	for _, impl := range impls {
+		named[impl] = true
+	}
+	scan := runtimeKnowledgeLeaks(t, dir, runtimeTells(impls), named)
+	if scan.files < 2 || scan.literals < 50 {
+		t.Errorf("the runtime-knowledge scan read %d file(s) and %d literal(s) of the fourth pack: "+
+			"a scan that parsed nothing reads exactly like a runtime-blind pack", scan.files, scan.literals)
+	}
+	if len(scan.leaks) != 0 {
+		t.Errorf("the fourth pack names the runtime %d time(s): %v", len(scan.leaks), scan.leaks)
+	}
+}
+
+// ---- The harness ------------------------------------------------------------
+
+// fourthPack builds Provider Four over a deterministic environment backed by
+// the shared contract recorder.
+//
+// The placements are forgotten first: they live in a package-level map keyed by
+// provider and address — state that must outlive one request cannot live in a
+// per-call Binding — and two tests handing out the same deterministic address
+// would otherwise see the previous test's machine as its holder, and record an
+// UnrouteAddress this one never asked for. That is the residue of a neighbour
+// being measured instead of the subject.
+func fourthPack(t *testing.T) (*providerfour.Pack, *machine.Recorder, *emulator.Env) {
+	t.Helper()
+	rec := machine.NewRecorder()
+	env := fourthEnv(t, rec)
+	return providerfour.New(env), rec, env
+}
+
+// fourthEnv is fourthPack's environment half, for the tests that need a
+// runtime other than a plain recorder.
+func fourthEnv(t *testing.T, runtime machine.Driver) *emulator.Env {
+	t.Helper()
+	machine.Binding{Provider: providerfour.Name}.ForgetPlacements()
+	n := 0
+	env := &emulator.Env{
+		Store: store.New(),
+		Now:   func() time.Time { return time.Unix(1700000000, 0).UTC() },
+		NewID: func() string {
+			n++
+			return fmt.Sprintf("00000000-0000-4000-8000-%012d", n)
+		},
+		Log: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	env.UseMachines(runtime)
+	return env
+}
+
+func must(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("the fourth pack refused an ordinary intent: %v", err)
+	}
+}
+
+// gesturesOn reports the recorded kinds acting on one resource, so an assertion
+// can name what it looked at rather than the whole run.
+func gesturesOn(rec *machine.Recorder, resource string) []string {
+	var kinds []string
+	for _, event := range rec.Events() {
+		if event.Resource == resource {
+			kinds = append(kinds, event.Kind)
+		}
+	}
+	return kinds
+}
+
+func counts(rec *machine.Recorder) map[string]int {
+	out := map[string]int{}
+	for _, kind := range rec.Sequence() {
+		out[kind]++
+	}
+	return out
+}
+
+// webRule is the rule every scenario below hands over: one port, one block.
+var webRule = providerfour.Rule{
+	Direction: "ingress",
+	Action:    "allow",
+	Protocol:  "tcp",
+	Source:    "0.0.0.0/0",
+	PortFrom:  443,
+	PortTo:    443,
+}
+
+// ---- What it had to supply, and what it got for nothing ---------------------
+
+// The fourth pack asks the runtime for all eight service families, through the
+// contract alone (#517).
+//
+// # What Provider Four had to supply
+//
+// Its binding — prefix, login, the two Runtime keys, the two state words, its
+// image table. Its plan: which stored field becomes which interface, which
+// addresses were promised. Its firewall translation: what a barrier and its
+// rules mean, who wears one, which barriers a node wears, which barriers name
+// another. Its isolation predicate: what "may reach" means between two of its
+// segments. Its balancer's shape and its backends. Its address planning, which
+// the runtime contract has no opinion on at all. And every call site: the
+// contract can refuse a gesture, never require one.
+//
+// # What it received without writing a line
+//
+// The machine's host-side name and the ownership check on it. The boot order —
+// addresses, then memberships, the firewall last. The published state being
+// the one the effect produced. The refusal to route an address outside its own
+// block. The write-back that a delete racing a launch cannot lose. The
+// re-expansion of every barrier a booted node's barriers are named by. The
+// network name recorded only once the runtime accepted it. The report of what
+// a balancer hand-off actually delivered, and the difference between a limit
+// and an incident.
+//
+// # What it can still forget, and this test does not pretend otherwise
+//
+// Calling any of it. The residue is named in #514 and measured here by the two
+// omission tests below, which is the honest form: forgetting is not made
+// impossible, it is made visible.
+func TestTheFourthPackDrivesTheWholeDataplaneThroughTheContract(t *testing.T) {
+	ctx := context.Background()
+	pack, rec, env := fourthPack(t)
+
+	// S4 — a network. The pack supplies the block and the label; the host-side
+	// name is derived, handed over, and recorded only on acceptance.
+	segment, err := pack.CreateSegment(ctx, "front", "10.40.0.0/24", "green")
+	must(t, err)
+	if segment.Runtime["four-segment"] == "" {
+		t.Fatal("the segment carries no backing network name: EnsureBackingNetwork records it on " +
+			"the resource, and a pack that had to write that key itself would be the pack that " +
+			"writes it before the runtime accepted the network")
+	}
+
+	// S6 — a rule set. The translation is the pack's; the hand-off is the
+	// skeleton's.
+	barrier := pack.CreateBarrier("web")
+	must(t, pack.AddRule(ctx, barrier.ID, webRule))
+
+	// S1 and S2 — a machine on its declared plan.
+	node, err := pack.CreateNode(ctx, providerfour.NodeRequest{
+		Name:        "web-1",
+		Image:       "four-linux",
+		HomeSegment: segment.ID,
+		Barriers:    []string{barrier.ID},
+	})
+	must(t, err)
+	must(t, pack.StartNode(ctx, node.ID))
+
+	node, err = pack.ReadNode(ctx, node.ID)
+	must(t, err)
+	if node.State != providerfour.StateUp {
+		t.Fatalf("the node is %q after a start the runtime accepted, want %q", node.State, providerfour.StateUp)
+	}
+	name := node.Runtime["four-node"]
+	if !strings.HasPrefix(name, "feint-four-") {
+		t.Fatalf("the machine is called %q: the pack never names its own machines, the binding "+
+			"derives the name from the prefix it declared", name)
+	}
+
+	// S5 — a second segment, joined hot.
+	second, err := pack.CreateSegment(ctx, "back", "10.41.0.0/24", "green")
+	must(t, err)
+	must(t, pack.JoinSegment(ctx, node.ID, second.ID))
+
+	// S3 — a public address, published then withdrawn.
+	anchor, err := pack.CreateAnchor()
+	must(t, err)
+	must(t, pack.AttachAnchor(ctx, anchor.ID, node.ID))
+	must(t, pack.DetachAnchor(ctx, anchor.ID))
+
+	// S8 — a balancer, handed over whole and reported back.
+	spreader, err := pack.CreateSpreader(ctx, "front-443", segment.ID, 443)
+	must(t, err)
+	must(t, pack.RegisterBackend(ctx, spreader.ID, node.ID))
+	stored, found := env.Store.Get(providerfour.Name, providerfour.KindSpreader, spreader.ID)
+	if !found {
+		t.Fatal("the spreader is gone")
+	}
+	if stored.Runtime[machine.RuntimeBalancerDistributed] == "" {
+		t.Errorf("the spreader records no delivery: the effect a hand-off produced is what the "+
+			"API's readers must be able to see, and %v is what the resource holds", stored.Runtime)
+	}
+
+	// And the whole thing undone.
+	must(t, pack.DeleteSpreader(ctx, spreader.ID))
+	must(t, pack.LeaveSegment(ctx, node.ID, second.ID))
+	must(t, pack.StopNode(ctx, node.ID))
+	must(t, pack.DeleteNode(ctx, node.ID))
+	must(t, pack.DeleteBarrier(ctx, barrier.ID))
+	must(t, pack.DeleteSegment(ctx, second.ID))
+	must(t, pack.DeleteSegment(ctx, segment.ID))
+
+	// Every mutating gesture of the contract except IsolateNetwork, which the
+	// isolation test below reaches with a runtime whose networks are born
+	// joined. A floor rather than an equality: what matters is that no family
+	// of the service list went unexercised, so a service the contract stopped
+	// offering would fail here rather than quietly stopping to be reachable.
+	seen := counts(rec)
+	for _, kind := range []string{
+		"EnsureNetwork", "PeerNetworks", "RemoveNetwork",
+		"EnsureFirewall", "ApplyFirewall", "RemoveFirewall",
+		"Start", "Stop", "Remove",
+		"Attach", "Detach",
+		"RouteAddress", "UnrouteAddress",
+		"EnsureBalancer", "RemoveBalancer",
+	} {
+		if seen[kind] == 0 {
+			t.Errorf("the fourth pack never asked the runtime for %s: a service family it cannot "+
+				"reach is a family a real fourth pack would have to reach around", kind)
+		}
+	}
+
+	// And nothing outside it. This is the half that cannot be got by writing
+	// more code: a gesture the contract does not name is a gesture the pack
+	// invented, and the recorder is what sees it.
+	if outside := rec.OutsideContract(); len(outside) > 0 {
+		t.Errorf("the fourth pack asked the runtime for %d gesture(s) the contract cannot name: %v",
+			len(outside), outside)
+	}
+}
+
+// ---- The order, on a pack that never wrote it -------------------------------
+
+// The fourth pack's boot routes, then joins, then applies the firewall.
+//
+// The same property #510 made true of the three real packs, asserted on a pack
+// that never had their comments to copy. It is the sharpest thing this lot can
+// say: the order is a property of the runtime, not of a provider, and a
+// provider that never heard of it still gets it.
+//
+// The replay is what is measured, not the first boot: a node that already
+// carries its memberships and its promised address is what a restart produces,
+// and it is exactly the case where a pack writing its own sequence would get
+// it wrong.
+func TestTheFourthPacksBootRoutesThenJoinsThenAppliesTheFirewall(t *testing.T) {
+	ctx := context.Background()
+	pack, rec, _ := fourthPack(t)
+
+	segment, err := pack.CreateSegment(ctx, "front", "10.40.0.0/24", "green")
+	must(t, err)
+	joined, err := pack.CreateSegment(ctx, "back", "10.41.0.0/24", "green")
+	must(t, err)
+	barrier := pack.CreateBarrier("web")
+	must(t, pack.AddRule(ctx, barrier.ID, webRule))
+
+	node, err := pack.CreateNode(ctx, providerfour.NodeRequest{
+		Name:        "web-1",
+		Image:       "four-linux",
+		HomeSegment: segment.ID,
+		Barriers:    []string{barrier.ID},
+		Public:      true,
+	})
+	must(t, err)
+	must(t, pack.StartNode(ctx, node.ID))
+	must(t, pack.JoinSegment(ctx, node.ID, joined.ID))
+	must(t, pack.StopNode(ctx, node.ID))
+
+	// Everything above is setup; the replay is the subject.
+	before := len(rec.Events())
+	must(t, pack.StartNode(ctx, node.ID))
+
+	var order []string
+	for _, event := range rec.Events()[before:] {
+		switch event.Kind {
+		case "Start", "RouteAddress", "Attach", "ApplyFirewall":
+			order = append(order, event.Kind)
+		}
+	}
+	want := []string{"Start", "RouteAddress", "Attach", "ApplyFirewall"}
+	if strings.Join(order, ",") != strings.Join(want, ",") {
+		t.Errorf("the fourth pack's boot replay is %v, want %v.\nThe order — the promised "+
+			"addresses, then the memberships, the firewall last — is the runtime's property and "+
+			"the reconciler's to hold. A pack that had to write it would be the fourth pack to "+
+			"write it in a fourth order", order, want)
+	}
+}
+
+// ---- The two omissions a fourth pack can still commit -----------------------
+
+// A rule the fourth pack adds reaches the runtime.
+//
+// This is #475 reproduced on a pack that did not exist when #475 was measured:
+// two packs of three described rules their host never enforced, for months,
+// because the hand-off was a line somebody had to remember to write. Nothing
+// in the contract can force it — the pack is the only party that knows its
+// rules changed — so the residue is held here, by name, and the proof is that
+// removing the SyncGroup call from providerfour.AddRule turns this red:
+// tools/falsify/specs/provider-four.json plants exactly that.
+func TestTheFourthPacksRuleChangeReachesTheRuntime(t *testing.T) {
+	ctx := context.Background()
+	pack, rec, _ := fourthPack(t)
+
+	barrier := pack.CreateBarrier("web")
+	if got := counts(rec)["EnsureFirewall"]; got != 0 {
+		t.Fatalf("%d rule set(s) written for a barrier nobody wears and nothing fills", got)
+	}
+	must(t, pack.AddRule(ctx, barrier.ID, webRule))
+
+	set := machine.FirewallName("four", barrier.ID)
+	if kinds := gesturesOn(rec, set); len(kinds) == 0 {
+		t.Fatalf("the barrier gained a rule and the runtime heard nothing about %s. The API "+
+			"would describe a rule that filters nothing, every gate would stay green, and that "+
+			"is #475 exactly — recorded gestures: %v", set, rec.Sequence())
+	}
+
+	// The rule itself, not merely the call: a hand-off that wrote an empty set
+	// would satisfy the assertion above and enforce nothing.
+	for _, event := range rec.Events() {
+		if event.Kind != "EnsureFirewall" || event.Resource != set {
+			continue
+		}
+		spec, ok := event.Args.(machine.FirewallSpec)
+		if !ok {
+			t.Fatalf("EnsureFirewall carried %T rather than a rule set", event.Args)
+		}
+		if len(spec.Rules) != 1 || spec.Rules[0].PortFrom != 443 {
+			t.Errorf("the rule set handed over carries %v, not the rule the barrier gained", spec.Rules)
+		}
+		return
+	}
+	t.Fatal("no rule set was written at all")
+}
+
+// A node the fourth pack boots is put into every barrier that names its
+// barriers.
+//
+// The second half of #475, and the one that reads as working when it is not: a
+// tiering statement — this barrier accepts that barrier and nobody else —
+// contains no machine at all until the machines that wear the named barrier
+// have addresses. The re-expansion is the skeleton's; what this holds is that
+// the fourth pack goes through it.
+func TestTheFourthPacksBootReExpandsTheBarriersThatNameItsOwn(t *testing.T) {
+	ctx := context.Background()
+	pack, rec, _ := fourthPack(t)
+
+	segment, err := pack.CreateSegment(ctx, "front", "10.40.0.0/24", "green")
+	must(t, err)
+	front := pack.CreateBarrier("front")
+	back := pack.CreateBarrier("back")
+	must(t, pack.AddRule(ctx, front.ID, webRule))
+	// The tiering statement: the back tier accepts the front tier, nobody else.
+	must(t, pack.AddRule(ctx, back.ID, providerfour.Rule{
+		Direction:     "ingress",
+		Action:        "allow",
+		Protocol:      "tcp",
+		SourceBarrier: front.ID,
+		PortFrom:      5432,
+		PortTo:        5432,
+	}))
+
+	node, err := pack.CreateNode(ctx, providerfour.NodeRequest{
+		Name:        "web-1",
+		Image:       "four-linux",
+		HomeSegment: segment.ID,
+		Barriers:    []string{front.ID},
+	})
+	must(t, err)
+	must(t, pack.StartNode(ctx, node.ID))
+
+	set := machine.FirewallName("four", back.ID)
+	var last machine.FirewallSpec
+	for _, event := range rec.Events() {
+		if event.Kind == "EnsureFirewall" && event.Resource == set {
+			last, _ = event.Args.(machine.FirewallSpec)
+		}
+	}
+	if len(last.Rules) == 0 {
+		t.Fatalf("the back tier's rule set was never re-expanded after the front tier booted: %v",
+			rec.Sequence())
+	}
+	if last.Rules[0].Source == "" {
+		t.Errorf("the back tier accepts %q: the tiering statement names the front tier and "+
+			"contains none of its machines, which is #475's own sentence", last.Rules[0].Source)
+	}
+}
+
+// A node the fourth pack deletes leaves no barrier naming it.
+//
+// The mirror of the boot half, and the one nothing in this repository held
+// before: a tiering statement that still names the address of a machine that
+// is gone describes traffic from nowhere, and the address may well be handed
+// to somebody else. It is the pack's to say, because only the pack knows a
+// node's barriers changed — so it is a named test rather than a guarantee.
+func TestTheFourthPacksDeleteReExpandsTheBarriersThatNameIt(t *testing.T) {
+	ctx := context.Background()
+	pack, rec, _ := fourthPack(t)
+
+	segment, err := pack.CreateSegment(ctx, "front", "10.40.0.0/24", "green")
+	must(t, err)
+	front := pack.CreateBarrier("front")
+	back := pack.CreateBarrier("back")
+	must(t, pack.AddRule(ctx, back.ID, providerfour.Rule{
+		Direction:     "ingress",
+		Action:        "allow",
+		Protocol:      "tcp",
+		SourceBarrier: front.ID,
+		PortFrom:      5432,
+		PortTo:        5432,
+	}))
+	node, err := pack.CreateNode(ctx, providerfour.NodeRequest{
+		Name:        "web-1",
+		Image:       "four-linux",
+		HomeSegment: segment.ID,
+		Barriers:    []string{front.ID},
+	})
+	must(t, err)
+	must(t, pack.StartNode(ctx, node.ID))
+
+	set := machine.FirewallName("four", back.ID)
+	written := 0
+	for _, event := range rec.Events() {
+		if event.Kind == "EnsureFirewall" && event.Resource == set {
+			written++
+		}
+	}
+	must(t, pack.DeleteNode(ctx, node.ID))
+
+	var last machine.FirewallSpec
+	rewritten := 0
+	for _, event := range rec.Events() {
+		if event.Kind == "EnsureFirewall" && event.Resource == set {
+			rewritten++
+			last, _ = event.Args.(machine.FirewallSpec)
+		}
+	}
+	if rewritten == written {
+		t.Fatalf("the back tier's rule set was not rewritten when the machine it named was "+
+			"deleted: it still accepts an address nothing answers on, and the next node to take "+
+			"that address inherits the permission. Recorded: %v", rec.Sequence())
+	}
+	for _, rule := range last.Rules {
+		if rule.Source != "" {
+			t.Errorf("the back tier still accepts %q after the only front-tier machine was "+
+				"deleted", rule.Source)
+		}
+	}
+}
+
+// ---- What the fourth pack received without writing it -----------------------
+
+// refusingRuntime is a runtime that takes every gesture except a start.
+//
+// It is the only way to ask the question #484 answers: what does the API say
+// about a machine the host refused to boot? A recorder that always succeeds
+// cannot be asked.
+type refusingRuntime struct{ *machine.Recorder }
+
+func (refusingRuntime) Start(context.Context, machine.Spec) (machine.Machine, error) {
+	return machine.Machine{}, errors.New("this host refuses to start machines")
+}
+
+// The state the fourth pack publishes is the one the effect produced.
+//
+// #484, obtained without writing a line: Binding.PowerOn answers the pack's own
+// FailedState when the host did not deliver, and the pack never touches
+// res.State on the start path. Answering "up" because the request asked for a
+// start is the exact lie this emulator exists to avoid — a client would wait
+// for an address that never comes, on a machine that does not exist.
+func TestTheFourthPackPublishesTheStateTheEffectProduced(t *testing.T) {
+	ctx := context.Background()
+	env := fourthEnv(t, refusingRuntime{machine.NewRecorder()})
+	pack := providerfour.New(env)
+
+	node, err := pack.CreateNode(ctx, providerfour.NodeRequest{Name: "web-1", Image: "four-linux"})
+	must(t, err)
+	must(t, pack.StartNode(ctx, node.ID))
+
+	stored, found := env.Store.Get(providerfour.Name, providerfour.KindNode, node.ID)
+	if !found {
+		t.Fatal("the node is gone")
+	}
+	if stored.State != providerfour.StateBroken {
+		t.Errorf("a start the host refused leaves the node %q, want %q: the published state is "+
+			"the one the effect produced, never the one the intent visited",
+			stored.State, providerfour.StateBroken)
+	}
+	if stored.Runtime["four-node"] != "" {
+		t.Errorf("the node names a machine %q that never started", stored.Runtime["four-node"])
+	}
+}
+
+// The fourth pack cannot route an address it never handed out.
+//
+// Obtained for free, and it is the guard a fourth pack would be least likely
+// to write: a stored address is untrusted input, because PUT /_feint/state and
+// `feint snapshot load` restore Attrs verbatim and the snapshot format is
+// designed to be loaded into another instance. Routing an arbitrary value
+// would send the host's traffic for that address into a container.
+//
+// The hostile value is written straight into the store, which is exactly what
+// a crafted snapshot does — the pack's own API never produces one.
+func TestTheFourthPackRefusesToRouteAnAddressOutsideItsOwnBlock(t *testing.T) {
+	ctx := context.Background()
+	pack, rec, env := fourthPack(t)
+
+	node, err := pack.CreateNode(ctx, providerfour.NodeRequest{Name: "web-1", Image: "four-linux"})
+	must(t, err)
+	must(t, pack.StartNode(ctx, node.ID))
+
+	anchor, err := pack.CreateAnchor()
+	must(t, err)
+	// The address a snapshot could carry: not this pack's block, and a real
+	// address on the operator's own network.
+	hostile, found := env.Store.Get(providerfour.Name, providerfour.KindAnchor, anchor.ID)
+	if !found {
+		t.Fatal("the anchor is gone")
+	}
+	base := hostile.Clone()
+	hostile.Attrs["address"] = "192.168.1.1"
+	if !env.Store.Commit(base, hostile, time.Unix(1700000000, 0).UTC()) {
+		t.Fatal("the crafted anchor could not be written")
+	}
+
+	before := counts(rec)["RouteAddress"]
+	must(t, pack.AttachAnchor(ctx, anchor.ID, node.ID))
+	if after := counts(rec)["RouteAddress"]; after != before {
+		t.Errorf("the runtime was asked to route 192.168.1.1, an address outside this pack's "+
+			"own block: %v", gesturesOn(rec, "192.168.1.1"))
+	}
+
+	// And the accepting half, because a guard that refuses everything passes
+	// every attack test and breaks the product.
+	honest, err := pack.CreateAnchor()
+	must(t, err)
+	must(t, pack.AttachAnchor(ctx, honest.ID, node.ID))
+	if after := counts(rec)["RouteAddress"]; after != before+1 {
+		t.Errorf("an address this pack itself handed out was not routed either: the guard is "+
+			"refusing the product, not the attack — %v", rec.Sequence())
+	}
+}
+
+// The fourth pack's boot attachment rides the launch; its memberships do not.
+//
+// Two lists in the plan rather than one, and the difference is measured rather
+// than aesthetic: editing a live interface re-plugs it and the guest loses its
+// lease. A pack declares which is which; nothing else about it is the pack's.
+func TestTheFourthPacksBootAttachmentRidesTheLaunchAndItsMembershipsDoNot(t *testing.T) {
+	ctx := context.Background()
+	pack, rec, _ := fourthPack(t)
+
+	home, err := pack.CreateSegment(ctx, "front", "10.40.0.0/24", "green")
+	must(t, err)
+	later, err := pack.CreateSegment(ctx, "back", "10.41.0.0/24", "green")
+	must(t, err)
+
+	node, err := pack.CreateNode(ctx, providerfour.NodeRequest{
+		Name:        "web-1",
+		Image:       "four-linux",
+		HomeSegment: home.ID,
+	})
+	must(t, err)
+	must(t, pack.StartNode(ctx, node.ID))
+
+	var spec machine.Spec
+	for _, event := range rec.Events() {
+		if event.Kind == "Start" {
+			spec, _ = event.Args.(machine.Spec)
+		}
+	}
+	if len(spec.Attachments) != 1 || spec.Attachments[0].Network != home.Runtime["four-segment"] {
+		t.Fatalf("the launch carried %v, not the node's home segment: an attachment that does "+
+			"not ride the start is one the driver has to add to a live machine",
+			spec.Attachments)
+	}
+	if attached := counts(rec)["Attach"]; attached != 0 {
+		t.Errorf("%d interface(s) were attached to a machine that had just declared them on its "+
+			"boot plan", attached)
+	}
+
+	must(t, pack.JoinSegment(ctx, node.ID, later.ID))
+	if attached := counts(rec)["Attach"]; attached != 1 {
+		t.Errorf("a segment joined on a running node produced %d attach(es), want 1", attached)
+	}
+}
+
+// The fourth pack's segments reach each other only when they share a realm.
+//
+// The predicate is the pack's — it is the one thing about isolation only a
+// provider knows — and everything else is the shared pass: which runtimes need
+// peering and which need reject rules, what a network deleted under the pass
+// means, and the fact that there is exactly one writer. Two packs of three had
+// written this loop before it was shared, and a fourth would have written it a
+// fourth time.
+func TestTheFourthPacksSegmentsReachEachOtherOnlyInTheSameRealm(t *testing.T) {
+	ctx := context.Background()
+	pack, rec, _ := fourthPack(t)
+
+	green, err := pack.CreateSegment(ctx, "green-1", "10.40.0.0/24", "green")
+	must(t, err)
+	blue, err := pack.CreateSegment(ctx, "blue-1", "10.41.0.0/24", "blue")
+	must(t, err)
+	sameRealm, err := pack.CreateSegment(ctx, "green-2", "10.42.0.0/24", "green")
+	must(t, err)
+
+	peers := map[string][]string{}
+	for _, event := range rec.Events() {
+		if event.Kind != "PeerNetworks" {
+			continue
+		}
+		list, _ := event.Args.([]string)
+		peers[event.Resource] = append([]string(nil), list...)
+	}
+	for _, want := range []struct {
+		network string
+		peers   []string
+	}{
+		{green.Runtime["four-segment"], []string{sameRealm.Runtime["four-segment"]}},
+		{sameRealm.Runtime["four-segment"], []string{green.Runtime["four-segment"]}},
+		{blue.Runtime["four-segment"], nil},
+	} {
+		got := peers[want.network]
+		sort.Strings(got)
+		sort.Strings(want.peers)
+		if strings.Join(got, ",") != strings.Join(want.peers, ",") {
+			t.Errorf("%s is peered with %v, want %v", want.network, got, want.peers)
+		}
+	}
+
+	// The other half of the fork, on a runtime whose networks are born joined:
+	// the same predicate, expressed as reject rules instead of peerings, and
+	// the pack says nothing about which.
+	joined := machine.NewRecorder()
+	joined.Joined = true
+	env := fourthEnv(t, joined)
+	other := providerfour.New(env)
+	first, err := other.CreateSegment(ctx, "green-1", "10.40.0.0/24", "green")
+	must(t, err)
+	_, err = other.CreateSegment(ctx, "blue-1", "10.41.0.0/24", "blue")
+	must(t, err)
+
+	var foreign []string
+	for _, event := range joined.Events() {
+		if event.Kind == "IsolateNetwork" && event.Resource == first.Runtime["four-segment"] {
+			foreign, _ = event.Args.([]string)
+		}
+	}
+	if len(foreign) != 1 || foreign[0] != "10.41.0.0/24" {
+		t.Errorf("the green segment keeps %v out, want the blue segment's block: the same "+
+			"predicate has to hold on both runtimes, and the pack never chose between them", foreign)
+	}
+}
+
+// The fourth pack records what the runtime took, and tells a limit from an
+// incident.
+//
+// #481 and #483, both obtained: a host balancer distributing to nobody while
+// the API described two healthy backends was found by a person reading the
+// host, because the only trace was a WARN. Here the delivery is written onto
+// the resource, readable through /_feint/state; and a runtime that does not
+// balance answers a named limit rather than an empty delivery, which reads
+// exactly like a balancer with no backend — a state every stack passes
+// through.
+func TestTheFourthPacksSpreaderRecordsTheDeliveryAndNotTheIntent(t *testing.T) {
+	ctx := context.Background()
+	pack, _, env := fourthPack(t)
+
+	segment, err := pack.CreateSegment(ctx, "front", "10.40.0.0/24", "green")
+	must(t, err)
+	node, err := pack.CreateNode(ctx, providerfour.NodeRequest{
+		Name:        "web-1",
+		Image:       "four-linux",
+		HomeSegment: segment.ID,
+	})
+	must(t, err)
+	must(t, pack.StartNode(ctx, node.ID))
+
+	spreader, err := pack.CreateSpreader(ctx, "front-443", segment.ID, 443)
+	must(t, err)
+	must(t, pack.RegisterBackend(ctx, spreader.ID, node.ID))
+
+	stored, found := env.Store.Get(providerfour.Name, providerfour.KindSpreader, spreader.ID)
+	if !found {
+		t.Fatal("the spreader is gone")
+	}
+	if got := stored.Runtime[machine.RuntimeBalancerDistributed]; got != "10.40.0.10" {
+		t.Errorf("the spreader records %q as distributed, want the backend's own address", got)
+	}
+
+	// A runtime that cannot balance: the pack leaves its family a record and
+	// asks the host for nothing, rather than reporting nothing distributed
+	// with no reason beside it.
+	silent := fourthEnv(t, machine.Noop{})
+	quiet := providerfour.New(silent)
+	other, err := quiet.CreateSegment(ctx, "front", "10.40.0.0/24", "green")
+	must(t, err)
+	balancer, err := quiet.CreateSpreader(ctx, "front-443", other.ID, 443)
+	must(t, err)
+	held, found := silent.Store.Get(providerfour.Name, providerfour.KindSpreader, balancer.ID)
+	if !found {
+		t.Fatal("the spreader is gone")
+	}
+	if _, recorded := held.Runtime[machine.RuntimeBalancerDistributed]; recorded {
+		t.Errorf("a runtime that does not balance produced a delivery record: %v", held.Runtime)
+	}
+}
+
+// ---- What the fourth pack rediscovered on its own ---------------------------
+
+// The fourth pack's balancer keeps its port across a snapshot.
+//
+// This test exists because the fake pack got it wrong first, which makes it the
+// most useful thing in this file: `res.Attrs["port"].(int)` is what anybody
+// writes, and it is wrong. Attrs is decoded as map[string]any, so a stored
+// number comes back a float64 and the int assertion yields zero — a balancer
+// listening on port 0 after `feint snapshot load`, with the API still
+// describing 443.
+//
+// It is a rediscovery, not a discovery, and that is the finding:
+// exoscale/privatenetworks.go carries intOf with the same one-line explanation,
+// and the two other real packs do not — outscale/volumes.go and
+// outscale/snapshots.go read Attrs["Size"].(int) at three sites. A lesson
+// living in one pack of three is a lesson a fourth pack cannot inherit, which
+// is #475's shape one storey below the runtime contract.
+func TestTheFourthPacksSpreaderKeepsItsPortAcrossASnapshot(t *testing.T) {
+	ctx := context.Background()
+	pack, _, env := fourthPack(t)
+
+	segment, err := pack.CreateSegment(ctx, "front", "10.40.0.0/24", "green")
+	must(t, err)
+	node, err := pack.CreateNode(ctx, providerfour.NodeRequest{
+		Name:        "web-1",
+		Image:       "four-linux",
+		HomeSegment: segment.ID,
+	})
+	must(t, err)
+	must(t, pack.StartNode(ctx, node.ID))
+	spreader, err := pack.CreateSpreader(ctx, "front-443", segment.ID, 443)
+	must(t, err)
+
+	// Through the door a snapshot really travels: the format is documented as
+	// meant to outlive its instance and be loaded into another one.
+	var saved bytes.Buffer
+	if err := env.Store.Snapshot(&saved); err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	restored := store.New()
+	if err := restored.Restore(bytes.NewReader(saved.Bytes())); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	rec := machine.NewRecorder()
+	next := fourthEnv(t, rec)
+	next.Store = restored
+	revived := providerfour.New(next)
+	must(t, revived.RegisterBackend(ctx, spreader.ID, node.ID))
+
+	var spec machine.BalancerSpec
+	for _, event := range rec.Events() {
+		if event.Kind == "EnsureBalancer" {
+			spec, _ = event.Args.(machine.BalancerSpec)
+		}
+	}
+	if len(spec.Listeners) != 1 {
+		t.Fatalf("the revived spreader was handed over with %d listener(s): %v", len(spec.Listeners), spec)
+	}
+	if spec.Listeners[0].Listen != 443 {
+		t.Errorf("the revived spreader listens on %d, want 443: a stored number comes back a "+
+			"float64, so the plain int assertion yields zero and the host distributes a port "+
+			"nothing asked for while the API still describes 443",
+			spec.Listeners[0].Listen)
+	}
+}
+
+// ---- The fourth pack is a resource like any other ---------------------------
+
+// The fourth pack's own store use obeys the shared write-back.
+//
+// Not a machine property, and it is here because it is the trap the contract
+// cannot see: resource.Clone shares nested values with the store, so a pack
+// writing into a map it read out of Attrs writes through the store's own copy,
+// outside every lock and every conditional write-back. updateNic paid for this
+// once (#295); a fourth pack has no scar to remember it by.
+//
+// The map rather than the slice, and that distinction is measured rather than
+// assumed: appending to a slice read out of Attrs reallocates whenever the
+// capacity is exhausted, so the aliasing shows up only sometimes and a test
+// built on it passes for the wrong reason. Writing a key into a shared map
+// aliases every time.
+func TestTheFourthPacksNestedAttributesAreNeverWrittenThroughTheStore(t *testing.T) {
+	ctx := context.Background()
+	pack, _, env := fourthPack(t)
+
+	home, err := pack.CreateSegment(ctx, "front", "10.40.0.0/24", "green")
+	must(t, err)
+	later, err := pack.CreateSegment(ctx, "back", "10.41.0.0/24", "green")
+	must(t, err)
+	node, err := pack.CreateNode(ctx, providerfour.NodeRequest{
+		Name:        "web-1",
+		Image:       "four-linux",
+		HomeSegment: home.ID,
+	})
+	must(t, err)
+	must(t, pack.StartNode(ctx, node.ID))
+
+	// The copy a client is holding — a read that has already answered — while
+	// another request joins a second segment.
+	stored, found := env.Store.Get(providerfour.Name, providerfour.KindNode, node.ID)
+	if !found {
+		t.Fatal("the node is gone")
+	}
+	held, _ := stored.Attrs["addresses"].(map[string]string)
+	if len(held) != 1 {
+		t.Fatalf("the node carries %d address(es) on one segment, want 1: %v", len(held), held)
+	}
+
+	must(t, pack.JoinSegment(ctx, node.ID, later.ID))
+
+	if len(held) != 1 {
+		t.Errorf("the answer already given to a reader now carries %d addresses: the pack wrote "+
+			"into a map the store still shares, outside the lock and outside the conditional "+
+			"write-back — %v", len(held), held)
+	}
+	after, found := env.Store.Get(providerfour.Name, providerfour.KindNode, node.ID)
+	if !found {
+		t.Fatal("the node is gone")
+	}
+	if addresses, _ := after.Attrs["addresses"].(map[string]string); len(addresses) != 2 {
+		t.Errorf("the store holds %d address(es) after a second segment was joined", len(addresses))
+	}
+}

--- a/internal/cli/runtime_blindness_test.go
+++ b/internal/cli/runtime_blindness_test.go
@@ -449,7 +449,11 @@ func TestNoPackKnowsWhichRuntimeIsBehindTheDriver(t *testing.T) {
 
 	var offences []string
 	files, literals := 0, 0
-	for _, dir := range packDirs(t) {
+	// The fourth pack is read here too (#517), and for the same reason the
+	// surface test reads it: a rule ratified on three packs that were cleaned
+	// up is a rule nobody has yet asked a newcomer to obey. It carries no
+	// exemption, where the three real packs carry three.
+	for _, dir := range disciplinedPackDirs(t) {
 		scan := runtimeKnowledgeLeaks(t, dir, tells, named)
 		files += scan.files
 		literals += scan.literals

--- a/internal/cli/testdata/provider-four/intents.go
+++ b/internal/cli/testdata/provider-four/intents.go
@@ -1,0 +1,896 @@
+package providerfour
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/netip"
+	"sort"
+
+	"github.com/stephrobert/feint/internal/core/machine"
+	"github.com/stephrobert/feint/internal/core/resource"
+	"github.com/stephrobert/feint/internal/core/store"
+)
+
+// Everything Provider Four lets a user ask for, in the order a user asks it.
+//
+// There are no routes here and no wire dialect: this pack is driven by Go
+// calls, because what #517 measures is whether the runtime contract suffices
+// for a newcomer, and a JSON shape would measure this file's own invention
+// instead. Each operation below is one intent — declare a segment, hand a
+// barrier over, boot a node, publish an address — and the comment on it says
+// what the pack had to supply and what the shared layer did on its own.
+
+// ErrNoSuchResource is what this pack answers for an identifier it does not
+// hold. A real pack would translate it into its provider's error dialect,
+// which is the one part of a pack that must never be shared.
+var ErrNoSuchResource = errors.New("four: no such resource")
+
+// ---- Segments: a private network, and keeping it apart --------------------
+
+// CreateSegment declares a private network and gives it a real one on the
+// host.
+//
+// What the pack supplies: the block, whether the runtime should reserve a
+// gateway in it, whether machines on it reach outward, and the label a sweep
+// finds an orphan by. What it never supplies is the network's host-side name —
+// EnsureBackingNetwork derives it, hands it to the runtime, and records it on
+// the resource only once the runtime accepted it. A pack writing that key
+// first keeps, on failure, a Runtime entry naming a network that does not
+// exist, and the delete path then tries to remove it.
+//
+// The isolation pass runs on every create, not on the new segment alone: a
+// reconciliation only has to be right about what is, where a patch has to be
+// right about what changed.
+func (p *Pack) CreateSegment(ctx context.Context, name, cidr, realm string) (*resource.Resource, error) {
+	block, err := netip.ParsePrefix(cidr)
+	if err != nil {
+		return nil, fmt.Errorf("four: %q is not a block: %w", cidr, err)
+	}
+	res := resource.New(p.env.NewID(), KindSegment, tenant(), StateUp, p.env.Now())
+	res.Attrs["name"] = name
+	res.Attrs["block"] = block.Masked().String()
+	res.Attrs["realm"] = realm
+
+	if err := p.binding().EnsureBackingNetwork(ctx, res, machine.BackingNetwork{
+		Key:     runtimeSegmentKey,
+		CIDR:    block,
+		Gateway: true,
+		NAT:     false,
+		Marker:  segmentMarker,
+	}); err != nil {
+		return nil, fmt.Errorf("four: the segment has no network: %w", err)
+	}
+	p.env.Store.Put(res)
+	p.ReconcileSegments(ctx)
+	return res, nil
+}
+
+// DeleteSegment takes the network away and forgets its name.
+//
+// The error comes back rather than being swallowed: reporting a segment gone
+// while the runtime still holds its block is the kind of half-truth this
+// emulator exists to avoid. Whether to refuse the delete or to log and proceed
+// is client-visible surface, so the shared layer leaves the choice here; this
+// pack refuses.
+func (p *Pack) DeleteSegment(ctx context.Context, id string) error {
+	res, found := p.env.Store.Get(Name, KindSegment, id)
+	if !found {
+		return ErrNoSuchResource
+	}
+	if err := p.binding().RemoveBackingNetwork(ctx, res, runtimeSegmentKey); err != nil {
+		return fmt.Errorf("four: the segment's network is still there: %w", err)
+	}
+	p.env.Store.Delete(Name, KindSegment, id)
+	p.ReconcileSegments(ctx)
+	return nil
+}
+
+// ReconcileSegments applies what every segment may reach, over the whole set.
+//
+// Provider Four's model, and the only part of this that is its own: two
+// segments reach each other when they declare the same realm. The pass itself
+// — which runtimes need peering and which need reject rules, what a vanished
+// network means, what to log — belongs to the shared layer, and there is one
+// writer for it.
+func (p *Pack) ReconcileSegments(ctx context.Context) (native, applied bool) {
+	segments := p.env.Store.List(KindSegment, tenant())
+	sort.Slice(segments, func(i, j int) bool { return segments[i].ID < segments[j].ID })
+
+	members := make([]machine.IsolationMember, 0, len(segments))
+	for _, segment := range segments {
+		members = append(members, machine.IsolationMember{
+			ID:      segment.ID,
+			Network: segment.Runtime[runtimeSegmentKey],
+			Block:   attrString(segment, "block"),
+		})
+	}
+	return p.binding().ReconcileIsolation(ctx, KindSegment, members, func(from, to int) bool {
+		return attrString(segments[from], "realm") == attrString(segments[to], "realm")
+	})
+}
+
+// ---- Barriers: a rule set, and what it means ------------------------------
+
+// Rule is one rule of a barrier, in Provider Four's own words.
+//
+// SourceBarrier is the half that makes a rule set more than a list of blocks:
+// a rule may name another barrier instead of a block, and then it means every
+// node wearing that barrier. It is also the half a fourth pack forgets — see
+// SyncReferrers below, and #475, which is exactly this sentence never
+// containing the machines it talks about.
+type Rule struct {
+	Direction     string
+	Action        string
+	Protocol      string
+	Source        string
+	SourceBarrier string
+	PortFrom      int
+	PortTo        int
+}
+
+// CreateBarrier declares an empty rule set. Nothing reaches the runtime yet:
+// an empty barrier nobody wears has nothing to enforce.
+func (p *Pack) CreateBarrier(name string) *resource.Resource {
+	res := resource.New(p.env.NewID(), KindBarrier, tenant(), StateUp, p.env.Now())
+	res.Attrs["name"] = name
+	res.Attrs["rules"] = []Rule{}
+	p.env.Store.Put(res)
+	return res
+}
+
+// AddRule adds one rule and hands the whole set to the runtime.
+//
+// The hand-off is the line #475 was born from: without it the API describes a
+// rule nothing enforces, every gate stays green, and the defect lives for
+// months. Nothing in the contract can force this call — the pack is the only
+// party that knows its rules changed — so it is held by a named test instead:
+// internal/cli's TestTheFourthPacksRuleChangeReachesTheRuntime, which is red
+// when this line is removed.
+//
+// The rules are replaced rather than appended in place: resource.Clone shares
+// nested values with the store, so a pack that appended to the stored slice
+// would be writing through the store's own copy.
+func (p *Pack) AddRule(ctx context.Context, barrierID string, rule Rule) error {
+	res, found := p.env.Store.Get(Name, KindBarrier, barrierID)
+	if !found {
+		return ErrNoSuchResource
+	}
+	base := res.Clone()
+	previous := rulesOf(res)
+	next := make([]Rule, 0, len(previous)+1)
+	next = append(next, previous...)
+	next = append(next, rule)
+	res.Attrs["rules"] = next
+	if !p.env.Store.Commit(base, res, p.env.Now()) {
+		return ErrNoSuchResource
+	}
+	p.groups().SyncGroup(ctx, res, nil)
+	return nil
+}
+
+// DeleteBarrier removes the rule set from the runtime and forgets it.
+func (p *Pack) DeleteBarrier(ctx context.Context, id string) error {
+	res, found := p.env.Store.Get(Name, KindBarrier, id)
+	if !found {
+		return ErrNoSuchResource
+	}
+	p.groups().Drop(ctx, machine.FirewallName(rulesetPrefix, res.ID))
+	p.env.Store.Delete(Name, KindBarrier, id)
+	return nil
+}
+
+// barrierSpec translates one barrier into the rule set the runtime takes. This
+// is the pack's whole contribution to the firewall: its own vocabulary, its
+// own defaults, and its own idea of what a rule naming another barrier means.
+//
+// fresh wins over the store's copy of the same resource, and that threading is
+// not this pack's cleverness — the skeleton hands it down. The boot that
+// triggers a re-expansion runs before its own commit, so the store does not
+// yet carry the address the expansion is being run for, and reading the store
+// alone here would silently miss the very node that booted.
+func (p *Pack) barrierSpec(group, fresh *resource.Resource) machine.FirewallSpec {
+	spec := machine.FirewallSpec{
+		Name:           machine.FirewallName(rulesetPrefix, group.ID),
+		DefaultIngress: "drop",
+		DefaultEgress:  "allow",
+	}
+	for _, rule := range rulesOf(group) {
+		shape := machine.FirewallRule{
+			Direction: rule.Direction,
+			Action:    rule.Action,
+			Protocol:  rule.Protocol,
+			PortFrom:  rule.PortFrom,
+			PortTo:    rule.PortTo,
+		}
+		if rule.SourceBarrier == "" {
+			shape.Source = rule.Source
+			shape.Destination = ""
+			spec.Rules = append(spec.Rules, shape)
+			continue
+		}
+		for _, address := range p.addressesWearing(rule.SourceBarrier, fresh) {
+			member := shape
+			member.Source = address + "/32"
+			spec.Rules = append(spec.Rules, member)
+		}
+	}
+	return spec
+}
+
+// barrierWearers lists the nodes wearing a barrier, so a changed set is
+// replayed onto every one of them.
+func (p *Pack) barrierWearers(group *resource.Resource) []*resource.Resource {
+	var wearers []*resource.Resource
+	for _, node := range p.nodes() {
+		for _, id := range wornBarriers(node) {
+			if id == group.ID {
+				wearers = append(wearers, node)
+				break
+			}
+		}
+	}
+	return wearers
+}
+
+// wornBarriers lists the barriers one node wears.
+func (p *Pack) wornBarriers(res *resource.Resource) []string { return wornBarriers(res) }
+
+// barrier resolves a worn identifier to its stored barrier.
+func (p *Pack) barrier(id string) (*resource.Resource, bool) {
+	return p.env.Store.Get(Name, KindBarrier, id)
+}
+
+// barrierReferrers lists the barriers one of whose rules names one of the
+// given barriers as a member source — the half of AfterBoot that makes a
+// tiering statement contain the machines it talks about.
+func (p *Pack) barrierReferrers(named map[string]bool) []*resource.Resource {
+	var referrers []*resource.Resource
+	for _, group := range p.env.Store.List(KindBarrier, tenant()) {
+		for _, rule := range rulesOf(group) {
+			if rule.SourceBarrier != "" && named[rule.SourceBarrier] {
+				referrers = append(referrers, group)
+				break
+			}
+		}
+	}
+	sort.Slice(referrers, func(i, j int) bool { return referrers[i].ID < referrers[j].ID })
+	return referrers
+}
+
+// addressesWearing lists the private addresses of every node wearing a
+// barrier, with fresh preferred over its stale store copy.
+func (p *Pack) addressesWearing(barrierID string, fresh *resource.Resource) []string {
+	var addresses []string
+	for _, node := range p.nodes() {
+		if fresh != nil && node.ID == fresh.ID {
+			node = fresh
+		}
+		worn := false
+		for _, id := range wornBarriers(node) {
+			if id == barrierID {
+				worn = true
+				break
+			}
+		}
+		if !worn {
+			continue
+		}
+		if address := p.binding().AddressOf(node); address != "" {
+			addresses = append(addresses, address)
+		}
+	}
+	sort.Strings(addresses)
+	return addresses
+}
+
+// ---- Nodes: the machine, and its boot -------------------------------------
+
+// NodeRequest is what a user asks for when it asks for a machine.
+type NodeRequest struct {
+	Name string
+	// Image is an identifier of this pack's own catalogue. One that resolves
+	// to nothing is refused at boot rather than substituted, which is the
+	// shared layer's rule: a stack that asked for one distribution and got
+	// another boots and then fails at its first package install.
+	Image string
+	// HomeSegment is the segment the node is born on, empty for a node born
+	// bare. It rides the launch rather than being attached afterwards.
+	HomeSegment string
+	// Barriers are the rule sets it wears.
+	Barriers []string
+	// Public asks for an anchor allocated at create, so the address rides the
+	// boot instead of being routed onto a live interface.
+	Public bool
+	// UserData replaces the generated boot configuration when the user
+	// supplied its own.
+	UserData string
+}
+
+// CreateNode stores the machine. Nothing runs yet: a node is born down, and
+// the boot is a separate intent, which is what every one of these clouds does.
+func (p *Pack) CreateNode(ctx context.Context, req NodeRequest) (*resource.Resource, error) {
+	res := resource.New(p.env.NewID(), KindNode, tenant(), StateDown, p.env.Now())
+	res.Attrs["name"] = req.Name
+	res.Attrs["image"] = req.Image
+	res.Attrs["barriers"] = append([]string(nil), req.Barriers...)
+	res.Attrs["segments"] = []string{}
+	res.Attrs["addresses"] = map[string]string{}
+	res.Attrs["user_data"] = req.UserData
+
+	if req.HomeSegment != "" {
+		segment, found := p.env.Store.Get(Name, KindSegment, req.HomeSegment)
+		if !found {
+			return nil, ErrNoSuchResource
+		}
+		address, ok := p.allocate(segment, res.ID)
+		if !ok {
+			return nil, fmt.Errorf("four: the segment %s has no address left", segment.ID)
+		}
+		res.Attrs["home_segment"] = req.HomeSegment
+		res.Attrs["addresses"] = map[string]string{req.HomeSegment: address}
+	}
+	p.env.Store.Put(res)
+
+	if req.Public {
+		anchor, err := p.CreateAnchor()
+		if err != nil {
+			return nil, err
+		}
+		if err := p.AttachAnchor(ctx, anchor.ID, res.ID); err != nil {
+			return nil, err
+		}
+	}
+	stored, found := p.env.Store.Get(Name, KindNode, res.ID)
+	if !found {
+		return nil, ErrNoSuchResource
+	}
+	return stored, nil
+}
+
+// StartNode boots the node on its declared plan.
+//
+// Three things the pack does not do here, and each is a defect it therefore
+// cannot have. It does not publish a state: Binding.PowerOn writes the one the
+// effect produced, so a start that failed answers "broken" and not "up". It
+// does not name its own machine: the shared layer derives it from the prefix
+// and records it out of reach of the API. And it does not order the boot: the
+// promised addresses, then the memberships, then the firewall is a property of
+// the runtime, and Reconciler.PowerOn is where it lives.
+//
+// Boot.Attachments and Boot.PublicAddresses are deliberately not set: the
+// reconciler fills them from the plan, and a pack setting them would be
+// declaring its interface shape in two places.
+func (p *Pack) StartNode(ctx context.Context, id string) error {
+	return p.binding().Transition(p.env.Store, p.env.Now, KindNode, id, func(res *resource.Resource) {
+		image, requested := p.image(res)
+		p.reconciler().PowerOn(ctx, res, machine.Boot{
+			Image:     image.Ref,
+			Requested: requested,
+			User:      image.User,
+			Hostname:  attrString(res, "name"),
+			CloudInit: attrString(res, "user_data"),
+			Labels:    map[string]string{"feint.node": res.ID},
+		})
+	})
+}
+
+// StopNode stops the machine and withdraws its address.
+//
+// The withdrawal is the shared layer's, and it is not tidiness: an address the
+// API publishes and nothing answers on is the defect this project exists to
+// avoid, and a stopped machine produces exactly that if nobody removes it.
+//
+// The state is the pack's here, where the start's was not, and the asymmetry
+// is real rather than an oversight: a stop that the runtime refused still
+// leaves the API describing a machine the user asked to be down. That gap is
+// the residue #514 lists honestly rather than hides.
+func (p *Pack) StopNode(ctx context.Context, id string) error {
+	return p.binding().Transition(p.env.Store, p.env.Now, KindNode, id, func(res *resource.Resource) {
+		p.binding().PowerOff(ctx, res)
+		res.State = StateDown
+	})
+}
+
+// DeleteNode destroys the machine and forgets the node.
+//
+// The last call is the one a fourth pack forgets: a deleted node changes what
+// every barrier naming its barriers means, and nothing in the contract can
+// know that. SyncReferrers is the door, and internal/cli's
+// TestTheFourthPacksDeleteReExpandsTheBarriersThatNameIt is red without it.
+func (p *Pack) DeleteNode(ctx context.Context, id string) error {
+	res, found := p.env.Store.Get(Name, KindNode, id)
+	if !found {
+		return ErrNoSuchResource
+	}
+	worn := wornBarriers(res)
+	name := res.Runtime[p.binding().RuntimeKey]
+	for _, address := range p.anchorsOf(res.ID) {
+		p.reconciler().Unroute(ctx, name, address)
+	}
+	p.binding().Destroy(ctx, res)
+	p.env.Store.Delete(Name, KindNode, id)
+	p.releaseAnchors(id)
+	p.groups().SyncReferrers(ctx, worn, nil)
+	return nil
+}
+
+// ReadNode answers what the store holds, having first asked the host for an
+// address the boot did not deliver in time.
+//
+// A container answers immediately; a virtual machine answers tens of seconds
+// later. So a start never waits and a read fills the gap, under the same
+// conditional write-back every other path uses.
+func (p *Pack) ReadNode(ctx context.Context, id string) (*resource.Resource, error) {
+	res, err := p.binding().Observe(p.env.Store, p.env.Now, KindNode, id, func(res *resource.Resource) bool {
+		changed := p.binding().RefreshIfRunning(ctx, res)
+		if changed {
+			// The late-address door: a virtual machine's agent answers long
+			// after the boot returned, and the guest half of its routes can
+			// only land then.
+			p.reconciler().ReplayAddresses(ctx, res)
+		}
+		return changed
+	})
+	if errors.Is(err, store.ErrNotFound) {
+		// The core reports one absence; a pack answers it in its own dialect,
+		// which is the half of a pack that must never be shared.
+		return nil, ErrNoSuchResource
+	}
+	return res, err
+}
+
+// AddressOfNode is the private address the machine answers on, empty when
+// nothing is running.
+func (p *Pack) AddressOfNode(res *resource.Resource) string {
+	return p.binding().AddressOf(res)
+}
+
+// image resolves the identifier the user sent through this pack's own
+// catalogue, then through the operator's declarations. Unresolved returns the
+// zero value, which the shared layer refuses to boot rather than substituting.
+func (p *Pack) image(res *resource.Resource) (machine.Image, string) {
+	requested := attrString(res, "image")
+	if image, found := images[requested]; found {
+		return image, requested
+	}
+	return machine.Image{}, requested
+}
+
+// nodes lists this pack's machines, in a stable order.
+func (p *Pack) nodes() []*resource.Resource {
+	nodes := p.env.Store.List(KindNode, tenant())
+	sort.Slice(nodes, func(i, j int) bool { return nodes[i].ID < nodes[j].ID })
+	return nodes
+}
+
+// ---- Memberships: joining a running machine to a segment ------------------
+
+// JoinSegment puts a running node on one more segment.
+//
+// The hot half of a membership, which cannot fold into a boot-time plan: a
+// cloud attaches an interface to a machine that is running. The pack allocates
+// the address and writes the membership; the shared layer attaches the
+// interface and resyncs the firewall, because the new interface carries the
+// node's rule sets like every other one.
+func (p *Pack) JoinSegment(ctx context.Context, nodeID, segmentID string) error {
+	segment, found := p.env.Store.Get(Name, KindSegment, segmentID)
+	if !found {
+		return ErrNoSuchResource
+	}
+	res, found := p.env.Store.Get(Name, KindNode, nodeID)
+	if !found {
+		return ErrNoSuchResource
+	}
+	address, ok := p.allocate(segment, nodeID)
+	if !ok {
+		return fmt.Errorf("four: the segment %s has no address left", segmentID)
+	}
+
+	base := res.Clone()
+	res.Attrs["segments"] = appendUnique(membershipsOf(res), segmentID)
+	res.Attrs["addresses"] = withAddress(addressesOf(res), segmentID, address)
+	if !p.env.Store.Commit(base, res, p.env.Now()) {
+		return ErrNoSuchResource
+	}
+
+	att, ok := p.attachment(res, segmentID)
+	if !ok {
+		return nil
+	}
+	return p.reconciler().Join(ctx, res, att)
+}
+
+// LeaveSegment takes the node off a segment. The exact undo of Join's attach
+// half; the membership and the address go from the store either way.
+func (p *Pack) LeaveSegment(ctx context.Context, nodeID, segmentID string) error {
+	segment, found := p.env.Store.Get(Name, KindSegment, segmentID)
+	if !found {
+		return ErrNoSuchResource
+	}
+	res, found := p.env.Store.Get(Name, KindNode, nodeID)
+	if !found {
+		return ErrNoSuchResource
+	}
+	base := res.Clone()
+	res.Attrs["segments"] = without(membershipsOf(res), segmentID)
+	res.Attrs["addresses"] = withoutAddress(addressesOf(res), segmentID)
+	if !p.env.Store.Commit(base, res, p.env.Now()) {
+		return ErrNoSuchResource
+	}
+	p.reconciler().Leave(ctx, res, segment.Runtime[runtimeSegmentKey])
+	return nil
+}
+
+// ---- Anchors: a public address ---------------------------------------------
+
+// CreateAnchor allocates one public address out of this pack's own block.
+func (p *Pack) CreateAnchor() (*resource.Resource, error) {
+	taken := map[string]bool{}
+	for _, anchor := range p.env.Store.List(KindAnchor, tenant()) {
+		taken[attrString(anchor, "address")] = true
+	}
+	address, ok := freeAddress(publicBlock, 1, taken)
+	if !ok {
+		return nil, errors.New("four: the public block is exhausted")
+	}
+	res := resource.New(p.env.NewID(), KindAnchor, tenant(), StateUp, p.env.Now())
+	res.Attrs["address"] = address
+	res.Attrs["node"] = ""
+	p.env.Store.Put(res)
+	return res, nil
+}
+
+// AttachAnchor makes the address reach the node.
+//
+// The pack says which address must reach which machine and nothing else. The
+// block guard is the shared layer's — a stored address is untrusted input, and
+// routing one from outside this pack's own block would send the host's traffic
+// for it into a container — and so is the question of whether the runtime can
+// route at all.
+func (p *Pack) AttachAnchor(ctx context.Context, anchorID, nodeID string) error {
+	anchor, found := p.env.Store.Get(Name, KindAnchor, anchorID)
+	if !found {
+		return ErrNoSuchResource
+	}
+	node, found := p.env.Store.Get(Name, KindNode, nodeID)
+	if !found {
+		return ErrNoSuchResource
+	}
+	base := anchor.Clone()
+	anchor.Attrs["node"] = nodeID
+	if !p.env.Store.Commit(base, anchor, p.env.Now()) {
+		return ErrNoSuchResource
+	}
+	p.reconciler().Route(ctx, node, attrString(anchor, "address"))
+	return nil
+}
+
+// DetachAnchor takes the route back.
+//
+// It takes the machine name rather than the resource, because the machine may
+// already be gone and the route may still be there — on a runtime whose
+// addresses outlive their machine, withdrawing it is the whole point.
+func (p *Pack) DetachAnchor(ctx context.Context, anchorID string) error {
+	anchor, found := p.env.Store.Get(Name, KindAnchor, anchorID)
+	if !found {
+		return ErrNoSuchResource
+	}
+	name := ""
+	if node, found := p.env.Store.Get(Name, KindNode, attrString(anchor, "node")); found {
+		name = node.Runtime[p.binding().RuntimeKey]
+	}
+	p.reconciler().Unroute(ctx, name, attrString(anchor, "address"))
+
+	base := anchor.Clone()
+	anchor.Attrs["node"] = ""
+	if !p.env.Store.Commit(base, anchor, p.env.Now()) {
+		return ErrNoSuchResource
+	}
+	return nil
+}
+
+// anchorsOf lists the public addresses promised to a node.
+func (p *Pack) anchorsOf(nodeID string) []string {
+	var addresses []string
+	for _, anchor := range p.env.Store.List(KindAnchor, tenant()) {
+		if attrString(anchor, "node") == nodeID {
+			addresses = append(addresses, attrString(anchor, "address"))
+		}
+	}
+	sort.Strings(addresses)
+	return addresses
+}
+
+// releaseAnchors unlinks every anchor a deleted node held, so no address stays
+// published against a machine that is gone.
+func (p *Pack) releaseAnchors(nodeID string) {
+	for _, anchor := range p.env.Store.List(KindAnchor, tenant()) {
+		if attrString(anchor, "node") != nodeID {
+			continue
+		}
+		base := anchor.Clone()
+		anchor.Attrs["node"] = ""
+		p.env.Store.Commit(base, anchor, p.env.Now())
+	}
+}
+
+// ---- Spreaders: a balancer -------------------------------------------------
+
+// CreateSpreader declares a balancer on a segment and hands it to the runtime.
+func (p *Pack) CreateSpreader(ctx context.Context, name, segmentID string, port int) (*resource.Resource, error) {
+	if _, found := p.env.Store.Get(Name, KindSegment, segmentID); !found {
+		return nil, ErrNoSuchResource
+	}
+	res := resource.New(p.env.NewID(), KindSpreader, tenant(), StateUp, p.env.Now())
+	res.Attrs["name"] = name
+	res.Attrs["segment"] = segmentID
+	res.Attrs["port"] = port
+	res.Attrs["backends"] = []string{}
+	p.env.Store.Put(res)
+	p.deliver(ctx, res)
+	return res, nil
+}
+
+// RegisterBackend puts one node behind the spreader and hands the whole
+// balancer over again.
+//
+// Whole, and not patched member by member: replacing is what makes a backend
+// removed upstream actually stop receiving connections.
+func (p *Pack) RegisterBackend(ctx context.Context, spreaderID, nodeID string) error {
+	res, found := p.env.Store.Get(Name, KindSpreader, spreaderID)
+	if !found {
+		return ErrNoSuchResource
+	}
+	base := res.Clone()
+	res.Attrs["backends"] = appendUnique(backendsOf(res), nodeID)
+	if !p.env.Store.Commit(base, res, p.env.Now()) {
+		return ErrNoSuchResource
+	}
+	p.deliver(ctx, res)
+	return nil
+}
+
+// DeleteSpreader withdraws the balancer and forgets it.
+func (p *Pack) DeleteSpreader(ctx context.Context, id string) error {
+	res, found := p.env.Store.Get(Name, KindSpreader, id)
+	if !found {
+		return ErrNoSuchResource
+	}
+	segment, segmentFound := p.env.Store.Get(Name, KindSegment, attrString(res, "segment"))
+	if segmentFound {
+		listen, ok := p.listenAddress(segment)
+		if ok {
+			if err := p.binding().RemoveBalancer(ctx, segment.Runtime[runtimeSegmentKey], listen); err != nil {
+				p.env.Log.Error("could not withdraw the spreader", "spreader", id, "error", err)
+			}
+		}
+	}
+	p.env.Store.Delete(Name, KindSpreader, id)
+	return nil
+}
+
+// deliver hands the whole balancer over and records what the host actually
+// took.
+//
+// Three outcomes, never two, and the middle one is the reason: a runtime that
+// does not balance answers a stated limit rather than an empty delivery, so
+// this pack leaves its balancer a record instead of reporting nothing
+// distributed with no reason beside it. What came back is written onto the
+// resource, because the state published must be the one the effect produced —
+// a host distributing to nobody while the API describes two healthy backends
+// is #483, and it was found by a person reading the host.
+func (p *Pack) deliver(ctx context.Context, res *resource.Resource) {
+	binding := p.binding()
+	if !binding.Balances() {
+		return
+	}
+	segment, found := p.env.Store.Get(Name, KindSegment, attrString(res, "segment"))
+	if !found {
+		return
+	}
+	listen, ok := p.listenAddress(segment)
+	if !ok {
+		return
+	}
+	spec := machine.BalancerSpec{
+		Name:      attrString(res, "name"),
+		Network:   segment.Runtime[runtimeSegmentKey],
+		Listen:    listen,
+		Listeners: []machine.BalancerListener{{Protocol: "tcp", Listen: portOf(res), Backend: portOf(res)}},
+		Targets:   p.backendAddresses(res, segment.ID),
+	}
+	delivery, err := binding.EnsureBalancer(ctx, spec)
+	switch {
+	case errors.Is(err, machine.ErrBalancerNotDistributed):
+		p.env.Log.Warn("this runtime does not distribute a spreader of this shape",
+			"spreader", res.ID, "error", err)
+		return
+	case err != nil:
+		p.env.Log.Error("could not hand the spreader to the runtime", "spreader", res.ID, "error", err)
+		return
+	}
+	distributed, undistributed := delivery.Lines()
+	machine.RecordBalancerDelivery(p.env.Store, res, p.env.Now(), distributed, undistributed)
+}
+
+// backendAddresses lists the addresses of the nodes behind a spreader, on the
+// segment it lives on.
+func (p *Pack) backendAddresses(res *resource.Resource, segmentID string) []string {
+	var targets []string
+	for _, nodeID := range backendsOf(res) {
+		node, found := p.env.Store.Get(Name, KindNode, nodeID)
+		if !found {
+			continue
+		}
+		if address := addressesOf(node)[segmentID]; address != "" {
+			targets = append(targets, address)
+		}
+	}
+	sort.Strings(targets)
+	return targets
+}
+
+// listenAddress is the address a spreader answers on: the second host address
+// of its segment's block, the runtime having reserved the first.
+func (p *Pack) listenAddress(segment *resource.Resource) (string, bool) {
+	block, err := netip.ParsePrefix(attrString(segment, "block"))
+	if err != nil {
+		return "", false
+	}
+	return hostAddress(block, 2)
+}
+
+// allocate hands the node its address on a segment: the lowest host address
+// from the tenth on that no node of this segment already holds.
+//
+// Deterministic and stored, rather than derived at read time: an address that
+// moved under a live machine because a neighbour was deleted would be a defect
+// nobody could see from the API. Address planning is the pack's own — the
+// runtime contract has no opinion on it.
+func (p *Pack) allocate(segment *resource.Resource, nodeID string) (string, bool) {
+	block, err := netip.ParsePrefix(attrString(segment, "block"))
+	if err != nil {
+		return "", false
+	}
+	taken := map[string]bool{}
+	for _, node := range p.nodes() {
+		if node.ID == nodeID {
+			continue
+		}
+		if address := addressesOf(node)[segment.ID]; address != "" {
+			taken[address] = true
+		}
+	}
+	return freeAddress(block, 10, taken)
+}
+
+// ---- Reading what the store holds -------------------------------------------
+
+func attrString(res *resource.Resource, key string) string {
+	if res == nil {
+		return ""
+	}
+	s, _ := res.Attrs[key].(string)
+	return s
+}
+
+func rulesOf(res *resource.Resource) []Rule {
+	rules, _ := res.Attrs["rules"].([]Rule)
+	return rules
+}
+
+func wornBarriers(res *resource.Resource) []string {
+	ids, _ := res.Attrs["barriers"].([]string)
+	return ids
+}
+
+func membershipsOf(res *resource.Resource) []string {
+	ids, _ := res.Attrs["segments"].([]string)
+	return ids
+}
+
+// portOf reads back the port a spreader answers on, tolerating the float64 a
+// snapshot restore produces.
+//
+// The plain `res.Attrs["port"].(int)` was what this pack wrote first, and it is
+// wrong in a way nothing here would have shown: Attrs is decoded as
+// map[string]any, so every stored number comes back a float64 and the int
+// assertion yields zero — a balancer silently listening on port 0 after a
+// `feint snapshot load`. Measured on 2026-08-27, and it is a rediscovery
+// rather than a discovery: exoscale/privatenetworks.go carries the same helper
+// with the same sentence, and two of the three real packs do not. That is the
+// #475 shape one storey down — a lesson living in one pack of three, which a
+// fourth pack has no way to inherit.
+func portOf(res *resource.Resource) int {
+	switch n := res.Attrs["port"].(type) {
+	case int:
+		return n
+	case float64:
+		return int(n)
+	}
+	return 0
+}
+
+func backendsOf(res *resource.Resource) []string {
+	ids, _ := res.Attrs["backends"].([]string)
+	return ids
+}
+
+func addressesOf(res *resource.Resource) map[string]string {
+	addresses, _ := res.Attrs["addresses"].(map[string]string)
+	if addresses == nil {
+		return map[string]string{}
+	}
+	return addresses
+}
+
+// The four helpers below all copy before writing, for one reason:
+// resource.Clone shares nested values with the store, so a pack that mutated a
+// slice or a map read out of Attrs would be writing through the store's own
+// copy, outside every lock and every conditional write-back.
+
+func appendUnique(list []string, value string) []string {
+	for _, existing := range list {
+		if existing == value {
+			return append([]string(nil), list...)
+		}
+	}
+	return append(append([]string(nil), list...), value)
+}
+
+func without(list []string, value string) []string {
+	out := make([]string, 0, len(list))
+	for _, existing := range list {
+		if existing != value {
+			out = append(out, existing)
+		}
+	}
+	return out
+}
+
+func withAddress(addresses map[string]string, segmentID, address string) map[string]string {
+	out := make(map[string]string, len(addresses)+1)
+	for key, value := range addresses {
+		out[key] = value
+	}
+	out[segmentID] = address
+	return out
+}
+
+func withoutAddress(addresses map[string]string, segmentID string) map[string]string {
+	out := make(map[string]string, len(addresses))
+	for key, value := range addresses {
+		if key != segmentID {
+			out[key] = value
+		}
+	}
+	return out
+}
+
+// hostAddress is the nth host address of a block, false when the block is too
+// small to hold it.
+func hostAddress(block netip.Prefix, offset int) (string, bool) {
+	addr := block.Masked().Addr()
+	for i := 0; i < offset; i++ {
+		addr = addr.Next()
+		if !addr.IsValid() || !block.Contains(addr) {
+			return "", false
+		}
+	}
+	return addr.String(), true
+}
+
+// freeAddress is the lowest host address from the given offset that nobody
+// holds.
+func freeAddress(block netip.Prefix, offset int, taken map[string]bool) (string, bool) {
+	for i := offset; ; i++ {
+		address, ok := hostAddress(block, i)
+		if !ok {
+			return "", false
+		}
+		if !taken[address] {
+			return address, true
+		}
+	}
+}

--- a/internal/cli/testdata/provider-four/pack.go
+++ b/internal/cli/testdata/provider-four/pack.go
@@ -1,0 +1,260 @@
+// Package providerfour is the fourth provider, written as code so the
+// milestone's promise stops being a sentence (#517).
+//
+// # It is not a cloud, and that is the point
+//
+// Nothing here imitates a real provider. The intended fourth pack is OVHcloud,
+// and nothing of its API has ever been measured in this repository — so a fake
+// pack shaped like OVH would be measuring a belief, which rule 4 forbids in
+// exactly those words. What this measures is the contract: the services
+// internal/core/machine offers a pack, and whether they suffice for a
+// newcomer that never had the three real packs' habits.
+//
+// So Provider Four is imaginary and deliberately minimal. It has nodes,
+// segments, barriers, anchors and spreaders — five words it made up — and it
+// carries no trait a real cloud would recognise. Its shape was chosen from the
+// dataplane #517 asks for, never from a cloud: a node boots on one home
+// segment, joins more afterwards, and wears barriers whose rules may name
+// another barrier. The day a real fourth pack starts, this is the recipe it
+// reads, never the model it copies.
+//
+// # What it never names
+//
+// No runtime implementation, no Incus, no OVN, no machine.Driver — and the
+// last one is not a discipline but a build error since #511: emulator.Env
+// hands out no driver value and machine.Binding's driver field is unexported.
+// What stays reachable without a driver value is held by internal/cli's
+// TestNoPackReachesPastTheDeclaredDriverSurface and
+// TestNoPackKnowsWhichRuntimeIsBehindTheDriver, which read this directory
+// beside the three real packs, with no exemption of its own.
+//
+// # Where it lives, and why no instrument counts it
+//
+// Under testdata/, which Go's ./... patterns skip. Measured on 2026-08-27
+// rather than assumed, which is what #517 asks for: `go build ./...` does not
+// build this directory and `go list ./...` does not name it, so no coverage,
+// evidence or drift artefact can count a fourth provider that has no upstream
+// SDK — an entry there would be a measured lie. An explicit import still
+// resolves, which is how it compiles at all, and `gofmt -l .` still walks in,
+// so `mise run check` holds its shape like any other file.
+//
+// It is never mounted and has no routes: it proves the contract's shape, never
+// wire fidelity. The polar star stays with scw, the exo CLI and Terraform.
+package providerfour
+
+import (
+	"net/netip"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/machine"
+	"github.com/stephrobert/feint/internal/core/resource"
+)
+
+// Name is what this provider calls itself, in the store and on every label the
+// shared layer writes.
+const Name = "four"
+
+// The kinds Provider Four stores. Five words of its own, because a pack's
+// vocabulary is its own business and reusing another cloud's would be the
+// first place this fake started measuring something other than the contract.
+const (
+	KindNode     = "node"     // a machine
+	KindSegment  = "segment"  // a private network
+	KindBarrier  = "barrier"  // a rule set some nodes wear
+	KindAnchor   = "anchor"   // a public address
+	KindSpreader = "spreader" // a balancer
+)
+
+// The node states this provider publishes. RunningState and FailedState below
+// are these; the words are the pack's, which is the whole reason those two are
+// fields rather than constants of the core.
+const (
+	StateDown   = "down"
+	StateUp     = "up"
+	StateBroken = "broken"
+)
+
+// DefaultUser is the login Provider Four provisions on every image. One login
+// for the whole cloud, which is the simple half of the fork Boot.User exists
+// for.
+const DefaultUser = "pilot"
+
+// machinePrefix names this pack's machines on a shared host, beside
+// feint-scw-, feint-osc- and feint-exo-. It is what Binding.ours checks a
+// stored name against before any destructive verb, and what a sweep
+// recognises: a fourth pack that picked a prefix already in use would be
+// asking the shared layer to hand it another pack's machines.
+const machinePrefix = "feint-four-"
+
+// rulesetPrefix names this pack's rule sets on the host, through
+// machine.FirewallName.
+const rulesetPrefix = "four"
+
+// The Runtime keys this pack keeps its host-side names under. Runtime and
+// never Attrs: a view must not be able to serialise them, and the shared layer
+// writes the first two itself.
+const (
+	runtimeNodeKey    = "four-node"
+	runtimeAddressKey = "four-address"
+	runtimeSegmentKey = "four-segment"
+)
+
+// segmentMarker labels a backing network with the segment it backs, so a sweep
+// can tell an orphan from a live one.
+const segmentMarker = "feint.segment"
+
+// publicBlock is the range Provider Four hands anchors out of, and the only
+// range it may ask the runtime to route.
+//
+// It guards Reconciler.Route and Reconciler.Unroute alike, because a stored
+// address is untrusted input: PUT /_feint/state and `feint snapshot load`
+// restore it verbatim, and routing an arbitrary value would send the host's
+// traffic for that address into a container. RFC 2544's benchmarking range,
+// picked so it cannot collide with the three real packs' documentation blocks.
+var publicBlock = netip.MustParsePrefix("198.18.0.0/24")
+
+// images is this pack's catalogue: the one table only this provider knows.
+// An identifier that resolves to nothing is refused at boot rather than
+// substituted, which is the shared layer's rule and not this pack's choice.
+var images = map[string]machine.Image{
+	"four-linux": {Ref: "debian:13", User: DefaultUser},
+}
+
+// Pack is Provider Four's control plane. It holds an environment and nothing
+// else — in particular no runtime, which since #511 it could not hold if it
+// wanted to.
+type Pack struct {
+	env *emulator.Env
+}
+
+// New returns a pack over env.
+func New(env *emulator.Env) *Pack { return &Pack{env: env} }
+
+// tenant is the isolation boundary every resource of this pack belongs to.
+// Provider Four scopes by nothing but itself, which is the minimum a tenant
+// can be and still be one.
+func tenant() resource.Tenant { return resource.Tenant{Provider: Name} }
+
+// binding is this pack's declaration of its machines: what it names them, what
+// login they carry, where their host-side name and address are kept, and the
+// two state words its API publishes.
+//
+// Everything here is a field, and that is the contract's own claim: what
+// varies between providers is a value, never a re-implementation. The driver
+// arrives through emulator.Env.Bind and never through this pack — the field it
+// lands in is unexported, so no expression below can reach it.
+func (p *Pack) binding() machine.Binding {
+	return p.env.Bind(machine.Binding{
+		Provider:     Name,
+		Prefix:       machinePrefix,
+		User:         DefaultUser,
+		RuntimeKey:   runtimeNodeKey,
+		AddressKey:   runtimeAddressKey,
+		RunningState: StateUp,
+		FailedState:  StateBroken,
+		Declared:     p.env.BootImages,
+		Log:          p.env.Log,
+	})
+}
+
+// groups is this pack's firewall orchestrator. The five fields below are the
+// whole of what Provider Four knows about its own barriers; the sequence that
+// consumes them — write the set, replay it onto every wearer, re-expand the
+// barriers that name it — is the shared skeleton's, written once for every
+// pack that will ever exist.
+func (p *Pack) groups() machine.GroupSync {
+	return machine.GroupSync{
+		Binding:   p.binding(),
+		SpecOf:    p.barrierSpec,
+		Wearers:   p.barrierWearers,
+		WornIDs:   p.wornBarriers,
+		Group:     p.barrier,
+		Referrers: p.barrierReferrers,
+	}
+}
+
+// reconciler is this pack's interface orchestrator: it starts a node on the
+// plan below and replays the one order — the promised addresses, then the
+// memberships, the firewall last.
+//
+// PublicBlock is on the reconciler rather than on the plan because the unroute
+// of a node already gone has no resource left to plan from.
+func (p *Pack) reconciler() machine.Reconciler {
+	return machine.Reconciler{
+		Groups:      p.groups(),
+		PlanOf:      p.planOf,
+		PublicBlock: publicBlock,
+	}
+}
+
+// planOf declares one node's interface shape: what rides the launch, what
+// joins afterwards, and which public addresses were promised.
+//
+// This is the whole of what a pack contributes to the boot. The order those
+// three are delivered in is the runtime's property and lives in
+// machine.Reconciler; a pack that wrote it here would be writing the recipe
+// #510 took out of three packs' comments.
+func (p *Pack) planOf(res *resource.Resource) machine.Plan {
+	// Built as a literal, and that is not a matter of style: the declared
+	// surface admits Plan.Memberships and no other member of Plan, so
+	// `plan.Boot = …` is a discipline failure with nothing in the type to warn
+	// a newcomer. The three real packs write it exactly this way, for exactly
+	// this reason.
+	plan := machine.Plan{
+		Boot:    p.bootAttachments(res),
+		Publics: p.anchorsOf(res.ID),
+	}
+	for _, id := range membershipsOf(res) {
+		if att, ok := p.attachment(res, id); ok {
+			plan.Memberships = append(plan.Memberships, att)
+		}
+	}
+	return plan
+}
+
+// bootAttachments is the one interface that rides the launch: the node's home
+// segment, when it has one.
+//
+// Carried on the start rather than attached afterwards because editing a live
+// interface re-plugs it and the guest loses its lease — which is the shared
+// layer's measurement and not this pack's, and the reason Plan carries two
+// lists instead of one.
+func (p *Pack) bootAttachments(res *resource.Resource) []machine.Attachment {
+	home := attrString(res, "home_segment")
+	if home == "" {
+		return nil
+	}
+	att, ok := p.attachment(res, home)
+	if !ok {
+		return nil
+	}
+	return []machine.Attachment{att}
+}
+
+// attachment turns one segment membership into the interface the node carries
+// on it: the backing network, the address this pack allocated in the segment's
+// block, and that block's mask.
+//
+// A segment with no backing network yet yields nothing: the membership is
+// still true in the store, and the interface arrives with the next boot's
+// plan. That is the shared layer's rule for a missing network, and stating it
+// here rather than attaching to an empty name is what keeps it true.
+func (p *Pack) attachment(node *resource.Resource, segmentID string) (machine.Attachment, bool) {
+	segment, found := p.env.Store.Get(Name, KindSegment, segmentID)
+	if !found || segment.Runtime[runtimeSegmentKey] == "" {
+		return machine.Attachment{}, false
+	}
+	block, err := netip.ParsePrefix(attrString(segment, "block"))
+	if err != nil {
+		return machine.Attachment{}, false
+	}
+	address := addressesOf(node)[segmentID]
+	if address == "" {
+		return machine.Attachment{}, false
+	}
+	return machine.Attachment{
+		Network:   segment.Runtime[runtimeSegmentKey],
+		Address:   address,
+		PrefixLen: block.Bits(),
+	}, true
+}

--- a/internal/providers/replay_test.go
+++ b/internal/providers/replay_test.go
@@ -9,6 +9,7 @@
 package providers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -19,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	providerfour "github.com/stephrobert/feint/internal/cli/testdata/provider-four"
 	"github.com/stephrobert/feint/internal/core/emulator"
 	"github.com/stephrobert/feint/internal/core/machine"
 	"github.com/stephrobert/feint/internal/core/store"
@@ -73,6 +75,7 @@ var intents = []intent{
 		replays: []packReplay{
 			{"scaleway", replayScalewayJoinsAfterBoot},
 			{"exoscale", replayExoscaleJoinsAfterBoot},
+			{"four", replayFourJoinsAfterBoot},
 		},
 	},
 	{
@@ -87,6 +90,7 @@ var intents = []intent{
 			{"scaleway", replayScalewayLinkedAfterBoot},
 			{"outscale", replayOutscaleLinkedAfterBoot},
 			{"exoscale", replayExoscaleLinkedAfterBoot},
+			{"four", replayFourLinkedAfterBoot},
 		},
 	},
 }
@@ -110,7 +114,7 @@ func allReplays() []packReplay {
 // UnrouteAddress the first never did: the determinism property would then be
 // measuring this suite's own residue, not the pack.
 func recorderEnv() (*emulator.Env, *machine.Recorder) {
-	for _, provider := range []string{scaleway.Name, outscale.Name, exoscale.Name} {
+	for _, provider := range []string{scaleway.Name, outscale.Name, exoscale.Name, providerfour.Name} {
 		machine.Binding{Provider: provider}.ForgetPlacements()
 	}
 	rec := machine.NewRecorder()
@@ -316,6 +320,110 @@ func replayExoscaleLinkedAfterBoot(t *testing.T) *machine.Recorder {
 	return rec
 }
 
+// ---- The fourth pack, which has no dialect ----------------------------------
+
+// The two replays below drive testdata/provider-four (#517), the pack that
+// does not exist.
+//
+// It joins this corpus for the property the corpus is for, and the property is
+// stronger with it in: the three real packs were migrated onto the Reconciler,
+// so each of them knows the order it used to write by hand. Provider Four
+// never wrote one. If the sequence still matches, the order is a property of
+// the runtime and not of three authors who were told about it — which is
+// #510's sentence, said about a pack that was not in the room.
+//
+// It is driven by Go calls where the three others are driven over HTTP,
+// because it has no wire dialect at all and inventing one would put this
+// suite's own JSON between the intent and the contract. What is compared is
+// never the dialect: it is the sequence of contract gestures.
+func replayFourJoinsAfterBoot(t *testing.T) *machine.Recorder {
+	t.Helper()
+	ctx := t.Context()
+	env, rec := recorderEnv()
+	pack := providerfour.New(env)
+
+	segment, err := pack.CreateSegment(ctx, "intent-net", "10.61.0.0/24", "intent")
+	if err != nil {
+		t.Fatalf("create the segment: %v", err)
+	}
+	barrier := fourBarrierWithRule(t, ctx, pack)
+
+	// Born public — Provider Four allocates the anchor at create, so the
+	// address rides the launch — and bare, so its segment is joined hot.
+	node, err := pack.CreateNode(ctx, providerfour.NodeRequest{
+		Name:     "intent-machine",
+		Image:    "four-linux",
+		Barriers: []string{barrier},
+		Public:   true,
+	})
+	if err != nil {
+		t.Fatalf("create the node: %v", err)
+	}
+	if err := pack.StartNode(ctx, node.ID); err != nil {
+		t.Fatalf("start the node: %v", err)
+	}
+	if err := pack.JoinSegment(ctx, node.ID, segment.ID); err != nil {
+		t.Fatalf("join the segment: %v", err)
+	}
+
+	anchor, err := pack.CreateAnchor()
+	if err != nil {
+		t.Fatalf("create the anchor: %v", err)
+	}
+	if err := pack.AttachAnchor(ctx, anchor.ID, node.ID); err != nil {
+		t.Fatalf("attach the anchor: %v", err)
+	}
+	return rec
+}
+
+// replayFourLinkedAfterBoot: a node born bare, wearing its barrier, its anchor
+// attached once it is up.
+func replayFourLinkedAfterBoot(t *testing.T) *machine.Recorder {
+	t.Helper()
+	ctx := t.Context()
+	env, rec := recorderEnv()
+	pack := providerfour.New(env)
+
+	barrier := fourBarrierWithRule(t, ctx, pack)
+	node, err := pack.CreateNode(ctx, providerfour.NodeRequest{
+		Name:     "intent-machine",
+		Image:    "four-linux",
+		Barriers: []string{barrier},
+	})
+	if err != nil {
+		t.Fatalf("create the node: %v", err)
+	}
+	if err := pack.StartNode(ctx, node.ID); err != nil {
+		t.Fatalf("start the node: %v", err)
+	}
+
+	anchor, err := pack.CreateAnchor()
+	if err != nil {
+		t.Fatalf("create the anchor: %v", err)
+	}
+	if err := pack.AttachAnchor(ctx, anchor.ID, node.ID); err != nil {
+		t.Fatalf("attach the anchor: %v", err)
+	}
+	return rec
+}
+
+func fourBarrierWithRule(t *testing.T, ctx context.Context, pack *providerfour.Pack) string {
+	t.Helper()
+	barrier := pack.CreateBarrier("intent-group")
+	err := pack.AddRule(ctx, barrier.ID, providerfour.Rule{
+		Direction: "ingress",
+		Action:    "allow",
+		Protocol:  "tcp",
+		Source:    "0.0.0.0/0",
+		PortFrom:  22,
+		PortTo:    22,
+	})
+	if err != nil {
+		t.Fatalf("add the barrier's rule: %v", err)
+	}
+	return barrier.ID
+}
+
 // ---- Dialect helpers shared by the intents ----------------------------------
 
 func scalewayGroupWithRule(t *testing.T, h http.Handler) string {
@@ -455,7 +563,7 @@ func TestAShuffledReplayIsToldFromItsOriginal(t *testing.T) {
 // intent, a missing reason, or a gesture kind gone from the whole corpus all
 // fail here — the ways a comparison quietly relaxes, each one closed.
 func TestSameIntentSameRuntimeSequenceAcrossPacks(t *testing.T) {
-	packs := map[string]bool{"scaleway": false, "outscale": false, "exoscale": false}
+	packs := map[string]bool{"scaleway": false, "outscale": false, "exoscale": false, "four": false}
 	recorded := map[string]bool{}
 
 	for _, in := range intents {

--- a/tools/falsify/specs/provider-four.json
+++ b/tools/falsify/specs/provider-four.json
@@ -1,0 +1,97 @@
+{
+  "package": "./internal/cli/",
+  "mutations": [
+    {
+      "label": "the fourth pack adds a rule its host never hears about, which is #475 verbatim on a pack that did not exist when #475 was measured (#517)",
+      "file": "internal/cli/testdata/provider-four/intents.go",
+      "find": "\tp.groups().SyncGroup(ctx, res, nil)\n\treturn nil",
+      "replace": "\tif false {\n\t\tp.groups().SyncGroup(ctx, res, nil)\n\t}\n\treturn nil",
+      "test": "TestTheFourthPacksRuleChangeReachesTheRuntime"
+    },
+    {
+      "label": "the fourth pack deletes a node and leaves every barrier that named it accepting an address nothing answers on (#517)",
+      "file": "internal/cli/testdata/provider-four/intents.go",
+      "find": "\tp.groups().SyncReferrers(ctx, worn, nil)\n\treturn nil",
+      "replace": "\tif false {\n\t\tp.groups().SyncReferrers(ctx, worn, nil)\n\t}\n\treturn nil",
+      "test": "TestTheFourthPacksDeleteReExpandsTheBarriersThatNameIt"
+    },
+    {
+      "label": "the fourth pack promises no address on its plan, so the boot order loses its first step and the sequence stops matching the three real packs (#510, #517)",
+      "file": "internal/cli/testdata/provider-four/pack.go",
+      "find": "\t\tPublics: p.anchorsOf(res.ID),",
+      "replace": "\t\tPublics: p.anchorsOf(res.ID)[:0],",
+      "test": "TestTheFourthPacksBootRoutesThenJoinsThenAppliesTheFirewall"
+    },
+    {
+      "label": "the fourth pack declares its home segment as a membership rather than a boot interface, so an attachment the launch could have carried is added to a live machine instead (#510, #517)",
+      "file": "internal/cli/testdata/provider-four/pack.go",
+      "find": "\t\tBoot:    p.bootAttachments(res),",
+      "replace": "\t\tBoot:        nil,\n\t\tMemberships: p.bootAttachments(res),",
+      "test": "TestTheFourthPacksBootAttachmentRidesTheLaunchAndItsMembershipsDoNot"
+    },
+    {
+      "label": "the fourth pack publishes the state its request asked for rather than the one the host produced, which is the lie this emulator exists to avoid (#484, #517)",
+      "file": "internal/cli/testdata/provider-four/intents.go",
+      "find": "\t\t\tLabels:    map[string]string{\"feint.node\": res.ID},\n\t\t})\n\t})",
+      "replace": "\t\t\tLabels:    map[string]string{\"feint.node\": res.ID},\n\t\t})\n\t\tres.State = StateUp\n\t})",
+      "test": "TestTheFourthPackPublishesTheStateTheEffectProduced"
+    },
+    {
+      "label": "the fourth pack declares a public block wide enough to cover the operator's own network, and the shared guard then routes whatever a restored snapshot named (#517)",
+      "file": "internal/cli/testdata/provider-four/pack.go",
+      "find": "var publicBlock = netip.MustParsePrefix(\"198.18.0.0/24\")",
+      "replace": "var publicBlock = netip.MustParsePrefix(\"0.0.0.0/0\")",
+      "test": "TestTheFourthPackRefusesToRouteAnAddressOutsideItsOwnBlock"
+    },
+    {
+      "label": "the fourth pack's isolation predicate lets every segment reach every other, which is the one thing about isolation only a provider knows (#517)",
+      "file": "internal/cli/testdata/provider-four/intents.go",
+      "find": "\t\treturn attrString(segments[from], \"realm\") == attrString(segments[to], \"realm\")",
+      "replace": "\t\treturn attrString(segments[from], \"realm\") == attrString(segments[to], \"realm\") || true",
+      "test": "TestTheFourthPacksSegmentsReachEachOtherOnlyInTheSameRealm"
+    },
+    {
+      "label": "the fourth pack hands a balancer over and records nothing, so its API describes backends the host may never have taken (#483, #517)",
+      "file": "internal/cli/testdata/provider-four/intents.go",
+      "find": "\tmachine.RecordBalancerDelivery(p.env.Store, res, p.env.Now(), distributed, undistributed)",
+      "replace": "\tif false {\n\t\tmachine.RecordBalancerDelivery(p.env.Store, res, p.env.Now(), distributed, undistributed)\n\t}",
+      "test": "TestTheFourthPacksSpreaderRecordsTheDeliveryAndNotTheIntent"
+    },
+    {
+      "label": "the fourth pack writes a segment address into the map the store still shares, outside the lock and outside the conditional write-back (#295, #517)",
+      "file": "internal/cli/testdata/provider-four/intents.go",
+      "find": "\tout := make(map[string]string, len(addresses)+1)\n\tfor key, value := range addresses {\n\t\tout[key] = value\n\t}\n\tout[segmentID] = address\n\treturn out\n}",
+      "replace": "\tout := make(map[string]string, len(addresses)+1)\n\tfor key, value := range addresses {\n\t\tout[key] = value\n\t}\n\taddresses[segmentID] = address\n\treturn addresses\n}",
+      "test": "TestTheFourthPacksNestedAttributesAreNeverWrittenThroughTheStore"
+    },
+    {
+      "label": "the fourth pack reads its stored port with a plain int assertion, so a restored snapshot leaves a balancer listening on port 0 while the API still describes 443 (#517)",
+      "file": "internal/cli/testdata/provider-four/intents.go",
+      "find": "\tcase float64:\n\t\treturn int(n)\n\t}\n\treturn 0\n}\n\nfunc backendsOf",
+      "replace": "\tcase float64:\n\t\treturn int(n) * 0\n\t}\n\treturn 0\n}\n\nfunc backendsOf",
+      "test": "TestTheFourthPacksSpreaderKeepsItsPortAcrossASnapshot"
+    },
+    {
+      "label": "the fourth pack builds a runtime of its own, the shape #511's surface excludes by name and the compiler cannot see because it needs no driver value (#511, #517)",
+      "file": "internal/cli/testdata/provider-four/pack.go",
+      "find": "// Pack is Provider Four's control plane.",
+      "replace": "// The runtime, built by the pack that exists to prove nobody needs to.\nfunc plantedRuntime() machine.Noop { return machine.Noop{} }\n\n// Pack is Provider Four's control plane.",
+      "test": "TestNoPackReachesPastTheDeclaredDriverSurface"
+    },
+    {
+      "label": "the fourth pack branches on which runtime is behind --vm, which every facade of #511 allows and only #516 can see (#516, #517)",
+      "file": "internal/cli/testdata/provider-four/pack.go",
+      "find": "const segmentMarker = \"feint.segment\"",
+      "replace": "// The mode comparison capabilities exist so no pack ever needs.\nfunc plantedMode(mode string) bool { return mode == \"incus-ovn\" }\n\nconst segmentMarker = \"feint.segment\"",
+      "test": "TestNoPackKnowsWhichRuntimeIsBehindTheDriver"
+    },
+    {
+      "label": "the fourth pack drops out of the population the two discipline detectors judge, and both go on passing over three packs that were cleaned up (#517)",
+      "file": "internal/cli/provider_four_test.go",
+      "find": "\treturn append(packDirs(t), fourthPackDir(t))",
+      "replace": "\treturn append(packDirs(t), fourthPackDir(t))[:len(packDirs(t))]",
+      "test": "TestTheDisciplineDetectorsReadTheFourthPack"
+    }
+  ],
+  "note": "#517 makes the milestone's promise — a fourth provider must not be able to forget — executable, and a fake pack written by reading the contract until it compiles proves only that its author read the contract. So every property is planted here. The first two are the residue #514 names honestly: nothing in the contract can force a pack to call SyncGroup when its rules change or SyncReferrers when a node goes, because the pack is the only party that knows either happened, and mutation one is #475 word for word on a pack that did not exist when #475 was measured. The next three plant the acquis a pack receives without writing them — the boot order, the boot-versus-membership split, the published state being the effect's — and each is red because the fourth pack never wrote them and would notice their loss. Mutations six to nine plant what stays the pack's own and therefore stays forgettable: the width of its public block, its isolation predicate, the record of what a balancer hand-off delivered, and the copy-before-write on a value resource.Clone shares with the store. One mutation stands apart because the fake pack committed its defect before this file caught it: reading a stored port with a plain int assertion, which the map[string]any decoding of Attrs turns into zero across a snapshot. It is a rediscovery — exoscale/privatenetworks.go carries the same helper with the same sentence and two of the three real packs do not — and it is the clearest thing #517 produced, because it is a lesson a fourth pack has no way to inherit. The last three are the instruments rather than the subject: a pack building its own runtime, a pack naming the mode, and — the one that catches every other mutation here silently stopping to mean anything — the fourth pack quietly leaving the population both detectors read."
+}


### PR DESCRIPTION
Closes #517. Last of the six that make up #514.

The milestone promised: *a fourth provider must not be able to forget.* That was
a sentence. `internal/cli/testdata/provider-four/` is an imaginary minimal cloud
— nodes, segments, barriers, anchors, spreaders — depending on no trait of any
real one, driving the whole dataplane through the contract alone. It joins the
recorder corpus in `replay_test.go` on **both** intents, and its sequence is the
other three's.

Placement was **measured rather than assumed**: `go build ./...` does not build
it, `go list ./...` does not name it, an explicit import resolves, and
`gofmt -l .` still walks in.

## What the fourth pack had to supply

Its `Binding` fields; its `Plan` — which stored field becomes which interface,
boot versus membership, promised publics; its firewall translation and the four
enumerators around it; its isolation predicate; its balancer's shape and
backends; **its own address planning**, since the runtime contract has no
opinion on it and `internal/core/network`'s allocator holds live state and is
not in `PackSurface`; and **every call site**, because the contract can refuse a
gesture and never require one.

## What it got for free

The host-side machine name and the ownership check on it. The boot order —
addresses, then memberships, then the firewall last. The published state being
the effect's, `FailedState` on a refused start. The emulated-block guard on
route **and** unroute. The conditional write-back and the per-target
serialisation. The referrer re-expansion after boot, `fresh` threading included.
The network name recorded only on acceptance. The balancer's delivery report and
its limit/incident split. And the `Peerer`/`Isolator` fork — the pack never
chose between peering and reject rules.

That list is the milestone's promise, itemised.

## What it could still forget — including two the brief did not predict

The five known ones are covered: rule hand-off (#475), memberships (#492),
produced state (#484), claimed dataplane (#481, #486), boot order (#510). Two
more came out of *writing* it, and both are filed:

- **#542** — the pack wrote `res.Attrs["port"].(int)` on its first draft.
  `Attrs` is `map[string]any`, so a restore yields `float64` and the assertion
  gives zero. This is a **rediscovery**: Exoscale carries `intOf` with that exact
  sentence and Outscale does not — three sites where a restored volume can be
  shrunk (the refusal never fires), publishes no size, and snapshots as
  `VolumeSize: 0`. *A lesson living in one pack of three is one a fourth cannot
  inherit.*
- **#543** — a pack that declares `GroupSync` without wiring it **panics on the
  first boot, under a runtime only**. `--vm off` — the default, and the whole CI
  matrix — is exactly the mode that cannot see it. A pack that wired nothing
  goes green everywhere and breaks for the first operator who starts a real
  machine.

Design friction worth recording: `Plan` must be built as a composite literal,
because `PackSurface` admits `Plan.Memberships` and no other member, with
nothing in the type to warn a newcomer.

## The reds

`provider-four.json`: **13 mutations, 13 compile, 13 bite.**

The planted #475 — `SyncGroup` dropped from `AddRule` — reddens
`TestTheFourthPacksRuleChangeReachesTheRuntime` **and independently**
`TestSameIntentSameRuntimeSequenceAcrossPacks`, which shows `four` diverging
from the other three. That second red is the milestone demonstrating itself: an
omission in a pack nobody has ever run is caught by a property written for three
other packs.

Planting `machine.Noop` and `"incus-ovn"` in the pack makes both discipline
detectors (#511, #516) name it by directory, file and line — the fake pack is
held to the same rules as the real three, with no exemption.

## Gates

`check`, `docs:check`, `prepush`, `go test ./... -race` all 0. `falsify:lint`
737 mutations over 123 specs; `provider-four`, `driver-surface`,
`runtime-blindness` and `contract-recorder` replayed in full.
**`FEINT_VM=incus-ovn mise run conformance` exit 0, 1282 s**, station delta nil
on machines, networks and rule sets.

**Two things stated rather than glossed.** The station was *not* free at the
start: the doorstep found 7 machines, 4 networks and 5 rule sets from an earlier
run, plus a live idle emulator on :4599 started from the shared scratchpad. It
was swept with the documented remedy — `acltest` and `hp-test-net` survived, so
ownership works — and the emulator stopped. And the stack ACL witnesses were
**not** re-measured: `stacks.sh` asserts no `used_by` anywhere and the stacks are
destroyed at run end, so those figures remain a manual observation this branch
cannot claim.

No CHANGELOG entry: no response shape and no limit moved.
