### PR TITLE
fix(machine): a re-plug of an OVN NIC gives the guest back every public address the device still routes (#675)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -152,6 +152,22 @@ change ni l'un ni l'autre a sa place dans `git log`.
   divergence, les reverses d'une stack pointant vers des adresses de
   documentation que rien ne résout).
 
+- **Un re-plug de NIC OVN rend à l'invité chaque adresse publique que le
+  device lui route encore** (#675). Attacher une seconde adresse publique à un
+  serveur qui en porte une, ou la détacher, re-plugge la NIC (les clés de
+  route ne se mettent pas à jour à chaud), et la réparation qui suit ne
+  remettait que l'adresse privée épinglée : mesuré le 2026-09-04 sous
+  `incus-ovn`, sur le device et dans l'invité à chaque étape, attacher
+  `203.0.113.5` à un serveur portant `203.0.113.3` a laissé le device router
+  les deux et l'invité ne porter que la nouvelle, et la détacher a laissé
+  l'invité sans aucune adresse publique. La jonction suivante rejouait les
+  adresses et réparait en silence, dont `repaired: 1` sur `/_feint/health`
+  était la seule trace. La réparation relit désormais le device après
+  l'édition et remet chaque `/32` d'`ipv4.routes.external` : une attache lit
+  la liste fusionnée, un détachement la liste conservée. Le chemin du routed
+  NIC n'était pas le défaut et un test le tient, pour que personne n'ait à le
+  déduire de nouveau.
+
 - **Un instantané d'un disque auquel rien n'a jamais été attaché était accepté,
   et la stack d'exemple publiée en dépendait** (#650, #646).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,21 @@ what this project is judged on: **a response shape a client can observe**, and
   `reverse` (`docs/limits.md` keeps that divergence, since a stack's reverses
   point at documentation addresses nothing resolves).
 
+- **A re-plug of an OVN NIC gives the guest back every public address the
+  device still routes to it** (#675). Attaching a second public address to a
+  server holding one, or detaching it, re-plugs the NIC — the route keys are
+  not live-updatable — and the repair that follows put back the pinned
+  private address alone: measured on 2026-09-04 under `incus-ovn`, on the
+  device and in the guest at each step, attaching `203.0.113.5` to a server
+  holding `203.0.113.3` left the device routing both and the guest carrying
+  the new one alone, and detaching it left the guest with no public address
+  at all. The next join replayed the addresses and repaired it in silence,
+  which `repaired: 1` on `/_feint/health` was the only trace of. The repair
+  now reads the device after the edit and re-adds every `/32` of
+  `ipv4.routes.external`: an attach reads the merged list, a detach the kept
+  one. The routed NIC's path was not the defect and is held by a test of its
+  own, so nobody reasons about it again.
+
 - **A snapshot of a disk nothing was ever attached to was accepted, and the
   published example stack depended on it** (#650, #646).
 

--- a/internal/core/machine/incus_external_test.go
+++ b/internal/core/machine/incus_external_test.go
@@ -1,0 +1,132 @@
+package machine
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// Every re-plug of an OVN NIC used to cost the guest the public addresses it
+// already carried (#675). Measured on 2026-09-04 under `--vm incus-ovn`, on
+// the device and in the guest of a server holding 203.0.113.3 on eth1:
+//
+//	after attaching 203.0.113.5   device external=.3/32,.5/32   guest .5/32 alone
+//	after detaching 203.0.113.5   device external=.3/32         guest no public address
+//
+// The machine answered again only because the next join replayed its
+// addresses — and #670's counters recorded that as one repair, which is the
+// only reason anybody knew. These hold the driver at the level the runner can
+// hold it: the commands it emits, and their order around the re-plug.
+
+// ovnNICWithExternal answers the fake for a machine with one OVN NIC on
+// fnt-web, pinned at 10.30.1.10 and routing the given public /32s, and keeps
+// the device's ipv4.routes.external in step with the driver's own edits: a
+// query after `config device set` reads what the set wrote, the way the
+// runtime answers.
+func ovnNICWithExternal(f *fakeRuntime, external string) {
+	f.hook = func(_ int, args []string) ([]byte, error, bool) {
+		key := strings.Join(args, " ")
+		switch {
+		case strings.HasPrefix(key, "config device set srv eth1 ipv4.routes.external="):
+			external = strings.TrimPrefix(key, "config device set srv eth1 ipv4.routes.external=")
+			return nil, nil, true
+		case key == "query /1.0/instances/srv":
+			doc := `{"devices": {"eth1": {"type": "nic", "network": "fnt-web", "ipv4.address": "10.30.1.10", "ipv4.routes.external": "` + external + `"}},
+			 "expanded_devices": {"eth1": {"type": "nic", "network": "fnt-web", "ipv4.address": "10.30.1.10", "ipv4.routes.external": "` + external + `"}}}`
+			return []byte(doc), nil, true
+		case key == "network get fnt-web ipv4.address":
+			return []byte("10.30.1.1/24\n"), nil, true
+		case strings.HasPrefix(key, "network get fnt-web user."):
+			return []byte("feint\n"), nil, true
+		case strings.HasPrefix(key, "network get "+DefaultUplinkName):
+			return []byte(""), nil, true
+		}
+		return nil, nil, false
+	}
+}
+
+// position answers the index of the first command carrying the substring,
+// or -1, so an order can be held rather than a presence.
+func position(f *fakeRuntime, substr string) int {
+	for i, cmd := range f.commands() {
+		if strings.Contains(cmd, substr) {
+			return i
+		}
+	}
+	return -1
+}
+
+// TestRoutingASecondAddressLeavesTheFirstOnTheGuest: the attach, which is the
+// gesture the measurement named first.
+func TestRoutingASecondAddressLeavesTheFirstOnTheGuest(t *testing.T) {
+	f := &fakeRuntime{}
+	ovnNICWithExternal(f, "203.0.113.3/32")
+	d := ovnDriver(f)
+
+	if err := d.RouteAddress(context.Background(), AddressSpec{Machine: "srv", Address: "203.0.113.5", Network: "fnt-web"}); err != nil {
+		t.Fatalf("route: %v", err)
+	}
+	replug := position(f, "config device set srv eth1 ipv4.routes.external=203.0.113.3/32,203.0.113.5/32")
+	first := position(f, "exec srv -- ip address add 203.0.113.3/32 dev eth1")
+	second := position(f, "exec srv -- ip address add 203.0.113.5/32 dev eth1")
+	if replug < 0 {
+		t.Fatalf("the device was not given the merged list:\n%s", strings.Join(f.commands(), "\n"))
+	}
+	if first < replug {
+		t.Fatalf("the first address was not given back to the guest after the re-plug (at %d, re-plug at %d):\n%s",
+			first, replug, strings.Join(f.commands(), "\n"))
+	}
+	if second < replug {
+		t.Fatalf("the second address was not added after the re-plug:\n%s", strings.Join(f.commands(), "\n"))
+	}
+}
+
+// TestDetachingOneAddressLeavesTheOthersOnTheGuest: the detach, asserted
+// before any join could hide it — the join is what hid it for a day.
+func TestDetachingOneAddressLeavesTheOthersOnTheGuest(t *testing.T) {
+	f := &fakeRuntime{}
+	ovnNICWithExternal(f, "203.0.113.3/32,203.0.113.5/32")
+	d := ovnDriver(f)
+
+	if err := d.UnrouteAddress(context.Background(), "srv", "203.0.113.5"); err != nil {
+		t.Fatalf("unroute: %v", err)
+	}
+	replug := position(f, "config device set srv eth1 ipv4.routes.external=203.0.113.3/32")
+	kept := position(f, "exec srv -- ip address add 203.0.113.3/32 dev eth1")
+	if replug < 0 {
+		t.Fatalf("the device was not given the kept list:\n%s", strings.Join(f.commands(), "\n"))
+	}
+	if kept < replug {
+		t.Fatalf("the address the device still routes was not given back to the guest after the re-plug (at %d, re-plug at %d):\n%s",
+			kept, replug, strings.Join(f.commands(), "\n"))
+	}
+	if gone := position(f, "exec srv -- ip address add 203.0.113.5/32"); gone >= 0 {
+		t.Fatalf("the detached address was given back to the guest:\n%s", strings.Join(f.commands(), "\n"))
+	}
+}
+
+// TestDetachingFromARoutedNICKeepsTheAddressItStillPins is the other path,
+// held so nobody has to reason about it: a routed NIC keeps its extras in
+// ipv4.routes in both modes (routeOntoRoutedNIC writes that key), and
+// repairRoutedInterface reads it back and re-adds the pinned address. It
+// passed before #675 and is the measurement that the defect was not here.
+func TestDetachingFromARoutedNICKeepsTheAddressItStillPins(t *testing.T) {
+	f := &fakeRuntime{answers: map[string]string{
+		"query /1.0/instances/srv": `{
+			"devices": {"eth0": {"type": "nic", "nictype": "routed", "ipv4.address": "203.0.113.3", "ipv4.routes": "203.0.113.5/32", "ipv4.host_address": "169.254.0.1"}},
+			"expanded_devices": {"eth0": {"type": "nic", "nictype": "routed", "ipv4.address": "203.0.113.3", "ipv4.routes": "203.0.113.5/32", "ipv4.host_address": "169.254.0.1"}}
+		}`,
+		"config device get srv eth0 ipv4.routes": "203.0.113.5/32\n",
+		"network get " + DefaultUplinkName:       "",
+	}}
+	d := ovnDriver(f)
+	if err := d.UnrouteAddress(context.Background(), "srv", "203.0.113.5"); err != nil {
+		t.Fatalf("unroute: %v", err)
+	}
+	if position(f, "exec srv -- ip address add 203.0.113.3/32 dev eth0") < 0 {
+		t.Fatalf("the routed NIC's pinned address was not restored after its edit:\n%s", strings.Join(f.commands(), "\n"))
+	}
+	if position(f, "exec srv -- ip route add default via 169.254.0.1 dev eth0") < 0 {
+		t.Fatalf("the routed NIC's default route was not restored:\n%s", strings.Join(f.commands(), "\n"))
+	}
+}

--- a/internal/core/machine/incus_ovn.go
+++ b/internal/core/machine/incus_ovn.go
@@ -943,6 +943,23 @@ func (d *Incus) repairGuestInterface(ctx context.Context, machine, network, devi
 		fmt.Sprintf("%s/%d", address, gateway.Bits())); err != nil {
 		return err
 	}
+	// And every public address the device still routes to this interface
+	// (#675). The re-plug dropped them with the rest, and this repair put
+	// back the pinned address alone: measured on 2026-09-04 under
+	// `--vm incus-ovn`, step by step on the device and in the guest of a
+	// server holding 203.0.113.3 — attaching 203.0.113.5 left the device
+	// with `ipv4.routes.external=203.0.113.3/32,203.0.113.5/32` and the
+	// guest with the new /32 alone, and detaching 203.0.113.5 then left the
+	// guest with no public address at all. The machine answered again only
+	// because the next join replayed its addresses, and #670's counters
+	// recorded that as one repair. The device is the record: what it routes
+	// here, the guest carries, read back after the edit so an attach reads
+	// the merged list and a detach the kept one.
+	// TestRoutingASecondAddressLeavesTheFirstOnTheGuest and
+	// TestDetachingOneAddressLeavesTheOthersOnTheGuest fail without this.
+	if err := d.restoreExternalAddresses(ctx, machine, device, devices.own[device]); err != nil {
+		return err
+	}
 	if leased {
 		// The default route died with the lease, and nothing renews either.
 		// Restored only for the leased case: a pinned private NIC never had
@@ -956,6 +973,28 @@ func (d *Incus) repairGuestInterface(ctx context.Context, machine, network, devi
 	}
 	// The routes towards the peered subnets died with the interface too.
 	return d.installGuestPrivateRoutes(ctx, machine, network, device)
+}
+
+// restoreExternalAddresses gives the guest back, as /32s, every address the
+// device's ipv4.routes.external still names: the public addresses routed
+// onto an OVN NIC (#675). Already-there is the second call's success, in
+// whichever wording the guest's `ip` uses.
+func (d *Incus) restoreExternalAddresses(ctx context.Context, machine, device string, cfg map[string]string) error {
+	external := splitList(cfg["ipv4.routes.external"])
+	if len(external) == 0 {
+		return nil
+	}
+	iface, err := d.guestInterface(ctx, machine, device)
+	if err != nil {
+		return err
+	}
+	for _, route := range external {
+		if _, err := d.run(ctx, "exec", machine, "--", "ip", "address", "add", route, "dev", iface); err != nil &&
+			!addressAlreadyThere(err) {
+			return fmt.Errorf("give %s back to %s/%s after the re-plug: %w", route, machine, iface, err)
+		}
+	}
+	return nil
 }
 
 // lastKnownAddress is the IPv4 the runtime last saw on an interface, from the

--- a/tools/falsify/specs/a-re-plug-keeps-every-external-address.json
+++ b/tools/falsify/specs/a-re-plug-keeps-every-external-address.json
@@ -1,0 +1,26 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "the repair after a re-plug puts back the pinned address alone, and every public address the OVN NIC already routed is lost with the re-plug (#675)",
+      "file": "internal/core/machine/incus_ovn.go",
+      "find": "\texternal := splitList(cfg[\"ipv4.routes.external\"])\n\tif len(external) == 0 {\n\t\treturn nil\n\t}",
+      "replace": "\texternal := splitList(cfg[\"ipv4.routes.external\"])\n\tif len(external) == 0 || true {\n\t\treturn nil\n\t}",
+      "test": "TestDetachingOneAddressLeavesTheOthersOnTheGuest"
+    },
+    {
+      "label": "the same loss, seen at the attach that the measurement named first (#675)",
+      "file": "internal/core/machine/incus_ovn.go",
+      "find": "\texternal := splitList(cfg[\"ipv4.routes.external\"])\n\tif len(external) == 0 {\n\t\treturn nil\n\t}",
+      "replace": "\texternal := splitList(cfg[\"ipv4.routes.external\"])\n\tif len(external) == 0 || true {\n\t\treturn nil\n\t}",
+      "test": "TestRoutingASecondAddressLeavesTheFirstOnTheGuest"
+    },
+    {
+      "label": "the restore reads the device before the edit rather than after it, so a detach gives the guest back the address it was asked to remove (#675)",
+      "file": "internal/core/machine/incus_ovn.go",
+      "find": "\tif err := d.restoreExternalAddresses(ctx, machine, device, devices.own[device]); err != nil {",
+      "replace": "\tif err := d.restoreExternalAddresses(ctx, machine, device, map[string]string{\"ipv4.routes.external\": devices.own[device][\"ipv4.routes.external\"] + \",203.0.113.5/32\"}); err != nil {",
+      "test": "TestDetachingOneAddressLeavesTheOthersOnTheGuest"
+    }
+  ]
+}


### PR DESCRIPTION
Attaching a second public address to a server holding one, or detaching
it, re-plugs the OVN NIC (its route keys are not live-updatable), and
the repair that follows put back the pinned private address alone.

Measured on 2026-09-04 under --vm incus-ovn, step by step, on the device
and in the guest of a server holding 203.0.113.3 on eth1:

  after attaching 203.0.113.5   device external=.3/32,.5/32   guest .5/32 alone
  after detaching 203.0.113.5   device external=.3/32         guest no public /32

The issue names the detach; the measurement puts the first loss at the
attach, and the detach then loses the rest. The next join replayed the
addresses and repaired it in silence, and the `repaired: 1` of #670's
counters was the only trace of it.

The path is routeAddressOVN / unrouteOVNDevice, then repairGuestInterface,
not repairRoutedInterface: eth1 is an OVN network NIC and carries its
publics in ipv4.routes.external. repairGuestInterface now reads the
device after the edit and re-adds every /32 of that key, so an attach
reads the merged list and a detach the kept one. A routed NIC keeps its
extras in ipv4.routes in both modes (routeOntoRoutedNIC writes that key)
and repairRoutedInterface reads the same one back: that path was not
the defect, and TestDetachingFromARoutedNICKeepsTheAddressItStillPins
holds it so nobody has to deduce it again.

Measured: the commands the driver emits and their order around the
re-plug, on a fake runtime (TestRoutingASecondAddressLeavesTheFirstOnTheGuest,
TestDetachingOneAddressLeavesTheOthersOnTheGuest); the three mutations
of tools/falsify/specs/a-re-plug-keeps-every-external-address.json bite.

Not measured here: the same sequence on real machines under #668's
verification layer, where `repaired` must fall to zero. That replay
needs the station and its result goes in the report.

Driver-only: this commit depends on nothing of the #667-#673 stack.

Assisted-by: Claude Code (claude-fable-5-1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
