### PR TITLE
docs(limits): CreateKeypair does not generate a key, and #476's section stopped being true the day it was fixed

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -31,7 +31,7 @@
 >
 > **Prouvé** : 350 des 373 opérations montées sont pilotées par un vrai client, à chaque pull request. `scw`, `octl`, `exo`, Terraform et OpenTofu tournent contre l'émulateur en CI, et les machines démarrent réellement : connexion ssh sur le compte par défaut de chaque provider, subnets isolés, pare-feu qui filtre. La chaîne complète est décrite dans [docs/conformance.md](docs/conformance.md).
 >
-> **Pas prouvé** : quotas, prix, capacité réelle, validation des identifiants, authentification, cohérence à terme. Les 51 sections de [docs/limits.md](docs/limits.md) disent chacune ce qu'elle coûte. Un émulateur avec un seul compte implicite et aucune grille tarifaire devrait inventer ces chiffres, et quelqu'un agirait dessus.
+> **Pas prouvé** : quotas, prix, capacité réelle, validation des identifiants, authentification, cohérence à terme. Les 52 sections de [docs/limits.md](docs/limits.md) disent chacune ce qu'elle coûte. Un émulateur avec un seul compte implicite et aucune grille tarifaire devrait inventer ces chiffres, et quelqu'un agirait dessus.
 >
 > **Inconnu** : 23 opérations sont montées et n'ont jamais été pilotées par un client. Chacune dit pourquoi aucun client officiel ne l'atteint, à la route et dans [docs/routes.md](docs/routes.md). Elles sont comptées plutôt qu'escamotées, une par une, dans [coverage/evidence.json](coverage/evidence.json).
 >

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 >
 > **Proven**: 350 of the 373 mounted operations are driven by a real client, on every pull request: each pack's own official CLI, and an infrastructure engine wherever a pack admits one, all of them running against the emulator in CI, and machines really boot: an ssh login on each provider's own default account, isolated subnets, a firewall that filters. The whole chain is described in [docs/conformance.md](docs/conformance.md).
 >
-> **Not proven**: quotas, prices, real capacity, identifier validation, authentication, eventual consistency. The 51 sections of [docs/limits.md](docs/limits.md) each say what one costs. An emulator with a single implicit account and no price list would have to invent those figures, and somebody would act on them.
+> **Not proven**: quotas, prices, real capacity, identifier validation, authentication, eventual consistency. The 52 sections of [docs/limits.md](docs/limits.md) each say what one costs. An emulator with a single implicit account and no price list would have to invent those figures, and somebody would act on them.
 >
 > **Unknown**: 23 operations are mounted and have never been driven by a client. Every one of them states why no official client reaches it, at the route and in [docs/routes.md](docs/routes.md). They are counted rather than glossed, one by one, in [coverage/evidence.json](coverage/evidence.json).
 >

--- a/docs/limits-acks.json
+++ b/docs/limits-acks.json
@@ -35,7 +35,7 @@
     "The three packs hand their security groups to the runtime, within two measured bounds": "2026-08-28",
     "Two Outscale filters reach the API only as a payload, and that is `octl`'s gap": "2026-08-27",
     "What survives a dead emulator, in one table": "2026-08-27",
-    "`feint images resolve` can print a `FEINT_BOOT_IMAGES` line that cannot boot (#476)": "2026-08-27",
+    "`feint images resolve` prints only what boots, and names what it left out (#476)": "2026-08-30",
     "`scw` 2.56.3 prints a recovered panic on every successful `lb acl delete`, and the defect is upstream (#505)": "2026-08-28"
   }
 }

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -822,6 +822,47 @@ Scaleway's Key Manager, which this emulator does not serve, so a create carrying
 one is rejected. Accepting it would let a client read its own key back from a
 volume nothing encrypts.
 
+## CreateKeypair does not generate a keypair, and a published course teaches that it does
+
+`CreateKeypair` on the real Outscale, given a name and nothing else, **generates**
+the pair and returns the private key in the response. This emulator refuses:
+
+```
+4001  PublicKey is required: this emulator does not generate keypairs,
+      because it would have to hand out a private key that only looks usable
+```
+
+The decision is deliberate and was reaffirmed on 2026-08-30. A generated private
+key here would be a real, usable key that unlocks nothing — the emulator boots
+machines whose authorised keys it controls, so the pair would be theatre. Worse,
+it is the kind of theatre somebody stores: a reader told to "save it, it is shown
+only once" saves a secret that is not one, and may reuse it.
+
+**What this costs, measured.** The Outscale course at
+`blog.stephane-robert.info` opens its first hands-on page with exactly this call:
+
+```bash
+octl iaas api CreateKeypair --KeypairName ma-cle-test
+```
+
+and says, in as many words, *"La commande retourne la clé privée dans la réponse
+JSON, à sauvegarder immédiatement, elle n'est affichée qu'une fois."* Against this
+emulator that command fails, and it is the first thing a reader types.
+
+**The way through is one flag**, and it is the shape the emulator wants anyway:
+
+```bash
+ssh-keygen -t ed25519 -f ./ma-cle-test -N ''
+octl iaas api CreateKeypair --KeypairName ma-cle-test --PublicKey "$(cat ./ma-cle-test.pub)"
+```
+
+The key is then one the reader really holds, and `conformance:ssh` proves a login
+with exactly that arrangement on all three packs.
+
+Not revisited unless somebody shows a use where a fabricated private key is
+better than an absent one. "The course says so" is not that argument: the course
+can carry the two lines above, and the emulator cannot un-hand a secret.
+
 ## Lifecycle transitions are immediate
 
 A server goes from `stopped` to `running` within the action call. Real hardware
@@ -3850,44 +3891,47 @@ found fourteen lines about a documented behaviour and nothing about the run
 that really failed, which is precisely how a team learns to skip a log's
 errors.
 
-## `feint images resolve` can print a `FEINT_BOOT_IMAGES` line that cannot boot (#476)
+## `feint images resolve` prints only what boots, and names what it left out (#476)
 
-The command exists to turn an opaque identifier into the line an operator
-pastes ("Identifiers are not checked against anything" describes it). For two
-of the three identifiers the surveyed stacks hardcode, the line it prints
-names a version the upstream image server withdrew, and it says so nowhere
-(measured at `main@72d861d`):
+**Lifted 2026-08-29 by #605.** What follows is the measurement that produced the
+limit, kept because the fact underneath it has not moved: `images:` still
+publishes neither `ubuntu/18.04` nor `debian/9`, and two of the three identifiers
+the surveyed stacks hardcode still resolve to them.
+
+What changed is that the command no longer hands you a line that cannot boot. It
+reads the image server's own simplestreams index, leaves an unbuildable version
+out of the declaration, and says why:
 
 ```console
 $ ./feint images resolve ami-a3ca408c ami-538af795 ami-47899c77 ; echo "rc=$?"
-…
+ami-538af795
+  Outscale official OMIs reference: Ubuntu-18.04-2021.02.04-0
+  → ubuntu:18.04 — the image server no longer publishes ubuntu/18.04/cloud, so this declaration
+    would refuse to boot; it is left out of the line below.
+    ubuntu versions published today: 22.04, 24.04, 26.04, jammy, noble, resolute
+    naming one of them is your call, not this command's
+
 declare and restart:
-  FEINT_BOOT_IMAGES='ami-a3ca408c=ubuntu:22.04,ami-538af795=ubuntu:18.04,ami-47899c77=debian:9' feint serve ...
+  FEINT_BOOT_IMAGES='ami-a3ca408c=ubuntu:22.04' feint serve ...
 rc=0
 ```
 
-`images:` no longer publishes ubuntu/18.04 or debian/9 — this file already
-names them as withdrawn — so pasting that line buys nothing: the declaration
-is honoured, the build fails ("The requested image couldn't be found"), and
-the boot is refused. Replayed on `michaelcourcy/kasten-on-outscale @f1fcc87`
-with exactly that declaration: **29 applied, 0 machines started**, five Vms
-tainted — the same figures as with no declaration at all. The absence was
-measured with a control so that "absent" is not "looked nowhere": the
-`images:` listing read as JSON holds 726 aliases, `ubuntu/18.04` and
-`debian/9` absent, `ubuntu/22.04` and `debian/12` present as controls. Read it
-as JSON deliberately — `incus image list -c l` prints one alias and
-`(7 more)`, and grepping that column reports present aliases as absent too.
+A run whose every identifier resolved to a withdrawn version exits **2**, the way
+an identifier in no listing already does.
 
-What to do with it: before pasting the printed line, check each version
-against the `images:` listing, and substitute a version it publishes yourself
-(the boot refusal's own fix line says as much: "name one it does") — a
-substitution the operator signs, rather than a fact about the identifier. What would lift it: `resolve`
-checking buildability before printing — a warning line on an unbuildable ref,
-a clearly-labelled nearest-buildable suggestion, or a non-zero exit; #476
-leaves the shape to the author. Not measured: whether the Scaleway and
-Exoscale resolve paths can produce the same unbuildable output — only the
-Outscale listing was exercised, because it is the one the surveyed stacks
-reach for.
+**What it deliberately does not do is substitute.** The published versions are
+printed as a fact; choosing among them stays the operator's act, because naming
+the nearest buildable version for them is the silent replacement #83 measured and
+closed on all three packs.
+
+**The cost the limit used to carry, for the record.** Pasting the old line bought
+nothing: replayed on `michaelcourcy/kasten-on-outscale @f1fcc87`, **29 applied, 0
+machines started**, five Vms tainted — the same figures as with no declaration at
+all. The absence was measured with a control so that "absent" is not "looked
+nowhere": the `images:` listing read as JSON held 726 aliases, `ubuntu/18.04` and
+`debian/9` absent, `ubuntu/22.04` and `debian/12` present as controls. Read as
+JSON deliberately — `incus image list -c l` prints one alias and `(7 more)`, and
+grepping that column reports present aliases as absent too.
 
 ## `scw` 2.56.3 prints a recovered panic on every successful `lb acl delete`, and the defect is upstream (#505)
 

--- a/tools/conformance/outscale/training-survey.sh
+++ b/tools/conformance/outscale/training-survey.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# What a real Outscale course asks of this emulator, played call by call.
+#
+# NOT a gate, and the difference matters. Every other script in this directory
+# asserts a property and reddens when it fails; this one SURVEYS. It plays the
+# calls a published training course tells a reader to type, records what the
+# emulator answered, and compares that against a file of expectations somebody
+# wrote down. It exits 2 only when a verdict MOVED — a call that used to be
+# served and is not, or one that was refused and now passes without anybody
+# saying so.
+#
+# Why a survey and not a gate: nineteen of the fifty-six calls do not pass
+# today, and eight of those are refusals this repository argued for on purpose.
+# A gate would be red by construction, and CLAUDE.md says what a permanently red
+# gate teaches. What is useful is the DIFF against last time.
+#
+# The subject, measured 2026-08-30: the Outscale course at
+# blog.stephane-robert.info — 54 pages, 48 distinct API operations, 94 pairs of
+# (operation, parameter). The census that produced this list is in the issue
+# this script was written for; the list below is the census applied.
+#
+# The harness is octl.sh's, deliberately: same fake credentials, same
+# config.json, same guard_no_real_profile. A fourth harness in this directory
+# would be a fourth place to get the endpoint wrong.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+ENDPOINT="${1:-http://127.0.0.1:4599}"
+EXPECTED="$SCRIPT_DIR/training-expected.tsv"
+ACTUAL="${FEINT_SURVEY_OUT:-$(mktemp -d)/actual.tsv}"
+
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/../shared/verdicts.sh" 2>/dev/null || {
+  fail() { echo "FAIL: $*" >&2; exit 1; }
+  ok() { echo "  ok: $*"; }
+}
+
+cd "$REPO"
+set -a
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/fake-credentials.env"
+# shellcheck disable=SC2034 # read by octl from the environment
+OSC_ENDPOINT_API="$ENDPOINT/api/v1"
+set +a
+
+command -v octl >/dev/null 2>&1 || {
+  echo "  SKIP: octl is not installed, so no call of the course can be played" >&2
+  exit 0
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+cat > "$WORK/config.json" <<EOF
+{
+  "default": {
+    "access_key": "$OSC_ACCESS_KEY",
+    "secret_key": "$OSC_SECRET_KEY",
+    "region": "$OSC_REGION",
+    "protocol": "http",
+    "endpoints": { "api": "$ENDPOINT/api/v1" }
+  }
+}
+EOF
+
+osc() { octl --config "$WORK/config.json" --no-upgrade -o raw iaas api "$@" </dev/null; }
+
+# field <key> — the first value of a key, out of a JSON body on stdin. Written
+# in python rather than jq because a course reader is not required to have jq,
+# and this script is read as often as it is run.
+field() { python3 -c '
+import json,sys
+try: d = json.load(sys.stdin)
+except Exception: print(""); raise SystemExit
+def walk(node, key):
+    if isinstance(node, dict):
+        if key in node and isinstance(node[key], str): return node[key]
+        for v in node.values():
+            got = walk(v, key)
+            if got: return got
+    if isinstance(node, list):
+        for v in node:
+            got = walk(v, key)
+            if got: return got
+    return ""
+print(walk(d, sys.argv[1]))' "$1" 2>/dev/null || true; }
+
+: > "$ACTUAL"
+# record <label> <call...> — the verdict, and the API's own reason when refused.
+#
+# Three outcomes, never two: served, refused BY the emulator with a document,
+# and refused by octl itself before a request left. The third reads as a product
+# refusal to anybody skimming, and it is not one.
+record() {
+  local label="$1"; shift
+  local body verdict
+  if body="$(osc "$@" 2>&1)"; then
+    verdict=served
+  elif printf '%s' "$body" | grep -q '"Errors"'; then
+    verdict=refused
+  else
+    verdict=client
+  fi
+  printf '%s\t%s\n' "$label" "$verdict" >> "$ACTUAL"
+}
+
+echo "survey: the Outscale course against $ENDPOINT"
+
+# ---- the resources the course assumes exist ---------------------------------
+NET="$(osc CreateNet --IpRange=10.20.0.0/16 2>/dev/null | field NetId)"
+SUBNET="$(osc CreateSubnet --NetId="$NET" --IpRange=10.20.1.0/24 2>/dev/null | field SubnetId)"
+IGW="$(osc CreateInternetService 2>/dev/null | field InternetServiceId)"
+EIP="$(osc CreatePublicIp 2>/dev/null | field PublicIpId)"
+SG="$(osc CreateSecurityGroup --SecurityGroupName=survey --Description=survey --NetId="$NET" 2>/dev/null | field SecurityGroupId)"
+IMG="$(osc ReadImages 2>/dev/null | field ImageId)"
+
+# The course writes `CreateKeypair --KeypairName x` alone and says the response
+# carries the private key. This emulator refuses to generate one, deliberately —
+# docs/limits.md carries the measurement. The call is surveyed as the course
+# writes it, and a usable keypair is then made the way the emulator requires, so
+# that this one refusal does not cascade into every call below it.
+record "CreateKeypair, as the course writes it" CreateKeypair --KeypairName=survey-nokey
+osc CreateKeypair --KeypairName=survey-key \
+  --PublicKey="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJk8f5rP0ZzQ2cVn0m5N4tYb7xQeR1sJ2wKpL9dHcMvA survey" \
+  >/dev/null 2>&1 || true
+
+VM="$(osc CreateVms --ImageId="$IMG" --VmType=tinav5.c1r1p2 --SubnetId="$SUBNET" \
+  --KeypairName=survey-key --MinVmsCount=1 --MaxVmsCount=1 2>/dev/null | field VmId)"
+VOL="$(osc CreateVolume --Size=10 --SubregionName="${OSC_REGION}a" --VolumeType=standard 2>/dev/null | field VolumeId)"
+SNAP="$(osc CreateSnapshot --VolumeId="$VOL" --Description=survey 2>/dev/null | field SnapshotId)"
+RT="$(osc ReadRouteTables 2>/dev/null | field RouteTableId)"
+
+for name in NET SUBNET IGW EIP SG IMG VM VOL SNAP RT; do
+  [ -n "${!name}" ] || fail "the survey could not create its $name, so every call below would measure the harness"
+done
+ok "the ten resources the course assumes are in place"
+
+# ---- reads with no filter ---------------------------------------------------
+for op in ReadVms ReadNets ReadSubnets ReadPublicIps ReadSecurityGroups ReadVolumes \
+          ReadSnapshots ReadImages ReadRouteTables ReadNatServices ReadNetPeerings \
+          ReadLoadBalancers ReadRegions ReadSubregions ReadTags; do
+  record "$op" "$op"
+done
+
+# ---- reads WITH the filters the course passes -------------------------------
+record "ReadVms Filters.VmStateNames"        ReadVms --Filters.VmStateNames=running
+record "ReadVms Filters.NetIds"              ReadVms --Filters.NetIds="$NET"
+record "ReadVms Filters.ImageIds"            ReadVms --Filters.ImageIds="$IMG"
+record "ReadNets Filters.NetIds"             ReadNets --Filters.NetIds="$NET"
+record "ReadNets Filters.Tags"               ReadNets --Filters.Tags=env=survey
+record "ReadSubnets Filters.NetIds"          ReadSubnets --Filters.NetIds="$NET"
+record "ReadSubnets Filters.Tags"            ReadSubnets --Filters.Tags=env=survey
+record "ReadPublicIps Filters.Tags"          ReadPublicIps --Filters.Tags=env=survey
+record "ReadVolumes Filters.Tags"            ReadVolumes --Filters.Tags=env=survey
+record "ReadRouteTables Filters.Tags"        ReadRouteTables --Filters.Tags=env=survey
+record "ReadNatServices Filters.Tags"        ReadNatServices --Filters.Tags=env=survey
+record "ReadNetPeerings Filters.Tags"        ReadNetPeerings --Filters.Tags=env=survey
+record "ReadSnapshots Filters.SnapshotIds"   ReadSnapshots --Filters.SnapshotIds="$SNAP"
+record "ReadSnapshots Filters.Descriptions"  ReadSnapshots --Filters.Descriptions=survey
+record "ReadSubregions Filters.SubregionNames" ReadSubregions --Filters.SubregionNames="${OSC_REGION}a"
+record "ReadImages Filters.ImageIds"         ReadImages --Filters.ImageIds="$IMG"
+record "ReadImages Filters.ImageNames"       ReadImages --Filters.ImageNames=none
+record "ReadImages Filters.AccountIds"       ReadImages --Filters.AccountIds=123456789012
+record "ReadImages Filters.TagKeys"          ReadImages --Filters.TagKeys=env
+record "ReadImages Filters.TagValues"        ReadImages --Filters.TagValues=survey
+
+# ---- the operations this pack declines, which the course still teaches ------
+for op in ReadAccessKeys ReadUsers ReadFlexibleGpus ReadFlexibleGpuCatalog \
+          ReadConsumptionAccount ReadCO2EmissionAccount; do
+  record "$op" "$op"
+done
+record "CreateFlexibleGpu" CreateFlexibleGpu --ModelName=nvidia-p6 --Generation=v5 --SubregionName="${OSC_REGION}a"
+record "CreatePolicy"      CreatePolicy --PolicyName=p --Document='{}'
+
+# ---- the writes and links the course chains --------------------------------
+record "CreateTags"              CreateTags --ResourceIds="$NET" --Tags.0.Key=env --Tags.0.Value=survey
+record "LinkInternetService"     LinkInternetService --InternetServiceId="$IGW" --NetId="$NET"
+record "LinkPublicIp"            LinkPublicIp --PublicIpId="$EIP" --VmId="$VM"
+record "CreateNatService"        CreateNatService --PublicIpId="$(osc CreatePublicIp 2>/dev/null | field PublicIpId)" --SubnetId="$SUBNET"
+record "CreateRoute"             CreateRoute --RouteTableId="$RT" --DestinationIpRange=0.0.0.0/0 --GatewayId="$IGW"
+record "LinkVolume"              LinkVolume --VolumeId="$VOL" --VmId="$VM" --DeviceName=/dev/xvdb
+record "CreateSecurityGroupRule" CreateSecurityGroupRule --SecurityGroupId="$SG" --Flow=Inbound --IpProtocol=tcp --FromPortRange=22 --ToPortRange=22 --IpRange=0.0.0.0/0
+record "CreateImage"             CreateImage --ImageName=survey-img --Description=d --VmId="$VM"
+record "CreateNetPeering"        CreateNetPeering --SourceNetId="$NET" --AccepterNetId="$NET"
+record "StopVms"                 StopVms --VmIds="$VM"
+record "DeleteVms"               DeleteVms --VmIds="$VM"
+record "DeleteSnapshot"          DeleteSnapshot --SnapshotId="$SNAP"
+
+# ---- the comparison ---------------------------------------------------------
+sort -o "$ACTUAL" "$ACTUAL"
+[ -f "$EXPECTED" ] || fail "no $EXPECTED to compare against; write it from a run you have read"
+
+if diff -u <(sort "$EXPECTED") "$ACTUAL" > "$WORK/diff.txt"; then
+  served="$(grep -c 'served$' "$ACTUAL" || true)"
+  refused="$(grep -c 'refused$' "$ACTUAL" || true)"
+  client="$(grep -c 'client$' "$ACTUAL" || true)"
+  ok "every one of the $(wc -l < "$ACTUAL") calls answered what was written down: $served served, $refused refused, $client refused by octl itself"
+  echo "survey: the course's verdicts are unchanged"
+  exit 0
+fi
+
+echo
+echo "A verdict moved. The left side is what was written down, the right side is this run:"
+sed -n '3,40p' "$WORK/diff.txt"
+echo
+echo "If the move is an improvement, record it: FEINT_SURVEY_OUT=$EXPECTED $0 $ENDPOINT"
+echo "A survey that rewrites its own expectations without a reader is a survey that measures nothing."
+exit 2


### PR DESCRIPTION
docs(limits): CreateKeypair does not generate a key, and #476's section stopped being true the day it was fixed

Two sections, one measurement session against a real Outscale account and a
published training course.

## CreateKeypair, new section

The course at blog.stephane-robert.info opens its first hands-on page with

    octl iaas api CreateKeypair --KeypairName ma-cle-test

and says the response carries the private key, to be saved at once. Against this
emulator that command fails — deliberately, and the maintainer reaffirmed it on
2026-08-30. A generated private key here would be a real key that unlocks
nothing, and the reader is told to store it: theatre somebody keeps and may
reuse.

The refusal lived only in the code. It lives in limits.md now, with the two
lines that get a reader through (`ssh-keygen` then `--PublicKey`), because a
refusal a user meets before typing costs a message and a refusal they meet after
costs a lesson.

## #476's section had become false

`## feint images resolve CAN PRINT a FEINT_BOOT_IMAGES line that cannot boot` —
present tense, and #605 fixed it hours earlier the same day. The tripwire of #558
said so the moment the issue closed, which is the case it exists for: a limit
that survives its cause reads exactly like a limit.

Rewritten rather than re-dated. The limit is lifted and says so; the fact
underneath is kept, because it has not moved — `images:` still publishes neither
ubuntu/18.04 nor debian/9, and two of the three surveyed identifiers still
resolve to them. What changed is that the command now leaves an unbuildable
version out of the line and names it, and exits 2 when nothing is left to paste.

The measurement that produced the old limit is kept verbatim, control included:
29 applied and 0 machines started on the replayed stack, and 726 aliases read as
JSON because `incus image list -c l` prints `(7 more)` and reports present
aliases as absent.

`feint docs` moved the safety banner's count from 51 sections to 52 on its own,
which is the chain doing its job.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>