### PR TITLE
fix(scaleway): the cloud stopped minting b_ssd, and five places here had not (#393)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -19,6 +19,62 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Corrigé
 
+- **Le cloud a retiré `b_ssd` à la création et cet émulateur en fabriquait
+  encore** (#393). Toutes les routes qui créaient un volume écrivaient ce type :
+  `POST /volumes` s'y repliait quand la requête n'en nommait aucun, le
+  `root_volume` d'un serveur y était forcé quel que soit le type local demandé,
+  un update ajoutant un disque s'y repliait, les images du catalogue
+  l'annonçaient, et un snapshot sans type lisible y retombait. `fr-par` le refuse
+  sur les deux routes de création.
+
+  Mesuré contre un vrai compte le 2026-09-02, et les deux routes ne partagent pas
+  leur formulation, ce qui est la raison pour laquelle les deux sont transcrites
+  plutôt que l'une réutilisée :
+
+  | requête | réponse de `fr-par` |
+  |---|---|
+  | `POST /volumes` sans `volume_type` | 400 `required` : *required key not provided* |
+  | `POST /volumes` `b_ssd` | 400 `constraint` : *b_ssd volumes are no longer supported. Use Scaleway Block Storage (SBS) volumes instead…* |
+  | `POST /volumes` `sbs_volume` | 400 `constraint` : *not a valid value* (c'est le produit de `block/v1`) |
+  | `POST /volumes` `l_ssd`, `scratch` | 201 |
+  | `POST /servers` `volumes.0.volume_type: b_ssd` | 400 `constraint` sur `volumes.0.volume_type` : *Create volumes with volume_type=sbs_volume instead* |
+  | `POST /servers` `l_ssd` | 201, et le volume revient en `l_ssd` : honoré, pas remplacé |
+  | `POST /servers` `scratch` | 400 `constraint` sur **`image`** : *Cannot use an image with a scratch volume* |
+
+  C'est la dérive que le scan de surface ne peut pas voir : aucune signature Go
+  n'a changé, sur aucune des deux opérations. Seul un enregistrement du cloud la
+  nomme, et c'est tout l'argument pour en tenir un. Les quatre entrées
+  d'acceptation qui portaient la divergence dans `corpus/accepted.json` sont
+  supprimées, et `feint corpus --check` compare désormais ces échanges pour de
+  bon.
+
+  **Une limite a bougé avec :** les types locaux ne sont plus écrasés. Une
+  création nommant `l_ssd` donne un `l_ssd`, là où elle donnait un `b_ssd` sous
+  un commentaire qui expliquait pourquoi. La raison de cet écrasement est
+  inchangée et tient toujours le catalogue en place : `volumes_constraint.min_size`
+  reste à 0, pour que la somme des volumes locaux faite par le CLI ne refuse pas
+  la création qu'il vient lui-même de demander. `docs/limits.md` porte le
+  paragraphe corrigé.
+
+  **Et un nombre a bougé avec le type.** Le volume racine de l'image du catalogue
+  est en `l_ssd` désormais (mesuré : un `DEV1-S` créé sur `fr-par` avec
+  `image=ubuntu_jammy` répond `image.root_volume.volume_type: l_ssd`,
+  `size: 10000000000`), ce qui le fait entrer dans l'arithmétique que `scw`
+  applique aux disques **locaux**. Aux 20 Go que cet émulateur annonçait, toute
+  création `STARDUST1-S` était refusée par « image … requires 20 GB on root
+  volume, but root volume is constrained between 0 B and 10 GB ». `rootVolumeSize`
+  vaut 10 Go, comme celui du cloud, et le point d'entrée des images lit cette
+  constante au lieu de répéter le nombre. C'est la suite de conformance qui l'a
+  attrapé, et aucun test unitaire ne le pouvait : l'arithmétique vit chez le
+  client.
+
+  **Ce que cela tranche aussi :** le déclin de `instance/v1/API.ListVolumesTypes`
+  reposait sur une phrase qui a expiré, « cet émulateur ne fabrique aucun des deux
+  types que liste `/products/volumes` ». Il fabrique exactement ces deux-là
+  désormais. Le déclin tient sur son autre condition seule, et le dit : aucun
+  enregistrement de cette route n'existe dans `corpus/`, et elle répond une table
+  de contraintes par type que la règle 4 interdit d'inventer.
+
 - **Un filtre booléen de requête ne lisait qu'une graphie et vidait
   silencieusement la liste pour les autres** (#630). `attached=true` filtrait
   correctement ; `attached=True`, ce qu'envoie le SDK Python officiel parce que

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,57 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Fixed
 
+- **The cloud retired `b_ssd` at creation and this emulator was still minting
+  it** (#393). Every route that made a volume wrote that type: `POST /volumes`
+  defaulted to it when the request named none, a server's `root_volume` was
+  forced to it whatever local type was asked for, an update that added a disk
+  defaulted to it, the catalogue images advertised it, and a snapshot with no
+  readable type fell back to it. `fr-par` refuses it on both creation routes.
+
+  Measured against a real account on 2026-09-02, and the two routes do not share
+  a wording — which is why both are transcribed rather than one being reused:
+
+  | request | `fr-par` answers |
+  |---|---|
+  | `POST /volumes` no `volume_type` | 400 `required` — *required key not provided* |
+  | `POST /volumes` `b_ssd` | 400 `constraint` — *b_ssd volumes are no longer supported. Use Scaleway Block Storage (SBS) volumes instead…* |
+  | `POST /volumes` `sbs_volume` | 400 `constraint` — *not a valid value* (it is `block/v1`'s product) |
+  | `POST /volumes` `l_ssd`, `scratch` | 201 |
+  | `POST /servers` `volumes.0.volume_type: b_ssd` | 400 `constraint` on `volumes.0.volume_type` — *Create volumes with volume_type=sbs_volume instead* |
+  | `POST /servers` `l_ssd` | 201, and the volume comes back `l_ssd` — honoured, not replaced |
+  | `POST /servers` `scratch` | 400 `constraint` on **`image`** — *Cannot use an image with a scratch volume* |
+
+  This is the drift the surface scan cannot see: no Go signature changed, on
+  either operation. Only a recording of the cloud names it, which is the whole
+  argument for keeping one. The four acceptance entries that carried the
+  divergence in `corpus/accepted.json` are deleted, and `feint corpus --check`
+  compares those exchanges for real now.
+
+  **A limit that moved with it:** the local types are no longer overridden. A
+  create naming `l_ssd` gets an `l_ssd`, where it used to get a `b_ssd` under a
+  comment explaining why. The reason that override existed is unchanged and
+  still holds the catalogue in place — `volumes_constraint.min_size` stays at 0
+  so the CLI's sum of local volumes cannot refuse the creation it just asked
+  for. `docs/limits.md` carries the corrected paragraph.
+
+  **And one number moved with the type.** The catalogue image's root volume is
+  `l_ssd` now (measured: a `DEV1-S` created on `fr-par` with `image=ubuntu_jammy`
+  answers `image.root_volume.volume_type: l_ssd`, `size: 10000000000`), which
+  puts it inside the arithmetic `scw` runs over *local* disks. At the 20 GB this
+  emulator advertised, every `STARDUST1-S` create was refused with *"image …
+  requires 20 GB on root volume, but root volume is constrained between 0 B and
+  10 GB"*. `rootVolumeSize` is 10 GB, the same as the cloud's, and the image
+  endpoint reads that constant instead of repeating the number. The conformance
+  suite caught this and no unit test could have: the arithmetic lives in the
+  client.
+
+  **What it also settles:** the decline on `instance/v1/API.ListVolumesTypes`
+  rested on a sentence that has expired — *this emulator makes neither of the
+  two types `/products/volumes` lists*. It makes exactly those two now. The
+  decline stands on its other condition alone, and says so: no recording of that
+  route exists in `corpus/`, and it answers a table of per-type constraints that
+  rule 4 forbids inventing.
+
 - **A boolean query filter read one spelling and silently emptied the listing for
   the others** (#630). `attached=true` filtered correctly; `attached=True` — what
   the official Python SDK sends, because `requests` renders a Python bool that

--- a/corpus/accepted.json
+++ b/corpus/accepted.json
@@ -1327,38 +1327,6 @@
     },
     {
       "file": "scaleway/scw-refusals.jsonl",
-      "operation": "instance/v1/API.CreateVolume",
-      "kind": "absent",
-      "path": "details",
-      "reason": "The cloud has retired b_ssd and refuses it at creation with a constraint on volume_type; this emulator accepts it and, worse, mints it for every root volume (rootVolume, servers.go). It is drift the surface scan cannot see, because CreateVolume's Go signature is unchanged.",
-      "issue": "https://github.com/stephrobert/feint/issues/393"
-    },
-    {
-      "file": "scaleway/scw-refusals.jsonl",
-      "operation": "instance/v1/API.CreateVolume",
-      "kind": "absent",
-      "path": "message",
-      "reason": "The cloud has retired b_ssd and refuses it at creation with a constraint on volume_type; this emulator accepts it and, worse, mints it for every root volume (rootVolume, servers.go). It is drift the surface scan cannot see, because CreateVolume's Go signature is unchanged.",
-      "issue": "https://github.com/stephrobert/feint/issues/393"
-    },
-    {
-      "file": "scaleway/scw-refusals.jsonl",
-      "operation": "instance/v1/API.CreateVolume",
-      "kind": "absent",
-      "path": "type",
-      "reason": "The cloud has retired b_ssd and refuses it at creation with a constraint on volume_type; this emulator accepts it and, worse, mints it for every root volume (rootVolume, servers.go). It is drift the surface scan cannot see, because CreateVolume's Go signature is unchanged.",
-      "issue": "https://github.com/stephrobert/feint/issues/393"
-    },
-    {
-      "file": "scaleway/scw-refusals.jsonl",
-      "operation": "instance/v1/API.CreateVolume",
-      "kind": "status",
-      "path": "",
-      "reason": "The cloud has retired b_ssd and refuses it at creation with a constraint on volume_type; this emulator accepts it and, worse, mints it for every root volume (rootVolume, servers.go). It is drift the surface scan cannot see, because CreateVolume's Go signature is unchanged.",
-      "issue": "https://github.com/stephrobert/feint/issues/393"
-    },
-    {
-      "file": "scaleway/scw-refusals.jsonl",
       "operation": "instance/v1/API.GetImage",
       "kind": "absent",
       "path": "message",

--- a/coverage/scaleway-coverage.json
+++ b/coverage/scaleway-coverage.json
@@ -1412,7 +1412,7 @@
     {
       "operation": "instance/v1/API.ListVolumesTypes",
       "product": "instance",
-      "reason": "a live read of /products/volumes on fr-par-1 answers l_ssd and scratch, and this emulator makes neither — its instance volumes are b_ssd and its root disks sbs_volume — so serving it would offer a client two types every create then refuses",
+      "reason": "no recording of /products/volumes exists in corpus/, and the route answers a table of per-type constraints that would have to be invented rather than measured",
       "version": "v1",
       "status": "declined"
     },

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -807,10 +807,22 @@ Measured by @vde-dis on #8, with OpenTofu 1.12.5 and `scaleway/scaleway` 2.80.0:
   disk is created in `block/v1`, and the provider reads it back through the
   fallback it always used — `instance.GetVolume` first, then `block.GetVolume`
   on a typed 404.
-- **The local types (`l_ssd`, `scratch`) are still overridden**, and that has its
-  own reason, unchanged: the emulated catalogue declares
-  `volumes_constraint.min_size` at 0 and the CLI sums local volumes against it,
-  so attaching one would make the CLI refuse the very creation it just asked for.
+- **The local types are honoured too, since #393**, and the override that used to
+  stand here is gone. `l_ssd` was answered as `b_ssd` whatever the client asked,
+  which is a type `instance/v1` has stopped minting at all: a create naming
+  `l_ssd` on `fr-par` answers `201` and the volume comes back `l_ssd`, measured
+  2026-09-02. `scratch` is refused, and on the argument the cloud names — `image`,
+  not the type: *"Cannot use an image with a scratch volume"*. The reason the
+  override existed is unchanged and still holds the catalogue in place: the
+  emulated `volumes_constraint.min_size` is 0 and the CLI sums local volumes
+  against it, so a value above zero would make the CLI refuse the very creation
+  it just asked for (`TestCatalogueKeepsTheLocalVolumeTrapDisarmed`).
+- **`b_ssd` is refused by this emulator now, the way `fr-par` refuses it**, and
+  the two routes do not share a wording: `POST /volumes` points at the SBS
+  migration page under `argument_name: volume_type`, `POST /servers` says
+  *"Create volumes with volume_type=sbs_volume instead"* under
+  `volumes.<key>.volume_type`. Both are transcribed in
+  `internal/providers/scaleway/volumetypes.go`.
 
 What is still not emulated behind an SBS volume is the storage itself: the size,
 the class and the IO/s are recorded and answered, and nothing is written

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -410,9 +410,9 @@ are in `coverage/`, one artefact per provider.
 - `instance` — 2 operations — it mounts Scaleway's File Storage product, and there is no filesystem service behind this emulator for a machine to mount
 - `instance` — 2 operations — the SDK's hand-written helpers, deprecated upstream in favour of AttachServerVolume and DetachServerVolume, which this pack serves and which the CLI calls
 - `instance` — 2 operations — there is no legacy storage behind this emulator to migrate from, so a plan would describe a move between two things that are the same store
-- `instance` — 1 operation — a live read of /products/volumes on fr-par-1 answers l_ssd and scratch, and this emulator makes neither — its instance volumes are b_ssd and its root disks sbs_volume — so serving it would offer a client two types every create then refuses
 - `instance` — 1 operation — it hands an instance flexible IP over to IPAM's pool, and the public addresses of this emulator live and die with the instance product: IPAM here holds private-network addresses only
 - `instance` — 1 operation — it writes into Object Storage, which is not emulated because the Terraform provider builds the S3 endpoint in code: supporting it needs DNS interception and a certificate, measured in docs/limits.md
+- `instance` — 1 operation — no recording of /products/volumes exists in corpus/, and the route answers a table of per-type constraints that would have to be invented rather than measured
 - `instance` — 1 operation — the server already publishes allowed_actions, derived from its state, so a second listing would be a second place to keep in step with the first
 - `ipam` — 1 operation — ipam/v1alpha1 is the superseded draft of ipam/v1, which is served
 - `lb` — 53 operations — the regional lb/v1 API is deprecated upstream in favour of the zoned one, which is served: the portal publishes only the zoned document, and every measured client calls ZonedAPI

--- a/examples/stacks/scaleway/main.tf
+++ b/examples/stacks/scaleway/main.tf
@@ -254,8 +254,10 @@ resource "scaleway_instance_security_group" "app" {
 # ---------------------------------------------------------------------------
 
 resource "scaleway_instance_volume" "golden" {
-  name       = "platform-golden-src"
-  type       = "b_ssd"
+  name = "platform-golden-src"
+  # l_ssd since #393: instance/v1 refuses b_ssd at creation the way fr-par does,
+  # so a stack declaring it would be refused by the emulator it is applied to.
+  type       = "l_ssd"
   size_in_gb = 10
 }
 
@@ -340,9 +342,10 @@ resource "scaleway_ipam_ip" "web" {
 }
 
 resource "scaleway_instance_volume" "web_data" {
-  count      = var.web_count
-  name       = "platform-web-data-${count.index}"
-  type       = "b_ssd"
+  count = var.web_count
+  name  = "platform-web-data-${count.index}"
+  # l_ssd, for the reason above.
+  type       = "l_ssd"
   size_in_gb = 10
 }
 

--- a/internal/providers/scaleway/block_attach_test.go
+++ b/internal/providers/scaleway/block_attach_test.go
@@ -259,8 +259,10 @@ func TestAnInstanceSnapshotOfABlockVolumeDoesNotPromiseTheBlockProduct(t *testin
 		t.Errorf("the snapshot reports size %v, want the volume's 20000000000", snap["size"])
 	}
 	// b_ssd would name the product it was NOT taken from.
-	if snap["volume_type"] == "b_ssd" {
-		t.Errorf("the snapshot of a block volume is typed b_ssd, which is the other product")
+	if snap["volume_type"] != "unified" {
+		t.Errorf("the snapshot of a block volume is typed %v, want unified: the fallback names the "+
+			"instance product, and stating the value keeps this test discriminating whatever that "+
+			"fallback becomes (it was b_ssd until #393)", snap["volume_type"])
 	}
 	// And the promise: sbs_snapshot means "this id resolves in block/v1alpha1".
 	if snap["volume_type"] == "sbs_snapshot" {

--- a/internal/providers/scaleway/block_restore_test.go
+++ b/internal/providers/scaleway/block_restore_test.go
@@ -161,7 +161,7 @@ func TestAnInstanceSnapshotOfARestoredVolumeInheritsItsSize(t *testing.T) {
 	defer ts.Close()
 
 	status, created := do(t, ts, "POST", instanceZone+"/volumes",
-		`{"name":"restored","volume_type":"b_ssd","size":10000000000}`)
+		`{"name":"restored","volume_type":"l_ssd","size":10000000000}`)
 	if status != http.StatusCreated && status != http.StatusOK {
 		t.Fatalf("create the instance volume: status %d, %v", status, created)
 	}

--- a/internal/providers/scaleway/catalog.go
+++ b/internal/providers/scaleway/catalog.go
@@ -61,10 +61,14 @@ type serverType struct {
 	// local volumes against volumes_constraint. A client reading the per-volume
 	// limits found nothing.
 	//
-	// Serialised as an empty object rather than a populated one: this emulator
-	// attaches no local volume, so it has no per-volume limit to state, and
-	// inventing one would put a bound in a client's arithmetic that nothing
-	// enforces.
+	// Serialised as an empty object rather than a populated one, and the reason
+	// changed with #393 without changing the answer. It used to be that this
+	// emulator attached no local volume at all; it attaches them now, since
+	// CreateVolume mints exactly what fr-par mints. What has not changed is that
+	// no recording of per_volume_constraint exists here, and inventing a bound
+	// would put it in a client's arithmetic with nothing enforcing it — the same
+	// arithmetic that refused a STARDUST1-S create the day the catalogue image
+	// became local and still claimed 20 GB.
 	PerVolumeConstraint map[string]any `json:"per_volume_constraint"`
 	// BlockBandwidth, EndOfService and the scratch fields complete what the
 	// real answer carries. GpuInfo and MigProfile are null there too — a type

--- a/internal/providers/scaleway/dashboard.go
+++ b/internal/providers/scaleway/dashboard.go
@@ -114,6 +114,13 @@ func (p *Pack) dashboard(w http.ResponseWriter, r *http.Request) {
 	}
 
 	volumes := p.env.Store.List(kindVolume, scope)
+	byVolumeType := map[string]int{}
+	sizeByType := map[string]int64{}
+	for _, v := range volumes {
+		t, _ := v.Attrs["volume_type"].(string)
+		byVolumeType[t]++
+		sizeByType[t] += resource.Int64(v, "size")
+	}
 	bssd, bssdSize := 0, int64(0)
 	for _, v := range volumes {
 		if t, _ := v.Attrs["volume_type"].(string); t == "b_ssd" {
@@ -144,12 +151,14 @@ func (p *Pack) dashboard(w http.ResponseWriter, r *http.Request) {
 		"volumes_count":            len(volumes),
 		"volumes_b_ssd_count":      bssd,
 		"volumes_b_ssd_total_size": bssdSize,
-		// Zero because this emulator makes neither, which is true of it rather
-		// than short of anything: /products/volumes on fr-par-1 lists l_ssd and
-		// scratch, and nothing here creates one.
-		"volumes_l_ssd_count":      0,
-		"volumes_l_ssd_total_size": 0,
-		"volumes_scratch_count":    0,
+		// Counted, not assumed. These three were zero on the ground that this
+		// emulator makes neither type, which was true while CreateVolume minted
+		// b_ssd alone. Since #393 it mints exactly what fr-par mints — l_ssd and
+		// scratch — so a constant here would answer none while the store held
+		// them.
+		"volumes_l_ssd_count":      byVolumeType["l_ssd"],
+		"volumes_l_ssd_total_size": sizeByType["l_ssd"],
+		"volumes_scratch_count":    byVolumeType["scratch"],
 		"snapshots_count":          len(p.env.Store.List(kindSnapshot, scope)),
 		"images_count":             len(p.env.Store.List(kindImage, scope)),
 		"ips_count":                len(ips),

--- a/internal/providers/scaleway/dashboard_test.go
+++ b/internal/providers/scaleway/dashboard_test.go
@@ -111,15 +111,21 @@ func TestTheDashboardCountsWhatTheStoreHolds(t *testing.T) {
 		t.Errorf("volumes_count is %v after a create whose root disk is an sbs_volume", after["volumes_count"])
 	}
 	if status, out := do(t, ts, "POST", zone+"/volumes",
-		`{"name":"own","volume_type":"b_ssd","size":10000000000}`); status != http.StatusCreated {
+		`{"name":"own","volume_type":"l_ssd","size":10000000000}`); status != http.StatusCreated {
 		t.Fatalf("volume create: status %d (%v)", status, out)
 	}
 	withVolume := read()
 	if count(withVolume, "volumes_count") != 1 {
 		t.Errorf("volumes_count is %v after one instance volume", withVolume["volumes_count"])
 	}
-	if count(withVolume, "volumes_b_ssd_count") != 1 {
-		t.Errorf("volumes_b_ssd_count is %v after one b_ssd volume", withVolume["volumes_b_ssd_count"])
+	// l_ssd, not b_ssd: since #393 CreateVolume refuses the type the cloud
+	// retired, so the b_ssd counter is one no create can move and the l_ssd one
+	// is what a client now watches.
+	if count(withVolume, "volumes_l_ssd_count") != 1 {
+		t.Errorf("volumes_l_ssd_count is %v after one l_ssd volume", withVolume["volumes_l_ssd_count"])
+	}
+	if count(withVolume, "volumes_b_ssd_count") != 0 {
+		t.Errorf("volumes_b_ssd_count is %v and no create can mint one", withVolume["volumes_b_ssd_count"])
 	}
 	byType, _ := after["servers_by_types"].(map[string]any)
 	if got, _ := byType["DEV1-S"].(float64); got != 1 {
@@ -136,14 +142,13 @@ func TestTheDashboardCountsWhatTheStoreHolds(t *testing.T) {
 		t.Error("running_servers_count did not follow the server that started")
 	}
 
-	// The two types this emulator never makes are zero because it makes none,
-	// which is true of it rather than short of anything: /products/volumes on
-	// fr-par-1 lists l_ssd and scratch, and nothing here creates one.
+	// scratch is a type this API mints and this test never asked for, so its
+	// counter is zero because the store holds none. It was a constant until #393
+	// made both l_ssd and scratch creatable, at which point a hardcoded zero
+	// would have answered none while the store held them.
 	final := read()
-	for _, key := range []string{"volumes_l_ssd_count", "volumes_scratch_count"} {
-		if count(final, key) != 0 {
-			t.Errorf("%s is %v; this emulator makes none", key, final[key])
-		}
+	if count(final, "volumes_scratch_count") != 0 {
+		t.Errorf("volumes_scratch_count is %v and nothing here made one", final["volumes_scratch_count"])
 	}
 }
 
@@ -159,7 +164,7 @@ func TestTheDashboardTotalsTheSizesItCounts(t *testing.T) {
 	const zone = "/instance/v1/zones/fr-par-1"
 
 	if status, out := do(t, ts, "POST", zone+"/volumes",
-		`{"name":"sized","volume_type":"b_ssd","size":10000000000}`); status != http.StatusCreated {
+		`{"name":"sized","volume_type":"l_ssd","size":10000000000}`); status != http.StatusCreated {
 		t.Fatalf("volume create: status %d (%v)", status, out)
 	}
 	status, out := do(t, ts, "GET", zone+"/dashboard", "")
@@ -167,9 +172,9 @@ func TestTheDashboardTotalsTheSizesItCounts(t *testing.T) {
 		t.Fatalf("dashboard: status %d", status)
 	}
 	d, _ := out["dashboard"].(map[string]any)
-	total, _ := d["volumes_b_ssd_total_size"].(float64)
+	total, _ := d["volumes_l_ssd_total_size"].(float64)
 	if total != 10000000000 {
-		t.Errorf("volumes_b_ssd_total_size is %v for one 10 GB volume; the count says %v",
-			d["volumes_b_ssd_total_size"], d["volumes_b_ssd_count"])
+		t.Errorf("volumes_l_ssd_total_size is %v for one 10 GB volume; the count says %v",
+			d["volumes_l_ssd_total_size"], d["volumes_l_ssd_count"])
 	}
 }

--- a/internal/providers/scaleway/images.go
+++ b/internal/providers/scaleway/images.go
@@ -99,11 +99,16 @@ func (p *Pack) imageView(zone, id, label string) map[string]any {
 		//
 		// TestTheCatalogueImageTypesFromServerLikeTheCloudDoes fails without this.
 		"from_server": "",
+		// l_ssd, measured rather than assumed: a server created on fr-par with
+		// image=ubuntu_jammy came back carrying
+		// image.root_volume.volume_type = "l_ssd" (2026-09-02, #393). It read
+		// b_ssd here, which is the type instance/v1 has stopped minting — an
+		// image no client could reproduce from this API.
 		"root_volume": map[string]any{
 			"id":          catalogueImageSnapshot,
 			"name":        label + "-root",
-			"size":        20_000_000_000,
-			"volume_type": "b_ssd",
+			"size":        rootVolumeSize,
+			"volume_type": "l_ssd",
 		},
 	}
 }

--- a/internal/providers/scaleway/lifecycle_test.go
+++ b/internal/providers/scaleway/lifecycle_test.go
@@ -290,7 +290,7 @@ func TestAdditionalVolumesAreAttachedAtCreate(t *testing.T) {
 	ts := newTestServer(t)
 	const zone = "/instance/v1/zones/fr-par-1"
 
-	status, out := do(t, ts, "POST", zone+"/volumes", `{"name":"extra","size":10000000000,"volume_type":"b_ssd"}`)
+	status, out := do(t, ts, "POST", zone+"/volumes", `{"name":"extra","size":10000000000,"volume_type":"l_ssd"}`)
 	if status != 201 {
 		t.Fatalf("volume create: status %d", status)
 	}

--- a/internal/providers/scaleway/listfilters_test.go
+++ b/internal/providers/scaleway/listfilters_test.go
@@ -164,7 +164,7 @@ func TestUpdateServerAttachesAndDetachesVolumes(t *testing.T) {
 	root, _ := volumes["0"].(map[string]any)
 	rootID, _ := root["id"].(string)
 
-	status, out = do(t, ts, "POST", zone+"/volumes", `{"name":"extra","volume_type":"b_ssd","size":10000000000}`)
+	status, out = do(t, ts, "POST", zone+"/volumes", `{"name":"extra","volume_type":"l_ssd","size":10000000000}`)
 	if status != http.StatusCreated {
 		t.Fatalf("create volume: status %d (%v)", status, out)
 	}

--- a/internal/providers/scaleway/listquery_test.go
+++ b/internal/providers/scaleway/listquery_test.go
@@ -227,7 +227,7 @@ func TestBlockListsHonourTheDeclaredFilters(t *testing.T) {
 		{"?tags=team-banana&tags=team-apple", []string{"banana", "apple"}}, // any-match
 		{"?project_id=00000000-0000-4000-9000-000000000001", []string{}},
 		{"?product_resource_id=00000000-dead-4000-9000-000000000001", []string{}},
-		{"?volume_type=b_ssd", []string{}},
+		{"?volume_type=scratch", []string{}},
 		{"?volume_type=sbs", []string{"banana", "apple"}},
 		// Deletion is immediate here, so both values answer the same list —
 		// served, with the difference recorded in docs/limits.md.
@@ -536,15 +536,18 @@ func TestInstanceListsHonourTheirRemainingFilters(t *testing.T) {
 	}
 
 	// Volumes: volume_type and tags.
-	status, _ = do(t, ts, "POST", zone+"/volumes", `{"name":"data","volume_type":"b_ssd","size":10000000000,"tags":["gold"]}`)
+	status, _ = do(t, ts, "POST", zone+"/volumes", `{"name":"data","volume_type":"l_ssd","size":10000000000,"tags":["gold"]}`)
 	if status != http.StatusCreated {
 		t.Fatalf("create volume: status %d", status)
 	}
-	if got := count("/volumes", "volumes", "?volume_type=l_ssd"); got != 0 {
-		t.Fatalf("volumes?volume_type=l_ssd matched %d, want 0", got)
+	// scratch, because the type that answers nothing here has to be one the
+	// filter would happily match: l_ssd played that part until #393 made it the
+	// type this create asks for.
+	if got := count("/volumes", "volumes", "?volume_type=scratch"); got != 0 {
+		t.Fatalf("volumes?volume_type=scratch matched %d, want 0", got)
 	}
-	if got := count("/volumes", "volumes", "?volume_type=b_ssd"); got != 1 {
-		t.Fatalf("volumes?volume_type=b_ssd matched %d, want 1", got)
+	if got := count("/volumes", "volumes", "?volume_type=l_ssd"); got != 1 {
+		t.Fatalf("volumes?volume_type=l_ssd matched %d, want 1", got)
 	}
 	if got := count("/volumes", "volumes", "?tags=gold"); got != 1 {
 		t.Fatalf("volumes?tags=gold matched %d, want 1", got)

--- a/internal/providers/scaleway/ownership_audit_test.go
+++ b/internal/providers/scaleway/ownership_audit_test.go
@@ -22,7 +22,7 @@ const zone = "/instance/v1/zones/fr-par-1"
 func aVolume(t *testing.T, ts *httptest.Server, name string) string {
 	t.Helper()
 	_, out := do(t, ts, "POST", zone+"/volumes",
-		`{"name":"`+name+`","volume_type":"b_ssd","size":10000000000}`)
+		`{"name":"`+name+`","volume_type":"l_ssd","size":10000000000}`)
 	vol, _ := out["volume"].(map[string]any)
 	id, _ := vol["id"].(string)
 	if id == "" {

--- a/internal/providers/scaleway/pack.go
+++ b/internal/providers/scaleway/pack.go
@@ -777,15 +777,23 @@ func (p *Pack) Declined() []emulator.Decline {
 		// emulator creates — a client picking DEV1-S gets a DEV1-S, and its
 		// values come from a recording (corpus/scaleway/scw-instance.jsonl seq
 		// 2-4). A live read of /products/volumes on fr-par-1, 2026-09-01, answers
-		// exactly two types: l_ssd (Local SSD) and scratch. This emulator makes
-		// neither. Serving it faithfully would hand a client a menu on which
-		// every item is one the create refuses, which is a worse answer than a
-		// refusal that points at the route list.
+		// exactly two types: l_ssd (Local SSD) and scratch.
 		//
-		// The day a recording of it exists beside a pack that makes those types,
-		// this becomes a serve. Until then the decline stands, on a sentence that
-		// says what is actually true.
-		emulator.Because("a live read of /products/volumes on fr-par-1 answers l_ssd and scratch, and this emulator makes neither — its instance volumes are b_ssd and its root disks sbs_volume — so serving it would offer a client two types every create then refuses",
+		// Half of that reasoning has since expired, and this comment says which
+		// half rather than leaving the sentence standing. #393 made CreateVolume
+		// answer exactly what fr-par answers, so l_ssd and scratch are now the
+		// two types this pack mints and nothing else is: the menu would no
+		// longer list items the create refuses. It names them.
+		//
+		// What is left is the other condition the decline already carried, and
+		// it is unchanged: no recording of /products/volumes exists in corpus/,
+		// and this route answers a table of per-type constraints — sizes, snapshot
+		// rules — that rule 4 forbids inventing. A menu made up here would be
+		// exactly the plausible-wrong answer this repository exists to avoid.
+		//
+		// The day that recording lands, this becomes a serve, and the pack that
+		// makes those types is already waiting for it.
+		emulator.Because("no recording of /products/volumes exists in corpus/, and the route answers a table of per-type constraints that would have to be invented rather than measured",
 			"instance/v1/API.ListVolumesTypes"),
 
 		// Migrating a legacy local volume, or a snapshot of one, to Scaleway

--- a/internal/providers/scaleway/project_test.go
+++ b/internal/providers/scaleway/project_test.go
@@ -24,7 +24,7 @@ func TestListsAreScopedToTheProject(t *testing.T) {
 	}{
 		{"servers", "/servers", `{"name":"scoped","commercial_type":"DEV1-S","project":"` + otherProject + `"}`, "servers"},
 		{"ips", "/ips", `{"project":"` + otherProject + `"}`, "ips"},
-		{"volumes", "/volumes", `{"name":"scoped","project":"` + otherProject + `"}`, "volumes"},
+		{"volumes", "/volumes", `{"name":"scoped","volume_type":"l_ssd","project":"` + otherProject + `"}`, "volumes"},
 		{"security_groups", "/security_groups", `{"name":"scoped","project":"` + otherProject + `"}`, "security_groups"},
 	}
 

--- a/internal/providers/scaleway/servers.go
+++ b/internal/providers/scaleway/servers.go
@@ -179,7 +179,21 @@ func projectOf(requested string) (project, organization string) {
 // rootVolumeSize is what the emulated image carries, matching the root_volume
 // the image endpoint publishes. The two must agree: a client that sizes a disk
 // from the image and reads it back from the server would otherwise see a diff.
-const rootVolumeSize = 20_000_000_000
+// imageView reads this constant rather than repeating the number, because they
+// drifted apart once already.
+//
+// 10 GB since #393, and the reason is a constraint the CLI enforces rather than
+// a preference. The catalogue image's root volume is typed l_ssd now — measured:
+// a DEV1-S created on fr-par with image=ubuntu_jammy comes back carrying
+// image.root_volume.volume_type "l_ssd" and size 10000000000 — and `scw` sums
+// the LOCAL disks of a create against volumes_constraint. At 20 GB the CLI
+// refused every STARDUST1-S create with "image … requires 20 GB on root volume,
+// but root volume is constrained between 0 B and 10 GB", which is the same trap
+// as the min_size one in catalog.go seen from its other end.
+//
+// The conformance suite is what caught it, and no unit test could have: the
+// arithmetic lives in the client.
+const rootVolumeSize = 10_000_000_000
 
 // rootVolume builds the volume a server always owns. The caller stores it and
 // puts it in the server's map under the key "0".
@@ -266,7 +280,7 @@ func (p *Pack) rootVolume(server *resource.Resource, name, project, organization
 	// copies had already drifted apart — one carried a clause the other did
 	// not. A fact written twice is a fact that will one day be written
 	// differently, and it was already halfway there.
-	vol := p.newVolume(server.Tenant.Zone, project, organization, volumeName, "b_ssd", size)
+	vol := p.newVolume(server.Tenant.Zone, project, organization, volumeName, wanted.VolumeType, size)
 	// A volume this call just built: it can belong to nobody else, so the only
 	// error attachVolume returns cannot happen here.
 	_ = p.attachVolume(vol, server, name)
@@ -383,6 +397,14 @@ func (p *Pack) createServer(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		placementGroup = req.PlacementGroup
+	}
+
+	// Before anything is stored, like the placement group above: a create whose
+	// volumes map names a type the cloud refuses must leave no server behind
+	// (#393). withImage is true because this pack always resolves one, including
+	// for a request that named none.
+	if refuseServerVolumeTypes(w, req.Volumes, true) {
+		return
 	}
 
 	resolvedImageID, imageDisplay, imageLabel := resolveImage(req.Image)
@@ -1334,7 +1356,16 @@ func (p *Pack) setServerVolumes(server *resource.Resource, wanted map[string]vol
 			if volumeName == "" {
 				volumeName = name + "-" + key
 			}
-			vol := p.newVolume(server.Tenant.Zone, project, organization, volumeName, orDefault(tmpl.VolumeType, "b_ssd"), uint64(tmpl.Size))
+			// b_ssd is refused here the way the create path refuses it, and
+			// the default moves to l_ssd: instance/v1 has stopped minting the
+			// former and still mints the latter (#393). UpdateServer's own
+			// answer to a template naming no type was not measured, so the
+			// default is a choice, not a recording — it is named as one here
+			// rather than in a table that would read like a measurement.
+			if err := serverVolumeTypeFault(key, tmpl.VolumeType); err != nil {
+				return err
+			}
+			vol := p.newVolume(server.Tenant.Zone, project, organization, volumeName, orDefault(tmpl.VolumeType, "l_ssd"), uint64(tmpl.Size))
 			// A volume this call just created: it can belong to nobody else.
 			_ = p.attachVolume(vol, server, name)
 			p.env.Store.Put(vol)

--- a/internal/providers/scaleway/snapshots.go
+++ b/internal/providers/scaleway/snapshots.go
@@ -149,8 +149,13 @@ func (p *Pack) createSnapshot(w http.ResponseWriter, r *http.Request) {
 			size = resource.Uint64(volume, "size")
 		}
 	}
+	// l_ssd since #393: the fallback named b_ssd, which instance/v1 no longer
+	// mints, so a snapshot reaching this line was typed after a product that can
+	// no longer be created. Every instance volume now carries l_ssd or scratch,
+	// which makes this a fallback for a volume with no readable type at all —
+	// and l_ssd is the one of the two a snapshot can be taken of.
 	if volumeType == "" {
-		volumeType = "b_ssd"
+		volumeType = "l_ssd"
 	}
 
 	project, organization := projectOf(textPtr(req.Project))

--- a/internal/providers/scaleway/volumes.go
+++ b/internal/providers/scaleway/volumes.go
@@ -117,9 +117,11 @@ func (p *Pack) createVolume(w http.ResponseWriter, r *http.Request) {
 	if req.Size != nil && *req.Size > 0 {
 		size = *req.Size
 	}
+	if bad := refuseRetiredVolumeType(w, req.VolumeType); bad {
+		return
+	}
 	project, organization := projectOf(req.Project)
-	res := p.newVolume(zone, project, organization, req.Name,
-		orDefault(req.VolumeType, "b_ssd"), size)
+	res := p.newVolume(zone, project, organization, req.Name, req.VolumeType, size)
 	res.Attrs["tags"] = orEmpty(req.Tags)
 	p.env.Store.Put(res)
 

--- a/internal/providers/scaleway/volumetypes.go
+++ b/internal/providers/scaleway/volumetypes.go
@@ -1,0 +1,172 @@
+package scaleway
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+)
+
+// What instance/v1 does with a volume_type, measured against a real fr-par
+// account on 2026-09-02 (#393). Two routes, two vocabularies, and the difference
+// is not decoration: a client branches on argument_name, and the two help
+// messages point at different products.
+//
+//	POST /volumes                     argument volume_type
+//	  absent      400 required    "required key not provided"
+//	  b_ssd       400 constraint  "b_ssd volumes are no longer supported. Use
+//	                               Scaleway Block Storage (SBS) volumes instead…"
+//	  sbs_volume  400 constraint  "not a valid value"  (block/v1 mints those)
+//	  l_ssd       201
+//	  scratch     201
+//
+//	POST /servers                     argument volumes.<key>.volume_type
+//	  b_ssd       400 constraint  "b_ssd volumes are no longer supported. Create
+//	                               volumes with volume_type=sbs_volume instead…"
+//	  nonsense    400 constraint  "not a valid value"
+//	  sbs_volume  201             (#365: it is what a DEV1-S is given)
+//	  l_ssd       201, and the volume comes back l_ssd — honoured, not replaced
+//	  scratch     400 constraint on argument image, not on the type:
+//	                               "Cannot use an image with a scratch volume"
+//
+// This emulator answered 201 to all of them and stored b_ssd whatever was asked,
+// standing on a type the platform has retired. The surface scan cannot see that:
+// CreateVolume's Go signature never changed, and neither did CreateServer's.
+// Only a recording of the cloud names this kind of drift, which is the whole
+// argument for keeping one.
+//
+// One fact, three entry points: a create of a volume, a create of a server whose
+// template asks for a disk, and an update that adds one. Written three times, a
+// correction on one survives on the other two, and this file exists so that
+// cannot happen.
+var (
+	// creatableVolumeTypes is what POST /volumes still mints, and it is exactly
+	// what GET /products/volumes lists — measured on fr-par the same day, which
+	// is what makes the two answers one fact rather than two tables.
+	creatableVolumeTypes = map[string]bool{"l_ssd": true, "scratch": true}
+
+	// serverVolumeTypes adds sbs_volume, which a server template may name and
+	// POST /volumes may not: block/v1 is where the cloud moved that product, and
+	// a server reaching into it is the normal path since #365.
+	serverVolumeTypes = map[string]bool{"l_ssd": true, "scratch": true, "sbs_volume": true}
+)
+
+// volumeTypeError names what POST /volumes answers for a volume_type, or nil
+// when the cloud creates it.
+//
+// TestCreateVolumeRefusesTheTypesTheCloudRefuses fails without this.
+func volumeTypeError(volumeType string) *ArgumentError {
+	switch {
+	case volumeType == "":
+		return &ArgumentError{
+			ArgumentName: "volume_type",
+			Reason:       "required",
+			HelpMessage:  "required key not provided",
+		}
+	case volumeType == "b_ssd":
+		return &ArgumentError{
+			ArgumentName: "volume_type",
+			Reason:       "constraint",
+			HelpMessage: "b_ssd volumes are no longer supported. Use Scaleway Block Storage (SBS) " +
+				"volumes instead. More details on " +
+				"https://www.scaleway.com/en/developers/api/instance/#path-volumes-migrate-a-volume-andor-snapshots-to-sbs-scaleway-block-storage" +
+				" for migration and https://www.scaleway.com/en/developers/api/block/#path-volume-create-a-volume" +
+				" about Scaleway Block Storage volume",
+		}
+	case !creatableVolumeTypes[volumeType]:
+		// sbs_volume lands here, and the cloud does not point at the product
+		// that serves it either: it answers the same flat refusal as for a type
+		// that never existed. Rule 4 says to copy the wording, not improve it.
+		return &ArgumentError{
+			ArgumentName: "volume_type",
+			Reason:       "constraint",
+			HelpMessage:  "not a valid value",
+		}
+	}
+	return nil
+}
+
+// refuseRetiredVolumeType writes the refusal above and reports whether it did.
+func refuseRetiredVolumeType(w http.ResponseWriter, volumeType string) bool {
+	err := volumeTypeError(volumeType)
+	if err == nil {
+		return false
+	}
+	writeInvalidArguments(w, *err)
+	return true
+}
+
+// serverVolumeTypeError names what POST /servers answers for one entry of its
+// volumes map, or nil when the cloud builds it. An empty type is not an error
+// here: a template naming no type gets the block root the cloud gives a DEV1-S
+// (#365), and a template naming an existing volume by id carries no type at all.
+//
+// withImage carries the other half of the scratch measurement: the cloud refuses
+// that combination on argument "image" rather than on the type, so a client
+// reading argument_name is told which input to change.
+func serverVolumeTypeError(key, volumeType string, withImage bool) *ArgumentError {
+	field := "volumes." + key + ".volume_type"
+	switch {
+	case volumeType == "":
+		return nil
+	case volumeType == "b_ssd":
+		return &ArgumentError{
+			ArgumentName: field,
+			Reason:       "constraint",
+			HelpMessage: "b_ssd volumes are no longer supported. Create volumes with " +
+				"volume_type=sbs_volume instead. More details at " +
+				"https://www.scaleway.com/en/developers/api/instance/#technical-information",
+		}
+	case volumeType == "scratch" && withImage:
+		return &ArgumentError{
+			ArgumentName: "image",
+			Reason:       "constraint",
+			HelpMessage:  "Cannot use an image with a scratch volume",
+		}
+	case !serverVolumeTypes[volumeType]:
+		return &ArgumentError{
+			ArgumentName: field,
+			Reason:       "constraint",
+			HelpMessage:  "not a valid value",
+		}
+	}
+	return nil
+}
+
+// refuseServerVolumeTypes answers a create whose volumes map names a type the
+// cloud will not build, before anything is stored — the same ordering the
+// flexible IPs are validated in, and for the same reason: a refusal written
+// after the Put leaves a phantom server behind.
+//
+// The keys are walked in order so that a request naming two bad types always
+// gets the same one named back. A map range would answer either, and a client
+// diffing two runs would read a flapping API.
+//
+// TestCreateServerRefusesTheVolumeTypesTheCloudRefuses fails without this.
+func refuseServerVolumeTypes(w http.ResponseWriter, volumes map[string]volumeTemplate, withImage bool) bool {
+	keys := make([]string, 0, len(volumes))
+	for key := range volumes {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if err := serverVolumeTypeError(key, volumes[key].VolumeType, withImage); err != nil {
+			writeInvalidArguments(w, *err)
+			return true
+		}
+	}
+	return false
+}
+
+// serverVolumeTypeFault is the same verdict for the update path, which reports
+// through an error rather than writing the response itself.
+//
+// The wording is CreateServer's, because the shape of the field is
+// CreateServer's — volumes.<key>.volume_type. UpdateServer was not measured, and
+// this comment says so rather than letting the borrowed sentence read as a
+// recording.
+func serverVolumeTypeFault(key, volumeType string) error {
+	if err := serverVolumeTypeError(key, volumeType, false); err != nil {
+		return fmt.Errorf("%s: %s", err.ArgumentName, err.HelpMessage)
+	}
+	return nil
+}

--- a/internal/providers/scaleway/volumetypes_test.go
+++ b/internal/providers/scaleway/volumetypes_test.go
@@ -1,0 +1,194 @@
+package scaleway_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// What instance/v1 CreateVolume answers to each volume_type, measured against
+// fr-par on 2026-09-02 with a real account (#393).
+//
+// The emulator answered 201 to all of them, and defaulted an absent type to
+// b_ssd: a value the platform retired, standing in the one field a client reads
+// back. The surface scan could not see it, because CreateVolume's Go signature
+// never changed. Only a recording of the cloud names this kind of drift, which
+// is why the corpus outranks the SDK here.
+//
+// The table below is the recording, transcribed. Each line is one request the
+// account served.
+func TestCreateVolumeRefusesTheTypesTheCloudRefuses(t *testing.T) {
+	ts := newTestServer(t)
+
+	for _, c := range []struct {
+		name    string
+		body    string
+		status  int
+		reason  string
+		message string
+	}{
+		{
+			name:    "absent",
+			body:    `{"name":"probe","size":10000000000}`,
+			status:  http.StatusBadRequest,
+			reason:  "required",
+			message: "required key not provided",
+		},
+		{
+			name:    "b_ssd",
+			body:    `{"name":"probe","volume_type":"b_ssd","size":10000000000}`,
+			status:  http.StatusBadRequest,
+			reason:  "constraint",
+			message: "b_ssd volumes are no longer supported",
+		},
+		{
+			// Served by block/v1, which is where the cloud moved it. The cloud
+			// does not point at the other product either: it answers the same
+			// flat refusal as for a type that never existed, and rule 4 says to
+			// copy the wording rather than improve it.
+			name:    "sbs_volume",
+			body:    `{"name":"probe","volume_type":"sbs_volume","size":10000000000}`,
+			status:  http.StatusBadRequest,
+			reason:  "constraint",
+			message: "not a valid value",
+		},
+		{
+			name:   "l_ssd",
+			body:   `{"name":"probe","volume_type":"l_ssd","size":10000000000}`,
+			status: http.StatusCreated,
+		},
+		{
+			name:   "scratch",
+			body:   `{"name":"probe","volume_type":"scratch","size":10000000000}`,
+			status: http.StatusCreated,
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			status, out := do(t, ts, "POST", zoneURL+"/volumes", c.body)
+			if status != c.status {
+				t.Fatalf("status %d, want %d (%v)", status, c.status, out)
+			}
+			if c.status == http.StatusCreated {
+				// Created is only half the answer: the type has to survive the
+				// round trip, because an emulator that accepted l_ssd and stored
+				// b_ssd would pass the status check and lie in the one field a
+				// client reads back.
+				volume, _ := out["volume"].(map[string]any)
+				if got, _ := volume["volume_type"].(string); got != c.name {
+					t.Fatalf("volume_type came back %q, want %q", got, c.name)
+				}
+				return
+			}
+			if got, _ := out["type"].(string); got != "invalid_arguments" {
+				t.Fatalf("error type is %q, want invalid_arguments (%v)", got, out)
+			}
+			details, _ := out["details"].([]any)
+			if len(details) != 1 {
+				t.Fatalf("details holds %d entries, want 1 (%v)", len(details), out)
+			}
+			d, _ := details[0].(map[string]any)
+			if got, _ := d["argument_name"].(string); got != "volume_type" {
+				t.Errorf("argument_name is %q, want volume_type", got)
+			}
+			if got, _ := d["reason"].(string); got != c.reason {
+				t.Errorf("reason is %q, want %q", got, c.reason)
+			}
+			if got, _ := d["help_message"].(string); !strings.Contains(got, c.message) {
+				t.Errorf("help_message is %q, want it to carry %q", got, c.message)
+			}
+		})
+	}
+}
+
+// The same fact one route further on: what POST /servers answers when its
+// volumes map names a type, measured the same day against the same account.
+//
+// The two routes do not share a vocabulary, and that is the point of testing
+// both: argument_name is volumes.0.volume_type here and volume_type there, the
+// b_ssd help message points at a different product, and scratch is refused on
+// argument "image" rather than on the type at all.
+func TestCreateServerRefusesTheVolumeTypesTheCloudRefuses(t *testing.T) {
+	ts := newTestServer(t)
+
+	for _, c := range []struct {
+		name     string
+		volume   string
+		status   int
+		argument string
+		message  string
+	}{
+		{
+			name:     "b_ssd",
+			volume:   `{"volume_type":"b_ssd","size":10000000000}`,
+			status:   http.StatusBadRequest,
+			argument: "volumes.0.volume_type",
+			message:  "Create volumes with volume_type=sbs_volume instead",
+		},
+		{
+			name:     "nonsense",
+			volume:   `{"volume_type":"nonsense","size":10000000000}`,
+			status:   http.StatusBadRequest,
+			argument: "volumes.0.volume_type",
+			message:  "not a valid value",
+		},
+		{
+			// Refused on the image, not on the type: a client reading
+			// argument_name is told which of its two inputs to change, and this
+			// pack always resolves an image, including for a request naming
+			// none.
+			name:     "scratch",
+			volume:   `{"volume_type":"scratch","size":10000000000}`,
+			status:   http.StatusBadRequest,
+			argument: "image",
+			message:  "Cannot use an image with a scratch volume",
+		},
+		{
+			name:   "sbs_volume",
+			volume: `{"volume_type":"sbs_volume","size":10000000000}`,
+			status: http.StatusCreated,
+		},
+		{
+			name:   "l_ssd",
+			volume: `{"volume_type":"l_ssd","size":10000000000}`,
+			status: http.StatusCreated,
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			body := `{"name":"probe","commercial_type":"DEV1-S","image":"ubuntu_jammy","volumes":{"0":` + c.volume + `}}`
+			status, out := do(t, ts, "POST", zoneURL+"/servers", body)
+			if status != c.status {
+				t.Fatalf("status %d, want %d (%v)", status, c.status, out)
+			}
+			if c.status == http.StatusCreated {
+				// Honoured, not replaced. This pack used to write b_ssd here
+				// whatever was asked, so a create naming l_ssd came back as a
+				// type the cloud no longer mints — the exact answer a client
+				// reads and stores.
+				server, _ := out["server"].(map[string]any)
+				volumes, _ := server["volumes"].(map[string]any)
+				root, _ := volumes["0"].(map[string]any)
+				if got, _ := root["volume_type"].(string); got != c.name {
+					t.Fatalf("the root volume came back %q, want %q", got, c.name)
+				}
+				return
+			}
+			details, _ := out["details"].([]any)
+			if len(details) != 1 {
+				t.Fatalf("details holds %d entries, want 1 (%v)", len(details), out)
+			}
+			d, _ := details[0].(map[string]any)
+			if got, _ := d["argument_name"].(string); got != c.argument {
+				t.Errorf("argument_name is %q, want %q", got, c.argument)
+			}
+			if got, _ := d["help_message"].(string); !strings.Contains(got, c.message) {
+				t.Errorf("help_message is %q, want it to carry %q", got, c.message)
+			}
+			// A refusal that left a server behind would be the defect this
+			// ordering exists to avoid, and it is invisible from the 400 alone.
+			_, list := do(t, ts, "GET", zoneURL+"/servers", "")
+			if servers, _ := list["servers"].([]any); len(servers) != 0 {
+				t.Fatalf("the refused create left %d server(s) behind", len(servers))
+			}
+		})
+	}
+}

--- a/tools/conformance/scaleway/scw-cli.sh
+++ b/tools/conformance/scaleway/scw-cli.sh
@@ -316,7 +316,7 @@ ok "membership walked, and the spread policy told the truth"
 # saw none of it. The fixture is the thing that had to grow.
 echo "- a volume is attached, refuses to be deleted under its server, and comes back"
 span="$(prove_begin behaviour)"
-vol="$(scw instance volume create name=conformance-vol volume-type=b_ssd size=10G zone="$ZONE" -o json)" \
+vol="$(scw instance volume create name=conformance-vol volume-type=l_ssd size=10G zone="$ZONE" -o json)" \
   || fail "volume create rejected: $vol"
 vol_id="$(printf '%s' "$vol" | jq -r '(.volume // .).id')"
 [ -n "$vol_id" ] && [ "$vol_id" != null ] || fail "no id in the volume create response: $vol"
@@ -414,7 +414,7 @@ scw block snapshot delete "$root_snap_id" zone="$ZONE" >/dev/null \
 # An instance volume for the instance snapshot, created by the client the way a
 # client does. It used to be the server's root disk, which was an instance
 # volume until #365 moved it where the cloud keeps it.
-img_vol="$(scw instance volume create name=conformance-golden-vol volume-type=b_ssd size=10G \
+img_vol="$(scw instance volume create name=conformance-golden-vol volume-type=l_ssd size=10G \
             zone="$ZONE" -o json)" || fail "volume create for the image test rejected: $img_vol"
 img_vol_id="$(printf '%s' "$img_vol" | jq -r '(.volume // .).id')"
 [ -n "$img_vol_id" ] && [ "$img_vol_id" != null ] || fail "no id in the volume create response: $img_vol"
@@ -939,7 +939,7 @@ scw instance ip list zone="$ZONE" -o json >/dev/null || fail "instance ip list r
 scw instance volume list zone="$ZONE" -o json >/dev/null || fail "instance volume list rejected"
 scw instance snapshot list zone="$ZONE" -o json >/dev/null || fail "instance snapshot list rejected"
 
-ivol="$(scw instance volume create name=conformance-iv size=10GB volume-type=b_ssd \
+ivol="$(scw instance volume create name=conformance-iv size=10GB volume-type=l_ssd \
          zone="$ZONE" -o json 2>&1)" || fail "instance volume create rejected: $ivol"
 ivol_id="$(printf '%s' "$ivol" | jq -r '.volume.id // .id // empty')"
 [ -n "$ivol_id" ] || fail "no id in the instance volume response: $ivol"

--- a/tools/conformance/scaleway/terraform/main.tf
+++ b/tools/conformance/scaleway/terraform/main.tf
@@ -211,8 +211,12 @@ resource "scaleway_vpc_route" "conformance" {
 # attached to a server" on every retry. Both were invisible to unit tests, which
 # read JSON, and to this fixture, which had no volume in it.
 resource "scaleway_instance_volume" "conformance" {
-  name       = "conformance-tf-data"
-  type       = "b_ssd"
+  name = "conformance-tf-data"
+  # l_ssd since #393: instance/v1 stopped minting b_ssd and this emulator now
+  # refuses it the way fr-par does, so the type this fixture declares has to be
+  # one the API still creates. That the provider plans and applies l_ssd here is
+  # the half of the measurement no unit test can make.
+  type       = "l_ssd"
   size_in_gb = 10
   zone       = "fr-par-1"
 }

--- a/tools/falsify/specs/block-volumes-reach-their-server.json
+++ b/tools/falsify/specs/block-volumes-reach-their-server.json
@@ -56,7 +56,7 @@
       "file": "internal/providers/scaleway/snapshots.go",
       "find": "\t\tif volumeType == \"\" && volume.Kind == kindBlockVolume {\n\t\t\tvolumeType = \"unified\"\n\t\t}",
       "replace": "\t\tif volumeType == \"\" && volume.Kind == kindBlockVolume && false {\n\t\t\tvolumeType = \"unified\"\n\t\t}",
-      "expect": "the snapshot falls through to the b_ssd default, naming a product it was not taken from",
+      "expect": "the snapshot falls through to the instance default, naming a product it was not taken from (l_ssd since #393, b_ssd before it)",
       "test": "TestAnInstanceSnapshotOfABlockVolumeDoesNotPromiseTheBlockProduct"
     },
     {

--- a/tools/falsify/specs/volume-types-the-cloud-mints.json
+++ b/tools/falsify/specs/volume-types-the-cloud-mints.json
@@ -1,0 +1,54 @@
+{
+  "package": "./internal/providers/scaleway/",
+  "mutations": [
+    {
+      "label": "b_ssd falls through to the generic refusal, so the create is still refused and the client is told nothing about the migration",
+      "file": "internal/providers/scaleway/volumetypes.go",
+      "find": "\tcase volumeType == \"b_ssd\":\n\t\treturn &ArgumentError{\n\t\t\tArgumentName: \"volume_type\",",
+      "replace": "\tcase volumeType == \"b_ssd\" && false:\n\t\treturn &ArgumentError{\n\t\t\tArgumentName: \"volume_type\",",
+      "test": "TestCreateVolumeRefusesTheTypesTheCloudRefuses"
+    },
+    {
+      "label": "an absent volume_type is defaulted again instead of refused, which is how this pack came to stand on a retired type",
+      "file": "internal/providers/scaleway/volumetypes.go",
+      "find": "\tcase volumeType == \"\":\n\t\treturn &ArgumentError{\n\t\t\tArgumentName: \"volume_type\",\n\t\t\tReason:       \"required\",",
+      "replace": "\tcase volumeType == \"\" && false:\n\t\treturn &ArgumentError{\n\t\t\tArgumentName: \"volume_type\",\n\t\t\tReason:       \"required\",",
+      "test": "TestCreateVolumeRefusesTheTypesTheCloudRefuses"
+    },
+    {
+      "label": "the server create stops reading its volumes map, so a template naming b_ssd builds a server the cloud refuses",
+      "file": "internal/providers/scaleway/volumetypes.go",
+      "find": "\t\tif err := serverVolumeTypeError(key, volumes[key].VolumeType, withImage); err != nil {",
+      "replace": "\t\tif err := serverVolumeTypeError(key, volumes[key].VolumeType, withImage); err != nil && false {",
+      "test": "TestCreateServerRefusesTheVolumeTypesTheCloudRefuses"
+    },
+    {
+      "label": "both routes answer CreateVolume's wording, so a client reading the server refusal is pointed at a migration page instead of at sbs_volume",
+      "file": "internal/providers/scaleway/volumetypes.go",
+      "find": "\t\t\tHelpMessage: \"b_ssd volumes are no longer supported. Create volumes with \" +\n\t\t\t\t\"volume_type=sbs_volume instead. More details at \" +\n\t\t\t\t\"https://www.scaleway.com/en/developers/api/instance/#technical-information\",",
+      "replace": "\t\t\tHelpMessage: \"b_ssd volumes are no longer supported. Use Scaleway Block Storage (SBS) \" +\n\t\t\t\t\"volumes instead. More details on \" +\n\t\t\t\t\"https://www.scaleway.com/en/developers/api/instance/#path-volumes-migrate-a-volume-andor-snapshots-to-sbs-scaleway-block-storage\",",
+      "test": "TestCreateServerRefusesTheVolumeTypesTheCloudRefuses"
+    },
+    {
+      "label": "scratch is refused on the type rather than on the image, so a client is told to change the input the cloud does not name",
+      "file": "internal/providers/scaleway/volumetypes.go",
+      "find": "\tcase volumeType == \"scratch\" && withImage:\n\t\treturn &ArgumentError{\n\t\t\tArgumentName: \"image\",",
+      "replace": "\tcase volumeType == \"scratch\" && withImage:\n\t\treturn &ArgumentError{\n\t\t\tArgumentName: field,",
+      "test": "TestCreateServerRefusesTheVolumeTypesTheCloudRefuses"
+    },
+    {
+      "label": "the root volume is forced back to b_ssd whatever the client asked for, which is the answer this pack gave for a year",
+      "file": "internal/providers/scaleway/servers.go",
+      "find": "\tvol := p.newVolume(server.Tenant.Zone, project, organization, volumeName, wanted.VolumeType, size)",
+      "replace": "\tvol := p.newVolume(server.Tenant.Zone, project, organization, volumeName, orDefault(\"b_ssd\", wanted.VolumeType), size)",
+      "test": "TestCreateServerRefusesTheVolumeTypesTheCloudRefuses"
+    },
+    {
+      "label": "the volumes map is read after the server is built, so a refused create leaves a phantom server behind",
+      "file": "internal/providers/scaleway/servers.go",
+      "find": "\tif refuseServerVolumeTypes(w, req.Volumes, true) {\n\t\treturn\n\t}\n\n\tresolvedImageID, imageDisplay, imageLabel := resolveImage(req.Image)",
+      "replace": "\tresolvedImageID, imageDisplay, imageLabel := resolveImage(req.Image)\n\tdefer func() {\n\t\tif refuseServerVolumeTypes(w, req.Volumes, true) {\n\t\t\treturn\n\t\t}\n\t}()",
+      "test": "TestCreateServerRefusesTheVolumeTypesTheCloudRefuses"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #393.

## The measurement

Against a real `fr-par` account, 2026-09-02. The two creation routes both refuse
`b_ssd`, and they do not share a wording, so both are transcribed in
`internal/providers/scaleway/volumetypes.go` rather than one being reused:

| request | `fr-par` answers |
|---|---|
| `POST /volumes` no `volume_type` | 400 `required` — *required key not provided* |
| `POST /volumes` `b_ssd` | 400 `constraint` — *b_ssd volumes are no longer supported. Use Scaleway Block Storage (SBS) volumes instead…* |
| `POST /volumes` `sbs_volume` | 400 `constraint` — *not a valid value* |
| `POST /volumes` `l_ssd`, `scratch` | 201 |
| `POST /servers` `volumes.0.volume_type: b_ssd` | 400 `constraint` on `volumes.0.volume_type` — *Create volumes with volume_type=sbs_volume instead* |
| `POST /servers` `nonsense` | 400 `constraint` — *not a valid value* |
| `POST /servers` `l_ssd` | 201, and the volume comes back `l_ssd` |
| `POST /servers` `scratch` | 400 `constraint` on **`image`** — *Cannot use an image with a scratch volume* |

Everything the probe created was deleted; the account is back to zero servers,
volumes and addresses.

## What was wrong, in five places

`POST /volumes` defaulted to `b_ssd`, a server's `root_volume` was forced to it
whatever local type was asked for, an update adding a disk defaulted to it, the
catalogue images advertised it, and a snapshot with no readable type fell back to
it. **No Go signature changed on either operation**, so the surface scan cannot
see any of this — it is the exact drift the corpus exists to catch.

One fact, one file: `volumetypes.go` holds the verdict for all three entry
points. Written three times, a correction on one would have survived on the other
two, which is how the default came to sit in five places at once.

## A limit moved, and a number with it

The local types are no longer overridden: a create naming `l_ssd` gets an
`l_ssd`. The reason that override existed is unchanged and still holds the
catalogue in place, and `docs/limits.md` carries the corrected paragraph instead
of the expired one.

That made the catalogue image's root volume *local*, which puts it inside the
arithmetic `scw` runs over local disks. At the 20 GB this emulator advertised,
every `STARDUST1-S` create was refused with *"image … requires 20 GB on root
volume, but root volume is constrained between 0 B and 10 GB"*. `rootVolumeSize`
is 10 GB now, the same as `fr-par`'s for the same image, and `imageView` reads
that constant instead of repeating the number. **The conformance suite caught
this and no unit test could have**: the arithmetic lives in the client.

## A decline re-examined rather than left standing

`instance/v1/API.ListVolumesTypes` was refused on the ground that *this emulator
makes neither of the two types `/products/volumes` lists*. It makes exactly those
two now. The decline holds on its other condition alone and says so: no recording
of that route exists in `corpus/`, and it answers a table of per-type constraints
that rule 4 forbids inventing.

## Proof

- `corpus/accepted.json` loses its four `instance/v1/API.CreateVolume` entries,
  and `mise run corpus:check` is green with them **gone** rather than hidden:
  *0 divergent findings nothing accepts*.
- `mise run conformance:leg -- fields` green, 353 of 378 routes proven by a real
  client (unchanged). `scw` and the Terraform provider both drive `l_ssd` through
  the fixture, which they used to drive as `b_ssd`.
- `mise run falsify -- tools/falsify/specs/volume-types-the-cloud-mints.json`:
  seven mutations, seven *the test bit*, all compiling.
- The neighbouring spec `block-volumes-reach-their-server.json` still bites, and
  its snapshot test now states the value it wants instead of the one it refuses —
  a *not b_ssd* assertion stops discriminating the moment the fallback is not
  `b_ssd`.
- `mise run prepush` green.

Not run: the full `mise run conformance` pass. This branch is one of a batch;
the whole suite is played once on the assembled set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
