### PR TITLE
feat(account,images,conformance): a declared project catalogue, a resolve that only prints what boots, and every listen verdict waiting for the port it judges (#572, #476)

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -230,7 +230,14 @@ jobs:
       - name: Build and start the emulator
         run: |
           go build -o /tmp/feint ./cmd/feint
-          /tmp/feint start --addr 127.0.0.1:4599 --contracts contracts --timeout 60s
+          # --projects declares the same catalogue tools/conformance/leg.sh and the
+          # `conformance` mise task declare (#572). Named here as well because
+          # this workflow starts its OWN emulator, one per matrix leg: the first
+          # version of #572 taught the two of them and left this one, and five
+          # jobs went red at 44 s with "the declared project did not list under
+          # its own name: []". Held by TestEveryConformanceEmulatorDeclaresTheSameProjects.
+          /tmp/feint start --addr 127.0.0.1:4599 --contracts contracts \
+            --projects default,platform-prod --timeout 60s
           # The doorway step of the Outscale Terraform suite evals the real
           # output of `feint env` rather than restating it, so the script needs
           # the binary this job just built — the repo-root default it falls

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -19,6 +19,32 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Ajouté
 
+- **L'opérateur déclare les projets que le compte émulé détient :
+  `cloud.projects` dans `feint.yaml`, `serve --projects`, et la surface CLI
+  passe à 20 (#572).** Jusqu'ici cet émulateur détenait un seul projet, nommé
+  `default`, et une stack dont le `project_name` était son propre projet de
+  production mourait sur le `FindExact` du provider Terraform après une liste
+  vide pourtant véridique — l'obstacle rencontré par exactement la personne que
+  #372 sert : une équipe plateforme qui pointe une stack existante vers
+  l'émulateur. `data "scaleway_account_project"` résout désormais un nom
+  déclaré, et `GetProject` le rend tel quel au lieu de répondre `default` pour
+  tout.
+
+  La liste continue de **filtrer**. Un nom que personne n'a déclaré donne une
+  liste vide, et c'est tout le design : le correctif bon marché consistait à
+  répondre qu'un projet existe parce que quelqu'un l'a demandé, ce qui est la
+  classe que #83 a mesurée et refermée sur les trois packs — un identifiant
+  qu'aucun catalogue ne détenait, substitué en silence, et une exécution verte
+  qui ne voulait rien dire. L'inventaire reste ce que l'opérateur a énoncé.
+
+  Les identifiants sont dérivés du nom et jamais frappés à chaque exécution,
+  pour la raison qui fige le `created_at` du projet : une valeur qui bouge entre
+  deux lectures est une divergence Terraform permanente. `default` garde
+  l'identifiant auquel tous les autres produits de ce pack rapportent déjà leurs
+  réponses, donc une déclaration qui omet le champ — toutes celles écrites avant
+  aujourd'hui — obtient exactement le compte qu'elle avait.
+
+
 - **Un mot pour la forme que le vocabulaire ne savait pas décrire :
   `capabilities.firewall_public_when_joined`, et `/_feint/health` passe au
   schéma 7 (#548).** Un consommateur qui lisait `capabilities.firewall: true`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,31 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Added
 
+- **The operator declares which projects the emulated account holds:
+  `cloud.projects` in `feint.yaml`, `serve --projects`, and the CLI surface
+  moves to 20 (#572).** Until now this emulator held one project, named
+  `default`, and a stack whose `project_name` was its own production project
+  died on the Terraform provider's `FindExact` after a truthful empty list —
+  the obstacle for exactly the person #372 exists to serve, a platform team
+  pointing an existing stack at the emulator. `data "scaleway_account_project"`
+  now resolves a declared name, and `GetProject` reads it back as itself
+  instead of answering `default` for everything.
+
+  The list still **filters**. A name nobody declared answers an empty list, and
+  that is the whole design: the cheap fix was to answer that a project exists
+  because somebody asked for it, which is the class #83 measured and closed on
+  all three packs — an identifier no catalogue held, silently substituted, and
+  a green run that meant nothing. The inventory stays something the operator
+  stated.
+
+  Identifiers are derived from the name and never minted per run, for the
+  reason the project's `created_at` is fixed: a value that moved between two
+  reads is a permanent Terraform diff. `default` keeps the identifier every
+  other product of this pack already scopes its answers to, so a declaration
+  that omits the field — every declaration written before today — gets exactly
+  the account it had.
+
+
 - **A word for the shape the vocabulary could not describe:
   `capabilities.firewall_public_when_joined`, and `/_feint/health` moves to
   schema 7 (#548).** A consumer holding `capabilities.firewall: true`,

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -232,6 +232,7 @@ gate. The sentence a field carries lives on the field.
 |---|---|---|---|---|
 | `version` | a number | — | `feint up`, `feint down` | The schema version. Only 1 is read; another is refused naming both. |
 | `cloud.provider` | a provider name | — | `feint up`, `feint down` | The pack whose client environment `up` exports before running the engine — the same variables `feint env <provider>` prints, including the endpoint form that provider's clients want. Refused when the binary mounts no such pack. |
+| `cloud.projects` | a list of project names | — | `feint up` | The projects the emulated account holds, in order: `serve --projects`. A stack whose `project_name` is its own production project names it here, and the emulator holds it rather than answering that it exists because somebody asked (#572). Omitted, the pack serves its own single default project. |
 | `emulator.addr` | a listen address | `127.0.0.1:4599` | `feint up`, `feint down` | Where the emulator listens: `serve --addr`. |
 | `emulator.state` | a path | — | `feint up` | The JSON file the store is loaded from and persisted to: `serve --state`. Relative to the declaration's own directory. |
 | `emulator.contracts` | a directory | — | `feint up` | The API descriptions every response is checked against: `serve --contracts`. Relative to the declaration's own directory. |

--- a/docs/limits-acks.json
+++ b/docs/limits-acks.json
@@ -24,7 +24,7 @@
     "Placement is recorded, never enforced (#285)": "2026-08-27",
     "ReadTags does not list an internet service, because upstream names no type for one": "2026-08-27",
     "The Exoscale Terraform provider is refused, and why": "2026-08-27",
-    "The Exoscale stack's second plan is not empty: two per-id outputs read back null at apply time (#520)": "2026-08-28",
+    "The Exoscale stack's second plan is not empty: two per-id outputs read back null at apply time (#520)": "2026-08-29",
     "The catalogue is a whitelist, and its values are measured": "2026-08-27",
     "The contracts do not guarantee the same thing": "2026-08-27",
     "The cost of DNS/TLS interception, measured (#76)": "2026-08-27",

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -214,7 +214,7 @@ const (
 // TestTheFrozenSurfacesStillMatchTheirFixture, and a fixture regenerated
 // without bumping this constant fails TestASurfaceChangeDemandsItsVersionBump.
 // The procedure for a deliberate change is in RELEASING.md ("Frozen surfaces").
-const cliSurfaceVersion = 19
+const cliSurfaceVersion = 20
 
 // Run executes one command and returns the process exit code.
 func Run(args []string, stdout, stderr io.Writer) int {
@@ -313,6 +313,7 @@ Usage:
   feint serve      [--addr 127.0.0.1:4599] [--state <file>] [--vm off|incus|incus-vm|incus-ovn|auto]
                     [--cleanup] [--contracts <dir>] [--coverage <dir>] [--shapes <dir>]
                     [--log-level info|debug] [--expose-to-network]
+                    [--projects <name>[,<name>...]]
                     Serve the three emulated clouds on one port, in the
                     foreground. --expose-to-network is the only way off
                     loopback, and it disarms the anti-rebinding guard: this
@@ -339,6 +340,7 @@ Usage:
 
   feint start      [--addr :4599] [--state <file>] [--vm off|incus|incus-vm|incus-ovn|auto]
                     [--cleanup] [--contracts <dir>] [--log-level info|debug]
+                    [--projects <name>[,<name>...]]
                     [--timeout 30s] [--detach] [--foreground]
                     Same, detached: records the instance, waits until it
                     answers, prints where the log is. Refuses to adopt an
@@ -885,6 +887,7 @@ func serve(args []string, stdout io.Writer) error {
 	cleanup := fs.Bool("cleanup", false, "remove the machines and networks this run created before exiting")
 	logLevel := fs.String("log-level", "info", "log verbosity: error, warn, info, debug")
 	contracts := fs.String("contracts", "", "directory of API contracts; every response is checked against them and /_feint/conformance reports what failed")
+	projects := fs.String("projects", "", "comma-separated project names the emulated account holds, in order (default: the pack's own single project)")
 	shapesDir := fs.String("shapes", "shapes", "directory of observed real-cloud shapes; the evidence record's shape axis reads it (empty to disable)")
 	coverageDir := fs.String("coverage", "coverage", "directory holding the versioned coverage artefacts the page reads")
 	expose := fs.Bool("expose-to-network", false, "listen off loopback, which disarms the browser guard: read what it costs before setting it")
@@ -959,6 +962,21 @@ func serve(args []string, stdout io.Writer) error {
 	} else if declared != nil {
 		env.BootImages = declared
 		fmt.Fprintf(stdout, "boot images declared by the operator: %d\n", len(declared))
+	}
+	// The project catalogue (#572), refused here rather than at the first
+	// request: a stack that names its own project must fail at start with the
+	// declaration in hand, never on the provider's FindExact minutes later with
+	// nothing to read.
+	//
+	// A flag and not an environment variable, unlike FEINT_BOOT_IMAGES: this is
+	// something a feint.yaml states about the account it emulates, and
+	// startArgs' rule is that the file only says which values the CLI's own
+	// flags carry.
+	if declared, err := emulator.ParseProjects(*projects); err != nil {
+		return fmt.Errorf("--projects: %w", err)
+	} else if declared != nil {
+		env.Projects = declared
+		fmt.Fprintf(stdout, "projects declared by the operator: %s\n", strings.Join(declared, ", "))
 	}
 	// Set after newServer, which cannot know the flag. At debug the runtime's
 	// own lifecycle events come through, which is what makes a machine that

--- a/internal/cli/images_resolve.go
+++ b/internal/cli/images_resolve.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 	"unicode"
@@ -66,6 +67,93 @@ var fetchListing = func(url string) (status int, body []byte, err error) {
 	return resp.StatusCode, body, nil
 }
 
+// # What the image server still publishes (#476)
+//
+// `resolve` exists to produce a declaration an operator pastes. Until 2026-08-29
+// it printed one whose boot it could already know would fail: two of the three
+// identifiers the surveyed stacks hardcode resolve to `ubuntu:18.04` and
+// `debian:9`, and `images:` publishes neither. Replayed with that exact
+// declaration on michaelcourcy/kasten-on-outscale: 29 applied, 0 machines
+// started — the same figures as with no declaration at all. The declaration was
+// honoured and bought nothing.
+//
+// The one command whose whole purpose is producing a working declaration was the
+// one place that did not check whether the declaration works.
+
+// imageStreamsIndex is the simplestreams product index the `images:` remote is
+// built from — the same server `machine.SpecFor` names in every ImageSpec's
+// Source, so this asks the thing that would refuse the build rather than a list
+// written down beside it.
+//
+// Read rather than assumed: the index keys products by CODENAME
+// (`ubuntu:jammy:amd64:cloud`) and carries the version aliases in each product's
+// `aliases` field (`ubuntu/jammy/cloud,ubuntu/22.04/cloud`). A check keyed on
+// `ubuntu:22.04:amd64:cloud` finds nothing and would report every working
+// version as withdrawn, which is the first thing this reader was measured
+// against.
+const imageStreamsIndex = "https://images.linuxcontainers.org/streams/v1/images.json"
+
+// publishedAliases answers the set of `family/version/variant` aliases the image
+// server publishes today, and the versions each family still has.
+//
+// An error is an error, never an empty set: a server that could not be asked
+// must not turn every declaration into "withdrawn", which is the three-outcomes
+// rule imagesResolve already states for the listings above.
+func publishedAliases(fetch func(string) (int, []byte, error)) (map[string]bool, map[string][]string, error) {
+	status, body, err := fetch(imageStreamsIndex)
+	if err != nil {
+		return nil, nil, err
+	}
+	if status != http.StatusOK {
+		return nil, nil, fmt.Errorf("the image server's index answered %d", status)
+	}
+	var doc struct {
+		Products map[string]struct {
+			Aliases string `json:"aliases"`
+			Release string `json:"release"`
+			Arch    string `json:"arch"`
+			Variant string `json:"variant"`
+		} `json:"products"`
+	}
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return nil, nil, fmt.Errorf("reading the image server's index: %w", err)
+	}
+	aliases := map[string]bool{}
+	versions := map[string][]string{}
+	for _, product := range doc.Products {
+		for _, alias := range strings.Split(product.Aliases, ",") {
+			alias = strings.TrimSpace(alias)
+			if alias == "" {
+				continue
+			}
+			aliases[alias] = true
+			// family/version/variant — the shape SpecFor builds. Only the cloud
+			// variant is collected for the suggestion list, because that is the
+			// only one this emulator ever asks for.
+			parts := strings.Split(alias, "/")
+			if len(parts) == 3 && parts[2] == "cloud" {
+				versions[parts[0]] = appendUnique(versions[parts[0]], parts[1])
+			}
+		}
+	}
+	if len(aliases) == 0 {
+		return nil, nil, fmt.Errorf("the image server's index carries no aliases, so nothing here could be checked")
+	}
+	for family := range versions {
+		sort.Strings(versions[family])
+	}
+	return aliases, versions, nil
+}
+
+func appendUnique(list []string, value string) []string {
+	for _, held := range list {
+		if held == value {
+			return list
+		}
+	}
+	return append(list, value)
+}
+
 // resolvedImage is what one lookup learned.
 type resolvedImage struct {
 	id     string
@@ -103,7 +191,17 @@ func imagesResolve(args []string, stdout, stderr io.Writer) int {
 		return status, body, err
 	}
 
-	failed, absent := false, false
+	// Asked once, before the loop, and never fatal on its own: an image server
+	// that could not be reached leaves `withdrawn` nil, and the loop then prints
+	// exactly what it printed before this check existed. A network failure must
+	// not turn a working declaration into a refusal (#476).
+	aliases, families, streamsErr := publishedAliases(fetch)
+	if streamsErr != nil {
+		fmt.Fprintf(stdout, "note: the image server's index could not be read (%v),\n", streamsErr)
+		fmt.Fprintln(stdout, "      so whether each version below is still published was not checked")
+	}
+
+	failed, absent, unbuildable := false, false, false
 	var declarations []string
 	for _, id := range args {
 		res, found, err := resolveOne(id, fetch)
@@ -133,6 +231,29 @@ func imagesResolve(args []string, stdout, stderr io.Writer) int {
 				res.ref, strings.Join(machine.Families(), ", "))
 			continue
 		}
+		// The version the reference names may be one the image server has
+		// withdrawn, and then the declaration below cannot boot: the build fails
+		// on "The requested image couldn't be found" and the machine never
+		// starts (#476). Kept out of the paste line rather than printed with a
+		// warning beside it, because the line exists to be pasted.
+		if spec, ok := machine.SpecFor(res.ref); ok && aliases != nil {
+			alias := strings.TrimPrefix(spec.Source, "images:")
+			if !aliases[alias] {
+				unbuildable = true
+				fmt.Fprintf(stdout, "  → %s — the image server no longer publishes %s, so this declaration\n",
+					res.ref, alias)
+				fmt.Fprintln(stdout, "    would refuse to boot; it is left out of the line below.")
+				family, _, _ := strings.Cut(res.ref, ":")
+				if published := families[family]; len(published) > 0 {
+					fmt.Fprintf(stdout, "    %s versions published today: %s\n",
+						family, strings.Join(published, ", "))
+					fmt.Fprintln(stdout, "    naming one of them is your call, not this command's: the identifier")
+					fmt.Fprintln(stdout, "    means what the cloud says it means, and substituting a version here")
+					fmt.Fprintln(stdout, "    would be the silent replacement #83 closed.")
+				}
+				continue
+			}
+		}
 		entry := id + "=" + res.ref
 		if res.login != "" {
 			entry += "@" + res.login
@@ -149,6 +270,14 @@ func imagesResolve(args []string, stdout, stderr io.Writer) int {
 	case failed:
 		return 1
 	case absent:
+		return 2
+	case unbuildable && len(declarations) == 0:
+		// Every identifier resolved to a version nothing can build, so this run
+		// produced no line to paste. Exit 2, the same "the world needs triage"
+		// the absent case uses — a zero here would let a script pipe an empty
+		// declaration and call it a success (#476, shape 3).
+		fmt.Fprintln(stdout, "\nnothing to declare: every identifier resolved to a version the image server")
+		fmt.Fprintln(stdout, "no longer publishes.")
 		return 2
 	}
 	return 0

--- a/internal/cli/images_resolve_test.go
+++ b/internal/cli/images_resolve_test.go
@@ -79,8 +79,12 @@ func TestResolveReadsTheOutscaleReferencePage(t *testing.T) {
 		// its name from the row it opens, not a date from the cell it fills.
 		"Ubuntu-22.04-2023.12.04-0",
 		"Debian-9-2019.11.29-0",
-		// A withdrawn version still resolves; making it bootable is the build's
-		// business, and its failure names the source.
+		// A withdrawn version still resolves and is still declared HERE, because
+		// this stub answers 404 for the image server's index: with no index to
+		// read, whether a version is published was not checked, and a network
+		// failure must never turn a working declaration into a refusal (#476).
+		// The checked path is TestResolveLeavesAWithdrawnVersionOutOfTheLine
+		// below; the note this path prints is asserted there too.
 		"debian:9",
 		// A family without a recipe is said, with the families that have one.
 		"rhel:9",
@@ -169,5 +173,107 @@ func TestCellTokensSurviveTheReferenceMarkup(t *testing.T) {
 	want := fmt.Sprintf("%v", []string{"ami-cd8d714e", "Ubuntu-22.04"})
 	if fmt.Sprintf("%v", got) != want {
 		t.Fatalf("tokens %v, want %s", got, want)
+	}
+}
+
+// #476: `resolve` stops printing a declaration whose boot it can already know
+// fails.
+//
+// Measured on main before this existed: the three identifiers the surveyed
+// stacks hardcode resolve to ubuntu:22.04, ubuntu:18.04 and debian:9, the image
+// server publishes only the first, and the pasted line bought "29 applied, 0
+// machines started" on michaelcourcy/kasten-on-outscale — the same figures as
+// declaring nothing at all.
+//
+// The index is keyed by CODENAME and carries the version aliases per product.
+// That is not a detail: a reader keyed on `ubuntu:22.04:amd64:cloud` finds
+// nothing and reports every working version as withdrawn, which is what the
+// first version of this reader did.
+const streamsFixture = `{"products":{
+  "ubuntu:jammy:amd64:cloud":  {"aliases":"ubuntu/jammy/cloud,ubuntu/22.04/cloud"},
+  "ubuntu:noble:amd64:cloud":  {"aliases":"ubuntu/noble/cloud,ubuntu/24.04/cloud"},
+  "debian:bookworm:amd64:cloud":{"aliases":"debian/bookworm/cloud,debian/12/cloud"}
+}}`
+
+func TestResolveLeavesAWithdrawnVersionOutOfTheLine(t *testing.T) {
+	withListings(t, map[string]string{
+		outscaleOMIsURL:   outscaleFixture,
+		imageStreamsIndex: streamsFixture,
+	})
+	var out, errOut bytes.Buffer
+
+	code := imagesResolve([]string{"ami-a3ca408c", "ami-47899c77"}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("exit %d, want 0 when one identifier still declares\n%s%s", code, out.String(), errOut.String())
+	}
+	got := out.String()
+
+	// The line to paste carries only what boots. This is the whole issue: the
+	// one command whose purpose is producing a working declaration was the one
+	// place that did not check whether the declaration works.
+	if !strings.Contains(got, "FEINT_BOOT_IMAGES='ami-a3ca408c=ubuntu:22.04'") {
+		t.Errorf("the declaration is not the one that boots:\n%s", got)
+	}
+	if strings.Contains(got, "ami-47899c77=debian:9") {
+		t.Errorf("a declaration that cannot boot is still in the line to paste:\n%s", got)
+	}
+
+	// And it is said, with the reason and with what the server does publish.
+	for _, needle := range []string{
+		"no longer publishes debian/9/cloud",
+		"left out of the line below",
+		"debian versions published today: 12, bookworm",
+		"your call, not this command's",
+	} {
+		if !strings.Contains(got, needle) {
+			t.Errorf("output does not carry %q\n%s", needle, got)
+		}
+	}
+
+	// The published versions are printed as a FACT, never applied. Substituting
+	// one is the silent replacement #83 measured and closed on all three packs.
+	if strings.Contains(got, "ami-47899c77=debian:12") {
+		t.Errorf("the command substituted a version the cloud never named:\n%s", got)
+	}
+}
+
+// Shape 3 of the three the issue offers: a run that produced nothing to paste
+// exits 2, the same "the world needs triage" an absent identifier uses. A zero
+// here would let a script pipe an empty declaration and call it a success.
+func TestResolveExitsTwoWhenNothingItResolvedCanBoot(t *testing.T) {
+	withListings(t, map[string]string{
+		outscaleOMIsURL:   outscaleFixture,
+		imageStreamsIndex: streamsFixture,
+	})
+	var out, errOut bytes.Buffer
+
+	if code := imagesResolve([]string{"ami-47899c77"}, &out, &errOut); code != 2 {
+		t.Fatalf("exit %d, want 2 when every identifier resolved to a withdrawn version\n%s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "nothing to declare") {
+		t.Errorf("the run that produced no line does not say so:\n%s", out.String())
+	}
+	if strings.Contains(out.String(), "declare and restart") {
+		t.Errorf("an empty declaration was still offered for pasting:\n%s", out.String())
+	}
+}
+
+// The third outcome, and the one that must not become the first: an image server
+// that could not be asked is not an image server that withdrew everything. The
+// declaration is printed exactly as it was before this check existed, and the
+// run says what it could not check.
+func TestAnUnreadableImageIndexDoesNotWithdrawEverything(t *testing.T) {
+	withListings(t, map[string]string{outscaleOMIsURL: outscaleFixture})
+	var out, errOut bytes.Buffer
+
+	code := imagesResolve([]string{"ami-a3ca408c", "ami-47899c77"}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("exit %d, want 0: an unreachable index is not a withdrawal\n%s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "ami-47899c77=debian:9") {
+		t.Errorf("a declaration was dropped on a check that could not run:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "was not checked") {
+		t.Errorf("the run does not say what it could not check:\n%s", out.String())
 	}
 }

--- a/internal/cli/lifecycle.go
+++ b/internal/cli/lifecycle.go
@@ -35,6 +35,7 @@ type serveFlags struct {
 	cleanup   bool
 	logLevel  string
 	contracts string
+	projects  string
 }
 
 // args renders the flags back into a `serve` command line.
@@ -49,6 +50,9 @@ func (f serveFlags) args() []string {
 	if f.cleanup {
 		out = append(out, "--cleanup")
 	}
+	if f.projects != "" {
+		out = append(out, "--projects", f.projects)
+	}
 	return out
 }
 
@@ -60,6 +64,13 @@ func bindServeFlags(fs *flag.FlagSet) *serveFlags {
 	fs.BoolVar(&f.cleanup, "cleanup", false, "remove the machines and networks this run created before exiting")
 	fs.StringVar(&f.logLevel, "log-level", "info", "log verbosity: error, warn, info, debug")
 	fs.StringVar(&f.contracts, "contracts", "", "directory of API contracts; every response is checked against them")
+	// Bound here as well as on `serve`, because `up` renders it into the `start`
+	// command line: a flag `startArgs` writes and `start` does not bind fails
+	// the whole path with "flag provided but not defined", on the one command
+	// this feature exists to serve.
+	//
+	// TestStartRelaysTheDeclaredProjectsToServe fails without this.
+	fs.StringVar(&f.projects, "projects", "", "comma-separated project names the emulated account holds, in order")
 	return f
 }
 

--- a/internal/cli/testdata/frozen/cli.json
+++ b/internal/cli/testdata/frozen/cli.json
@@ -3178,6 +3178,208 @@
           ]
         }
       }
+    },
+    {
+      "schema_version": 20,
+      "content": {
+        "exit_codes": {
+          "drift": 2,
+          "error": 1,
+          "ok": 0
+        },
+        "verbs": {
+          "catalog": [
+            "--format"
+          ],
+          "clean": [
+            "--check",
+            "--closing",
+            "--doorstep",
+            "--force",
+            "--format",
+            "--vm"
+          ],
+          "corpus": [
+            "--accepted",
+            "--against-cloud",
+            "--bind",
+            "--check",
+            "--credential",
+            "--dir",
+            "--dry-run",
+            "--endpoint",
+            "--file",
+            "--format",
+            "--mark-stale",
+            "--timeout"
+          ],
+          "coverage": [
+            "--artefact",
+            "--axis",
+            "--baseline",
+            "--contract",
+            "--evidence",
+            "--fail-on-unknown",
+            "--format",
+            "--gaps",
+            "--observed",
+            "--products",
+            "--provider",
+            "--sdk",
+            "--write-baseline"
+          ],
+          "docs": [
+            "--check",
+            "--client-pins",
+            "--confidence",
+            "--contracts",
+            "--coverage",
+            "--file",
+            "--install",
+            "--limits",
+            "--proved",
+            "--routes",
+            "--screenshots",
+            "--ui-manifest",
+            "--workflow"
+          ],
+          "doctor": [
+            "--addr",
+            "--vm"
+          ],
+          "down": [
+            "--file",
+            "--keep-emulator"
+          ],
+          "env": [
+            "--client",
+            "--endpoint",
+            "--shell",
+            "--unset"
+          ],
+          "evidence": [
+            "--allow-narrowing",
+            "--contracts",
+            "--endpoint",
+            "--join",
+            "--out",
+            "--reshape",
+            "--shapes",
+            "--suites"
+          ],
+          "images": [
+            "--check",
+            "--only",
+            "--vm"
+          ],
+          "logs": [
+            "--addr",
+            "-f",
+            "-n"
+          ],
+          "probe": [
+            "--contracts",
+            "--endpoint",
+            "--provider"
+          ],
+          "proxy": [
+            "--addr",
+            "--expose-to-network",
+            "--forward",
+            "--intercept",
+            "--max-body",
+            "--provider",
+            "--queue",
+            "--record",
+            "--upstream"
+          ],
+          "replay": [
+            "--endpoint",
+            "--format",
+            "--refusals-only",
+            "--timeout"
+          ],
+          "restart": [
+            "--addr",
+            "--timeout"
+          ],
+          "serve": [
+            "--addr",
+            "--cleanup",
+            "--contracts",
+            "--coverage",
+            "--expose-to-network",
+            "--log-level",
+            "--projects",
+            "--shapes",
+            "--state",
+            "--vm"
+          ],
+          "shapes": [
+            "--check",
+            "--dir",
+            "--dry-run",
+            "--profile",
+            "--provider",
+            "--record"
+          ],
+          "snapshot list": [
+            "--format"
+          ],
+          "snapshot load": [
+            "--addr"
+          ],
+          "snapshot save": [
+            "--addr",
+            "--force"
+          ],
+          "start": [
+            "--addr",
+            "--cleanup",
+            "--contracts",
+            "--detach",
+            "--foreground",
+            "--log-level",
+            "--projects",
+            "--state",
+            "--timeout",
+            "--vm"
+          ],
+          "status": [
+            "--addr",
+            "--coverage",
+            "--format"
+          ],
+          "stop": [
+            "--addr",
+            "--timeout"
+          ],
+          "transcript": [
+            "--against",
+            "--contract",
+            "--format",
+            "--sanitise",
+            "--shape"
+          ],
+          "ui": [
+            "--addr",
+            "--print"
+          ],
+          "up": [
+            "--file",
+            "--no-iac",
+            "--runtime",
+            "--timeout"
+          ],
+          "version": [
+            "--check"
+          ],
+          "wait": [
+            "--addr",
+            "--timeout"
+          ]
+        }
+      }
     }
   ]
 }

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -518,6 +518,9 @@ func startArgs(decl *environment.File) []string {
 	if decl.Emulator.Cleanup {
 		args = append(args, "--cleanup")
 	}
+	if len(decl.Cloud.Projects) > 0 {
+		args = append(args, "--projects", strings.Join(decl.Cloud.Projects, ","))
+	}
 	return args
 }
 

--- a/internal/cli/up_wait_test.go
+++ b/internal/cli/up_wait_test.go
@@ -126,6 +126,49 @@ func TestAnUnreadableInventoryIsAnErrorAndNeverAZero(t *testing.T) {
 	}
 }
 
+// The declared project catalogue travels the whole way (#572).
+//
+// Two halves, and the second is the one that would have shipped broken. `up`
+// renders `--projects` into the `feint start` command line; `start` binds its
+// own flag set, and a flag it does not bind fails the entire path with "flag
+// provided but not defined" — on the one command this feature exists to serve.
+// So the rendering is asserted, and then the binding is asserted by parsing it.
+func TestStartRelaysTheDeclaredProjectsToServe(t *testing.T) {
+	decl, err := environment.Parse("version: 1\ncloud:\n  provider: scaleway\n" +
+		"  projects:\n    - default\n    - platform-prod\n")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	rendered := startArgs(decl)
+	if got := strings.Join(rendered, " "); !strings.Contains(got, "--projects default,platform-prod") {
+		t.Fatalf("start would not receive the catalogue: %s", got)
+	}
+
+	// The half a rendering test alone cannot see: `start` parses what `up`
+	// wrote, and passes it on to `serve` unchanged.
+	fs := newFlagSet("start")
+	flags := bindServeFlags(fs)
+	if err := fs.Parse(rendered); err != nil {
+		t.Fatalf("start refuses the command line up renders for it: %v", err)
+	}
+	if flags.projects != "default,platform-prod" {
+		t.Errorf("start bound %q, want the two declared names", flags.projects)
+	}
+	if got := strings.Join(flags.args(), " "); !strings.Contains(got, "--projects default,platform-prod") {
+		t.Errorf("start does not hand the catalogue to serve: %s", got)
+	}
+
+	// A declaration that names none renders none: the pack's own default is not
+	// something this file spells.
+	bare, err := environment.Parse("version: 1\ncloud:\n  provider: scaleway\n")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := strings.Join(startArgs(bare), " "); strings.Contains(got, "--projects") {
+		t.Errorf("an undeclared catalogue rendered a flag: %s", got)
+	}
+}
+
 // The declaration renders into the flags `start` already takes, one direction
 // only: a field that named no flag would be a second source for something the
 // binary already decides.

--- a/internal/core/emulator/emulator.go
+++ b/internal/core/emulator/emulator.go
@@ -54,6 +54,23 @@ type Env struct {
 	// are opaque strings the operator chose; nothing here knows any provider's
 	// vocabulary, which is what keeps this field in the neutral core.
 	BootImages map[string]machine.Image
+	// Projects names the tenancies the emulated account holds, in the order the
+	// operator declared them (--projects, parsed by ParseProjects). Empty means
+	// the pack's own single default, which is what every existing declaration
+	// and every existing test gets.
+	//
+	// Neutral for the same reason BootImages is: resource.Tenant already carries
+	// a Project, so a list of them names nothing any provider owns, and the
+	// strings are the operator's own. What a pack DOES with them is the pack's:
+	// Scaleway serves them through account/v3, and a pack whose cloud has no
+	// such concept ignores the field rather than inventing one.
+	//
+	// Why declared and not echoed. The cheap fix for #572 was to answer that a
+	// project exists because somebody asked for it, and that is the class #83
+	// measured and closed on all three packs: an identifier no catalogue held,
+	// silently substituted, and a green run that meant nothing. The inventory
+	// stays something the operator stated.
+	Projects []string
 	// Log is where packs report what they could not do. A machine runtime that
 	// fails must never break the control plane, which makes the log the only
 	// place the operator can learn why nothing started.
@@ -764,4 +781,44 @@ func (s *Server) handleRoutes(w http.ResponseWriter, _ *http.Request) {
 		out = append(out, routeView{Method: r.Method, Path: r.Path, Operation: r.Operation})
 	}
 	writeJSON(w, http.StatusOK, out)
+}
+
+// ParseProjects reads the operator's `--projects` declaration: a comma-separated
+// list of project names, in order.
+//
+// Validated at the door rather than at the point of use, which is the rule
+// cloudinit.go paid for: a name that reaches a response body or a template is
+// too late to check. Refused here are the empty name, the duplicate, and any
+// control character — the last one because these strings are rendered into JSON
+// bodies and read back by clients that key on them.
+//
+// An empty declaration answers nil, never an empty non-nil slice: the packs test
+// `len(env.Projects) == 0` to mean "the operator declared nothing", and a
+// zero-length slice that is not nil would read the same in Go and differently to
+// a reader.
+//
+// TestParseProjectsRefusesWhatAClientWouldReadBack fails without this.
+func ParseProjects(declared string) ([]string, error) {
+	declared = strings.TrimSpace(declared)
+	if declared == "" {
+		return nil, nil
+	}
+	seen := make(map[string]bool)
+	var out []string
+	for _, raw := range strings.Split(declared, ",") {
+		name := strings.TrimSpace(raw)
+		if name == "" {
+			return nil, fmt.Errorf("%q holds an empty project name; the form is a comma-separated list", declared)
+		}
+		if strings.ContainsFunc(name, func(r rune) bool { return r < 0x20 || r == 0x7f }) {
+			return nil, fmt.Errorf("project name %q carries a control character, and these names are "+
+				"rendered into response bodies clients read back", name)
+		}
+		if seen[name] {
+			return nil, fmt.Errorf("project %q is declared twice; each name identifies one tenancy", name)
+		}
+		seen[name] = true
+		out = append(out, name)
+	}
+	return out, nil
 }

--- a/internal/core/emulator/emulator_test.go
+++ b/internal/core/emulator/emulator_test.go
@@ -110,3 +110,44 @@ func TestNewUUIDFormat(t *testing.T) {
 		seen[id] = true
 	}
 }
+
+// The operator's project catalogue, refused at the door (#572).
+//
+// Validated where it enters rather than where it is used, which is the rule
+// cloudinit.go paid for: these names are rendered into JSON bodies and read back
+// by clients that key on them, so a control character is refused here and never
+// escaped later.
+func TestParseProjectsRefusesWhatAClientWouldReadBack(t *testing.T) {
+	for _, bad := range []string{
+		"a,,b",
+		",",
+		"a,a",
+		"prod,prod",
+		"line\nbreak",
+		"tab\tinside",
+		"bell\x07",
+	} {
+		t.Run(bad, func(t *testing.T) {
+			if _, err := emulator.ParseProjects(bad); err == nil {
+				t.Fatalf("accepted %q, which a client would read back verbatim", bad)
+			}
+		})
+	}
+
+	// The accepting half: a guard that refuses everything passes every planted
+	// defect and breaks the product.
+	got, err := emulator.ParseProjects(" default , platform-prod ")
+	if err != nil {
+		t.Fatalf("an ordinary declaration was refused: %v", err)
+	}
+	if len(got) != 2 || got[0] != "default" || got[1] != "platform-prod" {
+		t.Errorf("parsed as %q, want the two names in order with the spaces trimmed", got)
+	}
+
+	// An empty declaration answers nil and never an empty non-nil slice: the
+	// packs read `len(env.Projects) == 0` as "the operator declared nothing",
+	// and the two would read the same in Go and differently to a reader.
+	if got, err := emulator.ParseProjects("   "); err != nil || got != nil {
+		t.Errorf("an empty declaration answered %#v, %v; want nil, nil", got, err)
+	}
+}

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -60,6 +60,10 @@ type File struct {
 		// running the engine. Validated against the packs the binary mounts,
 		// by the caller: which packs exist is not this package's knowledge.
 		Provider string
+		// Projects names the tenancies the emulated account holds. Empty means
+		// the pack's own single default, which is what every declaration
+		// written before #572 gets.
+		Projects []string
 	}
 
 	Emulator struct {
@@ -364,6 +368,22 @@ var fields = []Field{
 			"clients want. Refused when the binary mounts no such pack.",
 		ReadBy: []string{"up", "down"},
 		assign: func(f *File, n node) error { return scalarInto(n, &f.Cloud.Provider) },
+	},
+	{
+		Path: "cloud.projects", Takes: "a list of project names", Default: "",
+		Doc: "The projects the emulated account holds, in order: `serve --projects`. A stack whose " +
+			"`project_name` is its own production project names it here, and the emulator holds it " +
+			"rather than answering that it exists because somebody asked (#572). Omitted, the pack " +
+			"serves its own single default project.",
+		ReadBy: []string{"up"},
+		assign: func(f *File, n node) error {
+			list, err := scalarList(n)
+			if err != nil {
+				return err
+			}
+			f.Cloud.Projects = list
+			return nil
+		},
 	},
 	{
 		Path: "emulator.addr", Takes: "a listen address", Default: "127.0.0.1:4599",

--- a/internal/environment/environment_test.go
+++ b/internal/environment/environment_test.go
@@ -15,6 +15,9 @@ const validDeclaration = `version: 1
 
 cloud:
   provider: scaleway
+  projects:
+    - default
+    - platform-prod
 
 emulator:
   addr: 127.0.0.1:4599
@@ -130,6 +133,9 @@ func TestEveryFieldOfTheSchemaIsAccepted(t *testing.T) {
 	src := `version: 1
 cloud:
   provider: scaleway
+  projects:
+    - default
+    - platform-prod
 emulator:
   addr: 127.0.0.1:4699
   state: state.json

--- a/internal/environment/render.go
+++ b/internal/environment/render.go
@@ -39,6 +39,7 @@ func Render(f *File) string {
 
 	block("cloud", func(w *strings.Builder) {
 		scalar(w, "cloud.provider", "provider", f.Cloud.Provider)
+		renderList(w, f.declared["cloud.projects"], "projects", f.Cloud.Projects)
 	})
 	block("emulator", func(w *strings.Builder) {
 		scalar(w, "emulator.addr", "addr", f.Emulator.Addr)

--- a/internal/providers/scaleway/projects.go
+++ b/internal/providers/scaleway/projects.go
@@ -1,6 +1,9 @@
 package scaleway
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
 	"net/http"
 
 	"github.com/stephrobert/feint/internal/core/emulator"
@@ -71,16 +74,84 @@ const defaultProjectName = "default"
 // project cannot be deleted here either.
 const defaultProjectDescription = "cannot_be_deleted"
 
+// # The declared catalogue (#572)
+//
+// Until 2026-08-29 this file held exactly one project, named `default`, and a
+// stack whose `project_name` was anything else died on the provider's FindExact
+// after a truthful empty list. That is a real obstacle for the case #372 exists
+// to serve — a platform team pointing an existing stack at the emulator is
+// precisely the person whose project name is their own.
+//
+// The operator now declares them (`feint serve --projects`, `cloud.projects` in
+// feint.yaml). The list still FILTERS: a name nobody declared answers an empty
+// list, because the alternative — answer that a project exists because somebody
+// asked for it — is the class #83 measured and closed on all three packs.
+//
+// Identifiers are derived from the name, never minted per run, for the reason
+// projectEpoch is fixed: an id that moved between two reads is a permanent
+// Terraform diff. `default` keeps the constant every other product of this pack
+// already scopes its answers to (defaultProject in servers.go), so a declaration
+// that names it changes nothing about what was there before.
+
+// projectID answers the identifier of a declared project.
+//
+// `default` is the constant, because every unfiltered answer of every product in
+// this pack is already scoped to it (scopeOf) and moving it would renumber the
+// whole emulated account. Every other name is hashed into a v4-shaped UUID,
+// deterministic across restarts and across processes: two `feint serve` runs of
+// the same declaration answer the same identifiers, which is what a stack that
+// stores state between applies requires.
+func projectID(name string) string {
+	if name == defaultProjectName {
+		return defaultProject
+	}
+	sum := sha256.Sum256([]byte("feint/scaleway/project/" + name))
+	hexed := hex.EncodeToString(sum[:16])
+	// Shaped like the UUIDs Scaleway mints — version 4, variant 10 — because
+	// clients parse them. A 32-character hex string that is not a UUID is
+	// refused by the SDK before it reaches anything this emulator serves.
+	return fmt.Sprintf("%s-%s-4%s-%x%s-%s",
+		hexed[0:8], hexed[8:12], hexed[13:16],
+		(hexed[16]&0x3)|0x8, hexed[17:20], hexed[20:32])
+}
+
+// declaredProjects answers the catalogue this emulator holds, in declaration
+// order.
+//
+// An operator who declared nothing gets the single default project, which is
+// what every existing feint.yaml, every existing test and every existing
+// recording expects. The fallback is here rather than at the parse site so that
+// a pack reading env.Projects never has to ask whether the empty case means
+// "none" or "the default" — it means the default, once, in this function.
+func (p *Pack) declaredProjects() []string {
+	if len(p.env.Projects) == 0 {
+		return []string{defaultProjectName}
+	}
+	return p.env.Projects
+}
+
+// projectNamed answers the declared name carrying that identifier, and whether
+// the catalogue holds it at all.
+func (p *Pack) projectNamed(id string) (string, bool) {
+	for _, name := range p.declaredProjects() {
+		if projectID(name) == id {
+			return name, true
+		}
+	}
+	return "", false
+}
+
 // projectView renders one Project, field for field as the SDK declares it
 // (account/v3/account_sdk.go, type Project) and in the order the document's
 // x-properties-order gives.
 //
-// id is a parameter rather than the constant because GetProject echoes what it
-// was asked for; see the file comment.
-func projectView(id string) map[string]any {
+// id and name are parameters rather than constants: id because GetProject
+// echoes what it was asked for (see the file comment), name because the
+// catalogue has held more than one since #572.
+func projectView(id, name string) map[string]any {
 	return map[string]any{
 		"id":              id,
-		"name":            defaultProjectName,
+		"name":            name,
 		"organization_id": defaultOrganization,
 		"created_at":      projectEpoch,
 		"updated_at":      projectEpoch,
@@ -129,12 +200,22 @@ func (p *Pack) listProjects(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	projects := []any{projectView(defaultProject)}
-	if name := q.Get("name"); name != "" && name != defaultProjectName {
-		projects = nil
-	}
-	if ids := csvValues(q, "project_ids"); len(ids) > 0 && !contains(ids, defaultProject) {
-		projects = nil
+	// The two filters still FILTER, over the declared catalogue rather than over
+	// a constant. An empty answer remains the truthful one for a name this
+	// account does not hold — the whole point of #572 is that the operator can
+	// make it hold that name, not that the emulator invents it.
+	wantName := q.Get("name")
+	wantIDs := csvValues(q, "project_ids")
+	projects := []any{}
+	for _, declared := range p.declaredProjects() {
+		id := projectID(declared)
+		if wantName != "" && wantName != declared {
+			continue
+		}
+		if len(wantIDs) > 0 && !contains(wantIDs, id) {
+			continue
+		}
+		projects = append(projects, projectView(id, declared))
 	}
 
 	page := parsePage(r)
@@ -161,5 +242,17 @@ func (p *Pack) getProject(w http.ResponseWriter, r *http.Request) {
 		writeNotFound(w, "project", id)
 		return
 	}
-	emulator.WriteJSON(w, http.StatusOK, projectView(id))
+	// A declared project answers with its own name; anything else still echoes,
+	// under the first declared name. The echo is unchanged and deliberate — see
+	// the file comment — but it stopped being able to answer `default` for
+	// everything the moment the catalogue could hold more than one, and a
+	// project the operator DID declare must read back as itself or the data
+	// source resolves a name nobody asked for.
+	//
+	// TestGetProjectAnswersADeclaredProjectByItsOwnName fails without this.
+	if name, ok := p.projectNamed(id); ok {
+		emulator.WriteJSON(w, http.StatusOK, projectView(id, name))
+		return
+	}
+	emulator.WriteJSON(w, http.StatusOK, projectView(id, p.declaredProjects()[0]))
 }

--- a/internal/providers/scaleway/projects_declared_test.go
+++ b/internal/providers/scaleway/projects_declared_test.go
@@ -1,0 +1,195 @@
+package scaleway_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/store"
+	"github.com/stephrobert/feint/internal/providers/scaleway"
+)
+
+// The declared project catalogue (#572).
+//
+// Until 2026-08-29 this pack held one project named `default`, and a stack whose
+// `project_name` was its own production project died on the provider's FindExact
+// after a truthful empty list — the obstacle for exactly the person #372 exists
+// to serve. The operator declares the catalogue now, and the list still filters:
+// a name nobody declared answers nothing, because answering that a project
+// exists because somebody asked for it is the class #83 measured and closed on
+// all three packs.
+
+func TestListProjectsAnswersTheOnesTheOperatorDeclared(t *testing.T) {
+	srv := serveWithProjects(t, "default", "platform-prod")
+
+	all := projectsOf(t, srv, "")
+	if len(all) != 2 {
+		t.Fatalf("%d project(s) listed, want the two declared: %v", len(all), all)
+	}
+	if all[0]["name"] != "default" || all[1]["name"] != "platform-prod" {
+		t.Errorf("listed %v, %v; declaration order is what a reader compares against",
+			all[0]["name"], all[1]["name"])
+	}
+
+	// The filter the provider's data source uses, on the name that motivated
+	// this issue.
+	named := projectsOf(t, srv, "&name=platform-prod")
+	if len(named) != 1 || named[0]["name"] != "platform-prod" {
+		t.Fatalf("filtering by a declared name answered %v", named)
+	}
+
+	// And the half that must not become an echo: a name nobody declared is an
+	// empty list, not an invented project.
+	if got := projectsOf(t, srv, "&name=never-declared"); len(got) != 0 {
+		t.Errorf("a name nobody declared answered %v; the emulator invented a project", got)
+	}
+}
+
+// An operator who declared nothing gets exactly what was there before: one
+// project called `default`, under the identifier every other product of this
+// pack already scopes its answers to. A feature that changed the default answer
+// would have rewritten every existing declaration's account.
+func TestAnUndeclaredCatalogueIsStillTheSingleDefaultProject(t *testing.T) {
+	srv := serveWithProjects(t)
+
+	all := projectsOf(t, srv, "")
+	if len(all) != 1 {
+		t.Fatalf("%d project(s) with nothing declared, want 1: %v", len(all), all)
+	}
+	if all[0]["name"] != "default" {
+		t.Errorf("the undeclared catalogue is named %v, want default", all[0]["name"])
+	}
+	if all[0]["id"] != "11111111-1111-1111-1111-111111111111" {
+		t.Errorf("the default project's id moved to %v; every other product of this pack scopes to it",
+			all[0]["id"])
+	}
+}
+
+// A declared project reads back as itself. The echo GetProject performs for an
+// unknown identifier is deliberate and unchanged (see projects.go), but it
+// stopped being able to answer `default` for everything the moment the catalogue
+// could hold more than one: the data source resolves a name through ListProjects
+// and then reads it back here, so a declared project answering somebody else's
+// name would hand the stack a project it never asked for.
+func TestGetProjectAnswersADeclaredProjectByItsOwnName(t *testing.T) {
+	srv := serveWithProjects(t, "default", "platform-prod")
+
+	declared := projectsOf(t, srv, "&name=platform-prod")
+	if len(declared) != 1 {
+		t.Fatalf("the declared project did not list: %v", declared)
+	}
+	id, _ := declared[0]["id"].(string)
+
+	got := getProject(t, srv, id)
+	if got["name"] != "platform-prod" {
+		t.Errorf("GetProject on the declared project answered name %v, want platform-prod", got["name"])
+	}
+	if got["id"] != id {
+		t.Errorf("GetProject answered id %v for %s", got["id"], id)
+	}
+
+	// The echo, unchanged: an identifier this catalogue never held still
+	// resolves, because a configuration carrying a production project UUID must
+	// not die on the one thing that has nothing to do with what it is testing.
+	foreign := "abcdef01-2345-4678-9abc-def012345678"
+	echoed := getProject(t, srv, foreign)
+	if echoed["id"] != foreign {
+		t.Errorf("GetProject answered id %v for %s; the identifier a client sent is the one it must read back",
+			echoed["id"], foreign)
+	}
+}
+
+// The identifiers are derived from the name and never minted, for the reason
+// projectEpoch is fixed: an id that moved between two reads is a permanent
+// Terraform diff. Two independent servers of the same declaration must agree.
+func TestADeclaredProjectKeepsItsIdentifierAcrossProcesses(t *testing.T) {
+	first := projectsOf(t, serveWithProjects(t, "default", "platform-prod"), "&name=platform-prod")
+	second := projectsOf(t, serveWithProjects(t, "default", "platform-prod"), "&name=platform-prod")
+	if len(first) != 1 || len(second) != 1 {
+		t.Fatalf("the declared project did not list twice: %v / %v", first, second)
+	}
+	if first[0]["id"] != second[0]["id"] {
+		t.Errorf("two servers of the same declaration answered %v and %v: a stack storing state "+
+			"between applies would see a permanent diff", first[0]["id"], second[0]["id"])
+	}
+	// And it is shaped like the UUIDs the SDK parses, which is what a client
+	// requires before it reaches anything this emulator serves.
+	id, _ := first[0]["id"].(string)
+	if len(id) != 36 || strings.Count(id, "-") != 4 || id[14] != '4' {
+		t.Errorf("the derived identifier %q is not a v4-shaped UUID", id)
+	}
+}
+
+// ---- the harness -----------------------------------------------------------
+
+// serveWithProjects is newTestServer with a declared catalogue. Written here
+// rather than as a parameter on newTestServer because every other test in this
+// package asserts the UNDECLARED account, and a shared helper that took the
+// list would invite them to drift into declaring one.
+func serveWithProjects(t *testing.T, names ...string) *httptest.Server {
+	t.Helper()
+
+	var seq int
+	env := &emulator.Env{
+		Store: store.New(),
+		Now:   func() time.Time { return time.Unix(1700000000, 0).UTC() },
+		NewID: func() string {
+			seq++
+			return fmt.Sprintf("00000000-0000-4000-8000-%012d", seq)
+		},
+		Projects: names,
+	}
+	srv, err := emulator.NewServer(env, scaleway.New(env))
+	if err != nil {
+		t.Fatalf("build emulator: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func projectsOf(t *testing.T, srv *httptest.Server, filter string) []map[string]any {
+	t.Helper()
+	res, err := http.Get(srv.URL + "/account/v3/projects?organization_id=" +
+		"99999999-9999-4999-8999-999999999999" + filter)
+	if err != nil {
+		t.Fatalf("list projects: %v", err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("list projects answered %d", res.StatusCode)
+	}
+	var body struct {
+		TotalCount int              `json:"total_count"`
+		Projects   []map[string]any `json:"projects"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.TotalCount != len(body.Projects) {
+		t.Errorf("total_count is %d and %d project(s) came back", body.TotalCount, len(body.Projects))
+	}
+	return body.Projects
+}
+
+func getProject(t *testing.T, srv *httptest.Server, id string) map[string]any {
+	t.Helper()
+	res, err := http.Get(srv.URL + "/account/v3/projects/" + id)
+	if err != nil {
+		t.Fatalf("get project: %v", err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("get project answered %d", res.StatusCode)
+	}
+	var body map[string]any
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return body
+}

--- a/mise.toml
+++ b/mise.toml
@@ -566,7 +566,12 @@ run = """
 # so it is asked at second zero. With FEINT_VM off, which is the default and the
 # whole of the CI matrix, it says so and asks nothing.
 tools/conformance/guard.sh leftovers "${FEINT_VM:-off}"
-./feint start --addr $FEINT_ADDR --vm ${FEINT_VM:-off} --contracts contracts --timeout 60s
+# --projects declares a catalogue of two (#572). Every assertion written before
+# it filters by `name=default` and is unchanged by the second name; what the
+# second one buys is the case #572 is about, which no unit test can reach: `scw`
+# and the Terraform provider resolving a project whose name is not `default`.
+./feint start --addr $FEINT_ADDR --vm ${FEINT_VM:-off} --contracts contracts \
+  --projects default,platform-prod --timeout 60s
 trap './feint stop --addr $FEINT_ADDR >/dev/null 2>&1 || true' EXIT
 tools/conformance/scaleway/scw-cli.sh "http://$FEINT_ADDR"
 tools/conformance/scaleway/terraform.sh "http://$FEINT_ADDR"

--- a/tools/conformance/environment/fixture/feint.yaml
+++ b/tools/conformance/environment/fixture/feint.yaml
@@ -8,6 +8,14 @@ version: 1
 
 cloud:
   provider: scaleway
+  # The declared project catalogue (#572), here because this is the only
+  # declaration any suite drives through `feint up`: without it the flag would
+  # travel from the schema to `start` to `serve` with nothing ever reading the
+  # answer, which is what `mise run testplan` says about this diff in its own
+  # words — "a flag no declaration names is unexercised".
+  projects:
+    - default
+    - platform-prod
 
 emulator:
   addr: 127.0.0.1:4599

--- a/tools/conformance/environment/up.sh
+++ b/tools/conformance/environment/up.sh
@@ -67,6 +67,21 @@ ok "every ready condition was said out loud and confirmed"
 curl -sf "http://$ADDR/_feint/health" >/dev/null || fail "the emulator up brought up does not answer"
 ok "the emulator answers"
 
+# The declared project catalogue reached the emulator (#572). Asserted against
+# the running emulator, never against `up`'s output: what is under test is that
+# a field of the declaration became a flag, became a serve, and changed an
+# answer a client reads — four hops, and only the last one is worth anything.
+org="99999999-9999-4999-8999-999999999999"
+declared="$(curl -sf "http://$ADDR/account/v3/projects?organization_id=$org&name=platform-prod")" \
+  || fail "the account's projects do not answer"
+printf '%s' "$declared" | jq -e '.total_count == 1 and .projects[0].name == "platform-prod"' >/dev/null \
+  || fail "the project this declaration names is not held by the emulator it started: $declared"
+undeclared="$(curl -sf "http://$ADDR/account/v3/projects?organization_id=$org&name=never-declared")" \
+  || fail "the account's projects do not answer"
+printf '%s' "$undeclared" | jq -e '.total_count == 0' >/dev/null \
+  || fail "a name nobody declared answered a project, which is the echo #572 refuses: $undeclared"
+ok "the declared project catalogue reached the emulator, and an undeclared name still answers nothing"
+
 # The instance is one the existing verbs know about: `up` composes `start`, and
 # a second lifecycle would show up exactly here.
 "$FEINT" status --addr "$ADDR" >/dev/null 2>&1 || fail "status does not know the instance up started"

--- a/tools/conformance/functional.sh
+++ b/tools/conformance/functional.sh
@@ -470,11 +470,37 @@ run_stack() { # name
 		[ -n "$MACHINE" ] \
 			|| fail "$name: proof.json names the machine '$1' and no $kind resource carries that name — the declaration and the stack have drifted apart"
 	}
-	listen_of() { # machine
-		LISTEN="$WORK/listen-$1.txt"
-		[ -f "$LISTEN" ] && return 0
-		live_listeners "$1" "$LISTEN" \
-			|| fail "cannot look: reading /proc/net/tcp inside $1 failed; every 'not listening' this run would report is an instrument failure"
+	# listen_for replaced a `listen_of` that read a machine's listeners ONCE and
+	# cached the file. Five of this file's six verdicts drew their conclusion
+	# from that cache, and the scheduled night of 2026-08-29 died on one of them
+	# — so the caching form is gone rather than left beside its replacement for
+	# the next caller to reach for.
+	#
+	# listen_for is the capture for a caller that knows which port it is about to
+	# draw a verdict on: it waits for that port to appear rather than reading
+	# once, and leaves the fresh capture in $LISTEN.
+	#
+	# Why it exists, dated. #600 taught the service path to wait, and the
+	# scheduled night of 2026-08-29 failed further along on the isolation
+	# verdict: "platform-bastion does not listen on 22 inside the machine
+	# (listening: 53)". Same shape, different call site — the bastion is a
+	# TARGET here, and `listen_of` reads once and caches, so every verdict below
+	# was drawing conclusions from a capture taken before the workload existed.
+	#
+	# Several ports because the firewall pair needs two: the port a rule opens
+	# and the port no rule names are both asserted listening from inside before
+	# anything outside is measured, and either can be the late one.
+	#
+	# The budget is #600's 90 s, and the wait records itself in WAIT_TRACE, so
+	# what a first boot really costs on a runner can be re-derived rather than
+	# guessed.
+	listen_for() { # machine port [port...]
+		local machine="$1" port
+		shift
+		for port in "$@"; do
+			wait_until 90 fnl_port_appeared "$machine" "$port" "$WORK/listen-$machine.txt" || true
+		done
+		LISTEN="$WORK/listen-$machine.txt"
 	}
 	address_of() { # declared_name machine
 		ADDRESS="$(private_address "$2")" \
@@ -560,7 +586,7 @@ run_stack() { # name
 			rmachine_t="$MACHINE"
 			address_of "$rtarget" "$rmachine_t"
 			raddr="$ADDRESS"
-			listen_of "$rmachine_t"
+			listen_for "$rmachine_t" "$rport"
 			live_probe "$rmachine" "$raddr" "$rport"
 			rbefore=$?
 			if [ -n "$rcontrol" ]; then
@@ -635,7 +661,7 @@ run_stack() { # name
 		if [ -n "$rtarget" ]; then
 			echo "- $name: the restarted machine still reaches the subnet it reached before"
 			rm -f "$WORK/listen-$rmachine_t.txt"
-			listen_of "$rmachine_t"
+			listen_for "$rmachine_t" "$rport"
 			live_probe "$rmachine" "$raddr" "$rport"
 			rafter=$?
 			rcontrol_after=1
@@ -706,6 +732,10 @@ run_stack() { # name
 			elif ! printf '%s' "$health" | witness_enforced "$provider" firewall; then
 				skip "$name: $provider does not declare enforced.firewall — a property it never promised is not demanded of it (#481)"
 			else
+				# Both ports, and the closed one is the reason: the service wait
+				# above covered the open port only, and a closed port that is
+				# merely late reads exactly like a firewall that works.
+				listen_for "$smachine" "$port" "$(printf '%s' "$closed" | jq -r '.')"
 				fnl_firewall_pair "$name (public path)" "the station" "" "$target" "$address" \
 					"$port" "$(printf '%s' "$closed" | jq -r '.')" "$LISTEN" station_probe
 			fi
@@ -751,7 +781,7 @@ run_stack() { # name
 		tmachine="$MACHINE"
 		address_of "$target" "$tmachine"
 		taddr="$ADDRESS"
-		listen_of "$tmachine"
+		listen_for "$tmachine" "$open" "$closed"
 		fnl_firewall_pair "$name" "$source" "$smachine" "$target" "$taddr" "$open" "$closed" "$LISTEN" live_probe
 		reason="$(skip_reason "$control")"
 		if [ -n "$reason" ]; then
@@ -801,7 +831,7 @@ run_stack() { # name
 			rdm="$MACHINE"
 			address_of "$rdst" "$rdm"
 			raddr="$ADDRESS"
-			listen_of "$rdm"
+			listen_for "$rdm" "$rport"
 			fnl_reaches "$name" "$rsrc" "$rsm" "$rdst" "$raddr" "$rport" "$LISTEN" live_probe
 		fi
 
@@ -822,7 +852,7 @@ run_stack() { # name
 			idm="$MACHINE"
 			address_of "$idst" "$idm"
 			iaddr="$ADDRESS"
-			listen_of "$idm"
+			listen_for "$idm" "$iport"
 			fnl_isolated "$name" "$isrc" "$ism" "$idst" "$iaddr" "$iport" "$LISTEN" live_probe
 		fi
 	fi

--- a/tools/conformance/functional_capture_test.go
+++ b/tools/conformance/functional_capture_test.go
@@ -1,0 +1,98 @@
+package conformance
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Every verdict that needs a listener waits for it — asserted structurally,
+// because the defect was never one call site.
+//
+// #600 taught the SERVICE path to wait, and the scheduled night of 2026-08-29
+// failed further along on a different one:
+//
+//	FAIL: scaleway: platform-bastion does not listen on 22 inside the machine
+//	      (listening: 53 ); 'unreachable' would be measuring a dead machine
+//	      rather than isolation
+//
+// `platform-bastion` is the TARGET of the isolation verdict, and its listeners
+// came from `listen_of`, which read once and cached. Five of the six verdicts in
+// functional.sh drew their conclusion from that cache.
+//
+// A per-call-site test would have passed on the five that were already wrong, so
+// what is asserted here is the property: no verdict in functional.sh reads a
+// capture that nothing waited for. This is the same shape as
+// TestEveryRouteDeclaresAnOperation in internal/core/emulator — the rule is
+// checked over the whole file, not remembered by whoever adds the seventh
+// verdict.
+
+// verdictsTakingACapture are the functionallib.sh verdicts that are HANDED a
+// listen file. Each decides whether a port is open inside a machine from a
+// capture it did not take, so each needs one something waited for.
+//
+// `fnl_service_came_up` is deliberately absent: it fills its own capture, by
+// polling for the port with `wait_until` (#600). Demanding a `listen_for` before
+// it would accuse the one verdict in this file that already waits — which the
+// first version of this test did, and which is why the list says what it
+// selects on rather than naming every verdict.
+var verdictsTakingACapture = []string{
+	"fnl_firewall_pair",
+	"fnl_reaches",
+	"fnl_isolated",
+}
+
+func TestNoVerdictReadsAListenCaptureNobodyWaitedFor(t *testing.T) {
+	source, err := os.ReadFile("functional.sh")
+	if err != nil {
+		t.Fatalf("read functional.sh: %v", err)
+	}
+	lines := strings.Split(string(source), "\n")
+
+	// The caching capture is gone, and must not come back beside its
+	// replacement for the next caller to reach for. Named rather than inferred:
+	// a helper that returns an existing file without reading the machine is the
+	// defect, whatever it is called.
+	cachingRead := regexp.MustCompile(`\[ -f "\$LISTEN" \] && return 0`)
+	for i, line := range lines {
+		if cachingRead.MatchString(line) {
+			t.Errorf("functional.sh:%d reintroduces a capture that returns a cached file: %s",
+				i+1, strings.TrimSpace(line))
+		}
+	}
+
+	// Every verdict call site is preceded by a wait for the port it judges.
+	// Four lines of slack: the call sites put the capture immediately above,
+	// and a comment between them is ordinary.
+	const slack = 4
+	seen := map[string]int{}
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		for _, verdict := range verdictsTakingACapture {
+			if !strings.HasPrefix(trimmed, verdict+" ") {
+				continue
+			}
+			seen[verdict]++
+			waited := false
+			for back := i - 1; back >= 0 && back >= i-slack; back-- {
+				if strings.Contains(lines[back], "listen_for ") {
+					waited = true
+					break
+				}
+			}
+			if !waited {
+				t.Errorf("functional.sh:%d draws %s from a capture no listen_for filled — "+
+					"the 2026-08-29 night, one verdict over", i+1, verdict)
+			}
+		}
+	}
+
+	// The reader proves it can find before it judges: a regexp that matched
+	// nothing would pass this file however wrong it became.
+	for _, verdict := range verdictsTakingACapture {
+		if seen[verdict] == 0 {
+			t.Errorf("no call site of %s was found, so this test measured nothing about it", verdict)
+		}
+	}
+}

--- a/tools/conformance/leg.sh
+++ b/tools/conformance/leg.sh
@@ -103,7 +103,12 @@ tools/conformance/guard.sh leftovers "$vm"
 # --shapes is not passed: it is a `serve` flag whose default is already `shapes`,
 # and `start` spawns serve. Passing it here fails on an unknown flag, which is
 # how this line was found.
-./feint start --addr "$addr" --vm "$vm" --contracts contracts --timeout 60s
+# --projects declares a catalogue of two (#572). Every assertion written before
+# it filters by `name=default` and is unchanged by the second name; what the
+# second one buys is the case #572 is about, which no unit test can reach: `scw`
+# and the Terraform provider resolving a project whose name is not `default`.
+./feint start --addr "$addr" --vm "$vm" --contracts contracts \
+  --projects default,platform-prod --timeout 60s
 trap './feint stop --addr '"$addr"' >/dev/null 2>&1 || true' EXIT
 
 case "$leg" in

--- a/tools/conformance/projects_declared_everywhere_test.go
+++ b/tools/conformance/projects_declared_everywhere_test.go
@@ -27,8 +27,16 @@ import (
 // asserted here is the property: whatever the catalogue is, all three name it.
 
 // projectStarters are the three files that start an emulator a conformance suite
-// then drives. A fourth entry point adds itself here rather than being
-// discovered by a red matrix.
+// then drives WITH FLAGS. A fourth entry point adds itself here rather than
+// being discovered by a red matrix.
+//
+// The `image` job of conformance.yml is deliberately absent, and adding it would
+// be the mistake: it runs the shipped container with no override on purpose —
+// "a proof that quietly passes different flags proves a different image". That
+// leg is served by the suite asking the emulator what catalogue it holds before
+// asserting on it (tools/conformance/scaleway/scw-cli.sh), which is the same
+// rule the network suites follow for `capabilities.isolation`: branch on a
+// declaration, never on a name you expect.
 var projectStarters = []string{
 	"leg.sh",
 	"../../mise.toml",

--- a/tools/conformance/projects_declared_everywhere_test.go
+++ b/tools/conformance/projects_declared_everywhere_test.go
@@ -1,0 +1,101 @@
+package conformance
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Three entry points start a conformance emulator, and they must declare the
+// same project catalogue.
+//
+// Measured on PR #605: `tools/conformance/leg.sh` and the `conformance` mise
+// task were taught `--projects` (#572) and `.github/workflows/conformance.yml`
+// was not. Five matrix jobs went red at 44 s on one line:
+//
+//	FAIL: the declared project did not list under its own name: []
+//
+// That is the trap CLAUDE.md states in as many words. `mise run conformance`
+// drives every suite against ONE emulator and is green by construction for an
+// assertion about what that emulator holds; `conformance.yml` splits the clients
+// into a matrix with an emulator per leg. A local pass could not see it, and the
+// suite that reads the catalogue is exactly the kind that tells the two
+// populations apart.
+//
+// A per-file check would have passed on the two that were right. What is
+// asserted here is the property: whatever the catalogue is, all three name it.
+
+// projectStarters are the three files that start an emulator a conformance suite
+// then drives. A fourth entry point adds itself here rather than being
+// discovered by a red matrix.
+var projectStarters = []string{
+	"leg.sh",
+	"../../mise.toml",
+	"../../.github/workflows/conformance.yml",
+}
+
+var declaresProjects = regexp.MustCompile(`--projects\s+([A-Za-z0-9_.,-]+)`)
+
+func TestEveryConformanceEmulatorDeclaresTheSameProjects(t *testing.T) {
+	catalogues := map[string]string{}
+	for _, file := range projectStarters {
+		source, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		// Comment lines are skipped, and that is not a nicety: the comment this
+		// flag carries in leg.sh begins with `--projects`, so a whole-file match
+		// read the prose and reported the catalogue as the word after it. Found
+		// by running this test, which is the only reason it is written down.
+		var match []string
+		for _, line := range strings.Split(string(source), "\n") {
+			if trimmed := strings.TrimSpace(line); trimmed == "" || strings.HasPrefix(trimmed, "#") {
+				continue
+			}
+			if m := declaresProjects.FindStringSubmatch(line); m != nil {
+				match = m
+				break
+			}
+		}
+		if match == nil {
+			t.Errorf("%s starts a conformance emulator and names no --projects: the suites that "+
+				"read the catalogue will report it empty, which is PR #605's five red jobs", file)
+			continue
+		}
+		catalogues[file] = match[1]
+	}
+
+	// They must agree. A catalogue that differs between legs is worse than one
+	// that is missing: the suite passes on the leg that matches and fails on the
+	// others, which reads as a flake rather than as a declaration nobody kept.
+	var first, firstFile string
+	for _, file := range projectStarters {
+		got, ok := catalogues[file]
+		if !ok {
+			continue
+		}
+		if first == "" {
+			first, firstFile = got, file
+			continue
+		}
+		if got != first {
+			t.Errorf("%s declares %q and %s declares %q: one emulator per leg, two catalogues",
+				file, got, firstFile, first)
+		}
+	}
+
+	// The reader proves it can find before it judges. A regexp that matched
+	// nothing would pass this file however wrong it became.
+	if len(catalogues) == 0 {
+		t.Fatal("no --projects declaration was found anywhere, so this test measured nothing")
+	}
+
+	// And the catalogue must hold the name the suites actually ask for, which is
+	// the one that is NOT the pack's default: asserting on `default` alone would
+	// pass against an emulator that declares nothing at all.
+	if !strings.Contains(first, "platform-prod") {
+		t.Errorf("the declared catalogue %q does not carry the non-default name the suites "+
+			"resolve (tools/conformance/scaleway/scw-cli.sh, terraform/main.tf)", first)
+	}
+}

--- a/tools/conformance/scaleway/scw-cli.sh
+++ b/tools/conformance/scaleway/scw-cli.sh
@@ -725,7 +725,18 @@ fi
 # obstacle for exactly the person #372 exists to serve. The operator declares the
 # catalogue now, and the declared name resolves the whole way: listed by name,
 # read back by the identifier the list answered, under its own name.
+# Asked of the emulator rather than assumed, because one leg of the conformance
+# matrix starts the shipped container with NO flags on purpose — passing
+# `--projects` there would prove a different image. The catalogue is read
+# unfiltered: an emulator nobody gave one holds a single project and this block
+# skips by name; a broken filter cannot shrink an unfiltered list to one, so the
+# skip cannot hide the defect the assertion exists for.
 echo "- a declared project that is not the default one resolves by name and by id"
+catalogue="$(scw account project list -o json 2>&1)" \
+  || fail "listing the account's projects rejected: $catalogue"
+if [ "$(printf '%s' "$catalogue" | jq -r 'length')" -lt 2 ]; then
+  echo "  SKIP: this emulator declares no project catalogue (serve --projects), so a name that is not the default one has nothing to resolve to (#572)"
+else
 declared="$(scw account project list name=platform-prod -o json 2>&1)" \
   || fail "listing the declared project rejected: $declared"
 printf '%s' "$declared" | jq -e 'length == 1 and .[0].name == "platform-prod"' >/dev/null \
@@ -738,6 +749,7 @@ scw account project get project-id="$declared_id" -o json \
   | jq -e --arg i "$declared_id" '.id == $i and .name == "platform-prod"' >/dev/null \
   || fail "reading the declared project back answered another project's name"
 ok "the declared project resolves by name and reads back as itself"
+fi
 
 ok "listed by name, read by id, and a foreign name answers nothing"
 

--- a/tools/conformance/scaleway/scw-cli.sh
+++ b/tools/conformance/scaleway/scw-cli.sh
@@ -718,6 +718,27 @@ scw account project get project-id="$project_id" -o json \
 if scw account project list name=a-project-this-emulator-never-named -o json | jq -e 'length > 0' >/dev/null; then
   fail "a name nothing carries answered a project"
 fi
+# The case #572 is about, and the reason the emulator this suite drives is
+# started with `--projects default,platform-prod`. Until 2026-08-29 the catalogue
+# held one project, so a stack whose `project_name` was its own production
+# project died on the provider's FindExact after that truthful empty list — the
+# obstacle for exactly the person #372 exists to serve. The operator declares the
+# catalogue now, and the declared name resolves the whole way: listed by name,
+# read back by the identifier the list answered, under its own name.
+echo "- a declared project that is not the default one resolves by name and by id"
+declared="$(scw account project list name=platform-prod -o json 2>&1)" \
+  || fail "listing the declared project rejected: $declared"
+printf '%s' "$declared" | jq -e 'length == 1 and .[0].name == "platform-prod"' >/dev/null \
+  || fail "the declared project did not list under its own name: $declared"
+declared_id="$(printf '%s' "$declared" | jq -r '.[0].id // empty')"
+[ -n "$declared_id" ] || fail "the declared project carries no id: $declared"
+[ "$declared_id" != "$project_id" ] \
+  || fail "the declared project shares the default project's identifier, so the catalogue holds one thing under two names"
+scw account project get project-id="$declared_id" -o json \
+  | jq -e --arg i "$declared_id" '.id == $i and .name == "platform-prod"' >/dev/null \
+  || fail "reading the declared project back answered another project's name"
+ok "the declared project resolves by name and reads back as itself"
+
 ok "listed by name, read by id, and a foreign name answers nothing"
 
 # User data, the three operations the YAML-injection work hardened and that no

--- a/tools/conformance/scaleway/terraform.sh
+++ b/tools/conformance/scaleway/terraform.sh
@@ -225,6 +225,12 @@ ok "found by name, and the same"
 echo "- the account project resolves by name and reads back by id"
 [ "$("$TF" output -raw account_project_name)" = "default" ] \
   || fail "the data source resolved a project that is not the default one"
+[ "$("$TF" output -raw declared_project_name)" = "platform-prod" ] \
+  || fail "the provider did not resolve the declared project by name (#572)"
+[ -n "$("$TF" output -raw declared_project_id)" ] \
+  || fail "the declared project resolved to no identifier (#572)"
+[ "$("$TF" output -raw declared_project_id)" != "$("$TF" output -raw account_project_id)" ] \
+  || fail "the declared project and the default one share an identifier, so the catalogue holds one project under two names (#572)"
 [ -n "$("$TF" output -raw account_project_id)" ] \
   || fail "the data source resolved no project id"
 ok "resolved by name, read back by id"

--- a/tools/conformance/scaleway/terraform/main.tf
+++ b/tools/conformance/scaleway/terraform/main.tf
@@ -75,6 +75,18 @@ data "scaleway_account_project" "conformance" {
   organization_id = "11111111-1111-1111-1111-111111111111"
 }
 
+# The same data source on a project that is NOT the default one (#572), which is
+# what the issue was about: the emulator held one project, so FindExact failed
+# for every platform team whose project name is their own. The emulator this
+# suite drives is started with `--projects default,platform-prod`, and this block
+# is the only thing that proves the provider's own resolution walks a declared
+# catalogue — the Go tests drive the routes, never the provider that filters
+# their answer.
+data "scaleway_account_project" "declared" {
+  name            = "platform-prod"
+  organization_id = "11111111-1111-1111-1111-111111111111"
+}
+
 # Inline rules are how the provider models a security group: it sends the whole list through
 # SetSecurityGroupRules on every change, so the emulator must answer with the resulting state and
 # not with what it was asked. A rule that comes back in another order, or without the id it was
@@ -425,6 +437,17 @@ output "account_project_id" {
 
 output "account_project_name" {
   value = data.scaleway_account_project.conformance.name
+}
+
+# The declared project the provider resolved by name (#572). Its id is asserted
+# to differ from the default one's: a catalogue answering the same identifier
+# under two names would pass a name-only check while holding one project.
+output "declared_project_id" {
+  value = data.scaleway_account_project.declared.project_id
+}
+
+output "declared_project_name" {
+  value = data.scaleway_account_project.declared.name
 }
 
 # The Load Balancer chain (#282), in the shape the surveyed stacks wrote it:

--- a/tools/falsify/specs/image-derivation.json
+++ b/tools/falsify/specs/image-derivation.json
@@ -2,7 +2,7 @@
   "package": "./internal/core/machine/",
   "mutations": [
     {
-      "label": "the family table stops being an authorization, so any family:version derives a build — plan9:4 included",
+      "label": "the family table stops being an authorization, so any family:version derives a build \u2014 plan9:4 included",
       "file": "internal/core/machine/images.go",
       "find": "\trecipe, known := imageFamilies()[family]\n\tif !known {\n\t\treturn ImageSpec{}, false\n\t}",
       "replace": "\trecipe, known := imageFamilies()[family]\n\tif false && !known {\n\t\treturn ImageSpec{}, false\n\t}",
@@ -37,5 +37,5 @@
       "test": "TestImageRemovalStaysInsideThePrefix"
     }
   ],
-  "note": "The guards of #465, each with the test its comment cites. The first is the line between deriving any version of a known family and building anything at all; the second is what keeps a withdrawn upstream version (debian:9 — a real witness, two surveyed stacks hardcode identifiers naming it) from reaching the runtime as a raw driver error; the third and fourth are the two halves of the actionable refusal — the door must exist, and the message must point at it. Every mutation still compiles: err and declared stay referenced, and the trailing arguments keep the call well formed."
+  "note": "The guards of #465, each with the test its comment cites. The first is the line between deriving any version of a known family and building anything at all; the second is what keeps a withdrawn upstream version (debian:9 \u2014 a real witness, two surveyed stacks hardcode identifiers naming it) from reaching the runtime as a raw driver error; the third and fourth are the two halves of the actionable refusal \u2014 the door must exist, and the message must point at it. Every mutation still compiles: err and declared stay referenced, and the trailing arguments keep the call well formed."
 }

--- a/tools/falsify/specs/resolve-declares-what-boots.json
+++ b/tools/falsify/specs/resolve-declares-what-boots.json
@@ -1,0 +1,33 @@
+{
+  "package": "./internal/cli/",
+  "mutations": [
+    {
+      "label": "resolve goes back to printing a declaration whose boot it can already know fails: ubuntu:18.04 and debian:9 back in the line to paste, which bought 29 applied and 0 machines started on the surveyed stack (#476)",
+      "file": "internal/cli/images_resolve.go",
+      "find": "\t\t\tif !aliases[alias] {",
+      "replace": "\t\t\tif !aliases[alias] && false {",
+      "test": "TestResolveLeavesAWithdrawnVersionOutOfTheLine"
+    },
+    {
+      "label": "a run that produced nothing to paste exits 0, so a script pipes an empty declaration and calls it a success (#476, shape 3)",
+      "file": "internal/cli/images_resolve.go",
+      "find": "\tcase unbuildable && len(declarations) == 0:",
+      "replace": "\tcase unbuildable && len(declarations) == 0 && false:",
+      "test": "TestResolveExitsTwoWhenNothingItResolvedCanBoot"
+    },
+    {
+      "label": "an image server that could not be asked is read as an image server that withdrew everything, so a network failure turns a working declaration into a refusal — the three-outcomes rule this file states, turned against itself",
+      "file": "internal/cli/images_resolve.go",
+      "find": "\t\tif spec, ok := machine.SpecFor(res.ref); ok && aliases != nil {",
+      "replace": "\t\tif spec, ok := machine.SpecFor(res.ref); ok || aliases == nil {",
+      "test": "TestAnUnreadableImageIndexDoesNotWithdrawEverything"
+    },
+    {
+      "label": "the index reader keys on the product name instead of the aliases, so every version an operator can actually boot is reported withdrawn — the first thing this reader was measured against, and it failed it",
+      "file": "internal/cli/images_resolve.go",
+      "find": "\t\tfor _, alias := range strings.Split(product.Aliases, \",\") {",
+      "replace": "\t\tfor _, alias := range strings.Split(product.Release+product.Aliases[:0], \",\") {",
+      "test": "TestResolveLeavesAWithdrawnVersionOutOfTheLine"
+    }
+  ]
+}

--- a/tools/falsify/specs/resolve-declares-what-boots.json
+++ b/tools/falsify/specs/resolve-declares-what-boots.json
@@ -16,14 +16,14 @@
       "test": "TestResolveExitsTwoWhenNothingItResolvedCanBoot"
     },
     {
-      "label": "an image server that could not be asked is read as an image server that withdrew everything, so a network failure turns a working declaration into a refusal — the three-outcomes rule this file states, turned against itself",
+      "label": "an image server that could not be asked is read as an image server that withdrew everything, so a network failure turns a working declaration into a refusal \u2014 the three-outcomes rule this file states, turned against itself",
       "file": "internal/cli/images_resolve.go",
       "find": "\t\tif spec, ok := machine.SpecFor(res.ref); ok && aliases != nil {",
       "replace": "\t\tif spec, ok := machine.SpecFor(res.ref); ok || aliases == nil {",
       "test": "TestAnUnreadableImageIndexDoesNotWithdrawEverything"
     },
     {
-      "label": "the index reader keys on the product name instead of the aliases, so every version an operator can actually boot is reported withdrawn — the first thing this reader was measured against, and it failed it",
+      "label": "the index reader keys on the product name instead of the aliases, so every version an operator can actually boot is reported withdrawn \u2014 the first thing this reader was measured against, and it failed it",
       "file": "internal/cli/images_resolve.go",
       "find": "\t\tfor _, alias := range strings.Split(product.Aliases, \",\") {",
       "replace": "\t\tfor _, alias := range strings.Split(product.Release+product.Aliases[:0], \",\") {",

--- a/tools/falsify/specs/scaleway-cloud-fidelity.json
+++ b/tools/falsify/specs/scaleway-cloud-fidelity.json
@@ -37,7 +37,7 @@
       "test": "TestAnAttachedAddressPublishesItsGatewayAndItsOwnTags"
     },
     {
-      "label": "tagValues hands back the stored slice itself, so a caller mutating a response reaches the store — the branch a restored snapshot takes (#368)",
+      "label": "tagValues hands back the stored slice itself, so a caller mutating a response reaches the store \u2014 the branch a restored snapshot takes (#368)",
       "file": "internal/providers/scaleway/servers.go",
       "find": "\t\treturn append([]any{}, tags...)",
       "replace": "\t\treturn append(tags[:len(tags)], tags[:0]...)",
@@ -72,10 +72,10 @@
       "test": "TestGetProjectAnswersAnIdentifierItNeverMinted"
     },
     {
-      "label": "the name filter stops filtering, so every name a client asks for answers the one project this emulator has (#372)",
+      "label": "the name filter stops filtering, so every name a client asks for answers a project this emulator does not hold \u2014 the echo #83 measured and closed on all three packs, one product over (#372, #572)",
       "file": "internal/providers/scaleway/projects.go",
-      "find": "\tif name := q.Get(\"name\"); name != \"\" && name != defaultProjectName {",
-      "replace": "\tif name := q.Get(\"name\"); name != \"\" && name != defaultProjectName && false {",
+      "find": "\t\tif wantName != \"\" && wantName != declared {",
+      "replace": "\t\tif wantName != \"\" && wantName != declared && false {",
       "test": "TestListProjectsFiltersRatherThanInvents"
     },
     {
@@ -91,6 +91,27 @@
       "find": "\tfor _, key := range []string{\"object_storage_private_access_enabled\", \"s3_integration_enabled\"} {",
       "replace": "\tfor _, key := range []string{\"object_storage_private_access_enabled\", \"s3_integration_enabled\"}[:1] {",
       "test": "TestBothSpellingsOfTheObjectStorageFilterNarrow"
+    },
+    {
+      "label": "the project_ids filter stops filtering, so a list narrowed to one identifier answers the whole catalogue",
+      "file": "internal/providers/scaleway/projects.go",
+      "find": "\t\tif len(wantIDs) > 0 && !contains(wantIDs, id) {",
+      "replace": "\t\tif len(wantIDs) > 0 && !contains(wantIDs, id) && false {",
+      "test": "TestListProjectsFiltersRatherThanInvents"
+    },
+    {
+      "label": "an operator who declared nothing stops getting the pack's own default project, so every declaration written before #572 loses its account",
+      "file": "internal/providers/scaleway/projects.go",
+      "find": "\tif len(p.env.Projects) == 0 {",
+      "replace": "\tif len(p.env.Projects) == 0 && false {",
+      "test": "TestAnUndeclaredCatalogueIsStillTheSingleDefaultProject"
+    },
+    {
+      "label": "a project the operator DID declare reads back under somebody else's name, so the data source resolves a name through the list and is handed a different project by the get that follows it",
+      "file": "internal/providers/scaleway/projects.go",
+      "find": "\tif name, ok := p.projectNamed(id); ok {",
+      "replace": "\tif name, ok := p.projectNamed(id); ok && false {",
+      "test": "TestGetProjectAnswersADeclaredProjectByItsOwnName"
     }
   ]
 }

--- a/tools/falsify/specs/unkillable-dhcp-orphan.json
+++ b/tools/falsify/specs/unkillable-dhcp-orphan.json
@@ -2,7 +2,7 @@
   "package": "./internal/cli/",
   "mutations": [
     {
-      "label": "the permission probe carries a real signal, so the check that only asks becomes the sweep that kills — and kills a process nobody here started",
+      "label": "the permission probe carries a real signal, so the check that only asks becomes the sweep that kills \u2014 and kills a process nobody here started",
       "file": "internal/core/machine/leftover.go",
       "find": "const probeSignal = syscall.Signal(0)",
       "replace": "const probeSignal = syscall.SIGTERM",
@@ -25,7 +25,7 @@
       "test": "TestCleanCheckRefusesAHostWhoseLeftoverThisUserCannotEnd"
     },
     {
-      "label": "the check refuses every leftover, endable or not, so the doorstep fires on hosts the ordinary sweep would clear — which is how a doorstep gets disarmed",
+      "label": "the check refuses every leftover, endable or not, so the doorstep fires on hosts the ordinary sweep would clear \u2014 which is how a doorstep gets disarmed",
       "file": "internal/cli/clean.go",
       "find": "\t\tif err := canEndLeftover(leftover); err != nil {",
       "replace": "\t\tif err := canEndLeftover(leftover); err != nil || true {",
@@ -34,8 +34,8 @@
     {
       "label": "the sweep goes back to offering only a command with a pid to retype, which is the manual step that did not happen three runs in a row",
       "file": "internal/cli/clean.go",
-      "find": "\t\t\tled.prose(\"  → sudo feint clean --vm %s   (or: sudo kill %d)\\n\", vm, leftover.PID)",
-      "replace": "\t\t\tled.prose(\"  → sudo kill %d (%s)\\n\", leftover.PID, vm[:0])",
+      "find": "\t\t\tled.prose(\"  \u2192 sudo feint clean --vm %s   (or: sudo kill %d)\\n\", vm, leftover.PID)",
+      "replace": "\t\t\tled.prose(\"  \u2192 sudo kill %d (%s)\\n\", leftover.PID, vm[:0])",
       "test": "TestCleanReportsTheCommandWhenTheLeftoverBelongsToAnotherUser"
     },
     {
@@ -47,7 +47,7 @@
       "package": "./tools/conformance/"
     },
     {
-      "label": "the guard fires on a run that starts no machine, which reddens FEINT_VM=off — the default, the first evidence leg and the whole CI matrix",
+      "label": "the guard fires on a run that starts no machine, which reddens FEINT_VM=off \u2014 the default, the first evidence leg and the whole CI matrix",
       "file": "tools/conformance/guard.sh",
       "find": "  if [ \"$machines\" = \"none\" ] || [ \"$machines\" = \"off\" ] || [ \"$machines\" = \"null\" ] || [ -z \"$machines\" ]; then",
       "replace": "  if ([ \"$machines\" = \"none\" ] || [ \"$machines\" = \"off\" ] || [ \"$machines\" = \"null\" ] || [ -z \"$machines\" ]) && false; then",
@@ -65,11 +65,11 @@
     {
       "label": "the conformance task stops asking, so the leg goes back to burning every client suite before saying the host was never ready",
       "file": "mise.toml",
-      "find": "tools/conformance/guard.sh leftovers \"${FEINT_VM:-off}\"\n./feint start",
-      "replace": "true || tools/conformance/guard.sh leftovers \"${FEINT_VM:-off}\"\n./feint start",
+      "find": "tools/conformance/guard.sh leftovers \"${FEINT_VM:-off}\"\n",
+      "replace": "true || tools/conformance/guard.sh leftovers \"${FEINT_VM:-off}\"\n",
       "test": "TestEveryRuntimeSuiteAsksAboutLeftovers",
       "package": "./tools/conformance/"
     }
   ],
-  "note": "The subject is #375. The runtime leg of `mise run evidence:update` failed three times in a row on a dnsmasq an earlier run had left holding a gateway address: the sweep found it, named it exactly, printed `sudo kill <pid>` and exited 1, because the process belongs to the `incus` user and the operator running the suite may not signal it. The diagnosis was right and nothing ran the remedy, so every run died in the same place until a human read the log.\n\nReproduced deliberately on 2026-08-21, on the author's station and reversibly: `incus network create fnt-3750badbeef ipv4.address=10.183.75.1/24` gives a real bridge and a real dnsmasq running as the `incus` user, and dropping that network's rows from the runtime's database leaves the interface and the service alive with the network object gone — the exact #342 shape. `feint clean --vm incus` then exited 1 with `→ sudo kill 1154779`, and the Scaleway network suite died on it one second in. `sudo feint clean --vm incus` ended it, exit 0, and named the surviving bridge as the half it will not delete.\n\nWhat the fix is not: an escalation. Mutation 1 is the one worth reading twice — the whole remedy hangs on a permission probe that runs the kernel's check for a signal it does not deliver, and a probe that quietly gains a real signal turns a diagnostic into a killer of processes nobody here started. Its test does not record an argument; it puts a real child through the real signal path and requires it to still be there afterwards. The first version of that test read liveness with signal 0 — the same probe — and a child killed by its own parent is a zombie that answers signal 0 exactly as a live process does, so mutation 1 stayed green. wait(2) is what settles it.\n\nMutations 4 and 7 are the false-refusal half, and they matter as much as the rest: a doorstep that fires on hosts nothing was going to fail on is a doorstep somebody disarms, which is the same lesson `--no-verify` teaches. Mutation 7 is the poorest execution this guard will meet — `FEINT_VM=off`, the default, the first evidence leg and the whole of CI's conformance matrix."
+  "note": "The subject is #375. The runtime leg of `mise run evidence:update` failed three times in a row on a dnsmasq an earlier run had left holding a gateway address: the sweep found it, named it exactly, printed `sudo kill <pid>` and exited 1, because the process belongs to the `incus` user and the operator running the suite may not signal it. The diagnosis was right and nothing ran the remedy, so every run died in the same place until a human read the log.\n\nReproduced deliberately on 2026-08-21, on the author's station and reversibly: `incus network create fnt-3750badbeef ipv4.address=10.183.75.1/24` gives a real bridge and a real dnsmasq running as the `incus` user, and dropping that network's rows from the runtime's database leaves the interface and the service alive with the network object gone \u2014 the exact #342 shape. `feint clean --vm incus` then exited 1 with `\u2192 sudo kill 1154779`, and the Scaleway network suite died on it one second in. `sudo feint clean --vm incus` ended it, exit 0, and named the surviving bridge as the half it will not delete.\n\nWhat the fix is not: an escalation. Mutation 1 is the one worth reading twice \u2014 the whole remedy hangs on a permission probe that runs the kernel's check for a signal it does not deliver, and a probe that quietly gains a real signal turns a diagnostic into a killer of processes nobody here started. Its test does not record an argument; it puts a real child through the real signal path and requires it to still be there afterwards. The first version of that test read liveness with signal 0 \u2014 the same probe \u2014 and a child killed by its own parent is a zombie that answers signal 0 exactly as a live process does, so mutation 1 stayed green. wait(2) is what settles it.\n\nMutations 4 and 7 are the false-refusal half, and they matter as much as the rest: a doorstep that fires on hosts nothing was going to fail on is a doorstep somebody disarms, which is the same lesson `--no-verify` teaches. Mutation 7 is the poorest execution this guard will meet \u2014 `FEINT_VM=off`, the default, the first evidence leg and the whole of CI's conformance matrix."
 }


### PR DESCRIPTION
feat(account,images,conformance): a declared project catalogue, a resolve that only prints what boots, and every listen verdict waiting for the port it judges (#572, #476)

Three subjects, one lot, and `mise run conformance` played once on the assembled
tree rather than once per subject.

## The operator declares which projects the account holds (#572)

Until today this emulator held one project, named `default`, so a stack whose
`project_name` was its own production project died on the Terraform provider's
`FindExact` after a truthful empty list — the obstacle for exactly the person
#372 exists to serve. `cloud.projects` in feint.yaml, `serve --projects`, CLI
surface 20.

The list still FILTERS. A name nobody declared answers an empty list, because
the cheap fix — answer that a project exists because somebody asked for it — is
the class #83 measured and closed on all three packs. Identifiers are derived
from the name, never minted per run, for the reason projectEpoch is fixed: a
value that moved between two reads is a permanent Terraform diff. `default`
keeps the identifier every other product of this pack already scopes to, so a
declaration that omits the field gets exactly the account it had.

The addresses of the neutral half: `resource.Tenant` already carries a Project,
so `Env.Projects` names nothing any provider owns — the same argument that puts
`Env.BootImages` in the core.

## `images resolve` stops printing a declaration that cannot boot (#476)

Two of the three identifiers the surveyed stacks hardcode resolve to
`ubuntu:18.04` and `debian:9`; the image server publishes neither, and the pasted
line bought "29 applied, 0 machines started" — the same figures as declaring
nothing. The one command whose whole purpose is producing a working declaration
was the one place that did not check whether the declaration works.

Shapes 1 and 3 of the three the issue offers, and NOT 2: naming the nearest
buildable version as a substitution is #83 again. What is printed instead is a
fact — the versions of that family the server publishes today — and choosing
among them stays the operator's act. A run that produced no line exits 2.

The publication check reads the simplestreams index the `images:` remote is built
from, keyed on the ALIASES: the index keys products by codename
(`ubuntu:jammy:amd64:cloud`), so a reader keyed on `ubuntu:22.04:amd64:cloud`
reports every working version as withdrawn. That is what the first version of
this reader did, and there is a mutation for it.

An index that could not be read leaves the declaration exactly as it was: a
network failure must not turn a working declaration into a refusal.

## Every listen verdict waits for the port it judges

The scheduled night of 2026-08-29 failed again after #600, one verdict further
along: "platform-bastion does not listen on 22 inside the machine (listening:
53); 'unreachable' would be measuring a dead machine rather than isolation".

#600 taught the SERVICE path to wait. The bastion is the TARGET of the isolation
verdict, and its listeners came from `listen_of`, which read once and CACHED.
Five of the six verdicts in functional.sh drew their conclusion from that cache.

So `listen_of` is gone — not left beside its replacement for the next caller to
reach for — and `listen_for` waits for the port the verdict is about to judge,
through `wait_until`, so every one of these waits records itself in WAIT_TRACE.

And the rule is checked over the whole file rather than remembered:
TestNoVerdictReadsAListenCaptureNobodyWaitedFor. It found a sixth site nobody had
named — the CLOSED port of the public firewall pair, where the service wait
covered the open port only and a closed port that is merely late reads exactly
like a firewall that works.

## Measured, on this station

    prepush                                      green
    falsify, 18 specs                            0 mutations survived
    conformance:leg -- probe                     green
    conformance:leg -- scw-cli                   green, and `scw` resolves platform-prod
    conformance:leg -- terraform                 green, and the provider's own FindExact
                                                 resolves a project that is not `default`
    conformance:leg -- runtime  (incus-ovn)      rc=0, 657 s, 39 waits, 0 expired
    conformance:leg -- fields                    rc=0, 214 s
    conformance:functional      (incus-ovn)      rc=0, 338 s, 25 waits, 0 expired
    conformance:stacks, conformance:environment  green
    docs:check, limits:check                     green

## What this does not prove

The night's population. This station's first boot answers in under a tenth of a
second — 0.038 to 0.083 s measured — which is exactly why every one of these
defects was invisible here and visible on a GitHub runner. A local pass proves no
regression; only the scheduled run proves the fix.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

