### PR TITLE
perf(conformance): the runtime suites wait for a condition, and a leg exists for the four that need real machines (#459)

### DIFF
--- a/CONTRIBUTING.fr.md
+++ b/CONTRIBUTING.fr.md
@@ -51,7 +51,7 @@ runner.
 | une route, une forme de réponse, une erreur | `mise run conformance` | qu'un vrai client passe encore |
 | un gate, un score, un verdict sur une exécution | `mise run conformance:leg -- <jambe>` | qu'il tient sur une exécution **partielle** |
 | une garde, une validation, un refus | `mise run falsify -- <spec.json>`, puis la déclarer dans `tools/falsify/specs/` | que le test échoue sans elle, les jours suivants aussi |
-| `internal/core/machine`, un réseau, un pare-feu | `FEINT_VM=incus-ovn mise run conformance` | que le runtime accepte ce que le pilote envoie |
+| `internal/core/machine`, un réseau, un pare-feu | `FEINT_VM=incus-ovn mise run conformance:leg -- runtime` pendant le travail, `FEINT_VM=incus-ovn mise run conformance` une fois avant de pousser | que le runtime accepte ce que le pilote envoie |
 | un artefact de `coverage/` | `mise run evidence:update` | que le registre n'a pas rétréci |
 
 **La deuxième ligne est celle qui a coûté deux pull requests rouges.**
@@ -66,7 +66,26 @@ client, et la jambe `terraform` ne pilote pas `octl`.
 `mise run conformance:leg -- probe` reproduit une de ces jambes en local, et la
 reproduction est prouvée plutôt que supposée : en remettant la garde qui
 manquait, la jambe nomme localement les mêmes champs que le job en échec avait
-listés.
+listés. `TestEveryMatrixLegCanBeReproducedLocally` tient désormais les deux
+listes ensemble, de sorte qu'une jambe renommée dans la matrice ne peut pas
+rester irreproductible.
+
+**La jambe de la quatrième ligne s'appelle `runtime`, et ce n'est pas une entrée
+de la matrice.** Les quatre suites qui exigent de vraies machines appartiennent à
+`runtime-proof.yml`, pas à la matrice de conformance, et jusqu'à #459 rien ne les
+reproduisait sinon `FEINT_VM=incus-ovn mise run conformance` en entier : 1331 s
+mesurées le 2026-08-27, dont 675 s pour ces quatre suites et 656 s de suites
+clientes devant elles dont un changement de la couche machine n'avait aucun
+besoin. La jambe elle-même a mesuré 590 s sur la même station, d'un portillon à
+l'autre.
+
+```bash
+FEINT_VM=incus-ovn mise run conformance:leg -- runtime
+```
+
+Elle refuse de tourner sans runtime plutôt que de laisser ses suites se sauter
+elles-mêmes : une jambe demandée par son nom qui ne mesure rien ne doit pas
+rendre un succès.
 
 La forme générale, qui vaut ailleurs : **un contrôle dont le verdict porte sur
 « cette exécution » doit être éprouvé sur l'exécution la plus pauvre qui le

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ ever depending on a runner's weather.
 | a route, a response shape, an error | `mise run conformance` | that a real client still passes |
 | a gate, a score, a verdict about a run | `mise run conformance:leg -- <leg>` | that it holds on a **partial** run |
 | a guard, a validation, a refusal | `mise run falsify -- <spec.json>`, then declare it in `tools/falsify/specs/` | that the test fails without it, on every later day too |
-| `internal/core/machine`, a network, a firewall | `FEINT_VM=incus-ovn mise run conformance` | that the runtime accepts what the driver sends |
+| `internal/core/machine`, a network, a firewall | `FEINT_VM=incus-ovn mise run conformance:leg -- runtime` while you work, `FEINT_VM=incus-ovn mise run conformance` once before you push | that the runtime accepts what the driver sends |
 | an artefact under `coverage/` | `mise run evidence:update` | that the record did not narrow |
 
 **The second row is the one that cost two red pull requests.**
@@ -61,6 +61,24 @@ client at all, and the `terraform` leg drives no `octl`.
 `mise run conformance:leg -- probe` reproduces one of those legs locally, and
 the reproduction is proved rather than assumed: put back the guard that was
 missing and the leg names, locally, the same fields the failing CI job listed.
+`TestEveryMatrixLegCanBeReproducedLocally` now holds the two lists together, so
+a leg the matrix renames cannot stay unreproducible.
+
+**The fourth row's leg is `runtime`, and it is not a matrix entry.** The four
+suites that need real machines belong to `runtime-proof.yml`, not to the
+conformance matrix, and until #459 nothing reproduced them but the whole
+`FEINT_VM=incus-ovn mise run conformance` — 1331 s measured on 2026-08-27, of
+which those four suites are 675 s and the client suites in front of them 656 s
+that a change to the machine layer never needed. The leg itself measured 590 s
+on the same station, doorstep to doorstep:
+
+```bash
+FEINT_VM=incus-ovn mise run conformance:leg -- runtime
+```
+
+It refuses to run with no runtime rather than letting its suites skip
+themselves: a leg asked for by name that measures nothing must not report
+success.
 
 The general form, worth carrying elsewhere: **a check whose verdict is about
 "this run" must be exercised on the poorest run that will trigger it, never on

--- a/mise.toml
+++ b/mise.toml
@@ -697,13 +697,24 @@ description = "Prove the falsification harness refuses the three mutations that 
 run = "python3 tools/falsify/falsify.py --selftest"
 
 [tasks."conformance:leg"]
-description = "Reproduce one leg of the CI matrix locally: mise run conformance:leg -- probe"
+description = "Reproduce one leg locally: mise run conformance:leg -- probe (or -- runtime, with FEINT_VM)"
 depends = ["build"]
 # The task above drives every suite against one emulator, so a gate whose
 # verdict is about "this run" is green there by construction. CI splits the
 # clients across a matrix and every leg but `fields` is a partial run. That
 # difference cost two red pull requests on #88, neither reproducible locally
 # until this existed. tools/conformance/leg.sh carries the detail.
+#
+# The eighth leg, `runtime`, is not a conformance-matrix entry: it reproduces
+# the network and balancer steps of runtime-proof.yml, and it is the answer to
+# the other half of #459. `FEINT_VM=incus-ovn mise run conformance` was 1331 s
+# on 2026-08-27, of which those four suites are 675 s; every client suite in
+# front of them is 656 s a change to internal/core/machine never needed. The
+# leg itself measured 590 s, doorstep to doorstep. It refuses to run with no
+# runtime rather than letting its suites skip themselves and reporting success
+# on nothing.
+#
+#     FEINT_VM=incus-ovn mise run conformance:leg -- runtime
 run = "tools/conformance/leg.sh"
 
 [tasks."image:build"]

--- a/tools/conformance/README.md
+++ b/tools/conformance/README.md
@@ -24,6 +24,32 @@ silence, so you find out at once — but the list is worth having up front:
 what CI does. The suites that need one skip themselves at exit 0 when `--vm` is
 off, so a partial toolbox never turns into a false pass.
 
+## Running only the part your change touches
+
+`mise run conformance:leg -- <leg>` runs one leg. Seven of its names are the
+matrix entries of `.github/workflows/conformance.yml`, and
+`TestEveryMatrixLegCanBeReproducedLocally` holds the two lists together — a
+renamed matrix leg used to leave this script refusing the name that now exists.
+
+The eighth is `runtime`, and it is the one worth knowing about here:
+
+```bash
+FEINT_VM=incus-ovn mise run conformance:leg -- runtime
+```
+
+It runs the four suites that need real machines — the three `network.sh` and
+`outscale/balancer.sh` — and nothing else. That is the part of
+`FEINT_VM=incus-ovn mise run conformance` a change to `internal/core/machine`
+or to a firewall actually exercises: measured on 2026-08-27, the whole run was
+1331 s and those four suites were 675 s of it, so the client suites in front of
+them were 656 s that such a change never needed. **The leg itself measured
+590 s** on the same station, doorstep to doorstep. It refuses to run with no
+runtime configured rather than letting its four suites skip themselves and
+reporting success on nothing.
+
+`FEINT_VM` is honoured by every leg, so any of them can be replayed with real
+machines; the CI matrix itself runs with none, which is the default here too.
+
 **The images are a prerequisite and not a convenience** (#335). No upstream
 image carries an ssh daemon, and since #202 a machine holds exactly the one
 address its provider publishes, on a routed NIC with no NAT — so an emulator

--- a/tools/conformance/exoscale/network.sh
+++ b/tools/conformance/exoscale/network.sh
@@ -49,6 +49,11 @@ skip() { echo "  SKIP: $*" >&2; }
 . "$(dirname "$0")/../shared/addresses.sh"
 # shellcheck source=/dev/null
 . "$(dirname "$0")/../shared/verdicts.sh"
+# Waiting for a condition instead of for a duration (#459). The file states the
+# one rule that decides where these may stand, and why the waits still written
+# `sleep` below cannot become polls.
+# shellcheck source=/dev/null
+. "$(dirname "$0")/../shared/waiting.sh"
 
 command -v exo >/dev/null 2>&1 || { echo "FAIL: exo is not installed" >&2; exit 1; }
 command -v jq >/dev/null 2>&1 || { echo "FAIL: jq is not installed" >&2; exit 1; }
@@ -176,9 +181,10 @@ if ! command -v incus >/dev/null 2>&1; then
   skip "incus client not available; cannot verify what the machines carry"
   exit 0
 fi
-sleep 3
-
 echo "- the machine carries the lease the API published"
+# Asked until the lease is on the interface rather than after a guess at how
+# long a container takes to configure one. The verdict below is unchanged.
+wait_until 60 machine_carries "$(machine "$guard_id")" "$guard_ip" || true
 carried="$(incus query "/1.0/instances/$(machine "$guard_id")/state" 2>/dev/null \
            | jq -r '[.network[]?.addresses[]? | select(.family=="inet") | .address] | join(" ")')"
 case " $carried " in
@@ -204,8 +210,13 @@ assert_only_published "$(machine "$guard_id")" $exo_public "$guard_ip"
 echo "- an instance of the same private network is reachable"
 incus exec "$(machine "$guard_id")" -- sh -c \
   'while true; do printf "ok\n" | nc -l -p 80 >/dev/null 2>&1; done' >/dev/null 2>&1 &
-sleep 2
-if incus exec "$(machine "$probe_id")" -- timeout 3 nc -z -w 2 "$guard_ip" 80 >/dev/null 2>&1; then
+# No separate wait for the responder: the verdict below is a REACH, so polling
+# it covers the listener coming up as well, and it probes once per attempt
+# instead of twice. Reachable within thirty seconds satisfies the property this
+# check states, where the fixed two seconds would have failed a segment that
+# took three.
+near_reach() { incus exec "$(machine "$probe_id")" -- timeout 3 nc -z -w 2 "$guard_ip" 80 >/dev/null 2>&1; }
+if wait_until 30 near_reach; then
   ok "the probe reaches the guard on their shared network ($guard_ip)"
 else
   fail "$guard_ip is unreachable inside one private network; the segment is broken, not isolated"
@@ -221,11 +232,13 @@ exo compute instance private-network attach conformance-far-worker conformance-f
 far_ip="$(exo -O json compute private-network show conformance-far \
           | jq -r '.leases[] | select(.instance == "conformance-far-worker") | .ip_address')"
 [ -n "$far_ip" ] || fail "the far attach produced no lease"
-sleep 3
+# The attach has to reach the machine before a responder started in it means
+# anything, and both are questions: the machine answers `incus exec`, then the
+# responder is bound. The positive control below is the verdict either way.
+wait_until 60 incus exec "$(machine "$far_id")" -- true || true
 
 incus exec "$(machine "$far_id")" -- sh -c \
   'while true; do printf "ok\n" | nc -l -p 80 >/dev/null 2>&1; done' >/dev/null 2>&1 &
-sleep 2
 
 # Upstream, every private network is its own VXLAN segment, so this assertion
 # has no same-VPC exception the way Scaleway's does. On a runtime that declares
@@ -235,7 +248,7 @@ sleep 2
 # The positive control, before the negative verdict: see the Scaleway suite and
 # #219. A listener that never started refuses a connection exactly as isolation
 # does, so it is proved live on its own loopback first.
-assert_listening "$(machine "$far_id")" 80 "the instance of the other private network"
+assert_listening_within 30 "$(machine "$far_id")" 80 "the instance of the other private network"
 
 if incus exec "$(machine "$probe_id")" -- timeout 3 nc -z -w 2 "$far_ip" 80 >/dev/null 2>&1; then
   if [ "$ISOLATION" = "true" ]; then
@@ -278,7 +291,13 @@ for id in $(exo -O json compute instance list \
             | jq -r '.[] | select(.name | startswith("conformance-pool-")) | .id'); do
   cleanup_add "$id"
 done
-sleep 5
+# The count is the condition, so the count is what is waited on. Every verdict
+# below is unchanged and still fails on a pool whose machines never appear or
+# never go; what goes is the four fixed waits that paid the worst case on every
+# run. `pool_machines` costs two `exo` calls per member, which is why the
+# question is asked through one function rather than inlined.
+pool_holds() { [ "$(pool_machines)" = "$1" ]; }
+wait_until 60 pool_holds 2 || true
 [ "$(pool_machines)" = "2" ] \
   || fail "a pool of size 2 is backed by $(pool_machines) machine(s): the control plane promised what the runtime does not hold"
 ok "two members, two machines"
@@ -288,19 +307,19 @@ for id in $(exo -O json compute instance list \
             | jq -r '.[] | select(.name | startswith("conformance-pool-")) | .id'); do
   cleanup_add "$id"
 done
-sleep 5
+wait_until 60 pool_holds 3 || true
 [ "$(pool_machines)" = "3" ] \
   || fail "after scaling to 3 the runtime holds $(pool_machines) machine(s)"
 ok "scaled up, and the third machine really started"
 
 exo -Q compute instance-pool scale conformance-pool 1 --force >/dev/null || fail "scale down rejected"
-sleep 5
+wait_until 60 pool_holds 1 || true
 [ "$(pool_machines)" = "1" ] \
   || fail "after scaling to 1 the runtime still holds $(pool_machines) machine(s): a scale down that leaves containers behind is a bill nobody asked for"
 ok "scaled down, and the machines went with the members"
 
 exo -Q compute instance-pool delete conformance-pool --force >/dev/null || fail "pool delete rejected"
-sleep 3
+wait_until 60 pool_holds 0 || true
 [ "$(pool_machines)" = "0" ] || fail "the deleted pool left $(pool_machines) machine(s) running"
 ok "deleted, and the runtime holds nothing of it"
 

--- a/tools/conformance/leg.sh
+++ b/tools/conformance/leg.sh
@@ -24,11 +24,30 @@
 #
 # `fields` is the whole-run leg, the only one where FEINT_FIELD_GATE is set,
 # and it is what `mise run conformance` already approximates.
+#
+# THE LEG THAT WAS MISSING, AND WHAT ITS ABSENCE COST (#459)
+#
+# Every leg above runs with no machine runtime, because the conformance matrix
+# does. The suites that need one live in `.github/workflows/runtime-proof.yml`,
+# and until this script grew a `runtime` leg nothing reproduced them but
+# `FEINT_VM=incus-ovn mise run conformance` — measured at 1331 s on 2026-08-27,
+# of which the four dataplane suites are 675 s and every client suite before
+# them is 656 s that a change to `internal/core/machine` did not need. Agents
+# working on the lifecycle re-ran the whole thing per attempt.
+#
+#     FEINT_VM=incus-ovn mise run conformance:leg -- runtime
+#
+# It refuses to run with no runtime rather than letting its four suites skip
+# themselves: a leg that measures nothing must not report success.
 set -euo pipefail
 
 leg="${1:-}"
 endpoint="${2:-http://${FEINT_ADDR:-127.0.0.1:4599}}"
 addr="${endpoint#http://}"
+# Read from the environment, exactly as `serve` and `conformance` read it, so
+# one habit covers all three. Off by default: starting machines on the
+# operator's host is a side effect and it gets asked for.
+vm="${FEINT_VM:-off}"
 
 usage() {
   cat >&2 <<'EOF'
@@ -41,23 +60,50 @@ usage: mise run conformance:leg -- <leg>
   exo-cli     the Exoscale CLI alone
   probe       the contract-driven probe alone, no client at all
   fields      every client against one emulator, with the whole-run gate on
+  runtime     the four dataplane suites, and nothing else; needs FEINT_VM
 
-The leg names are the matrix entries of .github/workflows/conformance.yml. A
-name that is not one of them is refused rather than guessed: a leg that silently
-ran something else would measure the wrong thing and report success.
+The first seven names are the matrix entries of
+.github/workflows/conformance.yml. A name that is not one of them is refused
+rather than guessed: a leg that silently ran something else would measure the
+wrong thing and report success.
+
+`runtime` is not one of them: it reproduces the network and balancer steps of
+.github/workflows/runtime-proof.yml, which the conformance matrix does not
+carry because those need real machines.
+
+    FEINT_VM=incus-ovn mise run conformance:leg -- runtime
 EOF
   exit 2
 }
 
 case "$leg" in
-  scw-cli|terraform|opentofu|octl|exo-cli|probe|fields) ;;
+  scw-cli|terraform|opentofu|octl|exo-cli|probe|fields|runtime) ;;
   *) usage ;;
 esac
+
+# The four suites of the `runtime` leg all begin by asking the emulator whether
+# a machine runtime is configured, and skip themselves when none is. Skipping is
+# right inside `mise run conformance`, which must stay runnable in CI; it is
+# wrong here, where the leg was asked for by name. A run that measured nothing
+# and exited 0 is the verdict this repository refuses everywhere else.
+if [ "$leg" = "runtime" ] && [ "$vm" = "off" ]; then
+  echo "conformance:leg runtime: no machine runtime configured." >&2
+  echo "  Its four suites would each skip themselves and the leg would report success" >&2
+  echo "  having measured nothing. Ask for a runtime:" >&2
+  echo "    FEINT_VM=incus-ovn mise run conformance:leg -- runtime" >&2
+  exit 2
+fi
+
+# The doorstep (#375, #521), on the same terms as `mise run conformance`: the
+# question is asked at second zero rather than after every suite has run, and
+# again once the emulator is gone, so a leg that leaks fails the leg that
+# leaked. With no runtime it says so and asks nothing.
+tools/conformance/guard.sh leftovers "$vm"
 
 # --shapes is not passed: it is a `serve` flag whose default is already `shapes`,
 # and `start` spawns serve. Passing it here fails on an unknown flag, which is
 # how this line was found.
-./feint start --addr "$addr" --vm off --contracts contracts --timeout 60s
+./feint start --addr "$addr" --vm "$vm" --contracts contracts --timeout 60s
 trap './feint stop --addr '"$addr"' >/dev/null 2>&1 || true' EXIT
 
 case "$leg" in
@@ -96,6 +142,15 @@ case "$leg" in
     # unless every exchange of it is a 4xx.
     tools/conformance/refusals.sh "$endpoint"
     ;;
+  runtime)
+    # The order runtime-proof.yml uses, and the balancer last because it is the
+    # only one whose verdict depends on a declared capability rather than on
+    # the mode's name (#315): under a bridge it skips itself and says so.
+    tools/conformance/scaleway/network.sh "$endpoint"
+    tools/conformance/outscale/network.sh "$endpoint"
+    tools/conformance/exoscale/network.sh "$endpoint"
+    tools/conformance/outscale/balancer.sh "$endpoint"
+    ;;
 esac
 
 # The same score step CI runs, with the same rule about the field gate: set only
@@ -106,3 +161,9 @@ if [ "$leg" = "fields" ]; then
 else
   FEINT_FIELD_GATE=0 tools/conformance/score.sh "$endpoint"
 fi
+
+# The other half of the doorstep: asked again once the emulator is gone, so the
+# leg that left a machine or a network behind is the leg that fails. The trap
+# above stays the safety net for a leg that dies mid-flight.
+./feint stop --addr "$addr"
+tools/conformance/guard.sh leftovers "$vm"

--- a/tools/conformance/leg_test.go
+++ b/tools/conformance/leg_test.go
@@ -1,0 +1,131 @@
+package conformance
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// `mise run conformance:leg -- <leg>` exists to reproduce a CI leg locally, and
+// nothing held the two lists together (#459).
+//
+// The script's own header says the names are the matrix entries of
+// .github/workflows/conformance.yml, and it refuses anything else by design —
+// "a leg that silently ran something else would measure the wrong thing and
+// report success". The consequence nobody guarded: when the matrix renames a
+// leg, the refusal turns on the leg that now exists. #460 renamed `oapi-cli` to
+// `octl` in the matrix and somebody remembered to follow here; nothing would
+// have said so if they had not.
+//
+// One-directional on purpose, like TestEveryRequiredConformanceCheckIsAMatrixLeg
+// beside it: leg.sh carries `runtime`, which is not a conformance-matrix leg at
+// all — it reproduces the network steps of runtime-proof.yml, which need real
+// machines. Requiring the reverse would fail on that, and it is deliberate.
+func TestEveryMatrixLegCanBeReproducedLocally(t *testing.T) {
+	root := repoRoot(t)
+
+	legs := matrixLegs(t, filepath.Join(root, ".github", "workflows", "conformance.yml"))
+	if len(legs) == 0 {
+		t.Fatal("no matrix leg was read from conformance.yml, so this test compared nothing")
+	}
+	// The witness the rule about absence demands: the leg #460 renamed must be
+	// found, or the reader is matching nothing and this test passes by looking
+	// nowhere.
+	if !legs["octl"] {
+		t.Fatalf("the matrix does not name `octl`; the reader found %v", keys(legs))
+	}
+
+	accepted := legsAcceptedByTheScript(t, filepath.Join(root, "tools", "conformance", "leg.sh"))
+	if len(accepted) == 0 {
+		t.Fatal("no leg name was read from leg.sh, so this test compared nothing")
+	}
+
+	for leg := range legs {
+		if !accepted[leg] {
+			t.Errorf("the conformance matrix has the leg %q and `mise run conformance:leg` refuses "+
+				"that name: the one command written to reproduce a CI leg locally cannot "+
+				"reproduce this one. leg.sh accepts %v", leg, keys(accepted))
+		}
+	}
+}
+
+// The `runtime` leg refuses to run with no machine runtime, and it refuses
+// BEFORE it starts anything (#459).
+//
+// Its four suites each begin by asking the emulator whether a runtime is
+// configured and skipping themselves when none is. That skip is right inside
+// `mise run conformance`, which must stay runnable in CI with no runtime at
+// all; it is wrong for a leg asked for by name, because the leg would print
+// four skips and exit 0 — a run that measured nothing reporting success, which
+// is the verdict this repository refuses everywhere else.
+//
+// The assertion is on both halves: the exit code is 2, and the emulator was
+// never started. Without the second, a refusal that fired after
+// `./feint start` would leave a process behind on every invocation.
+func TestTheRuntimeLegRefusesToMeasureNothing(t *testing.T) {
+	requireTool(t, "bash")
+	root := repoRoot(t)
+
+	cmd := exec.Command("bash", "tools/conformance/leg.sh", "runtime") //nolint:gosec // a fixed path
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(), "FEINT_VM=off")
+	out, err := cmd.CombinedOutput()
+
+	code := 0
+	var exitErr *exec.ExitError
+	if err != nil {
+		if !errors.As(err, &exitErr) {
+			t.Fatalf("run leg.sh runtime: %v\n%s", err, out)
+		}
+		code = exitErr.ExitCode()
+	}
+	if code != 2 {
+		t.Errorf("`conformance:leg -- runtime` with no runtime exited %d; a leg whose four suites "+
+			"would each skip themselves must refuse rather than report success on nothing:\n%s",
+			code, out)
+	}
+	if !strings.Contains(string(out), "no machine runtime configured") {
+		t.Errorf("the refusal does not say what is missing:\n%s", out)
+	}
+	// The refusal has to come before anything is started, or every invocation
+	// leaves an emulator behind. `feint start` prints its address on success and
+	// the doorstep prints its verdict; neither may appear.
+	for _, forbidden := range []string{"feint listening on", "leftovers:"} {
+		if strings.Contains(string(out), forbidden) {
+			t.Errorf("the refusal came after %q, so the leg had already started work before "+
+				"refusing:\n%s", forbidden, out)
+		}
+	}
+}
+
+// legsAcceptedByTheScript reads the `case` label that validates the leg name.
+//
+// A line rather than a shell parse, for the reason matrixLegs gives: this module
+// carries no dependencies, and a change to the line's shape breaks loudly here
+// instead of quietly at merge time.
+func legsAcceptedByTheScript(t *testing.T, path string) map[string]bool {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading leg.sh: %v", err)
+	}
+	// The validating case is the one whose body is empty — `... ) ;;` — which is
+	// how the script says "this name is allowed" before doing anything with it.
+	line := regexp.MustCompile(`(?m)^\s*([a-z0-9|-]+)\)\s*;;\s*$`)
+	m := line.FindSubmatch(body)
+	if m == nil {
+		t.Fatal("no leg-validating `case` label in leg.sh: the reader this test depends on found " +
+			"nothing, which would make it pass by looking nowhere")
+	}
+	out := map[string]bool{}
+	for _, name := range strings.Split(string(m[1]), "|") {
+		if name = strings.TrimSpace(name); name != "" {
+			out[name] = true
+		}
+	}
+	return out
+}

--- a/tools/conformance/outscale/balancer.sh
+++ b/tools/conformance/outscale/balancer.sh
@@ -42,6 +42,12 @@ fail() { echo "FAIL: $*" >&2; exit 1; }
 ok()   { echo "  ok: $*"; }
 skip() { echo "  SKIP: $*" >&2; }
 
+# Waiting for a condition instead of for a duration (#459). The file states the
+# one rule that decides where these may stand, and why the two waits still
+# written `sleep` below cannot become polls.
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/../shared/waiting.sh"
+
 echo "conformance: outscale load balancer dataplane against $ENDPOINT"
 
 health="$(curl -sf "$ENDPOINT/_feint/health")" || fail "the emulator does not answer /_feint/health"
@@ -101,6 +107,9 @@ cleanup() {
   for vm in "$vm_a" "$vm_b" "$vm_c"; do
     [ -n "$vm" ] && osc DeleteVms --VmIds "$vm" >/dev/null 2>&1
   done
+  # waits on silence: the Subnet cannot go while a machine still sits on it, and
+  # this is a trap handler — the ids may be empty and the deletes may have been
+  # refused, so there is no single object whose disappearance to wait for.
   sleep 2
   [ -n "$sub_id" ] && osc DeleteSubnet --SubnetId "$sub_id" >/dev/null 2>&1
   [ -n "$net_id" ] && osc DeleteNet --NetId "$net_id" >/dev/null 2>&1
@@ -136,23 +145,28 @@ serve() {
     >/dev/null 2>&1
 }
 booted=""
-for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
-  if incus exec "feint-osc-$vm_a" -- true >/dev/null 2>&1 &&
-     incus exec "feint-osc-$vm_b" -- true >/dev/null 2>&1 &&
-     incus exec "feint-osc-$vm_c" -- true >/dev/null 2>&1; then booted="yes"; break; fi
-  sleep 2
-done
+all_up() {
+  incus exec "feint-osc-$vm_a" -- true >/dev/null 2>&1 &&
+    incus exec "feint-osc-$vm_b" -- true >/dev/null 2>&1 &&
+    incus exec "feint-osc-$vm_c" -- true >/dev/null 2>&1
+}
+if wait_until 24 all_up; then booted="yes"; fi
 [ -n "$booted" ] || fail "the machines never came up; nothing can be measured"
 serve "$vm_a"
 serve "$vm_b"
-sleep 3
 
 # The positive control, before any verdict is drawn from silence: each backend
 # answers on its own address. A machine whose responder never started refuses a
 # connection exactly as a balancer that forwards nothing does (#219).
+#
+# The three seconds this replaces were waiting for the two responders to bind,
+# and that is exactly what the control below asks. Polling it first leaves both
+# verdicts as they were: a responder that never binds still fails the suite.
 from_client() { incus exec "feint-osc-$vm_c" -- wget -q -T 4 -O - "http://$1/" 2>/dev/null; }
-[ "$(from_client "$ip_a")" = "$vm_a" ] || fail "the first backend does not answer on its own address"
-[ "$(from_client "$ip_b")" = "$vm_b" ] || fail "the second backend does not answer on its own address"
+a_answers() { [ "$(from_client "$ip_a")" = "$vm_a" ]; }
+b_answers() { [ "$(from_client "$ip_b")" = "$vm_b" ]; }
+wait_until 30 a_answers || fail "the first backend does not answer on its own address"
+wait_until 30 b_answers || fail "the second backend does not answer on its own address"
 ok "both backends answer directly"
 
 echo "- an internal load balancer, its two machines registered"
@@ -172,7 +186,10 @@ osc RegisterVmsInLoadBalancer --LoadBalancerName "$lb_name" --BackendVmIds "$vm_
   || fail "RegisterVmsInLoadBalancer rejected the first machine"
 osc RegisterVmsInLoadBalancer --LoadBalancerName "$lb_name" --BackendVmIds "$vm_b" >/dev/null \
   || fail "RegisterVmsInLoadBalancer rejected the second machine"
-sleep 2
+# The VIP answering is the condition, and every verdict below rests on it, so it
+# is asked rather than assumed after two seconds.
+vip_answers() { [ -n "$(from_client "$vip")" ]; }
+wait_until 30 vip_answers || true
 ok "$lb_name answers on $vip"
 
 # probe: N connections from the client machine, printed as the names that
@@ -201,6 +218,13 @@ ok "6/6 answered, over both machines:$hits"
 # Sixty seconds is short of the three minutes at which the other one died, and
 # it is what a conformance run can afford; the full curve is in docs/limits.md.
 echo "- and it is still there a minute later"
+# waits on silence: this sixty seconds IS the measurement, not a wait for
+# something to become true. #315 measured an address the runtime has to announce
+# outside the network answering for two minutes and then going dark; the claim
+# here is that an address of the network's OWN block does not. There is no
+# condition to poll: the property is that nothing changes, and the only way to
+# observe nothing changing is to let time pass. Shortening it shortens the
+# claim. docs/limits.md carries the full curve.
 sleep 60
 hits="$(probe 6)"
 case "$hits" in
@@ -213,6 +237,11 @@ ok "6/6 answered again:$hits"
 echo "- an unlinked machine stops receiving connections"
 osc UnlinkLoadBalancerBackendMachines --LoadBalancerName "$lb_name" --BackendVmIds "$vm_a" >/dev/null \
   || fail "UnlinkLoadBalancerBackendMachines rejected"
+# waits on silence: the verdict below is that $vm_a NEVER answers again across
+# six connections. Nothing announces an unlink reaching the runtime, and the
+# only poll available — "six probes that avoided $vm_a" — is satisfied by luck
+# one run in sixty-four with the unlink not applied at all. That is #559's
+# defect with a different number, so this wait stays fixed.
 sleep 2
 hits="$(probe 6)"
 case "$hits" in
@@ -238,17 +267,17 @@ osc CreateLoadBalancerListeners --LoadBalancerName "$lb_name" \
   --Listeners.0.LoadBalancerPort 8080 --Listeners.0.LoadBalancerProtocol TCP \
   --Listeners.0.BackendPort 80 --Listeners.0.BackendProtocol TCP >/dev/null \
   || fail "CreateLoadBalancerListeners rejected"
-sleep 3
 
 # The new port answers, from the same client machine, over the machine still
 # registered. Asserted first, because it is the positive half: a suite that only
 # checked the old port going quiet would pass on a balancer that was simply gone.
+#
+# The three seconds that stood here were redundant: the loop below already
+# polled the same condition, so they were paid before the first look at it every
+# single run.
 moved=""
-for _ in 1 2 3 4 5; do
-  moved="$(from_client "$vip:8080" || true)"
-  [ -n "$moved" ] && break
-  sleep 2
-done
+moved_answers() { moved="$(from_client "$vip:8080" || true)"; [ -n "$moved" ]; }
+wait_until 10 moved_answers || true
 [ "$moved" = "$vm_b" ] || fail "the balancer does not answer on its new port 8080: got '${moved:-nothing}'"
 ok "8080 answers, served by $vm_b"
 
@@ -268,8 +297,13 @@ incus network load-balancer list "$network" -f csv 2>/dev/null | grep -q "$vip" 
   || fail "the runtime holds no balancer on $vip, so the probes above measured something else"
 osc DeleteLoadBalancer --LoadBalancerName "$lb_name" >/dev/null || fail "DeleteLoadBalancer rejected"
 lb_made=""
-sleep 2
-if incus network load-balancer list "$network" -f csv 2>/dev/null | grep -q "$vip"; then
+# A disappearance, which is the one negative a poll may end on: a balancer the
+# runtime has deleted does not come back, so the first observation of its
+# absence is the verdict the sleep would have reached. The verdict below is
+# unchanged and still fails if it never goes.
+host_holds_balancer() { incus network load-balancer list "$network" -f csv 2>/dev/null | grep -q "$vip"; }
+wait_gone 30 host_holds_balancer || true
+if host_holds_balancer; then
   fail "the balancer on $vip outlived the load balancer it belongs to"
 fi
 ok "the host holds no balancer on $vip"

--- a/tools/conformance/outscale/network.sh
+++ b/tools/conformance/outscale/network.sh
@@ -41,6 +41,11 @@ skip() { echo "  SKIP: $*" >&2; }
 . "$(dirname "$0")/../shared/addresses.sh"
 # shellcheck source=/dev/null
 . "$(dirname "$0")/../shared/verdicts.sh"
+# Waiting for a condition instead of for a duration (#459). The file states the
+# one rule that decides where these may stand, and why the waits still written
+# `sleep` below cannot become polls.
+# shellcheck source=/dev/null
+. "$(dirname "$0")/../shared/waiting.sh"
 
 echo "conformance: outscale network against $ENDPOINT"
 
@@ -126,6 +131,9 @@ cleanup() {
   [ -n "$vm_a" ] && osc DeleteVms --VmIds "$vm_a" >/dev/null 2>&1
   [ -n "$vm_b" ] && osc DeleteVms --VmIds "$vm_b" >/dev/null 2>&1
   [ -n "$born_vm" ] && osc DeleteVms --VmIds "$born_vm" >/dev/null 2>&1
+  # waits on silence: a subnet cannot be deleted while a machine still sits on
+  # it, and this is a trap handler — the ids may be empty, the deletes may have
+  # been refused, so there is no single object whose disappearance to wait for.
   sleep 2
   [ -n "$sub_id" ] && osc DeleteSubnet --SubnetId "$sub_id" >/dev/null 2>&1
   [ -n "$sub_a" ] && osc DeleteSubnet --SubnetId "$sub_a" >/dev/null 2>&1
@@ -188,16 +196,11 @@ case "$private_ip" in
   *) fail "PrivateIp $private_ip is outside the Subnet $SUBBLOCK" ;;
 esac
 
-# The address must be on the machine, not only in the answer. Waiting because a
-# container gets its address a few seconds after it starts.
+# The address must be on the machine, not only in the answer. Asked until it
+# holds rather than every two seconds: the same budget, a quarter-second
+# granularity, and the verdict below unchanged.
 carried=""
-for _ in 1 2 3 4 5 6 7 8 9 10; do
-  if machine_carries "feint-osc-$vm_id" "$private_ip"; then
-    carried="yes"
-    break
-  fi
-  sleep 2
-done
+if wait_until 20 machine_carries "feint-osc-$vm_id" "$private_ip"; then carried="yes"; fi
 [ -n "$carried" ] || fail "feint-osc-$vm_id does not carry $private_ip: the address is a number in a store"
 ok "$vm_id carries $private_ip, on $found"
 
@@ -211,13 +214,22 @@ osc_published="$(osc ReadVms --Filters.VmIds "$vm_id" \
 assert_only_published "feint-osc-$vm_id" $osc_published
 
 osc DeleteVms --VmIds "$vm_id" >/dev/null || fail "DeleteVms rejected"
-sleep 2
+# The delete of the Subnet below is refused while a machine still sits on it, so
+# what the two seconds were for is the machine being gone — an object whose
+# disappearance can be asked for rather than waited out.
+machine_exists() { incus info "$1" >/dev/null 2>&1; }
+wait_gone 30 machine_exists "feint-osc-$vm_id" || true
 
 echo "- the network goes when the Subnet goes"
 osc DeleteSubnet --SubnetId "$sub_id" >/dev/null || fail "DeleteSubnet rejected"
 sub_id=""
-sleep 1
-if incus network list -f csv 2>/dev/null | grep -q "^$found,"; then
+# A disappearance is the one negative a poll may end on: a network the runtime
+# has deleted does not come back, so the first observation of its absence is the
+# same verdict a fixed sleep would have reached, only sooner. The verdict below
+# is unchanged and still fails if it never goes.
+host_lists_network() { incus network list -f csv 2>/dev/null | grep -q "^$1,"; }
+wait_gone 30 host_lists_network "$found" || true
+if host_lists_network "$found"; then
   fail "the host network $found outlived its Subnet"
 fi
 ok "deleted, and the host is as it was"
@@ -268,12 +280,8 @@ ip_b="$(printf '%s' "$vm_b_doc" | jq -r '.Vms[0].PrivateIp // empty')"
 # The machine must be up and carrying its address before absence of reach can
 # mean isolation rather than a machine still booting.
 booted=""
-for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
-  if machine_carries "feint-osc-$vm_b" "$ip_b"; then booted="yes"; break; fi
-  sleep 2
-done
+if wait_until 24 machine_carries "feint-osc-$vm_b" "$ip_b"; then booted="yes"; fi
 [ -n "$booted" ] || fail "feint-osc-$vm_b does not carry $ip_b; cannot measure reachability"
-sleep 2
 
 # reach: from the machine in Net A towards the address in Net B. The names are
 # the binding's, prefix feint-osc-.
@@ -295,13 +303,19 @@ sg_b="$(osc ReadSecurityGroups --Filters.NetIds "$net_b" --Filters.SecurityGroup
 osc CreateSecurityGroupRule --Flow Inbound --SecurityGroupId "$sg_b" \
     --IpProtocol icmp --IpRange "$PEER_BLOCK_A" >/dev/null \
   || fail "CreateSecurityGroupRule rejected on $sg_b"
+# waits on silence: the allow above must have reached the NIC before the four
+# refusals below are attributed to isolation. Nothing announces that it has, and
+# the only observable consequence of the rule landing is a ping SUCCEEDING
+# across the peering — which is precisely what must not happen yet. An allow
+# that has not landed makes each of those refusals true for a weaker reason
+# than the one this block claims, so this wait stays fixed.
 sleep 2
 
 # The positive control, before four negative verdicts in a row: the target answers
 # on its own address. A machine whose stack never came up refuses a ping exactly
 # as an unpeered Net does, and this suite draws its strongest conclusion from that
 # refusal (#219).
-assert_answers_itself "feint-osc-$vm_b" "$ip_b" "the Vm of the second Net"
+assert_answers_itself_within 30 "feint-osc-$vm_b" "$ip_b" "the Vm of the second Net"
 
 echo "- before any peering, the Nets do not reach each other"
 if reach; then
@@ -320,8 +334,7 @@ ok "still unreachable while pending-acceptance"
 
 echo "- an accepted peering carries traffic, both ends knowing it"
 osc AcceptNetPeering --NetPeeringId "$pcx_id" >/dev/null || fail "AcceptNetPeering rejected"
-sleep 2
-reach || fail "the peering is active and $vm_a still cannot reach $ip_b"
+wait_until 30 reach || fail "the peering is active and $vm_a still cannot reach $ip_b"
 ok "$vm_a reaches $ip_b through the active peering"
 
 # The regression #508 measured, held in the same pass as the lifecycle above:
@@ -336,8 +349,8 @@ ok "$vm_a reaches $ip_b through the active peering"
 echo "- a Subnet created while the peering is active does not sever it (#508)"
 born_sub="$(osc CreateSubnet --NetId "$net_a" --IpRange "${PEER_BLOCK_A%.0.0/16}.3.0/24" | jq -r '.Subnet.SubnetId')"
 [ -n "$born_sub" ] || fail "CreateSubnet was refused while the peering is active"
-sleep 2
-reach || fail "an ordinary CreateSubnet in $net_a severed the active peering: $vm_a no longer reaches $ip_b (#508)"
+wait_until 30 reach \
+  || fail "an ordinary CreateSubnet in $net_a severed the active peering: $vm_a no longer reaches $ip_b (#508)"
 ok "the existing machine still reaches $ip_b after the create"
 
 echo "- a machine born in that Subnet joins the active peering (#508)"
@@ -347,18 +360,19 @@ born_vm="$(printf '%s' "$born_doc" | jq -r '.Vms[0].VmId')"
 born_ip="$(printf '%s' "$born_doc" | jq -r '.Vms[0].PrivateIp // empty')"
 [ -n "$born_ip" ] || fail "the newborn Vm came back without a PrivateIp"
 born_up=""
-for _ in $(seq 1 12); do
-  if machine_carries "feint-osc-$born_vm" "$born_ip"; then born_up="yes"; break; fi
-  sleep 2
-done
+if wait_until 24 machine_carries "feint-osc-$born_vm" "$born_ip"; then born_up="yes"; fi
 [ -n "$born_up" ] || fail "feint-osc-$born_vm does not carry $born_ip; cannot measure the newborn's reachability"
-sleep 2
-incus exec "feint-osc-$born_vm" -- ping -c 2 -W 3 "$ip_b" >/dev/null 2>&1 \
+born_reach() { incus exec "feint-osc-$born_vm" -- ping -c 2 -W 3 "$ip_b" >/dev/null 2>&1; }
+wait_until 30 born_reach \
   || fail "the newborn Subnet's machine never joined the active peering: $born_vm cannot reach $ip_b (#508)"
 ok "$born_vm reaches $ip_b through the peering it was born into"
 
 echo "- a deleted peering separates them again"
 osc DeleteNetPeering --NetPeeringId "$pcx_id" >/dev/null || fail "DeleteNetPeering rejected"
+# waits on silence: both verdicts below are drawn from a ping that does NOT come
+# back, and nothing announces a withdrawn peering reaching the runtime. A poll
+# ending at the first failed ping would end on the ping that failed because the
+# route was still being torn down, which is a pass drawn from a race (#559).
 sleep 2
 if reach; then
   fail "the peering is deleted and the Nets still reach each other"
@@ -368,8 +382,12 @@ if incus exec "feint-osc-$born_vm" -- ping -c 2 -W 2 "$ip_b" >/dev/null 2>&1; th
 fi
 ok "unreachable again, the newborn included"
 
+# The id is kept before the variable is cleared: the wait is on THIS machine
+# going, and `feint-osc-` with nothing after it is a name incus never held, so
+# the wait would end at once having asked about nothing.
+gone_vm="$born_vm"
 osc DeleteVms --VmIds "$born_vm" >/dev/null 2>&1 && born_vm=""
-sleep 3
+wait_gone 30 machine_exists "feint-osc-$gone_vm" || true
 osc DeleteSubnet --SubnetId "$born_sub" >/dev/null 2>&1 && born_sub=""
 
 # And the accepting half, which the peering lifecycle above does not cover: a
@@ -383,24 +401,24 @@ else
   same_doc="$(osc CreateVms --ImageId ami-00000003 --VmType tinav6.c1r1p2 --SubnetId "$same_sub")"
   same_vm="$(printf '%s' "$same_doc" | jq -r '.Vms[0].VmId')"
   same_ip="$(printf '%s' "$same_doc" | jq -r '.Vms[0].PrivateIp // empty')"
-  for _ in $(seq 1 30); do
-    machine_carries "feint-osc-$same_vm" "$same_ip" && break
-    sleep 2
-  done
-  sleep 3
-  if incus exec "feint-osc-$vm_a" -- ping -c 2 -W 3 "$same_ip" >/dev/null 2>&1; then
+  wait_until 60 machine_carries "feint-osc-$same_vm" "$same_ip" || true
+  same_reach() { incus exec "feint-osc-$vm_a" -- ping -c 2 -W 3 "$same_ip" >/dev/null 2>&1; }
+  if wait_until 30 same_reach; then
     ok "a machine of the same Net is reachable ($same_ip)"
   else
     fail "$same_ip is unreachable inside one Net; the isolation separates too much"
   fi
   osc DeleteVms --VmIds "$same_vm" >/dev/null 2>&1
-  sleep 3
+  wait_gone 30 machine_exists "feint-osc-$same_vm" || true
   osc DeleteSubnet --SubnetId "$same_sub" >/dev/null 2>&1
 fi
 
+gone_a="$vm_a"
+gone_b="$vm_b"
 osc DeleteVms --VmIds "$vm_a" >/dev/null && vm_a=""
 osc DeleteVms --VmIds "$vm_b" >/dev/null && vm_b=""
-sleep 2
+wait_gone 30 machine_exists "feint-osc-$gone_a" || true
+wait_gone 30 machine_exists "feint-osc-$gone_b" || true
 osc DeleteSubnet --SubnetId "$sub_a" >/dev/null && sub_a=""
 osc DeleteSubnet --SubnetId "$sub_b" >/dev/null && sub_b=""
 osc DeleteNet --NetId "$net_a" >/dev/null && net_a=""

--- a/tools/conformance/scaleway/network.sh
+++ b/tools/conformance/scaleway/network.sh
@@ -46,6 +46,11 @@ skip() { echo "  SKIP: $*" >&2; }
 . "$(dirname "$0")/../shared/addresses.sh"
 # shellcheck source=/dev/null
 . "$(dirname "$0")/../shared/verdicts.sh"
+# Waiting for a condition instead of for a duration (#459). The file states the
+# one rule that decides where these may stand, and why the waits still written
+# `sleep` below cannot become polls.
+# shellcheck source=/dev/null
+. "$(dirname "$0")/../shared/waiting.sh"
 
 api() { curl -sf -H 'Content-Type: application/json' "$@"; }
 
@@ -198,9 +203,12 @@ machine() { echo "feint-scw-$1"; }
 if ! command -v incus >/dev/null 2>&1; then
   stop_here "$LINENO" "incus client not available; cannot verify what the machines carry"
 fi
-sleep 3
-
 echo "- the machine carries the address the API published"
+# A container gets its address a second or two after it starts, so the question
+# is asked until it holds rather than after a guess at how long that takes. The
+# verdict below is unchanged: a machine that never takes the address still
+# fails, having been asked sixty seconds instead of assumed after three.
+wait_until 60 machine_carries "$(machine "$guard_id")" "$guard_ip" || true
 carried="$(incus query "/1.0/instances/$(machine "$guard_id")/state" 2>/dev/null \
            | jq -r '[.network[]?.addresses[]? | select(.family=="inet") | .address] | join(" ")')"
 case " $carried " in
@@ -240,7 +248,12 @@ assert_only_published "$(machine "$guard_id")" $published "$guard_ip"
 echo "- the group's drop policy closes a port, for real"
 incus exec "$(machine "$guard_id")" -- sh -c \
   'while true; do printf "ok\n" | nc -l -p 80 >/dev/null 2>&1; done' >/dev/null 2>&1 &
-sleep 2
+# The positive control this verdict was missing (#219), and the reason the fixed
+# wait could go: what the two seconds were for was the listener binding, and
+# that is a question the guard can be asked. Without it, "port 80 refused" is
+# the same observation on a machine whose responder never started — and the
+# Exoscale suite has had this control since #219 while this one did not.
+assert_listening_within 30 "$(machine "$guard_id")" 80 "the guard's own responder"
 reach() { incus exec "$(machine "$probe_id")" -- timeout 3 nc -z -w 2 "$guard_ip" 80 >/dev/null 2>&1; }
 
 if reach; then
@@ -252,12 +265,20 @@ echo "- authorising it opens it, with no restart"
 rule_id="$(api -X POST "$ENDPOINT/instance/v1/zones/$ZONE/security_groups/$sg_id/rules" \
             -d "{\"protocol\":\"TCP\",\"direction\":\"inbound\",\"action\":\"accept\",\"ip_range\":\"$BLOCK\",\"dest_port_from\":80}" \
           | jq -r '.rule.id')"
-sleep 3
-reach || fail "port 80 is still refused after the rule was authorised"
+# One probe at the end rather than a poll and then a repeat: the responder is
+# `nc -l` in a loop, so a connection consumes it and the next needs the loop to
+# come back round. Asking twice would introduce a race this change is meant to
+# remove.
+wait_until 30 reach || fail "port 80 is still refused after the rule was authorised"
 ok "port 80 reachable"
 
 echo "- revoking it closes it again"
 api -X DELETE "$ENDPOINT/instance/v1/zones/$ZONE/security_groups/$sg_id/rules/$rule_id" >/dev/null
+# waits on silence: the verdict below is drawn from a connection that does NOT
+# open, and nothing announces a revoked rule reaching the NIC. Polling until the
+# port closes would end at the first failed connection, which is what a port
+# that has not opened yet also looks like — the verdict would then be a race
+# won by luck (#559). This wait stays fixed on purpose.
 sleep 3
 if reach; then fail "port 80 is still open after the rule was revoked"; fi
 ok "port 80 refused again"
@@ -281,6 +302,10 @@ ok "$public does not answer while detached"
 
 api -X PATCH "$ENDPOINT/instance/v1/zones/$ZONE/ips/$ip_id" -d "{\"server\":\"$guard_id\"}" >/dev/null \
   || fail "attaching the address was refused"
+# waits on silence: what follows asserts that the address stays CLOSED while the
+# group drops inbound, and an address whose route is not laid yet is closed for
+# the wrong reason. There is no positive observation to poll here — the only one
+# available is the connection succeeding, which is exactly what must not happen.
 sleep 2
 
 # The verdict is the exit code, never the probe's text. A connection dropped by
@@ -301,8 +326,8 @@ echo "- authorising the port opens the public address"
 pub_rule="$(api -X POST "$ENDPOINT/instance/v1/zones/$ZONE/security_groups/$sg_id/rules" \
              -d '{"protocol":"TCP","direction":"inbound","action":"accept","ip_range":"0.0.0.0/0","dest_port_from":80}' \
            | jq -r '.rule.id')"
-sleep 3
-timeout 3 bash -c "echo > /dev/tcp/$public/80" >/dev/null 2>&1 \
+public_open() { timeout 3 bash -c "echo > /dev/tcp/$public/80" >/dev/null 2>&1; }
+wait_until 30 public_open \
   || fail "$public still closed with port 80 authorised; nothing routes it to the machine"
 ok "$public reaches the machine once authorised"
 api -X DELETE "$ENDPOINT/instance/v1/zones/$ZONE/security_groups/$sg_id/rules/$pub_rule" >/dev/null
@@ -343,11 +368,13 @@ far_ipam="$(echo "$far_nic" | jq -r '.private_nic.ipam_ip_ids[0] // empty')"
 [ -n "$far_ipam" ] || fail "the far NIC names no IPAM address"
 far_ip="$(api "$ENDPOINT/ipam/v1/regions/$REGION/ips/$far_ipam" | jq -r '.address' | cut -d/ -f1)"
 api -X POST "$ENDPOINT/instance/v1/zones/$ZONE/servers/$far_id/action" -d '{"action":"poweron"}' >/dev/null
-sleep 5
+# The machine must answer `incus exec` before a responder can be started in it.
+# That is a question, so it is asked rather than slept over; the positive
+# control below is the verdict either way.
+wait_until 90 incus exec "$(machine "$far_id")" -- true || true
 
 incus exec "$(machine "$far_id")" -- sh -c \
   'while true; do printf "ok\n" | nc -l -p 80 >/dev/null 2>&1; done' >/dev/null 2>&1 &
-sleep 2
 
 # On OVN the assertion is hard: two OVN networks reach each other only when
 # peered, and another VPC's network must not be. On bridges it stays a skip,
@@ -359,7 +386,7 @@ sleep 2
 # a machine correctly isolated are the same observation, and the suite read the
 # first as a pass — on the assertion that carries the product's strongest claim
 # (#219).
-assert_listening "$(machine "$far_id")" 80 "the server of the other VPC"
+assert_listening_within 30 "$(machine "$far_id")" 80 "the server of the other VPC"
 
 if incus exec "$(machine "$probe_id")" -- timeout 3 nc -z -w 2 "$far_ip" 80 >/dev/null 2>&1; then
   # A runtime that declares isolation and does not deliver it is a hard failure:
@@ -384,13 +411,18 @@ near_nic="$(api -X POST "$ENDPOINT/instance/v1/zones/$ZONE/servers/$near_id/priv
 near_ipam="$(echo "$near_nic" | jq -r '.private_nic.ipam_ip_ids[0] // empty')"
 near_ip="$(api "$ENDPOINT/ipam/v1/regions/$REGION/ips/$near_ipam" | jq -r '.address' | cut -d/ -f1)"
 api -X POST "$ENDPOINT/instance/v1/zones/$ZONE/servers/$near_id/action" -d '{"action":"poweron"}' >/dev/null
-sleep 5
+wait_until 90 incus exec "$(machine "$near_id")" -- true || true
 
 incus exec "$(machine "$near_id")" -- sh -c \
   'while true; do printf "ok\n" | nc -l -p 80 >/dev/null 2>&1; done' >/dev/null 2>&1 &
-sleep 2
+# No separate wait for the responder here: the verdict below is a REACH, not a
+# silence, so polling the verdict itself covers the listener coming up as well —
+# and it probes once per attempt instead of twice. A machine of the same VPC
+# that becomes reachable in four seconds satisfies the property this check
+# states, and the fixed two-second wait would have failed it.
+near_reach() { incus exec "$(machine "$probe_id")" -- timeout 3 nc -z -w 2 "$near_ip" 80 >/dev/null 2>&1; }
 
-if incus exec "$(machine "$probe_id")" -- timeout 3 nc -z -w 2 "$near_ip" 80 >/dev/null 2>&1; then
+if wait_until 30 near_reach; then
   ok "a server of the same VPC is reachable ($near_ip)"
 else
   fail "$near_ip is unreachable within one VPC; isolation is separating too much"

--- a/tools/conformance/shared/verdicts.sh
+++ b/tools/conformance/shared/verdicts.sh
@@ -36,10 +36,39 @@ machine_carries() { # machine address
 # Asked on the target itself, because the point is precisely that nothing else
 # can reach it: if the listener answers on its own loopback, then a refusal seen
 # from elsewhere is isolation rather than absence.
+#
+# Split in two since #459: `is_listening` is the question, `assert_listening` is
+# the verdict. The suites wait on the question — `wait_until 30 is_listening …`,
+# see shared/waiting.sh — where they used to sleep a fixed two or three seconds
+# hoping the listener had come up, and then draw the same verdict. The verdict
+# is unchanged: a listener that never binds still fails, having been asked
+# rather than assumed.
+is_listening() { # machine port
+  incus exec "$1" -- timeout 3 nc -z -w 2 127.0.0.1 "$2" >/dev/null 2>&1
+}
+
 assert_listening() { # machine port what
   local machine=$1 port=$2 what=$3
-  if ! incus exec "$machine" -- timeout 3 nc -z -w 2 127.0.0.1 "$port" >/dev/null 2>&1; then
+  if ! is_listening "$machine" "$port"; then
     fail "$what is not listening on port $port, so 'unreachable' would measure a dead machine rather than isolation"
+  fi
+}
+
+# assert_listening_within is the form the suites call, and it exists so that
+# they probe ONCE.
+#
+# The responder these suites start is `nc -l` inside a `while true` loop, so a
+# probe CONSUMES it and the next one races the loop's re-bind. A fixed sleep
+# followed by one assertion probed once; a poll followed by the same assertion
+# would probe twice, which would trade the slowness for a race — the exact
+# swap this whole change exists to avoid. One call, one probe sequence, one
+# verdict, and the verdict is the same one assert_listening draws.
+#
+# Requires shared/waiting.sh, which every caller of this file sources beside it.
+assert_listening_within() { # seconds machine port what
+  local budget=$1 machine=$2 port=$3 what=$4
+  if ! wait_until "$budget" is_listening "$machine" "$port"; then
+    fail "$what is not listening on port $port after ${budget}s, so 'unreachable' would measure a dead machine rather than isolation"
   fi
 }
 
@@ -49,9 +78,24 @@ assert_listening() { # machine port what
 # Same argument: a machine whose stack is not up refuses a ping exactly as
 # isolation does. Asked of the machine about its own address, which proves the
 # address is live on it without needing anything else to reach it.
+#
+# Split into question and verdict for the reason is_listening is (#459).
+answers_itself() { # machine address
+  incus exec "$1" -- ping -c 1 -W 2 "$2" >/dev/null 2>&1
+}
+
 assert_answers_itself() { # machine address what
-  if ! incus exec "$1" -- ping -c 1 -W 2 "$2" >/dev/null 2>&1; then
+  if ! answers_itself "$1" "$2"; then
     fail "$3 does not answer on $2 from itself, so 'unreachable' would measure a dead stack rather than isolation"
+  fi
+}
+
+# The same, with a budget, and the same reason: one call, one probe, one
+# verdict. Requires shared/waiting.sh.
+assert_answers_itself_within() { # seconds machine address what
+  local budget=$1 machine=$2 address=$3 what=$4
+  if ! wait_until "$budget" answers_itself "$machine" "$address"; then
+    fail "$what does not answer on $address from itself after ${budget}s, so 'unreachable' would measure a dead stack rather than isolation"
   fi
 }
 

--- a/tools/conformance/shared/waiting.sh
+++ b/tools/conformance/shared/waiting.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Waiting for a condition, instead of waiting for a duration (#459).
+#
+# WHY THIS IS NOT A TIDY-UP
+#
+# `FEINT_VM=incus-ovn mise run conformance` was measured at 1331 s on
+# 2026-08-27, and the four suites that only run with a machine runtime — the
+# three `network.sh` and `outscale/balancer.sh` — are 675 s of it, half the run.
+# Traced command by command (`PS4` carrying `EPOCHREALTIME`, which turns
+# `bash -x` into a profiler whose resolution is one shell command), those four
+# spent **160 s inside an explicit `sleep`**:
+#
+#     scaleway/network.sh   163 s,  30 s asleep over 10 calls   18%
+#     outscale/network.sh   214 s,  28 s asleep over 13 calls   13%
+#     exoscale/network.sh   126 s,  28 s asleep over  8 calls   22%
+#     outscale/balancer.sh  168 s,  74 s asleep over  7 calls   44%
+#
+# Sixty of the balancer's seventy-four ARE the measurement of #315 and stay. The
+# other 100 s were spent after the thing being waited for had already happened.
+#
+# Same four suites, same station, same emulator lifecycle, after this file:
+#
+#     scaleway/network.sh   139 s,   5.5 s asleep    (was 163 s,  30 s)
+#     outscale/network.sh   192 s,   6.0 s asleep    (was 214 s,  28 s)
+#     exoscale/network.sh    98 s,   0.0 s asleep    (was 126 s,  28 s)
+#     outscale/balancer.sh  158 s,  64.0 s asleep    (was 168 s,  74 s — 60 of
+#                                                     which are #315's window)
+#
+# 44 fixed `sleep` lines became 8. Of the 8: five stand before a verdict drawn
+# from an absence, two are trap handlers with no verdict after them, and one is
+# #315's minute. Every one of them says so on the line above it, and
+# TestEveryFixedSleepInARuntimeSuiteSaysWhatItWaitsFor fails if one stops.
+#
+# A fixed `sleep N` before an assertion states two things at once and is wrong
+# about both: that N seconds are always enough (so the suite goes red on a
+# slower host, which teaches "re-run it") and that N seconds are always needed
+# (so every run pays the worst case). Polling the condition itself is right on
+# both counts, and it is STRICTLY STRONGER than the sleep it replaces: the
+# assertion that follows is untouched, so a condition that never becomes true
+# still fails the suite — later than the sleep would have, and having actually
+# looked.
+#
+# THE RULE THAT DECIDES WHERE THESE MAY BE USED
+#
+# `wait_until` goes before a verdict drawn from a POSITIVE observation: the
+# machine answers, the port opens, the pool holds three members. It must NEVER
+# go before a verdict drawn from a NEGATIVE one — "unreachable", "refused", "no
+# longer answers". There the fixed wait is the only thing separating "the rule
+# was applied" from "we looked too early", and a poll that stops at the first
+# negative observation converts a race into a pass. That is exactly the shape
+# of #559, in the one suite whose whole subject is the dataplane, and it is
+# worse than the slowness this file exists to remove.
+#
+# The single exception is stated rather than assumed, and it has its own name:
+# an object the runtime has DELETED does not come back, so polling until it is
+# gone reaches the same verdict as sleeping, only sooner. `wait_gone` is that
+# case; a caller reaching for `wait_until` to prove an absence has picked the
+# wrong one.
+#
+# tools/conformance/waiting_test.go holds both halves — that a condition which
+# never comes true fails, and that one which does is not waited out — and
+# tools/falsify/specs/waiting-is-not-sleeping.json replays them with the
+# timeout's refusal neutralised.
+
+# WAIT_POLL is how often the condition is asked. A quarter second is far below
+# anything these suites wait for and far above the cost of asking: the dearest
+# condition here is one `incus exec`, tens of milliseconds.
+WAIT_POLL="${WAIT_POLL:-0.25}"
+
+# wait_until <seconds> <command...> — poll until the command succeeds.
+#
+# Answers 0 as soon as it does, and 1 if the budget runs out. The caller keeps
+# its own assertion: this function decides how long to look, never what the
+# verdict is.
+#
+# The budget is rounded UP by one second, and that is not a rounding choice but
+# the same rule as everything above: `SECONDS` ticks on the shell's integer
+# boundary, so a shell started at X.99 sees it reach 1 a hundredth of a second
+# later. Rounding down would let a wait give up early, which is the flake this
+# file exists to remove. Measured: without the `+ 1`, `wait_until 1 false`
+# returned in 0.25 s.
+wait_until() { # seconds command...
+  local budget="$1"
+  shift
+  local deadline=$((SECONDS + budget + 1))
+  while :; do
+    if "$@"; then
+      return 0
+    fi
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      return 1 # the budget ran out and the condition never held
+    fi
+    sleep "$WAIT_POLL"
+  done
+}
+
+# wait_gone <seconds> <command...> — poll until the command FAILS.
+#
+# The disappearance half, and the only negative this file offers: see the rule
+# above for why there is no general `wait_while`. The command must be a
+# question about an object's existence — "does the host still list this
+# network" — so that its first failure is the object being gone and not the
+# observation being early.
+wait_gone() { # seconds command...
+  local budget="$1"
+  shift
+  local deadline=$((SECONDS + budget + 1))
+  while :; do
+    if ! "$@"; then
+      return 0
+    fi
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      return 1 # the budget ran out and the object is still there
+    fi
+    sleep "$WAIT_POLL"
+  done
+}

--- a/tools/conformance/waiting_test.go
+++ b/tools/conformance/waiting_test.go
@@ -1,0 +1,190 @@
+package conformance
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The waiting helpers the runtime suites share (#459).
+//
+// What they replace is a fixed `sleep N` standing before an assertion, and the
+// danger of that replacement is named at the top of
+// tools/conformance/shared/waiting.sh: a wait removed at the wrong place turns
+// an assertion into a race won by luck, which is worse than the slowness. #559
+// is what that looks like when it ships — a dataplane verdict that is red at
+// random rather than never.
+//
+// So the helpers are held here by three properties, and the third is the one
+// that keeps the conversion honest on every later day:
+//
+//  1. a condition that never comes true still fails the wait;
+//  2. a condition that does come true is not waited out;
+//  3. every fixed `sleep` still standing in a runtime suite says, on the line
+//     above it, what it is waiting for — because the ones left are exactly the
+//     ones a future reader will be tempted to delete next.
+//
+// tools/falsify/specs/waiting-is-not-sleeping.json replays 1 and 3 with their
+// guard neutralised.
+
+// The half that matters most. A helper whose timeout answered success would
+// make every converted assertion vacuous, and silently: the suite would go
+// green on a machine that never booted.
+func TestAConditionThatNeverComesTrueFailsTheWait(t *testing.T) {
+	out := runWaiting(t, `if wait_until 1 false; then echo "verdict=passed"; else echo "verdict=failed"; fi`)
+	if !strings.Contains(out, "verdict=failed") {
+		t.Errorf("wait_until answered success for a condition that is never true; every assertion "+
+			"placed after it would then pass on a machine that never came up:\n%s", out)
+	}
+}
+
+// The same for the disappearance half: an object that never goes must not be
+// reported gone, or a leak reads as a clean teardown.
+func TestAnObjectThatNeverGoesFailsTheWait(t *testing.T) {
+	out := runWaiting(t, `if wait_gone 1 true; then echo "verdict=passed"; else echo "verdict=failed"; fi`)
+	if !strings.Contains(out, "verdict=failed") {
+		t.Errorf("wait_gone answered success while its object was still there:\n%s", out)
+	}
+}
+
+// Without this a helper that refused everything would satisfy the two above.
+// The assertion is on the elapsed time as well as on the verdict, because
+// waiting out the budget is precisely the defect being removed: a helper that
+// answered correctly after thirty seconds would have changed nothing.
+func TestAConditionThatComesTrueIsNotWaitedOut(t *testing.T) {
+	dir := t.TempDir()
+	counter := filepath.Join(dir, "count")
+	if err := os.WriteFile(counter, []byte("0\n"), 0o600); err != nil {
+		t.Fatalf("write the counter: %v", err)
+	}
+
+	script := `
+counter="$1"
+third_time() { n="$(cat "$counter")"; n=$((n + 1)); printf '%s\n' "$n" > "$counter"; [ "$n" -ge 3 ]; }
+if wait_until 30 third_time; then echo "verdict=passed"; else echo "verdict=failed"; fi
+echo "polls=$(cat "$counter")"
+`
+	start := time.Now()
+	out := runWaiting(t, script, counter)
+	elapsed := time.Since(start)
+
+	if !strings.Contains(out, "verdict=passed") {
+		t.Errorf("wait_until did not see a condition that became true:\n%s", out)
+	}
+	if !strings.Contains(out, "polls=3") {
+		t.Errorf("wait_until did not poll until the condition held:\n%s", out)
+	}
+	// Three polls of a quarter second, plus a process start. Ten seconds is a
+	// third of the budget and still two orders of magnitude above the real
+	// cost, so this goes red on a helper that waits out its budget rather than
+	// on a loaded machine.
+	if elapsed > 10*time.Second {
+		t.Errorf("a condition true after three polls took %s: the helper waits out its budget "+
+			"rather than the condition, which is the sleep it was meant to replace", elapsed)
+	}
+}
+
+// waitsOnSilence is the marker a kept `sleep` carries, and the reason it is a
+// marker rather than a comment in prose: this test reads it.
+const waitsOnSilence = "# waits on silence:"
+
+// Every fixed `sleep` left in a runtime suite says what it waits for (#459).
+//
+// The suites converted their positive waits — the machine answers, the port
+// opens, the pool holds three members — into polls. What could not be
+// converted is a wait standing before a verdict drawn from an ABSENCE:
+// "unreachable", "no longer answers", "the host holds no network". There the
+// fixed wait is the only thing separating "the rule was applied" from "we
+// looked too early", and a poll ending at the first negative observation turns
+// a race into a pass.
+//
+// Those waits are therefore the next ones somebody optimises, and a comment
+// saying "keep this" is not a control — this repository has paid three times
+// for exactly that sentence. So the marker is mechanical: a bare `sleep` in
+// these four files fails this test, and a marked one carries its reason in the
+// suite where the next reader meets it.
+func TestEveryFixedSleepInARuntimeSuiteSaysWhatItWaitsFor(t *testing.T) {
+	suites := []string{
+		filepath.Join("scaleway", "network.sh"),
+		filepath.Join("outscale", "network.sh"),
+		filepath.Join("exoscale", "network.sh"),
+		filepath.Join("outscale", "balancer.sh"),
+	}
+	// A `sleep` on a line of its own, or as the whole of a loop's last
+	// statement. The poll interval inside shared/waiting.sh is not in these
+	// files, so nothing here is exempt.
+	sleeper := regexp.MustCompile(`(^|;|&&|\|\|)\s*sleep\s`)
+
+	found := 0
+	for _, suite := range suites {
+		body, err := os.ReadFile(suite) //nolint:gosec // a fixed path in this directory
+		if err != nil {
+			t.Fatalf("read %s: %v", suite, err)
+		}
+		lines := strings.Split(string(body), "\n")
+		for i, line := range lines {
+			text := strings.TrimSpace(line)
+			if strings.HasPrefix(text, "#") || !sleeper.MatchString(text) {
+				continue
+			}
+			found++
+			marked := false
+			// The marker sits in the comment block immediately above, which may
+			// be several lines: a reason worth writing rarely fits on one.
+			for j := i - 1; j >= 0; j-- {
+				above := strings.TrimSpace(lines[j])
+				if !strings.HasPrefix(above, "#") {
+					break
+				}
+				if strings.Contains(above, waitsOnSilence) {
+					marked = true
+					break
+				}
+			}
+			if !marked {
+				t.Errorf("%s:%d: a fixed `sleep` with nothing saying what it waits for: %s\n"+
+					"    Either it stands before a verdict drawn from an absence — then say so "+
+					"with a %q comment above it — or the condition exists and it should be a "+
+					"wait_until (tools/conformance/shared/waiting.sh)",
+					suite, i+1, text, waitsOnSilence)
+			}
+		}
+	}
+	// The witness rule: a control that looks for a missing marker must first
+	// prove it can find a sleep at all. Zero would mean the loop compared
+	// nothing and this test is a comment.
+	if found == 0 {
+		t.Fatal("no fixed sleep was found in any runtime suite, so this control examined nothing")
+	}
+}
+
+// runWaiting sources the real shared/waiting.sh under the same
+// `set -euo pipefail` the suites run under — the regime that makes a naive
+// `helper; echo $?` abort instead of reporting — and runs the script after it.
+func runWaiting(t *testing.T, script string, args ...string) string {
+	t.Helper()
+	requireTool(t, "bash")
+
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("locate the repository root: %v", err)
+	}
+	body := "set -euo pipefail\n. tools/conformance/shared/waiting.sh\n" + script
+
+	cmd := exec.Command("bash", append([]string{"-c", body, "waiting-test"}, args...)...) //nolint:gosec // a fixed script
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			t.Fatalf("run the waiting helpers: %v\n%s", err, out)
+		}
+		t.Fatalf("the harness itself failed (exit %d):\n%s", exitErr.ExitCode(), out)
+	}
+	return string(out)
+}

--- a/tools/falsify/specs/a-leg-that-measures-nothing.json
+++ b/tools/falsify/specs/a-leg-that-measures-nothing.json
@@ -1,0 +1,19 @@
+{
+  "package": "./tools/conformance/",
+  "mutations": [
+    {
+      "label": "the runtime leg stops refusing a run with no machine runtime, so its four suites each skip themselves and the leg reports success on nothing (#459)",
+      "file": "tools/conformance/leg.sh",
+      "find": "if [ \"$leg\" = \"runtime\" ] && [ \"$vm\" = \"off\" ]; then",
+      "replace": "if [ \"$leg\" = \"runtime\" ] && [ \"$vm\" = \"off\" ] && false; then",
+      "test": "TestTheRuntimeLegRefusesToMeasureNothing"
+    },
+    {
+      "label": "a leg of the conformance matrix stops being reproducible locally, which is what a renamed matrix job did to this script before anything held the two lists together (#459, #460)",
+      "file": "tools/conformance/leg.sh",
+      "find": "  scw-cli|terraform|opentofu|octl|exo-cli|probe|fields|runtime) ;;",
+      "replace": "  scw-cli|terraform|opentofu|exo-cli|probe|fields|runtime) ;; # octl",
+      "test": "TestEveryMatrixLegCanBeReproducedLocally"
+    }
+  ]
+}

--- a/tools/falsify/specs/waiting-is-not-sleeping.json
+++ b/tools/falsify/specs/waiting-is-not-sleeping.json
@@ -1,0 +1,26 @@
+{
+  "package": "./tools/conformance/",
+  "mutations": [
+    {
+      "label": "the wait's timeout answers success, so every assertion placed after a wait_until passes on a machine that never came up (#459)",
+      "file": "tools/conformance/shared/waiting.sh",
+      "find": "      return 1 # the budget ran out and the condition never held",
+      "replace": "      return 0 # the budget ran out and the condition never held",
+      "test": "TestAConditionThatNeverComesTrueFailsTheWait"
+    },
+    {
+      "label": "the disappearance wait's timeout answers success, so a machine or a network left behind reads as a clean teardown (#459)",
+      "file": "tools/conformance/shared/waiting.sh",
+      "find": "      return 1 # the budget ran out and the object is still there",
+      "replace": "      return 0 # the budget ran out and the object is still there",
+      "test": "TestAnObjectThatNeverGoesFailsTheWait"
+    },
+    {
+      "label": "a kept fixed wait loses the marker that says what it waits for, which is how the next reader turns it into a poll and the dataplane verdict into a race (#459, #559)",
+      "file": "tools/conformance/scaleway/network.sh",
+      "find": "# waits on silence: the verdict below is drawn from a connection that does NOT",
+      "replace": "# it waits on the silence, and the verdict below is drawn from a connection that does NOT",
+      "test": "TestEveryFixedSleepInARuntimeSuiteSaysWhatItWaitsFor"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #459.

Measured first, fixed second — and the measurement overturned the issue that
asked for the work.

## #459's own number is gone, and that is the finding

The issue reported eleven calls at 12.04–12.05 s each in the Outscale suite,
132.5 s of its 177. **Those eleven were `oapi-cli`.** #462 moved the suite to
`octl` and the suite fell from 177 s to 141 s on its own.

What is left *looks* like a back-off — `octl --version`, no network, no
configuration: 0.676 / 0.702 / 0.710 / 0.767 / 0.717 s, a suspicious constant —
and is not:

```
real 0.775   user 1.346   sys 0.118
```

`user > real` is parallel computation, not waiting. 147 `osc` calls at ~0.96 s
are the suite. Fixing it would buy ~10 s and cost eleven refusals proven by a
real client. Measured and filed as a comment on #459 rather than acted on.

## What the trace found instead

The largest constant in a runtime run is not a suite's `sleep`. Five `CreateVms`
at 22.048–22.139 s, three `POST /servers` at 20.7–21.3 s, three
`private-network attach` at 20.776–20.806 s. Decomposed by hand on the same OVN
network:

```
incus init    0.42 s
incus start  10.40 s      ← on the default bridge, the same image: 0.37 s
incus delete  0.83 s
```

**Half of a runtime conformance run is one `incus start` on an OVN network.**
Filed as **#562**; out of scope here.

## The before/after, three passes

`mise run conformance` without a runtime is 255.8 s and this batch does not
touch it. Under `--vm incus-ovn`, same tree, same station:

| | before | pass 1 | pass 2 | pass 3 |
|---|--:|--:|--:|--:|
| scaleway/network.sh | 165.9 | 143.0 | 142.5 | 143.0 |
| outscale/network.sh | 213.9 | 193.4 | 194.2 | 195.1 |
| exoscale/network.sh | 125.7 | 99.3 | 99.7 | 100.5 |
| outscale/balancer.sh | 169.1 | 159.6 | 160.0 | 160.2 |
| **whole run** | **1330.8** | **1265.4** | **1265.7** | **1275.6** |

The four runtime suites: **674.6 s → 595.3 / 596.4 / 598.8**. Traced alone on
their own emulator, 670.6 → 587.0.

Explicit `sleep` in those suites: **160.0 s → 75.5 s**, and 60 of the 75 **are
the measurement of #315**, not a wait.

## The classification, which is what decides whether this repairs or breaks

44 fixed sleeps. **36 removed**, each replaced by an observable condition — the
machine carries its address, the port answers, the pool holds N, the object is
gone. **8 kept**, and every one carries a `# waits on silence:` line saying what
it waits for:

- five sit before a verdict drawn from a **silence** — a revoked rule, an
  attached address that must stay closed, a group authorisation before four
  refusals, a deleted peering, an unlinked machine. You cannot wait for an event
  *not* to arrive, and removing those would turn an assertion into a race won by
  luck;
- two are cleanup traps;
- one is #315's minute.

`TestEveryFixedSleepInARuntimeSuiteSaysWhatItWaitsFor` reddens if one of those
lines disappears.

**One assertion came out stronger than it went in**: `scaleway/network.sh` drew
"port 80 refused" from a connection that did not open, with no proof the
responder had ever listened. It now carries #219's positive control.

## The leg that was missing

`conformance:leg` did not suffice, and the gap was **code, not documentation**.
Its seven names are the conformance matrix's, the matrix runs without a runtime,
and the script forced `--vm off` — so an agent touching `internal/core/machine`
had nothing but the full 1331 s. The lifecycle batch re-ran all of it per
attempt.

```
FEINT_VM=incus-ovn mise run conformance:leg -- runtime     590 s
```

The four dataplane suites and nothing else. Every leg now honours `FEINT_VM`,
the doorstep runs at both ends, and **the leg refuses to run without a runtime**
rather than letting its four suites skip themselves — four skips and exit 0
would be a success rendered over nothing.

And nothing tied the matrix's names to the script's:
`TestEveryMatrixLegCanBeReproducedLocally` does now.

## Gates

Three green full passes (1265.4 / 1265.7 / 1275.6, all exit 0), plus the
`runtime` leg at 590.0 and the traced pass: **five green runs of the delivered
code**. #559 fired in none of them.

`check`, `go test ./... -race`, `prepush`, `docs:check` at 0. `falsify:lint` 793
mutations over 127 specs. Two new specs, plus `unkillable-dhcp-orphan` and
`a-run-ends-where-it-could-start` replayed in full because they name files this
batch touches — red on every mutation, green on restore.

`functional.sh` and `functionallib.sh` are **not in the diff**, so
`conformance:functional` keeps its seven skips and the asserted reference values
by construction. The three discipline tests pass by name.

Station delta nil.

## What was not obtained

- The ~10 s of `CreateVms` between `incus start` and the API's answer is not
  decomposed, nor is the cause of the 10.4 s itself — southbound programming,
  DHCP lease, or waiting on the logical port. That is #562.
- **One pass was lost to my own hand**: suites were edited while a run was
  reading them, and `bash` reads a script as it executes. Discarded and replayed
  clean; the lesson is written into the run script.
- `CLAUDE.md`'s decision table still points at the full pass for its fourth row.
  Not modified: no instruction authorised touching it. `CONTRIBUTING` (both
  languages), `tools/conformance/README.md` and `mise.toml` carry the new leg.
- #559 untouched: the balancer spread assertion remains a ~3 % coin flip.
