### PR TITLE
fix(machine, scaleway): an address carries its kind, a VPC without enable_routing routes, and the uncovered interface is named (#541, #497, #496, #548)

### DIFF
--- a/docs/limits-acks.json
+++ b/docs/limits-acks.json
@@ -4,7 +4,7 @@
     "A Scaleway VPC's Network ACL is a record, and nothing at the edge applies it": "2026-08-27",
     "A Scaleway load balancer and public gateway record their configuration; nothing forwards packets": "2026-08-27",
     "A Scaleway server's root volume type: what is writable, and what is not": "2026-08-27",
-    "A VPC created without `enable_routing` answers `routing_enabled=false` where the real cloud answers `true` (#497)": "2026-08-27",
+    "A VPC created without `enable_routing` answered `routing_enabled=false` where the real cloud answers `true` (#497, lifted 2026-08-27)": "2026-08-27",
     "A declared query parameter is served or refused, never dropped — and `labels` is the refused one": "2026-08-27",
     "A machine's route out: which shapes reach a package repository (#507)": "2026-08-27",
     "A public address is the provider's value, made to answer on the host": "2026-08-27",

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -3233,7 +3233,64 @@ bare beside `eth1` on a managed network carrying the rule set). The pack hands
 the set over, the driver refuses with the typed error, and the log names the
 declaring capability instead of crying wolf. The capability is therefore
 broader than the machine it was written for: it is about the *interface*, not
-about a machine with only one.
+about a machine with only one — and `machine.Capabilities.FirewallPublicOnly`
+says so in its own words since #548, because a declaration whose subject is
+wrong reads like proof.
+
+Reproduced from the API alone on 2026-08-27, without the stack, under
+`--vm incus-ovn`: a group whose inbound default is `drop` with one rule
+allowing 443, a server created with its flexible IP, its private NIC attached
+afterwards. The escape and its negative control are in the same probe.
+
+```console
+$ incus query /1.0/instances/feint-scw-d3eaa40c-… | jq -c '.expanded_devices | …'
+{"eth0":{"ipv4.address":"203.0.113.2","nictype":"routed","type":"nic"},
+ "eth1":{"ipv4.address":"10.181.7.2","network":"fnt-c9b63dbeff0","security.acls":"scw-3bab95b997b","type":"nic"}}
+
+  203.0.113.2:22   connect_ex=0    OPEN      # no rule opens 22: the group is not on eth0
+  203.0.113.2:80   connect_ex=111  refused   # reached the machine, nothing listening
+  10.181.7.2:80    connect_ex=113  no route  # the private side, where the policy holds
+```
+
+`connect_ex=111` on a port the group never opened is the decisive line: the
+packet reached the guest and was refused by it, where a covered interface
+would have dropped it.
+
+**The migration was tried, and it is refused.** #548 left one thing untried —
+whether the driver could move the address onto the managed NIC once that one
+arrives, which is the shape the other creation order already produces and the
+one the rule set covers. It was attempted by hand on 2026-08-27, on the very
+machine above, and stopped on two measured facts:
+
+```console
+$ incus network set feint-uplink ipv4.routes "…,203.0.113.2/32"
+Error: Failed to add route {… Dst: 203.0.113.2/32 …}: file exists
+$ incus config device remove feint-scw-d3eaa40c-… eth0
+$ incus query /1.0/instances/feint-scw-d3eaa40c-… | jq -c '…'
+{"eth0":{"network":"incusbr0","type":"nic"}, "eth1":{…}}
+```
+
+The uplink cannot be given the `/32` while the routed NIC still owns the host
+route for it — the collision #498 documents, met from the other side — so the
+address would have to leave the routed NIC first, and there is no ordering
+where it is delivered throughout. And removing the routed device unmasks the
+profile's `eth0` on `incusbr0`, the operator's own default bridge: the machine
+lands on a bridge this emulator refuses to put anything on. A sequence that
+gets there exists on paper (mask `eth0` with a `none` device, then delegate,
+then set `ipv4.routes.external`, then repair the guest) and it costs a
+reconfiguration of the public interface on every private-NIC attach, which
+Terraform performs on every apply. That trade was not taken; this paragraph is
+the record of the measurement rather than a plan.
+
+What #548 delivered instead is the naming: the refusal now carries every
+routed interface that escapes *and the addresses it delivers*
+(`eth0 (203.0.113.2)`), read from both `ipv4.address` and `ipv4.routes` so an
+address attached after the boot is named too, and the warning no longer calls
+the machine public-only.
+`TestTheUnenforceableRefusalNamesTheAddressThatEscapes`,
+`TestTheUnenforceableRefusalNamesAnAddressRoutedAfterTheLaunch` and
+`TestTheUnenforceableWarningDoesNotCallTheMachinePublicOnly` fail without it,
+and `tools/falsify/specs/uncovered-interface.json` replays all three.
 
 Second, between two machines of one subnet the sender's permissive
 egress still wins over the receiver's ingress default (the single-pipeline

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -3347,14 +3347,59 @@ answers. One counter-witness is on record and stays on record: #491's probe of
 station→private measurement that worked at least once in a configuration this
 finding does not explain. Both observations are written here as they were made.
 
+Re-measured on 2026-08-27 on fresh networks (`10.181.7.0/24`, one machine,
+zero ACL relevance to the result), with the capture this time rather than
+beside it:
+
+```console
+$ ip route show 10.181.7.0/24
+10.181.7.0/24 dev feint-uplink proto static scope link
+$ sudo tcpdump -ni feint-uplink 'host 10.181.7.2 or arp'
+ARP, Request who-has 10.181.7.2 tell 10.209.83.1   (x3, no answer)
+  10.181.7.2:22 connect_ex=11    10.181.7.2:80 connect_ex=113
+
+$ sudo ip route replace 10.181.7.0/24 via 10.209.83.128 dev feint-uplink
+  10.181.7.2:22 connect_ex=111   10.181.7.2:80 connect_ex=111
+```
+
+The flip's *new* fact is the value it flips to. With the `via` route the two
+ports stop being unreachable (11, 113) and become **refused** (111) — the
+receiving NIC's own rule set answering, since the group under test opened
+neither. So the router does forward for the subnet when it is addressed
+directly; what fails is the scope-link form's ARP, exactly as the capture
+shows.
+
+**Why it will not lift here, measured.** The earlier wording said the fix was
+to post the route `via` the network's router instead of `dev`-only, as if the
+emulator were choosing the form. It is not: the emulator never writes a host
+route. Its only host binary is `incus` — every `ip` in `internal/core/machine`
+runs as `incus exec <machine> -- ip …`, inside a guest — and the host route
+above is Incus's own materialisation of the uplink bridge's `ipv4.routes`,
+which an OVN network's subnet must sit inside or the network is refused
+("Uplink network doesn't contain … in its routes"). That key takes CIDRs and
+nothing else, measured on a scratch bridge on 2026-08-27:
+
+```console
+$ incus network set probe496br ipv4.routes=10.223.0.0/24
+$ ip route show 10.223.0.0/24
+10.223.0.0/24 dev probe496br proto static scope link
+$ incus network set probe496br ipv4.routes="10.224.0.0/24 via 10.222.222.2"
+Error: Invalid value for network "probe496br" option "ipv4.routes":
+  Item "10.224.0.0/24 via 10.222.222.2": invalid CIDR address
+```
+
+So lifting this means the emulator running `ip route` as root on the operator's
+host, which is a different program from the one this repository ships: the
+machine driver's whole blast radius is what `incus` will do for the user who
+started it. The remedy stays where it belongs, with whoever wants the path —
+one `ip route replace … via <volatile.network.ipv4.address>` per subnet, which
+the block above is the recipe for.
+
 Who this touches: any harness that probes a private address from the station,
 firewall proofs first. Machines between themselves are not concerned. The
 capability already says it — `capabilities.private_from_host` is `false` under
 OVN — so a consumer asks `/_feint/health` instead of probing blind (see "A
-public address is the provider's value, made to answer on the host"). What
-would lift it: posting the subnet route `via` the network's router address
-instead of `dev`-only, which is what #496 asks and what the manual
-`ip route replace` above demonstrated.
+public address is the provider's value, made to answer on the host").
 
 ## A VPC created without `enable_routing` answered `routing_enabled=false` where the real cloud answers `true` (#497, lifted 2026-08-27)
 

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -3299,7 +3299,7 @@ would lift it: posting the subnet route `via` the network's router address
 instead of `dev`-only, which is what #496 asks and what the manual
 `ip route replace` above demonstrated.
 
-## A VPC created without `enable_routing` answers `routing_enabled=false` where the real cloud answers `true` (#497)
+## A VPC created without `enable_routing` answered `routing_enabled=false` where the real cloud answers `true` (#497, lifted 2026-08-27)
 
 The premise was verified on the real cloud before anything else (real account,
 2026-08-26, the test VPC deleted afterwards):
@@ -3309,11 +3309,13 @@ $ scw vpc vpc create name=feint-premise-routing        # no enable_routing
 RoutingEnabled                  true
 ```
 
-This emulator stores the request field as-is
-(`internal/providers/scaleway/vpc.go:207`,
+This emulator stored the request field as-is
+(`internal/providers/scaleway/vpc.go`,
 `res.Attrs["routing_enabled"] = req.EnableRouting`), so the Go zero value
-becomes the default — the inverse of upstream. The Scaleway example stack
-creates its two VPCs without the field, and both read back `false`:
+became the default — the inverse of upstream. The Scaleway example stack
+created its two VPCs without the field, and both read back `false` (its
+workload VPC has written `enable_routing = true` out since #503, for this
+reason; its management VPC still says nothing):
 
 ```console
 $ curl -s …/vpc/v2/regions/fr-par/vpcs | jq '.vpcs[] | {name, routing_enabled}'
@@ -3328,12 +3330,31 @@ the web group's rule accepts `0.0.0.0/0`. On the real cloud, two Private
 Networks of one routed VPC reach each other. Measured: the three blocks above.
 Deduced: nothing.
 
-What to do with it: declare `enable_routing = true` explicitly (Terraform) or
-`enable_routing` on the create. The stored value is the request's, so an
-explicit `true` is stored as `true`, and two networks of a routing VPC are
-joined the runtime's own way ("Subnet isolation depends on the runtime mode"
-carries that measurement). What would lift it: matching upstream's default at
-create, at the line named above.
+**The limit is gone; this section stays as its dated record.** The create no
+longer stores the Go zero of an absent field: `createVPCRequest.EnableRouting`
+is a pointer, and only a value the client actually sent overwrites the `true`
+`newVPC` already carried for the lazily provisioned default VPC. An explicit
+`false` is still stored as `false`, in either direction — the real-cloud
+measurement above covers the *absent* field and nothing else, and inventing an
+answer for a field that was sent is the guess this repository refuses.
+
+Re-measured after the fix, same runtime, 2026-08-27:
+
+```console
+$ curl -sH 'Content-Type: application/json' \
+    …/vpc/v2/regions/fr-par/vpcs -d '{"name":"audit-497"}' | jq .routing_enabled
+true
+$ incus network peer list fnt-e5ba51ab1fa          # two Private Networks of that VPC
+| fnt-aac94982924 | default/fnt-aac94982924 | local | CREATED |
+```
+
+The peering is the half that matters and the one the flag was never only about:
+`reachableFrom` reads it, so a default corrected in the view alone would have
+left the host exactly as it was — which is why
+`TestAVPCCreatedWithoutEnableRoutingRoutes` asserts on the peer list and not on
+the field, in both directions, and why
+`tools/falsify/specs/vpc-routing-default.json` replays it with the Go zero put
+back.
 
 ## An API reboot used to log `Failed to add route: file exists` for its own public /32 (#498, lifted 2026-08-27)
 

--- a/examples/stacks/scaleway/main.tf
+++ b/examples/stacks/scaleway/main.tf
@@ -86,21 +86,23 @@ resource "scaleway_vpc" "workload" {
   name = "platform-workload"
   tags = ["platform", "workload"]
 
-  # Written out although the real cloud answers `true` for a VPC created
-  # without the field, and #497 is why: this emulator stores the Go zero, so
-  # the same configuration gets `routing_enabled: false` here and `true` on a
-  # real fr-par account (that issue carries the `scw vpc vpc create` run that
-  # settled it). The consequence is not cosmetic under `--vm incus-ovn`, and it
-  # was measured again on 2026-08-27: no `incus network peer` between the web
-  # and app networks, their isolation sets rejecting each other, and
-  # web → app:8080 refused by that rejection rather than by any group.
+  # Redundant since #497 was fixed on 2026-08-27, and kept because it is true:
+  # the real cloud answers `routing_enabled: true` for a VPC created without
+  # the field, and this emulator now does the same — a VPC created without
+  # `enable_routing` routes, and its Private Networks are peered on the host.
   #
-  # So `scaleway_vpc_route` and the app group's "accept 8080 from the web
-  # block" described a path no packet could take. This line makes the emulated
-  # VPC behave the way the real one already does, and
-  # tools/conformance/functional.sh asserts the pair it unblocks: remove it and
-  # the firewall check goes red naming the port it could not reach. The day
-  # #497 is fixed the line becomes redundant, and it stays true.
+  # It was load-bearing when it was written, which is why the record stays.
+  # The emulator stored the Go zero, so the same configuration read `false`
+  # here and `true` on a real fr-par account, and under `--vm incus-ovn` the
+  # consequence was not cosmetic: no `incus network peer` between the web and
+  # app networks, their isolation sets rejecting each other, and
+  # web → app:8080 refused by that rejection rather than by any group — so
+  # `scaleway_vpc_route` and the app group's "accept 8080 from the web block"
+  # described a path no packet could take. tools/conformance/functional.sh
+  # asserts the pair that unblocks.
+  #
+  # The management VPC below still says nothing, deliberately: it is the half
+  # of this stack that exercises the emulator's own default.
   enable_routing = true
 }
 

--- a/internal/cli/driver_surface_test.go
+++ b/internal/cli/driver_surface_test.go
@@ -662,6 +662,15 @@ var mustStayOutside = []string{
 	// machine through the binding skips it.
 	"Binding.Start", "Binding.Stop", "Binding.Remove", "Binding.Address",
 	"Binding.Name", "Binding.PowerOn", "Binding.Refresh", "Binding.ForgetPlacements",
+	// The unkinded address reader (#541). It was in the surface until an
+	// Exoscale instance with no public IP published its private-network
+	// address as `public-ip`: the binding records whatever the runtime
+	// answered and says nothing about what kind of address it is, so every
+	// pack republishing it under a field whose name asserts one was asserting
+	// what nobody had checked. Reconciler.PublicAddressOf and
+	// PrivateAddressOf are the doors, and this line is what stops the old one
+	// from being quietly reopened.
+	"Binding.AddressOf",
 	"Binding.RouteAddress", "Binding.UnrouteAddress",
 	"Binding.SyncRuleSet", "Binding.ApplyRuleSets", "Binding.DropRuleSet",
 	"Binding.WithDriver",

--- a/internal/cli/testdata/provider-four/intents.go
+++ b/internal/cli/testdata/provider-four/intents.go
@@ -276,7 +276,7 @@ func (p *Pack) addressesWearing(barrierID string, fresh *resource.Resource) []st
 		if !worn {
 			continue
 		}
-		if address := p.binding().AddressOf(node); address != "" {
+		if address := p.reconciler().PrivateAddressOf(node); address != "" {
 			addresses = append(addresses, address)
 		}
 	}
@@ -463,8 +463,12 @@ func (p *Pack) ReadNode(ctx context.Context, id string) (*resource.Resource, err
 
 // AddressOfNode is the private address the machine answers on, empty when
 // nothing is running.
+//
+// Through the layer's kinded reader (#541): what the binding recorded is
+// whatever the runtime answered, and a field called "private" must not carry
+// an address this pack hands out as public.
 func (p *Pack) AddressOfNode(res *resource.Resource) string {
-	return p.binding().AddressOf(res)
+	return p.reconciler().PrivateAddressOf(res)
 }
 
 // image resolves the identifier the user sent through this pack's own

--- a/internal/core/machine/capabilities.go
+++ b/internal/core/machine/capabilities.go
@@ -25,17 +25,31 @@ type Capabilities struct {
 	// Firewall: a security group's rules are enforced on the machine's
 	// interface, and a change applies without restarting it.
 	Firewall bool `json:"firewall"`
-	// FirewallPublicOnly: the rules are enforced even on a machine that joins
-	// no emulated network — a server whose only interface is a routed NIC
-	// carrying the public addresses its API publishes (#202).
+	// FirewallPublicOnly: the rules are enforced on an address that lives on a
+	// routed NIC — the interface a machine gets when it joins no emulated
+	// network (#202), and the one a machine keeps beside its private NIC when
+	// the address came first (#548).
+	//
+	// The subject is the *interface*, and saying so is #548. This field read
+	// "a machine that joins no emulated network" until then, which is where it
+	// was first measured, and a consumer holding both fields concluded that a
+	// machine with a private network was covered whole. It is not: a Scaleway
+	// server created with its flexible IP boots carrying only that address, so
+	// the driver gives it a routed NIC, and the private NIC that arrives
+	// afterwards becomes eth1 and does not take the address with it. Measured
+	// on 2026-08-27 on examples/stacks/scaleway under `--vm incus-ovn`: eth0
+	// routed and bare beside eth1 wearing the rule set, and port 22 answering
+	// from the station under a group whose inbound default is drop. The order
+	// decides: with the private NIC first, the flexible IP is routed *through*
+	// the filtered NIC and is covered — fifteen runs both ways, in
+	// docs/limits.md.
 	//
 	// Declared apart from Firewall because the two were measured apart (#337).
-	// On Incus, the same group that closes a port for real on a machine with
-	// an emulated network under it — public address included, since a flexible
-	// IP is routed through the filtered NIC — attaches to nothing on a routed
-	// NIC: every security option is an invalid device option there, on 7.2 and
-	// 7.3 alike. A suite probing the ports of a public-only machine gates on
-	// this claim, never on capabilities.firewall.
+	// On Incus, the same group that closes a port for real on a managed NIC
+	// attaches to nothing on a routed one: every security option is an invalid
+	// device option there, on 7.2 and 7.3 alike. A suite probing a port on an
+	// address published over a routed NIC gates on this claim, never on
+	// capabilities.firewall.
 	FirewallPublicOnly bool `json:"firewall_public_only"`
 	// Isolation: two networks of two different VPCs cannot reach each other.
 	//

--- a/internal/core/machine/firewall_binding.go
+++ b/internal/core/machine/firewall_binding.go
@@ -121,19 +121,30 @@ func (b Binding) ApplyRuleSets(ctx context.Context, fw Firewaller, machine strin
 }
 
 // reportFirewall logs a failed application at the level it deserves. A rule
-// set the runtime has no mechanism for — a routed NIC, the interface of a
-// server with only a public address (#337) — is a declared limit, not an
-// operational failure: /_feint/health publishes it as
+// set the runtime has no mechanism for — a routed NIC (#337) — is a declared
+// limit, not an operational failure: /_feint/health publishes it as
 // capabilities.firewall_public_only=false and docs/limits.md carries the
 // measurement, so the warning names the declaration instead of crying wolf.
 // Anything else stays an error, because nothing declared it.
+//
+// The sentence used to say "this machine's public-only interface", and #548
+// measured that as false on the shape it fires on most: a Scaleway server
+// created with its flexible IP has a routed eth0 *and* a private eth1 on a
+// managed network carrying the rule set, so the machine is not public-only and
+// an operator reading the line concluded the wrong machine was concerned. What
+// the runtime cannot filter is the *interface*, whatever else the machine
+// carries; the error the driver raises names it and the addresses it delivers.
+//
 // TestAnUnenforceableGroupIsReportedAsTheDeclaredLimit fails without the
-// distinction.
+// distinction, and TestTheUnenforceableWarningDoesNotCallTheMachinePublicOnly
+// fails without the subject.
 func (b Binding) reportFirewall(err error, keyvals ...any) {
 	keyvals = append(keyvals, "provider", b.Provider, "error", err)
 	if errors.Is(err, ErrFirewallUnenforceable) {
-		b.logger().Warn("the security group is not enforced on this machine's public-only interface, "+
-			"which the runtime declares (capabilities.firewall_public_only=false, docs/limits.md)",
+		b.logger().Warn("the security group is not enforced on this machine's routed interface, "+
+			"which carries a published address and takes no rule set — the runtime declares it "+
+			"(capabilities.firewall_public_only=false, docs/limits.md); the error names the "+
+			"interface and the address that answers uncovered",
 			keyvals...)
 		return
 	}

--- a/internal/core/machine/firewall_binding_test.go
+++ b/internal/core/machine/firewall_binding_test.go
@@ -139,3 +139,38 @@ func TestDropRuleSetHandsTheNameToTheRuntime(t *testing.T) {
 		t.Fatalf("removed %v, want [scw-abc]", fw.removed)
 	}
 }
+
+// TestTheUnenforceableWarningDoesNotCallTheMachinePublicOnly is the subject
+// half of #548: a declaration whose subject is wrong is worse than none,
+// because it reads like proof.
+//
+// The line said "this machine's public-only interface", and the shape it fires
+// on most is not a public-only machine at all: a Scaleway server created with
+// its flexible IP carries a routed eth0 *and* a private eth1 on a managed
+// network wearing the rule set. Measured on 2026-08-27 under `--vm incus-ovn`,
+// that exact warning was emitted for feint-scw-675132c2… while `incus query`
+// showed two NICs. An operator reading it concluded the machine was one of the
+// public-only ones and that theirs was covered.
+//
+// What the runtime cannot filter is the interface, and the operator's next
+// gesture needs the address: the log carries the driver's error, which names
+// both.
+func TestTheUnenforceableWarningDoesNotCallTheMachinePublicOnly(t *testing.T) {
+	var buf bytes.Buffer
+	fw := &fakeFirewaller{applyErr: fmt.Errorf(
+		"apply firewall to m: a routed NIC accepts no security option, so what it carries "+
+			"is covered by nothing: eth0 (203.0.113.2): %w", ErrFirewallUnenforceable)}
+
+	firewallBinding(&buf).ApplyRuleSets(context.Background(), fw, "feint-test-a",
+		FirewallSpec{Name: "sg-r", DefaultIngress: "drop", DefaultEgress: "allow"})
+
+	said := buf.String()
+	if strings.Contains(said, "public-only interface") {
+		t.Errorf("the warning still describes the machine as public-only, which #548 measured false: %q", said)
+	}
+	for _, want := range []string{"eth0", "203.0.113.2", "firewall_public_only"} {
+		if !strings.Contains(said, want) {
+			t.Errorf("the warning does not carry %q, so it cannot be acted on: %q", want, said)
+		}
+	}
+}

--- a/internal/core/machine/incus_firewall.go
+++ b/internal/core/machine/incus_firewall.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/netip"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -206,7 +207,7 @@ func (d *Incus) ApplyFirewall(ctx context.Context, machine string, binding Firew
 	joined := strings.Join(binding.Names, ",")
 	networks := map[string]networkACLInfo{}
 	permissiveEnsured := false
-	var unenforceable error
+	var escaped []string
 	for _, device := range devices {
 		// A routed NIC takes no rule set at all (#337). Measured on Incus 7.2
 		// and confirmed by the 7.3 wording of the same refusal: every security
@@ -224,12 +225,26 @@ func (d *Incus) ApplyFirewall(ctx context.Context, machine string, binding Firew
 		// machine with a private NIC beside its routed one keeps its private
 		// plane covered.
 		//
+		// Every escaping interface is named, with the addresses it carries,
+		// and that is #548 rather than tidiness. The refusal used to keep the
+		// first one and drop the rest, and to name the device alone — so an
+		// operator reading the log learned that "eth0" was uncovered on a
+		// machine whose interfaces they cannot see, when what they needed was
+		// *which published address answers with no rule set on it*. Measured
+		// on 2026-08-27 under `--vm incus-ovn`, on the shape
+		// examples/stacks/scaleway produces and reproduced from the API alone:
+		// a server created with its flexible IP keeps a routed eth0 carrying
+		// 203.0.113.2 beside a filtered eth1, and port 22 — which the group's
+		// drop default never opened — answered from the station while the
+		// same port on the private address was refused.
+		//
 		// TestApplyFirewallRefusesAGroupOnARoutedNIC and
-		// TestApplyFirewallDetachIgnoresARoutedNIC fail without this.
+		// TestApplyFirewallDetachIgnoresARoutedNIC fail without this, and
+		// TestTheUnenforceableRefusalNamesTheAddressThatEscapes fails without
+		// the addresses.
 		if device.routed {
-			if joined != "" && unenforceable == nil {
-				unenforceable = fmt.Errorf("apply firewall to %s/%s: a routed NIC accepts no security option: %w",
-					machine, device.name, ErrFirewallUnenforceable)
+			if joined != "" {
+				escaped = append(escaped, device.describe())
 			}
 			continue
 		}
@@ -295,7 +310,13 @@ func (d *Incus) ApplyFirewall(ctx context.Context, machine string, binding Firew
 			return fmt.Errorf("apply firewall to %s/%s: %w", machine, device.name, err)
 		}
 	}
-	return unenforceable
+	if len(escaped) > 0 {
+		slices.Sort(escaped)
+		return fmt.Errorf("apply firewall to %s: a routed NIC accepts no security option, "+
+			"so what it carries is covered by nothing: %s: %w",
+			machine, strings.Join(escaped, ", "), ErrFirewallUnenforceable)
+	}
+	return nil
 }
 
 // networkACLInfo is what one network lookup answers ApplyFirewall: its type,
@@ -376,13 +397,31 @@ func FirewallName(prefix, id string) string {
 }
 
 // nicDevice is one interface of a machine: its name, the network it sits on,
-// whether it comes from a profile, and whether it is a routed NIC — the one
-// kind that sits on no network and takes no security option.
+// whether it comes from a profile, whether it is a routed NIC — the one kind
+// that sits on no network and takes no security option — and the addresses it
+// delivers.
 type nicDevice struct {
 	name      string
 	network   string
 	inherited bool
 	routed    bool
+	// addresses are what this interface makes the machine answer on: the ones
+	// the launch pinned (ipv4.address) and the ones routed onto it afterwards
+	// (ipv4.routes). Read only to be *named*, never to decide anything — a
+	// refusal that says "eth0" tells an operator nothing they can check, and a
+	// refusal that says "eth0 (203.0.113.2)" names the address a client is
+	// about to connect to (#548).
+	addresses []string
+}
+
+// describe is how one escaping interface is named in a refusal: the device,
+// and what it makes the machine answer on. An interface with no address is
+// named alone rather than with an empty pair of brackets.
+func (n nicDevice) describe() string {
+	if len(n.addresses) == 0 {
+		return n.name
+	}
+	return n.name + " (" + strings.Join(n.addresses, ", ") + ")"
 }
 
 // networkDevices lists every NIC of a machine, its own and the ones it inherits.
@@ -417,9 +456,31 @@ func (d *Incus) networkDevices(ctx context.Context, machine string) ([]nicDevice
 			network:   device["network"],
 			inherited: !own,
 			routed:    device["nictype"] == "routed",
+			addresses: carriedAddresses(device),
 		})
 	}
 	return devices, nil
+}
+
+// carriedAddresses is what one device makes the machine answer on: the pinned
+// addresses of the launch and the routes added onto it afterwards, the mask
+// dropped so the value reads as an address a client would dial.
+//
+// Both keys, because a public address reaches a machine through either — the
+// launch writes ipv4.address on a routed NIC, routeOntoRoutedNIC writes
+// ipv4.routes on the same one — and a refusal that named only half of them
+// would be silent about exactly the addresses attached after the boot.
+func carriedAddresses(device map[string]string) []string {
+	out := make([]string, 0, 2)
+	for _, key := range []string{"ipv4.address", "ipv4.routes"} {
+		for _, entry := range splitList(device[key]) {
+			address, _, _ := strings.Cut(entry, "/")
+			if address != "" && !slices.Contains(out, address) {
+				out = append(out, address)
+			}
+		}
+	}
+	return out
 }
 
 // toACLRules converts one emulated rule into the rules the runtime can express.

--- a/internal/core/machine/incus_firewall_test.go
+++ b/internal/core/machine/incus_firewall_test.go
@@ -927,3 +927,80 @@ func TestARestrictiveBindingKeepsItsGroupsOnAnIsolatedNetwork(t *testing.T) {
 		t.Errorf("the permissive set has no business near a restrictive binding: %v", got)
 	}
 }
+
+// TestTheUnenforceableRefusalNamesTheAddressThatEscapes is #548. The machine
+// under test is the one the Scaleway stack produces when the flexible IP is
+// attached at creation: a routed eth0 carrying the published address, and a
+// private eth1 on a managed network that takes the rule set. Measured on
+// 2026-08-27 under `--vm incus-ovn`, port 22 answered on 203.0.113.2 from the
+// station while the group's inbound default was drop and only 443 was allowed
+// — and the same port on the private address was refused, which is the
+// negative control that tells the two interfaces apart.
+//
+// The refusal already existed; what it did not do was say *what* escapes. An
+// operator reading "eth0" learns nothing they can check, because they cannot
+// see the machine's devices from the API. The address is the fact they can
+// act on: it is the one a client is about to connect to.
+//
+// Three halves, so a guard that refuses everything cannot pass here: the
+// enforceable interface still receives its rule set, no security key is ever
+// sent to the routed one, and the refusal carries both the interface and the
+// address.
+func TestTheUnenforceableRefusalNamesTheAddressThatEscapes(t *testing.T) {
+	f := &fakeRuntime{answers: map[string]string{
+		"/1.0/instances/srv": mixedNICs,
+		"/1.0/networks/":     `{"type": "bridge"}`,
+	}}
+	d := newFakeDriver(f)
+
+	err := d.ApplyFirewall(context.Background(), "srv", FirewallBinding{
+		Names:          []string{"sg-one"},
+		DefaultIngress: "drop",
+		DefaultEgress:  "allow",
+	})
+	if !errors.Is(err, ErrFirewallUnenforceable) {
+		t.Fatalf("a rule set on a routed NIC must be refused with the typed error, got %v", err)
+	}
+	for _, want := range []string{"eth0", "203.0.113.7"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal does not name %q, so nobody can check it: %v", want, err)
+		}
+	}
+	if strings.Contains(err.Error(), "eth1") {
+		t.Errorf("the refusal names the interface that *is* covered: %v", err)
+	}
+	if got := f.matching("config device set srv eth1 security.acls=sg-one"); len(got) != 1 {
+		t.Errorf("the enforceable interface must still get its rule set, got:\n%s",
+			strings.Join(f.commands(), "\n"))
+	}
+}
+
+// TestTheUnenforceableRefusalNamesAnAddressRoutedAfterTheLaunch holds the half
+// carriedAddresses exists for: a public address attached to a running machine
+// lands in the routed NIC's ipv4.routes, not in the ipv4.address list the
+// launch wrote. A refusal reading only the launch key would be silent about
+// exactly the addresses a client adds afterwards.
+func TestTheUnenforceableRefusalNamesAnAddressRoutedAfterTheLaunch(t *testing.T) {
+	const lateAddress = `{
+  "expanded_devices": {
+    "eth0": {"type": "nic", "nictype": "routed", "ipv4.address": "203.0.113.7", "ipv4.routes": "203.0.113.9/32"}
+  },
+  "devices": {
+    "eth0": {"type": "nic", "nictype": "routed", "ipv4.address": "203.0.113.7", "ipv4.routes": "203.0.113.9/32"}
+  }
+}`
+	f := &fakeRuntime{answers: map[string]string{"/1.0/instances/srv": lateAddress}}
+	d := newFakeDriver(f)
+
+	err := d.ApplyFirewall(context.Background(), "srv", FirewallBinding{
+		Names:          []string{"sg-one"},
+		DefaultIngress: "drop",
+		DefaultEgress:  "allow",
+	})
+	if !errors.Is(err, ErrFirewallUnenforceable) {
+		t.Fatalf("a rule set on a routed NIC must be refused with the typed error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "203.0.113.9") {
+		t.Fatalf("the address routed after the launch escapes unnamed: %v", err)
+	}
+}

--- a/internal/core/machine/plan.go
+++ b/internal/core/machine/plan.go
@@ -255,6 +255,66 @@ func (r Reconciler) Unroute(ctx context.Context, machine, address string) {
 	}
 }
 
+// PublicAddressOf is what the machine answers on, when that address is one
+// this pack could have handed out as a public one — and nothing otherwise.
+//
+// The binding records one address per machine and gives it no kind: it is
+// whatever the runtime answered, read off the first interface in name order.
+// Each pack then republishes it under a field whose *name asserts a kind* —
+// Exoscale as `public-ip`, Outscale as `PrivateIp` — and neither asked whether
+// the recorded address was of that kind. Measured on 2026-08-27 under
+// `--vm incus-ovn`: an Exoscale instance created with `public-ip-assignment:
+// "none"` and joined to a private network published `"public-ip":
+// "10.44.9.10"`, its private-network address, while the machine itself was
+// right — one NIC, one address, nothing public (#541). `exo compute instance
+// show` prints that as the instance's IP, so an isolated instance reads as
+// publicly addressed.
+//
+// The only fact that settles the kind is the emulated public block, and the
+// layer already holds it for the three packs — PublicBlock, the guard every
+// address passes on its way to the driver. So the layer answers the question
+// too, once, instead of each pack writing half of it: a pack that publishes
+// an address as public asks here, and a pack that publishes one as private
+// asks PrivateAddressOf. Binding.AddressOf is out of PackSurface for that
+// reason — the layer no longer hands a pack an address with no kind on it.
+//
+// A pack that declares no PublicBlock gets nothing here, which is the safe
+// direction: no block means nothing can be shown to be public.
+//
+// internal/providers/exoscale's TestAnInstanceWithNoPublicIPPublishesNone
+// fails without this, and its TestAnInstanceIsGivenAPublicAddressAtCreation
+// holds the accepting half.
+func (r Reconciler) PublicAddressOf(res *resource.Resource) string {
+	address := r.binding().AddressOf(res)
+	if !r.emulated(address) {
+		return ""
+	}
+	return address
+}
+
+// PrivateAddressOf is the mirror: what the machine answers on, when that
+// address is *not* one this pack hands out as public.
+//
+// It exists because the defect PublicAddressOf closes is symmetric and the
+// other half was live too. An Outscale Vm publishes the recorded address as
+// PrivateIp, and its plan carries promised public addresses onto the launch:
+// the guest then holds two global addresses on one interface, and Inspect
+// answers with whichever the runtime lists first. A restart that came back
+// with the public one would have published 198.51.100.x as PrivateIp and as
+// PublicIp at once. Nothing measured that happening — the pin in
+// rememberAddress hides it after the first boot — which is exactly why the
+// control belongs in the layer rather than in a pack's memory.
+//
+// internal/providers/outscale's TestAVmPublishesNoPublicAddressAsItsPrivateOne
+// fails without this.
+func (r Reconciler) PrivateAddressOf(res *resource.Resource) string {
+	address := r.binding().AddressOf(res)
+	if address == "" || r.emulated(address) {
+		return ""
+	}
+	return address
+}
+
 // emulated reports whether an address is one this pack can have handed out:
 // inside PublicBlock. Well-formed is not authorised; this is the authorisation
 // half, held once for the three packs.

--- a/internal/core/machine/surface.go
+++ b/internal/core/machine/surface.go
@@ -48,10 +48,14 @@ package machine
 //     runs it, last.
 //
 // Measured on 2026-08-26, the day the door closed: this package exports 97
-// package-level names and 297 members of them; the list below admits 17 and 41.
-// Binding alone offers 36 exported members and 14 are in — the other 22 are the
-// mechanics. What the three packs actually reach is 216 sites, every one of them
-// named here and none of them a driver.
+// package-level names and 297 members of them; the list below admitted 17 and
+// 41 that day. Re-counted on 2026-08-27 while #541 moved the address reader
+// into the layer: 17 and 43, Binding down to 13 of its 36 exported members.
+// The middle figure had already drifted by one before that change, which is
+// what a number written in prose does — it is re-counted here rather than
+// left standing, and the count is a fact about the list, never a gate. What
+// the three packs actually reach is 216 sites, every one of them named here
+// and none of them a driver.
 //
 // # The rule when something is missing
 //
@@ -96,7 +100,6 @@ func PackSurface() map[string]string {
 		"Binding.PowerOff":         "stop the machine behind a resource",
 		"Binding.Destroy":          "destroy the machine behind a resource",
 		"Binding.RefreshIfRunning": "re-read what the host holds for a machine the store calls running",
-		"Binding.AddressOf":        "the address the boot produced, as this pack publishes it",
 		"Binding.RuntimeKey":       "the pack's own Runtime key, to read the machine name it is about to hand to Unroute",
 		"Boot":                     "what to boot: image, login, keys, user data",
 		"Image":                    "one entry of the pack's image table, the runtime image and the login together",
@@ -105,13 +108,21 @@ func PackSurface() map[string]string {
 
 		// S2 — the interface plan. The pack declares the shape; the layer
 		// executes the one order.
-		"Reconciler":           "the orchestrator that executes a declared plan in the runtime's order",
-		"Reconciler.PowerOn":   "start a machine on its plan and replay the post-boot order",
-		"Reconciler.Reboot":    "take a machine down and bring it back on its plan",
-		"Plan":                 "the machine's declared interface shape",
-		"Plan.Memberships":     "the networks joined after boot, read back from the plan the pack built",
-		"Attachment":           "one interface: a network, an address, the mask, the secondaries",
-		"Attachment.PrefixLen": "the mask of an attachment the pack assembled",
+		"Reconciler":         "the orchestrator that executes a declared plan in the runtime's order",
+		"Reconciler.PowerOn": "start a machine on its plan and replay the post-boot order",
+		"Reconciler.Reboot":  "take a machine down and bring it back on its plan",
+		// The address the boot produced, with its kind on it. Binding.AddressOf
+		// used to be here and is not any more (#541): the binding records what
+		// the runtime answered and gives it no kind, and a pack republishing it
+		// under a field whose name asserts one — `public-ip`, `PrivateIp` — was
+		// asserting what nobody had checked. The block that settles the kind is
+		// the layer's, so the answer is too.
+		"Reconciler.PublicAddressOf":  "the address the machine answers on, when it is one this pack hands out as public",
+		"Reconciler.PrivateAddressOf": "the same address, when it is not",
+		"Plan":                        "the machine's declared interface shape",
+		"Plan.Memberships":            "the networks joined after boot, read back from the plan the pack built",
+		"Attachment":                  "one interface: a network, an address, the mask, the secondaries",
+		"Attachment.PrefixLen":        "the mask of an attachment the pack assembled",
 
 		// S3 — public addresses.
 		"Reconciler.Route":           "make one public address reach the machine, the hot half",

--- a/internal/providers/exoscale/machines.go
+++ b/internal/providers/exoscale/machines.go
@@ -262,7 +262,20 @@ func (p *Pack) refresh(ctx context.Context, res *resource.Resource) bool {
 }
 
 // addressOf is what an instance publishes as public-ip, a field Exoscale's own
-// instance schema declares.
+// instance schema declares — and only when the address the machine answers on
+// is one this pack hands out as public.
+//
+// The kind is asked of the shared layer rather than assumed here (#541). The
+// binding records whatever the runtime answered, and for an instance created
+// with `public-ip-assignment: "none"` that is its private-network address:
+// measured on 2026-08-27 under `--vm incus-ovn`, `GET /v2/instance/{id}`
+// answered `"public-ip": "10.44.9.10"` on an instance whose host side was
+// exactly right. Their own schema calls the field "Instance public IPv4
+// address", and `none` means the instance has none, so the field is absent —
+// publishing a 10.x there tells `exo compute instance show` that an isolated
+// instance is publicly addressed.
+//
+// TestAnInstanceWithNoPublicIPPublishesNone fails without this.
 func (p *Pack) addressOf(res *resource.Resource) string {
-	return p.binding().AddressOf(res)
+	return p.reconciler().PublicAddressOf(res)
 }

--- a/internal/providers/exoscale/machines_internal_test.go
+++ b/internal/providers/exoscale/machines_internal_test.go
@@ -131,3 +131,49 @@ func TestAServedTemplateBootsAsItsDefaultUser(t *testing.T) {
 		t.Fatalf("booted image=%q user=%q, want debian:12 as debian", got.Image, got.User)
 	}
 }
+
+// The address an instance publishes as public-ip carries a kind, and the kind
+// is checked (#541).
+//
+// Measured on 2026-08-27 under `--vm incus-ovn`, before the fix: an instance
+// created with `public-ip-assignment: "none"` and joined to a private network
+// answered `GET /v2/instance/{id}` with `"public-ip": "10.44.9.10"` — its
+// private-network address — while the machine itself carried exactly what was
+// asked, one NIC and nothing public. The fallback in view() had exactly one
+// live population, the instances that must publish no public address at all.
+//
+// Both halves here, because a guard that refuses everything passes every
+// attack test and breaks the product: an address of the emulated elastic block
+// is still published, and one outside it never is.
+func TestAnInstanceWithNoPublicIPPublishesNone(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		address string
+		want    string
+	}{
+		{"a private-network address is not a public one", "10.44.9.10", ""},
+		{"an address of the emulated elastic block is", "192.0.2.7", "192.0.2.7"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := runtimePack(&recordingDriver{})
+			res := &resource.Resource{
+				ID:    "00000000-0000-4000-8000-0000000000c1",
+				State: "running",
+				Attrs: map[string]any{
+					"name":                 "audit-541",
+					"public-ip-assignment": "none",
+				},
+				Runtime: map[string]string{
+					"machine": "feint-exo-00000000-0000-4000-8000-0000000000c1",
+					"address": tc.address,
+				},
+			}
+
+			published, _ := p.view(res)["public-ip"].(string)
+			if published != tc.want {
+				t.Fatalf("public-ip %q for a machine answering on %s, want %q",
+					published, tc.address, tc.want)
+			}
+		})
+	}
+}

--- a/internal/providers/outscale/machines.go
+++ b/internal/providers/outscale/machines.go
@@ -214,9 +214,20 @@ func (p *Pack) refreshMachine(ctx context.Context, res *resource.Resource) bool 
 }
 
 // addressOf is what a Vm publishes as PrivateIp. Outscale's Vm schema declares
-// the field and a real one carries a value, so the emulator fills it in.
+// the field and a real one carries a value, so the emulator fills it in — but
+// only when the address the machine answers on is not one this pack hands out
+// as public.
+//
+// The kind is asked of the shared layer, the mirror of the Exoscale half of
+// #541. A Vm's plan carries its promised public addresses onto the launch, so
+// the guest holds two global addresses on one interface and Inspect answers
+// with whichever the runtime lists first; a boot that came back with the
+// public one would publish 198.51.100.x as PrivateIp — and, through
+// publicIPOf, as PublicIp in the same view.
+//
+// TestAVmPublishesNoPublicAddressAsItsPrivateOne fails without this.
 func (p *Pack) addressOf(res *resource.Resource) string {
-	return p.binding().AddressOf(res)
+	return p.reconciler().PrivateAddressOf(res)
 }
 
 // attachmentOf rebuilds the placement a Vm was created with, so a machine

--- a/internal/providers/outscale/machines_internal_test.go
+++ b/internal/providers/outscale/machines_internal_test.go
@@ -158,3 +158,45 @@ func TestAServedOmiBootsWithItsLogin(t *testing.T) {
 		t.Fatalf("booted image=%q user=%q, want debian:12 as %s", got.Image, got.User, DefaultUser)
 	}
 }
+
+// The address a Vm publishes as PrivateIp carries a kind too, and it is the
+// mirror of #541's Exoscale half.
+//
+// A Vm's plan carries its promised public addresses onto the launch, so the
+// guest ends up holding two global addresses on one interface and Inspect
+// answers with whichever the runtime lists first. A boot that came back with
+// the public one used to be published as PrivateIp — and, through publicIPOf,
+// as PublicIp in the same view: one address, two contradictory fields. The
+// pin in rememberAddress hides it after the first boot, which is exactly why
+// the control belongs in the shared layer and not in a pack's memory.
+//
+// Both halves, so a guard that refuses everything cannot pass: an address of
+// the emulated public block is refused as private, one outside it is served.
+func TestAVmPublishesNoPublicAddressAsItsPrivateOne(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		address string
+		want    string
+	}{
+		{"a subnet address is a private one", "10.42.0.9", "10.42.0.9"},
+		{"an address of the emulated public block is not", "198.51.100.7", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := runtimePack(&recordingDriver{})
+			res := &resource.Resource{
+				ID:    "i-00000541",
+				State: stateRunning,
+				Attrs: map[string]any{"VmType": "tinav6.c1r1p2"},
+				Runtime: map[string]string{
+					"machine": "feint-osc-i-00000541",
+					"address": tc.address,
+				},
+			}
+
+			if got := p.addressOf(res); got != tc.want {
+				t.Fatalf("PrivateIp %q for a machine answering on %s, want %q",
+					got, tc.address, tc.want)
+			}
+		})
+	}
+}

--- a/internal/providers/scaleway/listquery_test.go
+++ b/internal/providers/scaleway/listquery_test.go
@@ -268,7 +268,11 @@ func TestVPCListsHonourTheDeclaredFilters(t *testing.T) {
 	ts := newTickingTestServer(t)
 	const region = "/vpc/v2/regions/fr-par"
 
-	status, out := do(t, ts, "POST", region+"/vpcs", `{"name":"team"}`)
+	// enable_routing is spelled out here, and false on purpose: since #497 a
+	// VPC created without the field routes like the real cloud's, so an
+	// omitted field would put both VPCs on the same side of the filter below
+	// and the routing_enabled cases would stop separating anything.
+	status, out := do(t, ts, "POST", region+"/vpcs", `{"name":"team","enable_routing":false}`)
 	if status != http.StatusOK {
 		t.Fatalf("create vpc: status %d (%v)", status, out)
 	}
@@ -293,8 +297,9 @@ func TestVPCListsHonourTheDeclaredFilters(t *testing.T) {
 		{"?is_default=true", []string{"default"}},
 		{"?is_default=false", []string{"team"}},
 		{"?name=tea", []string{"team"}},
-		// "team" was created without enable_routing; the lazily provisioned
-		// default VPC routes, like upstream's.
+		// "team" asked for enable_routing:false; the lazily provisioned
+		// default VPC routes, like upstream's — and so does every VPC created
+		// without the field (#497).
 		{"?routing_enabled=false", []string{"team"}},
 		{"?routing_enabled=true", []string{"default"}},
 		{"?s3_integration_enabled=true", []string{}},

--- a/internal/providers/scaleway/routes_test.go
+++ b/internal/providers/scaleway/routes_test.go
@@ -254,3 +254,67 @@ func TestEnableDHCPReadsBackEnabled(t *testing.T) {
 		t.Fatalf("dhcp did not read back enabled: %v", pn)
 	}
 }
+
+// A VPC created without enable_routing routes, like the real cloud's (#497),
+// and its Private Networks reach each other because of it.
+//
+// The premise was measured on a real account on 2026-08-26 before anything
+// was changed here, the test VPC deleted afterwards:
+//
+//	$ scw vpc vpc create name=feint-premise-routing   # no enable_routing
+//	RoutingEnabled                  true
+//
+// The emulator stored the request field as-is, so the Go zero became the
+// default and both VPCs of examples/stacks/scaleway read back false — with the
+// consequence measured on the host under `--vm incus-ovn`: the workload VPC's
+// two networks were never peered and `app→web:443` answered `connect_ex=111`
+// while the web group accepted 0.0.0.0/0.
+//
+// The assertion is on the peering and not only on the flag, because the flag
+// is not a record here: reachableFrom reads it, and a default corrected in the
+// view alone would leave the host exactly as it was.
+//
+// The explicit half is asserted too, in the other direction: a client that
+// says false is answered false. The real-cloud measurement above covers the
+// absent field and nothing else, so nothing here invents an answer for a field
+// that was sent.
+func TestAVPCCreatedWithoutEnableRoutingRoutes(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		body    string
+		routing bool
+	}{
+		{"without the field", `{"name":"audit-497"}`, true},
+		{"with an explicit false", `{"name":"audit-497-off","enable_routing":false}`, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := newPeeringRuntime()
+			ts, _ := newAddressTestServer(t, rt)
+
+			vpc := createVPC(t, ts, tc.body)
+			vpcID, _ := vpc["id"].(string)
+			if flag, _ := vpc["routing_enabled"].(bool); flag != tc.routing {
+				t.Fatalf("routing_enabled=%v for %s, want %v", flag, tc.body, tc.routing)
+			}
+
+			networks := make([]string, 0, 2)
+			for i, block := range []string{"10.83.0.0/24", "10.83.1.0/24"} {
+				status, pn := do(t, ts, "POST", vpcRegion+"/private-networks",
+					fmt.Sprintf(`{"name":"member-%d","vpc_id":%q,"subnets":[%q]}`, i, vpcID, block))
+				if status != http.StatusOK {
+					t.Fatalf("create pn %d: status %d (%v)", i, status, pn)
+				}
+				id, _ := pn["id"].(string)
+				networks = append(networks, id)
+			}
+
+			first := machine.NetworkName(machine.NetworkPrefix, networks[0])
+			second := machine.NetworkName(machine.NetworkPrefix, networks[1])
+			peered := contains(rt.peersOf(first), second) && contains(rt.peersOf(second), first)
+			if peered != tc.routing {
+				t.Fatalf("the two networks of a VPC created %s are peered=%v, want %v (peers: %v, %v)",
+					tc.name, peered, tc.routing, rt.peersOf(first), rt.peersOf(second))
+			}
+		})
+	}
+}

--- a/internal/providers/scaleway/vpc.go
+++ b/internal/providers/scaleway/vpc.go
@@ -94,10 +94,13 @@ const reservedPerSubnet = 2
 const vpcCreateStatus = http.StatusOK
 
 type createVPCRequest struct {
-	Name          string   `json:"name"`
-	ProjectID     string   `json:"project_id"`
-	Tags          []string `json:"tags"`
-	EnableRouting bool     `json:"enable_routing"`
+	Name      string   `json:"name"`
+	ProjectID string   `json:"project_id"`
+	Tags      []string `json:"tags"`
+	// A pointer because the absent field and the explicit false are two
+	// different requests here, and the Go zero conflated them (#497). See the
+	// create for the measurement on the real cloud.
+	EnableRouting *bool `json:"enable_routing"`
 	// Sent by the Terraform provider on every CreateVPC since it grew the
 	// enable_transitivity attribute. The unread-field gate caught it on the
 	// first conformance run of SW-4: honoured as the stored flag the SDK's
@@ -204,7 +207,32 @@ func (p *Pack) createVPC(w http.ResponseWriter, r *http.Request) {
 	project, _ := projectOf(req.ProjectID)
 	res := p.newVPC(region, project, req.Name, false)
 	res.Attrs["tags"] = orEmpty(req.Tags)
-	res.Attrs["routing_enabled"] = req.EnableRouting
+	// A VPC created without the field routes, which is what the real cloud
+	// answers (#497). Measured on a real account on 2026-08-26, the test VPC
+	// deleted afterwards:
+	//
+	//	$ scw vpc vpc create name=feint-premise-routing   # no enable_routing
+	//	RoutingEnabled                  true
+	//
+	// This line used to store the request field as-is, so the Go zero became
+	// the default — the inverse of upstream. That is not a cosmetic
+	// difference: reachableFrom keys on it, so the web and app Private
+	// Networks of one workload VPC were left unpeered and `app→web:443` read
+	// `connect_ex=111` while the web group accepted 0.0.0.0/0, which is what
+	// the audit measured on examples/stacks/scaleway. That stack has written
+	// `enable_routing = true` out on its workload VPC since #503 for exactly
+	// this reason; its management VPC still says nothing, and read back false
+	// until here. newVPC already carried true for the lazily provisioned
+	// default VPC; only the client-created path disagreed with it.
+	//
+	// An explicit value is still the client's, in either direction: the
+	// measurement above covers the absent field and nothing else, and
+	// inventing an answer for `enable_routing: false` would be the guess this
+	// repository refuses. TestAVPCCreatedWithoutEnableRoutingRoutes fails
+	// without this, in both directions.
+	if req.EnableRouting != nil {
+		res.Attrs["routing_enabled"] = *req.EnableRouting
+	}
 	res.Attrs["transitivity_enabled"] = req.EnableTransitivity
 	p.env.Store.Put(res)
 

--- a/tools/falsify/specs/address-kind.json
+++ b/tools/falsify/specs/address-kind.json
@@ -1,0 +1,19 @@
+{
+  "package": "./internal/providers/...",
+  "mutations": [
+    {
+      "label": "an address the machine answers on is published as public without being one",
+      "file": "internal/core/machine/plan.go",
+      "find": "\taddress := r.binding().AddressOf(res)\n\tif !r.emulated(address) {\n\t\treturn \"\"\n\t}\n\treturn address",
+      "replace": "\taddress := r.binding().AddressOf(res)\n\tif !r.emulated(address) && false {\n\t\treturn \"\"\n\t}\n\treturn address",
+      "test": "TestAnInstanceWithNoPublicIPPublishesNone"
+    },
+    {
+      "label": "an emulated public address is published as the machine's private one",
+      "file": "internal/core/machine/plan.go",
+      "find": "\tif address == \"\" || r.emulated(address) {\n\t\treturn \"\"\n\t}\n\treturn address",
+      "replace": "\tif address == \"\" || (r.emulated(address) && false) {\n\t\treturn \"\"\n\t}\n\treturn address",
+      "test": "TestAVmPublishesNoPublicAddressAsItsPrivateOne"
+    }
+  ]
+}

--- a/tools/falsify/specs/routed-nic.json
+++ b/tools/falsify/specs/routed-nic.json
@@ -46,8 +46,8 @@
     {
       "label": "a rule set on a routed NIC is silently skipped instead of refused",
       "file": "internal/core/machine/incus_firewall.go",
-      "find": "\t\tif device.routed {\n\t\t\tif joined != \"\" && unenforceable == nil {",
-      "replace": "\t\tif device.routed {\n\t\t\tif false && joined != \"\" && unenforceable == nil {",
+      "find": "\t\tif device.routed {\n\t\t\tif joined != \"\" {",
+      "replace": "\t\tif device.routed {\n\t\t\tif joined != \"\" && false {",
       "test": "TestApplyFirewallRefusesAGroupOnARoutedNIC"
     },
     {

--- a/tools/falsify/specs/uncovered-interface.json
+++ b/tools/falsify/specs/uncovered-interface.json
@@ -1,0 +1,26 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "the escaping interface is named without the address it carries",
+      "file": "internal/core/machine/incus_firewall.go",
+      "find": "\tif len(n.addresses) == 0 {\n\t\treturn n.name\n\t}",
+      "replace": "\tif len(n.addresses) == 0 || true {\n\t\treturn n.name\n\t}",
+      "test": "TestTheUnenforceableRefusalNamesTheAddressThatEscapes"
+    },
+    {
+      "label": "only the launch addresses are read, so an address routed afterwards escapes unnamed",
+      "file": "internal/core/machine/incus_firewall.go",
+      "find": "\tfor _, key := range []string{\"ipv4.address\", \"ipv4.routes\"} {\n\t\tfor _, entry := range splitList(device[key]) {",
+      "replace": "\tfor _, key := range []string{\"ipv4.address\", \"ipv4.routes\"} {\n\t\tif key == \"ipv4.routes\" {\n\t\t\tcontinue\n\t\t}\n\t\tfor _, entry := range splitList(device[key]) {",
+      "test": "TestTheUnenforceableRefusalNamesAnAddressRoutedAfterTheLaunch"
+    },
+    {
+      "label": "the warning goes back to calling the machine public-only, which #548 measured false",
+      "file": "internal/core/machine/firewall_binding.go",
+      "find": "\t\tb.logger().Warn(\"the security group is not enforced on this machine's routed interface, \"+\n\t\t\t\"which carries a published address and takes no rule set — the runtime declares it \"+\n\t\t\t\"(capabilities.firewall_public_only=false, docs/limits.md); the error names the \"+\n\t\t\t\"interface and the address that answers uncovered\",\n\t\t\tkeyvals...)",
+      "replace": "\t\tb.logger().Warn(\"the security group is not enforced on this machine's public-only interface, \"+\n\t\t\t\"which the runtime declares (capabilities.firewall_public_only=false, docs/limits.md)\",\n\t\t\tkeyvals...)",
+      "test": "TestTheUnenforceableWarningDoesNotCallTheMachinePublicOnly"
+    }
+  ]
+}

--- a/tools/falsify/specs/vpc-routing-default.json
+++ b/tools/falsify/specs/vpc-routing-default.json
@@ -1,0 +1,12 @@
+{
+  "package": "./internal/providers/scaleway/",
+  "mutations": [
+    {
+      "label": "the request's absent enable_routing becomes the Go zero again, and a VPC created without it stops routing",
+      "file": "internal/providers/scaleway/vpc.go",
+      "find": "\tif req.EnableRouting != nil {\n\t\tres.Attrs[\"routing_enabled\"] = *req.EnableRouting\n\t}",
+      "replace": "\tif req.EnableRouting != nil || true {\n\t\tres.Attrs[\"routing_enabled\"] = req.EnableRouting != nil && *req.EnableRouting\n\t}",
+      "test": "TestAVPCCreatedWithoutEnableRoutingRoutes"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #541. Closes #497. Closes #496.

**#548 stays open on purpose** — see the last section. Its warning is now honest;
its enforcement is not, and closing it because the message improved would be the
kind of green this repository exists to refuse.

Four findings of the 2026-08-27 address audit, all under `--vm incus-ovn` on the
example stacks. They were briefed as possibly one defect. **They are not, and
that was checked rather than assumed**: #541 is *which address a pack publishes*
and does have a shared cause, so its fix is shared; #548 is *which interface the
address lives on*, decided by the driver's NIC choice and by no address key. No
code path is common, and fusing them would have produced a commit whose message
could not name one defect.

## Reproductions, before → after

| # | before | after |
|---|---|---|
| **541** | `GET /v2/instance/{id}` → `"public-ip":"10.44.9.10"` on `public-ip-assignment:"none"`, host side clean | `has("public-ip") == false` |
| **497** | `routing_enabled=false` without the field; `incus network peer list` empty | `true`; the two Private Networks peered (`fnt-aac94982924 … CREATED`) |
| **548** | `eth0` routed `203.0.113.2` bare beside filtered `eth1`; **`:22 connect_ex=0 OPEN`** under a drop-default group opening only 443; `:80 → 111` (refused, so it reached the guest) against `10.181.7.2:80 → 113` | escape unchanged **by design**; the refusal now says `eth0 (203.0.113.2)` and stops calling the machine public-only |
| **496** | `10.181.7.0/24 dev feint-uplink scope link`, `who-has 10.181.7.2` ×3 unanswered, ports 11/113 | unchanged (a limit); `ip route replace … via 10.209.83.128` → both ports `111` |

## Two premises reversed

**#548's headline is already false on `main`.** *"and `docs/limits.md` claims the
opposite"* — commit `7d34517`, the 2026-08-27 limits audit, had already rewritten
that section with #548's own measurement, the order table and the corrected
vocabulary sentence; `tools/conformance/functional.sh:602` already skips the
public-path firewall assertion citing `capabilities.firewall_public_only` **and
#548**. Two of the three things the issue asks for were done before this branch
started.

What was left is what this branch does: the declared capability's own doc comment
still carried the wrong subject (*"a machine that joins no emulated network"*),
the warning still said *"this machine's **public-only** interface"* — measured
false, the machine has a private NIC — and neither named the address that
escapes.

**#496's proposed remedy is not available to feint.** The issue and the limits
section both said the route "should" be posted `via` the router. The emulator
never posts a host route: its only host binary is `incus` (every `ip` is
`incus exec <machine> -- ip …`), and that route is Incus's own materialisation of
the uplink bridge's `ipv4.routes` — **which takes CIDRs only**, measured on a
scratch bridge:

```
ipv4.routes="10.224.0.0/24 via 10.222.222.2"  →  invalid CIDR address
```

So it ships as a limit with the mechanism instrumented, and the new fact is the
flip's *value*: with the `via` route the ports go from unreachable (11/113) to
**refused** (111). The ACL decides; the router does forward when addressed
directly. That is worth more than the original issue asked for, because it says
what the limit is *not*.

**#548's "nothing was tried" is now tried and refused**, with two measured
failures rather than a sentence: the uplink cannot take the `/32` while the
routed NIC owns the host route (`file exists` — #498's collision seen from the
other side), and `incus config device remove … eth0` unmasks the profile's own
`eth0` on `incusbr0`, the operator's bridge. Recorded in `docs/limits.md` so the
next reader does not pay for it again.

## The shared control (#541)

`Reconciler.PublicAddressOf` / `PrivateAddressOf` in
`internal/core/machine/plan.go`. `Binding.AddressOf` **left** `PackSurface()` and
**joined** `mustStayOutside`, so the exclusion is asserted rather than merely
absent — the shape #511 established. Exoscale, Outscale and testdata's fourth
pack all go through the new door.

The Outscale mirror was **latent, not observed**: a boot returning the promised
public address would have published it as `PrivateIp` and `PublicIp` at once.
That is precisely why the control lives in the layer and not in the pack that
showed the symptom — a defect fixed on one side and surviving on the other is the
failure this repository has already paid for twice.

No provider name entered `internal/core`. `notInTheDriverSurface` is still empty.

## Gates

`prepush` green · `FEINT_VM=incus-ovn conformance:leg -- runtime` **green, 607 s,
doorstep clean both ends** · legs `exo-cli`, `scw-cli`, `octl`, `fields` green
(350/373 routes) · `FEINT_VM=incus-ovn conformance:functional` green, 255 s,
cross-VPC isolation still holding · `conformance:stacks` green (apply, empty
re-plan, destroy) · `limits:check` 0 · final doorstep 0.

**22 falsification specs replayed, 185 mutations, every one bit.** The three new
ones — `address-kind`, `vpc-routing-default`, `uncovered-interface` — bite in
both directions.

### What `mise run testplan` bought here

It named `octl` and `fields`, which a change to `internal/core/machine` does not
obviously earn, and it named the falsify subset — **including `routed-nic.json`,
whose mutation this branch's #548 change had killed.** `falsify:lint` caught it
and it was retargeted inside the same commit, rather than discovered by a nightly
run days later.

One coarseness worth knowing: a **comment-only** edit to
`examples/stacks/scaleway/main.tf` earned `conformance:stacks` +
`conformance:functional`, about nine minutes, on a diff that cannot change a byte
of applied configuration. Its rules are path-based by design, so that is a cost
rather than a bug.

## Why #548 stays open

The product divergence stands: **a public address on a routed NIC is covered by
nothing**, and the emulator differs from the real cloud there. What this branch
delivers is honesty — the capability no longer describes the machine wrongly, the
warning names the interface and the address, and the two obvious remedies are
recorded as measured refusals instead of untried suggestions.

Enforcement is the rest of the issue, and it is where the issue should stay.

## Also not obtained

- **No real-account re-verification of #497.** The issue's 2026-08-26
  `scw vpc vpc create` run is taken as the premise; only the *absent-field*
  default changed, and an explicit `false` remains the client's.
- The full `FEINT_VM=incus-ovn mise run conformance` was not run, as instructed:
  the `runtime` leg plus `functional` plus `stacks` is the population this diff
  touches, at a third of the cost.

## Files outside the lane, declared

`internal/providers/scaleway/{vpc.go, routes_test.go, listquery_test.go}` for
#497, and `examples/stacks/scaleway/main.tf` — the last because the #497 fix
falsified its comment, which justified `enable_routing = true` by asserting, in
the present tense, that *"this emulator stores the Go zero"*. None overlap the
Scaleway shape work running in parallel. Port 4599 was held throughout and this
was the only user of `FEINT_VM=incus-ovn`.
