### PR TITLE
fix(store, machine): a stored number is read once for every pack, and a pack that wired no orchestrator is named (#542, #543)

### DIFF
--- a/internal/cli/discipline_test.go
+++ b/internal/cli/discipline_test.go
@@ -221,6 +221,7 @@ func barrageCalls(t *testing.T, file string) map[string]int {
 func TestEveryBarrageExemptionSaysWhy(t *testing.T) {
 	for _, exemptions := range []map[string]string{
 		ownExclusion, notInTheBarrage, notInTheDriverSurface, runtimeKnowledgeExemptions,
+		storedNumberExemptions,
 	} {
 		for key, reason := range exemptions {
 			if reasonIsThin(reason) {

--- a/internal/cli/provider_four_wiring_test.go
+++ b/internal/cli/provider_four_wiring_test.go
@@ -1,0 +1,328 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	providerfour "github.com/stephrobert/feint/internal/cli/testdata/provider-four"
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/machine"
+	"github.com/stephrobert/feint/internal/core/resource"
+	"github.com/stephrobert/feint/internal/core/store"
+)
+
+// What a pack that declares an orchestrator without wiring it is told (#543).
+//
+// Beside the fourth pack, and for its reason: the three real packs wire all
+// five GroupSync fields, so nothing here is broken for them and nothing they
+// do could measure this. The pack that can be in this state is the one that
+// never had the habits — testdata/provider-four — and the state it can be in
+// is the zero value of a struct it has to build, which compiles.
+//
+// The reproduction, measured on 2026-08-27 before the fix, calling
+// Reconciler.PowerOn over a zero GroupSync:
+//
+//	with an enforcing runtime: PANIC: invalid memory address or nil pointer dereference
+//	with machine.Noop:         no panic; PowerOn=true state=up
+//
+// and through a mounted route rather than a direct call, which was the half
+// #543 recorded as read and not run:
+//
+//	the client saw: Post "http://127.0.0.1:.../repro/v1/boot": EOF
+//	the emulator still answers: status 204
+//
+// So net/http's per-connection recover is indeed the only thing between this
+// and a dead process — `grep -rn 'recover()' internal/` finds none, and no
+// pack starts a goroutine — and what the operator got was a dropped connection
+// and a stack trace naming machine/groupsync.go, with nothing naming their
+// pack or the field they forgot.
+//
+// The asymmetry is what these tests hold rather than the panic. `--vm off` is
+// the default, what CI runs and what every conformance leg runs, and it took
+// the `enforcer() == nil` branch before anything could touch a nil field: a
+// pack that had wired nothing was green everywhere it was ever measured, and
+// red on the first poweron of the first operator to attach a real runtime.
+
+// reportingEnv is fourthEnv with a logger a test can read, because "reports
+// rather than panics" is an assertion about what was said, and a discarded log
+// makes it an assertion that nothing crashed.
+func reportingEnv(t *testing.T, runtime machine.Driver) (*emulator.Env, *bytes.Buffer) {
+	t.Helper()
+	var log bytes.Buffer
+	n := 0
+	env := &emulator.Env{
+		Store: store.New(),
+		Now:   func() time.Time { return time.Unix(1700000000, 0).UTC() },
+		NewID: func() string {
+			n++
+			return fmt.Sprintf("00000000-0000-4000-8000-%012d", n)
+		},
+		Log: slog.New(slog.NewTextHandler(&log, nil)),
+	}
+	env.UseMachines(runtime)
+	return env, &log
+}
+
+// unwiredReconciler is the shape a fourth pack compiles with and forgets: the
+// binding is there, because nothing works without it, and the four translation
+// fields are not.
+func unwiredReconciler(env *emulator.Env) machine.Reconciler {
+	return machine.Reconciler{
+		Groups: machine.GroupSync{Binding: fourthBinding(env)},
+		PlanOf: func(*resource.Resource) machine.Plan { return machine.Plan{} },
+	}
+}
+
+func fourthBinding(env *emulator.Env) machine.Binding {
+	return env.Bind(machine.Binding{
+		Provider:     "four",
+		Prefix:       "feint-four-",
+		RuntimeKey:   "node",
+		AddressKey:   "address",
+		RunningState: "up",
+		FailedState:  "broken",
+		Log:          env.Log,
+	})
+}
+
+func aNode(env *emulator.Env) *resource.Resource {
+	res := resource.New("node-1", "node", resource.Tenant{Provider: "four"}, "stopped", env.Now())
+	res.Runtime = map[string]string{"node": "feint-four-node-1"}
+	env.Store.Put(res)
+	return res
+}
+
+// A boot under an enforcing runtime reports the omission instead of panicking.
+//
+// machine.NewRecorder implements Firewaller, so this takes the enforcing branch
+// — the one only `--vm incus` and `--vm incus-ovn` used to reach — without
+// needing a host.
+func TestABootUnderAnEnforcingRuntimeReportsAnUnwiredGroupSync(t *testing.T) {
+	env, log := reportingEnv(t, machine.NewRecorder())
+	res := aNode(env)
+
+	// A panic here fails the test by crashing it, which is the honest form: a
+	// recover() would turn the defect back into something a test can pass over.
+	started := unwiredReconciler(env).PowerOn(context.Background(), res, machine.Boot{Image: "four-linux"})
+
+	// The machine plane is not broken by a firewall omission, which is remedy
+	// one: the node really did start.
+	if !started {
+		t.Errorf("the node did not start: a pack that forgot its firewall translation must still "+
+			"boot machines — the log says %q", log.String())
+	}
+	if res.State != "up" {
+		t.Errorf("the node is %q, want up", res.State)
+	}
+
+	// And the operator is told, in a sentence naming the pack and the fields.
+	said := log.String()
+	if !strings.Contains(said, "four") {
+		t.Errorf("the report does not name the pack: %q", said)
+	}
+	for _, field := range []string{"SpecOf", "Wearers", "WornIDs", "Group"} {
+		if !strings.Contains(said, field) {
+			t.Errorf("the report does not name the missing %s: %q", field, said)
+		}
+	}
+}
+
+// The omission is reported under every runtime, which is the finding.
+//
+// Not "the panic is gone": the panic was only ever the symptom under one mode.
+// What #543 measured is that the mode everybody runs could not see the defect
+// at all, so a control that only stopped the crash would leave the fourth pack
+// silent in both modes — worse than loud in one, for the reason #475 was
+// expensive.
+func TestAnUnwiredGroupSyncIsReportedUnderEveryRuntime(t *testing.T) {
+	for _, tc := range []struct {
+		mode    string
+		runtime machine.Driver
+	}{
+		{"an enforcing runtime, what --vm incus-ovn gives", machine.NewRecorder()},
+		{"machine.Noop, the --vm off default and what CI runs", machine.Noop{}},
+	} {
+		t.Run(tc.mode, func(t *testing.T) {
+			env, log := reportingEnv(t, tc.runtime)
+			res := aNode(env)
+
+			unwiredReconciler(env).PowerOn(context.Background(), res, machine.Boot{Image: "four-linux"})
+
+			if !strings.Contains(log.String(), "SpecOf") {
+				t.Errorf("under %s the omission was not reported at all: %q — this is the mode "+
+					"asymmetry #543 is about, and a fix that only silences the panic reintroduces it",
+					tc.mode, log.String())
+			}
+		})
+	}
+}
+
+// The report names the pack and exactly the fields that are missing, and says
+// nothing about a pack that wired them or declared it wires nothing.
+//
+// Four cases, and the last two are the accepting half without which a guard
+// that refuses everything would pass the three tests above and break all three
+// real packs on their next boot.
+func TestAPackThatWiredNoGroupSyncIsToldWhichFieldIsMissing(t *testing.T) {
+	full := func(env *emulator.Env) machine.GroupSync {
+		return machine.GroupSync{
+			Binding: fourthBinding(env),
+			SpecOf:  func(_, _ *resource.Resource) machine.FirewallSpec { return machine.FirewallSpec{} },
+			Wearers: func(*resource.Resource) []*resource.Resource { return nil },
+			WornIDs: func(*resource.Resource) []string { return nil },
+			Group:   func(string) (*resource.Resource, bool) { return nil, false },
+		}
+	}
+
+	for _, tc := range []struct {
+		name    string
+		build   func(*emulator.Env) machine.GroupSync
+		names   []string
+		silent  bool
+		unnamed []string
+	}{
+		{
+			name:  "nothing wired",
+			build: func(env *emulator.Env) machine.GroupSync { return machine.GroupSync{Binding: fourthBinding(env)} },
+			names: []string{"four", "SpecOf", "Wearers", "WornIDs", "Group"},
+		},
+		{
+			name: "one field forgotten",
+			build: func(env *emulator.Env) machine.GroupSync {
+				groups := full(env)
+				groups.WornIDs = nil
+				return groups
+			},
+			names: []string{"four", "WornIDs"},
+			// The others are named in the sentence's tail, which lists what a
+			// wiring pack supplies; what must not happen is the report calling
+			// a wired field missing, so the assertion is on the prefix.
+		},
+		{
+			name: "a pack that declares it enforces nothing",
+			build: func(env *emulator.Env) machine.GroupSync {
+				return machine.GroupSync{Binding: fourthBinding(env), EnforcesNothing: true}
+			},
+			silent: true,
+		},
+		{
+			name:   "a pack that wired all four",
+			build:  full,
+			silent: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			env, log := reportingEnv(t, machine.NewRecorder())
+			res := aNode(env)
+			rec := machine.Reconciler{
+				Groups: tc.build(env),
+				PlanOf: func(*resource.Resource) machine.Plan { return machine.Plan{} },
+			}
+			rec.PowerOn(context.Background(), res, machine.Boot{Image: "four-linux"})
+
+			said := log.String()
+			if tc.silent {
+				if strings.Contains(said, "the firewall step is skipped") {
+					t.Errorf("a pack that wired what it meant to was reported anyway: %q — a control "+
+						"that cannot be satisfied is a control somebody works around", said)
+				}
+				return
+			}
+			if !strings.Contains(said, "the firewall step is skipped") {
+				t.Fatalf("nothing was reported for %s: %q", tc.name, said)
+			}
+			for _, name := range tc.names {
+				if !strings.Contains(said, name) {
+					t.Errorf("the report does not name %s: %q", name, said)
+				}
+			}
+			// The message must not accuse a field that is wired: "missing:
+			// SpecOf, Wearers, WornIDs, Group" for a pack missing one is a
+			// sentence that sends its reader to the wrong four lines.
+			if tc.name == "one field forgotten" {
+				before, _, _ := strings.Cut(said, "a pack that hands its groups")
+				for _, wired := range []string{"SpecOf", "Wearers", "Group"} {
+					if strings.Contains(before, wired+",") || strings.Contains(before, wired+":") {
+						t.Errorf("the report calls the wired %s missing: %q", wired, before)
+					}
+				}
+			}
+		})
+	}
+}
+
+// A boot with no declared plan is refused, and says so.
+//
+// PlanOf is the other required func field of the Reconciler, and #543 recorded
+// it as untested. It is measured now: it panics under machine.Noop exactly as
+// it does under an enforcing runtime, so unlike the GroupSync fields it is not
+// mode-dependent and a pack that forgets it fails its own first test. What it
+// still lacked was a sentence: the operator got a stack trace in
+// machine/plan.go rather than the name of the pack and the field.
+//
+// It refuses where GroupSync degrades, and plan.go says why: a machine started
+// with no plan is a machine on no network that the API would call running.
+func TestABootWithNoDeclaredPlanIsRefusedRatherThanPanicking(t *testing.T) {
+	for _, tc := range []struct {
+		mode    string
+		runtime machine.Driver
+	}{
+		{"an enforcing runtime", machine.NewRecorder()},
+		{"machine.Noop, the --vm off default", machine.Noop{}},
+	} {
+		t.Run(tc.mode, func(t *testing.T) {
+			env, log := reportingEnv(t, tc.runtime)
+			res := aNode(env)
+			rec := machine.Reconciler{Groups: machine.GroupSync{
+				Binding:         fourthBinding(env),
+				EnforcesNothing: true,
+			}}
+
+			if rec.PowerOn(context.Background(), res, machine.Boot{Image: "four-linux"}) {
+				t.Error("a boot with no declared plan reported success: the machine would be on no " +
+					"network while the API described it as running")
+			}
+			said := log.String()
+			if !strings.Contains(said, "PlanOf") || !strings.Contains(said, "four") {
+				t.Errorf("the refusal does not name the pack and the field: %q", said)
+			}
+			// The two other doors onto PlanOf, which a fix applied to PowerOn
+			// alone would leave dereferencing a nil func.
+			rec.ReplayAddresses(context.Background(), res)
+			rec.Route(context.Background(), res, "198.18.0.7")
+		})
+	}
+}
+
+// The fourth pack itself wires everything, which is what makes the tests above
+// about an omission rather than about the pack.
+//
+// It is the positive control of the whole file: if provider-four's own
+// orchestrators were incomplete, every assertion above would still pass and
+// none of them would be measuring the case they name.
+func TestTheFourthPacksOwnOrchestratorsAreComplete(t *testing.T) {
+	ctx := context.Background()
+	var log bytes.Buffer
+	pack, _, env := fourthPack(t)
+	env.Log = slog.New(slog.NewTextHandler(&log, nil))
+
+	segment, err := pack.CreateSegment(ctx, "front", "10.40.0.0/24", "green")
+	must(t, err)
+	node, err := pack.CreateNode(ctx, providerfour.NodeRequest{
+		Name:        "web-1",
+		Image:       "four-linux",
+		HomeSegment: segment.ID,
+	})
+	must(t, err)
+	must(t, pack.StartNode(ctx, node.ID))
+
+	if strings.Contains(log.String(), "the firewall step is skipped") ||
+		strings.Contains(log.String(), "declares no interface plan") {
+		t.Errorf("the fourth pack reports an unwired orchestrator on an ordinary boot: %q", log.String())
+	}
+}

--- a/internal/cli/stored_numbers_test.go
+++ b/internal/cli/stored_numbers_test.go
@@ -1,0 +1,290 @@
+package cli
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// A stored number is never read by a type assertion (#542).
+//
+// The measurement, on 2026-08-27: Resource.Attrs is a map[string]any and
+// store.Restore decodes the snapshot with encoding/json, so a number written
+// as an int, an int64 or a uint32 all come back a float64 — while a string and
+// a bool come back unchanged. A `.(int)` on a restored number therefore yields
+// ok=false and 0, and the door it travels through is a real one:
+// `PUT /_feint/state` restores a snapshot verbatim and snapshot.go documents
+// the format as meant to outlive its instance.
+//
+// What makes this a discipline test rather than three fixes is that the three
+// fixes were already written, six times, and did not travel. On the day #542
+// was filed the tree held seven copies of the same tolerance under six names —
+// exoscale's intOf and int64Of, exoscale's and outscale's numOf, scaleway's
+// positionOf and portValue, and the fake fourth pack's portOf — and
+// outscale/volumes.go still read a volume's size with a plain `.(int)` three
+// files away from one of them. A restored 40 GiB volume shrank to 1 with a
+// 200, and a snapshot taken of it recorded VolumeSize 0. Exoscale had found
+// that exact pair of readers — a shrink refusal and the size a snapshot
+// inherits — written the reason down in a doc comment and fixed it for its
+// own block volumes on 2026-08-17 (5680efb), ten days before #542 was filed.
+// Nothing carried it across, and nothing would have carried it to a fourth
+// pack: testdata/provider-four wrote `res.Attrs["port"].(int)` on its first
+// draft.
+//
+// So the reader lives in internal/core/resource and this refuses the gesture it
+// replaces. It reads the packs' own sources, which is the property #220 asked
+// for: a pack that forgets does not lack a test it never had to remember to
+// write — it fails one.
+//
+// Numbers only, and that boundary is measured rather than assumed: strings and
+// bools cross the snapshot unchanged, so `.(string)` and `.(bool)` on Attrs are
+// correct and forbidding them would be a guard that refuses working code. The
+// round trip that establishes it is
+// store.TestEveryGoTypeAPackWritesCrossesTheSnapshotAsMeasured.
+
+// numericTypes are the basic types a stored number can be asserted to. Bool and
+// string are deliberately absent — measured to cross a snapshot unchanged — and
+// so is any named type, which cannot be what a JSON decoder produced.
+var numericTypes = map[string]bool{
+	"int": true, "int8": true, "int16": true, "int32": true, "int64": true,
+	"uint": true, "uint8": true, "uint16": true, "uint32": true, "uint64": true,
+	"uintptr": true, "float32": true, "float64": true,
+	"complex64": true, "complex128": true, "byte": true, "rune": true,
+}
+
+// storedNumberExemptions lists the numeric assertions a pack legitimately
+// keeps, each with the reason — the discipline Declined() applies to a refusal,
+// applied to this one, and the shape TestEveryBarrageExemptionSaysWhy already
+// holds for the maps beside it.
+//
+// Keyed "<pack>/<file>:<type>" so an exemption cannot quietly widen to a whole
+// pack. One entry today, and it is the honest one: a value decoded straight out
+// of a request body has never been anything but a float64, because that is what
+// encoding/json produces for a JSON number, and reading it through the stored-
+// value reader would say something untrue about where it came from.
+var storedNumberExemptions = map[string]string{
+	"outscale/loadbalancers.go:float64": "the value is read out of the request body this handler just decoded, " +
+		"not out of a stored resource: encoding/json makes every JSON number a float64 on the way in, so the " +
+		"assertion is the decoder's own type rather than a guess about what a snapshot left behind",
+}
+
+// numericAssertion is one refused gesture: where it is, and what it asserted.
+type numericAssertion struct {
+	pack  string
+	file  string
+	typ   string
+	where string
+	how   string
+}
+
+// numericAssertionScan is what a pass over one pack saw, so a silence can be
+// told from a walk that read nothing.
+type numericAssertionScan struct {
+	files      int
+	assertions int
+	found      []numericAssertion
+}
+
+// storedNumberReads reports every numeric type assertion and numeric type-switch
+// case in a pack's non-test sources.
+//
+// Both shapes, because they fail the same way and are written differently. The
+// single assertion `v.(int)` is the defect #542 measured. The type switch is
+// how six packs wrote the correct version by hand, and admitting it would be
+// admitting the seventh copy — the one whose author forgets the float64 case,
+// which is exactly the draft testdata/provider-four shipped.
+func storedNumberReads(t *testing.T, dir string) numericAssertionScan {
+	t.Helper()
+	pack := filepath.Base(dir)
+	files, err := filepath.Glob(filepath.Join(dir, "*.go"))
+	if err != nil {
+		t.Fatalf("list %s: %v", pack, err)
+	}
+	scan := numericAssertionScan{}
+	for _, file := range files {
+		if strings.HasSuffix(file, "_test.go") {
+			// A test may assert a concrete type: it is checking what a
+			// handler produced, not reading a value back out of the store.
+			continue
+		}
+		fset := token.NewFileSet()
+		parsed, err := parser.ParseFile(fset, file, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", file, err)
+		}
+		scan.files++
+		base := filepath.Base(file)
+		record := func(node ast.Node, typ, how string) {
+			scan.found = append(scan.found, numericAssertion{
+				pack: pack, file: base, typ: typ,
+				where: fmt.Sprintf("%s/%s:%d", pack, base, fset.Position(node.Pos()).Line),
+				how:   how,
+			})
+		}
+		ast.Inspect(parsed, func(node ast.Node) bool {
+			switch n := node.(type) {
+			case *ast.TypeAssertExpr:
+				if n.Type == nil {
+					// `x.(type)`, the head of a type switch: its cases are
+					// visited below, and counting it here would report the
+					// switch twice.
+					return true
+				}
+				scan.assertions++
+				if name, ok := n.Type.(*ast.Ident); ok && numericTypes[name.Name] {
+					record(n, name.Name, "a type assertion to "+name.Name)
+				}
+			case *ast.TypeSwitchStmt:
+				for _, clause := range n.Body.List {
+					caseClause, ok := clause.(*ast.CaseClause)
+					if !ok {
+						continue
+					}
+					for _, typ := range caseClause.List {
+						name, ok := typ.(*ast.Ident)
+						if !ok || !numericTypes[name.Name] {
+							continue
+						}
+						record(typ, name.Name, "a type switch case on "+name.Name)
+					}
+				}
+			}
+			return true
+		})
+	}
+	return scan
+}
+
+// No pack reads a stored number by asserting its Go type (#542).
+func TestNoPackReadsAStoredNumberByAssertion(t *testing.T) {
+	var offences []string
+	files, assertions := 0, 0
+	// The fourth pack is in the population, and it is the member that matters:
+	// the three real packs were migrated onto the shared reader, so each of
+	// them knows what it used to do by hand. testdata/provider-four is the one
+	// that wrote the defect on its first draft with nobody watching.
+	for _, dir := range disciplinedPackDirs(t) {
+		scan := storedNumberReads(t, dir)
+		files += scan.files
+		assertions += scan.assertions
+		for _, found := range scan.found {
+			if reason := storedNumberExemptions[found.pack+"/"+found.file+":"+found.typ]; reason != "" {
+				continue
+			}
+			offences = append(offences, fmt.Sprintf("%s: %s", found.where, found.how))
+		}
+	}
+
+	// A scan that found nothing looks exactly like a repository whose packs
+	// never assert a type, and that repository does not exist: the packs assert
+	// strings, bools and slices out of Attrs on nearly every read. The floors
+	// are well under today's count — 89 files and 320 assertions on 2026-08-27
+	// — and well over zero.
+	if files < 40 || assertions < 200 {
+		t.Fatalf("the scan read %d file(s) and %d type assertion(s) across the packs: it is broken, "+
+			"and a broken scan reports a disciplined repository", files, assertions)
+	}
+
+	sort.Strings(offences)
+	if len(offences) > 0 {
+		t.Errorf("%d numeric type assertion(s) on values a pack may have read back out of a store. "+
+			"Attrs crosses encoding/json on every snapshot, so an int, an int64 and a uint32 all come "+
+			"back float64 and the assertion yields zero — measured as a restored volume shrinking with "+
+			"a 200 (#542). Read it with resource.Int, resource.Int64 or resource.Number; if this one "+
+			"genuinely never came from a store, add \"<pack>/<file>:<type>\" to storedNumberExemptions "+
+			"with the reason:\n  %s",
+			len(offences), strings.Join(offences, "\n  "))
+	}
+}
+
+// And the detector finds what it looks for, in both directions.
+//
+// The refusing half plants the two shapes that fail: the plain assertion #542
+// measured, and the hand-written type switch whose seventh copy forgets a case.
+// The accepting half is the larger one and is asserted as an exact set, because
+// a detector that also reported a string assertion, a bool assertion, a slice
+// assertion, an int conversion, an int-typed struct field or an []int literal
+// would pass every assertion above and refuse the vocabulary all four packs
+// legitimately write.
+func TestTheStoredNumberDetectorFindsWhatItLooksFor(t *testing.T) {
+	dir := t.TempDir()
+	fixture := `package p
+
+import "fmt"
+
+type box struct{ Size int }
+
+func read(m map[string]any) {
+	planted, _ := m["size"].(int)
+	alsoPlanted, _ := m["big"].(int64)
+	switch n := m["port"].(type) {
+	case float64:
+		fmt.Println(n)
+	case string:
+		fmt.Println(n)
+	}
+	name, _ := m["name"].(string)
+	flag, _ := m["on"].(bool)
+	list, _ := m["rules"].([]any)
+	converted := int(planted)
+	sizes := []int{1, 2}
+	b := box{Size: converted}
+	fmt.Println(alsoPlanted, name, flag, list, sizes, b)
+}
+`
+	if err := writeFixture(t, dir, "pack.go", fixture); err != nil {
+		t.Fatalf("write the fixture: %v", err)
+	}
+	// A _test.go neighbour, because the scan skips those on purpose and a scan
+	// that skipped everything would report a clean pack.
+	if err := writeFixture(t, dir, "pack_test.go", "package p\n\nfunc t(v any) int { n, _ := v.(int); return n }\n"); err != nil {
+		t.Fatalf("write the test fixture: %v", err)
+	}
+
+	scan := storedNumberReads(t, dir)
+	if scan.files != 1 {
+		t.Fatalf("the scan read %d file(s) of a fixture that has one non-test source: its silence "+
+			"about the rest would prove nothing", scan.files)
+	}
+	if scan.assertions < 5 {
+		t.Fatalf("the scan saw %d type assertion(s) in a fixture that writes five: it is not reading "+
+			"the file it was pointed at", scan.assertions)
+	}
+	got := map[string]bool{}
+	for _, found := range scan.found {
+		got[found.how] = true
+	}
+	planted := []string{
+		"a type assertion to int",
+		"a type assertion to int64",
+		"a type switch case on float64",
+	}
+	for _, want := range planted {
+		if !got[want] {
+			t.Errorf("the detector did not report the planted %q: a discipline test that finds "+
+				"nothing reads exactly like a disciplined repository", want)
+		}
+	}
+	expected := map[string]bool{}
+	for _, want := range planted {
+		expected[want] = true
+	}
+	for how := range got {
+		if !expected[how] {
+			t.Errorf("the detector reports %q in a fixture that plants three: a detector that "+
+				"refuses more than the numeric read breaks every pack instead of holding it", how)
+		}
+	}
+}
+
+// writeFixture drops one source into a temporary pack directory.
+func writeFixture(t *testing.T, dir, name, source string) error {
+	t.Helper()
+	return os.WriteFile(filepath.Join(dir, name), []byte(source), 0o600)
+}

--- a/internal/cli/testdata/provider-four/intents.go
+++ b/internal/cli/testdata/provider-four/intents.go
@@ -811,26 +811,23 @@ func membershipsOf(res *resource.Resource) []string {
 	return ids
 }
 
-// portOf reads back the port a spreader answers on, tolerating the float64 a
-// snapshot restore produces.
+// portOf reads back the port a spreader answers on.
 //
 // The plain `res.Attrs["port"].(int)` was what this pack wrote first, and it is
 // wrong in a way nothing here would have shown: Attrs is decoded as
 // map[string]any, so every stored number comes back a float64 and the int
 // assertion yields zero — a balancer silently listening on port 0 after a
-// `feint snapshot load`. Measured on 2026-08-27, and it is a rediscovery
-// rather than a discovery: exoscale/privatenetworks.go carries the same helper
-// with the same sentence, and two of the three real packs do not. That is the
-// #475 shape one storey down — a lesson living in one pack of three, which a
-// fourth pack has no way to inherit.
+// `feint snapshot load`. Measured on 2026-08-27, and it was a rediscovery
+// rather than a discovery: seven copies of the same tolerance existed across
+// the three real packs under six different names, and outscale/volumes.go
+// still read a size with a plain assertion three files from one of them. That
+// is the #475 shape one storey down — a lesson living in some packs and not
+// others, which a fourth pack has no way to inherit — and #542 is where it
+// stopped being a lesson: resource.Int is the reader, and internal/cli's
+// TestNoPackReadsAStoredNumberByAssertion is what refuses the assertion this
+// pack wrote first.
 func portOf(res *resource.Resource) int {
-	switch n := res.Attrs["port"].(type) {
-	case int:
-		return n
-	case float64:
-		return int(n)
-	}
-	return 0
+	return resource.Int(res, "port")
 }
 
 func backendsOf(res *resource.Resource) []string {

--- a/internal/core/machine/groupsync.go
+++ b/internal/core/machine/groupsync.go
@@ -2,6 +2,8 @@ package machine
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/stephrobert/feint/internal/core/resource"
 )
@@ -70,6 +72,130 @@ type GroupSync struct {
 	// cannot name a group at all (Scaleway), in which case the re-expansion
 	// half of AfterBoot is honestly empty rather than emptily looped.
 	Referrers func(named map[string]bool) []*resource.Resource
+
+	// EnforcesNothing declares a pack that hands no rules to the runtime at
+	// all, so its empty translation is a statement rather than an omission.
+	//
+	// The zero value is the loud one, and that is the whole design (#543). A
+	// pack that forgot to wire the four fields above and a pack that means to
+	// enforce nothing are indistinguishable from here, and the one that must
+	// not be silent is the one that forgot: it used to compile, pass every
+	// unit test and every conformance leg under `--vm off`, and then panic on
+	// the operator's first poweron under a real runtime. So enforcing is
+	// assumed and not-enforcing is declared — the GroupSync half of the
+	// sentence emulator.FirewallEnforcer already asks a pack to say out loud.
+	EnforcesNothing bool
+}
+
+// required names the fields the orchestration dereferences, in the order a
+// pack reads them off the struct.
+//
+// Referrers and ForeignBlocks are absent because they are documented optional
+// and nil-checked at their call sites: a provider whose rules cannot name a
+// group has nothing for the first, and a runtime that keeps networks apart by
+// construction has nothing for the second.
+func (s GroupSync) required() []struct {
+	name string
+	set  bool
+} {
+	return []struct {
+		name string
+		set  bool
+	}{
+		{"SpecOf", s.SpecOf != nil},
+		{"Wearers", s.Wearers != nil},
+		{"WornIDs", s.WornIDs != nil},
+		{"Group", s.Group != nil},
+	}
+}
+
+// check reports the required fields this orchestrator does not carry, naming
+// the pack and every one of them.
+//
+// It says nothing about EnforcesNothing: wired() asks that first, because a
+// pack that hands over nothing has no field to be missing, and folding the two
+// questions into one answer made the predicate impossible to falsify — a
+// mutation removing either half left the other covering for it, which is a
+// guard no test can kill.
+//
+// Why an error rather than a nil check at each call site: the four fields are
+// dereferenced from five places, two of them inside a loop, so a nil check per
+// site is five chances to miss one and a stack trace when somebody does. What
+// an operator needs is the pack and the field, in one sentence, the first time
+// the pack is asked to do anything.
+//
+// internal/cli's TestAPackThatWiredNoGroupSyncIsToldWhichFieldIsMissing fails
+// without this.
+func (s GroupSync) check() error {
+	var missing []string
+	for _, field := range s.required() {
+		if !field.set {
+			missing = append(missing, field.name)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	provider := s.Binding.Provider
+	if provider == "" {
+		provider = "an unnamed"
+	}
+	return fmt.Errorf("the %s pack builds a machine.GroupSync without %s: "+
+		"a pack that hands its groups to the runtime wires all of %s, and a pack that hands over "+
+		"nothing says so with EnforcesNothing",
+		provider, strings.Join(missing, ", "), strings.Join(fieldNames(s.required()), ", "))
+}
+
+func fieldNames(fields []struct {
+	name string
+	set  bool
+},
+) []string {
+	out := make([]string, 0, len(fields))
+	for _, field := range fields {
+		out = append(out, field.name)
+	}
+	return out
+}
+
+// wired reports whether the firewall step can run at all, and says why not
+// when it cannot.
+//
+// The order of the two questions is the correction #543 asks for, and it is
+// the whole of it. Asking `enforcer() == nil` first is what the layer used to
+// do, and it made the omission mode-dependent: under `--vm off` — the default,
+// and what every conformance leg and `mise run check` run — the firewall step
+// returned before it could touch a nil field, so a pack that had wired nothing
+// was green everywhere; under `--vm incus-ovn` the first poweron dereferenced
+// a nil func. The population that would have caught it is the one nobody runs
+// by default, which is CLAUDE.md's own rule pointing the wrong way.
+//
+// Asking check() first makes the omission report itself in both modes, at the
+// same moment, in the same words. What the runtime changes is only whether
+// there is anything to enforce afterwards.
+//
+// It degrades rather than refusing, because a machine runtime failing must
+// never break the control plane: the machine boots, its rules do not reach the
+// host, and the operator is told why. Reconciler.PlanOf is the deliberate
+// opposite — plan.go says why.
+//
+// internal/cli's TestABootUnderAnEnforcingRuntimeReportsAnUnwiredGroupSync and
+// TestAnUnwiredGroupSyncIsReportedUnderEveryRuntime fail without this.
+func (s GroupSync) wired() bool {
+	// The declaration first, and silently: a pack that says it enforces
+	// nothing has nothing missing, and reporting it would be a refusal nobody
+	// can satisfy — which is the shape somebody works around rather than
+	// answers. A pack that declares this and wires the fields anyway still
+	// enforces nothing; the declaration is the pack speaking about itself.
+	if s.EnforcesNothing {
+		return false
+	}
+	if err := s.check(); err != nil {
+		s.Binding.logger().Error("the firewall step is skipped: this pack's security groups reach no machine",
+			"provider", s.Binding.Provider, "error", err)
+		return false
+	}
+	return s.enforcer() != nil
 }
 
 // enforcer is the runtime's firewall half, nil when it has none — the
@@ -119,10 +245,10 @@ func (s GroupSync) spec(group, fresh *resource.Resource) FirewallSpec {
 // fresh, when non-nil, wins over the store's copy of the same resource, in the
 // wearer replay as in the expansion — SpecOf says why.
 func (s GroupSync) SyncGroup(ctx context.Context, group, fresh *resource.Resource) {
-	fw := s.enforcer()
-	if fw == nil {
+	if !s.wired() {
 		return
 	}
+	fw := s.enforcer()
 	if !s.Binding.SyncRuleSet(ctx, fw, s.spec(group, fresh)) {
 		return
 	}
@@ -151,6 +277,9 @@ func (s GroupSync) SyncGroup(ctx context.Context, group, fresh *resource.Resourc
 // in the log (SyncRuleSet). Two packs of three attached the remainder; the
 // conservative form is the one that cannot lie in the permissive direction.
 func (s GroupSync) ApplyMachine(ctx context.Context, res *resource.Resource) {
+	if !s.wired() {
+		return
+	}
 	s.applyMachine(ctx, res, res)
 }
 
@@ -166,6 +295,15 @@ func (s GroupSync) ApplyMachine(ctx context.Context, res *resource.Resource) {
 // TestTheWearerReplayKeepsTheFreshExpansion fails without the threading.
 func (s GroupSync) applyMachine(ctx context.Context, res, fresh *resource.Resource) {
 	fw := s.enforcer()
+	// No second wiring guard here, and that absence is deliberate rather than
+	// an oversight. Every caller — SyncGroup, ApplyMachine, AfterBoot — gates
+	// on wired() first, so a repeat would be a guard no mutation can redden:
+	// the falsification for #543 planted exactly that one and reported STILL
+	// GREEN, because the entry gate covered for it. A guard whose removal
+	// leaves every test passing is a comment. What holds a future caller
+	// instead is the entry points being the only doors, which
+	// internal/cli's TestNoPackReachesPastTheDeclaredDriverSurface already
+	// keeps closed.
 	if fw == nil {
 		return
 	}
@@ -194,10 +332,14 @@ func (s GroupSync) applyMachine(ctx context.Context, res, fresh *resource.Resour
 // writes — tier 2 accepts tier 1 and nobody else — never contains the machines
 // it talks about (#475).
 func (s GroupSync) AfterBoot(ctx context.Context, res *resource.Resource) {
-	if s.enforcer() == nil {
+	// wired() rather than `enforcer() == nil`, and that swap is #543: this
+	// line is the guard that made a missing field visible under one runtime
+	// and invisible under the other, because it returned before anything could
+	// dereference one. It now reports first and asks about the runtime second.
+	if !s.wired() {
 		return
 	}
-	s.ApplyMachine(ctx, res)
+	s.applyMachine(ctx, res, res)
 	s.SyncReferrers(ctx, s.WornIDs(res), res)
 }
 
@@ -205,7 +347,7 @@ func (s GroupSync) AfterBoot(ctx context.Context, res *resource.Resource) {
 // groups as a member source. fresh carries the resource whose addresses
 // changed, ahead of its own commit — SpecOf says why the store is not enough.
 func (s GroupSync) SyncReferrers(ctx context.Context, groupIDs []string, fresh *resource.Resource) {
-	if s.Referrers == nil || len(groupIDs) == 0 || s.enforcer() == nil {
+	if s.Referrers == nil || len(groupIDs) == 0 || !s.wired() {
 		return
 	}
 	named := make(map[string]bool, len(groupIDs))

--- a/internal/core/machine/plan.go
+++ b/internal/core/machine/plan.go
@@ -77,6 +77,37 @@ type Reconciler struct {
 
 func (r Reconciler) binding() Binding { return r.Groups.Binding }
 
+// plan asks the pack for the machine's declared interface shape, and reports
+// the pack rather than dereferencing a nil field (#543).
+//
+// PlanOf is required and has no honest empty meaning: a pack with no networks
+// at all still declares that, as `Plan{}`, in one line. So this refuses where
+// GroupSync degrades, and the asymmetry is deliberate. A missing firewall
+// translation costs the rules; a missing plan costs the boot's first two steps
+// — the promised addresses and the memberships — and a machine started without
+// them is a machine on no network that the API would describe as running. That
+// is the lie #484 named. Refusing publishes FailedState through the pack's own
+// vocabulary instead.
+//
+// Unlike GroupSync's omission this one is not mode-dependent: measured on
+// 2026-08-27, a nil PlanOf panics under machine.Noop exactly as it does under
+// an enforcing runtime, because nothing gates the call. A pack that forgets it
+// therefore fails its own first unit test, which is why the sentence matters
+// more than the timing here.
+//
+// internal/cli's TestABootWithNoDeclaredPlanIsRefusedRatherThanPanicking fails
+// without this.
+func (r Reconciler) plan(res *resource.Resource) (Plan, bool) {
+	if r.PlanOf == nil {
+		r.binding().logger().Error("this pack declares no interface plan, so nothing can be started for it",
+			"provider", r.binding().Provider, "resource", res.ID,
+			"error", "the pack builds a machine.Reconciler without PlanOf: every pack declares the "+
+				"shape of its machines' interfaces, and a pack with none declares that as an empty Plan")
+		return Plan{}, false
+	}
+	return r.PlanOf(res), true
+}
+
 // router is the runtime's routing half, nil when it has none — the assertion
 // every pack wrote for itself, now inside the layer.
 func (r Reconciler) router() Router {
@@ -89,7 +120,10 @@ func (r Reconciler) router() Router {
 // reports what PowerOn reported; a machine that did not start is not replayed
 // onto, and the state the pack publishes is the one the effect produced.
 func (r Reconciler) PowerOn(ctx context.Context, res *resource.Resource, boot Boot) bool {
-	plan := r.PlanOf(res)
+	plan, declared := r.plan(res)
+	if !declared {
+		return false
+	}
 	boot.Attachments = plan.Boot
 	boot.PublicAddresses = plan.Publics
 	if !r.binding().PowerOn(ctx, res, boot) {
@@ -160,7 +194,10 @@ func (r Reconciler) Reboot(ctx context.Context, res *resource.Resource, boot Boo
 // long after poweron returned, and the guest half of its routes can only land
 // then. Idempotent for a machine already served.
 func (r Reconciler) ReplayAddresses(ctx context.Context, res *resource.Resource) {
-	plan := r.PlanOf(res)
+	plan, declared := r.plan(res)
+	if !declared {
+		return
+	}
 	for _, address := range plan.Publics {
 		r.route(ctx, res, plan, address)
 	}
@@ -172,7 +209,11 @@ func (r Reconciler) ReplayAddresses(ctx context.Context, res *resource.Resource)
 // control plane, and the runtime carries it on at most one machine either way
 // (Binding.RouteAddress says why).
 func (r Reconciler) Route(ctx context.Context, res *resource.Resource, address string) {
-	r.route(ctx, res, r.PlanOf(res), address)
+	plan, declared := r.plan(res)
+	if !declared {
+		return
+	}
+	r.route(ctx, res, plan, address)
 }
 
 func (r Reconciler) route(ctx context.Context, res *resource.Resource, plan Plan, address string) {

--- a/internal/core/resource/attrs.go
+++ b/internal/core/resource/attrs.go
@@ -1,0 +1,129 @@
+package resource
+
+import "encoding/json"
+
+// Reading a stored value back, once, for every pack there will ever be (#542).
+//
+// Attrs is a map[string]any and the store's snapshot is JSON, so a resource
+// that has crossed store.Snapshot/store.Restore — the door `feint snapshot
+// load` and `PUT /_feint/state` both go through, and the format snapshot.go
+// documents as meant to outlive its instance — comes back decoded by
+// encoding/json. Measured on 2026-08-27, on a resource carrying one attribute
+// of each type a pack writes:
+//
+//	anInt   int     -> float64      aBoolTrue  bool   -> bool
+//	anInt64 int64   -> float64      aString    string -> string
+//	aUint32 uint32  -> float64      aMap[n]    int    -> float64
+//
+// So a `.(int)` assertion on a restored number yields ok=false and 0, while
+// `.(string)` and `.(bool)` are unaffected — which is why the readers below
+// cover numbers and nothing else, and why internal/cli's
+// TestNoPackReadsAStoredNumberByAssertion refuses a numeric assertion in a
+// pack and leaves the other two alone. A reader that repaired nothing would be
+// churn at every call site it reached.
+//
+// It lives here rather than in a pack because seven packs' worth of code had
+// already discovered it separately — exoscale's intOf and int64Of, exoscale's
+// and outscale's numOf, scaleway's positionOf and portValue, and the fake
+// fourth pack's portOf, each with its own name and its own sentence — and
+// outscale's own volumes.go still read a size with a plain assertion three
+// files away from a tolerant helper of the same pack. That is CLAUDE.md's
+// factorisation rule measured: written seven times, the eighth author writes
+// it wrong, and nothing carries the lesson to a pack that does not exist yet.
+//
+// No provider name enters any of this: a number that crossed JSON is a shape,
+// not a vocabulary (rule 5).
+
+// Number reads a stored number back as a float64, whatever Go type it was
+// written as and whichever side of a snapshot it is being read on.
+//
+// The value form, for a number that is not a direct attribute of a resource:
+// one inside a nested map a pack stored (a listener's port, a device mapping's
+// size), or one a caller already holds. Int and Int64 are the resource form.
+//
+// json.Number is accepted because a decoder configured with UseNumber produces
+// one — the proxy and the transcript readers are configured that way — and
+// because outscale's numOf accepted it before this file existed. The store's
+// own Restore does not produce one; it produces float64.
+//
+// Anything that is not a number reads 0, which is the same answer the comma-ok
+// assertions this replaces gave, and the same answer an absent key gives.
+func Number(v any) float64 {
+	switch n := v.(type) {
+	case float64:
+		return n
+	case float32:
+		return float64(n)
+	case int:
+		return float64(n)
+	case int8:
+		return float64(n)
+	case int16:
+		return float64(n)
+	case int32:
+		return float64(n)
+	case int64:
+		return float64(n)
+	case uint:
+		return float64(n)
+	case uint8:
+		return float64(n)
+	case uint16:
+		return float64(n)
+	case uint32:
+		return float64(n)
+	case uint64:
+		return float64(n)
+	case json.Number:
+		f, err := n.Float64()
+		if err != nil {
+			return 0
+		}
+		return f
+	}
+	return 0
+}
+
+// Int reads res.Attrs[key] back as an int.
+//
+// A nil resource, an absent key and a value that is not a number all read 0,
+// so a caller that wants to tell "absent" from "zero" asks Attrs itself — the
+// same distinction the comma-ok form offered, kept available rather than
+// hidden behind a reader that answers one thing.
+//
+// Exact for every magnitude these APIs name: float64 carries integers to 2^53,
+// and a volume size, a port or a VXLAN identifier is nowhere near it. A value
+// beyond that has already lost its precision in the snapshot, before any
+// reader sees it.
+func Int(res *Resource, key string) int {
+	return int(attr(res, key))
+}
+
+// Int64 is Int for the packs whose upstream field is a 64-bit integer — a
+// block volume's size in bytes, a pool's disk size. Same limits as Int.
+func Int64(res *Resource, key string) int64 {
+	return int64(attr(res, key))
+}
+
+// Uint64 is Int for the packs whose upstream field is unsigned — Scaleway
+// spells a volume size and a snapshot size uint64.
+//
+// A stored value below zero reads 0 rather than wrapping. It cannot arrive
+// from any handler of this emulator, and that is exactly why it is guarded: a
+// snapshot is designed to be loaded into another instance, so what comes back
+// through Restore is untrusted input and a negative number converted to uint64
+// is 18 million million million bytes of volume.
+func Uint64(res *Resource, key string) uint64 {
+	n := attr(res, key)
+	if !(n >= 0) { // false for NaN too, which is why it is written this way
+		return 0
+	}
+	return uint64(n)
+}
+
+func attr(res *Resource, key string) float64 {
+	if res == nil {
+		return 0
+	}
+	return Number(res.Attrs[key])
+}

--- a/internal/core/store/attrs_roundtrip_test.go
+++ b/internal/core/store/attrs_roundtrip_test.go
@@ -1,0 +1,171 @@
+package store_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/resource"
+	"github.com/stephrobert/feint/internal/core/store"
+)
+
+// What a snapshot does to every Go type a pack writes into Attrs (#542).
+//
+// This is the measurement two other controls are drawn from, and it exists so
+// that neither of them rests on a recollection. resource.Int and its
+// neighbours tolerate the numbers; internal/cli's
+// TestNoPackReadsAStoredNumberByAssertion refuses a numeric assertion in a
+// pack and deliberately leaves `.(string)` and `.(bool)` alone. That boundary
+// is only honest if strings and bools really do cross unchanged, and "JSON
+// round-trips a bool as a bool" was written in #542 as a supposition, marked
+// not established.
+//
+// It is established here. The door is the real one: store.Snapshot then
+// store.Restore, which is what `feint snapshot load` and `PUT /_feint/state`
+// perform, and the format snapshot.go documents as meant to outlive its
+// instance.
+func TestEveryGoTypeAPackWritesCrossesTheSnapshotAsMeasured(t *testing.T) {
+	st := store.New()
+	res := resource.New("r-1", "thing", resource.Tenant{Provider: "p"}, "ready", time.Unix(0, 0).UTC())
+	res.Attrs = map[string]any{
+		"anInt":      40,
+		"anInt64":    int64(40),
+		"aUint32":    uint32(40),
+		"aUint64":    uint64(40),
+		"anInt32":    int32(40),
+		"aFloat64":   40.5,
+		"aTrue":      true,
+		"aFalse":     false,
+		"aString":    "forty",
+		"nested":     map[string]any{"n": 7, "flag": true, "name": "seven"},
+		"collection": []any{1, "two", false},
+	}
+	st.Put(res)
+
+	var saved bytes.Buffer
+	if err := st.Snapshot(&saved); err != nil {
+		t.Fatalf("take the snapshot: %v", err)
+	}
+	// Into a fresh store, which is the case the format is designed for.
+	next := store.New()
+	if err := next.Restore(bytes.NewReader(saved.Bytes())); err != nil {
+		t.Fatalf("restore it: %v", err)
+	}
+	back, found := next.Get("p", "thing", "r-1")
+	if !found {
+		t.Fatal("the restored store lost the resource: nothing below measures anything")
+	}
+
+	// Every number, whatever it was written as, comes back a float64 — so a
+	// single-type assertion on any of them yields ok=false and zero.
+	for _, key := range []string{"anInt", "anInt64", "aUint32", "aUint64", "anInt32", "aFloat64"} {
+		if _, isFloat := back.Attrs[key].(float64); !isFloat {
+			t.Errorf("%s came back %T, not float64: the readers of resource/attrs.go are built on "+
+				"this and the discipline test's boundary is drawn from it", key, back.Attrs[key])
+		}
+	}
+	// Which is the defect, stated as the assertion a pack used to write.
+	if n, ok := back.Attrs["anInt"].(int); ok || n != 0 {
+		t.Errorf("the int assertion on a restored int yielded (%v, %v), want (0, false): #542 has "+
+			"no subject if this holds", n, ok)
+	}
+	// And the readers answer it anyway, which is the accepting half.
+	for _, key := range []string{"anInt", "anInt64", "aUint32", "aUint64", "anInt32"} {
+		if got := resource.Int(back, key); got != 40 {
+			t.Errorf("resource.Int(restored, %s) = %d, want 40", key, got)
+		}
+	}
+	if got := resource.Uint64(back, "aUint64"); got != 40 {
+		t.Errorf("resource.Uint64(restored, aUint64) = %d, want 40", got)
+	}
+	if got := resource.Int64(back, "anInt64"); got != 40 {
+		t.Errorf("resource.Int64(restored, anInt64) = %d, want 40", got)
+	}
+
+	// Strings and bools cross unchanged. This is the half that keeps the
+	// discipline test from refusing correct code, and it was the open question
+	// #542 recorded rather than measured.
+	if s, ok := back.Attrs["aString"].(string); !ok || s != "forty" {
+		t.Errorf("a stored string came back (%v, %v): the string assertions in every pack rest on this", s, ok)
+	}
+	for key, want := range map[string]bool{"aTrue": true, "aFalse": false} {
+		got, ok := back.Attrs[key].(bool)
+		if !ok || got != want {
+			t.Errorf("%s came back (%v, %v), want (%v, true): a bool assertion on Attrs is only "+
+				"correct because of this", key, got, ok, want)
+		}
+	}
+
+	// A number nested inside a stored map is converted too, which is the shape
+	// no grep for `Attrs[…].(int)` can see: the assertion is written against
+	// the inner map, one hop from the attribute.
+	nested, ok := back.Attrs["nested"].(map[string]any)
+	if !ok {
+		t.Fatalf("a stored map came back %T", back.Attrs["nested"])
+	}
+	if _, isFloat := nested["n"].(float64); !isFloat {
+		t.Errorf("a number nested in a stored map came back %T, not float64: resource.Number is "+
+			"the value form precisely for this", nested["n"])
+	}
+	if flag, ok := nested["flag"].(bool); !ok || !flag {
+		t.Errorf("a bool nested in a stored map came back (%v, %v)", flag, ok)
+	}
+	if name, ok := nested["name"].(string); !ok || name != "seven" {
+		t.Errorf("a string nested in a stored map came back (%v, %v)", name, ok)
+	}
+}
+
+// resource.Number answers the same value whatever width the pack wrote, and
+// answers zero rather than guessing for anything that is not a number.
+//
+// Table-driven and here rather than in internal/core/resource because what it
+// is really pinning is the set of shapes the snapshot above produces; a reader
+// tested only against the types its author remembered is the seventh
+// hand-written copy with a different name.
+func TestTheStoredNumberReaderCoversEveryWidthAndRefusesTheRest(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value any
+		want  float64
+	}{
+		{"int", 40, 40},
+		{"int8", int8(40), 40},
+		{"int16", int16(40), 40},
+		{"int32", int32(40), 40},
+		{"int64", int64(40), 40},
+		{"uint", uint(40), 40},
+		{"uint8", uint8(40), 40},
+		{"uint16", uint16(40), 40},
+		{"uint32", uint32(40), 40},
+		{"uint64", uint64(40), 40},
+		{"float32", float32(40), 40},
+		{"float64", float64(40), 40},
+		{"the float64 a restore produces", any(float64(40)), 40},
+		{"a string that looks like one", "40", 0},
+		{"a bool", true, 0},
+		{"nil", nil, 0},
+		{"a map", map[string]any{}, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resource.Number(tc.value); got != tc.want {
+				t.Errorf("resource.Number(%#v) = %v, want %v", tc.value, got, tc.want)
+			}
+		})
+	}
+
+	// A negative number never reaches an unsigned field: a snapshot is designed
+	// to be loaded into another instance, so what comes back through Restore is
+	// untrusted input, and uint64(-1) is a volume of eighteen exabytes.
+	res := &resource.Resource{Attrs: map[string]any{"size": float64(-1)}}
+	if got := resource.Uint64(res, "size"); got != 0 {
+		t.Errorf("resource.Uint64 on a stored -1 answered %d, want 0", got)
+	}
+	// And an absent key, and a nil resource, answer zero rather than panicking:
+	// every caller replaced a comma-ok assertion that did the same.
+	if got := resource.Int(res, "absent"); got != 0 {
+		t.Errorf("resource.Int on an absent key answered %d, want 0", got)
+	}
+	if got := resource.Int(nil, "size"); got != 0 {
+		t.Errorf("resource.Int on a nil resource answered %d, want 0", got)
+	}
+}

--- a/internal/providers/exoscale/block.go
+++ b/internal/providers/exoscale/block.go
@@ -217,7 +217,7 @@ func (p *Pack) createBlockVolume(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusNotFound, "resource not found")
 			return
 		}
-		size = int64Of(snapshot.Attrs["size"])
+		size = resource.Int64(snapshot, "size")
 	}
 	// A volume of no size is not a volume, and the refusal belongs at the door:
 	// a client that forgot the field gets told, rather than receiving a record
@@ -238,30 +238,6 @@ func (p *Pack) createBlockVolume(w http.ResponseWriter, r *http.Request) {
 	}
 	p.env.Store.Put(res)
 	p.writeOperation(w, p.operationReferring(nounBlockVolume, res.ID))
-}
-
-// int64Of reads a stored size back whatever shape it comes in.
-//
-// Not a convenience: a size written as int64 comes back as float64 after
-// `PUT /_feint/state`, because a snapshot round-trips the store through JSON.
-// A type assertion on int64 alone would quietly answer zero on a restored
-// store, and the two readers of this value are the shrink refusal and the size a
-// snapshot inherits — so a restored emulator would accept a shrink and hand out
-// zero-sized snapshots, with nothing red anywhere. That is the "a restored state
-// is untrusted input" rule of CLAUDE.md, met at the point where the value is
-// read rather than hoped away.
-//
-// TestABlockVolumeSurvivesASnapshotRestore fails without this.
-func int64Of(v any) int64 {
-	switch n := v.(type) {
-	case int64:
-		return n
-	case int:
-		return int64(n)
-	case float64:
-		return int64(n)
-	}
-	return 0
 }
 
 // labelsOrEmpty keeps a declared map present. A nil map marshals to null, and a
@@ -369,7 +345,12 @@ func (p *Pack) resizeBlockVolume(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "resource not found")
 		return
 	}
-	if current := int64Of(res.Attrs["size"]); *req.Size < current {
+	// Through the shared reader, which is where the tolerance this pack used to
+	// carry as int64Of now lives (#542): a size written as int64 comes back a
+	// float64 after `PUT /_feint/state`, and an assertion on int64 alone would
+	// answer zero on a restored store — so the refusal below would never fire.
+	// TestABlockVolumeSurvivesASnapshotRestore fails without this.
+	if current := resource.Int64(res, "size"); *req.Size < current {
 		writeError(w, http.StatusBadRequest, "a volume cannot be shrunk")
 		return
 	}
@@ -555,7 +536,7 @@ func (p *Pack) createBlockSnapshot(w http.ResponseWriter, r *http.Request) {
 	now := p.env.Now()
 	res := resource.New(p.env.NewID(), kindBlockSnapshot, resource.Tenant{Provider: Name}, blockSnapshotCreated, now)
 	volumeName, _ := volume.Attrs["name"].(string)
-	size := int64Of(volume.Attrs["size"])
+	size := resource.Int64(volume, "size")
 	res.Attrs = map[string]any{
 		"name": orSnapshotName(req.Name, volumeName, now),
 		// size is what the snapshot occupies, volume-size what it restores to.

--- a/internal/providers/exoscale/firewall.go
+++ b/internal/providers/exoscale/firewall.go
@@ -109,10 +109,10 @@ func (p *Pack) firewallRulesOf(rule map[string]any, fresh *resource.Resource) []
 		Action:    "allow",
 		Protocol:  strings.ToLower(stringAttr(rule["protocol"])),
 	}
-	if from := int(numOf(rule["start-port"])); from > 0 {
+	if from := int(resource.Number(rule["start-port"])); from > 0 {
 		base.PortFrom = from
 	}
-	if to := int(numOf(rule["end-port"])); to > 0 {
+	if to := int(resource.Number(rule["end-port"])); to > 0 {
 		base.PortTo = to
 	}
 
@@ -145,21 +145,6 @@ func (p *Pack) firewallRulesOf(rule map[string]any, fresh *resource.Resource) []
 		out = append(out, converted)
 	}
 	return out
-}
-
-// numOf reads a number that may be an int fresh from a handler or a float64
-// restored from a JSON snapshot.
-func numOf(v any) float64 {
-	switch n := v.(type) {
-	case int:
-		return float64(n)
-	case int64:
-		return float64(n)
-	case float64:
-		return n
-	default:
-		return 0
-	}
 }
 
 func stringAttr(v any) string {

--- a/internal/providers/exoscale/loadbalancers.go
+++ b/internal/providers/exoscale/loadbalancers.go
@@ -649,7 +649,7 @@ func (p *Pack) updateLoadBalancerService(w http.ResponseWriter, r *http.Request)
 			// Replaced whole rather than merged, which is what their update
 			// schema describes: `healthcheck` is one property, and a client
 			// sending it sends the block it wants to hold.
-			stored.Attrs["healthcheck"] = healthcheckOrDefault(req.Healthcheck, int64Of(stored.Attrs["target-port"]))
+			stored.Attrs["healthcheck"] = healthcheckOrDefault(req.Healthcheck, resource.Int64(stored, "target-port"))
 		}
 		return nil
 	})

--- a/internal/providers/exoscale/pools.go
+++ b/internal/providers/exoscale/pools.go
@@ -375,7 +375,7 @@ func (p *Pack) newPoolMember(pool *resource.Resource, index int64) *resource.Res
 
 	member.Attrs = map[string]any{
 		"name":      prefix + "-" + strconv.FormatInt(index+1, 10),
-		"disk-size": int64Of(pool.Attrs["disk-size"]),
+		"disk-size": resource.Int64(pool, "disk-size"),
 		"user-data": pool.Attrs["user-data"],
 		"labels":    pool.Attrs["labels"],
 		// The relation upstream publishes on the instance itself: a client
@@ -695,7 +695,7 @@ func (p *Pack) evictInstancePoolMembers(w http.ResponseWriter, r *http.Request) 
 	// An evict lowers the pool's declared size, which is upstream's behaviour:
 	// the pool does not replace what a client explicitly removed.
 	_ = p.env.Store.Update(Name, kindPool, id, func(stored *resource.Resource) error {
-		stored.Attrs["size"] = int64Of(stored.Attrs["size"]) - int64(len(evicting))
+		stored.Attrs["size"] = resource.Int64(stored, "size") - int64(len(evicting))
 		return nil
 	})
 	unlock()

--- a/internal/providers/exoscale/privatenetworks.go
+++ b/internal/providers/exoscale/privatenetworks.go
@@ -259,25 +259,13 @@ func (p *Pack) createPrivateNetwork(w http.ResponseWriter, r *http.Request) {
 func (p *Pack) freeVNI() int {
 	used := map[int]bool{}
 	for _, res := range p.env.Store.List(kindPrivateNetwork, resource.Tenant{Provider: Name}) {
-		used[intOf(res.Attrs["vni"])] = true
+		used[resource.Int(res, "vni")] = true
 	}
 	for vni := 1; ; vni++ {
 		if !used[vni] {
 			return vni
 		}
 	}
-}
-
-// intOf reads a stored integer back, tolerating the float64 a snapshot restore
-// produces.
-func intOf(v any) int {
-	switch n := v.(type) {
-	case int:
-		return n
-	case float64:
-		return int(n)
-	}
-	return 0
 }
 
 func stringOf(v *string) string {

--- a/internal/providers/outscale/firewall.go
+++ b/internal/providers/outscale/firewall.go
@@ -83,10 +83,10 @@ func (p *Pack) firewallRulesOf(group *resource.Resource, side, direction string,
 			Action:    "allow",
 			Protocol:  protocolOf(rule["IpProtocol"]),
 		}
-		if from := int(numOf(rule["FromPortRange"])); from > 0 {
+		if from := int(resource.Number(rule["FromPortRange"])); from > 0 {
 			base.PortFrom = from
 		}
-		if to := int(numOf(rule["ToPortRange"])); to > 0 {
+		if to := int(resource.Number(rule["ToPortRange"])); to > 0 {
 			base.PortTo = to
 		}
 

--- a/internal/providers/outscale/images.go
+++ b/internal/providers/outscale/images.go
@@ -91,7 +91,7 @@ func (p *Pack) createImage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		size := snapshotSize(snapshot)
-		if asked := int(numOf(bsu["VolumeSize"])); asked > 0 {
+		if asked := int(resource.Number(bsu["VolumeSize"])); asked > 0 {
 			size = asked
 		}
 		// Iops is refused rather than stored, and the reason is a measurement
@@ -121,7 +121,7 @@ func (p *Pack) createImage(w http.ResponseWriter, r *http.Request) {
 		// so the decline is true for both kinds and cannot rot into fiction.
 		//
 		// TestCreateImageRefusesAnIopsItCannotHonour fails without this.
-		if numOf(bsu["Iops"]) > 0 {
+		if resource.Number(bsu["Iops"]) > 0 {
 			p.badRequest(w, "Iops names a provisioned-IOPS volume, and an image's root device is "+
 				defaultVolumeType+" here: this emulator models no provisioned-IOPS storage")
 			return

--- a/internal/providers/outscale/listeners.go
+++ b/internal/providers/outscale/listeners.go
@@ -120,7 +120,7 @@ func listenerPorts(res *resource.Resource) []int {
 	ports := make([]int, 0, len(listeners))
 	for _, raw := range listeners {
 		listener, _ := raw.(map[string]any)
-		ports = append(ports, int(numOf(listener["LoadBalancerPort"])))
+		ports = append(ports, int(resource.Number(listener["LoadBalancerPort"])))
 	}
 	return ports
 }
@@ -212,7 +212,7 @@ func (p *Pack) deleteLoadBalancerListeners(w http.ResponseWriter, r *http.Reques
 		kept := make([]any, 0, len(listeners))
 		for _, raw := range listeners {
 			listener, _ := raw.(map[string]any)
-			if slices.Contains(req.LoadBalancerPorts, int(numOf(listener["LoadBalancerPort"]))) {
+			if slices.Contains(req.LoadBalancerPorts, int(resource.Number(listener["LoadBalancerPort"]))) {
 				continue
 			}
 			kept = append(kept, raw)

--- a/internal/providers/outscale/loadbalancer_dataplane.go
+++ b/internal/providers/outscale/loadbalancer_dataplane.go
@@ -204,8 +204,8 @@ func (p *Pack) balancerSpecOf(res *resource.Resource) (machine.BalancerSpec, boo
 		// numOf, because a listener that has crossed a snapshot carries
 		// json.Number where the handler stored an int — the same reason
 		// stringsOf exists beside it.
-		front := int(numOf(listener["LoadBalancerPort"]))
-		back := int(numOf(listener["BackendPort"]))
+		front := int(resource.Number(listener["LoadBalancerPort"]))
+		back := int(resource.Number(listener["BackendPort"]))
 		if front == 0 {
 			continue
 		}

--- a/internal/providers/outscale/nics.go
+++ b/internal/providers/outscale/nics.go
@@ -252,7 +252,7 @@ func (p *Pack) storedNicView(nic *resource.Resource) map[string]any {
 		flag, _ := nic.Attrs["DeleteOnVmDeletion"].(bool)
 		out["LinkNic"] = map[string]any{
 			"DeleteOnVmDeletion": flag,
-			"DeviceNumber":       numOf(nic.Attrs["DeviceNumber"]),
+			"DeviceNumber":       resource.Number(nic.Attrs["DeviceNumber"]),
 			"LinkNicId":          stringOf(nic.Attrs["LinkNicId"]),
 			"State":              "attached",
 			"VmAccountId":        accountID,
@@ -389,7 +389,7 @@ func (p *Pack) linkNic(w http.ResponseWriter, r *http.Request) {
 	// The device number is exclusive per Vm, primary included.
 	for _, other := range p.env.Store.List(kindNic, resource.Tenant{Provider: Name}) {
 		if stringOf(other.Attrs["LinkVmId"]) == req.VMID &&
-			int(numOf(other.Attrs["DeviceNumber"])) == *req.DeviceNumber {
+			int(resource.Number(other.Attrs["DeviceNumber"])) == *req.DeviceNumber {
 			p.conflict(w, "device number "+strconv.Itoa(*req.DeviceNumber)+" is already used on "+req.VMID)
 			return
 		}

--- a/internal/providers/outscale/securitygroups.go
+++ b/internal/providers/outscale/securitygroups.go
@@ -1,7 +1,6 @@
 package outscale
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -581,7 +580,7 @@ func sameRule(a, b any) bool {
 		return false
 	}
 	for _, key := range []string{"FromPortRange", "ToPortRange"} {
-		if numOf(am[key]) != numOf(bm[key]) {
+		if resource.Number(am[key]) != resource.Number(bm[key]) {
 			return false
 		}
 	}
@@ -601,22 +600,6 @@ func membersOf(rule map[string]any) string {
 	}
 	sort.Strings(ids)
 	return strings.Join(ids, ",")
-}
-
-// numOf reads a number that may have crossed JSON (float64), a snapshot
-// (json.Number) or the pack's own literals (int).
-func numOf(v any) float64 {
-	switch n := v.(type) {
-	case int:
-		return float64(n)
-	case float64:
-		return n
-	case json.Number:
-		f, _ := n.Float64()
-		return f
-	default:
-		return 0
-	}
 }
 
 // securityGroupByRef resolves a group by id first, then by name — the two ways

--- a/internal/providers/outscale/snapshots.go
+++ b/internal/providers/outscale/snapshots.go
@@ -57,7 +57,13 @@ func (p *Pack) createSnapshot(w http.ResponseWriter, r *http.Request) {
 		p.notFound(w, "volume", req.VolumeID)
 		return
 	}
-	size, _ := volume.Attrs["Size"].(int)
+	// Through the shared reader: the plain `.(int)` this used to be yielded 0
+	// on a volume that had crossed a snapshot, so a snapshot taken after a
+	// `feint snapshot load` recorded VolumeSize 0 for a 40 GiB volume — and
+	// every volume later created from that snapshot inherits the zero (#542,
+	// measured 2026-08-27).
+	// TestASnapshotOfARestoredVolumeInheritsItsSize fails without this.
+	size := resource.Int(volume, "Size")
 
 	now := p.env.Now()
 	res := resource.New(newID("snap", p.env.NewID()), kindSnapshot, resource.Tenant{Provider: Name}, "completed", now)
@@ -195,4 +201,4 @@ func (p *Pack) findSnapshot(id string) (map[string]any, bool) {
 // snapshotSize is a snapshot's VolumeSize, whatever numeric type it was stored
 // as. The catalogue holds ints and a client's snapshot copies the volume's, so
 // reading it with a single type assertion returned zero for one of the two.
-func snapshotSize(view map[string]any) int { return int(numOf(view["VolumeSize"])) }
+func snapshotSize(view map[string]any) int { return int(resource.Number(view["VolumeSize"])) }

--- a/internal/providers/outscale/vms.go
+++ b/internal/providers/outscale/vms.go
@@ -1168,7 +1168,7 @@ func (p *Pack) rootDeviceOf(imageID string) rootDevice {
 			continue
 		}
 		device.snapshotID = stringOf(bsu["SnapshotId"])
-		device.size = int(numOf(bsu["VolumeSize"]))
+		device.size = int(resource.Number(bsu["VolumeSize"]))
 		device.volumeType = orDefault(stringOf(bsu["VolumeType"]), defaultVolumeType)
 		return device
 	}
@@ -1198,7 +1198,7 @@ func (p *Pack) rootDeviceOfCatalogue(image map[string]any) rootDevice {
 	for _, raw := range mappings {
 		mapping, _ := raw.(map[string]any)
 		if bsu, ok := mapping["Bsu"].(map[string]any); ok {
-			return rootDevice{size: int(numOf(bsu["VolumeSize"]))}
+			return rootDevice{size: int(resource.Number(bsu["VolumeSize"]))}
 		}
 	}
 	return rootDevice{}

--- a/internal/providers/outscale/volumes.go
+++ b/internal/providers/outscale/volumes.go
@@ -174,7 +174,13 @@ func (p *Pack) updateVolume(w http.ResponseWriter, r *http.Request) {
 	var updated *resource.Resource
 	err := p.env.Store.Update(Name, kindVolume, req.VolumeID, func(stored *resource.Resource) error {
 		if req.Size > 0 {
-			current, _ := stored.Attrs["Size"].(int)
+			// Through the shared reader, because a size that has crossed a
+			// snapshot comes back a float64 and the plain `.(int)` this used
+			// to be yielded 0 — so `req.Size < current` was never true and a
+			// restored volume shrank from 40 to 1 with a 200 (#542, measured
+			// 2026-08-27). TestARestoredVolumeStillRefusesToShrink fails
+			// without this.
+			current := resource.Int(stored, "Size")
 			if req.Size < current {
 				return errVolumeShrinks
 			}
@@ -332,9 +338,24 @@ func volumeMatches(res *resource.Resource, f filterSet) bool {
 	if linkedVM != "" {
 		linkState = "attached"
 	}
+	// Through the shared reader for the same reason as the shrink refusal
+	// above, and with one honest difference: no test can redden this line
+	// today, because nothing reaches it. #542 said a restored volume "publishes
+	// no size at all" and the measurement disproved that twice over —
+	// volumeView copies Attrs verbatim, so the read publishes 40 either way,
+	// and the VolumeSizes filter is declared by the API as an array of
+	// integers, which filterSet.strings cannot decode: it reports the decode
+	// failure as "filter absent" and matchesAny then passes everything. So the
+	// comparison below has never discriminated, before or after a restore, for
+	// any client. That is a defect of its own and a wider one — Progresses is
+	// the second numeric filter this pack claims — and it is deliberately not
+	// fixed here: changing which volumes a filter answers is client-visible
+	// surface and belongs to a measurement of its own. This line is corrected
+	// so it is right on the day that one lands, and this comment is here so
+	// nobody reads its silence as proof.
 	size := ""
-	if n, ok := res.Attrs["Size"].(int); ok {
-		size = strconv.Itoa(n)
+	if _, present := res.Attrs["Size"]; present {
+		size = strconv.Itoa(resource.Int(res, "Size"))
 	}
 	// Read from the volume, not written here as false. It became a per-volume
 	// fact when a Vm's root device arrived (#378): a machine's root volume dies

--- a/internal/providers/outscale/volumes_restore_test.go
+++ b/internal/providers/outscale/volumes_restore_test.go
@@ -1,0 +1,136 @@
+package outscale_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/store"
+	"github.com/stephrobert/feint/internal/providers/outscale"
+)
+
+// A volume's size survives the door a snapshot really travels through (#542).
+//
+// Measured on 2026-08-27, before the fix, against this pack over a restored
+// store:
+//
+//	Attrs[Size] is float64 = 40; the int assertion yields 0
+//	shrink 40 -> 1 after a restore: status 200, Size now 1
+//	CreateSnapshot of a restored volume records VolumeSize=0
+//
+// Attrs is a map[string]any and store.Restore decodes the snapshot with
+// encoding/json, so the `Attrs["Size"].(int)` these two handlers used to write
+// answered zero — and a comparison against zero is a refusal that never fires.
+// Nothing in the tree was red: no unit test and no conformance suite restores a
+// snapshot and then reads a size back, which is why this file exists rather
+// than only the one-line fix.
+//
+// The restore goes into a *fresh* store behind a *second* emulator, because
+// that is the case the format is designed for: snapshot.go documents it as
+// meant to outlive its instance and be loaded into another one.
+func revivedOutscale(t *testing.T, size string) (*httptest.Server, string, *store.Store) {
+	t.Helper()
+	env := emulator.DefaultEnv()
+	srv, err := emulator.NewServer(env, outscale.New(env))
+	if err != nil {
+		t.Fatalf("mount the outscale pack: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	_, created := post(t, ts, "CreateVolume", `{"SubregionName":"eu-west-2a","Size":`+size+`}`)
+	volume, _ := created["Volume"].(map[string]any)
+	volumeID, _ := volume["VolumeId"].(string)
+	if volumeID == "" {
+		t.Fatalf("CreateVolume answered no VolumeId: %v", created)
+	}
+
+	var saved bytes.Buffer
+	if err := env.Store.Snapshot(&saved); err != nil {
+		t.Fatalf("take the snapshot: %v", err)
+	}
+	restored := store.New()
+	if err := restored.Restore(bytes.NewReader(saved.Bytes())); err != nil {
+		t.Fatalf("restore it: %v", err)
+	}
+
+	next := emulator.DefaultEnv()
+	next.Store = restored
+	revived, err := emulator.NewServer(next, outscale.New(next))
+	if err != nil {
+		t.Fatalf("mount the revived emulator: %v", err)
+	}
+	after := httptest.NewServer(revived.Handler())
+	t.Cleanup(after.Close)
+
+	// The precondition, asserted rather than assumed: the volume is still there
+	// and the store really did convert its size. Without this, a test that
+	// passes because the restore lost the record would read as the fix working.
+	stored, found := restored.Get(outscale.Name, "volume", volumeID)
+	if !found {
+		t.Fatalf("the restored store lost the volume: nothing below measures anything")
+	}
+	if _, isFloat := stored.Attrs["Size"].(float64); !isFloat {
+		t.Fatalf("the restored size is %T, not the float64 the JSON decoding produces: this test "+
+			"is not reproducing the case it names", stored.Attrs["Size"])
+	}
+	return after, volumeID, restored
+}
+
+// A restored volume still refuses to shrink.
+func TestARestoredVolumeStillRefusesToShrink(t *testing.T) {
+	ts, volumeID, _ := revivedOutscale(t, "40")
+
+	status, out := post(t, ts, "UpdateVolume", `{"VolumeId":"`+volumeID+`","Size":1}`)
+	if status == http.StatusOK {
+		volume, _ := out["Volume"].(map[string]any)
+		t.Errorf("a restored volume shrank from 40 to %v with a %d: the size it compares against "+
+			"was read as zero, so the refusal the API states is gone", volume["Size"], status)
+	}
+
+	// The accepting half, without which a handler that refused every update
+	// would pass the assertion above and break the product.
+	status, out = post(t, ts, "UpdateVolume", `{"VolumeId":"`+volumeID+`","Size":80}`)
+	if status != http.StatusOK {
+		t.Fatalf("a restored volume refused to grow to 80: status %d, %v", status, out)
+	}
+	volume, _ := out["Volume"].(map[string]any)
+	if size, _ := volume["Size"].(float64); size != 80 {
+		t.Errorf("the grown volume answers Size %v, want 80", volume["Size"])
+	}
+}
+
+// A snapshot of a restored volume inherits its size.
+func TestASnapshotOfARestoredVolumeInheritsItsSize(t *testing.T) {
+	ts, volumeID, _ := revivedOutscale(t, "40")
+
+	_, out := post(t, ts, "CreateSnapshot", `{"VolumeId":"`+volumeID+`"}`)
+	snapshot, _ := out["Snapshot"].(map[string]any)
+	if size, _ := snapshot["VolumeSize"].(float64); size != 40 {
+		t.Errorf("a snapshot taken of a restored volume records VolumeSize %v, want 40: every volume "+
+			"later created from that snapshot inherits the zero", snapshot["VolumeSize"])
+	}
+
+	// And the read itself, which is the half #542 got wrong and this records:
+	// the size was never missing from a read. volumeView copies Attrs verbatim,
+	// so a float64 40 marshals as 40 and every client saw the right number all
+	// along. What was broken was the two handlers that compared it.
+	_, listed := post(t, ts, "ReadVolumes", `{}`)
+	volumes, _ := listed["Volumes"].([]any)
+	found := false
+	for _, raw := range volumes {
+		volume, _ := raw.(map[string]any)
+		if volume["VolumeId"] != volumeID {
+			continue
+		}
+		found = true
+		if size, _ := volume["Size"].(float64); size != 40 {
+			t.Errorf("the restored volume reads back Size %v, want 40", volume["Size"])
+		}
+	}
+	if !found {
+		t.Errorf("ReadVolumes did not answer the restored volume at all: %v", listed)
+	}
+}

--- a/internal/providers/scaleway/block.go
+++ b/internal/providers/scaleway/block.go
@@ -146,7 +146,12 @@ func (p *Pack) createBlockVolume(w http.ResponseWriter, r *http.Request) {
 		parent = snapshot.ID
 		// The snapshot's size unless a resize was asked for, which is what the
 		// SDK says the optional size on this branch is for.
-		size, _ = snapshot.Attrs["size"].(uint64)
+		// Through the shared reader: a size written as a uint64 comes back a
+		// float64 once the store has crossed a snapshot, so the assertion this
+		// replaces answered 0 and a volume restored from a snapshot was created
+		// with no size at all (#542).
+		// TestASnapshotChainTakenAfterARestoreKeepsItsSize fails without this.
+		size = resource.Uint64(snapshot, "size")
 		if req.FromSnapshot.Size != nil && *req.FromSnapshot.Size > 0 {
 			// Larger only. A restore into something smaller than the snapshot is
 			// a volume the data cannot fit in, and answering 201 to it is the
@@ -418,7 +423,16 @@ func (p *Pack) updateBlockVolume(w http.ResponseWriter, r *http.Request) {
 	// to another field of the same volume after its 200 (#295).
 	var updated *resource.Resource
 	err := p.env.Store.Update(Name, kindBlockVolume, res.ID, func(stored *resource.Resource) error {
-		current, _ := stored.Attrs["size"].(uint64)
+		// Through the shared reader, and this is the site that carries the
+		// most: the plain `.(uint64)` answered 0 on a volume that had crossed a
+		// snapshot, so `*req.Size < current` was never true and a restored
+		// block volume shrank with a 200 — the refusal this handler exists for,
+		// gone, with nothing red anywhere (#542). Outscale had the same defect
+		// on the same reader in its own vocabulary; Exoscale found it, wrote it
+		// down and fixed it for its own block volumes on 2026-08-17 (5680efb),
+		// ten days before #542, and nothing carried it across.
+		// TestARestoredBlockVolumeStillRefusesToShrink fails without this.
+		current := resource.Uint64(stored, "size")
 		if req.Size != nil && *req.Size < current {
 			return errBlockVolumeShrinks
 		}

--- a/internal/providers/scaleway/block_restore_test.go
+++ b/internal/providers/scaleway/block_restore_test.go
@@ -1,0 +1,290 @@
+package scaleway_test
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/store"
+	"github.com/stephrobert/feint/internal/providers/scaleway"
+)
+
+// A block volume's size survives the door a snapshot really travels through
+// (#542).
+//
+// This pack was not in #542's inventory, and that is the finding rather than a
+// footnote: the issue's sweep looked for `Attrs[…].(int)` and
+// `Attrs[…].(float64)`, and this pack spells the same field `uint64` — so the
+// grep reported "Scaleway and Exoscale have no `.(int)` read of a stored
+// number", which is true and reads as absolution. The AST scan that replaced it
+// (internal/cli's TestNoPackReadsAStoredNumberByAssertion) found four more
+// sites here on its first run: this shrink refusal, the size a volume created
+// from a snapshot inherits, the size a snapshot records, and a backend health
+// check's forward port as an int32.
+//
+// Attrs is a map[string]any and store.Restore decodes the snapshot with
+// encoding/json, so every one of them came back a float64 and every assertion
+// answered zero. Exoscale had already found and fixed this exact pair of
+// readers for its own block volumes; nothing carried it here, which is what the
+// shared reader and the discipline test are for.
+func revivedScaleway(t *testing.T, size int) (*httptest.Server, string, *store.Store) {
+	t.Helper()
+	env := scalewayEnv()
+	srv, err := emulator.NewServer(env, scaleway.New(env))
+	if err != nil {
+		t.Fatalf("build emulator: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	volumeID := blockVolumeWith(t, ts, "restored", size)
+
+	var saved bytes.Buffer
+	if err := env.Store.Snapshot(&saved); err != nil {
+		t.Fatalf("take the snapshot: %v", err)
+	}
+	restored := store.New()
+	if err := restored.Restore(bytes.NewReader(saved.Bytes())); err != nil {
+		t.Fatalf("restore it: %v", err)
+	}
+
+	next := scalewayEnv()
+	next.Store = restored
+	revived, err := emulator.NewServer(next, scaleway.New(next))
+	if err != nil {
+		t.Fatalf("build the revived emulator: %v", err)
+	}
+	after := httptest.NewServer(revived.Handler())
+	t.Cleanup(after.Close)
+
+	// The precondition, asserted: the record survived and the store really did
+	// convert its size. A test that passed because the restore lost the volume
+	// would read exactly like the fix working.
+	stored, found := restored.Get(scaleway.Name, "block/volume", volumeID)
+	if !found {
+		t.Fatal("the restored store lost the block volume: nothing below measures anything")
+	}
+	if _, isFloat := stored.Attrs["size"].(float64); !isFloat {
+		t.Fatalf("the restored size is %T, not the float64 the JSON decoding produces: this test "+
+			"is not reproducing the case it names", stored.Attrs["size"])
+	}
+	return after, volumeID, restored
+}
+
+func scalewayEnv() *emulator.Env {
+	var seq int
+	return &emulator.Env{
+		Store: store.New(),
+		Now:   func() time.Time { return time.Unix(1700000000, 0).UTC() },
+		NewID: func() string {
+			seq++
+			return fmt.Sprintf("00000000-0000-4000-8000-%012d", seq)
+		},
+	}
+}
+
+// A restored block volume still refuses to shrink.
+func TestARestoredBlockVolumeStillRefusesToShrink(t *testing.T) {
+	ts, volumeID, _ := revivedScaleway(t, 40)
+
+	status, out := do(t, ts, "PATCH", blockURL+"/volumes/"+volumeID, `{"size":1}`)
+	if status == http.StatusOK {
+		t.Errorf("a restored block volume shrank from 40 to %v with a %d: the size it compares "+
+			"against was read as zero, so the refusal is gone", out["size"], status)
+	}
+
+	// The accepting half: a guard that refused every resize would pass the
+	// assertion above and break the product.
+	status, out = do(t, ts, "PATCH", blockURL+"/volumes/"+volumeID, `{"size":80}`)
+	if status != http.StatusOK {
+		t.Fatalf("a restored block volume refused to grow to 80: status %d, %v", status, out)
+	}
+	if size, _ := out["size"].(float64); size != 80 {
+		t.Errorf("the grown volume answers size %v, want 80", out["size"])
+	}
+}
+
+// A snapshot of a restored block volume inherits its size, and a volume created
+// from that snapshot inherits it in turn.
+//
+// The two other uint64 reads this pack held, one on each side of the same
+// number: scaleway/snapshots.go took the source volume's size and
+// scaleway/block.go took the snapshot's. Both answered zero over a restored
+// store, so a snapshot chain taken after a `feint snapshot load` propagated the
+// zero forward with a 200 at every step.
+func TestASnapshotChainTakenAfterARestoreKeepsItsSize(t *testing.T) {
+	ts, volumeID, _ := revivedScaleway(t, 40)
+
+	status, snapshot := do(t, ts, "POST", blockURL+"/snapshots",
+		`{"volume_id":"`+volumeID+`","name":"after-restore"}`)
+	if status != http.StatusOK {
+		t.Fatalf("create a snapshot of the restored volume: status %d, %v", status, snapshot)
+	}
+	if size, _ := snapshot["size"].(float64); size != 40 {
+		t.Errorf("a snapshot taken of a restored volume records size %v, want 40", snapshot["size"])
+	}
+	snapshotID, _ := snapshot["id"].(string)
+
+	status, volume := do(t, ts, "POST", blockURL+"/volumes",
+		`{"name":"from-snapshot","from_snapshot":{"snapshot_id":"`+snapshotID+`"}}`)
+	if status != http.StatusOK {
+		t.Fatalf("create a volume from that snapshot: status %d, %v", status, volume)
+	}
+	if size, _ := volume["size"].(float64); size != 40 {
+		t.Errorf("a volume created from that snapshot answers size %v, want 40: the zero would "+
+			"propagate through every restore of it", volume["size"])
+	}
+}
+
+// An instance snapshot of a restored volume inherits its size.
+//
+// A separate test from the block one above, and the falsification is why it
+// exists rather than a note: the first version of this file asserted the block
+// snapshot chain and was credited with the instance path too. Replaying the
+// mutation on scaleway/snapshots.go reported STILL GREEN —
+// createBlockSnapshot copies the size verbatim and never asserted anything, so
+// the block test could not have been measuring the site it was credited with.
+// Two paths, two tests.
+func TestAnInstanceSnapshotOfARestoredVolumeInheritsItsSize(t *testing.T) {
+	const instanceZone = "/instance/v1/zones/fr-par-1"
+
+	env := scalewayEnv()
+	srv, err := emulator.NewServer(env, scaleway.New(env))
+	if err != nil {
+		t.Fatalf("build emulator: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	status, created := do(t, ts, "POST", instanceZone+"/volumes",
+		`{"name":"restored","volume_type":"b_ssd","size":10000000000}`)
+	if status != http.StatusCreated && status != http.StatusOK {
+		t.Fatalf("create the instance volume: status %d, %v", status, created)
+	}
+	volume, _ := created["volume"].(map[string]any)
+	volumeID, _ := volume["id"].(string)
+	if volumeID == "" {
+		t.Fatalf("no volume id in %v", created)
+	}
+
+	var saved bytes.Buffer
+	if err := env.Store.Snapshot(&saved); err != nil {
+		t.Fatalf("take the snapshot: %v", err)
+	}
+	restored := store.New()
+	if err := restored.Restore(bytes.NewReader(saved.Bytes())); err != nil {
+		t.Fatalf("restore it: %v", err)
+	}
+	stored, found := restored.Get(scaleway.Name, "instance/volume", volumeID)
+	if !found {
+		t.Fatal("the restored store lost the instance volume: nothing below measures anything")
+	}
+	if _, isFloat := stored.Attrs["size"].(float64); !isFloat {
+		t.Fatalf("the restored size is %T, not the float64 the JSON decoding produces: this test "+
+			"is not reproducing the case it names", stored.Attrs["size"])
+	}
+
+	next := scalewayEnv()
+	next.Store = restored
+	revived, err := emulator.NewServer(next, scaleway.New(next))
+	if err != nil {
+		t.Fatalf("build the revived emulator: %v", err)
+	}
+	after := httptest.NewServer(revived.Handler())
+	defer after.Close()
+
+	status, snapshot := do(t, after, "POST", instanceZone+"/snapshots",
+		`{"name":"after-restore","volume_id":"`+volumeID+`"}`)
+	if status != http.StatusCreated {
+		t.Fatalf("snapshot the restored volume: status %d, %v", status, snapshot)
+	}
+	taken, _ := snapshot["snapshot"].(map[string]any)
+	if size, _ := taken["size"].(float64); size != 10000000000 {
+		t.Errorf("an instance snapshot of a restored volume records size %v, want 10000000000",
+			taken["size"])
+	}
+}
+
+// A restored backend's health check falls back to the forward port it really
+// carries.
+//
+// The fourth site the AST scan found in this pack, and the only one of the
+// seven that is not a size: forward_port is stored as an int32 and read back to
+// fill a health check whose own port the client left at zero. Over a restored
+// store the assertion answered zero too, so a health check that was meant to
+// probe the backend's port probed port 0 — a check that can only ever fail,
+// with a 200 on the call that installed it.
+//
+// The path is the API's own default rather than an edge: the SDK's
+// UpdateHealthCheck takes a port, and a client that does not name one is asking
+// for the backend's.
+func TestARestoredBackendsHealthCheckKeepsItsForwardPort(t *testing.T) {
+	env := scalewayEnv()
+	srv, err := emulator.NewServer(env, scaleway.New(env))
+	if err != nil {
+		t.Fatalf("build emulator: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	ipID, _ := lbIP(t, ts, `{}`)
+	status, lb := do(t, ts, "POST", lbURL+"/lbs",
+		`{"name":"restored","type":"LB-S","ip_ids":["`+ipID+`"]}`)
+	if status != http.StatusOK {
+		t.Fatalf("create lb: status %d, %v", status, lb)
+	}
+	lbID, _ := lb["id"].(string)
+	status, backend := do(t, ts, "POST", lbURL+"/lbs/"+lbID+"/backends",
+		`{"name":"api","forward_protocol":"tcp","forward_port":6443,
+		  "health_check":{"port":6443,"check_delay":30000,"check_timeout":5000,"check_max_retries":2,
+		                  "tcp_config":{}}}`)
+	if status != http.StatusOK {
+		t.Fatalf("create backend: status %d, %v", status, backend)
+	}
+	backendID, _ := backend["id"].(string)
+
+	var saved bytes.Buffer
+	if err := env.Store.Snapshot(&saved); err != nil {
+		t.Fatalf("take the snapshot: %v", err)
+	}
+	restored := store.New()
+	if err := restored.Restore(bytes.NewReader(saved.Bytes())); err != nil {
+		t.Fatalf("restore it: %v", err)
+	}
+	stored, found := restored.Get(scaleway.Name, "lb/backend", backendID)
+	if !found {
+		t.Fatal("the restored store lost the backend: nothing below measures anything")
+	}
+	if _, isFloat := stored.Attrs["forward_port"].(float64); !isFloat {
+		t.Fatalf("the restored forward_port is %T, not the float64 the JSON decoding produces: "+
+			"this test is not reproducing the case it names", stored.Attrs["forward_port"])
+	}
+
+	next := scalewayEnv()
+	next.Store = restored
+	revived, err := emulator.NewServer(next, scaleway.New(next))
+	if err != nil {
+		t.Fatalf("build the revived emulator: %v", err)
+	}
+	after := httptest.NewServer(revived.Handler())
+	defer after.Close()
+
+	// port omitted, which is the client asking for the backend's own.
+	status, updated := do(t, after, "PUT", lbURL+"/backends/"+backendID+"/healthcheck",
+		`{"check_delay":30000,"check_timeout":5000,"check_max_retries":2,"tcp_config":{}}`)
+	if status != http.StatusOK {
+		t.Fatalf("update the health check: status %d, %v", status, updated)
+	}
+	check, _ := updated["health_check"].(map[string]any)
+	if check == nil {
+		check = updated
+	}
+	if port, _ := check["port"].(float64); port != 6443 {
+		t.Errorf("a restored backend's health check falls back to port %v, want 6443: a check on "+
+			"port 0 can only ever fail, and the call that installed it answered 200", check["port"])
+	}
+}

--- a/internal/providers/scaleway/firewall.go
+++ b/internal/providers/scaleway/firewall.go
@@ -174,8 +174,12 @@ func toFirewallRule(res *resource.Resource) (machine.FirewallRule, bool) {
 	out := machine.FirewallRule{
 		Action:   toRuntimeAction(action),
 		Protocol: strings.ToLower(protocol),
-		PortFrom: portValue(res.Attrs["dest_port_from"]),
-		PortTo:   portValue(res.Attrs["dest_port_to"]),
+		// Through the shared reader: a port held as a uint32 fresh from a
+		// request comes back a float64 once the store has crossed a snapshot,
+		// and the tolerance this pack carried as portValue now lives in one
+		// place for every pack (#542).
+		PortFrom: resource.Int(res, "dest_port_from"),
+		PortTo:   resource.Int(res, "dest_port_to"),
 	}
 	switch direction {
 	case "outbound":
@@ -201,21 +205,6 @@ func toRuntimeAction(action string) string {
 		return "drop"
 	default:
 		return ""
-	}
-}
-
-// portValue reads a port back from Attrs, which may hold a uint32 fresh from a
-// request or a float64 restored from a JSON snapshot.
-func portValue(v any) int {
-	switch n := v.(type) {
-	case uint32:
-		return int(n)
-	case int:
-		return n
-	case float64:
-		return int(n)
-	default:
-		return 0
 	}
 }
 

--- a/internal/providers/scaleway/loadbalancer_children.go
+++ b/internal/providers/scaleway/loadbalancer_children.go
@@ -2,6 +2,7 @@ package scaleway
 
 import (
 	"encoding/json"
+	"math"
 	"net/http"
 	"strings"
 	"time"
@@ -382,9 +383,16 @@ func (p *Pack) updateLBHealthCheck(w http.ResponseWriter, r *http.Request) {
 		writeInvalidArguments(w, ArgumentError{ArgumentName: "body", Reason: "format", HelpMessage: err.Error()})
 		return
 	}
+	// Through the shared reader: forward_port is written as an int32 and comes
+	// back a float64 once the store has crossed a snapshot, so the assertion
+	// this replaces answered 0 and a restored backend's health check probed
+	// port 0 (#542) — a check that can only ever fail, installed by a call that
+	// answered 200. The bound is what a value from a restored snapshot needs
+	// before it becomes an int32: a stored number is untrusted input.
+	// TestARestoredBackendsHealthCheckKeepsItsForwardPort fails without this.
 	var forwardPort int32
-	if port, ok := res.Attrs["forward_port"].(int32); ok {
-		forwardPort = port
+	if port := resource.Int64(res, "forward_port"); port > 0 && port <= math.MaxInt32 {
+		forwardPort = int32(port)
 	}
 	attrs := healthCheckAttrs(&req, forwardPort)
 	err := p.env.Store.Update(Name, kindLBBackend, res.ID, func(stored *resource.Resource) error {

--- a/internal/providers/scaleway/securitygroups.go
+++ b/internal/providers/scaleway/securitygroups.go
@@ -911,7 +911,6 @@ func isProjectDefault(res *resource.Resource) bool {
 // Positions are 1-based, and the cap keeps the conversion from wrapping whatever
 // a caller passes.
 func nextPosition(count int) uint32 {
-	const maxPosition = 1 << 20
 	if count < 0 {
 		return 1
 	}
@@ -921,17 +920,29 @@ func nextPosition(count int) uint32 {
 	return uint32(count + 1) //nolint:gosec // bounded by maxPosition above
 }
 
+// maxPosition caps both the position handed to a new rule and the one read back
+// off a stored one. Shared between the two because a restored snapshot is
+// untrusted input: the value comes back through JSON as a float64, and a stored
+// number nobody bounded would reach the conversion below from a crafted state
+// file rather than from nextPosition.
+const maxPosition = 1 << 20
+
+// positionOf reads a rule's order back.
+//
+// Through the shared reader (#542): a restored snapshot comes back through
+// JSON, where every number is a float64, and an assertion on uint32 alone
+// would lose the order on restart. The bound is what a conversion from float64
+// needs and a type switch did not have — NaN, a negative and 1e30 all reach
+// uint32(v) as something nobody wrote.
 func positionOf(res *resource.Resource) uint32 {
-	switch v := res.Attrs["position"].(type) {
-	case uint32:
-		return v
-	// A restored snapshot comes back through JSON, where every number is a
-	// float64. Without this case the order is lost on restart.
-	case float64:
-		return uint32(v)
-	default:
+	n := resource.Number(res.Attrs["position"])
+	if !(n >= 1) { // false for NaN too, which is why it is written this way
 		return 0
 	}
+	if n > maxPosition {
+		return maxPosition
+	}
+	return uint32(n) //nolint:gosec // bounded by maxPosition above
 }
 
 // portOrNil maps an unset or zero port onto null, which is what the API returns

--- a/internal/providers/scaleway/snapshots.go
+++ b/internal/providers/scaleway/snapshots.go
@@ -95,8 +95,13 @@ func (p *Pack) createSnapshot(w http.ResponseWriter, r *http.Request) {
 		if volumeType == "" {
 			volumeType = textOf(volume.Attrs["volume_type"])
 		}
-		if got, ok := volume.Attrs["size"].(uint64); ok {
-			size = got
+		// Through the shared reader: the assertion this replaces answered
+		// ok=false on a volume that had crossed a snapshot, so a snapshot taken
+		// after a `feint snapshot load` recorded a size of zero (#542).
+		// TestAnInstanceSnapshotOfARestoredVolumeInheritsItsSize fails without
+		// this.
+		if _, present := volume.Attrs["size"]; present {
+			size = resource.Uint64(volume, "size")
 		}
 	}
 	if volumeType == "" {

--- a/tools/falsify/specs/catalogue-snapshot-chain.json
+++ b/tools/falsify/specs/catalogue-snapshot-chain.json
@@ -74,8 +74,8 @@
     {
       "label": "createImage stores an Iops it cannot honour, which makes the ReadImages decline fiction for one of the two kinds of object it answers",
       "file": "internal/providers/outscale/images.go",
-      "find": "\t\tif numOf(bsu[\"Iops\"]) > 0 {",
-      "replace": "\t\tif numOf(bsu[\"Iops\"]) > 0 && false {",
+      "find": "\t\tif resource.Number(bsu[\"Iops\"]) > 0 {",
+      "replace": "\t\tif resource.Number(bsu[\"Iops\"]) > 0 && false {",
       "test": "TestCreateImageRefusesAnIopsItCannotHonour"
     },
     {

--- a/tools/falsify/specs/groupsync-wiring.json
+++ b/tools/falsify/specs/groupsync-wiring.json
@@ -1,0 +1,55 @@
+{
+  "package": "./internal/cli/",
+  "mutations": [
+    {
+      "label": "the firewall step asks about the runtime before it asks about the pack, which is the order that made a missing field invisible under --vm off and a panic under --vm incus-ovn (#543)",
+      "file": "internal/core/machine/groupsync.go",
+      "find": "\tif err := s.check(); err != nil {\n\t\ts.Binding.logger().Error(\"the firewall step is skipped: this pack's security groups reach no machine\",",
+      "replace": "\tif err := s.check(); err != nil && s.enforcer() == nil {\n\t\ts.Binding.logger().Error(\"the firewall step is skipped: this pack's security groups reach no machine\",",
+      "test": "TestABootUnderAnEnforcingRuntimeReportsAnUnwiredGroupSync"
+    },
+    {
+      "label": "the same order, judged on the mode that never could see it: with the runtime asked first, --vm off is the only mode that reports and the asymmetry is back (#543)",
+      "file": "internal/core/machine/groupsync.go",
+      "find": "\tif err := s.check(); err != nil {\n\t\ts.Binding.logger().Error(\"the firewall step is skipped: this pack's security groups reach no machine\",",
+      "replace": "\tif err := s.check(); err != nil && s.enforcer() != nil {\n\t\ts.Binding.logger().Error(\"the firewall step is skipped: this pack's security groups reach no machine\",",
+      "test": "TestAnUnwiredGroupSyncIsReportedUnderEveryRuntime"
+    },
+    {
+      "label": "the check finds no missing field, so the orchestration runs on the nil funcs themselves: applyMachine calls WornIDs on one (#543)",
+      "file": "internal/core/machine/groupsync.go",
+      "find": "\tvar missing []string\n\tfor _, field := range s.required() {\n\t\tif !field.set {\n\t\t\tmissing = append(missing, field.name)\n\t\t}\n\t}",
+      "replace": "\tvar missing []string\n\tfor _, field := range s.required() {\n\t\tif !field.set && false {\n\t\t\tmissing = append(missing, field.name)\n\t\t}\n\t}",
+      "test": "TestABootUnderAnEnforcingRuntimeReportsAnUnwiredGroupSync"
+    },
+    {
+      "label": "the report names every field rather than the missing ones, so a pack that forgot one is sent to the four lines it wrote correctly (#543)",
+      "file": "internal/core/machine/groupsync.go",
+      "find": "\tfor _, field := range s.required() {\n\t\tif !field.set {\n\t\t\tmissing = append(missing, field.name)\n\t\t}\n\t}",
+      "replace": "\tfor _, field := range s.required() {\n\t\tif !field.set || true {\n\t\t\tmissing = append(missing, field.name)\n\t\t}\n\t}",
+      "test": "TestAPackThatWiredNoGroupSyncIsToldWhichFieldIsMissing"
+    },
+    {
+      "label": "the declaration stops being honoured, so a pack that said it enforces nothing is reported as having forgotten four fields — a refusal nobody can satisfy (#543)",
+      "file": "internal/core/machine/groupsync.go",
+      "find": "\tif s.EnforcesNothing {\n\t\treturn false\n\t}\n\tif err := s.check(); err != nil {",
+      "replace": "\tif s.EnforcesNothing && false {\n\t\treturn false\n\t}\n\tif err := s.check(); err != nil {",
+      "test": "TestAPackThatWiredNoGroupSyncIsToldWhichFieldIsMissing"
+    },
+    {
+      "label": "the boot dereferences a plan the pack never declared, which panics in every mode rather than naming the pack and PlanOf (#543)",
+      "file": "internal/core/machine/plan.go",
+      "find": "func (r Reconciler) plan(res *resource.Resource) (Plan, bool) {\n\tif r.PlanOf == nil {",
+      "replace": "func (r Reconciler) plan(res *resource.Resource) (Plan, bool) {\n\tif r.PlanOf == nil && false {",
+      "test": "TestABootWithNoDeclaredPlanIsRefusedRatherThanPanicking"
+    },
+    {
+      "label": "the boot starts a machine on a plan nobody declared and reports success, so the API describes as running a machine on no network (#484, #543)",
+      "file": "internal/core/machine/plan.go",
+      "find": "\tplan, declared := r.plan(res)\n\tif !declared {\n\t\treturn false\n\t}\n\tboot.Attachments = plan.Boot",
+      "replace": "\tplan, declared := r.plan(res)\n\tif !declared && false {\n\t\treturn false\n\t}\n\tboot.Attachments = plan.Boot",
+      "test": "TestABootWithNoDeclaredPlanIsRefusedRatherThanPanicking"
+    }
+  ],
+  "note": "#543 is not about a panic, and these mutations are arranged to say so. The panic was the symptom under one runtime; the finding is that the guard deciding between the two outcomes asked about the runtime first, so `--vm off` — the default, what CI runs, what every conformance leg runs — skipped the whole firewall step before anything could touch a nil field. A pack that had wired nothing was therefore green in every population anybody measures, and red on the first poweron of the first operator to attach a real one. Mutations one and two are the same rewrite judged from the two sides: with the runtime asked first, the enforcing mode stops reporting and the default mode is the only one that speaks — which is the mirror image of what was there before and equally wrong, and it is why the second test exists at all. Mutation three is the dereference itself, and it is the one that reads as proof most easily: it fails by crashing. Its first form did not, and the harness is the reason this note can say so: it targeted a second wiring guard inside applyMachine and reported STILL GREEN, because the entry gate covered for it. The guard was redundant, so it was deleted rather than excused — a guard whose removal leaves every test passing is a comment. Four and five hold what the report says rather than that it happened — a message naming four fields for one omission sends its reader to the wrong lines, and a declaration that does not actually stop the orchestration is a control nobody can satisfy. Six and seven are Reconciler.PlanOf, the other required func field, which #543 recorded as untested: measured on 2026-08-27 it panics under machine.Noop exactly as under an enforcing runtime, so it is not mode-dependent — the correction there is the sentence and the refusal, not the timing, and seven is the half that matters, because a boot reported as successful over an empty plan is #484's lie rather than a crash."
+}

--- a/tools/falsify/specs/provider-four.json
+++ b/tools/falsify/specs/provider-four.json
@@ -65,10 +65,10 @@
       "test": "TestTheFourthPacksNestedAttributesAreNeverWrittenThroughTheStore"
     },
     {
-      "label": "the fourth pack reads its stored port with a plain int assertion, so a restored snapshot leaves a balancer listening on port 0 while the API still describes 443 (#517)",
+      "label": "the fourth pack reads its stored port with a plain int assertion again, so a restored snapshot leaves a balancer listening on port 0 while the API still describes 443 (#517, #542)",
       "file": "internal/cli/testdata/provider-four/intents.go",
-      "find": "\tcase float64:\n\t\treturn int(n)\n\t}\n\treturn 0\n}\n\nfunc backendsOf",
-      "replace": "\tcase float64:\n\t\treturn int(n) * 0\n\t}\n\treturn 0\n}\n\nfunc backendsOf",
+      "find": "func portOf(res *resource.Resource) int {\n\treturn resource.Int(res, \"port\")\n}",
+      "replace": "func portOf(res *resource.Resource) int {\n\tn, _ := res.Attrs[\"port\"].(int)\n\treturn n + resource.Int(res, \"port\")*0\n}",
       "test": "TestTheFourthPacksSpreaderKeepsItsPortAcrossASnapshot"
     },
     {

--- a/tools/falsify/specs/stored-numbers.json
+++ b/tools/falsify/specs/stored-numbers.json
@@ -1,0 +1,84 @@
+{
+  "package": "./internal/providers/outscale/",
+  "mutations": [
+    {
+      "label": "the shrink refusal compares against a size read as zero, which is what a restored volume gave it before the shared reader: 40 shrank to 1 with a 200 (#542)",
+      "file": "internal/providers/outscale/volumes.go",
+      "find": "\t\t\tcurrent := resource.Int(stored, \"Size\")",
+      "replace": "\t\t\tcurrent := resource.Int(stored, \"Size\") * 0",
+      "test": "TestARestoredVolumeStillRefusesToShrink"
+    },
+    {
+      "label": "a snapshot inherits a size read as zero, so every volume later created from it is born empty while the API describes 40 (#542)",
+      "file": "internal/providers/outscale/snapshots.go",
+      "find": "\tsize := resource.Int(volume, \"Size\")",
+      "replace": "\tsize := resource.Int(volume, \"Size\") * 0",
+      "test": "TestASnapshotOfARestoredVolumeInheritsItsSize"
+    },
+    {
+      "label": "the same defect in the pack #542's grep cleared, because this one spells the field uint64 and the sweep looked for int (#542)",
+      "file": "internal/providers/scaleway/block.go",
+      "find": "\t\tcurrent := resource.Uint64(stored, \"size\")",
+      "replace": "\t\tcurrent := resource.Uint64(stored, \"size\") * 0",
+      "test": "TestARestoredBlockVolumeStillRefusesToShrink",
+      "package": "./internal/providers/scaleway/"
+    },
+    {
+      "label": "the size an instance snapshot records off a restored volume, which is the third uint64 read the AST scan found in the pack the grep had cleared (#542)",
+      "file": "internal/providers/scaleway/snapshots.go",
+      "find": "\t\t\tsize = resource.Uint64(volume, \"size\")",
+      "replace": "\t\t\tsize = resource.Uint64(volume, \"size\") * 0",
+      "test": "TestAnInstanceSnapshotOfARestoredVolumeInheritsItsSize",
+      "package": "./internal/providers/scaleway/"
+    },
+    {
+      "label": "the shared reader stops tolerating the one type a snapshot actually produces, which is the whole subject: every number in Attrs comes back float64 (#542)",
+      "file": "internal/core/resource/attrs.go",
+      "find": "func Number(v any) float64 {\n\tswitch n := v.(type) {\n\tcase float64:\n\t\treturn n",
+      "replace": "func Number(v any) float64 {\n\tswitch n := v.(type) {\n\tcase float64:\n\t\treturn n * 0",
+      "test": "TestEveryGoTypeAPackWritesCrossesTheSnapshotAsMeasured",
+      "package": "./internal/core/store/"
+    },
+    {
+      "label": "a pack writes the seventh hand-made copy of the tolerance and forgets the float64 case, which is the draft the fake fourth pack shipped (#542)",
+      "file": "internal/providers/outscale/volumes.go",
+      "find": "func volumeMatches(res *resource.Resource, f filterSet) bool {",
+      "replace": "func plantedSize(v any) int {\n\tswitch n := v.(type) {\n\tcase int:\n\t\treturn n\n\t}\n\treturn 0\n}\n\nfunc volumeMatches(res *resource.Resource, f filterSet) bool {",
+      "test": "TestNoPackReadsAStoredNumberByAssertion",
+      "package": "./internal/cli/"
+    },
+    {
+      "label": "a pack reads a stored number with the plain assertion again, in the pack the original sweep reported clean (#542)",
+      "file": "internal/providers/scaleway/securitygroups.go",
+      "find": "func positionOf(res *resource.Resource) uint32 {",
+      "replace": "func plantedPort(res *resource.Resource) int {\n\tn, _ := res.Attrs[\"port\"].(int)\n\treturn n\n}\n\nfunc positionOf(res *resource.Resource) uint32 {",
+      "test": "TestNoPackReadsAStoredNumberByAssertion",
+      "package": "./internal/cli/"
+    },
+    {
+      "label": "the detector stops recognising the very type the defect was written in, so it reports a disciplined repository because it looked for nothing (#542)",
+      "file": "internal/cli/stored_numbers_test.go",
+      "find": "\t\"int\": true, \"int8\": true,",
+      "replace": "\t\"int8\": true,",
+      "test": "TestTheStoredNumberDetectorFindsWhatItLooksFor",
+      "package": "./internal/cli/"
+    },
+    {
+      "label": "the size a block volume created from a snapshot inherits, which propagates the zero forward through every restore of that chain (#542)",
+      "file": "internal/providers/scaleway/block.go",
+      "find": "\t\tsize = resource.Uint64(snapshot, \"size\")",
+      "replace": "\t\tsize = resource.Uint64(snapshot, \"size\") * 0",
+      "test": "TestASnapshotChainTakenAfterARestoreKeepsItsSize",
+      "package": "./internal/providers/scaleway/"
+    },
+    {
+      "label": "the health check falls back to a forward port read as zero, so a restored backend is probed on port 0 and the call installing it still answers 200 (#542)",
+      "file": "internal/providers/scaleway/loadbalancer_children.go",
+      "find": "\tif port := resource.Int64(res, \"forward_port\"); port > 0 && port <= math.MaxInt32 {",
+      "replace": "\tif port := resource.Int64(res, \"forward_port\") * 0; port > 0 && port <= math.MaxInt32 {",
+      "test": "TestARestoredBackendsHealthCheckKeepsItsForwardPort",
+      "package": "./internal/providers/scaleway/"
+    }
+  ],
+  "note": "#542 filed three sites in one pack and asked whether any other stored number is read back anywhere, marking the answer not established because the sweep was a grep for `Attrs[…].(int)` and `.(float64)`. The AST scan that replaced it found four more on its first run, all in the pack the grep had cleared, because Scaleway spells the same field uint64 and one health check reads an int32 — the only one of the seven that is not a size, and the one whose cost is a check that can never pass — which is why mutations three, four and nine exist and why they are the ones worth reading. Four was mispointed on its first replay and the harness said so: it was written against the block snapshot chain while claiming the instance snapshot's read, and reported STILL GREEN because createBlockSnapshot copies the size verbatim and asserts nothing. Two paths, two tests, and the note is kept because a test credited with a site it never reaches is exactly the instrument this repository keeps finding: the defect was in two packs, at seven sites, and the instrument that said otherwise was a grep for two spellings of a number. Mutation five is the reader itself, judged on the round trip rather than on a pack: it is the measurement the numbers-only boundary rests on, and #542 recorded the bool half of that boundary as a supposition. The last three are the discipline test rather than the fix, and they are what buys the property the issue asked for — that the *next* pack cannot write this. Six plants the tolerant helper with a case missing, which is how six copies of it came to exist under six names; seven plants the plain assertion in a pack that no longer has one; and eight is the detector's own positive control, because a scan that finds nothing is indistinguishable from a scan that looked nowhere."
+}


### PR DESCRIPTION
Closes #542. Closes #543.

Two traps the fake fourth pack of #517 found, both invisible to every green gate
this repository had. They share nothing but their shape: a lesson learned once,
in one pack, that nothing carried anywhere else.

**Both issues left a decision open, and both are answered here with the
combination each recommended itself**: a neutral reader *and* the discipline test
that makes it stick (#542); refusal at construction *and* degradation for what is
genuinely optional (#543).

## The reproductions, before any fix

**#543**, over a zero `GroupSync`:

```
enforcing runtime (Recorder implements Firewaller): PANIC: invalid memory address or nil pointer dereference
machine.Noop, the --vm off default:                 no panic; PowerOn=true state=up
```

Through a mounted route on a real `emulator.NewServer`, the client gets `EOF` and
the emulator answers `204` on the next request — so the process survives and the
operator gets a stack trace instead of a sentence.

**#542**, Outscale, snapshot then restore into a fresh store:

```
Attrs[Size] is float64 = 40; the int assertion yields 0
shrink 40 -> 1 after a restore: status 200, Size now 1
CreateSnapshot of a restored volume records VolumeSize=0
```

## Two of #542's own premises are wrong, and that is the substance

**"Three sites, one pack" is seven sites, two packs.** The issue's sweep was a
grep for `Attrs[…].(int)` / `.(float64)`. Scaleway spells the same field
`uint64`, and one health check reads `int32` — so *"Scaleway and Exoscale have no
`.(int)` read of a stored number"* was true, and was read as absolution. An AST
scan found, on its first run: a block-volume shrink refusal, the size a volume
created from a snapshot inherits, the size an instance snapshot records, and **a
backend health check's forward port, which fell back to 0 — a check that could
only ever fail, installed with a 200.**

Seven hand-written copies of the same tolerance existed under six different
names, and Exoscale had found, documented and fixed *this exact pair of readers*
on 2026-08-17 (5680efb), ten days before #542 was written. The lesson does not
travel on its own. That is the whole argument for the shared reader.

**`volumes.go:336` does not do what the issue says.** "A restored volume
publishes no size at all" is disproved twice: `volumeView` copies `Attrs`
verbatim, so every client always read 40; and the `VolumeSizes` filter that line
feeds is declared as an array of **integers**, which `filterSet.strings` cannot
decode — it reports the decode failure as *"filter absent"*, and `matchesAny`
then passes everything. **That comparison has never discriminated, for any
client, restore or not.** The line is corrected because the discipline test
demands it, the disproof is written at the site including that no test can redden
it today, and filter semantics are **not** changed here: that is #566, because it
is client-visible surface with its own subject.

## The other measurements the issues left open

- **bool and string cross unchanged.** `int`, `int64`, `uint32`, `uint64` and
  `int32` all come back `float64`, including numbers nested inside a stored map.
  That is why the readers cover numbers only and the discipline test leaves
  `.(string)` / `.(bool)` alone — a boundary that is measured rather than
  assumed. `Iops` is written and never read back: harmless.
- **`net/http`'s recovery is the only thing between #543 and a dead process.**
  `recover()` appears nowhere under `internal/`, and the only goroutine in the
  tree is the Incus event watcher, which never reaches this path.
- **`Reconciler.PlanOf` has the same shape but not the same asymmetry.** It
  panics on `PowerOn`, `ReplayAddresses` and `Route` under `machine.Noop`
  exactly as under an enforcing runtime, because nothing gates the call — so a
  pack that forgets it fails its own first unit test. It lacked a sentence, not a
  mode. It therefore **refuses** (PowerOn false, the pack publishes
  `FailedState`) where `GroupSync` degrades, and the difference is deliberate.

## Why #543's fix is not just a nil check

The finding was never the panic; it was the asymmetry. `AfterBoot`'s
`if s.enforcer() == nil { return }` means `--vm off` — the default, and the whole
CI matrix — skips the firewall step before it can touch a nil field. Every unit
test, every conformance leg and `mise run check` were green for a pack that had
wired nothing, and the first `poweron` under a real runtime crashed. Degrading
alone would have made the omission silent in *both* modes, which is worse. So the
pack is **named** — the missing field and the pack, in a sentence — in both.

## Falsification changed the code, not just the notes

`stored-numbers.json` 10/10, `groupsync-wiring.json` 7/7.

Three mutations came back STILL GREEN on the way there, and each was a real
defect in the work:

- two `groupsync` mutations hit a second wiring guard the entry gates already
  covered — **deleted rather than excused**;
- one `stored-numbers` mutation showed my Scaleway snapshot test was credited
  with a site it never reached (`createBlockSnapshot` copies the size verbatim).
  It is now two tests, block path and instance path.

## Gates

| run | verdict |
|---|---|
| `mise run prepush` (14 tasks) | 0 |
| `conformance:leg -- probe` | 0 (1.7 s) |
| `conformance:leg -- exo-cli` | 0 (4.0 s) |
| `conformance:leg -- scw-cli` | 0 (7.0 s) |
| `conformance:environment` | 0 |
| `conformance:leg -- octl` | 0 (141 s) |
| `conformance:leg -- fields` | 0 (209 s) |
| `FEINT_VM=incus-ovn conformance:leg -- runtime` | 0 (602 s), no leftovers |

Standing contracts pass: `TestSameIntentSameRuntimeSequenceAcrossPacks`,
`TestNoPackReachesPastTheDeclaredDriverSurface`,
`TestNoPackKnowsWhichRuntimeIsBehindTheDriver`, `TestTheCoreNamesNoProvider`.
`notInTheDriverSurface` and `ownExclusion` stay empty. The one new registry,
`storedNumberExemptions`, holds a single entry — a value read straight out of a
request body, where `float64` is the decoder's own type rather than a guess about
what a snapshot left behind — and `TestEveryBarrageExemptionSaysWhy` holds it.

## What these runs are, and what chose them

The eight above are what `mise run testplan` prescribed for this diff (#564,
merged this morning): 33 paths, nothing un-triaged, `--check` exit 0. **The full
1331 s pass was not run and was not needed** — the `runtime` leg carries the four
suites that touch real machines, and the client legs carry the rest.

Its "what this does not prove" list surfaced, unprompted, the line most relevant
to #542: *"a snapshot written by one version and read by another is not exercised
by any leg."*

One note on the tool rather than a defect: `conformance:environment` was earned
partly by paths where this diff changes **test files and testdata only**. Its
rules match on directory, not on whether a `.go` file is a test. Here it was apt
— the subject *is* restore — but a diff of pure `_test.go` files currently earns
its directory's full runs.

## What was not obtained

- **#566**, filed: three Outscale numeric filters are declared applied and match
  everything, because a decode failure is reported as "filter absent". Not fixed
  here — it is client-visible behaviour and needs its own measurement of what the
  real cloud does.
- **#567**, filed and needing a decision: the fourth pack stores `[]Rule`,
  `[]string` and `map[string]string`, and after a restore they come back `nil`,
  `[]any` and `map[string]any` — so a restored node wears no barriers, joins no
  segments, and a spreader has no backends. The three real packs are immune by
  habit, not by construction. Whether `testdata/provider-four` is a model pack or
  a newcomer pack decides where that fix belongs, and #517 does not say.
- `volumes.go:336` is corrected without a test that can redden it, and the code
  says so rather than implying proof.
- Deliberately not run, per the plan: `falsify:all` (nightly), the full
  `mise run conformance`, `conformance:functional`, `conformance:zones`,
  `conformance:ssh`.
