### PR TITLE
fix(scaleway): an image is cut from an SBS snapshot, and a volume names its class (#651)

### DIFF
--- a/internal/providers/scaleway/block.go
+++ b/internal/providers/scaleway/block.go
@@ -57,6 +57,18 @@ const (
 	// available in stock, and the emulated catalogue offers the first: a number
 	// nothing measures, published because a client reads it back and compares.
 	blockDefaultIOPS = 5000
+	// The two types the real cloud serves, and they are the performance class
+	// rather than the storage class. Measured 2026-09-03 on a real account:
+	// `scw block volume get` answers `"type": "sbs_5k"` with
+	// `"specs": {"perf_iops": 5000, "class": "sbs"}`, and volume-type list
+	// answers exactly these two. The emulator answered "sbs" for the type,
+	// which is the class, at both places.
+	//
+	// Upstream names them too, in another product's SDK: documentdb/v1beta1
+	// declares VolumeTypeSbs5k and VolumeTypeSbs15k, and nothing else in sbs.
+	blockType5k  = "sbs_5k"
+	blockType15k = "sbs_15k"
+	blockIOPS15k = 15000
 )
 
 // blockCreateStatus is what a successful block/v1alpha1 create answers with.
@@ -214,11 +226,27 @@ func iopsOf(asked *uint32) uint32 {
 // resource bare where instance/v1 wraps it in {"volume": ...} — two products of
 // one cloud that do not agree, and copying the neighbouring product's habit here
 // would have broken every decode.
+// blockVolumeTypeOf answers the type a volume of these IOPS carries.
+//
+// resource.Number rather than a type assertion, and the gate of #542 caught
+// this one before a client did: Attrs crosses encoding/json on every snapshot,
+// so the uint32 a create stores comes back float64, an assertion yields zero,
+// and a restored 15k volume would answer sbs_5k.
+//
+// TestABlockVolumeCarriesItsPerformanceType and
+// TestARestoredVolumeKeepsItsPerformanceType fail without this.
+func blockVolumeTypeOf(iops any) string {
+	if resource.Number(iops) >= blockIOPS15k {
+		return blockType15k
+	}
+	return blockType5k
+}
+
 func (p *Pack) blockVolumeView(res *resource.Resource) map[string]any {
 	view := map[string]any{
 		"id":         res.ID,
 		"name":       textOf(res.Attrs["name"]),
-		"type":       blockStorageClass,
+		"type":       blockVolumeTypeOf(res.Attrs["perf_iops"]),
 		"size":       res.Attrs["size"],
 		"project_id": textOf(res.Attrs["project"]),
 		"created_at": res.Created.Format(time.RFC3339),
@@ -522,7 +550,20 @@ type createBlockSnapshotRequest struct {
 	Name      string    `json:"name"`
 	ProjectID *string   `json:"project_id"`
 	Tags      *[]string `json:"tags"`
-	Public    bool      `json:"public"`
+	// Sent by `scw block snapshot create` on every call without being an
+	// argument of it, and answered back: block-v1.yml declares `public` on the
+	// Snapshot schema and lists it among the REQUIRED fields, "True if the
+	// snapshot can be used by anyone to create a volume".
+	//
+	// Worth the paragraph because a measurement said the opposite and was
+	// wrong: `scw block snapshot get -o json` on a real account answers no
+	// such field, since the CLI serialises the SDK struct it decodes into and
+	// the vendored block SDK (v1alpha1) has no Public. That is what the CLI
+	// sees, not what the cloud sent, and taking one for the other removed a
+	// required field here for the length of two conformance legs.
+	//
+	// TestABlockSnapshotAnswersThePublicItWasAsked fails without this.
+	Public bool `json:"public"`
 }
 
 // createBlockSnapshot records a snapshot of a block volume.
@@ -565,9 +606,12 @@ func (p *Pack) createBlockSnapshot(w http.ResponseWriter, r *http.Request) {
 		"zone":    zone,
 		"public":  req.Public,
 		"parent_volume": map[string]any{
-			"id":     volume.ID,
-			"name":   textOf(volume.Attrs["name"]),
-			"type":   blockStorageClass,
+			"id":   volume.ID,
+			"name": textOf(volume.Attrs["name"]),
+			// The parent's own type, and the SDK says as much: "volume type of
+			// the parent volume". Measured sbs_5k on a real account where this
+			// answered sbs.
+			"type":   blockVolumeTypeOf(volume.Attrs["perf_iops"]),
 			"status": volume.State,
 		},
 	}
@@ -778,13 +822,33 @@ func (p *Pack) listBlockVolumeTypes(w http.ResponseWriter, r *http.Request) {
 	// that never ends to the SDK's own pagination loop.
 	//
 	// TestBlockVolumeTypesArePaged fails without it.
+	// Both types the real cloud serves, measured 2026-09-03: sbs_5k and
+	// sbs_15k, each with its own perf_iops and the same class. One entry was a
+	// catalogue that could not answer what a 15k volume is, on a product where
+	// the type is what a client picks.
+	//
+	// The zone stays on the entry: block-v1.yml declares it on VolumeType, and
+	// the Go SDK's struct not having it is a fact about the SDK, not about the
+	// answer. Reading `scw -o json` as the body is the mistake that took it off
+	// for a while, alongside `public` above.
+	//
+	// TestBlockVolumeTypesArePaged fails without both entries.
 	types := []map[string]any{{
-		"type":             blockStorageClass,
+		"type":             blockType5k,
 		"pricing":          price(),
 		"snapshot_pricing": price(),
 		"specs": map[string]any{
 			"class":     blockStorageClass,
 			"perf_iops": blockDefaultIOPS,
+		},
+		"zone": zone,
+	}, {
+		"type":             blockType15k,
+		"pricing":          price(),
+		"snapshot_pricing": price(),
+		"specs": map[string]any{
+			"class":     blockStorageClass,
+			"perf_iops": blockIOPS15k,
 		},
 		"zone": zone,
 	}}

--- a/internal/providers/scaleway/block_test.go
+++ b/internal/providers/scaleway/block_test.go
@@ -343,10 +343,26 @@ func TestTheBlockCatalogueAnswers(t *testing.T) {
 	if len(types) == 0 {
 		t.Fatal("the catalogue answered no volume type, and a client reads it before creating")
 	}
-	entry, _ := types[0].(map[string]any)
-	if entry["type"] != "sbs" {
-		t.Errorf("the catalogue offers %v, and the volumes this pack creates are sbs", entry["type"])
+	// The catalogue and the volumes this pack mints have to name the same
+	// thing, and the check is the join rather than a literal: the pair went out
+	// of step once already, the catalogue offering "sbs" where a real account
+	// answers "sbs_5k" for both (measured 2026-09-03).
+	offered := map[string]bool{}
+	for _, listed := range types {
+		entry, _ := listed.(map[string]any)
+		name, _ := entry["type"].(string)
+		offered[name] = true
 	}
+	// 200, not 201: block/v1 answers a create that way, and blockCreateStatus
+	// carries the measurement.
+	status, made := do(t, ts, "POST", blockURL+"/volumes", `{"name":"catalogue","from_empty":{"size":5000000000}}`)
+	if status != http.StatusOK {
+		t.Fatalf("create a volume: expected 200, got %d (%v)", status, made)
+	}
+	if got, _ := made["type"].(string); !offered[got] {
+		t.Errorf("this pack mints %q, which its own catalogue does not offer (%v)", got, offered)
+	}
+	entry, _ := types[0].(map[string]any)
 	if entry["pricing"] == nil {
 		t.Error("the entry carries no pricing, and the SDK decodes a Money there")
 	}

--- a/internal/providers/scaleway/blockimage_test.go
+++ b/internal/providers/scaleway/blockimage_test.go
@@ -1,0 +1,268 @@
+package scaleway_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/store"
+	"github.com/stephrobert/feint/internal/providers/scaleway"
+)
+
+// An Instance image is cut from an SBS snapshot, and that is now the only path
+// to a golden image (#651).
+//
+// b_ssd is retired (#393), so every root volume is SBS, and an instance
+// snapshot of an SBS root volume is refused upstream (#648): a stack that
+// builds an image goes through scaleway_block_snapshot or it does not build
+// one. The emulator resolved instance snapshots only, and answered 404 to the
+// id Terraform hands it.
+//
+// The shape is copied from a real account, 2026-09-03, reading an image whose
+// own root_volume named a block snapshot:
+//
+//	"root_volume": {"id": "<the block snapshot>", "name": "",
+//	                "size": 10000000000, "volume_type": "sbs_snapshot"}
+func TestAnImageIsCutFromAnSBSSnapshot(t *testing.T) {
+	ts := newTestServer(t)
+
+	status, volume := do(t, ts, "POST", blockURL+"/volumes",
+		`{"name":"root","from_empty":{"size":10000000000}}`)
+	if status != http.StatusOK {
+		t.Fatalf("create a volume: %d (%v)", status, volume)
+	}
+	volumeID, _ := volume["id"].(string)
+
+	status, snapshot := do(t, ts, "POST", blockURL+"/snapshots",
+		`{"name":"reference","volume_id":"`+volumeID+`"}`)
+	if status != http.StatusOK {
+		t.Fatalf("create a block snapshot: %d (%v)", status, snapshot)
+	}
+	snapshotID, _ := snapshot["id"].(string)
+
+	status, image := do(t, ts, "POST", zoneURL+"/images",
+		`{"name":"golden","root_volume":"`+snapshotID+`","arch":"x86_64"}`)
+	if status != http.StatusCreated {
+		t.Fatalf("cut an image from a block snapshot: expected 201, got %d (%v)", status, image)
+	}
+	made, _ := image["image"].(map[string]any)
+	root, _ := made["root_volume"].(map[string]any)
+	if got, _ := root["id"].(string); got != snapshotID {
+		t.Errorf("the image's root volume is %q, want the snapshot %q", got, snapshotID)
+	}
+	if got, _ := root["volume_type"].(string); got != "sbs_snapshot" {
+		t.Errorf("the image's root volume is of type %q, want sbs_snapshot", got)
+	}
+	// Empty on the real account, on an image whose snapshot carried a name.
+	if got, _ := root["name"].(string); got != "" {
+		t.Errorf("the image's root volume is named %q, and the real cloud names it \"\"", got)
+	}
+	if got, _ := root["size"].(float64); got != 10000000000 {
+		t.Errorf("the image's root volume is %v bytes, want the snapshot's 10000000000", root["size"])
+	}
+}
+
+// The half of #651 the measurement refused, and it is here so nobody "fixes"
+// it later: the issue asks for the same id to resolve through the Instance
+// API, and the real cloud does not resolve it.
+//
+// Measured 2026-09-03 on a real account, with a block snapshot in `available`:
+//
+//	$ scw instance snapshot get <that id>
+//	cannot find resource 'instance_snapshot' with ID '<that id>'
+//	$ scw instance snapshot list
+//	[]
+//
+// So the 404 is the cloud's answer, and serving the snapshot there would be a
+// divergence. What the cloud does accept is the id as an image's root volume,
+// which is TestAnImageIsCutFromAnSBSSnapshot above.
+func TestABlockSnapshotStaysInvisibleToTheInstanceAPI(t *testing.T) {
+	ts := newTestServer(t)
+
+	status, volume := do(t, ts, "POST", blockURL+"/volumes",
+		`{"name":"root","from_empty":{"size":10000000000}}`)
+	if status != http.StatusOK {
+		t.Fatalf("create a volume: %d (%v)", status, volume)
+	}
+	volumeID, _ := volume["id"].(string)
+	status, snapshot := do(t, ts, "POST", blockURL+"/snapshots",
+		`{"name":"reference","volume_id":"`+volumeID+`"}`)
+	if status != http.StatusOK {
+		t.Fatalf("create a block snapshot: %d (%v)", status, snapshot)
+	}
+	snapshotID, _ := snapshot["id"].(string)
+
+	if status, got := do(t, ts, "GET", zoneURL+"/snapshots/"+snapshotID, ""); status != http.StatusNotFound {
+		t.Errorf("the Instance API answered %d for a block snapshot, and the real cloud answers 404 (%v)", status, got)
+	}
+	status, listing := do(t, ts, "GET", zoneURL+"/snapshots", "")
+	if status != http.StatusOK {
+		t.Fatalf("list instance snapshots: %d", status)
+	}
+	if got, _ := listing["snapshots"].([]any); len(got) != 0 {
+		t.Errorf("the Instance listing carries %d snapshot(s), and the real cloud answers none", len(got))
+	}
+}
+
+// A block volume carries its performance type, and the snapshot repeats the
+// parent's (#651).
+//
+// Measured 2026-09-03: `scw block volume get` answers "sbs_5k" with
+// specs.perf_iops 5000, and the snapshot's parent_volume.type answers "sbs_5k"
+// too. Both answered "sbs" here, which is the storage class, the value that
+// belongs in specs.class and nowhere else.
+func TestABlockVolumeCarriesItsPerformanceType(t *testing.T) {
+	ts := newTestServer(t)
+
+	for _, want := range []struct {
+		iops string
+		typ  string
+	}{
+		{iops: "", typ: "sbs_5k"},
+		{iops: `,"perf_iops":5000`, typ: "sbs_5k"},
+		{iops: `,"perf_iops":15000`, typ: "sbs_15k"},
+	} {
+		status, volume := do(t, ts, "POST", blockURL+"/volumes",
+			`{"name":"typed","from_empty":{"size":5000000000}`+want.iops+`}`)
+		if status != http.StatusOK {
+			t.Fatalf("create a volume%s: %d (%v)", want.iops, status, volume)
+		}
+		if got, _ := volume["type"].(string); got != want.typ {
+			t.Errorf("a volume%s is of type %q, want %q", want.iops, got, want.typ)
+		}
+		specs, _ := volume["specs"].(map[string]any)
+		if class, _ := specs["class"].(string); class != "sbs" {
+			t.Errorf("specs.class is %q, and the storage class is where sbs belongs", class)
+		}
+
+		volumeID, _ := volume["id"].(string)
+		status, snapshot := do(t, ts, "POST", blockURL+"/snapshots",
+			`{"name":"of-typed","volume_id":"`+volumeID+`"}`)
+		if status != http.StatusOK {
+			t.Fatalf("snapshot a volume%s: %d (%v)", want.iops, status, snapshot)
+		}
+		parent, _ := snapshot["parent_volume"].(map[string]any)
+		if got, _ := parent["type"].(string); got != want.typ {
+			t.Errorf("the snapshot's parent_volume.type is %q, want the parent's %q", got, want.typ)
+		}
+	}
+}
+
+// The snapshot answers the `public` it was asked for (#651).
+//
+// This test replaces one that asserted the opposite, and the reason is worth
+// keeping: `scw block snapshot get -o json` on a real account answers no
+// `public` field, so a measurement concluded the emulator had invented one and
+// took it out. The CLI serialises the SDK struct it decodes into, and the
+// vendored block SDK (v1alpha1) has no Public — what that command shows is
+// what the CLI sees, not what the cloud sent.
+//
+// block-v1.yml settles it: `public` is on the Snapshot schema and in its
+// REQUIRED list, "True if the snapshot can be used by anyone to create a
+// volume". The `fields` leg said so too, from the other side, as soon as the
+// field went missing from the answer.
+//
+// So the field is served, and it carries what the client asked rather than a
+// constant: the omission gate checks that a field is present, never that it
+// means anything.
+func TestABlockSnapshotAnswersThePublicItWasAsked(t *testing.T) {
+	ts := newTestServer(t)
+
+	status, volume := do(t, ts, "POST", blockURL+"/volumes",
+		`{"name":"root","from_empty":{"size":5000000000}}`)
+	if status != http.StatusOK {
+		t.Fatalf("create a volume: %d (%v)", status, volume)
+	}
+	volumeID, _ := volume["id"].(string)
+
+	for _, want := range []bool{true, false} {
+		body := `{"name":"reference","volume_id":"` + volumeID + `","public":false}`
+		if want {
+			body = `{"name":"reference","volume_id":"` + volumeID + `","public":true}`
+		}
+		status, snapshot := do(t, ts, "POST", blockURL+"/snapshots", body)
+		if status != http.StatusOK {
+			t.Fatalf("create a block snapshot: %d (%v)", status, snapshot)
+		}
+		got, present := snapshot["public"].(bool)
+		if !present {
+			t.Fatalf("the snapshot answers no `public`, and block-v1.yml requires it (%v)", snapshot)
+		}
+		if got != want {
+			t.Errorf("a snapshot asked public=%v answers %v", want, got)
+		}
+		snapshotID, _ := snapshot["id"].(string)
+		status, read := do(t, ts, "GET", blockURL+"/snapshots/"+snapshotID, "")
+		if status != http.StatusOK {
+			t.Fatalf("read the snapshot back: %d", status)
+		}
+		if back, _ := read["public"].(bool); back != want {
+			t.Errorf("read back, a snapshot asked public=%v answers %v", want, back)
+		}
+	}
+}
+
+// A restored 15k volume still answers sbs_15k (#651, and #542's lesson).
+//
+// The type is computed from perf_iops, and Attrs crosses encoding/json on every
+// snapshot: the uint32 a create stores comes back float64. A type assertion
+// yields zero there, and zero is below the 15k threshold, so the volume would
+// come back from a snapshot as sbs_5k — a client's own record of what it paid
+// for, changed by a restart. internal/cli's TestNoPackReadsAStoredNumberByAssertion
+// caught the assertion before this test did, and this is the behaviour behind it.
+func TestARestoredVolumeKeepsItsPerformanceType(t *testing.T) {
+	env := scalewayEnv()
+	srv, err := emulator.NewServer(env, scaleway.New(env))
+	if err != nil {
+		t.Fatalf("build emulator: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	status, made := do(t, ts, "POST", blockURL+"/volumes",
+		`{"name":"fast","from_empty":{"size":5000000000},"perf_iops":15000}`)
+	if status != http.StatusOK {
+		t.Fatalf("create a 15k volume: %d (%v)", status, made)
+	}
+	volumeID, _ := made["id"].(string)
+	if got, _ := made["type"].(string); got != "sbs_15k" {
+		t.Fatalf("the fresh volume is %q, not sbs_15k: this test measures nothing", got)
+	}
+
+	var saved bytes.Buffer
+	if err := env.Store.Snapshot(&saved); err != nil {
+		t.Fatalf("take the snapshot: %v", err)
+	}
+	restored := store.New()
+	if err := restored.Restore(bytes.NewReader(saved.Bytes())); err != nil {
+		t.Fatalf("restore it: %v", err)
+	}
+	// The precondition, asserted: without the float64 the case is not staged.
+	stored, found := restored.Get(scaleway.Name, "block/volume", volumeID)
+	if !found {
+		t.Fatal("the restored store lost the volume: nothing below measures anything")
+	}
+	if _, isFloat := stored.Attrs["perf_iops"].(float64); !isFloat {
+		t.Fatalf("the restored perf_iops is %T, not the float64 JSON produces: "+
+			"this test is not reproducing the case it names", stored.Attrs["perf_iops"])
+	}
+
+	next := scalewayEnv()
+	next.Store = restored
+	revived, err := emulator.NewServer(next, scaleway.New(next))
+	if err != nil {
+		t.Fatalf("build the revived emulator: %v", err)
+	}
+	after := httptest.NewServer(revived.Handler())
+	t.Cleanup(after.Close)
+
+	status, read := do(t, after, "GET", blockURL+"/volumes/"+volumeID, "")
+	if status != http.StatusOK {
+		t.Fatalf("read the restored volume: %d (%v)", status, read)
+	}
+	if got, _ := read["type"].(string); got != "sbs_15k" {
+		t.Errorf("a restored 15k volume answers %q: a restart changed what the client paid for", got)
+	}
+}

--- a/internal/providers/scaleway/catalog_paging_test.go
+++ b/internal/providers/scaleway/catalog_paging_test.go
@@ -64,19 +64,42 @@ func TestBlockVolumeTypesArePaged(t *testing.T) {
 	if status != http.StatusOK {
 		t.Fatalf("unpaged: expected 200, got %d (%v)", status, all)
 	}
-	if types, _ := all["volume_types"].([]any); len(types) != 1 {
-		t.Fatalf("the catalogue answers %d volume types, want 1", len(types))
+	// Two, measured on a real account: sbs_5k and sbs_15k (#651). The first
+	// version of this catalogue served one, which is a stock that cannot
+	// answer what a 15k volume is on a product where the type is what a client
+	// picks.
+	if types, _ := all["volume_types"].([]any); len(types) != 2 {
+		t.Fatalf("the catalogue answers %d volume types, want 2", len(types))
 	}
 
-	// One entry, so page 2 must be empty — it answered the same entry again.
-	status, past := do(t, ts, "GET", url+"?page=2&page_size=1", "")
+	// A window of one over two entries: page 2 carries the OTHER one, and page
+	// 99 is empty. The single-entry table could not tell a window that slides
+	// from one that repeats itself, which is the defect #271 names.
+	_, firstPage := do(t, ts, "GET", url+"?page=1&page_size=1", "")
+	_, secondPage := do(t, ts, "GET", url+"?page=2&page_size=1", "")
+	one, _ := firstPage["volume_types"].([]any)
+	two, _ := secondPage["volume_types"].([]any)
+	if len(one) != 1 || len(two) != 1 {
+		t.Fatalf("a window of one answered %d then %d entries", len(one), len(two))
+	}
+	a, _ := one[0].(map[string]any)
+	b, _ := two[0].(map[string]any)
+	first, _ := a["type"].(string)
+	second, _ := b["type"].(string)
+	if first == second {
+		t.Errorf("page 1 and page 2 both answer %q: the window repeats instead of sliding", first)
+	}
+
+	// Past the stock the window is empty, which is how the SDK's loop stops.
+	status, past := do(t, ts, "GET", url+"?page=99&page_size=1", "")
 	if status != http.StatusOK {
 		t.Fatalf("paged: expected 200, got %d", status)
 	}
 	if types, _ := past["volume_types"].([]any); len(types) != 0 {
-		t.Errorf("page 2 of a one-entry catalogue answers %d entries", len(types))
+		t.Errorf("page 99 of the catalogue answers %d entries", len(types))
 	}
-	if got := int(past["total_count"].(float64)); got != 1 {
-		t.Errorf("the page reports total_count %d, want 1", got)
+	// The count is the stock, not the window: an empty page still reports two.
+	if got := int(past["total_count"].(float64)); got != 2 {
+		t.Errorf("the page reports total_count %d, want 2", got)
 	}
 }

--- a/internal/providers/scaleway/images.go
+++ b/internal/providers/scaleway/images.go
@@ -255,6 +255,55 @@ type createImageRequest struct {
 // missing volume — the client named a resource, and answering success about an
 // image of nothing is the half-success this project exists to avoid.
 // TestAnImageCutFromNothingIsRefused fails without this.
+// imageRoot resolves what an image is cut from, and renders the root_volume
+// the API publishes for it. The second answer is the point: the two kinds of
+// snapshot are described differently, and the difference is measured rather
+// than chosen.
+//
+// An SBS snapshot is the path #651 reports, and it is now the ONLY path to a
+// golden image: b_ssd is retired (#393), so every root volume is SBS, and an
+// instance snapshot of an SBS root volume is refused upstream (#648). An
+// emulator that accepts only instance snapshots here accepts nothing a current
+// stack can produce.
+//
+// What the real cloud does with such an id, measured 2026-09-03 on a real
+// account whose own image was cut this way:
+//
+//	"root_volume": {"id": "<the block snapshot's id>", "name": "",
+//	                "size": 10000000000, "volume_type": "sbs_snapshot"}
+//
+// The name is EMPTY, on an image whose block snapshot carried one, and the
+// type is `sbs_snapshot` — in the SDK's own enum,
+// VolumeVolumeTypeSbsSnapshot. Both are copied here rather than guessed.
+//
+// And the reverse direction stays as it is, deliberately: the issue asks for
+// the same id to resolve through `GET /instance/v1/…/snapshots/{id}`, and the
+// real cloud answers 404 there, with an empty instance listing beside it. Both
+// were measured the same day. Serving it would be a divergence, not a fix.
+//
+// TestAnImageIsCutFromAnSBSSnapshot fails without this.
+func (p *Pack) imageRoot(id string) (*resource.Resource, map[string]any, bool) {
+	if snapshot, found := p.env.Store.Get(Name, kindSnapshot, id); found {
+		return snapshot, map[string]any{
+			"id":          snapshot.ID,
+			"name":        textOf(snapshot.Attrs["name"]),
+			"size":        snapshot.Attrs["size"],
+			"volume_type": textOf(snapshot.Attrs["volume_type"]),
+		}, true
+	}
+	snapshot, found := p.env.Store.Get(Name, kindBlockSnapshot, id)
+	if !found {
+		return nil, nil, false
+	}
+	return snapshot, map[string]any{
+		"id": snapshot.ID,
+		// Empty, as measured, and not the snapshot's name.
+		"name":        "",
+		"size":        snapshot.Attrs["size"],
+		"volume_type": sbsSnapshotType,
+	}, true
+}
+
 func (p *Pack) createImage(w http.ResponseWriter, r *http.Request) {
 	zone, ok := zoneOf(w, r)
 	if !ok {
@@ -277,7 +326,7 @@ func (p *Pack) createImage(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	snapshot, found := p.env.Store.Get(Name, kindSnapshot, req.RootVolume)
+	snapshot, root, found := p.imageRoot(req.RootVolume)
 	if !found {
 		writeNotFound(w, "snapshot", req.RootVolume)
 		return
@@ -300,12 +349,7 @@ func (p *Pack) createImage(w http.ResponseWriter, r *http.Request) {
 		// The server the snapshot's volume came from, when there was one.
 		// A string rather than null, which is what a real account returns.
 		"from_server": textOf(snapshot.Attrs["from_server"]),
-		"root_volume": map[string]any{
-			"id":          snapshot.ID,
-			"name":        textOf(snapshot.Attrs["name"]),
-			"size":        snapshot.Attrs["size"],
-			"volume_type": textOf(snapshot.Attrs["volume_type"]),
-		},
+		"root_volume": root,
 	}
 	p.env.Store.Put(res)
 	emulator.WriteJSON(w, http.StatusCreated, map[string]any{"image": p.clientImageView(res)})

--- a/internal/providers/scaleway/volumetypes.go
+++ b/internal/providers/scaleway/volumetypes.go
@@ -50,6 +50,15 @@ var (
 	serverVolumeTypes = map[string]bool{"l_ssd": true, "scratch": true, "sbs_volume": true}
 )
 
+// sbsSnapshotType is how instance/v1 describes the root volume of an image cut
+// from an SBS snapshot. In the SDK's enum as VolumeVolumeTypeSbsSnapshot, and
+// measured on a real account's own image, 2026-09-03 (#651).
+//
+// Here rather than inline in images.go, because this file is where a fact
+// about a volume type lives: the one written in three places is the one that
+// gets corrected in one.
+const sbsSnapshotType = "sbs_snapshot"
+
 // volumeTypeError names what POST /volumes answers for a volume_type, or nil
 // when the cloud creates it.
 //

--- a/tools/falsify/specs/sbs-image-and-types.json
+++ b/tools/falsify/specs/sbs-image-and-types.json
@@ -1,0 +1,68 @@
+{
+  "mutations": [
+    {
+      "label": "an image cut from a block snapshot is described as an instance snapshot's volume type, so a client reads a type the cloud never answers there",
+      "file": "internal/providers/scaleway/images.go",
+      "package": "./internal/providers/scaleway/",
+      "find": "\t\t\"volume_type\": sbsSnapshotType,",
+      "replace": "\t\t\"volume_type\": sbsSnapshotType[:0],",
+      "test": "TestAnImageIsCutFromAnSBSSnapshot"
+    },
+    {
+      "label": "the image repeats the snapshot's name, where the real cloud answers an empty one",
+      "file": "internal/providers/scaleway/images.go",
+      "package": "./internal/providers/scaleway/",
+      "find": "\t\t\"name\":        \"\",",
+      "replace": "\t\t\"name\":        \"reference\",",
+      "test": "TestAnImageIsCutFromAnSBSSnapshot"
+    },
+    {
+      "label": "the block snapshot is no longer resolvable, so the only path left to a golden image answers 404 again",
+      "file": "internal/providers/scaleway/images.go",
+      "package": "./internal/providers/scaleway/",
+      "find": "\tsnapshot, found := p.env.Store.Get(Name, kindBlockSnapshot, id)\n\tif !found {",
+      "replace": "\tsnapshot, found := p.env.Store.Get(Name, kindBlockSnapshot, id)\n\tif !found || true {",
+      "test": "TestAnImageIsCutFromAnSBSSnapshot"
+    },
+    {
+      "label": "a 15k volume answers the 5k type, so the type stops naming the performance a client picked",
+      "file": "internal/providers/scaleway/block.go",
+      "package": "./internal/providers/scaleway/",
+      "find": "\tif resource.Number(iops) >= blockIOPS15k {",
+      "replace": "\tif resource.Number(iops) >= blockIOPS15k && false {",
+      "test": "TestABlockVolumeCarriesItsPerformanceType"
+    },
+    {
+      "label": "the snapshot's parent volume answers a type of its own rather than the parent's",
+      "file": "internal/providers/scaleway/block.go",
+      "package": "./internal/providers/scaleway/",
+      "find": "\t\t\t\"type\":   blockVolumeTypeOf(volume.Attrs[\"perf_iops\"]),",
+      "replace": "\t\t\t\"type\":   blockVolumeTypeOf(volume.Attrs[\"perf_iops\"])[:0],",
+      "test": "TestABlockVolumeCarriesItsPerformanceType"
+    },
+    {
+      "label": "the snapshot stops answering the public it was asked, so a required field of block-v1.yml goes missing",
+      "file": "internal/providers/scaleway/block.go",
+      "package": "./internal/providers/scaleway/",
+      "find": "\t\t\"public\":        res.Attrs[\"public\"],",
+      "replace": "\t\t\"public\":        res.Attrs[\"public\"] != nil,",
+      "test": "TestABlockSnapshotAnswersThePublicItWasAsked"
+    },
+    {
+      "label": "both catalogue entries answer the same type, so the window repeats instead of sliding",
+      "file": "internal/providers/scaleway/block.go",
+      "package": "./internal/providers/scaleway/",
+      "find": "\t\t\"type\":             blockType15k,",
+      "replace": "\t\t\"type\":             blockType5k + blockType15k[:0],",
+      "test": "TestBlockVolumeTypesArePaged"
+    },
+    {
+      "label": "the type is read back with a type assertion again, so a restored 15k volume comes back as 5k",
+      "file": "internal/providers/scaleway/block.go",
+      "package": "./internal/providers/scaleway/",
+      "find": "\tif resource.Number(iops) >= blockIOPS15k {",
+      "replace": "\tif n, _ := iops.(uint32); float64(n)*resource.Number(1) >= blockIOPS15k {",
+      "test": "TestARestoredVolumeKeepsItsPerformanceType"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #651.

## The premise, measured

The issue asks for a Block snapshot's id to resolve through the Instance API.
Measured on a real account, 2026-09-03, it does not:

```console
$ scw instance snapshot get <a block snapshot in `available`>
cannot find resource 'instance_snapshot' with ID '660732a4-…'
$ scw instance snapshot list
[]
```

Same 404, same empty listing as the emulator. Serving the snapshot there would
be a **divergence**, so `TestABlockSnapshotStaysInvisibleToTheInstanceAPI` now
pins that 404 in place with the measurement beside it, so nobody "fixes" it later.

## What actually blocks the stack

The cloud accepts that id as an **image's root volume**, and the same account's
own image says how it describes one:

```json
"root_volume": {"id": "<the block snapshot>", "name": "",
                "size": 10000000000, "volume_type": "sbs_snapshot"}
```

The name is empty on an image whose snapshot carried one, and the type is
`sbs_snapshot`, in the SDK's own enum. `imageRoot` now resolves both kinds of
snapshot and renders each the way it is described.

This is the whole golden-image path: `b_ssd` is retired (#393), so every root
volume is SBS, and an instance snapshot of an SBS root volume is refused
upstream (#648). Resolving only instance snapshots here resolves nothing a
current stack can produce.

## Three more, from the same measurement

| what | before | measured |
|---|---|---|
| a volume's `type` | `sbs` (the storage class) | `sbs_5k`, with `specs {perf_iops: 5000, class: "sbs"}` |
| the snapshot's `parent_volume.type` | `sbs` | the parent's own, `sbs_5k` |
| the volume-type catalogue | one entry | **two**: `sbs_5k` and `sbs_15k` |

`documentdb`'s SDK names the pair upstream (`VolumeTypeSbs5k`,
`VolumeTypeSbs15k`) and there is no third. `TestTheBlockCatalogueAnswers`
asserted the type against a literal; it now creates a volume and requires the
catalogue to offer what the pack mints, which is the join that had gone out of
step.

The type is read with `resource.Number`, not a type assertion: `internal/cli`'s
`TestNoPackReadsAStoredNumberByAssertion` caught `iops.(uint32)` before a client
did. `Attrs` crosses `encoding/json` on every snapshot, so a **restored** 15k
volume would have answered `sbs_5k` — a restart changing what the client paid
for. `TestARestoredVolumeKeepsItsPerformanceType` stages exactly that, float64
and all.

## One correction worth recording

This branch first **removed** `public` from the block snapshot, on the strength
of `scw block snapshot get -o json` answering no such field on a real account.

That command serialises the SDK struct the CLI decodes into, and the vendored
block SDK (v1alpha1) has no `Public`: **it shows what the CLI sees, not what the
cloud sent.** `block-v1.yml` declares `public` on the Snapshot schema and lists
it as REQUIRED. The `fields` leg said so from both sides within minutes — first
*"a field a real client sent that no handler read"*, then *"a field the real
cloud returns and no answer of this run carried"*. The field is served, and
`TestABlockSnapshotAnswersThePublicItWasAsked` now checks it carries what the
client asked rather than a constant. `zone` on a volume type went out and came
back for the same reason.

## Proof

- `mise run conformance:leg -- fields`, **exit 0**, which is where the omission
  gate judges and the only leg that judges a shape change.
- **Eight falsify mutations, all compiling, all biting**
  (`tools/falsify/specs/sbs-image-and-types.json`), and the five specs
  `testplan` named for the touched files replayed green.
- `mise run prepush`.

Conformance was **not** replayed in full for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
