### PR TITLE
fix(scaleway): two inputs the cloud refuses, one it accepts, and the shapes of both (#648)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -86,6 +86,49 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Corrigé
 
+- **Deux entrées que le cloud refuse et que cet émulateur acceptait, et une qu'il
+  accepte et que cet émulateur refusait** (#648, signalé par une exécution
+  différentielle : la même stack Terraform contre `main` et contre
+  `api.scaleway.com`).
+
+  La paire signalée, toutes deux dans la direction qui coûte, puisqu'un client
+  vert ici n'apprend rien sur le vrai cloud :
+
+  | entrée | `fr-par` | avant |
+  |---|---|---|
+  | une règle d'ACL dont `dst_port_high` est sous `dst_port_low` | 400, et il nomme **les deux** bornes | 200 |
+  | `instance/v1 CreateSnapshot` sur un volume block (SBS) | 404 `not_found`, `resource: instance_volume` | 201 |
+
+  La première n'est pas une entrée exotique : **c'est ce que le fournisseur
+  Terraform envoie pour la règle la plus courante qui soit**, un port ouvert,
+  puisqu'une règle qui ne nomme que `dst_port_low` laisse la borne haute à zéro.
+  Trois règles sur trois dans la stack du rapporteur avaient cette forme.
+
+  La seconde est le motif de l'image dorée. Le disque système d'un serveur vit
+  dans `block` depuis #365, ce que le cloud donne à un DEV1-S, et un volume block
+  n'est pas un `instance_volume` : instance/v1 n'en prend donc pas d'instantané.
+  Ce pack résolvait les deux produits là exprès (#571), et la mesure renverse ce
+  choix : la raison qui l'avait motivé est servie autrement depuis, et la suite
+  de conformance avait déjà cessé d'emprunter ce chemin.
+
+  **La mesure a fait apparaître deux écarts de plus sur la même route**, dont un
+  en sens inverse :
+
+  - `argument_name` s'écrit `rules[0]dst_port_high`, sans point avant l'indice ni
+    avant le champ. Ce pack écrivait `rules.0.dst_port_high`, faux pour toutes
+    les erreurs de règle et pas seulement pour l'une d'elles. Le `reason` diffère
+    aussi selon le champ : `unknown` pour `action` et `source`, `constraint` pour
+    les ports.
+  - **un protocole inconnu est normalisé en `ANY`, pas refusé.** `NONSENSE`
+    répond 200 et se relit en `ANY`. Ce pack le refusait, ce qui est la direction
+    la plus rare, plus stricte que le cloud : un client qui aurait fonctionné
+    contre `fr-par` rencontrait un 400 ici. Être plus strict, c'est encore être
+    différent.
+
+  Un détail est recopié plutôt que rangé, parce que personne ne l'inventerait :
+  dans le même corps, le `min` de la borne haute est la **chaîne** `"443"` et
+  celui de la borne basse le **nombre** `0`.
+
 - **Le filtre `organization` était ignoré, donc une organisation qui ne possède
   rien ici répondait toute la flotte** (#638). Sept des huit filtres déclarés de
   `ListServers` partitionnaient l'ensemble exactement, `project` compris et avec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,46 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Fixed
 
+- **Two inputs the cloud refuses and this emulator accepted, and one it accepts
+  that this emulator refused** (#648, reported with a differential run: the same
+  Terraform stack against `main` and against `api.scaleway.com`).
+
+  The reported pair, both in the direction that costs — a client green here
+  learns nothing about the real cloud:
+
+  | input | `fr-par` | before |
+  |---|---|---|
+  | an ACL rule whose `dst_port_high` is below `dst_port_low` | 400, and it names **both** bounds | 200 |
+  | `instance/v1 CreateSnapshot` on a block (SBS) volume | 404 `not_found`, `resource: instance_volume` | 201 |
+
+  The first is not an exotic input: **it is what the Terraform provider sends for
+  the commonest rule there is**, one port opened, since a rule that names only
+  `dst_port_low` leaves the high bound at zero. Three rules out of three in the
+  reporter's stack were that shape.
+
+  The second is the golden-image pattern. A server's root disk lives in `block`
+  since #365 — which is what the cloud gives a DEV1-S — and a block volume is not
+  an `instance_volume`, so instance/v1 does not snapshot it. This pack resolved
+  both products there on purpose (#571) and the measurement reverses that: the
+  reason it was written has been served differently since, and the conformance
+  suite had already stopped taking that route.
+
+  **Measuring it turned up two more divergences on the same route**, and one goes
+  the other way:
+
+  - `argument_name` is `rules[0]dst_port_high` — no dot before the index, none
+    before the field. This pack wrote `rules.0.dst_port_high`, wrong for every
+    rule error rather than for one of them. The `reason` differs per field too:
+    `unknown` for `action` and `source`, `constraint` for the ports.
+  - **an unknown protocol is normalised to `ANY`, not refused.** `NONSENSE`
+    answers 200 and reads back as `ANY`. This pack refused it — the rarer
+    direction, stricter than the cloud, and a client that would have worked
+    against `fr-par` met a 400 here. Being stricter is still being different.
+
+  One detail is copied rather than tidied because nobody would invent it: in the
+  same body, the high bound's `min` is the **string** `"443"` and the low bound's
+  is the **number** `0`.
+
 - **The `organization` filter was ignored, so an organization that owns nothing
   here answered the whole fleet** (#638). Seven of `ListServers`' eight declared
   filters partitioned the set exactly, `project` included and with the same

--- a/internal/providers/scaleway/acl.go
+++ b/internal/providers/scaleway/acl.go
@@ -168,8 +168,8 @@ func (p *Pack) setACL(w http.ResponseWriter, r *http.Request) {
 	stored := make([]any, 0, len(req.Rules))
 	for i, rule := range req.Rules {
 		normalised, bad := validateACLRule(rule, i)
-		if bad != nil {
-			writeInvalidArguments(w, *bad)
+		if len(bad) > 0 {
+			writeInvalidArguments(w, bad...)
 			return
 		}
 		stored = append(stored, normalised)
@@ -214,30 +214,70 @@ func (p *Pack) setACL(w http.ResponseWriter, r *http.Request) {
 // a rule no real API accepts, and answering 200 to it is the "a 200 that lies"
 // family this repository measures. The index is carried into the argument name
 // so a client with twenty rules is told which one.
-func validateACLRule(rule aclRule, index int) (map[string]any, *ArgumentError) {
+// What fr-par answers to a rule it will not take, measured 2026-09-03 on a VPC
+// made for the occasion and deleted after (#648).
+//
+//	rules[0]action        "maybe"      400 unknown    action: {"must_match_one_of": "Accept, Drop"}
+//	rules[0]source        "not-a-cidr" 400 unknown    network: {}
+//	rules[0]src_port_low  100          400 constraint range: {"min": 0, "max": 65535}
+//	rules[0]src_port_high 50           400 constraint range: {"max": 65535, "min": "100"}
+//	rules[0]protocol      "NONSENSE"   200, and the rule reads back as ANY
+//
+// Four things this pack had wrong, and they pull in both directions.
+//
+//  1. THE PORT RANGE WAS NOT CHECKED AT ALL when the high port was zero. The
+//     comment here said so and said why: "whether the real API narrows this
+//     further is unmeasured, and being permissive where the measurement is
+//     missing is the safe side". That was the right call with no measurement and
+//     it is the wrong answer with one. The cloud refuses `dst_port_high: 0`
+//     beside a non-zero low, and that is exactly what the Terraform provider
+//     sends for the commonest rule there is — one port, opened. Three rules out
+//     of three in the reporter's stack were that shape, green here and refused
+//     there.
+//
+//  2. AN INVALID RANGE ANSWERS TWO DETAILS, not one: the low and the high
+//     together, because the constraint is on the pair. Their order is not
+//     stable between two runs of the same request, so nothing here depends on
+//     it.
+//
+//  3. THE MIN OF THE HIGH PORT IS A STRING and the min of the low port is a
+//     number, in the same body. Nobody would invent that, which is why it is
+//     copied rather than tidied.
+//
+//  4. argument_name IS `rules[0]field`, with no dot and no dot before the
+//     field. This pack wrote `rules.0.field`, which is wrong for every rule
+//     error and not only for the ports.
+//
+// And one refusal REMOVED. An unknown protocol is normalised to ANY by the
+// cloud, not refused — measured, `NONSENSE` answers 200 and reads back as ANY.
+// This pack refused it, which is the rarer direction of divergence and the
+// harmless-looking one: a client that would have worked against fr-par met a
+// 400 here. Being stricter than the cloud is still being different from it.
+//
+// TestSetACLRefusesWhatTheEnumsRefuse fails without this.
+func validateACLRule(rule aclRule, index int) (map[string]any, []ArgumentError) {
 	at := func(field string) string {
-		return "rules." + strconv.Itoa(index) + "." + field
+		return "rules[" + strconv.Itoa(index) + "]" + field
 	}
 	protocol := strings.ToUpper(strings.TrimSpace(rule.Protocol))
-	if protocol == "" {
-		// ACLRuleProtocol.String() answers ANY for the empty value, so an
-		// omitted protocol is ANY rather than an error. Read from the SDK
-		// (vpc_sdk.go, ACLRuleProtocol.String), not assumed.
+	// ACLRuleProtocol.String() answers ANY for the empty value, so an omitted
+	// protocol is ANY rather than an error (vpc_sdk.go). And so is a protocol
+	// nobody declares: the cloud normalises rather than refuses, measured.
+	if !aclProtocols[protocol] {
 		protocol = "ANY"
 	}
-	if !aclProtocols[protocol] {
-		return nil, &ArgumentError{ArgumentName: at("protocol"), Reason: "constraint",
-			HelpMessage: "protocol must be one of ANY, TCP, UDP, ICMP"}
-	}
 	if !aclActions[rule.Action] {
-		return nil, &ArgumentError{ArgumentName: at("action"), Reason: "constraint",
-			HelpMessage: "action must be accept or drop"}
+		return nil, []ArgumentError{{
+			ArgumentName: at("action"),
+			Reason:       "unknown",
+			HelpMessage:  `action: {"must_match_one_of": "Accept, Drop"}`,
+		}}
 	}
 	if _, err := network.ParseCIDR(rule.Source); err != nil {
-		return nil, &ArgumentError{ArgumentName: at("source"), Reason: "format", HelpMessage: err.Error()}
+		return nil, []ArgumentError{{ArgumentName: at("source"), Reason: "unknown", HelpMessage: "network: {}"}}
 	}
 	if _, err := network.ParseCIDR(rule.Destination); err != nil {
-		return nil, &ArgumentError{ArgumentName: at("destination"), Reason: "format", HelpMessage: err.Error()}
+		return nil, []ArgumentError{{ArgumentName: at("destination"), Reason: "unknown", HelpMessage: "network: {}"}}
 	}
 	for _, port := range []struct {
 		lowName, highName string
@@ -246,21 +286,22 @@ func validateACLRule(rule aclRule, index int) (map[string]any, *ArgumentError) {
 		{lowName: "src_port_low", highName: "src_port_high", low: rule.SrcPortLow, high: rule.SrcPortHigh},
 		{lowName: "dst_port_low", highName: "dst_port_high", low: rule.DstPortLow, high: rule.DstPortHigh},
 	} {
-		if port.low > 65535 || port.high > 65535 {
-			return nil, &ArgumentError{ArgumentName: at(port.lowName), Reason: "constraint",
-				HelpMessage: "a port is between 0 and 65535"}
-		}
-		// A high of zero is "unset", not "port 0": both ports are non-pointer
-		// uint32 in the SDK, so a client that names only the low port sends a
-		// zero high, and refusing that pair would refuse the commonest rule
-		// there is. What this catches is the inverted range a client wrote by
-		// hand. Whether the real API narrows this further is unmeasured, and
-		// being permissive where the measurement is missing is the safe side:
-		// a refusal invented here is a defect a client meets, an acceptance is
-		// a check this emulator does not make.
-		if port.high != 0 && port.low > port.high {
-			return nil, &ArgumentError{ArgumentName: at(port.highName), Reason: "constraint",
-				HelpMessage: "the high port of a range is not below its low port"}
+		if port.low > 65535 || port.high > 65535 || port.low > port.high {
+			// Both bounds, because the constraint is on the pair and the cloud
+			// names both. The high port's min is the low port's value, rendered
+			// as a string; the low port's is the number 0.
+			return nil, []ArgumentError{
+				{
+					ArgumentName: at(port.lowName),
+					Reason:       "constraint",
+					HelpMessage:  `range: {"min": 0, "max": 65535}`,
+				},
+				{
+					ArgumentName: at(port.highName),
+					Reason:       "constraint",
+					HelpMessage:  `range: {"min": "` + strconv.FormatUint(uint64(port.low), 10) + `", "max": 65535}`,
+				},
+			}
 		}
 	}
 	out := map[string]any{

--- a/internal/providers/scaleway/acl_test.go
+++ b/internal/providers/scaleway/acl_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -154,22 +155,30 @@ func TestSetACLRefusesWhatTheEnumsRefuse(t *testing.T) {
 	ts := newTestServer(t)
 	vpc := newVPC(t, ts, "refusals")
 
+	// The names are the cloud's: `rules[0]field`, no dot before the index and
+	// none before the field. This pack wrote `rules.0.field` until #648, which
+	// was wrong for every rule error rather than for one of them.
 	cases := map[string]struct{ body, names string }{
-		"an unknown protocol": {
-			body:  `{"is_ipv6":false,"default_policy":"accept","rules":[{"protocol":"SCTP","source":"0.0.0.0/0","destination":"0.0.0.0/0","action":"accept"}]}`,
-			names: "rules.0.protocol",
-		},
 		"an unknown action": {
 			body:  `{"is_ipv6":false,"default_policy":"accept","rules":[{"protocol":"TCP","source":"0.0.0.0/0","destination":"0.0.0.0/0","action":"maybe"}]}`,
-			names: "rules.0.action",
+			names: "rules[0]action",
 		},
 		"a source that is not a CIDR": {
 			body:  `{"is_ipv6":false,"default_policy":"accept","rules":[{"protocol":"TCP","source":"not-a-cidr","destination":"0.0.0.0/0","action":"accept"}]}`,
-			names: "rules.0.source",
+			names: "rules[0]source",
 		},
 		"a port range the wrong way round": {
 			body:  `{"is_ipv6":false,"default_policy":"accept","rules":[{"protocol":"TCP","source":"0.0.0.0/0","destination":"0.0.0.0/0","action":"accept","dst_port_low":443,"dst_port_high":80}]}`,
-			names: "rules.0.dst_port_high",
+			names: "rules[0]dst_port_high",
+		},
+		// The case #648 is about, and the one a client meets by accident: the
+		// Terraform provider sends dst_port_high 0 for a rule that names only a
+		// low port — one port, opened, the commonest rule there is — and fr-par
+		// refuses it. This emulator answered 200, so three rules out of three in
+		// the reporter's stack were green here and refused there.
+		"a high port left at zero beside a real low port": {
+			body:  `{"is_ipv6":false,"default_policy":"accept","rules":[{"protocol":"TCP","source":"10.0.0.0/8","destination":"10.0.0.0/8","action":"accept","dst_port_low":22,"dst_port_high":0}]}`,
+			names: "rules[0]dst_port_high",
 		},
 		"a default policy outside the enum": {
 			body:  `{"is_ipv6":false,"default_policy":"unknown_action","rules":[]}`,
@@ -197,6 +206,64 @@ func TestSetACLRefusesWhatTheEnumsRefuse(t *testing.T) {
 	if got, _ := read["rules"].([]any); len(got) != 0 {
 		t.Errorf("a refused set left %d rule(s) behind: %v", len(got), read["rules"])
 	}
+
+	// An invalid range names the PAIR, not one bound: the constraint is on the
+	// two together and fr-par answers two details for it. Their order is not
+	// stable between two runs of the same request, so this asks that both are
+	// there rather than where each one sits.
+	t.Run("an invalid range names both bounds", func(t *testing.T) {
+		_, body := do(t, ts, "PUT", aclURL(vpc),
+			`{"is_ipv6":false,"default_policy":"accept","rules":[{"protocol":"TCP","source":"10.0.0.0/8","destination":"10.0.0.0/8","action":"accept","dst_port_low":443,"dst_port_high":80}]}`)
+		for _, want := range []string{"rules[0]dst_port_low", "rules[0]dst_port_high"} {
+			if !bodyNames(body, want) {
+				t.Errorf("the refusal does not name %s: %v", want, body)
+			}
+		}
+		// And the high bound's min is the low bound's value, rendered as a
+		// string where the low bound's is the number 0. Nobody would invent
+		// that, which is why it is copied rather than tidied.
+		details, _ := body["details"].([]any)
+		for _, entry := range details {
+			d, _ := entry.(map[string]any)
+			if d["argument_name"] != "rules[0]dst_port_high" {
+				continue
+			}
+			if help, _ := d["help_message"].(string); !strings.Contains(help, `"min": "443"`) {
+				t.Errorf("the high bound's help_message is %q, want the low port as a string", help)
+			}
+		}
+	})
+
+	// The one this pack used to refuse and the cloud does not. An unknown
+	// protocol is NORMALISED to ANY, measured: `NONSENSE` answers 200 and reads
+	// back as ANY. Refusing it was the rarer direction of divergence — stricter
+	// than the cloud — and a client that would have worked against fr-par met a
+	// 400 here.
+	t.Run("an unknown protocol is normalised rather than refused", func(t *testing.T) {
+		status, body := do(t, ts, "PUT", aclURL(vpc),
+			`{"is_ipv6":false,"default_policy":"accept","rules":[{"protocol":"SCTP","source":"0.0.0.0/0","destination":"0.0.0.0/0","action":"accept"}]}`)
+		if status != http.StatusOK {
+			t.Fatalf("an unknown protocol answered %d, want 200 (%v)", status, body)
+		}
+		rules, _ := body["rules"].([]any)
+		if len(rules) != 1 {
+			t.Fatalf("the answer carries %d rule(s) (%v)", len(rules), body)
+		}
+		rule, _ := rules[0].(map[string]any)
+		if rule["protocol"] != "ANY" {
+			t.Errorf("the rule read back as %v, want ANY", rule["protocol"])
+		}
+	})
+
+	// A range the pair agrees on still passes, without which a guard that
+	// refused every range would satisfy the table above and break the product.
+	t.Run("a range whose bounds agree is accepted", func(t *testing.T) {
+		status, body := do(t, ts, "PUT", aclURL(vpc),
+			`{"is_ipv6":false,"default_policy":"accept","rules":[{"protocol":"TCP","source":"10.0.0.0/8","destination":"10.0.0.0/8","action":"accept","dst_port_low":22,"dst_port_high":22}]}`)
+		if status != http.StatusOK {
+			t.Fatalf("dst_port_low 22 / dst_port_high 22 answered %d, want 200 (%v)", status, body)
+		}
+	})
 }
 
 // bodyNames reports whether an invalid-arguments body names this argument. The

--- a/internal/providers/scaleway/barrage_test.go
+++ b/internal/providers/scaleway/barrage_test.go
@@ -297,12 +297,26 @@ func barrageCycle(ts *httptest.Server, tag string, problems chan<- string) {
 	}
 
 	// A second path on the same resources, which is where a cross-path defect
-	// would live: snapshotting the root volume while other workers create and
-	// delete servers.
-	if rootID != "" {
-		if status, _ := doRaw(ts, "POST", zoneURL+"/snapshots",
-			`{"name":"barrage-`+tag+`","volume_id":"`+rootID+`"}`); status != http.StatusCreated {
-			problems <- fmt.Sprintf("%s: snapshot create answered %d", tag, status)
+	// would live: snapshotting a volume while other workers create and delete
+	// servers.
+	//
+	// An INSTANCE volume, made here, and not the server's root disk. That one
+	// lives in block since #365, and instance/v1 answers 404 instance_volume for
+	// a volume it does not own (#648) — so the barrage would report forty
+	// refusals that are the API working. What it stresses is unchanged: the
+	// snapshot handler under concurrency.
+	_ = rootID
+	status, made := doRaw(ts, "POST", zoneURL+"/volumes",
+		`{"name":"barrage-`+tag+`","volume_type":"l_ssd","size":10000000000}`)
+	if status != http.StatusCreated {
+		problems <- fmt.Sprintf("%s: volume create answered %d", tag, status)
+	} else {
+		volume, _ := made["volume"].(map[string]any)
+		if id, _ := volume["id"].(string); id != "" {
+			if status, _ := doRaw(ts, "POST", zoneURL+"/snapshots",
+				`{"name":"barrage-`+tag+`","volume_id":"`+id+`"}`); status != http.StatusCreated {
+				problems <- fmt.Sprintf("%s: snapshot create answered %d", tag, status)
+			}
 		}
 	}
 

--- a/internal/providers/scaleway/block_attach_test.go
+++ b/internal/providers/scaleway/block_attach_test.go
@@ -211,31 +211,33 @@ func TestACreateNamingABlockVolumeAttachesIt(t *testing.T) {
 	}
 }
 
-// An instance snapshot of a block volume works, and does not promise the block
-// product.
+// An instance/v1 snapshot of a block volume is REFUSED, and the refusal names
+// which product answered.
 //
-// The route resolved kindVolume alone, so it answered 404 on the disk the same
-// emulator published under the server's volumes["0"]. It answers now — and the
-// TYPE it answers was got wrong once, in this same change, which is why the
-// assertion below is about what the value must NOT be.
+// This test asserted the opposite until 2026-09-03, and the reason it did was
+// sound when it was written: the route resolved kindVolume alone and answered
+// 404 on the disk the same emulator published under the server's volumes["0"]
+// (#571). Making it resolve both products fixed that 404 and introduced a
+// different one — the emulator accepting what fr-par refuses.
 //
-// sbs_snapshot was the first answer, read straight off the SDK's
-// VolumeVolumeType enum, and it broke a command: `scw instance image list` calls
-// block.GetSnapshot for every image whose root_volume.volume_type is
-// sbs_snapshot and fails the WHOLE listing on error (scaleway-cli 2.56.3,
-// internal/namespaces/instance/v1/custom_image.go:222). Cutting an image from
-// such a snapshot made `scw instance image list` answer "cannot find resource
-// 'snapshot'" for the entire zone — measured 2026-08-28, against the emulator
-// this test runs in.
+// Measured (#648):
 //
-// So the invariant is not "the type is unified". It is: **a type that promises
-// the block product must be answerable by the block product**, and this test
-// asserts the promise rather than the spelling, so it keeps holding the day a
-// snapshot really does cross the two.
+//	POST /instance/v1/zones/fr-par-1/snapshots  {"volume_id": "<a block volume>"}
+//	  404 {"type": "not_found", "message": "resource is not found",
+//	       "resource": "instance_volume", "resource_id": "<the id>"}
 //
-// What a client asks for still wins, because the request field "overrides the
-// volume_type of the snapshot" in the SDK's own words.
-func TestAnInstanceSnapshotOfABlockVolumeDoesNotPromiseTheBlockProduct(t *testing.T) {
+// A block volume is not an instance_volume, and `resource` is the field a client
+// reads to know WHICH thing was not found. The permissive version was the
+// direction that costs: a golden-image path built on it is green here and fails
+// against the cloud, which is what the reporter met.
+//
+// The type question this test used to carry is settled elsewhere and stays
+// settled: an instance snapshot must not promise the block product, because
+// `scw instance image list` calls block.GetSnapshot for every image whose
+// root_volume.volume_type is sbs_snapshot and fails the WHOLE listing on error
+// (scaleway-cli 2.56.3, custom_image.go:222). Nothing here can promise it any
+// more, since nothing here can be taken of a block volume.
+func TestAnInstanceSnapshotRefusesAVolumeItDoesNotOwn(t *testing.T) {
 	ts := newTestServer(t)
 	_, body := serverWith(t, ts,
 		`{"name":"sbs","commercial_type":"DEV1-S","volumes":{"0":{"volume_type":"sbs_volume","size":20000000000}}}`)
@@ -244,37 +246,49 @@ func TestAnInstanceSnapshotOfABlockVolumeDoesNotPromiseTheBlockProduct(t *testin
 	rootID, _ := root["id"].(string)
 
 	status, out := do(t, ts, "POST", zone+"/snapshots", `{"name":"snap","volume_id":"`+rootID+`"}`)
+	if status != http.StatusNotFound {
+		t.Fatalf("an instance snapshot of a block volume answered %d, want 404: %v", status, out)
+	}
+	if out["resource"] != "instance_volume" {
+		t.Errorf("resource is %v, want instance_volume: it is the field that says which product "+
+			"did not hold the id", out["resource"])
+	}
+	if out["resource_id"] != rootID {
+		t.Errorf("resource_id is %v, want the volume that was named", out["resource_id"])
+	}
+	if out["type"] != "not_found" {
+		t.Errorf("type is %v, want not_found", out["type"])
+	}
+
+	// The accepting half, without which a guard that refused every snapshot
+	// would satisfy the assertions above and break the product: a volume
+	// instance/v1 DOES own is snapshotted, and the snapshot names it.
+	status, made := do(t, ts, "POST", zone+"/volumes",
+		`{"name":"owned","volume_type":"l_ssd","size":10000000000}`)
 	if status != http.StatusCreated {
-		t.Fatalf("snapshot of a block volume answered %d, want 201: %v", status, out)
+		t.Fatalf("create an instance volume: %d (%v)", status, made)
+	}
+	volume, _ := made["volume"].(map[string]any)
+	volumeID, _ := volume["id"].(string)
+
+	status, out = do(t, ts, "POST", zone+"/snapshots", `{"name":"snap","volume_id":"`+volumeID+`"}`)
+	if status != http.StatusCreated {
+		t.Fatalf("an instance snapshot of an instance volume answered %d, want 201: %v", status, out)
 	}
 	snap, _ := out["snapshot"].(map[string]any)
-	snapID, _ := snap["id"].(string)
 	base, _ := snap["base_volume"].(map[string]any)
-	if base == nil || base["id"] != rootID {
+	if base == nil || base["id"] != volumeID {
 		t.Errorf("the snapshot does not name the volume it was taken of: %v", snap["base_volume"])
 	}
 	// The size comes from the volume, not from the catalogue default: a
-	// snapshot that reports 20 GB of a 40 GB disk is a lie a client stores.
-	if size, _ := snap["size"].(float64); size != 20000000000 {
-		t.Errorf("the snapshot reports size %v, want the volume's 20000000000", snap["size"])
+	// snapshot that reports 20 GB of a 10 GB disk is a lie a client stores.
+	if size, _ := snap["size"].(float64); size != 10000000000 {
+		t.Errorf("the snapshot reports size %v, want the volume's 10000000000", snap["size"])
 	}
-	// b_ssd would name the product it was NOT taken from.
-	if snap["volume_type"] != "unified" {
-		t.Errorf("the snapshot of a block volume is typed %v, want unified: the fallback names the "+
-			"instance product, and stating the value keeps this test discriminating whatever that "+
-			"fallback becomes (it was b_ssd until #393)", snap["volume_type"])
-	}
-	// And the promise: sbs_snapshot means "this id resolves in block/v1alpha1".
-	if snap["volume_type"] == "sbs_snapshot" {
-		if status, _ := do(t, ts, "GET", blockURL+"/snapshots/"+snapID, ""); status != http.StatusOK {
-			t.Errorf("the snapshot is typed sbs_snapshot and block answers %d for it: "+
-				"`scw instance image list` reads block.GetSnapshot on exactly that type and fails the whole listing", status)
-		}
-	}
-
-	// A named type wins, because the request field overrides.
+	// And a named type still wins, because the request field overrides the
+	// volume's in the SDK's own words.
 	status, out = do(t, ts, "POST", zone+"/snapshots",
-		`{"name":"unified","volume_id":"`+rootID+`","volume_type":"unified"}`)
+		`{"name":"unified","volume_id":"`+volumeID+`","volume_type":"unified"}`)
 	if status != http.StatusCreated {
 		t.Fatalf("snapshot with an explicit type answered %d: %v", status, out)
 	}

--- a/internal/providers/scaleway/images_test.go
+++ b/internal/providers/scaleway/images_test.go
@@ -13,8 +13,7 @@ import (
 // apply"; `scw instance image get` simply describes the wrong object.
 func TestAnImageReadsBackAsItWasCreated(t *testing.T) {
 	ts := newTestServer(t)
-	_, server := serverWith(t, ts, `{"name":"golden","commercial_type":"DEV1-S"}`)
-	snapshotID := snapshotOfVolume(t, ts, "golden-snap", rootVolumeOf(t, server))
+	snapshotID := snapshotOfVolume(t, ts, "golden-snap", instanceVolumeOf(t, ts))
 
 	status, created := do(t, ts, "POST", zoneURL+"/images",
 		`{"name":"golden-img","root_volume":"`+snapshotID+`","tags":["release"]}`)
@@ -90,8 +89,7 @@ func TestListingImagesCarriesTheCatalogueAndTheClients(t *testing.T) {
 		t.Fatal("listing images answered nothing, and the catalogue is never empty")
 	}
 
-	_, server := serverWith(t, ts, `{"name":"golden","commercial_type":"DEV1-S"}`)
-	snapshotID := snapshotOfVolume(t, ts, "golden-snap", rootVolumeOf(t, server))
+	snapshotID := snapshotOfVolume(t, ts, "golden-snap", instanceVolumeOf(t, ts))
 	if status, got := do(t, ts, "POST", zoneURL+"/images",
 		`{"name":"golden-img","root_volume":"`+snapshotID+`"}`); status != http.StatusCreated {
 		t.Fatalf("create image: expected 201, got %d (%v)", status, got)

--- a/internal/providers/scaleway/snapshots.go
+++ b/internal/providers/scaleway/snapshots.go
@@ -83,16 +83,37 @@ func (p *Pack) createSnapshot(w http.ResponseWriter, r *http.Request) {
 	size := uint64(rootVolumeSize)
 	base := map[string]any{"id": "", "name": ""}
 	if req.VolumeID != nil && *req.VolumeID != "" {
-		// Both products. A server's root disk lives in block as soon as the
-		// client asks for sbs_volume, and this resolved kindVolume alone — so
-		// `scw instance snapshot create volume-id=<that root>` answered 404 on
-		// the disk the same emulator had just published in the server's own
-		// volumes map (#571). The conformance suite's golden-image path takes
-		// exactly that route: it snapshots volumes["0"] and cuts an image from
-		// the snapshot.
-		volume, found := p.anyVolume(*req.VolumeID)
+		// instance/v1 alone, and the resource name in the refusal says which
+		// product answered (#648).
+		//
+		// This resolved BOTH products until 2026-09-03, and the reason was
+		// sound when it was written: a server's root disk lives in block since
+		// #365, and resolving kindVolume alone answered 404 on the disk the same
+		// emulator had just published in the server's own volumes map (#571).
+		//
+		// The measurement reverses it. Against fr-par, an instance/v1
+		// CreateSnapshot naming a block volume answers:
+		//
+		//	404 {"type": "not_found", "message": "resource is not found",
+		//	     "resource": "instance_volume", "resource_id": "<the id>"}
+		//
+		// A block volume is not an instance_volume, and the cloud says so in the
+		// one field a client reads to know WHICH thing was not found. The
+		// emulator was more permissive than the cloud in the direction that
+		// costs: a golden-image path built this way is green here and fails
+		// there.
+		//
+		// Nothing in this repository needed the permissive version any more.
+		// The conformance suite already stopped taking that route — its own
+		// comment says `scw instance snapshot create volume-id=<a block volume>`
+		// cannot be the subject, because the CLI calls instance.GetVolume itself
+		// before it sends anything — and it snapshots a block volume through
+		// block/v1, the product that owns it.
+		//
+		// TestAnInstanceSnapshotRefusesAVolumeItDoesNotOwn fails without this.
+		volume, found := p.env.Store.Get(Name, kindVolume, *req.VolumeID)
 		if !found {
-			writeNotFound(w, "volume", *req.VolumeID)
+			writeNotFound(w, "instance_volume", *req.VolumeID)
 			return
 		}
 		base = map[string]any{
@@ -102,44 +123,27 @@ func (p *Pack) createSnapshot(w http.ResponseWriter, r *http.Request) {
 		if volumeType == "" {
 			volumeType = textOf(volume.Attrs["volume_type"])
 		}
-		// A block volume carries no volume_type attribute — its product has one
-		// class, "sbs" — so the reading above leaves it empty and the default
-		// below would call the snapshot b_ssd, which is a different product.
+		// The `unified` branch that stood here is gone with its subject (#648).
 		//
-		// `unified` rather than `sbs_snapshot`, and the difference was MEASURED
-		// rather than reasoned. sbs_snapshot was the first answer here, read
-		// straight off the SDK's VolumeVolumeType enum, and it broke a command:
-		// `scw instance image list` calls block.GetSnapshot for every image whose
-		// root_volume.volume_type is sbs_snapshot and fails the WHOLE listing on
-		// error (scaleway-cli 2.56.3,
-		// internal/namespaces/instance/v1/custom_image.go:222). Cutting an image
-		// from such a snapshot therefore made `scw instance image list` answer
-		// "cannot find resource 'snapshot'" for the entire zone — measured
-		// 2026-08-28. sbs_snapshot is a promise that the id resolves in the
-		// BLOCK product, and this snapshot lives in instance/v1.
+		// It typed the snapshot of a BLOCK volume, and this route no longer takes
+		// one: fr-par answers 404 instance_volume for that request, and so does
+		// this pack now. A branch for an input that cannot arrive is a control
+		// that can never fire, which is the defect this repository names.
 		//
-		// `unified` is the value the CLI itself sends for this very input: with
-		// `unified=true` it skips the volume lookup entirely and asks for
-		// SnapshotVolumeTypeUnified, whatever the volume is. And without that
-		// flag it reads the volume through instance.GetVolume and gives up on a
-		// 404 — so unified is the ONLY instance snapshot of a block volume any
-		// scw user can ask for.
+		// What it was protecting is worth keeping written down, because it is
+		// measured and it will matter again the day an instance snapshot really
+		// can cross into block. `sbs_snapshot` is a PROMISE that the id resolves
+		// in the block product: `scw instance image list` calls block.GetSnapshot
+		// for every image whose root_volume.volume_type is sbs_snapshot and fails
+		// the WHOLE listing on error (scaleway-cli 2.56.3,
+		// internal/namespaces/instance/v1/custom_image.go:222). Answering it for
+		// a snapshot block cannot resolve made `scw instance image list` say
+		// "cannot find resource 'snapshot'" for an entire zone, measured
+		// 2026-08-28. So: a type that names the block product must be answerable
+		// by the block product.
 		//
-		// What is not settled, and is not this change's to settle: whether the
-		// cloud makes such a snapshot readable through block/v1alpha1 as well.
-		// If it does, the honest answer is sbs_snapshot AND a snapshot that
-		// answers on both doors — which is the volume work of #571 done again
-		// for snapshots, and nothing here has measured it.
-		//
-		// TestAnInstanceSnapshotOfABlockVolumeDoesNotPromiseTheBlockProduct
-		// fails without this.
-		//
-		// Only when the client named none: the request field "overrides the
-		// volume_type of the snapshot", which is the SDK's own wording, so a
-		// client that asked for one keeps it.
-		if volumeType == "" && volume.Kind == kindBlockVolume {
-			volumeType = "unified"
-		}
+		// TestAnInstanceSnapshotRefusesAVolumeItDoesNotOwn holds the refusal that
+		// replaced the branch.
 		// Through the shared reader: the assertion this replaces answered
 		// ok=false on a volume that had crossed a snapshot, so a snapshot taken
 		// after a `feint snapshot load` recorded a size of zero (#542).

--- a/internal/providers/scaleway/snapshots_test.go
+++ b/internal/providers/scaleway/snapshots_test.go
@@ -13,6 +13,28 @@ import (
 // because a comment saying "this case is refused" is the defect this repository
 // has met three times: the sentence survives, the guard does not.
 
+// instanceVolumeOf makes a volume instance/v1 owns, which is the only kind it
+// snapshots.
+//
+// The tests here used to hand rootVolumeOf(server) to snapshotOfVolume, and that
+// disk lives in BLOCK since #365. fr-par answers 404 `instance_volume` to an
+// instance/v1 snapshot of a block volume (#648), so those tests were exercising
+// a route the cloud does not have.
+func instanceVolumeOf(t *testing.T, ts *httptest.Server) string {
+	t.Helper()
+	status, created := do(t, ts, "POST", zoneURL+"/volumes",
+		`{"name":"snapshot-subject","volume_type":"l_ssd","size":10000000000}`)
+	if status != http.StatusCreated {
+		t.Fatalf("create an instance volume: expected 201, got %d (%v)", status, created)
+	}
+	volume, _ := created["volume"].(map[string]any)
+	id, _ := volume["id"].(string)
+	if id == "" {
+		t.Fatalf("create an instance volume: no id in %v", created)
+	}
+	return id
+}
+
 // snapshotOfVolume takes a snapshot and returns its id.
 func snapshotOfVolume(t *testing.T, ts *httptest.Server, name, volumeID string) string {
 	t.Helper()
@@ -29,25 +51,14 @@ func snapshotOfVolume(t *testing.T, ts *httptest.Server, name, volumeID string) 
 	return id
 }
 
-// rootVolumeOf reads the id of the root volume a server carries.
-func rootVolumeOf(t *testing.T, server map[string]any) string {
-	t.Helper()
-	volumes, _ := server["volumes"].(map[string]any)
-	root, _ := volumes["0"].(map[string]any)
-	id, _ := root["id"].(string)
-	if id == "" {
-		t.Fatalf("the server carries no root volume: %v", server["volumes"])
-	}
-	return id
-}
-
 // The sequence a client walks, end to end: what a create answers, the following
 // read answers identically. A create whose GET disagrees is the most common
 // cause of "Provider produced inconsistent result after apply".
 func TestASnapshotReadsBackAsItWasCreated(t *testing.T) {
 	ts := newTestServer(t)
-	_, server := serverWith(t, ts, `{"name":"golden","commercial_type":"DEV1-S"}`)
-	volumeID := rootVolumeOf(t, server)
+	// An instance volume, not a server's root disk: that one lives in block
+	// since #365, and instance/v1 does not snapshot what it does not own (#648).
+	volumeID := instanceVolumeOf(t, ts)
 
 	status, created := do(t, ts, "POST", zoneURL+"/snapshots",
 		`{"name":"golden-snap","volume_id":"`+volumeID+`"}`)
@@ -136,8 +147,7 @@ func TestASnapshotImportedFromABucketIsRefused(t *testing.T) {
 // naming a snapshot that is gone, and the client has no signal to retry.
 func TestASnapshotAnImageIsCutFromDoesNotDelete(t *testing.T) {
 	ts := newTestServer(t)
-	_, server := serverWith(t, ts, `{"name":"golden","commercial_type":"DEV1-S"}`)
-	snapshotID := snapshotOfVolume(t, ts, "golden-snap", rootVolumeOf(t, server))
+	snapshotID := snapshotOfVolume(t, ts, "golden-snap", instanceVolumeOf(t, ts))
 
 	status, created := do(t, ts, "POST", zoneURL+"/images",
 		`{"name":"golden-img","root_volume":"`+snapshotID+`"}`)

--- a/tools/falsify/specs/acl-and-snapshot-refusals.json
+++ b/tools/falsify/specs/acl-and-snapshot-refusals.json
@@ -1,0 +1,47 @@
+{
+  "package": "./internal/providers/scaleway/",
+  "mutations": [
+    {
+      "label": "a high port left at zero is accepted again, so the commonest Terraform rule is green here and refused by the cloud",
+      "file": "internal/providers/scaleway/acl.go",
+      "find": "\t\tif port.low > 65535 || port.high > 65535 || port.low > port.high {",
+      "replace": "\t\tif port.low > 65535 || port.high > 65535 || (port.low > port.high && port.high != 0) {",
+      "test": "TestSetACLRefusesWhatTheEnumsRefuse"
+    },
+    {
+      "label": "the refusal names rules.0.field again, which is a shape the cloud never sends",
+      "file": "internal/providers/scaleway/acl.go",
+      "find": "\t\treturn \"rules[\" + strconv.Itoa(index) + \"]\" + field",
+      "replace": "\t\treturn \"rules.\" + strconv.Itoa(index) + \".\" + field",
+      "test": "TestSetACLRefusesWhatTheEnumsRefuse"
+    },
+    {
+      "label": "an invalid range names one bound instead of the pair the cloud names",
+      "file": "internal/providers/scaleway/acl.go",
+      "find": "\t\t\treturn nil, []ArgumentError{\n\t\t\t\t{\n\t\t\t\t\tArgumentName: at(port.lowName),",
+      "replace": "\t\t\treturn nil, []ArgumentError{\n\t\t\t\t{\n\t\t\t\t\tArgumentName: at(port.highName),",
+      "test": "TestSetACLRefusesWhatTheEnumsRefuse"
+    },
+    {
+      "label": "an unknown protocol is refused again, which is stricter than the cloud and turns a working client away",
+      "file": "internal/providers/scaleway/acl.go",
+      "find": "\tif !aclProtocols[protocol] {\n\t\tprotocol = \"ANY\"\n\t}",
+      "replace": "\tif !aclProtocols[protocol] {\n\t\treturn nil, []ArgumentError{{ArgumentName: at(\"protocol\"), Reason: \"constraint\", HelpMessage: \"unknown protocol\"}}\n\t}",
+      "test": "TestSetACLRefusesWhatTheEnumsRefuse"
+    },
+    {
+      "label": "instance/v1 resolves a block volume again, so a golden-image path built on it is green here and fails against the cloud",
+      "file": "internal/providers/scaleway/snapshots.go",
+      "find": "\t\tvolume, found := p.env.Store.Get(Name, kindVolume, *req.VolumeID)\n\t\tif !found {\n\t\t\twriteNotFound(w, \"instance_volume\", *req.VolumeID)",
+      "replace": "\t\tvolume, found := p.env.Store.Get(Name, kindVolume, *req.VolumeID)\n\t\tif !found {\n\t\t\tvolume, found = p.anyVolume(*req.VolumeID)\n\t\t}\n\t\tif !found {\n\t\t\twriteNotFound(w, \"instance_volume\", *req.VolumeID)",
+      "test": "TestAnInstanceSnapshotRefusesAVolumeItDoesNotOwn"
+    },
+    {
+      "label": "the refusal says `volume` where the cloud says `instance_volume`, so a client cannot tell which product did not hold the id",
+      "file": "internal/providers/scaleway/snapshots.go",
+      "find": "\t\t\twriteNotFound(w, \"instance_volume\", *req.VolumeID)",
+      "replace": "\t\t\twriteNotFound(w, \"volume\", *req.VolumeID)",
+      "test": "TestAnInstanceSnapshotRefusesAVolumeItDoesNotOwn"
+    }
+  ]
+}

--- a/tools/falsify/specs/block-volumes-reach-their-server.json
+++ b/tools/falsify/specs/block-volumes-reach-their-server.json
@@ -44,22 +44,6 @@
       "test": "TestACreateNamingABlockVolumeAttachesIt"
     },
     {
-      "label": "an instance snapshot cannot be taken of a block disk",
-      "file": "internal/providers/scaleway/snapshots.go",
-      "find": "\t\tvolume, found := p.anyVolume(*req.VolumeID)\n\t\tif !found {",
-      "replace": "\t\tvolume, found := p.anyVolume(*req.VolumeID)\n\t\tif !found || volume.Kind == kindBlockVolume {",
-      "expect": "the golden-image path answers 404 on the disk the server publishes under volumes[\"0\"]",
-      "test": "TestAnInstanceSnapshotOfABlockVolumeDoesNotPromiseTheBlockProduct"
-    },
-    {
-      "label": "a snapshot of a block disk falls back to the other product's type",
-      "file": "internal/providers/scaleway/snapshots.go",
-      "find": "\t\tif volumeType == \"\" && volume.Kind == kindBlockVolume {\n\t\t\tvolumeType = \"unified\"\n\t\t}",
-      "replace": "\t\tif volumeType == \"\" && volume.Kind == kindBlockVolume && false {\n\t\t\tvolumeType = \"unified\"\n\t\t}",
-      "expect": "the snapshot falls through to the instance default, naming a product it was not taken from (l_ssd since #393, b_ssd before it)",
-      "test": "TestAnInstanceSnapshotOfABlockVolumeDoesNotPromiseTheBlockProduct"
-    },
-    {
       "label": "a block disk is published inside a server with no type at all",
       "file": "internal/providers/scaleway/volumes.go",
       "find": "\tif res.Kind == kindBlockVolume {\n\t\treturn blockVolumeServerView(res)\n\t}\n\treturn volumeView(res)",
@@ -130,14 +114,16 @@
       "replace": "\tif detached := textOf(res.Attrs[\"last_detached_at\"]); detached != \"\" && false {\n\t\tview[\"last_detached_at\"] = detached\n\t}",
       "expect": "the field is recorded and never answered, which reads to a client exactly like a volume nothing has ever released",
       "test": "TestAReleasedBlockVolumeSaysWhenItWasDetached"
-    },
+    }
+  ],
+  "retired": [
     {
-      "label": "an instance snapshot of a block disk promises the block product again",
-      "file": "internal/providers/scaleway/snapshots.go",
-      "find": "\t\t\tvolumeType = \"unified\"\n",
-      "replace": "\t\t\tvolumeType = \"unified\"[:0] + \"sbs_snapshot\"\n",
-      "expect": "the type says the id resolves in block/v1alpha1 and it does not, so an image cut from it makes `scw instance image list` fail for the whole zone (custom_image.go:222) — measured 2026-08-28",
-      "test": "TestAnInstanceSnapshotOfABlockVolumeDoesNotPromiseTheBlockProduct"
+      "labels": [
+        "an instance snapshot cannot be taken of a block disk",
+        "a snapshot of a block disk falls back to the other product's type",
+        "an instance snapshot of a block disk promises the block product again"
+      ],
+      "why": "Their subject is gone, not moved. All three measured the instance/v1 snapshot of a BLOCK volume — that the route resolved one, and that it typed the result `unified` rather than promising the block product. #648 measured fr-par answering 404 not_found / instance_volume for exactly that request, so the route no longer takes a block volume and there is nothing left for these to neutralise. The refusal that replaced them is measured from the other side by acl-and-snapshot-refusals.json and by TestAnInstanceSnapshotRefusesAVolumeItDoesNotOwn. The reasoning they carried about `sbs_snapshot` being a promise the block product must keep is preserved in snapshots.go, where it will matter again the day such a snapshot really can cross the two products."
     }
   ]
 }


### PR DESCRIPTION
Closes #648.

Reported with a differential run — the same Terraform stack against `main` and
against `api.scaleway.com`, provider 2.81.0. Both reported gaps go in the
direction that costs: **the emulator more permissive than the cloud**, so a
client green here learns nothing about the real one.

| input | `fr-par` | before |
|---|---|---|
| an ACL rule whose `dst_port_high` is below `dst_port_low` | 400, naming **both** bounds | 200 |
| `instance/v1 CreateSnapshot` on a block (SBS) volume | 404 `not_found`, `resource: instance_volume` | 201 |

**The first is not an exotic input.** It is what the Terraform provider sends for
the commonest rule there is — one port opened — because a rule naming only
`dst_port_low` leaves the high bound at zero. Three rules out of three in the
reporter's stack had that shape.

The comment in `validateACLRule` named its own gap, and it deserves quoting
because it was right:

> whether the real API narrows this further is **unmeasured**, and being
> permissive where the measurement is missing is the safe side

That is the correct call with no measurement, and the wrong answer with one.

**The second is the golden-image pattern.** A root disk lives in `block` since
#365, and a block volume is not an `instance_volume`. This pack resolved both
products there on purpose (#571) — and the measurement reverses it: the 404 that
change fixed is served differently now, and the conformance suite had already
stopped taking that route. Its own comment says the CLI calls
`instance.GetVolume` before it sends anything.

## Measuring it turned up two more, and one goes the other way

I re-read the wire rather than trusting the SDK's rendering, and asked four more
refusals on the same route:

- **`argument_name` is `rules[0]dst_port_high`** — no dot before the index, none
  before the field. This pack wrote `rules.0.dst_port_high`, wrong for *every*
  rule error rather than for one of them. And `reason` differs per field:
  `unknown` for `action` and `source`, `constraint` for the ports.
- **An unknown protocol is normalised to `ANY`, not refused.** `NONSENSE` answers
  200 and reads back as `ANY`. This pack refused it — the rarer direction,
  stricter than the cloud, and a client that would have worked against `fr-par`
  met a 400 here. **Being stricter is still being different.**

One detail is copied rather than tidied because nobody would invent it: in the
same body, the high bound's `min` is the **string** `"443"` and the low bound's
is the **number** `0`.

## Six tests changed sides

They asserted the shapes this pack invented — the dotted argument name, the
protocol refusal, the snapshot of a block root — and now assert the measured
ones. `TestAnInstanceSnapshotOfABlockVolumeDoesNotPromiseTheBlockProduct` becomes
`TestAnInstanceSnapshotRefusesAVolumeItDoesNotOwn`, keeping the half of itself
that still stands.

**Three mutations of `block-volumes-reach-their-server.json` are retired rather
than retargeted**, with the reason written in the spec: their subject is gone,
not moved. What they were protecting — that a type naming the block product must
be answerable by the block product, or `scw instance image list` fails a whole
zone — is preserved in `snapshots.go` for the day an instance snapshot really can
cross the two.

## Proof

- `mise run falsify -- tools/falsify/specs/acl-and-snapshot-refusals.json`: six
  mutations, six *the test bit*, including the two accepting halves a guard that
  refused everything would satisfy — a range whose bounds agree still passes, and
  a volume instance/v1 owns is still snapshotted.
- `mise run conformance:leg -- fields` green, 356 of 381 routes proven by a real
  client (unchanged), and `tools/conformance/stacks.sh` green.
- `mise run corpus:check` green, `mise run prepush` green.

Not run: the full `mise run conformance` pass. This branch is one of a batch; the
whole suite is played once on the assembled set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
