### PR TITLE
fix(ci): the control cannot fail the job, not just its gate — tonight it would have opened the issue about a tag

### DIFF
--- a/.github/workflows/runtime-proof.yml
+++ b/.github/workflows/runtime-proof.yml
@@ -555,6 +555,18 @@ jobs:
     # runner with a quarter of its cores: sized so a slow pass is still a
     # verdict rather than a timeout, because a timeout measures the runner.
     timeout-minutes: 75
+    # The CONTROL leg cannot fail this job, and it has to be HERE rather than on
+    # the gate step alone. Measured on run 33249879475, the first that played it:
+    # the control died at `Build the machine images the stacks boot`, BEFORE the
+    # gate — v0.11.0 has no waitForBuilderAddress (#583/#585), so `apk add
+    # openssh` fetched the Alpine CDN from a build instance with no address. The
+    # job failed, and tools/ci/night-report.sh reads every completed job of the
+    # run: on a scheduled night it would have opened "the night is red" about a
+    # tag nobody can fix. That is #538 exactly, and it is the thing this design
+    # claimed to prevent.
+    #
+    # TestTheNightlyControlCannotOpenTheIssueAboutMain fails without this.
+    continue-on-error: ${{ matrix.control }}
     permissions:
       contents: read
     strategy:
@@ -893,20 +905,29 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          # "Did any step fail?", not "what did the gate step conclude". The
+          # control died at the image build on run 33249879475, before the gate
+          # ever ran, and a reader keyed on that one step would have seen nothing
+          # and said "not answered" about a leg that failed loudly. The job's own
+          # conclusion cannot be used either: it is `success` by construction on
+          # the control leg, which is the whole point of the continue-on-error
+          # above.
           jobs="$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" --paginate \
-            --jq '.jobs[] | select(.name | startswith("stacks (")) | "\(.name)\t\(.conclusion)\t\(.steps[]? | select(.name == "The example stacks, applied and probed") | .conclusion)"')"
+            --jq '.jobs[] | select(.name | startswith("stacks (")) | "\(.name)\t\([.steps[]? | select(.conclusion == "failure")] | length)"')"
           echo "${jobs}"
 
-          main_gate="$(printf '%s\n' "${jobs}" | grep -v 'last release' | cut -f3 | head -1)"
-          ctrl_gate="$(printf '%s\n' "${jobs}" | grep 'last release' | cut -f3 | head -1)"
+          main_failed="$(printf '%s\n' "${jobs}" | grep -v 'last release' | cut -f2 | head -1)"
+          ctrl_failed="$(printf '%s\n' "${jobs}" | grep 'last release' | cut -f2 | head -1)"
+          main_gate="$([ "${main_failed:-x}" = "0" ] && echo success || echo failure)"
+          ctrl_gate="$([ "${ctrl_failed:-x}" = "0" ] && echo success || echo failure)"
 
           # A conclusion this job could not read is said out loud, never scored:
           # a verdict computed from a missing input is the shape this repository
           # refuses everywhere else.
-          if [ -z "${main_gate}" ] || [ -z "${ctrl_gate}" ]; then
+          if [ -z "${main_failed}" ] || [ -z "${ctrl_failed}" ]; then
             {
               echo "## Us, or the world? — not answered"
-              echo "One of the two legs published no conclusion (main: '${main_gate:-none}', control: '${ctrl_gate:-none}'), so the comparison was not made."
+              echo "One of the two legs published no step conclusions (main: '${main_failed:-none}', control: '${ctrl_failed:-none}'), so the comparison was not made."
             } >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi

--- a/tools/conformance/nightly_control_test.go
+++ b/tools/conformance/nightly_control_test.go
@@ -38,9 +38,21 @@ func TestTheNightlyControlCannotOpenTheIssueAboutMain(t *testing.T) {
 	// 1. The gate is non-blocking on the control leg alone. A bare
 	// `continue-on-error: true` would silence main's own red, which is the
 	// opposite defect and just as easy to write.
-	if !strings.Contains(workflow, "continue-on-error: ${{ matrix.control }}") {
-		t.Error("the stacks gate is not conditionally non-blocking, so either the control can " +
-			"open the issue about main, or main's own red is silenced")
+	// It must be on the JOB, not on the gate step alone. Measured on run
+	// 33249879475, the first that played the control: it died at `Build the
+	// machine images the stacks boot`, BEFORE the gate — so the job failed, and
+	// tools/ci/night-report.sh reads every completed job of the run. On a
+	// scheduled night that would have opened "the night is red" about a tag
+	// nobody can fix, which is the poisoning this whole design claimed to
+	// prevent.
+	jobHead, _, _ := strings.Cut(workflow[strings.Index(workflow, "\n  stacks:\n"):], "steps:")
+	if !strings.Contains(jobHead, "continue-on-error: ${{ matrix.control }}") {
+		t.Error("the control leg can fail the stacks JOB, so a red control opens the issue about " +
+			"main: a step-level continue-on-error covers nothing that happens before the gate")
+	}
+	if strings.Contains(jobHead, "continue-on-error: true") {
+		t.Error("the stacks job is non-blocking for main too, which silences the very red the " +
+			"nightly exists to report")
 	}
 
 	// 2. Somebody reads it. A conclusion no job consumes is the shape #604 names:


### PR DESCRIPTION
fix(ci): the control cannot fail the job, not just its gate — tonight it would have opened the issue about a tag

Measured on run 33249879475, the first that ever played the control: the leg died
at `Build the machine images the stacks boot`, BEFORE the gate step I had made
non-blocking. v0.11.0 has no `waitForBuilderAddress` (#583/#585), so `apk add
openssh` fetched the Alpine CDN from a build instance carrying no address:

    WARNING: fetching https://dl-cdn.alpinelinux.org/alpine/v3.21/main: Permission denied
    ERROR: unable to select packages: openssh (no such package)

The job therefore failed, and `tools/ci/night-report.sh` reads EVERY completed
job of the run and treats any non-success as a finding. On tonight's scheduled
run it would have opened "the night is red" about a tag nobody can fix — #538
exactly, and the precise poisoning the control's design claimed to prevent. It
was invisible on the dispatch because `report` is schedule-only.

So `continue-on-error` moves to the JOB. It stays conditional on
`matrix.control`: a blanket `true` would silence main's own red, which is the
opposite defect and just as easy to write.

And the verdict stops reading one named step. "Did any step fail?" is the
question, because the control died before the gate and a reader keyed on the gate
would have said "not answered" about a leg that failed loudly. The job's own
conclusion cannot serve either — it is `success` by construction now, which is
the point.

The structural test grew the property and it was falsified by hand: removing the
job-level line reddens it, naming what a step-level one does not cover.

What this changes about the reading, and it is worth stating: the control will
stay red until 0.12.0 is cut, because the fix it wants is on main and not in the
release. The maintainer confirmed that is correct — it is the truth about what is
published, and with the verdict job now publishing on dispatch too (#609) that
red arrives as a sentence rather than as a colour.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>