### PR TITLE
feat(evidence): a consumer pins the level of proof it depends on, and 0.12.0's release invariant stops being measured by hand (#488)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -19,6 +19,43 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Ajouté
 
+- **Un projet en aval peut épingler le niveau de preuve dont il dépend, et sa
+  propre CI échoue quand feint cesse de le livrer : `feint evidence baseline` et
+  `feint evidence verify`, surface CLI 21 (#488).** Pas « feint a changé de
+  version » — **« feint a cessé de prouver ce sur quoi ce projet s'appuyait »**.
+  #325 et #326 existent parce qu'un consommateur a découvert un changement de
+  l'extérieur, après coup.
+
+  Ce n'est **pas** `drift:check`, et la frontière est le design : celui-là
+  surveille la surface du SDK amont — *le cloud a-t-il bougé ?* — celui-ci
+  surveille le niveau de preuve de cet émulateur, du point de vue de quelqu'un
+  qui n'est pas dans ce dépôt — *ce à quoi je me fiais a-t-il bougé ?* Un design
+  qui fond l'un dans l'autre répond deux fois à une question et jamais à l'autre.
+
+  **Seul ce qui est prouvé s'épingle.** Un axe dont le verdict est l'absence de
+  preuve — `false`, `none`, `unchecked`, `unobserved` — est écarté à la capture,
+  parce que l'épingler transforme tout progrès ultérieur en régression. Mesuré :
+  la première version les épinglait, et jouée contre `v0.11.0` elle rapportait
+  `osc/Client.AcceptNetPeering behaviour: false → true` comme une chute.
+
+  **Les revendications sont faites pour être retirées ici.** #475, #481 et #483
+  sont chacune « ceci a été revendiqué et n'aurait pas dû l'être », et un socle
+  qui ne fait que croître les aurait toutes trois empêchées. `--accepted` porte
+  un retrait **avec sa raison**, sur le modèle de `corpus/accepted.json` ; une
+  entrée sans raison est refusée plutôt qu'honorée, parce que toute la valeur du
+  fichier est qu'un retrait porte son pourquoi.
+
+  **Un socle pris sur une exécution partielle est pire que rien**, donc un
+  enregistrement obtenu sans runtime de machines est refusé à la capture : il
+  épingle `dataplane: false` sur toute opération qui l'aurait gagné, et le
+  consommateur s'entend alors dire que rien n'a régressé le jour où si.
+
+  `mise run evidence:verify` tient l'arbre contre la release précédente. Joué
+  aujourd'hui contre `v0.11.0` : 364 opérations épinglées sur sept axes,
+  **chaque niveau toujours livré** — l'invariant de release de 0.12.0 mesuré par
+  un instrument plutôt qu'à la main.
+
+
 - **L'opérateur déclare les projets que le compte émulé détient :
   `cloud.projects` dans `feint.yaml`, `serve --projects`, et la surface CLI
   passe à 20 (#572).** Jusqu'ici cet émulateur détenait un seul projet, nommé

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,43 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Added
 
+- **A downstream project can pin the level of proof it depends on, and its own
+  CI fails when feint stops delivering it: `feint evidence baseline` and
+  `feint evidence verify`, CLI surface 21 (#488).** Not *"feint changed
+  version"* — **"feint stopped proving what this project was relying on"**.
+  #325 and #326 exist because a consumer discovered a change from the outside,
+  after the fact.
+
+  This is **not** `drift:check`, and the boundary is the design: that one
+  watches the upstream SDK surface — *has the cloud moved?* — and this one
+  watches this emulator's own level of evidence, from the point of view of
+  somebody who is not in this repository — *has what I trusted moved?* A design
+  folding one into the other answers one question twice and the other never.
+
+  **Only what is proven is pinned.** An axis whose verdict is the absence of
+  proof — `false`, `none`, `unchecked`, `unobserved` — is dropped at capture,
+  because pinning it turns every later improvement into a regression. Measured:
+  the first version of this pinned them, and run against `v0.11.0` it reported
+  `osc/Client.AcceptNetPeering behaviour: false → true` as a fall.
+
+  **Claims are meant to be withdrawn here.** #475, #481 and #483 are each *"this
+  was claimed and should not have been"*, and a baseline that only grows would
+  have stopped all three. `--accepted` carries a withdrawal **with its reason**,
+  on the model `corpus/accepted.json` already uses; an entry with no reason is
+  refused rather than honoured, because the whole value of the file is that a
+  withdrawal carries why.
+
+  **A baseline from a partial run is worse than none**, so a record earned with
+  no machine runtime is refused at capture: it pins `dataplane: false` on every
+  operation that would have earned it, and the consumer is then told nothing
+  regressed on the day it did.
+
+  `mise run evidence:verify` holds the tree against the previous release. Run
+  today against `v0.11.0`: 364 operations pinned on seven axes, **every level
+  still delivered**, which is 0.12.0's release invariant measured by an
+  instrument rather than by hand.
+
+
 - **The operator declares which projects the emulated account holds:
   `cloud.projects` in `feint.yaml`, `serve --projects`, and the CLI surface
   moves to 20 (#572).** Until now this emulator held one project, named

--- a/coverage/evidence-accepted.json
+++ b/coverage/evidence-accepted.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "Levels this repository stopped delivering ON PURPOSE, each with the reason it was withdrawn. Read by `mise run evidence:verify` (#488). Claims are meant to be withdrawn here — #475, #481 and #483 are each 'this was claimed and should not have been' — and a baseline that only grows is a ratchet nobody can lower. An entry with no reason is refused rather than honoured.",
+  "accepted": []
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -214,7 +214,7 @@ const (
 // TestTheFrozenSurfacesStillMatchTheirFixture, and a fixture regenerated
 // without bumping this constant fails TestASurfaceChangeDemandsItsVersionBump.
 // The procedure for a deliberate change is in RELEASING.md ("Frozen surfaces").
-const cliSurfaceVersion = 20
+const cliSurfaceVersion = 21
 
 // Run executes one command and returns the process exit code.
 func Run(args []string, stdout, stderr io.Writer) int {
@@ -552,6 +552,25 @@ Usage:
                     axis of the record at --out from the catalogues in --shapes,
                     offline, and refuses a record whose contracts or suites have
                     moved since it was written.
+
+  feint evidence baseline [--evidence coverage/evidence.json] [--out <file>]
+                   [--axes driven,probed,contract,dataplane,shape,behaviour,negative]
+                    Pin the level of proof a downstream project depends on, as a
+                    file it commits. Only what is proven is pinned: an axis whose
+                    verdict is the absence of proof would turn every later
+                    improvement into a regression. Refuses a record earned with
+                    no machine runtime, because that one pins dataplane false
+                    everywhere and would report nothing on the day it broke.
+
+  feint evidence verify [--baseline .feint-evidence.json]
+                   [--evidence coverage/evidence.json] [--accepted <file>]
+                    Has what I trusted moved? Exits 2 naming every level the
+                    baseline pins that is no longer delivered. A claim withdrawn
+                    on purpose passes when --accepted carries it WITH a reason —
+                    claims are meant to be withdrawn here, and a baseline that
+                    only grows is a ratchet nobody can lower.
+                    Not drift:check: that one watches the upstream SDK surface,
+                    this one watches this emulator's own level of evidence.
 
   feint docs       [--file README.md] [--coverage <dir>] [--contracts <dir>] [--check]
                     [--limits <file>] [--routes <file>] [--confidence <file>]

--- a/internal/cli/evidence.go
+++ b/internal/cli/evidence.go
@@ -162,6 +162,20 @@ func reportAxesLost(w io.Writer, path string, next *evidenceArtefact) {
 }
 
 func evidence(args []string, stdout, stderr io.Writer) int {
+	// The two subcommands of #488, dispatched before the flag set: they pin and
+	// check a LEVEL OF PROOF for somebody outside this repository, which is a
+	// different question from writing the record and takes different flags.
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		switch args[0] {
+		case "baseline":
+			return evidenceCapture(args[1:], stdout, stderr)
+		case "verify":
+			return evidenceVerify(args[1:], stdout, stderr)
+		default:
+			fmt.Fprintf(stderr, "feint: unknown evidence subcommand %q; expected baseline or verify\n", args[0])
+			return exitError
+		}
+	}
 	fs := newFlagSet("evidence")
 	endpoint := fs.String("endpoint", "http://"+DefaultAddr, "the running emulator to read /_feint/conformance from")
 	shapesDir := fs.String("shapes", "shapes", "directory of observed real-cloud shapes; the shape axis is resolved from it (empty to leave the run's answer)")

--- a/internal/cli/evidence_baseline.go
+++ b/internal/cli/evidence_baseline.go
@@ -1,0 +1,384 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+)
+
+// `feint evidence baseline` and `feint evidence verify` (#488).
+//
+// # What they answer, and what they deliberately do not
+//
+// A downstream project pins the LEVEL OF PROOF it depends on, and its own CI
+// fails when this emulator stops delivering it. Not "feint changed version" —
+// "feint stopped proving what this project was relying on". #325 and #326 exist
+// because a consumer discovered a change from the outside, after the fact.
+//
+// This is NOT `drift:check`, and the boundary has to hold or one of the two
+// questions is lost:
+//
+//   - `coverage/*-baseline.json` + `drift:check` watch the UPSTREAM SDK surface:
+//     has the cloud moved?
+//   - these two watch THIS EMULATOR's own level of evidence, from the point of
+//     view of somebody who is not in this repository: has what I trusted moved?
+//
+// A design that folds one into the other answers one question twice.
+//
+// # Why a baseline that only grows would be wrong
+//
+// Claims are MEANT to be withdrawn here. #475, #481 and #483 are each "this was
+// claimed and should not have been", and a ratchet nobody can lower would have
+// stopped all three. So `verify` distinguishes a regression from a deliberate
+// withdrawal, and the second is accepted with a reason — the model
+// `corpus/accepted.json` already uses.
+//
+// # Why JSON and not the YAML the issue sketched
+//
+// A deviation, stated rather than slipped in. The artefact this pins is JSON,
+// the accepted-withdrawal file it is modelled on is JSON, and this repository
+// carries no YAML dependency: `internal/environment` hand-rolls a reader bound
+// to its own schema, so YAML here would be a second hand-rolled parser to get
+// wrong. The shape of the file is the issue's; the encoding is not.
+
+// axisValues reads an Evidence by axis name.
+//
+// Written out rather than reflected over, for the reason pinnedAxes is written
+// out: adding an axis to the record is then a decision about this file too,
+// visible in a diff, instead of something a baseline silently starts pinning.
+func axisValues(e emulator.Evidence) map[string]any {
+	return map[string]any{
+		"driven":    e.Driven,
+		"probed":    e.Probed,
+		"contract":  e.Contract,
+		"dataplane": e.Dataplane,
+		"shape":     e.Shape,
+		"behaviour": e.Behaviour,
+		"negative":  e.Negative,
+	}
+}
+
+// evidenceBaseline is what a consumer pins.
+//
+// Provenance is recorded rather than assumed, and that is the second of the
+// three ways this goes wrong: several axes are verdicts about ONE RUN. A
+// baseline captured from a leg that drove one client would pin `unobserved` as
+// if it were the truth. So the population is carried in the file, and a capture
+// that knows itself partial is refused below.
+type evidenceBaseline struct {
+	Format string `json:"format"`
+	// Version of this file's own schema, not of feint.
+	Version int `json:"version"`
+	// Machines are the runtimes the artefact was earned under, copied from it.
+	Machines []string `json:"machines"`
+	// GeneratedFrom is the artefact's own provenance digest, carried so a
+	// reader can tell two baselines apart when the suites moved under them.
+	GeneratedFrom provenance `json:"generated_from"`
+	// Operations maps an upstream operation to the axes pinned on it. An axis
+	// absent from the map is an axis this consumer does not rely on.
+	Operations map[string]map[string]any `json:"operations"`
+}
+
+// evidenceAccepted is a withdrawal somebody wrote down, with its reason.
+type evidenceAccepted struct {
+	Accepted []struct {
+		Operation string `json:"operation"`
+		Axis      string `json:"axis"`
+		Reason    string `json:"reason"`
+	} `json:"accepted"`
+}
+
+const (
+	evidenceBaselineFormat  = "feint-evidence-baseline"
+	evidenceBaselineVersion = 1
+)
+
+// pinnedAxes are the axes a baseline may carry, in the order the record prints
+// them. Named here rather than derived by reflection so that adding an axis to
+// the artefact is a decision about this file too.
+var pinnedAxes = []string{"driven", "probed", "contract", "dataplane", "shape", "behaviour", "negative"}
+
+// provesSomething answers whether a verdict is a level of proof at all.
+//
+// `false`, `none`, `unchecked`, `unobserved` and `unknown` are the record's ways
+// of saying nobody looked. A consumer cannot rely on them, and pinning them
+// would turn every later improvement into a regression — which is exactly what
+// the first version of this file did: run against v0.11.0 it reported
+// `osc/Client.AcceptNetPeering behaviour: false → true` as a fall.
+//
+// So they are dropped at capture. The baseline then carries only what somebody
+// depends on, which is the shape the issue sketched: its example lists proven
+// axes and nothing else.
+//
+// TestAnAxisThatProvesNothingIsNotPinned fails without this.
+func provesSomething(value any) bool {
+	switch v := value.(type) {
+	case bool:
+		return v
+	case string:
+		switch v {
+		case "", emulator.ProbeNone, emulator.ContractUnchecked,
+			emulator.ShapeUnobserved, emulator.ShapeUnknown:
+			return false
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+// satisfies answers whether a current verdict still delivers what was pinned.
+//
+// A relation rather than an ordering, and the difference is the whole design.
+// Ranking the verdicts would mean inventing where `violating` sits against
+// `unchecked`, which nothing in this repository states. What a consumer pins is
+// a LEVEL it relies on, so the only question is whether the level is still
+// delivered:
+//
+//   - a pinned boolean is `true` by construction — `false` proves nothing and
+//     is never pinned (see provesSomething) — and is delivered by `true` alone;
+//   - a pinned probe verdict is delivered by EITHER verdict, because `response`
+//     and `refusal` are both "a real client got an answer here" and neither is
+//     above the other — #156 took this axis from 181 arrivals down to 83
+//     verdicts and that was a fix;
+//   - every other pinned string is delivered by itself alone. `clean` stays
+//     `clean`; `observed` stays `observed`.
+func satisfies(axis string, pinned, current any) bool {
+	if axis == "probed" {
+		p, okP := pinned.(string)
+		c, okC := current.(string)
+		if !okP || !okC {
+			return false
+		}
+		verdict := func(v string) bool {
+			return v == emulator.ProbeResponse || v == emulator.ProbeRefusal
+		}
+		if verdict(p) {
+			return verdict(c)
+		}
+		return p == c
+	}
+	return fmt.Sprintf("%v", pinned) == fmt.Sprintf("%v", current)
+}
+
+// evidenceCapture writes the baseline.
+func evidenceCapture(args []string, stdout, stderr io.Writer) int {
+	fs := newFlagSet("evidence baseline")
+	from := fs.String("evidence", filepath.Join("coverage", "evidence.json"),
+		"the artefact to pin, as `feint evidence` wrote it")
+	out := fs.String("out", "", "where to write the baseline (default: standard output)")
+	axes := fs.String("axes", strings.Join(pinnedAxes, ","),
+		"which axes to pin, comma-separated; pin only what you actually rely on")
+	if err := fs.Parse(args); err != nil {
+		return exitError
+	}
+
+	art, err := readEvidence(*from)
+	if err != nil {
+		fmt.Fprintf(stderr, "feint: %v\n", err)
+		return exitError
+	}
+
+	// The refusal the issue asks for by name. An artefact earned with no machine
+	// runtime pins `dataplane: false` on every operation that would have earned
+	// it, and a consumer would then be told nothing regressed on the day it
+	// really did. Refused at capture rather than written and explained later —
+	// a baseline taken from a partial run is worse than none.
+	//
+	// TestABaselineIsRefusedWhenTheArtefactReachedNoRuntime fails without this.
+	if !reachesARuntime(art.Machines) {
+		fmt.Fprintf(stderr, "feint: %s was earned under %s alone, so every dataplane verdict in "+
+			"it is a fact about a run that started no machine.\n"+
+			"Pinning it would tell a consumer nothing regressed on the day it did. "+
+			"Regenerate with `mise run evidence:update` on a host that can start machines.\n",
+			*from, strings.Join(art.Machines, ", "))
+		return exitError
+	}
+
+	wanted := map[string]bool{}
+	for _, axis := range strings.Split(*axes, ",") {
+		axis = strings.TrimSpace(axis)
+		if axis == "" {
+			continue
+		}
+		if !contains(pinnedAxes, axis) {
+			fmt.Fprintf(stderr, "feint: %q is not an axis of this record; the axes are %s\n",
+				axis, strings.Join(pinnedAxes, ", "))
+			return exitError
+		}
+		wanted[axis] = true
+	}
+	if len(wanted) == 0 {
+		fmt.Fprintln(stderr, "feint: --axes named none, so this baseline would pin nothing")
+		return exitError
+	}
+
+	baseline := evidenceBaseline{
+		Format:        evidenceBaselineFormat,
+		Version:       evidenceBaselineVersion,
+		Machines:      art.Machines,
+		GeneratedFrom: art.GeneratedFrom,
+		Operations:    map[string]map[string]any{},
+	}
+	for operation, verdicts := range art.Operations {
+		values := axisValues(verdicts)
+		pinned := map[string]any{}
+		for _, axis := range pinnedAxes {
+			if wanted[axis] && provesSomething(values[axis]) {
+				pinned[axis] = values[axis]
+			}
+		}
+		if len(pinned) > 0 {
+			baseline.Operations[operation] = pinned
+		}
+	}
+
+	encoded, err := json.MarshalIndent(baseline, "", "  ")
+	if err != nil {
+		fmt.Fprintf(stderr, "feint: %v\n", err)
+		return exitError
+	}
+	encoded = append(encoded, '\n')
+	if *out == "" {
+		_, _ = stdout.Write(encoded)
+		return exitOK
+	}
+	if err := os.WriteFile(*out, encoded, 0o644); err != nil { //nolint:gosec // a baseline a consumer commits
+		fmt.Fprintf(stderr, "feint: %v\n", err)
+		return exitError
+	}
+	fmt.Fprintf(stdout, "pinned %d operation(s) on %d axis(es) to %s (machines: %s)\n",
+		len(baseline.Operations), len(wanted), *out, strings.Join(baseline.Machines, ", "))
+	return exitOK
+}
+
+// evidenceVerify compares the artefact against the baseline.
+func evidenceVerify(args []string, stdout, stderr io.Writer) int {
+	fs := newFlagSet("evidence verify")
+	baselinePath := fs.String("baseline", ".feint-evidence.json", "the baseline to hold this run against")
+	from := fs.String("evidence", filepath.Join("coverage", "evidence.json"), "the artefact to check")
+	acceptedPath := fs.String("accepted", "",
+		"withdrawals somebody wrote down with a reason; unset, every fall is a regression")
+	if err := fs.Parse(args); err != nil {
+		return exitError
+	}
+
+	raw, err := os.ReadFile(*baselinePath)
+	if err != nil {
+		fmt.Fprintf(stderr, "feint: %v\n", err)
+		return exitError
+	}
+	var baseline evidenceBaseline
+	if err := json.Unmarshal(raw, &baseline); err != nil {
+		fmt.Fprintf(stderr, "feint: reading %s: %v\n", *baselinePath, err)
+		return exitError
+	}
+	if baseline.Format != evidenceBaselineFormat {
+		fmt.Fprintf(stderr, "feint: %s is not a feint evidence baseline (format %q)\n",
+			*baselinePath, baseline.Format)
+		return exitError
+	}
+
+	art, err := readEvidence(*from)
+	if err != nil {
+		fmt.Fprintf(stderr, "feint: %v\n", err)
+		return exitError
+	}
+
+	accepted := map[string]string{}
+	if *acceptedPath != "" {
+		acceptedRaw, err := os.ReadFile(*acceptedPath)
+		if err != nil {
+			fmt.Fprintf(stderr, "feint: %v\n", err)
+			return exitError
+		}
+		var doc evidenceAccepted
+		if err := json.Unmarshal(acceptedRaw, &doc); err != nil {
+			fmt.Fprintf(stderr, "feint: reading %s: %v\n", *acceptedPath, err)
+			return exitError
+		}
+		for _, entry := range doc.Accepted {
+			// An entry with no reason is not an acceptance, it is a silencer.
+			// Refused rather than honoured: the whole value of this file is that
+			// a withdrawal carries why.
+			if strings.TrimSpace(entry.Reason) == "" {
+				fmt.Fprintf(stderr, "feint: %s accepts %s/%s with no reason, and a withdrawal "+
+					"without one is a claim nobody has to defend\n",
+					*acceptedPath, entry.Operation, entry.Axis)
+				return exitError
+			}
+			accepted[entry.Operation+"\x00"+entry.Axis] = entry.Reason
+		}
+	}
+
+	type fall struct{ operation, axis, was, now, reason string }
+	var regressions, withdrawals []fall
+
+	operations := make([]string, 0, len(baseline.Operations))
+	for operation := range baseline.Operations {
+		operations = append(operations, operation)
+	}
+	sort.Strings(operations)
+
+	for _, operation := range operations {
+		pinned := baseline.Operations[operation]
+		current, present := art.Operations[operation]
+		for _, axis := range pinnedAxes {
+			want, relied := pinned[axis]
+			if !relied {
+				continue
+			}
+			// An operation that is gone entirely is the strongest fall there is,
+			// and it must not read as "no verdict to compare".
+			now := "absent"
+			if present {
+				got := axisValues(current)[axis]
+				if satisfies(axis, want, got) {
+					continue
+				}
+				now = fmt.Sprintf("%v", got)
+			}
+			f := fall{operation, axis, fmt.Sprintf("%v", want), now, accepted[operation+"\x00"+axis]}
+			if f.reason != "" {
+				withdrawals = append(withdrawals, f)
+				continue
+			}
+			regressions = append(regressions, f)
+		}
+	}
+
+	for _, w := range withdrawals {
+		fmt.Fprintf(stdout, "  withdrawn: %s %s %s → %s — %s\n", w.operation, w.axis, w.was, w.now, w.reason)
+	}
+	if len(regressions) == 0 {
+		fmt.Fprintf(stdout, "every level %s pins is still delivered (%d operation(s), %d withdrawal(s) accepted)\n",
+			*baselinePath, len(baseline.Operations), len(withdrawals))
+		return exitOK
+	}
+	for _, r := range regressions {
+		fmt.Fprintf(stderr, "REGRESSED: %s %s: %s → %s\n", r.operation, r.axis, r.was, r.now)
+	}
+	fmt.Fprintf(stderr, "\n%d level(s) this baseline pins are no longer delivered.\n"+
+		"If a claim was withdrawn on purpose, write it down with its reason and pass --accepted:\n"+
+		"  {\"accepted\": [{\"operation\": %q, \"axis\": %q, \"reason\": \"…\"}]}\n",
+		len(regressions), regressions[0].operation, regressions[0].axis)
+	return exitDrift
+}
+
+// reachesARuntime answers whether the record was earned with a machine runtime.
+// "none" is a runtime name here, and it is the one that proves nothing about a
+// dataplane.
+func reachesARuntime(machines []string) bool {
+	for _, m := range machines {
+		if m != "" && m != "none" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/evidence_baseline_test.go
+++ b/internal/cli/evidence_baseline_test.go
@@ -1,0 +1,306 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// `feint evidence baseline` / `feint evidence verify` (#488).
+//
+// What is under test is the promise a consumer outside this repository relies
+// on: **feint stopped proving what this project was relying on**, said at the
+// moment it happens rather than discovered from the outside three releases
+// later, which is what #325 and #326 were.
+
+// artefactWith writes an evidence artefact the two subcommands read.
+func artefactWith(t *testing.T, machines []string, operations map[string]map[string]any) string {
+	t.Helper()
+	doc := map[string]any{
+		"format":         "feint-evidence",
+		"version":        3,
+		"machines":       machines,
+		"generated_from": map[string]string{"contracts": "aa", "shapes": "bb", "suites": "cc"},
+		"operations":     operations,
+	}
+	encoded, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "evidence.json")
+	if err := os.WriteFile(path, encoded, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return path
+}
+
+func proven(shape string) map[string]any {
+	return map[string]any{
+		"driven": true, "probed": "response", "contract": "clean",
+		"dataplane": true, "shape": shape, "behaviour": true, "negative": true,
+	}
+}
+
+// The whole point, in one exchange: an operation whose shape went from a
+// recording to `unobserved` fails, naming the operation and both values.
+func TestVerifyFailsWhenAPinnedLevelIsNoLongerDelivered(t *testing.T) {
+	pinned := artefactWith(t, []string{"incus", "none"}, map[string]map[string]any{
+		"instance/v1/API.CreateServer": proven("observed"),
+	})
+	baseline := filepath.Join(t.TempDir(), "pin.json")
+	var out, errOut bytes.Buffer
+	if code := evidenceCapture([]string{"--evidence", pinned, "--out", baseline}, &out, &errOut); code != exitOK {
+		t.Fatalf("capture exited %d: %s%s", code, out.String(), errOut.String())
+	}
+
+	// The same operation, one axis withdrawn.
+	regressed := artefactWith(t, []string{"incus", "none"}, map[string]map[string]any{
+		"instance/v1/API.CreateServer": proven("unobserved"),
+	})
+	out.Reset()
+	errOut.Reset()
+	code := evidenceVerify([]string{"--baseline", baseline, "--evidence", regressed}, &out, &errOut)
+	if code != exitDrift {
+		t.Fatalf("verify exited %d, want %d (drift): %s%s", code, exitDrift, out.String(), errOut.String())
+	}
+	for _, want := range []string{"instance/v1/API.CreateServer", "shape", "observed", "unobserved"} {
+		if !strings.Contains(errOut.String(), want) {
+			t.Errorf("the refusal never names %q:\n%s", want, errOut.String())
+		}
+	}
+
+	// The accepting half, and it is not ceremony: a verify that failed on
+	// everything would pass every planted defect above and stop anybody using it.
+	out.Reset()
+	errOut.Reset()
+	if code := evidenceVerify([]string{"--baseline", baseline, "--evidence", pinned}, &out, &errOut); code != exitOK {
+		t.Fatalf("verify exited %d on an unchanged artefact: %s%s", code, out.String(), errOut.String())
+	}
+}
+
+// An operation that disappeared entirely is the strongest fall there is, and it
+// must not read as "no verdict to compare".
+func TestVerifyCallsAVanishedOperationARegression(t *testing.T) {
+	pinned := artefactWith(t, []string{"incus"}, map[string]map[string]any{
+		"instance/v1/API.CreateServer": proven("observed"),
+	})
+	baseline := filepath.Join(t.TempDir(), "pin.json")
+	var out, errOut bytes.Buffer
+	if code := evidenceCapture([]string{"--evidence", pinned, "--out", baseline}, &out, &errOut); code != exitOK {
+		t.Fatalf("capture exited %d", code)
+	}
+
+	gone := artefactWith(t, []string{"incus"}, map[string]map[string]any{
+		"instance/v1/API.ListServers": proven("observed"),
+	})
+	out.Reset()
+	errOut.Reset()
+	if code := evidenceVerify([]string{"--baseline", baseline, "--evidence", gone}, &out, &errOut); code != exitDrift {
+		t.Fatalf("an operation that vanished was not a regression (exit %d)", code)
+	}
+	if !strings.Contains(errOut.String(), "absent") {
+		t.Errorf("the refusal does not say the operation is gone:\n%s", errOut.String())
+	}
+}
+
+// Claims are MEANT to be withdrawn here — #475, #481 and #483 are each "this was
+// claimed and should not have been". A baseline that only grows would have
+// stopped all three, so a withdrawal passes WITH a reason and fails without one.
+func TestAWithdrawalPassesWithItsReasonAndFailsWithout(t *testing.T) {
+	dir := t.TempDir()
+	pinned := artefactWith(t, []string{"incus"}, map[string]map[string]any{
+		"lb/v1/ZonedAPI.CreateLb": proven("observed"),
+	})
+	baseline := filepath.Join(dir, "pin.json")
+	var out, errOut bytes.Buffer
+	if code := evidenceCapture([]string{"--evidence", pinned, "--out", baseline}, &out, &errOut); code != exitOK {
+		t.Fatalf("capture exited %d", code)
+	}
+	withdrawn := artefactWith(t, []string{"incus"}, map[string]map[string]any{
+		"lb/v1/ZonedAPI.CreateLb": proven("unobserved"),
+	})
+
+	// Unaccepted: red.
+	out.Reset()
+	errOut.Reset()
+	if code := evidenceVerify([]string{"--baseline", baseline, "--evidence", withdrawn}, &out, &errOut); code != exitDrift {
+		t.Fatalf("an unaccepted withdrawal passed (exit %d)", code)
+	}
+
+	// Accepted with a reason: green, and the reason is printed rather than
+	// swallowed — an acceptance nobody can read is a silencer.
+	accepted := filepath.Join(dir, "accepted.json")
+	if err := os.WriteFile(accepted, []byte(`{"accepted":[{"operation":"lb/v1/ZonedAPI.CreateLb",`+
+		`"axis":"shape","reason":"the recording was withdrawn: it captured a field the cloud stopped sending"}]}`),
+		0o600); err != nil {
+		t.Fatalf("write accepted: %v", err)
+	}
+	out.Reset()
+	errOut.Reset()
+	code := evidenceVerify([]string{"--baseline", baseline, "--evidence", withdrawn, "--accepted", accepted}, &out, &errOut)
+	if code != exitOK {
+		t.Fatalf("an accepted withdrawal was refused (exit %d): %s%s", code, out.String(), errOut.String())
+	}
+	if !strings.Contains(out.String(), "the recording was withdrawn") {
+		t.Errorf("the accepted withdrawal's reason is not printed:\n%s", out.String())
+	}
+
+	// An acceptance with an empty reason is refused, because the whole value of
+	// this file is that a withdrawal carries why.
+	silent := filepath.Join(dir, "silent.json")
+	if err := os.WriteFile(silent, []byte(`{"accepted":[{"operation":"lb/v1/ZonedAPI.CreateLb","axis":"shape","reason":"  "}]}`),
+		0o600); err != nil {
+		t.Fatalf("write silent: %v", err)
+	}
+	out.Reset()
+	errOut.Reset()
+	if code := evidenceVerify([]string{"--baseline", baseline, "--evidence", withdrawn, "--accepted", silent}, &out, &errOut); code == exitOK {
+		t.Fatal("a withdrawal accepted with no reason was honoured")
+	}
+	if !strings.Contains(errOut.String(), "no reason") {
+		t.Errorf("the refusal does not say what is missing:\n%s", errOut.String())
+	}
+}
+
+// A baseline taken from a partial run is worse than none: it pins `dataplane:
+// false` on every operation that would have earned it, and the consumer is then
+// told nothing regressed on the day it did. Refused AT CAPTURE.
+func TestABaselineIsRefusedWhenTheArtefactReachedNoRuntime(t *testing.T) {
+	runtimeless := artefactWith(t, []string{"none"}, map[string]map[string]any{
+		"instance/v1/API.CreateServer": proven("observed"),
+	})
+	var out, errOut bytes.Buffer
+	code := evidenceCapture([]string{"--evidence", runtimeless}, &out, &errOut)
+	if code == exitOK {
+		t.Fatalf("a baseline was captured from a run that started no machine:\n%s", out.String())
+	}
+	for _, want := range []string{"started no machine", "evidence:update"} {
+		if !strings.Contains(errOut.String(), want) {
+			t.Errorf("the refusal never says %q:\n%s", want, errOut.String())
+		}
+	}
+
+	// The accepting half: the same artefact earned under a runtime is captured.
+	withRuntime := artefactWith(t, []string{"incus-ovn", "none"}, map[string]map[string]any{
+		"instance/v1/API.CreateServer": proven("observed"),
+	})
+	out.Reset()
+	errOut.Reset()
+	if code := evidenceCapture([]string{"--evidence", withRuntime}, &out, &errOut); code != exitOK {
+		t.Fatalf("a record earned under a runtime was refused (exit %d): %s", code, errOut.String())
+	}
+}
+
+// `response` and `refusal` are both "a real client got an answer here", and
+// neither is above the other — #156 took this axis from 181 arrivals down to 83
+// verdicts and that was a fix. A baseline that ranked them would fail every
+// consumer the day a suite started demanding a refusal where it used to read a
+// response.
+func TestAProbeVerdictIsDeliveredByEitherVerdict(t *testing.T) {
+	pinned := artefactWith(t, []string{"incus"}, map[string]map[string]any{
+		"instance/v1/API.CreateServer": proven("observed"),
+	})
+	baseline := filepath.Join(t.TempDir(), "pin.json")
+	var out, errOut bytes.Buffer
+	if code := evidenceCapture([]string{"--evidence", pinned, "--out", baseline}, &out, &errOut); code != exitOK {
+		t.Fatalf("capture exited %d", code)
+	}
+
+	swapped := proven("observed")
+	swapped["probed"] = "refusal"
+	other := artefactWith(t, []string{"incus"}, map[string]map[string]any{
+		"instance/v1/API.CreateServer": swapped,
+	})
+	out.Reset()
+	errOut.Reset()
+	if code := evidenceVerify([]string{"--baseline", baseline, "--evidence", other}, &out, &errOut); code != exitOK {
+		t.Fatalf("response → refusal was called a regression (exit %d): %s", code, errOut.String())
+	}
+
+	// And the fall that IS one: no client reached it at all.
+	none := proven("observed")
+	none["probed"] = "none"
+	unprobed := artefactWith(t, []string{"incus"}, map[string]map[string]any{
+		"instance/v1/API.CreateServer": none,
+	})
+	out.Reset()
+	errOut.Reset()
+	if code := evidenceVerify([]string{"--baseline", baseline, "--evidence", unprobed}, &out, &errOut); code != exitDrift {
+		t.Fatalf("an operation no client reached any more passed (exit %d)", code)
+	}
+}
+
+// A consumer pins only what it relies on. An axis it never named cannot fail it,
+// which is what makes the file something a downstream project actually commits.
+func TestOnlyTheAxesAConsumerNamedAreHeldAgainstIt(t *testing.T) {
+	pinned := artefactWith(t, []string{"incus"}, map[string]map[string]any{
+		"instance/v1/API.CreateServer": proven("observed"),
+	})
+	baseline := filepath.Join(t.TempDir(), "pin.json")
+	var out, errOut bytes.Buffer
+	if code := evidenceCapture([]string{"--evidence", pinned, "--out", baseline, "--axes", "contract,driven"},
+		&out, &errOut); code != exitOK {
+		t.Fatalf("capture exited %d: %s", code, errOut.String())
+	}
+
+	// Every other axis withdrawn; the two pinned ones held.
+	narrowed := map[string]any{
+		"driven": true, "probed": "none", "contract": "clean",
+		"dataplane": false, "shape": "unobserved", "behaviour": false, "negative": false,
+	}
+	after := artefactWith(t, []string{"incus"}, map[string]map[string]any{
+		"instance/v1/API.CreateServer": narrowed,
+	})
+	out.Reset()
+	errOut.Reset()
+	if code := evidenceVerify([]string{"--baseline", baseline, "--evidence", after}, &out, &errOut); code != exitOK {
+		t.Fatalf("an axis nobody pinned failed the run (exit %d): %s", code, errOut.String())
+	}
+
+	// And an axis that is not one of the record's is refused by name rather than
+	// silently pinning nothing.
+	out.Reset()
+	errOut.Reset()
+	if code := evidenceCapture([]string{"--evidence", pinned, "--axes", "vibes"}, &out, &errOut); code == exitOK {
+		t.Fatal("an axis this record does not carry was accepted")
+	}
+	if !strings.Contains(errOut.String(), "vibes") {
+		t.Errorf("the refusal does not name the axis:\n%s", errOut.String())
+	}
+}
+
+// An axis whose verdict IS the absence of proof is not pinned, and the reason is
+// a measurement: the first version of this file pinned them, and run against
+// v0.11.0 it reported `osc/Client.AcceptNetPeering behaviour: false → true` as a
+// regression. An absence that becomes a proof is progress; a baseline that calls
+// it a fall is a ratchet pointing the wrong way.
+func TestAnAxisThatProvesNothingIsNotPinned(t *testing.T) {
+	nothing := map[string]any{
+		"driven": false, "probed": "none", "contract": "unchecked",
+		"dataplane": false, "shape": "unobserved", "behaviour": false, "negative": false,
+	}
+	artefact := artefactWith(t, []string{"incus"}, map[string]map[string]any{
+		"instance/v1/API.CreateServer": nothing,
+		"instance/v1/API.ListServers":  proven("observed"),
+	})
+	var out, errOut bytes.Buffer
+	if code := evidenceCapture([]string{"--evidence", artefact}, &out, &errOut); code != exitOK {
+		t.Fatalf("capture exited %d: %s", code, errOut.String())
+	}
+	var baseline evidenceBaseline
+	if err := json.Unmarshal(out.Bytes(), &baseline); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, pinned := baseline.Operations["instance/v1/API.CreateServer"]; pinned {
+		t.Errorf("an operation nothing proves was pinned: %v",
+			baseline.Operations["instance/v1/API.CreateServer"])
+	}
+	// The reader proves it can find before it judges: the proven operation IS
+	// pinned, on all seven axes.
+	if got := len(baseline.Operations["instance/v1/API.ListServers"]); got != 7 {
+		t.Errorf("the proven operation pins %d axes, want 7", got)
+	}
+}

--- a/internal/cli/frozen_test.go
+++ b/internal/cli/frozen_test.go
@@ -425,6 +425,11 @@ func flagsTheBinaryAccepts(t *testing.T) map[string][]string {
 	drive("snapshot", "load", "a-name", "-h")
 	drive("snapshot", "list", "-h")
 	drive("snapshot", "rm", "a-name", "-h")
+	// `evidence` dispatches again too since #488: `evidence baseline` and
+	// `evidence verify` take flags the record-writing verb does not, and a union
+	// under `evidence` would claim all three take all three.
+	drive("evidence", "baseline", "-h")
+	drive("evidence", "verify", "-h")
 
 	// Assert the subject rather than skip on its absence. A verb whose set was
 	// never observed would otherwise leave the fixture quietly smaller, and a

--- a/internal/cli/testdata/frozen/cli.json
+++ b/internal/cli/testdata/frozen/cli.json
@@ -3380,6 +3380,218 @@
           ]
         }
       }
+    },
+    {
+      "schema_version": 21,
+      "content": {
+        "exit_codes": {
+          "drift": 2,
+          "error": 1,
+          "ok": 0
+        },
+        "verbs": {
+          "catalog": [
+            "--format"
+          ],
+          "clean": [
+            "--check",
+            "--closing",
+            "--doorstep",
+            "--force",
+            "--format",
+            "--vm"
+          ],
+          "corpus": [
+            "--accepted",
+            "--against-cloud",
+            "--bind",
+            "--check",
+            "--credential",
+            "--dir",
+            "--dry-run",
+            "--endpoint",
+            "--file",
+            "--format",
+            "--mark-stale",
+            "--timeout"
+          ],
+          "coverage": [
+            "--artefact",
+            "--axis",
+            "--baseline",
+            "--contract",
+            "--evidence",
+            "--fail-on-unknown",
+            "--format",
+            "--gaps",
+            "--observed",
+            "--products",
+            "--provider",
+            "--sdk",
+            "--write-baseline"
+          ],
+          "docs": [
+            "--check",
+            "--client-pins",
+            "--confidence",
+            "--contracts",
+            "--coverage",
+            "--file",
+            "--install",
+            "--limits",
+            "--proved",
+            "--routes",
+            "--screenshots",
+            "--ui-manifest",
+            "--workflow"
+          ],
+          "doctor": [
+            "--addr",
+            "--vm"
+          ],
+          "down": [
+            "--file",
+            "--keep-emulator"
+          ],
+          "env": [
+            "--client",
+            "--endpoint",
+            "--shell",
+            "--unset"
+          ],
+          "evidence": [
+            "--allow-narrowing",
+            "--contracts",
+            "--endpoint",
+            "--join",
+            "--out",
+            "--reshape",
+            "--shapes",
+            "--suites"
+          ],
+          "evidence baseline": [
+            "--axes",
+            "--evidence",
+            "--out"
+          ],
+          "evidence verify": [
+            "--accepted",
+            "--baseline",
+            "--evidence"
+          ],
+          "images": [
+            "--check",
+            "--only",
+            "--vm"
+          ],
+          "logs": [
+            "--addr",
+            "-f",
+            "-n"
+          ],
+          "probe": [
+            "--contracts",
+            "--endpoint",
+            "--provider"
+          ],
+          "proxy": [
+            "--addr",
+            "--expose-to-network",
+            "--forward",
+            "--intercept",
+            "--max-body",
+            "--provider",
+            "--queue",
+            "--record",
+            "--upstream"
+          ],
+          "replay": [
+            "--endpoint",
+            "--format",
+            "--refusals-only",
+            "--timeout"
+          ],
+          "restart": [
+            "--addr",
+            "--timeout"
+          ],
+          "serve": [
+            "--addr",
+            "--cleanup",
+            "--contracts",
+            "--coverage",
+            "--expose-to-network",
+            "--log-level",
+            "--projects",
+            "--shapes",
+            "--state",
+            "--vm"
+          ],
+          "shapes": [
+            "--check",
+            "--dir",
+            "--dry-run",
+            "--profile",
+            "--provider",
+            "--record"
+          ],
+          "snapshot list": [
+            "--format"
+          ],
+          "snapshot load": [
+            "--addr"
+          ],
+          "snapshot save": [
+            "--addr",
+            "--force"
+          ],
+          "start": [
+            "--addr",
+            "--cleanup",
+            "--contracts",
+            "--detach",
+            "--foreground",
+            "--log-level",
+            "--projects",
+            "--state",
+            "--timeout",
+            "--vm"
+          ],
+          "status": [
+            "--addr",
+            "--coverage",
+            "--format"
+          ],
+          "stop": [
+            "--addr",
+            "--timeout"
+          ],
+          "transcript": [
+            "--against",
+            "--contract",
+            "--format",
+            "--sanitise",
+            "--shape"
+          ],
+          "ui": [
+            "--addr",
+            "--print"
+          ],
+          "up": [
+            "--file",
+            "--no-iac",
+            "--runtime",
+            "--timeout"
+          ],
+          "version": [
+            "--check"
+          ],
+          "wait": [
+            "--addr",
+            "--timeout"
+          ]
+        }
+      }
     }
   ]
 }

--- a/mise.toml
+++ b/mise.toml
@@ -815,6 +815,33 @@ tools/conformance/scaleway/scw-cli.sh "http://$addr"
 ./dist/feint-linux-amd64 probe --endpoint "http://$addr" --contracts contracts
 """
 
+[tasks."evidence:verify"]
+description = "Has what a consumer trusted moved? Hold coverage/evidence.json against a pinned baseline (#488)"
+# NOT drift:check, and the boundary is the whole design: that one watches the
+# UPSTREAM SDK surface — has the cloud moved — and this one watches this
+# emulator's own level of evidence, from the point of view of somebody who is
+# not in this repository. A design that folded one into the other would answer
+# one question twice and the other never.
+#
+# The baseline this holds against is the previous release's record, which is
+# what #545's release invariant asks for in as many words: no axis of evidence
+# regresses between two releases without a written explanation. `--accepted` is
+# where the explanation goes, on the model corpus/accepted.json already uses.
+run = """
+set -e
+# `set -euo pipefail` is what every script in tools/ carries; mise runs this
+# with /bin/sh, which has no `pipefail`, and the task then dies on its own
+# first line. The neighbour above says `set -e` for the same reason.
+tag="${FEINT_EVIDENCE_BASELINE_TAG:-$(git describe --tags --abbrev=0 --match 'v*' HEAD^ 2>/dev/null || git describe --tags --abbrev=0 --match 'v*')}"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+git show "$tag:coverage/evidence.json" > "$work/previous.json"
+./feint evidence baseline --evidence "$work/previous.json" --out "$work/pinned.json"
+echo "held against $tag"
+./feint evidence verify --baseline "$work/pinned.json" --accepted coverage/evidence-accepted.json
+"""
+depends = ["build"]
+
 [tasks."evidence:update"]
 description = "Regenerate coverage/evidence.json from two fresh conformance runs, then refresh the docs that print it"
 depends = ["build"]

--- a/tools/falsify/specs/evidence-baseline.json
+++ b/tools/falsify/specs/evidence-baseline.json
@@ -1,0 +1,47 @@
+{
+  "package": "./internal/cli/",
+  "mutations": [
+    {
+      "label": "a level the baseline pins is no longer delivered and verify says nothing, so a consumer discovers from the outside three releases later that feint stopped proving what it relied on — which is what #325 and #326 were",
+      "file": "internal/cli/evidence_baseline.go",
+      "find": "\t\t\tif f.reason != \"\" {",
+      "replace": "\t\t\tif f.reason != \"\" || true {",
+      "test": "TestVerifyFailsWhenAPinnedLevelIsNoLongerDelivered"
+    },
+    {
+      "label": "an operation that vanished entirely reads as no verdict to compare rather than as the strongest fall there is",
+      "file": "internal/cli/evidence_baseline.go",
+      "find": "\t\t\tnow := \"absent\"",
+      "replace": "\t\t\tnow := \"absent\"\n\t\t\tif !present {\n\t\t\t\tcontinue\n\t\t\t}",
+      "test": "TestVerifyCallsAVanishedOperationARegression"
+    },
+    {
+      "label": "a withdrawal is accepted with no reason at all, so the file stops being a record of why a claim went and becomes a silencer",
+      "file": "internal/cli/evidence_baseline.go",
+      "find": "\t\t\tif strings.TrimSpace(entry.Reason) == \"\" {",
+      "replace": "\t\t\tif strings.TrimSpace(entry.Reason) == \"\" && false {",
+      "test": "TestAWithdrawalPassesWithItsReasonAndFailsWithout"
+    },
+    {
+      "label": "a baseline is captured from a run that started no machine, pinning dataplane false everywhere: the consumer is then told nothing regressed on the day it did — a baseline from a partial run is worse than none",
+      "file": "internal/cli/evidence_baseline.go",
+      "find": "\tif !reachesARuntime(art.Machines) {",
+      "replace": "\tif !reachesARuntime(art.Machines) && false {",
+      "test": "TestABaselineIsRefusedWhenTheArtefactReachedNoRuntime"
+    },
+    {
+      "label": "response and refusal are ranked against each other, so a suite that starts demanding a refusal where it used to read a response fails every consumer — #156 took this axis from 181 arrivals to 83 verdicts and that was a fix",
+      "file": "internal/cli/evidence_baseline.go",
+      "find": "\t\tif verdict(p) {\n\t\t\treturn verdict(c)\n\t\t}",
+      "replace": "\t\tif verdict(p) && false {\n\t\t\treturn verdict(c)\n\t\t}",
+      "test": "TestAProbeVerdictIsDeliveredByEitherVerdict"
+    },
+    {
+      "label": "an axis whose verdict is the absence of proof is pinned, so every later improvement is reported as a regression — measured against v0.11.0, which answered `osc/Client.AcceptNetPeering behaviour: false → true` as a fall",
+      "file": "internal/cli/evidence_baseline.go",
+      "find": "\t\t\tif wanted[axis] && provesSomething(values[axis]) {",
+      "replace": "\t\t\tif wanted[axis] && (provesSomething(values[axis]) || true) {",
+      "test": "TestAnAxisThatProvesNothingIsNotPinned"
+    }
+  ]
+}


### PR DESCRIPTION
feat(evidence): a consumer pins the level of proof it depends on, and 0.12.0's release invariant stops being measured by hand (#488)

`feint evidence baseline` writes what a downstream project relies on;
`feint evidence verify` exits 2 naming every level no longer delivered. Not
"feint changed version" — **"feint stopped proving what this project was
relying on"**. #325 and #326 exist because a consumer discovered a change from
the outside, after the fact.

Brought forward from 0.15.0 for one reason: **0.12.0's release invariant had no
instrument.** Its milestone says "no axis of evidence regresses between 0.11.0
and 0.12.0 without a written explanation", #545 names #488 as the machinery that
should be read before any comparison is written, and #488 sat three milestones
away. The invariant was therefore unenforceable, and I checked it by hand this
morning — which is exactly the shape this repository distrusts.

Measured now, by the tool, `mise run evidence:verify` against v0.11.0:

    364 operation(s) pinned on 7 axes
    every level is still delivered, 0 withdrawal(s) accepted   rc=0

and with two regressions planted in the artefact:

    REGRESSED: instance/v1/API.CreateServer dataplane: true → false
    REGRESSED: instance/v1/API.CreateServer shape: observed → unobserved   rc=2

## The boundary against drift:check, which the issue asked to be argued

`coverage/*-baseline.json` + `drift:check` watch the UPSTREAM SDK surface: has
the cloud moved? These two watch THIS EMULATOR's own level of evidence, from the
point of view of somebody who is not in this repository: has what I trusted
moved? A design folding one into the other answers one question twice and the
other never, so they stay apart and the file comment says so.

## The three ways the issue said it goes wrong, each answered

**A ratchet nobody can lower.** Claims are meant to be withdrawn here — #475,
#481 and #483 are each "this was claimed and should not have been", and a
baseline that only grows would have stopped all three. `--accepted` carries a
withdrawal WITH its reason, and an entry with no reason is refused rather than
honoured: the whole value of that file is that a withdrawal carries why.

**A baseline from a partial run is worse than none.** A record earned with no
machine runtime pins `dataplane: false` on every operation that would have
earned it, so the consumer is told nothing regressed on the day it did. Refused
at capture, reusing the shape `runtimesLost` already established.

**Naming.** `evidence baseline` / `evidence verify`, never `lock`: it pins a
level, not a version.

## What the tool found about itself, by being run rather than reasoned about

Its first version pinned every axis, and against v0.11.0 it reported
`osc/Client.AcceptNetPeering behaviour: false → true` as a REGRESSION. Pinning
`false` is pinning the absence of proof, and an absence that becomes a proof is
progress. `provesSomething` now drops those at capture, so the file carries only
what somebody depends on — which is the shape the issue's own example sketched.

And the verdicts are compared by a RELATION, not an ordering: ranking them would
mean inventing where `violating` sits against `unchecked`, which nothing in this
repository states. `response` and `refusal` satisfy each other, because both are
"a real client got an answer here" and #156 took that axis from 181 arrivals to
83 verdicts as a fix.

## One deviation, stated rather than slipped in

The issue sketches YAML at `.feint-evidence.yaml`; this writes JSON. The artefact
it pins is JSON, the accepted-withdrawal file it is modelled on is JSON, and this
repository carries no YAML dependency — `internal/environment` hand-rolls a
reader bound to its own schema, so YAML here would be a second hand-rolled parser
to get wrong. The shape of the file is the issue's; the encoding is not.

Measured: prepush green; falsify `evidence-baseline.json` 6/6 mutations bite;
frozen CLI surface 21 carries both subcommands with their own flags, driven by
name the way `snapshot save` is.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

