### PR TITLE
fix(machine): a machine's first boot takes the address its interface reserves, instead of trusting a guest DHCP client that declines its own lease (#587)

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -28,7 +28,7 @@
 >
 > **Prouvé** : 350 des 373 opérations montées sont pilotées par un vrai client, à chaque pull request. `scw`, `octl`, `exo`, Terraform et OpenTofu tournent contre l'émulateur en CI, et les machines démarrent réellement : connexion ssh sur le compte par défaut de chaque provider, subnets isolés, pare-feu qui filtre. La chaîne complète est décrite dans [docs/conformance.md](docs/conformance.md).
 >
-> **Pas prouvé** : quotas, prix, capacité réelle, validation des identifiants, authentification, cohérence à terme. Les 50 sections de [docs/limits.md](docs/limits.md) disent chacune ce qu'elle coûte. Un émulateur avec un seul compte implicite et aucune grille tarifaire devrait inventer ces chiffres, et quelqu'un agirait dessus.
+> **Pas prouvé** : quotas, prix, capacité réelle, validation des identifiants, authentification, cohérence à terme. Les 51 sections de [docs/limits.md](docs/limits.md) disent chacune ce qu'elle coûte. Un émulateur avec un seul compte implicite et aucune grille tarifaire devrait inventer ces chiffres, et quelqu'un agirait dessus.
 >
 > **Inconnu** : 23 opérations sont montées et n'ont jamais été pilotées par un client. Chacune dit pourquoi aucun client officiel ne l'atteint, à la route et dans [docs/routes.md](docs/routes.md). Elles sont comptées plutôt qu'escamotées, une par une, dans [coverage/evidence.json](coverage/evidence.json).
 >

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 >
 > **Proven**: 350 of the 373 mounted operations are driven by a real client, on every pull request: each pack's own official CLI, and an infrastructure engine wherever a pack admits one, all of them running against the emulator in CI, and machines really boot: an ssh login on each provider's own default account, isolated subnets, a firewall that filters. The whole chain is described in [docs/conformance.md](docs/conformance.md).
 >
-> **Not proven**: quotas, prices, real capacity, identifier validation, authentication, eventual consistency. The 50 sections of [docs/limits.md](docs/limits.md) each say what one costs. An emulator with a single implicit account and no price list would have to invent those figures, and somebody would act on them.
+> **Not proven**: quotas, prices, real capacity, identifier validation, authentication, eventual consistency. The 51 sections of [docs/limits.md](docs/limits.md) each say what one costs. An emulator with a single implicit account and no price list would have to invent those figures, and somebody would act on them.
 >
 > **Unknown**: 23 operations are mounted and have never been driven by a client. Every one of them states why no official client reaches it, at the route and in [docs/routes.md](docs/routes.md). They are counted rather than glossed, one by one, in [coverage/evidence.json](coverage/evidence.json).
 >

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -1745,6 +1745,97 @@ Until then `mise run conformance:parity` runs on demand and is deliberately not
 in the `conformance` aggregate: a red suite inside the gate every other change is
 judged by teaches people to skip the gate.
 
+## The guest's DHCP client is not how a published address reaches a machine (#587)
+
+The driver reserves the address on the NIC (`ipv4.address`) and, until
+2026-08-29, left the guest to ask for it. That worked on two of the three images
+the Outscale catalogue serves and **never** on the third, which is what a
+verdict that depends on the host looks like when the host is not the variable.
+
+One Subnet, one OVN network, one machine per image, twice each. The number is
+how long after `CreateVms` answered the machine carried the address the API had
+published, read from the runtime (`incus query /1.0/instances/<name>/state`),
+not from the emulator:
+
+| image | AMI | address carried after the create answered |
+|---|---|---|
+| `ubuntu:24.04` | `ami-00000001` | 27 ms, 32 ms |
+| `debian:12` | `ami-00000002` | 46 ms, 35 ms |
+| `alpine:3.21` | `ami-00000003` | **never** |
+
+`never` is measured, not inferred: six alpine machines, ceilings of 45 s, 90 s
+and 180 s, none of them carried it. Station of the maintainer, 2026-08-29,
+`--vm incus-ovn`, Incus 7.2, OVN 24.03.6, `CreateVms` itself 22.0–22.5 s
+throughout (#562's constant, unchanged).
+
+### Why alpine and not the other two
+
+The alpine cloud image ships **dhcpcd 10.1.0**, and `ifupdown-ng` prefers it to
+busybox's `udhcpc` whenever it is installed. dhcpcd ARP-probes the address it
+was offered before accepting it. Inside the guest:
+
+```text
+eth0: soliciting a DHCP lease
+eth0: offered 10.182.9.4 from 10.182.9.1
+eth0: probing address 10.182.9.4/24
+eth0: 10:66:6a:88:5e:54(10:66:6a:88:5e:54) claims 10.182.9.4
+eth0: DAD detected 10.182.9.4
+```
+
+once a second, for ever. The MAC that "claims" the address is not the machine's
+own (`10:66:6a:4a:aa:69` in that run) and not another machine's: it is the OVN
+**gateway router's external port**, `10.209.83.128` on `feint-uplink`. The probe
+is flooded to the network's localnet port, reaches the uplink, and the gateway
+answers it — answering ARP for the block it fronts is exactly that router's job,
+and the block is on the uplink because `ipv4.routes` puts it there so the host
+can reach the network at all. The guest reads its own address as taken, declines
+its own lease, and asks again.
+
+Ubuntu and Debian configure the interface from the lease without an ACD probe,
+so they never see the answer.
+
+### It was broken, not slow, and the budget was never the lever
+
+`tools/conformance/outscale/network.sh` waits `wait_until 24` for that address
+and expired at 24.816 s on this station while CI passed the same suite. The
+temptation is to raise 24. Three measurements say it would have been the wrong
+fix:
+
+- at the end of a 90 s wait the guest's DHCP client is **gone** — nothing is
+  asking any more, so no budget reaches it;
+- in that same guest, at that same moment, one `udhcpc` exchange is answered in
+  **97–143 ms**: the path was open the whole time;
+- waiting longer makes the DAD answer *more* certain, not less, because the
+  gateway is programmed by then. CI's green on this suite is its probe winning a
+  race, not the address arriving.
+
+### The fix, and where it sits
+
+`Incus.Start` now calls `settleFirstBoot` on the launch branch: for every NIC of
+ours that reserves an address, the address is configured inside the guest and —
+under OVN — the private aggregates are laid through the network's router. That
+is what `Attach` already does for a hot-added NIC and what `restoreGuestNetwork`
+puts back after a reboot (#548, #549); the first boot was the last door still
+trusting the lease. A device that reserves **nothing** is left to DHCP, which is
+correct and is the case #202 exists for.
+
+After it, on the same station and the same images: `alpine:3.21` carries its
+address 31 ms and 36 ms after the create answers, like the other two.
+
+### What this does not claim
+
+- It is not a statement about dhcpcd being wrong. A real cloud's DHCP server
+  does not sit behind a gateway that proxy-ARPs the block, so the probe is
+  answered here and not there.
+- Nothing was measured about `--vm incus-vm`. The same door is used, and a
+  virtual machine's `incus exec` needs its agent; no VM was booted for this.
+- The station also carried **394 stale `ovn-bridge-mappings` entries for two
+  live OVS bridges**, one added per OVN run, which made `ovn-controller` log
+  ~4 MB of `Bridge 'incusovnNNNN' not found for network 'feint-uplink'` per
+  machine creation. Pruning them changed nothing about the measurement above —
+  the alpine machines still never took their address — so it is a separate
+  matter, recorded here because it is real and nobody had looked.
+
 ## A machine's route out: which shapes reach a package repository (#507)
 
 Whether an emulated machine can reach the internet is a property of its

--- a/internal/core/machine/incus.go
+++ b/internal/core/machine/incus.go
@@ -641,6 +641,26 @@ func (d *Incus) Start(ctx context.Context, spec Spec) (Machine, error) {
 	if err := d.attachExtra(ctx, spec); err != nil {
 		return Machine{}, err
 	}
+	// The address this driver reserved must be ON the machine, and not because
+	// the guest's DHCP client agreed to it (#587). settleFirstBoot carries the
+	// measurement: alpine:3.21's dhcpcd ARP-probes the offered address, the OVN
+	// gateway answers the probe because fronting that block is its job, and the
+	// guest declines its own lease for ever — 45 s, 90 s and 180 s all measured,
+	// while ubuntu and debian were carrying theirs 30 ms after this call
+	// returned. This is the last door that still trusted DHCP: Attach configures
+	// the guest, restoreGuestNetwork puts it back after a reboot, and the first
+	// boot did neither.
+	//
+	// Not fatal, and for the same reason the restart path above is not: the
+	// machine IS running, and answering FailedState for a running machine is the
+	// lie in the other direction. What the machine carries is what the packs
+	// publish and what the network suites assert, so a failure here still shows
+	// up as itself rather than as a green run.
+	if err := d.settleFirstBoot(ctx, spec.Name); err != nil {
+		d.logger().Error("a machine did not take the address its interface reserves",
+			"machine", spec.Name, "error", err,
+			"consequence", "the machine is running and the API publishes an address it may not carry; a guest whose DHCP client refuses the offer (alpine's dhcpcd ARP-probes it and the OVN gateway answers) never gets one at all")
+	}
 	return d.inspectOrFail(ctx, spec.Name)
 }
 

--- a/internal/core/machine/incus_firstboot_test.go
+++ b/internal/core/machine/incus_firstboot_test.go
@@ -1,0 +1,178 @@
+package machine
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// The first boot owes the guest the same thing a restart does (#587).
+//
+// WHAT WAS MEASURED, and why an argument-level test is the right level for it.
+// On the maintainer's station (2026-08-29, `--vm incus-ovn`, Incus 7.2, OVN
+// 24.03.6), three machines were created on the same Subnet, twice each, and
+// asked how long after `CreateVms` answered they carried the address the API
+// had published:
+//
+//	ubuntu:24.04  (ami-…0001)   27 ms, 32 ms
+//	debian:12     (ami-…0002)   46 ms, 35 ms
+//	alpine:3.21   (ami-…0003)   never — 45 s, 90 s and 180 s ceilings, six times
+//
+// The alpine image ships dhcpcd 10.1.0, which ARP-probes the offered address
+// before accepting it; the probe reaches the uplink, the OVN gateway answers it
+// because fronting that block is its job, and the guest declines its own lease
+// for ever ("DAD detected 10.182.9.4", once a second). It is not slowness: at
+// the end of a 90 s wait the guest's client was gone and a `udhcpc` exchange in
+// that same guest was answered in 97–143 ms.
+//
+// So the driver must not depend on which DHCP client an image happens to ship,
+// and it already does not anywhere else: Attach configures the guest,
+// restoreGuestNetwork puts it back after a reboot. The first boot was the last
+// door still trusting the lease. That the runtime accepts these commands is
+// tools/conformance/outscale/network.sh's half; this is the half that holds
+// they are emitted at all, and that they are emitted for nobody else's NIC.
+
+// firstBootScript answers the calls a first Start makes: no instance before
+// `start`, one after, the devices the launch created, and the network's mask.
+func firstBootScript(f *fakeRuntime, devices string) {
+	started := false
+	f.hook = func(_ int, args []string) ([]byte, error, bool) {
+		switch args[0] {
+		case "list":
+			if started {
+				return []byte(`[{"name":"srv","status":"Running","state":{"network":{}}}]`), nil, true
+			}
+			return []byte(`[]`), nil, true
+		case "query":
+			last := args[len(args)-1]
+			if strings.HasSuffix(last, "/1.0/instances/srv") {
+				return []byte(devices), nil, true
+			}
+			if strings.Contains(last, "/1.0/networks/") {
+				return nil, errors.New("Network not found"), true
+			}
+		case "network":
+			if len(args) > 3 && args[1] == "get" && args[3] == "ipv4.address" {
+				return []byte("10.181.0.1/24\n"), nil, true
+			}
+		case "start":
+			started = true
+		}
+		return nil, nil, false
+	}
+}
+
+const firstBootPinned = `{
+  "devices": {
+    "eth0": {"type": "nic", "network": "fnt-368798629f8", "ipv4.address": "10.181.0.2"}
+  },
+  "expanded_devices": {
+    "eth0": {"type": "nic", "network": "fnt-368798629f8", "ipv4.address": "10.181.0.2"}
+  }
+}`
+
+// The test #587 names. Without settleFirstBoot on the launch branch of Start,
+// not one of these commands is emitted, and whether the machine ends up
+// carrying its address is decided by the image's DHCP client.
+func TestAFirstBootGivesTheGuestTheAddressItReserved(t *testing.T) {
+	f := &fakeRuntime{}
+	firstBootScript(f, firstBootPinned)
+	d := ovnDriver(f)
+
+	if _, err := d.Start(context.Background(), Spec{
+		Name:        "srv",
+		Image:       "alpine:3.21",
+		Attachments: []Attachment{{Network: "fnt-368798629f8", Address: "10.181.0.2"}},
+	}); err != nil {
+		t.Fatalf("start a new machine: %v", err)
+	}
+
+	// The mask is the network's, read off the runtime: an address configured as
+	// a /32 inside the guest has no connected route to its own subnet.
+	if len(f.matching("exec srv -- ip address add 10.181.0.2/24 dev eth0")) == 0 {
+		t.Errorf("a machine's first boot left its address to the guest's DHCP client:\n%s",
+			strings.Join(f.commands(), "\n"))
+	}
+	// And the routes that make the peered subnets reachable, which a lease that
+	// never arrives never lays either.
+	for _, block := range privateAggregates {
+		want := "exec srv -- ip route add " + block + " via 10.181.0.1 dev eth0"
+		if len(f.matching(want)) == 0 {
+			t.Errorf("a machine's first boot got no route to %s:\n%s",
+				block, strings.Join(f.commands(), "\n"))
+		}
+	}
+}
+
+// The refusing half, and it is the one that keeps the fix honest: a device that
+// reserves nothing is DHCP's, and inventing an address for it would put a
+// machine on an address no API published — the defect #202 removed.
+func TestAFirstBootDoesNotInventAnAddressForANICThatPinsNone(t *testing.T) {
+	const leased = `{
+	  "devices": {
+	    "eth0": {"type": "nic", "network": "fnt-368798629f8"}
+	  },
+	  "expanded_devices": {
+	    "eth0": {"type": "nic", "network": "fnt-368798629f8"}
+	  }
+	}`
+	f := &fakeRuntime{}
+	firstBootScript(f, leased)
+	d := ovnDriver(f)
+
+	if _, err := d.Start(context.Background(), Spec{
+		Name:        "srv",
+		Image:       "alpine:3.21",
+		Attachments: []Attachment{{Network: "fnt-368798629f8"}},
+	}); err != nil {
+		t.Fatalf("start a new machine: %v", err)
+	}
+	if got := f.matching("ip address add"); len(got) != 0 {
+		t.Errorf("the first boot invented an address for a NIC that pins none:\n%s",
+			strings.Join(got, "\n"))
+	}
+}
+
+// Ownership, on the second door. `ownedManagedNICs` is shared with the restart
+// path precisely so this cannot be true of one door and false of the other: a
+// NIC an operator added by hand to one of our machines is theirs, and no
+// command this path emits may name it.
+func TestAFirstBootLeavesAForeignNICAlone(t *testing.T) {
+	const foreign = `{
+	  "devices": {
+	    "eth0": {"type": "nic", "network": "fnt-368798629f8", "ipv4.address": "10.181.0.2"},
+	    "eth9": {"type": "nic", "network": "incusbr0", "ipv4.address": "10.76.154.9"}
+	  },
+	  "expanded_devices": {
+	    "eth0": {"type": "nic", "network": "fnt-368798629f8", "ipv4.address": "10.181.0.2"},
+	    "eth9": {"type": "nic", "network": "incusbr0", "ipv4.address": "10.76.154.9"}
+	  }
+	}`
+	f := &fakeRuntime{}
+	firstBootScript(f, foreign)
+	d := ovnDriver(f)
+
+	if _, err := d.Start(context.Background(), Spec{
+		Name:        "srv",
+		Image:       "alpine:3.21",
+		Attachments: []Attachment{{Network: "fnt-368798629f8", Address: "10.181.0.2"}},
+	}); err != nil {
+		t.Fatalf("start a new machine: %v", err)
+	}
+	if got := f.matching("eth9"); len(got) != 0 {
+		t.Errorf("the first boot configured a NIC on a network the emulator did not create:\n%s",
+			strings.Join(got, "\n"))
+	}
+	if got := f.matching("10.76.154.9"); len(got) != 0 {
+		t.Errorf("the first boot named an address of somebody else's network:\n%s",
+			strings.Join(got, "\n"))
+	}
+	// The accepting half in the same fixture: ours is still configured. A guard
+	// that refused everything would pass the two assertions above and break the
+	// product.
+	if len(f.matching("exec srv -- ip address add 10.181.0.2/24 dev eth0")) == 0 {
+		t.Errorf("the ownership check swallowed the emulator's own NIC:\n%s",
+			strings.Join(f.commands(), "\n"))
+	}
+}

--- a/internal/core/machine/incus_ovn.go
+++ b/internal/core/machine/incus_ovn.go
@@ -1041,29 +1041,10 @@ const (
 // TestARestartedMachineGetsItsPinnedAddressBack fail without this, the second
 // in both modes.
 func (d *Incus) restoreGuestNetwork(ctx context.Context, machine string) error {
-	devices, err := d.instanceDevices(ctx, machine)
+	devices, names, err := d.ownedManagedNICs(ctx, machine)
 	if err != nil {
 		return fmt.Errorf("inspect %s to restore its routes: %w", machine, err)
 	}
-	// Sorted, so a machine with several private NICs is repaired in the same
-	// order between two runs and a failure names the same device twice.
-	names := make([]string, 0, len(devices.own))
-	for device, cfg := range devices.own {
-		if cfg["type"] != "nic" || cfg["network"] == "" {
-			continue
-		}
-		// Ours only, and the question is asked of the name the emulator itself
-		// derives (NetworkName). This call reads a network's gateway and then
-		// writes a route inside the guest through it: a NIC an operator added
-		// by hand to one of our machines is theirs, and is left exactly as they
-		// configured it. TestRestoringRoutesLeavesAForeignNICAlone fails
-		// without this half.
-		if !ownedNetwork(cfg["network"]) {
-			continue
-		}
-		names = append(names, device)
-	}
-	slices.Sort(names)
 	for _, device := range names {
 		// The address first, when the device pins one (#548). A NIC attached
 		// to a running machine is configured inside the guest by this driver,
@@ -1095,6 +1076,109 @@ func (d *Incus) restoreGuestNetwork(ctx context.Context, machine string) error {
 		// DHCP case it was written for.
 		if err := d.waitForGuestInterface(ctx, machine, device); err != nil {
 			return err
+		}
+		if err := d.installGuestPrivateRoutes(ctx, machine, devices.own[device]["network"], device); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ownedManagedNICs answers the machine's own NIC devices that sit on a network
+// this emulator derived, sorted so two runs repair them in the same order and a
+// failure names the same device twice.
+//
+// Shared by the two doors below rather than written twice, which is this
+// repository's own rule for anything a second caller would copy: the ownership
+// half is what keeps a NIC an operator added by hand out of every command these
+// paths emit, and a copy is what one door eventually forgets.
+// TestRestoringRoutesLeavesAForeignNICAlone and
+// TestAFirstBootLeavesAForeignNICAlone fail without it, one per door.
+func (d *Incus) ownedManagedNICs(ctx context.Context, machine string) (instanceView, []string, error) {
+	devices, err := d.instanceDevices(ctx, machine)
+	if err != nil {
+		return devices, nil, err
+	}
+	names := make([]string, 0, len(devices.own))
+	for device, cfg := range devices.own {
+		if cfg["type"] != "nic" || cfg["network"] == "" {
+			continue
+		}
+		// Ours only, and the question is asked of the name the emulator itself
+		// derives (NetworkName). These calls read a network's gateway and then
+		// write inside the guest through it: a NIC an operator added by hand to
+		// one of our machines is theirs, and is left exactly as they
+		// configured it.
+		if !ownedNetwork(cfg["network"]) {
+			continue
+		}
+		names = append(names, device)
+	}
+	slices.Sort(names)
+	return devices, names, nil
+}
+
+// settleFirstBoot gives a machine that has just been created the addresses its
+// own devices reserve, and the routes that go with them.
+//
+// WHY THE FIRST BOOT NEEDS THE SAME THING AS A RESTART (#587).
+//
+// The launch pins `ipv4.address` on the NIC and then trusts the guest's DHCP
+// client to ask for it. That trust is not warranted, and the failure is not
+// slow — it is permanent, and it depends on which client the image ships:
+//
+//	image (Outscale catalogue)   address carried after CreateVms answered
+//	ubuntu:24.04  (ami-…0001)    27 ms, 32 ms
+//	debian:12     (ami-…0002)    46 ms, 35 ms
+//	alpine:3.21   (ami-…0003)    never — measured to 45 s, 90 s and 180 s
+//
+// Measured on the maintainer's station, 2026-08-29, `--vm incus-ovn`, Incus 7.2,
+// OVN 24.03.6. The alpine image ships dhcpcd 10.1.0, which ARP-probes the
+// offered address before accepting it. The probe is flooded to the network's
+// localnet port, reaches the uplink, and the OVN gateway router answers it —
+// answering ARP for the block it fronts is that router's job. The guest reads
+// its own address as taken and declines its own lease, forever:
+//
+//	eth0: offered 10.182.9.4 from 10.182.9.1
+//	eth0: probing address 10.182.9.4/24
+//	eth0: 10:66:6a:88:5e:54(10:66:6a:88:5e:54) claims 10.182.9.4
+//	eth0: DAD detected 10.182.9.4
+//
+// So the address the API published was never on the machine, `wait_until 24` in
+// tools/conformance/outscale/network.sh expired at 24.8 s, and no budget could
+// have helped: at the end of a 90 s wait the guest's client had given up, while
+// a `udhcpc` exchange in that same guest was answered in 97–143 ms. The path was
+// open the whole time. Raising the budget would only have made the DAD answer
+// more certain, which is why CI's green on the same suite is luck rather than
+// proof — its probe wins a race this station loses.
+//
+// The fix is the one the driver already makes everywhere else it reserves an
+// address: Attach configures the guest, and restoreGuestNetwork puts it back
+// after a reboot. Only the first boot was left trusting DHCP. It belongs in
+// this layer for the reason #549 gives: no pack can forget it, and a fourth
+// pack gets it without writing a line.
+//
+// Devices that pin nothing are left alone — that is the DHCP case, it is
+// correct, and inventing an address for it is exactly what this emulator must
+// not do. There is no wait here for the same reason: the address this puts on
+// the interface is the one it just reserved, so the routes that follow have
+// their connected subnet already.
+//
+// TestAFirstBootGivesTheGuestTheAddressItReserved fails without this.
+func (d *Incus) settleFirstBoot(ctx context.Context, machine string) error {
+	devices, names, err := d.ownedManagedNICs(ctx, machine)
+	if err != nil {
+		return fmt.Errorf("inspect %s to settle its interfaces: %w", machine, err)
+	}
+	for _, device := range names {
+		if devices.own[device]["ipv4.address"] == "" {
+			continue
+		}
+		if err := d.restorePinnedAddress(ctx, machine, device, devices.own[device]); err != nil {
+			return err
+		}
+		if !d.OVN {
+			continue
 		}
 		if err := d.installGuestPrivateRoutes(ctx, machine, devices.own[device]["network"], device); err != nil {
 			return err

--- a/internal/core/machine/incus_ovn.go
+++ b/internal/core/machine/incus_ovn.go
@@ -1172,16 +1172,18 @@ func (d *Incus) settleFirstBoot(ctx context.Context, machine string) error {
 	}
 	for _, device := range names {
 		if devices.own[device]["ipv4.address"] == "" {
-			continue
+			continue // DHCP owns this interface, and inventing an address for it is #202
 		}
 		if err := d.restorePinnedAddress(ctx, machine, device, devices.own[device]); err != nil {
-			return err
+			return fmt.Errorf("settle the first boot of %s: %w", machine, err)
 		}
-		if !d.OVN {
-			continue
-		}
-		if err := d.installGuestPrivateRoutes(ctx, machine, devices.own[device]["network"], device); err != nil {
-			return err
+		if d.OVN {
+			// A managed bridge has no router and no peerings, so there is
+			// nothing of this kind to lay there — the same mode split
+			// restoreGuestNetwork makes, for the same reason.
+			if err := d.installGuestPrivateRoutes(ctx, machine, devices.own[device]["network"], device); err != nil {
+				return fmt.Errorf("settle the first boot of %s: %w", machine, err)
+			}
 		}
 	}
 	return nil

--- a/tools/conformance/outscale/network.sh
+++ b/tools/conformance/outscale/network.sh
@@ -279,6 +279,18 @@ ip_b="$(printf '%s' "$vm_b_doc" | jq -r '.Vms[0].PrivateIp // empty')"
 
 # The machine must be up and carrying its address before absence of reach can
 # mean isolation rather than a machine still booting.
+#
+# 24 IS NOT A MEASUREMENT, AND RAISING IT WAS THE WRONG FIX (#587). It is the
+# `for _ in 1..12; do sleep 2; done` this line replaced, transcribed. This wait
+# expired at 24.816 s on the maintainer's station while CI passed the same
+# suite, and three measurements said the budget was never the lever: at the end
+# of a 90 s wait the guest's DHCP client was gone, a `udhcpc` exchange in that
+# same guest was answered in 97–143 ms, and the alpine machine never took its
+# address at 45 s, 90 s or 180 s. The defect was in the driver's first-boot
+# door, docs/limits.md carries the decomposition, and with it fixed the address
+# is on the machine 31–36 ms after the create answers. The number below is left
+# where it was because nothing measured asks it to move; WAIT_TRACE in
+# shared/waiting.sh is how the next reader re-derives it instead of guessing.
 booted=""
 if wait_until 24 machine_carries "feint-osc-$vm_b" "$ip_b"; then booted="yes"; fi
 [ -n "$booted" ] || fail "feint-osc-$vm_b does not carry $ip_b; cannot measure reachability"

--- a/tools/conformance/shared/waiting.sh
+++ b/tools/conformance/shared/waiting.sh
@@ -67,20 +67,53 @@
 # condition here is one `incus exec`, tens of milliseconds.
 WAIT_POLL="${WAIT_POLL:-0.25}"
 
-# --- INSTRUMENT (temporary, #587) --------------------------------------------
+# --- THE INSTRUMENT (#587) ---------------------------------------------------
+#
+# A budget nobody measured is a number, and every budget in these suites is one
+# until something records what the wait actually cost. #587 is what that costs:
+# `wait_until 24` was 12 iterations of `sleep 2` converted by hand, it fails on
+# the maintainer's station and passes in CI, and no artefact anywhere said how
+# long the wait it replaced had ever taken.
+#
+# WAIT_TRACE names a file; every wait appends one tab-separated row to it —
+# suite, kind, verdict, the budget the CALLER asked for, the seconds it really
+# took, and the condition. WAIT_SCALE multiplies every budget without editing a
+# call site, so "is it slow or is it broken" is asked in one run.
+#
+# Both are off unless set, so a suite run without them behaves exactly as
+# before. TestTheWaitsRecordWhatTheyCostWhenAskedTo holds that, and holds that
+# the row carries the budget as asked rather than as scaled — a trace that
+# reported the scaled number would make every scaled run look like a suite whose
+# budgets had already been raised.
 WAIT_TRACE="${WAIT_TRACE:-}"
 WAIT_SCALE="${WAIT_SCALE:-1}"
 
 _wait_now() { date +%s%N; }
+# The suite's name is its directory and its file: three of the four runtime
+# suites are called `network.sh`, so `basename` alone collapsed scaleway,
+# outscale and exoscale into one label and a distribution read off it was the
+# sum of three different populations.
+_wait_suite() {
+  local file=${0##*/} path=${0%/*}
+  if [ "$path" = "$0" ]; then
+    printf '%s' "$file"
+  else
+    printf '%s/%s' "${path##*/}" "$file"
+  fi
+}
 _wait_record() { # kind verdict budget started command...
-  [ -n "$WAIT_TRACE" ] || return 0
+  # `${WAIT_TRACE:-}`, not `$WAIT_TRACE`: the suites run under `set -u`, and a
+  # caller that unsets the variable after sourcing this file would abort the
+  # whole suite on an instrument nobody asked for. Absent and empty both mean
+  # "record nothing".
+  [ -n "${WAIT_TRACE:-}" ] || return 0
   local kind=$1 verdict=$2 budget=$3 started=$4
   shift 4
   local now elapsed
   now="$(_wait_now)"
   elapsed=$(((now - started) / 1000000))
   printf '%s\t%s\t%s\t%s\t%s.%03d\t%s\n' \
-    "$(basename "$0")" "$kind" "$verdict" "$budget" \
+    "$(_wait_suite)" "$kind" "$verdict" "$budget" \
     "$((elapsed / 1000))" "$((elapsed % 1000))" "$*" >>"$WAIT_TRACE"
 }
 # -----------------------------------------------------------------------------

--- a/tools/conformance/shared/waiting.sh
+++ b/tools/conformance/shared/waiting.sh
@@ -67,6 +67,24 @@
 # condition here is one `incus exec`, tens of milliseconds.
 WAIT_POLL="${WAIT_POLL:-0.25}"
 
+# --- INSTRUMENT (temporary, #587) --------------------------------------------
+WAIT_TRACE="${WAIT_TRACE:-}"
+WAIT_SCALE="${WAIT_SCALE:-1}"
+
+_wait_now() { date +%s%N; }
+_wait_record() { # kind verdict budget started command...
+  [ -n "$WAIT_TRACE" ] || return 0
+  local kind=$1 verdict=$2 budget=$3 started=$4
+  shift 4
+  local now elapsed
+  now="$(_wait_now)"
+  elapsed=$(((now - started) / 1000000))
+  printf '%s\t%s\t%s\t%s\t%s.%03d\t%s\n' \
+    "$(basename "$0")" "$kind" "$verdict" "$budget" \
+    "$((elapsed / 1000))" "$((elapsed % 1000))" "$*" >>"$WAIT_TRACE"
+}
+# -----------------------------------------------------------------------------
+
 # wait_until <seconds> <command...> — poll until the command succeeds.
 #
 # Answers 0 as soon as it does, and 1 if the budget runs out. The caller keeps
@@ -82,12 +100,18 @@ WAIT_POLL="${WAIT_POLL:-0.25}"
 wait_until() { # seconds command...
   local budget="$1"
   shift
+  local asked="$budget"
+  budget=$((budget * WAIT_SCALE))
+  local started
+  started="$(_wait_now)"
   local deadline=$((SECONDS + budget + 1))
   while :; do
     if "$@"; then
+      _wait_record until held "$asked" "$started" "$@"
       return 0
     fi
     if [ "$SECONDS" -ge "$deadline" ]; then
+      _wait_record until EXPIRED "$asked" "$started" "$@"
       return 1 # the budget ran out and the condition never held
     fi
     sleep "$WAIT_POLL"
@@ -104,12 +128,18 @@ wait_until() { # seconds command...
 wait_gone() { # seconds command...
   local budget="$1"
   shift
+  local asked="$budget"
+  budget=$((budget * WAIT_SCALE))
+  local started
+  started="$(_wait_now)"
   local deadline=$((SECONDS + budget + 1))
   while :; do
     if ! "$@"; then
+      _wait_record gone held "$asked" "$started" "$@"
       return 0
     fi
     if [ "$SECONDS" -ge "$deadline" ]; then
+      _wait_record gone EXPIRED "$asked" "$started" "$@"
       return 1 # the budget ran out and the object is still there
     fi
     sleep "$WAIT_POLL"

--- a/tools/conformance/waiting_test.go
+++ b/tools/conformance/waiting_test.go
@@ -212,10 +212,12 @@ func TestTheWaitsRecordWhatTheyCostWhenAskedTo(t *testing.T) {
 	dir := t.TempDir()
 	trace := filepath.Join(dir, "trace.tsv")
 
-	// Budget 1 at scale 2: the expiry must wait the SCALED budget, so an
-	// elapsed under two seconds means WAIT_SCALE was ignored.
+	// Budget 1 at scale 3: unscaled, `wait_until 1 false` gives up at about two
+	// seconds (the budget plus the one-second rounding the file explains), and
+	// scaled it must run to about four. The threshold sits between the two, so
+	// a multiplier that is ignored is measured rather than argued about.
 	script := `
-export WAIT_TRACE="$1" WAIT_SCALE=2
+export WAIT_TRACE="$1" WAIT_SCALE=3
 if wait_until 1 false; then echo "verdict=passed"; else echo "verdict=failed"; fi
 `
 	start := time.Now()
@@ -247,16 +249,17 @@ if wait_until 1 false; then echo "verdict=passed"; else echo "verdict=failed"; f
 		t.Errorf("a wait whose condition never held is traced %q, so the trace disagrees with "+
 			"the verdict the suite drew", fields[2])
 	}
-	// The property worth a test: 1, not 2. The scale is a lever on the run, not
+	// The property worth a test: 1, not 3. The scale is a lever on the run, not
 	// a rewrite of what the suite asks for.
 	if fields[3] != "1" {
 		t.Errorf("the row reports budget %q where the caller asked for 1; under WAIT_SCALE the "+
 			"trace would then describe budgets nobody wrote, and a distribution read off it "+
 			"would justify raising a number that had already been raised", fields[3])
 	}
-	if elapsed < 2*time.Second {
-		t.Errorf("wait_until 1 under WAIT_SCALE=2 gave up after %s: the multiplier did not "+
-			"reach the budget, so a scaled run measures the unscaled wait", elapsed)
+	if elapsed < 3500*time.Millisecond {
+		t.Errorf("wait_until 1 under WAIT_SCALE=3 gave up after %s, which is the unscaled "+
+			"budget: the multiplier never reached it, so a scaled run measures the "+
+			"unscaled wait", elapsed)
 	}
 
 	// The other half. Unset, the instrument must not exist: these suites run in

--- a/tools/conformance/waiting_test.go
+++ b/tools/conformance/waiting_test.go
@@ -212,10 +212,17 @@ func TestTheWaitsRecordWhatTheyCostWhenAskedTo(t *testing.T) {
 	dir := t.TempDir()
 	trace := filepath.Join(dir, "trace.tsv")
 
-	// Budget 1 at scale 3: unscaled, `wait_until 1 false` gives up at about two
-	// seconds (the budget plus the one-second rounding the file explains), and
-	// scaled it must run to about four. The threshold sits between the two, so
-	// a multiplier that is ignored is measured rather than argued about.
+	// Budget 1 at scale 3, and the threshold below is derived rather than
+	// picked. The wait ends when `SECONDS` reaches budget+1, and `SECONDS`
+	// ticks on the shell's own integer boundary, so a shell started at X.99
+	// sees it a hundredth of a second later: unscaled the wait lasts between
+	// 1 and 2 seconds, scaled between 3 and 4. 2.5 s is the midpoint of the
+	// gap, which is the only value that separates them on every host.
+	//
+	// The first version asserted 3.5 s and went red under `go test -race` at
+	// 3.27 s — a threshold inside the scaled band rather than between the two
+	// bands, which is the harness failing before its subject. It is written
+	// down because that is the mistake this repository keeps paying for.
 	script := `
 export WAIT_TRACE="$1" WAIT_SCALE=3
 if wait_until 1 false; then echo "verdict=passed"; else echo "verdict=failed"; fi
@@ -256,10 +263,10 @@ if wait_until 1 false; then echo "verdict=passed"; else echo "verdict=failed"; f
 			"trace would then describe budgets nobody wrote, and a distribution read off it "+
 			"would justify raising a number that had already been raised", fields[3])
 	}
-	if elapsed < 3500*time.Millisecond {
-		t.Errorf("wait_until 1 under WAIT_SCALE=3 gave up after %s, which is the unscaled "+
-			"budget: the multiplier never reached it, so a scaled run measures the "+
-			"unscaled wait", elapsed)
+	if elapsed < 2500*time.Millisecond {
+		t.Errorf("wait_until 1 under WAIT_SCALE=3 gave up after %s, which is inside the "+
+			"UNSCALED band of one to two seconds: the multiplier never reached the budget, "+
+			"so a scaled run measures the unscaled wait", elapsed)
 	}
 
 	// The other half. Unset, the instrument must not exist: these suites run in

--- a/tools/conformance/waiting_test.go
+++ b/tools/conformance/waiting_test.go
@@ -188,3 +188,91 @@ func runWaiting(t *testing.T, script string, args ...string) string {
 	}
 	return string(out)
 }
+
+// The instrument (#587), and the two properties that make its numbers usable.
+//
+// WHY IT IS IN THE TREE RATHER THAN IN A BRANCH. Every budget in the runtime
+// suites is a number nobody has re-derived: #459 converted 36 fixed sleeps into
+// polls and chose their budgets by hand from the loops it replaced — `wait_until
+// 24` is `for _ in 1..12; do sleep 2; done` transcribed — and nothing since has
+// measured one. #587 is the bill: a wait that fails on the maintainer's station,
+// passes in CI, and had no artefact anywhere saying what it ever cost.
+// WAIT_TRACE is what turns "raise it" into "measure it", and WAIT_SCALE is what
+// asks "slow or broken" in one run instead of by editing twenty call sites.
+//
+// The two halves below are what keep it from becoming a second thing to trust:
+//
+//  1. unset, it changes nothing — no file, no output, the same verdicts;
+//  2. the row reports the budget the CALLER asked for, never the scaled one, or
+//     every scaled run would read as a suite whose budgets had already been
+//     raised, which is the exact confusion the trace exists to end.
+//
+// tools/falsify/specs/waiting-is-not-sleeping.json replays both.
+func TestTheWaitsRecordWhatTheyCostWhenAskedTo(t *testing.T) {
+	dir := t.TempDir()
+	trace := filepath.Join(dir, "trace.tsv")
+
+	// Budget 1 at scale 2: the expiry must wait the SCALED budget, so an
+	// elapsed under two seconds means WAIT_SCALE was ignored.
+	script := `
+export WAIT_TRACE="$1" WAIT_SCALE=2
+if wait_until 1 false; then echo "verdict=passed"; else echo "verdict=failed"; fi
+`
+	start := time.Now()
+	out := runWaiting(t, script, trace)
+	elapsed := time.Since(start)
+
+	if !strings.Contains(out, "verdict=failed") {
+		t.Fatalf("the instrument changed the verdict of a condition that is never true:\n%s", out)
+	}
+	body, err := os.ReadFile(trace) //nolint:gosec // a path this test just made
+	if err != nil {
+		t.Fatalf("the wait wrote no trace though WAIT_TRACE named one: %v", err)
+	}
+	rows := strings.Split(strings.TrimSpace(string(body)), "\n")
+	if len(rows) != 1 {
+		t.Fatalf("expected one traced wait, got %d:\n%s", len(rows), body)
+	}
+	fields := strings.Split(rows[0], "\t")
+	if len(fields) != 6 {
+		t.Fatalf("a trace row is six tab-separated fields (suite, kind, verdict, "+
+			"budget asked, seconds, condition), got %d: %q", len(fields), rows[0])
+	}
+	if fields[0] != "waiting-test" {
+		t.Errorf("the row names the suite %q, not the script that ran the wait; a trace whose "+
+			"first field cannot tell scaleway/network.sh from outscale/network.sh sums three "+
+			"populations into one distribution", fields[0])
+	}
+	if fields[2] != "EXPIRED" {
+		t.Errorf("a wait whose condition never held is traced %q, so the trace disagrees with "+
+			"the verdict the suite drew", fields[2])
+	}
+	// The property worth a test: 1, not 2. The scale is a lever on the run, not
+	// a rewrite of what the suite asks for.
+	if fields[3] != "1" {
+		t.Errorf("the row reports budget %q where the caller asked for 1; under WAIT_SCALE the "+
+			"trace would then describe budgets nobody wrote, and a distribution read off it "+
+			"would justify raising a number that had already been raised", fields[3])
+	}
+	if elapsed < 2*time.Second {
+		t.Errorf("wait_until 1 under WAIT_SCALE=2 gave up after %s: the multiplier did not "+
+			"reach the budget, so a scaled run measures the unscaled wait", elapsed)
+	}
+
+	// The other half. Unset, the instrument must not exist: these suites run in
+	// CI and on a maintainer's station with nothing set, and a trace that wrote
+	// a file or a line there would be a side effect nobody asked for.
+	silent := filepath.Join(dir, "unasked.tsv")
+	out = runWaiting(t, `
+unset WAIT_TRACE
+export WAIT_SCALE=1
+if wait_until 1 false; then echo "verdict=passed"; else echo "verdict=failed"; fi
+`, silent)
+	if !strings.Contains(out, "verdict=failed") {
+		t.Errorf("without WAIT_TRACE the wait changed its verdict:\n%s", out)
+	}
+	if _, err := os.Stat(silent); !os.IsNotExist(err) {
+		t.Errorf("a trace file appeared with WAIT_TRACE unset (%v): the instrument is supposed "+
+			"to be absent unless asked for", err)
+	}
+}

--- a/tools/falsify/specs/first-boot-takes-its-address.json
+++ b/tools/falsify/specs/first-boot-takes-its-address.json
@@ -1,0 +1,19 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "the first boot skips the devices that reserve an address and settles the ones that do not, so whether a machine carries the address its API published is decided by the image's DHCP client again (#587)",
+      "file": "internal/core/machine/incus_ovn.go",
+      "find": "\t\tif devices.own[device][\"ipv4.address\"] == \"\" {\n\t\t\tcontinue // DHCP owns this interface, and inventing an address for it is #202",
+      "replace": "\t\tif devices.own[device][\"ipv4.address\"] != \"\" {\n\t\t\tcontinue // DHCP owns this interface, and inventing an address for it is #202",
+      "test": "TestAFirstBootGivesTheGuestTheAddressItReserved"
+    },
+    {
+      "label": "the ownership half the two doors share stops excluding foreign NICs, so a first boot configures an interface an operator added to one of our machines by hand (#587)",
+      "file": "internal/core/machine/incus_ovn.go",
+      "find": "\t\tif !ownedNetwork(cfg[\"network\"]) {\n\t\t\tcontinue\n\t\t}\n\t\tnames = append(names, device)",
+      "replace": "\t\tif !ownedNetwork(cfg[\"network\"]) && device == \"\\x00never\" {\n\t\t\tcontinue\n\t\t}\n\t\tnames = append(names, device)",
+      "test": "TestAFirstBootLeavesAForeignNICAlone"
+    }
+  ]
+}

--- a/tools/falsify/specs/waiting-is-not-sleeping.json
+++ b/tools/falsify/specs/waiting-is-not-sleeping.json
@@ -21,6 +21,20 @@
       "find": "# waits on silence: the verdict below is drawn from a connection that does NOT",
       "replace": "# it waits on the silence, and the verdict below is drawn from a connection that does NOT",
       "test": "TestEveryFixedSleepInARuntimeSuiteSaysWhatItWaitsFor"
+    },
+    {
+      "label": "the trace reports the SCALED budget instead of the one the caller asked for, so every WAIT_SCALE run reads as a suite whose budgets had already been raised (#587)",
+      "file": "tools/conformance/shared/waiting.sh",
+      "find": "      _wait_record until EXPIRED \"$asked\" \"$started\" \"$@\"",
+      "replace": "      _wait_record until EXPIRED \"${asked:+$budget}\" \"$started\" \"$@\"",
+      "test": "TestTheWaitsRecordWhatTheyCostWhenAskedTo"
+    },
+    {
+      "label": "WAIT_SCALE stops reaching the budget, so the one run that answers 'slow or broken' silently measures the unscaled wait (#587)",
+      "file": "tools/conformance/shared/waiting.sh",
+      "find": "wait_until() { # seconds command...\n  local budget=\"$1\"\n  shift\n  local asked=\"$budget\"\n  budget=$((budget * WAIT_SCALE))",
+      "replace": "wait_until() { # seconds command...\n  local budget=\"$1\"\n  shift\n  local asked=\"$budget\"\n  budget=$((budget * WAIT_SCALE / WAIT_SCALE))",
+      "test": "TestTheWaitsRecordWhatTheyCostWhenAskedTo"
     }
   ]
 }


### PR DESCRIPTION
Closes #587.

## Verdict: **broken**, not slow — and the budget was never the lever

The leg reproduced on the maintainer's station at the step #587 names:
`wait_until 24` **expired at 24.816 s** on
`feint-osc-… does not carry 10.184.1.4`.

Then the ceiling measurements — one Net, one Subnet, one alpine Vm, `--vm
incus-ovn`:

| iter | `CreateVms` | ceiling | address carried | guest DHCP client alive at the end | manual `udhcpc` in that guest |
|---|--:|--:|---|---|---|
| 1 | 22.185 s | 90 s | **never** | no | **answered in 135 ms** |
| 2 | 22.064 s | 90 s | **never** | no | 143 ms |
| 3 | 22.151 s | 90 s | **never** | no | 110 ms |
| 4 | 22.157 s | 90 s | **never** | no | 97 ms |

Two earlier machines went never at a **180 s** ceiling.

The address never arrives, **the guest has stopped asking**, and the path is open
the whole time — a hand `udhcpc` in that same guest answers in about a tenth of a
second. **No budget reaches a client that has exited.** Raising 24 would have
been wrong, and it stays 24 with a note saying what raising it would have missed.

## The cause

Split by image, same Subnet, twice each. This is the measurement that ends the
argument:

| image | address carried after the create answered |
|---|---|
| `ubuntu:24.04` | 27 ms, 32 ms |
| `debian:12` | 46 ms, 35 ms |
| **`alpine:3.21`** | **never** — 6 of 6 machines, at 45, 90 and 180 s |

The alpine cloud image ships **dhcpcd 10.1.0**, which **ARP-probes the offered
address**. From `/var/log/messages` inside the guest, once a second, for ever:

```
eth0: offered 10.182.9.4 from 10.182.9.1
eth0: probing address 10.182.9.4/24
eth0: 10:66:6a:88:5e:54 claims 10.182.9.4
eth0: DAD detected 10.182.9.4
```

The claiming MAC is neither the guest's own nor another machine's: it is the
**OVN gateway router's external port**. The probe floods to the localnet port,
reaches the uplink, and the gateway answers — **fronting that block is its job**,
and the block is on the uplink because `ipv4.routes` puts it there so the host
can reach the network at all. The guest reads its own address as taken and
**declines its own lease**.

## Station versus CI: CI's green is luck

Not a version difference — station Incus 7.2 / OVN 24.03.6, CI Zabbly stable with
Ubuntu's OVN, same family. It is a race the station **loses because it is
slower**: `incus start` under OVN is 10.4 s here (#562), so by the time alpine's
dhcpcd probes, the gateway is programmed and answers.

**A longer budget would have made the failure more certain, not less.**

That also explains #562's shape without widening into it: the same 22.0–22.5 s
`CreateVms` constant reappeared in every measurement above.

## The fix

`Start` now calls `settleFirstBoot` on the launch branch: for every NIC of ours
that **reserves** an address, the address is put in the guest and, under OVN, the
private aggregates are laid.

That is precisely what `Attach` already does for a hot NIC (#548) and what
`restoreGuestNetwork` does after a reboot (#549). **The first boot was the last
door still trusting the guest's DHCP client.** Devices that pin nothing stay
DHCP's, per #202. Non-fatal, like the restart path.

The ownership half is `ownedManagedNICs`, **shared by both doors rather than
copied** — a control recopied into each caller is a control one caller forgets.

After it, same station, same images: alpine carries its address in **31 ms and
36 ms**.

## Runs

**`FEINT_VM=incus-ovn mise run conformance:leg -- runtime`: four runs, all rc=0**,
all four suites green each time (651 s the first). Runs 1, 3 and 4 had the tree
untouched throughout.

**Run 2 is reported and not counted**: a hand falsification held mutations in
`shared/waiting.sh` for a few seconds inside its window, so its population is not
one this branch may claim.

`prepush` green · `conformance:leg -- fields` green · both falsify specs fully
red by hand against a warm cache — `first-boot-takes-its-address.json` (2) and
`waiting-is-not-sleeping.json` (5, including 2 new) · `falsify --lint` 966
mutations over 150 specs, every fragment still applying.

## The instrument stays

`WAIT_TRACE` and `WAIT_SCALE` in `shared/waiting.sh`, completed and tested. The
trace row now names `outscale/network.sh` rather than `network.sh` — three suites
share that basename, and a distribution read off it **summed three populations**.
`TestTheWaitsRecordWhatTheyCostWhenAskedTo` holds both load-bearing properties:
unset it writes nothing and changes no verdict; set, the row reports the budget
**as asked**, not as scaled.

It is the only thing that turns *"raise it"* into *"measure it"*.

**And the harness lied once, caught by prepush**: the first threshold was 3.5 s,
inside the *scaled* band, and went red under `-race` at 3.27 s. It is 2.5 s now,
derived as the midpoint between the unscaled and scaled bands, with the mistake
written into the test.

## The other budgets — a finding, untouched

Across the four green runs the instrument recorded **156 waits, zero expired**.
The slowest observation in the whole leg is **1.059 s**, against budgets of
20–90 s; the `machine_carries` waits are 0.015–0.030 s against 20, 24 and 60.

Every remaining budget is one to three orders of magnitude above what it waits
for. **None was changed**: nothing measured asks them to move, and a budget too
large costs nothing while a budget too small is what #587 was. Worth an issue —
*re-derive the eight kept budgets from a `WAIT_TRACE` distribution* — not a lot to
do here.

## What was not obtained

- **`--vm incus-vm` was not measured.** The new door is on the shared path, but
  no VM was booted; the gap is written into `docs/limits.md`.
- **Why CI's probe wins the race was not measured**, only that it must.
- **A station finding that is not this defect**: 394 stale `ovn-bridge-mappings`
  entries for two live OVS bridges, one added per OVN run, making `ovn-controller`
  log ~4 MB per machine creation. Pruned — every dropped entry named a bridge
  that no longer existed — **and it changed nothing**: the alpine machines still
  never took their address. Real, ours, and not #587. No issue opened.

## Where `testplan` was loose

It named `conformance:leg -- fields` *"because the helpers every suite sources,
waiting included"* — `shared/waiting.sh` is sourced by exactly the four **runtime**
suites, none of which run in `fields`. It routes on the path, not on who reads
it, so it over-named rather than under-named. `fields` was run anyway; green.
Everything else it named was right, and the leg it put first is the one that
carried the defect.
