### PR TITLE
fix(environment,conformance): a declaration can say that the workload answers, and the first boot is waited for like the second (#600)

### DIFF
--- a/docs/environment.md
+++ b/docs/environment.md
@@ -260,6 +260,7 @@ gate. The sentence a field carries lives on the field.
 - `http:<path>`
 - `tcp:<host>:<port>`
 - `resource:<kind>[:<count>]`
+- `service:<resource name>:<port>`
 
 A condition that is not one of those forms is refused at load, with the list.
 <!-- environment:end -->

--- a/examples/stacks/scaleway/feint.yaml
+++ b/examples/stacks/scaleway/feint.yaml
@@ -38,9 +38,23 @@ iac:
 
 # Asserted against the emulator, never against Terraform's state file: six
 # machines, two VPCs and the load balancer the stack puts in front of the web
-# tier.
+# tier — and, when a runtime is configured, the web tier's own workload.
+#
+# The last one is dated, and it is why `service:` exists (#600). On the scheduled
+# night of 2026-08-29 (run 33229486194) the four conditions above were every
+# condition this file carried; `feint up` confirmed all four and returned, and
+# 310 ms later the suite read platform-web-0 and found port 53 open and 443 not —
+# cloud-init had not reached the runcmd that starts the unit. `up` had not lied.
+# It confirmed exactly what it had been asked to confirm, and nothing here could
+# ask about the inside of a machine.
+#
+# Under `runtime.mode: off` above, nothing boots and `up` prints that the
+# condition was not asked, naming it, rather than passing it in silence — which
+# is what lets this stack keep running in both modes, as main.tf says an example
+# has to.
 ready:
   - http:/instance/v1/zones/fr-par-1/servers
   - resource:instance/server:6
   - resource:vpc/vpc:2
   - resource:lb/lb:1
+  - service:platform-web-0:443

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -124,17 +125,18 @@ func up(args []string, stdout, stderr io.Writer) int {
 	// fail every time, and a flag whose only outcome is a failure is a flag
 	// nobody uses. Said rather than silent — that is the whole difference
 	// between a skip and a lie.
-	proved := true
+	var proved []string
 	switch {
 	case *skipIaC && decl.IaC.Engine != "" && len(decl.Ready) > 0:
-		proved = false
 		fmt.Fprintf(stdout, "- not waiting: --no-iac skipped %s, and the ready conditions describe what it builds (%s)\n",
 			decl.IaC.Engine, strings.Join(decl.Ready, ", "))
 	default:
-		if err := waitReady(decl, *timeout, stdout); err != nil {
+		held, err := waitReady(decl, *timeout, stdout)
+		if err != nil {
 			fmt.Fprintf(stderr, "feint: %v\n", err)
 			return exitError
 		}
+		proved = held
 	}
 
 	// Step 6.
@@ -607,20 +609,40 @@ func engineEnvironment(decl *environment.File) ([]string, error) {
 // waitReady is step 5. Every condition is announced before it is waited on and
 // named when its deadline passes: a hang with no output is indistinguishable
 // from a broken emulator, and this repository has already paid for that.
-func waitReady(decl *environment.File, timeout time.Duration, stdout io.Writer) error {
+func waitReady(decl *environment.File, timeout time.Duration, stdout io.Writer) ([]string, error) {
 	conditions := decl.Conditions()
 	if len(conditions) == 0 {
-		return nil
+		return nil, nil
 	}
+	// What held, in the order it was asked. Returned rather than counted,
+	// because the summary must name what proved the environment and a count
+	// cannot tell a condition that held from one nothing asked.
+	held := make([]string, 0, len(conditions))
 	deadline := time.Now().Add(timeout)
 	for _, condition := range conditions {
+		// A service condition asks about the inside of a machine, and under
+		// `runtime.mode: off` there is no machine: the question does not apply
+		// rather than fails. Said out loud and never returned in silence — the
+		// rule `guard_leftovers_for` states for the same case in
+		// tools/conformance/guard.sh: a precondition that passes quietly on the
+		// very case it exists for reads as green when it never ran.
+		//
+		// This is also what lets a stack declare one and still run in both
+		// modes, which examples/stacks/scaleway/main.tf says an example has to
+		// do. The mode read here is the resolved one, so `--runtime` counts.
+		if condition.Kind == environment.ServiceCondition && decl.Runtime.Mode == "off" {
+			fmt.Fprintf(stdout, "  not asked: %s — this environment starts no machines\n",
+				condition.Raw)
+			continue
+		}
 		fmt.Fprintf(stdout, "- waiting: %s\n", condition.Describe())
 		if err := awaitCondition(decl, condition, deadline); err != nil {
-			return err
+			return held, err
 		}
 		fmt.Fprintf(stdout, "  ok: %s\n", condition.Raw)
+		held = append(held, condition.Raw)
 	}
-	return nil
+	return held, nil
 }
 
 func awaitCondition(decl *environment.File, condition environment.Condition, deadline time.Time) error {
@@ -674,38 +696,81 @@ func conditionMet(decl *environment.File, condition environment.Condition) (bool
 			return false, fmt.Sprintf("the emulator holds %d", held)
 		}
 		return true, ""
+	case environment.ServiceCondition:
+		addresses, err := addressesOfNamed(decl.Endpoint(), condition.Name)
+		if err != nil {
+			return false, err.Error()
+		}
+		if len(addresses) == 0 {
+			return false, fmt.Sprintf("no resource named %q carries an address yet", condition.Name)
+		}
+		for _, address := range addresses {
+			conn, dialErr := net.DialTimeout("tcp",
+				net.JoinHostPort(address, strconv.Itoa(condition.Port)), 3*time.Second)
+			if dialErr == nil {
+				_ = conn.Close()
+				return true, ""
+			}
+		}
+		return false, fmt.Sprintf("%s does not accept a connection on %d yet",
+			strings.Join(addresses, ", "), condition.Port)
 	default:
 		return false, "no reader for this condition"
 	}
 }
 
-// countKindInInventory reads the emulator's own inventory, which is
-// provider-neutral by construction: the store holds resources whose kind is a
-// value, so this counts a pack nobody has written yet.
-func countKindInInventory(endpoint, kind string) (int, error) {
+// inventoryResource is what a ready condition needs of the emulator's own
+// inventory. The shape is the emulator's, never a provider's: the store holds
+// resources whose kind is a value rather than a type, so a pack nobody has
+// written yet is read here without a line changing.
+type inventoryResource struct {
+	Kind    string            `json:"kind"`
+	Attrs   map[string]any    `json:"attrs"`
+	Runtime map[string]string `json:"runtime"`
+}
+
+// readInventory fetches and decodes /_feint/resources, once, for every
+// condition that needs it.
+//
+// Written once because the falsification harness refused it written twice.
+// `service:` (#600) arrived with a second fetch-and-decode of the same body, and
+// `mise run falsify -- tools/falsify/specs/environment-declaration.json`
+// answered that the fragment for "an unreadable inventory is read as a count of
+// zero" now matched two places and only the first was rewritten. A verdict
+// written twice is a verdict fixed in one of them, and here the harness said so
+// before anybody had to notice.
+//
+// The decode is strict: a body this does not understand is an error rather than
+// an empty list, because a silent empty list reads exactly like an emulator
+// nobody has used yet — three outcomes, never two.
+func readInventory(endpoint string) ([]inventoryResource, error) {
 	client := &http.Client{Timeout: 5 * time.Second}
 	res, err := client.Get(endpoint + "/_feint/resources")
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 	defer func() { _ = res.Body.Close() }()
 	if res.StatusCode != http.StatusOK {
-		return 0, fmt.Errorf("the inventory answered %d", res.StatusCode)
+		return nil, fmt.Errorf("the inventory answered %d", res.StatusCode)
 	}
-	// The shape is the emulator's own, and it is decoded strictly: a body this
-	// does not understand is an error rather than a zero, because a silent zero
-	// reads exactly like an emulator nobody has used yet.
 	var body struct {
-		Resources []struct {
-			Kind string `json:"kind"`
-		} `json:"resources"`
+		Resources []inventoryResource `json:"resources"`
 	}
 	decoder := json.NewDecoder(io.LimitReader(res.Body, maxStateBody))
 	if err := decoder.Decode(&body); err != nil {
-		return 0, fmt.Errorf("reading the inventory: %w", err)
+		return nil, fmt.Errorf("reading the inventory: %w", err)
+	}
+	return body.Resources, nil
+}
+
+// countKindInInventory answers how many resources of a kind the emulator holds.
+func countKindInInventory(endpoint, kind string) (int, error) {
+	resources, err := readInventory(endpoint)
+	if err != nil {
+		return 0, err
 	}
 	count := 0
-	for _, r := range body.Resources {
+	for _, r := range resources {
 		if r.Kind == kind {
 			count++
 		}
@@ -713,8 +778,78 @@ func countKindInInventory(endpoint, kind string) (int, error) {
 	return count, nil
 }
 
+// addressesOfNamed answers every address the emulator recorded for the resource
+// the stack named, and it is the one provider-shaped half of `service:`.
+//
+// The name lives in two places, because the packs put it in two places:
+// Scaleway writes `attrs.name`, Outscale a `Name` tag. A fourth pack adds its
+// clause here rather than getting a reader of its own — what varies is a field,
+// what does not is shared. The same two clauses, for the same reason, are in
+// `fnl_machine_named` in tools/conformance/functionallib.sh.
+//
+// The addresses come from the resource's runtime record, and they are taken by
+// TYPE rather than by key: every value that parses as an IP. The packs agree on
+// "address" today, but that agreement is a Binding field (machine.Binding's
+// AddressKey), which means it is allowed to differ — and a reader keyed on the
+// spelling would be a convention written into the CLI that the core deliberately
+// left to each pack.
+//
+// An empty answer is not an error. A machine that has not published an address
+// yet is the normal early state of the very wait this feeds, and returning an
+// error there would turn "not ready yet" into "the emulator is broken" — the
+// three-outcomes rule conditionMet states above.
+func addressesOfNamed(endpoint, name string) ([]string, error) {
+	resources, err := readInventory(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	var out []string
+	for _, r := range resources {
+		if nameOfResource(r.Attrs) != name {
+			continue
+		}
+		for _, value := range r.Runtime {
+			// A record can hold several, comma-joined, exactly as
+			// machine.Binding writes them.
+			for _, candidate := range strings.Split(value, ",") {
+				candidate = strings.TrimSpace(candidate)
+				if net.ParseIP(candidate) != nil {
+					out = append(out, candidate)
+				}
+			}
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// nameOfResource reads the two shapes the packs write. See addressesOfNamed for
+// why both live here rather than one reader per pack.
+func nameOfResource(attrs map[string]any) string {
+	if name, ok := attrs["name"].(string); ok && name != "" {
+		return name
+	}
+	tags, ok := attrs["Tags"].([]any)
+	if !ok {
+		return ""
+	}
+	for _, raw := range tags {
+		tag, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if key, _ := tag["Key"].(string); key != "Name" {
+			continue
+		}
+		if value, ok := tag["Value"].(string); ok {
+			return value
+		}
+	}
+	return ""
+}
+
 // printEndpoints is step 6: where the environment is, and what proved it.
-func printEndpoints(decl *environment.File, proved bool, stdout io.Writer) {
+func printEndpoints(decl *environment.File, proved []string, stdout io.Writer) {
 	fmt.Fprintf(stdout, "\nup: %s\n", decl.Endpoint())
 	if decl.Cloud.Provider != "" {
 		fmt.Fprintf(stdout, "  clients:  eval \"$(feint env %s)\"\n", decl.Cloud.Provider)
@@ -725,12 +860,23 @@ func printEndpoints(decl *environment.File, proved bool, stdout io.Writer) {
 	// What proved it, and never what would have. A summary that lists a
 	// condition nothing evaluated is the shape of every green verdict this
 	// project exists to distrust.
+	//
+	// The argument is the list that HELD, not the list that was declared, and
+	// that distinction was a boolean until #600. It stopped being one the moment
+	// a third case existed: a `service:` condition under `runtime.mode: off` is
+	// neither proved nor skipped-with-the-engine, and the boolean printed it as
+	// proved. Measured on examples/stacks/scaleway with `--runtime off`, which
+	// announced "not asked" and then listed the same condition as proof.
 	switch {
 	case len(decl.Ready) == 0:
-	case proved:
-		fmt.Fprintf(stdout, "  proved:   %s\n", strings.Join(decl.Ready, ", "))
-	default:
+	case len(proved) == 0:
 		fmt.Fprintf(stdout, "  proved:   nothing — the ready conditions were skipped with the engine\n")
+	default:
+		fmt.Fprintf(stdout, "  proved:   %s\n", strings.Join(proved, ", "))
+		if len(proved) < len(decl.Ready) {
+			fmt.Fprintf(stdout, "  not asked: %d of %d, named above\n",
+				len(decl.Ready)-len(proved), len(decl.Ready))
+		}
 	}
 	fmt.Fprintf(stdout, "  down:     feint down\n")
 }

--- a/internal/cli/up_service_test.go
+++ b/internal/cli/up_service_test.go
@@ -1,0 +1,239 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stephrobert/feint/internal/environment"
+)
+
+// `service:<name>:<port>` (#600), and the night that asked for it.
+//
+// On 2026-08-29 (run 33229486194) the Scaleway stack declared four ready
+// conditions — one route and three counts, all control plane — `feint up`
+// confirmed every one of them, and 310 ms later its web machine was listening on
+// 53 and not on 443. `up` did not lie: the vocabulary could not say what the
+// stack needed, so every suite downstream guessed, at its own moment and its own
+// budget.
+//
+// These drive `waitReady` against an inventory that answers exactly what the
+// emulator answers, and against a socket that really accepts — the same shape as
+// up_wait_test.go, for the reason its header states: the decision is tested
+// apart from the act.
+
+// declWithMachines is declFor with a runtime declared. A service condition does
+// not apply under `runtime.mode: off`, so a test that used declFor would skip
+// the very thing it measures — which is how the first version of this file went
+// green for the wrong reason before the announcement assertion caught it.
+func declWithMachines(t *testing.T, addr string, ready ...string) *environment.File {
+	t.Helper()
+	src := "version: 1\nemulator:\n  addr: " + addr + "\nruntime:\n  mode: incus-ovn\nready:\n"
+	for _, item := range ready {
+		src += "  - " + item + "\n"
+	}
+	decl, err := environment.Parse(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return decl
+}
+
+// inventoryOf serves one resource under both naming shapes, so a single helper
+// covers Scaleway's `attrs.name` and Outscale's `Name` tag.
+func inventoryOf(t *testing.T, shape, name, address string) *httptest.Server {
+	t.Helper()
+	var attrs string
+	switch shape {
+	case "name":
+		attrs = fmt.Sprintf(`{"name":%q}`, name)
+	case "tag":
+		attrs = fmt.Sprintf(`{"Tags":[{"Key":"Other","Value":"x"},{"Key":"Name","Value":%q}]}`, name)
+	default:
+		t.Fatalf("unknown shape %q", shape)
+	}
+	runtime := `{}`
+	if address != "" {
+		runtime = fmt.Sprintf(`{"machine":"feint-scw-1","address":%q}`, address)
+	}
+	body := fmt.Sprintf(`{"count":1,"resources":[{"kind":"instance/server","attrs":%s,"runtime":%s}]}`,
+		attrs, runtime)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/_feint/resources" {
+			_, _ = w.Write([]byte(body))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// listener opens a real socket and answers its address, so the condition is
+// proved against something that accepts rather than against a mock that says it
+// would.
+func listener(t *testing.T) (host string, port int) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	addr := ln.Addr().(*net.TCPAddr)
+	return addr.IP.String(), addr.Port
+}
+
+// The accepting half. Both naming shapes, because a reader that resolved only
+// one would make the condition a Scaleway feature.
+func TestAServiceConditionIsMetWhenTheNamedMachineAccepts(t *testing.T) {
+	for _, shape := range []string{"name", "tag"} {
+		t.Run(shape, func(t *testing.T) {
+			host, port := listener(t)
+			srv := inventoryOf(t, shape, "platform-web-0", host)
+
+			decl := declWithMachines(t, strings.TrimPrefix(srv.URL, "http://"),
+				fmt.Sprintf("service:platform-web-0:%d", port))
+			var out bytes.Buffer
+			if _, err := waitReady(decl, 5*time.Second, &out); err != nil {
+				t.Fatalf("a machine that accepts was reported not ready: %v\n%s", err, out.String())
+			}
+			if !strings.Contains(out.String(), "platform-web-0 answers on port") {
+				t.Errorf("the wait never announced what it was waiting for:\n%s", out.String())
+			}
+		})
+	}
+}
+
+// The refusing half, and it is the one that carries the night. A machine whose
+// unit has not started must NOT be reported ready, and the failure must name the
+// address it dialled — the difference between "the workload is late" and "the
+// emulator is broken".
+func TestAServiceConditionIsNotMetWhileTheUnitIsStillComingUp(t *testing.T) {
+	// A port nothing listens on: the socket is opened to reserve the number and
+	// closed at once, so the dial is refused rather than merely slow.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	closed := ln.Addr().(*net.TCPAddr)
+	_ = ln.Close()
+
+	srv := inventoryOf(t, "name", "platform-web-0", closed.IP.String())
+	decl := declWithMachines(t, strings.TrimPrefix(srv.URL, "http://"),
+		fmt.Sprintf("service:platform-web-0:%d", closed.Port))
+
+	var out bytes.Buffer
+	started := time.Now()
+	_, err = waitReady(decl, 300*time.Millisecond, &out)
+	if err == nil {
+		t.Fatal("a machine listening on nothing was reported ready, which is the 2026-08-29 night")
+	}
+	if elapsed := time.Since(started); elapsed > 5*time.Second {
+		t.Errorf("the wait took %s for a 300ms deadline: it hangs rather than fails", elapsed)
+	}
+	if !strings.Contains(err.Error(), "does not accept a connection") {
+		t.Errorf("the failure never says what it dialled: %v", err)
+	}
+}
+
+// A name no resource carries is not "not yet". It is a declaration and a stack
+// that have drifted apart, and the reason must say so rather than read as a slow
+// boot forever.
+func TestAServiceConditionNamingNobodySaysSo(t *testing.T) {
+	srv := inventoryOf(t, "name", "platform-app-0", "10.0.0.9")
+	decl := declWithMachines(t, strings.TrimPrefix(srv.URL, "http://"), "service:platform-web-0:443")
+
+	var out bytes.Buffer
+	_, err := waitReady(decl, 300*time.Millisecond, &out)
+	if err == nil {
+		t.Fatal("a condition naming no resource was reported met")
+	}
+	if !strings.Contains(err.Error(), "no resource named \"platform-web-0\"") {
+		t.Errorf("the failure never names what it could not find: %v", err)
+	}
+}
+
+// The addresses are taken by TYPE and not by key. The packs agree on "address"
+// today, but that agreement is a Binding field, so a reader keyed on the
+// spelling would write into the CLI a convention the core left to each pack.
+// Here the record holds the machine name, a joined pair of addresses and prose:
+// only the two addresses may be dialled, and the prose must never be.
+func TestTheAddressesAreReadByTypeAndNotByKey(t *testing.T) {
+	host, port := listener(t)
+	body := fmt.Sprintf(`{"count":1,"resources":[{"kind":"instance/server",`+
+		`"attrs":{"name":"platform-web-0"},`+
+		`"runtime":{"machine":"feint-scw-1","published":"10.0.0.254, %s","note":"never dialled"}}]}`,
+		host)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/_feint/resources" {
+			_, _ = w.Write([]byte(body))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	decl := declWithMachines(t, strings.TrimPrefix(srv.URL, "http://"),
+		fmt.Sprintf("service:platform-web-0:%d", port))
+	var out bytes.Buffer
+	if _, err := waitReady(decl, 5*time.Second, &out); err != nil {
+		t.Fatalf("an address under an unconventional key was not dialled: %v\n%s", err, out.String())
+	}
+}
+
+// The inapplicable case, and it must be LOUD. Under `runtime.mode: off` there is
+// no machine, so the question does not apply — but a condition that passed in
+// silence would read, in a journal six weeks later, exactly like a condition
+// that was measured and held.
+//
+// This is what lets examples/stacks/scaleway declare one and still run in both
+// modes, which its own main.tf says an example has to do.
+func TestAServiceConditionDoesNotApplyWithoutMachinesAndSaysSo(t *testing.T) {
+	srv := inventoryOf(t, "name", "platform-web-0", "")
+	// declFor, deliberately: no runtime section, so the mode is `off`.
+	decl := declFor(t, strings.TrimPrefix(srv.URL, "http://"), "service:platform-web-0:443")
+
+	var out bytes.Buffer
+	if _, err := waitReady(decl, 300*time.Millisecond, &out); err != nil {
+		t.Fatalf("a condition about machines failed an environment that starts none: %v", err)
+	}
+	if !strings.Contains(out.String(), "not asked") {
+		t.Errorf("the skip was silent, so a reader cannot tell it from a proof:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "service:platform-web-0:443") {
+		t.Errorf("the skip does not name what was not asked:\n%s", out.String())
+	}
+	if strings.Contains(out.String(), "ok: service:") {
+		t.Errorf("a condition nothing evaluated was reported met:\n%s", out.String())
+	}
+}
+
+// The forms, refused by name at load rather than at the end of a wait (#190).
+func TestAServiceConditionThatDoesNotReadIsRefusedAtLoad(t *testing.T) {
+	for _, raw := range []string{
+		"service:platform-web-0",
+		"service::443",
+		"service:platform-web-0:",
+		"service:platform-web-0:0",
+		"service:platform-web-0:65536",
+		"service:platform-web-0:https",
+	} {
+		t.Run(raw, func(t *testing.T) {
+			if _, err := environment.ParseCondition(raw); err == nil {
+				t.Fatalf("accepted, so `up` would wait on a condition nothing evaluates")
+			}
+		})
+	}
+	got, err := environment.ParseCondition("service:platform-web-0:443")
+	if err != nil {
+		t.Fatalf("the form was refused: %v", err)
+	}
+	if got.Name != "platform-web-0" || got.Port != 443 {
+		t.Errorf("parsed as %+v", got)
+	}
+}

--- a/internal/cli/up_wait_test.go
+++ b/internal/cli/up_wait_test.go
@@ -58,7 +58,7 @@ func TestAReadyConditionThatIsMetIsSaidOutLoudBothWays(t *testing.T) {
 	decl := declFor(t, strings.TrimPrefix(srv.URL, "http://"),
 		"http:/instance/v1/zones/fr-par-1/servers", "resource:instance/server:2")
 	var out bytes.Buffer
-	if err := waitReady(decl, 5*time.Second, &out); err != nil {
+	if _, err := waitReady(decl, 5*time.Second, &out); err != nil {
 		t.Fatalf("conditions the server satisfies were not met: %v\n%s", err, out.String())
 	}
 	for _, want := range []string{"waiting:", "ok: http:/instance", "ok: resource:instance/server:2"} {
@@ -85,7 +85,7 @@ func TestAReadyConditionThatCannotBeMetFailsWithinItsDeadlineNamingIt(t *testing
 	decl := declFor(t, strings.TrimPrefix(srv.URL, "http://"), "resource:instance/server:1")
 	var out bytes.Buffer
 	started := time.Now()
-	err := waitReady(decl, 300*time.Millisecond, &out)
+	_, err := waitReady(decl, 300*time.Millisecond, &out)
 	if err == nil {
 		t.Fatal("a condition nothing satisfies was reported met")
 	}
@@ -443,7 +443,7 @@ func TestTheSummaryClaimsNothingItDidNotProve(t *testing.T) {
 	}
 
 	var skipped bytes.Buffer
-	printEndpoints(decl, false, &skipped)
+	printEndpoints(decl, nil, &skipped)
 	if strings.Contains(skipped.String(), "resource:instance/server:6") {
 		t.Errorf("a condition nothing evaluated is listed as what proved the environment:\n%s", skipped.String())
 	}
@@ -454,8 +454,27 @@ func TestTheSummaryClaimsNothingItDidNotProve(t *testing.T) {
 	// The accepting half: when the wait did run, its conditions are exactly what
 	// the summary credits.
 	var proved bytes.Buffer
-	printEndpoints(decl, true, &proved)
+	printEndpoints(decl, []string{"resource:instance/server:6"}, &proved)
 	if !strings.Contains(proved.String(), "resource:instance/server:6") {
 		t.Errorf("a condition that was met is not credited:\n%s", proved.String())
+	}
+
+	// The third case, and the reason this argument stopped being a boolean
+	// (#600). Some conditions held and one was not asked — a `service:` under
+	// `runtime.mode: off`. Measured on examples/stacks/scaleway with
+	// `--runtime off`: the summary announced "not asked" and then listed the
+	// same condition among what proved the environment.
+	partial, err := environment.Parse("version: 1\nemulator:\n  addr: 127.0.0.1:4599\n" +
+		"ready:\n  - resource:instance/server:6\n  - service:platform-web-0:443\n")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var mixed bytes.Buffer
+	printEndpoints(partial, []string{"resource:instance/server:6"}, &mixed)
+	if strings.Contains(mixed.String(), "service:platform-web-0:443") {
+		t.Errorf("a condition nothing asked is credited as proof:\n%s", mixed.String())
+	}
+	if !strings.Contains(mixed.String(), "not asked: 1 of 2") {
+		t.Errorf("the summary does not say how much of the declaration went unasked:\n%s", mixed.String())
 	}
 }

--- a/internal/environment/ready.go
+++ b/internal/environment/ready.go
@@ -29,6 +29,22 @@ const (
 	// Count resources of a kind. Provider-neutral by construction: the store
 	// holds resource.Resource, whose kind is a value rather than a type.
 	ResourceCondition ConditionKind = "resource"
+	// ServiceCondition waits for the machine a named resource backs to accept a
+	// connection on a port, at an address the emulator itself recorded.
+	//
+	// The three forms above are all control plane: a route that answers, a
+	// socket the caller already knows the address of, a count in the inventory.
+	// None of them can say that the workload is up, and that gap has a date. On
+	// the scheduled night of 2026-08-29 the Scaleway stack's four conditions
+	// were all confirmed, `feint up` returned, and 310 ms later its web machine
+	// was listening on 53 and not on 443 — cloud-init had not reached the runcmd
+	// that starts the declared unit. `up` did not lie; it confirmed exactly what
+	// it had been asked to confirm.
+	//
+	// A stack that declares one of these cannot return before its workload
+	// answers, so no suite downstream has to guess afterwards — which is what
+	// every suite was doing, each at its own moment and its own budget.
+	ServiceCondition ConditionKind = "service"
 )
 
 // ConditionKinds names every form, for the refusal. A name that is not one of
@@ -37,6 +53,7 @@ var ConditionKinds = []string{
 	"http:<path>",
 	"tcp:<host>:<port>",
 	"resource:<kind>[:<count>]",
+	"service:<resource name>:<port>",
 }
 
 // Condition is one parsed ready condition.
@@ -52,6 +69,12 @@ type Condition struct {
 	// Resource and Count are set for ResourceCondition.
 	Resource string
 	Count    int
+	// Name and Port are set for ServiceCondition. Name is the name the client
+	// gave the resource, as the stack wrote it, never the runtime object behind
+	// it: a declaration that named a container would be a declaration coupled to
+	// the runtime that happens to be configured.
+	Name string
+	Port int
 }
 
 // ParseCondition reads one condition and refuses everything else by name.
@@ -92,6 +115,17 @@ func ParseCondition(raw string) (Condition, error) {
 			want = n
 		}
 		return Condition{Kind: ResourceCondition, Raw: raw, Resource: name, Count: want}, nil
+	case ServiceCondition:
+		name, port, split := strings.Cut(rest, ":")
+		if !split || name == "" || port == "" {
+			return Condition{}, fmt.Errorf("%q: a service condition takes the name the stack gave "+
+				"the resource and the port its workload listens on, as `name:port`", raw)
+		}
+		n, err := strconv.Atoi(port)
+		if err != nil || n < 1 || n > 65535 {
+			return Condition{}, fmt.Errorf("%q: %q is not a port number", raw, port)
+		}
+		return Condition{Kind: ServiceCondition, Raw: raw, Name: name, Port: n}, nil
 	default:
 		return Condition{}, fmt.Errorf("%q: %q is not a ready condition; the forms are %s",
 			raw, kind, strings.Join(ConditionKinds, ", "))
@@ -126,6 +160,8 @@ func (c Condition) Describe() string {
 			return "the emulator holds a " + c.Resource
 		}
 		return fmt.Sprintf("the emulator holds %d %s resources", c.Count, c.Resource)
+	case ServiceCondition:
+		return fmt.Sprintf("%s answers on port %d", c.Name, c.Port)
 	default:
 		return c.Raw
 	}

--- a/tools/conformance/functional.sh
+++ b/tools/conformance/functional.sh
@@ -619,18 +619,11 @@ run_stack() { # name
 		[ "$state" = "$running" ] \
 			|| fail "$name: $restart came back '$state' ${waited}s after the API was asked to start it — a stack whose machine does not restart is not a stack that works"
 		# The unit needs its own boot to come up, so the wait is on the port
-		# rather than on a fixed sleep, and the verdict below names how long
-		# it waited.
-		rm -f "$WORK/listen-$rmachine.txt"
-		waited=0
-		while [ "$waited" -lt 90 ]; do
-			live_listeners "$rmachine" "$WORK/listen-$rmachine.txt" \
-				|| fail "cannot look: reading /proc/net/tcp inside $rmachine failed after its restart"
-			fnl_listens "$port" "$WORK/listen-$rmachine.txt" && break
-			sleep 5
-			waited=$((waited + 5))
-		done
-		fnl_service_listens "$name" "$restart ($unit, ${waited}s after a restart through the API)" "$rmachine" "$port" "$WORK/listen-$rmachine.txt"
+		# rather than on a fixed sleep, and the verdict below names how long it
+		# waited. Shared with the first-boot path since #600: this loop lived here
+		# and nowhere else, and the first boot is the one that needed it most.
+		fnl_service_came_up "$name" "$restart" "$unit" "$rmachine" "$port" \
+			"$WORK/listen-$rmachine.txt" "after a restart through the API"
 		address="$(published_address "$provider" "$restart")" \
 			|| fail "cannot look: $provider's API did not answer when asked for $restart's published address"
 		if [ -n "$address" ]; then
@@ -683,8 +676,12 @@ run_stack() { # name
 		for target in $(printf '%s' "$service" | jq -r '.machines[]'); do
 			need_machine "$target"
 			smachine="$MACHINE"
-			listen_of "$smachine"
-			fnl_service_listens "$name" "$target ($unit)" "$smachine" "$port" "$LISTEN"
+			# The unit is waited for rather than asked once (#600). LISTEN is set
+			# from the same capture, because the firewall pair below reads it and
+			# must read the list this verdict was reached on.
+			LISTEN="$WORK/listen-$smachine.txt"
+			fnl_service_came_up "$name" "$target" "$unit" "$smachine" "$port" \
+				"$LISTEN" "after up returned"
 			address="$(published_address "$provider" "$target")" \
 				|| fail "cannot look: $provider's API did not answer when asked for $target's published address"
 			if [ -z "$address" ]; then

--- a/tools/conformance/functional_test.go
+++ b/tools/conformance/functional_test.go
@@ -32,6 +32,98 @@ import (
 // no host and no emulator: the functions read files and injected commands
 // precisely so that this file can hold them.
 
+// ---- a unit that comes up late is waited for, not called dead --------------
+
+// The night this exists for: 2026-08-29, run 33229486194, job `stacks
+// (incus-ovn)`. `feint up` returned with every declared ready condition
+// confirmed — four of them, all control plane — and 310 ms later the suite read
+// platform-web-0 and found port 53 open and 443 not. systemd-resolved was up;
+// cloud-init had not reached the runcmd that starts the declared unit. The night
+// died on pass 1 of 3, and nothing about the emulator was wrong.
+//
+// The stub counts its calls, so this asserts the wait *polled* rather than that
+// it slept: a fixed sleep would pass this test for the wrong reason, and this
+// repository has paid for a control that passes for the wrong reason.
+func TestAServiceThatComesUpLateIsWaitedFor(t *testing.T) {
+	// live_listeners is functional.sh's real transport (`incus exec`). Here it
+	// is a stub that reports only systemd-resolved for two reads and the
+	// declared port on the third — the shape the night measured.
+	const lateBoot = `
+counter="$DIR/reads"
+echo 0 >"$counter"
+live_listeners() { # machine out_file
+	n=$(( $(cat "$counter") + 1 ))
+	echo "$n" >"$counter"
+	if [ "$n" -ge 3 ]; then
+		printf '53\n443\n' >"$2"
+	else
+		printf '53\n' >"$2"
+	fi
+}
+WAIT_POLL=0.05
+fnl_service_came_up stack platform-web-0 platform-web.service m1 443 "$DIR/listen.txt" "after up returned"
+echo "READS $(cat "$counter")"
+`
+	code, output := runFunctional(t, nil, lateBoot)
+	if code != 0 {
+		t.Fatalf("a unit that came up on the third read was reported dead:\n%s", output)
+	}
+	if !strings.Contains(output, "READS 3") {
+		t.Errorf("the wait did not poll three times, so it is not polling on the port:\n%s", output)
+	}
+	// The verdict names how long it waited, so a slow boot and a dead unit do
+	// not read the same in a journal six weeks later.
+	if !strings.Contains(output, "after up returned") {
+		t.Errorf("the verdict does not name the moment it waited from:\n%s", output)
+	}
+}
+
+// The other half, and it is not ceremony: a wait that accepted everything would
+// pass every planted defect in this file. A unit that never comes up must still
+// go red, and must still name the ports it did find.
+func TestAServiceThatNeverComesUpIsStillCalledDead(t *testing.T) {
+	const neverUp = `
+live_listeners() { printf '53\n' >"$2"; }
+WAIT_POLL=0.05
+WAIT_SCALE=0
+fnl_service_came_up stack platform-web-0 platform-web.service m1 443 "$DIR/listen.txt" "after up returned"
+`
+	code, output := runFunctional(t, nil, neverUp)
+	if code == 0 {
+		t.Fatalf("a unit that never listened was accepted:\n%s", output)
+	}
+	if !strings.Contains(output, "listening: 53") {
+		t.Errorf("the refusal does not name what it did find:\n%s", output)
+	}
+}
+
+// The third outcome, which the single-read path had and a careless wait loses.
+// A read that fails is nobody being able to look, and it must not be spent as
+// budget and then reported as a dead unit.
+func TestAReadThatFailsIsNotSpentAsBudget(t *testing.T) {
+	const cannotLook = `
+counter="$DIR/reads"
+echo 0 >"$counter"
+live_listeners() {
+	n=$(( $(cat "$counter") + 1 ))
+	echo "$n" >"$counter"
+	return 1
+}
+WAIT_POLL=0.05
+# WAIT_SCALE=0 so the mutated run — where the read failure is swallowed and the
+# wait runs to its end — costs a second rather than ninety.
+WAIT_SCALE=0
+fnl_service_came_up stack platform-web-0 platform-web.service m1 443 "$DIR/listen.txt" "after up returned"
+`
+	code, output := runFunctional(t, nil, cannotLook)
+	if code == 0 {
+		t.Fatalf("an unreadable machine was accepted:\n%s", output)
+	}
+	if !strings.Contains(output, "cannot look") {
+		t.Errorf("an unreadable machine was reported as a dead unit:\n%s", output)
+	}
+}
+
 // ---- the readers prove they can find --------------------------------------
 
 func TestTheListenReaderReadsProcNetTcp(t *testing.T) {

--- a/tools/conformance/functionallib.sh
+++ b/tools/conformance/functionallib.sh
@@ -76,6 +76,13 @@
 # shellcheck source=/dev/null
 . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/witnesslib.sh"
 
+# shared/waiting.sh carries `wait_until`, and fnl_service_came_up below polls
+# with it rather than with a loop of its own: a bespoke loop is invisible to
+# WAIT_TRACE, and the budgets this repository keeps are only re-derivable
+# because every wait records itself (#587).
+# shellcheck source=/dev/null
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/shared/waiting.sh"
+
 # ---- readers: filters over stdin, no side effects ---------------------------
 
 # fnl_listening_ports reads /proc/net/tcp and /proc/net/tcp6 concatenated on
@@ -235,6 +242,61 @@ fnl_every_machine_started() { # stack machines_file instances_json floor running
 		fi
 	done <"$machines"
 	ok "$stack: $count machine(s), each '$running' and each Running on the host"
+}
+
+# fnl_port_appeared re-reads a machine's listeners and answers whether the port
+# is among them. It is the predicate `wait_until` polls below.
+#
+# It refreshes the file on every call, because a cached capture cannot become
+# true and `listen_of` in functional.sh caches by design.
+#
+# Three outcomes, not two, and this is the half worth reading. A read that fails
+# is not "the port is not open yet" — it is nobody being able to look. Collapsed
+# into one, a broken `incus exec` would spend the whole budget and then report
+# the unit dead, which is this file's own rule 2 turned against itself. So the
+# look failing exits here, with the message the single-read path already used.
+#
+# `live_listeners` is the caller's, never this file's: it runs `incus exec`, and
+# functional_test.go replaces it with a stub so the wait below can be driven
+# with no host.
+fnl_port_appeared() { # machine port listen_file
+	rm -f "$3"
+	live_listeners "$1" "$3" \
+		|| fail "cannot look: reading /proc/net/tcp inside $1 failed; every 'not listening' this run would report is an instrument failure"
+	fnl_listens "$2" "$3"
+}
+
+# fnl_service_came_up waits for a declared unit to answer inside its machine,
+# then hands the verdict to fnl_service_listens — which still decides, and still
+# names the port list it read.
+#
+# Why it exists, dated. The restart path in functional.sh has waited 90 s since
+# it was written, and its comment says why: "The unit needs its own boot to come
+# up". The first-boot path asked once and decided. On the scheduled night of
+# 2026-08-29 (run 33229486194) that cost the run — platform-web-0 was read
+# 310 ms after `feint up` returned and answered "listening: 53": systemd-resolved
+# up, the declared unit not yet, on a machine whose cloud-init had not reached
+# its runcmd. The first boot has *more* to do than a restart, not less. The wait
+# was written twice and lived on the wrong one of the two, so both callers share
+# this one now.
+#
+# The budget is the sibling path's 90 s, deliberately not raised. #587 measured
+# that a longer ceiling makes a broken wait *more* certain to look green, not
+# less, and nothing here has measured how long a first boot actually takes.
+# `wait_until` records every call in WAIT_TRACE, so that number can be re-derived
+# from a distribution rather than chosen by taste.
+#
+# The verdict names how long it waited, so a slow boot and a dead unit do not
+# read the same.
+#
+# The test that fails without this wait: TestAServiceThatComesUpLateIsWaitedFor
+# in functional_test.go plants a port that appears on the third read and
+# requires a pass; with the single read it reported the unit dead.
+fnl_service_came_up() { # stack declared unit machine port listen_file moment
+	local started="$SECONDS" waited
+	wait_until 90 fnl_port_appeared "$4" "$5" "$6" || true
+	waited=$((SECONDS - started))
+	fnl_service_listens "$1" "$2 ($3, ${waited}s $7)" "$4" "$5" "$6"
 }
 
 # fnl_service_listens is step 1 of the two-legged trip, and the precondition of

--- a/tools/falsify/specs/environment-declaration.json
+++ b/tools/falsify/specs/environment-declaration.json
@@ -51,7 +51,7 @@
       "test": "TestAVersionThisBinaryDoesNotReadIsRefusedNamingBoth"
     },
     {
-      "label": "an unreadable inventory is read as a count of zero, so a broken emulator is indistinguishable from one nobody has used",
+      "label": "an unreadable inventory is read as an empty one, so a broken emulator is indistinguishable from one nobody has used \u2014 now on the single reader both `resource:` and `service:` go through",
       "file": "internal/cli/up.go",
       "find": "\tif err := decoder.Decode(&body); err != nil {",
       "replace": "\tif err := decoder.Decode(&body); err != nil && false {",
@@ -91,10 +91,10 @@
       "package": "./internal/cli/"
     },
     {
-      "label": "the summary lists ready conditions nothing evaluated as what proved the environment",
+      "label": "the summary credits every condition the file DECLARES instead of the ones that held, so a `service:` nothing asked under `runtime.mode: off` is listed as proof \u2014 measured on examples/stacks/scaleway, which announced \"not asked\" and credited it in the same breath",
       "file": "internal/cli/up.go",
-      "find": "\tdefault:\n\t\tfmt.Fprintf(stdout, \"  proved:   nothing — the ready conditions were skipped with the engine\\n\")\n\t}",
-      "replace": "\tdefault:\n\t\tfmt.Fprintf(stdout, \"  proved:   %s\\n\", strings.Join(decl.Ready, \", \"))\n\t}",
+      "find": "\t\tfmt.Fprintf(stdout, \"  proved:   %s\\n\", strings.Join(proved, \", \"))",
+      "replace": "\t\tfmt.Fprintf(stdout, \"  proved:   %s\\n\", strings.Join(append(proved[:0:0], decl.Ready...), \", \"))",
       "test": "TestTheSummaryClaimsNothingItDidNotProve",
       "package": "./internal/cli/"
     }

--- a/tools/falsify/specs/stack-functional-proof.json
+++ b/tools/falsify/specs/stack-functional-proof.json
@@ -191,7 +191,7 @@
       "test": "TestTheDeliveryReaderReadsNoProseAsAnAddress"
     },
     {
-      "label": "the gate stops running its reader controls before it judges, so a broken reader files false absences again — the shape that very nearly published a false #475",
+      "label": "the gate stops running its reader controls before it judges, so a broken reader files false absences again \u2014 the shape that very nearly published a false #475",
       "file": "tools/conformance/functional.sh",
       "find": "fnl_listen_reader_control\nfnl_name_reader_control\nfnl_delivery_reader_control",
       "replace": "true || fnl_listen_reader_control\ntrue || fnl_name_reader_control\ntrue || fnl_delivery_reader_control",
@@ -212,14 +212,14 @@
       "test": "TestEveryStackTheGateNamesDeclaresWhatItMustProve"
     },
     {
-      "label": "a family is excused with an empty reason, and « non trié » starts passing for « hors périmètre » — the shape CLAUDE.md names as the most expensive defect measured here",
+      "label": "a family is excused with an empty reason, and \u00ab non tri\u00e9 \u00bb starts passing for \u00ab hors p\u00e9rim\u00e8tre \u00bb \u2014 the shape CLAUDE.md names as the most expensive defect measured here",
       "file": "examples/stacks/outscale/proof.json",
       "find": "      \"skip\": \"this stack declares no unpeered pair with a machine on each side",
       "replace": "      \"skip\": \"\", \"was\": \"this stack declares no unpeered pair with a machine on each side",
       "test": "TestEveryStackTheGateNamesDeclaresWhatItMustProve"
     },
     {
-      "label": "the reboot verdict stops comparing the runtime process, so a reboot that answered success and restarted nothing passes — #547 verbatim",
+      "label": "the reboot verdict stops comparing the runtime process, so a reboot that answered success and restarted nothing passes \u2014 #547 verbatim",
       "file": "tools/conformance/functionallib.sh",
       "find": "\t[ \"$before\" != \"$after\" ] \\",
       "replace": "\t[ \"$before\" != \"$after\" ] || true \\",
@@ -289,12 +289,33 @@
       "test": "TestAnEmptyRuleSetReadingIsAnInstrumentFailure"
     },
     {
-      "label": "the gate goes back to naming reachability after a restart instead of measuring it, which was honest exactly once — while #549 was open — and hides a working assertion now",
+      "label": "the gate goes back to naming reachability after a restart instead of measuring it, which was honest exactly once \u2014 while #549 was open \u2014 and hides a working assertion now",
       "file": "tools/conformance/functional.sh",
       "find": "\t\tassert_restart \"$RESTART_NAME\" \"$RESTART_UNIT\" \"$RESTART_PORT\"\n",
       "replace": "\t\tassert_restart \"$RESTART_NAME\" \"$RESTART_UNIT\" \"$RESTART_PORT\"\n\t\tskip \"$name: what this run does not assert after a restart is reachability to another subnet\"\n",
       "test": "TestTheGateNoLongerExcusesReachabilityAfterARestart"
+    },
+    {
+      "label": "the first boot is asked once instead of waited for, which is the night of 2026-08-29 (run 33229486194): platform-web-0 read 310 ms after `feint up` returned, 53 open and 443 not, and a run red on pass 1 of 3 with nothing wrong in the emulator",
+      "file": "tools/conformance/functionallib.sh",
+      "find": "\twait_until 90 fnl_port_appeared \"$4\" \"$5\" \"$6\" || true",
+      "replace": "\twait_until -1 fnl_port_appeared \"$4\" \"$5\" \"$6\" || true",
+      "test": "TestAServiceThatComesUpLateIsWaitedFor"
+    },
+    {
+      "label": "the wait accepts everything, so every planted defect in this file passes: a unit that never listens is no longer called dead",
+      "file": "tools/conformance/functionallib.sh",
+      "find": "\tif ! fnl_listens \"$port\" \"$listen\"; then",
+      "replace": "\tif ! fnl_listens \"$port\" \"$listen\" && false; then",
+      "test": "TestAServiceThatNeverComesUpIsStillCalledDead"
+    },
+    {
+      "label": "a machine nobody can read is spent as budget and then reported as a dead unit \u2014 the three-outcomes rule this file states, turned against itself by its own wait",
+      "file": "tools/conformance/functionallib.sh",
+      "find": "\tlive_listeners \"$1\" \"$3\" \\\n",
+      "replace": "\tlive_listeners \"$1\" \"$3\" || true \\\n",
+      "test": "TestAReadThatFailsIsNotSpentAsBudget"
     }
   ],
-  "note": "The subject is #503. On 2026-08-26 four defects were found by hand on the example stacks (#475, #481, #483, #484) and all four were green: apply exit 0, second plan empty, clean destroy, three of them without a single ERROR line. What found them was a person reading the host, so this gate is that reading, and every mutation here plants the defect one verdict names. Three of them are about the instrument rather than the cloud, and they are the ones worth reading twice: the listen reader counting established connections as listeners, the name reader matching by prefix, and the delivery reader reading a withheld backend's English reason as an address. Each was reachable by one character. The gate's own first run under --vm incus-ovn made the same class of mistake in the opposite direction and was caught by its own third outcome: `incus exec … -- command -v bash` fails on every machine because `command` is a shell builtin, and the probe answered « nobody could look » instead of reporting a firewall verdict it had not measured."
+  "note": "The subject is #503. On 2026-08-26 four defects were found by hand on the example stacks (#475, #481, #483, #484) and all four were green: apply exit 0, second plan empty, clean destroy, three of them without a single ERROR line. What found them was a person reading the host, so this gate is that reading, and every mutation here plants the defect one verdict names. Three of them are about the instrument rather than the cloud, and they are the ones worth reading twice: the listen reader counting established connections as listeners, the name reader matching by prefix, and the delivery reader reading a withheld backend's English reason as an address. Each was reachable by one character. The gate's own first run under --vm incus-ovn made the same class of mistake in the opposite direction and was caught by its own third outcome: `incus exec \u2026 -- command -v bash` fails on every machine because `command` is a shell builtin, and the probe answered \u00ab nobody could look \u00bb instead of reporting a firewall verdict it had not measured."
 }


### PR DESCRIPTION
fix(environment,conformance): a declaration can say that the workload answers, and the first boot is waited for like the second (#600)

On the scheduled night of 2026-08-29 (run 33229486194) `feint up` returned with
every ready condition confirmed, and 310 ms later the suite read platform-web-0
and found port 53 open and 443 not: systemd-resolved up, the declared unit not
yet. The night died on pass 1 of 3 and nothing about the emulator was wrong.

Two defects, and they are separate.

The harness asked once. functional.sh's restart path has waited 90 s since it
was written — its comment says "The unit needs its own boot to come up" — and
the first-boot path read a port list captured once and decided. The first boot
has MORE to do than a restart: cloud-init must reach its runcmd before any unit
exists. The wait went to the path where the delay was visible, not to the one
where it was possible, and the measurement says why: on this station the first
boot answers in 0.038–0.083 s and a restart takes up to 13.8 s. The GitHub
runner inverts that, and only the night could see it.

Both callers now share fnl_service_came_up, which polls with `wait_until` from
shared/waiting.sh rather than with a third hand-rolled loop — so every one of
these waits lands in WAIT_TRACE and the 90 s budget can be re-derived from a
distribution instead of from taste (#587). The budget is deliberately NOT
raised: #587 measured that a longer ceiling makes a broken wait more certain to
look green, not less. Three outcomes are kept: a read that fails is nobody being
able to look, and it exits rather than being spent as budget.

`up` could not lie, and that is the second defect. The Scaleway stack's four
conditions were all control plane — one route, three counts — because the
vocabulary had nothing else. `service:<name>:<port>` resolves the resource the
stack named in the emulator's own inventory and dials the port, so a stack that
declares one cannot return before its workload answers and no suite downstream
has to guess. The name is read in the two shapes the packs write (Scaleway's
`attrs.name`, Outscale's `Name` tag) in one function, the same clause
fnl_machine_named carries. The addresses are read by TYPE — every runtime value
that parses as an IP — never by key: the packs agree on "address" today, but
that agreement is a machine.Binding field and is allowed to differ.

Under `runtime.mode: off` nothing boots, so the condition does not apply rather
than fails. It is announced, never silent — the rule guard_leftovers_for states
for the same case — which is what lets examples/stacks/scaleway declare one and
still run in both modes.

Three defects found while building it, each by a different instrument:

  - falsify refused a second inventory reader: "the fragment matches 2 places
    and only the first is rewritten". A verdict written twice is a verdict fixed
    in one of them. There is one readInventory now.
  - running it by hand showed the summary announcing "not asked:
    service:platform-web-0:443" and then crediting the same condition as proof.
    `proved` was a boolean and stopped being able to carry three cases; it is
    now the list that held, and the summary says how much went unasked.
  - the new tests began skipping in silence the moment the inapplicable case
    landed, because declFor declares no runtime. Three went red, including the
    one that requires the wait to ANNOUNCE what it waits for.

Measured, all on this station under incus-ovn:

  conformance:functional  3 passes 1010 s rc=0, then 1 pass 332 s rc=0
  feint up --runtime incus-ovn on the Scaleway stack: "waiting: platform-web-0
    answers on port 443" / "ok: service:platform-web-0:443", down clean,
    50 resources destroyed, nothing left on the runtime
  falsify stack-functional-proof: 45/45 mutations bite, including the one that
    reproduces the night's sentence verbatim
  falsify environment-declaration, the-stack-gate-runs-somewhere,
    no-terraform-for-exoscale: green
  conformance:stacks, conformance:environment: green
  prepush: green
  WAIT_TRACE: 24 waits across the runs, 0 expired

What this does not prove: the night's population. This station's first boot
answers in under a tenth of a second, which is exactly why nobody saw the
defect here; only the scheduled run on a GitHub runner exercises the slow one.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

