### PR TITLE
feat(machine): a plan that claims the default route twice is refused before the runtime is asked (#667)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -58,6 +58,32 @@ change ni l'un ni l'autre a sa place dans `git log`.
   lb certificate list` et `scw lb subscriber list` dans la suite de
   conformance.
 
+- **Un plan qui revendique deux fois la route par défaut est refusé avant
+  toute demande au runtime** (#667). `Reconciler.Expect` dérive, du plan
+  déclaré, qui revendique quelle propriété : une adresse publique possède la
+  sortie, `Plan.Egress` la revendique, `NoEgress` la revendique, et une
+  propriété qui a plus d'un revendicateur refuse le démarrage en nommant chacun
+  d'eux, et publie l'état d'échec du pack comme le fait un plan absent. Sur les
+  portes chaudes (une adresse routée, un réseau rejoint), c'est l'étape qui
+  exécuterait la contradiction qui est refusée, et la route que la machine
+  porte est laissée en place.
+
+  C'est la garde de la couche pour #660 : le 2026-09-04, l'étape d'egress a
+  remplacé, par `ip route replace`, la route par défaut que l'adresse routée
+  avait posée, chaque exec a rendu 0, et la machine ne répondait plus à son
+  adresse publiée. Le correctif côté pack reste ; ceci empêche un quatrième
+  pack, ou une évolution de celui-ci, d'écrire la même contradiction sans
+  qu'aucun test ne bouge.
+
+  Ce qu'un plan cohérent revendique est rendu sous forme de revendications
+  typées, chacune avec sa tolérance (le masque seulement si le plan l'a dit,
+  n'importe quelle adresse du bloc pour un bail DHCP, les agrégats via une
+  passerelle du plan), jugées contre une `Shape` à trois issues : tenue, rompue,
+  illisible. La porte par laquelle sort la réponse d'une adresse publique est
+  une mesure et l'une des deux formes n'en a pas (#672) : la dérivation n'en
+  affirme aucune valeur, silence plutôt que devinette. La lecture qui remplit
+  une `Shape` depuis le runtime est #668.
+
 - **Flexible GPU est servi, toute la famille** (#619) : `osc/Client.ReadFlexibleGpuCatalog`,
   `osc/Client.CreateFlexibleGpu`, `osc/Client.ReadFlexibleGpus`,
   `osc/Client.UpdateFlexibleGpu`, `osc/Client.DeleteFlexibleGpu`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,30 @@ what this project is judged on: **a response shape a client can observe**, and
   Driven by `scw lb backend list-statistics`, `scw lb lb get-stats`, `scw lb
   certificate list` and `scw lb subscriber list` in the conformance suite.
 
+- **A plan that claims the default route twice is refused before the runtime
+  is asked for anything** (#667). `Reconciler.Expect` derives, from the
+  declared plan, who claims which property: a public address owns the way out,
+  `Plan.Egress` claims it, `NoEgress` claims it, and a property with more than
+  one claimant refuses the boot with every claimant named, publishing the
+  pack's own failed state the way a missing plan does. On the hot doors (an
+  address routed, a network joined) the step that would execute the
+  contradiction is refused instead, and the route the machine has is left
+  alone.
+
+  This is the layer's guard for #660: on 2026-09-04 the egress step replaced,
+  with `ip route replace`, the default route the routed address had laid, every
+  exec returned 0, and the machine answered nothing at its published address.
+  The pack-side fix stands; this is what stops a fourth pack, or a change in
+  this one, from writing the same contradiction and no test moving.
+
+  What a consistent plan claims is returned as typed claims, each with its own
+  tolerance (the mask only when the plan said one, any address of the block for
+  a DHCP lease, the aggregates via a gateway of the plan), answered against a
+  `Shape` with three outcomes: held, broken, unreadable. Which door a reply
+  leaves by for a public address is a measurement and one shape has none
+  (#672), so the derivation states no value for it: silence, not a guess. The
+  reading that fills a `Shape` from the runtime is #668.
+
 - **Flexible GPU is served, the whole family** (#619): `osc/Client.ReadFlexibleGpuCatalog`,
   `osc/Client.CreateFlexibleGpu`, `osc/Client.ReadFlexibleGpus`,
   `osc/Client.UpdateFlexibleGpu`, `osc/Client.DeleteFlexibleGpu`,

--- a/internal/core/machine/claims.go
+++ b/internal/core/machine/claims.go
@@ -1,0 +1,481 @@
+package machine
+
+import (
+	"fmt"
+	"net/netip"
+	"slices"
+	"strings"
+)
+
+// A Plan is a recipe, and two of its steps can claim the same property without
+// anything noticing (#667).
+//
+// RouteAddress lays a machine's default route towards the routed next hop
+// (routedNetworkConfig, repairRoutedInterface). installGuestDefaultRoute
+// replaces it with the gateway of the network Plan.Egress names. Both run
+// inside the Reconciler, both succeed, every exec returns 0 — and on a Scaleway
+// server holding a public address AND a private NIC the second overwrote the
+// first. Measured 2026-09-04 under `--vm incus-ovn`:
+//
+//	default via 10.77.0.1 dev eth0        <- the private gateway
+//	eth0 carries 10.77.0.2/24 and 203.0.113.2/32
+//	from the station: nothing
+//
+// #660 is that failure seen from the far end, two steps later, as "nothing
+// answers at 203.0.113.4:443". Its fix lives in the pack: egressNetworkOf
+// claims nothing when a public address is present. The layer had no guard, so
+// a fourth pack — or a change in this one — reintroduces the contradiction and
+// no test moves.
+//
+// This file is the guard, in two halves. Expect walks the plan and records
+// WHO claims WHAT; a property with more than one claimant refuses the plan
+// before the runtime is asked for anything, which makes it the cheapest of the
+// three controls the series builds. And what Expect returns on a consistent
+// plan is the list of claims a later reading answers (#668), each with its own
+// tolerance built in, so that a lease renewed or a metric changed never reads
+// as a defect.
+//
+// No provider is named here and none can be: the plan is the pack's, the
+// dialect is the driver's, and this file knows only the two.
+
+// Outcome is what one claim answered against a Shape. Three, never two: a
+// read that failed is neither held nor broken, and folding it onto either is
+// how a verifier starts lying.
+type Outcome int
+
+const (
+	// Held: the runtime carries what the plan claims.
+	Held Outcome = iota
+	// Broken: it carries something else, and the verdict says what.
+	Broken
+	// Unreadable: the fact could not be read, so nothing is known about it.
+	Unreadable
+)
+
+// String names the outcome the way the counters on /_feint/health spell it.
+func (o Outcome) String() string {
+	switch o {
+	case Held:
+		return "held"
+	case Broken:
+		return "broken"
+	case Unreadable:
+		return "unreadable"
+	}
+	return fmt.Sprintf("outcome(%d)", int(o))
+}
+
+// Verdict is one claim's answer.
+type Verdict struct {
+	// Claim names the claim, as its String() spells it.
+	Claim string
+	// Outcome is what the comparison found.
+	Outcome Outcome
+	// Want is what the plan claimed, rendered.
+	Want string
+	// Got is what the runtime carried instead, or why it could not be read.
+	Got string
+}
+
+// String renders a verdict the way the log and the resource cite it.
+func (v Verdict) String() string {
+	switch v.Outcome {
+	case Held:
+		return v.Claim + " held"
+	case Unreadable:
+		return v.Claim + " unreadable: " + v.Got
+	}
+	return v.Claim + " broken: want " + v.Want + ", got " + v.Got
+}
+
+func held(c Claim) Verdict { return Verdict{Claim: c.String(), Outcome: Held} }
+
+func broken(c Claim, want, got string) Verdict {
+	return Verdict{Claim: c.String(), Outcome: Broken, Want: want, Got: got}
+}
+
+func unreadable(c Claim, why string) Verdict {
+	return Verdict{Claim: c.String(), Outcome: Unreadable, Got: why}
+}
+
+// Claim is one property a plan states about the machine. Each kind carries
+// its own comparator, and the tolerance lives in the comparator rather than
+// in a shared ignore list: this is where "a route DHCP laid arrives later" and
+// "a metric differs" stop being differences.
+type Claim interface {
+	// Check answers the claim against what the runtime reported.
+	Check(Shape) Verdict
+	// String names the claim, the way a verdict cites it.
+	String() string
+}
+
+// Dialect is what a driver mode knows about itself and the derivation needs:
+// a field, not a convention, and no provider name anywhere near it.
+//
+// Pure on purpose. The first sketch carried a Gateway func here, so that a
+// claim could resolve a network's gateway while it was derived; that would
+// have made Expect query the runtime, and #667 is the control that exists
+// because it asks the runtime for nothing. The gateways travel in the Shape
+// instead (Shape.Gateways, read by the observer), and a claim that needs one
+// resolves it at Check time.
+type Dialect struct {
+	// RoutedNextHop is the link-local next hop a routed NIC reaches the host
+	// through: 169.254.0.1 on Incus.
+	RoutedNextHop netip.Addr
+	// Aggregates are the private blocks this mode routes towards the network's
+	// own router on every managed interface — the three RFC 1918 aggregates
+	// under OVN (installGuestPrivateRoutes), nothing under a bridge, which has
+	// no router of its own. A list rather than a flag, so the claim compares
+	// what the driver lays and not a copy of it.
+	Aggregates []netip.Prefix
+	// LaysDefaultRoute says whether RouteEgress and DropEgress do anything in
+	// this mode. Under a bridge both answer nil without touching the guest —
+	// the host routes for it — so a default-route claim there would judge a
+	// route nobody was asked to lay.
+	LaysDefaultRoute bool
+}
+
+// Dialected is the optional half of a driver that declares its Dialect, on
+// the model of Capable and EgressRouter: a driver that does not is read as a
+// zero Dialect, which claims nothing mode-dependent and refuses nothing less.
+type Dialected interface {
+	Dialect() Dialect
+}
+
+// dialect asks the runtime for its Dialect, or answers the zero one.
+func (r Reconciler) dialect() Dialect {
+	d, ok := r.binding().driver.(Dialected)
+	if !ok {
+		return Dialect{}
+	}
+	return d.Dialect()
+}
+
+// propertyDefaultRoute names the property two steps of the recipe claimed on
+// 2026-09-04.
+const propertyDefaultRoute = "the default route"
+
+// Expect derives the claims a plan makes, and refuses a plan whose steps
+// contradict each other — before the runtime is asked for anything.
+//
+// Who may claim the default route, and why a public address claims it with no
+// value beside it. A machine holding a public address has a way out already:
+// on the routed shape RouteAddress lays it, and on the shape where the address
+// rides a managed NIC the network's own router carries it. Which door a reply
+// leaves by on each shape is a MEASUREMENT, not a deduction, and one of the two
+// shapes has never been measured (#672). So the public address is registered
+// as the route's owner — which is what refuses a second owner — and no claim
+// states its value. Silence, not a guess: a verifier that invented its expected
+// values would be a second reconciler, wrong with the same confidence as the
+// first.
+//
+// TestAPlanWithTwoClaimantsToTheDefaultRouteIsRefusedBeforeTheRuntimeIsAsked
+// fails without the refusal, and TestAPublicAddressAloneClaimsNoValueForTheDefaultRoute
+// holds the silence.
+func (r Reconciler) Expect(plan Plan, d Dialect) ([]Claim, error) {
+	var claims []Claim
+	owners := ledger{}
+
+	// One interface per network. Boot and Memberships are two doors onto one
+	// shape, and the same network reached through both is one interface asked
+	// for twice: the first would ride the launch as the primary, the second
+	// would be attached after it, and nothing says which address it carries.
+	var networks []string
+	for _, att := range plan.attachments() {
+		if att.Network == "" {
+			// No backing network: the membership is true in the store and the
+			// interface arrives with a later boot, exactly as attach reads it.
+			continue
+		}
+		owners.claim("the interface on "+att.Network, att.describe())
+		if slices.Contains(networks, att.Network) {
+			continue
+		}
+		networks = append(networks, att.Network)
+		if att.Address == "" {
+			// DHCP owns this interface (#202): the claim is an address of the
+			// block, never a particular one.
+			claims = append(claims, leases{Network: att.Network})
+			continue
+		}
+		for _, address := range append([]string{att.Address}, att.Secondary...) {
+			addr, err := netip.ParseAddr(address)
+			if err != nil {
+				// A stored address is untrusted input; one that is not an
+				// address refuses the plan here rather than reaching a device
+				// key.
+				return nil, fmt.Errorf("the attachment on %s names %q, which is not an address: %w",
+					att.Network, address, err)
+			}
+			claims = append(claims, carries{Network: att.Network, Address: addr, Bits: att.PrefixLen})
+		}
+	}
+
+	// The promised public addresses. Each is carried as a /32 wherever it
+	// lands — the routed NIC's own, or the filtered NIC it moved onto (#548) —
+	// so the claim names no interface. An address outside the pack's block is
+	// one the layer never routes (route() refuses it), so it claims nothing.
+	var publics []string
+	for _, address := range plan.Publics {
+		addr, err := netip.ParseAddr(address)
+		if err != nil || !r.emulated(address) {
+			continue
+		}
+		if slices.Contains(publics, addr.String()) {
+			continue
+		}
+		publics = append(publics, addr.String())
+		claims = append(claims, carries{Address: addr, Bits: 32})
+	}
+	if len(publics) > 0 {
+		owners.claim(propertyDefaultRoute, "the public address "+strings.Join(publics, ", "))
+	}
+
+	// The way out the pack states, in the three-state model #660 gave the
+	// plan: a network to leave through, a refusal, or silence. Only the first
+	// two claim; and they claim a value only where the driver lays one.
+	if plan.Egress != "" {
+		owners.claim(propertyDefaultRoute, "egress through "+plan.Egress)
+		if d.LaysDefaultRoute {
+			claims = append(claims, defaultRoute{Network: plan.Egress})
+		}
+	}
+	if plan.NoEgress {
+		owners.claim(propertyDefaultRoute, "the refusal of any way out (NoEgress)")
+		if d.LaysDefaultRoute {
+			claims = append(claims, noDefaultRoute{})
+		}
+	}
+
+	// The private aggregates, on every mode that lays them, once per machine
+	// rather than once per interface: two managed NICs each lay the same three
+	// blocks and the kernel keeps the first, so the claim is that each block
+	// rides A gateway of the plan, not every one.
+	if len(d.Aggregates) > 0 && len(networks) > 0 {
+		claims = append(claims, reachesAggregates{Blocks: d.Aggregates, Networks: networks})
+	}
+
+	if err := owners.contradiction(); err != nil {
+		return nil, err
+	}
+	return claims, nil
+}
+
+// attachments is every interface the plan declares, the launch's first.
+func (p Plan) attachments() []Attachment {
+	out := make([]Attachment, 0, len(p.Boot)+len(p.Memberships))
+	out = append(out, p.Boot...)
+	return append(out, p.Memberships...)
+}
+
+// describe names an attachment as a claimant: the network and the address, so
+// a contradiction reads as what it is.
+func (a Attachment) describe() string {
+	if a.Address == "" {
+		return "an attachment on " + a.Network + " leased by DHCP"
+	}
+	return "an attachment on " + a.Network + " at " + a.Address
+}
+
+// ledger records who claims which property. It exists so that the refusal
+// names every claimant rather than the last one found.
+type ledger map[string][]string
+
+func (l ledger) claim(property, who string) {
+	if slices.Contains(l[property], who) {
+		// The same claimant twice is a duplicate, not a contradiction: a
+		// plan listing one attachment two times asks for one interface.
+		return
+	}
+	l[property] = append(l[property], who)
+}
+
+// contradiction names every property with more than one claimant, or nothing.
+func (l ledger) contradiction() error {
+	properties := make([]string, 0, len(l))
+	for property := range l {
+		properties = append(properties, property)
+	}
+	slices.Sort(properties)
+	var parts []string
+	for _, property := range properties {
+		claimants := l[property]
+		if len(claimants) < 2 {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s is claimed %d times, by %s",
+			property, len(claimants), strings.Join(claimants, " and by ")))
+	}
+	if len(parts) == 0 {
+		return nil
+	}
+	return fmt.Errorf("the plan contradicts itself: %s", strings.Join(parts, "; "))
+}
+
+// carries claims that an interface carries an address. Network empty means
+// any interface; Bits zero means the plan did not say the mask, which leaves
+// it unjudged rather than guessed — and a mask the plan did say is compared
+// exactly, because /24 and /32 are not the same address to the kernel: a /32
+// has no connected route to its own subnet (restorePinnedAddress).
+type carries struct {
+	Network string
+	Address netip.Addr
+	Bits    int
+}
+
+func (c carries) String() string {
+	where := c.Network
+	if where == "" {
+		where = "any interface"
+	}
+	if c.Bits == 0 {
+		return fmt.Sprintf("carries(%s, %s)", where, c.Address)
+	}
+	return fmt.Sprintf("carries(%s, %s/%d)", where, c.Address, c.Bits)
+}
+
+func (c carries) want() string {
+	if c.Bits == 0 {
+		return c.Address.String()
+	}
+	return fmt.Sprintf("%s/%d", c.Address, c.Bits)
+}
+
+func (c carries) Check(s Shape) Verdict {
+	var candidates []string
+	for _, name := range s.interfaceNames() {
+		iface := s.Interfaces[name]
+		if c.Network != "" && iface.Network != c.Network {
+			continue
+		}
+		candidates = append(candidates, name)
+		for _, p := range iface.Addresses {
+			if p.Addr() == c.Address && (c.Bits == 0 || p.Bits() == c.Bits) {
+				return held(c)
+			}
+		}
+	}
+	if len(candidates) == 0 {
+		return broken(c, c.want(), "no interface on "+c.Network)
+	}
+	return broken(c, c.want(), s.carriedBy(candidates))
+}
+
+// leases claims that the interface on a network carries an address of that
+// network's block — any address: DHCP chose it, and the plan never said which.
+type leases struct {
+	Network string
+}
+
+func (c leases) String() string { return "leases(" + c.Network + ")" }
+
+func (c leases) Check(s Shape) Verdict {
+	gateway, read := s.Gateways[c.Network]
+	if !read {
+		return unreadable(c, "the block of "+c.Network+" was not read")
+	}
+	block := gateway.Masked()
+	dev := s.interfaceOn(c.Network)
+	if dev == "" {
+		return broken(c, "an address of "+block.String(), "no interface on "+c.Network)
+	}
+	for _, p := range s.Interfaces[dev].Addresses {
+		if block.Contains(p.Addr()) {
+			return held(c)
+		}
+	}
+	return broken(c, "an address of "+block.String()+" on "+dev, s.carriedBy([]string{dev}))
+}
+
+// defaultRoute claims that the machine's default route leaves through the
+// gateway of a network, on the interface that sits on it — the value
+// RouteEgress lays (#647).
+type defaultRoute struct {
+	Network string
+}
+
+func (c defaultRoute) String() string { return "default route" }
+
+func (c defaultRoute) Check(s Shape) Verdict {
+	gateway, read := s.Gateways[c.Network]
+	if !read {
+		return unreadable(c, "the gateway of "+c.Network+" was not read")
+	}
+	dev := s.interfaceOn(c.Network)
+	if dev == "" {
+		return broken(c, "via "+gateway.Addr().String()+" on the interface of "+c.Network,
+			"no interface on "+c.Network)
+	}
+	want := Route{Dst: defaultDst, Via: gateway.Addr(), Dev: dev}
+	got, has := s.defaultRoute()
+	if !has {
+		return broken(c, want.String(), "no default route")
+	}
+	if got.Via == want.Via && got.Dev == want.Dev {
+		return held(c)
+	}
+	return broken(c, want.String(), got.String())
+}
+
+// noDefaultRoute claims that the machine has no way out at all — the state
+// DropEgress leaves, for a machine the cloud lets nowhere (#660).
+type noDefaultRoute struct{}
+
+func (noDefaultRoute) String() string { return "no default route" }
+
+func (c noDefaultRoute) Check(s Shape) Verdict {
+	if got, has := s.defaultRoute(); has {
+		return broken(c, "no default route", got.String())
+	}
+	return held(c)
+}
+
+// reachesAggregates claims that every private aggregate rides a gateway of one
+// of the plan's networks, on that network's interface: the routes towards the
+// peered subnets (#549), announced by the network and laid by the driver.
+type reachesAggregates struct {
+	Blocks   []netip.Prefix
+	Networks []string
+}
+
+func (c reachesAggregates) String() string { return "private aggregates" }
+
+func (c reachesAggregates) Check(s Shape) Verdict {
+	// Which next hops are legitimate: each gateway on its own interface.
+	doors := map[netip.Addr]string{}
+	for _, network := range c.Networks {
+		gateway, read := s.Gateways[network]
+		if !read {
+			return unreadable(c, "the gateway of "+network+" was not read")
+		}
+		if dev := s.interfaceOn(network); dev != "" {
+			doors[gateway.Addr()] = dev
+		}
+	}
+	want := "each of " + prefixes(c.Blocks) + " via a gateway of " + strings.Join(c.Networks, ", ")
+	if len(doors) == 0 {
+		return broken(c, want, "no interface on any of "+strings.Join(c.Networks, ", "))
+	}
+	var missing []string
+	for _, block := range c.Blocks {
+		if !slices.ContainsFunc(s.Routes, func(r Route) bool {
+			dev, legitimate := doors[r.Via]
+			return r.Dst == block && legitimate && r.Dev == dev
+		}) {
+			missing = append(missing, block.String()+": "+s.routesTo(block))
+		}
+	}
+	if len(missing) > 0 {
+		return broken(c, want, strings.Join(missing, "; "))
+	}
+	return held(c)
+}
+
+// prefixes renders a list of blocks for a verdict.
+func prefixes(blocks []netip.Prefix) string {
+	out := make([]string, 0, len(blocks))
+	for _, b := range blocks {
+		out = append(out, b.String())
+	}
+	return strings.Join(out, ", ")
+}

--- a/internal/core/machine/claims_test.go
+++ b/internal/core/machine/claims_test.go
@@ -1,0 +1,476 @@
+package machine
+
+import (
+	"context"
+	"net/netip"
+	"strings"
+	"testing"
+)
+
+// The guard of #667: a plan two of whose steps claim the same property is
+// refused before the runtime is asked for anything, and what a consistent plan
+// claims is answered against a Shape with three outcomes.
+//
+// The Recorder is the instrument for the first half: with the guard removed it
+// records Start, RouteAddress and the rest, and the assertion on an empty
+// sequence bites. Hand-built Shapes are the instrument for the second: a
+// comparator is a pure function of a claim and a Shape, so a Shape written by
+// the test is the exact fixture, with nothing between it and the verdict.
+
+// egressRecorder is the contract recorder with the egress half, which the
+// recorder itself deliberately lacks: adding RouteEgress to its vocabulary
+// would change the sequences the cross-pack equivalence compares. It also
+// declares a Dialect that lays a default route, so the derivation claims one.
+type egressRecorder struct {
+	*Recorder
+	laid []string
+}
+
+func (e *egressRecorder) RouteEgress(_ context.Context, machine, network string) error {
+	e.laid = append(e.laid, "RouteEgress "+machine+" via "+network)
+	return nil
+}
+
+func (e *egressRecorder) DropEgress(_ context.Context, machine string) error {
+	e.laid = append(e.laid, "DropEgress "+machine)
+	return nil
+}
+
+func (e *egressRecorder) Dialect() Dialect { return Dialect{LaysDefaultRoute: true} }
+
+// egressReconciler is rebootReconciler over an egress-capable runtime.
+func egressReconciler(b *groupSyncBench, e *egressRecorder, plan Plan) Reconciler {
+	sync := b.sync()
+	sync.Binding.driver = e
+	sync.Binding.RunningState = "running"
+	sync.Binding.FailedState = "stopped"
+	return Reconciler{
+		Groups:      sync,
+		PlanOf:      func(*testResource) Plan { return plan },
+		PublicBlock: netip.MustParsePrefix("203.0.113.0/24"),
+	}
+}
+
+// deriver is a Reconciler with nothing but the block, which is all Expect
+// reads of it.
+func deriver() Reconciler {
+	return Reconciler{PublicBlock: netip.MustParsePrefix("203.0.113.0/24")}
+}
+
+// ovnDialect is the OVN driver's dialect, restated so these tests do not
+// depend on the Incus file: a routed next hop, the three aggregates, and a
+// default route the driver lays.
+func ovnDialect() Dialect {
+	return Dialect{
+		RoutedNextHop:    netip.MustParseAddr("169.254.0.1"),
+		Aggregates:       privateAggregatePrefixes(),
+		LaysDefaultRoute: true,
+	}
+}
+
+// claimNames renders the claims the way a verdict cites them, for assertions.
+func claimNames(claims []Claim) []string {
+	out := make([]string, 0, len(claims))
+	for _, c := range claims {
+		out = append(out, c.String())
+	}
+	return out
+}
+
+// TestAPlanWithTwoClaimantsToTheDefaultRouteIsRefusedBeforeTheRuntimeIsAsked
+// is the whole of #667 at the level where it can be held deterministically: a
+// public address owns the default route, an egress network claims it too, and
+// the runtime must never hear of the plan.
+func TestAPlanWithTwoClaimantsToTheDefaultRouteIsRefusedBeforeTheRuntimeIsAsked(t *testing.T) {
+	b := newGroupSyncBench()
+	vm := b.machine("m", "")
+	r := rebootReconciler(b, Plan{Publics: []string{"203.0.113.2"}, Egress: "fnt-x"})
+	if r.PowerOn(context.Background(), vm, Boot{Image: "ubuntu:24.04"}) {
+		t.Fatal("a plan that claims the default route twice was started")
+	}
+	if got := b.rec.Sequence(); len(got) != 0 {
+		t.Fatalf("the runtime was asked before the plan was judged: %v", got)
+	}
+	// And the state is the pack's own failed one, the way a missing plan
+	// publishes it (#543): a refused boot is not a running machine.
+	if vm.State != "stopped" {
+		t.Errorf("a refused plan left the state %q, want the pack's failed state", vm.State)
+	}
+}
+
+// The accepting half, which matters as much: one claimant is not a
+// contradiction, whichever of the three it is. A guard that refused
+// everything would pass the test above and prove nothing.
+func TestAPlanWithOneClaimantToTheDefaultRouteIsStarted(t *testing.T) {
+	for name, plan := range map[string]Plan{
+		"a public address": {Publics: []string{"203.0.113.2"}},
+		"an egress":        {Egress: "fnt-x"},
+		"a refusal":        {NoEgress: true},
+		"silence":          {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			b := newGroupSyncBench()
+			vm := b.machine("m", "")
+			r := rebootReconciler(b, plan)
+			if !r.PowerOn(context.Background(), vm, Boot{Image: "ubuntu:24.04"}) {
+				t.Fatalf("a plan with %s alone was refused; sequence: %v", name, b.rec.Sequence())
+			}
+			if firstOf(b.rec.Sequence(), "Start") < 0 {
+				t.Fatalf("the runtime was never asked to start the machine: %v", b.rec.Sequence())
+			}
+		})
+	}
+}
+
+// TestAContradictoryPlanNeverReachesTheEgressRouter is the hot half. A machine
+// already running cannot be refused a start; what is refused is the step that
+// executes the contradiction. The accepting half runs first, on the same
+// double, so an empty list cannot be a double that records nothing.
+func TestAContradictoryPlanNeverReachesTheEgressRouter(t *testing.T) {
+	b := newGroupSyncBench()
+	e := &egressRecorder{Recorder: b.rec}
+	vm := b.machine("m", "10.0.0.5")
+	vm.State = "running"
+
+	consistent := egressReconciler(b, e, Plan{Egress: "fnt-x"})
+	consistent.ReplayAddresses(context.Background(), vm)
+	if len(e.laid) != 1 || !strings.HasSuffix(e.laid[0], "via fnt-x") {
+		t.Fatalf("the double did not record the egress a consistent plan lays: %v", e.laid)
+	}
+	e.laid = nil
+
+	contradictory := egressReconciler(b, e, Plan{Publics: []string{"203.0.113.2"}, Egress: "fnt-x"})
+	contradictory.ReplayAddresses(context.Background(), vm)
+	if len(e.laid) != 0 {
+		t.Fatalf("a contradictory plan reached the egress router, which is the overwrite #660 measured: %v", e.laid)
+	}
+	// The public address itself is still routed: the refusal is of the step
+	// that contradicts, never of the machine's other claims.
+	if firstOf(b.rec.Sequence(), "RouteAddress") < 0 {
+		t.Fatalf("the public address was not routed on the hot path: %v", b.rec.Sequence())
+	}
+}
+
+// The refusal names every claimant, so an operator reads which two steps
+// disagree rather than which port stopped answering.
+func TestARefusalNamesEveryClaimant(t *testing.T) {
+	_, err := deriver().Expect(Plan{Publics: []string{"203.0.113.2"}, Egress: "fnt-x", NoEgress: true}, Dialect{})
+	if err == nil {
+		t.Fatal("three claimants to the default route were accepted")
+	}
+	for _, claimant := range []string{"203.0.113.2", "egress through fnt-x", "NoEgress"} {
+		if !strings.Contains(err.Error(), claimant) {
+			t.Errorf("the refusal does not name %q: %v", claimant, err)
+		}
+	}
+}
+
+// TestAPublicAddressAloneClaimsNoValueForTheDefaultRoute holds the silence
+// #672 asks for: which door a reply leaves by is a measurement, one of the two
+// shapes has none, and the derivation states no value it cannot know. The
+// address still claims its /32 — that half is measured on every shape.
+func TestAPublicAddressAloneClaimsNoValueForTheDefaultRoute(t *testing.T) {
+	claims, err := deriver().Expect(Plan{Publics: []string{"203.0.113.2"}}, ovnDialect())
+	if err != nil {
+		t.Fatalf("a public address alone was refused: %v", err)
+	}
+	names := claimNames(claims)
+	for _, name := range names {
+		if strings.Contains(name, "default route") || strings.Contains(name, "door") {
+			t.Errorf("the derivation states a value for the way out of a public address, which nobody measured: %v", names)
+		}
+	}
+	if len(names) != 1 || names[0] != "carries(any interface, 203.0.113.2/32)" {
+		t.Errorf("a public address claims exactly its /32 on some interface, got %v", names)
+	}
+}
+
+// An egress or a refusal claims a value only where the driver lays one: under
+// a bridge RouteEgress and DropEgress answer nil without touching the guest.
+func TestTheWayOutIsClaimedOnlyWhereTheDriverLaysIt(t *testing.T) {
+	bridge := Dialect{RoutedNextHop: netip.MustParseAddr("169.254.0.1")}
+	for name, plan := range map[string]Plan{"egress": {Egress: "fnt-x"}, "refusal": {NoEgress: true}} {
+		claims, err := deriver().Expect(plan, bridge)
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		if len(claims) != 0 {
+			t.Errorf("%s under a bridge claims %v, where the driver lays nothing", name, claimNames(claims))
+		}
+		claims, err = deriver().Expect(plan, ovnDialect())
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		if len(claims) != 1 {
+			t.Errorf("%s under OVN claims %v, want exactly the way out", name, claimNames(claims))
+		}
+	}
+}
+
+// One interface per network. The same network reached through Boot and
+// Memberships is one interface asked for twice, and a plan listing the same
+// attachment two times is a duplicate rather than a contradiction.
+func TestANetworkAskedForTwiceIsRefusedAndADuplicateIsNot(t *testing.T) {
+	both := Plan{
+		Boot:        []Attachment{{Network: "fnt-x", Address: "10.0.0.2"}},
+		Memberships: []Attachment{{Network: "fnt-x", Address: "10.0.0.3"}},
+	}
+	if _, err := deriver().Expect(both, Dialect{}); err == nil ||
+		!strings.Contains(err.Error(), "the interface on fnt-x") {
+		t.Fatalf("one network with two addresses was accepted: %v", err)
+	}
+	twice := Plan{Boot: []Attachment{{Network: "fnt-x", Address: "10.0.0.2"}, {Network: "fnt-x", Address: "10.0.0.2"}}}
+	claims, err := deriver().Expect(twice, Dialect{})
+	if err != nil {
+		t.Fatalf("the same attachment listed twice was refused: %v", err)
+	}
+	if got := claimNames(claims); len(got) != 1 || got[0] != "carries(fnt-x, 10.0.0.2)" {
+		t.Errorf("a duplicate attachment claims %v, want one interface", got)
+	}
+}
+
+// A public address outside the pack's block is one the layer never routes, so
+// it claims nothing — and in particular it does not own the default route.
+func TestAPublicAddressOutsideTheBlockClaimsNothing(t *testing.T) {
+	claims, err := deriver().Expect(Plan{Publics: []string{"198.51.100.7"}, Egress: "fnt-x"}, ovnDialect())
+	if err != nil {
+		t.Fatalf("an address the layer never routes was counted as a claimant: %v", err)
+	}
+	if got := claimNames(claims); len(got) != 1 || got[0] != "default route" {
+		t.Errorf("claims %v, want the egress alone", got)
+	}
+}
+
+// A stored address is untrusted input: one that is not an address refuses the
+// plan here rather than reaching a device key.
+func TestAnAttachmentThatIsNotAnAddressRefusesThePlan(t *testing.T) {
+	_, err := deriver().Expect(Plan{Boot: []Attachment{{Network: "fnt-x", Address: "10.0.0.2; rm -rf /"}}}, Dialect{})
+	if err == nil || !strings.Contains(err.Error(), "not an address") {
+		t.Fatalf("a poisoned attachment address was derived into a claim: %v", err)
+	}
+}
+
+// What a whole plan claims under OVN, so a claim added or dropped by accident
+// moves this list.
+func TestTheDerivationClaimsWhatThePlanSays(t *testing.T) {
+	plan := Plan{
+		Boot:        []Attachment{{Network: "fnt-a", Address: "10.0.0.2", PrefixLen: 24, Secondary: []string{"10.0.0.9"}}},
+		Memberships: []Attachment{{Network: "fnt-b"}},
+		Publics:     []string{"203.0.113.2", "203.0.113.2"},
+	}
+	claims, err := deriver().Expect(plan, ovnDialect())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"carries(fnt-a, 10.0.0.2/24)",
+		"carries(fnt-a, 10.0.0.9/24)",
+		"leases(fnt-b)",
+		"carries(any interface, 203.0.113.2/32)",
+		"private aggregates",
+	}
+	if got := claimNames(claims); strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Errorf("claims:\n%s\nwant:\n%s", strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+}
+
+// ---- the comparators, each against a Shape written by the test -------------
+
+// shapeA is the routed shape beside a private NIC, as docs/limits.md records
+// it: eth0 routed carrying the public /32, eth1 on fnt-x pinned at /24, the
+// default route via the routed next hop, the aggregates via the gateway.
+func shapeA() Shape {
+	return Shape{
+		Interfaces: map[string]Interface{
+			"eth0": {Routed: true, Addresses: []netip.Prefix{netip.MustParsePrefix("203.0.113.2/32")}},
+			"eth1": {Network: "fnt-x", Addresses: []netip.Prefix{netip.MustParsePrefix("10.30.1.10/24")}},
+		},
+		Routes: []Route{
+			{Dst: defaultDst, Via: netip.MustParseAddr("169.254.0.1"), Dev: "eth0"},
+			{Dst: netip.MustParsePrefix("10.0.0.0/8"), Via: netip.MustParseAddr("10.30.1.1"), Dev: "eth1"},
+			{Dst: netip.MustParsePrefix("172.16.0.0/12"), Via: netip.MustParseAddr("10.30.1.1"), Dev: "eth1"},
+			{Dst: netip.MustParsePrefix("192.168.0.0/16"), Via: netip.MustParseAddr("10.30.1.1"), Dev: "eth1"},
+		},
+		Gateways: map[string]netip.Prefix{"fnt-x": netip.MustParsePrefix("10.30.1.1/24")},
+	}
+}
+
+func requireOutcome(t *testing.T, v Verdict, want Outcome) {
+	t.Helper()
+	if v.Outcome != want {
+		t.Fatalf("%s: got %s, want %s", v, v.Outcome, want)
+	}
+}
+
+// The mask is judged when the plan said one, and only then: /24 and /32 are
+// not the same address to the kernel.
+func TestCarriesJudgesTheMaskOnlyWhenThePlanSaidOne(t *testing.T) {
+	s := shapeA()
+	addr := netip.MustParseAddr("10.30.1.10")
+	requireOutcome(t, carries{Network: "fnt-x", Address: addr, Bits: 24}.Check(s), Held)
+	requireOutcome(t, carries{Network: "fnt-x", Address: addr}.Check(s), Held)
+	v := carries{Network: "fnt-x", Address: addr, Bits: 32}.Check(s)
+	requireOutcome(t, v, Broken)
+	if v.Want != "10.30.1.10/32" || !strings.Contains(v.Got, "10.30.1.10/24") {
+		t.Errorf("a broken mask does not say both masks: %s", v)
+	}
+	// Any interface for a public /32, and a network the machine is not on.
+	requireOutcome(t, carries{Address: netip.MustParseAddr("203.0.113.2"), Bits: 32}.Check(s), Held)
+	v = carries{Network: "fnt-y", Address: addr}.Check(s)
+	requireOutcome(t, v, Broken)
+	if !strings.Contains(v.Got, "no interface on fnt-y") {
+		t.Errorf("a missing interface is not named: %s", v)
+	}
+}
+
+// A leased interface carries some address of its block, whichever DHCP chose.
+func TestLeasesAcceptsAnyAddressOfTheBlock(t *testing.T) {
+	s := shapeA()
+	requireOutcome(t, leases{Network: "fnt-x"}.Check(s), Held)
+	s.Interfaces["eth1"] = Interface{Network: "fnt-x", Addresses: []netip.Prefix{netip.MustParsePrefix("10.99.0.5/24")}}
+	v := leases{Network: "fnt-x"}.Check(s)
+	requireOutcome(t, v, Broken)
+	if v.Want != "an address of 10.30.1.0/24 on eth1" {
+		t.Errorf("want %q", v.Want)
+	}
+}
+
+// The default route is via AND dev, exactly, and nothing else about it.
+func TestADefaultRouteClaimComparesViaAndDev(t *testing.T) {
+	s := shapeA()
+	s.Routes[0] = Route{Dst: defaultDst, Via: netip.MustParseAddr("10.30.1.1"), Dev: "eth1"}
+	requireOutcome(t, defaultRoute{Network: "fnt-x"}.Check(s), Held)
+
+	// The regression of 2026-09-04, seen by this comparator: the route left
+	// through the private gateway where the plan wanted another door.
+	s.Routes[0] = Route{Dst: defaultDst, Via: netip.MustParseAddr("10.77.0.1"), Dev: "eth1"}
+	v := defaultRoute{Network: "fnt-x"}.Check(s)
+	requireOutcome(t, v, Broken)
+	if v.Want != "via 10.30.1.1 dev eth1" || v.Got != "via 10.77.0.1 dev eth1" {
+		t.Errorf("the verdict does not cite both routes: %s", v)
+	}
+	s.Routes = s.Routes[1:]
+	v = defaultRoute{Network: "fnt-x"}.Check(s)
+	requireOutcome(t, v, Broken)
+	if v.Got != "no default route" {
+		t.Errorf("an absent route is not named as absent: %s", v)
+	}
+}
+
+func TestNoDefaultRouteIsBrokenByAnyDefaultRoute(t *testing.T) {
+	s := shapeA()
+	v := noDefaultRoute{}.Check(s)
+	requireOutcome(t, v, Broken)
+	if v.Got != "via 169.254.0.1 dev eth0" {
+		t.Errorf("the route that should not exist is not cited: %s", v)
+	}
+	s.Routes = s.Routes[1:]
+	requireOutcome(t, noDefaultRoute{}.Check(s), Held)
+}
+
+// Each aggregate rides a gateway of the plan, on that gateway's interface;
+// one via somebody else's gateway is the route DHCP replaced (#549).
+func TestTheAggregatesMustRideAGatewayOfThePlan(t *testing.T) {
+	s := shapeA()
+	claim := reachesAggregates{Blocks: privateAggregatePrefixes(), Networks: []string{"fnt-x"}}
+	requireOutcome(t, claim.Check(s), Held)
+	s.Routes[2] = Route{Dst: netip.MustParsePrefix("172.16.0.0/12"), Via: netip.MustParseAddr("10.77.0.1"), Dev: "eth1"}
+	v := claim.Check(s)
+	requireOutcome(t, v, Broken)
+	if !strings.Contains(v.Got, "172.16.0.0/12: via 10.77.0.1 dev eth1") {
+		t.Errorf("the misrouted aggregate is not named with its route: %s", v)
+	}
+	s.Routes = s.Routes[:1]
+	v = claim.Check(s)
+	requireOutcome(t, v, Broken)
+	if !strings.Contains(v.Got, "10.0.0.0/8: none") {
+		t.Errorf("a missing aggregate is not named as missing: %s", v)
+	}
+}
+
+// A claim whose gateway nobody read is unreadable, never held and never
+// broken: the third outcome, on the claims that need a second read.
+func TestAClaimNeedingAGatewayNobodyReadIsUnreadable(t *testing.T) {
+	s := shapeA()
+	s.Gateways = nil
+	for _, c := range []Claim{
+		leases{Network: "fnt-x"},
+		defaultRoute{Network: "fnt-x"},
+		reachesAggregates{Blocks: privateAggregatePrefixes(), Networks: []string{"fnt-x"}},
+	} {
+		v := c.Check(s)
+		requireOutcome(t, v, Unreadable)
+		if !strings.Contains(v.Got, "fnt-x") || !strings.Contains(v.Got, "not read") {
+			t.Errorf("an unreadable verdict does not say what was not read: %s", v)
+		}
+	}
+}
+
+// TestTheIncusDialectRestatesWhatTheModeLays holds the driver's dialect to the
+// code it describes: the routed next hop is the constant the routed NIC gets,
+// the aggregates are the blocks installGuestPrivateRoutes lays, and only OVN
+// lays a default route.
+func TestTheIncusDialectRestatesWhatTheModeLays(t *testing.T) {
+	ovn := ovnDriver(&fakeRuntime{}).Dialect()
+	if ovn.RoutedNextHop.String() != routedNextHop {
+		t.Errorf("OVN routed next hop %s, want %s", ovn.RoutedNextHop, routedNextHop)
+	}
+	if !ovn.LaysDefaultRoute {
+		t.Error("the OVN dialect does not lay a default route, and RouteEgress does")
+	}
+	if got := prefixes(ovn.Aggregates); got != strings.Join(privateAggregates, ", ") {
+		t.Errorf("OVN aggregates %s, want %s", got, strings.Join(privateAggregates, ", "))
+	}
+	bridge := newFakeDriver(&fakeRuntime{}).Dialect()
+	if bridge.LaysDefaultRoute || len(bridge.Aggregates) != 0 {
+		t.Errorf("the bridge dialect claims %+v, and the bridge lays neither", bridge)
+	}
+	if bridge.RoutedNextHop != ovn.RoutedNextHop {
+		t.Error("the routed next hop differs by mode, and the routed NIC does not")
+	}
+}
+
+// A driver with no dialect is read as the zero one: it refuses no less, and it
+// claims nothing that depends on a mode nobody declared.
+func TestADriverWithNoDialectClaimsNothingModeDependent(t *testing.T) {
+	b := newGroupSyncBench()
+	r := rebootReconciler(b, Plan{Egress: "fnt-x", Boot: []Attachment{{Network: "fnt-x"}}})
+	claims, err := r.Expect(r.PlanOf(nil), r.dialect())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := claimNames(claims); len(got) != 1 || got[0] != "leases(fnt-x)" {
+		t.Errorf("claims %v under a runtime that declares nothing, want the lease alone", got)
+	}
+	if _, err := r.Expect(Plan{Publics: []string{"203.0.113.2"}, Egress: "fnt-x"}, r.dialect()); err == nil {
+		t.Error("the zero dialect stopped the refusal, and the refusal depends on no dialect")
+	}
+}
+
+// TestSilenceLeavesTheRouteAloneAndOnlyARefusalTakesItAway holds the three
+// states #660 gave the plan, at the layer that executes them: an egress lays
+// the route, a refusal takes it away, and silence asks the runtime for
+// nothing — the state a machine holding a public address is in, whose route
+// RouteAddress owns. Before #660 silence meant "take it away", and a machine
+// with a public address lost the route its address had laid.
+func TestSilenceLeavesTheRouteAloneAndOnlyARefusalTakesItAway(t *testing.T) {
+	for name, tc := range map[string]struct {
+		plan Plan
+		want []string
+	}{
+		"an egress lays it":       {Plan{Egress: "fnt-x"}, []string{"RouteEgress feint-bench-m via fnt-x"}},
+		"a refusal takes it away": {Plan{NoEgress: true}, []string{"DropEgress feint-bench-m"}},
+		"silence asks nothing":    {Plan{Publics: []string{"203.0.113.2"}}, nil},
+	} {
+		t.Run(name, func(t *testing.T) {
+			b := newGroupSyncBench()
+			e := &egressRecorder{Recorder: b.rec}
+			vm := b.machine("m", "10.0.0.5")
+			vm.State = "running"
+			egressReconciler(b, e, tc.plan).ReplayEgress(context.Background(), vm)
+			if strings.Join(e.laid, "|") != strings.Join(tc.want, "|") {
+				t.Fatalf("the runtime was asked %v, want %v", e.laid, tc.want)
+			}
+		})
+	}
+}

--- a/internal/core/machine/incus_dialect.go
+++ b/internal/core/machine/incus_dialect.go
@@ -1,0 +1,35 @@
+package machine
+
+import "net/netip"
+
+// Dialect implements Dialected: what this driver mode knows about itself, for
+// the claims a plan makes (#667).
+//
+// Every value here is one the driver already acts on, restated rather than
+// decided: the routed next hop is the constant routedDevice hands the NIC, the
+// aggregates are the blocks installGuestPrivateRoutes lays, and the default
+// route is laid by RouteEgress under OVN alone — under a bridge that method
+// answers nil without touching the guest, and a claim there would judge a
+// route nobody was asked to lay.
+//
+// TestTheIncusDialectRestatesWhatTheModeLays fails if any of the three drifts
+// from the code it describes.
+func (d *Incus) Dialect() Dialect {
+	out := Dialect{RoutedNextHop: netip.MustParseAddr(routedNextHop)}
+	if d.OVN {
+		out.Aggregates = privateAggregatePrefixes()
+		out.LaysDefaultRoute = true
+	}
+	return out
+}
+
+// privateAggregatePrefixes is privateAggregates parsed, for the claims that
+// compare blocks rather than strings. The strings stay the driver's own
+// vocabulary because they are what reaches `ip route add`.
+func privateAggregatePrefixes() []netip.Prefix {
+	out := make([]netip.Prefix, 0, len(privateAggregates))
+	for _, block := range privateAggregates {
+		out = append(out, netip.MustParsePrefix(block))
+	}
+	return out
+}

--- a/internal/core/machine/plan.go
+++ b/internal/core/machine/plan.go
@@ -160,6 +160,20 @@ func (r Reconciler) router() router {
 	return rt
 }
 
+// consistent reports whether the plan agrees with itself, and logs the
+// contradiction as the failure it is: an ERROR naming every claimant, so an
+// operator reading it learns which two steps of which recipe disagree rather
+// than which port stopped answering. The claims themselves are not kept here;
+// the reading that answers them is #668's.
+func (r Reconciler) consistent(res *resource.Resource, plan Plan) bool {
+	if _, err := r.Expect(plan, r.dialect()); err != nil {
+		r.binding().logger().Error("this plan contradicts itself, so the runtime is not asked to execute it",
+			"provider", r.binding().Provider, "resource", res.ID, "error", err)
+		return false
+	}
+	return true
+}
+
 // PowerOn starts the machine on its declared plan and replays the post-boot
 // order: the promised addresses, the memberships, the firewall last. It
 // reports what PowerOn reported; a machine that did not start is not replayed
@@ -167,6 +181,15 @@ func (r Reconciler) router() router {
 func (r Reconciler) PowerOn(ctx context.Context, res *resource.Resource, boot Boot) bool {
 	plan, declared := r.plan(res)
 	if !declared {
+		return false
+	}
+	// The plan is judged before the runtime is asked for anything (#667): a
+	// plan two of whose steps claim the same property is refused here, and
+	// publishes the pack's own failed state the way a missing plan does. The
+	// alternative is what #660 measured — every step succeeding, and a
+	// machine whose reply left by a door the request had not come in through.
+	if !r.consistent(res, plan) {
+		res.State = r.binding().FailedState
 		return false
 	}
 	boot.Attachments = plan.Boot
@@ -299,7 +322,19 @@ func (r Reconciler) ReplayEgress(ctx context.Context, res *resource.Resource) {
 	if !declared {
 		return
 	}
+	// The hot doors — an address routed, a network joined — reach here on a
+	// machine already running, which a contradiction cannot refuse to start.
+	// What it can refuse is the step that executes the contradiction: with
+	// two claimants to the default route, laying the egress half is exactly
+	// the overwrite #660 measured, so the route the machine has is left alone
+	// and the log carries the error (#667).
+	// TestAContradictoryPlanNeverReachesTheEgressRouter fails without this.
+	if !r.consistent(res, plan) {
+		return
+	}
 	// Silence leaves the route alone; only an explicit refusal removes one.
+	// TestSilenceLeavesTheRouteAloneAndOnlyARefusalTakesItAway holds the
+	// three states.
 	if plan.Egress == "" && !plan.NoEgress {
 		return
 	}

--- a/internal/core/machine/plan.go
+++ b/internal/core/machine/plan.go
@@ -66,6 +66,27 @@ type Plan struct {
 	// route for every machine would be the emulator being more permissive than
 	// the cloud, in the one direction that teaches a client something false.
 	Egress string
+	// NoEgress asks for the machine's default route to be TAKEN AWAY, which is
+	// a different statement from Egress being empty (#660).
+	//
+	// Three states, because two were not enough and the missing one cost a red
+	// scheduled night. A pack says one of:
+	//
+	//	Egress: "fnt-…"  lay the default route through this network
+	//	NoEgress: true   take the default route away
+	//	neither          leave it alone: something else owns it
+	//
+	// The third is the one that was missing. A machine holding a routed public
+	// address already has a default route, laid by RouteAddress towards the
+	// uplink, and it is the route its INBOUND traffic must answer through.
+	// Naming a network for it made the reconciler replace that route with the
+	// private network's gateway, and a machine whose reply left by another door
+	// answered nothing at all: measured on the example stacks, platform-web-0
+	// served 443 inside and was unreachable at its published address.
+	//
+	// Empty-and-not-refused is also the safe default for a pack that says
+	// nothing, which the previous shape was not: silence meant "take it away".
+	NoEgress bool
 }
 
 // Reconciler executes a declared Plan in the one order — addresses, then
@@ -276,6 +297,10 @@ func (r Reconciler) ReplayEgress(ctx context.Context, res *resource.Resource) {
 	}
 	plan, declared := r.plan(res)
 	if !declared {
+		return
+	}
+	// Silence leaves the route alone; only an explicit refusal removes one.
+	if plan.Egress == "" && !plan.NoEgress {
 		return
 	}
 	if plan.Egress == "" {

--- a/internal/core/machine/shape.go
+++ b/internal/core/machine/shape.go
@@ -1,0 +1,147 @@
+package machine
+
+import (
+	"net/netip"
+	"slices"
+	"strings"
+)
+
+// What a machine actually carries, read back from the runtime and normalised.
+//
+// The types are declared beside the derivation (#667) because the claims a
+// plan makes are answered against them; the reading itself — the Observer
+// half a driver implements, and the parsers behind it — is #668's, and nothing
+// in this file reaches a runtime.
+//
+// Normalised means: what does not compare never enters a Shape. No metric, no
+// `proto`, no IPv6, no loopback, no link-local, no ordering. A Shape carrying
+// them would turn every legitimate difference between two boots — a lease
+// renewed, a kernel ordering its table another way — into a broken verdict,
+// and a verifier that cries wolf is switched off within the week.
+
+// Shape is what the runtime reports about one machine.
+type Shape struct {
+	// Interfaces are the machine's own NIC devices, by the name the guest
+	// gives them. Profile devices, which are the operator's, are not in it.
+	Interfaces map[string]Interface
+	// Routes is the guest's IPv4 table minus what does not compare: the
+	// connected routes an address implies, the link-local ones the kernel
+	// lays, and every attribute past `via` and `dev`. The default route is
+	// the entry whose Dst is 0.0.0.0/0.
+	Routes []Route
+	// Doors answers, per source address, which door a reply sent from that
+	// address leaves by — `ip route get <probe> from <address>`. Filled only
+	// for the addresses a claim asked about.
+	Doors map[netip.Addr]Route
+	// Gateways is the gateway, with its mask, of every emulated network the
+	// machine has an interface on, read by the observer so that the claims
+	// stay pure: Expect never queries. A network absent here was not read,
+	// and a claim that needs it answers Unreadable rather than guessing.
+	Gateways map[string]netip.Prefix
+}
+
+// Interface is one NIC as the guest sees it.
+type Interface struct {
+	// Network is the emulated network the device sits on, empty for a routed
+	// NIC, which sits on none (#202).
+	Network string
+	// Routed is the routed-NIC kind: an address handed to the guest with a
+	// host route and no L2 segment underneath.
+	Routed bool
+	// Addresses are the global IPv4 the interface carries, with their masks.
+	Addresses []netip.Prefix
+	// RuleSets are the rule sets bound to the device (security.acls), sorted.
+	RuleSets []string
+}
+
+// Route is one entry of the guest's table, reduced to what compares.
+type Route struct {
+	// Dst is the destination block; 0.0.0.0/0 for the default route.
+	Dst netip.Prefix
+	// Via is the next hop, the zero Addr for a connected route.
+	Via netip.Addr
+	// Dev is the guest's name for the interface the route leaves by.
+	Dev string
+}
+
+// String renders a route the way a verdict cites it: "via 10.0.0.1 dev eth0",
+// or "dev eth0" for a connected one.
+func (r Route) String() string {
+	if !r.Via.IsValid() {
+		return "dev " + r.Dev
+	}
+	return "via " + r.Via.String() + " dev " + r.Dev
+}
+
+// defaultDst is the destination of the default route.
+var defaultDst = netip.MustParsePrefix("0.0.0.0/0")
+
+// defaultRoute answers the shape's default route, and whether it has one.
+func (s Shape) defaultRoute() (Route, bool) {
+	for _, r := range s.Routes {
+		if r.Dst == defaultDst {
+			return r, true
+		}
+	}
+	return Route{}, false
+}
+
+// interfaceOn answers the name of the interface on a network, empty when the
+// machine has none there. Name order, so two reads answer the same one.
+func (s Shape) interfaceOn(network string) string {
+	for _, name := range s.interfaceNames() {
+		if s.Interfaces[name].Network == network {
+			return name
+		}
+	}
+	return ""
+}
+
+// interfaceNames is the interfaces in name order: a map has no order, and a
+// verdict that named a different interface on two reads of one machine would
+// be reporting the iteration rather than the machine.
+func (s Shape) interfaceNames() []string {
+	names := make([]string, 0, len(s.Interfaces))
+	for name := range s.Interfaces {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return names
+}
+
+// carriedBy renders what the named interfaces carry, for a broken verdict:
+// "eth0: 10.30.1.10/24, 203.0.113.2/32; eth1: nothing".
+func (s Shape) carriedBy(names []string) string {
+	parts := make([]string, 0, len(names))
+	for _, name := range names {
+		addresses := s.Interfaces[name].Addresses
+		if len(addresses) == 0 {
+			parts = append(parts, name+": nothing")
+			continue
+		}
+		rendered := make([]string, 0, len(addresses))
+		for _, p := range addresses {
+			rendered = append(rendered, p.String())
+		}
+		parts = append(parts, name+": "+strings.Join(rendered, ", "))
+	}
+	if len(parts) == 0 {
+		return "no interface"
+	}
+	return strings.Join(parts, "; ")
+}
+
+// routesTo renders the entries of the table towards a block, for a broken
+// verdict; "none" when the table holds nothing for it.
+func (s Shape) routesTo(dst netip.Prefix) string {
+	var found []string
+	for _, r := range s.Routes {
+		if r.Dst == dst {
+			found = append(found, r.String())
+		}
+	}
+	if len(found) == 0 {
+		return "none"
+	}
+	return strings.Join(found, ", ")
+}

--- a/internal/providers/scaleway/egress_internal_test.go
+++ b/internal/providers/scaleway/egress_internal_test.go
@@ -40,28 +40,54 @@ func serverOn(p *Pack, networkName string) *resource.Resource {
 	return server
 }
 
-// A server holding a public address reaches the Internet, through the network
-// its own NIC is on (#647).
+// A server holding a public address KEEPS the route that address carries, and
+// egress asks for nothing (#660, correcting #647).
 //
-// The rule is Scaleway's and the emulator had none of it: measured under
-// --vm incus-ovn, a bastion with a public address and three private NICs kept
-// its default route out of eth0 — the interface #548 takes the address OFF —
-// and could not reach anything, while every SSH hop through it worked. A fleet
-// tool could discover the machine and never provision it.
-func TestAServerWithAPublicAddressLeavesThroughItsOwnNetwork(t *testing.T) {
+// #647 had this return the server's private network, on the reasoning that a
+// public address rides the network its NIC is on. True of a machine whose only
+// NIC is the routed one; false the moment it also joins a Private Network, and
+// the example stacks caught it on the first scheduled night: platform-web-0
+// served 443 inside its machine and answered nothing at its published address.
+//
+// Measured 2026-09-04 under --vm incus-ovn, a server with a public address and
+// one private NIC:
+//
+//	default via 10.77.0.1 dev eth0        <- the private gateway
+//	eth0 carries 10.77.0.2/24 and 203.0.113.2/32
+//	from the station: nothing
+//
+// The reply was leaving by a door the request had not come in through. The same
+// server without the private NIC keeps `default via 169.254.0.1`, which
+// RouteAddress lays for the routed address, and answers. So the route has an
+// owner already, and the only correct thing for egress to do is nothing.
+//
+// Which is why NoEgress exists: an empty network name means "leave it alone"
+// here and "take it away" for the server below, and one string could not say
+// both.
+func TestAServerWithAPublicAddressKeepsTheRouteItsAddressCarries(t *testing.T) {
 	p := egressPack()
 	server := serverOn(p, "fnt-web")
 
+	// With neither address nor gateway: no network, and the route is refused.
 	if got := p.egressNetworkOf(server); got != "" {
 		t.Fatalf("a server with no address and no gateway leaves through %q, want nothing", got)
+	}
+	if !p.hasNoWayOut(server) {
+		t.Error("a server with no address and no gateway is not refused its route")
 	}
 
 	address := resource.New("ip-1", kindIP, resource.Tenant{Provider: Name, Zone: "fr-par-1"}, "available", p.env.Now())
 	address.Attrs = map[string]any{"address": "203.0.113.2", "server": map[string]any{"id": "srv-1"}}
 	p.env.Store.Put(address)
 
-	if got := p.egressNetworkOf(server); got != "fnt-web" {
-		t.Errorf("a server holding a public address leaves through %q, want fnt-web", got)
+	if got := p.egressNetworkOf(server); got != "" {
+		t.Errorf("a server holding a public address asks for egress through %q, and asking for any "+
+			"network here replaces the route its own address carries", got)
+	}
+	// And it is NOT refused: the difference between the two empty answers.
+	if p.hasNoWayOut(server) {
+		t.Error("a server holding a public address is refused its default route, which takes away " +
+			"the route RouteAddress laid and leaves it unreachable at its published address")
 	}
 }
 
@@ -97,10 +123,36 @@ func TestAPushedDefaultRouteIsTheOnlyWayOutForAPrivateServer(t *testing.T) {
 	if got := p.egressNetworkOf(server); got != "" {
 		t.Errorf("a gateway that pushes no default route gave a way out through %q", got)
 	}
+	if !p.hasNoWayOut(server) {
+		t.Error("a gateway that pushes no default route is not read as no way out, so the route is left to whatever DHCP laid")
+	}
 
 	attach(true)
 	if got := p.egressNetworkOf(server); got != "fnt-web" {
 		t.Errorf("a gateway pushing the default route gave %q, want fnt-web", got)
+	}
+	if p.hasNoWayOut(server) {
+		t.Error("a gateway pushing the default route still leaves the server refused one")
+	}
+
+	// A public address beside that gateway owns the route (#660): the answer
+	// is to leave it alone, not to replace it with the gateway's, and the
+	// server is not refused one either. Then the address goes, and the
+	// gateway's network is the way out again — which proves the address, and
+	// not something else, was the reason.
+	address := resource.New("ip-1", kindIP, resource.Tenant{Provider: Name, Zone: "fr-par-1"}, "available", p.env.Now())
+	address.Attrs = map[string]any{"address": "203.0.113.2", "server": map[string]any{"id": "srv-1"}}
+	p.env.Store.Put(address)
+	if got := p.egressNetworkOf(server); got != "" {
+		t.Errorf("a server holding a public address beside a pushing gateway asks for egress through %q, "+
+			"which replaces the route its address carries", got)
+	}
+	if p.hasNoWayOut(server) {
+		t.Error("a server holding a public address beside a pushing gateway is refused its route")
+	}
+	p.env.Store.Delete(Name, kindIP, "ip-1")
+	if got := p.egressNetworkOf(server); got != "fnt-web" {
+		t.Errorf("the address is gone and the gateway's way out did not come back: %q", got)
 	}
 
 	// And it is taken back with the attachment, which is what the driver's
@@ -108,5 +160,8 @@ func TestAPushedDefaultRouteIsTheOnlyWayOutForAPrivateServer(t *testing.T) {
 	p.env.Store.Delete(Name, kindGatewayNetwork, "gn-1")
 	if got := p.egressNetworkOf(server); got != "" {
 		t.Errorf("the attachment is gone and the server still leaves through %q", got)
+	}
+	if !p.hasNoWayOut(server) {
+		t.Error("the attachment is gone and the server is still not refused its route")
 	}
 }

--- a/internal/providers/scaleway/machines.go
+++ b/internal/providers/scaleway/machines.go
@@ -165,6 +165,11 @@ func (p *Pack) machinePlan(res *resource.Resource) machine.Plan {
 		Publics:  p.publicAddressesOf(res),
 		RouteVia: p.privateNetworkNameOf(res),
 		Egress:   p.egressNetworkOf(res),
+		// Only a server with NEITHER a public address NOR a gateway pushing the
+		// route is refused one, and that refusal is stated rather than inferred
+		// from an empty network name (#660): a public address leaves the route
+		// to RouteAddress, which is also an empty name and must not remove it.
+		NoEgress: p.hasNoWayOut(res),
 	}
 }
 
@@ -241,13 +246,34 @@ func (p *Pack) logger() *slog.Logger {
 // The network it names is the runtime's, not the API's: the driver needs
 // something it can ask a gateway address of.
 //
-// TestAServerWithAPublicAddressLeavesThroughItsOwnNetwork and
+// TestAServerWithAPublicAddressKeepsTheRouteItsAddressCarries and
 // TestAPushedDefaultRouteIsTheOnlyWayOutForAPrivateServer fail without this.
 func (p *Pack) egressNetworkOf(server *resource.Resource) string {
-	// A public address first: it is the server's own way out, and it rides the
-	// network its NIC is on — the same one RouteVia names, for the same reason.
+	// A public address first, and the answer is to LEAVE THE ROUTE ALONE (#660).
+	//
+	// This returned the server's private network, on the reasoning that a
+	// public address rides the network its NIC is on. That is true of a machine
+	// whose only NIC is the routed one, and false the moment it also joins a
+	// Private Network: the reconciler then replaced the default route towards
+	// the uplink with the private network's gateway, and the machine stopped
+	// answering at its published address. Its reply was leaving by a door the
+	// request had not come in through.
+	//
+	// Measured 2026-09-04, a server with a public address and one private NIC:
+	//
+	//	default via 10.77.0.1 dev eth0        <- the private gateway, wrong
+	//	eth0 carries 10.77.0.2/24 and 203.0.113.2/32
+	//	from the station: nothing
+	//
+	// The same server without the private NIC keeps `default via 169.254.0.1`,
+	// which RouteAddress lays for the routed address, and answers. So the route
+	// exists and has an owner already; egress has nothing to add and everything
+	// to break.
+	//
+	// TestAServerWithAPublicAddressKeepsTheRouteItsAddressCarries fails without
+	// this.
 	if len(p.publicAddressesOf(server)) > 0 {
-		return p.privateNetworkNameOf(server)
+		return ""
 	}
 	// Otherwise the gateway's, and only when the attachment pushes it. A
 	// gateway that masquerades for a network without pushing a default route is
@@ -267,6 +293,31 @@ func (p *Pack) egressNetworkOf(server *resource.Resource) string {
 		}
 	}
 	return ""
+}
+
+// hasNoWayOut reports a server the cloud lets nowhere: no public address, and
+// no gateway pushing a default route onto any network it joins.
+//
+// It is the refusal half of #647, kept separate from egressNetworkOf's empty
+// answer since #660, because the two mean opposite things. A server with a
+// public address gets an empty network name and must KEEP its route; this one
+// gets an empty name and must LOSE it.
+//
+// TestAServerWithAPublicAddressKeepsTheRouteItsAddressCarries holds the two
+// answers a public address decides here, and
+// TestAPushedDefaultRouteIsTheOnlyWayOutForAPrivateServer the two a gateway
+// decides.
+func (p *Pack) hasNoWayOut(server *resource.Resource) bool {
+	if len(p.publicAddressesOf(server)) > 0 {
+		return false
+	}
+	for _, nic := range p.privateNICsOf(server.ID) {
+		if privateNetworkID := nic.Runtime[runtimePrivateNetworkKey]; privateNetworkID != "" &&
+			p.gatewayPushesDefaultRoute(privateNetworkID) {
+			return false
+		}
+	}
+	return true
 }
 
 // gatewayPushesDefaultRoute reports whether a Public Gateway is attached to this

--- a/tools/conformance/functional.sh
+++ b/tools/conformance/functional.sh
@@ -278,6 +278,43 @@ station_fetch() { # address port
 	curl -sf --max-time 8 "http://$1:$2/" 2>/dev/null | tr -d '\r\n'
 }
 
+# station_fetch_within is station_fetch with a bounded wait, and it exists
+# because "the service listens inside" and "the station can reach it" are two
+# facts with a gap between them.
+#
+# The gap is the runtime's: after a restart the guest's unit comes up first, and
+# the route that carries its published address back to the station is put in
+# place around the same moment. fnl_service_came_up already waits for the first
+# fact; nothing waited for the second, so the fetch was a single attempt against
+# a race, and it lost one scheduled night in five (#660, the same failure seen
+# before).
+#
+# A bounded wait rather than a retry: the caller is told how long it waited, and
+# a fetch that never succeeds still fails. What a plain retry would buy is a
+# green run over a route that never came back, which is the verdict this whole
+# harness exists to refuse.
+#
+# It prints the body on success and nothing on failure, so every caller reads it
+# the way it read station_fetch. How long it waited goes to stderr, which is the
+# part worth keeping: a window that is 0 s on the station and seconds on a runner
+# is the difference this function exists for, and the next person to read a red
+# night can see whether it is widening instead of guessing.
+station_fetch_within() { # seconds address port
+	local budget="$1" address="$2" port="$3" waited=0 body=""
+	while [ "$waited" -lt "$budget" ]; do
+		body="$(station_fetch "$address" "$port")"
+		if [ -n "$body" ]; then
+			[ "$waited" -gt 0 ] && echo "    (the station reached $address:$port after ${waited}s)" >&2
+			printf '%s' "$body"
+			return 0
+		fi
+		sleep 2
+		waited=$((waited + 2))
+	done
+	echo "    (the station never reached $address:$port in ${budget}s)" >&2
+	return 1
+}
+
 # live_machine_pid answers the runtime process holding a machine, empty when
 # nobody could look. It is the witness #547 was filed on: a reboot that leaves
 # the same process leaves the same kernel and the same uptime. Read from the
@@ -653,8 +690,12 @@ run_stack() { # name
 		address="$(published_address "$provider" "$restart")" \
 			|| fail "cannot look: $provider's API did not answer when asked for $restart's published address"
 		if [ -n "$address" ]; then
-			body="$(station_fetch "$address" "$port")"
-			fnl_service_answers "$name" "$restart (after a restart)" "$rmachine" "$address" "$port" "$body"
+			# 60 s, against a route that is back in a second or two when it
+			# comes back at all. The budget is generous because the cost of
+			# being wrong here is a red night on a working emulator, and the
+			# cost of waiting is two seconds on every green one.
+			body="$(station_fetch_within 60 "$address" "$port")" || body=""
+			fnl_service_answers "$name" "$restart (after a restart, waited up to 60s)" "$rmachine" "$address" "$port" "$body"
 		fi
 
 		# ---- what the restarts must not have cost (#549) ---------------------
@@ -714,7 +755,7 @@ run_stack() { # name
 				skip "$name: $target publishes no public address, so the station leg has nothing to travel; its service was proved listening inside"
 				continue
 			fi
-			body="$(station_fetch "$address" "$port")"
+			body="$(station_fetch_within 60 "$address" "$port")" || body=""
 			fnl_service_answers "$name" "$target" "$smachine" "$address" "$port" "$body"
 
 			# The public pair, on the address a client dials (#548). The open

--- a/tools/falsify/specs/a-plan-that-contradicts-itself.json
+++ b/tools/falsify/specs/a-plan-that-contradicts-itself.json
@@ -1,0 +1,75 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "the ledger never reports a property with two claimants, and a plan that claims the default route twice is started (#667)",
+      "file": "internal/core/machine/claims.go",
+      "find": "\t\tif len(claimants) < 2 {\n\t\t\tcontinue\n\t\t}",
+      "replace": "\t\tif len(claimants) < 2 || true {\n\t\t\tcontinue\n\t\t}",
+      "test": "TestAPlanWithTwoClaimantsToTheDefaultRouteIsRefusedBeforeTheRuntimeIsAsked"
+    },
+    {
+      "label": "PowerOn judges the plan and starts the machine anyway (#667)",
+      "file": "internal/core/machine/plan.go",
+      "find": "\tif !r.consistent(res, plan) {\n\t\tres.State = r.binding().FailedState\n\t\treturn false\n\t}",
+      "replace": "\tif !r.consistent(res, plan) && false {\n\t\tres.State = r.binding().FailedState\n\t\treturn false\n\t}",
+      "test": "TestAPlanWithTwoClaimantsToTheDefaultRouteIsRefusedBeforeTheRuntimeIsAsked"
+    },
+    {
+      "label": "the hot path lays the egress of a contradictory plan, which is the overwrite #660 measured",
+      "file": "internal/core/machine/plan.go",
+      "find": "\tif !r.consistent(res, plan) {\n\t\treturn\n\t}",
+      "replace": "\tif !r.consistent(res, plan) && false {\n\t\treturn\n\t}",
+      "test": "TestAContradictoryPlanNeverReachesTheEgressRouter"
+    },
+    {
+      "label": "silence means take the route away again, which is the pre-#660 reading that cost a machine with a public address its own route",
+      "file": "internal/core/machine/plan.go",
+      "find": "\tif plan.Egress == \"\" && !plan.NoEgress {\n\t\treturn\n\t}",
+      "replace": "\tif plan.Egress == \"\" && !plan.NoEgress && false {\n\t\treturn\n\t}",
+      "test": "TestSilenceLeavesTheRouteAloneAndOnlyARefusalTakesItAway"
+    },
+    {
+      "label": "a public address stops owning the default route, so an egress beside it is no contradiction (#667)",
+      "file": "internal/core/machine/claims.go",
+      "find": "\tif len(publics) > 0 {\n\t\towners.claim(propertyDefaultRoute, \"the public address \"+strings.Join(publics, \", \"))\n\t}",
+      "replace": "\tif len(publics) > 0 && false {\n\t\towners.claim(propertyDefaultRoute, \"the public address \"+strings.Join(publics, \", \"))\n\t}",
+      "test": "TestAPlanWithTwoClaimantsToTheDefaultRouteIsRefusedBeforeTheRuntimeIsAsked"
+    },
+    {
+      "label": "the carries comparator stops judging the mask the plan said (#667)",
+      "file": "internal/core/machine/claims.go",
+      "find": "\t\t\tif p.Addr() == c.Address && (c.Bits == 0 || p.Bits() == c.Bits) {",
+      "replace": "\t\t\tif p.Addr() == c.Address && (c.Bits == 0 || p.Bits() == c.Bits || true) {",
+      "test": "TestCarriesJudgesTheMaskOnlyWhenThePlanSaidOne"
+    },
+    {
+      "label": "the default-route comparator ignores the next hop, which is the half the regression of 2026-09-04 lived in",
+      "file": "internal/core/machine/claims.go",
+      "find": "\tif got.Via == want.Via && got.Dev == want.Dev {\n\t\treturn held(c)\n\t}",
+      "replace": "\tif (got.Via == want.Via || true) && got.Dev == want.Dev {\n\t\treturn held(c)\n\t}",
+      "test": "TestADefaultRouteClaimComparesViaAndDev"
+    },
+    {
+      "label": "the aggregates comparator accepts any next hop, which is the route DHCP replaced in #549",
+      "file": "internal/core/machine/claims.go",
+      "find": "\t\t\tdev, legitimate := doors[r.Via]\n\t\t\treturn r.Dst == block && legitimate && r.Dev == dev",
+      "replace": "\t\t\tdev, legitimate := doors[r.Via]\n\t\t\treturn r.Dst == block && (legitimate || true) && (r.Dev == dev || true)",
+      "test": "TestTheAggregatesMustRideAGatewayOfThePlan"
+    },
+    {
+      "label": "a gateway nobody read is judged anyway, folding the third outcome onto the second",
+      "file": "internal/core/machine/claims.go",
+      "find": "\tgateway, read := s.Gateways[c.Network]\n\tif !read {\n\t\treturn unreadable(c, \"the block of \"+c.Network+\" was not read\")\n\t}",
+      "replace": "\tgateway, read := s.Gateways[c.Network]\n\tif !read && false {\n\t\treturn unreadable(c, \"the block of \"+c.Network+\" was not read\")\n\t}",
+      "test": "TestAClaimNeedingAGatewayNobodyReadIsUnreadable"
+    },
+    {
+      "label": "the OVN dialect stops declaring what the mode lays (#667)",
+      "file": "internal/core/machine/incus_dialect.go",
+      "find": "\tif d.OVN {\n\t\tout.Aggregates = privateAggregatePrefixes()\n\t\tout.LaysDefaultRoute = true\n\t}",
+      "replace": "\tif d.OVN && false {\n\t\tout.Aggregates = privateAggregatePrefixes()\n\t\tout.LaysDefaultRoute = true\n\t}",
+      "test": "TestTheIncusDialectRestatesWhatTheModeLays"
+    }
+  ]
+}

--- a/tools/falsify/specs/egress-entitlement.json
+++ b/tools/falsify/specs/egress-entitlement.json
@@ -41,12 +41,20 @@
       "test": "TestAPushedDefaultRouteIsTheOnlyWayOutForAPrivateServer"
     },
     {
-      "label": "a public address stops entitling its server, so the bastion loses the way out the cloud gives it",
+      "label": "a public address stops keeping its server's way out, so NoEgress takes away the route the address laid (#660)",
       "file": "internal/providers/scaleway/machines.go",
       "package": "./internal/providers/scaleway/",
-      "find": "\tif len(p.publicAddressesOf(server)) > 0 {",
-      "replace": "\tif len(p.publicAddressesOf(server)) > 0 && false {",
-      "test": "TestAServerWithAPublicAddressLeavesThroughItsOwnNetwork"
+      "find": "\tif len(p.publicAddressesOf(server)) > 0 {\n\t\treturn false\n\t}",
+      "replace": "\tif len(p.publicAddressesOf(server)) > 0 && false {\n\t\treturn false\n\t}",
+      "test": "TestAServerWithAPublicAddressKeepsTheRouteItsAddressCarries"
+    },
+    {
+      "label": "a public address stops leaving its route alone, and a pushing gateway's network replaces the route the address carries (#660)",
+      "file": "internal/providers/scaleway/machines.go",
+      "package": "./internal/providers/scaleway/",
+      "find": "\tif len(p.publicAddressesOf(server)) > 0 {\n\t\treturn \"\"\n\t}",
+      "replace": "\tif len(p.publicAddressesOf(server)) > 0 && false {\n\t\treturn \"\"\n\t}",
+      "test": "TestAPushedDefaultRouteIsTheOnlyWayOutForAPrivateServer"
     },
     {
       "label": "the network stops announcing where the private fleet is, so silencing its gateway takes the VPC away with it and two machines of one VPC stop reaching each other",

--- a/tools/falsify/specs/groupsync-wiring.json
+++ b/tools/falsify/specs/groupsync-wiring.json
@@ -46,8 +46,8 @@
     {
       "label": "the boot starts a machine on a plan nobody declared and reports success, so the API describes as running a machine on no network (#484, #543)",
       "file": "internal/core/machine/plan.go",
-      "find": "\tplan, declared := r.plan(res)\n\tif !declared {\n\t\treturn false\n\t}\n\tboot.Attachments = plan.Boot",
-      "replace": "\tplan, declared := r.plan(res)\n\tif !declared && false {\n\t\treturn false\n\t}\n\tboot.Attachments = plan.Boot",
+      "find": "\tplan, declared := r.plan(res)\n\tif !declared {\n\t\treturn false\n\t}\n\t// The plan is judged before the runtime is asked for anything (#667)",
+      "replace": "\tplan, declared := r.plan(res)\n\tif !declared && false {\n\t\treturn false\n\t}\n\t// The plan is judged before the runtime is asked for anything (#667)",
       "test": "TestABootWithNoDeclaredPlanIsRefusedRatherThanPanicking"
     }
   ],

--- a/tools/falsify/specs/interface-plan.json
+++ b/tools/falsify/specs/interface-plan.json
@@ -33,8 +33,8 @@
       "label": "one pack stops declaring its promised addresses, and the cross-pack equivalence names the divergence (#510, #515)",
       "package": "./internal/providers/",
       "file": "internal/providers/scaleway/machines.go",
-      "find": "\treturn machine.Plan{\n\t\tBoot:     p.attachmentsOf(res),\n\t\tPublics:  p.publicAddressesOf(res),\n\t\tRouteVia: p.privateNetworkNameOf(res),\n\t\tEgress:   p.egressNetworkOf(res),\n\t}",
-      "replace": "\treturn machine.Plan{\n\t\tBoot:     p.attachmentsOf(res),\n\t\tPublics:  p.publicAddressesOf(res)[:0],\n\t\tRouteVia: p.privateNetworkNameOf(res),\n\t\tEgress:   p.egressNetworkOf(res),\n\t}",
+      "find": "\treturn machine.Plan{\n\t\tBoot:     p.attachmentsOf(res),\n\t\tPublics:  p.publicAddressesOf(res),\n\t\tRouteVia: p.privateNetworkNameOf(res),\n",
+      "replace": "\treturn machine.Plan{\n\t\tBoot:     p.attachmentsOf(res),\n\t\tPublics:  p.publicAddressesOf(res)[:0],\n\t\tRouteVia: p.privateNetworkNameOf(res),\n",
       "test": "TestSameIntentSameRuntimeSequenceAcrossPacks"
     }
   ]


### PR DESCRIPTION
A Plan is a recipe, and two of its steps could claim the same property
without anything noticing. On 2026-09-04 the egress step replaced, with
`ip route replace`, the default route the routed address had laid; every
exec returned 0, and the machine answered nothing at its published address
(#660). The pack-side fix stands. This is the layer's guard, so a fourth
pack, or a change in this one, cannot write the same contradiction with no
test moving.

Reconciler.Expect derives from the plan who claims what, and a property
with more than one claimant refuses the boot with every claimant named,
publishing the pack's own failed state the way a missing plan does (#543).
On the hot doors — an address routed, a network joined — the machine is
already running, so what is refused is the step that would execute the
contradiction, and the route the machine has is left alone. Pure: Expect
runs no exec and no query, which is what makes it the cheapest of the
series' three controls; the Gateway func of the first sketch is gone for
that reason, and the gateways travel in the Shape instead.

What a consistent plan claims is returned as typed claims with their own
tolerance — the mask only when the plan said one, any address of the block
for a DHCP lease, the aggregates via a gateway of the plan, the default
route via the egress network only where the driver lays one — each
answered against a Shape with three outcomes: held, broken, unreadable.
The Shape types are declared here; the reading that fills one is #668.

What is deliberately NOT claimed: the door a reply leaves by for a public
address. That is a measurement, one of the two shapes has none (#672), and
the derivation registers the address as the route's owner — which refuses
a second owner — with no value beside it. Silence, not a guess.

Measured here, with the recorder as the instrument: a plan holding a
public address and an egress network starts nothing and records no
gesture; each of the three states of the way out (an egress, a refusal,
silence) is started alone; silence asks the runtime for nothing where
the pre-#660 reading asked it to drop the route. Not measured here:
anything about a running machine — no runtime was asked, by design.

tools/falsify/specs/a-plan-that-contradicts-itself.json replays ten
mutations and all ten bite (2026-09-04); groupsync-wiring.json's boot
fragment is retargeted past the new judgement and its seven still bite.

Assisted-by: Claude Code (claude-fable-5-1)


🤖 Generated with [Claude Code](https://claude.com/claude-code)
