### PR TITLE
fix(machine): a way out is a right the cloud grants, not a gift of DHCP (#647)

### DIFF
--- a/internal/core/machine/egress_internal_test.go
+++ b/internal/core/machine/egress_internal_test.go
@@ -1,0 +1,223 @@
+package machine
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// An OVN network announces no gateway, so no machine gets a default route the
+// cloud never gave it (#647).
+//
+// The defect this holds is one a client meets and the control plane never
+// shows. Measured 2026-09-03 under --vm incus-ovn: an OVN network hands every
+// machine that BOOTS on it a `default via <gateway> proto dhcp`, so a Scaleway
+// server with no public address and no Public Gateway reached the Internet here
+// — and a server whose gateway attachment had been removed went on reaching it,
+// because the next boot's DHCP put back what the driver had taken away.
+//
+// `none` is the documented way to stop it (Incus network_ovn reference,
+// ipv4.dhcp.gateway: "use none to turn off gateway announcement"). The rest of
+// DHCP is untouched: the machine still gets its address.
+func TestAnOVNNetworkAnnouncesNoGateway(t *testing.T) {
+	for _, mode := range []struct {
+		name  string
+		ovn   bool
+		wants bool
+	}{
+		{name: "ovn", ovn: true, wants: true},
+		// Under a bridge the host routes for the machine and the announcement
+		// is how it learns: silencing it there would take away a way out the
+		// mode does provide.
+		{name: "bridge", ovn: false, wants: false},
+	} {
+		t.Run(mode.name, func(t *testing.T) {
+			// The uplink harness of incus_uplink_test.go rather than a second
+			// one: an uplink this run already holds, and the network absent so
+			// EnsureNetwork creates rather than adopts.
+			f := &fakeRuntime{answers: map[string]string{
+				"query /1.0/networks/feint-uplink": ourUplinkJSON(
+					strconv.Itoa(os.Getpid()), "10.99.0.0/24"),
+				"query /1.0/networks?recursion=1": "[]",
+			}, fail: map[string]error{
+				"query /1.0/networks/fnt-probe": errors.New("Network not found"),
+			}}
+			d := newFakeDriver(f)
+			d.OVN = mode.ovn
+			if err := d.EnsureNetwork(context.Background(), NetworkSpec{
+				Name: "fnt-probe", CIDR: "10.99.0.0/24", NAT: true,
+			}); err != nil {
+				t.Fatalf("ensure: %v", err)
+			}
+
+			silenced := false
+			for _, call := range f.calls {
+				line := strings.Join(call, " ")
+				if strings.Contains(line, "network create") && strings.Contains(line, "ipv4.dhcp.gateway=none") {
+					silenced = true
+				}
+			}
+			if silenced != mode.wants {
+				t.Errorf("ipv4.dhcp.gateway=none present=%v, want %v; calls: %v", silenced, mode.wants, f.calls)
+			}
+		})
+	}
+}
+
+// An OVN network announces where the private fleet is, so silencing its
+// gateway does not silence the VPC with it (#647).
+//
+// This is the half that the first attempt at #647 got wrong, and the runtime
+// leg said so: with ipv4.dhcp.gateway=none alone, two machines of the SAME VPC
+// stopped reaching each other ("10.184.0.2 is unreachable within one VPC;
+// isolation is separating too much"). The announced default route had been
+// carrying the peered subnets too.
+//
+// Writing the aggregates from outside the guest does not replace the
+// announcement, which is why this is asserted on the network rather than on an
+// exec: measured 2026-09-03, all three `ip route add` returned nil and all
+// three were gone thirty seconds later, flushed by the guest's own DHCP client
+// as it configured the interface behind the driver.
+func TestAnOVNNetworkAnnouncesItsPrivateRoutes(t *testing.T) {
+	for _, mode := range []struct {
+		name  string
+		ovn   bool
+		wants bool
+	}{
+		{name: "ovn", ovn: true, wants: true},
+		// A managed bridge has no router and no peerings: there is nothing of
+		// this kind to announce, and the host routes for the machine anyway.
+		{name: "bridge", ovn: false, wants: false},
+	} {
+		t.Run(mode.name, func(t *testing.T) {
+			f := &fakeRuntime{answers: map[string]string{
+				"query /1.0/networks/feint-uplink": ourUplinkJSON(
+					strconv.Itoa(os.Getpid()), "10.99.0.0/24"),
+				"query /1.0/networks?recursion=1": "[]",
+			}, fail: map[string]error{
+				"query /1.0/networks/fnt-probe": errors.New("Network not found"),
+			}}
+			d := newFakeDriver(f)
+			d.OVN = mode.ovn
+			if err := d.EnsureNetwork(context.Background(), NetworkSpec{
+				Name: "fnt-probe", CIDR: "10.99.0.0/24", NAT: true,
+			}); err != nil {
+				t.Fatalf("ensure: %v", err)
+			}
+
+			// The three aggregates, each via the network's own router, and the
+			// router named by its host part alone: the option carries an
+			// address, not a CIDR, and 10.99.0.1/24 there is refused.
+			want := "ipv4.dhcp.routes=10.0.0.0/8,10.99.0.1,172.16.0.0/12,10.99.0.1,192.168.0.0/16,10.99.0.1"
+			announced := false
+			for _, call := range f.calls {
+				line := strings.Join(call, " ")
+				if strings.Contains(line, "network create") && strings.Contains(line, want) {
+					announced = true
+				}
+			}
+			if announced != mode.wants {
+				t.Errorf("%q present=%v, want %v; calls: %v", want, announced, mode.wants, f.calls)
+			}
+		})
+	}
+}
+
+// announcedPrivateRoutes takes a CIDR and must answer addresses: a pair whose
+// gateway still carries its prefix is refused by Incus, and the refusal
+// arrives at network create time, which is the worst place to learn it.
+func TestTheAnnouncedRoutesNameTheirGatewayWithoutItsPrefix(t *testing.T) {
+	got := announcedPrivateRoutes("10.42.0.1/24")
+	if strings.Contains(got, "/24") {
+		t.Errorf("announcedPrivateRoutes kept a prefix on its gateway: %q", got)
+	}
+	for _, block := range privateAggregates {
+		if !strings.Contains(got, block+",10.42.0.1") {
+			t.Errorf("announcedPrivateRoutes(%q) misses %s via the router: %q", "10.42.0.1/24", block, got)
+		}
+	}
+}
+
+// The default route is laid for a machine the plan entitles to one, and taken
+// away from a machine it does not (#647).
+//
+// Both halves, because a driver that laid one for everybody would satisfy the
+// first and be exactly the defect: the emulator more permissive than the cloud,
+// in the direction that teaches a client its fleet can be provisioned when the
+// real one cannot.
+func TestADefaultRouteIsLaidOnlyForAMachineEntitledToOne(t *testing.T) {
+	// Two interfaces, and the one that matters is not the first: eth0 is the
+	// bastion's shape — a NIC on another network, which #548 leaves carrying no
+	// address — so a lookup that takes any NIC would answer it and the route
+	// would ride an interface the plan never named.
+	devices := `{"devices":{` +
+		`"eth0":{"type":"nic","network":"fnt-other"},` +
+		`"eth1":{"type":"nic","network":"fnt-net"}},"expanded_devices":{}}`
+
+	t.Run("entitled", func(t *testing.T) {
+		f := &fakeRuntime{answers: map[string]string{
+			// `network get <net> ipv4.address` is what networkGateway asks,
+			// not the JSON of the network: the gateway address is read as a
+			// bare prefix.
+			"network get fnt-net ipv4.address":   "172.16.0.1/22",
+			"query /1.0/instances/feint-scw-one": devices,
+		}}
+		d := &Incus{runner: f.run, OVN: true}
+		if err := d.RouteEgress(context.Background(), "feint-scw-one", "fnt-net"); err != nil {
+			t.Fatalf("route egress: %v", err)
+		}
+		laid := ""
+		for _, call := range f.calls {
+			line := strings.Join(call, " ")
+			if strings.Contains(line, "route replace default") {
+				laid = line
+			}
+		}
+		if laid == "" {
+			t.Fatalf("no default route was laid: %v", f.calls)
+		}
+		// Through the network's own gateway, and on the device that carries
+		// that network — not on whatever interface came first. The bastion's
+		// eth0 is the counter-example: #548 takes the address off it and it
+		// keeps a default route out of an interface with no address.
+		if !strings.Contains(laid, "via 172.16.0.1") || !strings.Contains(laid, "dev eth1") {
+			t.Errorf("the route is %q, want it via 172.16.0.1 on eth1", laid)
+		}
+		// `replace` and not `add`: the routed NIC's own default route is
+		// already there, and `add` answers "file exists" over it.
+		if !strings.Contains(laid, "replace") {
+			t.Errorf("the route is added rather than replaced: %q", laid)
+		}
+	})
+
+	t.Run("not entitled", func(t *testing.T) {
+		f := &fakeRuntime{}
+		d := &Incus{runner: f.run, OVN: true}
+		if err := d.DropEgress(context.Background(), "feint-scw-one"); err != nil {
+			t.Fatalf("drop egress: %v", err)
+		}
+		dropped := false
+		for _, call := range f.calls {
+			if strings.Contains(strings.Join(call, " "), "route del default") {
+				dropped = true
+			}
+		}
+		if !dropped {
+			t.Fatalf("nothing took the default route away: %v", f.calls)
+		}
+	})
+
+	t.Run("a bridge lays none", func(t *testing.T) {
+		f := &fakeRuntime{}
+		d := &Incus{runner: f.run, OVN: false}
+		if err := d.RouteEgress(context.Background(), "feint-scw-one", "fnt-net"); err != nil {
+			t.Fatalf("route egress under a bridge: %v", err)
+		}
+		if len(f.calls) != 0 {
+			t.Errorf("a bridge-mode driver touched the machine: %v", f.calls)
+		}
+	})
+}

--- a/internal/core/machine/incus.go
+++ b/internal/core/machine/incus.go
@@ -1356,6 +1356,43 @@ func (d *Incus) EnsureNetwork(ctx context.Context, spec NetworkSpec) error {
 		"ipv4.nat="+strconv.FormatBool(spec.NAT),
 		"ipv6.address=none",
 	)
+	if d.OVN {
+		// The network announces no gateway, so no machine gets a default route
+		// it was not entitled to (#647).
+		//
+		// This is the half a default route inside the machine cannot do on its
+		// own. Measured 2026-09-03: an OVN network hands every machine that
+		// BOOTS on it a `default via <gateway> proto dhcp`, whatever the cloud's
+		// rule says — so a Scaleway server with no public address and no Public
+		// Gateway reached the Internet here, and one whose gateway attachment
+		// was removed went on reaching it, because the next boot's DHCP put the
+		// route back over whatever the driver had taken away.
+		//
+		// `none` is the documented way to stop it (Incus network_ovn reference,
+		// ipv4.dhcp.gateway: "use none to turn off gateway announcement"), and
+		// it leaves the rest of DHCP alone — the machine still gets its address
+		// and its lease.
+		//
+		// What replaces it is Plan.Egress: the pack says which machines the
+		// cloud lets out, and RouteEgress lays the route for those.
+		//
+		// Silencing the gateway alone would take away more than the way out.
+		// Measured: the announced default route had been carrying the traffic
+		// towards the OTHER subnets of the same VPC as well, and the runtime
+		// leg failed on "10.184.0.2 is unreachable within one VPC; isolation is
+		// separating too much" the first time this line stood alone. So the
+		// network keeps announcing where the private fleet is, and stops
+		// announcing where the Internet is, which is the split the cloud makes:
+		// a Scaleway server with no public address reaches its VPC and nothing
+		// beyond it.
+		//
+		// TestAnOVNNetworkAnnouncesNoGateway and
+		// TestAnOVNNetworkAnnouncesItsPrivateRoutes fail without this.
+		args = append(args,
+			"ipv4.dhcp.gateway=none",
+			"ipv4.dhcp.routes="+announcedPrivateRoutes(address),
+		)
+	}
 	for k, v := range spec.Labels {
 		args = append(args, "user."+k+"="+v)
 	}

--- a/internal/core/machine/incus_ovn.go
+++ b/internal/core/machine/incus_ovn.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -996,6 +997,39 @@ func (d *Incus) networkGateway(ctx context.Context, network string) (netip.Prefi
 // which is exactly where the isolation verdict belongs.
 var privateAggregates = []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"}
 
+// announcedPrivateRoutes is what an OVN network tells every machine that boots
+// on it about the rest of the emulated fleet: the three aggregates above, each
+// via the network's own router, in the ipv4.dhcp.routes syntax Incus serves as
+// DHCP option 121.
+//
+// This exists because a route written from OUTSIDE the guest does not survive
+// the guest. Measured 2026-09-03 under --vm incus-ovn: the three execs of
+// installGuestPrivateRoutes all returned nil, and thirty seconds later the
+// table held nothing but a connected route reading `proto dhcp`, on an
+// interface whose address the driver had pinned by hand. The guest's DHCP
+// client configures the interface after the driver does and flushes what it
+// finds, and a lease renewal would flush it again later. An announcement is
+// laid by the client itself, so a renewal rewrites it rather than erasing it.
+//
+// The address arrives as the gateway CIDR the network carries (10.0.0.1/24),
+// and what the option needs is the host part alone.
+//
+// TestAnOVNNetworkAnnouncesItsPrivateRoutes fails without this, and the
+// runtime leg fails with "10.184.0.2 is unreachable within one VPC" — two
+// machines of one VPC that had always reached each other, because the default
+// route the network used to announce had been carrying the peered subnets too.
+func announcedPrivateRoutes(address string) string {
+	gateway := address
+	if host, _, ok := strings.Cut(address, "/"); ok {
+		gateway = host
+	}
+	pairs := make([]string, 0, len(privateAggregates))
+	for _, block := range privateAggregates {
+		pairs = append(pairs, block+","+gateway)
+	}
+	return strings.Join(pairs, ",")
+}
+
 // guestRoutePoll and guestRouteWait bound the wait for a restarted guest to
 // have configured its interface again. A container's DHCP client answers in a
 // second or two, a virtual machine's in tens of them; past a minute and a half
@@ -1181,6 +1215,12 @@ func (d *Incus) settleFirstBoot(ctx context.Context, machine string) error {
 			// A managed bridge has no router and no peerings, so there is
 			// nothing of this kind to lay there — the same mode split
 			// restoreGuestNetwork makes, for the same reason.
+			//
+			// These are also what the network announces over DHCP now
+			// (announcedPrivateRoutes), and the redundancy is deliberate: this
+			// call reaches a guest that has not renewed its lease yet, and the
+			// announcement reaches one this call cannot, a DHCP-owned interface
+			// whose client flushes whatever the driver writes.
 			if err := d.installGuestPrivateRoutes(ctx, machine, devices.own[device]["network"], device); err != nil {
 				return fmt.Errorf("settle the first boot of %s: %w", machine, err)
 			}
@@ -1266,6 +1306,117 @@ func (d *Incus) installGuestPrivateRoutes(ctx context.Context, machine, network,
 			!strings.Contains(strings.ToLower(err.Error()), "file exists") {
 			return fmt.Errorf("route %s of %s via %s: %w", block, machine, gateway.Addr(), err)
 		}
+	}
+	return nil
+}
+
+// RouteEgress implements EgressRouter: the machine's default route leaves
+// through the gateway of the network the pack named (#647).
+//
+// Under a bridge there is nothing to do — the host already routes for the
+// machine — so this is the OVN half alone, and a bridge-mode driver answers
+// nil rather than laying a route the mode does not need.
+//
+// The device is looked up by network rather than passed in, because the caller
+// is the Reconciler and it knows the pack's vocabulary, not the runtime's: the
+// plan names a network, and which interface carries it is the runtime's own
+// answer. A machine that has not joined that network yet is not an error — the
+// interface arrives with the next attach, and the replay runs again then.
+func (d *Incus) RouteEgress(ctx context.Context, machine, network string) error {
+	if !d.OVN {
+		return nil
+	}
+	device, err := d.deviceOnNetwork(ctx, machine, network)
+	if err != nil || device == "" {
+		return err
+	}
+	return d.installGuestDefaultRoute(ctx, machine, network, device)
+}
+
+// DropEgress implements EgressRouter: the machine loses the way out it no
+// longer qualifies for.
+//
+// Silent about a machine that has none, and about one that is gone: a delete
+// path runs twice more often than anyone expects, which is the rule Detach
+// states for this whole layer.
+func (d *Incus) DropEgress(ctx context.Context, machine string) error {
+	if !d.OVN {
+		return nil
+	}
+	if _, err := d.run(ctx, "exec", machine, "--", "ip", "route", "del", "default"); err != nil {
+		msg := strings.ToLower(err.Error())
+		if isNotFound(err) || isNotRunning(err) ||
+			strings.Contains(msg, "no such process") || strings.Contains(msg, "cannot find device") {
+			return nil
+		}
+		return fmt.Errorf("drop the default route of %s: %w", machine, err)
+	}
+	return nil
+}
+
+// deviceOnNetwork answers the machine's interface on a network, empty when it
+// has none.
+func (d *Incus) deviceOnNetwork(ctx context.Context, machine, network string) (string, error) {
+	devices, err := d.instanceDevices(ctx, machine)
+	if err != nil {
+		if isNotFound(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("inspect %s: %w", machine, err)
+	}
+	// In name order, so two runs of the same question answer the same device.
+	// A map range would pick either of a machine's interfaces and this is the
+	// input to a route: the answer has to be a property of the machine, not of
+	// the iteration.
+	names := make([]string, 0, len(devices.own))
+	for device := range devices.own {
+		names = append(names, device)
+	}
+	sort.Strings(names)
+	for _, device := range names {
+		cfg := devices.own[device]
+		if cfg["type"] == "nic" && cfg["network"] == network {
+			return device, nil
+		}
+	}
+	return "", nil
+}
+
+// installGuestDefaultRoute gives a machine its way out, through the gateway of
+// the network the plan named (#647).
+//
+// Why it is not laid for everyone. Under OVN a machine reaches its own subnet
+// and the peered ones — installGuestPrivateRoutes above — and the network NATs,
+// so a default route is all that stands between it and the Internet. Measured
+// 2026-09-03: `ip route add default via <the network's gateway>` inside a
+// machine that had none reached 8.8.8.8 in 13 ms, with nothing else changed. So
+// the route is a decision, not a repair, and the decision is the cloud's:
+//
+//	scaleway-openapi/public-gateway-v2.yml, push_default_route:
+//	  "Enabling the default route also enables masquerading."
+//
+// A machine reaches out when it holds a public address, or when a Public Gateway
+// attached to its Private Network pushes the default route. A machine with
+// neither does not — and an emulator that gave it one anyway would teach a
+// client that its fleet can be provisioned when the real one cannot. Which of
+// the three a machine is, is the pack's to say: Plan.Egress.
+//
+// TestADefaultRouteIsLaidOnlyForAMachineEntitledToOne fails without this.
+func (d *Incus) installGuestDefaultRoute(ctx context.Context, machine, network, device string) error {
+	gateway, err := d.networkGateway(ctx, network)
+	if err != nil {
+		return err
+	}
+	// Replaced rather than added, and that is the half the bastion needed. A
+	// server created with its flexible IP boots on a routed NIC, whose default
+	// route leaves through a device #548 then takes the address off — so the
+	// machine kept a default route out of an interface with no address, and
+	// `ip route add` would have answered "file exists" over it. Measured
+	// 2026-09-03: eth0 bare with `default via 169.254.0.1`, the address on
+	// eth1, and no way out.
+	if _, err := d.run(ctx, "exec", machine, "--",
+		"ip", "route", "replace", "default", "via", gateway.Addr().String(), "dev", device); err != nil {
+		return fmt.Errorf("default route of %s via %s: %w", machine, gateway.Addr(), err)
 	}
 	return nil
 }

--- a/internal/core/machine/machine.go
+++ b/internal/core/machine/machine.go
@@ -190,6 +190,30 @@ type driver interface {
 	RemoveNetwork(ctx context.Context, name string) error
 }
 
+// EgressRouter is the optional half of a driver that can give a machine a
+// default route, and take one away (#647).
+//
+// Optional like Capable and Waiter, and for the same reason: a driver that
+// cannot do it counts as not doing it, so the replay skips rather than
+// asserting what nobody promised. The bridge driver does not implement it —
+// its machines sit on a bridge the host already routes — and OVN does, because
+// under OVN a machine reaches its own subnet and the peered ones and nothing
+// else until something lays a default route.
+//
+// Whether a machine is ENTITLED to one is not asked here. That is the cloud's
+// rule and the pack states it in Plan.Egress; this is only the driver saying it
+// knows how.
+type EgressRouter interface {
+	// RouteEgress lays the machine's default route through the gateway of the
+	// named network. It must be idempotent: the replay runs on every boot and
+	// on every interface a machine gains.
+	RouteEgress(ctx context.Context, machine, network string) error
+	// DropEgress takes the default route away, for a machine that had one and
+	// no longer qualifies — an address released, a gateway detached. It must
+	// succeed when there is nothing to remove.
+	DropEgress(ctx context.Context, machine string) error
+}
+
 // Waiter is the optional half of a driver that can tell when a machine is
 // ready. Start never waits, because an API call must not block for the tens of
 // seconds a virtual machine takes to boot; a caller that needs to reach the

--- a/internal/core/machine/plan.go
+++ b/internal/core/machine/plan.go
@@ -46,6 +46,26 @@ type Plan struct {
 	// the two others let the driver pick, and changing that would change what
 	// the runtime is asked without an upstream difference demanding it.
 	RouteVia string
+	// Egress names the network a default route leaves through, empty when the
+	// machine has none (#647).
+	//
+	// Empty is the ordinary answer and that is the point. A machine started
+	// under OVN reaches its own subnet and, through the router, the peered
+	// ones — the network announces the three RFC 1918 aggregates over DHCP for
+	// that (announcedPrivateRoutes) — and nothing else. Measured: the OVN network NATs (`ipv4.nat=true`
+	// over the emulator's own uplink) and a `ip route add default via <the
+	// network's gateway>` from inside a machine reaches 8.8.8.8 in 13 ms. So
+	// the way out exists; what decides is whether this machine is entitled to
+	// it.
+	//
+	// That entitlement is the pack's to state, because it is the cloud's rule
+	// rather than the runtime's. On Scaleway a machine reaches the Internet
+	// when it holds a public address, or when a public gateway attached to its
+	// private network pushes a default route — and a machine with neither has
+	// no way out, which a client provisioning one has to know. Laying a default
+	// route for every machine would be the emulator being more permissive than
+	// the cloud, in the one direction that teaches a client something false.
+	Egress string
 }
 
 // Reconciler executes a declared Plan in the one order — addresses, then
@@ -147,6 +167,14 @@ func (r Reconciler) PowerOn(ctx context.Context, res *resource.Resource, boot Bo
 	for _, m := range plan.Memberships {
 		_ = r.attach(ctx, res, m)
 	}
+	// And the way out, after the interfaces exist: a default route needs the
+	// device of the network it leaves through (#647). On the boot path and not
+	// only in ReplayAddresses, because a machine's entitlement changes without
+	// its addresses doing so — a Public Gateway attached to its Private Network
+	// pushes the route, and detaching that gateway takes it back. Measured: with
+	// this call only in ReplayAddresses, a server whose gateway pushed the route
+	// never got it, because it has no public address for that loop to replay.
+	r.ReplayEgress(ctx, res)
 	// What the two loops above delivered is read back before the firewall,
 	// because the record written at the boot is older than they are (#548):
 	// the addresses the plan promised are installed here, not there. The
@@ -217,6 +245,50 @@ func (r Reconciler) ReplayAddresses(ctx context.Context, res *resource.Resource)
 	}
 	for _, address := range plan.Publics {
 		r.route(ctx, res, plan, address)
+	}
+	r.ReplayEgress(ctx, res)
+}
+
+// ReplayEgress gives the machine the way out its plan entitles it to, and takes
+// away the one it no longer does (#647).
+//
+// Run beside ReplayAddresses on every path that changes what a machine has —
+// a boot, an interface joined, an address routed — because all three change the
+// answer: an address makes a machine entitled, a NIC on a gateway's network
+// makes it entitled, and losing either takes it back.
+//
+// The removal half matters as much as the laying half. A machine that keeps a
+// default route after its address is released reaches the Internet the cloud
+// would have cut off, which is the emulator being more permissive in the
+// direction that teaches a client something false.
+//
+// Idempotent, and silent for a driver that cannot route egress: under a bridge
+// the host already routes for the machine, and there is nothing to lay.
+func (r Reconciler) ReplayEgress(ctx context.Context, res *resource.Resource) {
+	driver := r.binding().driver
+	router, ok := driver.(EgressRouter)
+	if !ok {
+		return
+	}
+	name := res.Runtime[r.binding().RuntimeKey]
+	if name == "" {
+		return
+	}
+	plan, declared := r.plan(res)
+	if !declared {
+		return
+	}
+	if plan.Egress == "" {
+		if err := router.DropEgress(ctx, name); err != nil {
+			r.binding().logger().Error("could not take back the machine's default route",
+				"provider", r.binding().Provider, "machine", name, "resource", res.ID, "error", err)
+		}
+		return
+	}
+	if err := router.RouteEgress(ctx, name, plan.Egress); err != nil {
+		r.binding().logger().Error("could not give the machine its default route",
+			"provider", r.binding().Provider, "machine", name, "network", plan.Egress,
+			"resource", res.ID, "error", err)
 	}
 }
 

--- a/internal/providers/scaleway/egress_internal_test.go
+++ b/internal/providers/scaleway/egress_internal_test.go
@@ -1,0 +1,112 @@
+package scaleway
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/resource"
+	"github.com/stephrobert/feint/internal/core/store"
+)
+
+// egressPack is a pack over an empty store, with the clock and the identifiers
+// pinned the way every test in this package pins them.
+func egressPack() *Pack {
+	var seq int
+	env := &emulator.Env{
+		Store: store.New(),
+		Now:   func() time.Time { return time.Unix(1700000000, 0).UTC() },
+		NewID: func() string { seq++; return "00000000-0000-4000-8000-00000000000" + string(rune('0'+seq)) },
+	}
+	return New(env)
+}
+
+// serverOn stores a server, a private network with a backing runtime network,
+// and the NIC that joins them.
+func serverOn(p *Pack, networkName string) *resource.Resource {
+	now := p.env.Now()
+	server := resource.New("srv-1", kindServer, resource.Tenant{Provider: Name, Zone: "fr-par-1"}, "running", now)
+	server.Attrs = map[string]any{"name": "web"}
+	p.env.Store.Put(server)
+
+	pn := resource.New("pn-1", kindPrivateNetwork, resource.Tenant{Provider: Name, Zone: "fr-par"}, "available", now)
+	pn.Runtime = map[string]string{runtimeNetworkKey: networkName}
+	p.env.Store.Put(pn)
+
+	nic := resource.New("nic-1", kindPrivateNIC, resource.Tenant{Provider: Name, Zone: "fr-par-1"}, "available", now)
+	nic.Runtime = map[string]string{runtimePrivateNetworkKey: "pn-1", runtimeServerKey: "srv-1"}
+	nic.Attrs = map[string]any{"server_id": "srv-1", "private_network_id": "pn-1"}
+	p.env.Store.Put(nic)
+	return server
+}
+
+// A server holding a public address reaches the Internet, through the network
+// its own NIC is on (#647).
+//
+// The rule is Scaleway's and the emulator had none of it: measured under
+// --vm incus-ovn, a bastion with a public address and three private NICs kept
+// its default route out of eth0 — the interface #548 takes the address OFF —
+// and could not reach anything, while every SSH hop through it worked. A fleet
+// tool could discover the machine and never provision it.
+func TestAServerWithAPublicAddressLeavesThroughItsOwnNetwork(t *testing.T) {
+	p := egressPack()
+	server := serverOn(p, "fnt-web")
+
+	if got := p.egressNetworkOf(server); got != "" {
+		t.Fatalf("a server with no address and no gateway leaves through %q, want nothing", got)
+	}
+
+	address := resource.New("ip-1", kindIP, resource.Tenant{Provider: Name, Zone: "fr-par-1"}, "available", p.env.Now())
+	address.Attrs = map[string]any{"address": "203.0.113.2", "server": map[string]any{"id": "srv-1"}}
+	p.env.Store.Put(address)
+
+	if got := p.egressNetworkOf(server); got != "fnt-web" {
+		t.Errorf("a server holding a public address leaves through %q, want fnt-web", got)
+	}
+}
+
+// A private server's only way out is a Public Gateway that pushes the default
+// route, and it goes when the attachment goes (#647).
+//
+// The cloud's own words, from the document upstream:sync vendors —
+// public-gateway-v2.yml, push_default_route: "Enabling the default route also
+// enables masquerading." A gateway that masquerades without pushing the route
+// is a gateway whose clients were told to route another way, and the emulator
+// has no business deciding for them: that is why the flag is read rather than
+// the attachment's mere existence.
+func TestAPushedDefaultRouteIsTheOnlyWayOutForAPrivateServer(t *testing.T) {
+	p := egressPack()
+	server := serverOn(p, "fnt-web")
+
+	attach := func(pushed bool) {
+		gn := resource.New("gn-1", kindGatewayNetwork, resource.Tenant{Provider: Name, Zone: "fr-par-1"},
+			"ready", p.env.Now())
+		gn.Attrs = map[string]any{
+			"gateway_id":         "gw-1",
+			"private_network_id": "pn-1",
+			"push_default_route": pushed,
+			"masquerade_enabled": true,
+		}
+		p.env.Store.Put(gn)
+	}
+
+	// Masquerading without pushing: no way out, because the gateway did not
+	// offer one. This is the half that keeps the emulator from being more
+	// permissive than the cloud.
+	attach(false)
+	if got := p.egressNetworkOf(server); got != "" {
+		t.Errorf("a gateway that pushes no default route gave a way out through %q", got)
+	}
+
+	attach(true)
+	if got := p.egressNetworkOf(server); got != "fnt-web" {
+		t.Errorf("a gateway pushing the default route gave %q, want fnt-web", got)
+	}
+
+	// And it is taken back with the attachment, which is what the driver's
+	// DropEgress needs to be told.
+	p.env.Store.Delete(Name, kindGatewayNetwork, "gn-1")
+	if got := p.egressNetworkOf(server); got != "" {
+		t.Errorf("the attachment is gone and the server still leaves through %q", got)
+	}
+}

--- a/internal/providers/scaleway/machines.go
+++ b/internal/providers/scaleway/machines.go
@@ -164,6 +164,7 @@ func (p *Pack) machinePlan(res *resource.Resource) machine.Plan {
 		Boot:     p.attachmentsOf(res),
 		Publics:  p.publicAddressesOf(res),
 		RouteVia: p.privateNetworkNameOf(res),
+		Egress:   p.egressNetworkOf(res),
 	}
 }
 
@@ -214,4 +215,70 @@ func (p *Pack) logger() *slog.Logger {
 		return p.env.Log
 	}
 	return slog.Default()
+}
+
+// egressNetworkOf answers the runtime network a default route leaves through,
+// and empty when this server has no way out (#647).
+//
+// It is Scaleway's rule, transcribed:
+//
+//   - a server holding a public address reaches the Internet;
+//   - a server on a Private Network whose Public Gateway attachment declares
+//     `push_default_route` reaches it through that gateway;
+//   - a server with neither does not, and that is not a gap. It is what a
+//     client provisioning a machine has to know, and the reason this returns
+//     empty rather than picking something.
+//
+// Measured under `--vm incus-ovn` on 2026-09-03, which is what made this worth
+// serving rather than documenting: the OVN network NATs over the emulator's own
+// uplink, and one `ip route add default via <the network's gateway>` inside a
+// machine reached 8.8.8.8 in 13 ms. Nothing was missing but the route — so a
+// machine here could be reached and never provisioned, which is the half of a
+// client's surface a fleet tool spends its time in (#647, reported by a client
+// author whose Ansible runs died on `apt-get update` after every SSH hop
+// worked).
+//
+// The network it names is the runtime's, not the API's: the driver needs
+// something it can ask a gateway address of.
+//
+// TestAServerWithAPublicAddressLeavesThroughItsOwnNetwork and
+// TestAPushedDefaultRouteIsTheOnlyWayOutForAPrivateServer fail without this.
+func (p *Pack) egressNetworkOf(server *resource.Resource) string {
+	// A public address first: it is the server's own way out, and it rides the
+	// network its NIC is on — the same one RouteVia names, for the same reason.
+	if len(p.publicAddressesOf(server)) > 0 {
+		return p.privateNetworkNameOf(server)
+	}
+	// Otherwise the gateway's, and only when the attachment pushes it. A
+	// gateway that masquerades for a network without pushing a default route is
+	// a gateway whose clients were told to route another way, and the emulator
+	// has no business deciding for them.
+	for _, nic := range p.privateNICsOf(server.ID) {
+		privateNetworkID := nic.Runtime[runtimePrivateNetworkKey]
+		if privateNetworkID == "" {
+			continue
+		}
+		if !p.gatewayPushesDefaultRoute(privateNetworkID) {
+			continue
+		}
+		pn, found := p.env.Store.Get(Name, kindPrivateNetwork, privateNetworkID)
+		if found && pn.Runtime[runtimeNetworkKey] != "" {
+			return pn.Runtime[runtimeNetworkKey]
+		}
+	}
+	return ""
+}
+
+// gatewayPushesDefaultRoute reports whether a Public Gateway is attached to this
+// Private Network with push_default_route set.
+func (p *Pack) gatewayPushesDefaultRoute(privateNetworkID string) bool {
+	for _, gn := range p.env.Store.List(kindGatewayNetwork, resource.Tenant{Provider: Name}) {
+		if textOf(gn.Attrs["private_network_id"]) != privateNetworkID {
+			continue
+		}
+		if pushed, _ := gn.Attrs["push_default_route"].(bool); pushed {
+			return true
+		}
+	}
+	return false
 }

--- a/tools/falsify/specs/egress-entitlement.json
+++ b/tools/falsify/specs/egress-entitlement.json
@@ -1,0 +1,76 @@
+{
+  "mutations": [
+    {
+      "label": "the OVN network announces its gateway again, so every machine that boots gets a way out the cloud never gave it",
+      "file": "internal/core/machine/incus.go",
+      "package": "./internal/core/machine/",
+      "find": "\t\t\t\"ipv4.dhcp.gateway=none\",\n",
+      "replace": "\t\t\t\"ipv4.nat=\"+strconv.FormatBool(spec.NAT),\n",
+      "test": "TestAnOVNNetworkAnnouncesNoGateway"
+    },
+    {
+      "label": "the bridge mode is silenced too, taking away a way out that mode does provide",
+      "file": "internal/core/machine/incus.go",
+      "package": "./internal/core/machine/",
+      "find": "\tif d.OVN {\n\t\t// The network announces no gateway, so no machine gets a default route",
+      "replace": "\tif d.OVN || true {\n\t\t// The network announces no gateway, so no machine gets a default route",
+      "test": "TestAnOVNNetworkAnnouncesNoGateway"
+    },
+    {
+      "label": "the default route is added rather than replaced, so it loses to the routed NIC's own and the bastion stays without a way out",
+      "file": "internal/core/machine/incus_ovn.go",
+      "package": "./internal/core/machine/",
+      "find": "\t\t\"ip\", \"route\", \"replace\", \"default\", \"via\", gateway.Addr().String(), \"dev\", device); err != nil {",
+      "replace": "\t\t\"ip\", \"route\", \"add\", \"default\", \"via\", gateway.Addr().String(), \"dev\", device); err != nil {",
+      "test": "TestADefaultRouteIsLaidOnlyForAMachineEntitledToOne"
+    },
+    {
+      "label": "the route rides whatever interface came first instead of the one carrying the network the pack named",
+      "file": "internal/core/machine/incus_ovn.go",
+      "package": "./internal/core/machine/",
+      "find": "\t\tif cfg[\"type\"] == \"nic\" && cfg[\"network\"] == network {",
+      "replace": "\t\tif cfg[\"type\"] == \"nic\" || cfg[\"network\"] == network {",
+      "test": "TestADefaultRouteIsLaidOnlyForAMachineEntitledToOne"
+    },
+    {
+      "label": "a gateway that masquerades without pushing the route is read as a way out, which is the emulator deciding for a client that chose otherwise",
+      "file": "internal/providers/scaleway/machines.go",
+      "package": "./internal/providers/scaleway/",
+      "find": "\t\tif pushed, _ := gn.Attrs[\"push_default_route\"].(bool); pushed {",
+      "replace": "\t\tif pushed, _ := gn.Attrs[\"push_default_route\"].(bool); pushed || true {",
+      "test": "TestAPushedDefaultRouteIsTheOnlyWayOutForAPrivateServer"
+    },
+    {
+      "label": "a public address stops entitling its server, so the bastion loses the way out the cloud gives it",
+      "file": "internal/providers/scaleway/machines.go",
+      "package": "./internal/providers/scaleway/",
+      "find": "\tif len(p.publicAddressesOf(server)) > 0 {",
+      "replace": "\tif len(p.publicAddressesOf(server)) > 0 && false {",
+      "test": "TestAServerWithAPublicAddressLeavesThroughItsOwnNetwork"
+    },
+    {
+      "label": "the network stops announcing where the private fleet is, so silencing its gateway takes the VPC away with it and two machines of one VPC stop reaching each other",
+      "file": "internal/core/machine/incus.go",
+      "package": "./internal/core/machine/",
+      "find": "\t\t\t\"ipv4.dhcp.routes=\"+announcedPrivateRoutes(address),\n",
+      "replace": "\t\t\t\"ipv4.dhcp.routes=\"+announcedPrivateRoutes(address)[:0],\n",
+      "test": "TestAnOVNNetworkAnnouncesItsPrivateRoutes"
+    },
+    {
+      "label": "the announced gateway keeps the prefix of the CIDR it came from, which Incus refuses at network create time",
+      "file": "internal/core/machine/incus_ovn.go",
+      "package": "./internal/core/machine/",
+      "find": "\tif host, _, ok := strings.Cut(address, \"/\"); ok {",
+      "replace": "\tif host, _, ok := strings.Cut(address, \"/\"); ok && false {",
+      "test": "TestTheAnnouncedRoutesNameTheirGatewayWithoutItsPrefix"
+    },
+    {
+      "label": "the aggregates are announced with no gateway at all, so the guest learns of the blocks and not of the router that reaches them",
+      "file": "internal/core/machine/incus_ovn.go",
+      "package": "./internal/core/machine/",
+      "find": "\t\tpairs = append(pairs, block+\",\"+gateway)",
+      "replace": "\t\tpairs = append(pairs, block+\",\"+gateway[:0])",
+      "test": "TestTheAnnouncedRoutesNameTheirGatewayWithoutItsPrefix"
+    }
+  ]
+}

--- a/tools/falsify/specs/interface-plan.json
+++ b/tools/falsify/specs/interface-plan.json
@@ -33,8 +33,8 @@
       "label": "one pack stops declaring its promised addresses, and the cross-pack equivalence names the divergence (#510, #515)",
       "package": "./internal/providers/",
       "file": "internal/providers/scaleway/machines.go",
-      "find": "\treturn machine.Plan{\n\t\tBoot:     p.attachmentsOf(res),\n\t\tPublics:  p.publicAddressesOf(res),\n\t\tRouteVia: p.privateNetworkNameOf(res),\n\t}",
-      "replace": "\treturn machine.Plan{\n\t\tBoot:     p.attachmentsOf(res),\n\t\tPublics:  p.publicAddressesOf(res)[:0],\n\t\tRouteVia: p.privateNetworkNameOf(res),\n\t}",
+      "find": "\treturn machine.Plan{\n\t\tBoot:     p.attachmentsOf(res),\n\t\tPublics:  p.publicAddressesOf(res),\n\t\tRouteVia: p.privateNetworkNameOf(res),\n\t\tEgress:   p.egressNetworkOf(res),\n\t}",
+      "replace": "\treturn machine.Plan{\n\t\tBoot:     p.attachmentsOf(res),\n\t\tPublics:  p.publicAddressesOf(res)[:0],\n\t\tRouteVia: p.privateNetworkNameOf(res),\n\t\tEgress:   p.egressNetworkOf(res),\n\t}",
       "test": "TestSameIntentSameRuntimeSequenceAcrossPacks"
     }
   ]


### PR DESCRIPTION
Closes #647.

## The cloud's rule, and where it comes from

A Scaleway server reaches the Internet when it holds a public address, or when a
Public Gateway attached to its Private Network pushes the default route. The
vendored document says it in its own terms, `public-gateway-v2.yml`,
`push_default_route`: *"Enabling the default route also enables masquerading"*,
and `masquerade_enabled` is a separate setting beside it. A server with neither
reaches its VPC and nothing beyond it, and a client provisioning one has to
learn that here rather than in production.

## What was measured, and what the issue missed

Under `--vm incus-ovn`, 2026-09-03:

| case | before |
|---|---|
| bastion with a public address and three private NICs | reached **nothing**: #548 emptied the route on `eth0` and no other NIC carried one |
| any machine that **booted** on an OVN network | reached the Internet, entitled or not |
| a machine whose gateway attachment was **removed** | went on reaching it |

The second and third rows are the half the issue does not report, and they are
the permissive direction: the network announced a default route over DHCP, so
the next boot put back whatever the driver took away.

The issue's diagnosis ("no egress") is also wrong, and it is worth recording:
the NAT works. `ipv4.nat=true` on the emulator's own uplink is enough, and one
`ip route add default via <the network's gateway>` from inside a machine reached
8.8.8.8 in 13 ms. Only the route was missing, and only for those entitled to it.

## What this does

- `Plan.Egress` names the network a default route leaves through, empty when the
  machine has none. **Empty is the ordinary answer.**
- `scaleway.egressNetworkOf` transcribes the rule: a public address, or a
  gateway attachment whose `push_default_route` is set.
- `EgressRouter` (`RouteEgress`, `DropEgress`) is optional, like `Capable` and
  `Waiter`, and `Reconciler.ReplayEgress` runs it on every path that changes
  what a machine has. On the boot path too, not only in `ReplayAddresses`: an
  entitlement changes without an address changing.
- `ip route replace`, not `add`: the bastion's routed NIC already carries one.
- The network announces **no gateway** (`ipv4.dhcp.gateway=none`), so the driver
  alone decides who leaves.

## The second measurement, which is the one worth reading

`ipv4.dhcp.gateway=none` alone broke something else, and the runtime leg said so:

```
FAIL: 10.184.0.2 is unreachable within one VPC; isolation is separating too much
```

The announced default route had been carrying the traffic towards the **other
subnets of the same VPC** as well. Writing the three RFC 1918 aggregates from
outside the guest does not replace it: measured, all three `ip route add`
returned `nil` and all three were **gone thirty seconds later**, flushed by the
guest's own DHCP client as it configured the interface behind the driver, on an
interface whose address the driver had pinned by hand. A lease renewal would
flush them again.

So the aggregates go where the client cannot flush them: into what the network
announces (`ipv4.dhcp.routes`, DHCP option 121, `announcedPrivateRoutes`). The
guest lays them itself, a renewal rewrites rather than erases them, and the
network now announces where the private fleet is while staying silent about
where the Internet is. Which is the split the cloud makes.

## Proof

- `FEINT_VM=incus-ovn mise run conformance:leg -- runtime`, **exit 0 in 556 s**,
  and the two checks that carry the product's argument hold together: *a server
  of another VPC is unreachable (10.183.0.2)* and *a server of the same VPC is
  reachable (10.184.0.2)*, the very address that failed.
- On real machines: bastion out through its routed NIC in 15.7 ms; a machine
  with neither address nor gateway has no default route and answers *Network is
  unreachable*; a machine whose gateway pushes the route goes out in 14.3 ms and
  its route no longer reads `proto dhcp`, which is how we know the driver laid
  it; removing the attachment takes it back. Re-measured after the announcement
  change: two machines of one VPC reach each other in 1.05 ms and neither has a
  way out.
- **Nine falsify mutations, all compiling, all biting**
  (`tools/falsify/specs/egress-entitlement.json`), including the two halves that
  matter most: the route refused to a machine with no entitlement, and the
  announcement removed.
- `mise run prepush`.

Conformance was **not** replayed in full for this change; the `runtime` leg is
the one that judges it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
