### PR TITLE
fix(ci): the verdict publishes on a dispatch too, or the run that asked for the control never hears it

### DIFF
--- a/.github/workflows/runtime-proof.yml
+++ b/.github/workflows/runtime-proof.yml
@@ -867,7 +867,15 @@ jobs:
   verdict:
     name: Us, or the world?
     needs: [stacks]
-    if: always() && github.event_name == 'schedule'
+    # Not schedule-only, unlike `report` and `streak` beside it, and the
+    # distinction is what those two do rather than what they read: they open an
+    # issue and count a streak, which are facts about the NIGHTLY series. This
+    # one only publishes a reading of the run it belongs to, and the first
+    # workflow_dispatch after it landed — 33249879475, triggered to see the
+    # control before waiting for 02:31 — would have run the control leg and then
+    # printed nothing about it. A control whose reading is withheld from the one
+    # person who asked for it is the shape #604 names.
+    if: always()
     runs-on: ubuntu-24.04
     permissions:
       actions: read

--- a/tools/conformance/nightly_control_test.go
+++ b/tools/conformance/nightly_control_test.go
@@ -57,6 +57,20 @@ func TestTheNightlyControlCannotOpenTheIssueAboutMain(t *testing.T) {
 		t.Error("the verdict job does not depend on the legs it reads, so it can publish before " +
 			"either of them has a conclusion")
 	}
+	// And it publishes on a dispatch too. `report` and `streak` are schedule-only
+	// because they open an issue and count a streak — facts about the nightly
+	// SERIES — while this one reads the run it belongs to. Measured: the first
+	// workflow_dispatch after the control landed (33249879475) ran the control
+	// leg and would have printed nothing about it, which is a reading withheld
+	// from the one person who asked for it.
+	if i := strings.Index(workflow, "\n  verdict:\n"); i >= 0 {
+		window := workflow[i:min(i+1200, len(workflow))]
+		head, _, _ := strings.Cut(window, "steps:")
+		if strings.Contains(head, "github.event_name == 'schedule'") {
+			t.Error("the verdict job is schedule-only, so a dispatched run measures the control " +
+				"and then says nothing about it")
+		}
+	}
 	if !strings.Contains(workflow, `select(.name | startswith("stacks ("))`) {
 		t.Error("the verdict job does not read the legs' real conclusions from the API, so it " +
 			"cannot see a leg whose failure was made non-blocking")


### PR DESCRIPTION
fix(ci): the verdict publishes on a dispatch too, or the run that asked for the control never hears it

`report` and `streak` are schedule-only for a reason that does not apply here:
they open an issue and count a streak, which are facts about the nightly SERIES.
The verdict job only reads the run it belongs to.

Measured within minutes of the control landing: run 33249879475 was dispatched
to see the control before waiting for 02:31, and with `github.event_name ==
'schedule'` on the verdict it would have run the control leg and then printed
nothing about it. A reading withheld from the one person who asked for it is the
shape #604 names — a conclusion nobody receives.

Held by the same structural test, with the property falsified by hand: putting
the schedule condition back reddens it, naming what a dispatched run would lose.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>