### PR TITLE
docs: the command table becomes two tables because it was two audiences, and the page that answers "is this for me" is asked before the install (#591)

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -174,19 +174,21 @@ l'enregistre.
 
 La question se pose avant d'installer quoi que ce soit, et sa réponse est
 ailleurs qu'ici : **[ce que vous pouvez valider](docs/confidence.md)** est une
-page et un tableau, et il pose la question dans votre vocabulaire plutôt que dans
-celui du projet. Une ligne est une chose que vous pourriez vouloir tester ; son
+page et un tableau qui y répondent dans votre vocabulaire plutôt que dans celui
+du projet. Une ligne est une chose que vous pourriez vouloir tester ; son
 verdict porte ce qui l'établit : la suite qui le pilote, la capacité de runtime
 sur laquelle il s'appuie, ou la section de
 [ce qu'il ne fait pas](docs/limits.md) qui dit pourquoi la réponse est non. Une
 ligne qui ne pointe vers rien est refusée par un test, pas par un relecteur.
 
-Cette page est délibérément le seul endroit où ces verdicts sont écrits. En
-recopier six ici mettrait la réponse là où vous êtes, et l'y mettrait fausse en
-moins d'une version : une phrase de la ligne 41 de la page anglaise a contredit
-ce tableau pendant deux jours en août, à travers tous les contrôles de
-documentation verts de l'intervalle. La vue opération par opération, elle, est
-générée : [docs/routes.md](docs/routes.md).
+Cette page est délibérément le seul endroit où ces verdicts sont écrits, et
+celle-ci n'en recopie aucun. La promesse du démarrage rapide est générée depuis
+la matrice de capacités pour cette raison exacte : la phrase qu'un humain y
+tapait revendiquait un client que cet émulateur refuse au portillon, et elle a
+contredit la page de confiance pendant deux jours, à travers tous les contrôles
+de documentation verts de l'intervalle (#592). Un tableau recopié ici serait le
+même défaut, avec six lignes au lieu d'une. La vue opération par opération, elle,
+est générée : [docs/routes.md](docs/routes.md).
 
 ---
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -170,9 +170,30 @@ l'enregistre.
 
 ---
 
+## Savoir si feint convient à votre test
+
+La question se pose avant d'installer quoi que ce soit, et sa réponse est
+ailleurs qu'ici : **[ce que vous pouvez valider](docs/confidence.md)** est une
+page et un tableau, et il pose la question dans votre vocabulaire plutôt que dans
+celui du projet. Une ligne est une chose que vous pourriez vouloir tester ; son
+verdict porte ce qui l'établit : la suite qui le pilote, la capacité de runtime
+sur laquelle il s'appuie, ou la section de
+[ce qu'il ne fait pas](docs/limits.md) qui dit pourquoi la réponse est non. Une
+ligne qui ne pointe vers rien est refusée par un test, pas par un relecteur.
+
+Cette page est délibérément le seul endroit où ces verdicts sont écrits. En
+recopier six ici mettrait la réponse là où vous êtes, et l'y mettrait fausse en
+moins d'une version : une phrase de la ligne 41 de la page anglaise a contredit
+ce tableau pendant deux jours en août, à travers tous les contrôles de
+documentation verts de l'intervalle. La vue opération par opération, elle, est
+générée : [docs/routes.md](docs/routes.md).
+
+---
+
 ## Sommaire
 
 - [Démarrage rapide](#démarrage-rapide)
+- [Savoir si feint convient à votre test](#savoir-si-feint-convient-à-votre-test)
 - [Installer](#installer)
 - [S'en servir](#sen-servir)
 - [La page](#la-page)

--- a/README.fr.md
+++ b/README.fr.md
@@ -525,6 +525,17 @@ sont pas encore appliqués : [docs/conformance.fr.md](docs/conformance.fr.md).
 cette page ne nomme pas est un verbe que seul un lecteur du code trouvera, et
 c'est arrivé à dix d'entre eux avant qu'un test compare les deux listes.
 
+Les codes de sortie sont stables, parce que la CI en dépend : **0** succès,
+**1** erreur, **2** dérive détectée.
+
+Deux tableaux, parce que ce sont deux publics. Si vous venez pointer un client
+vers un cloud local, le premier est toute la surface qui vous concerne et vous
+pouvez arrêter votre lecture à la fin. Le second mesure la fidélité de ce
+cloud : c'est ce que ce dépôt exécute sur lui-même, et rien de ce qu'il contient
+n'est une étape dans le travail de qui que ce soit.
+
+### Usage quotidien
+
 | commande | ce qu'elle fait |
 | --- | --- |
 | `feint serve` | les trois clouds émulés sur un port, au premier plan |
@@ -540,6 +551,18 @@ c'est arrivé à dix d'entre eux avant qu'un test compare les deux listes.
 | `feint doctor` | diagnostique l'hôte : le port, le runtime, les clients |
 | `feint env <provider>` | l'environnement dont un vrai client de ce provider a besoin |
 | `feint snapshot` | nomme l'état d'un émulateur qui tourne et y revient : `save`, `load`, `list`, `rm` |
+| `feint images` | construit les images de machines, qui portent un démon ssh pour répondre sans dépôt de paquets |
+| `feint clean` | retire les machines, réseaux et jeux de règles que l'émulateur a créés |
+| `feint version` | affiche la version |
+
+### Outils de fidélité et de développement
+
+Ils répondent à la question *à quelle distance du vrai cloud sommes-nous*, et
+leur sujet est [docs/conformance.fr.md](docs/conformance.fr.md), pas le
+Terraform de qui que ce soit.
+
+| commande | ce qu'elle fait |
+| --- | --- |
 | `feint coverage` | la surface amont servie, déclinée ou non triée |
 | `feint proxy` | enregistre ce qu'un vrai client et un vrai cloud se disent, identifiants masqués |
 | `feint transcript` | lit un enregistrement : quoi servir ensuite, quelle forme, ce que l'émulateur omet |
@@ -548,14 +571,8 @@ c'est arrivé à dix d'entre eux avant qu'un test compare les deux listes.
 | `feint probe` | pilote chaque route montée depuis sa description d'API et contrôle les réponses |
 | `feint shapes` | ce qu'un vrai cloud renvoie, et ce que l'émulateur en omet |
 | `feint evidence` | écrit le registre de preuves qu'une exécution de conformance a gagnées, opération par opération |
-| `feint images` | construit les images de machines, qui portent un démon ssh pour répondre sans dépôt de paquets |
 | `feint docs` | régénère les tableaux de couverture de cette page |
 | `feint catalog` | affiche l'inventaire émulé qu'un client lit avant de créer |
-| `feint clean` | retire les machines, réseaux et jeux de règles que l'émulateur a créés |
-| `feint version` | affiche la version |
-
-Les codes de sortie sont stables, parce que la CI en dépend : **0** succès,
-**1** erreur, **2** dérive détectée.
 
 `feint replay` et `feint coverage --observed` ferment la boucle que `feint
 proxy` ouvre. Le premier renvoie chaque requête enregistrée à l'émulateur et

--- a/README.fr.md
+++ b/README.fr.md
@@ -205,6 +205,9 @@ générée : [docs/routes.md](docs/routes.md).
 - [Contribuer](#contribuer)
 - [Licence](#licence)
 
+Tout ce qui n'est pas sur cette page vit dans [docs/](docs/README.md), regroupé
+par la question à laquelle il répond plutôt que listé.
+
 ---
 
 ## Installer

--- a/README.md
+++ b/README.md
@@ -931,6 +931,19 @@ rather than assumed.
 
 ## Commands
 
+`feint --help` gives the flags. Exit codes are stable because CI depends on
+them: **0** ok, **1** error, **2** drift detected. `status` is the one verb that
+always exits 0, because a stopped emulator is a fact rather than a failure — the
+verb that gates is `wait`.
+
+Two tables, because they are two audiences. If you came here to point a client
+at a local cloud, the first one is the whole surface you need and you can stop
+reading at the end of it. The second measures how faithful that cloud is: it is
+what this repository runs on itself, and none of it is a step in anybody's
+workflow.
+
+### Everyday use
+
 | Command | What it does |
 |---|---|
 | `feint up` | read `feint.yaml` and bring the whole environment up: check the host, start the emulator, export the client environment, run the engine, wait for the ready conditions |
@@ -946,6 +959,17 @@ rather than assumed.
 | `feint doctor` | diagnose the host: the port, the machine runtime, the clients, the ssh trap |
 | `feint snapshot` | `save`, `load`, `list`, `rm` — name a running emulator's state and come back to it |
 | `feint serve` | serve the three emulated clouds on one port, in the foreground |
+| `feint images` | build the machine images, which carry an ssh daemon so a machine answers without a package repository |
+| `feint clean` | remove every machine, network and rule set the emulator created |
+| `feint version` | print the version |
+
+### Fidelity and development tools
+
+These answer *how close to the real cloud is this*, and they are the subject of
+[docs/conformance.md](docs/conformance.md) rather than of anybody's Terraform.
+
+| Command | What it does |
+|---|---|
 | `feint coverage` | compare the upstream API surface with what the packs serve |
 | `feint proxy` | sit between a real client and a real cloud and record every exchange, credentials redacted |
 | `feint transcript` | read a recording: what to serve next, what a response must look like, what the emulator omits |
@@ -954,16 +978,8 @@ rather than assumed.
 | `feint probe` | drive every mounted route from its API description and check the answers |
 | `feint shapes` | the field trees a real cloud returns, versioned — and what this emulator omits from them |
 | `feint evidence` | write the per-operation evidence record a conformance run earned |
-| `feint images` | build the machine images, which carry an ssh daemon so a machine answers without a package repository |
 | `feint docs` | regenerate the coverage tables in this README |
 | `feint catalog` | print the emulated inventory a client reads before creating |
-| `feint clean` | remove every machine, network and rule set the emulator created |
-| `feint version` | print the version |
-
-`feint --help` gives the flags. Exit codes are stable because CI depends on
-them: **0** ok, **1** error, **2** drift detected. `status` is the one verb that
-always exits 0, because a stopped emulator is a fact rather than a failure — the
-verb that gates is `wait`.
 
 `feint proxy` and `feint transcript` are the record-then-read pair that turns a
 real client against a real cloud into the next operation to serve, the shape its

--- a/README.md
+++ b/README.md
@@ -160,17 +160,19 @@ It needs Incus with OVN; `mise run demo:network` records it.
 
 Ask before installing anything, and read the answer somewhere other than here:
 **[what you can validate](docs/confidence.md)** is one page and one table, and it
-asks the question in your vocabulary rather than this project's. A row is a thing
-you might want to test; its verdict carries whatever establishes it — the suite
+answers that question in your vocabulary rather than this project's. A row is a
+thing you might want to test; its verdict carries whatever establishes it — the suite
 that drives it, the runtime capability it keys on, or the section of
 [what it does not do](docs/limits.md) that says why the answer is no. A row with
 nothing to point at is refused by a test rather than by a reviewer.
 
-That page is deliberately the only place those verdicts are written. Copying six
-of them onto this one would put the answer where you are, and put it there
-wrongly within a release: a sentence on line 41 of this file contradicted that
-page for two days in August, through every green documentation gate in between.
-The per-operation view, which is generated, is [docs/routes.md](docs/routes.md).
+That page is deliberately the only place those verdicts are written, and this one
+copies none of them. The promise above it is generated from the capability matrix
+for exactly that reason: the sentence a human used to type there claimed a client
+this emulator refuses at the doorstep, and it contradicted the confidence page
+for two days through every green documentation gate in between (#592). A table
+recopied here would be that defect again, with six rows instead of one. The
+per-operation view, which is generated, is [docs/routes.md](docs/routes.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -156,9 +156,28 @@ It needs Incus with OVN; `mise run demo:network` records it.
 
 ---
 
+## Is this the right tool for your test?
+
+Ask before installing anything, and read the answer somewhere other than here:
+**[what you can validate](docs/confidence.md)** is one page and one table, and it
+asks the question in your vocabulary rather than this project's. A row is a thing
+you might want to test; its verdict carries whatever establishes it — the suite
+that drives it, the runtime capability it keys on, or the section of
+[what it does not do](docs/limits.md) that says why the answer is no. A row with
+nothing to point at is refused by a test rather than by a reviewer.
+
+That page is deliberately the only place those verdicts are written. Copying six
+of them onto this one would put the answer where you are, and put it there
+wrongly within a release: a sentence on line 41 of this file contradicted that
+page for two days in August, through every green documentation gate in between.
+The per-operation view, which is generated, is [docs/routes.md](docs/routes.md).
+
+---
+
 ## Contents
 
 - [Quick start](#quick-start)
+- [Is this the right tool for your test?](#is-this-the-right-tool-for-your-test)
 - [Install](#install)
 - [Use it](#use-it)
 - [The page](#the-page)

--- a/README.md
+++ b/README.md
@@ -159,10 +159,10 @@ It needs Incus with OVN; `mise run demo:network` records it.
 ## Is this the right tool for your test?
 
 Ask before installing anything, and read the answer somewhere other than here:
-**[what you can validate](docs/confidence.md)** is one page and one table, and it
-answers that question in your vocabulary rather than this project's. A row is a
-thing you might want to test; its verdict carries whatever establishes it — the suite
-that drives it, the runtime capability it keys on, or the section of
+**[what you can validate](docs/confidence.md)** is one page and one table, and
+it answers that question in your vocabulary rather than this project's. A row is
+a thing you might want to test; its verdict carries whatever establishes it —
+the suite that drives it, the runtime capability it keys on, or the section of
 [what it does not do](docs/limits.md) that says why the answer is no. A row with
 nothing to point at is refused by a test rather than by a reviewer.
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,9 @@ The per-operation view, which is generated, is [docs/routes.md](docs/routes.md).
 - [Contributing](#contributing)
 - [License](#license)
 
+Everything that is not on this page lives in [docs/](docs/README.md), grouped
+by the question it answers rather than listed.
+
 ---
 
 ## Install

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,50 @@
+# Where to go in this directory
+
+Four questions, and the pages that answer each one. This is a guide, not a
+listing: GitHub already shows you every file above, and a page that names all of
+them would only tell you what you can already see. What it cannot tell you is
+which one to open, which is the whole job here.
+
+The English pages are the source. Where a French translation exists it is named
+beside its original, and the English one prevails if the two disagree.
+
+## I want to run something
+
+Start at the [quick start](../README.md#quick-start): four commands, a stack
+small enough to read, and no cloud account.
+
+- [install.md](install.md) — prerequisites, the released binary and its checksum,
+  the container image, Homebrew, and building from source.
+- [environment.md](environment.md) — every field of `feint.yaml`, generated from
+  the schema the code validates against, so a field added without a doc update
+  fails a gate rather than a reader.
+
+## I want to know whether it answers my question
+
+- [confidence.md](confidence.md) — one table: what you can reasonably validate
+  against this emulator, in your vocabulary. Read this before installing
+  anything. Each verdict points at the suite that proves it or the limit that
+  refuses it.
+- [limits.md](limits.md) — the record behind every **no**, measured rather than
+  assumed. It is long on purpose and not meant to be read through: search it for
+  the section a verdict sent you to.
+- [routes.md](routes.md) — the fine view, generated: what every mounted operation
+  has earned, operation by operation.
+
+## I want to know what "proven" means here
+
+- [conformance.md](conformance.md) ([fr](conformance.fr.md)) — the chain from a
+  real client to a verdict, and what a green run still does not prove.
+- [clients.md](clients.md) — which client drives which pack, at which version,
+  and the workflow that says so.
+
+## I want to change it
+
+- [architecture.md](architecture.md) — the packs, the neutral core, and the
+  boundary between them.
+- [../CONTRIBUTING.md](../CONTRIBUTING.md) — how a change is proved before it is
+  proposed.
+- [proxy.md](proxy.md) — record a real cloud, read the recording, and turn it
+  into the next operation to serve.
+- [fourth-pack.md](fourth-pack.md) — what adding a provider costs, written from
+  the three that exist.

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,8 +13,10 @@ beside its original, and the English one prevails if the two disagree.
 Start at the [quick start](../README.md#quick-start): four commands, a stack
 small enough to read, and no cloud account.
 
-- [install.md](install.md) — prerequisites, the released binary and its checksum,
-  the container image, Homebrew, and building from source.
+- [install.md](install.md) — the released binary and the signature to check it
+  against, the container image, Homebrew, and the prerequisites per
+  distribution. Building from source is in the README, beside the other
+  install routes.
 - [environment.md](environment.md) — every field of `feint.yaml`, generated from
   the schema the code validates against, so a field added without a doc update
   fails a gate rather than a reader.

--- a/internal/cli/docs_index_test.go
+++ b/internal/cli/docs_index_test.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// docs/README.md sends a reader down one of four paths, and every one of them
+// has to arrive (#591).
+
+// An index is a second copy of the directory's shape, and a second copy is what
+// this repository keeps paying for: the pages it names get renamed, merged and
+// moved, and a link that stopped resolving reads exactly like one that never
+// did. `docs/limits.md` alone has been split and re-headed enough times that
+// TestEveryConfidenceRowCarriesItsProof exists for the same reason one storey
+// down.
+//
+// So the index is held to the rule confidence.md is held to: every link
+// resolves, and a fragment resolves to a heading that really produces it. The
+// difference is the subject — that test reads the rows of one table, this one
+// reads the whole page, because an index is nothing but links.
+//
+// What is deliberately *not* asserted is that the index names every file in
+// `docs/`. It is a guide with four paths, and a check demanding completeness
+// would turn it back into the listing GitHub already renders — which is the
+// thing that guides nobody, and the reason the maintainer refused a restructure
+// on the same day this landed.
+func TestTheDocsIndexResolvesEveryPathItOffers(t *testing.T) {
+	root := repoRoot(t)
+	index := filepath.Join(root, "docs", "README.md")
+	body, err := os.ReadFile(index)
+	if err != nil {
+		t.Fatalf("read the docs index: %v", err)
+	}
+
+	link := regexp.MustCompile(`\[[^\]]+\]\(([^)]+)\)`)
+	targets := link.FindAllStringSubmatch(string(body), -1)
+	// An index whose links vanished would otherwise pass by having nothing left
+	// to resolve, which is the shape of every control that looks for an absence.
+	if len(targets) < 8 {
+		t.Fatalf("the docs index carries %d link(s): it exists to point a reader at a page, "+
+			"and it cannot do that in that few", len(targets))
+	}
+
+	for _, m := range targets {
+		target := m[1]
+		if strings.HasPrefix(target, "http://") || strings.HasPrefix(target, "https://") {
+			// An external link cannot be resolved offline, and a documentation
+			// test that needs the network is a test that gets skipped.
+			continue
+		}
+		file, fragment, _ := strings.Cut(target, "#")
+		if file == "" {
+			file = "README.md"
+		}
+		// Relative to docs/, which is where the index lives: a path may leave it
+		// (../CONTRIBUTING.md) and must still be checked where it lands.
+		path := filepath.Join(root, "docs", file)
+		content, err := os.ReadFile(path) //nolint:gosec // a path this repository owns
+		if err != nil {
+			t.Errorf("the index offers %q and that file does not exist: a path that does not "+
+				"arrive is worse than no index, because a reader trusts it", target)
+			continue
+		}
+		if fragment == "" {
+			continue
+		}
+		if !hasAnchor(string(content), fragment) {
+			t.Errorf("the index offers %q and no heading in %s produces that anchor: "+
+				"the reader lands on the page and not on the part of it they were sent to",
+				target, file)
+		}
+	}
+}

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -293,3 +293,138 @@ func flagsTheHelpNames(t *testing.T) map[string][]string {
 	}
 	return verbs
 }
+
+// The command table is two tables, because it was two audiences (#591).
+//
+// Twenty-six verbs stood in one table on both front pages, and ten of them are
+// this repository measuring itself: `corpus`, `shapes`, `evidence`, `probe`,
+// `proxy`, `transcript`, `replay`, `coverage`, `docs`, `catalog`. Somebody who
+// came to point Terraform at a local cloud had no way to know that, so they
+// read the whole list wondering which part of it they had to understand before
+// starting. The audit of 2026-08-28 measured that as friction and not as
+// length: the split costs no lines at all.
+//
+// A split, though, adds a way to go wrong that one table did not have, and it
+// is the class this repository pays for repeatedly — a fact expressed in two
+// places. A new verb can land in neither table, in both, or in a third stray
+// group, and TestEveryCommandIsNamedInTheReadmes would not notice: it accepts a
+// mention anywhere on the page, which is why `stop` and `restart` once read as
+// documented while they were folded into one entry about `start`.
+//
+// So this one asserts the partition rather than the mention:
+//
+//   - every dispatched verb has exactly one row, across every group;
+//   - every row names a verb the binary really dispatches, so a verb that is
+//     removed does not leave its row behind;
+//   - the rows are grouped under at least two headings, each holding at least
+//     three, so flattening the tables back into one fails here rather than
+//     silently undoing the split.
+//
+// Both pages, for the reason TestEveryCommandIsNamedInTheReadmes states:
+// README.fr.md is the one that fell ten verbs behind while nothing read it.
+func TestEveryCommandHasExactlyOneRowUnderAnAudience(t *testing.T) {
+	dispatched := topLevelCommands(t)
+	if len(dispatched) < 15 {
+		t.Fatalf("only %d commands found in the dispatch: the scan is broken, "+
+			"not the tables, and would otherwise pass while measuring nothing", len(dispatched))
+	}
+	accepts := map[string]bool{}
+	for _, name := range dispatched {
+		accepts[name] = true
+	}
+
+	for _, doc := range []string{"README.md", "README.fr.md"} {
+		body, err := os.ReadFile(filepath.Join("..", "..", doc))
+		if err != nil {
+			t.Fatalf("read %s: %v", doc, err)
+		}
+
+		groups := commandTableGroups(string(body))
+		rows := map[string][]string{}
+		for _, group := range groups {
+			for _, verb := range group.verbs {
+				rows[verb] = append(rows[verb], group.heading)
+			}
+		}
+		// A page whose tables vanished would otherwise pass every assertion
+		// below by having no row left to fail on: this count is the witness
+		// that the reader found the tables at all.
+		if len(rows) < 15 {
+			t.Fatalf("%s: only %d command row(s) were parsed out of the page: the reader is broken, "+
+				"not the tables, and would otherwise pass while measuring nothing", doc, len(rows))
+		}
+
+		if len(groups) < 2 {
+			t.Errorf("%s: the %d command rows sit under %d heading(s). That table is two audiences — "+
+				"what somebody drives the emulator with, and what this repository measures it with — "+
+				"and one list makes a reader wonder which half they must understand before starting",
+				doc, len(rows), len(groups))
+		}
+		for _, group := range groups {
+			if len(group.verbs) < 3 {
+				t.Errorf("%s: the group %q holds %d command row(s): a group that small is not an "+
+					"audience, and it lets the split read as done while the tables are back to one",
+					doc, group.heading, len(group.verbs))
+			}
+		}
+
+		for _, name := range dispatched {
+			switch where := rows[name]; len(where) {
+			case 1:
+			case 0:
+				t.Errorf("%s: `feint %s` dispatches and no command table has a row for it. "+
+					"Naming it in a sentence somewhere is not the same thing: a reader looking for "+
+					"the list of verbs will not find it there", doc, name)
+			default:
+				t.Errorf("%s: `feint %s` has %d rows, under %s. One verb belongs to one audience, "+
+					"and two rows are two descriptions that will eventually disagree",
+					doc, name, len(where), strings.Join(where, " and "))
+			}
+		}
+
+		for verb, where := range rows {
+			if !accepts[verb] {
+				t.Errorf("%s: a command table row under %s names `feint %s` and the binary dispatches "+
+					"no such verb: a reader who types it is answered with the usage text",
+					doc, strings.Join(where, " and "), verb)
+			}
+		}
+	}
+}
+
+// commandGroup is one heading and the verbs the table rows under it name.
+type commandGroup struct {
+	heading string
+	verbs   []string
+}
+
+// commandTableGroups reads the command tables off a front page: a Markdown
+// heading opens a group, and every "| `feint <verb>` …" row until the next
+// heading belongs to it. A heading with no such row under it produces no group,
+// so the page's twenty other headings do not read as empty audiences.
+//
+// The space after the binary's name is load-bearing: the released-binary table
+// carries rows like "| `feint-darwin-amd64` |", and without it every one of
+// them would read as a command row naming a verb that does not exist.
+func commandTableGroups(page string) []commandGroup {
+	row := regexp.MustCompile("^\\|\\s*`feint ([a-z][a-z-]*)")
+
+	var groups []commandGroup
+	heading := "no heading"
+	for _, line := range strings.Split(page, "\n") {
+		if strings.HasPrefix(line, "#") {
+			heading = strings.TrimSpace(strings.TrimLeft(line, "# "))
+			continue
+		}
+		m := row.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		if len(groups) == 0 || groups[len(groups)-1].heading != heading {
+			groups = append(groups, commandGroup{heading: heading})
+		}
+		last := &groups[len(groups)-1]
+		last.verbs = append(last.verbs, m[1])
+	}
+	return groups
+}

--- a/tools/falsify/specs/command-tables-two-audiences.json
+++ b/tools/falsify/specs/command-tables-two-audiences.json
@@ -1,0 +1,48 @@
+{
+  "package": "./internal/cli/",
+  "mutations": [
+    {
+      "label": "the second heading dissolves into prose, so the twenty-six verbs are back in one list and the split reads as done while it is undone",
+      "file": "README.md",
+      "find": "### Fidelity and development tools",
+      "replace": "Fidelity and development tools",
+      "test": "TestEveryCommandHasExactlyOneRowUnderAnAudience"
+    },
+    {
+      "label": "a verb loses its row while the page still names it in prose, which is exactly what TestEveryCommandIsNamedInTheReadmes accepts",
+      "file": "README.md",
+      "find": "| `feint catalog` | print the emulated inventory a client reads before creating |",
+      "replace": "| `feint-catalog` | print the emulated inventory a client reads before creating |",
+      "test": "TestEveryCommandHasExactlyOneRowUnderAnAudience"
+    },
+    {
+      "label": "a verb is described in both audiences at once, which is one fact in two places and the class this repository keeps paying for",
+      "file": "README.md",
+      "find": "| `feint probe` | drive every mounted route from its API description and check the answers |",
+      "replace": "| `feint probe` | drive every mounted route from its API description and check the answers |\n| `feint probe` | drive every mounted route from its API description and check the answers |",
+      "test": "TestEveryCommandHasExactlyOneRowUnderAnAudience"
+    },
+    {
+      "label": "a row survives the verb it described, so a reader types a command the binary answers with the usage text",
+      "file": "README.fr.md",
+      "find": "| `feint catalog` | affiche l'inventaire émulé qu'un client lit avant de créer |",
+      "replace": "| `feint catalog` | affiche l'inventaire émulé qu'un client lit avant de créer |\n| `feint inventaire` | affiche l'inventaire émulé qu'un client lit avant de créer |",
+      "test": "TestEveryCommandHasExactlyOneRowUnderAnAudience"
+    },
+    {
+      "label": "a path of the docs index stops arriving at a file, and an index a reader trusts is worse than no index",
+      "file": "docs/README.md",
+      "find": "- [fourth-pack.md](fourth-pack.md)",
+      "replace": "- [fourth-pack.md](fourth-pack-renamed.md)",
+      "test": "TestTheDocsIndexResolvesEveryPathItOffers"
+    },
+    {
+      "label": "a path arrives at the page and not at the section it named, which is how limits.md's fifty headings rot a link without moving a file",
+      "file": "docs/README.md",
+      "find": "Start at the [quick start](../README.md#quick-start)",
+      "replace": "Start at the [quick start](../README.md#quick-start-guide)",
+      "test": "TestTheDocsIndexResolvesEveryPathItOffers"
+    }
+  ],
+  "note": "#591. The commands table listed twenty-six verbs on both front pages and ten of them are this repository measuring itself; splitting it by audience costs no lines and answers the audit's finding, but it adds three ways to be wrong that one table did not have — a verb in neither half, a verb in both, a stray third group — and TestEveryCommandIsNamedInTheReadmes cannot see any of them, because it accepts a mention anywhere on the page. That is not hypothetical: `stop` and `restart` read as documented for a while because both were folded into one entry about `start`. The last two mutations hold the docs index to the same rule the confidence page is held to, since an index is nothing but links and a link that stopped resolving reads exactly like one that never did."
+}


### PR DESCRIPTION
The rest of **#591**, reduced by a maintainer decision: **file size is not a
problem.** Two of the audit's recommendations fall with that premise and were
**not** smuggled back under another name:

- **no `docs/` restructure** — the argument was "at twenty files a flat directory
  stops working", which is an argument about mass;
- **no summary of `docs/limits.md`** — the argument was "3950 lines is
  unreadable". That file is a **register**: nobody reads it whole, they look a
  section up, and its length is the evidence it is doing its job.

What survives, survives on other grounds.

## 1. The command table was two audiences

| | before | after |
|---|--:|---|
| command rows, `README.md` | 26, one table | 16 + 10, two tables |
| command rows, `README.fr.md` | 26, one table | 16 + 10 |
| verbs in the dispatch | 26 | 26 |

Someone who came to test their Terraform met `feint proxy`, `feint corpus`,
`feint evidence` and `feint shapes` in the same table as `feint up`, with nothing
telling them the last four are not theirs. **Same 26 rows, same wording, two
headings**, each with one sentence saying who it is for.

**The brief's split was wrong and the dispatch said so.** It listed 24 verbs;
checking against the switch `TestEveryDispatchedCommandIsInTheHelp` already
parses found **`serve`** and **`images`** missing — both everyday, `serve` being
the foreground emulator the quick-start banner shows and `images` building what a
`--vm` user needs. Neither table is generated, so the READMEs were the right
files to edit; that was checked, not assumed.

## 2. `confidence.md` was not where it is looked for

Probably the best page here: 73 lines answering *"what can I reasonably test
against this emulator?"*, every verdict pointing at its proof, held by
`TestEveryConfidenceRowCarriesItsProof`. It was cited twice, in a nav strip and
in prose after the demo, and **in neither table of contents**.

A new section — *"Is this the right tool for your test?"* — sits **before
`## Install`** in both pages, in both tables of contents.

### And it copies nothing. The argument matters more than the section.

The obvious move was a six-row extract in the README. It was refused, for three
reasons in order of weight:

1. **A generator producing an extract would have to *select* rows, and selection
   is a judgement.** `internal/cli/docs_confidence.go` says in its own header
   that the counts are generated and *"what stays hand-written is the table,
   because a verdict is a judgement and this file has none to offer"*. Any rule —
   first N, rows by verdict class — either moves when someone reorders the table
   or needs a new marker in the source. The generator would silently own an
   editorial decision.
2. **The FR/EN axis makes it worse.** The source table is English prose;
   injecting it into `README.fr.md` is finding 4 of #591 restated, and #595 has
   just paid to undo exactly that.
3. **The README already carries two early generated blocks** answering nearby
   questions — the safety callout and the promise block derived from #592's
   matrix. A third statement of the same thing is the *one fact in two places*
   class this repository keeps paying for.

The section states the framing and links. No verdict, no count, no capability
pair is duplicated.

**And its own first draft was corrected**: it cited *"a sentence on line 41"*,
which is true today and false after the next paragraph anybody inserts above it.
It names #592 instead (`d50d620`).

## 3. An index, because four paths guide and a listing does not

`docs/README.md`: run something · does it answer my question · what "proven"
means · change it. **Every claim in it was checked against the page it
describes**, and one was wrong: `docs/install.md` has no "from source" section —
that route is in the README.

## The guards, and a weakness they close

Two new tests, and the first closes something that predates this branch:
`TestEveryCommandIsNamedInTheReadmes` accepts a mention **anywhere on the page**,
which is why `stop` and `restart` once read as documented while both were folded
into one entry about `start`.

- **`TestEveryCommandHasExactlyOneRowUnderAnAudience`** asserts the **partition**:
  every dispatched verb has exactly one row across every group, every row names a
  dispatched verb, and the rows sit under at least two headings each holding at
  least three.
- **`TestTheDocsIndexResolvesEveryPathItOffers`** — every link resolves, and a
  `#fragment` resolves to a heading that really produces it. It deliberately does
  **not** assert completeness: that would turn the index back into the listing
  GitHub already renders, which is where the maintainer's refusal is written down
  in code.

`command-tables-two-audiences.json`, **6 mutations, all 6 bite**, none dropping an
identifier:

```
the second heading dissolves into prose            → red
a verb loses its row, still named in prose         → red
a verb described under both audiences              → red
a row survives the verb it described               → red
an index path stops arriving at a file             → red
an index path arrives at the page, not the section → red
```

A hand witness was planted on `docs/README.md#quick-start` before the spec was
written, to prove the anchor reader can fail at all rather than passing
vacuously.

## What `docs:check` cannot see, said plainly

`feint docs --check` compares **only the marker blocks**. Neither command table,
neither new section, neither ToC entry and none of `docs/README.md` sits inside
one — **`docs:check` is silent about every line this branch adds**. What covers
them is the two new Go tests plus the two pre-existing ones, all running under
`mise run check` inside `prepush`.

## Gates

`prepush` **0**, twice, the second on the final diff · `docs:check` **0** ·
`falsify` 6/6 · `falsify:lint` 968 mutations over 150 specs.

`limits:check` is **2 and pre-existing** — three `docs/limits.md` sections cite
#365, #570 and #571, all closed 2026-08-28, before this branch.
`git diff origin/main -- docs/limits.md docs/limits-acks.json` is empty.

## What was not obtained

- **No `docs/README.fr.md`.** The index names the French pages where they exist
  and states that English is the source, but it is itself English. A translated
  index is a fifth page to keep in step.
- **No conformance run**: no route, response shape or error changed.
- **One tension left for the maintainer**: `docs/routes.md` opens with *"Is your
  resource emulated? This page answers it without installing anything."* — very
  close to the new section's framing. They are complementary (capability versus
  operation) and the section links both, but if only one front-page signpost is
  wanted, that is the tension to resolve.

## Where `testplan` was slightly wrong

It named `limits:check` because `docs/README.md` matched *"prose, including what
this project says it does not do"* — but that gate reads only `docs/limits.md`,
which this diff does not touch. Over-trigger, not a false green, and it cost a run
that exits 2 for somebody else's reason.
