### PR TITLE
fix(lifecycle): a reboot is a stop then a start, a restarted machine gets its routes back, and the gate stops excusing it (#547, #549, #498)

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -28,7 +28,7 @@
 >
 > **Prouvé** : 348 des 371 opérations montées sont pilotées par un vrai client, à chaque pull request. `scw`, `octl`, `exo`, Terraform et OpenTofu tournent contre l'émulateur en CI, et les machines démarrent réellement : connexion ssh sur le compte par défaut de chaque provider, subnets isolés, pare-feu qui filtre. La chaîne complète est décrite dans [docs/conformance.md](docs/conformance.md).
 >
-> **Pas prouvé** : quotas, prix, capacité réelle, validation des identifiants, authentification, cohérence à terme. Les 49 sections de [docs/limits.md](docs/limits.md) disent chacune ce qu'elle coûte. Un émulateur avec un seul compte implicite et aucune grille tarifaire devrait inventer ces chiffres, et quelqu'un agirait dessus.
+> **Pas prouvé** : quotas, prix, capacité réelle, validation des identifiants, authentification, cohérence à terme. Les 50 sections de [docs/limits.md](docs/limits.md) disent chacune ce qu'elle coûte. Un émulateur avec un seul compte implicite et aucune grille tarifaire devrait inventer ces chiffres, et quelqu'un agirait dessus.
 >
 > **Inconnu** : 23 opérations sont montées et n'ont jamais été pilotées par un client. Chacune dit pourquoi aucun client officiel ne l'atteint, à la route et dans [docs/routes.md](docs/routes.md). Elles sont comptées plutôt qu'escamotées, une par une, dans [coverage/evidence.json](coverage/evidence.json).
 >

--- a/README.fr.md
+++ b/README.fr.md
@@ -28,7 +28,7 @@
 >
 > **Prouvé** : 348 des 371 opérations montées sont pilotées par un vrai client, à chaque pull request. `scw`, `octl`, `exo`, Terraform et OpenTofu tournent contre l'émulateur en CI, et les machines démarrent réellement : connexion ssh sur le compte par défaut de chaque provider, subnets isolés, pare-feu qui filtre. La chaîne complète est décrite dans [docs/conformance.md](docs/conformance.md).
 >
-> **Pas prouvé** : quotas, prix, capacité réelle, validation des identifiants, authentification, cohérence à terme. Les 50 sections de [docs/limits.md](docs/limits.md) disent chacune ce qu'elle coûte. Un émulateur avec un seul compte implicite et aucune grille tarifaire devrait inventer ces chiffres, et quelqu'un agirait dessus.
+> **Pas prouvé** : quotas, prix, capacité réelle, validation des identifiants, authentification, cohérence à terme. Les 49 sections de [docs/limits.md](docs/limits.md) disent chacune ce qu'elle coûte. Un émulateur avec un seul compte implicite et aucune grille tarifaire devrait inventer ces chiffres, et quelqu'un agirait dessus.
 >
 > **Inconnu** : 23 opérations sont montées et n'ont jamais été pilotées par un client. Chacune dit pourquoi aucun client officiel ne l'atteint, à la route et dans [docs/routes.md](docs/routes.md). Elles sont comptées plutôt qu'escamotées, une par une, dans [coverage/evidence.json](coverage/evidence.json).
 >

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 >
 > **Proven**: 348 of the 371 mounted operations are driven by a real client, on every pull request. `scw`, `octl`, `exo`, Terraform and OpenTofu run against the emulator in CI, and machines really boot: an ssh login on each provider's own default account, isolated subnets, a firewall that filters. The whole chain is described in [docs/conformance.md](docs/conformance.md).
 >
-> **Not proven**: quotas, prices, real capacity, identifier validation, authentication, eventual consistency. The 50 sections of [docs/limits.md](docs/limits.md) each say what one costs. An emulator with a single implicit account and no price list would have to invent those figures, and somebody would act on them.
+> **Not proven**: quotas, prices, real capacity, identifier validation, authentication, eventual consistency. The 49 sections of [docs/limits.md](docs/limits.md) each say what one costs. An emulator with a single implicit account and no price list would have to invent those figures, and somebody would act on them.
 >
 > **Unknown**: 23 operations are mounted and have never been driven by a client. Every one of them states why no official client reaches it, at the route and in [docs/routes.md](docs/routes.md). They are counted rather than glossed, one by one, in [coverage/evidence.json](coverage/evidence.json).
 >

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 >
 > **Proven**: 348 of the 371 mounted operations are driven by a real client, on every pull request. `scw`, `octl`, `exo`, Terraform and OpenTofu run against the emulator in CI, and machines really boot: an ssh login on each provider's own default account, isolated subnets, a firewall that filters. The whole chain is described in [docs/conformance.md](docs/conformance.md).
 >
-> **Not proven**: quotas, prices, real capacity, identifier validation, authentication, eventual consistency. The 49 sections of [docs/limits.md](docs/limits.md) each say what one costs. An emulator with a single implicit account and no price list would have to invent those figures, and somebody would act on them.
+> **Not proven**: quotas, prices, real capacity, identifier validation, authentication, eventual consistency. The 50 sections of [docs/limits.md](docs/limits.md) each say what one costs. An emulator with a single implicit account and no price list would have to invent those figures, and somebody would act on them.
 >
 > **Unknown**: 23 operations are mounted and have never been driven by a client. Every one of them states why no official client reaches it, at the route and in [docs/routes.md](docs/routes.md). They are counted rather than glossed, one by one, in [coverage/evidence.json](coverage/evidence.json).
 >

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -3355,7 +3355,7 @@ the noise that teaches ignoring the next true ERROR.
 The record above left the fault undecided between two candidates: the stop
 half not removing the route, or the re-install not tolerating `file exists`.
 The measurement that closed it (2026-08-27, #498, delivered with the
-#547/#549/#498 lifecycle batch, commit `29d4359`) answered *neither*. A
+#547/#549/#498 lifecycle batch, PR #561) answered *neither*. A
 Scaleway server is created before its private NIC exists, so its public
 address rides a routed NIC (#202) and the runtime installs the host route with
 the device; by the time the private NIC is there, `Plan.RouteVia` names the

--- a/examples/stacks/outscale/proof.json
+++ b/examples/stacks/outscale/proof.json
@@ -22,7 +22,25 @@
     "unit": "platform-web.service",
     "port": 80,
     "machines": ["platform-web-a", "platform-web-b"],
-    "restart": "platform-web-a"
+    "restart": "platform-web-a",
+    "restart_reaches": {
+      "_why": [
+        "platform-app sits in another Subnet of the same Net, and 8080 is what",
+        "outscale_security_group_rule.app_from_web opens to public-a, where the",
+        "restarted machine lives. So the pair crosses the Net's router, which is",
+        "the path #549 measured a restart losing on the other cloud.",
+        "",
+        "control is a skip and not a machine, for the same reason platform-web-b",
+        "is the firewall family's control_source here: the rule names",
+        "10.50.1.0/24 alone, so web-b is refused on 8080 by design, and a machine",
+        "that must be refused cannot be the control of a reachability pass."
+      ],
+      "target": "platform-app",
+      "port": 8080,
+      "control": {
+        "skip": "no second machine of this stack reaches platform-app on 8080: outscale_security_group_rule.app_from_web names 10.50.1.0/24, and platform-web-b sits in public-b, which is exactly why it serves as the firewall family's control_source. An unrestarted machine the rule refuses would prove nothing about a restart, so the before-probe of the restarted machine carries the pass alone here. The Scaleway stack's platform-web-1 is the neighbour control."
+      }
+    }
   },
 
   "firewall": {
@@ -81,5 +99,16 @@
     "port": 80,
     "client": "platform-web-a",
     "probes": 6
+  },
+
+  "rule_sets": {
+    "_why": [
+      "Measured on 2026-08-27 by reading what every machine of this stack",
+      "carries. See the Scaleway stack's declaration for why this is asserted",
+      "after the restarts and what a moved number means."
+    ],
+    "prefix": "osc-",
+    "sets": 2,
+    "references": 3
   }
 }

--- a/examples/stacks/scaleway/proof.json
+++ b/examples/stacks/scaleway/proof.json
@@ -7,7 +7,8 @@
     "somebody thought to check', which is the criticism examples/stacks exists",
     "to answer for the configurations themselves.",
     "",
-    "Every one of the four families must appear. A family this stack cannot",
+    "Every one of the families must appear — service, firewall, network,",
+    "balancer, rule_sets. A family this stack cannot",
     "offer is written as {\"skip\": \"<reason>\"} and the run stays exit 0 while",
     "naming the bound out loud — a check that skips in silence is worse than",
     "an absent one. A family that is simply missing is a FAIL, because 'this",
@@ -36,17 +37,35 @@
       "The web tier serves 443, which is the port scaleway_instance_security_group.web",
       "opens, from an installed systemd unit rather than a transient one.",
       "",
-      "restart names the machine the harness stops and starts again through the",
-      "provider's API. It is poweroff+poweron and not the reboot action, and that",
-      "is a measurement rather than a preference: on 2026-08-27 a reboot answered",
-      "success, left the container's pid and uptime untouched and a transient",
-      "marker unit still active: nothing restarted, so an assertion resting on it",
-      "would be a control that cannot fail. Filed as #547."
+      "restart names the machine the harness restarts through the provider's API,",
+      "by both doors: the reboot action, then poweroff+poweron. The reboot action",
+      "used to be excluded here, and that was a measurement rather than a",
+      "preference: on 2026-08-27 it answered success, left the container's pid and",
+      "uptime untouched and a transient marker unit still active, so an assertion",
+      "resting on it could not fail (#547). It is asserted now, on the witness that",
+      "filed the issue: the runtime process must differ across the call.",
+      "",
+      "restart_reaches is what the restart must not have cost. #549 measured this",
+      "very machine coming back running, on its address, reaching its own subnet",
+      "and no longer reaching the app tier one subnet away — while platform-web-1,",
+      "the same subnet, the same group, never restarted, kept reaching it in the",
+      "same pass. That neighbour is the control here, for the same reason it named",
+      "the cause then: without it, a target that simply died reads exactly like a",
+      "restart that lost its routes. The pair is the firewall family's own, 8080",
+      "across the peered VPC, so the port is one a rule opens and a refusal cannot",
+      "be the group."
     ],
     "unit": "platform-web.service",
     "port": 443,
     "machines": ["platform-web-0", "platform-web-1"],
-    "restart": "platform-web-0"
+    "restart": "platform-web-0",
+    "restart_reaches": {
+      "target": "platform-app-worker-a",
+      "port": 8080,
+      "control": {
+        "source": "platform-web-1"
+      }
+    }
   },
 
   "firewall": {
@@ -100,5 +119,24 @@
 
   "balancer": {
     "skip": "the Scaleway pack does not hand its load balancers to the runtime: enforced.balancing names outscale alone (#481), and a balancer here records its configuration and forwards nothing (docs/limits.md). The harness re-reads that declaration at run time rather than trusting this line, so the day the pack wires it, this skip stops being taken."
+  },
+
+  "rule_sets": {
+    "_why": [
+      "What the runtime must hold once the restarts are done, in two numbers.",
+      "",
+      "Measured rather than chosen, on 2026-08-27, by reading the rule sets every",
+      "machine of this stack carries. A rule set lives on a NIC and a restart",
+      "re-plugs NICs, so a count that moved is a machine that came back without",
+      "its group: the API describing a filtered machine the host does not filter.",
+      "Asserted here so a number that moves fails a gate rather than waiting to be",
+      "noticed by somebody reading `incus network acl list`.",
+      "",
+      "prefix is what tells this pack's sets from another pack's on a shared",
+      "host: two stacks run against one station in the default population."
+    ],
+    "prefix": "scw-",
+    "sets": 3,
+    "references": 6
   }
 }

--- a/internal/cli/testdata/provider-four/intents.go
+++ b/internal/cli/testdata/provider-four/intents.go
@@ -363,15 +363,36 @@ func (p *Pack) CreateNode(ctx context.Context, req NodeRequest) (*resource.Resou
 // declaring its interface shape in two places.
 func (p *Pack) StartNode(ctx context.Context, id string) error {
 	return p.binding().Transition(p.env.Store, p.env.Now, KindNode, id, func(res *resource.Resource) {
-		image, requested := p.image(res)
-		p.reconciler().PowerOn(ctx, res, machine.Boot{
-			Image:     image.Ref,
-			Requested: requested,
-			User:      image.User,
-			Hostname:  attrString(res, "name"),
-			CloudInit: attrString(res, "user_data"),
-			Labels:    map[string]string{"feint.node": res.ID},
-		})
+		p.reconciler().PowerOn(ctx, res, p.bootOf(res))
+	})
+}
+
+// bootOf is what this pack asks the runtime for when a node comes up. One
+// function for both doors that boot a machine, because a boot described twice
+// is a boot that differs on one of them.
+func (p *Pack) bootOf(res *resource.Resource) machine.Boot {
+	image, requested := p.image(res)
+	return machine.Boot{
+		Image:     image.Ref,
+		Requested: requested,
+		User:      image.User,
+		Hostname:  attrString(res, "name"),
+		CloudInit: attrString(res, "user_data"),
+		Labels:    map[string]string{"feint.node": res.ID},
+	}
+}
+
+// RebootNode takes the machine down and brings it back.
+//
+// The pack says what a boot is and nothing else: the sequence — stop, then
+// start, then the whole post-boot order again — is Reconciler.Reboot's, which
+// is the point of this pack existing. Three real packs wrote that sentence
+// themselves and one of them wrote only half of it, answering `success` on an
+// action that restarted nothing (#547). Provider Four was never told; it gets
+// the whole sequence because it asks the layer for it.
+func (p *Pack) RebootNode(ctx context.Context, id string) error {
+	return p.binding().Transition(p.env.Store, p.env.Now, KindNode, id, func(res *resource.Resource) {
+		p.reconciler().Reboot(ctx, res, p.bootOf(res))
 	})
 }
 

--- a/internal/core/machine/incus.go
+++ b/internal/core/machine/incus.go
@@ -97,6 +97,13 @@ type Incus struct {
 	busyPoll   time.Duration
 	busyBudget time.Duration
 
+	// routePoll and routeBudget override how restoreGuestRoutes waits for a
+	// restarted guest to have configured its interface again. Only a test sets
+	// them, for the same reason busyPoll exists; zero means the defaults in
+	// waitForGuestInterface.
+	routePoll   time.Duration
+	routeBudget time.Duration
+
 	// leftoverScan replaces the host process scan behind networkCreateError,
 	// and is only ever set by a test: which processes a diagnostic may name is
 	// an argument-level fact, and the real scan reads the tester's own /proc.
@@ -414,6 +421,23 @@ func (d *Incus) Start(ctx context.Context, spec Spec) (Machine, error) {
 		if _, err := d.run(ctx, "start", spec.Name); err != nil &&
 			!strings.Contains(strings.ToLower(err.Error()), "already running") {
 			return Machine{}, fmt.Errorf("start instance %s: %w", spec.Name, err)
+		}
+		// A machine that comes back from a stop has a brand new guest network:
+		// the kernel booted again, DHCP configured the interface again, and
+		// nothing inside it remembers the routes this driver laid by hand the
+		// first time. Restoring them belongs here rather than in any pack,
+		// because it is a property of what starting a machine does, and every
+		// pack's poweron arrives through this one door (#549).
+		//
+		// Not fatal: the machine is up, and reporting a failed start would
+		// publish FailedState for a machine the runtime is running — the lie
+		// in the other direction. The log names what the machine cannot do,
+		// and tools/conformance/functional.sh asserts the reachability this
+		// restores.
+		if err := d.restoreGuestRoutes(ctx, spec.Name); err != nil {
+			d.logger().Error("a restarted machine did not get back its routes to the peered subnets",
+				"machine", spec.Name, "error", err,
+				"consequence", "the machine is running and reaches its own subnet, but not the subnets its network is peered with (#549)")
 		}
 		return d.inspectOrFail(ctx, spec.Name)
 	}

--- a/internal/core/machine/incus_address.go
+++ b/internal/core/machine/incus_address.go
@@ -46,6 +46,40 @@ func (d *Incus) RouteAddress(ctx context.Context, spec AddressSpec) error {
 		}
 		return d.routeOntoRoutedNIC(ctx, spec.Machine, device, spec.Address)
 	}
+	// The machine already answers on this address through a routed NIC, and
+	// there is nothing left to install: the launch put the address in the
+	// device's ipv4.address list and the runtime created the host route with
+	// the device.
+	//
+	// Routing it a second time through the network the pack names is not a
+	// no-op, it is a collision. A Scaleway server is created before its private
+	// NIC exists, so its public address rides a routed NIC (#202); by the time
+	// the NIC is there, Plan.RouteVia names the private network, and the replay
+	// a poweron or a reboot runs sends the very same /32 at the OVN uplink —
+	// where the delegation meets the host route the routed NIC already owns.
+	// Measured on 2026-08-27, twice in one run, on a host that ended up
+	// perfectly correct:
+	//
+	//   ERROR could not route the public address to the machine address=203.0.113.4
+	//     error="set routes of uplink feint-uplink: incus network: Error: Failed
+	//     to add route {… Dst: 203.0.113.4/32 …}: file exists"
+	//
+	// An ERROR shouted over a correct host is exactly the noise that makes the
+	// next real one unreadable (#498). The replay is documented as idempotent;
+	// this is the door where it was not. The routed half already answered the
+	// same question for itself — routeOntoRoutedNIC returns nil for an address
+	// that rode the launch — and this is that answer, asked before the network
+	// the pack names decides which interface is edited.
+	//
+	// TestReRoutingAnAddressARoutedNICAlreadyCarriesTouchesNothing fails
+	// without this.
+	carried, err := d.routedNICCarries(ctx, spec.Machine, spec.Address)
+	if err != nil {
+		return err
+	}
+	if carried {
+		return nil
+	}
 	// OVN NICs take no live route edits, so the address travels as a network
 	// forward instead; see routeAddressOVN for the measurements behind it.
 	if d.OVN {
@@ -90,6 +124,35 @@ func addressAlreadyThere(err error) bool {
 	said := strings.ToLower(err.Error())
 	return strings.Contains(said, "file exists") ||
 		strings.Contains(said, "address already assigned")
+}
+
+// routedNICCarries reports whether one of the machine's own routed NICs already
+// delivers this address.
+//
+// ipv4.address and nothing else, because that is the key the launch writes and
+// the key the host route follows: routedDevice builds the device from the
+// addresses the pack promised, and Incus installs one host route per entry. A
+// route key would be the wrong question — ipv4.routes on a routed NIC is where
+// routeOntoRoutedNIC puts an address added after the launch, and that path is
+// already idempotent on its own terms.
+//
+// Devices the instance owns, never the expanded set: a NIC inherited from a
+// profile belongs to the profile, and an address on it is not one this emulator
+// promised.
+func (d *Incus) routedNICCarries(ctx context.Context, machine, address string) (bool, error) {
+	devices, err := d.instanceDevices(ctx, machine)
+	if err != nil {
+		return false, fmt.Errorf("inspect %s: %w", machine, err)
+	}
+	for _, cfg := range devices.own {
+		if cfg["type"] != "nic" || cfg["nictype"] != "routed" {
+			continue
+		}
+		if routeListContains(cfg["ipv4.address"], address) {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // mustOwn refuses to touch a network the emulator did not create. The label is

--- a/internal/core/machine/incus_address_replay_test.go
+++ b/internal/core/machine/incus_address_replay_test.go
@@ -1,0 +1,129 @@
+package machine
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// The replay of a machine's promised public addresses is documented as
+// idempotent, and #498 is where it was not.
+//
+// The shape is every Scaleway server's: created before its private NIC exists,
+// so the public address rides a routed NIC (#202); once the NIC is there,
+// Plan.RouteVia names the private network, and the replay a poweron or a reboot
+// runs asks for the same /32 through the OVN NIC. Measured twice in one run on
+// 2026-08-27 — once on the reboot, once on the poweron — each time an ERROR on
+// a host that ended up perfectly correct:
+//
+//	set routes of uplink feint-uplink: incus network: Error: Failed to add
+//	route {… Dst: 203.0.113.4/32 …}: file exists
+//
+// The host route was the routed NIC's own, installed with the device.
+
+// routedAndPrivate is that machine: a routed NIC carrying the public address,
+// and one OVN NIC on a network the emulator owns.
+const routedAndPrivate = `{
+  "devices": {
+    "eth0": {"type": "nic", "nictype": "routed",
+             "ipv4.address": "203.0.113.4", "ipv4.host_address": "169.254.0.1"},
+    "eth1": {"type": "nic", "network": "fnt-368798629f8", "ipv4.address": "10.30.1.10"}
+  },
+  "expanded_devices": {
+    "eth0": {"type": "nic", "nictype": "routed",
+             "ipv4.address": "203.0.113.4", "ipv4.host_address": "169.254.0.1"},
+    "eth1": {"type": "nic", "network": "fnt-368798629f8", "ipv4.address": "10.30.1.10"}
+  }
+}`
+
+// TestReRoutingAnAddressARoutedNICAlreadyCarriesTouchesNothing: the address is
+// delivered, so the replay emits nothing at all — and in particular never asks
+// the uplink to carry a /32 the host already routes.
+func TestReRoutingAnAddressARoutedNICAlreadyCarriesTouchesNothing(t *testing.T) {
+	for name, ovn := range map[string]bool{"bridge mode": false, "ovn mode": true} {
+		t.Run(name, func(t *testing.T) {
+			f := &fakeRuntime{answers: map[string]string{
+				"/1.0/instances/srv": routedAndPrivate,
+			}}
+			d := newFakeDriver(f)
+			d.OVN = ovn
+
+			if err := d.RouteAddress(context.Background(), AddressSpec{
+				Machine: "srv", Address: "203.0.113.4", Network: "fnt-368798629f8",
+			}); err != nil {
+				t.Fatalf("replaying a delivered address must be a no-op, got: %v", err)
+			}
+
+			for _, forbidden := range []string{
+				"network set " + DefaultUplinkName,
+				"ipv4.routes.external",
+				"config device set srv eth1",
+			} {
+				if got := f.matching(forbidden); len(got) != 0 {
+					t.Errorf("the replay reconfigured a machine that already answers on the address:\n%s",
+						strings.Join(got, "\n"))
+				}
+			}
+		})
+	}
+}
+
+// The accepting half, without which the guard above would be a refusal rather
+// than an idempotence: an address no routed NIC carries still travels the OVN
+// path in full — the uplink first, because Incus validates ipv4.routes.external
+// against it, then the device.
+func TestAnAddressNoRoutedNICCarriesStillTravelsTheOVNPath(t *testing.T) {
+	f := &fakeRuntime{answers: map[string]string{
+		"/1.0/instances/srv":                                routedAndPrivate,
+		"network get fnt-368798629f8 user." + LabelKey:      "feint\n",
+		"network get fnt-368798629f8 ipv4.address":          "10.30.1.1/24\n",
+		"network get " + DefaultUplinkName + " ipv4.routes": "",
+	}}
+	d := newFakeDriver(f)
+	d.OVN = true
+
+	if err := d.RouteAddress(context.Background(), AddressSpec{
+		Machine: "srv", Address: "203.0.113.9", Network: "fnt-368798629f8",
+	}); err != nil {
+		t.Fatalf("route: %v", err)
+	}
+
+	for _, must := range []string{
+		"network set " + DefaultUplinkName + " ipv4.routes=203.0.113.9/32",
+		"config device set srv eth1 ipv4.routes.external=203.0.113.9/32",
+	} {
+		if len(f.matching(must)) == 0 {
+			t.Errorf("missing %q in:\n%s", must, strings.Join(f.commands(), "\n"))
+		}
+	}
+}
+
+// And a machine with no routed NIC at all — every Outscale Vm, every server
+// whose only interface is its private one — is not affected by the question.
+func TestAMachineWithNoRoutedNICIsRoutedAsBefore(t *testing.T) {
+	const privateOnly = `{
+	  "devices": {
+	    "eth0": {"type": "nic", "network": "fnt-368798629f8", "ipv4.address": "10.30.1.10"}
+	  },
+	  "expanded_devices": {
+	    "eth0": {"type": "nic", "network": "fnt-368798629f8", "ipv4.address": "10.30.1.10"}
+	  }
+	}`
+	f := &fakeRuntime{answers: map[string]string{
+		"/1.0/instances/srv":                                privateOnly,
+		"network get fnt-368798629f8 user." + LabelKey:      "feint\n",
+		"network get fnt-368798629f8 ipv4.address":          "10.30.1.1/24\n",
+		"network get " + DefaultUplinkName + " ipv4.routes": "",
+	}}
+	d := newFakeDriver(f)
+	d.OVN = true
+
+	if err := d.RouteAddress(context.Background(), AddressSpec{
+		Machine: "srv", Address: "203.0.113.4", Network: "fnt-368798629f8",
+	}); err != nil {
+		t.Fatalf("route: %v", err)
+	}
+	if len(f.matching("config device set srv eth0 ipv4.routes.external=203.0.113.4/32")) == 0 {
+		t.Errorf("the address did not reach the private NIC:\n%s", strings.Join(f.commands(), "\n"))
+	}
+}

--- a/internal/core/machine/incus_ovn.go
+++ b/internal/core/machine/incus_ovn.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/stephrobert/feint/internal/core/serialise"
 )
@@ -994,6 +995,121 @@ func (d *Incus) networkGateway(ctx context.Context, network string) (netip.Prefi
 // wins, and a destination the router has no peering for dies at the router,
 // which is exactly where the isolation verdict belongs.
 var privateAggregates = []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"}
+
+// guestRoutePoll and guestRouteWait bound the wait for a restarted guest to
+// have configured its interface again. A container's DHCP client answers in a
+// second or two, a virtual machine's in tens of them; past a minute and a half
+// the machine has a problem an operator should read about rather than wait
+// through.
+const (
+	guestRoutePoll = 2 * time.Second
+	guestRouteWait = 90 * time.Second
+)
+
+// restoreGuestRoutes puts back, inside a machine that has just been started
+// again, the routes towards the peered subnets that a boot does not restore.
+//
+// The measurement is #549, and it is the exact shape of "a machine the control
+// plane describes correctly and that does not work". A Scaleway server was
+// stopped and started through the API; it came back running, on its address,
+// answering on its own subnet — and no longer reaching the machine one subnet
+// away, while its identical neighbour, never restarted, kept reaching it in the
+// same pass. The three RFC 1918 aggregates installGuestPrivateRoutes lays were
+// gone from its table: the guest's network had been rebuilt by DHCP, which
+// knows nothing about the peerings, and the only two callers that laid them —
+// Attach, and the repair of an interface that bounced — are exactly the two a
+// poweron does not go through.
+//
+// So it belongs on the start path and in this layer: no pack can forget it,
+// and a fourth pack gets it without writing a line. What is restored is read
+// off the runtime rather than off the caller's Spec, because the machine's
+// interfaces are the runtime's own answer and a Spec built from a stale store
+// would restore the wrong thing — or nothing, which is what a Scaleway server
+// whose NICs ride the launch would have got.
+//
+// TestARestartedMachineGetsItsPeeredRoutesBack fails without this.
+func (d *Incus) restoreGuestRoutes(ctx context.Context, machine string) error {
+	if !d.OVN {
+		// The aggregates exist because an OVN network's peers are only
+		// reachable through its router. A managed bridge has no router of its
+		// own and no peerings, so there is nothing here to put back.
+		return nil
+	}
+	devices, err := d.instanceDevices(ctx, machine)
+	if err != nil {
+		return fmt.Errorf("inspect %s to restore its routes: %w", machine, err)
+	}
+	// Sorted, so a machine with several private NICs is repaired in the same
+	// order between two runs and a failure names the same device twice.
+	names := make([]string, 0, len(devices.own))
+	for device, cfg := range devices.own {
+		if cfg["type"] != "nic" || cfg["network"] == "" {
+			continue
+		}
+		// Ours only, and the question is asked of the name the emulator itself
+		// derives (NetworkName). This call reads a network's gateway and then
+		// writes a route inside the guest through it: a NIC an operator added
+		// by hand to one of our machines is theirs, and is left exactly as they
+		// configured it. TestRestoringRoutesLeavesAForeignNICAlone fails
+		// without this half.
+		if !ownedNetwork(cfg["network"]) {
+			continue
+		}
+		names = append(names, device)
+	}
+	slices.Sort(names)
+	for _, device := range names {
+		// The wait is the ordering, not politeness: `ip route add … via <gw>
+		// dev ethN` is refused while the interface carries no address of that
+		// subnet, and a route laid before DHCP finished is a route DHCP
+		// replaces.
+		if err := d.waitForGuestInterface(ctx, machine, device); err != nil {
+			return err
+		}
+		if err := d.installGuestPrivateRoutes(ctx, machine, devices.own[device]["network"], device); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// waitForGuestInterface blocks until the guest carries an IPv4 address on the
+// interface behind a device, which is what tells a boot that has finished
+// configuring the interface from one still doing it.
+func (d *Incus) waitForGuestInterface(ctx context.Context, machine, device string) error {
+	poll := d.routePoll
+	if poll <= 0 {
+		poll = guestRoutePoll
+	}
+	budget := d.routeBudget
+	if budget <= 0 {
+		budget = guestRouteWait
+	}
+	deadline := time.Now().Add(budget)
+	var last error
+	for {
+		iface, err := d.guestInterface(ctx, machine, device)
+		if err == nil {
+			var carried map[string]bool
+			carried, err = d.guestAddresses(ctx, machine, iface)
+			if err == nil && len(carried) > 0 {
+				return nil
+			}
+		}
+		last = err
+		if time.Now().After(deadline) {
+			if last == nil {
+				last = fmt.Errorf("it carries no IPv4 address")
+			}
+			return fmt.Errorf("wait for %s/%s to be configured inside the guest: %w", machine, device, last)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(poll):
+		}
+	}
+}
 
 // installGuestPrivateRoutes points the guest's private traffic at the OVN
 // router. "file exists" is a previous call's work still standing.

--- a/internal/core/machine/incus_restart_test.go
+++ b/internal/core/machine/incus_restart_test.go
@@ -1,0 +1,210 @@
+package machine
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// What a machine loses when it is stopped and started again, and what this
+// driver owes it back (#549).
+//
+// The measurement, on the Scaleway example stack under --vm incus-ovn on
+// 2026-08-27: platform-web-0 was stopped and started through the API, came back
+// running, on its address, reaching its own subnet — and no longer reaching
+// platform-app-worker-a one subnet away, while platform-web-1, its identical
+// neighbour and never restarted, kept reaching it in the same pass. Inside the
+// restarted guest the three RFC 1918 aggregates were gone.
+//
+// These are argument-level assertions, which is the only level at which "the
+// driver put the routes back" can be held without a runtime. That the runtime
+// accepts them is tools/conformance/functional.sh's half.
+
+// restartedInstance answers the calls Start makes on the path where the
+// instance already exists, for a machine shaped like every Scaleway server the
+// stack builds: a routed NIC carrying the public address, and one OVN NIC on a
+// network the emulator owns.
+func restartedInstance(f *fakeRuntime, devices string) {
+	f.hook = func(_ int, args []string) ([]byte, error, bool) {
+		switch args[0] {
+		case "list":
+			return []byte(`[{"name":"srv","status":"Running","state":{"network":{}}}]`), nil, true
+		case "query":
+			if strings.HasSuffix(args[len(args)-1], "/1.0/instances/srv") {
+				return []byte(devices), nil, true
+			}
+		case "network":
+			if len(args) > 3 && args[1] == "get" && args[3] == "ipv4.address" {
+				return []byte("10.30.1.1/24\n"), nil, true
+			}
+		case "exec":
+			// The guest answers that its interface is configured, which is what
+			// the wait is looking for.
+			if strings.Contains(strings.Join(args, " "), "-o addr show dev") {
+				return []byte("2: eth1    inet 10.30.1.10/24 scope global eth1\n"), nil, true
+			}
+		}
+		return nil, nil, false
+	}
+}
+
+const routedPlusPrivate = `{
+  "devices": {
+    "eth0": {"type": "nic", "nictype": "routed", "ipv4.address": "203.0.113.4"},
+    "eth1": {"type": "nic", "network": "fnt-368798629f8", "ipv4.address": "10.30.1.10"}
+  },
+  "expanded_devices": {
+    "eth0": {"type": "nic", "nictype": "routed", "ipv4.address": "203.0.113.4"},
+    "eth1": {"type": "nic", "network": "fnt-368798629f8", "ipv4.address": "10.30.1.10"}
+  }
+}`
+
+// TestARestartedMachineGetsItsPeeredRoutesBack is the test #549 names: without
+// restoreGuestRoutes on the already-exists branch of Start, not one of these
+// commands is emitted and the guest comes back reaching its own subnet alone.
+func TestARestartedMachineGetsItsPeeredRoutesBack(t *testing.T) {
+	f := &fakeRuntime{}
+	restartedInstance(f, routedPlusPrivate)
+	d := ovnDriver(f)
+
+	if _, err := d.Start(context.Background(), Spec{Name: "srv", Image: "ubuntu:22.04"}); err != nil {
+		t.Fatalf("start an existing machine: %v", err)
+	}
+
+	for _, block := range privateAggregates {
+		want := "exec srv -- ip route add " + block + " via 10.30.1.1 dev eth1"
+		if len(f.matching(want)) == 0 {
+			t.Errorf("a restarted machine was not given back its route to %s:\n%s",
+				block, strings.Join(f.commands(), "\n"))
+		}
+	}
+}
+
+// A machine that never went down must not pay for the repair either: the same
+// commands are what a poweron on an already-running machine emits, and they are
+// idempotent by construction ("file exists" is a previous call's work standing).
+// This is the accepting half — a guard that refused everything would pass every
+// negative test and break the product.
+func TestRestoringRoutesIsIdempotent(t *testing.T) {
+	f := &fakeRuntime{}
+	restartedInstance(f, routedPlusPrivate)
+	f.fail = map[string]error{
+		"ip route add": errors.New("incus: Error: RTNETLINK answers: File exists"),
+	}
+	d := ovnDriver(f)
+
+	if _, err := d.Start(context.Background(), Spec{Name: "srv", Image: "ubuntu:22.04"}); err != nil {
+		t.Fatalf("a second restore must not fail the start: %v", err)
+	}
+}
+
+// TestRestoringRoutesLeavesAForeignNICAlone: the name of the network comes off
+// the runtime, and a NIC an operator added by hand to one of our machines is
+// theirs. Nothing is read from it and nothing is written through it.
+func TestRestoringRoutesLeavesAForeignNICAlone(t *testing.T) {
+	const foreign = `{
+	  "devices": {
+	    "eth1": {"type": "nic", "network": "incusbr0", "ipv4.address": "10.76.154.10"}
+	  },
+	  "expanded_devices": {
+	    "eth1": {"type": "nic", "network": "incusbr0", "ipv4.address": "10.76.154.10"}
+	  }
+	}`
+	f := &fakeRuntime{}
+	restartedInstance(f, foreign)
+	d := ovnDriver(f)
+
+	if _, err := d.Start(context.Background(), Spec{Name: "srv", Image: "ubuntu:22.04"}); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	for _, forbidden := range []string{"network get incusbr0", "ip route add"} {
+		if got := f.matching(forbidden); len(got) != 0 {
+			t.Errorf("the repair reached a network the emulator did not create:\n%s",
+				strings.Join(got, "\n"))
+		}
+	}
+}
+
+// The bridge mode has no router of its own and no peerings, so there is nothing
+// to put back there. Asserted rather than assumed: the aggregates point at an
+// OVN router, and laying them on a bridge would send a guest's private traffic
+// at an address that answers nothing.
+func TestABridgeModeRestartLaysNoAggregates(t *testing.T) {
+	f := &fakeRuntime{}
+	restartedInstance(f, routedPlusPrivate)
+	d := newFakeDriver(f) // OVN is false
+
+	if _, err := d.Start(context.Background(), Spec{Name: "srv", Image: "ubuntu:22.04"}); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if got := f.matching("ip route add"); len(got) != 0 {
+		t.Errorf("bridge mode laid OVN aggregates:\n%s", strings.Join(got, "\n"))
+	}
+}
+
+// A guest that never finishes configuring its interface must be reported, not
+// waited through for ever, and the report must name the machine and the device
+// — an operator reading "the machine is running" and finding it unreachable is
+// the state #549 was.
+func TestAGuestThatNeverConfiguresItsInterfaceIsReported(t *testing.T) {
+	f := &fakeRuntime{}
+	f.hook = func(_ int, args []string) ([]byte, error, bool) {
+		switch args[0] {
+		case "list":
+			return []byte(`[{"name":"srv","status":"Running","state":{"network":{}}}]`), nil, true
+		case "query":
+			if strings.HasSuffix(args[len(args)-1], "/1.0/instances/srv") {
+				return []byte(routedPlusPrivate), nil, true
+			}
+		case "exec":
+			return nil, errors.New("incus: Error: Command not found"), true
+		}
+		return nil, nil, false
+	}
+	d := ovnDriver(f)
+	d.routePoll = time.Millisecond
+	d.routeBudget = 5 * time.Millisecond
+
+	err := d.restoreGuestRoutes(context.Background(), "srv")
+	if err == nil {
+		t.Fatal("a guest that never configured its interface was reported as repaired")
+	}
+	for _, want := range []string{"srv", "eth1"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the failure does not name %q: %v", want, err)
+		}
+	}
+}
+
+// And the start still succeeds: the machine is up, and answering FailedState
+// for a machine the runtime is running is the lie in the other direction.
+func TestAFailedRouteRestoreStillReportsTheMachineStarted(t *testing.T) {
+	f := &fakeRuntime{}
+	f.hook = func(_ int, args []string) ([]byte, error, bool) {
+		switch args[0] {
+		case "list":
+			return []byte(`[{"name":"srv","status":"Running","state":{"network":{}}}]`), nil, true
+		case "query":
+			if strings.HasSuffix(args[len(args)-1], "/1.0/instances/srv") {
+				return []byte(routedPlusPrivate), nil, true
+			}
+		case "exec":
+			return nil, errors.New("incus: Error: Command not found"), true
+		}
+		return nil, nil, false
+	}
+	d := ovnDriver(f)
+	d.routePoll = time.Millisecond
+	d.routeBudget = 5 * time.Millisecond
+
+	m, err := d.Start(context.Background(), Spec{Name: "srv", Image: "ubuntu:22.04"})
+	if err != nil {
+		t.Fatalf("a machine that is running must not be reported as a failed start: %v", err)
+	}
+	if m.Name != "srv" {
+		t.Errorf("the started machine is %q, want srv", m.Name)
+	}
+}

--- a/internal/core/machine/plan.go
+++ b/internal/core/machine/plan.go
@@ -120,6 +120,41 @@ func (r Reconciler) PowerOn(ctx context.Context, res *resource.Resource, boot Bo
 	return true
 }
 
+// Reboot takes the machine down and brings it back up on its declared plan.
+//
+// It exists because the sequence was written three times and one copy forgot
+// half of it. Outscale's RebootVms and Exoscale's reboot-instance both said "a
+// reboot is a stop then a start"; Scaleway's action filed reboot with poweron
+// and called the start alone, under a comment stating that the reboot case was
+// handled — the exact shape CLAUDE.md names, a comment standing where a control
+// belongs. The runtime refuses to relaunch a name it has already served, so the
+// measured outcome on 2026-08-27 was an action answered `success`, an API
+// reporting `running`, and a machine with the same container pid, an uptime
+// still climbing and a transient marker unit still alive (#547).
+//
+// Worse than the usage cost was the testing one: any assertion of the form
+// "the service survives a restart" wired through that action could not fail.
+//
+// What it publishes is what the effect produced, never what the request asked
+// for: PowerOn writes FailedState when the runtime did not deliver, so a reboot
+// the runtime refuses leaves a server a client can read as down, in that
+// provider's own vocabulary. That is #484's form, kept rather than reinvented.
+//
+// TestARebootStopsTheMachineBeforeStartingIt fails without this, and so does
+// internal/providers' TestSameIntentSameRuntimeSequenceAcrossPacks, where the
+// reboot intent is now one of the compared ones: the three packs must ask the
+// runtime for the same gestures, and before this they did not.
+func (r Reconciler) Reboot(ctx context.Context, res *resource.Resource, boot Boot) bool {
+	// A machine that is not up has nothing to take down, and asking the runtime
+	// to stop a stopped instance logs a failure for an ordinary case. Which
+	// word means "up" is the pack's, held once here rather than compared to a
+	// literal in three places.
+	if res.State == r.binding().RunningState {
+		r.binding().PowerOff(ctx, res)
+	}
+	return r.PowerOn(ctx, res, boot)
+}
+
 // ReplayAddresses re-routes every promised address of a machine that just
 // proved reachable — the late-address door: a virtual machine's agent answers
 // long after poweron returned, and the guest half of its routes can only land

--- a/internal/core/machine/reboot_test.go
+++ b/internal/core/machine/reboot_test.go
@@ -1,0 +1,183 @@
+package machine
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/netip"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/resource"
+)
+
+// What a reboot is, held once for every pack (#547).
+//
+// Two packs wrote "a reboot is a stop then a start" and did it; the third filed
+// reboot with poweron and called the start alone, under a comment saying the
+// case was handled. The runtime refuses to relaunch a name it has already
+// served, so on 2026-08-27 the action answered `success`, the API reported
+// `running`, and the machine came out of it with the same container pid, an
+// uptime still climbing and a transient marker unit still alive.
+
+// rebootReconciler is the group-sync bench with a binding that names its
+// running and failed states, which Reboot and PowerOn read.
+func rebootReconciler(b *groupSyncBench, plan Plan) Reconciler {
+	sync := b.sync()
+	sync.Binding.RunningState = "running"
+	sync.Binding.FailedState = "stopped"
+	return Reconciler{
+		Groups:      sync,
+		PlanOf:      func(*testResource) Plan { return plan },
+		PublicBlock: netip.MustParsePrefix("203.0.113.0/24"),
+	}
+}
+
+// firstOf returns the index of the first gesture of that kind, or -1.
+func firstOf(sequence []string, kind string) int {
+	for i, got := range sequence {
+		if got == kind {
+			return i
+		}
+	}
+	return -1
+}
+
+// TestARebootStopsTheMachineBeforeStartingIt is the whole of #547 at the level
+// where it can be held deterministically: the gestures the pack asks of the
+// runtime, in order.
+func TestARebootStopsTheMachineBeforeStartingIt(t *testing.T) {
+	b := newGroupSyncBench()
+	vm := b.machine("m", "10.0.0.5")
+	vm.State = "running"
+
+	r := rebootReconciler(b, Plan{})
+	if !r.Reboot(context.Background(), vm, Boot{Image: "ubuntu:24.04"}) {
+		t.Fatalf("the reboot did not bring the machine back; sequence: %v", b.rec.Sequence())
+	}
+
+	sequence := b.rec.Sequence()
+	stop, start := firstOf(sequence, "Stop"), firstOf(sequence, "Start")
+	if stop < 0 {
+		t.Fatalf("the reboot never asked the runtime to stop the machine, so nothing restarted (#547); sequence: %v", sequence)
+	}
+	if start < 0 {
+		t.Fatalf("the reboot never asked the runtime to start the machine; sequence: %v", sequence)
+	}
+	if stop > start {
+		t.Fatalf("a reboot is a stop THEN a start; sequence: %v", sequence)
+	}
+	if vm.State != "running" {
+		t.Errorf("state %q after a reboot the runtime honoured, want running", vm.State)
+	}
+}
+
+// The accepting half of the state question, and the half a guard that refused
+// everything would still pass: a reboot of a machine that is not up has nothing
+// to take down, and asking the runtime to stop a stopped instance would log a
+// failure for an ordinary case.
+func TestARebootOfAStoppedMachineDoesNotStopItAgain(t *testing.T) {
+	b := newGroupSyncBench()
+	vm := b.machine("m", "10.0.0.5")
+	vm.State = "stopped"
+
+	r := rebootReconciler(b, Plan{})
+	if !r.Reboot(context.Background(), vm, Boot{Image: "ubuntu:24.04"}) {
+		t.Fatalf("the reboot did not start the machine; sequence: %v", b.rec.Sequence())
+	}
+	if sequence := b.rec.Sequence(); firstOf(sequence, "Stop") >= 0 {
+		t.Errorf("a machine that was not running was stopped anyway; sequence: %v", sequence)
+	}
+	if firstOf(b.rec.Sequence(), "Start") < 0 {
+		t.Errorf("a reboot of a stopped machine must still start it; sequence: %v", b.rec.Sequence())
+	}
+}
+
+// refusingDriver starts nothing, which is what a runtime out of disk, out of
+// address space or simply down does.
+type refusingDriver struct{ stopped []string }
+
+func (d *refusingDriver) Name() string                   { return "refusing" }
+func (d *refusingDriver) Available(context.Context) bool { return true }
+func (d *refusingDriver) Start(context.Context, Spec) (Machine, error) {
+	return Machine{}, errors.New("no space left on device")
+}
+func (d *refusingDriver) Stop(_ context.Context, name string) error {
+	d.stopped = append(d.stopped, name)
+	return nil
+}
+func (d *refusingDriver) Remove(context.Context, string) error { return nil }
+func (d *refusingDriver) Inspect(_ context.Context, name string) (Machine, bool, error) {
+	return Machine{Name: name}, true, nil
+}
+func (d *refusingDriver) EnsureNetwork(context.Context, NetworkSpec) error { return nil }
+func (d *refusingDriver) Attach(context.Context, string, Attachment) error { return nil }
+func (d *refusingDriver) Detach(context.Context, string, string) error     { return nil }
+func (d *refusingDriver) RemoveNetwork(context.Context, string) error      { return nil }
+
+// The answer to "what does a reboot the runtime refused publish?", which is the
+// question #547 makes unavoidable: a control plane that answers `success` on an
+// action it did not perform is the lie this project exists to refuse. The shape
+// is #484's, not a new one — the binding writes FailedState, in the provider's
+// own vocabulary.
+func TestARebootTheRuntimeRefusesPublishesTheFailedState(t *testing.T) {
+	driver := &refusingDriver{}
+	binding := Binding{
+		driver:       driver,
+		Provider:     "acme",
+		Prefix:       "feint-acme-",
+		RuntimeKey:   "machine",
+		AddressKey:   "address",
+		RunningState: "running",
+		FailedState:  "stopped",
+		Log:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	r := Reconciler{
+		Groups: GroupSync{Binding: binding},
+		PlanOf: func(*resource.Resource) Plan { return Plan{} },
+	}
+	res := &resource.Resource{
+		ID:      "srv-1",
+		State:   "running",
+		Runtime: map[string]string{"machine": "feint-acme-srv-1", "address": "10.0.0.5"},
+	}
+
+	if r.Reboot(context.Background(), res, Boot{Image: "ubuntu:24.04"}) {
+		t.Fatal("a reboot the runtime refused reported success")
+	}
+	if res.State != "stopped" {
+		t.Errorf("state %q after a reboot nothing came back from, want the failed state", res.State)
+	}
+	if len(driver.stopped) != 1 || driver.stopped[0] != "feint-acme-srv-1" {
+		t.Errorf("the machine was not taken down: %v", driver.stopped)
+	}
+	if res.Runtime["address"] != "" {
+		t.Errorf("an address is still published for a machine that did not come back: %q", res.Runtime["address"])
+	}
+}
+
+// With no runtime at all the control plane must keep working, which is the
+// documented degraded mode every conformance suite in CI runs in.
+func TestARebootWithoutARuntimeKeepsTheControlPlaneWorking(t *testing.T) {
+	binding := Binding{
+		Provider:     "acme",
+		Prefix:       "feint-acme-",
+		RuntimeKey:   "machine",
+		AddressKey:   "address",
+		RunningState: "running",
+		FailedState:  "stopped",
+		Log:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	r := Reconciler{
+		Groups: GroupSync{Binding: binding},
+		PlanOf: func(*resource.Resource) Plan { return Plan{} },
+	}
+	res := &resource.Resource{ID: "srv-1", State: "running", Runtime: map[string]string{}}
+
+	if !r.Reboot(context.Background(), res, Boot{}) {
+		t.Fatal("a reboot with no runtime configured must still reach running")
+	}
+	if res.State != "running" {
+		t.Errorf("state %q, want running: metadata-only is the documented degraded mode", res.State)
+	}
+}

--- a/internal/core/machine/surface.go
+++ b/internal/core/machine/surface.go
@@ -107,6 +107,7 @@ func PackSurface() map[string]string {
 		// executes the one order.
 		"Reconciler":           "the orchestrator that executes a declared plan in the runtime's order",
 		"Reconciler.PowerOn":   "start a machine on its plan and replay the post-boot order",
+		"Reconciler.Reboot":    "take a machine down and bring it back on its plan",
 		"Plan":                 "the machine's declared interface shape",
 		"Plan.Memberships":     "the networks joined after boot, read back from the plan the pack built",
 		"Attachment":           "one interface: a network, an address, the mask, the secondaries",

--- a/internal/providers/exoscale/lifecycle.go
+++ b/internal/providers/exoscale/lifecycle.go
@@ -82,11 +82,12 @@ func (p *Pack) stopInstance(w http.ResponseWriter, r *http.Request) {
 	p.writeOperation(w, p.operationReferring(nounInstance, id))
 }
 
-// rebootInstance is a stop then a start, under one hold of the target.
+// rebootInstance is a stop then a start, under one hold of the target. The
+// sequence is the shared layer's since #547: it was written here, in Outscale,
+// and half-written in Scaleway, whose copy had lost its stop.
 func (p *Pack) rebootInstance(w http.ResponseWriter, r *http.Request) {
 	id, ok := p.transitionInstance(w, r, func(res *resource.Resource) {
-		p.binding().PowerOff(r.Context(), res)
-		p.start(r.Context(), res)
+		p.reboot(r.Context(), res)
 	})
 	if !ok {
 		return

--- a/internal/providers/exoscale/machines.go
+++ b/internal/providers/exoscale/machines.go
@@ -132,6 +132,21 @@ func templateFor(id string) (machine.Image, bool) {
 // started: with no runtime the instance still reaches running, which is what a
 // client waits for, and the log says nothing is behind it.
 func (p *Pack) start(ctx context.Context, res *resource.Resource) {
+	p.reconciler().PowerOn(ctx, res, p.bootOf(res))
+}
+
+// reboot takes the instance down and brings it back, through the shared
+// sequence (#547). The stop-then-start was written here, in Outscale, and
+// half-written in Scaleway, whose copy called the start alone.
+func (p *Pack) reboot(ctx context.Context, res *resource.Resource) {
+	p.reconciler().Reboot(ctx, res, p.bootOf(res))
+}
+
+// bootOf is what this pack asks the runtime for when an instance comes up. One
+// function for the two doors that boot a machine — start-instance and
+// reboot-instance — because a boot described twice is a boot that differs on
+// one of them.
+func (p *Pack) bootOf(res *resource.Resource) machine.Boot {
 	templateID := ""
 	if t, ok := res.Attrs["template"].(map[string]any); ok {
 		templateID, _ = t["id"].(string)
@@ -147,7 +162,7 @@ func (p *Pack) start(ctx context.Context, res *resource.Resource) {
 	// pack used to keep as a comment — a membership must never become the
 	// primary the way a Boot.Attachment would — is the layer's law now:
 	// Plan.Memberships never ride the launch.
-	p.reconciler().PowerOn(ctx, res, machine.Boot{
+	return machine.Boot{
 		Image:     img.Ref,
 		Requested: templateID,
 		Hostname:  name,
@@ -169,7 +184,7 @@ func (p *Pack) start(ctx context.Context, res *resource.Resource) {
 		// so that is what a read gives back and what cloud-init must not see.
 		CloudInit: cloudinit.Decode(userData),
 		Labels:    map[string]string{"feint.instance": res.ID},
-	})
+	}
 }
 
 // reconciler is this pack's half of the shared interface choreography (#510):

--- a/internal/providers/outscale/machines.go
+++ b/internal/providers/outscale/machines.go
@@ -95,6 +95,21 @@ func (p *Pack) bootRefusalReason(imageID string) string {
 // reported running while nothing exists is the defect this project is built to
 // avoid, not a rounding of it.
 func (p *Pack) powerOn(ctx context.Context, res *resource.Resource) {
+	p.reconciler().PowerOn(ctx, res, p.bootOf(res))
+}
+
+// reboot takes the Vm down and brings it back, through the shared sequence
+// (#547). RebootVms wrote its own stop-then-start, and so did Exoscale's; the
+// third pack's copy of that sentence had lost its stop, which is the
+// duplication the layer removes rather than the defect it patches.
+func (p *Pack) reboot(ctx context.Context, res *resource.Resource) {
+	p.reconciler().Reboot(ctx, res, p.bootOf(res))
+}
+
+// bootOf is what this pack asks the runtime for when a Vm comes up. One
+// function for the two doors that boot a machine — RunVms/StartVms and
+// RebootVms — because a boot described twice is a boot that differs on one.
+func (p *Pack) bootOf(res *resource.Resource) machine.Boot {
 	imageID, _ := res.Attrs["ImageId"].(string)
 	keypair, _ := res.Attrs["KeypairName"].(string)
 	userData, _ := res.Attrs["UserData"].(string)
@@ -109,7 +124,7 @@ func (p *Pack) powerOn(ctx context.Context, res *resource.Resource) {
 	// is declared to the shared Reconciler, which executes the one post-boot
 	// order: addresses, then memberships, the firewall last (#510). Written
 	// here as a comment three ways before that; held by a test now.
-	p.reconciler().PowerOn(ctx, res, machine.Boot{
+	return machine.Boot{
 		Image:          img.Ref,
 		User:           img.User,
 		Requested:      imageID,
@@ -121,7 +136,7 @@ func (p *Pack) powerOn(ctx context.Context, res *resource.Resource) {
 		// cloud-init must never receive.
 		CloudInit: cloudinit.Decode(userData),
 		Labels:    map[string]string{"feint.vm": res.ID},
-	})
+	}
 }
 
 // reconciler is this pack's half of the shared interface choreography (#510):

--- a/internal/providers/outscale/vms.go
+++ b/internal/providers/outscale/vms.go
@@ -759,10 +759,11 @@ func (p *Pack) rebootVms(w http.ResponseWriter, r *http.Request) {
 	for _, id := range req.VMIDs {
 		// A reboot is a stop then a start, which is the longest window of the
 		// three: another action landing between them would act on a VM that has
-		// no machine yet and write its own state over this one's.
+		// no machine yet and write its own state over this one's. The sequence
+		// itself is the shared layer's since #547 — it was written here, in
+		// Exoscale, and half-written in Scaleway.
 		p.transitionOne(id, func(res *resource.Resource) string {
-			p.powerOff(r.Context(), res)
-			p.powerOn(r.Context(), res)
+			p.reboot(r.Context(), res)
 			return res.State
 		})
 	}

--- a/internal/providers/replay_test.go
+++ b/internal/providers/replay_test.go
@@ -93,6 +93,28 @@ var intents = []intent{
 			{"four", replayFourLinkedAfterBoot},
 		},
 	},
+	{
+		// The same machine, restarted through each cloud's own reboot verb.
+		//
+		// This intent is here because the answer diverged and nothing said so
+		// (#547). Outscale's RebootVms and Exoscale's reboot-instance both did
+		// a stop then a start; Scaleway's action filed reboot with poweron and
+		// called the start alone, so the runtime — which refuses to relaunch a
+		// name it has already served — did nothing at all, while the API
+		// answered `success` and reported `running`. Measured on 2026-08-27:
+		// same container pid, uptime still climbing, a transient marker unit
+		// still alive after the call.
+		//
+		// A reboot is one thing on every cloud, so no pack is excused from it.
+		name:     "the machine is restarted through the provider's own reboot verb",
+		excluded: map[string]string{},
+		replays: []packReplay{
+			{"scaleway", replayScalewayRebooted},
+			{"outscale", replayOutscaleRebooted},
+			{"exoscale", replayExoscaleRebooted},
+			{"four", replayFourRebooted},
+		},
+	},
 }
 
 // allReplays flattens the corpus for the properties that hold per replay.
@@ -243,6 +265,25 @@ func replayExoscaleJoinsAfterBoot(t *testing.T) *machine.Recorder {
 // nothing else; the flexible IP is attached afterwards.
 func replayScalewayLinkedAfterBoot(t *testing.T) *machine.Recorder {
 	t.Helper()
+	rec, _, _ := scalewayLinked(t)
+	return rec
+}
+
+// replayScalewayRebooted: the same machine, restarted through the action
+// endpoint. Before #547 this replay recorded no Stop at all.
+func replayScalewayRebooted(t *testing.T) *machine.Recorder {
+	t.Helper()
+	rec, h, serverID := scalewayLinked(t)
+	request(t, h, "POST", "/instance/v1/zones/fr-par-1/servers/"+serverID+"/action",
+		`{"action":"reboot"}`)
+	return rec
+}
+
+// scalewayLinked is the prologue two intents share: a server wearing a group
+// with a rule, powered on, its flexible IP linked afterwards. It hands back the
+// handler and the id so an intent can go on acting on the same machine.
+func scalewayLinked(t *testing.T) (*machine.Recorder, http.Handler, string) {
+	t.Helper()
 	env, rec := recorderEnv()
 	srv, err := emulator.NewServer(env, scaleway.New(env))
 	if err != nil {
@@ -259,7 +300,7 @@ func replayScalewayLinkedAfterBoot(t *testing.T) *machine.Recorder {
 
 	ip := request(t, h, "POST", zone+"/ips", `{}`)
 	request(t, h, "PATCH", zone+"/ips/"+id(t, ip, "ip", "id"), `{"server":"`+serverID+`"}`)
-	return rec
+	return rec, h, serverID
 }
 
 // replayOutscaleLinkedAfterBoot: the Vm lives outside any Net — Outscale's
@@ -267,6 +308,20 @@ func replayScalewayLinkedAfterBoot(t *testing.T) *machine.Recorder {
 // launch — wearing its group; the public IP is linked afterwards, which is the
 // only moment its dialect can link one.
 func replayOutscaleLinkedAfterBoot(t *testing.T) *machine.Recorder {
+	t.Helper()
+	rec, _, _ := outscaleLinked(t)
+	return rec
+}
+
+// replayOutscaleRebooted: the same Vm, restarted through RebootVms.
+func replayOutscaleRebooted(t *testing.T) *machine.Recorder {
+	t.Helper()
+	rec, h, vmID := outscaleLinked(t)
+	request(t, h, "POST", "/api/v1/RebootVms", `{"VmIds":["`+vmID+`"]}`)
+	return rec
+}
+
+func outscaleLinked(t *testing.T) (*machine.Recorder, http.Handler, string) {
 	t.Helper()
 	env, rec := recorderEnv()
 	srv, err := emulator.NewServer(env, outscale.New(env))
@@ -296,13 +351,27 @@ func replayOutscaleLinkedAfterBoot(t *testing.T) *machine.Recorder {
 	vmID := id(t, map[string]any{"Vm": list[0]}, "Vm", "VmId")
 
 	post("LinkPublicIp", `{"PublicIpId":"`+ipID+`","VmId":"`+vmID+`"}`)
-	return rec
+	return rec, h, vmID
 }
 
 // replayExoscaleLinkedAfterBoot: the instance declares public-ip-assignment
 // none — a real upstream setting — so nothing rides the boot but the group;
 // the elastic IP is attached afterwards.
 func replayExoscaleLinkedAfterBoot(t *testing.T) *machine.Recorder {
+	t.Helper()
+	rec, _, _ := exoscaleLinked(t)
+	return rec
+}
+
+// replayExoscaleRebooted: the same instance, restarted through :reboot.
+func replayExoscaleRebooted(t *testing.T) *machine.Recorder {
+	t.Helper()
+	rec, h, instanceID := exoscaleLinked(t)
+	request(t, h, "PUT", "/v2/instance/"+instanceID+":reboot", `{}`)
+	return rec
+}
+
+func exoscaleLinked(t *testing.T) (*machine.Recorder, http.Handler, string) {
 	t.Helper()
 	env, rec := recorderEnv()
 	srv, err := emulator.NewServer(env, exoscale.New(env))
@@ -317,7 +386,7 @@ func replayExoscaleLinkedAfterBoot(t *testing.T) *machine.Recorder {
 	eip := request(t, h, "POST", "/v2/elastic-ip", `{}`)
 	request(t, h, "PUT", "/v2/elastic-ip/"+id(t, eip, "reference", "id")+":attach",
 		`{"instance":{"id":"`+instanceID+`"}}`)
-	return rec
+	return rec, h, instanceID
 }
 
 // ---- The fourth pack, which has no dialect ----------------------------------
@@ -380,6 +449,23 @@ func replayFourJoinsAfterBoot(t *testing.T) *machine.Recorder {
 // attached once it is up.
 func replayFourLinkedAfterBoot(t *testing.T) *machine.Recorder {
 	t.Helper()
+	rec, _, _, _ := fourLinked(t)
+	return rec
+}
+
+// replayFourRebooted: the same node, restarted through the pack that was never
+// told what a reboot is. It asks the layer, so it gets the whole sequence.
+func replayFourRebooted(t *testing.T) *machine.Recorder {
+	t.Helper()
+	rec, ctx, pack, nodeID := fourLinked(t)
+	if err := pack.RebootNode(ctx, nodeID); err != nil {
+		t.Fatalf("reboot the node: %v", err)
+	}
+	return rec
+}
+
+func fourLinked(t *testing.T) (*machine.Recorder, context.Context, *providerfour.Pack, string) {
+	t.Helper()
 	ctx := t.Context()
 	env, rec := recorderEnv()
 	pack := providerfour.New(env)
@@ -404,7 +490,7 @@ func replayFourLinkedAfterBoot(t *testing.T) *machine.Recorder {
 	if err := pack.AttachAnchor(ctx, anchor.ID, node.ID); err != nil {
 		t.Fatalf("attach the anchor: %v", err)
 	}
-	return rec
+	return rec, ctx, pack, node.ID
 }
 
 func fourBarrierWithRule(t *testing.T, ctx context.Context, pack *providerfour.Pack) string {

--- a/internal/providers/scaleway/machines.go
+++ b/internal/providers/scaleway/machines.go
@@ -97,9 +97,10 @@ func requestedImageOf(res *resource.Resource, label string) string {
 	return id
 }
 
-// startMachine powers the server on: the boot, the address replay and the
-// firewall, in the shared Reconciler's one order.
-func (p *Pack) startMachine(ctx context.Context, res *resource.Resource) {
+// bootOf is what this pack asks the runtime for when a server comes up. One
+// function for the two doors that boot a machine — poweron and reboot — because
+// a boot described twice is a boot that differs on one of them.
+func (p *Pack) bootOf(res *resource.Resource) machine.Boot {
 	label, _ := res.Attrs["image_label"].(string)
 	hostname, _ := res.Attrs["hostname"].(string)
 	img, _ := imageFor(label)
@@ -108,7 +109,7 @@ func (p *Pack) startMachine(ctx context.Context, res *resource.Resource) {
 	// hands the "cloud-init" user data key to cloud-init at boot. The
 	// consequence is stated in docs/limits.md: with a custom cloud-init, the
 	// project's SSH keys are only installed if the script installs them.
-	p.reconciler().PowerOn(ctx, res, machine.Boot{
+	return machine.Boot{
 		Image:          img.Ref,
 		User:           img.User,
 		Requested:      requestedImageOf(res, label),
@@ -119,7 +120,19 @@ func (p *Pack) startMachine(ctx context.Context, res *resource.Resource) {
 			"feint.server": res.ID,
 			"feint.zone":   res.Tenant.Zone,
 		},
-	})
+	}
+}
+
+// startMachine powers the server on: the boot, the address replay and the
+// firewall, in the shared Reconciler's one order.
+func (p *Pack) startMachine(ctx context.Context, res *resource.Resource) {
+	p.reconciler().PowerOn(ctx, res, p.bootOf(res))
+}
+
+// rebootMachine takes the server down and brings it back, which is the shared
+// sequence the two other packs already asked for and this one did not (#547).
+func (p *Pack) rebootMachine(ctx context.Context, res *resource.Resource) {
+	p.reconciler().Reboot(ctx, res, p.bootOf(res))
 }
 
 // reconciler is this pack's half of the shared interface choreography (#510):

--- a/internal/providers/scaleway/servers.go
+++ b/internal/providers/scaleway/servers.go
@@ -766,15 +766,14 @@ func (p *Pack) serverAction(w http.ResponseWriter, r *http.Request) {
 func (p *Pack) applyServerAction(w http.ResponseWriter, r *http.Request, req serverActionRequest,
 	res *resource.Resource, id, zone string, now time.Time, reply *func()) bool {
 	switch req.Action {
-	case "poweron", "reboot":
+	case "poweron":
 		// A poweron on a server that is already running is not a second launch.
 		// The runtime refuses a name it has already handed out, so relaunching
 		// reported a failed start on a machine that was running perfectly well:
 		// the same lie as the race above, arriving through the other door. It is
 		// also what the real API does, which lists poweron only for a server
-		// that is not up. reboot is deliberately not covered: acting on a
-		// running machine is its whole purpose.
-		if req.Action == "reboot" || res.State != "running" {
+		// that is not up.
+		if res.State != "running" {
 			// The ephemeral address dynamic_ip_required asks for, allocated
 			// before the boot so it rides the launch like an attached flexible
 			// IP does.
@@ -791,6 +790,25 @@ func (p *Pack) applyServerAction(w http.ResponseWriter, r *http.Request, req ser
 			// Reconciler in the one order every pack follows (#510).
 			p.startMachine(r.Context(), res)
 		}
+		res.Attrs["allowed_actions"] = allowedActions(res.State, protectedServer(res))
+	case "reboot":
+		// A reboot is a stop then a start, which is what the two other packs
+		// already asked of the runtime and what this one did not. Filed with
+		// poweron under a comment saying the case was handled, it called the
+		// start alone: the runtime refuses to relaunch a name it has already
+		// served, so the action answered `success`, the API said `running`, and
+		// the machine had the same container pid, an uptime still climbing and
+		// a transient marker unit still alive (#547, measured 2026-08-27).
+		//
+		// The dynamic address is not released here, and that is the whole
+		// difference with poweroff: upstream releases it on a stop, never on a
+		// reboot, so a client's ephemeral address survives its own restart.
+		p.ensureDynamicAddress(res)
+		// A reboot of a server that is not up is a start: the SDK lists reboot
+		// for a running server only, but nothing here leans on that list, and
+		// inventing a refusal upstream may not answer would be a divergence
+		// nobody measured. Reconciler.Reboot skips the stop for it.
+		p.rebootMachine(r.Context(), res)
 		res.Attrs["allowed_actions"] = allowedActions(res.State, protectedServer(res))
 	case "poweroff", "stop_in_place":
 		// Two actions, two states, and the difference is not cosmetic: the SDK

--- a/tools/conformance/functional.sh
+++ b/tools/conformance/functional.sh
@@ -17,7 +17,10 @@
 #
 #   service    a service listens inside the machine, answers over the address
 #              the provider's own API publishes, and survives a restart of the
-#              machine through that same API
+#              machine through that same API — both doors of it, and the machine
+#              still reaches the subnet it reached before (service.restart_reaches)
+#   rule_sets  the runtime holds, after those restarts, exactly the rule sets and
+#              the references the stack declares
 #   firewall   a port a rule opens answers and a port no rule opens refuses,
 #              both in the same pass, both proved listening inside first
 #   network    two machines of one network reach each other, and two networks
@@ -46,18 +49,22 @@
 # Three decisions taken from measurement rather than preference, all 2026-08-27
 # under `--vm incus-ovn`, and each one found by this file going red:
 #
-#   The restart is poweroff + poweron, not the reboot action. A reboot answered
-#   success and restarted nothing: same container pid, uptime still climbing, a
-#   transient marker unit still active. An assertion resting on it could not
-#   fail, which is the definition of a demonstration. Filed as #547.
+#   The restart is BOTH doors, in order: the provider's own reboot verb first,
+#   then poweroff + poweron. The reboot verb used to be excluded here, because
+#   it answered success and restarted nothing — same container pid, uptime still
+#   climbing, a transient marker unit still active (#547). It is asserted now
+#   rather than avoided: the runtime process must differ across the call, which
+#   is the witness that filed the issue, read from the host.
 #
-#   The restart runs LAST, after every other family. A machine that comes back
-#   from a poweroff/poweron has lost the guest routes to its peered subnets, so
-#   anything probed after one measures that loss rather than the property it
+#   The restart runs LAST, after every other family. A machine that came back
+#   from a restart used to have lost the guest routes to its peered subnets, so
+#   anything probed after one measured that loss rather than the property it
 #   names. The first ordering restarted a web machine before the firewall pair,
 #   the pair went red on its positive half, and the control in the same pass —
-#   the neighbour nobody restarted, still reaching — named the cause. Filed as
-#   #549, and the skip beside the restart says what is therefore not asserted.
+#   the neighbour nobody restarted, still reaching — named the cause (#549).
+#   The order stays, and what used to be a skip beside it is now the assertion:
+#   the restarted machine must still reach the other subnet it reached before,
+#   with that same unrestarted neighbour as the control of the pass.
 #
 #   The firewall pair runs between two subnets, never between neighbours. Within
 #   one subnet the sender's permissive egress outranks the receiver's ingress
@@ -151,6 +158,7 @@ echo "- the readers find their planted witnesses"
 fnl_listen_reader_control
 fnl_name_reader_control
 fnl_delivery_reader_control
+fnl_rule_set_reader_control
 
 # ---- live transports --------------------------------------------------------
 #
@@ -198,6 +206,24 @@ live_fetch() { # machine address port
 # station_fetch is the same trip from where the operator stands.
 station_fetch() { # address port
 	curl -sf --max-time 8 "http://$1:$2/" 2>/dev/null | tr -d '\r\n'
+}
+
+# live_machine_pid answers the runtime process holding a machine, empty when
+# nobody could look. It is the witness #547 was filed on: a reboot that leaves
+# the same process leaves the same kernel and the same uptime. Read from the
+# host, like witness.sh reads an instance's status — never from inside the
+# target, which this gate only uses as the console that originates a probe.
+live_machine_pid() { # machine
+	incus query "/1.0/instances/$1/state" 2>/dev/null | jq -r '.pid // empty'
+}
+
+# live_machine_acls answers the rule sets a machine's interfaces carry, comma
+# separated, non-zero when the instance could not be read at all. The reading of
+# the document is witnesslib's, not a second one written here.
+live_machine_acls() { # machine
+	local doc
+	doc="$(incus query "/1.0/instances/$1" 2>/dev/null)" || return 1
+	printf '%s' "$doc" | witness_instance_acls | paste -sd, -
 }
 
 # private_address answers the address a machine carries on an emulated network,
@@ -252,17 +278,19 @@ resource_state() { # provider id
 	esac
 }
 
-power() { # provider id off|on
+power() { # provider id off|on|reboot
 	local action
 	case "$1" in
 	scaleway)
 		action=poweroff
 		[ "$3" = on ] && action=poweron
+		[ "$3" = reboot ] && action=reboot
 		curl -sf -X POST -H 'Content-Type: application/json' -d "{\"action\":\"$action\"}" \
 			"$ENDPOINT/instance/v1/zones/$ZONE/servers/$2/action" >/dev/null ;;
 	outscale)
 		action=StopVms
 		[ "$3" = on ] && action=StartVms
+		[ "$3" = reboot ] && action=RebootVms
 		osc "$action" "{\"VmIds\":[\"$2\"]}" >/dev/null ;;
 	*) return 3 ;;
 	esac
@@ -411,9 +439,15 @@ run_stack() { # name
 	# run, after every other family, and the order is a measurement rather than
 	# a taste: #549 measured a machine coming back from a poweroff/poweron
 	# without the routes to its peered subnets, so anything probed after a
-	# restart measures that loss instead of the property it names. The first
+	# restart measured that loss instead of the property it names. The first
 	# version of this file restarted a web machine before the firewall pair and
 	# went red on the pair's positive half, which is how #549 was found.
+	#
+	# The order stays now that #549 is fixed, and it is not superstition: every
+	# family above states a property of a machine as the stack built it, and a
+	# restarted machine is a different measurement. That measurement is made
+	# here, deliberately and by itself, with its own before-probe and its own
+	# unrestarted control.
 	assert_restart() { # declared_name unit port
 		local restart="$1" unit="$2" port="$3" body address
 		echo "- $name: the service survives a restart of the machine"
@@ -421,9 +455,71 @@ run_stack() { # name
 		local rmachine="$MACHINE" id state waited status
 		id="$(id_of "$restart")"
 		[ -n "$id" ] || fail "$name: no resource id for $restart"
-		# poweroff + poweron, never the reboot action: #547 measured a
-		# reboot leaving the container's pid and uptime untouched, so an
-		# assertion resting on it could not fail.
+
+		# What must still be reachable afterwards, measured BEFORE anything is
+		# restarted: the after-probe alone cannot tell a restart that lost its
+		# routes from a pair that never held (#549).
+		local reaches rtarget rport rcontrol rmachine_t raddr rbefore rafter rcontrol_after rcmachine
+		reaches="$(printf '%s' "$service" | jq -c 'if has("restart_reaches") then .restart_reaches else "MISSING" end')"
+		[ "$reaches" != '"MISSING"' ] \
+			|| fail "$name: the service family declares a restart and nothing about what must still be reachable after it — that silence is where #549 lived, a machine coming back running, on its address, reaching its own subnet and nothing beyond it"
+		rtarget=""
+		reason="$(skip_reason "$reaches")"
+		if [ -n "$reason" ]; then
+			skip "$name service.restart_reaches: $reason"
+		else
+			rtarget="$(printf '%s' "$reaches" | jq -r '.target')"
+			rport="$(printf '%s' "$reaches" | jq -r '.port')"
+			# The control is the unrestarted machine that must go on reaching
+			# the same target in the same pass — the half that told #549 apart
+			# from a target that simply died. A stack with no such machine
+			# writes the reason; absent, it is the silence this gate removes.
+			local control
+			control="$(printf '%s' "$reaches" | jq -c 'if has("control") then .control else "MISSING" end')"
+			[ "$control" != '"MISSING"' ] \
+				|| fail "$name: service.restart_reaches declares no control; a machine that stops reaching after a restart is told from a target that died by a neighbour that did not restart, or by a written reason there is none"
+			rcontrol=""
+			rcmachine=""
+			reason="$(skip_reason "$control")"
+			if [ -n "$reason" ]; then
+				skip "$name service.restart_reaches.control: $reason"
+			else
+				rcontrol="$(printf '%s' "$control" | jq -r '.source')"
+			fi
+			need_machine "$rtarget"
+			rmachine_t="$MACHINE"
+			address_of "$rtarget" "$rmachine_t"
+			raddr="$ADDRESS"
+			listen_of "$rmachine_t"
+			live_probe "$rmachine" "$raddr" "$rport"
+			rbefore=$?
+			if [ -n "$rcontrol" ]; then
+				need_machine "$rcontrol"
+				rcmachine="$MACHINE"
+			fi
+		fi
+
+		# ---- the provider's own reboot verb, which used to restart nothing ---
+		echo "- $name: the provider's own reboot verb restarts the machine"
+		local pid_before pid_after
+		pid_before="$(live_machine_pid "$rmachine")"
+		power "$provider" "$id" reboot || fail "$name: $provider refused the reboot of $restart"
+		waited=0
+		while [ "$waited" -lt 240 ]; do
+			state="$(resource_state "$provider" "$id")" || fail "cannot look: $provider's API did not answer the state of $restart"
+			if [ "$state" = "$running" ] && incus exec "$rmachine" -- true >/dev/null 2>&1; then
+				pid_after="$(live_machine_pid "$rmachine")"
+				[ -n "$pid_after" ] && [ "$pid_after" != "$pid_before" ] && break
+			fi
+			sleep 4
+			waited=$((waited + 4))
+		done
+		[ "$state" = "$running" ] \
+			|| fail "$name: $restart came back '$state' ${waited}s after the API was asked to reboot it"
+		pid_after="$(live_machine_pid "$rmachine")"
+		fnl_restart_replaced_the_machine "$name" "$restart" "$rmachine" "$pid_before" "$pid_after"
+
+		# ---- and the whole cycle through the other door ----------------------
 		power "$provider" "$id" off || fail "$name: $provider refused the stop of $restart"
 		waited=0
 		state="$running"
@@ -470,6 +566,22 @@ run_stack() { # name
 		if [ -n "$address" ]; then
 			body="$(station_fetch "$address" "$port")"
 			fnl_service_answers "$name" "$restart (after a restart)" "$rmachine" "$address" "$port" "$body"
+		fi
+
+		# ---- what the restarts must not have cost (#549) ---------------------
+		if [ -n "$rtarget" ]; then
+			echo "- $name: the restarted machine still reaches the subnet it reached before"
+			rm -f "$WORK/listen-$rmachine_t.txt"
+			listen_of "$rmachine_t"
+			live_probe "$rmachine" "$raddr" "$rport"
+			rafter=$?
+			rcontrol_after=1
+			if [ -n "$rcmachine" ]; then
+				live_probe "$rcmachine" "$raddr" "$rport"
+				rcontrol_after=$?
+			fi
+			fnl_restart_keeps_reaching "$name" "$restart" "$rtarget" "$raddr" "$rport" \
+				"$LISTEN" "$rbefore" "$rafter" "$rcontrol" "$rcontrol_after"
 		fi
 	}
 
@@ -681,7 +793,33 @@ run_stack() { # name
 	# ---- the restart, last ---------------------------------------------------
 	if [ -n "${RESTART_NAME:-}" ]; then
 		assert_restart "$RESTART_NAME" "$RESTART_UNIT" "$RESTART_PORT"
-		skip "$name: what this run does not assert after a restart is reachability to another subnet, which #549 measured a restarted machine losing while its unrestarted neighbour keeps it. Naming it here rather than probing it keeps the gate green on a known defect instead of silent about one."
+	fi
+
+	# ---- the rule sets, after the restarts -----------------------------------
+	#
+	# After, and that is the measurement: a rule set lives on a NIC, a restart
+	# re-plugs NICs, and a machine that came back without its set is a machine
+	# the API describes as filtered and the host does not filter. The counts are
+	# the stack's own, so a number that moves fails a gate instead of waiting to
+	# be noticed by somebody reading `incus network acl list`.
+	local rulesets prefix wantsets wantrefs aclmachine
+	declare_or_fail "$name" "$proof" rule_sets
+	rulesets="$DECLARED"
+	reason="$(skip_reason "$rulesets")"
+	echo "- $name: the runtime holds the rule sets this stack declares"
+	if [ -n "$reason" ]; then
+		skip "$name rule_sets: $reason"
+	else
+		prefix="$(printf '%s' "$rulesets" | jq -r '.prefix')"
+		wantsets="$(printf '%s' "$rulesets" | jq -r '.sets')"
+		wantrefs="$(printf '%s' "$rulesets" | jq -r '.references')"
+		: >"$WORK/rulesets.tsv"
+		while IFS=$'\t' read -r _ _ _ aclmachine; do
+			[ -n "$aclmachine" ] || continue
+			printf '%s\t%s\n' "$aclmachine" "$(live_machine_acls "$aclmachine")" >>"$WORK/rulesets.tsv" \
+				|| fail "cannot look: reading the rule sets of $aclmachine off the runtime failed"
+		done <"$WORK/machines.tsv"
+		fnl_rule_sets "$name" "$prefix" "$WORK/rulesets.tsv" "$wantsets" "$wantrefs"
 	fi
 
 	# ---- down ---------------------------------------------------------------

--- a/tools/conformance/functional_test.go
+++ b/tools/conformance/functional_test.go
@@ -495,6 +495,7 @@ type stackProof struct {
 	Firewall    json.RawMessage `json:"firewall"`
 	Network     json.RawMessage `json:"network"`
 	Balancer    json.RawMessage `json:"balancer"`
+	RuleSets    json.RawMessage `json:"rule_sets"`
 }
 
 // TestEveryStackTheGateNamesDeclaresWhatItMustProve is the structural half of
@@ -539,15 +540,57 @@ func TestEveryStackTheGateNamesDeclaresWhatItMustProve(t *testing.T) {
 		if proof.Provider == "" || proof.MachineKind == "" || proof.Running == "" || proof.Expect <= 0 {
 			t.Errorf("%s: proof.json must name provider, machine_kind, running_state and a non-zero expect_machines; without the floor a reader that found nothing reads as a cloud that holds nothing", stack)
 		}
+		assertRestartIsDeclared(t, stack, proof.Service)
 		for name, family := range map[string]json.RawMessage{
 			"service": proof.Service, "firewall": proof.Firewall,
 			"network": proof.Network, "balancer": proof.Balancer,
+			"rule_sets": proof.RuleSets,
 		} {
 			if len(family) == 0 {
 				t.Errorf("%s: proof.json declares nothing about its %s; a stack that says nothing about what its machines must do is the silence #503 was opened about", stack, name)
 				continue
 			}
 			assertReasoned(t, stack, name, family)
+		}
+	}
+}
+
+// assertRestartIsDeclared: a stack that restarts a machine must say what that
+// restart may not cost it, and name the unrestarted machine that proves the
+// pass — or write why there is none.
+//
+// The silence this closes is where #549 lived for as long as the gate existed:
+// the restart was asserted to leave the service listening and answering, and
+// the machine came back doing exactly that while no longer reaching the subnet
+// one router away.
+func assertRestartIsDeclared(t *testing.T, stack string, service json.RawMessage) {
+	t.Helper()
+	var doc map[string]json.RawMessage
+	if err := json.Unmarshal(service, &doc); err != nil {
+		return
+	}
+	if _, excused := doc["skip"]; excused {
+		return
+	}
+	if _, restarts := doc["restart"]; !restarts {
+		return
+	}
+	reaches, declared := doc["restart_reaches"]
+	if !declared {
+		t.Errorf("%s: the service family restarts a machine and declares no restart_reaches; a machine that comes back listening and answering can still have lost every route past its own subnet, which is #549", stack)
+		return
+	}
+	var pair map[string]json.RawMessage
+	if err := json.Unmarshal(reaches, &pair); err != nil {
+		t.Errorf("%s: service.restart_reaches is not an object", stack)
+		return
+	}
+	if _, excused := pair["skip"]; excused {
+		return
+	}
+	for _, key := range []string{"target", "port", "control"} {
+		if _, ok := pair[key]; !ok {
+			t.Errorf("%s: service.restart_reaches declares no %s; without the control, a target that died reads exactly like a restart that lost its routes", stack, key)
 		}
 	}
 }
@@ -587,6 +630,7 @@ func TestTheGateRunsItsReaderControlsBeforeAnyVerdict(t *testing.T) {
 		"fnl_listen_reader_control",
 		"fnl_name_reader_control",
 		"fnl_delivery_reader_control",
+		"fnl_rule_set_reader_control",
 	} {
 		called := false
 		for _, line := range strings.Split(gate, "\n") {
@@ -601,25 +645,217 @@ func TestTheGateRunsItsReaderControlsBeforeAnyVerdict(t *testing.T) {
 	}
 }
 
-// TestTheRestartGoesThroughPowerAndNeverThroughReboot is #547 written as a
-// control on this gate rather than on the emulator.
+// TestTheRestartGoesThroughBothDoors replaces the control that used to forbid
+// the reboot verb here, and the replacement is the point.
 //
-// A reboot through the API leaves the container's pid and uptime untouched
-// (measured 2026-08-27), so a restart assertion sent through it cannot fail —
-// and a control that cannot fail is a demonstration. The day #547 is fixed this
-// test is what has to be revisited on purpose, rather than the gate silently
-// going back to measuring nothing.
-func TestTheRestartGoesThroughPowerAndNeverThroughReboot(t *testing.T) {
+// Until #547 this gate was forbidden to drive a reboot: the action answered
+// success and left the container's pid, its uptime and a transient marker unit
+// untouched (measured 2026-08-27), so a restart assertion sent through it could
+// not fail. That test said, in as many words, that the day #547 was fixed it
+// had to be revisited on purpose rather than let the gate silently go back to
+// measuring nothing. This is that revision: the verb is driven, and what it
+// must produce is asserted — a different runtime process, which is the witness
+// the issue was filed on.
+//
+// Both doors, not one: the reboot verb and the full stop-and-start. They are
+// two paths through the pack and #549 was measured on the second.
+func TestTheRestartGoesThroughBothDoors(t *testing.T) {
 	gate := readGate(t)
-	for _, forbidden := range []string{"action=reboot", "RebootVms"} {
-		if strings.Contains(gate, forbidden) {
-			t.Errorf("functional.sh carries %q; #547 measured a reboot leaving the container's pid and uptime untouched, so the service would be asserted to survive a restart that never happened", forbidden)
+	for _, want := range []string{
+		"action=reboot", "action=RebootVms",
+		"action=poweroff", "action=poweron",
+		"action=StopVms", "action=StartVms",
+	} {
+		if !strings.Contains(gate, want) {
+			t.Errorf("functional.sh does not carry %q; the restart must be driven through both doors on every provider it drives", want)
 		}
 	}
-	for _, want := range []string{`action=poweroff`, `action=poweron`, `action=StopVms`, `action=StartVms`} {
-		if !strings.Contains(gate, want) {
-			t.Errorf("functional.sh does not carry %q; the restart must be a real stop and start on every provider it drives", want)
+	// And the reboot leg must draw a verdict, not merely make the call: an
+	// action that is issued and never checked is exactly what let #547 live.
+	if !strings.Contains(gate, "fnl_restart_replaced_the_machine") {
+		t.Error("functional.sh drives a reboot and never asserts the machine was replaced; the action answering success is what #547 measured as sufficient to prove nothing")
+	}
+	if !strings.Contains(gate, "fnl_restart_keeps_reaching") {
+		t.Error("functional.sh restarts a machine and never asserts what the restart cost it (#549)")
+	}
+}
+
+// The gate must not carry the skip it used to write in place of the assertion:
+// a run that names a defect instead of measuring it is honest exactly once, and
+// stops being so the day the defect is fixed.
+func TestTheGateNoLongerExcusesReachabilityAfterARestart(t *testing.T) {
+	gate := readGate(t)
+	if strings.Contains(gate, "what this run does not assert after a restart") {
+		t.Error("functional.sh still excuses reachability after a restart; #549 is fixed and the excuse now hides a working assertion")
+	}
+}
+
+// ---- the lifecycle verdicts -------------------------------------------------
+
+const webListens = "22\n443\n8080\n"
+
+func TestARebootThatLeavesTheSameProcessFails(t *testing.T) {
+	code, output := runFunctional(t, nil,
+		`fnl_restart_replaced_the_machine scaleway platform-web-0 feint-scw-1 1188677 1188677`)
+	if code == 0 {
+		t.Fatalf("a reboot that restarted nothing passed, which is #547 exactly:\n%s", output)
+	}
+	for _, want := range []string{"FAIL:", "platform-web-0", "feint-scw-1", "1188677", "#547"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("the failure does not carry %q:\n%s", want, output)
 		}
+	}
+}
+
+func TestARebootNobodyCouldLookAtIsNotAPass(t *testing.T) {
+	code, output := runFunctional(t, nil,
+		`fnl_restart_replaced_the_machine scaleway platform-web-0 feint-scw-1 1188677 ""`)
+	if code == 0 {
+		t.Fatalf("an unreadable runtime process passed as a restart:\n%s", output)
+	}
+	if !strings.Contains(output, "cannot look") {
+		t.Errorf("an instrument failure was reported as a defect of the stack:\n%s", output)
+	}
+}
+
+func TestARealRebootPasses(t *testing.T) {
+	code, output := runFunctional(t, nil,
+		`fnl_restart_replaced_the_machine scaleway platform-web-0 feint-scw-1 1188677 1711198`)
+	if code != 0 {
+		t.Fatalf("a machine that really restarted was reported as one that did not:\n%s", output)
+	}
+}
+
+// #549 itself: the witness the issue carries, replayed as arguments.
+func TestAMachineThatStopsReachingAfterARestartFailsNamingItsNeighbour(t *testing.T) {
+	code, output := runFunctional(t, map[string]string{"listen": webListens},
+		`fnl_restart_keeps_reaching scaleway platform-web-0 platform-app-worker-a 10.30.2.10 8080 "$DIR/listen" 0 1 platform-web-1 0`)
+	if code == 0 {
+		t.Fatalf("a machine that lost its route to the peered subnet passed:\n%s", output)
+	}
+	for _, want := range []string{
+		"FAIL:", "platform-web-0", "platform-app-worker-a", "10.30.2.10", "8080",
+		"platform-web-1", "never restarted", "#549",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("the failure does not carry %q; a red that names neither the machine nor its control teaches nothing:\n%s", want, output)
+		}
+	}
+}
+
+// The pair that never held is a finding about the declaration or the stack, and
+// must not be reported as a restart cost: that would be #549 filed against a
+// stack that never reached anything.
+func TestARestartVerdictRefusesAPairThatNeverHeld(t *testing.T) {
+	code, output := runFunctional(t, map[string]string{"listen": webListens},
+		`fnl_restart_keeps_reaching scaleway platform-web-0 platform-app-worker-a 10.30.2.10 8080 "$DIR/listen" 1 1 platform-web-1 0`)
+	if code == 0 {
+		t.Fatalf("a pair that did not hold before the restart passed:\n%s", output)
+	}
+	if !strings.Contains(output, "BEFORE any restart") {
+		t.Errorf("the failure blames the restart for a pair that never held:\n%s", output)
+	}
+	if strings.Contains(output, "#549") {
+		t.Errorf("a pair that never held was filed as #549:\n%s", output)
+	}
+}
+
+// Neither reaching is the target or the network, not the restart. Reporting the
+// wrong subject is the failure this repository has paid for most often.
+func TestARestartVerdictWithABrokenControlBlamesTheNetworkNotTheRestart(t *testing.T) {
+	code, output := runFunctional(t, map[string]string{"listen": webListens},
+		`fnl_restart_keeps_reaching scaleway platform-web-0 platform-app-worker-a 10.30.2.10 8080 "$DIR/listen" 0 1 platform-web-1 1`)
+	if code == 0 {
+		t.Fatalf("a pass where nothing reaches the target passed:\n%s", output)
+	}
+	if !strings.Contains(output, "says nothing about the restart") {
+		t.Errorf("a target that went away was reported as a restart defect:\n%s", output)
+	}
+}
+
+func TestARestartVerdictRefusesToJudgeADeadListener(t *testing.T) {
+	code, output := runFunctional(t, map[string]string{"listen": "22\n"},
+		`fnl_restart_keeps_reaching scaleway platform-web-0 platform-app-worker-a 10.30.2.10 8080 "$DIR/listen" 0 1 platform-web-1 0`)
+	if code == 0 {
+		t.Fatalf("a target that listens on nothing was judged:\n%s", output)
+	}
+	if !strings.Contains(output, "dead service") {
+		t.Errorf("the failure does not say the service is what was measured:\n%s", output)
+	}
+}
+
+func TestARestartProbeThatCouldNotBeMadeIsNotALostRoute(t *testing.T) {
+	code, output := runFunctional(t, map[string]string{"listen": webListens},
+		`fnl_restart_keeps_reaching scaleway platform-web-0 platform-app-worker-a 10.30.2.10 8080 "$DIR/listen" 0 2 platform-web-1 0`)
+	if code == 0 {
+		t.Fatalf("a probe that could not be made passed:\n%s", output)
+	}
+	if !strings.Contains(output, "cannot look") {
+		t.Errorf("an instrument failure was reported as #549:\n%s", output)
+	}
+}
+
+// The accepting half, twice: with a control and with a written reason there is
+// none. A verdict that refused the second would break the Outscale stack, whose
+// rule refuses every machine that could have been the control.
+func TestAHealthyRestartReachabilityPasses(t *testing.T) {
+	code, output := runFunctional(t, map[string]string{"listen": webListens},
+		`fnl_restart_keeps_reaching scaleway platform-web-0 platform-app-worker-a 10.30.2.10 8080 "$DIR/listen" 0 0 platform-web-1 0`)
+	if code != 0 {
+		t.Fatalf("a machine that kept reaching after a restart was failed:\n%s", output)
+	}
+	code, output = runFunctional(t, map[string]string{"listen": webListens},
+		`fnl_restart_keeps_reaching outscale platform-web-a platform-app 10.50.2.10 8080 "$DIR/listen" 0 0 "" 1`)
+	if code != 0 {
+		t.Fatalf("a stack with a written reason for having no control was failed:\n%s", output)
+	}
+}
+
+// ---- the rule sets ----------------------------------------------------------
+
+const scalewaySets = "feint-scw-1\tscw-web\nfeint-scw-2\tscw-web\nfeint-scw-3\tscw-web\nfeint-scw-4\tscw-app\nfeint-scw-5\tscw-app\nfeint-scw-6\tscw-bastion\n"
+
+func TestARuleSetCountThatMovedFails(t *testing.T) {
+	code, output := runFunctional(t, map[string]string{"sets": scalewaySets},
+		`fnl_rule_sets scaleway scw- "$DIR/sets" 3 6`)
+	if code != 0 {
+		t.Fatalf("the measured counts were rejected:\n%s", output)
+	}
+	// One machine came back without its group, which is what a restart that
+	// dropped a NIC's rule set looks like from the host.
+	fewer := strings.Replace(scalewaySets, "feint-scw-2\tscw-web\n", "feint-scw-2\t\n", 1)
+	code, output = runFunctional(t, map[string]string{"sets": fewer},
+		`fnl_rule_sets scaleway scw- "$DIR/sets" 3 6`)
+	if code == 0 {
+		t.Fatalf("a machine that lost its rule set passed:\n%s", output)
+	}
+	for _, want := range []string{"FAIL:", "scaleway", "5", "6"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("the failure does not carry %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestARuleSetThatAppearedFails(t *testing.T) {
+	more := scalewaySets + "feint-scw-7\tscw-ghost\n"
+	code, output := runFunctional(t, map[string]string{"sets": more},
+		`fnl_rule_sets scaleway scw- "$DIR/sets" 3 6`)
+	if code == 0 {
+		t.Fatalf("a rule set nothing declares passed:\n%s", output)
+	}
+	if !strings.Contains(output, "scw-ghost") {
+		t.Errorf("the failure does not name the set that appeared:\n%s", output)
+	}
+}
+
+func TestAnEmptyRuleSetReadingIsAnInstrumentFailure(t *testing.T) {
+	code, output := runFunctional(t, map[string]string{"sets": ""},
+		`fnl_rule_sets scaleway scw- "$DIR/sets" 3 6`)
+	if code == 0 {
+		t.Fatalf("a run that read no machine at all passed:\n%s", output)
+	}
+	if !strings.Contains(output, "cannot look") {
+		t.Errorf("reading nothing was reported as a cloud holding nothing:\n%s", output)
 	}
 }
 

--- a/tools/conformance/functionallib.sh
+++ b/tools/conformance/functionallib.sh
@@ -436,3 +436,157 @@ fnl_backend_withdrawn() { # stack name withdrawn hits_file remaining
 		|| fail "$stack: $name answered $answered of $probes probes with no backend left registered — something is serving that address which the control plane does not describe"
 	ok "$stack: $name answers nothing once its last backend is unregistered, which is the withdrawal seen from outside"
 }
+
+# ---- the lifecycle: what a machine must still be after a restart ------------
+#
+# Every family above starts its machines once and measures afterwards. None of
+# them restarted one, so the gap between "launched" and "relaunched" was
+# measured nowhere — and three defects lived in it (#547, #549, #498), all found
+# by hand on 2026-08-27. The three verdicts below are that gap, written down.
+
+# fnl_restart_replaced_the_machine: the provider's own reboot verb really
+# restarted the machine.
+#
+# The witness is the runtime's process for the instance, read from the host the
+# way witness.sh reads an instance's status — never from inside the target,
+# which this file only ever uses as the console that originates a probe. A
+# reboot that leaves the same process leaves the same kernel, the same uptime
+# and the same transient units: that is #547, where the action answered
+# "success", the API answered "running", and nothing had happened.
+#
+# Empty on either side is "nobody could look", never "it did not restart": the
+# whole point of the third outcome.
+fnl_restart_replaced_the_machine() { # stack name machine before after
+	local stack="$1" name="$2" machine="$3" before="$4" after="$5"
+	{ [ -n "$before" ] && [ -n "$after" ]; } \
+		|| fail "cannot look: the runtime did not say which process holds $machine before ('$before') and after ('$after') the reboot; no measurement is not a measurement"
+	[ "$before" != "$after" ] \
+		|| fail "$stack: $name ($machine) came out of a reboot through the provider's own API on the same runtime process ($after) — the action was accepted and the machine never restarted (#547)"
+	ok "$stack: $name really restarts on the provider's own reboot verb (process $before then $after)"
+}
+
+# fnl_restart_keeps_reaching: a machine restarted through the provider's API
+# still reaches the machine one subnet away that it reached before it went down.
+#
+# This is #549, and its shape is the reason it needs four probes rather than
+# one. The defect is not "unreachable": it is "reachable, then not, while an
+# identical neighbour that was not restarted goes on reaching it in the same
+# pass". So the before-probe is the positive control of the after-probe, and the
+# control machine is the positive control of the whole pass — without them, a
+# target that simply died reads exactly like a restart that lost its routes.
+#
+# before, after and control_after are probe codes the caller captured: 0 the
+# port answers, 1 refused or timed out, 2 nobody could look. control is the
+# unrestarted machine's declared name, empty when the stack wrote a reason it
+# has none.
+fnl_restart_keeps_reaching() { # stack restarted target address port listen_file before after control control_after
+	local stack="$1" restarted="$2" target="$3" address="$4" port="$5" listen="$6"
+	local before="$7" after="$8" control="$9" control_after="${10}"
+
+	fnl_listens "$port" "$listen" \
+		|| fail "$stack: $target does not listen on $port inside the machine (listening: $(tr '\n' ' ' <"$listen")); 'no longer reachable' would be measuring a dead service rather than a restart"
+
+	[ "$before" != 2 ] \
+		|| fail "cannot look: the probe from $restarted towards $address:$port could not be made at all before the restart"
+	[ "$before" = 0 ] \
+		|| fail "$stack: $restarted does not reach $target at $address:$port BEFORE any restart, on a port $target is listening on — this run cannot say what a restart cost, and the pair the stack declares does not hold in the first place"
+
+	[ "$after" != 2 ] \
+		|| fail "cannot look: the probe from $restarted towards $address:$port could not be made at all after the restart"
+
+	if [ "$after" != 0 ]; then
+		# Which of the two findings this is, said rather than left to the
+		# reader: the neighbour is what separates "the restart lost its routes"
+		# from "the target or the network went away". Blaming the restart in the
+		# second case would be reporting the wrong subject, which is the failure
+		# this repository has paid for most often.
+		if [ -n "$control" ] && [ "$control_after" = 2 ]; then
+			fail "cannot look: the control probe from $control towards $address:$port could not be made at all, so what $restarted lost cannot be attributed"
+		fi
+		if [ -n "$control" ] && [ "$control_after" != 0 ]; then
+			fail "$stack: neither $restarted, which was restarted, nor $control, which was not, reaches $target at $address:$port — and $restarted reached it before. The target or the network went away between the two probes, so this pass says nothing about the restart"
+		fi
+		if [ -n "$control" ]; then
+			fail "$stack: $restarted reached $target at $address:$port before being restarted through the API and does not afterwards, while $control — the same subnet, the same group, never restarted — still reaches it in the same pass (#549)"
+		fi
+		fail "$stack: $restarted reached $target at $address:$port before being restarted through the API and does not afterwards (#549)"
+	fi
+
+	if [ -n "$control" ]; then
+		[ "$control_after" != 2 ] \
+			|| fail "cannot look: the control probe from $control towards $address:$port could not be made at all"
+		[ "$control_after" = 0 ] \
+			|| fail "$stack: $restarted reaches $target at $address:$port and $control, which was never restarted, does not — this pass is measuring something other than the restart, and reading it either way would be reading an instrument"
+		ok "$stack: $restarted still reaches $target at $address:$port after a restart, and so does $control, which was not restarted"
+		return
+	fi
+	ok "$stack: $restarted still reaches $target at $address:$port after a restart"
+}
+
+# fnl_rule_sets: the rule sets the runtime holds for this stack's machines, in
+# the two numbers the stack declares.
+#
+# It runs after the restarts on purpose. A rule set lives on a NIC, a restart
+# re-plugs NICs, and a machine that came back without its set is a machine the
+# API describes as filtered and the host does not filter — the same family of
+# defect as #549, one layer up. The counts are the stack's own declaration
+# rather than a table here, so a stack that grows a tier changes one file.
+#
+# sets_file: `<machine>\t<comma-separated rule sets>`, one line per machine, the
+# whole set the runtime reports; the prefix is what selects this pack's own.
+fnl_rule_sets() { # stack prefix sets_file want_sets want_references
+	local stack="$1" prefix="$2" file="$3" want_sets="$4" want_refs="$5"
+	local machine acls acl seen="" sets=0 refs=0 machines=0
+
+	[ -s "$file" ] \
+		|| fail "cannot look: no machine of $stack was read for its rule sets; every count this run would report is an instrument failure"
+	while IFS=$'\t' read -r machine acls; do
+		[ -n "$machine" ] || continue
+		machines=$((machines + 1))
+		for acl in $(printf '%s' "$acls" | tr ',' ' '); do
+			case "$acl" in
+			"$prefix"*) ;;
+			*) continue ;;
+			esac
+			refs=$((refs + 1))
+			case " $seen " in
+			*" $acl "*) ;;
+			*)
+				seen="$seen $acl"
+				sets=$((sets + 1))
+				;;
+			esac
+		done
+	done <"$file"
+
+	[ "$sets" = "$want_sets" ] \
+		|| fail "$stack: the runtime holds $sets rule set(s) named $prefix* across its $machines machine(s), where the stack declares $want_sets ($(echo "$seen" | tr -s ' ')) — a count that moved is a group that stopped being applied or one that was applied twice, and either is a finding"
+	[ "$refs" = "$want_refs" ] \
+		|| fail "$stack: the $sets rule set(s) named $prefix* are referenced $refs time(s) across its $machines machine(s), where the stack declares $want_refs — a machine lost or gained a group without the control plane saying so"
+	ok "$stack: $sets rule set(s) $prefix*, $refs reference(s) across $machines machine(s), as declared"
+}
+
+# The rule-set reader proves it can find before it judges, and that it refuses a
+# near miss: another pack's sets on the same host must not be counted as this
+# one's, which is exactly what a run of two stacks would otherwise do.
+fnl_rule_set_reader_control() {
+	local dir out code
+	dir="$(mktemp -d)"
+	printf '%s\t%s\n' \
+		"feint-scw-1" "scw-aaa" \
+		"feint-scw-2" "scw-aaa,scw-bbb" \
+		"feint-osc-1" "osc-zzz" >"$dir/sets"
+	out="$(fnl_rule_sets control scw- "$dir/sets" 2 3 2>&1)"
+	code=$?
+	[ "$code" = 0 ] \
+		|| { rm -rf "$dir"; fail "the rule-set reader cannot count two planted sets and three references: $out"; }
+	# The near miss, and it is the one a two-stack run would hit: the osc- line
+	# is on the same host and must not be counted here. Declaring three sets
+	# must therefore go red, or the reader is counting somebody else's.
+	out="$(fnl_rule_sets control scw- "$dir/sets" 3 4 2>&1)"
+	code=$?
+	rm -rf "$dir"
+	[ "$code" != 0 ] \
+		|| fail "the rule-set reader accepted a count that includes another pack's sets: $out"
+	ok "the rule-set reader counts a pack's own sets and references, and no other pack's"
+}

--- a/tools/conformance/scaleway/scw-cli.sh
+++ b/tools/conformance/scaleway/scw-cli.sh
@@ -57,6 +57,17 @@ got="$(scw instance server get "$id" zone="$ZONE" -o json)" || fail "get rejecte
 printf '%s' "$got" | jq -e --arg id "$id" '.id == $id' >/dev/null || fail "get returned another server"
 ok "read back identical"
 
+# The reboot verb, driven by the client that owns it (#547). It answered `success` on an
+# action the emulator did not perform until the sequence moved into the shared layer, and
+# the state a client reads afterwards is the whole of what this suite can see from here —
+# that the machine really restarted is asserted from the host by
+# tools/conformance/functional.sh, which compares the runtime process across the call.
+echo "- reboot"
+scw instance server reboot "$id" zone="$ZONE" >/dev/null || fail "reboot rejected"
+state="$(scw instance server get "$id" zone="$ZONE" -o json | jq -r '.state')"
+[ "$state" = "running" ] || fail "expected the server to be running after a reboot, got '$state'"
+ok "rebooted, and still running"
+
 # The CLI starts the server right after creating it, and the API refuses to delete a running
 # server. Powering off first is what a real user does, so the suite does it too.
 echo "- stop"

--- a/tools/falsify/specs/lifecycle-tells-the-truth.json
+++ b/tools/falsify/specs/lifecycle-tells-the-truth.json
@@ -1,0 +1,35 @@
+{
+  "_comment": [
+    "A machine that comes back from a stop must come back whole (#549).",
+    "",
+    "Measured on 2026-08-27 on the Scaleway example stack under --vm",
+    "incus-ovn: platform-web-0 was stopped and started through the API, came",
+    "back running, on its address, reaching its own subnet — and no longer",
+    "reaching the app tier one subnet away, while platform-web-1, never",
+    "restarted, kept reaching it in the same pass."
+  ],
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "#549: a restarted guest stops being given back the routes to its peered subnets, so it comes back running, on its address, reaching its own subnet and nothing one router away",
+      "file": "internal/core/machine/incus_ovn.go",
+      "find": "\tif !d.OVN {\n\t\t// The aggregates exist because an OVN network's peers are only",
+      "replace": "\tif !d.OVN || true {\n\t\t// The aggregates exist because an OVN network's peers are only",
+      "test": "TestARestartedMachineGetsItsPeeredRoutesBack"
+    },
+    {
+      "label": "#549, the ownership half: the repair stops asking whether the network is one the emulator created, and reads the gateway of an operator's own bridge to write a route inside a guest through it",
+      "file": "internal/core/machine/incus_ovn.go",
+      "find": "\t\tif !ownedNetwork(cfg[\"network\"]) {\n\t\t\tcontinue\n\t\t}\n\t\tnames = append(names, device)",
+      "replace": "\t\tif !ownedNetwork(cfg[\"network\"]) && false {\n\t\t\tcontinue\n\t\t}\n\t\tnames = append(names, device)",
+      "test": "TestRestoringRoutesLeavesAForeignNICAlone"
+    },
+    {
+      "label": "#549, the mode half: the bridge mode starts laying OVN aggregates, pointing a guest's private traffic at an address no router answers on",
+      "file": "internal/core/machine/incus_ovn.go",
+      "find": "\tif !d.OVN {\n\t\t// The aggregates exist because an OVN network's peers are only",
+      "replace": "\tif !d.OVN && false {\n\t\t// The aggregates exist because an OVN network's peers are only",
+      "test": "TestABridgeModeRestartLaysNoAggregates"
+    }
+  ]
+}

--- a/tools/falsify/specs/lifecycle-tells-the-truth.json
+++ b/tools/falsify/specs/lifecycle-tells-the-truth.json
@@ -1,14 +1,37 @@
 {
   "_comment": [
-    "A machine that comes back from a stop must come back whole (#549), and",
-    "the replay that brings it back must be idempotent (#498).",
+    "The three lies the lifecycle of a machine told, each guard neutralised",
+    "and each matching test required to go red (#547, #549, #498).",
     "",
-    "Both measured on 2026-08-27 on the Scaleway example stack under --vm",
-    "incus-ovn, and they are one spec because they are one path: the address",
-    "replay a restart runs is what shouted the ERROR."
+    "They were measured together on 2026-08-27, on the Scaleway example stack",
+    "under --vm incus-ovn, and they are one spec because they are one path: a",
+    "reboot that restarted nothing hid a restart that lost its routes, and",
+    "both ran the address replay whose ERROR was the third."
   ],
   "package": "./internal/core/machine/",
   "mutations": [
+    {
+      "label": "#547: a reboot stops taking the machine down, so the action answers success and the runtime — which refuses to relaunch a name it has already served — does nothing at all",
+      "file": "internal/core/machine/plan.go",
+      "find": "\tif res.State == r.binding().RunningState {\n\t\tr.binding().PowerOff(ctx, res)\n\t}",
+      "replace": "\tif res.State == r.binding().RunningState && false {\n\t\tr.binding().PowerOff(ctx, res)\n\t}",
+      "test": "TestARebootStopsTheMachineBeforeStartingIt"
+    },
+    {
+      "label": "#547, the accepting half: a reboot stops asking whether the machine was up, so a stopped one is stopped again and the runtime is told to stop what it already stopped",
+      "file": "internal/core/machine/plan.go",
+      "find": "\tif res.State == r.binding().RunningState {\n\t\tr.binding().PowerOff(ctx, res)\n\t}",
+      "replace": "\tif res.State == r.binding().RunningState || true {\n\t\tr.binding().PowerOff(ctx, res)\n\t}",
+      "test": "TestARebootOfAStoppedMachineDoesNotStopItAgain"
+    },
+    {
+      "label": "#547 across the packs: Scaleway's reboot calls the start alone again, which is the defect verbatim — the three other packs go on asking the runtime for a stop and the sequences diverge",
+      "file": "internal/providers/scaleway/servers.go",
+      "package": "./internal/providers/",
+      "find": "\t\tp.rebootMachine(r.Context(), res)",
+      "replace": "\t\tp.startMachine(r.Context(), res)\n\t\t_ = p.rebootMachine",
+      "test": "TestSameIntentSameRuntimeSequenceAcrossPacks"
+    },
     {
       "label": "#549: a restarted guest stops being given back the routes to its peered subnets, so it comes back running, on its address, reaching its own subnet and nothing one router away",
       "file": "internal/core/machine/incus_ovn.go",
@@ -29,6 +52,13 @@
       "find": "\tif !d.OVN {\n\t\t// The aggregates exist because an OVN network's peers are only",
       "replace": "\tif !d.OVN && false {\n\t\t// The aggregates exist because an OVN network's peers are only",
       "test": "TestABridgeModeRestartLaysNoAggregates"
+    },
+    {
+      "label": "#549, the diagnosis: a guest that never finishes configuring its interface is no longer reported by the wait, so the failure an operator reads names the network rather than the machine and the device that could not be repaired",
+      "file": "internal/core/machine/incus_ovn.go",
+      "find": "\t\tif err := d.waitForGuestInterface(ctx, machine, device); err != nil {\n\t\t\treturn err\n\t\t}",
+      "replace": "\t\tif err := d.waitForGuestInterface(ctx, machine, device); err != nil && false {\n\t\t\treturn err\n\t\t}",
+      "test": "TestAGuestThatNeverConfiguresItsInterfaceIsReported"
     },
     {
       "label": "#498: the replay stops noticing that a routed NIC already delivers the address, so it delegates the same /32 to the uplink where the routed NIC's own host route already sits, and shouts an ERROR over a correct host",

--- a/tools/falsify/specs/lifecycle-tells-the-truth.json
+++ b/tools/falsify/specs/lifecycle-tells-the-truth.json
@@ -1,12 +1,11 @@
 {
   "_comment": [
-    "A machine that comes back from a stop must come back whole (#549).",
+    "A machine that comes back from a stop must come back whole (#549), and",
+    "the replay that brings it back must be idempotent (#498).",
     "",
-    "Measured on 2026-08-27 on the Scaleway example stack under --vm",
-    "incus-ovn: platform-web-0 was stopped and started through the API, came",
-    "back running, on its address, reaching its own subnet — and no longer",
-    "reaching the app tier one subnet away, while platform-web-1, never",
-    "restarted, kept reaching it in the same pass."
+    "Both measured on 2026-08-27 on the Scaleway example stack under --vm",
+    "incus-ovn, and they are one spec because they are one path: the address",
+    "replay a restart runs is what shouted the ERROR."
   ],
   "package": "./internal/core/machine/",
   "mutations": [
@@ -30,6 +29,20 @@
       "find": "\tif !d.OVN {\n\t\t// The aggregates exist because an OVN network's peers are only",
       "replace": "\tif !d.OVN && false {\n\t\t// The aggregates exist because an OVN network's peers are only",
       "test": "TestABridgeModeRestartLaysNoAggregates"
+    },
+    {
+      "label": "#498: the replay stops noticing that a routed NIC already delivers the address, so it delegates the same /32 to the uplink where the routed NIC's own host route already sits, and shouts an ERROR over a correct host",
+      "file": "internal/core/machine/incus_address.go",
+      "find": "\tif carried {\n\t\treturn nil\n\t}",
+      "replace": "\tif carried && false {\n\t\treturn nil\n\t}",
+      "test": "TestReRoutingAnAddressARoutedNICAlreadyCarriesTouchesNothing"
+    },
+    {
+      "label": "#498, the accepting half: every address reads as already delivered, so an address that genuinely needs the OVN path never gets it and the machine answers on nothing",
+      "file": "internal/core/machine/incus_address.go",
+      "find": "\t\tif routeListContains(cfg[\"ipv4.address\"], address) {\n\t\t\treturn true, nil\n\t\t}",
+      "replace": "\t\tif routeListContains(cfg[\"ipv4.address\"], address) || true {\n\t\t\treturn true, nil\n\t\t}",
+      "test": "TestAnAddressNoRoutedNICCarriesStillTravelsTheOVNPath"
     }
   ]
 }

--- a/tools/falsify/specs/provider-four.json
+++ b/tools/falsify/specs/provider-four.json
@@ -32,8 +32,8 @@
     {
       "label": "the fourth pack publishes the state its request asked for rather than the one the host produced, which is the lie this emulator exists to avoid (#484, #517)",
       "file": "internal/cli/testdata/provider-four/intents.go",
-      "find": "\t\t\tLabels:    map[string]string{\"feint.node\": res.ID},\n\t\t})\n\t})",
-      "replace": "\t\t\tLabels:    map[string]string{\"feint.node\": res.ID},\n\t\t})\n\t\tres.State = StateUp\n\t})",
+      "find": "\t\tp.reconciler().PowerOn(ctx, res, p.bootOf(res))\n\t})",
+      "replace": "\t\tp.reconciler().PowerOn(ctx, res, p.bootOf(res))\n\t\tres.State = StateUp\n\t})",
       "test": "TestTheFourthPackPublishesTheStateTheEffectProduced"
     },
     {

--- a/tools/falsify/specs/stack-functional-proof.json
+++ b/tools/falsify/specs/stack-functional-proof.json
@@ -198,11 +198,11 @@
       "test": "TestTheGateRunsItsReaderControlsBeforeAnyVerdict"
     },
     {
-      "label": "the restart goes back through the reboot action, which #547 measured leaving the container's pid and uptime untouched: the service would be asserted to survive a restart that never happened",
+      "label": "the gate stops driving the provider's own reboot verb and restarts only through stop-and-start, which is the state it was in while #547 was open: the path that answered success and restarted nothing was measured by nothing at all",
       "file": "tools/conformance/functional.sh",
-      "find": "\t\taction=poweroff\n\t\t[ \"$3\" = on ] && action=poweron",
-      "replace": "\t\taction=poweroff\n\t\t[ \"$3\" = on ] && action=poweron\n\t\taction=reboot",
-      "test": "TestTheRestartGoesThroughPowerAndNeverThroughReboot"
+      "find": "\t\t[ \"$3\" = reboot ] && action=reboot\n",
+      "replace": "\t\t[ \"$3\" = reboot ] && action=never_reboot\n",
+      "test": "TestTheRestartGoesThroughBothDoors"
     },
     {
       "label": "a stack stops declaring what its balancer must do, and the gate measures it against nothing while reading like a register of proofs",
@@ -217,6 +217,83 @@
       "find": "      \"skip\": \"this stack declares no unpeered pair with a machine on each side",
       "replace": "      \"skip\": \"\", \"was\": \"this stack declares no unpeered pair with a machine on each side",
       "test": "TestEveryStackTheGateNamesDeclaresWhatItMustProve"
+    },
+    {
+      "label": "the reboot verdict stops comparing the runtime process, so a reboot that answered success and restarted nothing passes — #547 verbatim",
+      "file": "tools/conformance/functionallib.sh",
+      "find": "\t[ \"$before\" != \"$after\" ] \\",
+      "replace": "\t[ \"$before\" != \"$after\" ] || true \\",
+      "test": "TestARebootThatLeavesTheSameProcessFails"
+    },
+    {
+      "label": "the reboot verdict reads a runtime that could not be asked as a machine that restarted: no measurement reported as a pass",
+      "file": "tools/conformance/functionallib.sh",
+      "find": "\t{ [ -n \"$before\" ] && [ -n \"$after\" ]; } \\",
+      "replace": "\t{ [ -n \"$before\" ] && [ -n \"$after\" ]; } || true \\",
+      "test": "TestARebootNobodyCouldLookAtIsNotAPass"
+    },
+    {
+      "label": "the restart verdict stops requiring its listen proof, so a target that died reads exactly like a restart that lost its routes",
+      "file": "tools/conformance/functionallib.sh",
+      "find": "\tfnl_listens \"$port\" \"$listen\" \\\n\t\t|| fail \"$stack: $target does not listen on $port inside the machine (listening: $(tr '\\n' ' ' <\"$listen\")); 'no longer reachable' would be measuring a dead service rather than a restart\"",
+      "replace": "\tfnl_listens \"$port\" \"$listen\" || true \\\n\t\t|| fail \"$stack: $target does not listen on $port inside the machine (listening: $(tr '\\n' ' ' <\"$listen\")); 'no longer reachable' would be measuring a dead service rather than a restart\"",
+      "test": "TestARestartVerdictRefusesToJudgeADeadListener"
+    },
+    {
+      "label": "the restart verdict stops requiring the pair to have held before the restart, so a stack whose machines never reached each other is filed as #549",
+      "file": "tools/conformance/functionallib.sh",
+      "find": "\t[ \"$before\" = 0 ] \\",
+      "replace": "\t[ \"$before\" = 0 ] || true \\",
+      "test": "TestARestartVerdictRefusesAPairThatNeverHeld"
+    },
+    {
+      "label": "the restart verdict stops reading the after-probe, so a machine that came back without its routes to the peered subnets passes: #549 with the gate watching",
+      "file": "tools/conformance/functionallib.sh",
+      "find": "\tif [ \"$after\" != 0 ]; then",
+      "replace": "\tif [ \"$after\" != 0 ] && false; then",
+      "test": "TestAMachineThatStopsReachingAfterARestartFailsNamingItsNeighbour"
+    },
+    {
+      "label": "a probe nobody could make after the restart reads as a lost route, which files #549 against an instrument failure",
+      "file": "tools/conformance/functionallib.sh",
+      "find": "\t[ \"$after\" != 2 ] \\\n\t\t|| fail \"cannot look: the probe from $restarted towards $address:$port could not be made at all after the restart\"",
+      "replace": "\t[ \"$after\" != 2 ] || true \\\n\t\t|| fail \"cannot look: the probe from $restarted towards $address:$port could not be made at all after the restart\"",
+      "test": "TestARestartProbeThatCouldNotBeMadeIsNotALostRoute"
+    },
+    {
+      "label": "the restart verdict stops asking the unrestarted control, so a target or a network that went away is reported as a restart defect: the wrong subject, which is this repository's most expensive failure",
+      "file": "tools/conformance/functionallib.sh",
+      "find": "\t\tif [ -n \"$control\" ] && [ \"$control_after\" != 0 ]; then",
+      "replace": "\t\tif [ -n \"$control\" ] && [ \"$control_after\" != 0 ] && false; then",
+      "test": "TestARestartVerdictWithABrokenControlBlamesTheNetworkNotTheRestart"
+    },
+    {
+      "label": "the rule-set count stops holding the number of sets, so a rule set nothing declares appears on the host and no gate says so",
+      "file": "tools/conformance/functionallib.sh",
+      "find": "\t[ \"$sets\" = \"$want_sets\" ] \\",
+      "replace": "\t[ \"$sets\" = \"$want_sets\" ] || true \\",
+      "test": "TestARuleSetThatAppearedFails"
+    },
+    {
+      "label": "the rule-set count stops holding the references, so a machine that came back from a restart without its group is described as filtered by an API the host does not follow",
+      "file": "tools/conformance/functionallib.sh",
+      "find": "\t[ \"$refs\" = \"$want_refs\" ] \\",
+      "replace": "\t[ \"$refs\" = \"$want_refs\" ] || true \\",
+      "test": "TestARuleSetCountThatMovedFails"
+    },
+    {
+      "label": "a run that read no machine's rule sets at all passes as a stack whose numbers match: nobody could look, reported as no defect",
+      "file": "tools/conformance/functionallib.sh",
+      "find": "\t[ -s \"$file\" ] \\",
+      "replace": "\t[ -s \"$file\" ] || true \\",
+      "test": "TestAnEmptyRuleSetReadingIsAnInstrumentFailure"
+    },
+    {
+      "label": "the gate goes back to naming reachability after a restart instead of measuring it, which was honest exactly once — while #549 was open — and hides a working assertion now",
+      "file": "tools/conformance/functional.sh",
+      "find": "\t\tassert_restart \"$RESTART_NAME\" \"$RESTART_UNIT\" \"$RESTART_PORT\"\n",
+      "replace": "\t\tassert_restart \"$RESTART_NAME\" \"$RESTART_UNIT\" \"$RESTART_PORT\"\n\t\tskip \"$name: what this run does not assert after a restart is reachability to another subnet\"\n",
+      "test": "TestTheGateNoLongerExcusesReachabilityAfterARestart"
     }
   ],
   "note": "The subject is #503. On 2026-08-26 four defects were found by hand on the example stacks (#475, #481, #483, #484) and all four were green: apply exit 0, second plan empty, clean destroy, three of them without a single ERROR line. What found them was a person reading the host, so this gate is that reading, and every mutation here plants the defect one verdict names. Three of them are about the instrument rather than the cloud, and they are the ones worth reading twice: the listen reader counting established connections as listeners, the name reader matching by prefix, and the delivery reader reading a withheld backend's English reason as an address. Each was reachable by one character. The gate's own first run under --vm incus-ovn made the same class of mistake in the opposite direction and was caught by its own third outcome: `incus exec … -- command -v bash` fails on every machine because `command` is a shell builtin, and the probe answered « nobody could look » instead of reporting a firewall verdict it had not measured."


### PR DESCRIPTION
Closes #547. Closes #549. Closes #498.

Three lies of a machine's lifecycle, in one subsystem. They answered each other:
the action did nothing, when it did something it broke the network, and the
route replay behind both was not idempotent. Fixing one alone would have left
the path wrong while declaring it repaired.

## The three reproductions, before any fix

One pass on `examples/stacks/scaleway` under `feint up --runtime incus-ovn`. The
rig lives outside the repository and drives the emulator **only through its HTTP
API**; `incus` observes — pid, uptime, guest routes, probes — and never plants a
defect.

**#547** — `POST action {"action":"reboot"}` answers 202, task `success`, api
`running`:

```
incus pid before: 1703666      incus pid after: 1703666
uptime before: 31.40           uptime after: 54.91
marker-alive: active           marker-alive: active
```

Same pid, uptime climbing, the transient unit planted as a witness still alive.
The control plane reported success for an action it never performed — the exact
lie `CLAUDE.md` names: *the published state is the one the effect produced, not
the one the intent aimed at.*

**#549** — poweroff then poweron of `platform-web-0` only:

```
web0 -> app:8080 closed      <- restarted
web1 -> app:8080 OPEN        <- the control, never restarted
web0 -> web1:443 OPEN        <- its own subnet still works
web0 -> app:8080 closed      <- again 60 s later: not a delay
```

The three RFC 1918 aggregates gone from web-0's table, still present on web-1's.

**#498** — `Failed to add route {Dst: 203.0.113.4/32}: file exists`, **twice** per
run: on the reboot and on the poweron.

## #498's cause was not the one its issue left open

The issue could not decide between "the withdrawal is missing" and "the
re-install does not tolerate `file exists`". Neither: `eth0` is a routed NIC
**already carrying** the address — the host route is installed with the device —
and once the private NIC exists, `Plan.RouteVia` sends the replay at the OVN
uplink for the same /32. The address was never lost. The replay simply was not
idempotent.

## After the fix, same stack, same runtime

pid `1833116 → 1847030`, uptime `33.63 → 12.70`, marker `inactive`; the
aggregates back, `web0 -> app:8080` OPEN **with `web1` OPEN in the same pass**
and `web0 -> app:9090` still closed — so the firewall is untouched; zero
`file exists`, zero ERROR.

## The gate stops excusing what a restart costs

`functional.sh` carried, since yesterday, a skip reading *"what this run does not
assert after a restart…"*, naming #549. **It is gone**, and
`TestTheGateNoLongerExcusesReachabilityAfterARestart` forbids its return.

The assertion that replaced it is proved by a planted red — neutralise
`restoreGuestRoutes` and:

```
FAIL: scaleway: platform-web-0 reached platform-app-worker-a at 10.30.2.4:8080 before
being restarted through the API and does not afterwards, while platform-web-1 — the same
subnet, the same group, never restarted — still reaches it in the same pass (#549)
```

`conformance:functional` now runs with **7 skips where the base has 8**. A gate
that stops saying "I cannot check this" and starts checking it is the clearest
acceptance criterion this milestone has had.

## The contract held throughout

`Reconciler.Reboot` enters `PackSurface()` as **a service the shared layer
gained** — the maintainer's doctrine applied: if a pack needs a gesture the
driver does not expose, the driver gains a service, the pack never works around
it. The exemption register is still empty, nothing was exported, no pack names a
runtime, and the reboot goes through `Reconciler.PowerOn`, so the whole of
#510's order rides inside it.

`TestSameIntentSameRuntimeSequenceAcrossPacks`,
`TestNoPackReachesPastTheDeclaredDriverSurface` and
`TestNoPackKnowsWhichRuntimeIsBehindTheDriver` all still pass.

## Gates

`check`, `go test ./... -race`, `prepush`, `docs:check` — 0.
`FEINT_VM=incus-ovn mise run conformance` green end to end: exit 0, 202 ok, 0
FAIL, doorstep clean. Reference values now **asserted and measured**: Scaleway 3
`scw-*` sets / 6 references / 6 machines, Outscale 2 / 3 / 3.

Falsification: new spec `lifecycle-tells-the-truth.json`, 9 mutations, all bite;
`stack-functional-proof.json` grows from 31 to 42 mutations, all bite;
`falsify:lint` 788 mutations over 125 specs; the 31 specs naming a touched file
replayed in full.

## What was not obtained

- **The first conformance run went red** in `outscale/balancer.sh` — six
  connections to one backend. Measured rather than assumed: three replays on the
  same tree, 3 pass, distributions 6/0, 5/1, 3/3, 3/3, and 5/1→3/3 *within* one
  run. A ~3 % flake in the assertion, not in this branch. Filed as **#559**; the
  green run reported above is the re-run.
- Exoscale's reboot is driven by `exo compute instance reboot`, not Terraform —
  #525's refusal stands.
- `waitForGuestInterface`'s 90 s ceiling was never observed firing; only a unit
  test with a 5 ms budget exercises that path.
- Neither #547 nor #549 was measured under `--vm incus` (bridge): a unit test
  asserts bridge mode lays no aggregates, but no live run was made there.
- #548 untouched, deliberately — it is firewall, not lifecycle.

## Also filed

**#557** — a private NIC attached hot is configured statically while the same
NIC at the next boot takes a DHCP lease, so the two guest states differ. This is
#549's second symptom, and the issue **disproves it as a defect**: the extra
default route on `eth1` carries metric 100 against `eth0`'s 0, and the gate
proves the published address still answers from the station after the restart.
Recorded rather than fixed, with what is not measured.

Station delta nil — the only object left is the operator's own `acltest`, which
was there first and was not touched.
