### PR TITLE
fix(machine): a start takes turns with the isolation detach, so a peering acceptance no longer kills the machines booting beside it

### DIFF
--- a/internal/core/machine/incus.go
+++ b/internal/core/machine/incus.go
@@ -418,7 +418,24 @@ func (d *Incus) Start(ctx context.Context, spec Spec) (Machine, error) {
 	if _, ok, err := d.Inspect(ctx, spec.Name); err != nil {
 		return Machine{}, err
 	} else if ok {
-		if _, err := d.run(ctx, "start", spec.Name); err != nil &&
+		// Starting an instance plugs every one of its OVN ports, and the
+		// daemon re-ensures each rule set the port's network references while
+		// doing so — the references are read as the start begins and resolved
+		// to IDs as the port is set up, with no lock shared with its own ACL
+		// paths (#493's mechanism, on a third call site). An isolation detach
+		// landing inside deletes the set between the two steps, and the start
+		// dies on `Cannot find security ACL ID for "iso-fnt-…"`. Same lock as
+		// the detach, so the two take turns; every network the NICs sit on,
+		// in sorted order, which is the multi-lock rule peerLock follows.
+		// TestARestartAndAnIsolationDetachTakeTurns fails without it.
+		devices, err := d.instanceDevices(ctx, spec.Name)
+		if err != nil {
+			return Machine{}, fmt.Errorf("inspect %s before starting it: %w", spec.Name, err)
+		}
+		release := d.lockNetworks(nicNetworks(devices.expanded))
+		_, err = d.run(ctx, "start", spec.Name)
+		release()
+		if err != nil &&
 			!strings.Contains(strings.ToLower(err.Error()), "already running") {
 			return Machine{}, fmt.Errorf("start instance %s: %w", spec.Name, err)
 		}
@@ -597,9 +614,27 @@ func (d *Incus) Start(ctx context.Context, spec Spec) (Machine, error) {
 		}
 	}
 
-	if _, err := d.run(ctx, "start", spec.Name); err != nil {
+	// The same turn-taking as the already-running branch above: this first
+	// `incus start` plugs eth0's OVN port, the daemon resolves the network's
+	// ACL references inside it, and an isolation detach — a peering
+	// acceptance empties the foreign list mid-apply, and IsolateNetwork then
+	// unsets and deletes the set — landing inside kills the start with
+	// `Cannot find security ACL ID for "iso-fnt-…"`, a machine left
+	// 'stopped' behind a green apply. Staged on the host: 12 failures in 14
+	// starts with a detach 50–300 ms in. Held only around the start itself:
+	// everything before edits a cold instance, which plugs nothing.
+	// TestAStartAndAnIsolationDetachTakeTurns fails without it.
+	var gate func()
+	if !routed && !bare {
+		gate = d.networkLock(primary.Network)
+	}
+	_, startErr := d.run(ctx, "start", spec.Name)
+	if gate != nil {
+		gate()
+	}
+	if startErr != nil {
 		return Machine{}, d.abandonStart(ctx, spec.Name,
-			fmt.Errorf("start instance %s: %w", spec.Name, err))
+			fmt.Errorf("start instance %s: %w", spec.Name, startErr))
 	}
 	if err := d.attachExtra(ctx, spec); err != nil {
 		return Machine{}, err
@@ -633,7 +668,13 @@ func (d *Incus) attachExtra(ctx context.Context, spec Spec) error {
 		if att.Address != "" {
 			args = append(args, "ipv4.address="+att.Address)
 		}
-		if _, err := d.run(ctx, args...); err != nil {
+		// The instance is running by now, so this add plugs an OVN port and
+		// resolves the network's ACL references inside it — the same window
+		// the two start branches close above, on this interface's network.
+		release := d.networkLock(att.Network)
+		_, err := d.run(ctx, args...)
+		release()
+		if err != nil {
 			return fmt.Errorf("attach instance %s to network %s: %w", spec.Name, att.Network, err)
 		}
 	}
@@ -1134,6 +1175,40 @@ func freeInterface(devices map[string]map[string]string) string {
 // TestAnIsolationDetachDoesNotOrphanTheNetworkBeingDeleted fails without it.
 func (d *Incus) networkLock(name string) func() {
 	return serialise.Lock("incus.network." + name)
+}
+
+// nicNetworks answers the networks an instance's NIC devices sit on, sorted
+// and deduplicated. From the expanded devices, because the daemon plugs a
+// profile's NIC at start exactly as it plugs the instance's own.
+func nicNetworks(devices map[string]map[string]string) []string {
+	seen := map[string]bool{}
+	for _, cfg := range devices {
+		if cfg["type"] == "nic" && cfg["network"] != "" {
+			seen[cfg["network"]] = true
+		}
+	}
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return names
+}
+
+// lockNetworks takes each named network's lock and answers one release for
+// them all. The caller passes the set sorted (nicNetworks does), which is the
+// same deadlock rule peerLock applies: two takers of several locks must ask
+// in the same order, or each ends up holding the other's next one.
+func (d *Incus) lockNetworks(names []string) func() {
+	releases := make([]func(), 0, len(names))
+	for _, name := range names {
+		releases = append(releases, d.networkLock(name))
+	}
+	return func() {
+		for i := len(releases) - 1; i >= 0; i-- {
+			releases[i]()
+		}
+	}
 }
 
 // EnsureNetwork implements Driver. It creates a managed bridge carrying the

--- a/internal/core/machine/incus_start_race_test.go
+++ b/internal/core/machine/incus_start_race_test.go
@@ -1,0 +1,411 @@
+package machine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// The third call site of #493's daemon behaviour, measured on a live host
+// before being staged (2026-08-28, Incus 7.2, OVN mode): `incus start` reads
+// the ACL names each NIC's network references as it begins, and resolves them
+// to IDs as it sets the OVN ports up, with no lock shared with the daemon's
+// own ACL paths. An isolation detach landing between the two steps — a
+// peering acceptance empties every foreign list mid-apply, so IsolateNetwork
+// unsets and deletes the rule sets while the stack's machines are starting —
+// kills the start with:
+//
+//	Failed to start device "eth0": Failed setting up OVN port: Failed
+//	ensuring security ACLs are configured in OVN for instance: Cannot find
+//	security ACL ID for "iso-fnt-…"
+//
+// Staged on the host: with the detach fired 50–300 ms into a ~600 ms
+// container start, 12 of 14 starts died exactly so; fired before the start
+// had read its config, none did; and the attach direction — the rule set
+// created and referenced while the start was in flight — produced it in 0 of
+// 14 tries. The reference can only dangle behind a delete, which is why
+// retrying the wording is still wrong (TestANonTransientFailureIsNotRetried)
+// and the ordering is still the fix. The failed start is terminal:
+// abandonStart removes the instance, the pack publishes its failed state, and
+// nothing retries — a machine left 'stopped' behind an apply that returned 0
+// (tools/conformance/functional.sh outscale, 9 red runs in 13).
+//
+// Same medicine as the two device-edit call sites one file over
+// (incus_unroute_race_test.go): the start holds the lock of every network it
+// plugs, the detach already holds it, so the two take turns.
+
+const (
+	racedStartNet     = "fnt-b2c3d4e5f60"
+	racedStartNet2    = "fnt-c3d4e5f6071"
+	racedStartMachine = "feint-osc-i-9"
+)
+
+// fakeStartd is the daemon's start-time ACL resolution as observed, not a
+// line-by-line replay: an operation that plugs an OVN port (an instance
+// start, a NIC add on a running instance) snapshots the ACLs its networks
+// reference when it begins, resolves them when the port comes up, and a
+// delete landing in between fails the operation. The channels make the
+// interleaving a fact rather than a probability, exactly as in fakeOVNd one
+// file over.
+type fakeStartd struct {
+	mu sync.Mutex
+	// networkACLs is what each network references in security.acls.
+	networkACLs map[string]string
+	acls        map[string]bool
+	exists      bool
+	running     bool
+	devices     map[string]map[string]string
+	failures    []string
+
+	// landed closes when the ACL delete has been applied, so a plug in
+	// flight can meet it instead of hoping to.
+	landed chan struct{}
+	// plugBegun closes when the staged plugging operation has begun: the
+	// signal for the concurrent detach to start, with the ordering guard in
+	// place and with it removed.
+	plugBegun chan struct{}
+	// plugOn names the network whose plug is staged against the detach;
+	// plugs of other networks resolve without waiting.
+	plugOn    string
+	landOnce  sync.Once
+	begunOnce sync.Once
+	// beat is how long a plug waits for a delete to cross it: long enough
+	// that a racing delete is inside rather than merely likely to be.
+	beat time.Duration
+}
+
+func newFakeStartd(exists bool) *fakeStartd {
+	f := &fakeStartd{
+		networkACLs: map[string]string{
+			racedStartNet:  isolationACL(racedStartNet),
+			racedStartNet2: isolationACL(racedStartNet2),
+		},
+		acls: map[string]bool{
+			isolationACL(racedStartNet):  true,
+			isolationACL(racedStartNet2): true,
+		},
+		exists:    exists,
+		plugOn:    racedStartNet,
+		landed:    make(chan struct{}),
+		plugBegun: make(chan struct{}),
+		beat:      200 * time.Millisecond,
+	}
+	f.devices = map[string]map[string]string{}
+	if exists {
+		f.devices["eth0"] = map[string]string{"type": "nic", "network": racedStartNet}
+	}
+	return f
+}
+
+func (f *fakeStartd) instanceJSON() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	status := "Stopped"
+	if f.running {
+		status = "Running"
+	}
+	return fmt.Sprintf(`{"name":%q,"status":%q,"state":{"network":{}}}`,
+		racedStartMachine, status)
+}
+
+func (f *fakeStartd) devicesJSON() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	parts := make([]string, 0, len(f.devices))
+	for name, cfg := range f.devices {
+		parts = append(parts,
+			fmt.Sprintf(`%q:{"type":%q,"network":%q}`, name, cfg["type"], cfg["network"]))
+	}
+	body := "{" + strings.Join(parts, ",") + "}"
+	return fmt.Sprintf(`{"name":%q,"devices":%s,"expanded_devices":%s}`,
+		racedStartMachine, body, body)
+}
+
+// plug is the daemon's OVN port setup as observed: the referenced rule sets
+// are read when the operation begins and resolved when the port comes up, and
+// a delete landing between the two fails the operation.
+func (f *fakeStartd) plug(networks ...string) error {
+	f.mu.Lock()
+	snapshots := map[string]string{}
+	staged := false
+	for _, network := range networks {
+		snapshots[network] = f.networkACLs[network]
+		if network == f.plugOn {
+			staged = true
+		}
+	}
+	f.mu.Unlock()
+
+	if staged {
+		f.begunOnce.Do(func() { close(f.plugBegun) })
+		select {
+		case <-f.landed:
+		case <-time.After(f.beat):
+		}
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, network := range networks {
+		snapshot := snapshots[network]
+		if snapshot != "" && !f.acls[snapshot] {
+			failure := fmt.Sprintf(
+				`Failed to start device "eth0": Failed setting up OVN port: Cannot find security ACL ID for %q`,
+				snapshot)
+			f.failures = append(f.failures, failure)
+			return errors.New("Error: " + failure)
+		}
+	}
+	return nil
+}
+
+func (f *fakeStartd) run(_ context.Context, args ...string) ([]byte, error) {
+	key := strings.Join(args, " ")
+
+	switch {
+	case key == "list "+racedStartMachine+" --format json":
+		f.mu.Lock()
+		exists := f.exists
+		f.mu.Unlock()
+		if !exists {
+			return []byte("[]"), nil
+		}
+		return []byte("[" + f.instanceJSON() + "]"), nil
+
+	case key == "query /1.0/instances/"+racedStartMachine:
+		f.mu.Lock()
+		exists := f.exists
+		f.mu.Unlock()
+		if !exists {
+			return nil, errors.New("Error: Instance not found")
+		}
+		return []byte(f.devicesJSON()), nil
+
+	case key == "query /1.0/instances?recursion=1":
+		// The permissive sweep of a detach: no NICs of ours to touch.
+		return []byte("[]"), nil
+
+	case strings.HasPrefix(key, "query /1.0/networks/"):
+		name := strings.TrimPrefix(key, "query /1.0/networks/")
+		return []byte(`{"type":"ovn","config":{"ipv4.address":"10.0.9.1/24","user.` +
+			LabelKey + `":"outscale"}}`), fakeStartdNetworkErr(name)
+
+	case strings.HasPrefix(key, "network unset ") && strings.HasSuffix(key, " security.acls"):
+		name := strings.TrimSuffix(strings.TrimPrefix(key, "network unset "), " security.acls")
+		f.mu.Lock()
+		f.networkACLs[name] = ""
+		f.mu.Unlock()
+		return nil, nil
+
+	case strings.HasPrefix(key, "network acl delete "):
+		name := strings.TrimPrefix(key, "network acl delete ")
+		f.mu.Lock()
+		for _, ref := range f.networkACLs {
+			if ref == name {
+				f.mu.Unlock()
+				return nil, errors.New("Error: Cannot delete an ACL that is in use")
+			}
+		}
+		delete(f.acls, name)
+		f.mu.Unlock()
+		f.landOnce.Do(func() { close(f.landed) })
+		return nil, nil
+
+	case strings.HasPrefix(key, "init "):
+		f.mu.Lock()
+		f.exists = true
+		f.mu.Unlock()
+		return nil, nil
+
+	case key == "start "+racedStartMachine:
+		f.mu.Lock()
+		devices := make([]string, 0, len(f.devices))
+		for _, cfg := range f.devices {
+			if cfg["type"] == "nic" && cfg["network"] != "" {
+				devices = append(devices, cfg["network"])
+			}
+		}
+		f.mu.Unlock()
+		if len(devices) == 0 {
+			// The cold path: eth0 is the --network of the init.
+			devices = []string{racedStartNet}
+		}
+		if err := f.plug(devices...); err != nil {
+			return nil, err
+		}
+		f.mu.Lock()
+		f.running = true
+		f.mu.Unlock()
+		return nil, nil
+
+	case strings.HasPrefix(key, "config device add "+racedStartMachine+" ") &&
+		strings.Contains(key, " nic network="):
+		network := key[strings.Index(key, " nic network=")+len(" nic network="):]
+		if err := f.plug(network); err != nil {
+			return nil, err
+		}
+		f.mu.Lock()
+		f.devices[fmt.Sprintf("eth%d", len(f.devices))] =
+			map[string]string{"type": "nic", "network": network}
+		f.mu.Unlock()
+		return nil, nil
+	}
+	return nil, nil
+}
+
+// fakeStartdNetworkErr keeps every emulator network present: the detach's
+// gone-question must answer "still there", or it would take the ErrNetworkGone
+// door and never reach the delete this race is about.
+func fakeStartdNetworkErr(string) error { return nil }
+
+func (f *fakeStartd) plugFailures() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.failures...)
+}
+
+func (f *fakeStartd) isRunning() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.running
+}
+
+// The reproduction of the suite's red runs: a first boot (init, then `start`,
+// which plugs eth0's OVN port) and the isolation detach of the machine's
+// network, issued concurrently the way a peering acceptance meets a burst of
+// Vm creates, must take turns: the start must never resolve a rule set the
+// detach deleted inside it.
+//
+// The interleaving is staged: the detach starts at the exact moment the plug
+// begins, and the plug waits long enough for the detach's ACL delete to land
+// inside it if nothing orders the two. With the ordering in place the detach
+// waits its turn, and both orders of the two winners are acceptable — what
+// must never happen is the third order, the delete inside the plug.
+func TestAStartAndAnIsolationDetachTakeTurns(t *testing.T) {
+	f := newFakeStartd(false)
+	d := NewIncusOVN()
+	d.runner = f.run
+
+	var wg sync.WaitGroup
+	var startErr, detachErr error
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, startErr = d.Start(context.Background(), Spec{
+			Name:        racedStartMachine,
+			Image:       "alpine:3.21",
+			Attachments: []Attachment{{Network: racedStartNet}},
+		})
+	}()
+	go func() {
+		defer wg.Done()
+		<-f.plugBegun
+		detachErr = d.IsolateNetwork(context.Background(), racedStartNet, nil)
+	}()
+	wg.Wait()
+
+	if failures := f.plugFailures(); len(failures) != 0 {
+		t.Fatalf("the isolation detach landed inside the start:\n%s\nstart: %v\ndetach: %v",
+			strings.Join(failures, "\n"), startErr, detachErr)
+	}
+	if startErr != nil {
+		t.Fatalf("the start failed: %v", startErr)
+	}
+	if detachErr != nil && !errors.Is(detachErr, ErrNetworkGone) {
+		t.Fatalf("the detach failed for a reason other than the network being gone: %v", detachErr)
+	}
+	if !f.isRunning() {
+		t.Fatal("the machine never came up")
+	}
+}
+
+// The same turn-taking on the poweron door: a machine that already exists is
+// started again through the same `incus start`, which re-plugs every one of
+// its OVN ports and resolves the same references. Every pack's poweron
+// arrives through this branch (#549), so a detach must wait for it too.
+func TestARestartAndAnIsolationDetachTakeTurns(t *testing.T) {
+	f := newFakeStartd(true)
+	d := NewIncusOVN()
+	d.runner = f.run
+	// The route restoration that follows a poweron polls the guest; the fake
+	// has no guest, so let it give up immediately — its failure is logged,
+	// never fatal, and is not what this test is about.
+	d.routePoll = time.Millisecond
+	d.routeBudget = 2 * time.Millisecond
+
+	var wg sync.WaitGroup
+	var startErr, detachErr error
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, startErr = d.Start(context.Background(), Spec{
+			Name:        racedStartMachine,
+			Image:       "alpine:3.21",
+			Attachments: []Attachment{{Network: racedStartNet}},
+		})
+	}()
+	go func() {
+		defer wg.Done()
+		<-f.plugBegun
+		detachErr = d.IsolateNetwork(context.Background(), racedStartNet, nil)
+	}()
+	wg.Wait()
+
+	if failures := f.plugFailures(); len(failures) != 0 {
+		t.Fatalf("the isolation detach landed inside the restart:\n%s\nstart: %v\ndetach: %v",
+			strings.Join(failures, "\n"), startErr, detachErr)
+	}
+	if startErr != nil {
+		t.Fatalf("the restart failed: %v", startErr)
+	}
+	if detachErr != nil && !errors.Is(detachErr, ErrNetworkGone) {
+		t.Fatalf("the detach failed for a reason other than the network being gone: %v", detachErr)
+	}
+}
+
+// And on the extra interfaces: the second attachment is added after the
+// start, onto a machine that is by then running, so the add plugs an OVN
+// port on its own network and resolves that network's references the same
+// way. A detach of that network must wait for the add.
+func TestAnExtraInterfaceAndAnIsolationDetachTakeTurns(t *testing.T) {
+	f := newFakeStartd(false)
+	f.plugOn = racedStartNet2
+	d := NewIncusOVN()
+	d.runner = f.run
+
+	var wg sync.WaitGroup
+	var startErr, detachErr error
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, startErr = d.Start(context.Background(), Spec{
+			Name:  racedStartMachine,
+			Image: "alpine:3.21",
+			Attachments: []Attachment{
+				{Network: racedStartNet},
+				{Network: racedStartNet2},
+			},
+		})
+	}()
+	go func() {
+		defer wg.Done()
+		<-f.plugBegun
+		detachErr = d.IsolateNetwork(context.Background(), racedStartNet2, nil)
+	}()
+	wg.Wait()
+
+	if failures := f.plugFailures(); len(failures) != 0 {
+		t.Fatalf("the isolation detach landed inside the interface add:\n%s\nstart: %v\ndetach: %v",
+			strings.Join(failures, "\n"), startErr, detachErr)
+	}
+	if startErr != nil {
+		t.Fatalf("the start failed: %v", startErr)
+	}
+	if detachErr != nil && !errors.Is(detachErr, ErrNetworkGone) {
+		t.Fatalf("the detach failed for a reason other than the network being gone: %v", detachErr)
+	}
+}

--- a/tools/falsify/specs/start-vs-isolation-detach.json
+++ b/tools/falsify/specs/start-vs-isolation-detach.json
@@ -1,0 +1,27 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "the first boot stops holding its network's lock across `incus start`, so an isolation detach deletes the referenced rule set inside the plug and the machine is left stopped behind a green apply",
+      "file": "internal/core/machine/incus.go",
+      "find": "\tvar gate func()\n\tif !routed && !bare {\n\t\tgate = d.networkLock(primary.Network)\n\t}",
+      "replace": "\tvar gate func()\n\tif !routed && !bare && false {\n\t\tgate = d.networkLock(primary.Network)\n\t}",
+      "test": "TestAStartAndAnIsolationDetachTakeTurns"
+    },
+    {
+      "label": "the poweron door stops locking the networks its NICs sit on, so a detach lands inside the re-plug of a restarted machine",
+      "file": "internal/core/machine/incus.go",
+      "find": "\t\trelease := d.lockNetworks(nicNetworks(devices.expanded))\n\t\t_, err = d.run(ctx, \"start\", spec.Name)",
+      "replace": "\t\trelease := d.lockNetworks(nicNetworks(devices.expanded)[:0])\n\t\t_, err = d.run(ctx, \"start\", spec.Name)",
+      "test": "TestARestartAndAnIsolationDetachTakeTurns"
+    },
+    {
+      "label": "the extra-interface add takes its network's lock only after the add has run, which is no ordering at all",
+      "file": "internal/core/machine/incus.go",
+      "find": "\t\trelease := d.networkLock(att.Network)\n\t\t_, err := d.run(ctx, args...)\n\t\trelease()",
+      "replace": "\t\t_, err := d.run(ctx, args...)\n\t\trelease := d.networkLock(att.Network)\n\t\trelease()",
+      "test": "TestAnExtraInterfaceAndAnIsolationDetachTakeTurns"
+    }
+  ],
+  "note": "The interleaving is staged, not bet on: fakeStartd's plug snapshots the referenced rule sets when the operation begins and resolves them when it ends, and the detach goroutine is released at the exact moment the plug begins, so without the ordering the delete is inside on every run. The daemon behaviour the fake models was measured on the station on 2026-08-28 (Incus 7.2, OVN): a detach fired 50-300 ms into a ~600 ms container start killed 12 of 14 starts with `Cannot find security ACL ID`; the attach direction produced it in 0 of 14 tries. Each mutation keeps every name of its find: the first neutralises the condition, the second empties the lock set, the third reorders the lock after the act."
+}


### PR DESCRIPTION
`FEINT_VM=incus-ovn tools/conformance/functional.sh outscale` failed **nine times
in thirteen** across five revisions and two branches:

```
FAIL: outscale: machine platform-web-a (i-19244b38) is 'stopped', not 'running',
      after an apply that returned 0 — a stack whose machine does not start is
      not a stack that works (#484)
```

with, in the emulator's journal every time:

```
Failed to start device "eth0": Failed setting up OVN port: Failed ensuring
security ACLs are configured in OVN for instance:
Cannot find security ACL ID for "iso-fnt-3d2faba9739"
```

This is **#493's mechanism on a third call site: `incus start`.**

## The cause, measured on the host and not deduced

`AcceptNetPeering` makes both Nets' subnets mutually reachable, so the isolation
pass it triggers empties every `foreign` list and `IsolateNetwork` **detaches
then deletes** each `iso-fnt-*`. Meanwhile the same apply's `CreateVms` are
starting their machines. The daemon reads the ACL names a NIC's network
references at the beginning of the start and resolves them to identifiers while
it wires the OVN ports — with **no lock shared with its own ACL paths**. A delete
landing between the read and the resolution kills the start.

| measurement | result |
|---|---|
| bare runtime, detach fired 50–300 ms into a ~600 ms start | **12 of 14 starts killed**, with the exact message |
| same, detach fired at 0 ms — before the start reads its config | **0 of 2** |
| full chain (2 Nets, 2 Subnets, 3 CreateVms, accept offset 0–5 s) | **6 red of 6** |
| same, accept fired immediately, before the first `incus start` | **0 red of 5** |

What decides the verdict is only *where* the pass lands.

## The hypothesis this refutes is the one the brief led with

*"The ACL exists for Incus but not yet for OVN"* — a materialisation lag — does
**not** hold. In the **attach** direction (ACL created and referenced during a
start) there are **0 failures in 14**, and Incus outright refuses
`network set security.acls=X` for an ACL absent from its own database. The
reference can only dangle **behind a delete**. The message comes from a name→ID
resolution in Incus's database, not from OVN being slow.

## The named trap, and why it stands

`TestANonTransientFailureIsNotRetried` records this repository's deliberate
refusal to retry this exact wording, because *"retrying it would paper over a
deleted rule set"*. The question raised during triage was whether that refusal
conflates two states — a deleted ACL and one not yet materialised.

**It does not**, and that is now measured: the second state cannot produce this
message. The test stands unchanged, and its own comment already carried the
answer — *"this is the ordering defect the network lock closes"*. The fix is the
ordering, never a retry.

## The fix, and where it lives

The same medicine as the two device-editing sites in
`incus_unroute_race_test.go`: **the start holds the `networkLock` of each network
it plugs into, the detach already holds it, so the two take turns.** Three doors
in `incus.go`:

- the first boot — the primary network's lock, held only around `incus start`,
  because everything before it edits a cold instance that plugs nothing;
- the poweron door — every network its NICs sit on, sorted, following
  `peerLock`'s multi-lock rule, via the new `nicNetworks` / `lockNetworks`;
- the extra-interface add (`attachExtra`).

No wait to place in a pack or in a suite: **the control point is the boundary
itself**, which is what this repository does everywhere else the state's lock
cannot hold a slow side effect.

## Also measured, because the brief asked

**The machine stays `stopped`** — this is not a slow boot polled too early. Six
probes over 60 s after a failure: the API answers `stopped` every time, **and the
host carries no container at all**. `abandonStart` removed the half-made
instance; nothing resumes a failed boot.

## Was this a regression? No — and the bisection says so

One run per revision, chronological order:

```
057e4c8  (#459, 36 fixed sleeps converted)   GREEN
6052d71  (#561, lifecycle)                   RED
5498d98  (#573, uncovered NIC)               GREEN
9a50c04  (#574, security-group scope)        RED
154c204  (head)                              GREEN
```

**It alternates.** A regression gives green…green then red…red.

The race is **older than the whole range**: the isolation pass on accept dates
from `b4b4c34` (2026-08-26) and the start has never held the lock. What recent
work changed is the *timing offset*, which is what made an existing race
reachable — the alternation above is exactly what a timing threshold at ~50 %
produces. No single lot is blamed, and one sample per revision could not blame
one honestly.

## Gates

`prepush` 0 · `conformance:leg -- runtime` under `incus-ovn` 0, 51 assertions,
626 s · **`functional.sh outscale` green three times in a row**, 21/21 each pass ·
the full curl chain 6 green of 6 after the fix, zero ACL line in the journal ·
`falsify:lint` 862 mutations over 139 specs, plus the 8 neighbouring specs that
name `incus.go`, all green.

New spec `start-vs-isolation-detach.json`: three mutations — the condition
neutralised, the lock set emptied, the lock taken *after* the act — **each
compiles, each bites**.

## What was not obtained

- **No attribution of the timing shift to a specific lot.** One sample per
  revision cannot support it, and the fix does not need it.
- Two observations **out of scope**, recorded rather than fixed: `EnsureFirewall`
  logged a transient OVN port-group conflict (`constraint violation … Port_Group`)
  without the retry `ApplyFirewall` has; and `Attach` — the packs' hot attach —
  does the same port wiring **without `networkLock`**. Same shape, never observed
  failing, and not corrected without its own falsification.
