### PR TITLE
docs: name the handbook where a reader arrives, in both languages

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -18,6 +18,9 @@
 
 **Autre langue :** [English](./README.md)
 
+**Le guide complet**, avec captures et un tableau de maturité par provider :
+[blog.stephane-robert.info](https://blog.stephane-robert.info/docs/cloud/outils/feint/)
+
 [**Ce que vous pouvez valider**](docs/confidence.md) • [Installer](#installer) •
 [S'en servir](#sen-servir) • [Ce qui est prouvé](#état) • [Commandes](#commandes) •
 [Ce qu'il ne fait pas](docs/limits.md) • [Contribuer](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@
 
 **Read this in another language:** [Français](./README.fr.md)
 
+**The handbook**, with screenshots and a maturity table per provider:
+[blog.stephane-robert.info](https://blog.stephane-robert.info/en/docs/cloud/outils/feint/)
+
 [**What you can validate**](docs/confidence.md) • [Install](#install) •
 [Use it](#use-it) • [What is proven](#status) • [Commands](#commands) •
 [What it does not do](docs/limits.md) • [Contributing](CONTRIBUTING.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,17 @@ which one to open, which is the whole job here.
 The English pages are the source. Where a French translation exists it is named
 beside its original, and the English one prevails if the two disagree.
 
+**The handbook lives outside this repository**, in both languages, and it is what
+the repository's own homepage field points at:
+[English](https://blog.stephane-robert.info/en/docs/cloud/outils/feint/) ·
+[Français](https://blog.stephane-robert.info/docs/cloud/outils/feint/).
+It carries screenshots and a maturity table per provider — a thing this directory
+does not do, and the reason it is named here rather than left to be found.
+
+What it cannot be is checked. Nothing offline can tell you whether an external
+page still says what it said, so it is listed as a known surface rather than
+gated — the same problem as #599, one field over.
+
 ## I want to run something
 
 Start at the [quick start](../README.md#quick-start): four commands, a stack


### PR DESCRIPTION
docs: name the handbook where a reader arrives, in both languages

The full guide lives outside this repository, in two languages, and the
repository's `homepage` field already points at the English one — the most
discoverable place and the only structured one. What was missing is the three
spots a reader reaches without ever seeing the repository card: both READMEs and
the `docs/` index.

Read today, minutes after v0.12.0, both pages are correct and current: they name
0.12.0 and their maturity table reads Scaleway "Terraform, OpenTofu, `scw`",
Outscale "Terraform, OpenTofu, `octl`", Exoscale "`exo`" — the Exoscale Terraform
provider named as voluntarily rejected. That is exactly what
`internal/cli/capability.go` carries.

They are correct because somebody kept them so, and `docs/README.md` says that
out loud rather than implying a check exists: nothing offline can tell you
whether an external page still says what it said, so the handbook is listed as a
known surface rather than gated. Checking it would make `docs:check` depend on a
third-party site being up, and a gate that reddens because a blog is down is a
gate people learn to ignore.

The distinction is recorded on #599, which is the same problem one field over:
the GitHub description CAN be derived from the matrix and compared, an external
page cannot. One is a control; the other is a release-checklist item, and calling
the second a control would be the shape this repository names first.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>