### PR TITLE
feat(machine): the runtime reads back what a machine carries, and every claim is answered with three outcomes (#668)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -58,6 +58,35 @@ change ni l'un ni l'autre a sa place dans `git log`.
   lb certificate list` et `scw lb subscriber list` dans la suite de
   conformance.
 
+- **Le runtime relit ce qu'une machine porte réellement, et chaque
+  revendication de son plan reçoit l'une de trois issues** (#668). Le pilote
+  Incus implémente `Observer` : un `query` pour les devices propres de la
+  machine, un `network get` par réseau émulé où elle siège, et trois execs
+  dans l'invité pour les adresses, la table et, par porte qu'une revendication
+  demande, `ip route get <to> from <from>`. Le texte des deux implémentations
+  de `ip` est analysé (iproute2 sur Debian, Ubuntu et la famille RHEL, busybox
+  sur Alpine), et ce qui ne se compare pas n'entre jamais dans la `Shape` :
+  routes connectées, bloc link-local, métriques, `proto`, `src`, loopback, les
+  devices de profil de l'opérateur et les passerelles de leurs réseaux.
+
+  `held`, `broken`, `unreadable`, jamais deux : une lecture qui échoue répond
+  illisible sur chaque revendication, comptée, et un runtime sans moitié de
+  lecture est un quatrième état, non interrogé, pour que « personne n'a
+  regardé » ne passe jamais pour « rien n'était faux ». Les rule sets qu'une
+  machine porte sont revendiqués sur ses interfaces filtrées à partir des
+  champs mêmes que lit l'étape pare-feu, nus sur les réseaux qu'un pack a
+  déclarés hors de portée de ses groupes, et pas du tout sur un hôte qui a
+  retiré la capacité pare-feu.
+
+  Deux contrôles tiennent l'instrument, exigés par `measurement-integrity` :
+  une divergence plantée à un chiffre près est rapportée telle quelle, et une
+  lecture échouée n'est ni tenue ni rompue. Et la régression du 2026-09-04
+  est reproduite à travers le runtime factice : la réponse depuis l'adresse
+  publique sort par la passerelle privée, et une revendication de porte est
+  rompue en nommant les deux portes. Le comparateur de porte existe ; rien
+  n'en dérive encore (#672). Publier les verdicts est #670, comparer l'avant
+  et l'après d'un reboot est #669.
+
 - **Un plan qui revendique deux fois la route par défaut est refusé avant
   toute demande au runtime** (#667). `Reconciler.Expect` dérive, du plan
   déclaré, qui revendique quelle propriété : une adresse publique possède la

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,33 @@ what this project is judged on: **a response shape a client can observe**, and
   Driven by `scw lb backend list-statistics`, `scw lb lb get-stats`, `scw lb
   certificate list` and `scw lb subscriber list` in the conformance suite.
 
+- **The runtime reads back what a machine actually carries, and every claim
+  of its plan is answered with three outcomes** (#668). The Incus driver
+  implements `Observer`: one `query` for the machine's own devices, one
+  `network get` per emulated network it sits on, and three execs into the
+  guest for the addresses, the table and, per door a claim asks about, `ip
+  route get <to> from <from>`. The text of both `ip` implementations is parsed
+  (iproute2 on Debian, Ubuntu and the RHEL family, busybox on Alpine), and what
+  does not compare never enters the `Shape`: connected routes, the link-local
+  block, metrics, `proto`, `src`, loopback, the operator's profile devices and
+  their networks' gateways.
+
+  `held`, `broken`, `unreadable`, never two: a read that failed answers
+  unreadable on every claim, counted, and a runtime with no reading half is a
+  fourth state, not asked, so "nobody looked" cannot pass as "nothing was
+  wrong". The rule sets a machine wears are claimed on its filtered interfaces
+  from the same fields the firewall step reads, bare on the networks a pack
+  declared outside its groups' reach, and not at all on a host that withdrew
+  the firewall capability.
+
+  Two controls hold the instrument, both required by `measurement-integrity`:
+  a divergence planted one digit off is reported as itself, and a failed read
+  is neither held nor broken. And the regression of 2026-09-04 is reproduced
+  through the fake runtime: the reply from the public address leaves through
+  the private gateway, and a door claim is broken with both doors named. The
+  door comparator exists; nothing derives a door claim yet (#672). Publishing
+  the verdicts is #670, comparing a reboot's before and after is #669.
+
 - **A plan that claims the default route twice is refused before the runtime
   is asked for anything** (#667). `Reconciler.Expect` derives, from the
   declared plan, who claims which property: a public address owns the way out,

--- a/internal/core/machine/claims.go
+++ b/internal/core/machine/claims.go
@@ -479,3 +479,72 @@ func prefixes(blocks []netip.Prefix) string {
 	}
 	return strings.Join(out, ", ")
 }
+
+// door claims which door a reply sent from an address leaves by, towards a
+// destination: the answer to `ip route get <To> from <From>`, compared on
+// `via` and `dev` alone. The comparator exists for the reading half (#668);
+// nothing derives a door claim yet, because the value is a measurement per
+// machine shape and one of the two shapes has none (#672).
+type door struct {
+	From, To netip.Addr
+	Via      netip.Addr
+	Dev      string
+}
+
+func (c door) String() string { return "door(" + c.From.String() + ")" }
+
+// door is what the reading half asks the runtime for on this claim's behalf.
+func (c door) door() (from, to netip.Addr) { return c.From, c.To }
+
+func (c door) Check(s Shape) Verdict {
+	got, read := s.Doors[c.From]
+	if !read {
+		return unreadable(c, "the door of "+c.From.String()+" was not read")
+	}
+	want := Route{Via: c.Via, Dev: c.Dev}
+	if got.Dev == "" {
+		return broken(c, want.String(), "no route")
+	}
+	if got.Via == c.Via && got.Dev == c.Dev {
+		return held(c)
+	}
+	return broken(c, want.String(), got.String())
+}
+
+// wears claims the rule sets the interface on a network carries: exactly Sets,
+// and none at all when Sets is empty — an interface on a network the pack
+// declared outside its security groups' reach (Attachment.Unfiltered, #574).
+// The contents of the sets are EnsureFirewall's and the network suites';
+// this compares the binding alone.
+type wears struct {
+	Network string
+	Sets    []string
+}
+
+func (c wears) String() string { return "wears(" + c.Network + ")" }
+
+func (c wears) want(dev string) string {
+	if len(c.Sets) == 0 {
+		return "no rule set on " + dev
+	}
+	return strings.Join(c.Sets, ", ") + " on " + dev
+}
+
+func (c wears) Check(s Shape) Verdict {
+	dev := s.interfaceOn(c.Network)
+	if dev == "" {
+		return broken(c, c.want("the interface of "+c.Network), "no interface on "+c.Network)
+	}
+	got := s.Interfaces[dev].RuleSets
+	if len(got) == 0 && len(c.Sets) == 0 {
+		return held(c)
+	}
+	if slices.Equal(got, c.Sets) {
+		return held(c)
+	}
+	rendered := "none"
+	if len(got) > 0 {
+		rendered = strings.Join(got, ", ")
+	}
+	return broken(c, c.want(dev), rendered+" on "+dev)
+}

--- a/internal/core/machine/incus_readback.go
+++ b/internal/core/machine/incus_readback.go
@@ -1,0 +1,278 @@
+package machine
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"slices"
+	"strings"
+)
+
+// How Incus reads back what a machine carries (#668). The contract is in
+// readback.go; what this file adds is the reading and the three parsers.
+//
+// Everything below is a read: one `query` for the devices, one `network get`
+// per emulated network the machine sits on, and three execs into the guest —
+// the addresses, the table, and one `route get` per door a claim asks about.
+// Nothing here changes the host.
+//
+// No `-j`, deliberately. iproute2 renders JSON on request and busybox's `ip`,
+// which is the one an Alpine image ships, does not — so the text is parsed,
+// the way guestAddresses already parses `ip -4 -o addr show`. The three
+// formats are stable across the two implementations because both print the
+// same keywords in the same order (`via`, `dev`, `scope`), and the parsers
+// scan for keywords rather than positions for exactly that reason.
+// TestTheParsersReadBothImplementationsOfIp holds the pairs.
+
+// linkLocal is the block the kernel lays its own routes in and a routed NIC
+// reaches the host through. Neither compares: a route or an address here is
+// the runtime's plumbing, never the plan's.
+var linkLocal = netip.MustParsePrefix("169.254.0.0/16")
+
+// Observe implements Observer.
+//
+// Own devices only, and that is a control rather than tidiness: a profile
+// device is the operator's — their default bridge, their address — and a
+// verifier that read it would judge what no plan ever claimed. The same rule
+// keeps `network get` off a network the emulator did not derive: the gateway
+// of an operator's bridge is theirs, and a claim needing it answers Unreadable
+// rather than reading it. TestObserveReadsOnlyTheMachinesOwnNICs and
+// TestObserveReadsNoForeignNetwork fail without the two halves.
+func (d *Incus) Observe(ctx context.Context, machine string) (Shape, error) {
+	if !safeName.MatchString(machine) {
+		return Shape{}, fmt.Errorf("invalid machine name %q", machine)
+	}
+	devices, err := d.instanceDevices(ctx, machine)
+	if err != nil {
+		return Shape{}, fmt.Errorf("inspect %s: %w", machine, err)
+	}
+	shape := Shape{Interfaces: map[string]Interface{}, Gateways: map[string]netip.Prefix{}}
+	names := make([]string, 0, len(devices.own))
+	for device, cfg := range devices.own {
+		if cfg["type"] == "nic" {
+			names = append(names, device)
+		}
+	}
+	slices.Sort(names)
+	for _, device := range names {
+		cfg := devices.own[device]
+		// The guest's name for it: the same as the device's on a container,
+		// the kernel's PCI name on a virtual machine (guestInterface).
+		iface, err := d.guestInterface(ctx, machine, device)
+		if err != nil {
+			return Shape{}, err
+		}
+		shape.Interfaces[iface] = Interface{
+			Network:  cfg["network"],
+			Routed:   cfg["nictype"] == "routed",
+			RuleSets: sortedList(cfg["security.acls"]),
+		}
+		network := cfg["network"]
+		if network == "" || !ownedNetwork(network) {
+			continue
+		}
+		if _, read := shape.Gateways[network]; read {
+			continue
+		}
+		gateway, err := d.networkGateway(ctx, network)
+		if err != nil {
+			return Shape{}, err
+		}
+		shape.Gateways[network] = gateway
+	}
+
+	out, err := d.run(ctx, "exec", machine, "--", "ip", "-4", "-o", "addr", "show")
+	if err != nil {
+		return Shape{}, fmt.Errorf("read the addresses of %s: %w", machine, err)
+	}
+	for iface, addresses := range parseAddresses(out) {
+		entry, ours := shape.Interfaces[iface]
+		if !ours {
+			// lo, or an interface behind a device this emulator does not own.
+			continue
+		}
+		entry.Addresses = addresses
+		shape.Interfaces[iface] = entry
+	}
+
+	out, err = d.run(ctx, "exec", machine, "--", "ip", "-4", "route", "show")
+	if err != nil {
+		return Shape{}, fmt.Errorf("read the routes of %s: %w", machine, err)
+	}
+	shape.Routes = parseRoutes(out)
+	return shape, nil
+}
+
+// Door implements Observer.
+func (d *Incus) Door(ctx context.Context, machine string, from, to netip.Addr) (Route, error) {
+	if !safeName.MatchString(machine) {
+		return Route{}, fmt.Errorf("invalid machine name %q", machine)
+	}
+	out, err := d.run(ctx, "exec", machine, "--",
+		"ip", "-4", "route", "get", to.String(), "from", from.String())
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "network is unreachable") {
+			// A fact about the machine — it has no route there — rather than
+			// a failure to read it. The zero Route says so.
+			return Route{}, nil
+		}
+		return Route{}, fmt.Errorf("read the door of %s from %s: %w", machine, from, err)
+	}
+	route, err := parseDoor(out)
+	if err != nil {
+		return Route{}, fmt.Errorf("read the door of %s from %s: %w", machine, from, err)
+	}
+	route.Dst = netip.PrefixFrom(to, to.BitLen())
+	return route, nil
+}
+
+// sortedList reads a comma-separated device value into a sorted list.
+func sortedList(value string) []string {
+	out := splitList(value)
+	slices.Sort(out)
+	return out
+}
+
+// parseAddresses reads `ip -4 -o addr show`: one address per line, the
+// interface second, the CIDR after `inet`, and the scope after `scope`. Only a
+// global address enters the Shape; link-local and host scopes are the
+// kernel's own.
+//
+//	iproute2  2: eth0    inet 10.30.1.10/24 brd 10.30.1.255 scope global eth0\       valid_lft forever preferred_lft forever
+//	busybox   2: eth0    inet 10.30.1.10/24 scope global eth0
+func parseAddresses(out []byte) map[string][]netip.Prefix {
+	found := map[string][]netip.Prefix{}
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			continue
+		}
+		iface := strings.TrimSuffix(fields[1], ":")
+		var cidr, scope string
+		for i, field := range fields {
+			if i+1 >= len(fields) {
+				break
+			}
+			switch field {
+			case "inet":
+				cidr = fields[i+1]
+			case "scope":
+				scope = fields[i+1]
+			}
+		}
+		if cidr == "" || scope != "global" {
+			continue
+		}
+		prefix, err := netip.ParsePrefix(cidr)
+		if err != nil || !prefix.Addr().Is4() || linkLocal.Contains(prefix.Addr()) {
+			continue
+		}
+		found[iface] = append(found[iface], prefix)
+	}
+	return found
+}
+
+// parseRoutes reads `ip -4 route show` down to what compares: a destination,
+// a next hop and a device. Everything else on the line — proto, src, metric,
+// onlink, linkdown — is dropped, and so is every line with no `via`: a
+// connected route is implied by the address that created it, and comparing
+// it would compare the address twice.
+//
+//	iproute2  default via 10.30.1.1 dev eth0 proto dhcp src 10.30.1.10 metric 100
+//	          10.30.1.0/24 dev eth0 proto kernel scope link src 10.30.1.10
+//	busybox   default via 10.30.1.1 dev eth0  metric 100
+//	          10.0.0.0/8 via 10.30.1.1 dev eth0
+func parseRoutes(out []byte) []Route {
+	var routes []Route
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		var dst netip.Prefix
+		switch first := fields[0]; first {
+		case "default":
+			dst = defaultDst
+		case "unreachable", "blackhole", "prohibit", "throw", "local", "broadcast", "multicast", "anycast", "nat":
+			continue
+		default:
+			parsed, err := parseDestination(first)
+			if err != nil {
+				continue
+			}
+			dst = parsed
+		}
+		via, dev := nextHop(fields)
+		if !via.IsValid() || dev == "" {
+			continue
+		}
+		if dst != defaultDst && linkLocal.Contains(dst.Addr()) {
+			continue
+		}
+		routes = append(routes, Route{Dst: dst.Masked(), Via: via, Dev: dev})
+	}
+	return routes
+}
+
+// parseDoor reads the first line of `ip -4 route get <to> from <from>`:
+//
+//	iproute2  10.209.83.1 from 203.0.113.2 via 169.254.0.1 dev eth0 uid 0
+//	busybox   10.209.83.1 from 203.0.113.2 via 169.254.0.1 dev eth0  src 203.0.113.2
+//
+// and a connected answer names the device alone. The device is required: an
+// answer with none is not a door.
+func parseDoor(out []byte) (Route, error) {
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		via, dev := nextHop(fields)
+		if dev == "" {
+			return Route{}, fmt.Errorf("no device in the answer %q", strings.TrimSpace(line))
+		}
+		return Route{Via: via, Dev: dev}, nil
+	}
+	return Route{}, fmt.Errorf("an empty answer")
+}
+
+// parseDestination reads a route's destination: a block, or a bare address
+// the kernel prints for a host route.
+func parseDestination(field string) (netip.Prefix, error) {
+	if strings.Contains(field, "/") {
+		prefix, err := netip.ParsePrefix(field)
+		if err != nil {
+			return netip.Prefix{}, err
+		}
+		if !prefix.Addr().Is4() {
+			return netip.Prefix{}, fmt.Errorf("%s is not IPv4", field)
+		}
+		return prefix, nil
+	}
+	addr, err := netip.ParseAddr(field)
+	if err != nil {
+		return netip.Prefix{}, err
+	}
+	if !addr.Is4() {
+		return netip.Prefix{}, fmt.Errorf("%s is not IPv4", field)
+	}
+	return netip.PrefixFrom(addr, addr.BitLen()), nil
+}
+
+// nextHop scans a route line for its `via` and `dev`, wherever they sit.
+func nextHop(fields []string) (via netip.Addr, dev string) {
+	for i, field := range fields {
+		if i+1 >= len(fields) {
+			break
+		}
+		switch field {
+		case "via":
+			if addr, err := netip.ParseAddr(fields[i+1]); err == nil {
+				via = addr
+			}
+		case "dev":
+			dev = fields[i+1]
+		}
+	}
+	return via, dev
+}

--- a/internal/core/machine/readback.go
+++ b/internal/core/machine/readback.go
@@ -1,0 +1,171 @@
+package machine
+
+import (
+	"context"
+	"net/netip"
+	"slices"
+
+	"github.com/stephrobert/feint/internal/core/resource"
+)
+
+// Nothing in this repository read back what a machine actually carried after
+// a lifecycle action (#668). Every step reported its own success, and the sum
+// of successful steps was not a working machine: on 2026-09-04 a route was
+// replaced, every exec returned 0, and the machine answered nothing at its
+// published address (#660). This file is the reading half of the guard whose
+// derivation half is claims.go: the driver reads a Shape, and every claim the
+// plan made is answered against it.
+//
+// Three outcomes, never two. A read that fails is Unreadable — neither held
+// nor broken, and counted — because folding it onto either is how a verifier
+// starts lying. And a runtime that cannot be asked at all is a fourth state,
+// held apart from the three: verify answers asked=false for it, so that
+// nothing downstream mistakes "nobody looked" for "nothing was wrong".
+//
+// When to read. The layer already knows when a container has finished
+// configuring itself, because it already waits: waitForGuestInterface blocks
+// until the interface carries an address, and settleFirstBoot and
+// restoreGuestNetwork run inside Start. When Binding.PowerOn returns, a
+// container is configured, and the aggregates arrive in DHCP option 121 with
+// the lease. A virtual machine is Unreadable until its agent answers, and the
+// verification replays from ReplayAddresses, the late-address door that
+// already exists for exactly that.
+
+// Observer is the optional half a driver implements, on the model of
+// EgressRouter and Capable: it reads back what a machine carries. A driver
+// that does not implement it is a driver nobody can ask, which is not a
+// failed read — see verify.
+type Observer interface {
+	// Observe reads the machine's interfaces, addresses, routes, rule-set
+	// bindings and the gateways of its emulated networks, normalised the way
+	// Shape documents.
+	Observe(ctx context.Context, machine string) (Shape, error)
+	// Door answers which door a reply from one address leaves by towards a
+	// destination: `ip route get <to> from <from>`. A machine with no route
+	// at all answers the zero Route and no error, because "no route" is a
+	// fact about the machine and not a failure to read it.
+	Door(ctx context.Context, machine string, from, to netip.Addr) (Route, error)
+}
+
+// doorAsker is the claim-side half of Door: a claim that needs one read says
+// which, and the reading half asks on its behalf before checking.
+type doorAsker interface {
+	door() (from, to netip.Addr)
+}
+
+// observer answers the runtime's reading half, nil when it has none.
+func (r Reconciler) observer() Observer {
+	obs, _ := r.binding().driver.(Observer)
+	return obs
+}
+
+// verify derives what the plan claims, reads what the machine carries, and
+// answers every claim. asked is false when nobody could look: a runtime with
+// no Observer, a resource with no machine, or a plan that was refused before
+// the runtime was asked (its refusal is already in the log).
+//
+// A shape that could not be read answers Unreadable on every claim rather
+// than nothing, so the count of what was not verified is visible where the
+// count of what was is. A door that could not be read answers Unreadable on
+// that claim alone.
+//
+// TestAPlantedDivergenceIsReported and TestAnUnreadableShapeIsNeitherHeldNorBroken
+// are the instrument's two controls, and both fail without this.
+func (r Reconciler) verify(ctx context.Context, res *resource.Resource) (verdicts []Verdict, asked bool) {
+	obs := r.observer()
+	name := res.Runtime[r.binding().RuntimeKey]
+	if obs == nil || name == "" {
+		return nil, false
+	}
+	plan, declared := r.plan(res)
+	if !declared {
+		return nil, false
+	}
+	claims, err := r.Expect(plan, r.dialect())
+	if err != nil {
+		return nil, false
+	}
+	claims = append(claims, r.wears(res, plan)...)
+	if len(claims) == 0 {
+		return nil, true
+	}
+	shape, err := obs.Observe(ctx, name)
+	if err != nil {
+		for _, c := range claims {
+			verdicts = append(verdicts, unreadable(c, err.Error()))
+		}
+		return verdicts, true
+	}
+	for _, c := range claims {
+		if asker, asks := c.(doorAsker); asks {
+			from, to := asker.door()
+			route, err := obs.Door(ctx, name, from, to)
+			if err != nil {
+				verdicts = append(verdicts, unreadable(c, err.Error()))
+				continue
+			}
+			if shape.Doors == nil {
+				shape.Doors = map[netip.Addr]Route{}
+			}
+			shape.Doors[from] = route
+		}
+		verdicts = append(verdicts, c.Check(shape))
+	}
+	return verdicts, true
+}
+
+// wears derives the rule-set claims from the same fields the firewall step
+// reads, so the claim cannot drift from what ApplyRuleSets asked for: the
+// machine's worn groups become names through the pack's own translation, and
+// the networks its groups do not reach come off the plan (#574).
+//
+// Claimed only when the machine wears at least one enforcing group. A machine
+// wearing none is left to the isolation pass, which binds either nothing or
+// the permissive posture set depending on whether the network is isolated —
+// a distinction that is the isolation pass's to make and would read as a
+// broken claim here. And not at all when the host withdrew the firewall
+// capability (#454): a claim about rule sets the host refused to bind would
+// be broken on every machine, for a fact /_feint/health already publishes.
+//
+// TestTheRuleSetsAMachineWearsAreClaimedOnItsFilteredInterfaces fails without
+// this.
+func (r Reconciler) wears(res *resource.Resource, plan Plan) []Claim {
+	s := r.Groups
+	if !s.wired() || s.enforcer() == nil {
+		return nil
+	}
+	if !CapabilitiesOf(r.binding().driver).Firewall {
+		return nil
+	}
+	var names []string
+	for _, id := range s.WornIDs(res) {
+		group, found := s.Group(id)
+		if !found {
+			continue
+		}
+		spec := s.spec(group, res)
+		if spec.EnforcesNothing() || slices.Contains(names, spec.Name) {
+			continue
+		}
+		names = append(names, spec.Name)
+	}
+	if len(names) == 0 {
+		return nil
+	}
+	slices.Sort(names)
+	unfiltered := s.unfiltered(res)
+	var claims []Claim
+	var seen []string
+	for _, att := range plan.attachments() {
+		if att.Network == "" || slices.Contains(seen, att.Network) {
+			continue
+		}
+		seen = append(seen, att.Network)
+		if slices.Contains(unfiltered, att.Network) {
+			claims = append(claims, wears{Network: att.Network})
+			continue
+		}
+		claims = append(claims, wears{Network: att.Network, Sets: names})
+	}
+	return claims
+}

--- a/internal/core/machine/readback_test.go
+++ b/internal/core/machine/readback_test.go
@@ -1,0 +1,509 @@
+package machine
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"strings"
+	"testing"
+)
+
+// The reading half of the guard (#668): what the driver reads back, how the
+// three outcomes are told apart, and the two controls without which the
+// instrument proves nothing — a divergence planted on purpose must be found,
+// and a read that failed must be neither held nor broken.
+
+// regressionMachine answers the fake runtime for the machine of 2026-09-04
+// (#660): one OVN interface on fnt-web carrying its private address and the
+// public /32, the default route through the private gateway, and the noise a
+// real table carries — connected routes, a link-local one, an unreachable
+// line, a metadata route, a profile device the operator owns.
+func regressionMachine(f *fakeRuntime) {
+	f.hook = func(_ int, args []string) ([]byte, error, bool) {
+		switch key := strings.Join(args, " "); {
+		case key == "query /1.0/instances/srv":
+			return []byte(`{
+  "devices": {
+    "eth0": {"type": "nic", "network": "fnt-web", "ipv4.address": "10.77.0.2", "ipv4.routes.external": "203.0.113.2/32", "security.acls": "fnt-sg1"},
+    "root": {"type": "disk", "path": "/"}
+  },
+  "expanded_devices": {
+    "eth0": {"type": "nic", "network": "fnt-web", "ipv4.address": "10.77.0.2", "ipv4.routes.external": "203.0.113.2/32", "security.acls": "fnt-sg1"},
+    "eth9": {"type": "nic", "network": "incusbr0"},
+    "root": {"type": "disk", "path": "/"}
+  }
+}`), nil, true
+		case key == "network get fnt-web ipv4.address":
+			return []byte("10.77.0.1/24\n"), nil, true
+		case key == "exec srv -- ip -4 -o addr show":
+			return []byte(`1: lo    inet 127.0.0.1/8 scope host lo\       valid_lft forever preferred_lft forever
+2: eth0    inet 10.77.0.2/24 brd 10.77.0.255 scope global eth0\       valid_lft forever preferred_lft forever
+2: eth0    inet 203.0.113.2/32 scope global eth0\       valid_lft forever preferred_lft forever
+2: eth0    inet 10.99.0.1/24 scope link eth0\       valid_lft forever preferred_lft forever
+9: eth9    inet 10.76.154.20/24 brd 10.76.154.255 scope global dynamic eth9\       valid_lft 3000sec preferred_lft 3000sec
+`), nil, true
+		case key == "exec srv -- ip -4 route show":
+			return []byte(`default via 10.77.0.1 dev eth0 proto dhcp src 10.77.0.2 metric 100
+10.0.0.0/8 via 10.77.0.1 dev eth0 proto dhcp src 10.77.0.2 metric 100
+10.77.0.0/24 dev eth0 proto kernel scope link src 10.77.0.2 metric 100
+10.77.0.1 dev eth0 proto dhcp scope link src 10.77.0.2 metric 100
+169.254.0.0/16 dev eth0 scope link metric 1000
+169.254.169.254 via 10.77.0.1 dev eth0 proto static
+172.16.0.0/12 via 10.77.0.1 dev eth0 proto dhcp src 10.77.0.2 metric 100
+192.168.0.0/16 via 10.77.0.1 dev eth0 proto dhcp src 10.77.0.2 metric 100
+unreachable 198.51.100.0/24 dev lo
+`), nil, true
+		case strings.HasPrefix(key, "exec srv -- ip -4 route get 10.209.83.1 from 203.0.113.2"):
+			return []byte("10.209.83.1 from 203.0.113.2 via 10.77.0.1 dev eth0 uid 0 \n    cache \n"), nil, true
+		}
+		return nil, nil, false
+	}
+}
+
+func mustObserve(t *testing.T, d *Incus) Shape {
+	t.Helper()
+	shape, err := d.Observe(context.Background(), "srv")
+	if err != nil {
+		t.Fatalf("observe: %v", err)
+	}
+	return shape
+}
+
+// TestObserveReadsBackWhatTheMachineCarries is the reading on the machine of
+// the regression, with everything a real table carries that must NOT enter
+// the Shape: the connected routes, the link-local block and the metadata
+// route inside it, the unreachable line, the scope-link address, the
+// loopback, and the profile device's address.
+func TestObserveReadsBackWhatTheMachineCarries(t *testing.T) {
+	f := &fakeRuntime{}
+	regressionMachine(f)
+	shape := mustObserve(t, ovnDriver(f))
+
+	if len(shape.Interfaces) != 1 {
+		t.Fatalf("interfaces %v, want eth0 alone", shape.interfaceNames())
+	}
+	eth0 := shape.Interfaces["eth0"]
+	if eth0.Network != "fnt-web" || eth0.Routed {
+		t.Errorf("eth0 read as %+v", eth0)
+	}
+	if got := prefixes(eth0.Addresses); got != "10.77.0.2/24, 203.0.113.2/32" {
+		t.Errorf("eth0 carries %s, want the private /24 and the public /32 and nothing of scope link", got)
+	}
+	if strings.Join(eth0.RuleSets, ",") != "fnt-sg1" {
+		t.Errorf("eth0 wears %v", eth0.RuleSets)
+	}
+	want := []string{
+		"0.0.0.0/0 via 10.77.0.1 dev eth0",
+		"10.0.0.0/8 via 10.77.0.1 dev eth0",
+		"172.16.0.0/12 via 10.77.0.1 dev eth0",
+		"192.168.0.0/16 via 10.77.0.1 dev eth0",
+	}
+	got := make([]string, 0, len(shape.Routes))
+	for _, r := range shape.Routes {
+		got = append(got, r.Dst.String()+" "+r.String())
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Errorf("routes:\n%s\nwant:\n%s", strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+	if gw := shape.Gateways["fnt-web"]; gw.String() != "10.77.0.1/24" {
+		t.Errorf("gateway of fnt-web read as %s", gw)
+	}
+	if len(shape.Gateways) != 1 {
+		t.Errorf("gateways %v, want fnt-web alone", shape.Gateways)
+	}
+}
+
+// A profile device is the operator's: their bridge, their address, and no
+// plan ever claimed it.
+func TestObserveReadsOnlyTheMachinesOwnNICs(t *testing.T) {
+	f := &fakeRuntime{}
+	regressionMachine(f)
+	shape := mustObserve(t, ovnDriver(f))
+	if _, read := shape.Interfaces["eth9"]; read {
+		t.Fatal("the profile's eth9 entered the Shape, and it carries an address no plan claims")
+	}
+}
+
+// A NIC the machine owns on a network the emulator did not derive is read as
+// an interface, and its network's gateway is not asked for: that gateway is
+// the operator's, and a claim needing it answers Unreadable instead.
+func TestObserveReadsNoForeignNetwork(t *testing.T) {
+	f := &fakeRuntime{}
+	f.hook = func(_ int, args []string) ([]byte, error, bool) {
+		switch key := strings.Join(args, " "); key {
+		case "query /1.0/instances/srv":
+			return []byte(`{"devices": {"eth1": {"type": "nic", "network": "incusbr0"}},
+ "expanded_devices": {"eth1": {"type": "nic", "network": "incusbr0"}}}`), nil, true
+		case "exec srv -- ip -4 -o addr show":
+			return []byte("3: eth1    inet 10.76.154.20/24 scope global eth1\n"), nil, true
+		case "exec srv -- ip -4 route show":
+			return []byte("default via 10.76.154.1 dev eth1 proto dhcp\n"), nil, true
+		}
+		return nil, nil, false
+	}
+	shape := mustObserve(t, newFakeDriver(f))
+	if shape.Interfaces["eth1"].Network != "incusbr0" {
+		t.Errorf("the foreign NIC was not read as an interface: %+v", shape.Interfaces)
+	}
+	if len(f.matching("network get incusbr0")) != 0 || len(shape.Gateways) != 0 {
+		t.Errorf("the operator's network was asked for its gateway: %v", f.matching("network get"))
+	}
+	v := leases{Network: "incusbr0"}.Check(shape)
+	if v.Outcome != Unreadable {
+		t.Errorf("a claim on the foreign network answered %s, want unreadable", v)
+	}
+}
+
+// A virtual machine names its interfaces by PCI slot, not by device: the
+// Shape is keyed by what the guest calls them, the way the routes are.
+func TestObserveNamesAVirtualMachinesInterfacesByMAC(t *testing.T) {
+	f := &fakeRuntime{}
+	f.hook = func(_ int, args []string) ([]byte, error, bool) {
+		switch key := strings.Join(args, " "); key {
+		case "query /1.0/instances/srv":
+			return []byte(`{"devices": {"eth0": {"type": "nic", "network": "fnt-web", "ipv4.address": "10.77.0.2"}},
+ "expanded_devices": {"eth0": {"type": "nic", "network": "fnt-web", "ipv4.address": "10.77.0.2"}}}`), nil, true
+		case "query /1.0/instances/srv/state":
+			return []byte(`{"network": {"enp5s0": {"hwaddr": "00:16:3e:11:22:33"}, "lo": {"hwaddr": ""}}}`), nil, true
+		case "config device get srv eth0 hwaddr":
+			return []byte("00:16:3e:11:22:33\n"), nil, true
+		case "network get fnt-web ipv4.address":
+			return []byte("10.77.0.1/24\n"), nil, true
+		case "exec srv -- ip -4 -o addr show":
+			return []byte("2: enp5s0    inet 10.77.0.2/24 brd 10.77.0.255 scope global enp5s0\n"), nil, true
+		case "exec srv -- ip -4 route show":
+			return []byte("default via 10.77.0.1 dev enp5s0 proto dhcp\n"), nil, true
+		}
+		return nil, nil, false
+	}
+	d := ovnDriver(f)
+	d.VM = true
+	shape := mustObserve(t, d)
+	iface, read := shape.Interfaces["enp5s0"]
+	if !read || prefixes(iface.Addresses) != "10.77.0.2/24" {
+		t.Fatalf("the VM's interface was not read under the guest's name: %+v", shape.Interfaces)
+	}
+	if v := (carries{Network: "fnt-web", Address: netip.MustParseAddr("10.77.0.2"), Bits: 24}).Check(shape); v.Outcome != Held {
+		t.Errorf("the pinned address on a VM answered %s", v)
+	}
+}
+
+// TestTheReplyDoorOfTheRegressionIsBroken reproduces #660 through the fake
+// runtime: the reply from the public address leaves through the private
+// gateway, and a door claim wanting the routed next hop is broken with both
+// doors named.
+//
+// The wanted door is the TEST's, written down as what docs/limits.md records
+// for the routed shape, and deliberately not derived: which door is right on
+// the shape this fixture models is the measurement #672 asks for, and this
+// test holds the comparator, not the table.
+func TestTheReplyDoorOfTheRegressionIsBroken(t *testing.T) {
+	f := &fakeRuntime{}
+	regressionMachine(f)
+	d := ovnDriver(f)
+	shape := mustObserve(t, d)
+
+	from, to := netip.MustParseAddr("203.0.113.2"), netip.MustParseAddr("10.209.83.1")
+	got, err := d.Door(context.Background(), "srv", from, to)
+	if err != nil {
+		t.Fatalf("door: %v", err)
+	}
+	shape.Doors = map[netip.Addr]Route{from: got}
+
+	claim := door{From: from, To: to, Via: netip.MustParseAddr("169.254.0.1"), Dev: "eth0"}
+	v := claim.Check(shape)
+	if v.Outcome != Broken {
+		t.Fatalf("the regression's door answered %s, want broken", v)
+	}
+	if v.Want != "via 169.254.0.1 dev eth0" || v.Got != "via 10.77.0.1 dev eth0" {
+		t.Errorf("the verdict does not name both doors: %s", v)
+	}
+	if v.String() != "door(203.0.113.2) broken: want via 169.254.0.1 dev eth0, got via 10.77.0.1 dev eth0" {
+		t.Errorf("rendered as %q", v.String())
+	}
+}
+
+// A machine with no route towards the destination has answered a fact about
+// itself, not refused a read: the door is broken, never unreadable. A read
+// the kernel refuses for another reason stays a failed read.
+func TestADoorWithNoRouteIsBrokenNotUnreadable(t *testing.T) {
+	f := &fakeRuntime{fail: map[string]error{
+		"route get": errors.New("RTNETLINK answers: Network is unreachable"),
+	}}
+	d := ovnDriver(f)
+	from, to := netip.MustParseAddr("203.0.113.2"), netip.MustParseAddr("10.209.83.1")
+	got, err := d.Door(context.Background(), "srv", from, to)
+	if err != nil || got.Dev != "" {
+		t.Fatalf("no route answered (%v, %v), want the zero route and no error", got, err)
+	}
+	v := (door{From: from, To: to, Via: netip.MustParseAddr("169.254.0.1"), Dev: "eth0"}).Check(
+		Shape{Doors: map[netip.Addr]Route{from: got}})
+	if v.Outcome != Broken || v.Got != "no route" {
+		t.Errorf("a machine with no route answered %s", v)
+	}
+
+	f.fail["route get"] = errors.New("RTNETLINK answers: Invalid argument")
+	if _, err := d.Door(context.Background(), "srv", from, to); err == nil {
+		t.Error("a read the kernel refused for another reason was not reported as a failed read")
+	}
+}
+
+// TestTheParsersReadBothImplementationsOfIp holds each parser to the two
+// formats in play: iproute2 on the Debian, Ubuntu and RHEL images, busybox on
+// Alpine. A parser that read one would report the other's machines bare.
+func TestTheParsersReadBothImplementationsOfIp(t *testing.T) {
+	for name, out := range map[string]string{
+		"iproute2": `2: eth0    inet 10.30.1.10/24 brd 10.30.1.255 scope global eth0\       valid_lft forever preferred_lft forever`,
+		"busybox":  `2: eth0    inet 10.30.1.10/24 scope global eth0`,
+	} {
+		got := parseAddresses([]byte(out))
+		if prefixes(got["eth0"]) != "10.30.1.10/24" {
+			t.Errorf("%s addresses: %v", name, got)
+		}
+	}
+	for name, out := range map[string]string{
+		"iproute2": "default via 10.30.1.1 dev eth0 proto dhcp src 10.30.1.10 metric 100\n10.30.1.0/24 dev eth0 proto kernel scope link src 10.30.1.10\n",
+		"busybox":  "default via 10.30.1.1 dev eth0  metric 100\n10.30.1.0/24 dev eth0 scope link  src 10.30.1.10\n",
+	} {
+		got := parseRoutes([]byte(out))
+		if len(got) != 1 || got[0].Dst != defaultDst || got[0].String() != "via 10.30.1.1 dev eth0" {
+			t.Errorf("%s routes: %v", name, got)
+		}
+	}
+	for name, out := range map[string]string{
+		"iproute2": "10.209.83.1 from 203.0.113.2 via 169.254.0.1 dev eth0 uid 0 \n    cache \n",
+		"busybox":  "10.209.83.1 from 203.0.113.2 via 169.254.0.1 dev eth0  src 203.0.113.2 \n",
+	} {
+		got, err := parseDoor([]byte(out))
+		if err != nil || got.String() != "via 169.254.0.1 dev eth0" {
+			t.Errorf("%s door: %v, %v", name, got, err)
+		}
+	}
+	// iproute2 ends every route line with a space, which the repository's
+	// whitespace hook strips from a fixture: held here as an escape, so the
+	// tolerance is measured rather than assumed.
+	if got := parseRoutes([]byte("default via 10.30.1.1 dev eth0 proto dhcp metric 100\x20\n")); len(got) != 1 {
+		t.Errorf("a trailing space on a route line: %v", got)
+	}
+	// A host route prints its address bare, and a connected door names the
+	// device alone.
+	if got := parseRoutes([]byte("203.0.113.9 via 10.0.0.1 dev eth1\n")); len(got) != 1 || got[0].Dst.String() != "203.0.113.9/32" {
+		t.Errorf("a bare host route: %v", got)
+	}
+	if got, err := parseDoor([]byte("10.30.1.11 from 10.30.1.10 dev eth0 uid 0\n")); err != nil || got.Via.IsValid() || got.Dev != "eth0" {
+		t.Errorf("a connected door: %v, %v", got, err)
+	}
+	if _, err := parseDoor([]byte("\n")); err == nil {
+		t.Error("an empty answer parsed as a door")
+	}
+}
+
+// ---- the layer: verify over an observing runtime ----------------------------
+
+// observingRecorder is the contract recorder with the reading half: the
+// Shape a test writes is what the runtime reports, which is the only way to
+// plant a divergence and know exactly what the verifier had to find.
+type observingRecorder struct {
+	*Recorder
+	shape      Shape
+	err        error
+	noFirewall bool
+}
+
+func (o *observingRecorder) Observe(context.Context, string) (Shape, error) {
+	return o.shape, o.err
+}
+
+func (o *observingRecorder) Door(_ context.Context, _ string, from, _ netip.Addr) (Route, error) {
+	if route, read := o.shape.Doors[from]; read {
+		return route, nil
+	}
+	return Route{}, errors.New("no door was planted")
+}
+
+func (o *observingRecorder) Capabilities() Capabilities {
+	caps := o.Recorder.Capabilities()
+	if o.noFirewall {
+		caps.Firewall = false
+	}
+	return caps
+}
+
+func observingReconciler(b *groupSyncBench, o *observingRecorder, plan Plan) Reconciler {
+	sync := b.sync()
+	sync.Binding.driver = o
+	sync.Binding.RunningState = "running"
+	sync.Binding.FailedState = "stopped"
+	sync.PlanOf = func(*testResource) Plan { return plan }
+	return Reconciler{
+		Groups:      sync,
+		PlanOf:      func(*testResource) Plan { return plan },
+		PublicBlock: netip.MustParsePrefix("203.0.113.0/24"),
+	}
+}
+
+// pinnedOn is the Shape of a machine carrying one pinned address on one
+// emulated network, its gateway read.
+func pinnedOn(network, cidr string, sets ...string) Shape {
+	return Shape{
+		Interfaces: map[string]Interface{
+			"eth0": {Network: network, Addresses: []netip.Prefix{netip.MustParsePrefix(cidr)}, RuleSets: sets},
+		},
+		Gateways: map[string]netip.Prefix{network: netip.MustParsePrefix("10.30.1.1/24")},
+	}
+}
+
+func outcomes(verdicts []Verdict) string {
+	out := make([]string, 0, len(verdicts))
+	for _, v := range verdicts {
+		out = append(out, v.String())
+	}
+	return strings.Join(out, "\n")
+}
+
+// TestAPlantedDivergenceIsReported is the positive control: a verifier that
+// has never found anything is indistinguishable from one that does not look.
+// The accepting half runs on the same plan and the same runtime, so the
+// finding cannot be a verifier that refuses everything.
+func TestAPlantedDivergenceIsReported(t *testing.T) {
+	plan := Plan{Boot: []Attachment{{Network: "fnt-x", Address: "10.30.1.10", PrefixLen: 24}}}
+	b := newGroupSyncBench()
+	o := &observingRecorder{Recorder: b.rec, shape: pinnedOn("fnt-x", "10.30.1.10/24")}
+	vm := b.machine("m", "10.30.1.10")
+	r := observingReconciler(b, o, plan)
+
+	verdicts, asked := r.verify(context.Background(), vm)
+	if !asked || len(verdicts) != 1 || verdicts[0].Outcome != Held {
+		t.Fatalf("a machine carrying what its plan claims answered asked=%v:\n%s", asked, outcomes(verdicts))
+	}
+
+	// One digit off, planted: the address the runtime reports is not the
+	// one the plan pinned.
+	o.shape = pinnedOn("fnt-x", "10.30.1.11/24")
+	verdicts, asked = r.verify(context.Background(), vm)
+	if !asked || len(verdicts) != 1 {
+		t.Fatalf("asked=%v, verdicts:\n%s", asked, outcomes(verdicts))
+	}
+	v := verdicts[0]
+	if v.Outcome != Broken || v.Claim != "carries(fnt-x, 10.30.1.10/24)" || v.Got != "eth0: 10.30.1.11/24" {
+		t.Fatalf("the planted divergence was not reported as itself: %s", v)
+	}
+}
+
+// TestAnUnreadableShapeIsNeitherHeldNorBroken is the second control: a read
+// that failed answers Unreadable on every claim, counted, and a runtime that
+// cannot be asked at all is not asked — a fourth state, told from the third.
+func TestAnUnreadableShapeIsNeitherHeldNorBroken(t *testing.T) {
+	plan := Plan{Boot: []Attachment{{Network: "fnt-x", Address: "10.30.1.10", PrefixLen: 24}}, Publics: []string{"203.0.113.2"}}
+	b := newGroupSyncBench()
+	o := &observingRecorder{Recorder: b.rec, err: errors.New("the agent isn't currently running")}
+	vm := b.machine("m", "10.30.1.10")
+
+	verdicts, asked := observingReconciler(b, o, plan).verify(context.Background(), vm)
+	if !asked || len(verdicts) != 2 {
+		t.Fatalf("asked=%v, verdicts:\n%s", asked, outcomes(verdicts))
+	}
+	for _, v := range verdicts {
+		if v.Outcome != Unreadable || !strings.Contains(v.Got, "agent") {
+			t.Errorf("a failed read answered %s, want unreadable naming the failure", v)
+		}
+	}
+
+	// A runtime with no reading half is not asked, and says so.
+	plain := rebootReconciler(b, plan)
+	if verdicts, asked := plain.verify(context.Background(), vm); asked || len(verdicts) != 0 {
+		t.Errorf("a runtime that cannot be asked answered asked=%v with %d verdicts", asked, len(verdicts))
+	}
+	// And so is a resource with no machine behind it.
+	bare := b.machine("bare", "")
+	if verdicts, asked := observingReconciler(b, o, plan).verify(context.Background(), bare); asked || len(verdicts) != 0 {
+		t.Errorf("a resource with no machine answered asked=%v with %d verdicts", asked, len(verdicts))
+	}
+}
+
+// The rule sets a machine wears are claimed on its filtered interfaces, from
+// the same fields the firewall step reads; an interface on a network the
+// pack declared outside its groups' reach is claimed bare.
+func TestTheRuleSetsAMachineWearsAreClaimedOnItsFilteredInterfaces(t *testing.T) {
+	plan := Plan{
+		Boot:        []Attachment{{Network: "fnt-x", Address: "10.30.1.10", PrefixLen: 24}},
+		Memberships: []Attachment{{Network: "fnt-y", Unfiltered: true}},
+	}
+	b := newGroupSyncBench()
+	b.group("g", "")
+	set := FirewallName("bench", "g")
+	shape := pinnedOn("fnt-x", "10.30.1.10/24", set)
+	shape.Interfaces["eth1"] = Interface{Network: "fnt-y", Addresses: []netip.Prefix{netip.MustParsePrefix("10.40.0.5/24")}}
+	shape.Gateways["fnt-y"] = netip.MustParsePrefix("10.40.0.1/24")
+	o := &observingRecorder{Recorder: b.rec, shape: shape}
+	vm := b.machine("m", "10.30.1.10", "g")
+	r := observingReconciler(b, o, plan)
+
+	verdicts, _ := r.verify(context.Background(), vm)
+	names := map[string]Verdict{}
+	for _, v := range verdicts {
+		names[v.Claim] = v
+	}
+	for _, claim := range []string{"wears(fnt-x)", "wears(fnt-y)"} {
+		v, claimed := names[claim]
+		if !claimed {
+			t.Fatalf("%s was not claimed:\n%s", claim, outcomes(verdicts))
+		}
+		if v.Outcome != Held {
+			t.Errorf("%s answered %s on a machine wearing exactly its group", claim, v)
+		}
+	}
+
+	// The unfiltered interface planted wearing the set: the pack said its
+	// groups do not reach it, and the runtime bound one anyway.
+	eth1 := shape.Interfaces["eth1"]
+	eth1.RuleSets = []string{set}
+	shape.Interfaces["eth1"] = eth1
+	verdicts, _ = r.verify(context.Background(), vm)
+	for _, v := range verdicts {
+		if v.Claim == "wears(fnt-y)" && (v.Outcome != Broken || v.Want != "no rule set on eth1") {
+			t.Errorf("an unfiltered interface wearing a set answered %s", v)
+		}
+	}
+}
+
+// A host that withdrew the firewall capability (#454) binds nothing, and a
+// claim about the bindings would be broken on every machine for a fact
+// /_feint/health already publishes.
+func TestAWithdrawnFirewallClaimsNoRuleSets(t *testing.T) {
+	plan := Plan{Boot: []Attachment{{Network: "fnt-x", Address: "10.30.1.10", PrefixLen: 24}}}
+	b := newGroupSyncBench()
+	b.group("g", "")
+	o := &observingRecorder{Recorder: b.rec, shape: pinnedOn("fnt-x", "10.30.1.10/24"), noFirewall: true}
+	vm := b.machine("m", "10.30.1.10", "g")
+
+	verdicts, _ := observingReconciler(b, o, plan).verify(context.Background(), vm)
+	for _, v := range verdicts {
+		if strings.HasPrefix(v.Claim, "wears(") {
+			t.Fatalf("a withdrawn firewall still claims rule sets: %s", v)
+		}
+	}
+}
+
+// The wears comparator on hand-built shapes: exact set equality, and "none"
+// when the claim is bare.
+func TestWearsComparesTheRuleSetsPerInterface(t *testing.T) {
+	shape := pinnedOn("fnt-x", "10.30.1.10/24", "fnt-a", "fnt-b")
+	requireOutcome(t, wears{Network: "fnt-x", Sets: []string{"fnt-a", "fnt-b"}}.Check(shape), Held)
+	v := wears{Network: "fnt-x", Sets: []string{"fnt-a"}}.Check(shape)
+	requireOutcome(t, v, Broken)
+	if v.Want != "fnt-a on eth0" || v.Got != "fnt-a, fnt-b on eth0" {
+		t.Errorf("the verdict does not name both bindings: %s", v)
+	}
+	v = wears{Network: "fnt-x"}.Check(shape)
+	requireOutcome(t, v, Broken)
+	if v.Want != "no rule set on eth0" {
+		t.Errorf("a bare claim wants %q", v.Want)
+	}
+	requireOutcome(t, wears{Network: "fnt-x"}.Check(pinnedOn("fnt-x", "10.30.1.10/24")), Held)
+	v = wears{Network: "fnt-z", Sets: []string{"fnt-a"}}.Check(shape)
+	requireOutcome(t, v, Broken)
+	if !strings.Contains(v.Got, "no interface on fnt-z") {
+		t.Errorf("a missing interface is not named: %s", v)
+	}
+}

--- a/tools/falsify/specs/a-shape-read-back.json
+++ b/tools/falsify/specs/a-shape-read-back.json
@@ -1,0 +1,82 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "the door comparator ignores the next hop, and the regression of 2026-09-04 reads as held (#668)",
+      "file": "internal/core/machine/claims.go",
+      "find": "\tif got.Via == c.Via && got.Dev == c.Dev {\n\t\treturn held(c)\n\t}",
+      "replace": "\tif (got.Via == c.Via || true) && got.Dev == c.Dev {\n\t\treturn held(c)\n\t}",
+      "test": "TestTheReplyDoorOfTheRegressionIsBroken"
+    },
+    {
+      "label": "a read that failed is judged on an empty shape, folding the third outcome onto the second (#668)",
+      "file": "internal/core/machine/readback.go",
+      "find": "\tshape, err := obs.Observe(ctx, name)\n\tif err != nil {\n\t\tfor _, c := range claims {",
+      "replace": "\tshape, err := obs.Observe(ctx, name)\n\tif err != nil && false {\n\t\tfor _, c := range claims {",
+      "test": "TestAnUnreadableShapeIsNeitherHeldNorBroken"
+    },
+    {
+      "label": "the carries comparator accepts any address of the right mask, so a planted divergence reads as held (#668)",
+      "file": "internal/core/machine/claims.go",
+      "find": "\t\t\tif p.Addr() == c.Address && (c.Bits == 0 || p.Bits() == c.Bits) {",
+      "replace": "\t\t\tif (p.Addr() == c.Address || true) && (c.Bits == 0 || p.Bits() == c.Bits) {",
+      "test": "TestAPlantedDivergenceIsReported"
+    },
+    {
+      "label": "the table parser keeps the connected routes, which compare the address twice (#668)",
+      "file": "internal/core/machine/incus_readback.go",
+      "find": "\t\tif !via.IsValid() || dev == \"\" {\n\t\t\tcontinue\n\t\t}",
+      "replace": "\t\tif (!via.IsValid() && false) || dev == \"\" {\n\t\t\tcontinue\n\t\t}",
+      "test": "TestObserveReadsBackWhatTheMachineCarries"
+    },
+    {
+      "label": "the table parser keeps the link-local block, which is the kernel's plumbing (#668)",
+      "file": "internal/core/machine/incus_readback.go",
+      "find": "\t\tif dst != defaultDst && linkLocal.Contains(dst.Addr()) {",
+      "replace": "\t\tif dst != defaultDst && linkLocal.Contains(dst.Addr()) && false {",
+      "test": "TestObserveReadsBackWhatTheMachineCarries"
+    },
+    {
+      "label": "the address parser ignores the scope, and a link-scope address enters the shape (#668)",
+      "file": "internal/core/machine/incus_readback.go",
+      "find": "\t\tif cidr == \"\" || scope != \"global\" {",
+      "replace": "\t\tif cidr == \"\" || (scope != \"global\" && false) {",
+      "test": "TestObserveReadsBackWhatTheMachineCarries"
+    },
+    {
+      "label": "the reading walks the profile devices too, and the operator's bridge enters the shape (#668)",
+      "file": "internal/core/machine/incus_readback.go",
+      "find": "\tfor device, cfg := range devices.own {\n\t\tif cfg[\"type\"] == \"nic\" {",
+      "replace": "\tfor device, cfg := range devices.expanded {\n\t\tif cfg[\"type\"] == \"nic\" {",
+      "test": "TestObserveReadsOnlyTheMachinesOwnNICs"
+    },
+    {
+      "label": "the reading asks an operator's network for its gateway (#668)",
+      "file": "internal/core/machine/incus_readback.go",
+      "find": "\t\tif network == \"\" || !ownedNetwork(network) {\n\t\t\tcontinue\n\t\t}",
+      "replace": "\t\tif network == \"\" || (!ownedNetwork(network) && false) {\n\t\t\tcontinue\n\t\t}",
+      "test": "TestObserveReadsNoForeignNetwork"
+    },
+    {
+      "label": "a machine with no route towards the destination is reported as a failed read rather than as a fact about the machine (#668)",
+      "file": "internal/core/machine/incus_readback.go",
+      "find": "\t\tif strings.Contains(strings.ToLower(err.Error()), \"network is unreachable\") {",
+      "replace": "\t\tif strings.Contains(strings.ToLower(err.Error()), \"network is unreachable\") && false {",
+      "test": "TestADoorWithNoRouteIsBrokenNotUnreadable"
+    },
+    {
+      "label": "the rule sets are claimed on a host that withdrew the firewall capability, broken on every machine for a fact health already publishes (#454, #668)",
+      "file": "internal/core/machine/readback.go",
+      "find": "\tif !CapabilitiesOf(r.binding().driver).Firewall {\n\t\treturn nil\n\t}",
+      "replace": "\tif !CapabilitiesOf(r.binding().driver).Firewall && false {\n\t\treturn nil\n\t}",
+      "test": "TestAWithdrawnFirewallClaimsNoRuleSets"
+    },
+    {
+      "label": "an interface the pack declared outside its groups' reach is claimed wearing them (#574, #668)",
+      "file": "internal/core/machine/readback.go",
+      "find": "\t\tif slices.Contains(unfiltered, att.Network) {\n\t\t\tclaims = append(claims, wears{Network: att.Network})\n\t\t\tcontinue\n\t\t}",
+      "replace": "\t\tif slices.Contains(unfiltered, att.Network) && false {\n\t\t\tclaims = append(claims, wears{Network: att.Network})\n\t\t\tcontinue\n\t\t}",
+      "test": "TestTheRuleSetsAMachineWearsAreClaimedOnItsFilteredInterfaces"
+    }
+  ]
+}


### PR DESCRIPTION
Nothing read back what a machine actually carried after a lifecycle
action; every step reported its own success, and the sum of successful
steps was not a working machine (#660). This is the reading half of the
guard whose derivation half is #667.

The Incus driver implements Observer: one `query` for the machine's own
devices, one `network get` per emulated network it sits on, and three
execs into the guest — `ip -4 -o addr show`, `ip -4 route show`, and one
`ip -4 route get <to> from <from>` per door a claim asks about. The text
of both `ip` implementations is parsed, iproute2 and busybox, because an
Alpine image has no `-j`; the parsers scan for keywords rather than
positions for that reason. What does not compare never enters the Shape:
connected routes, the link-local block and a metadata route inside it,
metrics, proto, src, an unreachable line, a scope-link address, the
loopback, the operator's profile devices, and the gateway of a network
the emulator did not derive.

Three outcomes, never two, and a fourth state held apart from them: a
read that failed answers unreadable on every claim, counted; a runtime
with no reading half is not asked, so "nobody looked" cannot pass as
"nothing was wrong". The rule sets a machine wears are claimed on its
filtered interfaces from the fields the firewall step reads, bare on the
networks a pack declared outside its groups' reach (#574), and not at all
where the host withdrew the firewall capability (#454) or the machine
wears no enforcing group — the permissive posture set is the isolation
pass's to bind, and would read as a broken claim here.

Measured here, with the fake runtime and a written Shape as the two
instruments: the machine of 2026-09-04 reads back as one interface on
fnt-web carrying 10.77.0.2/24 and 203.0.113.2/32 with four routes via
10.77.0.1 and nothing else; its reply door from the public address is
`via 10.77.0.1 dev eth0`, and a door claim wanting the routed next hop is
broken with both doors named; a divergence planted one digit off is
reported as itself; a failed read is neither held nor broken; a virtual
machine's interface is read under the guest's own name. Not measured
here: which door is RIGHT on that shape — the claim in the test is the
test's, written as what docs/limits.md records for the routed shape, and
nothing derives one (#672). Nor a real runtime: every read here is the
fake's answer, and the runtime leg is what proves the parsers against a
kernel.

verify is unexported and not yet wired into a lifecycle door; publishing
its verdicts is #670 and comparing a reboot's before and after is #669.

tools/falsify/specs/a-shape-read-back.json replays eleven mutations and
all eleven bite (2026-09-04).

Assisted-by: Claude Code (claude-fable-5-1)


🤖 Generated with [Claude Code](https://claude.com/claude-code)
