### PR TITLE
feat(conformance, ci): the example stacks are applied every night, and the gate that does it names its runtime and its budget (#504)

### DIFF
--- a/.github/workflows/runtime-proof.yml
+++ b/.github/workflows/runtime-proof.yml
@@ -39,6 +39,13 @@
 # the layer conformance.yml deliberately leaves out — the machine behind the
 # answer — so it runs the network and ssh suites, which are exactly the scripts
 # that skip themselves when no runtime is configured.
+#
+# A third job joined the two legs on 2026-08-28 (#504): `stacks`, which applies
+# the example stacks to real machines. That widens the promotion criterion above
+# rather than leaving it alone, and it is meant to: the streak is counted from
+# this workflow's own conclusion, so a night whose stack gate went red is a
+# night the runtime proof was red. Narrowing the criterion to exclude a gate
+# because it might redden is how a criterion becomes decoration.
 name: Runtime proof
 
 on:
@@ -402,6 +409,196 @@ jobs:
           MODE: ${{ matrix.mode }}
         run: sudo env FEINT_VM="${MODE}" tools/conformance/crash.sh
 
+  # The stack gate (#504): the only thing in this repository that applies the
+  # example stacks against real machines, and until now nothing in CI played it.
+  #
+  # WHY IT EARNED A JOB, on the day it was wired. `conformance:functional` is
+  # what surfaced the isolation-detach race — an ACL deleted while the daemon
+  # resolved it at `incus start`, killing machines behind a green apply. Finding
+  # it cost three pull requests (#577, #578 and the diagnosis before them) and
+  # the defect was older than the whole range bisected. No leg above plays the
+  # stacks, and `mise run conformance` skips the stack suites without a runtime,
+  # so a defect that only appears when a real apply races a real accept had no
+  # gate at all.
+  #
+  # WHY A PARALLEL JOB RATHER THAN A STEP ON THE incus-ovn LEG, which is the
+  # decision this issue asked to be argued rather than assumed:
+  #
+  #   - A step there queues behind six suites that were red on four of the last
+  #     seven scheduled nights (Scaleway ssh, 2026-08-22 to 08-25), and a step
+  #     that is never reached is a gate that never runs — which is #504's whole
+  #     complaint about `conformance:functional` itself.
+  #   - It would also inherit that leg's host. Measured on this station on
+  #     2026-08-28, reproducing the leg: the three ssh suites each exit 0 and
+  #     each leave something standing — `scw-…` and `exo-…` rule sets no client
+  #     can delete, `fnt-default` and `feint-uplink` no resource owns — and
+  #     `feint stop` sweeps none of them. That is why the witness gate below
+  #     failed at its own doorstep on the one night it has been reached since it
+  #     landed — 2026-08-27, "this host still holds what an earlier run left",
+  #     naming feint-uplink and fnt-default; the night after never got that far.
+  #     A job of its own starts on a runner nothing has touched.
+  #   - Three passes is half an hour. Added to that leg it would push a 45-minute
+  #     job onto its own timeout, and a job that times out is a verdict nobody
+  #     wrote.
+  #
+  # Its red is its own, and that is the point: "runtime-proof failed" is noise,
+  # "the stack gate failed on outscale, platform-web-a is stopped" is a finding.
+  #
+  # WHY incus-ovn ALONE. The gate's own default is incus-ovn and one of its
+  # families needs it: two networks nothing peers must not reach each other, and
+  # a bridge cannot deliver that (docs/limits.md). Under a bridge the gate would
+  # skip its own subject by name, which is honest and worth nothing nightly.
+  #
+  # The setup below repeats the incus-ovn leg's, deliberately and not silently:
+  # extracting it while that leg is red would make any new red ambiguous between
+  # the gate and the refactor. TestBothRuntimeJobsPinTheSameHost holds the two
+  # copies to the same pins, so a drift between them fails `mise run check`
+  # rather than a night three weeks later.
+  stacks:
+    name: stacks (incus-ovn)
+    runs-on: ubuntu-24.04
+    # Three passes of a gate measured at 295 s on the author's station, on a
+    # runner with a quarter of its cores: sized so a slow pass is still a
+    # verdict rather than a timeout, because a timeout measures the runner.
+    timeout-minutes: 75
+    permissions:
+      contents: read
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.26.6'
+          cache: false
+
+      - name: Install Incus (Zabbly stable, key fingerprint pinned)
+        env:
+          ZABBLY_FPR: '4EFC590696CB15B87C73A3AD82CC8797C838DCFD'
+        run: |
+          set -euo pipefail
+          workdir="$(mktemp -d)"
+          curl --retry 3 --retry-connrefused -fsSL https://pkgs.zabbly.com/key.asc -o "${workdir}/zabbly.asc"
+          fpr="$(gpg --show-keys --with-colons "${workdir}/zabbly.asc" | awk -F: '/^fpr/ {print $10; exit}')"
+          if [ "${fpr}" != "${ZABBLY_FPR}" ]; then
+            echo "unexpected Zabbly key fingerprint: ${fpr}" >&2
+            exit 1
+          fi
+          sudo install -D -m 0644 "${workdir}/zabbly.asc" /etc/apt/keyrings/zabbly.asc
+          # shellcheck disable=SC1091
+          codename="$(. /etc/os-release && echo "${VERSION_CODENAME}")"
+          arch="$(dpkg --print-architecture)"
+          sudo tee /etc/apt/sources.list.d/zabbly-incus.sources >/dev/null <<EOF
+          Enabled: yes
+          Types: deb
+          URIs: https://pkgs.zabbly.com/incus/stable
+          Suites: ${codename}
+          Components: main
+          Architectures: ${arch}
+          Signed-By: /etc/apt/keyrings/zabbly.asc
+          EOF
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends incus incus-client netcat-openbsd
+          sudo incus --version
+
+      - name: Install and wire OVN
+        run: |
+          set -euo pipefail
+          sudo apt-get install -y --no-install-recommends ovn-central ovn-host openvswitch-switch
+          if ! sudo modprobe openvswitch; then
+            sudo apt-get install -y --no-install-recommends "linux-modules-extra-$(uname -r)"
+            sudo modprobe openvswitch
+          fi
+          sudo systemctl enable --now openvswitch-switch ovn-central ovn-host
+          # The units return before the databases listen (docs/install.md).
+          for _ in $(seq 1 30); do
+            [ -S /run/ovn/ovnnb_db.sock ] && break
+            sleep 1
+          done
+          if [ ! -S /run/ovn/ovnnb_db.sock ]; then
+            echo 'ovnnb_db.sock never appeared' >&2
+            sudo journalctl -u ovn-central --no-pager | tail -n 50 >&2
+            exit 1
+          fi
+          sudo ovs-vsctl set open_vswitch . \
+            external_ids:ovn-remote=unix:/run/ovn/ovnsb_db.sock \
+            external_ids:ovn-encap-type=geneve \
+            external_ids:ovn-encap-ip=127.0.0.1
+
+      - name: Initialise Incus
+        run: |
+          set -euo pipefail
+          sudo incus admin init --minimal
+          sudo incus config set network.ovn.northbound_connection unix:/run/ovn/ovnnb_db.sock
+
+      # The same reason as the leg above: the runner image's Docker sets the
+      # host FORWARD policy to DROP, and the stacks' machines are reached over
+      # routed addresses.
+      - name: Keep the runner's Docker firewall out of the verdict
+        run: sudo iptables -P FORWARD ACCEPT
+
+      - name: Build feint and diagnose the runtime
+        run: |
+          set -euo pipefail
+          go build -o feint ./cmd/feint
+          sudo ./feint doctor --vm incus-ovn
+
+      # The gate refuses without them rather than booting an upstream image with
+      # no ssh daemon, so this is the half that makes the refusal never fire.
+      - name: Build the machine images the stacks boot
+        run: sudo ./feint images --vm incus-ovn
+
+      # `feint up` drives Terraform, which is what applies both stacks. Same
+      # pinned version and upstream checksums as conformance.yml — one client,
+      # three workflows, one truth. No provider CLI is installed: this gate
+      # speaks curl and jq to the emulator and reads the machines with `incus`.
+      - name: Install Terraform
+        env:
+          TERRAFORM_VERSION: '1.13.3'
+        run: |
+          set -euo pipefail
+          workdir="$(mktemp -d)"
+          base="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}"
+          asset="terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
+          curl --retry 3 --retry-connrefused -fsSL -o "${workdir}/${asset}" "${base}/${asset}"
+          curl --retry 3 --retry-connrefused -fsSL -o "${workdir}/sums" "${base}/terraform_${TERRAFORM_VERSION}_SHA256SUMS"
+          (cd "${workdir}" && grep " ${asset}$" sums | sha256sum -c -)
+          sudo unzip -o "${workdir}/${asset}" terraform -d /usr/local/bin
+          terraform version
+
+      # The gate itself. FEINT_VM is exported rather than left to the default so
+      # the mode is announced with the provenance a reader can check against
+      # this job's own name — the property tools/runtime-mode.sh holds and #574
+      # paid three 1300-second passes to learn.
+      #
+      # The pass budget is the gate's own default (3) rather than a number set
+      # here: a CI budget that differs from the local one means the green an
+      # operator proves and the green this job publishes are two different
+      # measurements.
+      - name: The example stacks, applied and probed
+        run: sudo env FEINT_VM=incus-ovn tools/conformance/functional.sh
+
+      # On failure: what the host STILL holds, and this is thin by construction
+      # rather than by oversight. The gate tears its own stack down on the way
+      # out, so a red leaves almost nothing behind — the finding is the verdict
+      # line itself, which already names the stack, the machine, the address and
+      # the port. What this catches is the other shape: a red that left
+      # something standing, which is the doorstep's own subject.
+      - name: What the runtime still holds
+        if: failure()
+        run: |
+          sudo incus list || true
+          sudo incus network list || true
+          sudo incus network acl list || true
+
   # The criterion, counted rather than remembered.
   #
   # The header above states the rule: promotion to `pull_request` when 14
@@ -419,7 +616,7 @@ jobs:
   # of an opinion.
   streak:
     name: Consecutive green scheduled runs
-    needs: runtime
+    needs: [runtime, stacks]
     if: always() && github.event_name == 'schedule'
     runs-on: ubuntu-24.04
     permissions:
@@ -494,7 +691,7 @@ jobs:
   # with each decision neutralised.
   report:
     name: A red night opens the issue, a green one closes it
-    needs: runtime
+    needs: [runtime, stacks]
     if: always() && github.event_name == 'schedule'
     permissions:
       contents: read

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -17,7 +17,57 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ## [Unreleased]
 
+### Ajouté
+
+- **Les stacks d'exemple sont appliquées à de vraies machines chaque nuit, et
+  la porte qui le fait dit combien de fois (#504).** `conformance:functional`
+  est la seule chose ici qui applique `examples/stacks/` contre un runtime, et
+  rien en CI ne la jouait : aucune jambe de `runtime-proof.yml` n'applique de
+  stack, et `mise run conformance` saute les suites de stack sans runtime.
+  C'est elle qui a fait apparaître la course détachement contre démarrage, au
+  prix de trois pull requests (#577, #578), sur un défaut plus vieux que toute
+  la plage bissectée. Elle tourne désormais dans un job à elle sur ce workflow.
+  Un job plutôt qu'une étape, parce que les suites ssh de la jambe incus-ovn
+  étaient rouges quatre des sept dernières nuits planifiées et que chacune
+  laisse des jeux de règles et des réseaux que `feint stop` ne balaie pas : une
+  étape y attendrait derrière un rouge, puis rencontrerait un portillon
+  qu'elle ne pourrait pas passer. **Trois passes**, et le nombre est un
+  arbitrage : cette classe de défaut a frappé 9 fois sur 13, donc une seule
+  passe la déclare absente 31 % du temps, là où trois passes ramènent ce risque
+  à 3 %, pour 295 s la passe.
+
 ### Corrigé
+
+- **Le portillon de sortie de la porte des stacks pose enfin la question que
+  son propre commentaire annonçait, et la porte cesse de choisir son runtime
+  en silence (#504).** Elle se terminait sur
+  `guard_leftovers_for "$RUNTIME" "the end of the run"`, sous un paragraphe
+  affirmant que la question du portillon était reposée à la sortie. Le garde
+  n'arme cette question que sur le littéral `doorstep` : une passe qui laissait
+  une machine ou un réseau sortait donc en 0, et c'est l'exécution suivante qui
+  rencontrait le refus. C'est l'état que #521 avait retiré de
+  `mise run conformance`, décrit ici et jamais fait. Elle ouvrait par ailleurs
+  sur `RUNTIME="${FEINT_FUNCTIONAL_RUNTIME:-incus-ovn}"`, donc un `FEINT_VM`
+  exporté était ignoré sans un mot : la ligne de #574, un répertoire plus loin,
+  sur la seule porte dont le sujet est justement l'assertion où les deux modes
+  divergent. La résolution est passée dans `tools/runtime-mode.sh`, partagée
+  avec `evidence:update`, dont les tests inchangés sont ce qui prouve que le
+  déplacement n'a rien changé.
+
+- **Les deux sorties nulles de la stack Exoscale ne viennent pas de cet
+  émulateur (#520).** Le constat déduisait, sans l'instrumenter, que le GET par
+  identifiant du pack courait contre sa propre complétion asynchrone. Mesuré le
+  2026-08-28 contre le pack directement : 100 lectures par identifiant à la
+  suite sur un répartiteur, 100 paires création puis lecture neuves, et 50 pour
+  le pool d'instances. **Zéro** nom, adresse ou taille vide. Il n'y a pas de
+  fenêtre : la création écrit `name` et `ip` dans le store *avant* d'émettre
+  une opération qui annonce déjà `state: success`. La troisième porte par
+  identifiant de la stack se relisait correctement dans le même apply, donc ce
+  qui a produit les valeurs nulles distingue les trois, et ce pack ne les
+  distingue pas. `docs/limits.md` porte la mesure et la réfutation. Ce qui
+  lèverait la limite est le correctif amont
+  `terraform-provider-exoscale#573` ; aucune modification de ce pack ne le
+  ferait.
 
 - **Un groupe de sécurité Exoscale s'arrête à l'interface publique, là où le
   vrai cloud l'arrête (#574).** Exoscale le dit en une phrase : « Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Added
 
+- **The example stacks are applied to real machines every night, and the gate
+  that does it says how many times (#504).** `conformance:functional` is the
+  only thing here that applies `examples/stacks/` against a runtime, and
+  nothing in CI played it: no leg of `runtime-proof.yml` applies a stack, and
+  `mise run conformance` skips the stack suites without one. It is what
+  surfaced the isolation-detach race that cost three pull requests (#577,
+  #578), on a defect older than the whole range bisected. It now runs as a job
+  of its own on that workflow — a job rather than a step, because the incus-ovn
+  leg's ssh suites were red on four of the last seven scheduled nights and each
+  of them leaves rule sets and networks `feint stop` does not sweep, so a step
+  there would queue behind a red and then meet a doorstep it could not pass.
+  **Three passes**, and the number is an arbitrage: the defect class struck 9
+  times in 13 runs, so one pass calls it absent 31% of the time, and three bring
+  that to 3%, at 295 s a pass.
+
 - **The Account product's projects, so a third-party VPC stack reaches a VPC
   path at all: `account/v3/ProjectAPI.ListProjects` and
   `account/v3/ProjectAPI.GetProject` (#372).** `data "scaleway_account_project"`
@@ -37,6 +52,33 @@ what this project is judged on: **a response shape a client can observe**, and
   the provider's own `FindExact`.
 
 ### Fixed
+
+- **The stack gate's closing doorstep asks the question its own comment
+  claimed, and the gate stops choosing its runtime in silence (#504).** It
+  closed with `guard_leftovers_for "$RUNTIME" "the end of the run"` under a
+  paragraph saying the doorstep was asked again on the way out; the guard arms
+  that question on the literal `doorstep` alone, so a pass that leaked a
+  machine or a network exited 0 and the next run met the refusal — the state
+  #521 removed from `mise run conformance`, described here and never done. And
+  it opened with `RUNTIME="${FEINT_FUNCTIONAL_RUNTIME:-incus-ovn}"`, so an
+  exported `FEINT_VM` was ignored without a word: #574's line one directory
+  over, on the one gate whose subject is the assertion the two modes disagree
+  about. The resolution moved to `tools/runtime-mode.sh`, shared with
+  `evidence:update`, whose unchanged tests are what prove the move changed
+  nothing.
+
+- **The Exoscale stack's two null outputs are not this emulator's (#520).** The
+  filing deduced, without instrumenting it, that the pack's by-id GET raced its
+  own async create-completion. Measured on 2026-08-28 against the pack
+  directly: 100 back-to-back by-id reads of one balancer, 100 fresh
+  create-then-read pairs, and 50 for the instance pool — **zero** empty names,
+  addresses or sizes. There is no window: the create puts `name` and `ip` in
+  the store *before* it writes an operation that already says `state: success`.
+  The stack's third by-id door read back correctly in the same apply, so
+  whatever produced the nulls tells the three apart and this pack does not.
+  `docs/limits.md` carries the measurement and the disproof; what would lift
+  the limit is upstream `terraform-provider-exoscale#573`, and no change to
+  this pack would.
 
 - **An Exoscale security group stops at the public interface, where the real
   cloud stops it (#574).** Exoscale states it in one sentence: "Security group

--- a/docs/limits-acks.json
+++ b/docs/limits-acks.json
@@ -24,7 +24,7 @@
     "Placement is recorded, never enforced (#285)": "2026-08-27",
     "ReadTags does not list an internet service, because upstream names no type for one": "2026-08-27",
     "The Exoscale Terraform provider is refused, and why": "2026-08-27",
-    "The Exoscale stack's second plan is not empty: two per-id outputs read back null at apply time (#520)": "2026-08-27",
+    "The Exoscale stack's second plan is not empty: two per-id outputs read back null at apply time (#520)": "2026-08-28",
     "The catalogue is a whitelist, and its values are measured": "2026-08-27",
     "The contracts do not guarantee the same thing": "2026-08-27",
     "The cost of DNS/TLS interception, measured (#76)": "2026-08-27",

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -3826,16 +3826,50 @@ data sources is present from the first apply. The clean second plan
 `docs/clients.md` records for 2026-08-18 was measured on the 13-resource
 stack, before those doors existed.
 
-Deduced, not instrumented: Terraform omits an output whose value is null, so
-the first apply's by-id read — issued immediately after the create — answered
-a document whose `name` (and the elastic IP's address) was empty, while the
-same read at plan time answers the filled document. That points at the pack's
-by-id GET racing its own async create-completion, but nobody has captured the
-raw exchange; a `feint proxy --record` of the apply would settle it.
+The reading above was deduced rather than instrumented: Terraform omits an
+output whose value is null, so the first apply's by-id read — issued
+immediately after the create — must have answered a document whose `name` (and
+the elastic IP's address) was empty. That pointed at the pack's by-id GET
+racing its own async create-completion.
 
-What to do with it: this stack is replayed by hand (it is deliberately not in
-CI — "The Exoscale Terraform provider is refused, and why"), and
-`-detailed-exitcode` does not distinguish an outputs-only diff from a resource
-diff. An honest replay of it therefore reports "exit 2, outputs-only,
-resources at zero", not "red". What would lift it: capturing the exchange and
-making the by-id read answer the filled document on the first apply (#520).
+**Measured on 2026-08-28, and that reading is wrong.** The by-id read was
+driven against the pack directly, which is the surface this repository has
+decided to drive, with `--vm off` because the question is the document and not
+the runtime:
+
+| what was asked | reads | empty answers |
+|---|--:|--:|
+| `GET /v2/load-balancer/{id}` on one balancer, back to back | 100 | **0** |
+| create a balancer, read it by id with no delay | 100 | **0** name, **0** ip |
+| create an elastic IP, read it by id with no delay | 1 | **0** |
+| create an instance pool, read its size by id with no delay | 50 | **0** |
+
+There is no window to race. `createLoadBalancer` puts the resource with `name`
+and `ip` in its attributes **before** it writes the operation, and the
+operation it writes is already `state: success` — the async shape is in the
+envelope, never in the document. The same holds for the elastic IP. The `exo`
+CLI reads the same balancer back with its name and `ip_address` filled.
+
+Two consequences, and the second is why this stays here rather than becoming a
+fix:
+
+- **The emulator does not discriminate between the three per-id doors.** The
+  stack has three by-id data sources — the NLB, the elastic IP and the instance
+  pool — and only the first two came back null. The emulator serves all three
+  from one store and answers all three completely, so whatever produced the
+  nulls tells them apart and this pack does not.
+- **What tells them apart is on the client side, and it is the client this
+  repository refuses.** The provider builds two clients and only one honours
+  `EXOSCALE_API_ENDPOINT` (the section above, and
+  [#573][exo-573]); `setEndpointFromContext` in `egoscale/v2` does not rewrite
+  a literal address, so which door answers depends on which client the provider
+  built for it. That is a reading of the provider, not a measurement of it —
+  the fork is not checked out here — and it is written as one.
+
+What to do with it: nothing drives this stack, by decision (#525), so this is
+not a defect anybody can meet through a supported path. The replay that found
+it was the pinned maintainer fork, and `-detailed-exitcode` does not
+distinguish an outputs-only diff from a resource diff either, so an honest
+replay reports "exit 2, outputs-only, resources at zero" rather than "red".
+What would lift it is upstream [#573][exo-573]; what would **not** lift it is
+any change to this pack, and the table above is why.

--- a/mise.toml
+++ b/mise.toml
@@ -307,7 +307,7 @@ depends = ["build"]
 run = "tools/conformance/witness.sh"
 
 [tasks."conformance:functional"]
-description = "What each example stack must prove (#503): a live service, a firewall pair, the network, the balancer. Needs incus-ovn"
+description = "What each example stack must prove (#503): a live service, a firewall pair, the network, the balancer. Three passes, needs incus-ovn"
 depends = ["build"]
 # The other half of the witness gate above, and the division of labour matters:
 # witness.sh asks whether the OBJECT is on the runtime, this asks whether a
@@ -324,8 +324,25 @@ depends = ["build"]
 #
 # Not in the `conformance` aggregate, and on its own port: it boots machines and
 # starts emulators of its own. Same terms as conformance:ssh, the environment
-# suite and conformance:witness — here by hand, and on the incus-ovn leg of
-# .github/workflows/runtime-proof.yml, which #504 wires.
+# suite and conformance:witness — here by hand, and in CI on the `stacks` job of
+# .github/workflows/runtime-proof.yml, which #504 wired. A job of its own rather
+# than a step on the incus-ovn leg: that leg's ssh suites were red on four of
+# the last seven scheduled nights, and each of them leaves something on the host
+# that `feint stop` does not sweep, so a step there would have queued behind a
+# red and then met a doorstep it could not pass.
+#
+# THREE PASSES, and the number is an arbitrage rather than a habit. The defect
+# class this gate exists for is intermittent — the isolation-detach race struck
+# 9 times in 13 runs — so one pass calls it absent nearly one time in three. At
+# 295 s a pass (measured 2026-08-28, two stacks, incus-ovn), three passes are
+# ~15 min here and a 3% chance of a meaningless green. FEINT_FUNCTIONAL_PASSES
+# lowers it for a debugging loop, and the gate says so when it does.
+#
+# FEINT_VM is honoured, and that is not cosmetic: this task used to pin
+# incus-ovn from FEINT_FUNCTIONAL_RUNTIME alone, so `FEINT_VM=incus mise run
+# conformance:functional` measured OVN and said nothing — #574's line, one
+# directory over, on the gate whose own subject is the assertion the two modes
+# disagree about.
 run = "tools/conformance/functional.sh"
 
 [tasks."conformance:parity"]

--- a/tools/conformance/functional.sh
+++ b/tools/conformance/functional.sh
@@ -91,9 +91,14 @@
 # ---------------------------------------------------------------------------
 # Where this runs. It boots machines, so it belongs on the same terms as
 # `conformance:ssh` and `conformance:witness`: `mise run conformance:functional`
-# by hand, and the incus-ovn leg of .github/workflows/runtime-proof.yml, which
-# #504 wires. It must never join a gate the CI runs without a runtime: there it
-# could not look, and a check that cannot look says so rather than passing.
+# by hand, and the `stacks` job of .github/workflows/runtime-proof.yml, which
+# #504 wired. A job of its own rather than a step on the incus-ovn leg, and the
+# reason is measured: that leg's ssh suites were red on four of the last seven
+# scheduled nights, and each of them leaves a rule set or a network `feint stop`
+# does not sweep, so a step there would queue behind a red and then meet a
+# doorstep it could not pass. It must never join a gate the CI runs without a
+# runtime: there it could not look, and a check that cannot look says so rather
+# than passing.
 #
 # It is written to be called: stack names as arguments, one verdict line per
 # assertion naming the stack and the object, exit 0 / 1, a doorstep that refuses
@@ -111,7 +116,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 ADDR="${FEINT_FUNCTIONAL_ADDR:-127.0.0.1:4595}"
 ENDPOINT="http://$ADDR"
-RUNTIME="${FEINT_FUNCTIONAL_RUNTIME:-incus-ovn}"
 ZONE="${FEINT_FUNCTIONAL_ZONE:-fr-par-1}"
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
@@ -125,7 +129,60 @@ skip() { echo "  SKIP: $*" >&2; }
 
 guard_local "$ENDPOINT"
 
-echo "conformance: what the example stacks must prove, on $ENDPOINT, runtime $RUNTIME"
+# ---- the intermittency budget, and why it is three --------------------------
+#
+# The defect class this gate exists for is intermittent by nature: the
+# isolation-detach race that cost three pull requests struck 9 times in 13 runs.
+# A gate that plays the suite once and reads a green as a proof is measuring
+# luck — at that rate a single pass calls the defect absent nearly one time in
+# three (0.31), which is not a verdict.
+#
+# Three passes, and the arithmetic is the argument rather than a preference:
+# 0.31^3 is a 3% chance of a green that means nothing, against 9.6% for two.
+# Five would buy
+# another factor of ten and cost the same again — measured at 295 s a pass on
+# the author's station on 2026-08-28, three passes are ~15 min locally and fit
+# inside runtime-proof.yml's 45-minute job with the runner being slower; five
+# would put that job on its own timeout, and a job that times out is a verdict
+# nobody wrote. The other bound is the one .pre-commit-config.yaml states about
+# `conformance`: a gate long enough to be worked around is worse than no gate.
+#
+# Sequential on one host, deliberately: pass k+1's doorstep is pass k's closing
+# verdict, so a run that leaks is the run that fails rather than the next one.
+PASSES="${FEINT_FUNCTIONAL_PASSES:-3}"
+if ! printf '%s' "$PASSES" | grep -Eq '^[1-9][0-9]*$'; then
+	fail "FEINT_FUNCTIONAL_PASSES is $PASSES, which is not a number of passes; a budget nobody can read is a budget nobody set"
+fi
+if [ -n "${FEINT_FUNCTIONAL_PASSES:-}" ]; then
+	echo "   the stack gate plays $PASSES pass(es) (FEINT_FUNCTIONAL_PASSES, exported by the caller)" >&2
+	if [ "$PASSES" -lt 3 ]; then
+		echo "   below the default of 3: an intermittent defect that misses once now reads as absent" >&2
+	fi
+else
+	echo "   the stack gate plays $PASSES pass(es) (this gate's default)" >&2
+fi
+
+# ---- the mode, before anything is spent -------------------------------------
+#
+# This file used to open with
+#
+#     RUNTIME="${FEINT_FUNCTIONAL_RUNTIME:-incus-ovn}"
+#
+# which is `mise run evidence:update`'s #574 line one directory over: an
+# exported FEINT_VM was ignored in silence, so `FEINT_VM=incus mise run
+# conformance:functional` measured OVN and said nothing. That is worse here than
+# it was there, because the mode is the one variable this gate's subject turns
+# on — isolation exists under OVN and not under a bridge — so the verdict would
+# name a mode nobody asked for on the very assertion the modes disagree about.
+#
+# tools/runtime-mode.sh holds the resolution for both callers.
+# TestTheStackGateResolvesAndAnnouncesItsMode fails without this line.
+RUNTIME="$("$ROOT/tools/runtime-mode.sh" "the stack gate" FEINT_FUNCTIONAL_RUNTIME incus-ovn \
+	"Its stacks boot machines and every assertion reads them off the host, so with no
+runtime there is nothing to look at and nothing to look with — and a gate that
+went on would report a green having measured nothing.")" || exit 1
+
+echo "conformance: what the example stacks must prove, on $ENDPOINT, runtime $RUNTIME, $PASSES pass(es)"
 
 # ---- doorstep: can anybody look? -------------------------------------------
 #
@@ -842,13 +899,33 @@ run_stack() { # name
 DEFAULT_STACKS=(scaleway outscale)
 STACKS=("$@")
 [ "${#STACKS[@]}" -gt 0 ] || STACKS=("${DEFAULT_STACKS[@]}")
-for stack in "${STACKS[@]}"; do
-	run_stack "$stack"
+
+pass=1
+while [ "$pass" -le "$PASSES" ]; do
+	echo "== pass $pass of $PASSES"
+	for stack in "${STACKS[@]}"; do
+		run_stack "$stack"
+	done
+
+	# The host this pass found is the host it leaves. A pass that measured every
+	# assertion and left a container or a network behind has broken the next one
+	# rather than this one (#493), so the doorstep question is asked again on the
+	# way out — of every pass, because the next pass is a run too.
+	#
+	# `doorstep` is the scope, and it is the whole of the check. This line used
+	# to read
+	#
+	#     guard_leftovers_for "$RUNTIME" "the end of the run"
+	#
+	# and guard_leftovers_for arms `--doorstep` on the literal `doorstep` alone,
+	# so the closing check asked about DHCP orphans and traps and never once
+	# asked what machines and networks were left standing — the exact question
+	# the comment above it claimed to ask. A green run that leaked a network
+	# exited 0 and the next run paid for it, which is the state #521 fixed in
+	# `mise run conformance` and this file described without doing.
+	# TestTheStackGateEndsOnItsOwnDoorstep fails without the scope.
+	guard_leftovers_for "$RUNTIME" doorstep
+	pass=$((pass + 1))
 done
 
-# The host this run found is the host it leaves. A run that measured every
-# assertion and left a container behind has broken the next run rather than this
-# one (#493), so the doorstep question is asked again on the way out.
-guard_leftovers_for "$RUNTIME" "the end of the run"
-
-echo "conformance: every stack proved what it declares, and every bound it cannot measure was named"
+echo "conformance: every stack proved what it declares over $PASSES pass(es), and every bound it cannot measure was named"

--- a/tools/conformance/functionalgate_test.go
+++ b/tools/conformance/functionalgate_test.go
@@ -1,0 +1,291 @@
+package conformance
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The stack gate says which runtime it answers under, and cannot be handed one
+// nobody asked for (#504, and #574 one directory over).
+//
+// What the wrong output looked like is the whole danger: nothing was printed at
+// all. `tools/conformance/functional.sh` opened with
+//
+//	RUNTIME="${FEINT_FUNCTIONAL_RUNTIME:-incus-ovn}"
+//
+// so `FEINT_VM=incus mise run conformance:functional` applied the stacks under
+// OVN, reported green, and the operator read the verdict as the bridge's. That
+// is the same line `mise run evidence:update` carried when it manufactured two
+// false attributions during an Exoscale diagnosis, at three 1300-second passes
+// each — and it is worse here, because the one assertion the two modes disagree
+// about, isolation between two VPCs, is this gate's own subject.
+//
+// Driven against the gate itself rather than against the shared resolver: a
+// resolver nothing calls resolves nothing, which is the instrument this
+// repository keeps finding. Every case below stops the gate before it starts an
+// emulator, so this test needs no runtime, no images and no clients.
+func TestTheStackGateResolvesAndAnnouncesItsMode(t *testing.T) {
+	cases := []struct {
+		name string
+		env  []string
+		says []string
+	}{
+		{
+			// The budget is announced first, so this one case carries both the
+			// default budget line and the refusal.
+			name: "machines off is refused by name, and the budget was already said",
+			env:  []string{"FEINT_VM=off"},
+			says: []string{
+				"the stack gate plays 3 pass(es) (this gate's default)",
+				"the stack gate was asked for --vm off (FEINT_VM, exported by the caller)",
+				"nothing to look at and nothing to look with",
+			},
+		},
+		{
+			name: "two different runtimes are refused rather than arbitrated",
+			env:  []string{"FEINT_VM=incus-ovn", "FEINT_FUNCTIONAL_RUNTIME=incus", "FEINT_FUNCTIONAL_PASSES=1"},
+			says: []string{
+				"the stack gate plays 1 pass(es) (FEINT_FUNCTIONAL_PASSES, exported by the caller)",
+				"below the default of 3",
+				"FEINT_VM=incus-ovn and FEINT_FUNCTIONAL_RUNTIME=incus name two different runtimes for the stack gate",
+			},
+		},
+		{
+			name: "a budget that is not a number is refused, never rounded to one pass",
+			env:  []string{"FEINT_VM=incus-ovn", "FEINT_FUNCTIONAL_PASSES=zero"},
+			says: []string{"FEINT_FUNCTIONAL_PASSES is zero, which is not a number of passes"},
+		},
+		{
+			name: "a budget of zero passes is refused: it would measure nothing and exit 0",
+			env:  []string{"FEINT_VM=incus-ovn", "FEINT_FUNCTIONAL_PASSES=0"},
+			says: []string{"FEINT_FUNCTIONAL_PASSES is 0, which is not a number of passes"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			code, out := runStackGate(t, tc.env)
+			if code == 0 {
+				t.Fatalf("the gate accepted what it must refuse, and would have spent a run on it:\n%s", out)
+			}
+			for _, want := range tc.says {
+				if !strings.Contains(out, want) {
+					t.Errorf("the gate never said %q; it said:\n%s", want, out)
+				}
+			}
+		})
+	}
+}
+
+// The accepting half, without which every case above would pass on a gate that
+// refuses everything: a mode it can honour is announced with its provenance and
+// carried into the run.
+//
+// The mode named here is deliberately one no host has, so the gate announces
+// it, fails `feint doctor` and skips — a fast, host-independent way to read the
+// announcement of an ACCEPTED mode rather than of a refusal.
+func TestTheStackGateAnnouncesTheModeItAccepts(t *testing.T) {
+	// The gate reaches `feint doctor` only once jq, curl and incus are on PATH,
+	// and it says so and exits 0 when they are not. Both endings prove the
+	// announcement, which is what this asserts; what must never happen is the
+	// announcement being absent.
+	_, out := runStackGate(t, []string{"FEINT_VM=incus-nothing-declares-this"})
+	want := "the stack gate runs under --vm incus-nothing-declares-this (FEINT_VM, exported by the caller)"
+	if !strings.Contains(out, want) {
+		t.Errorf("the gate never said %q, so it would answer under a mode nobody reads; it said:\n%s", want, out)
+	}
+}
+
+// The literal must not come back, which is the direction a behaviour test
+// cannot cover: a resolver call plus the old silent default would announce one
+// mode and use another.
+func TestTheStackGateAsksForItsModeRatherThanPinningIt(t *testing.T) {
+	body := shellCode(t, "functional.sh")
+	if !strings.Contains(body, "tools/runtime-mode.sh") {
+		t.Error("functional.sh no longer asks tools/runtime-mode.sh which runtime it answers " +
+			"under: whatever it picks instead, it picks silently (#504)")
+	}
+	if strings.Contains(body, `RUNTIME="${FEINT_FUNCTIONAL_RUNTIME:`) {
+		t.Error("functional.sh pins its runtime from FEINT_FUNCTIONAL_RUNTIME again instead of " +
+			"delegating the whole question: that is the line that ignored an exported FEINT_VM " +
+			"and, one directory over, manufactured two false attributions (#574)")
+	}
+}
+
+// The doorstep at BOTH ends, and the closing one was a comment (#504).
+//
+// The line read
+//
+//	guard_leftovers_for "$RUNTIME" "the end of the run"
+//
+// under a comment saying the doorstep question was asked again on the way out.
+// It was not: guard_leftovers_for arms `--doorstep` on the literal `doorstep`
+// alone, so the closing call asked about DHCP orphans and trapped objects and
+// never once asked what machines and networks the pass had left standing. A run
+// that leaked a network exited 0 and the next run met the refusal — which is
+// exactly the state #521 removed from `mise run conformance`, described here in
+// prose and never done.
+//
+// This reads the scope the file actually passes and then EXECUTES the guard
+// with it, so it measures the effect rather than the spelling: any scope that
+// does not arm the question fails, whatever it is called.
+func TestTheStackGateEndsOnItsOwnDoorstep(t *testing.T) {
+	body := shellCode(t, "functional.sh")
+
+	// The reader proves it can find before it judges. Without the loop marker,
+	// "no closing call after it" would be vacuously true.
+	loopAt := strings.Index(body, `while [ "$pass" -le "$PASSES" ]`)
+	if loopAt < 0 {
+		t.Fatal("functional.sh no longer runs its stacks in a pass loop: the reader is the " +
+			"suspect, not the gate")
+	}
+
+	call := regexp.MustCompile(`guard_leftovers_for "\$RUNTIME" ("[^"]*"|\S+)`)
+	opening := call.FindStringSubmatch(body[:loopAt])
+	if opening == nil {
+		t.Fatal("functional.sh never asks the doorstep question before its pass loop: it would " +
+			"start on a host an earlier run still holds and die minutes in on an address block")
+	}
+	closing := call.FindStringSubmatch(body[loopAt:])
+	if closing == nil {
+		t.Fatal("functional.sh never re-asks the doorstep question inside its pass loop: a pass " +
+			"that leaks a machine or a network exits 0 and the next run pays for it (#493, #521)")
+	}
+
+	for _, scope := range []struct{ what, arg string }{
+		{"the opening doorstep", opening[1]},
+		{"the closing doorstep", closing[1]},
+	} {
+		code, out := bashGuard(t,
+			`. "$1"; guard_leftovers_for "$2" `+scope.arg,
+			"incus", stubBinary(t, 0))
+		if code != 0 {
+			t.Fatalf("%s refused a host the stub reports clean (exit %d):\n%s", scope.what, code, out)
+		}
+		if !strings.Contains(out, "--doorstep") {
+			t.Errorf("%s of functional.sh passes %s, which does not ask what machines and "+
+				"networks are standing — the question the comment beside it claims to ask:\n%s",
+				scope.what, scope.arg, out)
+		}
+	}
+}
+
+// The budget the gate announces is the budget it plays (#504).
+//
+// A gate that prints "3 pass(es)" and runs one is the lying instrument this
+// repository keeps meeting, and it would be worse than no budget at all: the
+// number in the log is what a reader would take the green to mean.
+//
+// Structural, and said out loud rather than dressed as behaviour: driving three
+// real passes takes fifteen minutes and a machine runtime, so what a unit test
+// can hold is that the loop is bounded by the announced variable and that every
+// pass names itself. The behavioural half is the run — `== pass 3 of 3` in the
+// output of `FEINT_VM=incus-ovn mise run conformance:functional`.
+func TestTheStackGatePlaysTheBudgetItAnnounces(t *testing.T) {
+	body := shellCode(t, "functional.sh")
+
+	if !strings.Contains(body, `PASSES="${FEINT_FUNCTIONAL_PASSES:-3}"`) {
+		t.Error("the gate no longer defaults to three passes: the number was chosen against a " +
+			"defect class that struck 9 times in 13 runs, and a single pass calls it absent " +
+			"nearly one time in three (#504)")
+	}
+
+	loop := regexp.MustCompile(`while \[ "\$pass" -le (\S+) \]`).FindStringSubmatch(body)
+	if loop == nil {
+		t.Fatal("functional.sh no longer bounds its pass loop with `while [ \"$pass\" -le … ]`: " +
+			"the reader is the suspect, not the gate")
+	}
+	if loop[1] != `"$PASSES"` {
+		t.Errorf("the pass loop is bounded by %s rather than by the budget it announced: the gate "+
+			"would print a number of passes and play another one", loop[1])
+	}
+	if !strings.Contains(body, `echo "== pass $pass of $PASSES"`) {
+		t.Error("no pass names itself in the output, so a run that stopped after the first would " +
+			"read exactly like a run that played them all")
+	}
+}
+
+// shellCode is a script with its comment lines removed, because the two tests
+// above ask what the gate DOES and this file quotes what it used to do. Read
+// whole, `RUNTIME="${FEINT_FUNCTIONAL_RUNTIME:-incus-ovn}"` is present in
+// functional.sh forever — inside the paragraph explaining why it was removed —
+// and a reader that swallowed the prose would report the defect present for
+// good, which is the mirror image of the comment that reads as a fix.
+//
+// It proves it can find before it judges: a stripped body that no longer holds
+// the gate's own shebang means the reader is the suspect.
+func shellCode(t *testing.T, path string) string {
+	t.Helper()
+	var kept []string
+	for _, line := range strings.Split(readFile(t, path), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "#!") ||
+			!strings.HasPrefix(strings.TrimSpace(line), "#") {
+			kept = append(kept, line)
+		}
+	}
+	body := strings.Join(kept, "\n")
+	if !strings.Contains(body, "#!/usr/bin/env bash") {
+		t.Fatalf("stripping the comments of %s left no script behind: the reader is the suspect", path)
+	}
+	return body
+}
+
+// runStackGate executes functional.sh with exactly the environment a case
+// names, and nothing of the station's own.
+//
+// The four variables under test are stripped from the inherited environment for
+// the reason mode_test.go strips its two: a station that already exports
+// FEINT_VM would otherwise decide the verdict, which is the shape of the defect
+// itself.
+func runStackGate(t *testing.T, env []string) (code int, output string) {
+	t.Helper()
+	requireTool(t, "bash")
+
+	script, err := filepath.Abs("functional.sh")
+	if err != nil {
+		t.Fatalf("locate functional.sh: %v", err)
+	}
+	if _, err := os.Stat(script); err != nil {
+		t.Fatalf("functional.sh is not where this test looks (%s): %v", script, err)
+	}
+
+	cmd := exec.Command("bash", script) //nolint:gosec // a fixed script in this repository
+	cmd.Env = append(gateEnvironment(), env...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		var exit *exec.ExitError
+		if !errors.As(err, &exit) {
+			t.Fatalf("run the gate: %v\n%s", err, out)
+		}
+		code = exit.ExitCode()
+	}
+	return code, string(out)
+}
+
+// gateEnvironment is the parent environment without the variables the gate
+// reads, so a case says the whole truth about its own inputs.
+func gateEnvironment() []string {
+	stripped := []string{
+		"FEINT_VM=", "FEINT_FUNCTIONAL_RUNTIME=", "FEINT_FUNCTIONAL_PASSES=",
+		"FEINT_FUNCTIONAL_ADDR=", "FEINT_FUNCTIONAL_ZONE=",
+	}
+	out := make([]string, 0, len(os.Environ()))
+	for _, entry := range os.Environ() {
+		skip := false
+		for _, prefix := range stripped {
+			if strings.HasPrefix(entry, prefix) {
+				skip = true
+				break
+			}
+		}
+		if !skip {
+			out = append(out, entry)
+		}
+	}
+	return out
+}

--- a/tools/conformance/runtimeproofstacks_test.go
+++ b/tools/conformance/runtimeproofstacks_test.go
@@ -1,0 +1,147 @@
+package conformance
+
+import (
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// The stack gate is played by a scheduled job, which is the whole of #504.
+//
+// `conformance:functional` is the only thing in this repository that applies
+// the example stacks against real machines, and nothing in CI ran it. It is
+// what surfaced the isolation-detach race — an ACL deleted while the daemon
+// resolved it at `incus start`, killing machines behind a green apply — a
+// defect that cost three pull requests and was older than the whole range
+// bisected. No leg played the stacks, and `mise run conformance` skips the
+// stack suites without a runtime, so that class had no gate at all.
+//
+// Three properties, and the second is the one an ordinary "the workflow
+// mentions the script" test would miss: the gate has to be a job of its own.
+// Appended to the incus-ovn leg it would queue behind six suites that were red
+// on four of the last seven scheduled nights, and a step that is never reached
+// is a gate that never runs.
+func TestTheStackGateIsPlayedByAScheduledJob(t *testing.T) {
+	root := repoRoot(t)
+	body := readFile(t, filepath.Join(root, ".github", "workflows", "runtime-proof.yml"))
+
+	gate := "tools/conformance/functional.sh"
+	if !strings.Contains(body, gate) {
+		t.Fatalf("runtime-proof.yml never runs %s: the only gate that applies the example stacks "+
+			"against real machines is played by nothing again (#504)", gate)
+	}
+
+	jobs := workflowJobs(t, body)
+	// The reader proves it can find before it judges: without the split, every
+	// containment question below would be asked of an empty string.
+	for _, name := range []string{"runtime", "stacks", "streak", "report"} {
+		if _, ok := jobs[name]; !ok {
+			t.Fatalf("no `%s:` job found in runtime-proof.yml (found %v): the reader is the "+
+				"suspect, not the workflow", name, sortedJobNames(jobs))
+		}
+	}
+
+	if !strings.Contains(jobs["stacks"], gate) {
+		t.Errorf("the `stacks` job does not run %s, so whatever it does it is not the stack gate", gate)
+	}
+	if strings.Contains(jobs["runtime"], gate) {
+		t.Error("the stack gate is a step of the `runtime` job again: it then queues behind the " +
+			"ssh suites, which were red on four of the last seven scheduled nights, and a step " +
+			"that is never reached is a gate that never runs (#504)")
+	}
+	// Half an hour of passes does not fit that leg's budget either, and a job
+	// that times out is a verdict nobody wrote.
+	if !strings.Contains(jobs["stacks"], "timeout-minutes:") {
+		t.Error("the `stacks` job declares no timeout, so a hung apply holds a runner until " +
+			"GitHub's own six-hour ceiling")
+	}
+	// The mode is exported rather than left to the default, so the announcement
+	// a reader meets in the log carries a provenance they can check against the
+	// job's own name.
+	if !strings.Contains(jobs["stacks"], "FEINT_VM=incus-ovn") {
+		t.Error("the `stacks` job does not export FEINT_VM, so the gate announces `this gate's " +
+			"default` for a mode this job's name claims: that is #574's shape, not its fix")
+	}
+
+	// A job outside the night's verdict is a job nobody reads. `streak` counts
+	// the workflow's own conclusion and `report` opens the issue, so both wait
+	// for this one.
+	for _, name := range []string{"streak", "report"} {
+		if !strings.Contains(jobs[name], "needs: [runtime, stacks]") {
+			t.Errorf("the `%s` job does not wait for `stacks`, so a night whose stack gate went "+
+				"red is summarised, and possibly closed, before anybody looked at it", name)
+		}
+	}
+}
+
+// The two jobs that build an Incus host build the same one (#504).
+//
+// The `stacks` job repeats the incus-ovn leg's setup deliberately: extracting
+// it into a composite action while that leg is red would make any new red
+// ambiguous between the gate and the refactor. Duplication is only defensible
+// when something holds the copies together, and this is that thing — a pin that
+// moves in one job and not the other fails `mise run check` rather than a night
+// three weeks later.
+func TestBothRuntimeJobsPinTheSameHost(t *testing.T) {
+	root := repoRoot(t)
+	jobs := workflowJobs(t, readFile(t, filepath.Join(root, ".github", "workflows", "runtime-proof.yml")))
+
+	for _, pin := range []struct{ what, line string }{
+		{"the Zabbly signing key", "ZABBLY_FPR: '4EFC590696CB15B87C73A3AD82CC8797C838DCFD'"},
+		{"the Incus packages", "incus incus-client netcat-openbsd"},
+		{"the OVN packages", "ovn-central ovn-host openvswitch-switch"},
+		{"the northbound socket", "network.ovn.northbound_connection unix:/run/ovn/ovnnb_db.sock"},
+		{"the runner's Docker FORWARD policy", "sudo iptables -P FORWARD ACCEPT"},
+		{"the Terraform version", "TERRAFORM_VERSION: '1.13.3'"},
+	} {
+		for _, job := range []string{"runtime", "stacks"} {
+			if !strings.Contains(jobs[job], pin.line) {
+				t.Errorf("the `%s` job no longer pins %s (%q): the two jobs claim to build the "+
+					"same host and one of them has drifted", job, pin.what, pin.line)
+			}
+		}
+	}
+}
+
+// workflowJobs splits a workflow into its top-level jobs, keyed by id.
+//
+// String work rather than a YAML parser, because this module carries no
+// dependencies: a job starts on a line indented by exactly two spaces under
+// `jobs:` and ends where the next one starts.
+func workflowJobs(t *testing.T, body string) map[string]string {
+	t.Helper()
+	_, after, found := strings.Cut(body, "\njobs:\n")
+	if !found {
+		t.Fatal("the workflow declares no `jobs:` block: the reader is the suspect")
+	}
+	header := regexp.MustCompile(`^ {2}([A-Za-z0-9_-]+):\s*$`)
+	out := map[string]string{}
+	current := ""
+	var lines []string
+	flush := func() {
+		if current != "" {
+			out[current] = strings.Join(lines, "\n")
+		}
+	}
+	for _, line := range strings.Split(after, "\n") {
+		if m := header.FindStringSubmatch(line); m != nil {
+			flush()
+			current, lines = m[1], nil
+			continue
+		}
+		lines = append(lines, line)
+	}
+	flush()
+	return out
+}
+
+func sortedJobNames(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/tools/evidence/mode.sh
+++ b/tools/evidence/mode.sh
@@ -14,49 +14,22 @@
 # attributions while an Exoscale defect was being diagnosed — first "the
 # population", then "the branch" — and cost three 1300-second passes to unmake.
 #
-# The rule this file is: an instrument that answers under a mode may not choose
-# that mode silently. So the caller's FEINT_VM wins, FEINT_EVIDENCE_VM stays as
-# the way to steer the leg without touching leg 1, a disagreement between the
-# two is refused by name rather than arbitrated, and the mode is announced
-# before anything starts.
+# The resolution itself moved to tools/runtime-mode.sh when the stack gate was
+# found carrying the same line one directory over (#504): what varies between
+# the two callers — the subject, the knob, the default, and what `off` would
+# cost — is passed, and what does not vary is shared. This file stays because
+# the leg's four facts are the leg's, not the resolver's, and because
+# tools/evidence/mode_test.go drives it: those tests were written against the
+# behaviour, so they are what proves the move changed none of it.
 #
 # Prints the resolved mode on stdout, the announcement on stderr, and exits 1
 # with the reason when the two variables cannot both be honoured.
-#
-# Driven by tools/evidence/mode_test.go, which is where the four outcomes are
-# asserted; a green run of this script proves nothing on its own.
 set -euo pipefail
 
-vm="${FEINT_VM:-}"
-evidence_vm="${FEINT_EVIDENCE_VM:-}"
-
-if [ -n "$vm" ] && [ -n "$evidence_vm" ] && [ "$vm" != "$evidence_vm" ]; then
-  echo "FEINT_VM=$vm and FEINT_EVIDENCE_VM=$evidence_vm name two different runtimes for the same leg." >&2
-  echo "Picking one of them is what made this task report a verdict under a mode nobody asked for (#574)." >&2
-  echo "Export one, or set them to the same value." >&2
-  exit 1
-fi
-
-if [ -n "$vm" ]; then
-  mode="$vm"
-  source="FEINT_VM, exported by the caller"
-elif [ -n "$evidence_vm" ]; then
-  mode="$evidence_vm"
-  source="FEINT_EVIDENCE_VM"
-else
-  mode="incus"
-  source="this task's default"
-fi
-
-# Refused by name rather than honoured: with machines off the runtime leg is
-# leg 1 run twice, so it would earn no dataplane axis and quietly narrow the
-# record. The refusal says which leg already does that.
-if [ "$mode" = "off" ]; then
-  echo "the runtime leg was asked for --vm off ($source), which is leg 1 run a second time:" >&2
-  echo "it can earn no dataplane axis, and the record would narrow without anyone asking." >&2
-  echo "Ask for a runtime (incus, incus-ovn, incus-vm), or run leg 1 alone." >&2
-  exit 1
-fi
-
-echo "   the runtime leg runs under --vm $mode ($source)" >&2
-printf '%s\n' "$mode"
+exec "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/runtime-mode.sh" \
+	"the runtime leg" \
+	FEINT_EVIDENCE_VM \
+	incus \
+	"That is leg 1 run a second time: it can earn no dataplane axis, and the
+record would narrow without anyone asking. Run leg 1 alone if that is what
+you meant."

--- a/tools/falsify/specs/evidence-leg-mode.json
+++ b/tools/falsify/specs/evidence-leg-mode.json
@@ -3,30 +3,37 @@
   "mutations": [
     {
       "label": "an exported FEINT_VM is ignored again, so the leg answers under a mode nobody asked for (#574)",
-      "file": "tools/evidence/mode.sh",
-      "find": "if [ -n \"$vm\" ]; then\n  mode=\"$vm\"",
-      "replace": "if [ -n \"$vm\" ] && false; then\n  mode=\"$vm\"",
+      "file": "tools/runtime-mode.sh",
+      "find": "if [ -n \"$vm\" ]; then\n\tmode=\"$vm\"",
+      "replace": "if [ -n \"$vm\" ] && false; then\n\tmode=\"$vm\"",
       "test": "TestTheRuntimeLegResolvesAndAnnouncesItsMode"
     },
     {
       "label": "two variables naming two different runtimes are arbitrated instead of refused",
-      "file": "tools/evidence/mode.sh",
-      "find": "if [ -n \"$vm\" ] && [ -n \"$evidence_vm\" ] && [ \"$vm\" != \"$evidence_vm\" ]; then",
-      "replace": "if [ -n \"$vm\" ] && [ -n \"$evidence_vm\" ] && [ \"$vm\" != \"$evidence_vm\" ] && false; then",
+      "file": "tools/runtime-mode.sh",
+      "find": "if [ -n \"$vm\" ] && [ -n \"$knob_value\" ] && [ \"$vm\" != \"$knob_value\" ]; then",
+      "replace": "if [ -n \"$vm\" ] && [ -n \"$knob_value\" ] && [ \"$vm\" != \"$knob_value\" ] && false; then",
       "test": "TestTheRuntimeLegResolvesAndAnnouncesItsMode"
     },
     {
       "label": "machines off is accepted for the runtime leg, and the record narrows without anyone asking",
-      "file": "tools/evidence/mode.sh",
+      "file": "tools/runtime-mode.sh",
       "find": "if [ \"$mode\" = \"off\" ]; then",
       "replace": "if [ \"$mode\" = \"off\" ] && false; then",
       "test": "TestTheRuntimeLegResolvesAndAnnouncesItsMode"
     },
     {
       "label": "the leg stops naming the mode it runs, which is the half that was missing entirely",
+      "file": "tools/runtime-mode.sh",
+      "find": "echo \"   $subject runs under --vm $mode ($source)\" >&2",
+      "replace": "echo \"   $subject runs\" >&2",
+      "test": "TestTheRuntimeLegResolvesAndAnnouncesItsMode"
+    },
+    {
+      "label": "the leg's own facts stop deciding the answer: the default it passes is changed and the leg answers under a runtime nobody chose",
       "file": "tools/evidence/mode.sh",
-      "find": "echo \"   the runtime leg runs under --vm $mode ($source)\" >&2",
-      "replace": "echo \"   the runtime leg runs\" >&2",
+      "find": "\tFEINT_EVIDENCE_VM \\\n\tincus \\",
+      "replace": "\tFEINT_EVIDENCE_VM \\\n\tincus-vm \\",
       "test": "TestTheRuntimeLegResolvesAndAnnouncesItsMode"
     },
     {
@@ -43,5 +50,6 @@
       "replace": "echo \"== leg 1/2: machines off, probe on\"",
       "test": "TestTheEvidenceTaskAsksForItsModeRatherThanPinningIt"
     }
-  ]
+  ],
+  "note": "The subject is #574's second half, and the file it points at moved on 2026-08-28. The resolution itself now lives in tools/runtime-mode.sh, because tools/conformance/functional.sh was found carrying the same silent line one directory over (#504): `RUNTIME=\"${FEINT_FUNCTIONAL_RUNTIME:-incus-ovn}\"`. What varies between the two callers — the subject, the knob, the default, and what `off` would cost — is passed; what does not vary is shared. tools/evidence/mode.sh is now the four facts of the evidence leg and nothing else, which is why the fifth mutation below is on it: change one of those four facts and the leg answers under a runtime nobody chose, which is how a delegation that looks right resolves somebody else's question.\n\nThe tests did not move with the code, deliberately: tools/evidence/mode_test.go was written against the behaviour, so it is what proved the extraction changed none of it."
 }

--- a/tools/falsify/specs/the-stack-gate-runs-somewhere.json
+++ b/tools/falsify/specs/the-stack-gate-runs-somewhere.json
@@ -1,0 +1,70 @@
+{
+  "package": "./tools/conformance/",
+  "mutations": [
+    {
+      "label": "the closing check goes back to the scope that armed nothing, so a pass that leaked a machine or a network exits 0 under a comment claiming the doorstep was asked",
+      "file": "tools/conformance/functional.sh",
+      "find": "\tguard_leftovers_for \"$RUNTIME\" doorstep\n\tpass=$((pass + 1))",
+      "replace": "\tguard_leftovers_for \"$RUNTIME\" \"the end of the run\" # doorstep\n\tpass=$((pass + 1))",
+      "test": "TestTheStackGateEndsOnItsOwnDoorstep",
+      "package": "./tools/conformance/"
+    },
+    {
+      "label": "the budget goes back to one pass, so a defect that struck 9 times in 13 runs reads as absent nearly one time in three",
+      "file": "tools/conformance/functional.sh",
+      "find": "PASSES=\"${FEINT_FUNCTIONAL_PASSES:-3}\"",
+      "replace": "PASSES=\"${FEINT_FUNCTIONAL_PASSES:-1}\" # 3",
+      "test": "TestTheStackGatePlaysTheBudgetItAnnounces",
+      "package": "./tools/conformance/"
+    },
+    {
+      "label": "the loop stops at one whatever the gate announced, which is the lying instrument: the number in the log is what a reader takes the green to mean",
+      "file": "tools/conformance/functional.sh",
+      "find": "while [ \"$pass\" -le \"$PASSES\" ]; do",
+      "replace": "while [ \"$pass\" -le 1 ] && [ \"$pass\" -le \"$PASSES\" ]; do",
+      "test": "TestTheStackGatePlaysTheBudgetItAnnounces",
+      "package": "./tools/conformance/"
+    },
+    {
+      "label": "a budget that is not a number is accepted, so FEINT_FUNCTIONAL_PASSES=0 runs zero passes and exits 0 having measured nothing",
+      "file": "tools/conformance/functional.sh",
+      "find": "if ! printf '%s' \"$PASSES\" | grep -Eq '^[1-9][0-9]*$'; then",
+      "replace": "if false && ! printf '%s' \"$PASSES\" | grep -Eq '^[1-9][0-9]*$'; then",
+      "test": "TestTheStackGateResolvesAndAnnouncesItsMode",
+      "package": "./tools/conformance/"
+    },
+    {
+      "label": "the resolver stops announcing, which is exactly what #574 looked like: the right mode picked, nothing printed, and the reader believing the mode they exported",
+      "file": "tools/runtime-mode.sh",
+      "find": "echo \"   $subject runs under --vm $mode ($source)\" >&2",
+      "replace": "[ -n \"$subject$mode$source\" ] || echo \"   $subject runs under --vm $mode ($source)\" >&2",
+      "test": "TestTheStackGateAnnouncesTheModeItAccepts",
+      "package": "./tools/conformance/"
+    },
+    {
+      "label": "the scheduled job plays the witness gate instead of the stack gate, which is the state #504 was opened about with one more step in it",
+      "file": ".github/workflows/runtime-proof.yml",
+      "find": "        run: sudo env FEINT_VM=incus-ovn tools/conformance/functional.sh",
+      "replace": "        run: sudo env FEINT_VM=incus-ovn tools/conformance/witness.sh # functional.sh",
+      "test": "TestTheStackGateIsPlayedByAScheduledJob",
+      "package": "./tools/conformance/"
+    },
+    {
+      "label": "the night's summary and its issue stop waiting for the stack gate, so a red night is reported, and possibly closed, before anybody looked at it",
+      "file": ".github/workflows/runtime-proof.yml",
+      "find": "    needs: [runtime, stacks]\n    if: always() && github.event_name == 'schedule'\n    runs-on: ubuntu-24.04",
+      "replace": "    needs: [runtime]\n    if: always() && github.event_name == 'schedule' # stacks\n    runs-on: ubuntu-24.04",
+      "test": "TestTheStackGateIsPlayedByAScheduledJob",
+      "package": "./tools/conformance/"
+    },
+    {
+      "label": "the stack gate becomes a step of the incus-ovn leg again, where it queues behind suites red on four of the last seven nights and inherits what they leave on the host",
+      "file": ".github/workflows/runtime-proof.yml",
+      "find": "  stacks:\n    name: stacks (incus-ovn)",
+      "replace": "  runtime2:\n    name: stacks (incus-ovn)",
+      "test": "TestTheStackGateIsPlayedByAScheduledJob",
+      "package": "./tools/conformance/"
+    }
+  ],
+  "note": "The subject is #504. `conformance:functional` is the only gate in this repository that applies the example stacks to real machines, and until this change nothing in CI played it: no leg of runtime-proof.yml applies a stack, and `mise run conformance` skips the stack suites without a runtime. That gap is measured rather than argued — the isolation-detach race it would have caught on the day it landed (an ACL deleted while the daemon resolved it at `incus start`, machines dying behind a green apply) cost three pull requests, and the defect was older than the whole range bisected.\n\nFour properties came out of that day, and each has a mutation here.\n\nTHE DOORSTEP AT BOTH ENDS. Mutation 1 is the defect this change found rather than introduced: functional.sh closed with `guard_leftovers_for \"$RUNTIME\" \"the end of the run\"` under a comment saying the doorstep question was asked again on the way out. guard_leftovers_for arms `--doorstep` on the literal `doorstep` alone, so the closing call asked about DHCP orphans and trapped objects and never once asked what machines and networks were left standing. A green run that leaked a network exited 0 and the next run met the refusal — the state #521 removed from `mise run conformance`, described here in prose and never done. Its test reads the scope the file passes and then executes the guard with it, so it measures the effect and not the spelling.\n\nTHE MODE, ANNOUNCED WITH ITS PROVENANCE. Mutation 5 is #574 one directory over, and the resolver's own refusals are replayed by evidence-leg-mode.json, which owns that file. functional.sh opened with `RUNTIME=\"${FEINT_FUNCTIONAL_RUNTIME:-incus-ovn}\"`, so an exported FEINT_VM was ignored in silence; the same line in `mise run evidence:update` manufactured two successive false attributions during an Exoscale diagnosis, at three 1300-second passes to unmake. It is worse on this gate than it was there, because the one assertion the two modes disagree about — two networks nothing peers must not reach each other — is this gate's own subject. Mutation 5 is the one worth reading twice: the mode is still resolved correctly and simply not said, which is exactly what the defect looked like.\n\nTHE INTERMITTENCY BUDGET. Mutations 2, 3 and 4. The class of defect this gate exists for struck 9 times in 13 runs, so one pass calls it absent nearly one time in three; three passes make that one green in thirty-three, at 295 s a pass measured on the author's station on 2026-08-28. Mutation 3 is the instrument's own failure mode rather than the gate's: the gate announces three passes and plays one, and the number in the log is what a reader takes the green to mean.\n\nWHERE IT RUNS. Mutations 6 to 8. A gate nothing plays is the subject of the issue, so the wiring is held: the job runs the gate and not its neighbour, the night's summary and its issue wait for it, and it stays a job of its own. That last one is not a preference — a step on the incus-ovn leg queues behind six suites that were red on four of the last seven scheduled nights, and it would meet a host those suites leave dirty. Measured on 2026-08-28 by reproducing that leg locally: the three ssh suites each exit 0 and each leave something behind — `scw-…` and `exo-…` rule sets no client can delete, `fnt-default` and `feint-uplink` no resource owns — and `feint stop` sweeps none of them. That is why the witness gate failed at its own doorstep on the one night it has been reached since it landed (2026-08-27); the night after never got that far."
+}

--- a/tools/runtime-mode.sh
+++ b/tools/runtime-mode.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Which machine runtime a task answers under, resolved once and said out loud.
+#
+# THE DEFECT THIS IS, AND IT HAS NOW HAPPENED TWICE.
+#
+# `mise run evidence:update` used to open its second leg with
+#
+#     FEINT_VM="${FEINT_EVIDENCE_VM:-incus}"
+#
+# so an operator who exported FEINT_VM=incus-ovn got the bridge, was told
+# nothing, and read a verdict about a mode nobody had asked for. It manufactured
+# two successive false attributions while an Exoscale defect was being diagnosed
+# — first "the population", then "the branch" — and cost three 1300-second
+# passes to unmake (#574).
+#
+# `tools/conformance/functional.sh` carried the same line one directory over:
+#
+#     RUNTIME="${FEINT_FUNCTIONAL_RUNTIME:-incus-ovn}"
+#
+# `FEINT_VM=incus mise run conformance:functional` answered under OVN and said
+# nothing about it — and the mode is the one variable this gate's whole subject
+# turns on, since isolation exists in one of the two (#504).
+#
+# So the resolution lives here, once, and both callers pass what differs. That
+# is the repository's own rule about what varies being a field: a control copied
+# into two scripts is a control the third forgets, and the third is the one that
+# will be written next.
+#
+# THE RULE. An instrument that answers under a mode may not choose that mode
+# silently. The caller's FEINT_VM wins; the task's own knob steers it without
+# touching anything else; a disagreement between the two is refused by name
+# rather than arbitrated; `off` is refused with the caller's own reason; and the
+# mode is announced, with its provenance, before anything is spent.
+#
+# Prints the resolved mode on stdout, the announcement on stderr, and exits 1
+# with the reason when the two variables cannot both be honoured.
+#
+#   usage: tools/runtime-mode.sh <subject> <knob variable> <default> <off reason>
+#
+# Driven by tools/evidence/mode_test.go and tools/conformance/mode_test.go,
+# which is where the outcomes are asserted; a green run of this script proves
+# nothing on its own.
+set -euo pipefail
+
+if [ "$#" -ne 4 ]; then
+	echo "usage: tools/runtime-mode.sh <subject> <knob variable> <default> <off reason>" >&2
+	echo "  A resolver called with the wrong arity must not guess: the mode it picked" >&2
+	echo "  would be nobody's, which is the defect it exists to remove." >&2
+	exit 2
+fi
+
+subject="$1"
+knob="$2"
+default="$3"
+off_reason="$4"
+
+vm="${FEINT_VM:-}"
+# Indirect rather than a case list: the knob's name is the caller's, and this
+# file knows no task.
+knob_value="${!knob:-}"
+
+if [ -n "$vm" ] && [ -n "$knob_value" ] && [ "$vm" != "$knob_value" ]; then
+	echo "FEINT_VM=$vm and $knob=$knob_value name two different runtimes for $subject." >&2
+	echo "Picking one of them is what made a task report a verdict under a mode nobody asked for (#574)." >&2
+	echo "Export one, or set them to the same value." >&2
+	exit 1
+fi
+
+if [ -n "$vm" ]; then
+	mode="$vm"
+	source="FEINT_VM, exported by the caller"
+elif [ -n "$knob_value" ]; then
+	mode="$knob_value"
+	source="$knob"
+else
+	mode="$default"
+	source="this task's default"
+fi
+
+# Refused by name rather than honoured. What `off` costs is the caller's to
+# say — it is the one fact about the mode that is not the same in two places —
+# so the sentence arrives as an argument.
+if [ "$mode" = "off" ]; then
+	echo "$subject was asked for --vm off ($source)." >&2
+	printf '%s\n' "$off_reason" >&2
+	echo "Ask for a runtime (incus, incus-ovn, incus-vm)." >&2
+	exit 1
+fi
+
+echo "   $subject runs under --vm $mode ($source)" >&2
+printf '%s\n' "$mode"

--- a/tools/testplan/rules.go
+++ b/tools/testplan/rules.go
@@ -311,11 +311,37 @@ var rules = []rule{
 		Runs:     []string{"conformance:environment"},
 		Unproven: prepushIsTheWholeGate,
 	},
+	// The stack gate, by name, because the catch-all below sent a change to it
+	// to `conformance:leg -- fields` — a leg with no machine runtime, which is
+	// the one population this gate refuses to run in. Measured on this diff on
+	// 2026-08-28: the plan for a change to functional.sh named five falsify
+	// specs and two legs, and never the gate itself.
+	{
+		Path:     "tools/conformance/functional.sh",
+		Why:      "the stack gate — the only gate that applies the example stacks to real machines",
+		Runs:     []string{"FEINT_VM=incus-ovn mise run conformance:functional"},
+		Unproven: "three passes on one host prove what one host holds; the CI job of runtime-proof.yml is a second population and only the night plays it",
+	},
+	{
+		Path:     "tools/conformance/functionallib.sh",
+		Why:      "the stack gate's verdicts, held by functional_test.go against planted defects",
+		Runs:     []string{"FEINT_VM=incus-ovn mise run conformance:functional"},
+		Unproven: "the unit tests judge each verdict; only the gate judges them against machines that really boot",
+	},
 	{
 		Path:     "tools/conformance/",
 		Why:      "the shared harness: doorstep, score, faults, refusals, stacks, functional",
 		Runs:     []string{"conformance:leg -- fields"},
 		Unproven: "score.sh judges the field gate on the `fields` leg alone; on every other leg it prints and judges nothing",
+	},
+	// Both callers of the runtime resolver, named: `evidence:update` is twenty
+	// minutes and the stack gate is fifteen, so the cheap one is the run and the
+	// expensive one is the bound.
+	{
+		Path:     "tools/runtime-mode.sh",
+		Why:      "which runtime a task answers under, and the announcement that says so (#574)",
+		Runs:     []string{"FEINT_VM=incus-ovn mise run conformance:functional"},
+		Unproven: "`mise run evidence:update` is the other caller, and its twenty minutes are not in this plan; tools/evidence/mode_test.go is what holds its four outcomes offline",
 	},
 	{
 		Path:     "tools/falsify/",


### PR DESCRIPTION
Closes #504.

**#520 is not closed here** — it is **disproved**, measured, and recorded. See the
last section.

`conformance:functional` is the only gate that boots real machines and applies the
example stacks, and **nothing in CI ran it**. Yesterday it earned that sentence:
it is what surfaced the isolation-detach race, finding that cost **three pull
requests**, and the defect was older than the entire range bisected.

## Where the gate runs, and why not where it seemed obvious

A **`stacks` job of its own**, parallel to the two mode legs on
`runtime-proof.yml`, incus-ovn only. Not a step on the existing incus-ovn leg,
and both reasons are measurements:

- **that leg was red on four of the last seven scheduled nights**, and a step
  queued behind a red is a gate that never runs — which is #504's own complaint;
- **it would inherit that leg's host.** Reproduced locally: the three ssh suites
  each exit 0 and each **leave something standing** (`scw-*` and `exo-*` rule
  sets no client call can delete, `fnt-default`, `feint-uplink`), and `feint stop`
  sweeps none of them;
- three passes is half an hour, which would push a 45-minute job onto its own
  timeout, and a job that times out is a verdict nobody reads.

**No job renamed**, so `.github/rulesets/main.json` is untouched — this workflow
is schedule/dispatch only and none of its jobs is a required check. `streak` and
`report` now `needs: [runtime, stacks]`, so **a red stack gate cannot be
summarised or closed unseen**, and the header says out loud that #125's promotion
criterion is widened on purpose.

The setup steps are duplicated from the incus-ovn leg **deliberately**:
extracting them while that leg is red would make any new red ambiguous.
`TestBothRuntimeJobsPinTheSameHost` holds the two copies to the same pins.
actionlint, zizmor (`--persona regular --min-severity low`) and poutine clean. No
secret, no cross-repository token.

## The budget: three passes, and the arithmetic that chose it

The class this gate hunts struck **9 times in 13 runs**. So one pass calls it
absent **31 %** of the time; three passes bring that to **3 %**, against 9.6 % for
two. At **295 s** a pass, measured, three are about fifteen minutes and fit a
75-minute job; five would double the cost for a factor of ten and sit on the
timeout.

Sequential on one host, so pass *k+1*'s doorstep is pass *k*'s closing verdict.

## Proof the gate bites

A gate that has never refused anything is the thing this repository spends its
time removing. So: #475 planted (`ApplyFirewall` returns nil), rebuilt, one pass —
**red in 69 s**, naming stack, machine, address and port:

```
scaleway: a rule of platform-app-worker-a's group opens 8080 and
platform-web-0 does not reach 10.30.2.5:8080
```

Restored, rebuilt, green.

## Two defects found inside the gate itself, both "a comment is not a control"

**The closing doorstep was a comment.** `functional.sh` ended with
`guard_leftovers_for "$RUNTIME" "the end of the run"` under a paragraph stating
the doorstep question was asked again on the way out. It was not:
`guard_leftovers_for` arms `--doorstep` on the literal word `doorstep`, so it
never asked what machines and networks were left standing. Fixed — and the test
reads the scope the file passes and then **executes** the guard with it.

**The runtime resolution was #574's line, one directory over.**
`RUNTIME="${FEINT_FUNCTIONAL_RUNTIME:-incus-ovn}"` silently overrode what the
caller asked for, exactly as `evidence:update` did before yesterday. Extracted to
`tools/runtime-mode.sh` and shared with `evidence:update` — whose **unchanged**
tests are what prove the move changed nothing.

## Falsification

`the-stack-gate-runs-somewhere.json` — **8 of 8 bite**.
`evidence-leg-mode.json` retargeted onto the moved file (`falsify --lint` caught
its four dead fragments) — **7 of 7 bite**.

One mutation was **dropped rather than kept**: neutralising `|| exit 1` on the
resolver call does not bite, because the resolver still prints its refusal. It
was removed instead of being wrapped in a comment that would have lied about it.

## #520 — out of the pilotable, and its stated cause disproved

Terraform is refused for that pack since #525, so the pack's own API was driven
instead: **100 back-to-back by-id reads** of one balancer, **100 fresh
create-then-read pairs**, one elastic IP, **50 instance pools** — **zero empty
names, addresses or sizes**.

There is no window: `createLoadBalancer` writes `name` and `ip` **before** the
operation that already says `state: success`. And the stack's *third* by-id door
read back fine in the same apply, so whatever produced the nulls discriminates
between the three doors and this pack does not.

Recorded in `docs/limits.md` with its acknowledgement re-dated. What would lift it
is upstream `exoscale/terraform-provider-exoscale#573`; **no change to this pack
would.** The issue is left open for the maintainer to act on rather than closed
from here.

## The nightly red of `runtime-proof` — the brief's attribution was wrong

Seven consecutive red scheduled nights, last green 2026-08-21, and **four
distinct causes**, of which the witness doorstep is one:

| night | incus | incus-ovn |
|---|---|---|
| 08-22 … 08-25 | Scaleway ssh suite | Scaleway ssh suite |
| 08-26 | Scaleway ssh suite | Outscale network suite |
| 08-27 | green | **dataplane witness gate** (doorstep) |
| 08-28 | `feint images` (alpine CDN) | same |

The witness gate landed 2026-08-26 18:15, so **08-27 is the only night it has
ever been reached**. Not fixed here: the honest repair is #521's shape — ask the
doorstep *after* the stop, so the leak reddens the run that leaked — and that
needs the leaking suites fixed too. A bare `feint clean` there would hide a real
leak. The `stacks` job is immune by construction.

## Gates

`prepush` green · `docs:check` green · `falsify:lint` 899 mutations over 145
specs · two spec replays 15/15 · actionlint, zizmor, poutine clean ·
`FEINT_VM=incus-ovn mise run conformance:functional` **green 3/3**, plus six
extra single-pass runs green · host clean at the end.

## What was not obtained

- **One pass of the first three-pass run went red** on the Scaleway firewall
  pair, the same verdict shape as the planted defect. This diff touches no
  emulator code, so it is on `main`. **Not reproduced**: 6/6 green single passes
  and a clean 3/3 green run (884 s). That pass ran while the station was
  compiling and running `go test`; the perturbation is a candidate that could not
  be separated. It is in the commit body rather than swept away.
- **`mise run limits:check` is red on `main` before this branch** — the
  "#277 per-parameter half" section cites #570, closed today. Not this lot's, and
  no section was re-dated that had not been audited.
- **An internal poller's machine filter was wrong** (`scw-` against
  `feint-scw-`), so half its evidence never existed. Nothing went red under it —
  but it would have.
- `golangci-lint` reported 32 issues in files under a **deleted sibling
  worktree**: a stale cache, not code. Cleared.

## Where `testplan` was wrong

It sent a change to `tools/conformance/functional.sh` to
`conformance:leg -- fields` — **a leg with no machine runtime, the one population
this gate refuses to run in** — and never named the gate itself. Fixed in the same
lot: `rules.go` now triages `functional.sh`, `functionallib.sh` and
`runtime-mode.sh` by name onto `FEINT_VM=incus-ovn mise run conformance:functional`,
each with what it still does not prove.
