### PR TITLE
feat(testplan): the conformance runs a change has earned are read off its diff, not remembered (#564)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -49,6 +49,11 @@ conditional: if a block does not apply, write `N/A` rather than leaving it blank
 - [ ] Nothing in the diff could be written identically for another provider. If
       it could, it belongs in the core — that is the rule that stopped the same
       lifecycle bug being fixed once and surviving twice
+- [ ] `mise run testplan` was run, and what it printed was run — or this pull
+      request names the run it skipped and why. A run not played is **written
+      down**, never left blank: the reviewer cannot tell an omission that was
+      considered from one that was forgotten, and only one of the two is a
+      decision
 
 ### When a model wrote a substantive part of this — otherwise N/A
 

--- a/.gitignore
+++ b/.gitignore
@@ -213,6 +213,10 @@ pyrightconfig.json
 
 # Build output
 /feint
+# The tools that `go build ./tools/...` leaves at the root. Un-ignored, they
+# reach `mise run testplan` as untracked paths no rule triages, which is a red
+# with nothing behind it (#564).
+/testplan
 /dist/
 
 # Upstream SDK checkouts read by the drift scan (cloned by `mise run upstream:sync`)

--- a/CONTRIBUTING.fr.md
+++ b/CONTRIBUTING.fr.md
@@ -44,7 +44,52 @@ Déterministe, hors ligne, quelques secondes.
 C'est ce qu'une pull request refusera, sans jamais dépendre de la météo d'un
 runner.
 
-**Ce n'est pas suffisant**, et ce qui manque dépend de ce que vous avez changé :
+**Ce n'est pas suffisant**, et ce qui manque dépend de ce que vous avez changé.
+Vous n'avez pas à vous en souvenir — demandez :
+
+```bash
+mise run testplan          # ce que ce diff a mérité, du moins cher au plus cher
+```
+
+Il lit le diff, imprime les exécutions, et imprime ce qu'elles ne prouvent
+**pas**. Il ne lance rien lui-même : le choix est la moitié qu'un humain doit
+pouvoir contester. `mise run prepush` l'appelle avec `--check`, donc chaque
+poussée dit quoi jouer ensuite et refuse un chemin qu'aucune règle ne trie —
+« ça ne correspond à rien, donc on ne joue rien » est le défaut bon marché, et
+un chemin non trié est une absence, pas une décision (#564).
+
+Les coûts sur lesquels il ordonne sont mesurés, une passe chacun le 2026-08-27 :
+
+| exécution | mesure | ce qu'elle porte |
+|---|--:|---|
+| `conformance:leg -- probe` | **0,7 s** | chaque route montée pilotée depuis sa propre description d'API, sans client |
+| `conformance:leg -- exo-cli` | 4,0 s | le vrai `exo` |
+| `conformance:leg -- scw-cli` | 7,1 s | le vrai `scw` |
+| `conformance:leg -- terraform` | 45,4 s | les deux fixtures Terraform, sur l'un ou l'autre moteur |
+| `conformance:leg -- octl` | 141,3 s | le vrai `octl` |
+| `conformance:leg -- fields` | 208,1 s | les quatre clients, les fautes, les refus — **la seule jambe où le gate d'omission juge** |
+| `conformance:leg -- runtime` | 590 s | les quatre suites qui exigent de vraies machines ; refuse de tourner sans `FEINT_VM` |
+| `mise run conformance` | 256 s | tout sauf les suites runtime, qui se sautent elles-mêmes |
+| `FEINT_VM=incus-ovn mise run conformance` | **1331 s** | l'ensemble |
+
+**Une décision domine toutes les autres** : le changement atteint-il
+`internal/core/machine`. Répondez juste et le travail coûte des secondes ;
+répondez faux et il coûte 590 s ou 1331 s. Le reste du tableau vaut des dizaines
+de secondes — `fields` à 208 s contre la passe complète sans runtime à 256 s
+économise 48 s, c'est-à-dire rien. `testplan` répond donc à cette seule question
+en **lisant les imports** des fichiers modifiés, et non en consultant une liste
+de noms de répertoires, qui est la moitié qu'une table se tromperait en premier.
+
+**Le plan remplace la passe complète en local. Il ne remplace jamais la matrice
+CI.** Tous les autres gates d'ici ajoutent de la preuve ; celui-ci en retire, et
+cela inverse le mode de défaillance : une règle fausse est silencieuse. La CI
+inchangée, le pire cas d'une règle fausse est une pull request rouge, ce pour
+quoi la CI existe. Ce qu'aucun test n'attrape, c'est une règle qui nomme un vrai
+répertoire et prescrit la mauvaise jambe : les deux pourritures mécaniques sont
+gardées dans `tools/testplan/plan_test.go`, la sémantique ne l'est pas, et c'est
+écrit plutôt que dissimulé.
+
+La table qu'il lit, sous forme courte :
 
 | ce que votre changement touche | à lancer en plus | ce que cela prouve |
 |---|---|---|

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,51 @@ The `pre-push` hook runs `mise run prepush`: `check`, `docs:check`,
 Deterministic, offline, seconds. It is what a pull request will refuse without
 ever depending on a runner's weather.
 
-**It is not enough**, and what it misses depends on what you changed:
+**It is not enough**, and what it misses depends on what you changed. You do not
+have to remember which — ask:
+
+```bash
+mise run testplan          # what this diff has earned, cheapest run first
+```
+
+It reads the diff, prints the runs, and prints what they still **do not** prove.
+It runs nothing itself: the choice is the half a human has to be able to
+disagree with. `mise run prepush` calls it with `--check`, so every push says
+what to run next, and refuses a path no rule triages — "it matched nothing, so
+run nothing" is the cheap default, and an un-triaged path is an absence, not a
+decision (#564).
+
+The costs it orders by are measured, one pass each on 2026-08-27:
+
+| run | measured | what it carries |
+|---|--:|---|
+| `conformance:leg -- probe` | **0.7 s** | every mounted route driven from its own API description, no client |
+| `conformance:leg -- exo-cli` | 4.0 s | the real `exo` |
+| `conformance:leg -- scw-cli` | 7.1 s | the real `scw` |
+| `conformance:leg -- terraform` | 45.4 s | both Terraform fixtures, on either engine |
+| `conformance:leg -- octl` | 141.3 s | the real `octl` |
+| `conformance:leg -- fields` | 208.1 s | all four clients, faults, refusals — **the only leg where the omission gate judges** |
+| `conformance:leg -- runtime` | 590 s | the four suites that need real machines; refuses to run without `FEINT_VM` |
+| `mise run conformance` | 256 s | everything but the runtime suites, which skip themselves |
+| `FEINT_VM=incus-ovn mise run conformance` | **1331 s** | all of it |
+
+**One decision dominates every other**: does the change reach
+`internal/core/machine`. Answer it right and the work costs seconds; answer it
+wrong and it costs 590 s or 1331 s. The rest of that table is worth tens of
+seconds — `fields` at 208 s against the whole runtime-free pass at 256 s saves
+48 s, which is nothing. So `testplan` answers that one question by **reading the
+imports** of the files you changed rather than by consulting a list of directory
+names, which is the half of it a table would get wrong first.
+
+**The plan replaces the full pass locally. It never replaces the CI matrix.**
+Every other gate here adds proof; this one subtracts it, and that inverts the
+failure mode — a wrong rule is silent. With CI untouched, the worst case of a
+wrong rule is a red pull request, which is exactly what CI is for. What no test
+can catch is a rule that names a real directory and prescribes the wrong leg:
+the two mechanical rots are guarded in `tools/testplan/plan_test.go`, the
+semantic one is not, and it is written down rather than pretended away.
+
+The table it reads, in short form:
 
 | what your change touches | run as well | what that proves |
 |---|---|---|

--- a/mise.toml
+++ b/mise.toml
@@ -629,7 +629,7 @@ run = "python3 tools/falsify/falsify.py"
 
 [tasks.prepush]
 description = "Everything a pull request will fail on that costs seconds and needs no client"
-depends = ["check", "docs:check", "drift:check", "shapes:check", "corpus:check", "falsify:selftest", "falsify:lint", "release:surface"]
+depends = ["check", "docs:check", "drift:check", "shapes:check", "corpus:check", "falsify:selftest", "falsify:lint", "release:surface", "testplan:check"]
 # What this is, and what it deliberately is not.
 #
 # Each of these is deterministic, offline, and takes seconds: they can be a hook
@@ -641,8 +641,8 @@ depends = ["check", "docs:check", "drift:check", "shapes:check", "corpus:check",
 # by construction, because that task drives every suite against one emulator.
 # CI splits the clients across a matrix. `mise run conformance:leg -- <leg>`
 # reproduces one of those partial legs, and it is what to run when a change adds
-# or moves a gate. CLAUDE.md carries the decision table.
-run = "echo 'prepush passed - conformance and conformance:leg are the two it does not cover'"
+# or moves a gate. `mise run testplan` reads the diff and says which (#564).
+run = "echo 'prepush passed - run `mise run testplan` for what this does not cover'"
 
 [tasks."falsify:all"]
 description = "Replay every declared falsification, so a guard whose test stopped biting fails a run"
@@ -695,6 +695,35 @@ description = "Prove the falsification harness refuses the three mutations that 
 # of 2026-08-15 and against the three fixes. Both halves, because a rule that
 # refused every mutation would pass the first half and make the tool useless.
 run = "python3 tools/falsify/falsify.py --selftest"
+
+[tasks."testplan:check"]
+description = "Refuse a diff whose paths no rule triages, and print what this one has earned (#564)"
+# In prepush, and it belongs there for the reason `conformance` does not: it is
+# deterministic, offline, and takes a second. What it enforces is that the
+# routing table is complete for the paths in hand — the whole-tree version of
+# the same question is TestEveryTrackedPathIsTriagedBySomeRule, which `check`
+# already runs.
+#
+# The second half is why it is here rather than in a workflow: every `git push`
+# now prints which runs this change has earned, at the moment somebody can still
+# act on it.
+run = "go run ./tools/testplan --check"
+
+[tasks.testplan]
+description = "Which conformance runs this diff has earned — and which it has not (#564)"
+# The measured reason this exists, in one line: the `probe` leg is 0.7 s, the
+# whole pass under `incus-ovn` is 1331 s, and the only decision that separates
+# them is whether the change reaches the machine layer.
+#
+# --check exits 2 when a changed path is triaged by no rule. That is the point
+# of the tool rather than a flourish: "matched nothing, so run nothing" is the
+# cheap default it exists to refuse, and an un-triaged path is an absence, not a
+# decision.
+#
+# It never runs a suite. A tool that both chose the runs and performed them
+# would be believed about both, and the choice is the half a human has to be
+# able to disagree with.
+run = "go run ./tools/testplan {{arg(name='args', var=true, default='')}}"
 
 [tasks."conformance:leg"]
 description = "Reproduce one leg locally: mise run conformance:leg -- probe (or -- runtime, with FEINT_VM)"

--- a/tools/conformance/README.md
+++ b/tools/conformance/README.md
@@ -26,6 +26,29 @@ off, so a partial toolbox never turns into a false pass.
 
 ## Running only the part your change touches
 
+**Ask rather than remember**: `mise run testplan` reads the diff and prints the
+runs it has earned, cheapest first, along with what they still do not prove
+(#564). `mise run prepush` calls it with `--check`, so a path no rule triages
+refuses the push instead of quietly earning nothing.
+
+One pass each, measured on 2026-08-27, which is what the plan orders by:
+
+| run | measured |
+|---|--:|
+| `conformance:leg -- probe` | **0.7 s** |
+| `conformance:leg -- exo-cli` | 4.0 s |
+| `conformance:leg -- scw-cli` | 7.1 s |
+| `conformance:leg -- terraform` | 45.4 s |
+| `conformance:leg -- octl` | 141.3 s |
+| `conformance:leg -- fields` | 208.1 s |
+| `conformance:leg -- runtime` | 590 s |
+| `mise run conformance`, no runtime | 256 s |
+| `FEINT_VM=incus-ovn mise run conformance` | **1331 s** |
+
+The gap that matters is the last one against the first: whether a change reaches
+`internal/core/machine` decides between seconds and twenty-two minutes, and
+every other choice in that table is worth tens of seconds.
+
 `mise run conformance:leg -- <leg>` runs one leg. Seven of its names are the
 matrix entries of `.github/workflows/conformance.yml`, and
 `TestEveryMatrixLegCanBeReproducedLocally` holds the two lists together — a

--- a/tools/falsify/specs/a-plan-that-cannot-rot.json
+++ b/tools/falsify/specs/a-plan-that-cannot-rot.json
@@ -1,0 +1,75 @@
+{
+  "package": "./tools/testplan/",
+  "mutations": [
+    {
+      "label": "a path no rule triages stops being reported, so `testplan` answers \"nothing to run\" for a directory nobody has thought about — the cheap default this tool exists to refuse (#564)",
+      "file": "tools/testplan/plan.go",
+      "find": "\t\tif !matched {\n\t\t\tp.Untriaged = append(p.Untriaged, path)\n\t\t}",
+      "replace": "\t\tif !matched && false {\n\t\t\tp.Untriaged = append(p.Untriaged, path)\n\t\t}",
+      "test": "TestAnUntriagedPathIsAFailureNotACheapDefault"
+    },
+    {
+      "label": "the un-triaged report stops being printed, so `--check` still exits 2 but the reader is never told which path caused it (#564)",
+      "file": "tools/testplan/plan.go",
+      "find": "\t\tfmt.Fprintf(&b, \"%d path(s) no rule triages:\\n\", len(p.Untriaged))",
+      "replace": "\t\tfmt.Fprintf(&b, \"%d path(s)\\n\", len(p.Untriaged))",
+      "test": "TestAnUntriagedPathIsAFailureNotACheapDefault"
+    },
+    {
+      "label": "a directory of this repository loses the rule that triages it, which is what a new package looks like on the day it is added (#564)",
+      "file": "tools/testplan/rules.go",
+      "find": "\t\tPath:     \"internal/shape/\",",
+      "replace": "\t\tPath:     \"internal/shapeless/\",",
+      "test": "TestEveryTrackedPathIsTriagedBySomeRule"
+    },
+    {
+      "label": "a rule keeps naming a directory that no longer exists, reading as coverage while covering nothing — the rot docs/limits.md suffered for a fortnight (#558, #564)",
+      "file": "tools/testplan/rules.go",
+      "find": "\t\tPath:     \"internal/trace/\",",
+      "replace": "\t\tPath:     \"internal/tracing/\",",
+      "test": "TestNoRuleMatchesNothing"
+    },
+    {
+      "label": "a rule prints a mise task that does not exist, so the reader pastes it, sees `no such task`, and stops trusting the whole output (#564)",
+      "file": "tools/testplan/rules.go",
+      "find": "\t\tRuns:     []string{\"shapes:check\"},\n\t\tUnproven: \"redaction is proved",
+      "replace": "\t\tRuns:     []string{\"shapes:verify\"},\n\t\tUnproven: \"redaction is proved",
+      "test": "TestEveryTaskTheRulesNameExistsInMiseToml"
+    },
+    {
+      "label": "a rule sends a reader to a conformance leg that leg.sh refuses, which is exactly how the workflow matrix and the script drifted apart once already (#460, #564)",
+      "file": "tools/testplan/rules.go",
+      "find": "\t\tRuns:     []string{\"conformance:leg -- exo-cli\", \"conformance:zones\"},",
+      "replace": "\t\tRuns:     []string{\"conformance:leg -- exoscale\", \"conformance:zones\"},",
+      "test": "TestEveryLegTheRulesNameIsALegTheScriptAccepts"
+    },
+    {
+      "label": "the machine layer stops being found by reading imports, so a pack file that starts containers on the operator's own station is judged by a client leg alone (#564)",
+      "file": "tools/testplan/plan.go",
+      "find": "\t\tif strings.Trim(imp.Path.Value, `\"`) == machineLayer {",
+      "replace": "\t\tif strings.Trim(imp.Path.Value, `\"`) == machineLayer && false {",
+      "test": "TestAFileThatImportsTheMachineLayerEarnsTheRuntimeLeg"
+    },
+    {
+      "label": "every file is treated as reaching the machine layer, which asks for the 590 s leg unconditionally — the most expensive possible way to be wrong, and the reason that test carries a control (#564)",
+      "file": "tools/testplan/plan.go",
+      "find": "\tfor _, imp := range f.Imports {",
+      "replace": "\tif true {\n\t\treturn true\n\t}\n\tfor _, imp := range f.Imports {",
+      "test": "TestAFileThatImportsTheMachineLayerEarnsTheRuntimeLeg"
+    },
+    {
+      "label": "the plan stops ordering the cheapest run first, so a reader spends 590 s before reaching the 0.7 s leg that would have gone red (#564)",
+      "file": "tools/testplan/plan.go",
+      "find": "\tsort.Slice(order, func(i, j int) bool { return cost(order[i]) < cost(order[j]) })",
+      "replace": "\tsort.Slice(order, func(i, j int) bool { return cost(order[i]) > cost(order[j]) })",
+      "test": "TestThePlanPutsTheCheapRunBeforeTheExpensiveOne"
+    },
+    {
+      "label": "a rule that runs several commands stops having to say what it leaves unproven, and the plan becomes a green describing a smaller world than its reader believes (#564)",
+      "file": "tools/testplan/rules.go",
+      "find": "\t\tUnproven: \"a change to the stored shape is proved across a restart by `mise run conformance:environment`\",",
+      "replace": "\t\tUnproven: prepushIsTheWholeGate,",
+      "test": "TestEveryRuleWithRunsSaysWhatItDoesNotProve"
+    }
+  ]
+}

--- a/tools/testplan/main.go
+++ b/tools/testplan/main.go
@@ -1,0 +1,104 @@
+// Command testplan says which conformance runs a diff has earned, and which it
+// has not.
+//
+// The whole pass is 1331 s under `FEINT_VM=incus-ovn` and 256 s without a
+// runtime, measured on 2026-08-27. The `probe` leg is 0.7 s. Almost no change
+// needs the first, and the cost of not knowing which is that everybody either
+// runs everything — which is how a batch of three issues spent three full
+// passes — or runs nothing and says so afterwards.
+//
+// This reads the diff and answers. It is not a suggestion engine: `--check`
+// exits 2 when a changed path is triaged by nobody, because an unmapped path is
+// an absence and must not be read as "nothing to run".
+//
+//	mise run testplan                 # against origin/main, prints the plan
+//	mise run testplan -- --since HEAD~1
+//	mise run testplan -- --check      # exit 2 on an un-triaged path
+//	git diff --name-only | mise run testplan -- --paths -
+//
+// What it deliberately does not do is run anything. A tool that both chose the
+// runs and performed them would be believed about both, and the choice is the
+// part a human has to be able to disagree with.
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// command runs git, and only git.
+//
+// The name is a constant rather than a parameter, and the arguments come from
+// literals in plan.go — never from a flag, an environment variable or a path
+// out of the diff. That is what makes the //nolint honest: gosec's G204 is
+// about a subprocess an attacker can steer, and there is no route from input to
+// this call site. Reviewing it means checking that claim, not the annotation.
+func command(dir, name string, args ...string) *exec.Cmd {
+	if name != "git" {
+		panic("testplan runs git and nothing else: " + name)
+	}
+	cmd := exec.Command(name, args...) //nolint:gosec // literal arguments, see above
+	cmd.Dir = dir
+	return cmd
+}
+
+func main() {
+	since := flag.String("since", "origin/main", "the base to diff against")
+	check := flag.Bool("check", false, "exit 2 when a changed path is triaged by no rule")
+	fromStdin := flag.String("paths", "", "read repository-relative paths from a file, or - for stdin")
+	flag.Parse()
+
+	root, err := repoRoot()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "testplan:", err)
+		os.Exit(1)
+	}
+
+	var paths []string
+	if *fromStdin != "" {
+		paths, err = readPaths(*fromStdin)
+	} else {
+		paths, err = changed(root, *since)
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "testplan:", err)
+		os.Exit(1)
+	}
+
+	if len(paths) == 0 {
+		fmt.Printf("No path changed against %s. Nothing to run.\n", *since)
+		return
+	}
+
+	p := build(root, paths)
+	fmt.Printf("%d path(s) changed against %s\n\n", len(paths), *since)
+	fmt.Print(p.String())
+
+	if len(p.Untriaged) > 0 && *check {
+		os.Exit(2)
+	}
+}
+
+func readPaths(from string) ([]string, error) {
+	in := os.Stdin
+	if from != "-" {
+		f, err := os.Open(from)
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close() //nolint:errcheck // read-only
+		in = f
+	}
+	var paths []string
+	scan := bufio.NewScanner(in)
+	for scan.Scan() {
+		if line := strings.TrimSpace(scan.Text()); line != "" {
+			paths = append(paths, line)
+		}
+	}
+	return paths, scan.Err()
+}

--- a/tools/testplan/plan.go
+++ b/tools/testplan/plan.go
@@ -1,0 +1,320 @@
+package main
+
+import (
+	"fmt"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// The machine layer, named once. A file that imports it starts containers on
+// the operator's own station whatever directory it lives in, and that is the
+// one fact this tool refuses to take from the table in rules.go.
+const machineLayer = "github.com/stephrobert/feint/internal/core/machine"
+
+const runtimeLeg = "FEINT_VM=incus-ovn mise run conformance:leg -- runtime"
+
+// plan is what a diff earns: the runs, why each was earned, and what is still
+// unproven once they are green.
+type plan struct {
+	Runs     []planRun
+	Unproven []string
+	// Untriaged is the failure this tool exists to make loud: a changed path
+	// that no rule names. It is never silently cheap and never silently
+	// expensive — somebody has to write down what it costs.
+	Untriaged []string
+}
+
+type planRun struct {
+	Command string
+	// Because is the human reason, so a reader can disagree with the plan
+	// rather than only obey it.
+	Because []string
+}
+
+// matches reports whether a rule's Path covers a repository-relative path.
+//
+// Three forms, and no regular expressions: a directory prefix ending in `/`, a
+// `*.suffix` glob that applies at the repository root only, or an exact path.
+// A suffix glob matches at any depth; longest-match then hands `docs/limits.md`
+// to the `docs/` rule and `tools/conformance/README.md` to `*.md`, which is what
+// each should get.
+func matches(pattern, path string) bool {
+	switch {
+	case strings.HasSuffix(pattern, "/"):
+		return strings.HasPrefix(path, pattern)
+	case strings.HasPrefix(pattern, "*."):
+		return strings.HasSuffix(path, pattern[1:])
+	default:
+		return path == pattern
+	}
+}
+
+// governing returns the rule that decides a path: the most specific one that
+// matches it.
+//
+// Longest prefix, not union of every match. Union was the first shape and it was
+// wrong in a way that would have discredited the tool on its first use: a change
+// to `tools/conformance/scaleway/scw-cli.sh` matches both that directory and the
+// `tools/conformance/` rule above it, and the union sends the reader to the
+// 208 s `fields` leg for a file the 7 s `scw-cli` leg drives entirely. A tool
+// that over-prescribes is ignored exactly as fast as one that under-prescribes,
+// and it is the same failure — the plan stops matching what the reader can see
+// for themselves.
+// Two questions, not one: what kind of file is this, and where does it live.
+// Longest-prefix answers the second, and answering the second alone was wrong on
+// this tool's own diff — `tools/conformance/README.md` earned the 208 s `fields`
+// leg because it sits under the harness. A Markdown file is documentation
+// wherever it lives, and no prose in this repository changes a served answer.
+func documentation(path string) bool {
+	return strings.HasSuffix(path, ".md") || path == "docs/"
+}
+
+func governing(path string) (rule, bool) {
+	prose := strings.HasSuffix(path, ".md")
+	best, found := rule{}, false
+	for _, r := range rules {
+		if !matches(r.Path, path) {
+			continue
+		}
+		if prose && !documentation(r.Path) {
+			continue
+		}
+		if !found || len(r.Path) > len(best.Path) {
+			best, found = r, true
+		}
+	}
+	return best, found
+}
+
+// reachesMachineLayer reports whether a Go file imports the machine layer
+// directly.
+//
+// Directly, and not through `go list -deps`, on purpose. `internal/cli` depends
+// on the machine layer transitively — every sub-command does, because `serve`
+// carries `--vm` — so a transitive test would demand a 590 s leg for a change to
+// the `version` sub-command and would be ignored within a week. What is being
+// asked here is narrower and answerable: does *this file* speak to the layer
+// that acts on the operator's station.
+func reachesMachineLayer(root, path string) bool {
+	if !strings.HasSuffix(path, ".go") {
+		return false
+	}
+	f, err := parser.ParseFile(token.NewFileSet(), filepath.Join(root, path), nil, parser.ImportsOnly)
+	if err != nil {
+		// A file the diff deleted, or one that does not parse. Neither is this
+		// tool's verdict to give: `mise run check` is where a broken file is
+		// reported, and answering "no runtime needed" because a parse failed
+		// would be a cheap default earned by an error.
+		return false
+	}
+	for _, imp := range f.Imports {
+		if strings.Trim(imp.Path.Value, `"`) == machineLayer {
+			return true
+		}
+	}
+	return false
+}
+
+// build assembles the plan for a set of repository-relative paths.
+func build(root string, paths []string) plan {
+	var p plan
+	because := map[string][]string{}
+	order := []string{}
+	unproven := map[string]bool{}
+
+	add := func(cmd, why string) {
+		if _, seen := because[cmd]; !seen {
+			order = append(order, cmd)
+		}
+		for _, w := range because[cmd] {
+			if w == why {
+				return
+			}
+		}
+		because[cmd] = append(because[cmd], why)
+	}
+
+	for _, path := range paths {
+		r, matched := governing(path)
+		if matched {
+			for _, cmd := range r.Runs {
+				add(normalise(cmd), r.Why)
+			}
+			if r.Unproven != prepushIsTheWholeGate {
+				unproven[r.Unproven] = true
+			}
+		}
+		// Measured rather than tabulated: a file that speaks to the machine
+		// layer earns the runtime leg wherever it lives, including a pack file
+		// the table above sends to a client leg alone.
+		if reachesMachineLayer(root, path) {
+			add(runtimeLeg, "imports "+machineLayer+", so it acts on the operator's own station")
+		}
+		if !matched {
+			p.Untriaged = append(p.Untriaged, path)
+		}
+	}
+
+	sort.Slice(order, func(i, j int) bool { return cost(order[i]) < cost(order[j]) })
+	for _, cmd := range order {
+		p.Runs = append(p.Runs, planRun{Command: cmd, Because: because[cmd]})
+	}
+	for u := range unproven {
+		p.Unproven = append(p.Unproven, u)
+	}
+	sort.Strings(p.Unproven)
+	sort.Strings(p.Untriaged)
+	return p
+}
+
+// normalise turns a bare task name into the command a reader can paste.
+func normalise(cmd string) string {
+	if strings.HasPrefix(cmd, "mise ") || strings.Contains(cmd, "=") {
+		return cmd
+	}
+	return "mise run " + cmd
+}
+
+// cost orders the plan cheapest first, from what was measured on 2026-08-27
+// rather than from an impression. The numbers are in seconds on one station and
+// they are not a promise: their job is to put the 0.7 s run above the 590 s one
+// so a reader stops at the first red rather than at the last.
+var measured = map[string]int{
+	"conformance:leg -- probe":     1,   // 0.7
+	"conformance:leg -- exo-cli":   4,   // 4.0
+	"conformance:leg -- scw-cli":   7,   // 7.1
+	"conformance:leg -- terraform": 45,  // 45.4
+	"conformance:leg -- octl":      141, // 141.3
+	"conformance:leg -- fields":    208, // 208.1
+	"conformance:leg -- runtime":   590, // 590.0, and it needs a runtime
+}
+
+func cost(cmd string) int {
+	for leg, seconds := range measured {
+		if strings.Contains(cmd, leg) {
+			return seconds
+		}
+	}
+	if strings.Contains(cmd, "conformance:functional") {
+		return 600
+	}
+	if strings.Contains(cmd, "conformance") {
+		return 60
+	}
+	return 5
+}
+
+func (p plan) String() string {
+	var b strings.Builder
+	if len(p.Untriaged) > 0 {
+		fmt.Fprintf(&b, "%d path(s) no rule triages:\n", len(p.Untriaged))
+		for _, path := range p.Untriaged {
+			fmt.Fprintf(&b, "  ! %s\n", path)
+		}
+		b.WriteString("\nAdd a rule to tools/testplan/rules.go saying what a change there costs.\n")
+		b.WriteString("\"It matched nothing so run nothing\" is the default this refuses: an\n")
+		b.WriteString("un-triaged path is an absence, and silence must not read as a decision.\n\n")
+	}
+	if len(p.Runs) == 0 && len(p.Untriaged) == 0 {
+		b.WriteString("Nothing beyond `mise run prepush`.\n")
+		b.WriteString("That is a claim this table makes, not a gap in it: no changed path can\n")
+		b.WriteString("alter an answer a real client reads.\n")
+	} else if len(p.Runs) > 0 {
+		b.WriteString("Run these, cheapest first, and stop at the first red:\n\n")
+		for _, r := range p.Runs {
+			fmt.Fprintf(&b, "  %s\n", r.Command)
+			for _, w := range r.Because {
+				fmt.Fprintf(&b, "      because %s\n", w)
+			}
+		}
+	}
+	if len(p.Unproven) > 0 {
+		b.WriteString("\nWhat this plan still does not prove:\n")
+		for _, u := range p.Unproven {
+			fmt.Fprintf(&b, "  · %s\n", u)
+		}
+	}
+	return b.String()
+}
+
+// resolve turns the requested base into one this clone actually has.
+//
+// `origin/main` is the right default and it is not always present: a fresh
+// clone that has never fetched, a worktree on a detached head, CI with a
+// shallow checkout. The fallback is `main`, and if neither resolves this says
+// so and stops. What it must never do is quietly diff against nothing and
+// report an empty plan — a tool that answers "nothing to run" because it could
+// not find the base has told the reader the most dangerous possible lie.
+func resolve(root, since string) (string, error) {
+	for _, candidate := range []string{since, strings.TrimPrefix(since, "origin/")} {
+		if _, err := git(root, "rev-parse", "--verify", "--quiet", candidate+"^{commit}"); err == nil {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("neither %q nor %q names a commit in this clone; pass --since",
+		since, strings.TrimPrefix(since, "origin/"))
+}
+
+// changed lists the repository-relative paths a range touched.
+func changed(root, since string) ([]string, error) {
+	base, err := resolve(root, since)
+	if err != nil {
+		return nil, err
+	}
+	out, err := git(root, "diff", "--name-only", "--diff-filter=d", base+"...HEAD")
+	if err != nil {
+		return nil, err
+	}
+	// Uncommitted work counts: the plan is for what will be delivered, and a
+	// tool that judged only the committed half would send its reader to a leg
+	// that misses the file they are still editing.
+	dirty, err := git(root, "diff", "--name-only", "--diff-filter=d", "HEAD")
+	if err != nil {
+		return nil, err
+	}
+	// And a file that exists but has never been added, which is the case this
+	// tool was blind to on its own first run: a whole new package under
+	// tools/ was invisible to `git diff`, so the plan described the one file
+	// that happened to be tracked. A new directory is precisely what the
+	// un-triaged check is for, and it would have been reached only after
+	// somebody remembered to stage it.
+	fresh, err := git(root, "ls-files", "--others", "--exclude-standard")
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string]bool{}
+	var paths []string
+	for _, line := range append(append(out, dirty...), fresh...) {
+		if line != "" && !seen[line] {
+			seen[line] = true
+			paths = append(paths, line)
+		}
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+func git(root string, args ...string) ([]string, error) {
+	cmd := command(root, "git", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+	}
+	return strings.Split(strings.TrimRight(string(out), "\n"), "\n"), nil
+}
+
+func repoRoot() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	out, err := git(wd, "rev-parse", "--show-toplevel")
+	if err != nil || len(out) == 0 {
+		return "", fmt.Errorf("not a git repository: %w", err)
+	}
+	return out[0], nil
+}

--- a/tools/testplan/plan_test.go
+++ b/tools/testplan/plan_test.go
@@ -1,0 +1,424 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// What keeps a routing table from becoming a lie.
+//
+// A table that says which runs a change earns is the most inviting place in this
+// repository to write a comment instead of a control. It is read once, believed
+// afterwards, and it goes wrong in two directions that look nothing alike:
+//
+//   - a new directory nobody triaged, whose changes then earn *nothing* because
+//     no line matched — the failure mode of every fall-through default;
+//   - a line naming a directory that was deleted or renamed, which keeps reading
+//     as coverage while covering nothing — the same rot as a limit that no
+//     longer holds.
+//
+// Both are cheap to detect and neither is detectable by reading. So the table is
+// held against `git ls-files` in both directions, its commands are held against
+// the tasks that actually exist, and its one measured claim — that a file
+// reaching the machine layer earns the runtime leg — is exercised with a file
+// that reaches it and a control file that does not.
+
+func root(t *testing.T) string {
+	t.Helper()
+	abs, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return abs
+}
+
+func tracked(t *testing.T) []string {
+	t.Helper()
+	cmd := exec.Command("git", "ls-files")
+	cmd.Dir = root(t)
+	if out, err := cmd.Output(); err == nil {
+		return lines(t, string(out))
+	}
+	// No git here, and skipping would be the wrong answer twice over.
+	//
+	// The falsification harness copies this repository **without** `.git`
+	// (tools/falsify/falsify.py, EXCLUDE), so the first shape of this helper
+	// skipped inside the copy — and a skipped test is not a red one. The two
+	// strongest guards in this file, the ones that walk the whole tree in both
+	// directions, reported "TEST STILL PASSED" for every mutation aimed at
+	// them. They were unfalsifiable, which is the precise thing this repository
+	// says a guard must never be.
+	//
+	// So the fallback walks the tree and honours .gitignore's simple patterns,
+	// which is all this repository's has: 272 lines, no negation, no `**`.
+	return walked(t)
+}
+
+func lines(t *testing.T, out string) []string {
+	t.Helper()
+	var paths []string
+	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		if line != "" {
+			paths = append(paths, line)
+		}
+	}
+	if len(paths) == 0 {
+		t.Fatal("the file inventory is empty; this test would pass over an empty world")
+	}
+	return paths
+}
+
+// ignores reads the simple patterns of .gitignore: a trailing-slash directory,
+// a `*.suffix`, a rooted `/path`, or a bare name. Anything cleverer is refused
+// out loud rather than silently mis-applied, because a pattern this misreads
+// turns into a file that looks un-triaged and a red nobody can explain.
+func ignores(t *testing.T, dir string) []string {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	if err != nil {
+		return nil
+	}
+	var pats []string
+	for _, line := range strings.Split(string(body), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.HasPrefix(line, "!") || strings.Contains(line, "**") {
+			t.Fatalf(".gitignore carries a pattern this fallback cannot read: %q", line)
+		}
+		pats = append(pats, line)
+	}
+	return pats
+}
+
+// ignored applies git's own anchoring rule, which the first version of this
+// dropped and paid for immediately: a pattern that contains a slash anywhere is
+// anchored to the repository root, and only a bare name matches at any depth.
+// `/feint` names the built binary at the root; read as a bare name it also ate
+// `cmd/feint/`, and the walk then reported the entry point as a directory no
+// rule covers. The failure was loud, which is the only reason it cost minutes.
+func ignored(pats []string, rel string) bool {
+	base := filepath.Base(rel)
+	for _, pat := range pats {
+		anchored := strings.Contains(strings.TrimSuffix(pat, "/"), "/")
+		clean := strings.Trim(pat, "/")
+		switch {
+		case anchored:
+			if rel == clean || strings.HasPrefix(rel, clean+"/") {
+				return true
+			}
+		case strings.HasPrefix(pat, "*."):
+			if strings.HasSuffix(base, pat[1:]) {
+				return true
+			}
+		case strings.HasSuffix(pat, "/"):
+			if base == clean {
+				return true
+			}
+		default:
+			if base == clean {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func walked(t *testing.T) []string {
+	t.Helper()
+	dir := root(t)
+	pats := append(ignores(t, dir), ".git/", ".claude/", ".upstream/", "notes/")
+	var paths []string
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, relErr := filepath.Rel(dir, path)
+		if relErr != nil || rel == "." {
+			return relErr
+		}
+		if ignored(pats, rel) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !d.IsDir() {
+			paths = append(paths, rel)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", dir, err)
+	}
+	if len(paths) == 0 {
+		t.Fatal("the file inventory is empty; this test would pass over an empty world")
+	}
+	return paths
+}
+
+// A path this table does not name is an absence, and the tool prints it as one.
+// This test is what puts the discovery on the commit that adds the directory
+// rather than on the pull request that is surprised by it months later.
+func TestEveryTrackedPathIsTriagedBySomeRule(t *testing.T) {
+	var orphans []string
+	for _, path := range tracked(t) {
+		found := false
+		for _, r := range rules {
+			if matches(r.Path, path) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			orphans = append(orphans, path)
+		}
+	}
+	if len(orphans) > 0 {
+		t.Errorf("%d tracked path(s) no rule in rules.go triages:\n  %s\n\n"+
+			"Add a rule saying what a change there costs to prove. Leaving it unmatched\n"+
+			"makes `testplan` answer \"nothing to run\" for it, which is the cheap default\n"+
+			"this tool exists to refuse.", len(orphans), strings.Join(orphans, "\n  "))
+	}
+}
+
+// The other direction, and the one nobody thinks to write. A rule naming a
+// directory that no longer exists reads as coverage on every later day.
+func TestNoRuleMatchesNothing(t *testing.T) {
+	paths := tracked(t)
+	for _, r := range rules {
+		hit := false
+		for _, path := range paths {
+			if matches(r.Path, path) {
+				hit = true
+				break
+			}
+		}
+		if !hit {
+			t.Errorf("rule %q (%s) matches no tracked path: it is either a directory that "+
+				"moved, or coverage of nothing", r.Path, r.Why)
+		}
+	}
+}
+
+var taskName = regexp.MustCompile(`(?m)^\[tasks\."?([a-z0-9:_-]+)"?\]`)
+
+// A plan that prints a command nobody can run is worse than no plan: the reader
+// pastes it, sees `mise: no such task`, and stops trusting the whole output.
+func TestEveryTaskTheRulesNameExistsInMiseToml(t *testing.T) {
+	body, err := os.ReadFile(filepath.Join(root(t), "mise.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	exists := map[string]bool{}
+	for _, m := range taskName.FindAllStringSubmatch(string(body), -1) {
+		exists[m[1]] = true
+	}
+	if len(exists) == 0 {
+		t.Fatal("no task parsed out of mise.toml; this test would pass over an empty world")
+	}
+
+	seen := map[string]bool{}
+	for _, r := range rules {
+		for _, cmd := range append([]string{}, r.Runs...) {
+			seen[taskIn(cmd)] = true
+		}
+	}
+	seen[taskIn(runtimeLeg)] = true
+	for task := range seen {
+		if task != "" && !exists[task] {
+			t.Errorf("rules.go names task %q, which mise.toml does not define", task)
+		}
+	}
+}
+
+// taskIn extracts the mise task out of a command a rule prints.
+func taskIn(cmd string) string {
+	fields := strings.Fields(cmd)
+	for i, f := range fields {
+		if f == "run" && i > 0 && strings.HasSuffix(fields[i-1], "mise") {
+			if i+1 < len(fields) {
+				return fields[i+1]
+			}
+			return ""
+		}
+	}
+	// A bare task name, which normalise() prefixes later.
+	if len(fields) > 0 && !strings.Contains(fields[0], "=") {
+		return fields[0]
+	}
+	return ""
+}
+
+// The legs this table sends people to must be legs `leg.sh` accepts. The two
+// lists drifted once already between the workflow matrix and the script, which
+// is why tools/conformance carries TestEveryMatrixLegCanBeReproducedLocally for
+// leg.sh; a third list naming legs deserves the same treatment rather than the
+// same trust.
+func TestEveryLegTheRulesNameIsALegTheScriptAccepts(t *testing.T) {
+	body, err := os.ReadFile(filepath.Join(root(t), "tools", "conformance", "leg.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	accepted := map[string]bool{}
+	for _, line := range strings.Split(string(body), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasSuffix(trimmed, ") ;;") {
+			continue
+		}
+		for _, name := range strings.Split(strings.TrimSuffix(trimmed, ") ;;"), "|") {
+			accepted[strings.TrimSpace(name)] = true
+		}
+	}
+	if len(accepted) == 0 {
+		t.Fatal("no leg name parsed out of leg.sh; this test would pass over an empty world")
+	}
+
+	named := map[string]bool{}
+	for _, r := range rules {
+		for _, cmd := range r.Runs {
+			if leg, ok := legIn(cmd); ok {
+				named[leg] = true
+			}
+		}
+	}
+	if leg, ok := legIn(runtimeLeg); ok {
+		named[leg] = true
+	}
+	if len(named) == 0 {
+		t.Fatal("no rule names a conformance leg, which cannot be right")
+	}
+	for leg := range named {
+		if !accepted[leg] {
+			t.Errorf("rules.go sends a reader to leg %q, which tools/conformance/leg.sh refuses", leg)
+		}
+	}
+}
+
+func legIn(cmd string) (string, bool) {
+	if !strings.Contains(cmd, "conformance:leg") {
+		return "", false
+	}
+	_, after, found := strings.Cut(cmd, "--")
+	if !found {
+		return "", false
+	}
+	return strings.TrimSpace(after), true
+}
+
+// The one claim in this tool that is measured rather than tabulated. A pack file
+// that speaks to the machine layer starts containers on the operator's own
+// station, wherever it lives, and the table in rules.go would send it to a
+// client leg alone.
+func TestAFileThatImportsTheMachineLayerEarnsTheRuntimeLeg(t *testing.T) {
+	dir := t.TempDir()
+	reaching := "internal/providers/scaleway/servers.go"
+	if err := os.MkdirAll(filepath.Join(dir, filepath.Dir(reaching)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "package scaleway\n\nimport (\n\t\"fmt\"\n\n\t\"" + machineLayer + "\"\n)\n\n" +
+		"var _ = fmt.Sprint\nvar _ = machine.Binding{}\n"
+	if err := os.WriteFile(filepath.Join(dir, reaching), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := build(dir, []string{reaching})
+	if !hasRun(got, runtimeLeg) {
+		t.Fatalf("a file importing %s did not earn %q; the plan was:\n%s",
+			machineLayer, runtimeLeg, got)
+	}
+
+	// The control, and it is the half that makes the assertion mean something:
+	// the same path, the same rule, an import that is not the machine layer.
+	// Without it this test would pass over a build() that always asks for the
+	// runtime leg — which would be the most expensive possible way to be wrong.
+	plain := "internal/providers/scaleway/catalog.go"
+	if err := os.WriteFile(filepath.Join(dir, plain), []byte("package scaleway\n\nimport \"fmt\"\n\nvar _ = fmt.Sprint\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if control := build(dir, []string{plain}); hasRun(control, runtimeLeg) {
+		t.Fatalf("a file importing nothing but fmt earned %q; build() asks for the runtime "+
+			"leg unconditionally and this test would have passed over that:\n%s", runtimeLeg, control)
+	}
+}
+
+func hasRun(p plan, cmd string) bool {
+	for _, r := range p.Runs {
+		if r.Command == cmd {
+			return true
+		}
+	}
+	return false
+}
+
+// An un-triaged path must be loud and must not be cheap. The tempting behaviour
+// is "matched nothing, so run nothing", and it is exactly how an operation that
+// appeared upstream and that nobody sorted becomes a silent decision.
+func TestAnUntriagedPathIsAFailureNotACheapDefault(t *testing.T) {
+	got := build(t.TempDir(), []string{"quantum/teleporter.go"})
+	if len(got.Untriaged) != 1 || got.Untriaged[0] != "quantum/teleporter.go" {
+		t.Fatalf("an unmatched path was not reported as un-triaged: %+v", got.Untriaged)
+	}
+	if !strings.Contains(got.String(), "no rule triages") {
+		t.Fatalf("the printed plan does not name the un-triaged path:\n%s", got)
+	}
+	if strings.Contains(got.String(), "Nothing beyond") {
+		t.Fatal("an un-triaged path printed the reassuring answer reserved for a triaged one")
+	}
+}
+
+// Cheapest first, so a reader stops at the first red rather than at the last.
+func TestThePlanPutsTheCheapRunBeforeTheExpensiveOne(t *testing.T) {
+	got := build(t.TempDir(), []string{"internal/core/machine/incus.go", "internal/contract/check.go"})
+	if len(got.Runs) < 2 {
+		t.Fatalf("expected at least two runs, got %+v", got.Runs)
+	}
+	if !strings.Contains(got.Runs[0].Command, "probe") {
+		t.Errorf("the 0.7 s leg is not first: %q", got.Runs[0].Command)
+	}
+	if !strings.Contains(got.Runs[len(got.Runs)-1].Command, "runtime") {
+		t.Errorf("the 590 s leg is not last: %q", got.Runs[len(got.Runs)-1].Command)
+	}
+}
+
+// Every rule that claims its runs are sufficient says so by writing nothing in
+// Unproven, and that is a claim. This does not judge the claim — no test can —
+// but it refuses the third state, where a rule neither proves nor admits.
+func TestEveryRuleWithRunsSaysWhatItDoesNotProve(t *testing.T) {
+	for _, r := range rules {
+		if len(r.Runs) > 1 && r.Unproven == prepushIsTheWholeGate {
+			t.Errorf("rule %q runs %d commands and claims to leave nothing unproven; "+
+				"a plan that expensive has a residual, and hiding it is how a green "+
+				"comes to describe a smaller world than its reader believes",
+				r.Path, len(r.Runs))
+		}
+	}
+}
+
+// Prose is prose wherever it sits. Without this, a README under the conformance
+// harness earned the 208 s `fields` leg, and a tool that over-prescribes is
+// ignored exactly as fast as one that under-prescribes.
+func TestAMarkdownFileIsDocumentationWhereverItLives(t *testing.T) {
+	for _, path := range []string{
+		"tools/conformance/README.md",
+		"internal/core/machine/README.md",
+		"CONTRIBUTING.fr.md",
+	} {
+		got := build(t.TempDir(), []string{path})
+		for _, r := range got.Runs {
+			if strings.Contains(r.Command, "conformance") || strings.Contains(r.Command, "runtime") {
+				t.Errorf("%s earned %q; changing prose cannot alter a served answer", path, r.Command)
+			}
+		}
+	}
+	// The control: the file beside that README, which is not prose.
+	got := build(t.TempDir(), []string{"tools/conformance/score.sh"})
+	if len(got.Runs) == 0 {
+		t.Fatal("a harness script earned nothing; the documentation rule has swallowed the directory")
+	}
+}

--- a/tools/testplan/rules.go
+++ b/tools/testplan/rules.go
@@ -1,0 +1,439 @@
+package main
+
+// What each part of this tree costs to prove, declared rather than remembered.
+//
+// The rule this table encodes is the one the maintainer stated: *on ne joue que
+// ce qui est nécessaire*. The whole pass exists and is measured — 1331 s under
+// `FEINT_VM=incus-ovn`, 256 s without a runtime — and almost no change needs it.
+// A change to `internal/contract` needs the `probe` leg, which measured **0.7 s**
+// on 2026-08-27. Between those two numbers sits every wasted hour this repository
+// has spent re-proving parts of itself that the diff never touched.
+//
+// Three properties make this a control rather than a suggestion, and each is held
+// by a test in plan_test.go:
+//
+//  1. **A path nobody triaged is an error, not a cheap default.** `--check` exits
+//     2 naming the path. The tempting default is "matched nothing, so run
+//     nothing", and it is the same failure as an operation that appears upstream
+//     and that nobody sorted: silence reads as a decision when it is an absence.
+//     `TestEveryTrackedPathIsTriagedBySomeRule` walks `git ls-files` so a new
+//     directory reddens the build on the commit that adds it.
+//  2. **A rule that matches nothing is removed.** A line naming a path that no
+//     longer exists rots exactly the way a stale limit rots, and reads as
+//     coverage while covering nothing. `TestNoRuleMatchesNothing`.
+//  3. **The machine layer is found by what the code imports, not by what this
+//     table remembers.** A file that imports `internal/core/machine` earns the
+//     runtime leg wherever it lives, because the import is readable and a
+//     hand-kept list of file names forgets. See reachesMachineLayer in plan.go,
+//     held by `TestAFileThatImportsTheMachineLayerEarnsTheRuntimeLeg` — which
+//     carries its own control, a file importing nothing but fmt, so it cannot
+//     pass over a build() that asks for the 590 s leg unconditionally.
+//
+// `Unproven` is not decoration. The plan replaces a run that would have proved
+// more, and the part it drops has to be *printed* rather than quietly forgone —
+// otherwise this tool becomes the thing it exists to prevent: a green that
+// describes a smaller world than the reader believes.
+
+// A rule maps a part of the tree to the runs that judge a change to it.
+type rule struct {
+	// Path is a directory prefix (ending in /), an exact file, or a *.suffix
+	// glob. First-match does not apply: every matching rule contributes.
+	Path string
+	// Why names what this part of the tree is, in the reader's terms.
+	Why string
+	// Runs are the commands, cheapest first. A `mise run ` prefix is implied
+	// for a bare task name; anything else is printed verbatim.
+	Runs []string
+	// Unproven is what the plan still does not establish, printed under it.
+	// Empty means the runs are sufficient for this path, which is a claim.
+	Unproven string
+}
+
+// prepushIsTheWholeGate is the honest answer for a path whose change cannot
+// reach a served response. It is not "no rule": it is a rule that says so.
+const prepushIsTheWholeGate = ""
+
+var rules = []rule{
+	// ---------------------------------------------------------------- packs
+	{
+		Path: "internal/providers/scaleway/",
+		Why:  "the Scaleway pack — routes, response shapes, errors",
+		Runs: []string{"conformance:leg -- scw-cli", "conformance:leg -- fields"},
+		Unproven: "the `fields` leg is the only one where the omission gate judges, so it is " +
+			"required for a shape change and not merely for a new field; it does not run " +
+			"the example stacks, the second Exoscale zone, `feint up`, or the probe",
+	},
+	{
+		Path:     "internal/providers/outscale/",
+		Why:      "the Outscale pack — POST /api/v1/<Action>, ResponseContext",
+		Runs:     []string{"conformance:leg -- octl", "conformance:leg -- fields"},
+		Unproven: "octl reshapes its answers unless a call pins `-o raw`; the leg proves the wire, not the CLI's rendering",
+	},
+	{
+		Path: "internal/providers/exoscale/",
+		Why:  "the Exoscale pack — REST /v2/<resource>, asynchronous operations",
+		Runs: []string{"conformance:leg -- exo-cli", "conformance:leg -- fields"},
+		Unproven: "no Terraform drives this pack until upstream exoscale/terraform-provider-exoscale#573 " +
+			"is fixed (#525), and the second zone is `mise run conformance:zones`, which no leg carries",
+	},
+
+	// ----------------------------------------------------------- the runtime
+	{
+		Path: "internal/core/machine/",
+		Why:  "the only layer that acts on the operator's own machine",
+		Runs: []string{"FEINT_VM=incus-ovn mise run conformance:leg -- runtime"},
+		Unproven: "the leg runs under OVN; a bridge is a different verdict for isolation alone, " +
+			"and the stacks' functional proof is `FEINT_VM=incus-ovn mise run conformance:functional`",
+	},
+	{
+		Path:     "internal/core/cloudinit/",
+		Why:      "the boot payload a pack hands its machines",
+		Runs:     []string{"FEINT_VM=incus-ovn mise run conformance:leg -- runtime"},
+		Unproven: "a rendered document is proved by a machine that booted on it, which is `mise run conformance:ssh`",
+	},
+	{
+		Path:     "internal/core/network/",
+		Why:      "addressing plans, subnets, firewall bindings",
+		Runs:     []string{"FEINT_VM=incus-ovn mise run conformance:leg -- runtime"},
+		Unproven: "isolation between two VPCs is delivered by OVN alone; under a bridge that assertion skips itself",
+	},
+
+	// -------------------------------------------------------- the shared core
+	{
+		Path: "internal/core/emulator/",
+		Why:  "Env, Pack, Route, the single-port mount — all three packs ride it",
+		Runs: []string{"conformance:leg -- probe", "conformance:leg -- fields"},
+		Unproven: "a mount collision fails `NewServer` at boot, so `mise run check` already covers it; " +
+			"what these legs add is that the three packs still answer through it",
+	},
+	{
+		Path:     "internal/core/resource/",
+		Why:      "the neutral resource every pack stores",
+		Runs:     []string{"conformance:leg -- probe", "conformance:leg -- fields"},
+		Unproven: "a change to the stored shape is proved across a restart by `mise run conformance:environment`",
+	},
+	{
+		Path:     "internal/core/store/",
+		Why:      "memory store and JSON snapshot, restored as untrusted input",
+		Runs:     []string{"conformance:leg -- probe", "conformance:environment"},
+		Unproven: "a snapshot written by one version and read by another is not exercised by any leg",
+	},
+
+	// ------------------------------------------------------ what describes it
+	{
+		Path:     "internal/contract/",
+		Why:      "the API descriptions, and the check that answers conform",
+		Runs:     []string{"conformance:leg -- probe"},
+		Unproven: prepushIsTheWholeGate,
+	},
+	{
+		Path:     "internal/probe/",
+		Why:      "the driver that walks every mounted route from its description",
+		Runs:     []string{"conformance:leg -- probe"},
+		Unproven: prepushIsTheWholeGate,
+	},
+	{
+		Path:     "contracts/",
+		Why:      "the extracted API descriptions the probe and --contracts read",
+		Runs:     []string{"conformance:leg -- probe"},
+		Unproven: "a contract loosened rather than tightened still passes; the probe proves conformity, not strictness",
+	},
+
+	// ------------------------------------------------------ the measurements
+	{
+		Path:     "internal/drift/",
+		Why:      "the upstream surface scan, coverage and baseline",
+		Runs:     []string{"drift:check"},
+		Unproven: "the scan reads a vendored SDK clone; `mise run upstream:sync` decides which one",
+	},
+	{
+		Path:     "coverage/",
+		Why:      "the versioned artefacts the gates read",
+		Runs:     []string{"drift:check", "evidence:update"},
+		Unproven: "`evidence:update` drives the whole pass by construction — it is the one caller allowed to write the record",
+	},
+	{
+		Path:     "shapes/",
+		Why:      "the frozen response shapes",
+		Runs:     []string{"shapes:check"},
+		Unproven: prepushIsTheWholeGate,
+	},
+	{
+		Path:     "corpus/",
+		Why:      "the recorded exchanges, replayed as refusals",
+		Runs:     []string{"conformance:leg -- fields"},
+		Unproven: "the `fields` leg is where refusals.sh runs; nothing else can raise the negative axis",
+	},
+
+	// -------------------------------- what the orphan guard named, one by one
+	// There is no `internal/` catch-all below, and that is the design: a new
+	// package under internal/ reddens `TestEveryTrackedPathIsTriagedBySomeRule`
+	// on the commit that adds it, and somebody writes down what proving it
+	// costs. A catch-all would answer "nothing to run" for a package nobody has
+	// thought about yet, which is the one answer this tool must never give by
+	// accident.
+	{
+		Path:     "internal/core/serialise/",
+		Why:      "how a resource is written down and read back",
+		Runs:     []string{"conformance:leg -- probe"},
+		Unproven: prepushIsTheWholeGate,
+	},
+	{
+		Path:     "internal/core/sshkey/",
+		Why:      "the keys a machine is handed at boot",
+		Runs:     []string{"FEINT_VM=incus-ovn mise run conformance:ssh"},
+		Unproven: "that suite is not part of `mise run conformance`, which must stay runnable with no runtime",
+	},
+	{
+		Path:     "internal/proxy/",
+		Why:      "the recording proxy that captured the real clouds",
+		Runs:     []string{"corpus:check"},
+		Unproven: "nothing here re-records against a real cloud; a corpus is captured by hand, with credentials this repository does not hold",
+	},
+	{
+		Path:     "internal/transcript/",
+		Why:      "the recorded exchange format",
+		Runs:     []string{"corpus:check"},
+		Unproven: prepushIsTheWholeGate,
+	},
+	{
+		Path:     "internal/corpus/",
+		Why:      "the corpus reader",
+		Runs:     []string{"corpus:check", "conformance:leg -- fields"},
+		Unproven: "the refusals replay runs on the `fields` leg alone, and it is the only thing that can raise the negative axis",
+	},
+	{
+		Path:     "internal/replay/",
+		Why:      "replaying a corpus against the emulator",
+		Runs:     []string{"conformance:leg -- fields"},
+		Unproven: prepushIsTheWholeGate,
+	},
+	{
+		Path:     "internal/shape/",
+		Why:      "the frozen response shapes and their redaction",
+		Runs:     []string{"shapes:check"},
+		Unproven: "redaction is proved by what the committed shapes contain, not by what this package intends",
+	},
+	{
+		Path:     "internal/upstream/",
+		Why:      "reading the vendored SDK clones the drift scan measures",
+		Runs:     []string{"drift:check"},
+		Unproven: prepushIsTheWholeGate,
+	},
+	{
+		Path:     "internal/environment/",
+		Why:      "the declaration `feint up` applies",
+		Runs:     []string{"conformance:environment"},
+		Unproven: prepushIsTheWholeGate,
+	},
+	{
+		Path:     "internal/release/",
+		Why:      "the released surface, the formula and the tap",
+		Runs:     []string{"release:check"},
+		Unproven: "a release is proved by the release, and this repository has published one that its own gates called green",
+	},
+	{
+		Path:     "internal/compat/",
+		Why:      "the compatibility classification",
+		Runs:     []string{"compat:check"},
+		Unproven: prepushIsTheWholeGate,
+	},
+	{
+		Path:     "internal/trace/",
+		Why:      "the exchange trace",
+		Runs:     nil,
+		Unproven: prepushIsTheWholeGate,
+	},
+	{
+		Path:     "internal/providers/",
+		Why:      "what the three packs share at their own level",
+		Runs:     []string{"conformance:leg -- fields"},
+		Unproven: "a change here reaches all three packs, and the `fields` leg is the only one carrying all three clients",
+	},
+
+	// ------------------------------------------------------------- the binary
+	{
+		Path:     "internal/cli/",
+		Why:      "the sub-commands: lifecycle, serve, doctor, snapshot, coverage",
+		Runs:     []string{"conformance:environment"},
+		Unproven: "`feint up`/`down` on a declaration is what that suite drives; a flag no declaration names is unexercised",
+	},
+	{
+		Path:     "cmd/feint/",
+		Why:      "the entry point, and nothing else",
+		Runs:     nil,
+		Unproven: prepushIsTheWholeGate,
+	},
+
+	// -------------------------------------------------------------- the stacks
+	{
+		Path: "examples/stacks/",
+		Why:  "the example stacks, which are examples and tests at once",
+		Runs: []string{"conformance:stacks", "FEINT_VM=incus-ovn mise run conformance:functional"},
+		Unproven: "the Exoscale stack is applied by hand, never by CI: no gate here clones a third-party " +
+			"repository and a patched client is not the official one (#525)",
+	},
+	{
+		Path:     "examples/",
+		Why:      "the example declarations and fixtures",
+		Runs:     []string{"conformance:environment"},
+		Unproven: prepushIsTheWholeGate,
+	},
+
+	// ------------------------------------------------------------ the harness
+	{
+		Path:     "tools/conformance/scaleway/",
+		Why:      "the Scaleway suites",
+		Runs:     []string{"conformance:leg -- scw-cli"},
+		Unproven: "scaleway/network.sh belongs to the runtime leg, not to this one",
+	},
+	{
+		Path:     "tools/conformance/outscale/",
+		Why:      "the Outscale suites",
+		Runs:     []string{"conformance:leg -- octl", "conformance:leg -- terraform"},
+		Unproven: "outscale/network.sh and outscale/balancer.sh belong to the runtime leg",
+	},
+	{
+		Path:     "tools/conformance/exoscale/",
+		Why:      "the Exoscale suites",
+		Runs:     []string{"conformance:leg -- exo-cli", "conformance:zones"},
+		Unproven: "exoscale/network.sh belongs to the runtime leg",
+	},
+	{
+		Path:     "tools/conformance/shared/",
+		Why:      "the helpers every suite sources, waiting included",
+		Runs:     []string{"FEINT_VM=incus-ovn mise run conformance:leg -- runtime", "conformance:leg -- fields"},
+		Unproven: "a helper changed here is read by suites in both legs, so both are the minimum",
+	},
+	{
+		Path:     "tools/conformance/environment/",
+		Why:      "the `feint up` / `feint down` suite",
+		Runs:     []string{"conformance:environment"},
+		Unproven: prepushIsTheWholeGate,
+	},
+	{
+		Path:     "tools/conformance/",
+		Why:      "the shared harness: doorstep, score, faults, refusals, stacks, functional",
+		Runs:     []string{"conformance:leg -- fields"},
+		Unproven: "score.sh judges the field gate on the `fields` leg alone; on every other leg it prints and judges nothing",
+	},
+	{
+		Path:     "tools/falsify/",
+		Why:      "the falsification harness and its specs",
+		Runs:     []string{"falsify:lint"},
+		Unproven: "`falsify:lint` is the cheap half; `mise run falsify:all` replays every mutation and belongs to the night",
+	},
+	{
+		Path:     "tools/drift/",
+		Why:      "the drift gate",
+		Runs:     []string{"drift:check"},
+		Unproven: prepushIsTheWholeGate,
+	},
+	{
+		Path:     "tools/docs/",
+		Why:      "the documentation gates, limits acknowledgements included",
+		Runs:     []string{"docs:check", "limits:check"},
+		Unproven: "`limits:check` sees a section citing an issue that has since closed, and nothing else: the one limit that went false for ten days cited no issue at all",
+	},
+	{
+		Path:     "tools/",
+		Why:      "repository tooling",
+		Runs:     nil,
+		Unproven: "this is the one catch-all here, and it covers scripts whose own Go tests run in `mise run check`",
+	},
+
+	// ------------------------------------------------------------ everything
+	// else that is tracked. Each of these is a claim that a change there cannot
+	// alter a served answer — which is why they are written down rather than
+	// left to fall through a default.
+	{
+		Path:     "docs/",
+		Why:      "prose, including what this project says it does not do",
+		Runs:     []string{"docs:check", "limits:check"},
+		Unproven: "a document can be wrong in ways no gate reads; three of fifty limits had gone false on 2026-08-27",
+	},
+	{
+		Path:     ".github/",
+		Why:      "workflows and repository configuration",
+		Runs:     []string{"lint-shell"},
+		Unproven: "actionlint, zizmor and poutine run in CI; a renamed job silently stops being a required check",
+	},
+	{
+		Path:     "feinttest/",
+		Why:      "the test helpers the packages share",
+		Runs:     nil,
+		Unproven: prepushIsTheWholeGate,
+	},
+	{
+		Path:     "mise.toml",
+		Why:      "the task definitions every run here goes through",
+		Runs:     []string{"conformance:leg -- probe"},
+		Unproven: "a task nobody runs locally is proved by the workflow that runs it, not by this plan",
+	},
+	{
+		Path:     "go.mod",
+		Why:      "the module, whose three lines are a rule of this project",
+		Runs:     nil,
+		Unproven: prepushIsTheWholeGate,
+	},
+	{
+		Path:     "Dockerfile",
+		Why:      "the published image",
+		Runs:     []string{"conformance:image"},
+		Unproven: prepushIsTheWholeGate,
+	},
+	{
+		Path:     "*.md",
+		Why:      "prose, wherever it lives and in either language",
+		Runs:     []string{"docs:check"},
+		Unproven: prepushIsTheWholeGate,
+	},
+	{
+		Path:     "*.yml",
+		Why:      "root configuration",
+		Runs:     nil,
+		Unproven: prepushIsTheWholeGate,
+	},
+	{
+		Path:     "*.yaml",
+		Why:      "root configuration",
+		Runs:     nil,
+		Unproven: prepushIsTheWholeGate,
+	},
+	{
+		Path:     "*.toml",
+		Why:      "root configuration",
+		Runs:     nil,
+		Unproven: prepushIsTheWholeGate,
+	},
+	{
+		Path:     "*.lock",
+		Why:      "a pinned dependency set",
+		Runs:     nil,
+		Unproven: prepushIsTheWholeGate,
+	},
+	{
+		Path:     ".editorconfig",
+		Why:      "editor settings",
+		Runs:     nil,
+		Unproven: prepushIsTheWholeGate,
+	},
+	{
+		Path:     ".gitignore",
+		Why:      "what this repository does not track",
+		Runs:     nil,
+		Unproven: prepushIsTheWholeGate,
+	},
+	{
+		Path:     ".dockerignore",
+		Why:      "what the image build does not read",
+		Runs:     nil,
+		Unproven: prepushIsTheWholeGate,
+	},
+	{
+		Path:     "LICENSE",
+		Why:      "the licence",
+		Runs:     nil,
+		Unproven: prepushIsTheWholeGate,
+	},
+}


### PR DESCRIPTION
Closes #564.

Nobody could say, from a diff, which conformance runs it had earned. So either
everything was run — the lifecycle batch replayed the 1331 s pass once per
attempt for a change confined to `internal/core/machine` — or nothing was, and
the pull request said so, leaving the reviewer to guess whether it mattered.

```bash
mise run testplan          # what this diff has earned, cheapest run first
```

It reads the diff, prints the runs, and prints what they still **do not** prove.
`prepush` calls it with `--check`, so every push says what to run next and
refuses a path no rule triages.

## The measurements this rests on

One pass each, same tree, same station, 2026-08-27:

| run | measured |
|---|--:|
| `conformance:leg -- probe` | **0.7 s** |
| `conformance:leg -- exo-cli` | 4.0 s |
| `conformance:leg -- scw-cli` | 7.1 s |
| `conformance:leg -- terraform` | 45.4 s |
| `conformance:leg -- octl` | 141.3 s |
| `conformance:leg -- fields` | 208.1 s |
| `conformance:leg -- runtime` | 590 s |
| `mise run conformance`, no runtime | 256 s |
| `FEINT_VM=incus-ovn mise run conformance` | **1331 s** |

**One decision dominates every other**: does the change reach the machine layer.
Answer it right and the work costs seconds; wrong and it costs 590 s or 1331 s.
Everything else in that table is worth tens of seconds — `fields` at 208 s
against the whole runtime-free pass at 256 s saves 48 s, which is nothing. This
is a tool with one good question, not thirty.

So that question is answered by **reading the imports** of the changed files
rather than by consulting a list of directory names. Transitively would be
useless: `internal/cli` reaches the machine layer from every sub-command,
because `serve` carries `--vm`, so a transitive test would demand 590 s for a
change to `version` and be ignored within a week.

## The condition, and it is not negotiable

**The plan replaces the full pass *locally*. It never replaces the CI matrix.**

Every other gate here adds proof. This one subtracts it, and that inverts the
failure mode: a wrong rule is silent. With the CI matrix untouched, the worst
case of a wrong table is a red pull request, which is what CI is for. No
workflow is modified by this branch.

## What keeps the table from becoming a lie

A routing table is the most inviting place in this repository to write a comment
instead of a control. It goes wrong in two directions that look nothing alike,
and both are held by tests rather than by reading:

- **an un-triaged path is a failure, not a cheap default.** "It matched nothing,
  so run nothing" is the same failure as an operation that appears upstream and
  that nobody sorted. `TestEveryTrackedPathIsTriagedBySomeRule` walks the whole
  tree, so a new package reddens the build on the commit that adds it — there is
  deliberately **no `internal/` catch-all**;
- **a rule matching nothing is removed.** A line naming a directory that moved
  reads as coverage while covering nothing, which is the rot `docs/limits.md`
  suffered for a fortnight (#558). `TestNoRuleMatchesNothing`.

Plus: every task a rule prints exists in `mise.toml`; every leg it names is one
`leg.sh` accepts — the third list of leg names in this repository, and the two
that came before it drifted (#460); and a rule running several commands must say
what it leaves unproven, because a plan that expensive has a residual and hiding
it is how a green comes to describe a smaller world than its reader believes.

## Two guards were unfalsifiable, which is the finding

`mise run falsify` copies the repository **without `.git`** (`falsify.py`,
`EXCLUDE`). The first shape of `tracked()` called `git ls-files` and skipped when
it failed — and a skipped test is not a red one. Every mutation aimed at the two
whole-tree guards reported `TEST STILL PASSED`.

They now fall back to walking the tree, honouring `.gitignore`'s simple patterns
— all this repository has: 272 lines, no negation, no `**`, and the fallback
refuses out loud rather than misreading anything cleverer. The anchoring rule bit
within a minute of being written: `/feint` read as a bare name also ate
`cmd/feint/`, and the walk reported the entry point as a directory no rule
covers.

**Ten mutations, ten bites, green after restoration.**

## Two defects the tool found in itself

- **It over-prescribed on its own diff.** `tools/conformance/README.md` earned
  the 208 s `fields` leg because it sits under the harness. Longest-prefix
  answers *where a file lives* and not *what kind of file it is*; a Markdown
  file is documentation wherever it lives, and
  `TestAMarkdownFileIsDocumentationWhereverItLives` carries the control — the
  script beside that README must still earn something. A tool that
  over-prescribes is ignored exactly as fast as one that under-prescribes.
- **It was blind to a new package.** `git diff` does not list untracked files, so
  four new `.go` files were invisible and the plan described the one tracked file
  in the change. A new directory is precisely what the un-triaged check is for.

It also caught my own build artefact: `go build ./tools/testplan/` leaves a
binary at the root that nothing ignored, which arrived as an un-triaged path.
Same class as `/feint`, now in `.gitignore`.

## Gates

`prepush` 0 · `go test ./... -race` 0 · `golangci-lint` 0 issues · `falsify`
10/10 on the new spec · `falsify:lint` 803 mutations over 128 specs · and the
plan this tool prints for its own diff was run: `probe` 0.6 s, `docs:check`,
`falsify:lint`.

An existing gate caught one of my comments — a citation naming a test from
another package without saying so. Fixed rather than exempted.

## What no test here can catch

A rule that names a real directory and prescribes the **wrong leg** passes every
guard above. The two mechanical rots are covered; the semantic one is not. That
is the same class as the limit that was false for ten days while citing no issue
at all, and it is written into `rules.go` and both `CONTRIBUTING` files rather
than pretended away.

## Documentation

`CONTRIBUTING.md`, `CONTRIBUTING.fr.md`, `tools/conformance/README.md`, and one
line in the pull request template's **Always** block: a run not played is written
down, never left blank — the reviewer cannot tell an omission that was considered
from one that was forgotten, and only one of the two is a decision.
