### PR TITLE
feat(testplan): the falsifications a diff earned are read off the specs, and a test file earns no leg (#564)

### DIFF
--- a/CONTRIBUTING.fr.md
+++ b/CONTRIBUTING.fr.md
@@ -58,6 +58,19 @@ poussée dit quoi jouer ensuite et refuse un chemin qu'aucune règle ne trie —
 « ça ne correspond à rien, donc on ne joue rien » est le défaut bon marché, et
 un chemin non trié est une absence, pas une décision (#564).
 
+Il imprime aussi **les falsifications que le diff a méritées**, lues dans
+`tools/falsify/specs/` plutôt que retenues : 128 specs nomment 186 fichiers
+distincts, et une spec qui mute un fichier que vous avez touché est le
+sous-ensemble de `falsify:all` que votre changement peut avoir empêché de mordre.
+Chaque lot d'ici a suivi cette discipline à la main et l'a écrit dans sa pull
+request, ce qui veut dire qu'il l'a aussi oubliée à la main — `mise run check`
+ne voit pas une garde dont le test passe encore, au-dessus de rien.
+
+Un fichier `_test.go` ou un répertoire `testdata/` ne mérite aucune jambe de
+conformance, pour la raison qui vaut pour la prose : rien de compilé dans les
+seuls tests n'atteint un client. Il reste trié, donc un fichier de test dans un
+paquet qu'aucune règle ne nomme rougit toujours.
+
 Les coûts sur lesquels il ordonne sont mesurés, une passe chacun le 2026-08-27 :
 
 | exécution | mesure | ce qu'elle porte |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,17 @@ what to run next, and refuses a path no rule triages — "it matched nothing, so
 run nothing" is the cheap default, and an un-triaged path is an absence, not a
 decision (#564).
 
+It also prints **the falsifications the diff has earned**, read off
+`tools/falsify/specs/` rather than remembered: 128 specs name 186 distinct files,
+and a spec that mutates a file you touched is the subset of `falsify:all` your
+change can have stopped biting. Every batch here has followed that discipline by
+hand and said so in its pull request, which means it has also been forgotten by
+hand — `mise run check` cannot see a guard whose test still passes over nothing.
+
+A `_test.go` file or a `testdata/` tree earns no conformance leg at all, for the
+same reason prose does not: nothing compiled into tests alone reaches a client.
+It is still triaged, so a test file in a package no rule names still reddens.
+
 The costs it orders by are measured, one pass each on 2026-08-27:
 
 | run | measured | what it carries |

--- a/tools/conformance/README.md
+++ b/tools/conformance/README.md
@@ -31,6 +31,10 @@ runs it has earned, cheapest first, along with what they still do not prove
 (#564). `mise run prepush` calls it with `--check`, so a path no rule triages
 refuses the push instead of quietly earning nothing.
 
+It also names the specs under `tools/falsify/` that mutate a file the diff
+touches — the subset of `falsify:all` a change can have stopped biting, read
+off the specs rather than remembered.
+
 One pass each, measured on 2026-08-27, which is what the plan orders by:
 
 | run | measured |

--- a/tools/falsify/specs/a-plan-that-cannot-rot.json
+++ b/tools/falsify/specs/a-plan-that-cannot-rot.json
@@ -70,6 +70,34 @@
       "find": "\t\tUnproven: \"a change to the stored shape is proved across a restart by `mise run conformance:environment`\",",
       "replace": "\t\tUnproven: prepushIsTheWholeGate,",
       "test": "TestEveryRuleWithRunsSaysWhatItDoesNotProve"
+    },
+    {
+      "label": "a file compiled into tests alone starts earning conformance legs again, so a diff of pure _test.go files pays for runs that cannot judge it (#564)",
+      "file": "tools/testplan/plan.go",
+      "find": "\t\tif matched && !testOnly(path) {",
+      "replace": "\t\tif matched && (!testOnly(path) || true) {",
+      "test": "TestAFileCompiledOnlyIntoTestsEarnsNoConformanceRun"
+    },
+    {
+      "label": "the test-file exemption swallows the triage too, so a _test.go in a package no rule names stops being reported as the absence it is (#564)",
+      "file": "tools/testplan/plan.go",
+      "find": "\t\tif !matched {\n\t\t\tp.Untriaged = append(p.Untriaged, path)\n\t\t}",
+      "replace": "\t\tif !matched && !testOnly(path) {\n\t\t\tp.Untriaged = append(p.Untriaged, path)\n\t\t}",
+      "test": "TestAFileCompiledOnlyIntoTestsEarnsNoConformanceRun"
+    },
+    {
+      "label": "the falsifications a diff earned stop being read off the specs, so the discipline every batch here states in its pull request goes back to being remembered by hand (#564)",
+      "file": "tools/testplan/plan.go",
+      "find": "\tfor _, spec := range falsifications(root, paths) {",
+      "replace": "\tfor _, spec := range falsifications(root, paths)[:0] {",
+      "test": "TestAChangedFileEarnsTheSpecsThatMutateIt"
+    },
+    {
+      "label": "every spec is earned rather than the ones naming a changed file, which reads as thoroughness and is noise nobody runs twice (#564)",
+      "file": "tools/testplan/specs.go",
+      "find": "\t\t\tif changed[m.File] {",
+      "replace": "\t\t\tif changed[m.File] || true {",
+      "test": "TestAChangedFileEarnsTheSpecsThatMutateIt"
     }
   ]
 }

--- a/tools/testplan/plan.go
+++ b/tools/testplan/plan.go
@@ -140,7 +140,12 @@ func build(root string, paths []string) plan {
 
 	for _, path := range paths {
 		r, matched := governing(path)
-		if matched {
+		// A test file is still triaged — a `_test.go` in a package no rule
+		// names is exactly as un-triaged as its neighbour — but it earns no
+		// conformance run, because nothing compiled into tests alone can
+		// change an answer a real client reads. What judges it is `check`,
+		// and the falsifications below.
+		if matched && !testOnly(path) {
 			for _, cmd := range r.Runs {
 				add(normalise(cmd), r.Why)
 			}
@@ -157,6 +162,11 @@ func build(root string, paths []string) plan {
 		if !matched {
 			p.Untriaged = append(p.Untriaged, path)
 		}
+	}
+
+	for _, spec := range falsifications(root, paths) {
+		add(spec, "this spec mutates a file the diff touches, so it is the subset of "+
+			"`falsify:all` that can have stopped biting")
 	}
 
 	sort.Slice(order, func(i, j int) bool { return cost(order[i]) < cost(order[j]) })
@@ -198,6 +208,9 @@ func cost(cmd string) int {
 		if strings.Contains(cmd, leg) {
 			return seconds
 		}
+	}
+	if strings.Contains(cmd, "falsify --") || strings.Contains(cmd, "falsify -- ") {
+		return 30
 	}
 	if strings.Contains(cmd, "conformance:functional") {
 		return 600

--- a/tools/testplan/plan_test.go
+++ b/tools/testplan/plan_test.go
@@ -422,3 +422,82 @@ func TestAMarkdownFileIsDocumentationWhereverItLives(t *testing.T) {
 		t.Fatal("a harness script earned nothing; the documentation rule has swallowed the directory")
 	}
 }
+
+// A file compiled into tests alone cannot change a served answer, so it earns no
+// conformance leg — the same argument that makes prose prose wherever it lives.
+// It is still triaged: a `_test.go` in a package no rule names must redden.
+func TestAFileCompiledOnlyIntoTestsEarnsNoConformanceRun(t *testing.T) {
+	for _, path := range []string{
+		"internal/core/machine/incus_test.go",
+		"internal/providers/scaleway/testdata/servers.json",
+	} {
+		got := build(t.TempDir(), []string{path})
+		for _, r := range got.Runs {
+			if strings.Contains(r.Command, "conformance") {
+				t.Errorf("%s earned %q; nothing compiled into tests alone reaches a client", path, r.Command)
+			}
+		}
+		if len(got.Untriaged) > 0 {
+			t.Errorf("%s was reported un-triaged; the exemption must not swallow the triage", path)
+		}
+	}
+	// The control: the production file beside it must still earn its leg,
+	// otherwise this test would pass over an exemption that swallowed the
+	// whole directory.
+	got := build(t.TempDir(), []string{"internal/core/machine/incus.go"})
+	if len(got.Runs) == 0 {
+		t.Fatal("a production file in the machine layer earned nothing")
+	}
+	// And a test file in a package no rule names is still an absence.
+	if orphan := build(t.TempDir(), []string{"quantum/teleporter_test.go"}); len(orphan.Untriaged) != 1 {
+		t.Fatalf("an un-triaged test file was excused rather than reported: %+v", orphan.Untriaged)
+	}
+}
+
+// The falsifications a diff has earned, read off the specs. This is the
+// discipline every batch here has followed by hand and stated in its own pull
+// request, which means it has also been forgotten by hand.
+func TestAChangedFileEarnsTheSpecsThatMutateIt(t *testing.T) {
+	dir := t.TempDir()
+	specs := filepath.Join(dir, "tools", "falsify", "specs")
+	if err := os.MkdirAll(specs, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(name, body string) {
+		if err := os.WriteFile(filepath.Join(specs, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("names-it.json", `{"mutations":[{"file":"internal/core/store/store.go","find":"a","replace":"b","test":"T"}]}`)
+	write("names-another.json", `{"mutations":[{"file":"internal/probe/probe.go","find":"a","replace":"b","test":"T"}]}`)
+
+	got := build(dir, []string{"internal/core/store/store.go"})
+	want := "mise run falsify -- tools/falsify/specs/names-it.json"
+	if !hasRun(got, want) {
+		t.Fatalf("a changed file did not earn the spec that mutates it; the plan was:\n%s", got)
+	}
+	// The control, and it is what stops this passing over a build() that
+	// prints every spec it can find: the spec naming another file must not
+	// appear.
+	if hasRun(got, "mise run falsify -- tools/falsify/specs/names-another.json") {
+		t.Fatal("a spec naming an untouched file was earned; the mapping is not read, it is emitted")
+	}
+}
+
+// The real corpus, not a fixture: the mapping is only worth having if it is
+// exact against what this repository actually declares.
+func TestTheRealSpecsAreReadAndOnlyTheMatchingOnesAreEarned(t *testing.T) {
+	dir := root(t)
+	got := falsifications(dir, []string{"internal/core/machine/incus_ovn.go"})
+	if len(got) == 0 {
+		t.Fatal("no spec earned for a file 20 mutations name; the specs are not being read")
+	}
+	for _, cmd := range got {
+		if !strings.HasPrefix(cmd, "mise run falsify -- tools/falsify/specs/") {
+			t.Errorf("earned command is not runnable as printed: %q", cmd)
+		}
+	}
+	if none := falsifications(dir, []string{"quantum/teleporter.go"}); len(none) != 0 {
+		t.Errorf("a file no spec names earned %v", none)
+	}
+}

--- a/tools/testplan/specs.go
+++ b/tools/testplan/specs.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// The falsifications a diff has earned, read off the specs rather than
+// remembered.
+//
+// This is a discipline every batch on this repository has followed by hand and
+// stated in its own pull request — *"the 31 specs naming a touched file replayed
+// in full"* — which means it has also been forgotten by hand. A guard whose test
+// stopped biting is invisible to `mise run check`: the test still passes, and it
+// passes over nothing. `falsify:lint` checks only that each declared fragment
+// still applies textually; replaying the mutation is what proves the test bites.
+//
+// 128 specs name 186 distinct files today, so the mapping is far past the size
+// anybody holds in their head, and it is exact: a spec says which file it
+// mutates. Nothing here is a judgement — the specs are the source, and a spec
+// that stops naming a file stops earning its replay on the same commit.
+//
+// `falsify:all` is the whole set and belongs to the night. What this prints is
+// the subset the diff can possibly have broken.
+
+// falsifications lists the specs whose mutations name one of these paths.
+func falsifications(root string, paths []string) []string {
+	changed := make(map[string]bool, len(paths))
+	for _, p := range paths {
+		changed[p] = true
+	}
+
+	dir := filepath.Join(root, "tools", "falsify", "specs")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		// No specs directory: a worktree without them, or a caller pointing at
+		// a synthetic tree. Silence is right here and nowhere else in this
+		// tool — the specs are an artefact this reads, not a claim it makes.
+		return nil
+	}
+
+	var earned []string
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		var spec struct {
+			Mutations []struct {
+				File string `json:"file"`
+			} `json:"mutations"`
+		}
+		if json.Unmarshal(body, &spec) != nil {
+			continue
+		}
+		for _, m := range spec.Mutations {
+			if changed[m.File] {
+				earned = append(earned, "mise run falsify -- tools/falsify/specs/"+entry.Name())
+				break
+			}
+		}
+	}
+	sort.Strings(earned)
+	return earned
+}
+
+// testOnly reports whether a path is compiled into tests and nothing else.
+//
+// A `_test.go` file and a `testdata/` tree cannot change an answer a real client
+// reads, so no conformance leg can judge them — the same argument that makes
+// prose prose wherever it lives. What judges them is `mise run check`, which
+// prepush already runs, and the falsifications above, which is the half worth
+// having: a change to a test is exactly the change that can stop a guard biting
+// without turning anything red.
+func testOnly(path string) bool {
+	return strings.HasSuffix(path, "_test.go") ||
+		strings.HasPrefix(path, "testdata/") ||
+		strings.Contains(path, "/testdata/")
+}


### PR DESCRIPTION
Follows #564, merged this morning. Two sharpenings found by using it, and the
second is the one worth having.

## The exemption was not the point — it was the question

A `_test.go` file and a `testdata/` tree earn no conformance leg, for the same
reason prose does not: nothing compiled into tests alone reaches a client. They
stay **triaged**, so a test file in a package no rule names still reddens —
`TestAFileCompiledOnlyIntoTestsEarnsNoConformanceRun` carries that control, plus
the production file beside it which must still earn its leg.

That raised the real question: **what does judge a test change?** And the answer
was already a discipline of this repository, followed by hand and stated in every
pull request — *"the 31 specs naming a touched file replayed in full"*.

**128 specs name 186 distinct files.** That is far past what anybody holds in
their head, and it is exact, because a spec says which file it mutates. Followed
by hand means forgotten by hand, and `mise run check` cannot see a guard whose
test still passes over nothing: `falsify:lint` checks only that each declared
fragment still applies textually.

So the plan reads the specs. Nothing is remembered — a spec that stops naming a
file stops earning its replay on the same commit, the way the surface scan is
derived from the SDK rather than from a list.

## Demonstrated on itself

This diff earns `falsify:lint` and exactly one spec — the one that mutates the
file it changes:

```
  mise run falsify:lint
  mise run falsify -- tools/falsify/specs/a-plan-that-cannot-rot.json
      because this spec mutates a file the diff touches, so it is the subset of
      `falsify:all` that can have stopped biting
```

`plan_test.go` is in that diff and earns no conformance leg, which is the first
sharpening working.

## The harness refused three of my mutations, and it was right

`falsify` requires every name in `find` to survive into `replace`. A dropped term
orphans a name, fails to compile, and **fails every test in the package — which
reads exactly like the guard being proven.** All three were neutralised
(`&& (… || true)`, `[:0]`) rather than deleted.

**Fourteen mutations, fourteen bites**, green after restoration. The four new ones
cover both directions of each rule: the exemption disappearing, the exemption
swallowing the triage, the spec reading disappearing, and — the one that matters
most — every spec being earned rather than the matching ones, which would read as
thoroughness and be noise nobody runs twice.

## Gates

`mise run prepush` 0 (it calls `testplan --check`), `docs:check` 0, `falsify`
14/14, and the plan this tool printed for its own diff was run.

Documentation: `CONTRIBUTING.md`, `CONTRIBUTING.fr.md`, `tools/conformance/README.md`.

## Not obtained

`falsify:all` is still the nightly job and this does not change that. What is new
is that the *subset* a diff can have broken is now named at the moment somebody
can act on it, rather than recalled afterwards.
