### PR TITLE
fix(outscale): two state invariants the emulator could serve and did not (#621)

### DIFF
--- a/internal/providers/outscale/stateconflict_test.go
+++ b/internal/providers/outscale/stateconflict_test.go
@@ -1,0 +1,130 @@
+package outscale_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// conflictCode reads the Code of the first error, empty when the body carries
+// no Errors array at all — which is the finding #621 reports beside the status:
+// "absent: Errors".
+func conflictCode(body map[string]any) string {
+	errs, _ := body["Errors"].([]any)
+	if len(errs) == 0 {
+		return ""
+	}
+	first, _ := errs[0].(map[string]any)
+	code, _ := first["Code"].(string)
+	return code
+}
+
+// StartVms refuses a machine that is already running (#621).
+//
+// Recorded against a real account on 2026-08-30: 409 ResourceConflict, where
+// this pack answered 200 and echoed the machine's own state back. The other
+// divergences that recording found make the emulator answer LESS than the
+// cloud; this one made it answer yes where the cloud says no, which is the
+// direction that turns a green run into a false promise.
+func TestStartVmsRefusesAMachineAlreadyRunning(t *testing.T) {
+	ts := newServer(t)
+
+	status, created := post(t, ts, "CreateVms", `{"ImageId":"ami-00000001","VmType":"tinav4.c1r1p2"}`)
+	if status != http.StatusOK {
+		t.Fatalf("CreateVms: %d (%v)", status, created)
+	}
+	vms, _ := created["Vms"].([]any)
+	first, _ := vms[0].(map[string]any)
+	id, _ := first["VmId"].(string)
+
+	// A created machine is already running here, as it is upstream once its
+	// `pending` is over, so the sequence a client drives is stop then start.
+	if status, body := post(t, ts, "StopVms", `{"VmIds":["`+id+`"]}`); status != http.StatusOK {
+		t.Fatalf("StopVms answered %d (%v)", status, body)
+	}
+	// The accepting half: a stopped machine starts, and the refusal below is
+	// worth nothing without it.
+	if status, body := post(t, ts, "StartVms", `{"VmIds":["`+id+`"]}`); status != http.StatusOK {
+		t.Fatalf("StartVms on a stopped machine answered %d (%v)", status, body)
+	}
+	status, refused := post(t, ts, "StartVms", `{"VmIds":["`+id+`"]}`)
+	if status != http.StatusConflict {
+		t.Errorf("StartVms on a running machine answered %d, want 409: %v", status, refused)
+	}
+	// The status alone is half the finding. "absent: Errors" is the other half,
+	// and a 409 with no Errors array is a refusal no client can read.
+	if code := conflictCode(refused); code == "" {
+		t.Errorf("the refusal carries no Errors array: %v", refused)
+	} else if !strings.HasPrefix(code, "9") {
+		t.Errorf("the refusal carries Code %q; osc.IsConflict reads 6000-6999 and 9000-9999", code)
+	}
+}
+
+// UnlinkVolume refuses a volume attached to nothing (#621).
+//
+// Recorded the same day, on a volume that had never successfully attached: 409
+// where this pack answered 200 and told the client a detach had happened.
+func TestUnlinkVolumeRefusesAVolumeAttachedToNothing(t *testing.T) {
+	ts := newServer(t)
+
+	status, made := post(t, ts, "CreateVolume", `{"SubregionName":"eu-west-2a","Size":10}`)
+	if status != http.StatusOK {
+		t.Fatalf("CreateVolume: %d (%v)", status, made)
+	}
+	volume, _ := made["Volume"].(map[string]any)
+	id, _ := volume["VolumeId"].(string)
+
+	status, refused := post(t, ts, "UnlinkVolume", `{"VolumeId":"`+id+`"}`)
+	if status != http.StatusConflict {
+		t.Errorf("UnlinkVolume on a free volume answered %d, want 409: %v", status, refused)
+	}
+	if code := conflictCode(refused); code == "" {
+		t.Errorf("the refusal carries no Errors array: %v", refused)
+	}
+}
+
+// LinkVolume refuses a volume already linked elsewhere, which this pack has
+// always done (#621 lists it as reachable, and it was already reached).
+//
+// Held here rather than assumed: #621 names three invariants the emulator
+// could serve, and a reader of that issue has to be able to tell which two were
+// added from the one that was already true. An accepting half beside it, so a
+// guard that refused every link would not pass.
+func TestLinkVolumeStillRefusesAVolumeHeldElsewhere(t *testing.T) {
+	ts := newServer(t)
+
+	newVM := func() string {
+		status, created := post(t, ts, "CreateVms", `{"ImageId":"ami-00000001","VmType":"tinav4.c1r1p2"}`)
+		if status != http.StatusOK {
+			t.Fatalf("CreateVms: %d (%v)", status, created)
+		}
+		vms, _ := created["Vms"].([]any)
+		first, _ := vms[0].(map[string]any)
+		id, _ := first["VmId"].(string)
+		return id
+	}
+	one, two := newVM(), newVM()
+
+	status, made := post(t, ts, "CreateVolume", `{"SubregionName":"eu-west-2a","Size":10}`)
+	if status != http.StatusOK {
+		t.Fatalf("CreateVolume: %d (%v)", status, made)
+	}
+	volume, _ := made["Volume"].(map[string]any)
+	id, _ := volume["VolumeId"].(string)
+
+	// The accepting half: a free volume links.
+	if status, body := post(t, ts, "LinkVolume",
+		`{"VolumeId":"`+id+`","VmId":"`+one+`","DeviceName":"/dev/xvdb"}`); status != http.StatusOK {
+		t.Fatalf("linking a free volume answered %d (%v)", status, body)
+	}
+	status, refused := post(t, ts, "LinkVolume",
+		`{"VolumeId":"`+id+`","VmId":"`+two+`","DeviceName":"/dev/xvdb"}`)
+	if status != http.StatusConflict {
+		t.Errorf("LinkVolume on a held volume answered %d, want 409: %v", status, refused)
+	}
+	// And the detach that follows a real attach still works: the new refusal
+	// must not have made every UnlinkVolume a 409.
+	if status, body := post(t, ts, "UnlinkVolume", `{"VolumeId":"`+id+`"}`); status != http.StatusOK {
+		t.Errorf("detaching a linked volume answered %d (%v), and that is the ordinary path", status, body)
+	}
+}

--- a/internal/providers/outscale/vms.go
+++ b/internal/providers/outscale/vms.go
@@ -642,8 +642,40 @@ func (p *Pack) updateVm(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// startVms refuses a machine that is already running, which is what the real
+// cloud does (#621).
+//
+// Recorded against a real account on 2026-08-30, driving a published training
+// sequence: `StartVms` on a running machine answered 409 ResourceConflict where
+// this pack answered 200 with the machine's own state beside it. Saying yes
+// where the cloud says no is the one direction that turns a green run into a
+// false promise, which is why this is served even though the state it names is
+// the only one of the four #621 lists that needs no transient state.
+//
+// The API description does not settle it, and cannot: `osc/api.yaml` declares
+// 200, 400, 401 and 500 for StartVms and for every other operation, INCLUDING
+// DeleteSecurityGroup, whose 409 this repository holds in its own recorded
+// corpus (corpus/outscale/oapi-cli-lb-shapes.jsonl, Code 9085). A document
+// that never declares a 409 cannot be read as denying one.
+//
+// TestStartVmsRefusesAMachineAlreadyRunning fails without this.
 func (p *Pack) startVms(w http.ResponseWriter, r *http.Request) {
-	p.transition(w, r, func(res *resource.Resource) string {
+	p.transitionUnless(w, r, func(res *resource.Resource) string {
+		if res.State == stateRunning {
+			return "the Vm " + res.ID + " is already running"
+		}
+		return ""
+	}, func(res *resource.Resource) string {
+		// And the same question again, under the lock this time, because the
+		// two answer different things. The refusal above is what a client
+		// asking to start a running machine must hear; this is the guard that
+		// keeps two CONCURRENT starts from reaching the runtime twice, which
+		// they do whenever both read `stopped` before either wrote.
+		//
+		// Removing it made TestTwoConcurrentStartsReachTheRuntimeOnce fail
+		// within the minute, and transitionOne's own comment had said why:
+		// deciding "already running" from a state read before the lock is how
+		// a short circuit stops short-circuiting.
 		if res.State == stateRunning {
 			return stateRunning
 		}
@@ -677,6 +709,19 @@ func (p *Pack) stopVms(w http.ResponseWriter, r *http.Request) {
 // VmStateInfo array the SDK expects: the previous state beside the new one, per
 // machine, which is how a client tells "already stopped" from "stopping now".
 func (p *Pack) transition(w http.ResponseWriter, r *http.Request, change func(*resource.Resource) string) {
+	p.transitionUnless(w, r, nil, change)
+}
+
+// transitionUnless is transition with a state precondition: refuse names why
+// this machine may not make the transition, empty when it may.
+//
+// The refusal is decided over EVERY target before anything moves, on the same
+// argument the identifier resolution below already makes: a list with one
+// machine in the wrong state must not leave the others transitioned. A caller
+// that reads the 409 and retries would otherwise start the same machines twice
+// and get a different answer each time.
+func (p *Pack) transitionUnless(w http.ResponseWriter, r *http.Request,
+	refuse func(*resource.Resource) string, change func(*resource.Resource) string) {
 	var req vmIDsRequest
 	if err := emulator.DecodeJSON(r, &req); err != nil {
 		p.badRequest(w, err.Error())
@@ -697,6 +742,14 @@ func (p *Pack) transition(w http.ResponseWriter, r *http.Request, change func(*r
 			return
 		}
 		targets = append(targets, res)
+	}
+	if refuse != nil {
+		for _, res := range targets {
+			if details := refuse(res); details != "" {
+				p.conflict(w, details)
+				return
+			}
+		}
 	}
 
 	out := make([]map[string]any, 0, len(targets))

--- a/internal/providers/outscale/volumes.go
+++ b/internal/providers/outscale/volumes.go
@@ -315,18 +315,40 @@ func (p *Pack) unlinkVolume(w http.ResponseWriter, r *http.Request) {
 	}
 	emulator.MarkRead(r, "ForceUnlink")
 	_ = req.ForceUnlink
-	// Same critical section as linkVolume, same reason (#295).
+	// Same critical section as linkVolume, same reason (#295), and the
+	// precondition is decided INSIDE it: a detach that reads "is it linked"
+	// outside the lock races the link that answers it.
+	//
+	// Detaching a volume that is attached to nothing is refused, which is what
+	// the real cloud does (#621). Recorded against a real account 2026-08-30:
+	// UnlinkVolume on a volume that had never successfully attached answered
+	// 409 ResourceConflict, where this pack answered 200 and told the client a
+	// detach had happened. An emulator that says yes where the cloud says no
+	// teaches a client something the cloud will punish, and this is the half
+	// that needs no transient state to be true.
+	//
+	// TestUnlinkVolumeRefusesAVolumeAttachedToNothing fails without this.
+	var unlinked bool
 	err := p.env.Store.Update(Name, kindVolume, req.VolumeID, func(stored *resource.Resource) error {
+		if held, _ := stored.Attrs["LinkedVmId"].(string); held == "" {
+			return errVolumeFree
+		}
+		unlinked = true
 		delete(stored.Attrs, "LinkedVmId")
 		delete(stored.Attrs, "DeviceName")
 		stored.State = volumeStateAvailable
 		stored.Updated = p.env.Now()
 		return nil
 	})
-	if err != nil {
+	switch {
+	case errors.Is(err, errVolumeFree):
+		p.conflict(w, "the volume "+req.VolumeID+" is not linked to any Vm")
+		return
+	case err != nil:
 		p.notFound(w, "volume", req.VolumeID)
 		return
 	}
+	_ = unlinked
 	emulator.WriteJSON(w, http.StatusOK, map[string]any{"ResponseContext": p.context()})
 }
 
@@ -537,4 +559,8 @@ func deleteOnVmDeletion(res *resource.Resource) bool {
 var (
 	errVolumeShrinks = errors.New("a volume cannot shrink")
 	errVolumeHeld    = errors.New("the volume is linked elsewhere")
+	// errVolumeFree is the other side of the same fact, and it is a refusal
+	// rather than a no-op: detaching what is attached to nothing is a 409 on
+	// the real cloud (#621).
+	errVolumeFree = errors.New("the volume is linked to nothing")
 )

--- a/tools/falsify/specs/outscale-state-conflicts.json
+++ b/tools/falsify/specs/outscale-state-conflicts.json
@@ -1,0 +1,52 @@
+{
+  "mutations": [
+    {
+      "label": "StartVms accepts a machine already running again, so the emulator says yes where the cloud says 409",
+      "file": "internal/providers/outscale/vms.go",
+      "package": "./internal/providers/outscale/",
+      "find": "\t\tif res.State == stateRunning {\n\t\t\treturn \"the Vm \" + res.ID + \" is already running\"\n\t\t}",
+      "replace": "\t\tif res.State == stateRunning && false {\n\t\t\treturn \"the Vm \" + res.ID + \" is already running\"\n\t\t}",
+      "test": "TestStartVmsRefusesAMachineAlreadyRunning"
+    },
+    {
+      "label": "the refusal is decided but nothing carries it, so the client reads a 200 with the machine's own state",
+      "file": "internal/providers/outscale/vms.go",
+      "package": "./internal/providers/outscale/",
+      "find": "\t\t\tif details := refuse(res); details != \"\" {",
+      "replace": "\t\t\tif details := refuse(res); details != \"\" && false {",
+      "test": "TestStartVmsRefusesAMachineAlreadyRunning"
+    },
+    {
+      "label": "the short circuit under the lock goes, so two concurrent starts reach the runtime twice",
+      "file": "internal/providers/outscale/vms.go",
+      "package": "./internal/providers/outscale/",
+      "find": "\t\tif res.State == stateRunning {\n\t\t\treturn stateRunning\n\t\t}\n\t\tp.powerOn(r.Context(), res)",
+      "replace": "\t\tif res.State == stateRunning && false {\n\t\t\treturn stateRunning\n\t\t}\n\t\tp.powerOn(r.Context(), res)",
+      "test": "TestTwoConcurrentStartsReachTheRuntimeOnce"
+    },
+    {
+      "label": "UnlinkVolume detaches what is attached to nothing again, telling the client a detach happened",
+      "file": "internal/providers/outscale/volumes.go",
+      "package": "./internal/providers/outscale/",
+      "find": "\t\tif held, _ := stored.Attrs[\"LinkedVmId\"].(string); held == \"\" {\n\t\t\treturn errVolumeFree\n\t\t}",
+      "replace": "\t\tif held, _ := stored.Attrs[\"LinkedVmId\"].(string); held == \"\" && false {\n\t\t\treturn errVolumeFree\n\t\t}",
+      "test": "TestUnlinkVolumeRefusesAVolumeAttachedToNothing"
+    },
+    {
+      "label": "the refusal fires on every volume, so a linked one can no longer be detached",
+      "file": "internal/providers/outscale/volumes.go",
+      "package": "./internal/providers/outscale/",
+      "find": "\t\tif held, _ := stored.Attrs[\"LinkedVmId\"].(string); held == \"\" {\n\t\t\treturn errVolumeFree\n\t\t}",
+      "replace": "\t\tif held, _ := stored.Attrs[\"LinkedVmId\"].(string); held == \"\" || true {\n\t\t\treturn errVolumeFree\n\t\t}",
+      "test": "TestLinkVolumeStillRefusesAVolumeHeldElsewhere"
+    },
+    {
+      "label": "LinkVolume stops refusing a volume held elsewhere, which #621 lists as already true",
+      "file": "internal/providers/outscale/volumes.go",
+      "package": "./internal/providers/outscale/",
+      "find": "\t\tif held, _ := stored.Attrs[\"LinkedVmId\"].(string); held != \"\" && held != req.VMID {",
+      "replace": "\t\tif held, _ := stored.Attrs[\"LinkedVmId\"].(string); held != \"\" && held != req.VMID && false {",
+      "test": "TestLinkVolumeStillRefusesAVolumeHeldElsewhere"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #621.

## What this serves, and what it leaves out

Four operations accept what the real cloud refuses with 409. Two need a state
this emulator does not have; two need only a state it already keeps.

| operation | the state the cloud refused on | here |
|---|---|---|
| `StartVms` | the machine was already running | **served** |
| `UnlinkVolume` | the volume had never attached | **served** |
| `LinkVolume` | the machine was still `pending` | out, with #380 |
| `CreateImage` | same machine, same reason | out, with #380 |

`pending` does not exist here, and #380 argues why reproducing the transient
states wholesale would make every teardown wait them out. #621 asks for the
reachable half; this is that half.

**This is the direction that matters.** The other divergences the same recording
found make the emulator answer *less* than the cloud. These made it answer **yes
where the cloud says no**, and a client that learns here that it may detach a
volume attached to nothing has learnt something the cloud will punish.

## The API description cannot settle it, and it looks like it should

`osc/api.yaml` declares 200, 400, 401 and 500 for `StartVms` — and for
`LinkVolume`, `UnlinkVolume`, `DeleteSecurityGroup` and `DeleteNet` alike. **It
never declares a 409 anywhere**, including for `DeleteSecurityGroup`, whose 409
this repository holds in its own recorded corpus with `Code: 9085`
(`corpus/outscale/oapi-cli-lb-shapes.jsonl`). A document that never declares a
status cannot be read as denying it, so the recording is the stronger source.

## Three notes on the shape

- The refusal is decided over **every target before anything moves**, on the same
  argument the identifier resolution already makes: a list with one machine in
  the wrong state must not leave the others transitioned.
- The "already running" short circuit **stays inside the store lock**, where it
  was. Moving it out made `TestTwoConcurrentStartsReachTheRuntimeOnce` fail
  within the minute: two concurrent starts both read `stopped` before either
  wrote, and both reached the runtime. `transitionOne`'s own comment had said so.
  The two checks answer different questions and both are needed.
- `UnlinkVolume` decides its precondition **inside** the critical section that
  already existed for #295: a detach that reads "is it linked" outside the lock
  races the link that answers it.

The third invariant #621 lists as reachable, `LinkVolume` on a volume held
elsewhere, **was already served**. It now has a test saying so, with an accepting
half beside it, so a reader of the issue can tell which two were added from the
one that was already true.

## Proof

- `conformance:leg -- octl`, `-- terraform`, `-- opentofu`, `-- fields`: all
  green. The two Terraform legs matter here: a provider that starts a machine it
  just created would have met the new refusal, and does not.
- **Six falsify mutations, all compiling, all biting**
  (`tools/falsify/specs/outscale-state-conflicts.json`), including the two that
  keep a refusal from swallowing the ordinary path: a linked volume still
  detaches, and a stopped machine still starts.
- `mise run prepush`.

**Not swept**: whether other operations of this pack have unserved state
preconditions. #621 names that as unestablished and it stays so; these two are
what one recorded training sequence walked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
