### PR TITLE
fix(machine, exoscale): a security group covers the interfaces its own provider says it covers (#574)

### DIFF
--- a/.github/workflows/runtime-proof.yml
+++ b/.github/workflows/runtime-proof.yml
@@ -314,6 +314,21 @@ jobs:
       - name: Outscale network suite
         run: sudo tools/conformance/outscale/network.sh http://127.0.0.1:4599
 
+      # The third one, and its absence is half of why #574 lived as long as it
+      # did. Two of the three network suites ran here and the Exoscale one ran
+      # nowhere: no leg, bridge or OVN, replayed it, local work happens under
+      # OVN where the defect was masked by rule ordering (#491), and the only
+      # routine that replayed it under the bridge was `evidence:update`'s
+      # second leg, which nobody had run since a344f8d. A suite no matrix
+      # carries is a suite whose verdict is a year old.
+      #
+      # On both legs, deliberately: the bridge is the poorer population here —
+      # it is where a rule set wrongly bound to a private NIC actually bites —
+      # and this repository's own rule is that a verdict about "this run" is
+      # tried on the poorest run that triggers it.
+      - name: Exoscale network suite
+        run: sudo tools/conformance/exoscale/network.sh http://127.0.0.1:4599
+
       # The end of the chain the emulator exists for: a key registered through
       # the API, a server booted by the official client, a real shell on the
       # provider's own default login — three providers, three logins.

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -17,6 +17,54 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ## [Unreleased]
 
+### Corrigé
+
+- **Un groupe de sécurité Exoscale s'arrête à l'interface publique, là où le
+  vrai cloud l'arrête (#574).** Exoscale le dit en une phrase : « Security
+  group rules do not apply to traffic inside private networks ». Depuis
+  `a344f8d` (#494/#475), cet émulateur les appliquait quand même. Le groupe
+  `default` émulé ne porte aucune règle d'entrée, donc son jeu de règles se
+  traduit par un défaut `drop`, et le pilote l'écrivait sur la NIC de
+  rattachement : **deux instances d'un même réseau privé ne se joignaient
+  plus**. Mesuré le 2026-08-27 sous `--vm incus`, avec un réseau et deux
+  instances créées en `--public-ip none`, dont la seule interface est celle du
+  rattachement : `security.acls=exo-…` et
+  `security.acls.default.ingress.action=drop` sur la NIC, 0/10 sondes
+  connectées ; avec le correctif, plus aucune clé `security.acls`, 10/10. Sous
+  `--vm incus-ovn`, le même jeu de règles fautif était posé et ne mordait pas,
+  parce que le `allow` fourre-tout en sortie de l'émetteur, à la priorité 300,
+  surclasse le refus par défaut de la NIC réceptrice à 100/111 (#491). Tout
+  vert obtenu là reposait donc sur un ordre de règles, et l'état d'après se lit
+  sur la NIC, jamais sur une connexion qui passe.
+
+  Ce qu'un groupe couvre est désormais un fait provider porté par la couche
+  partagée, et non une règle de cette couche : le pack le déclare par interface
+  sur `machine.Attachment.Unfiltered`, `machine.GroupSync` le lit sur le plan
+  que le pack déclare déjà, et il arrive au pilote via
+  `FirewallBinding.Unfiltered`. Scaleway et Outscale ne déclarent rien et
+  continuent de filtrer leurs NIC privées, ce que leurs propres suites réseau
+  vérifient. Conséquence à connaître en lisant l'hôte : une instance Exoscale
+  sans adresse publique, rattachée seulement à des réseaux privés, ne porte
+  **aucun jeu de règles sur aucune interface**, faute d'interface qu'un groupe
+  couvre.
+
+- **Les trois instruments qui l'ont caché, réparés dans le même lot (#574).**
+  `.github/workflows/runtime-proof.yml` jouait deux des trois suites réseau et
+  pas `tools/conformance/exoscale/network.sh`, sur aucune de ses deux jambes :
+  rien en CI ne la rejouait. `TestEveryNetworkSuiteIsReplayedByTheRuntimeProof`
+  dérive maintenant la liste des suites présentes sur disque, au lieu d'une
+  liste que quelqu'un doit se rappeler. `mise run evidence:update` écrasait en
+  silence un `FEINT_VM` exporté sur sa jambe runtime
+  (`FEINT_VM="${FEINT_EVIDENCE_VM:-incus}"`), ce qui a produit deux
+  attributions fausses successives pendant le diagnostic ;
+  `tools/evidence/mode.sh` honore désormais l'appelant, refuse par leur nom un
+  désaccord entre les deux variables et le mode `off`, et **annonce le mode
+  qu'il exécute** avant que quoi que ce soit démarre. Enfin, l'en-tête de la
+  suite réseau Exoscale affirmait que le pack « ne synchronise pas encore ses
+  groupes de sécurité sur les machines » : vrai avant `a344f8d`, lu comme un
+  fait courant des mois après, et c'est lui qui détournait tous les lecteurs du
+  pare-feu.
+
 ## [0.11.0] - 2026-08-26
 
 La version où l'émulateur a cessé de se croire sur parole. Quatre défauts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,49 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ## [Unreleased]
 
+### Fixed
+
+- **An Exoscale security group stops at the public interface, where the real
+  cloud stops it (#574).** Exoscale states it in one sentence: "Security group
+  rules do not apply to traffic inside private networks". Since `a344f8d`
+  (#494/#475) this emulator applied them there. The emulated `default` group
+  carries no ingress rule, so its rule set translates to a drop default, and
+  the driver wrote it onto the membership NIC: **two instances of one private
+  network could not reach each other**. Measured 2026-08-27 under `--vm incus`,
+  one network and two instances created with `--public-ip none`, whose only
+  interface is the membership one: `security.acls=exo-…` plus
+  `security.acls.default.ingress.action=drop` on the NIC, 0/10 probes
+  connected; with the fix, no `security.acls` key at all, 10/10. Under
+  `--vm incus-ovn` the same wrong rule set was written and did *not* bite,
+  because the sender's catch-all egress `allow` at priority 300 outranks the
+  receiver's NIC default deny at 100/111 (#491) — so every green that segment
+  produced under OVN rested on rule ordering, and the after-state is read off
+  the NIC rather than off a connection succeeding.
+
+  Where a security group applies is now a provider fact carried by the shared
+  layer, not a rule of the layer: the pack declares it per interface on
+  `machine.Attachment.Unfiltered`, `machine.GroupSync` reads it off the plan
+  the pack already declares, and it reaches the driver on
+  `FirewallBinding.Unfiltered`. Scaleway and Outscale declare nothing and keep
+  filtering their private NICs, which their own network suites assert.
+  Consequence a reader of the host will meet: an Exoscale instance with no
+  public address and only private memberships carries **no rule set on any
+  interface**, because it has no interface a group covers.
+
+- **The three instruments that hid it, repaired in the same change (#574).**
+  `.github/workflows/runtime-proof.yml` ran two of the three network suites and
+  not `tools/conformance/exoscale/network.sh`, on either leg, so nothing in CI
+  replayed it; `TestEveryNetworkSuiteIsReplayedByTheRuntimeProof` now derives
+  the list from the suites on disk rather than from a list somebody remembers.
+  `mise run evidence:update` overrode an exported `FEINT_VM` in silence on its
+  runtime leg (`FEINT_VM="${FEINT_EVIDENCE_VM:-incus}"`), which manufactured
+  two successive false attributions during the diagnosis; `tools/evidence/mode.sh`
+  now honours the caller, refuses a disagreement and `--vm off` by name, and
+  **announces the mode it runs** before anything starts. And the Exoscale
+  network suite's own header claimed the pack "does not yet sync its security
+  groups onto the machines" — true before `a344f8d`, read as a live fact for
+  months after, and what steered every reader away from the firewall.
+
 ## [0.11.0] - 2026-08-26
 
 The release where the emulator stopped taking its own word for it. Four defects

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -3194,7 +3194,9 @@ stayed open whatever the group said, and the API answered success on every
 rule. All three packs now hand their rules over through the shared layer
 (`machine.Binding`), and the witness is observable on the host: `incus network
 acl list` carries `scw-*`, `osc-*` and `exo-*` sets marked `feint security
-group`, attached to the machines that wear the groups (measured 2026-08-26 on
+group`, attached to the machines that wear the groups — on the interfaces each
+provider says its groups cover, which is not every interface (#574, below;
+measured 2026-08-26 on
 `examples/stacks/scaleway` — three `scw-*` sets, six interfaces between them —
 `examples/stacks/outscale` and `examples/stacks/exoscale`, each under
 `feint up --runtime incus-ovn`).
@@ -3306,6 +3308,56 @@ stated bounds" carries the runs).
 Group-sourced rules (the tiering statement, "tier 2 accepts tier 1") are
 expanded into the member machines' addresses, since the runtime has no group
 selector, and re-expanded whenever a member boots or gains an interface.
+
+**Which interfaces a group covers is the provider's answer, not this
+emulator's (#574).** Exoscale documents the difference in one sentence —
+"Security group rules do not apply to traffic inside private networks"
+([Private Network Overview](https://community.exoscale.com/product/networking/private-network/overview/))
+— and from `a344f8d` (#494/#475) to 2026-08-27 this emulator applied them
+there anyway. The emulated `default` group carries no ingress rule, so its
+rule set translates to a drop default, and the driver wrote it onto the
+membership NIC. Measured 2026-08-27, one private network and two instances
+created with `--public-ip none`, whose only interface is therefore the
+membership one:
+
+```console
+# --vm incus, before                     # --vm incus, after
+eth0:                                    eth0:
+  ipv4.address: 10.186.0.20                ipv4.address: 10.186.0.20
+  network: fnt-49f6b5af641                 network: fnt-378ef075b46
+  security.acls: exo-11e594f4819           type: nic
+  security.acls.default.ingress.action: drop
+  type: nic
+0/10 probes connected                    10/10 probes connected
+```
+
+Under `--vm incus-ovn` the same wrong rule set was written and did **not**
+bite: the sender's catch-all egress `allow` at priority 300 outranks the
+receiver NIC's default deny at 100/111, the ordering the paragraph above
+records as #491. Both runs are in the record because they say different
+things — every green this segment produced under OVN rested on that accident,
+so the after-state is read off the NIC (`incus config device get`) and never
+off a connection succeeding.
+
+The scope is declared per interface by the pack
+(`machine.Attachment.Unfiltered`) and reaches the driver on
+`FirewallBinding.Unfiltered`; Scaleway and Outscale declare nothing, keep
+filtering their private NICs, and their own network suites assert it. Two
+consequences for whoever reads the witness at the top of this section. An
+Exoscale instance with no public address and only private memberships now
+carries **no rule set on any interface** — it has no interface a security
+group covers, which is what upstream describes. And under OVN, a membership
+NIC on a network carrying the emulator's isolation set wears the permissive
+posture set (`opn-fnt…`) rather than nothing, because a network-level ACL
+forces the reject default onto every NIC attached to it: unfiltered has to
+mean open inside the segment, not closed by the network.
+
+Three instruments had to agree to hide this for as long as it lasted, and all
+three are repaired in the same change: `runtime-proof.yml` ran two of the
+three network suites and not the Exoscale one, `evidence:update`'s runtime leg
+overrode an exported `FEINT_VM` in silence, and this suite's own header
+claimed the pack "does not yet sync its security groups onto the machines" —
+true before `a344f8d`, read as a live fact for as long after.
 
 ## The station reaches an OVN private address only via the network's router, and the posted uplink routes do not go there (#496)
 

--- a/internal/core/machine/firewall.go
+++ b/internal/core/machine/firewall.go
@@ -3,6 +3,7 @@ package machine
 import (
 	"context"
 	"errors"
+	"slices"
 )
 
 // ErrFirewallUnenforceable reports an interface the runtime has no mechanism
@@ -84,6 +85,27 @@ type FirewallSpec struct {
 type FirewallBinding struct {
 	Names                         []string
 	DefaultIngress, DefaultEgress string
+	// Unfiltered names the networks whose interfaces carry no rule set at all,
+	// because the pack declared them outside what its security groups cover
+	// (Attachment.Unfiltered, #574). An interface on one of them is bound as
+	// if the machine wore no group: never the names above, never the default
+	// actions.
+	//
+	// Carried per network rather than per device because a pack declares
+	// networks and never sees a device name — the runtime picks those, and
+	// which ethN a membership lands on depends on what the launch already
+	// used.
+	Unfiltered []string
+}
+
+// covers reports whether the rule sets of this binding reach an interface
+// sitting on the named network.
+//
+// A device on no network — a routed NIC — is covered as far as this question
+// goes; what happens to it is ApplyFirewall's own refusal (#337), which is a
+// statement about the runtime rather than about the provider's model.
+func (b FirewallBinding) covers(network string) bool {
+	return network == "" || !slices.Contains(b.Unfiltered, network)
 }
 
 // Firewaller is the optional half of a Driver: a runtime that can enforce rules
@@ -98,8 +120,10 @@ type Firewaller interface {
 	// rather than patching is what makes a rule removed upstream disappear here
 	// instead of lingering.
 	EnsureFirewall(ctx context.Context, spec FirewallSpec) error
-	// ApplyFirewall attaches rule sets to every interface of a machine, and
-	// detaches everything when the binding names none.
+	// ApplyFirewall attaches rule sets to every interface of a machine the
+	// binding covers, and detaches everything when the binding names none. An
+	// interface on one of the binding's Unfiltered networks is treated as if
+	// the machine wore no group at all.
 	ApplyFirewall(ctx context.Context, machine string, binding FirewallBinding) error
 	// RemoveFirewall deletes the rule set. It must succeed when nothing is
 	// there, and it must fail when the set is still attached rather than

--- a/internal/core/machine/firewall_binding.go
+++ b/internal/core/machine/firewall_binding.go
@@ -95,11 +95,16 @@ func (b Binding) SyncRuleSet(ctx context.Context, fw Firewaller, spec FirewallSp
 // The combined default is deny-dominant: one set that drops what no rule
 // matches keeps dropping it whatever a more permissive neighbour says, which
 // is the semantics every provider here documents for stacked groups.
-func (b Binding) ApplyRuleSets(ctx context.Context, fw Firewaller, machine string, specs ...FirewallSpec) {
+//
+// unfiltered names the machine's networks this provider's groups do not cover
+// (#574). It travels beside the sets rather than being applied here, because
+// the decision is per interface and only the driver knows which interface sits
+// on which network.
+func (b Binding) ApplyRuleSets(ctx context.Context, fw Firewaller, machine string, unfiltered []string, specs ...FirewallSpec) {
 	if fw == nil || machine == "" {
 		return
 	}
-	binding := FirewallBinding{DefaultIngress: "allow", DefaultEgress: "allow"}
+	binding := FirewallBinding{DefaultIngress: "allow", DefaultEgress: "allow", Unfiltered: unfiltered}
 	for _, spec := range specs {
 		if spec.EnforcesNothing() {
 			continue
@@ -113,7 +118,13 @@ func (b Binding) ApplyRuleSets(ctx context.Context, fw Firewaller, machine strin
 		}
 	}
 	if len(binding.Names) == 0 {
-		binding = FirewallBinding{}
+		// The scope is a property of the machine, not of the sets it happens
+		// to wear, so the detach carries it too. Nothing in the driver turns
+		// on it here — an empty name list already leaves every interface bare
+		// — but a binding that dropped it would describe one machine two ways
+		// depending on how many groups it wore, and that difference would
+		// reach the recorder the packs are compared through.
+		binding = FirewallBinding{Unfiltered: unfiltered}
 	}
 	if err := fw.ApplyFirewall(ctx, machine, binding); err != nil {
 		b.reportFirewall(err, "machine", machine)

--- a/internal/core/machine/firewall_binding_test.go
+++ b/internal/core/machine/firewall_binding_test.go
@@ -70,7 +70,7 @@ func TestAPermissiveGroupBindsNothingOnEveryRuntime(t *testing.T) {
 	fw := &fakeFirewaller{}
 	b := firewallBinding(&buf)
 
-	b.ApplyRuleSets(context.Background(), fw, "feint-test-a", permissive)
+	b.ApplyRuleSets(context.Background(), fw, "feint-test-a", nil, permissive)
 	if len(fw.applied) != 1 || len(fw.applied[0].Names) != 0 {
 		t.Fatalf("a group that filters nothing must attach nothing, got %+v", fw.applied)
 	}
@@ -78,7 +78,7 @@ func TestAPermissiveGroupBindsNothingOnEveryRuntime(t *testing.T) {
 	// The accepting half: a group that restricts something still attaches, and
 	// its defaults ride the binding.
 	fw.applied = nil
-	b.ApplyRuleSets(context.Background(), fw, "feint-test-a", restrictive)
+	b.ApplyRuleSets(context.Background(), fw, "feint-test-a", nil, restrictive)
 	if len(fw.applied) != 1 {
 		t.Fatalf("%d applications, want 1", len(fw.applied))
 	}
@@ -91,7 +91,7 @@ func TestAPermissiveGroupBindsNothingOnEveryRuntime(t *testing.T) {
 	// the default closed whatever a permissive one says, while the permissive
 	// one still attaches nothing.
 	fw.applied = nil
-	b.ApplyRuleSets(context.Background(), fw, "feint-test-a", permissive, restrictive)
+	b.ApplyRuleSets(context.Background(), fw, "feint-test-a", nil, permissive, restrictive)
 	got = fw.applied[0]
 	if len(got.Names) != 1 || got.DefaultIngress != "drop" {
 		t.Fatalf("stacked sets must combine deny-dominant, got %+v", got)
@@ -111,7 +111,7 @@ func TestAnUnenforceableGroupIsReportedAsTheDeclaredLimit(t *testing.T) {
 	fw := &fakeFirewaller{applyErr: fmt.Errorf("apply firewall to m/eth0: %w", ErrFirewallUnenforceable)}
 	b := firewallBinding(&buf)
 
-	b.ApplyRuleSets(context.Background(), fw, "feint-test-a", restrictive)
+	b.ApplyRuleSets(context.Background(), fw, "feint-test-a", nil, restrictive)
 	declared := buf.String()
 	if !strings.Contains(declared, "level=WARN") {
 		t.Fatalf("a declared limit must be a warning, got %q", declared)
@@ -122,7 +122,7 @@ func TestAnUnenforceableGroupIsReportedAsTheDeclaredLimit(t *testing.T) {
 
 	buf.Reset()
 	fw.applyErr = errors.New("the daemon went away")
-	b.ApplyRuleSets(context.Background(), fw, "feint-test-a", restrictive)
+	b.ApplyRuleSets(context.Background(), fw, "feint-test-a", nil, restrictive)
 	if failure := buf.String(); !strings.Contains(failure, "level=ERROR") {
 		t.Fatalf("an undeclared failure must stay an error, got %q", failure)
 	}
@@ -161,7 +161,7 @@ func TestTheUnenforceableWarningDoesNotCallTheMachinePublicOnly(t *testing.T) {
 		"apply firewall to m: a routed NIC accepts no security option, so what it carries "+
 			"is covered by nothing: eth0 (203.0.113.2): %w", ErrFirewallUnenforceable)}
 
-	firewallBinding(&buf).ApplyRuleSets(context.Background(), fw, "feint-test-a",
+	firewallBinding(&buf).ApplyRuleSets(context.Background(), fw, "feint-test-a", nil,
 		FirewallSpec{Name: "sg-r", DefaultIngress: "drop", DefaultEgress: "allow"})
 
 	said := buf.String()

--- a/internal/core/machine/groupsync.go
+++ b/internal/core/machine/groupsync.go
@@ -3,6 +3,7 @@ package machine
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/stephrobert/feint/internal/core/resource"
@@ -66,6 +67,24 @@ type GroupSync struct {
 
 	// Group resolves a worn identifier to its stored group.
 	Group func(id string) (*resource.Resource, bool)
+
+	// PlanOf, optional, is the machine's declared interface shape — the very
+	// function Reconciler.PlanOf carries, wired here rather than spelled a
+	// second way, so the scope below cannot drift from the plan that creates
+	// the interfaces.
+	//
+	// Exactly one thing is read from it: which of the machine's networks this
+	// provider's security groups do not cover (Attachment.Unfiltered, #574).
+	// Nil means every interface is covered, which is what two of the three
+	// providers do and what the emulator did for all three until an Exoscale
+	// private network was measured firewalled where the real cloud states it
+	// is not.
+	//
+	// It lives on the orchestrator rather than only on the Reconciler because
+	// the wearer replay reaches a machine without going through a boot: a
+	// group whose rules change re-applies onto every machine wearing it, and
+	// that path has no plan of its own to read.
+	PlanOf func(res *resource.Resource) Plan
 
 	// Referrers, optional, lists the groups one of whose rules names one of
 	// the given groups as a member source. Nil where the provider's rules
@@ -322,7 +341,36 @@ func (s GroupSync) applyMachine(ctx context.Context, res, fresh *resource.Resour
 		}
 		specs = append(specs, spec)
 	}
-	s.Binding.ApplyRuleSets(ctx, fw, res.Runtime[s.Binding.RuntimeKey], specs...)
+	s.Binding.ApplyRuleSets(ctx, fw, res.Runtime[s.Binding.RuntimeKey], s.unfiltered(res), specs...)
+}
+
+// unfiltered is the machine's networks this provider's security groups do not
+// cover, read off the plan the pack declares for that very machine (#574).
+//
+// Both halves of the plan are walked, not just the memberships: which half an
+// interface rides in is a fact about *when* it is created — with the launch or
+// after it — and says nothing about whether a group reaches it. A provider
+// whose boot interface is out of scope would be silently filtered by a reader
+// that only looked at Memberships, which is the same defect one interface to
+// the left.
+//
+// A network named twice is named once here: the plan may repeat one — a
+// membership re-declared after a boot — and the driver reads this as a set.
+//
+// TestTheUnfilteredScopeIsReadFromBothHalvesOfThePlan fails without the first
+// half.
+func (s GroupSync) unfiltered(res *resource.Resource) []string {
+	if s.PlanOf == nil || res == nil {
+		return nil
+	}
+	plan := s.PlanOf(res)
+	var out []string
+	for _, att := range slices.Concat(plan.Boot, plan.Memberships) {
+		if att.Unfiltered && att.Network != "" && !slices.Contains(out, att.Network) {
+			out = append(out, att.Network)
+		}
+	}
+	return out
 }
 
 // AfterBoot runs once a machine exists or first publishes an address: its own

--- a/internal/core/machine/groupsync_scope_test.go
+++ b/internal/core/machine/groupsync_scope_test.go
@@ -1,0 +1,92 @@
+package machine
+
+import (
+	"context"
+	"slices"
+	"testing"
+)
+
+// The scope a pack declares travels from its plan to the binding the driver
+// applies, and it is read from both halves of that plan (#574).
+//
+// Both halves on purpose: which half an interface rides in is a fact about
+// *when* it is created — with the launch or after it — and says nothing about
+// whether a security group reaches it. A reader that only walked Memberships
+// would be right for the provider that motivated this and wrong for the next
+// one, which is the same defect one interface to the left.
+func TestTheUnfilteredScopeIsReadFromBothHalvesOfThePlan(t *testing.T) {
+	b := newGroupSyncBench()
+	group := b.group("g-1", "")
+	res := b.machine("m-1", "10.0.0.7", "g-1")
+
+	sync := b.sync()
+	sync.PlanOf = func(*testResource) Plan {
+		return Plan{
+			Boot: []Attachment{
+				{Network: "fnt-public"},
+				{Network: "fnt-bootpriv", Unfiltered: true},
+			},
+			Memberships: []Attachment{
+				{Network: "fnt-privnet", Unfiltered: true},
+				// Declared twice, the way a membership re-declared after a
+				// boot is; the driver reads this as a set.
+				{Network: "fnt-privnet", Unfiltered: true},
+				{Network: "fnt-managed"},
+			},
+		}
+	}
+	sync.SyncGroup(context.Background(), group, res)
+
+	binding := appliedBinding(t, b.rec, res.Runtime["machine"])
+	want := []string{"fnt-bootpriv", "fnt-privnet"}
+	if len(binding.Unfiltered) != len(want) {
+		t.Fatalf("the applied binding declares %v, want exactly %v", binding.Unfiltered, want)
+	}
+	for _, network := range want {
+		if !slices.Contains(binding.Unfiltered, network) {
+			t.Errorf("the applied binding does not declare %s out of scope: %v", network, binding.Unfiltered)
+		}
+	}
+	// The accepting half: a network the pack did not declare stays covered, so
+	// the scope cannot quietly become "nothing is filtered anywhere".
+	for _, network := range []string{"fnt-public", "fnt-managed"} {
+		if slices.Contains(binding.Unfiltered, network) {
+			t.Errorf("%s was never declared out of scope, and the binding excuses it: %v", network, binding.Unfiltered)
+		}
+	}
+	if len(binding.Names) == 0 {
+		t.Error("the machine wears a restrictive group and the binding names no rule set at all")
+	}
+}
+
+// A pack that declares no plan to the orchestrator declares no exemption
+// either: the binding covers every interface, which is what the two packs that
+// do filter their private NICs send, and what every pack sent before #574.
+func TestAPackThatDeclaresNoPlanExemptsNothing(t *testing.T) {
+	b := newGroupSyncBench()
+	group := b.group("g-1", "")
+	res := b.machine("m-1", "10.0.0.7", "g-1")
+
+	b.sync().SyncGroup(context.Background(), group, res)
+
+	if binding := appliedBinding(t, b.rec, res.Runtime["machine"]); len(binding.Unfiltered) != 0 {
+		t.Fatalf("a pack declaring no plan must exempt nothing, got %v", binding.Unfiltered)
+	}
+}
+
+// appliedBinding is the last firewall binding one machine received, read off
+// the shared contract recorder.
+func appliedBinding(t *testing.T, rec *Recorder, machine string) FirewallBinding {
+	t.Helper()
+	var found *FirewallBinding
+	for _, e := range rec.Events() {
+		if e.Kind == "ApplyFirewall" && e.Resource == machine {
+			binding := e.Args.(FirewallBinding)
+			found = &binding // the last write is what the runtime holds
+		}
+	}
+	if found == nil {
+		t.Fatalf("the runtime never received a firewall binding for %s", machine)
+	}
+	return *found
+}

--- a/internal/core/machine/incus_firewall.go
+++ b/internal/core/machine/incus_firewall.go
@@ -173,11 +173,18 @@ func (d *Incus) firewallRefused(err error) error {
 }
 
 // ApplyFirewall implements Firewaller. It sets the rule sets, and the default
-// actions, on every NIC of the machine.
+// actions, on every NIC of the machine the binding covers.
 //
 // A machine can carry NICs of both kinds at once — the runtime's default
 // profile hands out a bridged eth0 next to the OVN interfaces the pack
 // attached — so the split below is per NIC, not per driver mode.
+//
+// "Every NIC" was the whole sentence until 2026-08-27, and it was the defect
+// (#574): a pack whose security groups do not reach inside its private
+// networks got them written onto the membership NIC all the same, so two
+// machines of one segment could not reach each other. What a group covers is
+// declared per network by the pack (Attachment.Unfiltered) and arrives here on
+// FirewallBinding.Unfiltered.
 func (d *Incus) ApplyFirewall(ctx context.Context, machine string, binding FirewallBinding) error {
 	if !safeName.MatchString(machine) {
 		return fmt.Errorf("invalid machine name %q", machine)
@@ -209,6 +216,31 @@ func (d *Incus) ApplyFirewall(ctx context.Context, machine string, binding Firew
 	permissiveEnsured := false
 	var escaped []string
 	for _, device := range devices {
+		// What this interface is asked to wear, which is not always what the
+		// machine wears (#574). A pack declares the networks its security
+		// groups do not cover — Exoscale's private networks, where upstream
+		// says in as many words that "security group rules do not apply" —
+		// and an interface on one of them is bound as if the machine wore no
+		// group at all.
+		//
+		// Emptied rather than skipped, deliberately, and each half is
+		// measured. Skipping would leave a rule set a previous version of this
+		// code had already written standing on the NIC, so the defect would
+		// survive a restart of the very machine that fixes it. And the empty
+		// binding is not "write nothing": under OVN a network carrying the
+		// emulator's isolation set forces the reject default onto every NIC
+		// attached to it, so the branch below dresses a set-less NIC in the
+		// permissive posture instead — an unfiltered interface must end up
+		// open inside its own segment, which is the entire point.
+		//
+		// TestNoRuleSetIsBoundToAnUnfilteredInterface and
+		// TestAnUnfilteredInterfaceStaysOpenOnAnIsolatedNetwork fail without
+		// this; TestApplyFirewallCoversEveryInterface holds the accepting
+		// half.
+		attached := joined
+		if !binding.covers(device.network) {
+			attached = ""
+		}
 		// A routed NIC takes no rule set at all (#337). Measured on Incus 7.2
 		// and confirmed by the 7.3 wording of the same refusal: every security
 		// option is an invalid device option there — security.acls, its two
@@ -243,7 +275,7 @@ func (d *Incus) ApplyFirewall(ctx context.Context, machine string, binding Firew
 		// TestTheUnenforceableRefusalNamesTheAddressThatEscapes fails without
 		// the addresses.
 		if device.routed {
-			if joined != "" {
+			if attached != "" {
 				escaped = append(escaped, device.describe())
 			}
 			continue
@@ -256,7 +288,7 @@ func (d *Incus) ApplyFirewall(ctx context.Context, machine string, binding Firew
 		if device.inherited {
 			verb = "override"
 		}
-		args := []string{"config", "device", verb, machine, device.name, "security.acls=" + joined}
+		args := []string{"config", "device", verb, machine, device.name, "security.acls=" + attached}
 		switch {
 		case d.isOVNNetwork(ctx, device.network, networks):
 			// Only security.acls: it is the one ACL key an OVN NIC updates in
@@ -281,7 +313,7 @@ func (d *Incus) ApplyFirewall(ctx context.Context, machine string, binding Firew
 			// TestAMachineWithoutAGroupStaysOpenOnAnIsolatedNetwork fails
 			// without this; TestAnEmptyBindingStillClearsANICOnAnUnisolatedNetwork
 			// holds the other half.
-			if joined == "" && networks[device.network].acls != "" {
+			if attached == "" && networks[device.network].acls != "" {
 				if !permissiveEnsured {
 					if err := d.EnsureFirewall(ctx, permissiveSpec()); err != nil {
 						return fmt.Errorf("apply firewall to %s/%s: %w", machine, device.name, err)
@@ -290,7 +322,7 @@ func (d *Incus) ApplyFirewall(ctx context.Context, machine string, binding Firew
 				}
 				args[len(args)-1] = "security.acls=" + permissiveACL()
 			}
-		case joined != "":
+		case attached != "":
 			// The default actions only mean something while a rule set is
 			// attached, and Incus rejects them on a NIC that carries none.
 			args = append(args,

--- a/internal/core/machine/incus_firewall_scope_test.go
+++ b/internal/core/machine/incus_firewall_scope_test.go
@@ -1,0 +1,156 @@
+package machine
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// Where a security group applies is a provider fact, and until 2026-08-27 this
+// driver had no way to be told it (#574).
+//
+// Exoscale states the divergence in one sentence — "Security group rules do
+// not apply to traffic inside private networks" — and the emulator applied
+// them anyway, onto the very NIC that carries the private lease. The `default`
+// group has no ingress rule, so its rule set translates to a drop default: two
+// instances of one private network measured 0/10 probes through, and 10/10
+// with the rule set stripped off the NIC by hand, under `--vm incus`.
+//
+// Under `--vm incus-ovn` the same wrong write did not bite, because the
+// sender's catch-all egress allow sits at priority 300 and outranks the
+// receiver's NIC default deny at 100/111 (#491). That is an accident of rule
+// ordering, so the assertions below are about the *commands emitted*, never
+// about a connection succeeding: an argument-level fact is the only one that
+// distinguishes "the rule is absent" from "the rule is present and outranked".
+
+// unfilteredNICs is a machine with an interface on a network the pack covers
+// and one on a network it does not — the shape an Exoscale instance has the
+// moment it joins a private network.
+const unfilteredNICs = `{
+  "expanded_devices": {
+    "eth0": {"type": "nic", "network": "fnt-default"},
+    "eth1": {"type": "nic", "network": "fnt-privnet"}
+  },
+  "devices": {
+    "eth0": {"type": "nic", "network": "fnt-default"},
+    "eth1": {"type": "nic", "network": "fnt-privnet"}
+  }
+}`
+
+func TestNoRuleSetIsBoundToAnUnfilteredInterface(t *testing.T) {
+	f := &fakeRuntime{answers: map[string]string{
+		"/1.0/instances/srv": unfilteredNICs,
+		"/1.0/networks/":     `{"type": "bridge"}`,
+	}}
+	d := newFakeDriver(f)
+
+	if err := d.ApplyFirewall(context.Background(), "srv", FirewallBinding{
+		Names:          []string{"exo-one"},
+		DefaultIngress: "drop",
+		DefaultEgress:  "allow",
+		Unfiltered:     []string{"fnt-privnet"},
+	}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	// The refusing half: nothing the driver emitted names a rule set on the
+	// membership interface. Asserted over every command rather than over the
+	// one the test expects to find, which is the difference between "the set
+	// is not there" and "the set is not where I looked".
+	for _, cmd := range f.matching(" eth1 ") {
+		if strings.Contains(cmd, "exo-one") {
+			t.Errorf("a rule set reached the unfiltered interface: %q", cmd)
+		}
+		if strings.Contains(cmd, "security.acls.default") {
+			t.Errorf("a default action reached the unfiltered interface: %q", cmd)
+		}
+	}
+	// It is emptied, not skipped: a rule set an earlier version of this code
+	// already wrote onto the NIC has to come off, or restarting the machine
+	// that the fix repairs would keep the defect alive.
+	cleared := f.matching(" eth1 security.acls=")
+	if len(cleared) != 1 || !strings.HasSuffix(cleared[0], "security.acls=") {
+		t.Fatalf("the unfiltered interface must be cleared exactly once, got %v", cleared)
+	}
+
+	// The accepting half, and it is what stops this from being a guard that
+	// refuses everything: the covered interface still wears the set and its
+	// defaults. Scaleway and Outscale filter their private NICs, their suites
+	// assert it, and nothing here may take that away.
+	covered := f.matching(" eth0 security.acls=")
+	if len(covered) != 1 || !strings.Contains(covered[0], "security.acls=exo-one") {
+		t.Fatalf("the covered interface must wear the rule set, got %v", covered)
+	}
+	if !strings.Contains(covered[0], "security.acls.default.ingress.action=drop") {
+		t.Errorf("the covered interface must keep its default actions, got %q", covered[0])
+	}
+}
+
+// Under OVN an unfiltered interface must end up *open inside its own segment*,
+// which is not the same as "no key written".
+//
+// A network carrying the emulator's isolation set forces the reject default
+// onto every NIC attached to it (a network's security.acls "apply to NICs
+// connected to this network"). Clearing the NIC and stopping there would close
+// the very segment this change exists to reopen, so the set-less NIC wears the
+// permissive posture instead — whose catch-all allows at 300 still lose to the
+// isolation's rejects at 400, so two private networks stay apart.
+func TestAnUnfilteredInterfaceStaysOpenOnAnIsolatedNetwork(t *testing.T) {
+	f := &fakeRuntime{answers: map[string]string{
+		"/1.0/instances/srv":        unfilteredNICs,
+		"/1.0/networks/fnt-privnet": `{"type": "ovn", "config": {"security.acls": "iso-fnt-privnet"}}`,
+		"/1.0/networks/fnt-default": `{"type": "ovn", "config": {}}`,
+	}}
+	d := newFakeDriver(f)
+	d.OVN = true
+
+	if err := d.ApplyFirewall(context.Background(), "srv", FirewallBinding{
+		Names:          []string{"exo-one"},
+		DefaultIngress: "drop",
+		DefaultEgress:  "allow",
+		Unfiltered:     []string{"fnt-privnet"},
+	}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	membership := f.matching(" eth1 security.acls=")
+	if len(membership) != 1 || !strings.Contains(membership[0], "security.acls=opn-fnt") {
+		t.Fatalf("the unfiltered interface of an isolated network must wear the permissive set, got %v", membership)
+	}
+	if got := f.matching("/1.0/network-acls/opn-fnt"); len(got) == 0 {
+		t.Error("the permissive set was attached without being written first")
+	}
+	for _, cmd := range f.matching(" eth1 ") {
+		if strings.Contains(cmd, "exo-one") {
+			t.Errorf("the group still reached the unfiltered interface under OVN: %q", cmd)
+		}
+	}
+	if covered := f.matching(" eth0 security.acls=exo-one"); len(covered) != 1 {
+		t.Fatalf("the covered interface must still wear the group under OVN, got %v", covered)
+	}
+}
+
+// A binding that declares no scope is the binding two of the three packs send,
+// and it must reach every interface exactly as it did before #574. Without
+// this the change would be indistinguishable from one that stopped filtering
+// altogether.
+func TestABindingThatDeclaresNoScopeCoversEveryInterface(t *testing.T) {
+	f := &fakeRuntime{answers: map[string]string{
+		"/1.0/instances/srv": unfilteredNICs,
+		"/1.0/networks/":     `{"type": "bridge"}`,
+	}}
+	d := newFakeDriver(f)
+
+	if err := d.ApplyFirewall(context.Background(), "srv", FirewallBinding{
+		Names:          []string{"scw-one"},
+		DefaultIngress: "drop",
+		DefaultEgress:  "allow",
+	}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	applied := f.matching("security.acls=scw-one")
+	if len(applied) != 2 {
+		t.Fatalf("both interfaces must wear the rule set, got %d: %v", len(applied), applied)
+	}
+}

--- a/internal/core/machine/machine.go
+++ b/internal/core/machine/machine.go
@@ -65,6 +65,27 @@ type Attachment struct {
 	// while its API said it was gone, which is the shape of defect #202 exists
 	// to prevent — an address nothing publishes.
 	Secondary []string
+	// Unfiltered declares that this provider's security groups do not cover
+	// the interface this attachment creates, so no rule set is ever bound to
+	// it.
+	//
+	// Which interfaces a security group covers is a provider fact, like an
+	// address key or a login, and it is not the same fact on the three clouds
+	// (#574). Exoscale states it plainly — "Security group rules do not apply
+	// to traffic inside private networks" — while Scaleway and Outscale do
+	// filter their private interfaces, and their network suites assert it.
+	//
+	// So the zero value is "covered": a pack that says nothing keeps every
+	// interface filtered, which is the direction that cannot silently open a
+	// machine. A pack that sets it declares a divergence it would otherwise
+	// have shipped, and it is read once, by GroupSync, on its way to the
+	// binding the driver applies.
+	//
+	// internal/core/machine's TestNoRuleSetIsBoundToAnUnfilteredInterface and
+	// internal/providers/exoscale's
+	// TestALateNetworkAttachLeavesThePrivateInterfaceUnfiltered fail without
+	// it.
+	Unfiltered bool
 }
 
 // Spec describes the machine a provider pack wants.

--- a/internal/core/machine/surface.go
+++ b/internal/core/machine/surface.go
@@ -51,6 +51,8 @@ package machine
 // package-level names and 297 members of them; the list below admitted 17 and
 // 41 that day. Re-counted on 2026-08-27 while #541 moved the address reader
 // into the layer: 17 and 43, Binding down to 13 of its 36 exported members.
+// Re-counted again on 2026-08-27 when #574 gave a pack a way to say where its
+// security groups apply: 17 and 45.
 // The middle figure had already drifted by one before that change, which is
 // what a number written in prose does — it is re-counted here rather than
 // left standing, and the count is a fact about the list, never a gate. What
@@ -123,6 +125,7 @@ func PackSurface() map[string]string {
 		"Plan.Memberships":            "the networks joined after boot, read back from the plan the pack built",
 		"Attachment":                  "one interface: a network, an address, the mask, the secondaries",
 		"Attachment.PrefixLen":        "the mask of an attachment the pack assembled",
+		"Attachment.Unfiltered":       "declare that this provider's security groups do not reach this interface",
 
 		// S3 — public addresses.
 		"Reconciler.Route":           "make one public address reach the machine, the hot half",
@@ -147,6 +150,7 @@ func PackSurface() map[string]string {
 		"GroupSync.ApplyMachine":              "write every set one resource wears and attach them in one call",
 		"GroupSync.SyncReferrers":             "re-expand the groups whose rules name the groups this resource wears",
 		"GroupSync.Drop":                      "remove a deleted group's rule set from the runtime",
+		"GroupSync.PlanOf":                    "declare the plan the scope of the groups is read from, the pack's own",
 		"FirewallSpec":                        "one rule set as the runtime takes it, translated by the pack",
 		"FirewallSpec.Rules":                  "the rules of a set the pack is assembling",
 		"FirewallSpec.DefaultEgress":          "the set's default egress action, which upstream models differ on",

--- a/internal/providers/exoscale/firewall.go
+++ b/internal/providers/exoscale/firewall.go
@@ -40,6 +40,15 @@ func (p *Pack) groupSync() machine.GroupSync {
 			return p.env.Store.Get(Name, kindSecurityGroup, id)
 		},
 		Referrers: p.groupsReferencing,
+		// Where this provider's groups apply, which on Exoscale is not every
+		// interface (#574): the same plan the Reconciler executes, read here
+		// for the one thing it says about scope — a private-network
+		// membership is declared Unfiltered, because upstream states that
+		// security group rules do not apply inside private networks. Wiring
+		// the same function twice rather than a second walk of the same
+		// attributes: a scope spelled apart from the plan is a scope that
+		// stops describing the interfaces the plan creates.
+		PlanOf: p.machinePlan,
 	}
 }
 

--- a/internal/providers/exoscale/firewall_internal_test.go
+++ b/internal/providers/exoscale/firewall_internal_test.go
@@ -242,8 +242,14 @@ func (p *Pack) poolMembersOfOnlyPool(t *testing.T) []*resource.Resource {
 // TestALateNetworkAttachCarriesTheRuleSets covers the interface born after the
 // boot: the Terraform provider attaches private networks once the create has
 // answered, and a rule set applied at boot never reaches a NIC that does not
-// exist yet. The attach path must re-apply — idempotently, since ApplyFirewall
-// covers every NIC of the machine.
+// exist yet. The attach path must re-apply, so the machine's covered
+// interfaces hold what the API describes.
+//
+// "Since ApplyFirewall covers every NIC of the machine" was the second half of
+// this comment until 2026-08-27, and it was the defect: the interface this
+// attach creates is precisely the one the groups must *not* reach (#574).
+// TestALateNetworkAttachLeavesThePrivateInterfaceUnfiltered holds that half,
+// and this one keeps the resync itself from being dropped along with it.
 func TestALateNetworkAttachCarriesTheRuleSets(t *testing.T) {
 	driver := newFirewallDriver()
 	p := sequencedPack(driver)

--- a/internal/providers/exoscale/firewall_scope_internal_test.go
+++ b/internal/providers/exoscale/firewall_scope_internal_test.go
@@ -1,0 +1,69 @@
+package exoscale
+
+import (
+	"context"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/resource"
+)
+
+// Exoscale's security groups stop at the public interface, and this pack has
+// to say so (#574).
+//
+// Upstream's Private Network Overview is explicit: "Security group rules do
+// not apply to traffic inside private networks." From a344f8d to 2026-08-27
+// this pack handed the runtime a machine-wide binding, so the `default`
+// group's rule set — no ingress rule, therefore a drop default — landed on the
+// membership NIC and two instances of one private network could not reach each
+// other. Measured under `--vm incus`: 0/10 probes with the rule set on the
+// NIC, 10/10 with it stripped off by hand.
+//
+// The assertion is on what the pack declares to the shared layer, because that
+// is where the fact belongs — the two other packs do filter their private
+// NICs, so this is a field on the attachment, not a rule of the layer.
+func TestALateNetworkAttachLeavesThePrivateInterfaceUnfiltered(t *testing.T) {
+	driver := newFirewallDriver()
+	p := sequencedPack(driver)
+	group := storedSecurityGroup(p, "web", []any{map[string]any{
+		"id": "r1", "flow-direction": "ingress", "protocol": "tcp",
+		"network": "0.0.0.0/0", "start-port": 443, "end-port": 443,
+	}})
+	inst := storedInstance(p, "192.0.2.7", group.ID)
+	p.start(context.Background(), inst)
+	p.env.Store.Put(inst)
+	machineName := inst.Runtime["machine"]
+
+	r := httptest.NewRequest("POST", "/v2/private-network",
+		strings.NewReader(`{"name":"back","start-ip":"10.90.2.20","end-ip":"10.90.2.200","netmask":"255.255.255.0"}`))
+	p.createPrivateNetwork(httptest.NewRecorder(), r)
+	pns := p.env.Store.List(kindPrivateNetwork, resource.Tenant{Provider: Name})
+	if len(pns) != 1 {
+		t.Fatalf("%d private networks, want 1", len(pns))
+	}
+	backing := pns[0].Runtime[runtimeNetworkKey]
+	if backing == "" {
+		t.Fatal("the private network has no backing network, so this test would assert about nothing")
+	}
+
+	ar := httptest.NewRequest("POST", "/v2/private-network/"+pns[0].ID+":attach",
+		strings.NewReader(`{"instance":{"id":"`+inst.ID+`"}}`))
+	ar.SetPathValue("id", pns[0].ID)
+	p.attachInstanceToPrivateNetwork(httptest.NewRecorder(), ar)
+
+	binding, applied := driver.applied[machineName]
+	if !applied {
+		t.Fatal("the attach applied no firewall binding at all")
+	}
+	if !slices.Contains(binding.Unfiltered, backing) {
+		t.Fatalf("the private network %s is not declared out of the groups' scope: %+v", backing, binding)
+	}
+	// The accepting half, and the reason this is a scope rather than a
+	// switch: the machine still wears its group, so whatever interface the
+	// groups *do* cover keeps being filtered.
+	if len(binding.Names) == 0 {
+		t.Error("the instance wears a restrictive group and the binding names no rule set at all")
+	}
+}

--- a/internal/providers/exoscale/privatenetworks.go
+++ b/internal/providers/exoscale/privatenetworks.go
@@ -684,13 +684,17 @@ func (p *Pack) attachInstanceToPrivateNetwork(w http.ResponseWriter, r *http.Req
 		writeError(w, http.StatusNotFound, "resource not found")
 		return
 	}
-	// Join attaches and then resyncs the firewall: the interface this attach
-	// just created carries the instance's rule sets like every other one — the
-	// Terraform provider attaches networks after the create returns, and a set
-	// applied at boot never reaches an interface born later (#475).
-	// ApplyFirewall covers every NIC of the machine, so re-applying is
-	// idempotent for the older ones; the groups naming this instance's groups
-	// re-expand with it, because the new lease is now part of what they mean.
+	// Join attaches and then resyncs the firewall: a set applied at boot never
+	// reaches an interface born later, and the Terraform provider attaches
+	// networks after the create returns (#475). Re-applying is idempotent for
+	// the interfaces that were already there; the groups naming this
+	// instance's groups re-expand with it, because the new lease is now part
+	// of what they mean.
+	//
+	// What the resync does *not* do, since 2026-08-27, is carry a rule set
+	// onto the interface it just created: membershipAttachment declares a
+	// private-network membership out of the groups' scope, which is upstream's
+	// own rule (#574).
 	p.joinPrivateNetwork(r.Context(), inst, pn, leaseIP)
 	p.writeOperation(w, p.operationReferring(nounPrivateNetwork, id))
 }
@@ -915,8 +919,29 @@ func (p *Pack) moveLease(w http.ResponseWriter, pn *resource.Resource, dhcp mana
 // runtime: the backing network, the leased address, and the range's mask when
 // the network is managed — configuring the interface inside the guest needs
 // both halves.
+//
+// Unfiltered is upstream's own sentence, and the whole of #574: "Security
+// group rules do not apply to traffic inside private networks" (Exoscale,
+// Private Network Overview). From a344f8d to 2026-08-27 this emulator applied
+// them anyway — the `default` group carries no ingress rule, so its rule set
+// translates to a drop default, and the driver wrote it onto the membership
+// NIC. Two instances of one private network then could not reach each other,
+// measured 0/10 with the rule set and 10/10 without it, under `--vm incus`.
+// Under `--vm incus-ovn` the same wrong rule was written and did not bite,
+// because the sender's catch-all egress allow at priority 300 outranks the
+// receiver's default deny at 100/111 — the ordering #491 records, an accident
+// no assertion may rest on.
+//
+// The two other packs do filter their private interfaces and their network
+// suites assert it, so this is a field and not a rule of the layer.
+//
+// TestALateNetworkAttachLeavesThePrivateInterfaceUnfiltered fails without it.
 func (p *Pack) membershipAttachment(pn *resource.Resource, ip string) machine.Attachment {
-	att := machine.Attachment{Network: pn.Runtime[runtimeNetworkKey], Address: ip}
+	att := machine.Attachment{
+		Network:    pn.Runtime[runtimeNetworkKey],
+		Address:    ip,
+		Unfiltered: true,
+	}
 	if dhcp, managed := rangeOf(pn); managed && ip != "" {
 		att.PrefixLen = dhcp.prefix.Bits()
 	}

--- a/mise.toml
+++ b/mise.toml
@@ -807,15 +807,33 @@ depends = ["build"]
 # than logging, and `feint clean --check` refusing at the doorstep on a host
 # that still holds a previous run's networks. Three consecutive stacks.sh runs
 # then left the host byte-identical to its inventory before them.
+#
+# MEASURED 2026-08-27 (#574). Leg 2 used to open with
+# `FEINT_VM="${FEINT_EVIDENCE_VM:-incus}"`, so an operator who exported
+# FEINT_VM=incus-ovn got the bridge and was never told. That line produced two
+# successive false attributions during an Exoscale diagnosis — "the
+# population", then "the branch" — and three 1300-second passes to unmake them.
+# A harness that answers under a mode nobody asked for does not measure its
+# subject. tools/evidence/mode.sh resolves the mode, refuses what it cannot
+# honour, and says which one it runs; its four outcomes are asserted by
+# tools/evidence/mode_test.go, and TestTheEvidenceTaskAsksForItsModeRatherThanPinningIt
+# holds the wiring.
 run = """
 set -e
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
-echo "== leg 1/2: machines off, probe on"
-FEINT_VM=off FEINT_EVIDENCE_OUT="$tmp/off.json" mise run conformance
+# Both modes settled at second zero, before the twenty minutes: a mode this
+# task cannot honour must refuse now, not after leg 1 has been paid for. Same
+# discipline as the doorstep question in `conformance`.
+leg2_vm=""
 if command -v incus >/dev/null 2>&1; then
-  echo "== leg 2/2: machines on"
-  FEINT_VM="${FEINT_EVIDENCE_VM:-incus}" FEINT_EVIDENCE_OUT="$PWD/coverage/evidence.json" \
+  leg2_vm="$(tools/evidence/mode.sh)"
+fi
+echo "== leg 1/2: machines off, probe on (--vm off always: the probe walks every Create* route, and would boot a container per route)"
+FEINT_VM=off FEINT_EVIDENCE_OUT="$tmp/off.json" mise run conformance
+if [ -n "$leg2_vm" ]; then
+  echo "== leg 2/2: machines on, --vm $leg2_vm"
+  FEINT_VM="$leg2_vm" FEINT_EVIDENCE_OUT="$PWD/coverage/evidence.json" \
     FEINT_EVIDENCE_JOIN="$tmp/off.json" mise run conformance
 else
   echo "== no incus on this host: the runtime leg is skipped, the artefact says machines: none"

--- a/tools/conformance/exoscale/network.sh
+++ b/tools/conformance/exoscale/network.sh
@@ -10,9 +10,25 @@
 # because a bridge-backed mode cannot deliver it (docs/limits.md) and claiming
 # it anyway would be the half-truth this project exists to avoid.
 #
-# What is deliberately not here: firewall assertions. The Exoscale pack does
-# not yet sync its security groups onto the machines, so a rule assertion would
-# measure nothing — the Scaleway and Outscale suites own that ground for now.
+# What used to stand here, and what it cost. Until 2026-08-27 this header said
+# that firewall assertions were deliberately absent "because the Exoscale pack
+# does not yet sync its security groups onto the machines, so a rule assertion
+# would measure nothing". That stopped being true at a344f8d (#494/#475), when
+# the packs began handing their groups to the host — and the sentence stayed,
+# read as a live fact, steering every reader of this file away from the
+# firewall. It is the exact shape CLAUDE.md names: a control's obituary read as
+# a measurement.
+#
+# What it hid is #574. The pack applied the `default` group's rule set to every
+# interface, the private-network NIC included, where Exoscale states the
+# opposite in as many words — "Security group rules do not apply to traffic
+# inside private networks". The group carries no ingress rule, so the NIC ended
+# up with a drop default and two instances of one segment could not reach each
+# other under `--vm incus`: 0/10 probes, and 10/10 with the rule set stripped.
+# The reachability assertion below is what fails when that comes back, and it
+# fails only under the bridge — under OVN the same wrong rule is outranked by
+# the sender's catch-all egress allow (#491), so a green there proves nothing
+# about the rule being absent.
 #
 # Requires a machine runtime: `FEINT_VM=incus mise run serve` at least, and
 # `FEINT_VM=incus-ovn` for the isolation assertion to be hard. With --vm off

--- a/tools/conformance/runtimeproof_test.go
+++ b/tools/conformance/runtimeproof_test.go
@@ -1,0 +1,104 @@
+package conformance
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// Every network suite this repository carries is replayed by the workflow that
+// exists to replay them (#574).
+//
+// It was not, and that absence is a third of why an Exoscale defect lived from
+// a344f8d to 2026-08-27. runtime-proof.yml ran the Scaleway and Outscale
+// network suites and not the Exoscale one; no leg, bridge or OVN, replayed it;
+// local work happens under OVN, where the defect was masked by rule ordering
+// (#491); and the only routine that replayed it under the bridge was
+// `evidence:update`'s second leg, which nobody had run since. A suite no
+// matrix carries has a verdict as old as the last person who thought to run it
+// by hand.
+//
+// The denominator is derived, never listed: what has to run is every
+// `tools/conformance/*/network.sh` on disk, so a fourth pack's suite is
+// demanded the day it exists rather than the day somebody remembers. Both
+// consumers are checked, because they answer different questions — the
+// workflow is what CI proves, `leg.sh runtime` is what an operator reproduces,
+// and leg.sh's own comment claims to carry the workflow's order.
+func TestEveryNetworkSuiteIsReplayedByTheRuntimeProof(t *testing.T) {
+	root := repoRoot(t)
+
+	suites := networkSuites(t, root)
+	// The reader proves it can find before it judges: three packs ship a
+	// network suite today, and a glob that matched nothing would make every
+	// assertion below vacuously true.
+	if len(suites) < 3 {
+		t.Fatalf("found %d network suite(s) under tools/conformance (%v): the reader is the "+
+			"suspect, not the workflow", len(suites), suites)
+	}
+	if !contains(suites, "tools/conformance/exoscale/network.sh") {
+		t.Fatalf("the reader did not find the Exoscale network suite, which is the one #574 was "+
+			"about; it found %v", suites)
+	}
+
+	for _, consumer := range []struct {
+		path string
+		what string
+	}{
+		{
+			path: filepath.Join(".github", "workflows", "runtime-proof.yml"),
+			what: "the workflow that proves the dataplane on real machines, on both its legs",
+		},
+		{
+			path: filepath.Join("tools", "conformance", "leg.sh"),
+			what: "`mise run conformance:leg -- runtime`, which is how an operator reproduces that workflow",
+		},
+	} {
+		body := readFile(t, filepath.Join(root, consumer.path))
+		for _, suite := range suites {
+			if !strings.Contains(body, suite) {
+				t.Errorf("%s never runs %s — %s. A suite nothing replays reports the verdict of "+
+					"whenever somebody last ran it by hand (#574)", consumer.path, suite, consumer.what)
+			}
+		}
+	}
+}
+
+// networkSuites is every provider network suite on disk, as the repository-
+// relative paths the workflow and leg.sh name them by.
+func networkSuites(t *testing.T, root string) []string {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(root, "tools", "conformance", "*", "network.sh"))
+	if err != nil {
+		t.Fatalf("list the network suites: %v", err)
+	}
+	out := make([]string, 0, len(matches))
+	for _, match := range matches {
+		rel, err := filepath.Rel(root, match)
+		if err != nil {
+			t.Fatalf("relativise %s: %v", match, err)
+		}
+		out = append(out, filepath.ToSlash(rel))
+	}
+	sort.Strings(out)
+	return out
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	raw, err := os.ReadFile(path) //nolint:gosec // a fixed path in this repository
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(raw)
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, entry := range haystack {
+		if entry == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/tools/evidence/mode.sh
+++ b/tools/evidence/mode.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Which runtime the evidence record's second leg runs under, said out loud.
+#
+# `mise run evidence:update` drives two conformance runs: leg 1 with machines
+# off, because the probe walks every Create* route and would boot a container
+# per route, and leg 2 with machines on, because the dataplane axis only exists
+# there. Leg 2 used to open with
+#
+#     FEINT_VM="${FEINT_EVIDENCE_VM:-incus}"
+#
+# and that single line is #574's second half. An operator who exported
+# FEINT_VM=incus-ovn got the bridge, was told nothing, and read a verdict about
+# a mode nobody had asked for. It manufactured two successive false
+# attributions while an Exoscale defect was being diagnosed — first "the
+# population", then "the branch" — and cost three 1300-second passes to unmake.
+#
+# The rule this file is: an instrument that answers under a mode may not choose
+# that mode silently. So the caller's FEINT_VM wins, FEINT_EVIDENCE_VM stays as
+# the way to steer the leg without touching leg 1, a disagreement between the
+# two is refused by name rather than arbitrated, and the mode is announced
+# before anything starts.
+#
+# Prints the resolved mode on stdout, the announcement on stderr, and exits 1
+# with the reason when the two variables cannot both be honoured.
+#
+# Driven by tools/evidence/mode_test.go, which is where the four outcomes are
+# asserted; a green run of this script proves nothing on its own.
+set -euo pipefail
+
+vm="${FEINT_VM:-}"
+evidence_vm="${FEINT_EVIDENCE_VM:-}"
+
+if [ -n "$vm" ] && [ -n "$evidence_vm" ] && [ "$vm" != "$evidence_vm" ]; then
+  echo "FEINT_VM=$vm and FEINT_EVIDENCE_VM=$evidence_vm name two different runtimes for the same leg." >&2
+  echo "Picking one of them is what made this task report a verdict under a mode nobody asked for (#574)." >&2
+  echo "Export one, or set them to the same value." >&2
+  exit 1
+fi
+
+if [ -n "$vm" ]; then
+  mode="$vm"
+  source="FEINT_VM, exported by the caller"
+elif [ -n "$evidence_vm" ]; then
+  mode="$evidence_vm"
+  source="FEINT_EVIDENCE_VM"
+else
+  mode="incus"
+  source="this task's default"
+fi
+
+# Refused by name rather than honoured: with machines off the runtime leg is
+# leg 1 run twice, so it would earn no dataplane axis and quietly narrow the
+# record. The refusal says which leg already does that.
+if [ "$mode" = "off" ]; then
+  echo "the runtime leg was asked for --vm off ($source), which is leg 1 run a second time:" >&2
+  echo "it can earn no dataplane axis, and the record would narrow without anyone asking." >&2
+  echo "Ask for a runtime (incus, incus-ovn, incus-vm), or run leg 1 alone." >&2
+  exit 1
+fi
+
+echo "   the runtime leg runs under --vm $mode ($source)" >&2
+printf '%s\n' "$mode"

--- a/tools/evidence/mode_test.go
+++ b/tools/evidence/mode_test.go
@@ -1,0 +1,209 @@
+// Package evidence holds the tests of the shell `mise run evidence:update`
+// leans on. The task itself takes twenty minutes and needs Incus, real
+// clients and a station nobody else is using; deciding which runtime its
+// second leg answers under takes none of that, and it is the part that lied.
+package evidence
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The evidence record's second leg says which runtime it ran under, and cannot
+// be handed one nobody asked for (#574).
+//
+// What the wrong output looked like matters more than the fix: nothing was
+// printed at all. `FEINT_VM=incus-ovn mise run evidence:update` ran the bridge,
+// answered green, and the operator read the verdict as OVN's. Two false
+// attributions came out of that in one session — an Exoscale reachability
+// defect was blamed first on the population of the run, then on the branch it
+// ran from — and each disproof cost a 1300-second pass.
+//
+// Four outcomes, and the third and fourth are the ones a two-way resolver
+// would have collapsed: honour the caller, honour the task's own knob, refuse
+// a disagreement rather than arbitrate it, refuse a mode that would silently
+// narrow the record.
+func TestTheRuntimeLegResolvesAndAnnouncesItsMode(t *testing.T) {
+	cases := []struct {
+		name    string
+		env     []string
+		mode    string
+		refused bool
+		says    string
+	}{
+		{
+			name: "an exported FEINT_VM wins, which is the whole defect",
+			env:  []string{"FEINT_VM=incus-ovn"},
+			mode: "incus-ovn",
+			says: "FEINT_VM, exported by the caller",
+		},
+		{
+			name: "the task's own knob still steers the leg without touching leg 1",
+			env:  []string{"FEINT_EVIDENCE_VM=incus-vm"},
+			mode: "incus-vm",
+			says: "FEINT_EVIDENCE_VM",
+		},
+		{
+			name: "nothing exported: the default, said out loud rather than assumed",
+			env:  nil,
+			mode: "incus",
+			says: "this task's default",
+		},
+		{
+			name: "both set to the same runtime is not a disagreement",
+			env:  []string{"FEINT_VM=incus-ovn", "FEINT_EVIDENCE_VM=incus-ovn"},
+			mode: "incus-ovn",
+			says: "FEINT_VM, exported by the caller",
+		},
+		{
+			name:    "two different runtimes are refused by name, never arbitrated",
+			env:     []string{"FEINT_VM=incus-ovn", "FEINT_EVIDENCE_VM=incus"},
+			refused: true,
+			says:    "name two different runtimes",
+		},
+		{
+			name:    "machines off is refused: it is leg 1 run twice, and it would narrow the record",
+			env:     []string{"FEINT_VM=off"},
+			refused: true,
+			says:    "leg 1 run a second time",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			code, stdout, stderr := runMode(t, tc.env)
+			if tc.refused {
+				if code == 0 {
+					t.Fatalf("the resolver accepted what it must refuse (mode %q)", strings.TrimSpace(stdout))
+				}
+				if strings.TrimSpace(stdout) != "" {
+					t.Errorf("a refusal still printed a mode on stdout (%q), which the task would run",
+						strings.TrimSpace(stdout))
+				}
+			} else {
+				if code != 0 {
+					t.Fatalf("the resolver refused a mode it must honour: %s", stderr)
+				}
+				if got := strings.TrimSpace(stdout); got != tc.mode {
+					t.Fatalf("the leg would run under %q, want %q", got, tc.mode)
+				}
+			}
+			// The announcement is the half that was missing entirely, so it is
+			// asserted for every outcome: a resolver that picks right and says
+			// nothing leaves the reader exactly where #574 found them.
+			if !strings.Contains(stderr, tc.says) {
+				t.Errorf("the resolver never said %q; it said:\n%s", tc.says, stderr)
+			}
+			if !tc.refused && !strings.Contains(stderr, "--vm "+tc.mode) {
+				t.Errorf("the resolver never named the mode it runs; it said:\n%s", stderr)
+			}
+		})
+	}
+}
+
+// The resolver is only worth its file if the task actually asks it. A
+// behaviour test on a script nothing calls is the instrument this repository
+// keeps finding: green, honest about itself, and measuring nothing.
+//
+// Two halves, because the wiring can rot in two directions: the call must be
+// there, and the literal it replaced must not come back.
+func TestTheEvidenceTaskAsksForItsModeRatherThanPinningIt(t *testing.T) {
+	body := evidenceTask(t)
+	if !strings.Contains(body, "tools/evidence/mode.sh") {
+		t.Error("the evidence task no longer asks tools/evidence/mode.sh which runtime its second leg " +
+			"runs under: whatever it picks instead, it picks silently (#574)")
+	}
+	if strings.Contains(body, "FEINT_EVIDENCE_VM") {
+		t.Error("the evidence task arbitrates FEINT_EVIDENCE_VM itself again instead of delegating " +
+			"the whole question to the resolver: that is the line that ignored an exported " +
+			"FEINT_VM and manufactured two false attributions (#574)")
+	}
+	// Leg 1 is the one mode that is genuinely fixed, and it says so where a
+	// reader meets it rather than only in a comment above the task.
+	if !strings.Contains(body, "--vm off always") {
+		t.Error("the evidence task no longer says that its first leg is fixed at --vm off: an " +
+			"unexplained override is the same defect one leg to the left")
+	}
+}
+
+// evidenceTask is what `mise run evidence:update` executes, read from
+// mise.toml: the run block alone, never the prose above it. The comment there
+// quotes the line this change removed, and a reader that swallowed it would
+// report the defect present forever.
+//
+// The reader proves it can find before it judges: a slice that came back empty
+// would let both assertions above pass on a task that no longer exists.
+func evidenceTask(t *testing.T) string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("..", "..", "mise.toml")) //nolint:gosec // a fixed path in this repository
+	if err != nil {
+		t.Fatalf("read mise.toml: %v", err)
+	}
+	_, after, found := strings.Cut(string(raw), `[tasks."evidence:update"]`)
+	if !found {
+		t.Fatal("mise.toml declares no evidence:update task: this test would pass on its absence")
+	}
+	_, script, found := strings.Cut(after, "run = \"\"\"")
+	if !found {
+		t.Fatal("the evidence:update task carries no run block: this test would pass on its absence")
+	}
+	body, _, found := strings.Cut(script, "\"\"\"")
+	if !found {
+		t.Fatal("the evidence:update run block is never closed: the reader is the suspect")
+	}
+	if !strings.Contains(body, "mise run conformance") {
+		t.Fatalf("the evidence:update task read from mise.toml drives no conformance run, so the "+
+			"reader is the suspect, not the task:\n%s", body)
+	}
+	return body
+}
+
+// runMode executes the resolver with exactly the environment a case names.
+//
+// The parent environment is deliberately not inherited for the two variables
+// under test: a station that already exports FEINT_VM would otherwise decide
+// the verdict, which is the shape of the defect itself.
+func runMode(t *testing.T, env []string) (code int, stdout, stderr string) {
+	t.Helper()
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Fatalf("bash is not on this host, and the resolver is shell because the task is shell: %v", err)
+	}
+	script, err := filepath.Abs("mode.sh")
+	if err != nil {
+		t.Fatalf("locate mode.sh: %v", err)
+	}
+	if _, err := os.Stat(script); err != nil {
+		t.Fatalf("mode.sh is not where this test looks (%s): %v", script, err)
+	}
+
+	cmd := exec.Command("bash", script) //nolint:gosec // a fixed script in this repository
+	cmd.Env = append(cleanEnvironment(), env...)
+	var out, errBuf strings.Builder
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		var exit *exec.ExitError
+		if !errors.As(err, &exit) {
+			t.Fatalf("run the resolver: %v\n%s", err, errBuf.String())
+		}
+		code = exit.ExitCode()
+	}
+	return code, out.String(), errBuf.String()
+}
+
+// cleanEnvironment is the parent environment without the two variables the
+// resolver reads, so a case says the whole truth about its own inputs.
+func cleanEnvironment() []string {
+	out := make([]string, 0, len(os.Environ()))
+	for _, entry := range os.Environ() {
+		if strings.HasPrefix(entry, "FEINT_VM=") || strings.HasPrefix(entry, "FEINT_EVIDENCE_VM=") {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return out
+}

--- a/tools/falsify/specs/evidence-leg-mode.json
+++ b/tools/falsify/specs/evidence-leg-mode.json
@@ -1,0 +1,47 @@
+{
+  "package": "./tools/evidence/",
+  "mutations": [
+    {
+      "label": "an exported FEINT_VM is ignored again, so the leg answers under a mode nobody asked for (#574)",
+      "file": "tools/evidence/mode.sh",
+      "find": "if [ -n \"$vm\" ]; then\n  mode=\"$vm\"",
+      "replace": "if [ -n \"$vm\" ] && false; then\n  mode=\"$vm\"",
+      "test": "TestTheRuntimeLegResolvesAndAnnouncesItsMode"
+    },
+    {
+      "label": "two variables naming two different runtimes are arbitrated instead of refused",
+      "file": "tools/evidence/mode.sh",
+      "find": "if [ -n \"$vm\" ] && [ -n \"$evidence_vm\" ] && [ \"$vm\" != \"$evidence_vm\" ]; then",
+      "replace": "if [ -n \"$vm\" ] && [ -n \"$evidence_vm\" ] && [ \"$vm\" != \"$evidence_vm\" ] && false; then",
+      "test": "TestTheRuntimeLegResolvesAndAnnouncesItsMode"
+    },
+    {
+      "label": "machines off is accepted for the runtime leg, and the record narrows without anyone asking",
+      "file": "tools/evidence/mode.sh",
+      "find": "if [ \"$mode\" = \"off\" ]; then",
+      "replace": "if [ \"$mode\" = \"off\" ] && false; then",
+      "test": "TestTheRuntimeLegResolvesAndAnnouncesItsMode"
+    },
+    {
+      "label": "the leg stops naming the mode it runs, which is the half that was missing entirely",
+      "file": "tools/evidence/mode.sh",
+      "find": "echo \"   the runtime leg runs under --vm $mode ($source)\" >&2",
+      "replace": "echo \"   the runtime leg runs\" >&2",
+      "test": "TestTheRuntimeLegResolvesAndAnnouncesItsMode"
+    },
+    {
+      "label": "the task goes back to pinning its own mode, so the resolver is a script nothing calls",
+      "file": "mise.toml",
+      "find": "  leg2_vm=\"$(tools/evidence/mode.sh)\"",
+      "replace": "  leg2_vm=\"${FEINT_EVIDENCE_VM:-incus}\" # instead of $(tools/evidence/mode.sh)",
+      "test": "TestTheEvidenceTaskAsksForItsModeRatherThanPinningIt"
+    },
+    {
+      "label": "the first leg stops saying its mode is fixed, so an override is silent one leg to the left",
+      "file": "mise.toml",
+      "find": "echo \"== leg 1/2: machines off, probe on (--vm off always: the probe walks every Create* route, and would boot a container per route)\"",
+      "replace": "echo \"== leg 1/2: machines off, probe on\"",
+      "test": "TestTheEvidenceTaskAsksForItsModeRatherThanPinningIt"
+    }
+  ]
+}

--- a/tools/falsify/specs/forbidden-port-refuses.json
+++ b/tools/falsify/specs/forbidden-port-refuses.json
@@ -39,15 +39,15 @@
     {
       "label": "an empty binding goes back to the bare detach on an isolated network, and the reject default closes the machine entirely",
       "file": "internal/core/machine/incus_firewall.go",
-      "find": "\t\t\tif joined == \"\" && networks[device.network].acls != \"\" {",
-      "replace": "\t\t\tif joined == \"\" && networks[device.network].acls != \"\" && false {",
+      "find": "\t\t\tif attached == \"\" && networks[device.network].acls != \"\" {",
+      "replace": "\t\t\tif attached == \"\" && networks[device.network].acls != \"\" && false {",
       "test": "TestAMachineWithoutAGroupStaysOpenOnAnIsolatedNetwork"
     },
     {
       "label": "the permissive set attaches to every bare NIC whatever its network carries, handing its egress catch-all to the sender's side of the pipeline",
       "file": "internal/core/machine/incus_firewall.go",
-      "find": "\t\t\tif joined == \"\" && networks[device.network].acls != \"\" {",
-      "replace": "\t\t\tif joined == \"\" && (networks[device.network].acls != \"\" || true) {",
+      "find": "\t\t\tif attached == \"\" && networks[device.network].acls != \"\" {",
+      "replace": "\t\t\tif attached == \"\" && (networks[device.network].acls != \"\" || true) {",
       "test": "TestAnEmptyBindingStillClearsANICOnAnUnisolatedNetwork"
     },
     {

--- a/tools/falsify/specs/groups-stop-where-the-provider-says.json
+++ b/tools/falsify/specs/groups-stop-where-the-provider-says.json
@@ -1,0 +1,42 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "the rule sets go back onto every interface, whatever the pack declared — the whole of #574",
+      "file": "internal/core/machine/incus_firewall.go",
+      "find": "\t\tattached := joined\n\t\tif !binding.covers(device.network) {\n\t\t\tattached = \"\"\n\t\t}",
+      "replace": "\t\tattached := joined\n\t\tif !binding.covers(device.network) && false {\n\t\t\tattached = \"\"\n\t\t}",
+      "test": "TestNoRuleSetIsBoundToAnUnfilteredInterface"
+    },
+    {
+      "label": "every network is covered again, so an unfiltered NIC wears the group under OVN too — where the accident of rule ordering would hide it",
+      "file": "internal/core/machine/firewall.go",
+      "find": "\treturn network == \"\" || !slices.Contains(b.Unfiltered, network)",
+      "replace": "\treturn network == \"\" || !slices.Contains(b.Unfiltered, network) || true",
+      "test": "TestAnUnfilteredInterfaceStaysOpenOnAnIsolatedNetwork"
+    },
+    {
+      "label": "the scope is read from the memberships alone, so a boot interface a pack declares out of scope is filtered anyway",
+      "file": "internal/core/machine/groupsync.go",
+      "find": "\tfor _, att := range slices.Concat(plan.Boot, plan.Memberships) {",
+      "replace": "\tfor _, att := range slices.Concat(plan.Boot[:0], plan.Memberships) {",
+      "test": "TestTheUnfilteredScopeIsReadFromBothHalvesOfThePlan"
+    },
+    {
+      "label": "the orchestrator stops reading the pack's plan, so no pack can say where its groups stop",
+      "package": "./internal/providers/exoscale/",
+      "file": "internal/core/machine/groupsync.go",
+      "find": "\tif s.PlanOf == nil || res == nil {",
+      "replace": "\tif s.PlanOf != nil || res == nil {",
+      "test": "TestALateNetworkAttachLeavesThePrivateInterfaceUnfiltered"
+    },
+    {
+      "label": "the Exoscale pack stops declaring its private networks out of scope, which is the state a344f8d left the emulator in",
+      "package": "./internal/providers/exoscale/",
+      "file": "internal/providers/exoscale/privatenetworks.go",
+      "find": "\t\tUnfiltered: true,",
+      "replace": "\t\tUnfiltered: true && false,",
+      "test": "TestALateNetworkAttachLeavesThePrivateInterfaceUnfiltered"
+    }
+  ]
+}

--- a/tools/falsify/specs/routed-nic.json
+++ b/tools/falsify/specs/routed-nic.json
@@ -46,8 +46,8 @@
     {
       "label": "a rule set on a routed NIC is silently skipped instead of refused",
       "file": "internal/core/machine/incus_firewall.go",
-      "find": "\t\tif device.routed {\n\t\t\tif joined != \"\" {",
-      "replace": "\t\tif device.routed {\n\t\t\tif joined != \"\" && false {",
+      "find": "\t\tif device.routed {\n\t\t\tif attached != \"\" {",
+      "replace": "\t\tif device.routed {\n\t\t\tif attached != \"\" && false {",
       "test": "TestApplyFirewallRefusesAGroupOnARoutedNIC"
     },
     {

--- a/tools/falsify/specs/runtime-proof-replays-every-suite.json
+++ b/tools/falsify/specs/runtime-proof-replays-every-suite.json
@@ -1,0 +1,19 @@
+{
+  "package": "./tools/conformance/",
+  "mutations": [
+    {
+      "label": "the workflow's third network step points at another pack's suite, so one suite is replayed nowhere again (#574)",
+      "file": ".github/workflows/runtime-proof.yml",
+      "find": "      - name: Exoscale network suite\n        run: sudo tools/conformance/exoscale/network.sh http://127.0.0.1:4599",
+      "replace": "      - name: Exoscale network suite\n        run: sudo tools/conformance/scaleway/network.sh http://127.0.0.1:4599 # not exoscale",
+      "test": "TestEveryNetworkSuiteIsReplayedByTheRuntimeProof"
+    },
+    {
+      "label": "the local reproduction stops carrying a suite the workflow runs, so an operator cannot reproduce a red leg",
+      "file": "tools/conformance/leg.sh",
+      "find": "    tools/conformance/exoscale/network.sh \"$endpoint\"",
+      "replace": "    tools/conformance/scaleway/network.sh \"$endpoint\" # not exoscale",
+      "test": "TestEveryNetworkSuiteIsReplayedByTheRuntimeProof"
+    }
+  ]
+}


### PR DESCRIPTION
# Summary

Exoscale documents that **"Security group rules do not apply to traffic inside
private networks"**. Since `a344f8d` (#494/#475) this emulator applied them
there: the `default` group carries no ingress rule, so `firewallSpecOf`
translates it to a drop default, and `ApplyFirewall` wrote it onto the
membership NIC. **Two instances of one private network could not reach each
other.** The segment was not broken, it was firewalled, wrongly.

Where a security group applies is now a **provider fact carried by the shared
layer**, not a rule of the layer: the pack declares it per interface on
`machine.Attachment.Unfiltered`, `machine.GroupSync` reads it off the plan the
pack already declares to the `Reconciler`, and it reaches the driver on
`FirewallBinding.Unfiltered`. Scaleway and Outscale declare nothing and keep
filtering their private NICs, which their own network suites assert. The zero
value is "covered", so a pack that says nothing cannot silently open a machine,
and no provider name enters `internal/core`.

The three instruments that hid it are repaired in the same lot, because each of
them on its own would have caught it:

| instrument | what it did | what it does now |
|---|---|---|
| `.github/workflows/runtime-proof.yml` | ran two of the three network suites | runs all three, on both legs, with the list derived from the suites on disk |
| `mise run evidence:update` | overrode an exported `FEINT_VM` in silence | honours it, refuses a disagreement and `--vm off` by name, **announces the mode** |
| `tools/conformance/exoscale/network.sh` header | said the defect could not exist | says what stopped being true and when |

## Reproduction, before and after, under both modes

Read off the NIC (`incus config device get`), never off the connection: under
OVN the same wrong rule set was written and did *not* bite, because the sender's
catch-all egress `allow` at priority 300 outranks the receiver NIC's default
deny at 100/111 — the ordering #491 records. Measured 2026-08-27, one private
network, two instances created with `--public-ip none`.

| mode | build | `security.acls` on the membership NIC | probes |
|---|---|---|---|
| `--vm incus` | before | `exo-11e594f4819`, `default.ingress.action: drop` | **0/10** |
| `--vm incus` | after | absent | 10/10 |
| `--vm incus-ovn` | before | `exo-11e594f4819` | 10/10 (masked) |
| `--vm incus-ovn` | after | absent | 10/10 |

With the emulator's isolation set on the network (two private networks, OVN),
the unfiltered NIC wears the permissive posture set `opn-fnt` rather than
nothing — read live during the runtime leg — because a network-level ACL forces
the reject default onto every NIC attached to it. Unfiltered has to mean open
inside the segment, not closed by the network.

## Type of change

- [ ] A route added or changed
- [x] Bug fix
- [ ] Refactor
- [x] Documentation
- [x] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes (gofmt, vet, golangci-lint, `go test -race`)
- [x] No new external Go dependency
- [x] `internal/core` still knows no provider — the scope is a field on
      `Attachment` and a function on `GroupSync`; `TestTheCoreNamesNoProvider`
      and `TestNoPackReachesPastTheDeclaredDriverSurface` are green,
      `notInTheDriverSurface` still empty
- [x] Nothing in the diff could be written identically for another provider.
      The layer holds the mechanism for the three packs; the pack holds only
      the declaration Exoscale's documentation makes
- [x] `mise run testplan` was run and what it printed was run, except the two
      named below

Skipped, and why:

- `mise run evidence:update` — 1300 s and it holds the station. The wiring was
  exercised instead by driving the task's own resolution lines with the two
  conformance calls stubbed out, over five environments, and the resolver's
  four outcomes are asserted by `tools/evidence/mode_test.go`.

### When a model wrote a substantive part of this

- [x] `Assisted-by:` names the tool and the model version on every commit
- [x] The suites were run for real: `FEINT_VM=incus mise run conformance:leg --
      runtime` **and** `FEINT_VM=incus-ovn mise run conformance:leg -- runtime`,
      plus the `probe`, `exo-cli` and `fields` legs and `conformance:zones`
- [x] No field name is invented: the divergence removed is quoted from
      Exoscale's own Private Network Overview

### When a route is added or changed — N/A

No route added or changed.

### When behaviour a client can observe changes

- [x] `docs/limits.md` updated: the section "The three packs hand their security
      groups to the runtime" now states which interfaces a group covers, with
      both before/after runs; `mise run limits:check` is 0
- [x] The README's generated tables are unaffected (`mise run docs:check` green)

### When `.github/workflows/` is touched

- [x] Every action still pinned by SHA — no action added, one `run:` step
- [x] `step-security/harden-runner` is still the job's first step
- [x] `permissions:` unchanged and least-privilege
- [x] **No job renamed**, so the required status checks are untouched
- [x] The exit-code contract holds: the new step is a bare `run:` whose exit
      code is the job's

### When a machine runtime is involved

- [x] Tested with `FEINT_VM=incus` **and** `FEINT_VM=incus-ovn`
- [x] Nothing the emulator did not create was touched — the operator's own
      `acltest` ACL is untouched, and the ownership checks are unchanged
- [x] The run leaves nothing behind: `tools/conformance/guard.sh leftovers` at
      second zero and after every run, green each time

## Related issues

Closes #574.
