### PR TITLE
fix(scaleway): an unfiltered list answers the account, not the default project (#369)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -19,6 +19,33 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Corrigé
 
+- **Un serveur créé sous un projet nommé était invisible de la liste qui
+  suivait** (#369). `createServer` honorait le `project` que la requête nommait,
+  et toute liste sans filtre se limitait au projet par défaut : la création et la
+  liste se contredisaient, et un client qui crée puis liste, c'est-à-dire tous
+  les clients, lisait une flotte vide. Le commentaire au-dessus de `scopeOf`
+  disait déjà la bonne chose, « Neither means the token's default project », trois
+  lignes au-dessus du code qui faisait l'inverse.
+
+  L'issue proposait deux réponses cohérentes, et le cloud a tranché laquelle il
+  prend. Mesuré sur fr-par le 2026-09-02, avec un second projet créé pour
+  l'occasion et supprimé après :
+
+  | requête | le volume de l'autre projet |
+  |---|---|
+  | `GET /volumes` (sans filtre) | **visible** |
+  | `GET /volumes?project=<le défaut>` | caché |
+  | `GET /volumes?organization=<l'organisation>` | visible |
+
+  La création fait donc foi : nommer un projet le rend réel, et une liste sans
+  filtre répond le compte entier. L'isolation que l'ancien comportement défendait
+  est celle de la lecture **filtrée**, et elle est intacte : une liste qui nomme
+  un projet répond toujours ce projet seul.
+
+  L'entrée d'acceptation sur `instance/v1/API.ListServers` est supprimée, et le
+  gate l'a réclamée dans ces termes : « excused nothing this run: either it is
+  fixed and the entry goes, or the corpus no longer carries it ».
+
 - **Le cloud a retiré `b_ssd` à la création et cet émulateur en fabriquait
   encore** (#393). Toutes les routes qui créaient un volume écrivaient ce type :
   `POST /volumes` s'y repliait quand la requête n'en nommait aucun, le

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,33 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Fixed
 
+- **A server created under a named project was invisible to the list that
+  followed it** (#369). `createServer` honoured the `project` a request named,
+  and every unfiltered list scoped itself to the default project, so the create
+  and the list disagreed: a client that creates then lists — which is every
+  client — read an empty fleet. The comment above `scopeOf` already said the
+  right thing, *"Neither means the token's default project"*, three lines above
+  the code doing the opposite.
+
+  The issue offered two coherent answers and the cloud settled which one it
+  takes. Measured on fr-par, 2026-09-02, with a second project made for the
+  occasion and deleted after:
+
+  | request | the other project's volume |
+  |---|---|
+  | `GET /volumes` (no filter) | **visible** |
+  | `GET /volumes?project=<the default>` | hidden |
+  | `GET /volumes?organization=<the org>` | visible |
+
+  So the create is authoritative: naming a project makes it real, and an
+  unfiltered list answers the account. The isolation the old behaviour was
+  defending is the *filtered* read, and it is untouched — a list naming a
+  project still answers that project alone.
+
+  The acceptance entry on `instance/v1/API.ListServers` is deleted, and the gate
+  asked for it in those words: *"excused nothing this run: either it is fixed and
+  the entry goes, or the corpus no longer carries it"*.
+
 - **The cloud retired `b_ssd` at creation and this emulator was still minting
   it** (#393). Every route that made a volume wrote that type: `POST /volumes`
   defaulted to it when the request named none, a server's `root_volume` was

--- a/corpus/accepted.json
+++ b/corpus/accepted.json
@@ -1190,14 +1190,6 @@
       "issue": "https://github.com/stephrobert/feint/issues/570"
     },
     {
-      "file": "scaleway/scw-instance.jsonl",
-      "operation": "instance/v1/API.ListServers",
-      "kind": "absent",
-      "path": "servers[]",
-      "reason": "the create honours the project the request named and the unfiltered list is scoped to the default project, so the server the cloud listed is invisible to the list that follows it here",
-      "issue": "#369"
-    },
-    {
       "file": "scaleway/scw-refusals.jsonl",
       "operation": "instance/v1/API.CreateIP",
       "kind": "absent",

--- a/internal/providers/scaleway/project_test.go
+++ b/internal/providers/scaleway/project_test.go
@@ -10,9 +10,14 @@ import (
 // stay invisible from the default project.
 const otherProject = "22222222-2222-4222-8222-222222222222"
 
-// A project is an isolation boundary, not a label. Every list must be scoped to
-// the project the caller named, or a client reads resources it does not own and
-// Terraform plans a destroy for something another project created.
+// A project is an isolation boundary, not a label. A list that NAMES a project
+// must answer that project alone, or a client reads resources it does not own
+// and Terraform plans a destroy for something another project created.
+//
+// This test used to assert one thing more, and that thing was wrong: that an
+// unfiltered list answers the default project only. It answers the whole
+// account, measured (#369), and TestAnUnfilteredListAnswersEveryProjectLikeTheCloud
+// now carries that half. What is left here is the half the cloud agrees with.
 func TestListsAreScopedToTheProject(t *testing.T) {
 	ts := newTestServer(t)
 
@@ -40,13 +45,13 @@ func TestListsAreScopedToTheProject(t *testing.T) {
 				t.Fatalf("no id in the create response: %v", created)
 			}
 
-			// The default project must not see it. It may legitimately own
-			// resources of its own, so the assertion is on this id, not on an
-			// empty list.
-			_, listed := do(t, ts, "GET", zoneURL+k.path, "")
+			// A list naming the default project must not see it. It may
+			// legitimately own resources of its own, so the assertion is on
+			// this id, not on an empty list.
+			_, listed := do(t, ts, "GET", zoneURL+k.path+"?project="+defaultProjectID, "")
 			for _, item := range listed[k.field].([]any) {
 				if m, _ := item.(map[string]any); m["id"] == id {
-					t.Errorf("the default project sees %s of another project", id)
+					t.Errorf("a list naming the default project sees %s of another project", id)
 				}
 			}
 
@@ -125,3 +130,65 @@ func firstID(body map[string]any) (string, bool) {
 	}
 	return "", false
 }
+
+// defaultProjectID is the project a create with no project lands in. Spelled out
+// here rather than imported: this is the external test package, and the value is
+// part of what a client sees.
+const defaultProjectID = "11111111-1111-1111-1111-111111111111"
+
+// An unfiltered list answers every project of the account, which is what the
+// cloud answers and what this emulator used to get backwards.
+//
+// Measured on fr-par, 2026-09-02 (#369), with a second project made for the
+// occasion and deleted after: a volume created in it came back from
+// GET /volumes with no filter, stayed hidden from
+// GET /volumes?project=<the default>, and came back again from
+// GET /volumes?organization=<the org>.
+//
+// Why it matters beyond a filter: `createServer` honours the project a request
+// names, so a server created under a named project was invisible to the very
+// next unfiltered list. The create and the list disagreed, and a client that
+// creates then lists — which is every client — read an empty fleet.
+//
+// The emulator has no credential, so "the caller's project" had to come from
+// somewhere. The cloud settled which of the two coherent answers it takes: the
+// create is authoritative. It accepted a create naming another project and then
+// listed what it had made.
+func TestAnUnfilteredListAnswersEveryProjectLikeTheCloud(t *testing.T) {
+	ts := newTestServer(t)
+
+	status, created := do(t, ts, "POST", zoneURL+"/servers",
+		`{"name":"elsewhere","commercial_type":"DEV1-S","project":"`+otherProject+`"}`)
+	if status != http.StatusCreated {
+		t.Fatalf("create in %s: expected 201, got %d (%v)", otherProject, status, created)
+	}
+	id, _ := firstID(created)
+	if id == "" {
+		t.Fatalf("no id in the create response: %v", created)
+	}
+
+	seen := func(query string) bool {
+		t.Helper()
+		_, listed := do(t, ts, "GET", zoneURL+"/servers"+query, "")
+		for _, item := range listed["servers"].([]any) {
+			if m, _ := item.(map[string]any); m["id"] == id {
+				return true
+			}
+		}
+		return false
+	}
+
+	if !seen("") {
+		t.Error("an unfiltered list hides a server the same emulator just created: " +
+			"the create honoured the project and the list did not")
+	}
+	if seen("?project=" + defaultProjectID) {
+		t.Error("a list naming the default project answers another project's server")
+	}
+	if !seen("?organization=" + defaultOrganizationID) {
+		t.Error("an organization filter hides a project of that same organization")
+	}
+}
+
+// defaultOrganizationID is the one organization this emulator hosts.
+const defaultOrganizationID = "99999999-9999-4999-8999-999999999999"

--- a/internal/providers/scaleway/servers.go
+++ b/internal/providers/scaleway/servers.go
@@ -153,19 +153,47 @@ func (p *Pack) tenant(zone string) resource.Tenant {
 //
 // A project is an isolation boundary, not a label: two projects of the same
 // organization do not see each other, and a client that names one must never be
-// shown another one's resources. The rules follow the API. A `project` filter
-// scopes to it. An `organization` filter alone scopes to the whole account,
-// which here means every project, since the emulator hosts a single
-// organization. Neither means the token's default project.
+// shown another one's resources. A `project` filter scopes to it. An
+// `organization` filter alone scopes to the whole account, which here means
+// every project, since the emulator hosts a single organization.
+//
+// And an unfiltered list means the account too, not the default project. That
+// last line used to answer defaultProject under a comment that already said it
+// should not — "Neither means the token's default project" — which is the
+// repository's own defect: a sentence describing the fix, three lines above the
+// code that does the opposite.
+//
+// Measured on fr-par, 2026-09-02 (#369), with a second project created for the
+// occasion and deleted after:
+//
+//	GET /volumes                          the other project's volume: VISIBLE
+//	GET /volumes?project=<the default>    HIDDEN
+//	GET /volumes?organization=<the org>   VISIBLE
+//
+// So the create is authoritative — a create that honours a named project makes
+// that project real, and the list that follows answers it. The alternative the
+// issue offered, refusing a foreign project at creation, is the one the cloud
+// does not take: it accepted the create and then listed what it had made.
+//
+// What this is NOT: a client that names a project still sees only that project.
+// The isolation the previous behaviour was defending is the filtered read, and
+// it is untouched.
+//
+// TestAnUnfilteredListAnswersEveryProjectLikeTheCloud fails without this.
 func (p *Pack) scopeOf(r *http.Request, zone string) resource.Tenant {
 	q := r.URL.Query()
 	if project := q.Get("project"); project != "" {
 		return resource.Tenant{Provider: Name, Project: project, Zone: zone}
 	}
+	// The organization branch answers the same tenant as the fall-through, and
+	// it stays because the parameter has to be READ. #277's gate refuses a
+	// declared query parameter a handler never names: dropping this branch made
+	// four operations fail it at once, which is the gate doing exactly its job —
+	// an emulator that ignores a filter answers a superset and calls it a match.
 	if q.Get("organization") != "" {
 		return p.tenant(zone)
 	}
-	return resource.Tenant{Provider: Name, Project: defaultProject, Zone: zone}
+	return p.tenant(zone)
 }
 
 // projectOf resolves the project a create request belongs to, and the

--- a/tools/falsify/specs/unfiltered-list-scope.json
+++ b/tools/falsify/specs/unfiltered-list-scope.json
@@ -1,0 +1,26 @@
+{
+  "package": "./internal/providers/scaleway/",
+  "mutations": [
+    {
+      "label": "an unfiltered list goes back to the default project, so a server created under a named project is invisible to the list that follows it",
+      "file": "internal/providers/scaleway/servers.go",
+      "find": "\tif q.Get(\"organization\") != \"\" {\n\t\treturn p.tenant(zone)\n\t}\n\treturn p.tenant(zone)\n}",
+      "replace": "\tif q.Get(\"organization\") != \"\" {\n\t\treturn p.tenant(zone)\n\t}\n\treturn resource.Tenant{Provider: Name, Project: defaultProject, Zone: zone}\n}",
+      "test": "TestAnUnfilteredListAnswersEveryProjectLikeTheCloud"
+    },
+    {
+      "label": "a project filter is ignored, so the isolation the previous behaviour was defending is gone with it",
+      "file": "internal/providers/scaleway/servers.go",
+      "find": "\tif project := q.Get(\"project\"); project != \"\" {\n\t\treturn resource.Tenant{Provider: Name, Project: project, Zone: zone}\n\t}",
+      "replace": "\tif project := q.Get(\"project\"); project != \"\" && false {\n\t\treturn resource.Tenant{Provider: Name, Project: project, Zone: zone}\n\t}",
+      "test": "TestListsAreScopedToTheProject"
+    },
+    {
+      "label": "the create stops honouring the project it was given, which is the other half of the disagreement #369 named",
+      "file": "internal/providers/scaleway/servers.go",
+      "find": "func projectOf(requested string) (project, organization string) {\n\treturn orDefault(requested, defaultProject), defaultOrganization\n}",
+      "replace": "func projectOf(requested string) (project, organization string) {\n\treturn orDefault(requested[:0], defaultProject), defaultOrganization\n}",
+      "test": "TestListsAreScopedToTheProject"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #369.

## The question the issue left open, and who settled it

`createServer` honoured the `project` a request named; every unfiltered list
scoped itself to `defaultProject`. So a server created under a named project was
invisible to the list that followed it, and a client that creates then lists —
which is every client — read an empty fleet.

The issue named two coherent answers and took neither, because the emulator has
no credential to read "the caller's project" from. **The cloud settled it.**
Measured on `fr-par`, 2026-09-02, with a second project made for the occasion and
deleted after:

| request | the other project's volume |
|---|---|
| `GET /volumes` (no filter) | **visible** |
| `GET /volumes?project=<the default>` | hidden |
| `GET /volumes?organization=<the org>` | visible |

So **the create is authoritative**: naming a project makes it real, and an
unfiltered list answers the account. The other answer the issue offered —
refusing a foreign project at creation — is the one the cloud does not take: it
accepted the create and then listed what it had made.

The account is back to zero servers, volumes and addresses, and the probe project
is deleted.

## A comment that was already right

```go
// … An `organization` filter alone scopes to the whole account, which here means
// every project, since the emulator hosts a single organization. Neither means
// the token's default project.
func (p *Pack) scopeOf(…) resource.Tenant {
	…
	return resource.Tenant{Provider: Name, Project: defaultProject, Zone: zone}
}
```

Three lines apart. This is the repository's own named defect — a sentence
describing the fix, never asserted, therefore never a fix — and it is why the new
behaviour ships with a falsify spec rather than a paragraph.

## What did NOT change

The isolation the old behaviour was defending is the **filtered** read. A list
naming a project still answers that project alone.
`TestListsAreScopedToTheProject` keeps that half and loses the half that was
wrong; `TestAnUnfilteredListAnswersEveryProjectLikeTheCloud` carries the rest.

The `organization` branch of `scopeOf` now answers the same tenant as the
fall-through and stays anyway: #277's gate refuses a declared query parameter a
handler never names, and dropping the branch made four operations fail it at
once. That is the gate doing its job — an emulator that ignores a filter answers
a superset and calls it a match.

## Proof

- `corpus/accepted.json` loses its `instance/v1/API.ListServers` entry, and the
  gate asked for it in those words: *"excused nothing this run: either it is
  fixed and the entry goes, or the corpus no longer carries it"*.
- `mise run conformance:leg -- fields` green, 353 of 378 routes proven by a real
  client (unchanged).
- `tools/conformance/stacks.sh` against a host emulator, with `tofu`: both stacks
  applied, second plan empty, destroyed. **Run deliberately**, because the stacks
  are what neither `fields` nor `leg.sh` covers — the lesson #393 charged three
  red CI jobs for.
- `mise run falsify -- tools/falsify/specs/unfiltered-list-scope.json`: three
  mutations, three *the test bit*, all compiling.
- `mise run prepush` green.

Not run: the full `mise run conformance` pass. This branch is one of a batch; the
whole suite is played once on the assembled set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
