### PR TITLE
fix(scaleway): a reboot leaves running, because an accepted action is not a done one (#654)

### DIFF
--- a/internal/core/resource/resource.go
+++ b/internal/core/resource/resource.go
@@ -91,6 +91,25 @@ type Resource struct {
 	// saved is a reboot still in flight when it is loaded. That also makes it
 	// untrusted input on the way back in, which is why Restore treats it as one.
 	Pending []string
+	// PendingOnlySignal marks a chain whose arrival is its departure: the
+	// action settles on the state it started from, so a client watching the
+	// state has nothing else to go on. The store walks such a chain whatever
+	// the consistency mode, where an ordinary one is walked only under eventual
+	// consistency (#654).
+	//
+	// The distinction is a property of the chain, not of a provider: a pack
+	// says what it pushed and from where, and the core never learns that the
+	// action was called "reboot". Measured on this emulator before the flag
+	// existed: poweron and poweroff stayed observable with the mode off,
+	// because their state changes; reboot answered `running` on every read of
+	// a six-read poll, indistinguishable from an action that never happened.
+	//
+	// It survives a snapshot for the reason Pending does, and it has to: a
+	// chain restored without it would be walked by no mode at all, leaving the
+	// resource with states to pass through that nothing ever consumes. Same
+	// consequence as Pending on the way back in, and the same treatment: what
+	// Restore accepts here it accepts as untrusted input.
+	PendingOnlySignal bool
 }
 
 // New returns a resource stamped at now, with Created and Updated aligned and
@@ -139,6 +158,7 @@ func (r *Resource) Clone() *Resource {
 	if r.Pending != nil {
 		out.Pending = append([]string(nil), r.Pending...)
 	}
+	out.PendingOnlySignal = r.PendingOnlySignal
 	return &out
 }
 

--- a/internal/core/store/commit_test.go
+++ b/internal/core/store/commit_test.go
@@ -171,3 +171,41 @@ func TestCommitKeepsAConcurrentWriteToAnotherField(t *testing.T) {
 		t.Fatalf("the acknowledged tag was erased by a writer that never touched it: %v", stored.Attrs["tags"])
 	}
 }
+
+// Commit carries the only-signal mark with the chain it merges (#654).
+//
+// The pack pushes both on a clone it holds outside the lock, and Commit is the
+// door back in. A chain that arrives without its mark is a chain the store
+// walks in one mode out of two, so the action it was the only signal of becomes
+// invisible again in the default mode — the exact defect, one layer further in.
+//
+// Merged on the same condition as the chain, which the second half asserts: a
+// caller that touched neither leaves the stored mark alone.
+func TestCommitCarriesTheOnlySignalMarkWithTheChain(t *testing.T) {
+	s := store.New()
+	base := resource.New("id-1", "server", resource.Tenant{Provider: "p"}, "running",
+		time.Unix(1700000000, 0).UTC())
+	s.Put(base)
+
+	held, _ := s.Get("p", "server", "id-1")
+	before, _ := s.Get("p", "server", "id-1")
+	held.Pending = []string{"stopping", "starting", "running"}
+	held.PendingOnlySignal = true
+	if !s.Commit(before, held, time.Unix(1700000001, 0).UTC()) {
+		t.Fatal("commit refused")
+	}
+	// The store walks it now, which is only true if the mark came through.
+	if got, _ := s.Get("p", "server", "id-1"); got.State != "stopping" {
+		t.Errorf("after a commit the resource answers %q, want stopping: the mark did not travel", got.State)
+	}
+
+	// And a commit that touched neither leaves what is stored alone.
+	stored, _ := s.Get("p", "server", "id-1")
+	again, _ := s.Get("p", "server", "id-1")
+	if !s.Commit(stored, again, time.Unix(1700000002, 0).UTC()) {
+		t.Fatal("second commit refused")
+	}
+	if got, _ := s.Get("p", "server", "id-1"); got.State != "running" {
+		t.Errorf("the chain answers %q, want running: a commit that changed nothing disturbed it", got.State)
+	}
+}

--- a/internal/core/store/store.go
+++ b/internal/core/store/store.go
@@ -27,10 +27,37 @@ type Store struct {
 	items map[string]*resource.Resource
 	// observe, when set, is told about every touch a caller makes. See Observe.
 	observe func(Event)
-	// eventual turns the pending chains on. Off is the default and is
-	// byte-identical to a store that never had them, which is what keeps the
-	// conformance suite and every existing test untouched (#124).
+	// eventual turns the ordinary pending chains on. Off is the default: a
+	// chain a client can do without is not walked, which is what keeps a local
+	// emulator from making anyone wait for information no runtime is producing
+	// (#124).
+	//
+	// It does not govern the chains marked PendingOnlySignal, which are walked
+	// in both modes. See onlySignal.
 	eventual bool
+	// onlySignal counts the resources carrying a chain whose arrival is its
+	// departure. Kept rather than searched for, because Get and List consult it
+	// on the way in to decide which lock to take, and scanning the store to
+	// answer that would cost more than the chains do.
+	onlySignal int
+}
+
+// countOnlySignal adjusts the tally when a stored resource is replaced. Called
+// under the write lock, with what was there and what replaces it; either may be
+// nil, which is a create or a delete.
+func (s *Store) countOnlySignal(before, after *resource.Resource) {
+	if walkable(before) {
+		s.onlySignal--
+	}
+	if walkable(after) {
+		s.onlySignal++
+	}
+}
+
+// walkable reports whether a resource carries a chain the store must walk
+// whatever the mode.
+func walkable(r *resource.Resource) bool {
+	return r != nil && r.PendingOnlySignal && len(r.Pending) > 0
 }
 
 // Eventual turns transient states on, so a resource carrying a pending chain
@@ -60,11 +87,25 @@ func (s *Store) Eventual(on bool) {
 // that advanced the clone instead would answer the same first state for ever,
 // which is the defect this exists to avoid rather than a subtlety of it.
 func (s *Store) advance(r *resource.Resource) {
-	if !s.eventual || r == nil || len(r.Pending) == 0 {
+	if r == nil || len(r.Pending) == 0 {
+		return
+	}
+	// Two kinds of chain, and the difference is what the client can observe
+	// without it. An ordinary chain narrates a change the state already shows
+	// — stopped becomes running whether or not anyone watched it pass through
+	// `starting` — so the mode decides. A chain marked PendingOnlySignal
+	// settles where it started, so skipping it leaves an action that answered
+	// success and changed nothing observable: measured on a reboot, six reads
+	// of `running` before and after (#654).
+	if !s.eventual && !r.PendingOnlySignal {
 		return
 	}
 	r.State = r.Pending[0]
 	r.Pending = r.Pending[1:]
+	if len(r.Pending) == 0 && r.PendingOnlySignal {
+		r.PendingOnlySignal = false
+		s.onlySignal--
+	}
 }
 
 // Event is one observed touch of the store: something was created, read,
@@ -132,8 +173,10 @@ func key(provider, kind, id string) string {
 func (s *Store) Put(r *resource.Resource) {
 	s.mu.Lock()
 	k := key(r.Tenant.Provider, r.Kind, r.ID)
-	_, existed := s.items[k]
-	s.items[k] = r.Clone()
+	before, existed := s.items[k]
+	stored := r.Clone()
+	s.items[k] = stored
+	s.countOnlySignal(before, stored)
 	s.mu.Unlock()
 
 	action := EventCreated
@@ -245,6 +288,7 @@ func (s *Store) Update(provider, kind, id string, change func(*resource.Resource
 			return err
 		}
 		s.items[key(provider, kind, id)] = draft
+		s.countOnlySignal(r, draft)
 		return nil
 	}()
 	if err != nil {
@@ -310,6 +354,12 @@ func (s *Store) Commit(base, res *resource.Resource, now time.Time) bool {
 		// (scaleway's TestARebootIsObservableUnderEventualConsistency).
 		if !slices.Equal(base.Pending, res.Pending) {
 			stored.Pending = append([]string(nil), res.Pending...)
+			// The chain and what it means travel together: a chain that is an
+			// action's only signal, merged without its mark, is a chain the
+			// store walks in one mode out of two (#654). Carried on the same
+			// condition as the chain itself, so a caller that did not touch
+			// either leaves both alone.
+			stored.PendingOnlySignal = res.PendingOnlySignal
 		}
 		stored.Updated = now
 		return nil
@@ -354,8 +404,9 @@ func mergeRuntime(stored, base, res map[string]string) {
 func (s *Store) Delete(provider, kind, id string) bool {
 	s.mu.Lock()
 	k := key(provider, kind, id)
-	_, ok := s.items[k]
+	before, ok := s.items[k]
 	delete(s.items, k)
+	s.countOnlySignal(before, nil)
 	s.mu.Unlock()
 
 	if ok {
@@ -418,7 +469,7 @@ func sortByCreation(out []*resource.Resource) {
 func (s *Store) advancing() bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.eventual
+	return s.eventual || s.onlySignal > 0
 }
 
 // All returns a clone of every resource, whatever its provider or kind, in the
@@ -593,7 +644,9 @@ func (s *Store) Restore(r io.Reader) error {
 		if res == nil {
 			continue
 		}
-		s.items[key(res.Tenant.Provider, res.Kind, res.ID)] = res
+		k := key(res.Tenant.Provider, res.Kind, res.ID)
+		s.countOnlySignal(s.items[k], res)
+		s.items[k] = res
 	}
 	return nil
 }

--- a/internal/core/store/transient_test.go
+++ b/internal/core/store/transient_test.go
@@ -1,6 +1,7 @@
 package store_test
 
 import (
+	"bytes"
 	"testing"
 	"time"
 
@@ -107,5 +108,71 @@ func TestPeekDoesNotAdvanceAChain(t *testing.T) {
 	got, _ := s.Get("p", "server", "id-1")
 	if got.State != "stopping" {
 		t.Errorf("the first observation after three peeks answered %q, want stopping", got.State)
+	}
+}
+
+// A chain marked as an action's only signal is walked with the mode off (#654).
+//
+// The distinction the store reads is a property of the chain, not of a
+// provider: PendingOnlySignal says "this action settles where it started, so
+// nothing else tells the client it happened". A reboot is the case that exists
+// today, and this core never learns the word.
+//
+// Both halves are asserted, because a store that walked everything would pass
+// the first one and undo #124: the ordinary chain beside it must stay inert.
+func TestAChainThatIsAnActionsOnlySignalIsWalkedInAnyMode(t *testing.T) {
+	s := store.New()
+
+	only := pendingServer()
+	only.ID = "only-signal"
+	only.PendingOnlySignal = true
+	s.Put(only)
+	s.Put(pendingServer()) // id-1, an ordinary chain
+
+	for i, want := range []string{"stopping", "starting", "running"} {
+		got, ok := s.Get("p", "server", "only-signal")
+		if !ok {
+			t.Fatal("the resource went missing")
+		}
+		if got.State != want {
+			t.Fatalf("read %d answers %q, want %q: a chain nothing else signals must walk in any mode", i, got.State, want)
+		}
+		if plain, _ := s.Get("p", "server", "id-1"); plain.State != "running" {
+			t.Fatalf("read %d moved the ordinary chain to %q: the mode still governs those", i, plain.State)
+		}
+	}
+	// Settled, and it stays settled rather than walking for ever.
+	if got, _ := s.Get("p", "server", "only-signal"); got.State != "running" {
+		t.Errorf("the chain settled at %q, want running", got.State)
+	}
+	// And the mark is spent with the chain: what is left is an ordinary
+	// resource, not one the store keeps taking the write lock for.
+	if got, _ := s.Get("p", "server", "only-signal"); got.PendingOnlySignal {
+		t.Error("a spent chain still carries its mark")
+	}
+}
+
+// The mark survives a snapshot, for the reason the chain does (#654).
+//
+// A reboot in flight when the state is saved is a reboot still in flight when
+// it is loaded. Restoring the states without the mark would leave a resource
+// with a chain no mode ever walks: it would answer the first state of the chain
+// for ever, which is worse than either behaviour this flag chooses between.
+func TestTheOnlySignalMarkSurvivesASnapshot(t *testing.T) {
+	s := store.New()
+	r := pendingServer()
+	r.PendingOnlySignal = true
+	s.Put(r)
+
+	var saved bytes.Buffer
+	if err := s.Snapshot(&saved); err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	loaded := store.New()
+	if err := loaded.Restore(bytes.NewReader(saved.Bytes())); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if got, ok := loaded.Get("p", "server", "id-1"); !ok || got.State != "stopping" {
+		t.Errorf("a restored chain answers %v, want stopping: the reboot was still in flight", got)
 	}
 }

--- a/internal/providers/scaleway/servers.go
+++ b/internal/providers/scaleway/servers.go
@@ -897,6 +897,12 @@ func (p *Pack) serverAction(w http.ResponseWriter, r *http.Request) {
 // answers something other than the accepted task.
 func (p *Pack) applyServerAction(w http.ResponseWriter, r *http.Request, req serverActionRequest,
 	res *resource.Resource, id, zone string, now time.Time, reply *func()) bool {
+	// Where the action starts, read before anything below moves it. Captured
+	// here rather than beside each chain, because two of the cases set the
+	// state themselves first: a value read after that is the state the action
+	// ARRIVED at, and a chain built from it would say every action settles
+	// where it began (#654).
+	before := res.State
 	switch req.Action {
 	case "poweron":
 		// A poweron on a server that is already running is not a second launch.
@@ -926,7 +932,7 @@ func (p *Pack) applyServerAction(w http.ResponseWriter, r *http.Request, req ser
 			// them. Pushed after the machine call, so a start that FAILED keeps
 			// the failed state it earned rather than walking a chain towards a
 			// running it never reached.
-			transitionTo(res, res.State, "starting")
+			transitionTo(res, before, res.State, "starting")
 		}
 		res.Attrs["allowed_actions"] = allowedActions(res.State, protectedServer(res))
 	case "reboot":
@@ -952,7 +958,7 @@ func (p *Pack) applyServerAction(w http.ResponseWriter, r *http.Request, req ser
 		// proves nothing to a client waiting on it: the only signal available
 		// without task support is watching the machine LEAVE its initial state,
 		// and there was nothing to see.
-		transitionTo(res, res.State, "stopping", "starting")
+		transitionBackTo(res, before, res.State, "stopping", "starting")
 		res.Attrs["allowed_actions"] = allowedActions(res.State, protectedServer(res))
 	case "poweroff", "stop_in_place":
 		// Two actions, two states, and the difference is not cosmetic: the SDK
@@ -975,7 +981,7 @@ func (p *Pack) applyServerAction(w http.ResponseWriter, r *http.Request, req ser
 		// the whole difference between dynamic and flexible.
 		p.releaseDynamicAddress(r.Context(), res)
 		p.stopMachine(r.Context(), res)
-		transitionTo(res, res.State, "stopping")
+		transitionTo(res, before, res.State, "stopping")
 	case "terminate":
 		p.releaseDynamicAddress(r.Context(), res)
 		p.removeMachine(r.Context(), res)
@@ -1933,7 +1939,28 @@ func (p *Pack) nextVolumeKey(res *resource.Resource) string {
 // this project exists to avoid.
 //
 // TestARebootIsObservableUnderEventualConsistency fails without this.
-func transitionTo(res *resource.Resource, settled string, through ...string) {
+// transitionBackTo is transitionTo for an action that means to settle where it
+// started, which today is exactly one: a reboot.
+//
+// The chain it pushes is the action's only signal, so the store walks it in
+// both consistency modes (#654). The mark is still conditional on the action
+// having come back: a reboot of a STOPPED server is a start, arrives somewhere
+// new, and gets an ordinary chain like any other.
+//
+// The intent is declared here rather than inferred from `from == settled`
+// alone, because a failed action also settles where it started. A poweron that
+// could not boot stays `stopped`, and marking that chain would have the API
+// narrate a `starting` that never happened, one read at a time.
+// TestAnUnknownImageDoesNotBootASubstitute caught exactly that.
+//
+// TestOnlyAChainThatSettlesWhereItStartedIsTheOnlySignal and
+// TestARebootIsObservableWithoutEventualConsistency fail without this.
+func transitionBackTo(res *resource.Resource, from, settled string, through ...string) {
+	transitionTo(res, from, settled, through...)
+	res.PendingOnlySignal = len(res.Pending) > 0 && from == settled
+}
+
+func transitionTo(res *resource.Resource, from, settled string, through ...string) {
 	if len(through) == 0 {
 		return
 	}
@@ -1945,8 +1972,13 @@ func transitionTo(res *resource.Resource, settled string, through ...string) {
 	}
 	res.State = settled
 	res.Pending = append(append([]string(nil), through...), settled)
+	// An ordinary chain narrates a change the state already carries, so the
+	// consistency mode governs it. transitionBackTo is where a chain becomes
+	// the only signal an action happened.
+	res.PendingOnlySignal = false
 	// The first state a reader sees is the first of the chain, so the resource
 	// as stored has to be the one BEFORE the chain runs. Pending carries the
 	// settled state as its last step; State holds it too, so a store with the
-	// mode off answers exactly what it answered before.
+	// mode off answers exactly what it answered before — unless the chain is
+	// the action's only signal, and then it is walked in both modes.
 }

--- a/internal/providers/scaleway/transient_internal_test.go
+++ b/internal/providers/scaleway/transient_internal_test.go
@@ -24,7 +24,7 @@ func TestAFailedActionWalksNoChain(t *testing.T) {
 
 	for _, settled := range []string{"running", "stopped", "stopped in place"} {
 		r := res(settled)
-		transitionTo(r, settled, "stopping", "starting")
+		transitionTo(r, "stopped", settled, "stopping", "starting")
 		if len(r.Pending) == 0 {
 			t.Errorf("a %s action pushed no chain, so a client waiting on it observes nothing", settled)
 		}
@@ -37,7 +37,7 @@ func TestAFailedActionWalksNoChain(t *testing.T) {
 	// they are not states this chain knows how to arrive at.
 	for _, failed := range []string{"failed", "starting", "unknown", ""} {
 		r := res(failed)
-		transitionTo(r, failed, "stopping", "starting")
+		transitionTo(r, "stopped", failed, "stopping", "starting")
 		if len(r.Pending) != 0 {
 			t.Errorf("an action that ended in %q pushed %v: the emulator would narrate a path to a "+
 				"state the machine never reached", failed, r.Pending)
@@ -50,8 +50,43 @@ func TestAFailedActionWalksNoChain(t *testing.T) {
 	// And an empty chain is a no-op rather than a resource stuck with an empty
 	// pending slice, which the store would then treat as settled anyway.
 	r := res("running")
-	transitionTo(r, "running")
+	transitionTo(r, "running", "running")
 	if len(r.Pending) != 0 {
 		t.Errorf("an action with no chain pushed %v", r.Pending)
+	}
+}
+
+// A chain that settles where it started is marked as the action's only signal,
+// and one that arrives somewhere new is not (#654).
+//
+// This is the whole distinction the store reads to decide whether the mode
+// governs a chain. Written from where the action STARTED rather than from its
+// name, so the core never learns that this one was a reboot: measured before
+// the mark existed, a reboot answered `running` on all six reads of a poll
+// while poweron and poweroff stayed observable with the mode off.
+func TestOnlyAChainThatSettlesWhereItStartedIsTheOnlySignal(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	for _, c := range []struct {
+		name    string
+		from    string
+		settled string
+		through []string
+		want    bool
+	}{
+		{name: "reboot", from: "running", settled: "running", through: []string{"stopping", "starting"}, want: true},
+		{name: "poweron", from: "stopped", settled: "running", through: []string{"starting"}, want: false},
+		{name: "poweroff", from: "running", settled: "stopped", through: []string{"stopping"}, want: false},
+		// A reboot of a stopped server is a start, and it arrives somewhere
+		// new: the mark follows the states, not the verb.
+		{name: "reboot of a stopped server", from: "stopped", settled: "running", through: []string{"stopping", "starting"}, want: false},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			r := resource.New("id", kindServer, resource.Tenant{Provider: Name}, c.settled, now)
+			transitionBackTo(r, c.from, c.settled, c.through...)
+			if r.PendingOnlySignal != c.want {
+				t.Errorf("a chain %s -> %s is marked only-signal=%v, want %v",
+					c.from, c.settled, r.PendingOnlySignal, c.want)
+			}
+		})
 	}
 }

--- a/internal/providers/scaleway/transient_test.go
+++ b/internal/providers/scaleway/transient_test.go
@@ -114,29 +114,76 @@ func TestARebootIsObservableUnderEventualConsistency(t *testing.T) {
 	}
 }
 
-// With the mode off — the default — nothing about a reboot changed, which is
-// what keeps every other test in this package and the conformance suite
-// untouched.
+// A reboot is observable with the mode OFF, which is the default (#654).
 //
-// The accepting half of the guard above: a mechanism that made every emulator
-// walk chains would pass that test and change what every existing client sees.
-func TestARebootIsStillInstantWithoutEventualConsistency(t *testing.T) {
+// This test replaces one that asserted the opposite, and the reversal is the
+// decision #654 asked for. The old property was "with the mode off nothing
+// about a reboot changed", and it was true: measured on main, six reads of
+// `running` after a reboot that answered success. A Day-2 client cannot build
+// on that — an action that was ACCEPTED is not an action that HAPPENED, so a
+// waiter watches the state leave `running`, and here it never did. The reporter's
+// module timed out at 300 s against an emulator whose reboot had worked.
+//
+// poweron and poweroff stay observable in this mode by accident of arriving
+// somewhere else. Reboot is the one action whose target state is its starting
+// state, so it is the one the mode made invisible, and PendingOnlySignal is
+// what singles it out without the core learning the word.
+//
+// What does NOT change: the settled state. The chain still ends at `running`,
+// and a client that reads twice more sees it.
+func TestARebootIsObservableWithoutEventualConsistency(t *testing.T) {
 	ts := newTestServer(t)
 	id, _ := serverWith(t, ts, `{"name":"rebooter","commercial_type":"DEV1-S"}`)
 
 	if status, _ := do(t, ts, "POST", zoneURL+"/servers/"+id+"/action", `{"action":"poweron"}`); status != http.StatusAccepted {
 		t.Fatalf("poweron: %d", status)
 	}
+	// The accepting half, and it is not decoration: a mechanism that walked
+	// every chain in every mode would pass the reboot assertions below and
+	// change what every existing client sees of a poweron.
 	if got := state(t, ts, id); got != "running" {
-		t.Fatalf("poweron answered %q rather than settling at running", got)
+		t.Fatalf("poweron answered %q rather than settling at running, with the mode off", got)
 	}
 	if status, _ := do(t, ts, "POST", zoneURL+"/servers/"+id+"/action", `{"action":"reboot"}`); status != http.StatusAccepted {
 		t.Fatalf("reboot: %d", status)
 	}
-	for i := 0; i < 3; i++ {
+	want := []string{"stopping", "starting", "running"}
+	for i, expect := range want {
+		if got := state(t, ts, id); got != expect {
+			t.Fatalf("read %d after a reboot answered %q, want %q: the chain a client waits on", i, got, expect)
+		}
+	}
+	// And it settles: a client that keeps reading is not left walking for ever.
+	if got := state(t, ts, id); got != "running" {
+		t.Errorf("the reboot settled at %q, want running", got)
+	}
+}
+
+// A poweroff is NOT given the reboot's treatment, and neither is a poweron.
+//
+// Their chains narrate a change the state already carries, so the consistency
+// mode governs them as it did before #654. Without this the fix would be "walk
+// every chain always", which is the change nobody asked for: it would make a
+// local emulator answer `starting` to clients that have waited for nothing
+// since #124 settled that question.
+func TestAPoweronAndAPoweroffStaySettledWithoutEventualConsistency(t *testing.T) {
+	ts := newTestServer(t)
+	id, _ := serverWith(t, ts, `{"name":"plain","commercial_type":"DEV1-S"}`)
+
+	if status, _ := do(t, ts, "POST", zoneURL+"/servers/"+id+"/action", `{"action":"poweron"}`); status != http.StatusAccepted {
+		t.Fatalf("poweron: %d", status)
+	}
+	for i := 0; i < 2; i++ {
 		if got := state(t, ts, id); got != "running" {
-			t.Fatalf("read %d after a reboot answered %q, and with the mode off the state must "+
-				"never leave running", i, got)
+			t.Fatalf("read %d after a poweron answered %q, and with the mode off it settles at once", i, got)
+		}
+	}
+	if status, _ := do(t, ts, "POST", zoneURL+"/servers/"+id+"/action", `{"action":"poweroff"}`); status != http.StatusAccepted {
+		t.Fatalf("poweroff: %d", status)
+	}
+	for i := 0; i < 2; i++ {
+		if got := state(t, ts, id); got != "stopped" {
+			t.Fatalf("read %d after a poweroff answered %q, and with the mode off it settles at once", i, got)
 		}
 	}
 }

--- a/tools/conformance/scaleway/scw-cli.sh
+++ b/tools/conformance/scaleway/scw-cli.sh
@@ -64,9 +64,22 @@ ok "read back identical"
 # tools/conformance/functional.sh, which compares the runtime process across the call.
 echo "- reboot"
 scw instance server reboot "$id" zone="$ZONE" >/dev/null || fail "reboot rejected"
-state="$(scw instance server get "$id" zone="$ZONE" -o json | jq -r '.state')"
-[ "$state" = "running" ] || fail "expected the server to be running after a reboot, got '$state'"
-ok "rebooted, and still running"
+# Read until it settles, which is what a Day-2 client does, and record that it
+# LEFT running on the way (#654). A single read right after the call used to be
+# the check here, and it asserted the wrong thing: fr-par answers stopping then
+# starting to that read, so the assertion would have failed against the real
+# cloud and passed against an emulator that did nothing at all. An action that
+# was ACCEPTED is not an action that HAPPENED, and the transition is the only
+# thing that tells them apart from out here.
+left=""
+for _ in $(seq 1 10); do
+  state="$(scw instance server get "$id" zone="$ZONE" -o json | jq -r '.state')"
+  [ "$state" = "running" ] && break
+  left="$state"
+done
+[ -n "$left" ] || fail "the reboot never left running: nothing distinguishes it from an action that did not happen"
+[ "$state" = "running" ] || fail "the reboot did not settle back to running, got '$state'"
+ok "rebooted: left running through '$left', and settled back"
 
 # The CLI starts the server right after creating it, and the API refuses to delete a running
 # server. Powering off first is what a real user does, so the suite does it too.

--- a/tools/falsify/specs/observable-transitions.json
+++ b/tools/falsify/specs/observable-transitions.json
@@ -4,15 +4,15 @@
     {
       "label": "a reboot pushes no chain, so a client waiting on it observes nothing and returns having proven nothing",
       "file": "internal/providers/scaleway/servers.go",
-      "find": "\t\ttransitionTo(res, res.State, \"stopping\", \"starting\")",
-      "replace": "\t\ttransitionTo(res, res.State)",
+      "find": "\t\ttransitionBackTo(res, before, res.State, \"stopping\", \"starting\")",
+      "replace": "\t\ttransitionBackTo(res, before, res.State)",
       "test": "TestARebootIsObservableUnderEventualConsistency"
     },
     {
       "label": "the reboot chain is invented rather than transcribed, so it skips the stopping fr-par answers first",
       "file": "internal/providers/scaleway/servers.go",
-      "find": "\t\ttransitionTo(res, res.State, \"stopping\", \"starting\")",
-      "replace": "\t\ttransitionTo(res, res.State, \"starting\")",
+      "find": "\t\ttransitionBackTo(res, before, res.State, \"stopping\", \"starting\")",
+      "replace": "\t\ttransitionBackTo(res, before, res.State, \"starting\")",
       "test": "TestARebootIsObservableUnderEventualConsistency"
     },
     {

--- a/tools/falsify/specs/reboot-is-observable.json
+++ b/tools/falsify/specs/reboot-is-observable.json
@@ -1,0 +1,52 @@
+{
+  "mutations": [
+    {
+      "label": "a reboot's chain is no longer its only signal, so the default mode answers running on every read again",
+      "file": "internal/providers/scaleway/servers.go",
+      "package": "./internal/providers/scaleway/",
+      "find": "\tres.PendingOnlySignal = len(res.Pending) > 0 && from == settled",
+      "replace": "\tres.PendingOnlySignal = len(res.Pending) > 0 && from == settled && false",
+      "test": "TestARebootIsObservableWithoutEventualConsistency"
+    },
+    {
+      "label": "every chain becomes an only signal, so a poweron narrates `starting` to clients that never asked for it",
+      "file": "internal/core/store/store.go",
+      "package": "./internal/core/store/",
+      "find": "\tif !s.eventual && !r.PendingOnlySignal {",
+      "replace": "\tif !s.eventual && !r.PendingOnlySignal && false {",
+      "test": "TestAChainThatIsAnActionsOnlySignalIsWalkedInAnyMode"
+    },
+    {
+      "label": "the store keeps the read lock, so the chain it must walk is never walked",
+      "file": "internal/core/store/store.go",
+      "package": "./internal/core/store/",
+      "find": "\treturn s.eventual || s.onlySignal > 0\n}",
+      "replace": "\treturn s.eventual || (s.onlySignal > 0 && false)\n}",
+      "test": "TestAChainThatIsAnActionsOnlySignalIsWalkedInAnyMode"
+    },
+    {
+      "label": "the mark does not travel with the chain through Commit, so the pack's reboot loses it on the way to the store",
+      "file": "internal/core/store/store.go",
+      "package": "./internal/core/store/",
+      "find": "\t\t\tstored.PendingOnlySignal = res.PendingOnlySignal",
+      "replace": "\t\t\tstored.PendingOnlySignal = res.PendingOnlySignal && false",
+      "test": "TestCommitCarriesTheOnlySignalMarkWithTheChain"
+    },
+    {
+      "label": "an ordinary chain is marked when the action happens to end where it began, so a poweron that could not boot narrates a `starting` that never happened",
+      "file": "internal/providers/scaleway/servers.go",
+      "package": "./internal/providers/scaleway/",
+      "find": "\tres.PendingOnlySignal = false",
+      "replace": "\tres.PendingOnlySignal = from == settled",
+      "test": "TestAnUnknownImageDoesNotBootASubstitute"
+    },
+    {
+      "label": "the store stops counting the chains it must walk, so the lock it takes never lets one advance",
+      "file": "internal/core/store/store.go",
+      "package": "./internal/core/store/",
+      "find": "\tif walkable(after) {\n\t\ts.onlySignal++\n\t}",
+      "replace": "\tif walkable(after) && false {\n\t\ts.onlySignal++\n\t}",
+      "test": "TestAChainThatIsAnActionsOnlySignalIsWalkedInAnyMode"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #654.

## The defect, and why only this action has it

Measured on `main`, `--vm off`, six reads after a reboot that answered
`success`: `running running running running running running`.

`poweroff` and `poweron` are observable in the same mode. This is not a general
property of the emulator's actions: **reboot is the one action whose target
state is the state it started from.** The other two arrive somewhere new, so
their transition shows up in the state whether or not anyone watched them pass
through `starting`. A reboot has nothing else to show, and an action that was
ACCEPTED is not an action that HAPPENED — the reporter's Day-2 module waits for
the state to *leave* `running` before accepting `running` again, and timed out
at 300 s on a reboot that had actually worked.

#649 gave the chains and put them behind `--consistency eventual`. That is the
right default for poweron and poweroff, and the wrong one here: it left the one
action that needs a transition as the only one that never has it.

## What this does

A chain now says whether it is **the only signal its action happened**:

| | ordinary chain | only-signal chain |
|---|---|---|
| example | poweron, poweroff | reboot |
| arrival | somewhere new | where it started |
| walked | under `--consistency eventual` | in **both** modes |

- `resource.PendingOnlySignal` marks the second kind. The core stays neutral: it
  never learns the word "reboot".
- `scaleway.transitionBackTo` is where the intent is declared, and the mark is
  still conditional on the action having come back — a reboot of a **stopped**
  server is a start, arrives somewhere new, and gets an ordinary chain.
- `before` is read once at the top of `applyServerAction`: two cases set the
  state themselves first, so a value read beside each chain says every action
  settles where it began.

Two things this deliberately does **not** do, each held by a test:

- poweron and poweroff still settle at once with the mode off
  (`TestAPoweronAndAPoweroffStaySettledWithoutEventualConsistency`). #124's
  decision is not this one's to revisit.
- the intent is declared rather than inferred from `from == settled`, because a
  **failed** action also settles where it started. Inferring it made a poweron
  that could not boot narrate a `starting` that never happened, and
  `TestAnUnknownImageDoesNotBootASubstitute` caught it within the hour.

## The conformance suite asserted the old behaviour, and was wrong to

```sh
state="$(scw instance server get … | jq -r '.state')"
[ "$state" = "running" ] || fail …
```

One read, right after the call. **fr-par answers `stopping` to that read**, so
this assertion would have failed against the real cloud and passed against an
emulator that did nothing at all. It now reads until the state settles and
records that it left `running` on the way:

```text
ok: rebooted: left running through 'stopping', and settled back
```

## Proof

- `conformance:leg -- scw-cli`, `-- probe`, `-- fields`: all green, the real
  client walking the chain.
- `FEINT_VM=incus-ovn conformance:leg -- runtime`: green on real machines. The
  functional harness already waited for the state to come back rather than
  reading it once, so the chain costs it two polls.
- **Six falsify mutations, all compiling, all biting**
  (`tools/falsify/specs/reboot-is-observable.json`). Two did not bite at first
  and said something true: the guard on ordinary chains is held by the lock the
  store takes, not by the filter beside it, and `Commit`'s propagation of the
  mark was covered by no test at all. Both have one now.
- `observable-transitions.json` retargeted; `falsify:lint` clean, 1067 mutations
  across 169 specs.
- `mise run prepush`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
