### PR TITLE
fix(scaleway): a disk nothing was ever attached to has nothing to snapshot (#650, #646)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -86,6 +86,55 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Corrigé
 
+- **Un instantané d'un disque auquel rien n'a jamais été attaché était accepté,
+  et la stack d'exemple publiée en dépendait** (#650, #646).
+
+  Le cloud le refuse : `cannot create a RO disk from an empty disk`. Le motif de
+  l'image dorée que démontre la stack Scaleway, un volume puis son instantané
+  puis une image taillée dedans, **ne pouvait donc pas s'appliquer contre la
+  vraie API Scaleway**, et le rapporteur l'a découvert en y lançant sa copie.
+
+  Où passe la ligne a été mesuré de trois façons, parce qu'elle n'est pas où on
+  la croit :
+
+  | sujet | `fr-par` |
+  |---|---|
+  | un volume créé et jamais attaché | 400, `cannot create a RO disk from an empty disk` |
+  | le disque système d'un serveur jamais démarré | 201 |
+  | un disque détaché d'un serveur supprimé | 201 |
+
+  La question n'est donc pas de savoir si la machine a tourné, ni si le disque
+  est attaché maintenant. C'est **s'il a déjà appartenu à quelqu'un**, ce qui est
+  la raison pour laquelle la marque est posée à l'attachement et jamais effacée
+  au détachement.
+
+  Le refus porte une entrée `details` avec une raison et un message d'aide, et
+  **aucun `argument_name`** : `ArgumentError` omet donc ce champ quand il est
+  vide plutôt que d'envoyer `""`.
+
+  **La stack d'exemple construit désormais son image dorée depuis un disque porté
+  par une machine de construction**, ce qu'un client doit faire face au cloud, et
+  le motif qu'elle enseigne survit au contact.
+
+- **La stack Scaleway d'exemple disait une chose et en faisait une autre, et
+  n'était pas routable telle qu'écrite** (#646). Son `vpc_route` était commentée
+  « joindre la plage de management par le réseau **admin** » et pointait `app`,
+  et c'est le code qui avait raison : le prochain saut d'une route est un réseau
+  privé de son propre VPC, et `admin` est dans l'autre.
+
+  En dessous, la topologie ne peut pas porter ce que l'en-tête annonce : deux VPC
+  qui ne partagent rien ne se joignent pas, donc le bastion décrit comme « la
+  seule porte publique » n'ouvre sur rien. Sous `mode: off`, rien ne démarre et
+  la différence ne se voit jamais. Le rapporteur l'a rencontrée en lançant
+  Ansible à travers ce bastion sous `--vm incus-ovn`, et a passé un moment à
+  soupçonner son propre `ProxyCommand`.
+
+  L'en-tête le dit désormais, dans le fichier que le lecteur copie et pas
+  seulement dans le `feint.yaml` d'à côté. Rendre la stack routable, un seul VPC
+  et plusieurs réseaux privés, n'est délibérément **pas** fait ici : cela
+  échangerait l'isolation que cette stack démontre contre une accessibilité
+  qu'elle ne démontre pas, et c'est un choix sur ce à quoi l'exemple sert.
+
 - **Deux entrées que le cloud refuse et que cet émulateur acceptait, et une qu'il
   accepte et que cet émulateur refusait** (#648, signalé par une exécution
   différentielle : la même stack Terraform contre `main` et contre

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,55 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Fixed
 
+- **A snapshot of a disk nothing was ever attached to was accepted, and the
+  published example stack depended on it** (#650, #646).
+
+  The cloud refuses it: `cannot create a RO disk from an empty disk`. So the
+  golden-image pattern the Scaleway example stack demonstrates — a volume, a
+  snapshot of it, an image cut from the snapshot — **could not apply against the
+  real Scaleway API**, and the reporter found out by running their copy of it
+  there.
+
+  Where the line falls was measured three ways, because it is not where it first
+  looks:
+
+  | subject | `fr-par` |
+  |---|---|
+  | a volume created and never attached | 400, `cannot create a RO disk from an empty disk` |
+  | the root disk of a server that never started | 201 |
+  | a disk detached from a deleted server | 201 |
+
+  So the question is not whether the machine ran, and not whether the disk is
+  attached now. It is **whether the disk was ever anybody's** — which is why the
+  mark is set on attach and never cleared on detach.
+
+  The refusal carries a `details` entry with a reason and a help message and **no
+  `argument_name` at all**, so `ArgumentError` omits that field when it is empty
+  rather than sending `""`.
+
+  **The example stack now builds its golden image from a disk a builder machine
+  carries**, which is what a client has to do against the cloud, and the pattern
+  it teaches survives contact.
+
+- **The Scaleway example stack said one thing and did another, and was not
+  routable as written** (#646). Its `vpc_route` was commented "reach the
+  management range through the **admin** network" and pointed at `app` — and the
+  code was the half that was right: a route's next hop is a private network of
+  its own VPC, and `admin` is in the other one.
+
+  Underneath that, the topology cannot carry what the header advertises: two VPCs
+  that share nothing cannot reach each other, so the bastion described as "the
+  only public door" opens onto nothing. Under `mode: off` nothing boots and the
+  difference never shows — the reporter met it by running Ansible through that
+  bastion under `--vm incus-ovn`, and spent a while suspecting their own
+  `ProxyCommand`.
+
+  The header says so now, in the file a reader copies rather than only in the
+  `feint.yaml` beside it. Making the stack routable — one VPC, several private
+  networks — is deliberately **not** done here: it would trade the isolation this
+  stack demonstrates for reachability it does not, and that is a choice about
+  what the example is for.
+
 - **Two inputs the cloud refuses and this emulator accepted, and one it accepts
   that this emulator refused** (#648, reported with a differential run: the same
   Terraform stack against `main` and against `api.scaleway.com`).

--- a/examples/stacks/scaleway/main.tf
+++ b/examples/stacks/scaleway/main.tf
@@ -12,6 +12,21 @@
 # It exists to be run against Feint with no cloud account. Everything here is
 # ordinary Terraform: if it applies, re-plans empty and destroys, the emulator
 # held up under something that looks like production rather than under a test.
+#
+# WHAT THIS ASSERTS, AND WHAT IT DOES NOT (#646). It asserts the control plane:
+# the shapes, the ordering, the read-backs, the second plan being empty. It is
+# NOT routable as written, and that is a property of the topology rather than of
+# the emulator: two VPCs that share nothing cannot reach each other, so the
+# bastion in the workload VPC opens onto nothing in the management one. Under
+# `mode: off` — which is what feint.yaml declares, and why — nothing boots and
+# the difference never shows.
+#
+# It is written here because a reader who copies the Terraform without the yaml
+# has no other way to learn it. Somebody did, ran Ansible through the bastion
+# under `--vm incus-ovn`, and spent a while suspecting their own ProxyCommand.
+# If you want a topology packets actually cross, collapse to one VPC with
+# several private networks and attach the bastion to all of them — which trades
+# the isolation this stack demonstrates for reachability it does not.
 
 terraform {
   required_version = ">= 1.7.0"
@@ -135,8 +150,18 @@ resource "scaleway_vpc_private_network" "admin" {
   }
 }
 
-# A route a platform team really writes: reach the management range through the
-# admin network.
+# A route a platform team really writes, and the next hop is `app` on purpose.
+#
+# The comment here used to say "through the admin network", which is in the
+# OTHER VPC and cannot be a next hop for a route in this one — the two disagreed
+# and the code was the half that was right (#646). A route's next hop is a
+# private network of its own VPC; `app` is the workload VPC's, `admin` is the
+# management VPC's.
+#
+# So what this route demonstrates is the API — a destination, a next hop, a
+# read-back, an empty second plan — and not a path a packet takes. Nothing in
+# the workload VPC reaches 10.40.0.0/16, because that is what "two VPCs that do
+# not share a network" means. See the header.
 resource "scaleway_vpc_route" "to_management" {
   vpc_id                     = scaleway_vpc.workload.id
   description                = "management range"
@@ -261,9 +286,36 @@ resource "scaleway_instance_volume" "golden" {
   size_in_gb = 10
 }
 
+# The disk has to have been somebody's before it can be snapshotted, and this
+# machine is why (#650). Measured on fr-par: a volume created and never attached
+# answers `cannot create a RO disk from an empty disk`, while the same volume
+# attached to a server — even one that never started — snapshots fine, and goes
+# on doing so after it is detached.
+#
+# This stack used to snapshot the volume straight after creating it, so the
+# golden-image pattern it teaches did not survive contact with the real cloud.
+# The reporter found out by running their copy of it there.
+resource "scaleway_instance_server" "golden_builder" {
+  name                  = "platform-golden-builder"
+  type                  = "DEV1-S"
+  image                 = "ubuntu_jammy"
+  zone                  = "fr-par-1"
+  additional_volume_ids = [scaleway_instance_volume.golden.id]
+
+  root_volume {
+    volume_type = "sbs_volume"
+    size_in_gb  = 20
+  }
+}
+
 resource "scaleway_instance_snapshot" "golden" {
   name      = "platform-golden-snap"
   volume_id = scaleway_instance_volume.golden.id
+
+  # The disk must carry the builder's attachment before the snapshot is asked
+  # for; without this Terraform is free to order the two the other way and the
+  # apply fails on a disk the cloud calls empty.
+  depends_on = [scaleway_instance_server.golden_builder]
 }
 
 resource "scaleway_instance_image" "golden" {

--- a/internal/providers/scaleway/barrage_test.go
+++ b/internal/providers/scaleway/barrage_test.go
@@ -300,11 +300,12 @@ func barrageCycle(ts *httptest.Server, tag string, problems chan<- string) {
 	// would live: snapshotting a volume while other workers create and delete
 	// servers.
 	//
-	// An INSTANCE volume, made here, and not the server's root disk. That one
-	// lives in block since #365, and instance/v1 answers 404 instance_volume for
-	// a volume it does not own (#648) — so the barrage would report forty
-	// refusals that are the API working. What it stresses is unchanged: the
-	// snapshot handler under concurrency.
+	// An instance volume, attached to this server and then snapshotted, which is
+	// the only subject the cloud takes. The root lives in block since #365 and
+	// instance/v1 answers 404 instance_volume for a volume it does not own
+	// (#648); a volume never attached to anything is refused for having nothing
+	// on it (#650). What the barrage stresses is unchanged: the snapshot handler
+	// under concurrency.
 	_ = rootID
 	status, made := doRaw(ts, "POST", zoneURL+"/volumes",
 		`{"name":"barrage-`+tag+`","volume_type":"l_ssd","size":10000000000}`)
@@ -312,11 +313,13 @@ func barrageCycle(ts *httptest.Server, tag string, problems chan<- string) {
 		problems <- fmt.Sprintf("%s: volume create answered %d", tag, status)
 	} else {
 		volume, _ := made["volume"].(map[string]any)
-		if id, _ := volume["id"].(string); id != "" {
-			if status, _ := doRaw(ts, "POST", zoneURL+"/snapshots",
-				`{"name":"barrage-`+tag+`","volume_id":"`+id+`"}`); status != http.StatusCreated {
-				problems <- fmt.Sprintf("%s: snapshot create answered %d", tag, status)
-			}
+		diskID, _ := volume["id"].(string)
+		if status, _ := doRaw(ts, "POST", zoneURL+"/servers/"+serverID+"/attach-volume",
+			`{"volume_id":"`+diskID+`"}`); status != http.StatusOK {
+			problems <- fmt.Sprintf("%s: attach-volume answered %d", tag, status)
+		} else if status, _ := doRaw(ts, "POST", zoneURL+"/snapshots",
+			`{"name":"barrage-`+tag+`","volume_id":"`+diskID+`"}`); status != http.StatusCreated {
+			problems <- fmt.Sprintf("%s: snapshot create answered %d", tag, status)
 		}
 	}
 

--- a/internal/providers/scaleway/block_attach_test.go
+++ b/internal/providers/scaleway/block_attach_test.go
@@ -270,6 +270,14 @@ func TestAnInstanceSnapshotRefusesAVolumeItDoesNotOwn(t *testing.T) {
 	}
 	volume, _ := made["volume"].(map[string]any)
 	volumeID, _ := volume["id"].(string)
+	// Attached, because a disk nothing was ever attached to has nothing to
+	// snapshot (#650). Two separate refusals live on this route now, and this
+	// test is about the other one.
+	serverID, _ := serverWith(t, ts, `{"name":"holder","commercial_type":"DEV1-S"}`)
+	if status, out := do(t, ts, "POST", zone+"/servers/"+serverID+"/attach-volume",
+		`{"volume_id":"`+volumeID+`"}`); status != http.StatusOK {
+		t.Fatalf("attach the volume: %d (%v)", status, out)
+	}
 
 	status, out = do(t, ts, "POST", zone+"/snapshots", `{"name":"snap","volume_id":"`+volumeID+`"}`)
 	if status != http.StatusCreated {

--- a/internal/providers/scaleway/block_restore_test.go
+++ b/internal/providers/scaleway/block_restore_test.go
@@ -170,6 +170,15 @@ func TestAnInstanceSnapshotOfARestoredVolumeInheritsItsSize(t *testing.T) {
 	if volumeID == "" {
 		t.Fatalf("no volume id in %v", created)
 	}
+	// Attached before the snapshot is taken, because a disk nothing was ever
+	// attached to has nothing to snapshot (#650) — and because that mark living
+	// in Runtime is exactly what this test is about: it has to survive the store
+	// snapshot below, like the size does.
+	holder, _ := serverWith(t, ts, `{"name":"holder","commercial_type":"DEV1-S"}`)
+	if status, out := do(t, ts, "POST", instanceZone+"/servers/"+holder+"/attach-volume",
+		`{"volume_id":"`+volumeID+`"}`); status != http.StatusOK {
+		t.Fatalf("attach the volume: status %d, %v", status, out)
+	}
 
 	var saved bytes.Buffer
 	if err := env.Store.Snapshot(&saved); err != nil {

--- a/internal/providers/scaleway/errors.go
+++ b/internal/providers/scaleway/errors.go
@@ -26,7 +26,11 @@ type APIError struct {
 
 // ArgumentError is one entry of an invalid_arguments error.
 type ArgumentError struct {
-	ArgumentName string `json:"argument_name"`
+	// Omitted when empty, because one measured refusal carries none: fr-par's
+	// "cannot create a RO disk from an empty disk" answers a details entry with
+	// a reason and a help message and no argument at all (#650). An
+	// `"argument_name": ""` would be a field the cloud does not send.
+	ArgumentName string `json:"argument_name,omitempty"`
 	Reason       string `json:"reason"`
 	HelpMessage  string `json:"help_message,omitempty"`
 }

--- a/internal/providers/scaleway/listquery_test.go
+++ b/internal/providers/scaleway/listquery_test.go
@@ -595,6 +595,13 @@ func TestInstanceListsHonourTheirRemainingFilters(t *testing.T) {
 	volumes, _ := out["volumes"].([]any)
 	volume, _ := volumes[0].(map[string]any)
 	volumeID, _ := volume["id"].(string)
+	// Attached first: a disk nothing was ever attached to has nothing to
+	// snapshot, and the cloud refuses it (#650).
+	holder, _ := serverWith(t, ts, `{"name":"snapshot-holder","commercial_type":"DEV1-S"}`)
+	if status, out := do(t, ts, "POST", zone+"/servers/"+holder+"/attach-volume",
+		`{"volume_id":"`+volumeID+`"}`); status != http.StatusOK {
+		t.Fatalf("attach the volume before snapshotting it: status %d, %v", status, out)
+	}
 	for _, name := range []string{"s1", "s2"} {
 		body := fmt.Sprintf(`{"name":%q,"volume_id":%q}`, name, volumeID)
 		if status, _ := do(t, ts, "POST", zone+"/snapshots", body); status != http.StatusCreated {

--- a/internal/providers/scaleway/snapshots.go
+++ b/internal/providers/scaleway/snapshots.go
@@ -116,6 +116,34 @@ func (p *Pack) createSnapshot(w http.ResponseWriter, r *http.Request) {
 			writeNotFound(w, "instance_volume", *req.VolumeID)
 			return
 		}
+		// A disk nothing ever wrote to has nothing to snapshot, and fr-par says
+		// so in those words (#650):
+		//
+		//	400 {"type": "invalid_arguments", "message": "invalid argument(s)",
+		//	     "details": [{"reason": "constraint",
+		//	                  "help_message": "cannot create a RO disk from an empty disk"}]}
+		//
+		// No argument_name in that details entry, which is why ArgumentError
+		// omits the field when it is empty.
+		//
+		// ATTACHMENT is the line, measured rather than assumed: a volume never
+		// attached to anything is refused, and the root disk of a server that was
+		// created and never started is ACCEPTED. So the question is not whether
+		// the machine ran, it is whether the disk was ever anybody's.
+		//
+		// This is the third of the same shape in one report: the emulator more
+		// permissive than the cloud, so a green run here says nothing. It cost
+		// the reporter a real apply — the published example stack builds its
+		// golden image exactly this way, and the cloud refused it.
+		//
+		// TestASnapshotOfAVolumeNothingEverWroteToIsRefused fails without this.
+		if volume.Kind == kindVolume && volume.Runtime[runtimeAttachedKey] == "" {
+			writeInvalidArguments(w, ArgumentError{
+				Reason:      "constraint",
+				HelpMessage: "cannot create a RO disk from an empty disk",
+			})
+			return
+		}
 		base = map[string]any{
 			"id":   volume.ID,
 			"name": textOf(volume.Attrs["name"]),

--- a/internal/providers/scaleway/snapshots_test.go
+++ b/internal/providers/scaleway/snapshots_test.go
@@ -32,6 +32,15 @@ func instanceVolumeOf(t *testing.T, ts *httptest.Server) string {
 	if id == "" {
 		t.Fatalf("create an instance volume: no id in %v", created)
 	}
+	// Attached, because a disk nothing was ever attached to has nothing to
+	// snapshot and fr-par refuses it (#650). The server is the cheapest way to
+	// give the disk a history; it is never started, which the measurement says
+	// is enough.
+	serverID, _ := serverWith(t, ts, `{"name":"snapshot-host","commercial_type":"DEV1-S"}`)
+	if status, out := do(t, ts, "POST", zoneURL+"/servers/"+serverID+"/attach-volume",
+		`{"volume_id":"`+id+`"}`); status != http.StatusOK {
+		t.Fatalf("attach the volume: expected 200, got %d (%v)", status, out)
+	}
 	return id
 }
 
@@ -175,5 +184,85 @@ func TestASnapshotAnImageIsCutFromDoesNotDelete(t *testing.T) {
 	}
 	if status, got := do(t, ts, "DELETE", zoneURL+"/snapshots/"+snapshotID, ""); status != http.StatusNoContent {
 		t.Errorf("delete snapshot after its image: expected 204, got %d (%v)", status, got)
+	}
+}
+
+// A disk nothing was ever attached to has nothing to snapshot, and the cloud
+// says so in those words (#650).
+//
+// Measured on fr-par, 2026-09-03, three ways, because the line between accepted
+// and refused is not where it first looks:
+//
+//	a volume created and never attached          400 "cannot create a RO disk from an empty disk"
+//	the root disk of a server that never started 201
+//	a disk detached from a deleted server        201
+//
+// So the question is not whether the machine ran. It is whether the disk was
+// ever anybody's — which is why the mark is set on attach and never cleared on
+// detach.
+//
+// Why it is worth a refusal rather than a shrug: the published example stack
+// built its golden image exactly this way, so the pattern it teaches did not
+// survive contact with the real cloud. The reporter found out by running their
+// copy of it there.
+func TestASnapshotOfAVolumeNothingEverWroteToIsRefused(t *testing.T) {
+	ts := newTestServer(t)
+
+	status, created := do(t, ts, "POST", zoneURL+"/volumes",
+		`{"name":"empty","volume_type":"l_ssd","size":10000000000}`)
+	if status != http.StatusCreated {
+		t.Fatalf("create a volume: %d (%v)", status, created)
+	}
+	volume, _ := created["volume"].(map[string]any)
+	volumeID, _ := volume["id"].(string)
+
+	status, body := do(t, ts, "POST", zoneURL+"/snapshots",
+		`{"name":"of-nothing","volume_id":"`+volumeID+`"}`)
+	if status != http.StatusBadRequest {
+		t.Fatalf("a snapshot of a never-attached volume answered %d, want 400 (%v)", status, body)
+	}
+	if body["type"] != "invalid_arguments" {
+		t.Errorf("type is %v, want invalid_arguments", body["type"])
+	}
+	details, _ := body["details"].([]any)
+	if len(details) != 1 {
+		t.Fatalf("details holds %d entries, want 1 (%v)", len(details), body)
+	}
+	d, _ := details[0].(map[string]any)
+	if d["help_message"] != "cannot create a RO disk from an empty disk" {
+		t.Errorf("help_message is %v, want the cloud's own sentence", d["help_message"])
+	}
+	if d["reason"] != "constraint" {
+		t.Errorf("reason is %v, want constraint", d["reason"])
+	}
+	// No argument_name at all in that entry, which is why ArgumentError omits
+	// the field when it is empty. A `"argument_name": ""` is a field the cloud
+	// does not send.
+	if _, carries := d["argument_name"]; carries {
+		t.Errorf("the details entry carries an argument_name and fr-par sends none: %v", d)
+	}
+
+	// Attached once, and it can be snapshotted — the accepting half, without
+	// which a guard that refused every snapshot would satisfy everything above.
+	serverID, _ := serverWith(t, ts, `{"name":"holder","commercial_type":"DEV1-S"}`)
+	if status, out := do(t, ts, "POST", zoneURL+"/servers/"+serverID+"/attach-volume",
+		`{"volume_id":"`+volumeID+`"}`); status != http.StatusOK {
+		t.Fatalf("attach the volume: %d (%v)", status, out)
+	}
+	if status, out := do(t, ts, "POST", zoneURL+"/snapshots",
+		`{"name":"of-something","volume_id":"`+volumeID+`"}`); status != http.StatusCreated {
+		t.Fatalf("a snapshot of an attached volume answered %d, want 201 (%v)", status, out)
+	}
+
+	// And still after it is detached: the disk keeps what the machine wrote, so
+	// deleting the server does not empty it. Measured — this is the half that
+	// makes the mark a history rather than a current state.
+	if status, out := do(t, ts, "DELETE", zoneURL+"/servers/"+serverID, ""); status != http.StatusNoContent {
+		t.Fatalf("delete the server: %d (%v)", status, out)
+	}
+	if status, out := do(t, ts, "POST", zoneURL+"/snapshots",
+		`{"name":"after-detach","volume_id":"`+volumeID+`"}`); status != http.StatusCreated {
+		t.Fatalf("a snapshot of a detached volume answered %d, want 201: the mark is a current "+
+			"state where it must be a history (%v)", status, out)
 	}
 }

--- a/internal/providers/scaleway/volumes.go
+++ b/internal/providers/scaleway/volumes.go
@@ -25,6 +25,21 @@ const kindVolume = "instance/volume"
 // carries the server as an object, not as a bare ID.
 const runtimeServerKey = "server"
 
+// runtimeAttachedKey marks a volume that has been attached to a server at some
+// point, which is what fr-par uses to decide whether there is anything to
+// snapshot (#650).
+//
+// A mark rather than a look at the current owner, because the question is about
+// history: a volume detached from a dead server still carries what that server
+// wrote. runtimeServerKey answers "who holds it now" and goes on a detach; this
+// one answers "was it ever held" and does not.
+//
+// In Runtime and not in Attrs: it is emulator bookkeeping, and Attrs is the
+// provider's wire shape. It survives a snapshot for the same reason the backing
+// machine name does — a volume that was attached before the state was saved is
+// still a volume that was attached.
+const runtimeAttachedKey = "attached-once"
+
 type createVolumeRequest struct {
 	Name         string   `json:"name"`
 	Project      string   `json:"project"`
@@ -241,6 +256,19 @@ func (p *Pack) attachVolume(vol *resource.Resource, server *resource.Resource, s
 		vol.Runtime = map[string]string{}
 	}
 	vol.Runtime[runtimeServerKey] = server.ID
+	// Set here and never cleared: detachVolume drops the owner and leaves this,
+	// because the disk keeps whatever the machine wrote to it. Measured: a disk
+	// detached from a deleted server still snapshots on fr-par (201), so the
+	// question is "was it ever anybody's", not "is it attached now".
+	//
+	// The value is the volume's OWN identifier rather than a flag, and that is
+	// not decoration. storetest.Sweep holds that a runtime value naming
+	// something is an object exactly one resource owns — a container, a bridge —
+	// and a shared "1" made every marked volume claim the same object. An
+	// identifier the store already holds is excused by that invariant
+	// (isStoredIdentifier) and is unique per volume, which is both properties
+	// this mark needs.
+	vol.Runtime[runtimeAttachedKey] = vol.ID
 	vol.Attrs["server_name"] = serverName
 	return nil
 }
@@ -280,6 +308,12 @@ func (p *Pack) attachStoredVolume(vol *resource.Resource, server *resource.Resou
 			stored.Runtime = map[string]string{}
 		}
 		stored.Runtime[runtimeServerKey] = server.ID
+		// The same mark attachVolume sets, on the other door into this: a volume
+		// attached here has been somebody's, so it has something to snapshot
+		// (#650). Written twice would be written differently one day, which is
+		// why both doors set the same key to the same thing — the volume's own
+		// identifier.
+		stored.Runtime[runtimeAttachedKey] = stored.ID
 		stored.Attrs["server_name"] = serverName
 		// The mirror of what detachStoredVolume does on the way out, and the
 		// same asymmetry: block/v1's `status` IS res.State, so a volume a server

--- a/tools/conformance/scaleway/scw-cli.sh
+++ b/tools/conformance/scaleway/scw-cli.sh
@@ -419,6 +419,15 @@ img_vol="$(scw instance volume create name=conformance-golden-vol volume-type=l_
 img_vol_id="$(printf '%s' "$img_vol" | jq -r '(.volume // .).id')"
 [ -n "$img_vol_id" ] && [ "$img_vol_id" != null ] || fail "no id in the volume create response: $img_vol"
 
+# Attached before it is snapshotted, which is what a client has to do against the
+# cloud: fr-par refuses an instance snapshot of a disk nothing was ever attached
+# to with "cannot create a RO disk from an empty disk", and so does this emulator
+# since #650. Attaching is enough — the machine is never started, and a disk
+# detached later still snapshots.
+attached="$(scw instance server attach-volume server-id="$img_server_id" volume-id="$img_vol_id" \
+             zone="$ZONE" -o json 2>&1)" \
+  || fail "attaching the golden volume before snapshotting it was rejected: $attached"
+
 snap="$(scw instance snapshot create name=conformance-snap volume-id="$img_vol_id" zone="$ZONE" -o json)" \
   || fail "snapshot create rejected: $snap"
 snap_id="$(printf '%s' "$snap" | jq -r '(.snapshot // .).id')"
@@ -455,6 +464,11 @@ prove_end "$neg"
 scw instance image delete "$img_id" zone="$ZONE" >/dev/null || fail "image delete rejected"
 scw instance snapshot delete "$snap_id" zone="$ZONE" >/dev/null \
   || fail "snapshot delete rejected once its image was gone"
+# Detached before it is deleted, because it has been attached since #650: a
+# volume a server still holds refuses its own delete, which is the API working.
+detached="$(scw instance server detach-volume server-id="$img_server_id" volume-id="$img_vol_id" \
+             zone="$ZONE" -o json 2>&1)" \
+  || fail "detaching the golden volume before deleting it was rejected: $detached"
 scw instance volume delete "$img_vol_id" zone="$ZONE" >/dev/null \
   || fail "delete of the snapshotted volume rejected"
 scw instance server stop "$img_server_id" zone="$ZONE" >/dev/null || fail "cleanup: poweroff rejected"
@@ -1020,6 +1034,17 @@ ivol_id="$(printf '%s' "$ivol" | jq -r '.volume.id // .id // empty')"
 scw instance volume update "$ivol_id" name=conformance-iv-2 zone="$ZONE" -o json \
   | jq -e '(.volume.name // .name) == "conformance-iv-2"' >/dev/null || fail "instance volume update did not carry the name"
 
+# A machine to carry the disk, because a snapshot of one nothing was ever
+# attached to is refused — "cannot create a RO disk from an empty disk", which is
+# fr-par's own sentence (#650). The server exists for that and nothing else.
+ivol_host="$(scw instance server create name=conformance-iv-host type=DEV1-S zone="$ZONE" -o json 2>&1)" \
+  || fail "create of the host for the instance volume rejected: $ivol_host"
+ivol_host_id="$(printf '%s' "$ivol_host" | jq -r '(.server // .).id')"
+[ -n "$ivol_host_id" ] && [ "$ivol_host_id" != null ] || fail "no id in the host response: $ivol_host"
+iattached="$(scw instance server attach-volume server-id="$ivol_host_id" volume-id="$ivol_id" \
+              zone="$ZONE" -o json 2>&1)" \
+  || fail "attaching the instance volume before snapshotting it was rejected: $iattached"
+
 isnap="$(scw instance snapshot create name=conformance-is volume-id="$ivol_id" \
           zone="$ZONE" -o json 2>&1)" || fail "instance snapshot create rejected: $isnap"
 isnap_id="$(printf '%s' "$isnap" | jq -r '.snapshot.id // .id // empty')"
@@ -1036,7 +1061,14 @@ scw instance image update "$iimg_id" name=conformance-ii-2 zone="$ZONE" -o json 
 
 scw instance image delete "$iimg_id" zone="$ZONE" >/dev/null || fail "instance image delete rejected"
 scw instance snapshot delete "$isnap_id" zone="$ZONE" >/dev/null || fail "instance snapshot delete rejected"
+idetached="$(scw instance server detach-volume server-id="$ivol_host_id" volume-id="$ivol_id" \
+              zone="$ZONE" -o json 2>&1)" \
+  || fail "detaching the instance volume before deleting it was rejected: $idetached"
 scw instance volume delete "$ivol_id" zone="$ZONE" >/dev/null || fail "instance volume delete rejected"
+scw instance server stop "$ivol_host_id" zone="$ZONE" >/dev/null \
+  || fail "cleanup: poweroff of the volume host rejected"
+scw instance server delete "$ivol_host_id" zone="$ZONE" >/dev/null \
+  || fail "cleanup: delete of the volume host rejected"
 prove_end "$span"
 ok "three lists paged, three renames carried back"
 

--- a/tools/falsify/specs/empty-disk-snapshot.json
+++ b/tools/falsify/specs/empty-disk-snapshot.json
@@ -1,0 +1,33 @@
+{
+  "package": "./internal/providers/scaleway/",
+  "mutations": [
+    {
+      "label": "a disk nothing was ever attached to is snapshotted again, which is what made the published stack fail against the real cloud",
+      "file": "internal/providers/scaleway/snapshots.go",
+      "find": "\t\tif volume.Kind == kindVolume && volume.Runtime[runtimeAttachedKey] == \"\" {",
+      "replace": "\t\tif volume.Kind == kindVolume && volume.Runtime[runtimeAttachedKey] == \"\" && false {",
+      "test": "TestASnapshotOfAVolumeNothingEverWroteToIsRefused"
+    },
+    {
+      "label": "the mark is cleared when a server is deleted, so a disk keeps nothing of what its machine wrote",
+      "file": "internal/providers/scaleway/volumes.go",
+      "find": "\t\tdelete(stored.Runtime, runtimeServerKey)\n\t\tdelete(stored.Attrs, \"server_name\")",
+      "replace": "\t\tdelete(stored.Runtime, runtimeServerKey)\n\t\tdelete(stored.Runtime, runtimeAttachedKey)\n\t\tdelete(stored.Attrs, \"server_name\")",
+      "test": "TestASnapshotOfAVolumeNothingEverWroteToIsRefused"
+    },
+    {
+      "label": "only one of the two attach doors sets the mark, so a volume attached through attach-volume still reads as empty",
+      "file": "internal/providers/scaleway/volumes.go",
+      "find": "\t\tstored.Runtime[runtimeAttachedKey] = stored.ID",
+      "replace": "\t\tstored.Runtime[runtimeAttachedKey] = \"\"",
+      "test": "TestASnapshotOfAVolumeNothingEverWroteToIsRefused"
+    },
+    {
+      "label": "the refusal carries an argument_name the cloud does not send",
+      "file": "internal/providers/scaleway/snapshots.go",
+      "find": "\t\t\twriteInvalidArguments(w, ArgumentError{\n\t\t\t\tReason:      \"constraint\",",
+      "replace": "\t\t\twriteInvalidArguments(w, ArgumentError{\n\t\t\t\tArgumentName: \"volume_id\",\n\t\t\t\tReason:      \"constraint\",",
+      "test": "TestASnapshotOfAVolumeNothingEverWroteToIsRefused"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #650. Closes #646 — with one option deliberately not taken, explained
below.

The cloud refuses a snapshot of a disk nothing ever wrote to — *"cannot create a
RO disk from an empty disk"* — and this emulator answered 201. **The published
Scaleway example stack builds its golden image exactly that way**, so the pattern
it teaches could not apply against the real API. The reporter found out by
running their copy of it there.

## Where the line falls, measured three ways

It is not where it first looks:

| subject | `fr-par` |
|---|---|
| a volume created and never attached | 400, `cannot create a RO disk from an empty disk` |
| the root disk of a server that **never started** | 201 |
| a disk **detached** from a deleted server | 201 |

So the question is not whether the machine ran, and not whether the disk is
attached now. It is **whether the disk was ever anybody's** — which is why the
mark is set on attach and never cleared on detach.

Two details worth naming:

- **The mark's value is the volume's own identifier, not a flag.**
  `storetest.Sweep` holds that a runtime value naming something is an object
  exactly one resource owns, so a shared `"1"` made every marked volume claim the
  same object and the barrage said so immediately. An identifier the store
  already holds is excused by that invariant and is unique per volume.
- **The refusal carries no `argument_name` at all**, so `ArgumentError` omits the
  field when empty rather than sending `""` — a field the cloud does not send.

## #646, same file, two more things a reader copies

**The `vpc_route` said one thing and did another.** It was commented *"reach the
management range through the **admin** network"* and pointed at `app`. The code
was the half that was right: a route's next hop is a private network of its own
VPC, and `admin` is in the other one.

**The topology cannot carry what the header advertises.** Two VPCs that share
nothing cannot reach each other, so the bastion described as *"the only public
door"* opens onto nothing. Under `mode: off` nothing boots and the difference
never shows — the reporter met it by running Ansible through that bastion under
`--vm incus-ovn`, and spent a while suspecting their own `ProxyCommand`. The
header says so now, **in the file a reader copies** rather than only in the
`feint.yaml` beside it.

**What is deliberately not done:** making the stack routable, one VPC with
several private networks. The issue offers it as its third option and says what
it costs — it would trade the isolation this stack demonstrates for reachability
it does not. That is a choice about what the example is *for*, so it is named
rather than taken. Option 2, which the reporter says alone would have saved them
the detour, is done.

## What changed beside the emulator

The example stack builds its golden image from a disk a **builder machine**
carries, which is what a client has to do against the cloud. The conformance
suite does the same at both its snapshot sites, and each **attaches before and
detaches after** — the sequence the API imposes, walked by the client that owns
it.

## Proof

- `mise run falsify -- tools/falsify/specs/empty-disk-snapshot.json`: four
  mutations, four *the test bit*, including the one that clears the mark on
  detach and the one that sets it on only one of the two attach doors.
- `mise run conformance:leg -- fields` green, 356 of 381 routes proven by a real
  client (unchanged), and `tools/conformance/stacks.sh` green with the rewritten
  golden-image block.
- `mise run prepush` green.

Not run: the full `mise run conformance` pass. This branch is one of a batch; the
whole suite is played once on the assembled set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
