### PR TITLE
fix(outscale): the burst test slept where it should have waited, and main went red on it

### DIFF
--- a/internal/core/serialise/coalesce.go
+++ b/internal/core/serialise/coalesce.go
@@ -34,6 +34,33 @@ type Coalescer struct {
 	// numbered strictly above the value begun had when it arrived.
 	begun uint64
 	done  uint64
+	// waiting counts the callers parked on cond, and exists so a test can wait
+	// for a burst to have ARRIVED rather than sleep and hope. See Waiting.
+	waiting int
+}
+
+// Waiting is how many callers are parked waiting for a pass to cover them.
+//
+// It is an observation point for tests, and it is here rather than in a test
+// helper because the fact it reports is not observable from outside: a caller
+// that has entered Run has not necessarily reached the wait, and the difference
+// is exactly what a burst test depends on.
+//
+// The defect it was added for, on 2026-09-02: outscale's
+// TestConcurrentSubnetCreatesShareTheirIsolationPasses staged a burst of five
+// callers and then slept 100 ms, under a comment calling the pass count "a
+// staged fact rather than a bet". It was a bet, and macos-15-intel called it —
+// three passes instead of two, on the same tree that had passed on every other
+// runner minutes earlier. A caller still walking towards the wait when the held
+// pass is released starts a pass of its own, and the count is one higher.
+//
+// A number that moves the moment it is read, so it is only sound in the shape
+// the test uses it: wait for it to REACH a value that cannot then drop without
+// the test's own doing.
+func (c *Coalescer) Waiting() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.waiting
 }
 
 // Run executes pass, or waits for an execution that covers this call.
@@ -51,7 +78,9 @@ func (c *Coalescer) Run(pass func()) {
 	target := c.begun + 1
 	for c.done < target {
 		if c.running {
+			c.waiting++
 			c.cond.Wait()
+			c.waiting--
 			continue
 		}
 		c.running = true

--- a/internal/core/serialise/coalesce_test.go
+++ b/internal/core/serialise/coalesce_test.go
@@ -117,3 +117,102 @@ func TestAnIdleCoalescerRunsAtOnce(t *testing.T) {
 		t.Fatal("the pass did not run")
 	}
 }
+
+// Waiting reports the callers parked on the wait, and the two facts a burst test
+// needs from it: it reaches the number that arrived, and it is back to zero once
+// they are covered.
+//
+// It exists because a test cannot otherwise tell "the burst has arrived" from
+// "the burst is still walking towards the wait", and outscale's burst test slept
+// 100 ms instead — a bet that macos-15-intel called on 2026-09-02.
+func TestWaitingCountsTheCallersParkedOnAPass(t *testing.T) {
+	var c Coalescer
+	held := make(chan struct{})
+	started := make(chan struct{})
+	var once sync.Once
+
+	go c.Run(func() {
+		once.Do(func() { close(started) })
+		<-held
+	})
+	<-started
+
+	const burst = 5
+	var wg sync.WaitGroup
+	for i := 0; i < burst; i++ {
+		wg.Add(1)
+		go func() { defer wg.Done(); c.Run(func() {}) }()
+	}
+	deadline := time.Now().Add(30 * time.Second)
+	for c.Waiting() < burst {
+		if time.Now().After(deadline) {
+			t.Fatalf("Waiting reached %d of %d callers", c.Waiting(), burst)
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	close(held)
+	wg.Wait()
+	if got := c.Waiting(); got != 0 {
+		t.Errorf("Waiting is %d once every caller returned, want 0", got)
+	}
+}
+
+// A caller that arrives AFTER the covering pass has begun needs one of its own,
+// and that is the coalescer being correct rather than wasteful: the pass in
+// flight started before this caller's change, so nothing it does can cover it.
+//
+// This is the fact that made outscale's burst test flaky, and it is worth a test
+// of its own because the flake read as a defect in the coalescer. A burst of
+// five that all arrive in time costs two passes; one straggler makes it three,
+// legitimately. The old test slept 100 ms and then asserted "at most two", so on
+// a slow enough runner it was asserting that no straggler existed — a race, not
+// a property. Staged here instead of raced.
+func TestALateCallerNeedsAPassOfItsOwn(t *testing.T) {
+	var c Coalescer
+	var passes atomic.Int64
+	first := make(chan struct{})
+	second := make(chan struct{})
+	started := make(chan struct{}, 8)
+
+	pass := func() {
+		n := passes.Add(1)
+		started <- struct{}{}
+		switch n {
+		case 1:
+			<-first
+		case 2:
+			<-second
+		}
+	}
+
+	go c.Run(pass) // pass 1, held open
+	<-started
+
+	// One caller arrives while pass 1 runs: it will be covered by pass 2.
+	intime := make(chan struct{})
+	go func() { c.Run(pass); close(intime) }()
+	for c.Waiting() < 1 {
+		time.Sleep(time.Millisecond)
+	}
+
+	close(first) // pass 1 ends, pass 2 begins and is held
+	<-started
+
+	// The straggler arrives now, with pass 2 already running. Nothing pass 2
+	// does can cover it, so it must run a third.
+	late := make(chan struct{})
+	go func() { c.Run(pass); close(late) }()
+	for c.Waiting() < 1 {
+		time.Sleep(time.Millisecond)
+	}
+
+	close(second) // pass 2 ends, pass 3 begins for the straggler
+	<-started
+	<-intime
+	<-late
+
+	if got := passes.Load(); got != 3 {
+		t.Fatalf("a burst with one straggler cost %d passes, want 3: two for the burst and one the late caller cannot share", got)
+	}
+}

--- a/internal/providers/outscale/isolate_pass_internal_test.go
+++ b/internal/providers/outscale/isolate_pass_internal_test.go
@@ -98,13 +98,31 @@ func TestConcurrentSubnetCreatesShareTheirIsolationPasses(t *testing.T) {
 	}
 	go func() { wg.Wait(); close(burstDone) }()
 
-	// Long enough for every burst caller to have reached the coalescer while
-	// the first pass is still held open — which is what makes the pass count
-	// below a staged fact rather than a bet.
+	// Every burst caller has to have REACHED the coalescer while the first pass
+	// is still held open, or the count below means nothing: a caller still
+	// walking towards the wait when the held pass is released starts a pass of
+	// its own.
+	//
+	// This was a 100 ms sleep, under a comment calling the result "a staged fact
+	// rather than a bet". It was a bet, and macos-15-intel called it on
+	// 2026-09-02: three passes instead of two, on a tree that had passed on
+	// every other runner minutes earlier, with nothing in the change touching
+	// this pack. Waiting on the fact itself makes the sentence true.
+	deadline := time.Now().Add(30 * time.Second)
+	for p.isolation.Waiting() < burst {
+		if time.Now().After(deadline) {
+			t.Fatalf("only %d of %d burst callers reached the coalescer", p.isolation.Waiting(), burst)
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	// And none of them may have returned: the only pass in flight predates their
+	// subnets, so satisfying one would be the coalescer covering a change the
+	// running pass never read.
 	select {
 	case <-burstDone:
 		t.Fatal("a burst caller returned while the only pass in flight predates its subnet")
-	case <-time.After(100 * time.Millisecond):
+	default:
 	}
 
 	close(driver.release)


### PR DESCRIPTION
`main` went red on 2026-09-02: the `Go` workflow, job `Test on macos-15-intel`,
on the merge commit of #636 — the same tree that had passed on every runner
minutes earlier as the pull request, with nothing in that change touching this
pack.

```
--- FAIL: TestConcurrentSubnetCreatesShareTheirIsolationPasses (0.16s)
    a burst of 5 callers inside one pass cost 3 passes; sharing means the pass
    in flight plus one, and one per caller is #473's slope
```

## What was actually wrong

The test staged five concurrent callers, **slept 100 ms**, and then asserted the
pass count — under a comment calling the result *"a staged fact rather than a
bet"*.

It was a bet. A caller still walking towards the coalescer's wait when the held
pass is released starts a pass of its own, and the count is one higher. On a slow
enough runner the sleep was asserting that no straggler existed, which is a race
rather than a property.

This is the repository's own named defect in its most literal form: a comment
saying the case is handled, three lines above the code that does not handle it.

## The fix

`serialise.Coalescer` gains `Waiting()`, the number of callers parked on the
wait. It is production code for a test's sake and that is deliberate: a test
cannot otherwise tell *"the burst has arrived"* from *"the burst is still
walking"*, and the difference is the whole fact this test depends on. The
outscale test waits on it instead of sleeping.

## The coalescer was never wrong, and two tests now say so from both sides

- **`TestWaitingCountsTheCallersParkedOnAPass`** — `Waiting` reaches the number
  that arrived, and returns to zero once they are covered.
- **`TestALateCallerNeedsAPassOfItsOwn`** — a burst of five that all arrive in
  time costs two passes, and one straggler makes it **three**, legitimately: the
  pass in flight began before that caller's change, so nothing it does can cover
  it. Staged rather than raced.

That three is exactly what `macos-15-intel` saw. The flake read as a defect in
the coalescer and was not one, which is why it is worth a test of its own.

## What is not proven

**The failure does not reproduce on this machine** — `-race`, `-cpu=1`,
`-count=40`, every core saturated with busy loops, both before and after the
change. Saying so rather than claiming a repro I do not have.

What is proven is the mechanism (the second test above) and the removal of the
timing dependency the failure needed. `-count=50 -cpu=1 -race` on the fixed test
is green, which is evidence of nothing on its own — the old one passed that way
too.

`mise run prepush` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
