### PR TITLE
fix(machine): a restart reconciles the routed NIC to its device, and the guest's config keeps laying the launch shape (#674)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -168,6 +168,28 @@ change ni l'un ni l'autre a sa place dans `git log`.
   NIC n'était pas le défaut et un test le tient, pour que personne n'ait à le
   déduire de nouveau.
 
+- **Un redémarrage réconcilie la NIC routed sur son device, et la config
+  propre de l'invité continue de poser la forme de lancement** (#674). Un
+  serveur créé avec une adresse publique et sans réseau démarre sur une NIC
+  `routed` (#202), déclarée en statique dans la network-config remise à
+  cloud-init : l'adresse en `/32`, la route par défaut on-link via
+  `169.254.0.1`. cloud-init la rend une fois, au premier boot, dans le
+  `/etc/netplan/50-cloud-init.yaml` de l'invité, et ce fichier survit à toute
+  édition du device par le pilote : mesuré le 2026-09-04 sous `incus-ovn`, un
+  serveur dont la NIC privée est arrivée à chaud et a emporté l'adresse (#548)
+  déclarait encore `203.0.113.3/32` sur `eth0` dans l'invité alors que le
+  device n'épinglait plus rien, et un reboot par l'API remettait l'adresse sur
+  `eth0` à côté de celle que le pilote avait posée sur `eth1`. Deux écrivains
+  pour une interface, désormais dans un ordre fixe : la config de l'invité la
+  pose à chaque boot, et le doit, mesuré le même jour : une première tentative
+  qui retirait `eth0` de cette config laissait systemd-networkd sans rien à
+  gérer, `systemd-networkd-wait-online` attendre jusqu'à son plafond de 120 s
+  et sshd démarrer 90 s après que la suite ssh eut abandonné, là où `main` se
+  connecte en vingt secondes ; puis le chemin de redémarrage attend, borné,
+  que l'invité ait posé l'interface, retire toute adresse que le device
+  n'épingle ni ne route, et remet ce qu'il épingle, le next-hop link-local et
+  la route par défaut qui passe par lui.
+
 - **Un instantané d'un disque auquel rien n'a jamais été attaché était accepté,
   et la stack d'exemple publiée en dépendait** (#650, #646).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,27 @@ what this project is judged on: **a response shape a client can observe**, and
   one. The routed NIC's path was not the defect and is held by a test of its
   own, so nobody reasons about it again.
 
+- **A restart reconciles the routed NIC to its device, and the guest's own
+  config keeps laying the launch shape** (#674). A server created with a
+  public address and no network boots on a `routed` NIC (#202), declared
+  statically in the network-config the launch hands cloud-init — the address
+  as a `/32`, the on-link default route through `169.254.0.1`. cloud-init
+  renders it once, at the first boot, into the guest's own
+  `/etc/netplan/50-cloud-init.yaml`, and that file outlives every edit the
+  driver makes to the device afterwards: measured on 2026-09-04 under
+  `incus-ovn`, a server whose private NIC arrived hot and took the address
+  with it (#548) still declared `203.0.113.3/32` on `eth0` in the guest while
+  the device pinned nothing, and an API reboot put the address back on `eth0`
+  beside the one the driver had laid on `eth1`. Two writers of one interface,
+  now in a fixed order: the guest's config lays it at every boot — and must,
+  measured the same day: a first attempt that took `eth0` out of that config
+  left systemd-networkd managing nothing, `systemd-networkd-wait-online`
+  waiting to its 120 s ceiling and sshd starting 90 s after the ssh suite had
+  given up, where main logs in within twenty seconds — and the restart path
+  then waits, bounded, for the guest to have laid the interface, takes off
+  every address the device neither pins nor routes, and puts back what it
+  does, the link-local next hop and the default route through it.
+
 - **A snapshot of a disk nothing was ever attached to was accepted, and the
   published example stack depended on it** (#650, #646).
 

--- a/internal/core/machine/incus.go
+++ b/internal/core/machine/incus.go
@@ -542,9 +542,11 @@ func (d *Incus) Start(ctx context.Context, spec Spec) (Machine, error) {
 			"-d", "root,pool="+d.rootPool(ctx))
 	}
 	if routed {
-		// The guest has to be told. A routed NIC hands the kernel a static
-		// address and Incus's generated config says `dhcp` regardless, so
-		// without this the interface comes up carrying nothing — measured.
+		// The guest has to be told, and has to manage the interface itself:
+		// a routed NIC hands the kernel a static address, Incus's generated
+		// config says `dhcp` regardless, and a guest whose network config
+		// matches no interface waits out systemd-networkd-wait-online before
+		// it ever starts sshd (#674, routedNetworkConfig).
 		netcfg, err := routedNetworkConfig(spec.PublicAddresses)
 		if err != nil {
 			return Machine{}, err

--- a/internal/core/machine/incus_address.go
+++ b/internal/core/machine/incus_address.go
@@ -347,8 +347,9 @@ func (d *Incus) UnrouteAddress(ctx context.Context, machine, address string) err
 // ipv4.address list created. Two more measured facts shape the branches:
 //
 //   - an address already in ipv4.address rode the launch: the guest's netplan
-//     declares it and the host route exists, so the replay is a no-op. This is
-//     what lets poweron replay every published address through here without
+//     declares it, the restart reconciles it (reconcileRoutedNICs, #674) and
+//     the host route exists, so the replay is a no-op. This is what lets
+//     poweron replay every published address through here without
 //     re-plugging the interface at each boot.
 //   - a live ipv4.routes edit re-plugs the device: the veth is torn down and
 //     rebuilt, and the guest interface comes back down and bare. The repair is
@@ -389,9 +390,11 @@ func (d *Incus) routeOntoRoutedNIC(ctx context.Context, machine, device, address
 }
 
 // repairRoutedInterface restores what an ipv4.routes edit cost the guest of a
-// routed NIC. Measured on 7.2: the edit removes and re-adds the device, and
-// the new interface comes up down and bare — no address, no default route, and
-// no DHCP client to notice, since a routed NIC never had one.
+// routed NIC, and since #674 it is also the second half of a restart's
+// reconciliation (reconcileRoutedNICs). Measured on 7.2: the edit removes and
+// re-adds the device, and the new interface comes up down and bare — no
+// address, no default route, and no DHCP client to notice, since a routed NIC
+// never had one.
 //
 // Everything restored is read back from the device itself: the launch
 // addresses from ipv4.address, the extra ones from ipv4.routes, the next hop
@@ -407,8 +410,9 @@ func (d *Incus) repairRoutedInterface(ctx context.Context, machine, device strin
 	cfg := devices.own[device]
 	if _, err := d.run(ctx, "exec", machine, "--", "ip", "link", "set", device, "up"); err != nil {
 		if isNotRunning(err) {
-			// A cold edit re-plugged nothing: the next boot reads its netplan
-			// and the poweron replay hands the guest the routed extras.
+			// A cold edit re-plugged nothing: the next boot reads its netplan,
+			// the restart reconciles it to the device (reconcileRoutedNICs,
+			// #674), and the poweron replay hands the guest the routed extras.
 			return nil
 		}
 		return fmt.Errorf("bring %s/%s back up: %w", machine, device, err)

--- a/internal/core/machine/incus_ovn.go
+++ b/internal/core/machine/incus_ovn.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/netip"
 	"os"
@@ -1118,6 +1119,19 @@ func (d *Incus) restoreGuestNetwork(ctx context.Context, machine string) error {
 	if err != nil {
 		return fmt.Errorf("inspect %s to restore its routes: %w", machine, err)
 	}
+	// The routed NIC first: the guest's own config lays it at every boot, with
+	// the addresses the launch pinned, and that config outlives the migration
+	// of #548 — so it is reconciled to the device here, once the guest has
+	// laid it (#674). TestARestartReconcilesTheRoutedNICToItsDevice fails
+	// without this.
+	//
+	// Its report does not pre-empt the managed NICs': an expired wait on
+	// eth0 and one on eth1 are two facts, and an operator reading the
+	// restart's failure needs both (errors.Join).
+	var routed error
+	if err := d.reconcileRoutedNICs(ctx, machine, devices); err != nil {
+		routed = fmt.Errorf("reconcile the routed interface of %s: %w", machine, err)
+	}
 	for _, device := range names {
 		// The address first, when the device pins one (#548). A NIC attached
 		// to a running machine is configured inside the guest by this driver,
@@ -1137,7 +1151,7 @@ func (d *Incus) restoreGuestNetwork(ctx context.Context, machine string) error {
 		// nobody offers.
 		// TestARestartedMachineGetsItsPinnedAddressBack fails without this.
 		if err := d.restorePinnedAddress(ctx, machine, device, devices.own[device]); err != nil {
-			return err
+			return errors.Join(routed, err)
 		}
 		if !d.OVN {
 			continue
@@ -1148,13 +1162,13 @@ func (d *Incus) restoreGuestNetwork(ctx context.Context, machine string) error {
 		// replaces. It still runs for a device that pins nothing, which is the
 		// DHCP case it was written for.
 		if err := d.waitForGuestInterface(ctx, machine, device); err != nil {
-			return err
+			return errors.Join(routed, err)
 		}
 		if err := d.installGuestPrivateRoutes(ctx, machine, devices.own[device]["network"], device); err != nil {
-			return err
+			return errors.Join(routed, err)
 		}
 	}
-	return nil
+	return routed
 }
 
 // ownedManagedNICs answers the machine's own NIC devices that sit on a network
@@ -1243,6 +1257,11 @@ func (d *Incus) settleFirstBoot(ctx context.Context, machine string) error {
 	if err != nil {
 		return fmt.Errorf("inspect %s to settle its interfaces: %w", machine, err)
 	}
+	// The routed NIC is not settled here: the guest's own config lays it,
+	// and must — measured on 2026-09-04, a first boot the driver laid instead
+	// left the guest's network stack managing nothing and waiting out
+	// systemd-networkd-wait-online before sshd (#674, routedNetworkConfig).
+	// TestAFirstBootLeavesTheRoutedNICToTheGuestsOwnConfig fails without this.
 	for _, device := range names {
 		if devices.own[device]["ipv4.address"] == "" {
 			continue // DHCP owns this interface, and inventing an address for it is #202
@@ -1263,6 +1282,93 @@ func (d *Incus) settleFirstBoot(ctx context.Context, machine string) error {
 			if err := d.installGuestPrivateRoutes(ctx, machine, devices.own[device]["network"], device); err != nil {
 				return fmt.Errorf("settle the first boot of %s: %w", machine, err)
 			}
+		}
+	}
+	return nil
+}
+
+// reconcileRoutedNICs makes the guest's routed NIC carry what its device
+// carries, after a boot (#674).
+//
+// Two writers of one interface, in a fixed order. The guest's own boot-time
+// config (routedNetworkConfig, rendered once by cloud-init at the first boot)
+// lays eth0 with the addresses the launch pinned, and it must: a guest whose
+// network stack manages no interface waits out systemd-networkd-wait-online
+// before it ever starts sshd, measured. But that config outlives every edit
+// this driver makes to the device: measured on 2026-09-04 under `--vm
+// incus-ovn`, a server created with 203.0.113.3 whose private NIC arrived hot
+// and took the address with it (#548) still declared `203.0.113.3/32` on eth0
+// in the guest while the device pinned nothing, and an API reboot put the
+// address back on eth0 beside the one the driver had laid on eth1.
+//
+// So the driver goes second, and waits its turn: once the guest carries an
+// address on the interface — its own config has done its work — every address
+// the device does not pin (ipv4.address) or route (ipv4.routes) is taken off,
+// and the repair a re-plug gets (repairRoutedInterface) puts back what it does,
+// the link-local next hop and the default route through it, idempotently. The
+// wait is bounded (waitForGuestInterface); when it expires the reconciliation
+// still runs, and the wait is reported, since a routed NIC with nothing on it
+// is exactly what an operator will ask about.
+//
+// Only the NIC this driver adds: routedDevice names it routedDeviceName and
+// gives it no network, and the instance's ownership was asked at the door
+// (Binding.ours for the name, mustOwnInstance for the label). A routed NIC an
+// operator added by hand under another name is theirs, and nothing here
+// names it.
+func (d *Incus) reconcileRoutedNICs(ctx context.Context, machine string, devices instanceView) error {
+	for device, cfg := range devices.own {
+		if cfg["type"] != "nic" || cfg["nictype"] != "routed" || device != routedDeviceName {
+			continue
+		}
+		waited := d.waitForGuestInterface(ctx, machine, device)
+		if err := d.releaseStaleRoutedAddresses(ctx, machine, device, cfg); err != nil {
+			return err
+		}
+		if err := d.repairRoutedInterface(ctx, machine, device); err != nil {
+			return err
+		}
+		if waited != nil {
+			return waited
+		}
+	}
+	return nil
+}
+
+// releaseStaleRoutedAddresses takes off the guest's routed interface every
+// address its device neither pins nor routes: what the guest's boot-time config
+// remembered from the launch and the device has since let go of (#548, #674).
+func (d *Incus) releaseStaleRoutedAddresses(ctx context.Context, machine, device string, cfg map[string]string) error {
+	wanted := map[string]bool{}
+	for _, address := range splitList(cfg["ipv4.address"]) {
+		wanted[address] = true
+	}
+	for _, route := range splitList(cfg["ipv4.routes"]) {
+		address, _, _ := strings.Cut(route, "/")
+		wanted[address] = true
+	}
+	iface, err := d.guestInterface(ctx, machine, device)
+	if err != nil {
+		return err
+	}
+	carried, err := d.guestAddresses(ctx, machine, iface)
+	if err != nil {
+		if isNotRunning(err) {
+			return nil
+		}
+		return fmt.Errorf("read what %s/%s carries: %w", machine, device, err)
+	}
+	addresses := make([]string, 0, len(carried))
+	for address := range carried {
+		addresses = append(addresses, address)
+	}
+	slices.Sort(addresses)
+	for _, address := range addresses {
+		if wanted[address] {
+			continue
+		}
+		if _, err := d.run(ctx, "exec", machine, "--",
+			"ip", "address", "del", address+"/32", "dev", iface); err != nil && !isNotRunning(err) {
+			return fmt.Errorf("take the migrated %s off %s/%s: %w", address, machine, device, err)
 		}
 	}
 	return nil

--- a/internal/core/machine/incus_restart_test.go
+++ b/internal/core/machine/incus_restart_test.go
@@ -27,6 +27,14 @@ import (
 // stack builds: a routed NIC carrying the public address, and one OVN NIC on a
 // network the emulator owns.
 func restartedInstance(f *fakeRuntime, devices string) {
+	restartedInstanceCarrying(f, devices, "203.0.113.4")
+}
+
+// restartedInstanceCarrying is restartedInstance with the address the guest's
+// own boot-time config laid on the routed NIC (#674): what netplan remembered
+// from the launch, whatever the device pins now. Empty means the guest never
+// lays anything there.
+func restartedInstanceCarrying(f *fakeRuntime, devices, onRouted string) {
 	f.hook = func(_ int, args []string) ([]byte, error, bool) {
 		switch args[0] {
 		case "list":
@@ -40,9 +48,16 @@ func restartedInstance(f *fakeRuntime, devices string) {
 				return []byte("10.30.1.1/24\n"), nil, true
 			}
 		case "exec":
-			// The guest answers that its interface is configured, which is what
-			// the wait is looking for.
-			if strings.Contains(strings.Join(args, " "), "-o addr show dev") {
+			// The guest answers what each interface carries, which is what
+			// the waits and the reconciliation read.
+			joined := strings.Join(args, " ")
+			if strings.Contains(joined, "-o addr show dev eth0") {
+				if onRouted == "" {
+					return []byte(""), nil, true
+				}
+				return []byte("2: eth0    inet " + onRouted + "/32 scope global eth0\n"), nil, true
+			}
+			if strings.Contains(joined, "-o addr show dev") {
 				return []byte("2: eth1    inet 10.30.1.10/24 scope global eth1\n"), nil, true
 			}
 		}
@@ -110,12 +125,16 @@ func TestARestartedMachineGetsItsPinnedAddressBack(t *testing.T) {
 		t.Errorf("a restarted machine was not given back the address its device reserves:\n%s",
 			strings.Join(f.commands(), "\n"))
 	}
-	// And the routed NIC is not one of these: it has no network to read a mask
-	// from, its address is the launch's own, and the guest's boot-time config
-	// declares it.
-	if got := f.matching("ip address add 203.0.113.4"); len(got) != 0 {
-		t.Errorf("the restart path configured the routed NIC's address inside the guest:\n%s",
-			strings.Join(got, "\n"))
+	// The routed NIC used to be the exception here — "the guest's boot-time
+	// config declares it" — and that config is what #674 measured putting a
+	// migrated address back on eth0 at every reboot, beside the one this
+	// driver had moved. The guest still lays it (it must, see
+	// routedNetworkConfig); the restart then reconciles the interface to the
+	// device, and the address the device still pins is put back idempotently.
+	// TestARestartReconcilesTheRoutedNICToItsDevice holds the other half.
+	if len(f.matching("exec srv -- ip address add 203.0.113.4/32 dev eth0")) == 0 {
+		t.Errorf("the restart path did not reconcile the routed NIC to its device:\n%s",
+			strings.Join(f.commands(), "\n"))
 	}
 }
 
@@ -198,6 +217,11 @@ func TestRestoringRoutesLeavesAForeignNICAlone(t *testing.T) {
 // to put back there. Asserted rather than assumed: the aggregates point at an
 // OVN router, and laying them on a bridge would send a guest's private traffic
 // at an address that answers nothing.
+//
+// The aggregates, and only them: the routed NIC's own door — the link-local
+// next hop and the default route through it — is laid in both modes since
+// #674, as the guest's netplan laid it in both modes before, and it goes
+// through the veth, not through any router.
 func TestABridgeModeRestartLaysNoAggregates(t *testing.T) {
 	f := &fakeRuntime{}
 	restartedInstance(f, routedPlusPrivate)
@@ -206,8 +230,12 @@ func TestABridgeModeRestartLaysNoAggregates(t *testing.T) {
 	if _, err := d.Start(context.Background(), Spec{Name: "srv", Image: "ubuntu:22.04"}); err != nil {
 		t.Fatalf("start: %v", err)
 	}
-	if got := f.matching("ip route add"); len(got) != 0 {
+	if got := f.matching("via 10.30.1.1"); len(got) != 0 {
 		t.Errorf("bridge mode laid OVN aggregates:\n%s", strings.Join(got, "\n"))
+	}
+	if len(f.matching("exec srv -- ip route add default via 169.254.0.1 dev eth0")) == 0 {
+		t.Errorf("bridge mode took the routed NIC's door away with the aggregates:\n%s",
+			strings.Join(f.commands(), "\n"))
 	}
 }
 

--- a/internal/core/machine/incus_routed.go
+++ b/internal/core/machine/incus_routed.go
@@ -37,24 +37,47 @@ import (
 // value Incus's own routed-NIC guide uses.
 const routedNextHop = "169.254.0.1"
 
-// routedNetworkConfig renders the netplan a machine on a routed NIC needs.
+// routedDeviceName is the interface routedDevice adds, and the only routed
+// NIC the restart path reconciles (#674): a routed NIC an operator added by
+// hand to one of our machines is theirs, under whatever name they gave it.
+const routedDeviceName = "eth0"
+
+// routedNetworkConfig renders the netplan a machine on a routed NIC boots with.
 //
 // The guest must be told: a routed NIC hands the kernel a static address and
 // Incus's generated config says `dhcp` regardless, so without this the interface
 // comes up with nothing on it. Measured — the address was declared on the device
 // and the guest carried none.
 //
+// AND THE GUEST MUST MANAGE THE INTERFACE ITSELF (#674). A first attempt at
+// #674 took eth0 out of this file and had the driver lay it after `incus
+// start`, so that nothing inside the guest could put a migrated address back.
+// Measured on 2026-09-04 under `--vm incus-ovn`, Ubuntu jammy, against the
+// ssh suite: with no interface matched by the guest's own network config,
+// systemd-networkd manages nothing, systemd-networkd-wait-online stays
+// `activating` to its 120 s ceiling, network-online.target and with it
+// cloud-init's network stage wait behind it, and the ssh module that
+// generates the host keys and starts sshd ran at 181 s of uptime — 90 s after
+// the suite had given up. The same suite against main's driver logged in
+// within twenty seconds. The default route the driver had laid was also gone
+// at 91 s and at 181 s. So eth0 stays declared here, with the addresses the
+// launch pinned, and the driver's answer to the migrated address is on the
+// other side of the boot: restoreGuestNetwork reconciles the interface to the
+// device once the guest's own config has laid it (reconcileRoutedNICs).
+//
 // Every address is parsed before it is rendered, and an unparseable one is a
 // refusal rather than an escape. This file renders a structured format by
 // concatenation, which the cloud-init templates already show is a way to hand
 // somebody a key in the document; the answer here is that nothing but a valid IP
 // can reach the rendering at all.
+//
+// TestTheRoutedNetplanDeclaresTheLaunchAddress fails without this.
 func routedNetworkConfig(addresses []string) (string, error) {
 	if len(addresses) == 0 {
 		return "", fmt.Errorf("a routed interface needs at least one address")
 	}
 	var b strings.Builder
-	b.WriteString("network:\n  version: 2\n  ethernets:\n    eth0:\n      addresses:\n")
+	b.WriteString("network:\n  version: 2\n  ethernets:\n    " + routedDeviceName + ":\n      addresses:\n")
 	for _, address := range addresses {
 		parsed, err := netip.ParseAddr(address)
 		if err != nil {
@@ -115,7 +138,7 @@ func routedDevice(name string, addresses []string) ([]string, error) {
 		}
 	}
 	return []string{
-		"config", "device", "add", name, "eth0", "nic",
+		"config", "device", "add", name, routedDeviceName, "nic",
 		"nictype=routed",
 		"ipv4.address=" + strings.Join(addresses, ","),
 		"ipv4.host_address=" + routedNextHop,

--- a/internal/core/machine/incus_routed_boot_test.go
+++ b/internal/core/machine/incus_routed_boot_test.go
@@ -1,0 +1,222 @@
+package machine
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The routed NIC has two writers, in a fixed order (#674): the guest's own
+// boot-time config lays it at every boot with the addresses the launch pinned,
+// and the restart path reconciles it to the device once the guest has done so.
+//
+// Both halves are measured. The guest must lay it: a first attempt at #674
+// took eth0 out of the guest's config and had the driver lay it, and on
+// 2026-09-04 under `--vm incus-ovn` (Ubuntu jammy, the ssh suite) that left
+// systemd-networkd managing nothing, systemd-networkd-wait-online `activating`
+// to its 120 s ceiling, and sshd started at 181 s of uptime, 90 s after the
+// suite gave up; main's driver logged in within twenty seconds. And the
+// driver must reconcile: the same day, a server whose private NIC had taken
+// its address (#548) still declared `203.0.113.3/32` on eth0 in its netplan
+// while the device pinned nothing, and an API reboot put the address back on
+// eth0 beside the one on eth1.
+
+// launchRouted is a machine created with one public address and no network:
+// the shape #202 gives it, as the launch leaves the device.
+const launchRouted = `{
+  "devices": {
+    "eth0": {"type": "nic", "nictype": "routed", "ipv4.address": "203.0.113.7", "ipv4.host_address": "169.254.0.1"}
+  },
+  "expanded_devices": {
+    "eth0": {"type": "nic", "nictype": "routed", "ipv4.address": "203.0.113.7", "ipv4.host_address": "169.254.0.1"}
+  }
+}`
+
+// migratedRouted is the same machine after #548 moved its address onto a
+// private NIC that arrived hot: the routed device pins nothing, and the
+// address is routed onto eth1.
+const migratedRouted = `{
+  "devices": {
+    "eth0": {"type": "nic", "nictype": "routed", "ipv4.host_address": "169.254.0.1"},
+    "eth1": {"type": "nic", "network": "fnt-368798629f8", "ipv4.address": "10.30.1.10", "ipv4.routes.external": "203.0.113.7/32"}
+  },
+  "expanded_devices": {
+    "eth0": {"type": "nic", "nictype": "routed", "ipv4.host_address": "169.254.0.1"},
+    "eth1": {"type": "nic", "network": "fnt-368798629f8", "ipv4.address": "10.30.1.10", "ipv4.routes.external": "203.0.113.7/32"}
+  }
+}`
+
+// TestTheRoutedNetplanDeclaresTheLaunchAddress: the guest's boot-time config
+// names eth0, its launch address as a /32 and the on-link default through the
+// link-local next hop, and the stanza for interfaces attached later. The
+// interface is managed by the guest, or its boot waits on nothing.
+func TestTheRoutedNetplanDeclaresTheLaunchAddress(t *testing.T) {
+	f := &fakeRuntime{}
+	startScript(f)
+	d := newFakeDriver(f)
+
+	if _, err := d.Start(context.Background(), Spec{
+		Name: "srv", Image: "alpine:3.21", PublicAddresses: []string{"203.0.113.7"},
+	}); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	inits := f.matching("init ")
+	if len(inits) != 1 {
+		t.Fatalf("expected one init, got:\n%s", strings.Join(f.commands(), "\n"))
+	}
+	_, cfg, found := strings.Cut(inits[0], "cloud-init.network-config=")
+	if !found {
+		t.Fatalf("no network-config was handed to the guest: %s", inits[0])
+	}
+	for _, want := range []string{"    eth0:", "        - 203.0.113.7/32", "via: 169.254.0.1", "on-link: true", `name: "eth[1-9]"`} {
+		if !strings.Contains(cfg, want) {
+			t.Errorf("the guest's boot-time config lacks %q, so its network stack manages nothing and its boot waits:\n%s", want, cfg)
+		}
+	}
+}
+
+// TestAFirstBootLeavesTheRoutedNICToTheGuestsOwnConfig: the first door is the
+// guest's. No address is written to eth0 by the driver at the first boot, and
+// nothing is taken off it.
+func TestAFirstBootLeavesTheRoutedNICToTheGuestsOwnConfig(t *testing.T) {
+	f := &fakeRuntime{}
+	firstBootScript(f, launchRouted)
+	d := ovnDriver(f)
+
+	if _, err := d.Start(context.Background(), Spec{
+		Name: "srv", Image: "alpine:3.21", PublicAddresses: []string{"203.0.113.7"},
+	}); err != nil {
+		t.Fatalf("start a new machine: %v", err)
+	}
+	for _, forbidden := range []string{"ip address add", "ip address del", "ip route add default"} {
+		if got := f.matching(forbidden); len(got) != 0 {
+			t.Errorf("the first boot wrote the routed NIC the guest's own config lays (%q):\n%s", forbidden, strings.Join(got, "\n"))
+		}
+	}
+}
+
+// TestARestartReconcilesTheRoutedNICToItsDevice is the measurement of
+// 2026-09-04 as a test: the device pins nothing on eth0 (the address migrated
+// to eth1), the guest's own config laid 203.0.113.7 on eth0 anyway, and the
+// restart takes it off — and keeps the door, the default route through the
+// link-local next hop, which is what a public address answers through (#660).
+func TestARestartReconcilesTheRoutedNICToItsDevice(t *testing.T) {
+	f := &fakeRuntime{}
+	restartedInstanceCarrying(f, migratedRouted, "203.0.113.7")
+	d := ovnDriver(f)
+
+	if _, err := d.Start(context.Background(), Spec{Name: "srv", Image: "ubuntu:22.04"}); err != nil {
+		t.Fatalf("start an existing machine: %v", err)
+	}
+	if len(f.matching("exec srv -- ip address del 203.0.113.7/32 dev eth0")) == 0 {
+		t.Errorf("the restart left the migrated address on the routed NIC, where the guest's config put it back:\n%s",
+			strings.Join(f.commands(), "\n"))
+	}
+	if got := f.matching("ip address add 203.0.113.7/32 dev eth0"); len(got) != 0 {
+		t.Errorf("the restart put the migrated address back on the routed NIC:\n%s", strings.Join(got, "\n"))
+	}
+	if len(f.matching("exec srv -- ip route add default via 169.254.0.1 dev eth0")) == 0 {
+		t.Errorf("the restart took the door away with the address:\n%s", strings.Join(f.commands(), "\n"))
+	}
+}
+
+// TestARestartKeepsTheAddressTheRoutedNICStillPins is the accepting half: the
+// device still pins 203.0.113.4, the guest laid it, nothing is taken off.
+func TestARestartKeepsTheAddressTheRoutedNICStillPins(t *testing.T) {
+	f := &fakeRuntime{}
+	restartedInstance(f, routedPlusPrivate)
+	d := ovnDriver(f)
+
+	if _, err := d.Start(context.Background(), Spec{Name: "srv", Image: "ubuntu:22.04"}); err != nil {
+		t.Fatalf("start an existing machine: %v", err)
+	}
+	if got := f.matching("ip address del"); len(got) != 0 {
+		t.Errorf("the restart took off an address the device still pins:\n%s", strings.Join(got, "\n"))
+	}
+}
+
+// TestARestartWaitsForTheGuestToLayItsRoutedNICBeforeReconciling: the order is
+// the mechanism. The guest's config lays eth0 a moment after `incus start`
+// returns; a reconciliation that read the interface before that would find it
+// bare, take nothing off, and the stale address would land afterwards. The
+// guest here answers bare twice and then carries the migrated address; the
+// removal must come after that.
+func TestARestartWaitsForTheGuestToLayItsRoutedNICBeforeReconciling(t *testing.T) {
+	f := &fakeRuntime{}
+	restartedInstanceCarrying(f, migratedRouted, "203.0.113.7")
+	inner := f.hook
+	reads := 0
+	f.hook = func(n int, args []string) ([]byte, error, bool) {
+		if args[0] == "exec" && strings.Contains(strings.Join(args, " "), "-o addr show dev eth0") {
+			reads++
+			if reads <= 2 {
+				return []byte(""), nil, true
+			}
+		}
+		return inner(n, args)
+	}
+	d := ovnDriver(f)
+	d.routePoll = time.Millisecond
+
+	if _, err := d.Start(context.Background(), Spec{Name: "srv", Image: "ubuntu:22.04"}); err != nil {
+		t.Fatalf("start an existing machine: %v", err)
+	}
+	if len(f.matching("exec srv -- ip address del 203.0.113.7/32 dev eth0")) == 0 {
+		t.Errorf("the reconciliation read the routed NIC before the guest had laid it, and took nothing off (%d reads):\n%s",
+			reads, strings.Join(f.commands(), "\n"))
+	}
+}
+
+// TestARestartStillReconcilesWhenTheGuestNeverLaysItsRoutedNIC: the wait is
+// bounded, and when it expires the device is still put on the interface and
+// the wait is reported — a routed NIC with nothing on it is what an operator
+// will ask about, and a start that hangs is not an answer.
+func TestARestartStillReconcilesWhenTheGuestNeverLaysItsRoutedNIC(t *testing.T) {
+	f := &fakeRuntime{}
+	restartedInstanceCarrying(f, launchRouted, "")
+	d := ovnDriver(f)
+	d.routePoll = time.Millisecond
+	d.routeBudget = 5 * time.Millisecond
+
+	err := d.restoreGuestNetwork(context.Background(), "srv")
+	if err == nil {
+		t.Fatal("a guest that never laid its routed NIC was not reported")
+	}
+	for _, want := range []string{"srv", "eth0"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the report does not name %q: %v", want, err)
+		}
+	}
+	if len(f.matching("exec srv -- ip address add 203.0.113.7/32 dev eth0")) == 0 {
+		t.Errorf("the expired wait left the routed NIC bare instead of laying the device on it:\n%s",
+			strings.Join(f.commands(), "\n"))
+	}
+	if got := f.matching("ip address del"); len(got) != 0 {
+		t.Errorf("nothing was carried and something was taken off:\n%s", strings.Join(got, "\n"))
+	}
+}
+
+// TestARestartLeavesAForeignRoutedNICAlone: ownership at the device. The
+// driver names its routed NIC routedDeviceName; one an operator added by hand
+// under another name is theirs, and no command names it.
+func TestARestartLeavesAForeignRoutedNICAlone(t *testing.T) {
+	const foreign = `{
+	  "devices": {
+	    "wan0": {"type": "nic", "nictype": "routed", "ipv4.address": "198.51.100.9", "ipv4.host_address": "169.254.0.1"}
+	  },
+	  "expanded_devices": {
+	    "wan0": {"type": "nic", "nictype": "routed", "ipv4.address": "198.51.100.9", "ipv4.host_address": "169.254.0.1"}
+	  }
+	}`
+	f := &fakeRuntime{}
+	restartedInstance(f, foreign)
+	d := ovnDriver(f)
+
+	if _, err := d.Start(context.Background(), Spec{Name: "srv", Image: "ubuntu:22.04"}); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if got := f.matching("wan0"); len(got) != 0 {
+		t.Errorf("the restart reconfigured a routed NIC the driver did not add:\n%s", strings.Join(got, "\n"))
+	}
+}

--- a/tools/falsify/specs/a-restart-reconciles-the-routed-nic.json
+++ b/tools/falsify/specs/a-restart-reconciles-the-routed-nic.json
@@ -1,0 +1,47 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "the first boot lays the routed NIC again, and the guest's network stack manages nothing while it waits (#674, measured 2026-09-04)",
+      "file": "internal/core/machine/incus_ovn.go",
+      "find": "\t// TestAFirstBootLeavesTheRoutedNICToTheGuestsOwnConfig fails without this.\n\tfor _, device := range names {",
+      "replace": "\t// TestAFirstBootLeavesTheRoutedNICToTheGuestsOwnConfig fails without this.\n\tif err := d.reconcileRoutedNICs(ctx, machine, devices); err != nil {\n\t\treturn err\n\t}\n\tfor _, device := range names {",
+      "test": "TestAFirstBootLeavesTheRoutedNICToTheGuestsOwnConfig"
+    },
+    {
+      "label": "the guest's boot-time config names eth0 without its address, so the interface comes up bare (#674)",
+      "file": "internal/core/machine/incus_routed.go",
+      "find": "\t\tfmt.Fprintf(&b, \"        - %s/32\\n\", parsed.String())",
+      "replace": "\t\tfmt.Fprintf(&b, \"        - %s/32\\n\"[:0], parsed.String())",
+      "test": "TestTheRoutedNetplanDeclaresTheLaunchAddress"
+    },
+    {
+      "label": "the restart never reconciles the routed NIC, and the migrated address the guest put back stays (#674)",
+      "file": "internal/core/machine/incus_ovn.go",
+      "find": "\tif err := d.reconcileRoutedNICs(ctx, machine, devices); err != nil {\n\t\trouted = fmt.Errorf(\"reconcile the routed interface of %s: %w\", machine, err)\n\t}",
+      "replace": "\tif err := d.reconcileRoutedNICs(ctx, machine, instanceView{}); err != nil && devices.own != nil {\n\t\trouted = fmt.Errorf(\"reconcile the routed interface of %s: %w\", machine, err)\n\t}",
+      "test": "TestARestartReconcilesTheRoutedNICToItsDevice"
+    },
+    {
+      "label": "every address the guest carries reads as wanted, so nothing migrated is ever taken off (#674)",
+      "file": "internal/core/machine/incus_ovn.go",
+      "find": "\t\tif wanted[address] {\n\t\t\tcontinue\n\t\t}",
+      "replace": "\t\tif wanted[address] || true {\n\t\t\tcontinue\n\t\t}",
+      "test": "TestARestartReconcilesTheRoutedNICToItsDevice"
+    },
+    {
+      "label": "the reconciliation does not wait for the guest to lay the interface, reads it bare, and takes nothing off (#674)",
+      "file": "internal/core/machine/incus_ovn.go",
+      "find": "\t\twaited := d.waitForGuestInterface(ctx, machine, device)",
+      "replace": "\t\twaited := func() error { _ = d.waitForGuestInterface; _, _, _ = ctx, machine, device; return nil }()",
+      "test": "TestARestartWaitsForTheGuestToLayItsRoutedNICBeforeReconciling"
+    },
+    {
+      "label": "the restart reconciles every routed NIC, an operator's included (#674)",
+      "file": "internal/core/machine/incus_ovn.go",
+      "find": "\t\tif cfg[\"type\"] != \"nic\" || cfg[\"nictype\"] != \"routed\" || device != routedDeviceName {\n\t\t\tcontinue\n\t\t}",
+      "replace": "\t\tif cfg[\"type\"] != \"nic\" || cfg[\"nictype\"] != \"routed\" || (device != routedDeviceName && false) {\n\t\t\tcontinue\n\t\t}",
+      "test": "TestARestartLeavesAForeignRoutedNICAlone"
+    }
+  ]
+}

--- a/tools/falsify/specs/lifecycle-tells-the-truth.json
+++ b/tools/falsify/specs/lifecycle-tells-the-truth.json
@@ -11,7 +11,7 @@
   "package": "./internal/core/machine/",
   "mutations": [
     {
-      "label": "#547: a reboot stops taking the machine down, so the action answers success and the runtime \u2014 which refuses to relaunch a name it has already served \u2014 does nothing at all",
+      "label": "#547: a reboot stops taking the machine down, so the action answers success and the runtime — which refuses to relaunch a name it has already served — does nothing at all",
       "file": "internal/core/machine/plan.go",
       "find": "\tif res.State == r.binding().RunningState {\n\t\tr.binding().PowerOff(ctx, res)\n\t}",
       "replace": "\tif res.State == r.binding().RunningState && false {\n\t\tr.binding().PowerOff(ctx, res)\n\t}",
@@ -25,7 +25,7 @@
       "test": "TestARebootOfAStoppedMachineDoesNotStopItAgain"
     },
     {
-      "label": "#547 across the packs: Scaleway's reboot calls the start alone again, which is the defect verbatim \u2014 the three other packs go on asking the runtime for a stop and the sequences diverge",
+      "label": "#547 across the packs: Scaleway's reboot calls the start alone again, which is the defect verbatim — the three other packs go on asking the runtime for a stop and the sequences diverge",
       "file": "internal/providers/scaleway/servers.go",
       "package": "./internal/providers/",
       "find": "\t\tp.rebootMachine(r.Context(), res)",
@@ -56,12 +56,12 @@
     {
       "label": "#549, the diagnosis: a guest that never finishes configuring its interface is no longer reported by the wait, so the failure an operator reads names the network rather than the machine and the device that could not be repaired",
       "file": "internal/core/machine/incus_ovn.go",
-      "find": "\t\tif err := d.waitForGuestInterface(ctx, machine, device); err != nil {\n\t\t\treturn err\n\t\t}",
-      "replace": "\t\tif err := d.waitForGuestInterface(ctx, machine, device); err != nil && false {\n\t\t\treturn err\n\t\t}",
+      "find": "\t\tif err := d.waitForGuestInterface(ctx, machine, device); err != nil {\n\t\t\treturn errors.Join(routed, err)\n\t\t}",
+      "replace": "\t\tif err := d.waitForGuestInterface(ctx, machine, device); err != nil && false {\n\t\t\treturn errors.Join(routed, err)ors.Join(routed, err)\n\t\t}",
       "test": "TestAGuestThatNeverConfiguresItsInterfaceIsReported"
     },
     {
-      "label": "#498, since #548: the address is no longer released from the routed NIC before the uplink is asked for the same /32, which is the `file exists` that shouted an ERROR over a correct host \u2014 and the published address stays where no rule set reaches it",
+      "label": "#498, since #548: the address is no longer released from the routed NIC before the uplink is asked for the same /32, which is the `file exists` that shouted an ERROR over a correct host — and the published address stays where no rule set reaches it",
       "file": "internal/core/machine/incus_address.go",
       "find": "\tif routed != \"\" {",
       "replace": "\tif routed != \"\" && false {",

--- a/tools/falsify/specs/public-address-migration.json
+++ b/tools/falsify/specs/public-address-migration.json
@@ -55,8 +55,8 @@
     {
       "label": "a restarted machine is left waiting for a lease nobody offers, so it comes back with neither its private address nor its routes",
       "file": "internal/core/machine/incus_ovn.go",
-      "find": "\t\tif err := d.restorePinnedAddress(ctx, machine, device, devices.own[device]); err != nil {\n\t\t\treturn err\n\t\t}",
-      "replace": "\t\tif false {\n\t\t\tif err := d.restorePinnedAddress(ctx, machine, device, devices.own[device]); err != nil {\n\t\t\t\treturn err\n\t\t\t}\n\t\t}",
+      "find": "\t\tif err := d.restorePinnedAddress(ctx, machine, device, devices.own[device]); err != nil {\n\t\t\treturn errors.Join(routed, err)\n\t\t}",
+      "replace": "\t\tif false {\n\t\t\tif err := d.restorePinnedAddress(ctx, machine, device, devices.own[device]); err != nil {\n\t\t\t\treturn errors.Join(routed, err)ors.Join(routed, err)\n\t\t\t}\n\t\t}",
       "test": "TestARestartedMachineGetsItsPinnedAddressBack"
     },
     {


### PR DESCRIPTION
A server created with a public address and no network boots on a routed
NIC (#202), declared statically in the network-config the launch hands
cloud-init: the address as a /32, the on-link default route through
169.254.0.1. cloud-init renders it once, at the first boot, into the
guest's /etc/netplan/50-cloud-init.yaml, and that file outlives every
edit the driver makes to the device afterwards.

Measured on 2026-09-04 under --vm incus-ovn, on a Scaleway server created
with 203.0.113.3 whose private NIC arrived hot and took the address with
it (#548):

  device eth0        nictype=routed, ipv4.address empty
  device eth1        ipv4.routes.external=203.0.113.3/32
  guest netplan      eth0: addresses [203.0.113.3/32], routes [0.0.0.0/0 via 169.254.0.1 on-link]
  after API reboot   eth0 203.0.113.3/32, eth1 10.30.1.10/24 + 203.0.113.3/32

WHAT THE FIRST TAKE BROKE, MEASURED. Two writers of one interface, and
the first take of this fix made the driver the only one: eth0 out of the
guest's config, laid by the driver after `incus start`. It passed the
Day-2 leg (shape identical across the reboot, broken 2 -> 0) and the
runtime leg (four suites green) and would have shipped. It broke the
first boot of a routed-only server, and only the ssh suite saw it. Same
day, same runtime, Ubuntu jammy:

  uptime 91 s    eth0 203.0.113.2/32 and its link route, no default route;
                 systemd-networkd-wait-online `activating` since boot;
                 network-online.target, cloud-init.service (network stage)
                 and ssh.service waiting behind it; /etc/ssh/ssh_host_*
                 absent (the images carry none; cloud-init's ssh module
                 generates them); `ss -ltn`: resolved's :53 alone
  uptime 181 s   cloud-init `done`, sshd listening, `nc 22` succeeded;
                 still no default route
  main's driver  the same suite logged in within twenty seconds

With no interface matched by the guest's own network config,
systemd-networkd manages nothing and wait-online waits out its 120 s
ceiling; the ssh suite gives up at 90 s. Whoever touches the routed NIC's
netplan next meets this measurement first: eth0 must stay declared, and
managed by the guest.

WHY TWO LEGS OUT OF THREE DID NOT SEE IT. The runtime leg and the Day-2
leg boot machines and dial their services from the station, and never
log into one; the routed-only shape they boot answers on 443 through a
unit cloud-init starts late enough not to matter to them. The real login
lives in `mise run conformance:ssh`, which is outside the `conformance`
aggregate by construction (it needs a machine runtime, and the aggregate
must run without one in CI). The runtime leg has needed a runtime since
#459, so it could carry that login; it does not yet, and that is a
coverage hole, named here so the next reader does not deduce that two
green legs prove a first boot.

So the two writers stay, in a fixed order. The guest's config lays eth0
at every boot, with the addresses the launch pinned, exactly as before.
The restart path (restoreGuestNetwork, reconcileRoutedNICs) then waits,
bounded, for the guest to carry an address on the interface, takes off
every address the device neither pins (ipv4.address) nor routes
(ipv4.routes), and puts back what it does through the repair a re-plug
already gets (repairRoutedInterface): the link-local next hop and the
default route through it, idempotently. When the wait expires the
reconciliation still runs and the wait is reported, joined to the managed
NICs' own report rather than in front of it. The first boot is left to
the guest, on purpose, and TestAFirstBootLeavesTheRoutedNICToTheGuestsOwnConfig
holds that nothing writes eth0 there.

The claim that changed, with its reason where the next reader meets it:
TestARestartedMachineGetsItsPinnedAddressBack held that the restart path
does NOT configure the routed NIC's address ("the guest's boot-time
config declares it"); it now holds that the restart reconciles it. And
TestABridgeModeRestartLaysNoAggregates names the aggregates instead of
every route, since the routed NIC's door is laid in both modes.

Measured on a fake runtime that answers per interface
(TestTheRoutedNetplanDeclaresTheLaunchAddress,
TestAFirstBootLeavesTheRoutedNICToTheGuestsOwnConfig,
TestARestartReconcilesTheRoutedNICToItsDevice,
TestARestartKeepsTheAddressTheRoutedNICStillPins,
TestARestartWaitsForTheGuestToLayItsRoutedNICBeforeReconciling,
TestARestartStillReconcilesWhenTheGuestNeverLaysItsRoutedNIC,
TestARestartLeavesAForeignRoutedNICAlone); the six mutations of
tools/falsify/specs/a-restart-reconciles-the-routed-nic.json bite.

Measured live, 2026-09-04 13:42, --vm incus-ovn, the station empty before
and after: `mise run conformance:ssh` behind `feint start -cleanup` logged
into all three (Scaleway root at 203.0.113.2, Outscale, Exoscale), where
the first take failed the Scaleway login twice at 90 s. And the Day-2
leg, on the #667-#673 stack with #675 and this commit cherry-picked
(13:43-13:51): platform-web-0 carries after 44 Day-2 writes exactly what
it carried before the restart, verification held=49 broken=0
unreadable=0 repaired=0. That leg stays red on its last gate — nothing
answers at 203.0.113.3:443 from the station — which is #660 (an on-link
/32 to the DHCP-announced DNS server, laid by the guest's networkd), present
on main and untouched here.

Driver-only: this commit depends on nothing of the #667-#673 stack.

Assisted-by: Claude Code (claude-fable-5-1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
