### PR TITLE
feat(outscale): the three tag filters, on the nine reads a course drives (#618)

### DIFF
--- a/internal/providers/outscale/audit_test.go
+++ b/internal/providers/outscale/audit_test.go
@@ -859,12 +859,18 @@ func TestAnUnsupportedFilterIsRefused(t *testing.T) {
 
 	for _, probe := range []struct{ action, body string }{
 		{"ReadVms", `{"Filters":{"Architectures":["x86_64"]}}`},
-		{"ReadVms", `{"Filters":{"Tags":["a=b"]}}`},
+		// Tags was the probe on these two until #618; the three tag filters are
+		// served now, and TestTagFiltersSelectAndExclude holds the accepting
+		// half. Lifecycles and IsDefault are declared by FiltersVm and
+		// FiltersNet upstream and still not applied, so they keep the refusal
+		// measured, which is the third time this test has changed probes for
+		// exactly this reason.
+		{"ReadVms", `{"Filters":{"Lifecycles":["spot"]}}`},
 		// DhcpOptionsSetIds used to be the probe here; it is served since the
 		// DHCP lifecycle landed (#172) — the provider's own delete path filters
 		// on it — and TestReadNetsFiltersOnTheDhcpOptionsSet now holds the
 		// accepting half.
-		{"ReadNets", `{"Filters":{"Tags":["a=b"]}}`},
+		{"ReadNets", `{"Filters":{"IsDefault":true}}`},
 		// SubregionNames was the probe here until it became a served filter
 		// (#269); AvailableIpsCounts is declared by FiltersSubnet upstream and
 		// still not applied, so it keeps the refusal measured.

--- a/internal/providers/outscale/catalog.go
+++ b/internal/providers/outscale/catalog.go
@@ -419,7 +419,12 @@ func (p *Pack) readVmTypes(w http.ResponseWriter, r *http.Request) {
 // imageFilters are what an image can answer. ImageIds is the one a client
 // actually sends on the path to a create — it resolves the image it was given
 // before posting anything.
-var imageFilters = stringFilters("ImageIds", "ImageNames", "AccountIds", "States", "Architectures", "RootDeviceTypes")
+var imageFilters = joinFilters(
+	stringFilters("ImageIds", "ImageNames", "AccountIds", "States", "Architectures", "RootDeviceTypes"),
+	// The three tag filters, accepted by the real account on every one of
+	// these reads (#618).
+	taggableFilters,
+)
 
 // readImages serves the fixed catalogue and everything a client registered on
 // top of it. Both, always: an image a client made and could not then read back
@@ -461,6 +466,9 @@ func (p *Pack) readImages(w http.ResponseWriter, r *http.Request) {
 // imageMatches filters a rendered image, so a catalogue entry and a registered
 // one are filtered by exactly the same rules.
 func imageMatches(image map[string]any, f filterSet) bool {
+	if !matchesTagsView(f, image) {
+		return false
+	}
 	accountID, _ := image["AccountId"].(string)
 	return matchesStrings(f, "ImageIds", stringOf(image["ImageId"])) &&
 		matchesStrings(f, "ImageNames", stringOf(image["ImageName"])) &&

--- a/internal/providers/outscale/filters.go
+++ b/internal/providers/outscale/filters.go
@@ -166,6 +166,102 @@ func filterNames(specs []filterSpec) []string {
 	return out
 }
 
+// taggableFilters are the three tag filters, and they are three rather than one
+// with three spellings (#618):
+//
+//	Tags        "Key=Value", the pair
+//	TagKeys     the key alone
+//	TagValues   the value alone
+//
+// Measured against a real account on 2026-08-30: eleven calls, every one
+// accepted, across ReadNets, ReadSubnets, ReadPublicIps, ReadVolumes,
+// ReadRouteTables, ReadNatServices, ReadNetPeerings, ReadVms and ReadImages.
+// This pack refused all of them with a 4001 naming what it did accept, so a
+// published course that tags everything and then looks things up by tag could
+// not complete its own capstone.
+//
+// The refusal was the honest half of the defect and is what made it measurable:
+// a pack that had dropped the unknown filter would have answered 200 with the
+// whole inventory, and nobody would have noticed for a year.
+var taggableFilters = stringFilters("Tags", "TagKeys", "TagValues")
+
+// matchesTags applies them to one resource. Absent filters match everything,
+// which is what every other matcher here does.
+//
+// The pair is compared on the WHOLE "Key=Value" string rather than on either
+// half, because that is what the recording shows and #618 says the partial case
+// was not tried. Matching a bare key here would be inventing the more permissive
+// of two behaviours, and the more permissive one is the direction that teaches a
+// client something the cloud may not do.
+//
+// TestTagFiltersSelectAndExclude fails without this.
+func matchesTags(f filterSet, res *resource.Resource) bool {
+	return matchesTagsOf(f, tagsOf(res))
+}
+
+// matchesTagsView is matchesTags for a rendered object rather than a stored
+// one. The image list is half catalogue and half store, and the catalogue half
+// exists only as a view: a filter that skipped it would answer a client's tag
+// question with a list that quietly drops the fixed images.
+func matchesTagsView(f filterSet, view map[string]any) bool {
+	tags := map[string]string{}
+	entries, _ := view["Tags"].([]any)
+	for _, entry := range entries {
+		tag, _ := entry.(map[string]any)
+		key, _ := tag["Key"].(string)
+		value, _ := tag["Value"].(string)
+		if key != "" {
+			tags[key] = value
+		}
+	}
+	return matchesTagsOf(f, tags)
+}
+
+func matchesTagsOf(f filterSet, tags map[string]string) bool {
+	if wanted, present, err := f.strings("Tags"); present && err == nil {
+		pairs := make([]string, 0, len(tags))
+		for key, value := range tags {
+			pairs = append(pairs, key+"="+value)
+		}
+		if !anyOf(wanted, pairs) {
+			return false
+		}
+	}
+	if wanted, present, err := f.strings("TagKeys"); present && err == nil {
+		keys := make([]string, 0, len(tags))
+		for key := range tags {
+			keys = append(keys, key)
+		}
+		if !anyOf(wanted, keys) {
+			return false
+		}
+	}
+	if wanted, present, err := f.strings("TagValues"); present && err == nil {
+		values := make([]string, 0, len(tags))
+		for _, value := range tags {
+			values = append(values, value)
+		}
+		if !anyOf(wanted, values) {
+			return false
+		}
+	}
+	return true
+}
+
+// anyOf reports whether the resource carries any of the values asked for. An
+// empty ask matches nothing, the way filterSet.strings already documents: asking
+// for an empty set is not asking for everything.
+func anyOf(wanted, carried []string) bool {
+	for _, want := range wanted {
+		for _, got := range carried {
+			if got == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // filtersByAction names, for every action of this pack that reads Filters, the
 // list its handler applies.
 //

--- a/internal/providers/outscale/natservices.go
+++ b/internal/providers/outscale/natservices.go
@@ -104,7 +104,12 @@ func (p *Pack) createNatService(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-var natServiceFilters = stringFilters("NatServiceIds", "NetIds", "SubnetIds", "States")
+var natServiceFilters = joinFilters(
+	stringFilters("NatServiceIds", "NetIds", "SubnetIds", "States"),
+	// The three tag filters, accepted by the real account on every one of
+	// these reads (#618).
+	taggableFilters,
+)
 
 func (p *Pack) readNatServices(w http.ResponseWriter, r *http.Request) {
 	var req struct {
@@ -128,7 +133,8 @@ func (p *Pack) readNatServices(w http.ResponseWriter, r *http.Request) {
 		if !matchesStrings(req.Filters, "NatServiceIds", res.ID) ||
 			!matchesStrings(req.Filters, "NetIds", stringOf(res.Attrs["NetId"])) ||
 			!matchesStrings(req.Filters, "SubnetIds", stringOf(res.Attrs["SubnetId"])) ||
-			!matchesStrings(req.Filters, "States", res.State) {
+			!matchesStrings(req.Filters, "States", res.State) ||
+			!matchesTags(req.Filters, res) {
 			continue
 		}
 		out = append(out, natServiceView(res))

--- a/internal/providers/outscale/netpeerings.go
+++ b/internal/providers/outscale/netpeerings.go
@@ -110,11 +110,15 @@ type readNetPeeringsRequest struct {
 // the tag filters are refused rather than silently matched, the same triage
 // as every other Read* of this pack; the Terraform provider's own read sends
 // NetPeeringIds and nothing else (resource_net_peering.go, v1.8.0).
-var netPeeringFilters = stringFilters(
-	"NetPeeringIds",
-	"AccepterNetAccountIds", "AccepterNetIpRanges", "AccepterNetNetIds",
-	"SourceNetAccountIds", "SourceNetIpRanges", "SourceNetNetIds",
-	"StateMessages", "StateNames",
+var netPeeringFilters = joinFilters(
+	stringFilters(
+		"NetPeeringIds",
+		"AccepterNetAccountIds", "AccepterNetIpRanges", "AccepterNetNetIds",
+		"SourceNetAccountIds", "SourceNetIpRanges", "SourceNetNetIds",
+		"StateMessages", "StateNames",
+	),
+	// The three tag filters (#618).
+	taggableFilters,
 )
 
 func (p *Pack) createNetPeering(w http.ResponseWriter, r *http.Request) {
@@ -358,7 +362,8 @@ func (p *Pack) readNetPeerings(w http.ResponseWriter, r *http.Request) {
 			!matchesStrings(req.Filters, "SourceNetIpRanges", stringOf(res.Attrs["SourceIpRange"])) ||
 			!matchesStrings(req.Filters, "SourceNetNetIds", stringOf(res.Attrs["SourceNetId"])) ||
 			!matchesStrings(req.Filters, "StateMessages", peeringMessage(res.State)) ||
-			!matchesStrings(req.Filters, "StateNames", res.State) {
+			!matchesStrings(req.Filters, "StateNames", res.State) ||
+			!matchesTags(req.Filters, res) {
 			continue
 		}
 		out = append(out, netPeeringView(res))

--- a/internal/providers/outscale/nets.go
+++ b/internal/providers/outscale/nets.go
@@ -84,11 +84,21 @@ type readNetsRequest struct {
 // keyword. Refusing the filter fails every `terraform destroy` of an
 // outscale_dhcp_option.
 var (
-	netFilters = stringFilters("NetIds", "IpRanges", "States", "DhcpOptionsSetIds")
+	netFilters = joinFilters(
+		stringFilters("NetIds", "IpRanges", "States", "DhcpOptionsSetIds"),
+		// The three tag filters, accepted by the real account on every one of
+		// these reads (#618).
+		taggableFilters,
+	)
 	// SubregionNames is served since the subregion became a stored fact
 	// (#269): FiltersSubnet declares it (osc-sdk-go, client.gen.go:5058), and
 	// it is how a stack that spreads subnets across zones reads its own back.
-	subnetFilters = stringFilters("SubnetIds", "NetIds", "IpRanges", "States", "SubregionNames")
+	subnetFilters = joinFilters(
+		stringFilters("SubnetIds", "NetIds", "IpRanges", "States", "SubregionNames"),
+		// The three tag filters, accepted by the real account on every one of
+		// these reads (#618).
+		taggableFilters,
+	)
 )
 
 type readSubnetsRequest struct {
@@ -180,7 +190,8 @@ func (p *Pack) readNets(w http.ResponseWriter, r *http.Request) {
 		if !matchesStrings(req.Filters, "NetIds", res.ID) ||
 			!matchesStrings(req.Filters, "IpRanges", ipRange) ||
 			!matchesStrings(req.Filters, "States", res.State) ||
-			!matchesStrings(req.Filters, "DhcpOptionsSetIds", stringOf(res.Attrs["DhcpOptionsSetId"])) {
+			!matchesStrings(req.Filters, "DhcpOptionsSetIds", stringOf(res.Attrs["DhcpOptionsSetId"])) ||
+			!matchesTags(req.Filters, res) {
 			continue
 		}
 		nets = append(nets, netView(res))
@@ -417,7 +428,8 @@ func (p *Pack) readSubnets(w http.ResponseWriter, r *http.Request) {
 			!matchesStrings(req.Filters, "NetIds", netID) ||
 			!matchesStrings(req.Filters, "IpRanges", ipRange) ||
 			!matchesStrings(req.Filters, "States", res.State) ||
-			!matchesStrings(req.Filters, "SubregionNames", p.subnetSubregion(res.ID)) {
+			!matchesStrings(req.Filters, "SubregionNames", p.subnetSubregion(res.ID)) ||
+			!matchesTags(req.Filters, res) {
 			continue
 		}
 		subnets = append(subnets, p.subnetView(res))

--- a/internal/providers/outscale/publicips.go
+++ b/internal/providers/outscale/publicips.go
@@ -194,7 +194,12 @@ func (p *Pack) createPublicIP(w http.ResponseWriter, r *http.Request) {
 // publicIPFilters are what a stored address can answer. LinkPublicIpIds is here
 // because the Terraform provider reads the link back by its own id right after
 // creating it — without it, `outscale_public_ip_link` fails the apply.
-var publicIPFilters = stringFilters("PublicIpIds", "PublicIps", "LinkPublicIpIds", "VmIds", "NicIds")
+var publicIPFilters = joinFilters(
+	stringFilters("PublicIpIds", "PublicIps", "LinkPublicIpIds", "VmIds", "NicIds"),
+	// The three tag filters, accepted by the real account on every one of
+	// these reads (#618).
+	taggableFilters,
+)
 
 func (p *Pack) readPublicIPs(w http.ResponseWriter, r *http.Request) {
 	var req struct {
@@ -219,7 +224,8 @@ func (p *Pack) readPublicIPs(w http.ResponseWriter, r *http.Request) {
 			!matchesStrings(req.Filters, "PublicIps", stringOf(res.Attrs["PublicIp"])) ||
 			!matchesStrings(req.Filters, "LinkPublicIpIds", stringOf(res.Attrs["LinkPublicIpId"])) ||
 			!matchesStrings(req.Filters, "VmIds", stringOf(res.Attrs["VmId"])) ||
-			!matchesStrings(req.Filters, "NicIds", stringOf(res.Attrs["NicId"])) {
+			!matchesStrings(req.Filters, "NicIds", stringOf(res.Attrs["NicId"])) ||
+			!matchesTags(req.Filters, res) {
 			continue
 		}
 		out = append(out, publicIPView(res))

--- a/internal/providers/outscale/routetables.go
+++ b/internal/providers/outscale/routetables.go
@@ -88,6 +88,8 @@ var routeTableFilters = joinFilters(
 	),
 	// FiltersRouteTable declares this one as a bare boolean, not a list.
 	boolFilters("LinkRouteTableMain"),
+	// The three tag filters (#618).
+	taggableFilters,
 )
 
 func (p *Pack) readRouteTables(w http.ResponseWriter, r *http.Request) {
@@ -121,6 +123,9 @@ func (p *Pack) readRouteTables(w http.ResponseWriter, r *http.Request) {
 // carries the value asked for, which is the semantics the API describes and the
 // provider relies on.
 func (p *Pack) routeTableMatches(res *resource.Resource, f filterSet) bool {
+	if !matchesTags(f, res) {
+		return false
+	}
 	if !matchesStrings(f, "RouteTableIds", res.ID) ||
 		!matchesStrings(f, "NetIds", stringOf(res.Attrs["NetId"])) {
 		return false

--- a/internal/providers/outscale/tagfilters_test.go
+++ b/internal/providers/outscale/tagfilters_test.go
@@ -1,0 +1,161 @@
+package outscale_test
+
+import (
+	"net/http"
+	"testing"
+)
+
+// The three tag filters select, exclude, and hand the object back WITH its tags
+// (#618).
+//
+// Measured against a real account on 2026-08-30: eleven calls carrying
+// Filters.Tags, Filters.TagKeys or Filters.TagValues, every one accepted, and
+// this pack refused all of them with a 4001 naming what it did accept. A
+// published course tags everything and then looks things up by tag; its capstone
+// could not complete.
+//
+// Three filters rather than one with three spellings, which is the first thing
+// #618 says an implementation must not get wrong:
+//
+//	Tags        Key=Value, the pair
+//	TagKeys     the key alone
+//	TagValues   the value alone
+func TestTagFiltersSelectAndExclude(t *testing.T) {
+	ts := newServer(t)
+
+	made := func(ipRange string) string {
+		status, net := post(t, ts, "CreateNet", `{"IpRange":"`+ipRange+`"}`)
+		if status != http.StatusOK {
+			t.Fatalf("CreateNet: %d (%v)", status, net)
+		}
+		inner, _ := net["Net"].(map[string]any)
+		id, _ := inner["NetId"].(string)
+		return id
+	}
+	tagged, plain := made("10.90.0.0/16"), made("10.91.0.0/16")
+	if status, out := post(t, ts, "CreateTags",
+		`{"ResourceIds":["`+tagged+`"],"Tags":[{"Key":"env","Value":"survey"}]}`); status != http.StatusOK {
+		t.Fatalf("CreateTags: %d (%v)", status, out)
+	}
+
+	read := func(filters string) []any {
+		t.Helper()
+		status, out := post(t, ts, "ReadNets", filters)
+		if status != http.StatusOK {
+			t.Fatalf("ReadNets %s: %d (%v)", filters, status, out)
+		}
+		nets, _ := out["Nets"].([]any)
+		return nets
+	}
+
+	// Selecting: one of the two, by each of the three filters.
+	for _, filter := range []string{
+		`{"Filters":{"Tags":["env=survey"]}}`,
+		`{"Filters":{"TagKeys":["env"]}}`,
+		`{"Filters":{"TagValues":["survey"]}}`,
+	} {
+		nets := read(filter)
+		if len(nets) != 1 {
+			t.Fatalf("%s answered %d Nets, want the one that carries the tag", filter, len(nets))
+		}
+		net, _ := nets[0].(map[string]any)
+		if got, _ := net["NetId"].(string); got != tagged {
+			t.Errorf("%s answered %q, want %q", filter, got, tagged)
+		}
+		// The second thing #618 says must not go wrong: an object that matched
+		// a tag filter and came back without its tags is a shape divergence on
+		// top of the missing filter.
+		tags, _ := net["Tags"].([]any)
+		if len(tags) != 1 {
+			t.Fatalf("%s answered the object without its Tags: %v", filter, net)
+		}
+		tag, _ := tags[0].(map[string]any)
+		if tag["Key"] != "env" || tag["Value"] != "survey" {
+			t.Errorf("%s answered Tags %v", filter, tags)
+		}
+	}
+
+	// Excluding: a tag nothing carries answers nothing, on each filter. This is
+	// the half that catches a filter declared and compared nowhere, which is
+	// what #566 was.
+	for _, filter := range []string{
+		`{"Filters":{"Tags":["env=absent"]}}`,
+		`{"Filters":{"TagKeys":["absent"]}}`,
+		`{"Filters":{"TagValues":["absent"]}}`,
+	} {
+		if nets := read(filter); len(nets) != 0 {
+			t.Errorf("%s answered %d Nets, want none", filter, len(nets))
+		}
+	}
+
+	// And the pair is matched whole. A key that matches with the wrong value
+	// selects nothing: #618 records that the partial case was never measured
+	// upstream, so the emulator takes the stricter of the two readings rather
+	// than inventing the more permissive one.
+	if nets := read(`{"Filters":{"Tags":["env=other"]}}`); len(nets) != 0 {
+		t.Errorf("Tags env=other answered %d Nets: the pair is being matched on its key alone", len(nets))
+	}
+	// And a bare key in Tags selects nothing either, which is the same property
+	// from the other side. Written because a mutation that added the bare key
+	// beside the pair went unnoticed by the assertion above: env=other misses a
+	// bare-key match too, so it could not tell the two readings apart.
+	if nets := read(`{"Filters":{"Tags":["env"]}}`); len(nets) != 0 {
+		t.Errorf("Tags env answered %d Nets: TagKeys is the filter for a key, and Tags is the pair", len(nets))
+	}
+
+	// Unfiltered, both are there: a filter that answered nothing at all would
+	// pass every exclusion above.
+	if nets := read(`{}`); len(nets) < 2 {
+		t.Errorf("an unfiltered read answers %d Nets, want at least the two created (%s, %s)",
+			len(nets), tagged, plain)
+	}
+}
+
+// The same three filters on the other reads the recording exercised (#618).
+//
+// One assertion each, because the mechanism is shared: what is worth holding
+// per operation is that the filter is DECLARED and reaches the comparison, and
+// an operation that forgot to call it answers the whole inventory here.
+func TestTagFiltersReachEveryReadTheRecordingExercised(t *testing.T) {
+	ts := newServer(t)
+
+	_, subnetID := netAndSubnet(t, ts, "10.92.0.0/16", "10.92.1.0/24")
+	status, vm := post(t, ts, "CreateVms",
+		`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+	if status != http.StatusOK {
+		t.Fatalf("CreateVms: %d (%v)", status, vm)
+	}
+	status, volume := post(t, ts, "CreateVolume", `{"SubregionName":"eu-west-2a","Size":10}`)
+	if status != http.StatusOK {
+		t.Fatalf("CreateVolume: %d (%v)", status, volume)
+	}
+	status, ip := post(t, ts, "CreatePublicIp", `{}`)
+	if status != http.StatusOK {
+		t.Fatalf("CreatePublicIp: %d (%v)", status, ip)
+	}
+
+	// A tag no object carries: every read must answer an empty list rather than
+	// its inventory.
+	for _, read := range []struct{ action, key string }{
+		{"ReadVms", "Vms"},
+		{"ReadNets", "Nets"},
+		{"ReadSubnets", "Subnets"},
+		{"ReadVolumes", "Volumes"},
+		{"ReadPublicIps", "PublicIps"},
+		{"ReadRouteTables", "RouteTables"},
+		{"ReadNatServices", "NatServices"},
+		{"ReadNetPeerings", "NetPeerings"},
+		{"ReadImages", "Images"},
+	} {
+		status, out := post(t, ts, read.action, `{"Filters":{"TagKeys":["nothing-carries-this"]}}`)
+		if status != http.StatusOK {
+			t.Errorf("%s refused a tag filter: %d (%v)", read.action, status, out)
+			continue
+		}
+		got, _ := out[read.key].([]any)
+		if len(got) != 0 {
+			t.Errorf("%s answered %d %s for a tag nothing carries: the filter is declared and compared nowhere",
+				read.action, len(got), read.key)
+		}
+	}
+}

--- a/internal/providers/outscale/vms.go
+++ b/internal/providers/outscale/vms.go
@@ -60,18 +60,22 @@ type readVmsRequest struct {
 // preamble names. Found by TestEveryDeclaredFilterKindIsTheOneTheContractDeclares
 // on the day it was written (#566); nothing outside this pack's own tests used
 // the old spelling.
-var vmFilters = stringFilters(
-	"VmIds", "VmStateNames", "ImageIds", "VmTypes", "KeypairNames",
-	"SubnetIds", "NetIds", "PrivateIps",
-	// The zone filter FiltersVm declares (osc-sdk-go, client.gen.go:5304),
-	// served since the subregion became a stored fact rather than a constant
-	// (#268): a constant made this filter either a tautology or a void.
-	"SubregionNames",
-	// The group filters are what `terraform destroy` asks before removing a
-	// security group: which machines still wear it. Without them the destroy
-	// fails on the group, after the apply succeeded — so the whole fixture is
-	// left standing by a filter nobody had declared.
-	"SecurityGroupIds", "SecurityGroupNames",
+var vmFilters = joinFilters(
+	stringFilters(
+		"VmIds", "VmStateNames", "ImageIds", "VmTypes", "KeypairNames",
+		"SubnetIds", "NetIds", "PrivateIps",
+		// The zone filter FiltersVm declares (osc-sdk-go, client.gen.go:5304),
+		// served since the subregion became a stored fact rather than a constant
+		// (#268): a constant made this filter either a tautology or a void.
+		"SubregionNames",
+		// The group filters are what `terraform destroy` asks before removing a
+		// security group: which machines still wear it. Without them the destroy
+		// fails on the group, after the apply succeeded — so the whole fixture is
+		// left standing by a filter nobody had declared.
+		"SecurityGroupIds", "SecurityGroupNames",
+	),
+	// The three tag filters (#618).
+	taggableFilters,
 )
 
 // vmPlacement is CreateVmsRequest's Placement (osc-sdk-go,
@@ -206,6 +210,9 @@ func (p *Pack) readVms(w http.ResponseWriter, r *http.Request) {
 // would answer more than was asked for, which is the defect this whole file
 // exists to remove.
 func (p *Pack) vmMatches(res *resource.Resource, f filterSet) bool {
+	if !matchesTags(f, res) {
+		return false
+	}
 	attr := func(key string) string {
 		value, _ := res.Attrs[key].(string)
 		return value

--- a/internal/providers/outscale/volumes.go
+++ b/internal/providers/outscale/volumes.go
@@ -121,6 +121,8 @@ var volumeFilters = joinFilters(
 	// reading it as strings reported every value as "filter absent" (#566).
 	intFilters("VolumeSizes"),
 	boolFilters("LinkVolumeDeleteOnVmDeletion"),
+	// The three tag filters (#618).
+	taggableFilters,
 )
 
 func (p *Pack) readVolumes(w http.ResponseWriter, r *http.Request) {
@@ -356,6 +358,9 @@ func (p *Pack) unlinkVolume(w http.ResponseWriter, r *http.Request) {
 // the volume holds — which is where the Terraform provider waits for an attach
 // and a detach.
 func volumeMatches(res *resource.Resource, f filterSet) bool {
+	if !matchesTags(f, res) {
+		return false
+	}
 	linkedVM := stringOf(res.Attrs["LinkedVmId"])
 	device := stringOf(res.Attrs["DeviceName"])
 	// The link state, in the same words volumeView publishes: one fact, one

--- a/tools/conformance/outscale/octl.sh
+++ b/tools/conformance/outscale/octl.sh
@@ -1086,8 +1086,13 @@ refuse_call() { # expected-code operation args...
 echo "- every read refuses the filter it does not emulate"
 neg="$(prove_begin negative)"
 refuse_call 4001 ReadVms               --Filters.Architectures x86_64
-refuse_call 4001 ReadNets              --Filters.TagKeys owner
-refuse_call 4001 ReadSubnets           --Filters.TagKeys owner
+# TagKeys was the probe on these two until #618, when the three tag filters
+# became served; the block below drives the accepting half. IsDefault and
+# AvailableIpsCounts are declared by FiltersNet and FiltersSubnet and still not
+# applied, so the refusal stays measured. Both travel as a payload because
+# octl's flag builder mishandles their types, the way CreationDates does below.
+refuse_call 4001 ReadNets              --payload '{"Filters":{"IsDefault":true}}'
+refuse_call 4001 ReadSubnets           --payload '{"Filters":{"AvailableIpsCounts":[251]}}'
 refuse_call 4001 ReadKeypairs          --Filters.KeypairIds key-feintnone
 refuse_call 4001 ReadSecurityGroups    --Filters.InboundRuleAccountIds 000000000001
 refuse_call 4001 ReadRouteTables       --Filters.LinkRouteTableLinkRouteTableIds rtbassoc-feintnone
@@ -1103,6 +1108,31 @@ refuse_call 4001 ReadImages            --Filters.AccountAliases none
 refuse_call 4001 ReadVmsState          --Filters.MaintenanceEventCodes none
 prove_end "$neg"
 ok "sixteen reads named the filter they do not apply, instead of answering the whole inventory"
+
+# And the other half of the same guard: the filters this pack DOES serve have to
+# select rather than be politely accepted (#618). A published course tags
+# everything and then looks things up by tag, and that is what this drives: tag
+# one Net, ask for it by each of the three filters, and ask for a tag nothing
+# carries.
+#
+# The object has to come back WITH its Tags, which #618 names as the second
+# thing an implementation gets wrong: an object that matched a tag filter and
+# answered without its tags is a shape divergence on top of the missing filter.
+echo "- the tag filters select, exclude, and answer the object with its tags"
+tagspan="$(prove_begin behaviour)"
+tagged_net="$(osc CreateNet --IpRange 10.94.0.0/16 | jq -r '.Net.NetId')"
+[ -n "$tagged_net" ] || fail "no NetId for the tag survey"
+osc CreateTags --ResourceIds "$tagged_net"   --payload '{"Tags":[{"Key":"course","Value":"capstone"}]}' >/dev/null   || fail "CreateTags rejected"
+
+for filter in '{"Filters":{"Tags":["course=capstone"]}}'               '{"Filters":{"TagKeys":["course"]}}'               '{"Filters":{"TagValues":["capstone"]}}'; do
+  found="$(osc ReadNets --payload "$filter")" || fail "ReadNets $filter rejected: $found"
+  printf '%s' "$found" | jq -e --arg id "$tagged_net" '.Nets | length == 1 and .[0].NetId == $id' >/dev/null     || fail "$filter did not select the tagged Net alone: $found"
+  printf '%s' "$found" | jq -e '.Nets[0].Tags | length == 1 and .[0].Key == "course"' >/dev/null     || fail "$filter answered the Net without its Tags: $found"
+done
+osc ReadNets --payload '{"Filters":{"TagKeys":["nothing-carries-this"]}}'   | jq -e '.Nets | length == 0' >/dev/null   || fail "a tag nothing carries selected something"
+osc DeleteNet --NetId "$tagged_net" >/dev/null || fail "DeleteNet rejected"
+prove_end "$tagspan"
+ok "the three tag filters select the tagged object, exclude the rest, and carry Tags"
 
 # The two attach spellings, at a balancer that does not exist. LBU is the one
 # family where a wrong name is a refusal rather than an empty list, because the

--- a/tools/falsify/specs/outscale-tag-filters.json
+++ b/tools/falsify/specs/outscale-tag-filters.json
@@ -1,0 +1,52 @@
+{
+  "mutations": [
+    {
+      "label": "the pair filter matches on the key alone, inventing the more permissive of two behaviours nobody measured",
+      "file": "internal/providers/outscale/filters.go",
+      "package": "./internal/providers/outscale/",
+      "find": "\t\t\tpairs = append(pairs, key+\"=\"+value)",
+      "replace": "\t\t\tpairs = append(pairs, key+\"=\"+value, key)",
+      "test": "TestTagFiltersSelectAndExclude"
+    },
+    {
+      "label": "TagKeys stops being compared, so a read answers its whole inventory to a tag question",
+      "file": "internal/providers/outscale/filters.go",
+      "package": "./internal/providers/outscale/",
+      "find": "\tif wanted, present, err := f.strings(\"TagKeys\"); present && err == nil {",
+      "replace": "\tif wanted, present, err := f.strings(\"TagKeys\"); present && err == nil && false {",
+      "test": "TestTagFiltersReachEveryReadTheRecordingExercised"
+    },
+    {
+      "label": "TagValues stops being compared",
+      "file": "internal/providers/outscale/filters.go",
+      "package": "./internal/providers/outscale/",
+      "find": "\tif wanted, present, err := f.strings(\"TagValues\"); present && err == nil {",
+      "replace": "\tif wanted, present, err := f.strings(\"TagValues\"); present && err == nil && false {",
+      "test": "TestTagFiltersSelectAndExclude"
+    },
+    {
+      "label": "the filter excludes everything, so a tag that exists selects nothing",
+      "file": "internal/providers/outscale/filters.go",
+      "package": "./internal/providers/outscale/",
+      "find": "func anyOf(wanted, carried []string) bool {",
+      "replace": "func anyOf(wanted, carried []string) bool {\n\tif len(wanted) > 0 && len(carried) >= 0 {\n\t\treturn false\n\t}",
+      "test": "TestTagFiltersSelectAndExclude"
+    },
+    {
+      "label": "the image list stops applying tags to its catalogue half, so a tag question quietly drops the fixed images",
+      "file": "internal/providers/outscale/catalog.go",
+      "package": "./internal/providers/outscale/",
+      "find": "\tif !matchesTagsView(f, image) {",
+      "replace": "\tif !matchesTagsView(f, image) && false {",
+      "test": "TestTagFiltersReachEveryReadTheRecordingExercised"
+    },
+    {
+      "label": "the machines read stops applying them, which is the operation the course's capstone uses",
+      "file": "internal/providers/outscale/vms.go",
+      "package": "./internal/providers/outscale/",
+      "find": "\tif !matchesTags(f, res) {\n\t\treturn false\n\t}\n\tattr := func(key string) string {",
+      "replace": "\tif !matchesTags(f, res) && false {\n\t\treturn false\n\t}\n\tattr := func(key string) string {",
+      "test": "TestTagFiltersReachEveryReadTheRecordingExercised"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #618.

## What was missing

The real Outscale accepts `Filters.Tags`, `Filters.TagKeys` and
`Filters.TagValues` everywhere a published course uses them: **eleven calls
recorded against a real account, every one accepted**. This pack refused all of
them with a 4001 naming what it did accept, so a course that tags everything and
then looks things up by tag could not complete its capstone.

`CreateTags` always worked, and so did `ReadTags --Filters.ResourceIds`. What was
missing is the reverse question, and it is a **filter reader rather than a
model**: the store already carries the tags.

## Three filters, not one with three spellings

| filter | matches on |
|---|---|
| `Tags` | `Key=Value`, the pair |
| `TagKeys` | the key alone |
| `TagValues` | the value alone |

The pair is compared **whole**. #618 records that a partial match was never tried
upstream, so the emulator takes the stricter reading: `Tags: ["env"]` selects
nothing, and `TagKeys` is the filter for a key. Inventing the more permissive
behaviour is the direction that teaches a client something the cloud may not do.

Served on the nine reads the recording exercised: `ReadNets`, `ReadSubnets`,
`ReadPublicIps`, `ReadVolumes`, `ReadRouteTables`, `ReadNatServices`,
`ReadNetPeerings`, `ReadVms`, `ReadImages`. The image list needed both halves,
being half catalogue and half store.

And the object comes back **with its `Tags` array**, the second thing #618 names.

## Two guards changed probes rather than being weakened

`TestAnUnsupportedFilterIsRefused` used `Tags` on `ReadVms` and `ReadNets`; it
now uses `Lifecycles` and `IsDefault`, which the API description declares and
this pack still does not apply. That is the **third** time this test has changed
probes for exactly this reason, and the comment beside it records the previous
two. `octl`'s refusal table did the same on `ReadNets` and `ReadSubnets`.

## Proof

- `conformance:leg -- octl`, green, and the accepting half is **driven** rather
  than asserted in a unit test: the suite tags a Net, asks for it by each of the
  three filters, checks it comes back with its `Tags`, and asks for a tag nothing
  carries.
- `conformance:leg -- fields`, green.
- **Six falsify mutations, all compiling, all biting**
  (`tools/falsify/specs/outscale-tag-filters.json`). One did not bite at first
  and found a real hole: the test could not tell *"the pair is matched whole"*
  from *"a bare key also matches"*, because `env=other` misses both. The bare-key
  assertion was added, and the mutation bites.
- `mise run prepush`.

**Not established, and left so**: whether the other packs have the same gap. Only
Outscale was surveyed, because only Outscale has a course driving it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
