### PR TITLE
fix(machine): a package install ran under the cap made for a control command (#641)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -117,6 +117,30 @@ change ni l'un ni l'autre a sa place dans `git log`.
   constante de cet émulateur, et le `fake-credentials.env` de la suite de
   conformance porte la même valeur.
 
+- **Une installation de paquets tournait sous le plafond prévu pour une commande
+  de contrôle, et la preuve d'exécution nocturne en est morte** (#641). Tous les
+  appels `incus` passaient par un plafond unique de 120 secondes, qui est la
+  bonne borne pour `info`, `start` ou `network create`, où un plan de contrôle
+  plus lent que ça est cassé et non occupé. `incus exec <builder> -- dnf install
+  -y -q openssh-server` y passait aussi, et le 2026-09-03 il a été tué exactement
+  à cette limite pendant la construction d'`almalinux/9`, emportant toute
+  l'exécution planifiée. La nuit précédente, la même commande avait fini juste en
+  dessous.
+
+  Une étape à l'intérieur d'une instance de construction a désormais son propre
+  plafond, dix minutes, et la construction entière reste bornée par les vingt
+  minutes qui empêchent un téléchargement bloqué de garder le verrou pour
+  toujours. Un opérateur qui a réglé `Timeout` parce que sa station est lente
+  obtient les deux mis à l'échelle : une station qui demande un plafond de
+  contrôle plus long demande un plafond d'installation plus long dans la même
+  proportion.
+
+  Le plafond est affirmé plutôt que décrit : l'échéance est posée avant la
+  couture du runner autant qu'avant le vrai binaire, de sorte qu'un test lit
+  `ctx.Deadline()` et dit sous quel plafond un appel a tourné. Les deux moitiés
+  sont tenues : un garde qui donnerait dix minutes à tout casserait ce à quoi
+  sert le plafond de contrôle.
+
 - **Deux refus répondaient le mauvais statut, et c'est exactement là-dessus qu'un
   client branche** (#394). Un 404 dit « crée le parent d'abord », un 400 dit
   « ton corps est mauvais et le parent n'y est pour rien », un 403 dit « tu n'as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,27 @@ what this project is judged on: **a response shape a client can observe**, and
   publishes `SCW_DEFAULT_ORGANIZATION_ID` as this emulator's own constant, and the
   conformance suite's `fake-credentials.env` carries the same value.
 
+- **A package install ran under the cap made for a control command, and the
+  nightly runtime proof died on it** (#641). Every `incus` call went through one
+  120-second cap — the right bound for `info`, `start` or `network create`, where
+  a control plane slower than that is broken rather than busy. `incus exec
+  <builder> -- dnf install -y -q openssh-server` went through it too, and on
+  2026-09-03 it was killed at exactly that limit while building `almalinux/9`,
+  taking the whole scheduled run with it. The night before, the same command had
+  finished just under.
+
+  A step inside a build instance now runs under its own cap, ten minutes, and the
+  build as a whole is still bounded by the twenty minutes that stop a wedged
+  download from holding the lock for ever. An operator who set `Timeout` because
+  their station is slow gets both scaled, since a station that needs a longer
+  control cap needs a longer install cap by the same measure.
+
+  The cap is asserted rather than described: the deadline is set before the
+  runner seam as well as before the real binary, so a test reads
+  `ctx.Deadline()` and says which cap a call ran under. Both halves are held —
+  a guard that gave everything ten minutes would break what the control cap is
+  for.
+
 - **Two refusals answered the wrong status, and a client branches on exactly
   that** (#394). A 404 says "create the parent first", a 400 says "your body is
   wrong and the parent is beside the point", a 403 says "you are not allowed

--- a/internal/core/machine/incus.go
+++ b/internal/core/machine/incus.go
@@ -1880,16 +1880,63 @@ func (d *Incus) inspectOrFail(ctx context.Context, name string) (Machine, error)
 }
 
 func (d *Incus) run(ctx context.Context, args ...string) ([]byte, error) {
+	return d.runWithin(ctx, d.controlTimeout(), args...)
+}
+
+// controlTimeout caps a CONTROL command: `incus info`, `start`, `network
+// create`, `delete`. Two minutes because a control plane that takes longer than
+// that to answer is broken, not busy.
+//
+// It is not the cap for everything the driver runs, and that distinction is
+// #641: `incus exec <builder> -- dnf install openssh-server` went through here
+// and was killed at exactly 120 s on 2026-09-03, taking the whole nightly
+// runtime proof with it. Installing a package is not a control command — it
+// resolves metadata over whatever mirror the runner is given — and the night
+// before, the same command had finished just under the cap. An intermittent
+// failure whose cause is a fixed limit applied to the wrong kind of work.
+func (d *Incus) controlTimeout() time.Duration {
+	if d.Timeout > 0 {
+		return d.Timeout
+	}
+	return 120 * time.Second
+}
+
+// buildStepTimeout caps one command run INSIDE a build instance.
+//
+// Generous on purpose, and bounded twice rather than not at all: the build as a
+// whole already runs under imageBuildTimeout (20 minutes), which is what stops a
+// wedged download from holding the lock for ever. This is one step's share of
+// it, and it exists so that a slow mirror costs minutes instead of a red night.
+//
+// An operator who sets Timeout still gets it here, multiplied: the field means
+// "this station is slow", and a station slow enough to need a longer control cap
+// needs a longer install cap by the same measure.
+const buildStepTimeout = 10 * time.Minute
+
+// buildTimeout is buildStepTimeout, scaled by whatever the operator said about
+// this station.
+func (d *Incus) buildTimeout() time.Duration {
+	if d.Timeout > 0 {
+		return d.Timeout * 5
+	}
+	return buildStepTimeout
+}
+
+// runWithin is run with the cap named by the caller rather than by the field.
+//
+// The deadline is set before the runner seam as well as before the real binary,
+// which is what makes the cap observable: a test cannot time a ten-minute
+// timeout, but it can read ctx.Deadline() and say which cap a call ran under.
+// TestABuildStepRunsUnderTheBuildCapAndNotTheControlCap does exactly that.
+func (d *Incus) runWithin(ctx context.Context, timeout time.Duration, args ...string) ([]byte, error) {
 	if d.runner != nil {
+		ctx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
 		return d.runner(ctx, args...)
 	}
 	binary := d.Binary
 	if binary == "" {
 		binary = "incus"
-	}
-	timeout := d.Timeout
-	if timeout <= 0 {
-		timeout = 120 * time.Second
 	}
 	return runCLI(ctx, binary, timeout, args...)
 }

--- a/internal/core/machine/incus_imagebuild_test.go
+++ b/internal/core/machine/incus_imagebuild_test.go
@@ -216,3 +216,96 @@ func TestImageRemovalStaysInsideThePrefix(t *testing.T) {
 		t.Fatalf("argv %v, want exactly %v", rec.calls, want)
 	}
 }
+
+// deadlineRecorder answers like buildRecorder and, for each call, keeps how long
+// the caller gave it. That is the only way this property is observable: a test
+// cannot wait out a ten-minute cap, but it can read the deadline the call runs
+// under and say which cap set it.
+type deadlineRecorder struct {
+	mu    sync.Mutex
+	calls []deadlineCall
+}
+
+type deadlineCall struct {
+	args []string
+	left time.Duration
+	set  bool
+}
+
+func (r *deadlineRecorder) run(ctx context.Context, args ...string) ([]byte, error) {
+	call := deadlineCall{args: append([]string(nil), args...)}
+	if deadline, ok := ctx.Deadline(); ok {
+		call.left, call.set = time.Until(deadline), true
+	}
+	r.mu.Lock()
+	r.calls = append(r.calls, call)
+	r.mu.Unlock()
+
+	switch {
+	case len(args) > 3 && args[0] == "exec" && args[3] == "ip":
+		return []byte("2: eth0    inet 10.248.68.10/24 scope global eth0\n"), nil
+	case len(args) > 1 && args[0] == "image" && args[1] == "list":
+		return []byte("[]"), nil
+	}
+	return nil, nil
+}
+
+// find answers the first call whose argv joins to something containing want.
+func (r *deadlineRecorder) find(want string) (deadlineCall, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, call := range r.calls {
+		if strings.Contains(strings.Join(call.args, " "), want) {
+			return call, true
+		}
+	}
+	return deadlineCall{}, false
+}
+
+// A command run inside the build instance gets the build cap, and a control
+// command gets the control cap (#641).
+//
+// The defect this holds: every `incus` call went through one 120 s cap, chosen
+// for control commands — a control plane slower than that is broken, not busy.
+// `incus exec <builder> -- dnf install -y -q openssh-server` on almalinux/9 went
+// through it too and was killed at exactly that limit on 2026-09-03, taking the
+// whole nightly runtime proof with it. The night before, the same command had
+// finished just under. An intermittent red whose cause is a fixed limit applied
+// to the wrong kind of work.
+//
+// Both halves are asserted. A guard that gave everything ten minutes would pass
+// the first and break what the control cap is for.
+func TestABuildStepRunsUnderTheBuildCapAndNotTheControlCap(t *testing.T) {
+	rec := &deadlineRecorder{}
+	d := &Incus{runner: rec.run}
+	spec := RequiredImages()[0]
+
+	if _, err := BuildIfMissing(context.Background(), d, spec, nil); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	install, ok := rec.find(spec.Package)
+	if !ok {
+		t.Fatalf("no call installed %s: %v", spec.Package, rec.calls)
+	}
+	if !install.set {
+		t.Fatal("the install ran with no deadline at all, so nothing bounds a wedged mirror")
+	}
+	if install.left <= 2*time.Minute {
+		t.Errorf("the install had %s, which is the control cap: a package install waits on a mirror, "+
+			"and 120 s is what killed the nightly proof", install.left.Round(time.Second))
+	}
+
+	// The control cap still binds what it was chosen for.
+	launch, ok := rec.find("launch")
+	if !ok {
+		t.Fatalf("no launch call: %v", rec.calls)
+	}
+	if !launch.set {
+		t.Fatal("a control command ran with no deadline")
+	}
+	if launch.left > 3*time.Minute {
+		t.Errorf("a control command had %s: the build cap leaked onto the control path, and a "+
+			"daemon that never answers would hang for minutes", launch.left.Round(time.Second))
+	}
+}

--- a/internal/core/machine/incus_images.go
+++ b/internal/core/machine/incus_images.go
@@ -224,9 +224,18 @@ func (d *Incus) waitForBuilderAddress(ctx context.Context, builder string, deadl
 		"package fetch below would fail on the network rather than on the package")
 }
 
+// execInBuilder runs one step of a build inside the builder instance.
+//
+// Under the build cap and not the control cap (#641). `dnf install -y -q
+// openssh-server` on almalinux/9 was killed at the control cap's 120 s on
+// 2026-09-03 and took the nightly runtime proof with it; the night before, the
+// same command had finished just under it. A package install waits on a mirror,
+// which is not the thing 120 seconds was chosen to bound.
+//
+// TestABuildStepRunsUnderTheBuildCapAndNotTheControlCap fails without this.
 func (d *Incus) execInBuilder(ctx context.Context, builder string, command []string) error {
 	args := append([]string{"exec", builder, "--"}, command...)
-	if _, err := d.run(ctx, args...); err != nil {
+	if _, err := d.runWithin(ctx, d.buildTimeout(), args...); err != nil {
 		return fmt.Errorf("%s in the build instance: %w", strings.Join(command, " "), err)
 	}
 	return nil

--- a/tools/falsify/specs/build-step-cap.json
+++ b/tools/falsify/specs/build-step-cap.json
@@ -1,0 +1,26 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "a build step goes back through the control cap, which is the 120 s that killed the nightly proof",
+      "file": "internal/core/machine/incus_images.go",
+      "find": "\tif _, err := d.runWithin(ctx, d.buildTimeout(), args...); err != nil {",
+      "replace": "\tif _, err := d.runWithin(ctx, d.controlTimeout(), args...); err != nil {",
+      "test": "TestABuildStepRunsUnderTheBuildCapAndNotTheControlCap"
+    },
+    {
+      "label": "the build cap leaks onto the control path, so a daemon that never answers hangs for ten minutes instead of two",
+      "file": "internal/core/machine/incus.go",
+      "find": "func (d *Incus) run(ctx context.Context, args ...string) ([]byte, error) {\n\treturn d.runWithin(ctx, d.controlTimeout(), args...)\n}",
+      "replace": "func (d *Incus) run(ctx context.Context, args ...string) ([]byte, error) {\n\t_ = d.controlTimeout\n\treturn d.runWithin(ctx, d.buildTimeout(), args...)\n}",
+      "test": "TestABuildStepRunsUnderTheBuildCapAndNotTheControlCap"
+    },
+    {
+      "label": "the deadline stops reaching the runner seam, so no test can say which cap a call ran under",
+      "file": "internal/core/machine/incus.go",
+      "find": "\tif d.runner != nil {\n\t\tctx, cancel := context.WithTimeout(ctx, timeout)\n\t\tdefer cancel()\n\t\treturn d.runner(ctx, args...)\n\t}",
+      "replace": "\tif d.runner != nil {\n\t\t_, cancel := context.WithTimeout(ctx, timeout)\n\t\tdefer cancel()\n\t\treturn d.runner(ctx, args...)\n\t}",
+      "test": "TestABuildStepRunsUnderTheBuildCapAndNotTheControlCap"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #641.

The scheduled runtime proof of 2026-09-03 died on one line:

```
feint: almalinux/9: sh -c dnf install -y -q openssh-server in the build instance:
incus exec: signal: killed
```

**Killed, not failed.** Every `incus` call went through `d.run` and its
120-second cap — the right bound for a *control* command (`info`, `start`,
`network create`), where a plane slower than that is broken rather than busy. A
package install is not that: it waits on whatever mirror the runner is given.

The night before, the same command finished just under the cap. That is why this
was intermittent, and why the first green after it would have meant nothing.

Everything else in that job is downstream, and the issue says so itself: the
emulator never came up, so `score.sh` answered *"the emulator did not answer
/_feint/conformance"* under `if: always()`.

## The fix

A step inside a build instance runs under its own cap, ten minutes, while the
build as a whole stays bounded by `imageBuildTimeout`'s twenty — which is what
stops a wedged download from holding the lock for ever. Bounded twice rather than
not at all.

An operator who set `Timeout` because their station is slow gets **both** scaled:
a station that needs a longer control cap needs a longer install cap by the same
measure.

## The cap is asserted, not described

`runWithin` sets the deadline before the runner seam as well as before the real
binary, and that is what makes the property measurable: a test cannot wait out
ten minutes, but it can read `ctx.Deadline()` and say which cap a call ran under.

`TestABuildStepRunsUnderTheBuildCapAndNotTheControlCap` holds **both halves** — a
guard that gave everything ten minutes would pass the first assertion and break
what the control cap exists for.

## Proof

- `mise run falsify -- tools/falsify/specs/build-step-cap.json`: three mutations,
  three *the test bit*, including the one that stops the deadline reaching the
  seam and so makes the property unmeasurable.
- `mise run prepush` green.

## What this does not prove

**That the nightly goes green.** This changes a timeout, and the only thing that
settles it is the next scheduled run — or an operator running `FEINT_VM=incus
mise run conformance:leg -- runtime` on a station whose mirror is slow. Saying so
rather than claiming the red is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
