### PR TITLE
fix(scaleway): two refusals answered the wrong status, and a client branches on exactly that (#394)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -43,6 +43,40 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Corrigé
 
+- **Deux refus répondaient le mauvais statut, et c'est exactement là-dessus qu'un
+  client branche** (#394). Un 404 dit « crée le parent d'abord », un 400 dit
+  « ton corps est mauvais et le parent n'y est pour rien », un 403 dit « tu n'as
+  pas le droit ici », et Terraform ne réessaie aucun des trois de la même façon.
+
+  `vpc/v2 CreateRoute` résolvait le VPC avant de lire le corps. Mesuré sur fr-par
+  le 2026-09-02, avec un `vpc_id` qui ne nomme rien :
+
+  | requête | réponse de `fr-par` |
+  |---|---|
+  | aucun next hop | 400, `argument_name: route`, `requires_one_of: {"fields": "nexthop_vpc_connector_id, nexthop_private_network_id"}` |
+  | avec un next hop | 404 `resource is not found` |
+  | aucun `vpc_id` | 400, `argument_name: vpc_id`, `help_message: "uuid: {}"` |
+
+  Le cloud ne valide donc pas « le corps d'abord » par habitude : sa couche
+  générée applique ce que **le document déclare**, un champ requis, une forme
+  d'UUID, un `requires_one_of`, et ce n'est qu'ensuite qu'un handler résout quoi
+  que ce soit. La même requête répond 400 ou 404 selon celui des deux murs
+  qu'elle rencontre, et cet émulateur répondait 404 aux trois.
+
+  `lb/v1 CreateRoute` répondait 404 pour un frontend inexistant, là où fr-par
+  répond **403**, et c'est la réponse propre à cette route et non au produit :
+  `GET /frontends/{id}` et `GET /lbs/{id}` répondent 404 des deux côtés. Le
+  statut est désormais celui du cloud.
+
+  **Une divergence demeure, et elle est écrite plutôt que laissée implicite.**
+  `lb/v1` n'envoie aucune enveloppe d'erreur `scw` sur ces trois refus : ni
+  `type`, ni `details`. Cet émulateur en envoie une, parce que
+  `contracts/scaleway.json` déclare un `errorSchema` unique pour tout le
+  document, `scw.ResponseError` avec `required: ["type"]`, extrait du SDK, et que
+  `internal/probe` valide chaque refus contre lui. Lever cela demande un
+  `errorSchema` par produit, arbitré par un enregistrement plutôt que par un
+  document. `docs/limits.md` le porte.
+
 - **Une création nommant un projet inexistant était acceptée ici et refusée par
   le cloud, sur sept produits** (#391). Enregistré par #390 et relu champ par
   champ le 2026-09-02, parce que le corpus rédige les valeurs et que les mots

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,40 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Fixed
 
+- **Two refusals answered the wrong status, and a client branches on exactly
+  that** (#394). A 404 says "create the parent first", a 400 says "your body is
+  wrong and the parent is beside the point", a 403 says "you are not allowed
+  here", and Terraform retries none of the three the same way.
+
+  `vpc/v2 CreateRoute` resolved the VPC before it read the body. Measured on
+  fr-par, 2026-09-02, with a `vpc_id` that names nothing:
+
+  | request | `fr-par` answers |
+  |---|---|
+  | no next hop at all | 400, `argument_name: route`, `requires_one_of: {"fields": "nexthop_vpc_connector_id, nexthop_private_network_id"}` |
+  | with a next hop | 404 `resource is not found` |
+  | no `vpc_id` at all | 400, `argument_name: vpc_id`, `help_message: "uuid: {}"` |
+
+  So the cloud is not validating the body first as a habit: its generated layer
+  enforces what the **document declares** — a required field, a UUID shape, a
+  `requires_one_of` — and only then does a handler resolve anything. The same
+  request answers 400 or 404 depending on which of those two walls it meets, and
+  this emulator answered 404 to all three.
+
+  `lb/v1 CreateRoute` answered 404 for a frontend that does not exist, where
+  fr-par answers **403** — and that is this route's own answer rather than the
+  product's: `GET /frontends/{id}` and `GET /lbs/{id}` both answer 404 on both
+  sides. The status is now the cloud's.
+
+  **One divergence stays, and it is written down rather than left implicit.**
+  `lb/v1` sends no `scw` error envelope on any of those three refusals: no
+  `type`, no `details`. This emulator sends one, because
+  `contracts/scaleway.json` declares a single `errorSchema` for the whole
+  document — `scw.ResponseError`, `required: ["type"]`, extracted from the SDK —
+  and `internal/probe` validates every refusal against it. Lifting that means an
+  `errorSchema` per product, arbitrated by a recording rather than a document.
+  `docs/limits.md` carries it.
+
 - **A create naming a project that does not exist was accepted here and refused
   by the cloud, across seven products** (#391). Recorded in #390 and re-read
   field by field on 2026-09-02, because the corpus redacts values and the words

--- a/README.fr.md
+++ b/README.fr.md
@@ -31,7 +31,7 @@
 >
 > **Prouvé** : 354 des 379 opérations montées sont pilotées par un vrai client, à chaque pull request. `scw`, `octl`, `exo`, Terraform et OpenTofu tournent contre l'émulateur en CI, et les machines démarrent réellement : connexion ssh sur le compte par défaut de chaque provider, subnets isolés, pare-feu qui filtre. La chaîne complète est décrite dans [docs/conformance.md](docs/conformance.md).
 >
-> **Pas prouvé** : quotas, prix, capacité réelle, validation des identifiants, authentification, cohérence à terme. Les 52 sections de [docs/limits.md](docs/limits.md) disent chacune ce qu'elle coûte. Un émulateur avec un seul compte implicite et aucune grille tarifaire devrait inventer ces chiffres, et quelqu'un agirait dessus.
+> **Pas prouvé** : quotas, prix, capacité réelle, validation des identifiants, authentification, cohérence à terme. Les 53 sections de [docs/limits.md](docs/limits.md) disent chacune ce qu'elle coûte. Un émulateur avec un seul compte implicite et aucune grille tarifaire devrait inventer ces chiffres, et quelqu'un agirait dessus.
 >
 > **Inconnu** : 25 opérations sont montées et n'ont jamais été pilotées par un client. Chacune dit pourquoi aucun client officiel ne l'atteint, à la route et dans [docs/routes.md](docs/routes.md). Elles sont comptées plutôt qu'escamotées, une par une, dans [coverage/evidence.json](coverage/evidence.json).
 >

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 >
 > **Proven**: 354 of the 379 mounted operations are driven by a real client, on every pull request: each pack's own official CLI, and an infrastructure engine wherever a pack admits one, all of them running against the emulator in CI, and machines really boot: an ssh login on each provider's own default account, isolated subnets, a firewall that filters. The whole chain is described in [docs/conformance.md](docs/conformance.md).
 >
-> **Not proven**: quotas, prices, real capacity, identifier validation, authentication, eventual consistency. The 52 sections of [docs/limits.md](docs/limits.md) each say what one costs. An emulator with a single implicit account and no price list would have to invent those figures, and somebody would act on them.
+> **Not proven**: quotas, prices, real capacity, identifier validation, authentication, eventual consistency. The 53 sections of [docs/limits.md](docs/limits.md) each say what one costs. An emulator with a single implicit account and no price list would have to invent those figures, and somebody would act on them.
 >
 > **Unknown**: 25 operations are mounted and have never been driven by a client. Every one of them states why no official client reaches it, at the route and in [docs/routes.md](docs/routes.md). They are counted rather than glossed, one by one, in [coverage/evidence.json](coverage/evidence.json).
 >

--- a/corpus/accepted.json
+++ b/corpus/accepted.json
@@ -1223,14 +1223,6 @@
     },
     {
       "file": "scaleway/scw-refusals.jsonl",
-      "operation": "lb/v1/ZonedAPI.CreateRoute",
-      "kind": "status",
-      "path": "",
-      "reason": "Both sides refuse and disagree on which refusal it is: upstream validates the body before it resolves the parent (400 naming the field) where this pack resolves the parent first (404), and lb answers 403 where the frontend is simply absent. A client branches on the status, so the difference is not cosmetic; changing it is a rule about every handler rather than about these two.",
-      "issue": "https://github.com/stephrobert/feint/issues/394"
-    },
-    {
-      "file": "scaleway/scw-refusals.jsonl",
       "operation": "marketplace/v2/API.ListLocalImages",
       "kind": "absent",
       "path": "message",
@@ -1268,22 +1260,6 @@
       "path": "",
       "reason": "An image identifier that names nothing answers success here by decision: getImage serves the default catalogue entry for an unknown ID (docs/limits.md, so a script holding a real one keeps working), the marketplace local-image list does the same, and the Outscale createVms never looks the image up. The cloud refuses all three. A fix has to say what an emulator with no account does with an image identifier it never minted, and corpus/outscale/oapi-cli-lifecycle.jsonl is what would grade the answer.",
       "issue": "https://github.com/stephrobert/feint/issues/392"
-    },
-    {
-      "file": "scaleway/scw-refusals.jsonl",
-      "operation": "vpc/v2/API.CreateRoute",
-      "kind": "absent",
-      "path": "details",
-      "reason": "Both sides refuse and disagree on which refusal it is: upstream validates the body before it resolves the parent (400 naming the field) where this pack resolves the parent first (404), and lb answers 403 where the frontend is simply absent. A client branches on the status, so the difference is not cosmetic; changing it is a rule about every handler rather than about these two.",
-      "issue": "https://github.com/stephrobert/feint/issues/394"
-    },
-    {
-      "file": "scaleway/scw-refusals.jsonl",
-      "operation": "vpc/v2/API.CreateRoute",
-      "kind": "status",
-      "path": "",
-      "reason": "Both sides refuse and disagree on which refusal it is: upstream validates the body before it resolves the parent (400 naming the field) where this pack resolves the parent first (404), and lb answers 403 where the frontend is simply absent. A client branches on the status, so the difference is not cosmetic; changing it is a rule about every handler rather than about these two.",
-      "issue": "https://github.com/stephrobert/feint/issues/394"
     },
     {
       "file": "scaleway/terraform.jsonl",

--- a/docs/limits-acks.json
+++ b/docs/limits-acks.json
@@ -16,7 +16,7 @@
     "An Outscale load balancer distributes packets inside its network, and nowhere else": "2026-08-27",
     "An Outscale machine owns a root volume, and that volume holds no bytes": "2026-08-27",
     "Exoscale has one zone per process, and the reason is the client": "2026-08-27",
-    "Identifiers are not checked against anything": "2026-08-27",
+    "Identifiers are not checked against anything": "2026-09-02",
     "Lifecycle transitions are immediate": "2026-08-29",
     "Managed Kubernetes is not emulated, and a CRUD-only version is refused (#283)": "2026-08-27",
     "Object Storage is not emulated": "2026-08-27",

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -571,6 +571,37 @@ the table is its fix); an emulator-side refusal would add a second wall for
 raw SDK users and catch nothing the first does not. The real cloud does
 refuse an unknown type, so this is a divergence, recorded here on purpose.
 
+## `lb/v1` refusals carry an envelope the real one does not
+
+Measured on `fr-par`, 2026-09-02 (#394). Three refusals of the load balancer
+product, and not one of them carries the `scw` error envelope:
+
+| request | `fr-par` answers |
+|---|---|
+| `POST /lb/v1/zones/fr-par-1/routes`, frontend that does not exist | 403 `{"message": "Permission denied"}` |
+| `GET /lb/v1/zones/fr-par-1/frontends/{id}`, absent | 404 `{"message": "frontend not Found"}` |
+| `GET /lb/v1/zones/fr-par-1/lbs/{id}`, absent | 404 `{"message": "lbs not Found"}` |
+
+No `type`, no `details`, no `resource`. This emulator answers all three with the
+envelope, and the reason is structural rather than chosen:
+`contracts/scaleway.json` declares **one** `errorSchema` for the whole document,
+`scw.ResponseError` with `required: ["type"]`, extracted from the SDK — and
+`internal/probe` validates every refusal against it. A body without `type` fails
+the probe, which is the gate being right about the document it was given, and the
+document being a document rather than a recording.
+
+**What is faithful is the status**, which is the half a client branches on:
+`POST /routes` answers 403 here now, where this emulator used to answer 404 and
+where the two reads beside it answer 404 on both sides. Terraform retries a 403
+and a 404 differently.
+
+Lifting this means giving the contract an `errorSchema` per product rather than
+per document, and a way to say "this product's refusals are not validatable
+against the SDK's struct" that a recording rather than a document arbitrates.
+`RecordedFields` already does the opposite direction — a field a recording
+carries and the document does not declare — and the symmetric one does not exist
+yet.
+
 ## Identifiers are not checked against anything
 
 A create that names an image, a template or a machine type the emulator has never

--- a/internal/providers/scaleway/errors.go
+++ b/internal/providers/scaleway/errors.go
@@ -150,3 +150,37 @@ func writeProjectStillInUse(w http.ResponseWriter) {
 		HelpMessage:  "all resources are not deleted",
 	})
 }
+
+// writePermissionDenied answers lb/v1's refusal for a frontend it does not hold.
+//
+// The STATUS is the measurement and the point of #394: fr-par answers 403 here
+// where its own reads of the same absent frontend answer 404, so a client
+// branching on the status — which Terraform does, retrying a 403 and a 404
+// differently — took the wrong path against this emulator.
+//
+// The message is the cloud's word for word. The `type` is NOT, and that is a
+// known divergence rather than an oversight, so it is written here:
+//
+//	fr-par POST /lb/v1/zones/fr-par-1/routes  403 {"message": "Permission denied"}
+//	fr-par GET  /lb/v1/.../frontends/{ghost}  404 {"message": "frontend not Found"}
+//	fr-par GET  /lb/v1/.../lbs/{ghost}        404 {"message": "lbs not Found"}
+//
+// lb/v1 sends no scw error envelope at all, on any of the three. This pack does,
+// on every one of them — writeNotFound has answered lb/v1's 404s with a `type`
+// since long before this route existed — and the reason is structural rather
+// than chosen: contracts/scaleway.json declares ONE errorSchema for the whole
+// document (scw.ResponseError, `required: ["type"]`), extracted from the SDK,
+// and internal/probe validates every refusal against it. A body without `type`
+// fails that probe, which is the gate being right about the document it was
+// given and the document being a document rather than a recording.
+//
+// So this answers the status the cloud answers, in the envelope this pack serves
+// for the whole product. Making the envelope per-product is a change to the
+// contract extraction, and docs/limits.md carries it as a limit rather than
+// leaving it implicit here.
+func writePermissionDenied(w http.ResponseWriter) {
+	emulator.WriteJSON(w, http.StatusForbidden, APIError{
+		Type:    "permissions_denied",
+		Message: "Permission denied",
+	})
+}

--- a/internal/providers/scaleway/loadbalancer_children.go
+++ b/internal/providers/scaleway/loadbalancer_children.go
@@ -921,9 +921,26 @@ func (p *Pack) createLBRoute(w http.ResponseWriter, r *http.Request) {
 		writeInvalidArguments(w, ArgumentError{ArgumentName: "body", Reason: "format", HelpMessage: err.Error()})
 		return
 	}
+	// 403 and not 404, and it is measured rather than reasoned (#394). Against
+	// fr-par, 2026-09-02, with a frontend identifier that names nothing:
+	//
+	//	POST   /lb/v1/zones/fr-par-1/routes         403 {"message": "Permission denied"}
+	//	GET    /lb/v1/zones/fr-par-1/frontends/{id} 404 {"message": "frontend not Found"}
+	//	GET    /lb/v1/zones/fr-par-1/lbs/{id}       404 {"message": "lbs not Found"}
+	//
+	// So this is not the product answering 403 to everything it does not hold —
+	// the two reads beside it answer 404. It is this route's own answer, and it
+	// is the platform's choice rather than a shape worth improving: rule 4 says
+	// to copy it. A client branches on the status, and Terraform retries a 403
+	// and a 404 differently.
+	//
+	// The body carries `message` alone, with no `type`, which is the older lb/v1
+	// error shape and another thing nobody would invent.
+	//
+	// TestALBRouteRefusesAnAbsentFrontendTheWayTheCloudDoes fails without this.
 	fe, found := p.env.Store.Get(Name, kindLBFrontend, req.FrontendID)
 	if !found || fe.Tenant.Zone != zone {
-		writeNotFound(w, "frontend", req.FrontendID)
+		writePermissionDenied(w)
 		return
 	}
 	backend, found := p.env.Store.Get(Name, kindLBBackend, req.BackendID)

--- a/internal/providers/scaleway/routes.go
+++ b/internal/providers/scaleway/routes.go
@@ -57,6 +57,33 @@ func (p *Pack) createRoute(w http.ResponseWriter, r *http.Request) {
 		writeInvalidArguments(w, ArgumentError{ArgumentName: "body", Reason: "format", HelpMessage: err.Error()})
 		return
 	}
+	// What the document DECLARES is checked before what the store HOLDS, and
+	// that ordering is measured rather than preferred (#394). Against fr-par,
+	// 2026-09-02, with a vpc_id that names nothing:
+	//
+	//	no next hop at all   400 invalid_arguments, argument_name "route",
+	//	                     help_message `requires_one_of: {"fields":
+	//	                     "nexthop_vpc_connector_id, nexthop_private_network_id"}`
+	//	with a next hop      404 resource is not found
+	//	no vpc_id at all     400 invalid_arguments, argument_name "vpc_id",
+	//	                     help_message "uuid: {}"
+	//
+	// So the cloud is not "validating the body first" as a habit: its generated
+	// layer enforces the constraints the document declares — a required field, a
+	// UUID shape, a requires_one_of — and only then does a handler resolve
+	// anything. The same request answers 400 or 404 depending on which of those
+	// two walls it meets, and a client branches on exactly that: 404 says
+	// "create the parent first", 400 says "your body is wrong and the parent is
+	// beside the point".
+	//
+	// This emulator resolved the VPC first and answered 404 to both.
+	//
+	// TestCreateRouteChecksWhatTheDocumentDeclaresBeforeWhatTheStoreHolds fails
+	// without this.
+	if bad := routeBodyFault(req); bad != nil {
+		writeInvalidArguments(w, *bad)
+		return
+	}
 	vpc, found := p.env.Store.Get(Name, kindVPC, req.VpcID)
 	if !found || vpc.Tenant.Zone != region {
 		writeNotFound(w, "vpc", req.VpcID)
@@ -233,4 +260,35 @@ func setOrDelete(attrs map[string]any, key, value string) {
 		return
 	}
 	attrs[key] = value
+}
+
+// routeBodyFault answers the constraint vpc/v2's document declares on a route,
+// or nil when the body satisfies them.
+//
+// Two constraints, both transcribed from what fr-par answered rather than
+// paraphrased. The help_message of the first is a JSON fragment inside a string,
+// which is not a shape anyone would invent: the cloud's generated layer renders
+// its constraint that way and a client reads it back verbatim.
+//
+// The order between them is measured too: a body with neither a vpc_id nor a
+// next hop answers about vpc_id, so the field-level constraints come before the
+// object-level one.
+func routeBodyFault(req createRouteRequest) *ArgumentError {
+	if req.VpcID == "" {
+		return &ArgumentError{
+			ArgumentName: "vpc_id",
+			Reason:       "unknown",
+			HelpMessage:  "uuid: {}",
+		}
+	}
+	connector := req.NexthopVpcConnectorID != nil && *req.NexthopVpcConnectorID != ""
+	network := req.NexthopPrivateNetworkID != nil && *req.NexthopPrivateNetworkID != ""
+	if !connector && !network {
+		return &ArgumentError{
+			ArgumentName: "route",
+			Reason:       "unknown",
+			HelpMessage:  `requires_one_of: {"fields": "nexthop_vpc_connector_id, nexthop_private_network_id"}`,
+		}
+	}
+	return nil
 }

--- a/internal/providers/scaleway/routes_test.go
+++ b/internal/providers/scaleway/routes_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
@@ -234,11 +235,71 @@ func TestARouteRefusesWhatCannotExistHere(t *testing.T) {
 		t.Fatalf("a foreign nexthop network was accepted: status %d", status)
 	}
 
-	// An unknown VPC is not found, in the SDK's shape.
+	// An unknown VPC is not found, in the SDK's shape — and the body has to be
+	// valid for the request to reach that wall at all. This case used to send no
+	// next hop and expect 404, which is the very thing #394 measured as wrong:
+	// fr-par answers 400 there, about the body, and 404 only once the body
+	// satisfies the constraints its document declares.
 	status, _ = do(t, ts, "POST", vpcRegion+"/routes",
-		`{"vpc_id":"00000000-dead-4000-8000-000000000000","destination":"10.9.0.0/24"}`)
+		fmt.Sprintf(`{"vpc_id":"00000000-dead-4000-8000-000000000000","destination":"10.9.0.0/24","nexthop_private_network_id":%q}`, otherPN))
 	if status != http.StatusNotFound {
 		t.Fatalf("an unknown VPC answered %d", status)
+	}
+}
+
+// The order the two refusals come in, measured against fr-par on 2026-09-02
+// (#394). A client branches on the status: 404 says "create the parent first",
+// 400 says "your body is wrong and the parent is beside the point", and this
+// emulator answered 404 to both.
+func TestCreateRouteChecksWhatTheDocumentDeclaresBeforeWhatTheStoreHolds(t *testing.T) {
+	ts := newTestServer(t)
+	const ghost = "00000000-dead-4000-8000-000000000000"
+
+	// A ghost VPC and no next hop: the cloud answers about the next hop, not
+	// about the VPC it was never asked to resolve.
+	status, body := do(t, ts, "POST", vpcRegion+"/routes",
+		`{"vpc_id":"`+ghost+`","destination":"10.9.0.0/24"}`)
+	if status != http.StatusBadRequest {
+		t.Fatalf("a body missing its next hop answered %d, want 400 (%v)", status, body)
+	}
+	details, _ := body["details"].([]any)
+	if len(details) != 1 {
+		t.Fatalf("details holds %d entries, want 1 (%v)", len(details), body)
+	}
+	d, _ := details[0].(map[string]any)
+	if d["argument_name"] != "route" {
+		t.Errorf("argument_name is %v, want route: the constraint is on the object, not on a field", d["argument_name"])
+	}
+	// The help_message is a JSON fragment inside a string, which is not a shape
+	// anyone would invent — the cloud's generated layer renders it that way.
+	if help, _ := d["help_message"].(string); !strings.Contains(help, "requires_one_of") ||
+		!strings.Contains(help, "nexthop_private_network_id") {
+		t.Errorf("help_message is %q, want the requires_one_of the cloud answers", help)
+	}
+
+	// No vpc_id at all: the field-level constraint comes before the object-level
+	// one, so this answers about vpc_id rather than about the next hop.
+	status, body = do(t, ts, "POST", vpcRegion+"/routes", `{"destination":"10.9.0.0/24"}`)
+	if status != http.StatusBadRequest {
+		t.Fatalf("a body with no vpc_id answered %d, want 400 (%v)", status, body)
+	}
+	details, _ = body["details"].([]any)
+	d, _ = details[0].(map[string]any)
+	if d["argument_name"] != "vpc_id" {
+		t.Errorf("argument_name is %v, want vpc_id", d["argument_name"])
+	}
+	if d["help_message"] != "uuid: {}" {
+		t.Errorf("help_message is %v, want the cloud's own \"uuid: {}\"", d["help_message"])
+	}
+
+	// And the accepting half: a body the document is happy with reaches the
+	// store, and THEN the ghost VPC is not found. Without this a guard that
+	// refused every route would pass the two cases above.
+	pnID, _ := createPN(t, ts, "10.86.0.0/24")
+	status, body = do(t, ts, "POST", vpcRegion+"/routes",
+		fmt.Sprintf(`{"vpc_id":%q,"destination":"10.9.0.0/24","nexthop_private_network_id":%q}`, ghost, pnID))
+	if status != http.StatusNotFound {
+		t.Fatalf("a valid body naming a ghost VPC answered %d, want 404 (%v)", status, body)
 	}
 }
 
@@ -316,5 +377,46 @@ func TestAVPCCreatedWithoutEnableRoutingRoutes(t *testing.T) {
 					tc.name, peered, tc.routing, rt.peersOf(first), rt.peersOf(second))
 			}
 		})
+	}
+}
+
+// lb/v1 answers 403 for a frontend it does not hold, where its own reads answer
+// 404 (#394).
+//
+// Measured on fr-par, 2026-09-02: POST /routes with a ghost frontend answers
+// 403 {"message": "Permission denied"}, while GET /frontends/{id} and
+// GET /lbs/{id} both answer 404. So this is not the product refusing everything
+// it cannot see — it is this route's own answer, and the emulator answered 404.
+//
+// The body carries `message` alone, with no `type`: the older lb/v1 error shape,
+// which is why it does not share a helper with the projectguard's 403.
+func TestALBRouteRefusesAnAbsentFrontendTheWayTheCloudDoes(t *testing.T) {
+	ts := newTestServer(t)
+	const ghost = "00000000-dead-4000-8000-000000000000"
+
+	status, body := do(t, ts, "POST", "/lb/v1/zones/fr-par-1/routes",
+		`{"frontend_id":"`+ghost+`","backend_id":"`+ghost+`","match":{"sni":"probe.example.com"}}`)
+	if status != http.StatusForbidden {
+		t.Fatalf("a route naming a frontend nothing holds answered %d, want 403 (%v)", status, body)
+	}
+	if body["message"] != "Permission denied" {
+		t.Errorf("message is %v, want the cloud's own \"Permission denied\"", body["message"])
+	}
+	// The `type` this pack adds and lb/v1 does not send: asserted rather than
+	// left to drift, because it is a known divergence and the contract is why.
+	// contracts/scaleway.json declares one errorSchema for the whole document,
+	// scw.ResponseError with `required: ["type"]`, so a body without it fails
+	// internal/probe. docs/limits.md carries the limit.
+	if body["type"] != "permissions_denied" {
+		t.Errorf("type is %v, want the envelope this pack serves for all of lb/v1", body["type"])
+	}
+
+	// The reads beside it still answer 404, which is what makes the 403 above a
+	// property of the route rather than of the product.
+	if status, _ := do(t, ts, "GET", "/lb/v1/zones/fr-par-1/frontends/"+ghost, ""); status != http.StatusNotFound {
+		t.Errorf("GET a frontend that does not exist answered %d, want 404", status)
+	}
+	if status, _ := do(t, ts, "GET", "/lb/v1/zones/fr-par-1/lbs/"+ghost, ""); status != http.StatusNotFound {
+		t.Errorf("GET a load balancer that does not exist answered %d, want 404", status)
 	}
 }

--- a/tools/falsify/specs/refusal-order-and-status.json
+++ b/tools/falsify/specs/refusal-order-and-status.json
@@ -1,0 +1,40 @@
+{
+  "package": "./internal/providers/scaleway/",
+  "mutations": [
+    {
+      "label": "the body constraints stop firing altogether, so a request missing its next hop answers 404 about a parent the cloud never looked at",
+      "file": "internal/providers/scaleway/routes.go",
+      "find": "\tif bad := routeBodyFault(req); bad != nil {\n\t\twriteInvalidArguments(w, *bad)\n\t\treturn\n\t}\n\tvpc, found := p.env.Store.Get(Name, kindVPC, req.VpcID)",
+      "replace": "\tif bad := routeBodyFault(req); bad != nil && false {\n\t\twriteInvalidArguments(w, *bad)\n\t\treturn\n\t}\n\tvpc, found := p.env.Store.Get(Name, kindVPC, req.VpcID)",
+      "test": "TestCreateRouteChecksWhatTheDocumentDeclaresBeforeWhatTheStoreHolds"
+    },
+    {
+      "label": "the requires_one_of constraint stops firing, so a route with no next hop is created rather than refused",
+      "file": "internal/providers/scaleway/routes.go",
+      "find": "\tif !connector && !network {",
+      "replace": "\tif !connector && !network && false {",
+      "test": "TestCreateRouteChecksWhatTheDocumentDeclaresBeforeWhatTheStoreHolds"
+    },
+    {
+      "label": "the field constraint yields to the object one, so a body with no vpc_id is told about its next hop instead",
+      "file": "internal/providers/scaleway/routes.go",
+      "find": "\tif req.VpcID == \"\" {\n\t\treturn &ArgumentError{\n\t\t\tArgumentName: \"vpc_id\",",
+      "replace": "\tif req.VpcID == \"\" && false {\n\t\treturn &ArgumentError{\n\t\t\tArgumentName: \"vpc_id\",",
+      "test": "TestCreateRouteChecksWhatTheDocumentDeclaresBeforeWhatTheStoreHolds"
+    },
+    {
+      "label": "the lb route answers 404 for an absent frontend again, so a client that retries a 403 differently takes the wrong path",
+      "file": "internal/providers/scaleway/loadbalancer_children.go",
+      "find": "\tfe, found := p.env.Store.Get(Name, kindLBFrontend, req.FrontendID)\n\tif !found || fe.Tenant.Zone != zone {\n\t\twritePermissionDenied(w)\n\t\treturn\n\t}",
+      "replace": "\tfe, found := p.env.Store.Get(Name, kindLBFrontend, req.FrontendID)\n\tif !found || fe.Tenant.Zone != zone {\n\t\twriteNotFound(w, \"frontend\", req.FrontendID)\n\t\t_ = writePermissionDenied\n\t\treturn\n\t}",
+      "test": "TestALBRouteRefusesAnAbsentFrontendTheWayTheCloudDoes"
+    },
+    {
+      "label": "the 403 stops carrying the cloud's own message, so a client reads a sentence fr-par never sent",
+      "file": "internal/providers/scaleway/errors.go",
+      "find": "\t\tType:    \"permissions_denied\",\n\t\tMessage: \"Permission denied\",",
+      "replace": "\t\tType:    \"permissions_denied\",\n\t\tMessage: \"insufficient permissions\",",
+      "test": "TestALBRouteRefusesAnAbsentFrontendTheWayTheCloudDoes"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #394.

Both sides refused, and they disagreed on which refusal it was. A client branches
on exactly that: a 404 says *"create the parent first"*, a 400 says *"your body is
wrong and the parent is beside the point"*, a 403 says *"you are not allowed
here"*, and Terraform retries none of the three the same way.

## `vpc/v2 CreateRoute`: what the document declares, before what the store holds

The issue asked whether refusals should validate the body before resolving the
parent, "a rule that applies to every handler and not to these two". Measured
against `fr-par`, 2026-09-02, with a `vpc_id` that names nothing — and the answer
is more precise than the question:

| request | `fr-par` answers |
|---|---|
| no next hop at all | 400, `argument_name: route`, `requires_one_of: {"fields": "nexthop_vpc_connector_id, nexthop_private_network_id"}` |
| **with** a next hop | 404 `resource is not found` |
| no `vpc_id` at all | 400, `argument_name: vpc_id`, `help_message: "uuid: {}"` |

So the cloud is **not** validating the body first as a habit. Its generated layer
enforces what the *document declares* — a required field, a UUID shape, a
`requires_one_of` — and only then does a handler resolve anything. The same
request answers 400 or 404 depending on which of those two walls it meets. This
emulator resolved the VPC first and answered 404 to all three.

The `help_message` of the first is a JSON fragment inside a string, which is not
a shape anyone would invent.

## `lb/v1 CreateRoute`: 403, and it is the route's answer rather than the product's

The issue asked whether this one is worth reproducing at all. Measured, it is —
and the measurement is what settles it:

| request | `fr-par` answers |
|---|---|
| `POST /routes`, frontend that does not exist | **403** `{"message": "Permission denied"}` |
| `GET /frontends/{id}`, absent | 404 `{"message": "frontend not Found"}` |
| `GET /lbs/{id}`, absent | 404 `{"message": "lbs not Found"}` |

The two reads beside it answer 404 on both sides, so this is not the product
refusing everything it cannot see. The status is now the cloud's.

## One divergence stays, and it is written down rather than left implicit

`lb/v1` sends **no `scw` error envelope** on any of those three refusals: no
`type`, no `details`. This emulator sends one — it always has, `writeNotFound`
has answered lb/v1's 404s with a `type` since long before this route existed —
and the reason is structural rather than chosen: `contracts/scaleway.json`
declares **one** `errorSchema` for the whole document (`scw.ResponseError`,
`required: ["type"]`, extracted from the SDK) and `internal/probe` validates
every refusal against it. A body without `type` fails that probe, which is the
gate being right about the document it was given, and the document being a
document rather than a recording.

Lifting it means an `errorSchema` per product, arbitrated by a recording rather
than a document — `RecordedFields` already does the opposite direction and the
symmetric one does not exist. `docs/limits.md` carries the new section.

## Proof

- `corpus/accepted.json` loses its three entries naming this issue, and the gate
  asked for them in its own words: *"excused nothing this run"*.
  `mise run corpus:check` green with them gone.
- `mise run falsify -- tools/falsify/specs/refusal-order-and-status.json`: five
  mutations, five *the test bit*, all compiling.
- `mise run conformance:leg -- fields` green, 356 of 381 routes proven by a real
  client (unchanged).
- `tools/conformance/stacks.sh` green, run deliberately: it is what neither
  `fields` nor `leg.sh` covers.
- `mise run prepush` green.

Not run: the full `mise run conformance` pass. This branch is one of a batch; the
whole suite is played once on the assembled set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
