### PR TITLE
fix(scaleway): the organization filter partitions the fleet (#638)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -43,6 +43,37 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Corrigé
 
+- **Le filtre `organization` était ignoré, donc une organisation qui ne possède
+  rien ici répondait toute la flotte** (#638). Sept des huit filtres déclarés de
+  `ListServers` partitionnaient l'ensemble exactement, `project` compris et avec
+  la même forme ; seul celui-ci n'avait aucun effet.
+
+  C'est le mode d'échec qui mérite la ligne : un filtre ignoré ne répond pas une
+  erreur et ne répond pas rien. Il répond une page **bien formée, plausible, plus
+  grande**, et le client ne peut pas s'en apercevoir. C'est le défaut de #630 en
+  miroir : « tout correspond » là où l'autre disait « rien ne correspond ».
+
+  Mesuré sur fr-par le 2026-09-02, avec un volume sur le compte :
+
+  | requête | réponse de `fr-par` |
+  |---|---|
+  | `?organization=<celle du compte>` | le volume, visible |
+  | `?organization=<un UUID fantôme>` | 200, vide |
+  | `?organization=not-a-uuid` | 400 `invalid_arguments`, `argument_name: organization`, « not-a-uuid is not a valid UUID. » |
+
+  Les deux faits manquaient : le filtre partitionne, et une valeur qui n'est pas
+  un UUID est refusée plutôt qu'acceptée puis ignorée.
+
+  **Pourquoi cela avait été laissé, et ce qui a changé.** La raison est écrite
+  dans `listSSHKeys` et elle était bonne : `scw` nomme son organisation
+  configurée sur chaque liste, rien n'oblige cette configuration à épeler la
+  constante de cet émulateur, et comparer avait un jour dit au CLI que la clé
+  qu'il venait de créer n'existait pas. #391 a tranché le même argument pour les
+  projets : le cloud filtre, et un client configuré depuis `feint env` n'y est pas
+  exposé. `feint env scaleway` publie `SCW_DEFAULT_ORGANIZATION_ID` avec la
+  constante de cet émulateur, et le `fake-credentials.env` de la suite de
+  conformance porte la même valeur.
+
 - **Deux refus répondaient le mauvais statut, et c'est exactement là-dessus qu'un
   client branche** (#394). Un 404 dit « crée le parent d'abord », un 400 dit
   « ton corps est mauvais et le parent n'y est pour rien », un 403 dit « tu n'as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,36 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Fixed
 
+- **The `organization` filter was ignored, so an organization that owns nothing
+  here answered the whole fleet** (#638). Seven of `ListServers`' eight declared
+  filters partitioned the set exactly, `project` included and with the same
+  shape; only this one had no effect.
+
+  The failure mode is what makes it worth a line: an ignored filter does not
+  answer an error and does not answer nothing. It answers a **well-shaped,
+  plausible, larger** page, and the client cannot tell. It is #630's defect
+  mirrored — *match everything* where that one was *match nothing*.
+
+  Measured on fr-par, 2026-09-02, with one volume on the account:
+
+  | request | `fr-par` answers |
+  |---|---|
+  | `?organization=<the account's own>` | the volume, visible |
+  | `?organization=<a ghost uuid>` | 200, empty |
+  | `?organization=not-a-uuid` | 400 `invalid_arguments`, `argument_name: organization`, *"not-a-uuid is not a valid UUID."* |
+
+  Both facts were missing: the filter partitions, and a value that is not a UUID
+  is refused rather than accepted and ignored.
+
+  **Why this was left alone until now, and what changed.** The reason is written
+  in `listSSHKeys` and it was a good one: `scw` names its configured organization
+  on every list, nothing obliges that configuration to spell this emulator's
+  constant, and comparing once told the CLI that the key it had just created did
+  not exist. #391 settled the same argument for projects — the cloud filters, and
+  a client configured from `feint env` is clear of it. `feint env scaleway`
+  publishes `SCW_DEFAULT_ORGANIZATION_ID` as this emulator's own constant, and the
+  conformance suite's `fake-credentials.env` carries the same value.
+
 - **Two refusals answered the wrong status, and a client branches on exactly
   that** (#394). A 404 says "create the parent first", a 400 says "your body is
   wrong and the parent is beside the point", a 403 says "you are not allowed

--- a/internal/providers/scaleway/dashboard.go
+++ b/internal/providers/scaleway/dashboard.go
@@ -99,7 +99,10 @@ func (p *Pack) dashboard(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	scope := p.scopeOf(r, zone)
+	scope, ok := p.scopeOf(w, r, zone)
+	if !ok {
+		return
+	}
 
 	servers := p.env.Store.List(kindServer, scope)
 	byType := map[string]int{}

--- a/internal/providers/scaleway/ips.go
+++ b/internal/providers/scaleway/ips.go
@@ -270,7 +270,11 @@ func (p *Pack) listIPs(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	all := p.env.Store.List(kindIP, p.scopeOf(r, zone))
+	scope, ok := p.scopeOf(w, r, zone)
+	if !ok {
+		return
+	}
+	all := p.env.Store.List(kindIP, scope)
 	q := r.URL.Query()
 	// `name` is the SDK's own reading, not this pack's: "filter on the IP
 	// address (Works as a LIKE operation on the IP address)". There is no name

--- a/internal/providers/scaleway/project_test.go
+++ b/internal/providers/scaleway/project_test.go
@@ -190,3 +190,70 @@ func TestAnUnfilteredListAnswersEveryProjectLikeTheCloud(t *testing.T) {
 
 // defaultOrganizationID is the one organization this emulator hosts.
 const defaultOrganizationID = "99999999-9999-4999-8999-999999999999"
+
+// The organization filter partitions the fleet, and a value that is not a UUID
+// is refused rather than accepted and ignored (#638).
+//
+// Measured on fr-par, 2026-09-02, with one volume on the account:
+//
+//	GET /volumes?organization=<the account's own>  the volume: VISIBLE
+//	GET /volumes?organization=<a ghost uuid>       200, empty
+//	GET /volumes?organization=not-a-uuid           400 invalid_arguments,
+//	                                               argument_name "organization",
+//	                                               "not-a-uuid is not a valid UUID."
+//
+// Why the failure mode mattered more than the missing filter: an ignored filter
+// does not answer an error and does not answer nothing. It answers a well-shaped,
+// plausible, LARGER page, and the client cannot tell. That is #630's defect
+// mirrored — match everything instead of match this one.
+func TestAnOrganizationFilterPartitionsTheFleet(t *testing.T) {
+	ts := newTestServer(t)
+	const ghostOrganization = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+
+	if status, created := do(t, ts, "POST", zoneURL+"/servers",
+		`{"name":"one","commercial_type":"DEV1-S"}`); status != http.StatusCreated {
+		t.Fatalf("create: %d (%v)", status, created)
+	}
+
+	count := func(query string) (int, map[string]any) {
+		t.Helper()
+		status, listed := do(t, ts, "GET", zoneURL+"/servers"+query, "")
+		if status != http.StatusOK {
+			return -status, listed
+		}
+		servers, _ := listed["servers"].([]any)
+		return len(servers), listed
+	}
+
+	// The accepting half first: without it a filter that answered nothing would
+	// pass every assertion below and break the product.
+	if got, body := count(""); got != 1 {
+		t.Fatalf("an unfiltered list answered %d server(s), want 1 (%v)", got, body)
+	}
+	if got, body := count("?organization=" + defaultOrganizationID); got != 1 {
+		t.Errorf("the account's own organization answered %d server(s), want 1 (%v)", got, body)
+	}
+
+	// The filter this issue is about. An organization that is not this one owns
+	// nothing here, and answering the whole fleet is the plausible-wrong answer.
+	if got, body := count("?organization=" + ghostOrganization); got != 0 {
+		t.Errorf("an organization nothing belongs to answered %d server(s), want 0 (%v)", got, body)
+	}
+
+	// And a value that is not a UUID is refused, in the cloud's own words.
+	status, body := do(t, ts, "GET", zoneURL+"/servers?organization=not-a-uuid", "")
+	if status != http.StatusBadRequest {
+		t.Fatalf("a malformed organization answered %d, want 400 (%v)", status, body)
+	}
+	details, _ := body["details"].([]any)
+	if len(details) != 1 {
+		t.Fatalf("details holds %d entries, want 1 (%v)", len(details), body)
+	}
+	d, _ := details[0].(map[string]any)
+	if d["argument_name"] != "organization" {
+		t.Errorf("argument_name is %v, want organization", d["argument_name"])
+	}
+	if d["help_message"] != "not-a-uuid is not a valid UUID." {
+		t.Errorf("help_message is %v, want the cloud's own sentence", d["help_message"])
+	}
+}

--- a/internal/providers/scaleway/servers.go
+++ b/internal/providers/scaleway/servers.go
@@ -179,22 +179,66 @@ func (p *Pack) tenant(zone string) resource.Tenant {
 // The isolation the previous behaviour was defending is the filtered read, and
 // it is untouched.
 //
-// TestAnUnfilteredListAnswersEveryProjectLikeTheCloud fails without this.
-func (p *Pack) scopeOf(r *http.Request, zone string) resource.Tenant {
+// # The organization filter filters too (#638)
+//
+// It did not, and the failure mode was the worst kind: an ignored filter answers
+// a well-shaped, plausible, LARGER page, and the client cannot tell. Measured on
+// fr-par the same day, with one volume on the account:
+//
+//	GET /volumes?organization=<the account's own>  the volume: VISIBLE
+//	GET /volumes?organization=<a ghost uuid>       200, empty
+//	GET /volumes?organization=not-a-uuid           400 invalid_arguments,
+//	                                               argument_name "organization",
+//	                                               "not-a-uuid is not a valid UUID."
+//
+// Two facts, and both were missing here: the filter partitions, and a value that
+// is not a UUID is refused rather than accepted and ignored.
+//
+// The reason this was left alone until now is written in listSSHKeys and it was
+// a good one: `scw` names its configured organization on every list, nothing
+// obliges that configuration to spell this emulator's constant, and comparing
+// told the CLI that the key it had just created did not exist. What changed is
+// that the same argument was settled for projects in #391 — the cloud filters,
+// and a client configured from `feint env` is clear of it because `feint env
+// scaleway` publishes SCW_DEFAULT_ORGANIZATION_ID as this constant. The
+// conformance suite's fake-credentials.env carries the same value, which is why
+// filtering here costs no client anything.
+//
+// TestAnUnfilteredListAnswersEveryProjectLikeTheCloud and
+// TestAnOrganizationFilterPartitionsTheFleet fail without this.
+func (p *Pack) scopeOf(w http.ResponseWriter, r *http.Request, zone string) (resource.Tenant, bool) {
 	q := r.URL.Query()
 	if project := q.Get("project"); project != "" {
-		return resource.Tenant{Provider: Name, Project: project, Zone: zone}
+		return resource.Tenant{Provider: Name, Project: project, Zone: zone}, true
 	}
-	// The organization branch answers the same tenant as the fall-through, and
-	// it stays because the parameter has to be READ. #277's gate refuses a
-	// declared query parameter a handler never names: dropping this branch made
-	// four operations fail it at once, which is the gate doing exactly its job —
-	// an emulator that ignores a filter answers a superset and calls it a match.
-	if q.Get("organization") != "" {
-		return p.tenant(zone)
+	organization := q.Get("organization")
+	if organization == "" {
+		return p.tenant(zone), true
 	}
-	return p.tenant(zone)
+	// looksLikeUUID lives in images.go and is the same question asked there: one
+	// shape, one reader.
+	if !looksLikeUUID(organization) {
+		writeInvalidArguments(w, ArgumentError{
+			ArgumentName: "organization",
+			Reason:       "constraint",
+			HelpMessage:  organization + " is not a valid UUID.",
+		})
+		return resource.Tenant{}, false
+	}
+	if organization != defaultOrganization {
+		return tenantNothingMatches, true
+	}
+	return p.tenant(zone), true
 }
+
+// tenantNothingMatches is a scope no resource can be filed under, so a list
+// scoped to it is empty by construction.
+//
+// The Provider field carries it rather than the Project, and that is what makes
+// it sound: Provider is written by the pack when a resource is created and never
+// by a client, so no request can conjure a resource that matches. A sentinel
+// project identifier would be one declaration away from being real.
+var tenantNothingMatches = resource.Tenant{Provider: "no-such-organization"}
 
 // projectOf resolves the project a create request belongs to, and the
 // organization above it. The organization is not taken from the request: the
@@ -342,7 +386,11 @@ func (p *Pack) listServers(w http.ResponseWriter, r *http.Request) {
 	}
 
 	q := r.URL.Query()
-	all := filterServers(p.env.Store.List(kindServer, p.scopeOf(r, zone)), q)
+	scope, ok := p.scopeOf(w, r, zone)
+	if !ok {
+		return
+	}
+	all := filterServers(p.env.Store.List(kindServer, scope), q)
 	all, err := p.filterServersByLinks(all, q)
 	if err != nil {
 		writeInvalidArguments(w, ArgumentError{

--- a/internal/providers/scaleway/volumes.go
+++ b/internal/providers/scaleway/volumes.go
@@ -48,7 +48,11 @@ func (p *Pack) listVolumes(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	all := p.env.Store.List(kindVolume, p.scopeOf(r, zone))
+	scope, ok := p.scopeOf(w, r, zone)
+	if !ok {
+		return
+	}
+	all := p.env.Store.List(kindVolume, scope)
 	// A substring, not an equality: instance_sdk.go documents the filter with its
 	// own example — "vol" returns "myvolume" but not "data". Compared by equality
 	// here, `scw instance volume list name=vol` came back empty against a volume

--- a/tools/falsify/specs/organization-filter.json
+++ b/tools/falsify/specs/organization-filter.json
@@ -1,0 +1,40 @@
+{
+  "package": "./internal/providers/scaleway/",
+  "mutations": [
+    {
+      "label": "the organization filter is ignored again, so a client asking for one organization is answered the whole fleet and cannot tell",
+      "file": "internal/providers/scaleway/servers.go",
+      "find": "\tif organization != defaultOrganization {\n\t\treturn tenantNothingMatches, true\n\t}",
+      "replace": "\tif organization != defaultOrganization && false {\n\t\treturn tenantNothingMatches, true\n\t}",
+      "test": "TestAnOrganizationFilterPartitionsTheFleet"
+    },
+    {
+      "label": "a value that is not a UUID is accepted and ignored, which is the silence an explicit refusal replaced",
+      "file": "internal/providers/scaleway/servers.go",
+      "find": "\tif !looksLikeUUID(organization) {\n\t\twriteInvalidArguments(w, ArgumentError{",
+      "replace": "\tif !looksLikeUUID(organization) && false {\n\t\twriteInvalidArguments(w, ArgumentError{",
+      "test": "TestAnOrganizationFilterPartitionsTheFleet"
+    },
+    {
+      "label": "the refusal stops carrying the cloud's own sentence, so a client reads a message fr-par never sent",
+      "file": "internal/providers/scaleway/servers.go",
+      "find": "\t\t\tHelpMessage:  organization + \" is not a valid UUID.\",",
+      "replace": "\t\t\tHelpMessage:  organization + \" is not a valid identifier\",",
+      "test": "TestAnOrganizationFilterPartitionsTheFleet"
+    },
+    {
+      "label": "the account's own organization is filtered out too, so a client configured from `feint env` reads an empty fleet",
+      "file": "internal/providers/scaleway/servers.go",
+      "find": "\tif organization != defaultOrganization {\n\t\treturn tenantNothingMatches, true\n\t}\n\treturn p.tenant(zone), true",
+      "replace": "\tif organization != defaultOrganization || true {\n\t\treturn tenantNothingMatches, true\n\t}\n\treturn p.tenant(zone), true",
+      "test": "TestAnOrganizationFilterPartitionsTheFleet"
+    },
+    {
+      "label": "the sentinel becomes a real scope, so an organization nothing belongs to answers the default project's resources",
+      "file": "internal/providers/scaleway/servers.go",
+      "find": "var tenantNothingMatches = resource.Tenant{Provider: \"no-such-organization\"}",
+      "replace": "var tenantNothingMatches = resource.Tenant{Provider: Name}",
+      "test": "TestAnOrganizationFilterPartitionsTheFleet"
+    }
+  ]
+}

--- a/tools/falsify/specs/unfiltered-list-scope.json
+++ b/tools/falsify/specs/unfiltered-list-scope.json
@@ -4,15 +4,15 @@
     {
       "label": "an unfiltered list goes back to the default project, so a server created under a named project is invisible to the list that follows it",
       "file": "internal/providers/scaleway/servers.go",
-      "find": "\tif q.Get(\"organization\") != \"\" {\n\t\treturn p.tenant(zone)\n\t}\n\treturn p.tenant(zone)\n}",
-      "replace": "\tif q.Get(\"organization\") != \"\" {\n\t\treturn p.tenant(zone)\n\t}\n\treturn resource.Tenant{Provider: Name, Project: defaultProject, Zone: zone}\n}",
+      "find": "\tif organization == \"\" {\n\t\treturn p.tenant(zone), true\n\t}",
+      "replace": "\tif organization == \"\" {\n\t\tscoped := p.tenant(zone)\n\t\tscoped.Project = defaultProject\n\t\treturn scoped, true\n\t}",
       "test": "TestAnUnfilteredListAnswersEveryProjectLikeTheCloud"
     },
     {
       "label": "a project filter is ignored, so the isolation the previous behaviour was defending is gone with it",
       "file": "internal/providers/scaleway/servers.go",
-      "find": "\tif project := q.Get(\"project\"); project != \"\" {\n\t\treturn resource.Tenant{Provider: Name, Project: project, Zone: zone}\n\t}",
-      "replace": "\tif project := q.Get(\"project\"); project != \"\" && false {\n\t\treturn resource.Tenant{Provider: Name, Project: project, Zone: zone}\n\t}",
+      "find": "\tif project := q.Get(\"project\"); project != \"\" {\n\t\treturn resource.Tenant{Provider: Name, Project: project, Zone: zone}, true\n\t}",
+      "replace": "\tif project := q.Get(\"project\"); project != \"\" && false {\n\t\treturn resource.Tenant{Provider: Name, Project: project, Zone: zone}, true\n\t}",
       "test": "TestListsAreScopedToTheProject"
     },
     {


### PR DESCRIPTION
Closes #638.

`ListServers` honoured every declared filter except `organization`, which was
ignored: an organization that owns nothing here answered the whole fleet. Seven
of the eight partitioned the set exactly, `project` included and **with the same
shape**.

## The failure mode is the point

An ignored filter does not answer an error and does not answer nothing. It
answers a **well-shaped, plausible, larger** page, and the client cannot tell.
It is #630's defect mirrored — *match everything* where that one was *match
nothing*.

## Measured

On `fr-par`, 2026-09-02, with one volume on the account — an empty account cannot
answer this, since a filter that works and a filter that is ignored both return
nothing:

| request | `fr-par` answers |
|---|---|
| `?organization=<the account's own>` | the volume, **visible** |
| `?organization=<a ghost uuid>` | 200, empty |
| `?organization=not-a-uuid` | 400 `invalid_arguments`, `argument_name: organization`, *"not-a-uuid is not a valid UUID."* |

Both facts were missing: the filter partitions, **and** a value that is not a
UUID is refused rather than accepted and ignored. The issue asked for the first
and offered the second as a fallback; the cloud does both.

## Why this was left alone until now

The reason is written in `listSSHKeys` and it was a good one:

> `scw` names its configured organization on every list, nothing obliges that
> configuration to spell this emulator's constant, and comparing told the CLI
> that the key it had just created did not exist.

**#391 settled the same argument for projects**, and the same resolution applies:
the cloud filters, and a client configured from `feint env` is clear of it.
`feint env scaleway` publishes `SCW_DEFAULT_ORGANIZATION_ID` as this emulator's
own constant, and the conformance suite's `fake-credentials.env` carries the same
value — which is why filtering here costs no client anything, and the suite
proves it rather than the argument doing so.

## Two details worth naming

**The empty scope is a tenant whose `Provider` is not one this emulator mounts**,
not a sentinel project identifier. `Provider` is written by the pack when a
resource is created and never by a client, so no request can conjure a resource
that matches. A sentinel project would be one `--projects` declaration away from
being real.

**`looksLikeUUID` is the one already in `images.go`**, not a second copy.

## Proof

- `mise run falsify -- tools/falsify/specs/organization-filter.json`: five
  mutations, five *the test bit* — including the two halves a guard that refused
  everything would pass: the account's own organization still answers, and the
  sentinel really matches nothing.
- **`unfiltered-list-scope.json`, #369's spec, is retargeted** at the rewritten
  `scopeOf` and still bites on all three of its mutations. `falsify:lint` caught
  that it had stopped applying, which is that gate doing exactly its job.
- `mise run conformance:leg -- fields` green, 356 of 381 routes proven by a real
  client (unchanged), and `tools/conformance/stacks.sh` green — the legs neither
  `fields` nor `leg.sh` covers.
- `mise run corpus:check` green, `mise run prepush` green.

Not run: the full `mise run conformance` pass. This branch is one of a batch; the
whole suite is played once on the assembled set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
