### PR TITLE
fix(scaleway): a boolean query filter reads every spelling the cloud reads, and refuses the ones it refuses (#630)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -17,6 +17,39 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ## [Unreleased]
 
+### Corrigé
+
+- **Un filtre booléen de requête ne lisait qu'une graphie et vidait
+  silencieusement la liste pour les autres** (#630). `attached=true` filtrait
+  correctement ; `attached=True`, ce qu'envoie le SDK Python officiel parce que
+  `requests` rend ainsi un booléen Python, ne correspondait à rien et répondait
+  une page vide bien formée. Autrement dit
+  `IpamV1API.list_i_ps_all(attached=True)`, la façon documentée de poser cette
+  question depuis Python, rendait un inventaire vide contre cet émulateur et les
+  adresses attachées contre la vraie API.
+
+  Mesuré sur fr-par le 2026-09-01 : la vraie API accepte `true`, `True`, `1` et
+  tout ce que prend `strconv.ParseBool`, parce qu'elle est un service Go qui
+  utilise cette fonction. Ce pack analyse désormais avec la même.
+
+  **Et une valeur illisible est refusée au lieu d'être avalée.** Elle était lue
+  comme fausse, ce qui affirme que la flotte est vide, affirmation différente et
+  fausse par rapport à « la question était mal formée ». Les deux dialectes
+  d'erreur sont ceux du cloud et ne sont pas identiques : `instance/v1` rend son
+  `invalid_arguments` typé, tandis que `ipam/v1`, `vpc/v2`, `vpc-gw/v2`, `lb/v1`,
+  `block/v1` et `iam/v1alpha1` rendent l'erreur de strconv telle quelle. Recopier
+  l'une sur l'autre aurait été inventer un format.
+
+  Le correctif couvre tous les booléens que le pack lit dans une requête, pas
+  seulement celui signalé : onze filtres et, plus grave, deux **drapeaux
+  d'action**. Un client envoyant `release_ip=True` ou `delete_ip=True` gardait
+  son adresse sans en être averti. Ces deux-là sont aussi analysés *avant* la
+  recherche de l'objet, ordre dans lequel fr-par répond : un 400 renvoie le
+  client à sa requête, un 404 l'envoie chercher une ressource.
+
+  Signalé par un consommateur qui construit un inventaire Ansible dynamique pour
+  Scaleway.
+
 ### Ajouté
 
 - **`instance/v1/API.UpdatePrivateNIC` est servie**, et le refus qu'elle remplace est

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,37 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ## [Unreleased]
 
+### Fixed
+
+- **A boolean query filter read one spelling and silently emptied the listing for
+  the others** (#630). `attached=true` filtered correctly; `attached=True` — what
+  the official Python SDK sends, because `requests` renders a Python bool that
+  way — matched nothing and answered a well-shaped empty page. So
+  `IpamV1API.list_i_ps_all(attached=True)`, the documented way to ask that
+  question from Python, returned an empty inventory against this emulator and the
+  attached addresses against the real API.
+
+  Measured on fr-par, 2026-09-01: the real API accepts `true`, `True`, `1` and
+  the rest of what `strconv.ParseBool` takes, because it is a Go service using
+  that function. This pack now parses with the same one.
+
+  **And an unparseable value is refused rather than swallowed.** It used to be
+  read as false, which says the fleet is empty — a different and wrong statement
+  from *the question was malformed*. The two error dialects are the cloud's own
+  and are not one: `instance/v1` answers its typed `invalid_arguments`, while
+  `ipam/v1`, `vpc/v2`, `vpc-gw/v2`, `lb/v1`, `block/v1` and `iam/v1alpha1` answer
+  strconv's error verbatim. Copying one onto the other would have been inventing
+  a format.
+
+  The fix covers every boolean the pack reads from a query, not only the one
+  reported: eleven filters and, more seriously, two **action flags**. A client
+  sending `release_ip=True` or `delete_ip=True` kept its address and was told
+  nothing. Those two are also parsed *before* the object is looked up, which is
+  the order fr-par answers in — a 400 sends a client to its own request, a 404
+  sends it hunting for a resource.
+
+  Reported by a consumer building a dynamic Ansible inventory for Scaleway.
+
 ### Added
 
 - **`instance/v1/API.UpdatePrivateNIC` is served**, and the refusal it replaces is

--- a/internal/providers/scaleway/acl.go
+++ b/internal/providers/scaleway/acl.go
@@ -138,7 +138,11 @@ func (p *Pack) getACL(w http.ResponseWriter, r *http.Request) {
 	// The SDK sends is_ipv6 as a query parameter on the GET (the contract
 	// declares it there too). Absent means IPv4, which is the SDK's own zero
 	// for a non-pointer bool and what `scw` sends when the flag is false.
-	ipv6 := r.URL.Query().Get("is_ipv6") == "true"
+	ipv6, _, err := queryBool(r.URL.Query(), "is_ipv6")
+	if err != nil {
+		writeParseFailure(w, "is_ipv6", err)
+		return
+	}
 	emulator.WriteJSON(w, http.StatusOK, p.aclView(vpc.ID, ipv6))
 }
 

--- a/internal/providers/scaleway/block.go
+++ b/internal/providers/scaleway/block.go
@@ -367,7 +367,12 @@ func (p *Pack) listBlockVolumes(w http.ResponseWriter, r *http.Request) {
 	// the store never holds one and the flag widens the answer by nothing. It
 	// is still read — the state filter is real — and docs/limits.md says why
 	// both values answer alike.
-	if includeDeleted, _ := queryBool(q, "include_deleted"); !includeDeleted {
+	includeDeleted, _, err := queryBool(q, "include_deleted")
+	if err != nil {
+		writeParseFailure(w, "include_deleted", err)
+		return
+	}
+	if !includeDeleted {
 		all = filterResources(all, func(res *resource.Resource) bool {
 			return res.State != "deleted"
 		})
@@ -628,7 +633,12 @@ func (p *Pack) listBlockSnapshots(w http.ResponseWriter, r *http.Request) {
 	}
 	// Same reading as listBlockVolumes: deletion is immediate, the filter is
 	// real, docs/limits.md carries the consequence.
-	if includeDeleted, _ := queryBool(q, "include_deleted"); !includeDeleted {
+	includeDeleted, _, err := queryBool(q, "include_deleted")
+	if err != nil {
+		writeParseFailure(w, "include_deleted", err)
+		return
+	}
+	if !includeDeleted {
 		all = filterResources(all, func(res *resource.Resource) bool {
 			return res.State != "deleted"
 		})

--- a/internal/providers/scaleway/boolfilter_test.go
+++ b/internal/providers/scaleway/boolfilter_test.go
@@ -1,0 +1,175 @@
+package scaleway_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// A boolean filter reads every spelling the real API reads, and refuses the ones
+// it refuses (#630).
+//
+// The filter compared against "true" alone, on the ground that this is what the
+// Go SDK writes. It is not what every client writes: the official Python SDK
+// renders a Python True as `True`, and requests puts that on the wire, so
+// `list_i_ps_all(attached=True)` — the documented way to ask the question from
+// Python — matched nothing here and answered an empty inventory.
+//
+// Both halves are measured against fr-par on 2026-09-01 rather than reasoned
+// about. The real API accepts true, True and 1, and refuses `banana` with 400
+// and strconv's own error text, because it is a Go service using
+// strconv.ParseBool.
+
+func anAttachedAddress(t *testing.T, ts *httptest.Server) {
+	t.Helper()
+	const zone = "/instance/v1/zones/fr-par-1"
+	const region = "/vpc/v2/regions/fr-par"
+
+	status, out := do(t, ts, "POST", region+"/private-networks",
+		`{"name":"filtered","subnets":["10.194.0.0/24"]}`)
+	if status != http.StatusOK && status != http.StatusCreated {
+		t.Fatalf("private network: status %d", status)
+	}
+	pnID, _ := out["id"].(string)
+
+	status, out = do(t, ts, "POST", zone+"/servers", `{"name":"filtered","commercial_type":"DEV1-S"}`)
+	if status != http.StatusCreated {
+		t.Fatalf("server: status %d", status)
+	}
+	server, _ := out["server"].(map[string]any)
+	id, _ := server["id"].(string)
+
+	if status, out := do(t, ts, "POST", zone+"/servers/"+id+"/private_nics",
+		`{"private_network_id":"`+pnID+`"}`); status != http.StatusCreated {
+		t.Fatalf("attach: status %d (%v)", status, out)
+	}
+}
+
+// Every spelling Go accepts partitions the set the same way. The listing is the
+// subject: a filter that matches nothing looks exactly like an empty fleet, and
+// that is what the reporter's inventory saw.
+func TestABooleanFilterReadsEverySpellingTheCloudReads(t *testing.T) {
+	ts := newTestServer(t)
+	anAttachedAddress(t, ts)
+
+	total := func(value string) float64 {
+		t.Helper()
+		status, out := do(t, ts, "GET", "/ipam/v1/regions/fr-par/ips?attached="+value, "")
+		if status != http.StatusOK {
+			t.Fatalf("attached=%s answered %d (%v)", value, status, out)
+		}
+		n, ok := out["total_count"].(float64)
+		if !ok {
+			t.Fatalf("attached=%s carries no total_count: %v", value, out)
+		}
+		return n
+	}
+
+	attached := total("true")
+	if attached < 1 {
+		t.Fatalf("attached=true found %v addresses; the fixture attached one", attached)
+	}
+	// The spelling the Python SDK sends, and the ones strconv also takes. Each is
+	// asserted against the lowercase answer rather than against a constant: what
+	// matters is that they agree, not what the number is.
+	for _, spelling := range []string{"True", "1", "t", "T", "TRUE"} {
+		if got := total(spelling); got != attached {
+			t.Errorf("attached=%s found %v where attached=true found %v", spelling, got, attached)
+		}
+	}
+	free := total("false")
+	for _, spelling := range []string{"False", "0", "f", "FALSE"} {
+		if got := total(spelling); got != free {
+			t.Errorf("attached=%s found %v where attached=false found %v", spelling, got, free)
+		}
+	}
+	// And the filter still partitions rather than matching everything, or the
+	// parsing fix would have turned a wrong answer into a useless one.
+	if attached == free {
+		t.Errorf("attached=true and attached=false both answer %v: the filter stopped filtering", attached)
+	}
+}
+
+// The second half, and the one this milestone is named for: an unparseable value
+// is a client mistake, and an empty page says the fleet is empty instead.
+//
+// The two dialects are the real API's own, measured on fr-par: instance/v1
+// answers its typed invalid_arguments, and ipam/v1, vpc/v2, vpc-gw/v2, lb/v1,
+// block/v1 and iam/v1alpha1 answer strconv's error verbatim. Copying one onto
+// the other would be inventing a format.
+func TestAnUnparseableBooleanIsRefusedInEachProductsOwnDialect(t *testing.T) {
+	ts := newTestServer(t)
+
+	t.Run("the products that surface strconv", func(t *testing.T) {
+		for _, c := range []struct{ path, field string }{
+			{"/ipam/v1/regions/fr-par/ips?attached=banana", "attached"},
+			{"/vpc/v2/regions/fr-par/vpcs?is_default=banana", "is_default"},
+		} {
+			status, out := do(t, ts, "GET", c.path, "")
+			if status != http.StatusBadRequest {
+				t.Errorf("%s answered %d, want 400: an empty page says the fleet is empty, "+
+					"which is a different and wrong statement", c.path, status)
+				continue
+			}
+			msg, _ := out["message"].(string)
+			want := `parsing field "` + c.field + `": strconv.ParseBool: parsing "banana": invalid syntax`
+			if msg != want {
+				t.Errorf("%s answered %q, want the message fr-par answers: %q", c.path, msg, want)
+			}
+			// No type key at all, which is the shape the cloud answers; an empty
+			// one would be a shape it never sends.
+			if _, typed := out["type"]; typed {
+				t.Errorf("%s carries a type key: %v", c.path, out)
+			}
+		}
+	})
+
+	t.Run("instance/v1, which answers its own typed error", func(t *testing.T) {
+		for _, c := range []struct{ path, field string }{
+			{"/instance/v1/zones/fr-par-1/images?public=banana", "public"},
+			{"/instance/v1/zones/fr-par-1/servers?without_ip=banana", "without_ip"},
+		} {
+			status, out := do(t, ts, "GET", c.path, "")
+			if status != http.StatusBadRequest {
+				t.Errorf("%s answered %d, want 400", c.path, status)
+				continue
+			}
+			if out["type"] != "invalid_arguments" {
+				t.Errorf("%s answered type %v, want invalid_arguments", c.path, out["type"])
+			}
+			details, _ := out["details"].([]any)
+			if len(details) != 1 {
+				t.Fatalf("%s carries %d detail(s): %v", c.path, len(details), out)
+			}
+			first, _ := details[0].(map[string]any)
+			if name, _ := first["argument_name"].(string); name != c.field {
+				t.Errorf("%s names argument %q, want %q", c.path, name, c.field)
+			}
+		}
+	})
+
+	// And a well-formed value is not refused, or the guard would answer 400 to
+	// every client and the filter would be worse than before.
+	if status, _ := do(t, ts, "GET", "/ipam/v1/regions/fr-par/ips?attached=True", ""); status != http.StatusOK {
+		t.Errorf("a value the cloud accepts was refused with %d", status)
+	}
+}
+
+// An action flag reads the same way, and the silence costs more there: a client
+// sending release_ip=True kept its address and was told nothing.
+func TestAnActionFlagRefusesAnUnparseableValueRatherThanIgnoringIt(t *testing.T) {
+	ts := newTestServer(t)
+
+	// A bogus identifier is enough: the real API parses the query before it looks
+	// the object up, measured on fr-par with a UUID that exists nowhere.
+	const bogus = "00000000-0000-4000-8000-000000000000"
+	status, out := do(t, ts, "DELETE",
+		"/lb/v1/zones/fr-par-1/lbs/"+bogus+"?release_ip=banana", "")
+	if status != http.StatusBadRequest {
+		t.Errorf("release_ip=banana answered %d, want 400 before the lookup: an unread flag "+
+			"keeps the address and says nothing", status)
+	}
+	if msg, _ := out["message"].(string); msg == "" {
+		t.Errorf("the refusal carries no message: %v", out)
+	}
+}

--- a/internal/providers/scaleway/errors.go
+++ b/internal/providers/scaleway/errors.go
@@ -1,6 +1,7 @@
 package scaleway
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/stephrobert/feint/internal/core/emulator"
@@ -96,5 +97,32 @@ func writePreconditionFailed(w http.ResponseWriter, precondition, help string) {
 		Message:      "precondition is not respected",
 		Precondition: precondition,
 		HelpMessage:  help,
+	})
+}
+
+// writeParseFailure answers a query value the route could not read, in the
+// dialect the newer products use for it (#630).
+//
+// Measured against fr-par on 2026-09-01, because the two shapes are not one and
+// choosing between them by taste would be inventing a format:
+//
+//	ipam/v1, vpc/v2, vpc-gw/v2, lb/v1
+//	  400 {"message":"parsing field \"attached\": strconv.ParseBool: parsing
+//	       \"banana\": invalid syntax"}
+//	instance/v1
+//	  400 {"type":"invalid_arguments", …, "details":[{"argument_name":"public",
+//	       "reason":"format","help_message":"expected boolean"}]}
+//
+// So instance/v1 keeps writeInvalidArguments and everything else comes here. The
+// message is not copied: the real API is a Go service surfacing strconv's own
+// error, and this pack parses with the same function, so passing err through
+// reproduces it exactly — including the day Go rewords it.
+//
+// No "type" key at all, which is why this does not go through APIError: the
+// field has no omitempty and an empty one would be a shape the cloud never
+// answers.
+func writeParseFailure(w http.ResponseWriter, field string, err error) {
+	emulator.WriteJSON(w, http.StatusBadRequest, map[string]any{
+		"message": fmt.Sprintf("parsing field %q: %s", field, err),
 	})
 }

--- a/internal/providers/scaleway/gateways.go
+++ b/internal/providers/scaleway/gateways.go
@@ -166,7 +166,12 @@ func (p *Pack) listGatewayIPs(w http.ResponseWriter, r *http.Request) {
 			return hasAllTags(res, tags)
 		})
 	}
-	if isFree, present := queryBool(q, "is_free"); present {
+	isFree, present, err := queryBool(q, "is_free")
+	if err != nil {
+		writeParseFailure(w, "is_free", err)
+		return
+	}
+	if present {
 		all = filterResources(all, func(res *resource.Resource) bool {
 			gw, _ := res.Attrs["gateway_id"].(string)
 			return (gw == "") == isFree
@@ -538,6 +543,13 @@ func (p *Pack) updateGateway(w http.ResponseWriter, r *http.Request) {
 }
 
 func (p *Pack) deleteGateway(w http.ResponseWriter, r *http.Request) {
+	// Before the lookup, the order fr-par answers in: a bogus id with a bad
+	// boolean answered 400 there rather than 404.
+	deleteIP, _, err := queryBool(r.URL.Query(), "delete_ip")
+	if err != nil {
+		writeParseFailure(w, "delete_ip", err)
+		return
+	}
 	res, ok := p.zonalResourceOf(w, r, kindGateway, "gatewayID", "gateway")
 	if !ok {
 		return
@@ -558,7 +570,7 @@ func (p *Pack) deleteGateway(w http.ResponseWriter, r *http.Request) {
 	p.env.Store.Delete(Name, kindGateway, res.ID)
 
 	ipID, _ := res.Attrs["ip_id"].(string)
-	if r.URL.Query().Get("delete_ip") == "true" {
+	if deleteIP {
 		p.env.Store.Delete(Name, kindGatewayIP, ipID)
 	} else if ipID != "" {
 		_ = p.env.Store.Update(Name, kindGatewayIP, ipID, func(stored *resource.Resource) error {
@@ -641,7 +653,12 @@ func (p *Pack) listGatewayNetworks(w http.ResponseWriter, r *http.Request) {
 			return ids[textOf(res.Attrs["private_network_id"])]
 		})
 	}
-	if masquerade, present := queryBool(q, "masquerade_enabled"); present {
+	masquerade, present, err := queryBool(q, "masquerade_enabled")
+	if err != nil {
+		writeParseFailure(w, "masquerade_enabled", err)
+		return
+	}
+	if present {
 		all = filterResources(all, func(res *resource.Resource) bool {
 			enabled, _ := res.Attrs["masquerade_enabled"].(bool)
 			return enabled == masquerade

--- a/internal/providers/scaleway/images.go
+++ b/internal/providers/scaleway/images.go
@@ -336,7 +336,15 @@ func (p *Pack) listImages(w http.ResponseWriter, r *http.Request) {
 	// image populations answer them from different places: a client image
 	// carries what its create stored, a catalogue image is public, x86_64 and
 	// untagged by construction (#277).
-	out = filterImageViews(out, q)
+	out, err := filterImageViews(out, q)
+	if err != nil {
+		// instance/v1 is the one product that answers a typed error here; the
+		// rest surface strconv's own text. Measured on fr-par, 2026-09-01.
+		writeInvalidArguments(w, ArgumentError{
+			ArgumentName: "public", Reason: "format", HelpMessage: "expected boolean",
+		})
+		return
+	}
 	// Paged like every other list of this pack. This was the one that ignored
 	// per_page — five images whatever the client asked — found the day the
 	// probe started holding paged answers to the size they asked, which is the
@@ -354,7 +362,7 @@ func (p *Pack) listImages(w http.ResponseWriter, r *http.Request) {
 // arch, public, organization, project and tags. The views carry every one of
 // those fields for both image populations, so the filter reads what the client
 // would.
-func filterImageViews(views []map[string]any, q url.Values) []map[string]any {
+func filterImageViews(views []map[string]any, q url.Values) ([]map[string]any, error) {
 	arch := q.Get("arch")
 	// organization scopes to the whole account rather than comparing the
 	// identifier — one organization lives here (scopeOf's rule), so a named
@@ -363,10 +371,15 @@ func filterImageViews(views []map[string]any, q url.Values) []map[string]any {
 	// cloud filtering by yours excludes the public catalogue the same way.
 	_ = q.Get("organization")
 	project := q.Get("project")
-	wantPublic, publicSet := queryBool(q, "public")
+	// Returned rather than written: this helper holds no ResponseWriter, and the
+	// handler is where instance/v1's typed dialect belongs.
+	wantPublic, publicSet, err := queryBool(q, "public")
+	if err != nil {
+		return nil, err
+	}
 	tags := csvValues(q, "tags")
 	if arch == "" && project == "" && !publicSet && len(tags) == 0 {
-		return views
+		return views, nil
 	}
 	kept := views[:0]
 	for _, view := range views {
@@ -387,7 +400,7 @@ func filterImageViews(views []map[string]any, q url.Values) []map[string]any {
 		}
 		kept = append(kept, view)
 	}
-	return kept
+	return kept, nil
 }
 
 // viewHasEveryTag is hasEveryTag for a rendered view, whose tags are []string

--- a/internal/providers/scaleway/ipam.go
+++ b/internal/providers/scaleway/ipam.go
@@ -182,8 +182,17 @@ func (p *Pack) listIPAMIPs(w http.ResponseWriter, r *http.Request) {
 			})
 		}
 	}
-	if attached := q.Get("attached"); attached != "" {
-		want := attached == "true"
+	// The filter #630 was filed about. It compared against "true" alone, so the
+	// spelling the official Python SDK sends — `True`, because requests renders
+	// a Python bool that way — matched nothing and answered an empty inventory
+	// rather than an error. Measured on fr-par, 2026-09-01: the real API accepts
+	// true, True and 1, and refuses an unparseable value with 400.
+	want, present, err := queryBool(q, "attached")
+	if err != nil {
+		writeParseFailure(w, "attached", err)
+		return
+	}
+	if present {
 		all = filterResources(all, func(res *resource.Resource) bool {
 			return ipamAttached(res) == want
 		})
@@ -242,7 +251,12 @@ func (p *Pack) listIPAMIPs(w http.ResponseWriter, r *http.Request) {
 	// Every address served here is IPv4 and regional: a zonal filter matches
 	// nothing, an is_ipv6=true filter matches nothing, and their opposites keep
 	// everything.
-	if q.Get("is_ipv6") == "true" || q.Get("zonal") != "" {
+	wantIPv6, _, err := queryBool(q, "is_ipv6")
+	if err != nil {
+		writeParseFailure(w, "is_ipv6", err)
+		return
+	}
+	if wantIPv6 || q.Get("zonal") != "" {
 		all = all[:0]
 	}
 

--- a/internal/providers/scaleway/listquery.go
+++ b/internal/providers/scaleway/listquery.go
@@ -1,9 +1,11 @@
 package scaleway
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/stephrobert/feint/internal/core/resource"
@@ -102,14 +104,33 @@ func orderSpelling(value string) (field string, descending bool) {
 	return value, false
 }
 
-// queryBool reads a boolean filter: present only when the client sent a
-// value, true only on the spelling the SDK writes (fmt.Sprint on a bool).
-func queryBool(q url.Values, key string) (value, present bool) {
+// queryBool reads a boolean filter the way the real API reads one.
+//
+// It used to compare against "true" alone, on the ground that this is the
+// spelling the Go SDK writes. It is not the spelling every client writes: the
+// official Python SDK renders a Python True as `True`, and `requests` puts that
+// on the wire — so `list_i_ps_all(attached=True)`, the documented way to ask the
+// question from Python, matched nothing here and returned an empty inventory
+// (#630).
+//
+// Worse than wrong: silent. An unparseable value was read as false and answered
+// a well-shaped empty page, which says the fleet is empty rather than that the
+// question was malformed.
+//
+// Measured on fr-par, 2026-09-01: the real API accepts true, True and 1, and
+// refuses `banana` with 400 and strconv's own error text. It is a Go service
+// using strconv.ParseBool, so this parses with the same function and the caller
+// answers the error rather than swallowing it.
+func queryBool(q url.Values, key string) (value, present bool, err error) {
 	raw := q.Get(key)
 	if raw == "" {
-		return false, false
+		return false, false, nil
 	}
-	return raw == "true", true
+	parsed, err := strconv.ParseBool(raw)
+	if err != nil {
+		return false, true, err
+	}
+	return parsed, true, nil
 }
 
 // objectStorageFilter reads the "only VPCs (or Private Networks) whose Object
@@ -128,13 +149,19 @@ func queryBool(q url.Values, key string) (value, present bool) {
 // answers a filtered list with everything.
 //
 // TestBothSpellingsOfTheObjectStorageFilterNarrow fails without this.
-func objectStorageFilter(q url.Values) (value, present bool) {
+func objectStorageFilter(q url.Values) (value, present bool, err error) {
 	for _, key := range []string{"object_storage_private_access_enabled", "s3_integration_enabled"} {
-		if v, ok := queryBool(q, key); ok {
-			return v, true
+		v, ok, parseErr := queryBool(q, key)
+		if parseErr != nil {
+			// The key that failed is named, never the pair: a client that sent
+			// one spelling must not be told about the other.
+			return false, true, fmt.Errorf("%s: %w", key, parseErr)
+		}
+		if ok {
+			return v, true, nil
 		}
 	}
-	return false, false
+	return false, false, nil
 }
 
 // idSet turns the repeated values of an identifier filter into a lookup —

--- a/internal/providers/scaleway/loadbalancer.go
+++ b/internal/providers/scaleway/loadbalancer.go
@@ -468,6 +468,14 @@ func (p *Pack) updateLB(w http.ResponseWriter, r *http.Request) {
 }
 
 func (p *Pack) deleteLB(w http.ResponseWriter, r *http.Request) {
+	// Before the lookup, which is the order fr-par answers in: a bogus id with a
+	// bad boolean answered 400 there, not 404. The difference is where a client
+	// then looks — at the resource, or at its own request.
+	release, _, err := queryBool(r.URL.Query(), "release_ip")
+	if err != nil {
+		writeParseFailure(w, "release_ip", err)
+		return
+	}
 	res, ok := p.zonalResourceOf(w, r, kindLB, "lbID", "lb")
 	if !ok {
 		return
@@ -494,7 +502,6 @@ func (p *Pack) deleteLB(w http.ResponseWriter, r *http.Request) {
 			p.releaseHeldIPAMIPs(at.ID)
 		}
 	}
-	release := r.URL.Query().Get("release_ip") == "true"
 	for _, ipID := range stringsOf(res.Attrs["ip_ids"]) {
 		if release {
 			p.env.Store.Delete(Name, kindLBIP, ipID)

--- a/internal/providers/scaleway/securitygroups.go
+++ b/internal/providers/scaleway/securitygroups.go
@@ -166,7 +166,12 @@ func (p *Pack) listSecurityGroups(w http.ResponseWriter, r *http.Request) {
 			return hasEveryTag(res, tags)
 		})
 	}
-	if wantDefault, present := queryBool(q, "project_default"); present {
+	wantDefault, present, err := queryBool(q, "project_default")
+	if err != nil {
+		writeInvalidArguments(w, ArgumentError{ArgumentName: "project_default", Reason: "format", HelpMessage: "expected boolean"})
+		return
+	}
+	if present {
 		all = filterResources(all, func(res *resource.Resource) bool {
 			isDefault, _ := res.Attrs["project_default"].(bool)
 			return isDefault == wantDefault

--- a/internal/providers/scaleway/servers.go
+++ b/internal/providers/scaleway/servers.go
@@ -301,7 +301,13 @@ func (p *Pack) listServers(w http.ResponseWriter, r *http.Request) {
 
 	q := r.URL.Query()
 	all := filterServers(p.env.Store.List(kindServer, p.scopeOf(r, zone)), q)
-	all = p.filterServersByLinks(all, q)
+	all, err := p.filterServersByLinks(all, q)
+	if err != nil {
+		writeInvalidArguments(w, ArgumentError{
+			ArgumentName: "without_ip", Reason: "format", HelpMessage: "expected boolean",
+		})
+		return
+	}
 	// creation_date_desc when the client names no order — not this pack's
 	// habit but the SDK's own default ("Default value: creation_date_desc"),
 	// and the empty value every instance/v1 list sends: the request's Order is
@@ -1414,7 +1420,7 @@ func filterServers(all []*resource.Resource, q url.Values) []*resource.Resource 
 // `without_ip=false` keeps everything: the SDK documents only the true
 // direction ("list Instances that are not attached to a public IP"), and
 // serving an undocumented complement would be an invented semantic.
-func (p *Pack) filterServersByLinks(all []*resource.Resource, q url.Values) []*resource.Resource {
+func (p *Pack) filterServersByLinks(all []*resource.Resource, q url.Values) ([]*resource.Resource, error) {
 	ids := idSet(q, "servers")
 	mac := q.Get("private_nic_mac_address")
 	networks := csvValues(q, "private_networks")
@@ -1423,9 +1429,13 @@ func (p *Pack) filterServersByLinks(all []*resource.Resource, q url.Values) []*r
 	}
 	withIP := q.Get("with_ip")
 	privateIP := q.Get("private_ip")
-	withoutIP, _ := queryBool(q, "without_ip")
+	// Returned rather than written: this helper holds no ResponseWriter.
+	withoutIP, _, err := queryBool(q, "without_ip")
+	if err != nil {
+		return nil, err
+	}
 	if ids == nil && mac == "" && len(networks) == 0 && withIP == "" && privateIP == "" && !withoutIP {
-		return all
+		return all, nil
 	}
 
 	kept := make([]*resource.Resource, 0, len(all))
@@ -1451,7 +1461,7 @@ func (p *Pack) filterServersByLinks(all []*resource.Resource, q url.Values) []*r
 		}
 		kept = append(kept, res)
 	}
-	return kept
+	return kept, nil
 }
 
 func nicWithMAC(nics []*resource.Resource, mac string) bool {

--- a/internal/providers/scaleway/sshkeys.go
+++ b/internal/providers/scaleway/sshkeys.go
@@ -75,7 +75,12 @@ func (p *Pack) listSSHKeys(w http.ResponseWriter, r *http.Request) {
 	// widener over a default exclusion, but that default would be invented —
 	// nothing upstream states one, and this pack has always answered a bare
 	// list with every key.
-	if wantDisabled, present := queryBool(q, "disabled"); present {
+	wantDisabled, present, err := queryBool(q, "disabled")
+	if err != nil {
+		writeParseFailure(w, "disabled", err)
+		return
+	}
+	if present {
 		all = filterResources(all, func(res *resource.Resource) bool {
 			disabled, _ := res.Attrs["disabled"].(bool)
 			return disabled == wantDisabled

--- a/internal/providers/scaleway/vpc.go
+++ b/internal/providers/scaleway/vpc.go
@@ -154,13 +154,23 @@ func (p *Pack) listVPCs(w http.ResponseWriter, r *http.Request) {
 			return hasAnyTag(res, tags)
 		})
 	}
-	if wantDefault, present := queryBool(q, "is_default"); present {
+	wantDefault, present, err := queryBool(q, "is_default")
+	if err != nil {
+		writeParseFailure(w, "is_default", err)
+		return
+	}
+	if present {
 		all = filterResources(all, func(res *resource.Resource) bool {
 			isDefault, _ := res.Attrs["is_default"].(bool)
 			return isDefault == wantDefault
 		})
 	}
-	if wantRouting, present := queryBool(q, "routing_enabled"); present {
+	wantRouting, present, err := queryBool(q, "routing_enabled")
+	if err != nil {
+		writeParseFailure(w, "routing_enabled", err)
+		return
+	}
+	if present {
 		all = filterResources(all, func(res *resource.Resource) bool {
 			enabled, _ := res.Attrs["routing_enabled"].(bool)
 			return enabled == wantRouting
@@ -168,7 +178,12 @@ func (p *Pack) listVPCs(w http.ResponseWriter, r *http.Request) {
 	}
 	// No VPC here integrates with Object Storage — the product is not emulated
 	// (docs/limits.md) — so true truthfully matches nothing.
-	if wantS3, present := objectStorageFilter(q); present && wantS3 {
+	wantS3, present, err := objectStorageFilter(q)
+	if err != nil {
+		writeParseFailure(w, "object_storage_private_access_enabled", err)
+		return
+	}
+	if present && wantS3 {
 		all = all[:0]
 	}
 	if !orderResources(w, r, "order_by", "created_at_asc", map[string]resourceCmp{
@@ -336,14 +351,24 @@ func (p *Pack) listPrivateNetworks(w http.ResponseWriter, r *http.Request) {
 	// Every network here runs managed DHCP — createPrivateNetwork writes the
 	// field and a legacy one is upgraded on read — so the filter is an
 	// equality against that stored truth.
-	if wantDHCP, present := queryBool(q, "dhcp_enabled"); present {
+	wantDHCP, present, err := queryBool(q, "dhcp_enabled")
+	if err != nil {
+		writeParseFailure(w, "dhcp_enabled", err)
+		return
+	}
+	if present {
 		all = filterResources(all, func(res *resource.Resource) bool {
 			enabled, _ := res.Attrs["dhcp_enabled"].(bool)
 			return enabled == wantDHCP
 		})
 	}
 	// Same answer as ListVPCs: no Object Storage integration exists here.
-	if wantS3, present := objectStorageFilter(q); present && wantS3 {
+	wantS3, present, err := objectStorageFilter(q)
+	if err != nil {
+		writeParseFailure(w, "object_storage_private_access_enabled", err)
+		return
+	}
+	if present && wantS3 {
 		all = all[:0]
 	}
 	if !orderResources(w, r, "order_by", "created_at_asc", map[string]resourceCmp{

--- a/tools/falsify/specs/boolean-filters.json
+++ b/tools/falsify/specs/boolean-filters.json
@@ -1,0 +1,33 @@
+{
+  "package": "./internal/providers/scaleway/",
+  "mutations": [
+    {
+      "label": "the filter compares against \"true\" again, so the Python SDK's spelling matches nothing",
+      "file": "internal/providers/scaleway/listquery.go",
+      "find": "\tparsed, err := strconv.ParseBool(raw)\n\tif err != nil {\n\t\treturn false, true, err\n\t}\n\treturn parsed, true, nil",
+      "replace": "\tparsed, err := strconv.ParseBool(raw)\n\tif err != nil {\n\t\treturn false, true, err\n\t}\n\t_ = parsed\n\treturn raw == \"true\", true, nil",
+      "test": "TestABooleanFilterReadsEverySpellingTheCloudReads"
+    },
+    {
+      "label": "an unparseable value is swallowed and answers an empty page",
+      "file": "internal/providers/scaleway/listquery.go",
+      "find": "\tif err != nil {\n\t\treturn false, true, err\n\t}",
+      "replace": "\tif err != nil {\n\t\treturn false, true, nil\n\t}",
+      "test": "TestAnUnparseableBooleanIsRefusedInEachProductsOwnDialect"
+    },
+    {
+      "label": "the refusal carries a type key, which is a shape the cloud never answers",
+      "file": "internal/providers/scaleway/errors.go",
+      "find": "\temulator.WriteJSON(w, http.StatusBadRequest, map[string]any{\n\t\t\"message\": fmt.Sprintf(\"parsing field %q: %s\", field, err),\n\t})",
+      "replace": "\temulator.WriteJSON(w, http.StatusBadRequest, APIError{\n\t\tType:    \"invalid_arguments\",\n\t\tMessage: fmt.Sprintf(\"parsing field %q: %s\", field, err),\n\t})",
+      "test": "TestAnUnparseableBooleanIsRefusedInEachProductsOwnDialect"
+    },
+    {
+      "label": "the action flag is read after the lookup, so a bad value answers 404 instead of 400",
+      "file": "internal/providers/scaleway/loadbalancer.go",
+      "find": "\trelease, _, err := queryBool(r.URL.Query(), \"release_ip\")\n\tif err != nil {\n\t\twriteParseFailure(w, \"release_ip\", err)\n\t\treturn\n\t}\n\tres, ok := p.zonalResourceOf(w, r, kindLB, \"lbID\", \"lb\")\n\tif !ok {\n\t\treturn\n\t}",
+      "replace": "\tres, ok := p.zonalResourceOf(w, r, kindLB, \"lbID\", \"lb\")\n\tif !ok {\n\t\treturn\n\t}\n\trelease, _, err := queryBool(r.URL.Query(), \"release_ip\")\n\tif err != nil {\n\t\twriteParseFailure(w, \"release_ip\", err)\n\t\treturn\n\t}",
+      "test": "TestAnActionFlagRefusesAnUnparseableValueRatherThanIgnoringIt"
+    }
+  ]
+}

--- a/tools/falsify/specs/scaleway-list-parameters.json
+++ b/tools/falsify/specs/scaleway-list-parameters.json
@@ -39,15 +39,15 @@
     {
       "label": "the ssh-key disabled filter goes inert and disabled=true answers the enabled keys",
       "file": "internal/providers/scaleway/sshkeys.go",
-      "find": "\tif wantDisabled, present := queryBool(q, \"disabled\"); present {",
-      "replace": "\tif wantDisabled, present := queryBool(q, \"disabled-never\"); present {",
+      "find": "\twantDisabled, present, err := queryBool(q, \"disabled\")\n\tif err != nil {\n\t\twriteParseFailure(w, \"disabled\", err)\n\t\treturn\n\t}\n\tif present {",
+      "replace": "\twantDisabled, present, err := queryBool(q, \"disabled\")\n\tif err != nil {\n\t\twriteParseFailure(w, \"disabled\", err)\n\t\treturn\n\t}\n\tif present && false {",
       "test": "TestSSHKeysHonourTheDeclaredParameters"
     },
     {
       "label": "a handler that still reads its query drops one declared parameter — the half #271's gate cannot see, and the per-operation gate must",
       "file": "internal/providers/scaleway/vpc.go",
-      "find": "\tif wantDHCP, present := queryBool(q, \"dhcp_enabled\"); present {",
-      "replace": "\tif wantDHCP, present := queryBool(q, \"dhcp_enabled-never\"); present {",
+      "find": "\twantDHCP, present, err := queryBool(q, \"dhcp_enabled\")",
+      "replace": "\twantDHCP, present, err := queryBool(q, \"dhcp_enabled_no_longer_read\")",
       "test": "TestNoDeclaredQueryParameterIsDroppedByItsHandler",
       "package": "./internal/core/emulator/"
     }


### PR DESCRIPTION
Closes #630.

`attached=true` filtered correctly and `attached=True` matched nothing, answering
a **well-shaped empty page**. `True` is what the official Python SDK sends —
`requests` renders a Python bool that way — so the documented way to ask that
question from Python returned an empty inventory here and the attached addresses
against the real API.

## Both halves are the cloud's, measured rather than reasoned about

Against fr-par on 2026-09-01:

```
?attached=true    200      ?attached=banana
?attached=True    200      400 {"message":"parsing field \"attached\":
?attached=1       200           strconv.ParseBool: parsing \"banana\": invalid syntax"}
```

The real API is a Go service using `strconv.ParseBool`, so this pack uses the
same function and passes the error through — which reproduces the message
exactly, including the day Go rewords it.

The refusal is the half this milestone is named for. An unparseable value was
read as **false**, and an empty page says *the fleet is empty*, which is a
different and wrong statement from *the question was malformed*.

## Two dialects, because the cloud has two

| products | shape |
|---|---|
| `instance/v1` | typed `invalid_arguments`, with `argument_name` and `help_message` |
| `ipam/v1`, `vpc/v2`, `vpc-gw/v2`, `lb/v1`, `block/v1`, `iam/v1alpha1` | bare `{"message": "parsing field …"}`, **no `type` key at all** |

Each was measured before it was written. Copying one onto the other would have
been inventing a format, and an empty `"type"` would be a shape the cloud never
sends.

## The report named one filter; the defect was in the shared helper

`queryBool` compared against `"true"` alone, so **eleven** filters carried it.
Two of its callers are worse than a listing: `release_ip` and `delete_ip` are
**action flags**, and a client sending `True` kept its address and was told
nothing.

Those two now parse **before** the lookup, which is the order fr-par answers in —
measured with a UUID that exists nowhere, and it answered 400 rather than 404. A
400 sends a client to its own request; a 404 sends it hunting for a resource that
was never the problem.

## One control caught a weakening I introduced

Retargeting an existing falsify spec at the moved code, I neutralised the branch
and left the `queryBool` call standing.
`TestNoDeclaredQueryParameterIsDroppedByItsHandler` reads the pack's *sources* for
whether a handler names each declared parameter, so it could not see that mutation
and reported green. The mutation now removes the read itself, and bites again.

## Measured

| | |
|---|---|
| `mise run prepush` | green |
| `mise run falsify:lint` | 1000 mutations across 156 specs, all still applying |
| `mise run falsify -- specs/boolean-filters.json` | 4 mutations, all bite |
| `scw` and Terraform legs | green |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
