### PR TITLE
feat(machine): a verdict somebody reads, and the runtime leg gates on it (#670)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -58,6 +58,35 @@ change ni l'un ni l'autre a sa place dans `git log`.
   lb certificate list` et `scw lb subscriber list` dans la suite de
   conformance.
 
+- **Un verdict que quelqu'un lit : la vérification est publiée, et la jambe
+  runtime en fait un gate** (#670). Après chaque porte du cycle de vie (un
+  démarrage, un reboot, une jonction à chaud, une route à chaud, la porte
+  tardive d'une machine virtuelle), ce que le runtime a relu est publié là où
+  un humain regarde et là où un gate échoue : une ligne `ERROR` par
+  revendication rompue, nommant la revendication, la valeur attendue et celle
+  trouvée ; `Runtime["verified"]` sur la ressource, hors de toute vue client
+  et sur `/_feint/state` pour qui le demande ; et quatre compteurs sur
+  `/_feint/health`, `verification.{held,broken,unreadable,repaired}`, ce qui
+  porte le schéma de health à la version 8.
+
+  L'état de l'API ne bouge pas. Une machine qui tourne avec la mauvaise porte
+  tourne et est injoignable, et la publier arrêtée serait le mensonge dans
+  l'autre sens. Une réparation bornée : une première lecture rompue rejoue
+  une fois l'ordre d'après-démarrage, dont chaque étape est idempotente, et
+  relit ; la seconde lecture est ce qui est publié, et `repaired` compte
+  combien de fois la première avait tort, parce qu'une réparation qui tire à
+  chaque démarrage est un défaut caché derrière une relance. Une lecture
+  illisible n'est jamais rejouée, et la porte tardive ne lit que tant que
+  rien de lisible n'a été publié : un GET n'exécute jamais rien dans une
+  machine déjà vérifiée.
+
+  `tools/conformance/guard.sh verification <endpoint>`, appelé par chaque
+  jambe avant l'arrêt de son émulateur : `broken > 0` fait échouer la jambe en
+  nommant chaque revendication depuis l'état, plus d'illisibles que de tenues
+  la fait échouer comme une passe qui a mesuré son propre aveuglement, des
+  compteurs absents la font échouer plutôt que d'être lus comme zéro, et une
+  passe sans runtime est prévenue plutôt que jugée.
+
 - **Le runtime relit ce qu'une machine porte réellement, et chaque
   revendication de son plan reçoit l'une de trois issues** (#668). Le pilote
   Incus implémente `Observer` : un `query` pour les devices propres de la

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,32 @@ what this project is judged on: **a response shape a client can observe**, and
   Driven by `scw lb backend list-statistics`, `scw lb lb get-stats`, `scw lb
   certificate list` and `scw lb subscriber list` in the conformance suite.
 
+- **A verdict somebody reads: the verification is published, and the runtime
+  leg gates on it** (#670). After every lifecycle door — a boot, a reboot, a
+  hot join, a hot route, the late-address door of a virtual machine — what the
+  runtime read back is published where a human looks and where a gate fails:
+  an `ERROR` line per broken claim naming the claim, the wanted value and the
+  one found; `Runtime["verified"]` on the resource, out of every client's view
+  and on `/_feint/state` for whoever asks; and four counters on
+  `/_feint/health`, `verification.{held,broken,unreadable,repaired}`, which
+  moves the health schema to version 8.
+
+  The API state does not move. A machine running with the wrong door is
+  running and unreachable, and publishing it stopped would be the lie in the
+  other direction. One bounded repair: a broken first reading replays the
+  post-boot order once, every step of it idempotent, and reads again; the
+  second reading is what is published, and `repaired` counts how often the
+  first was wrong, because a repair that fires on every boot is a defect
+  hidden behind a retry. An unreadable reading is never replayed onto, and the
+  late-address door reads only while nothing readable was published, so a GET
+  never execs into a verified machine.
+
+  `tools/conformance/guard.sh verification <endpoint>`, called by every leg
+  before its emulator stops: `broken > 0` fails the leg naming each claim from
+  the state, more unreadable than held fails it as a pass that measured its
+  own blindness, absent counters fail it rather than read as zero, and a pass
+  with no runtime is told so rather than judged.
+
 - **The runtime reads back what a machine actually carries, and every claim
   of its plan is answered with three outcomes** (#668). The Incus driver
   implements `Observer`: one `query` for the machine's own devices, one

--- a/internal/cli/testdata/frozen/health.json
+++ b/internal/cli/testdata/frozen/health.json
@@ -592,6 +592,129 @@
           }
         ]
       }
+    },
+    {
+      "schema_version": 8,
+      "content": {
+        "fields": [
+          {
+            "path": "capabilities",
+            "type": "object"
+          },
+          {
+            "path": "capabilities.addresses",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.balancing",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.firewall",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.firewall_public_only",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.firewall_public_when_joined",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.isolation",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.machines",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.own_kernel",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.private_from_host",
+            "type": "bool"
+          },
+          {
+            "path": "enforced",
+            "type": "object"
+          },
+          {
+            "path": "enforced.balancing",
+            "type": "array"
+          },
+          {
+            "path": "enforced.balancing[]",
+            "type": "string"
+          },
+          {
+            "path": "enforced.firewall",
+            "type": "array"
+          },
+          {
+            "path": "enforced.firewall[]",
+            "type": "string"
+          },
+          {
+            "path": "instance",
+            "type": "object"
+          },
+          {
+            "path": "instance.pid",
+            "type": "number"
+          },
+          {
+            "path": "instance.started_at",
+            "type": "string"
+          },
+          {
+            "path": "machines",
+            "type": "string"
+          },
+          {
+            "path": "providers",
+            "type": "array"
+          },
+          {
+            "path": "providers[]",
+            "type": "string"
+          },
+          {
+            "path": "resources",
+            "type": "number"
+          },
+          {
+            "path": "schema_version",
+            "type": "number"
+          },
+          {
+            "path": "status",
+            "type": "string"
+          },
+          {
+            "path": "verification",
+            "type": "object"
+          },
+          {
+            "path": "verification.broken",
+            "type": "number"
+          },
+          {
+            "path": "verification.held",
+            "type": "number"
+          },
+          {
+            "path": "verification.repaired",
+            "type": "number"
+          },
+          {
+            "path": "verification.unreadable",
+            "type": "number"
+          }
+        ]
+      }
     }
   ]
 }

--- a/internal/core/emulator/emulator.go
+++ b/internal/core/emulator/emulator.go
@@ -722,6 +722,12 @@ func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
 		"machines":       driver,
 		"capabilities":   capabilities,
 		"enforced":       enforcement(s.packs),
+		// What the reading half answered so far (#670): claims held, broken
+		// and unreadable, and verifications repaired by one replay. Counters
+		// rather than claims, because a claim names a resource and this
+		// payload names none; /_feint/state carries the claim under each
+		// resource's Runtime, and tools/conformance/guard.sh reads both.
+		"verification": s.env.machines.Verification(),
 		"instance": map[string]any{
 			"pid":        os.Getpid(),
 			"started_at": s.started.Format(time.RFC3339),

--- a/internal/core/emulator/schema.go
+++ b/internal/core/emulator/schema.go
@@ -76,7 +76,16 @@ const (
 	// modes on 2026-08-28. Two shapes, two words: this one is true, the older
 	// one is still false, and a build that cannot answer the second question
 	// is what the bump makes visible.
-	HealthSchemaVersion = 7
+	//
+	// 8 since #670: the payload gained `verification`, four counters —
+	// `held`, `broken`, `unreadable`, `repaired` — of what the runtime read
+	// back after every lifecycle action against what each machine's plan
+	// claimed. Additive, and a gate rather than a detail: the runtime leg
+	// fails on `broken > 0` and on more unreadable than held, and a consumer
+	// that branches on this version can tell a build that answers the
+	// question from one that never asked it. A verdict nobody reads is a
+	// confession nobody hears.
+	HealthSchemaVersion = 8
 	// RoutesSchemaVersion is the shape of GET /_feint/routes.
 	//
 	// This one is not on the wire: the endpoint answers a bare JSON array — the

--- a/internal/core/emulator/verification_test.go
+++ b/internal/core/emulator/verification_test.go
@@ -1,0 +1,58 @@
+package emulator_test
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+)
+
+// TestHealthCarriesTheVerificationCounters: /_feint/health publishes what the
+// runtime read back against every plan, as four counters (#670). The frozen
+// fixture holds the shape and the version; this holds that the four are
+// there and numeric on the ordinary runtime-less emulator, where they are
+// honestly zero — nothing booted, so nothing was read.
+func TestHealthCarriesTheVerificationCounters(t *testing.T) {
+	env := emulator.DefaultEnv()
+	srv, err := emulator.NewServer(env, stubPack{name: "stub"})
+	if err != nil {
+		t.Fatalf("build emulator: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	resp, err := ts.Client().Get(ts.URL + "/_feint/health")
+	if err != nil {
+		t.Fatalf("health: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var health struct {
+		Schema       int `json:"schema_version"`
+		Verification *struct {
+			Held       *int64 `json:"held"`
+			Broken     *int64 `json:"broken"`
+			Unreadable *int64 `json:"unreadable"`
+			Repaired   *int64 `json:"repaired"`
+		} `json:"verification"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&health); err != nil {
+		t.Fatalf("health: decode: %v", err)
+	}
+	if health.Verification == nil {
+		t.Fatal("health carries no verification: a verdict nobody reads is a confession nobody hears")
+	}
+	for name, value := range map[string]*int64{
+		"held": health.Verification.Held, "broken": health.Verification.Broken,
+		"unreadable": health.Verification.Unreadable, "repaired": health.Verification.Repaired,
+	} {
+		if value == nil {
+			t.Errorf("verification.%s is absent, and a gate reading its absence as zero would pass every build", name)
+		} else if *value != 0 {
+			t.Errorf("verification.%s = %d on an emulator that booted nothing", name, *value)
+		}
+	}
+	if health.Schema != emulator.HealthSchemaVersion || health.Schema < 8 {
+		t.Errorf("schema_version %d: the counters are a surface change, and the version is what lets a consumer notice", health.Schema)
+	}
+}

--- a/internal/core/machine/binding.go
+++ b/internal/core/machine/binding.go
@@ -45,6 +45,12 @@ type Binding struct {
 	// internal/cli's TestNoPackReachesPastTheDeclaredDriverSurface holds what
 	// typing cannot.
 	driver driver
+	// tally is where this binding's verifications are counted (#670): the
+	// Runtime handle's, handed over with the driver by WithRuntime, so every
+	// pack bound into one emulator counts into the same four numbers and
+	// /_feint/health reads them off the handle. Nil for a binding built
+	// without a runtime, which counts nowhere.
+	tally *tally
 	// Provider labels everything this binding creates, so a sweep can find its
 	// own work and an operator's machines are never touched.
 	Provider string
@@ -132,6 +138,7 @@ type Binding struct {
 // carry one and hand it over without ever naming what is inside it.
 func (b Binding) WithRuntime(r Runtime) Binding {
 	b.driver = r.d
+	b.tally = r.tally
 	return b
 }
 

--- a/internal/core/machine/plan.go
+++ b/internal/core/machine/plan.go
@@ -3,6 +3,7 @@ package machine
 import (
 	"context"
 	"net/netip"
+	"strings"
 
 	"github.com/stephrobert/feint/internal/core/resource"
 )
@@ -197,12 +198,25 @@ func (r Reconciler) PowerOn(ctx context.Context, res *resource.Resource, boot Bo
 	if !r.binding().PowerOn(ctx, res, boot) {
 		return false
 	}
+	r.replay(ctx, res, plan)
+	// And what the replay produced is read back and published (#670): the
+	// state above is the one the boot produced, the verdict is the one the
+	// reading produced, and neither is allowed to stand in for the other.
+	r.check(ctx, res)
+	return true
+}
+
+// replay is the post-boot order, in the one order — the promised addresses,
+// the memberships, the way out, the record, the pack's bookkeeping, the
+// firewall last. It is PowerOn's second half, and check runs it a second time
+// on a broken reading, which is why it is a function: every step is
+// idempotent, and a machine that needs no repair is a machine this changes
+// nothing on.
+func (r Reconciler) replay(ctx context.Context, res *resource.Resource, plan Plan) {
 	// The launch installed the host half of every public route; this hands
 	// the guest its addresses, and repairs a machine that already existed.
 	// Idempotent, like everything in the replay.
-	for _, address := range plan.Publics {
-		r.route(ctx, res, plan, address)
-	}
+	r.replayAddresses(ctx, res, plan)
 	// The memberships come back as extra interfaces, after the boot rather
 	// than on it. Attach is idempotent by network, so a machine that kept its
 	// devices across a stop is repaired, not doubled. A refusal is already in
@@ -240,7 +254,6 @@ func (r Reconciler) PowerOn(ctx context.Context, res *resource.Resource, boot Bo
 	// packs kept in comments; TestTheReplayRoutesThenJoinsThenAppliesTheFirewall
 	// is what holds it now.
 	r.Groups.AfterBoot(ctx, res)
-	return true
 }
 
 // Reboot takes the machine down and brings it back up on its declared plan.
@@ -287,10 +300,24 @@ func (r Reconciler) ReplayAddresses(ctx context.Context, res *resource.Resource)
 	if !declared {
 		return
 	}
+	r.replayAddresses(ctx, res, plan)
+	r.ReplayEgress(ctx, res)
+	// This door sits on a read path, and an exec per GET would make the
+	// emulator's latency the runtime's. So the reading happens here only
+	// while nothing readable has been published for the machine: the boot of
+	// a virtual machine, whose shape was unreadable until its agent answered.
+	// Once a reading held or broke, this door reads no more (#670).
+	// TestTheLateAddressDoorVerifiesOnceItCanRead fails without the bound.
+	if last := res.Runtime[VerifiedKey]; last == "" || strings.HasPrefix(last, "unreadable") {
+		r.check(ctx, res)
+	}
+}
+
+// replayAddresses routes every promised address, the loop three doors share.
+func (r Reconciler) replayAddresses(ctx context.Context, res *resource.Resource, plan Plan) {
 	for _, address := range plan.Publics {
 		r.route(ctx, res, plan, address)
 	}
-	r.ReplayEgress(ctx, res)
 }
 
 // ReplayEgress gives the machine the way out its plan entitles it to, and takes
@@ -363,6 +390,7 @@ func (r Reconciler) Route(ctx context.Context, res *resource.Resource, address s
 		return
 	}
 	r.route(ctx, res, plan, address)
+	r.check(ctx, res)
 }
 
 func (r Reconciler) route(ctx context.Context, res *resource.Resource, plan Plan, address string) {
@@ -519,6 +547,7 @@ func (r Reconciler) Join(ctx context.Context, res *resource.Resource, att Attach
 	err := r.attach(ctx, res, att)
 	r.ReplayAddresses(ctx, res)
 	r.Groups.AfterBoot(ctx, res)
+	r.check(ctx, res)
 	return err
 }
 

--- a/internal/core/machine/readback_test.go
+++ b/internal/core/machine/readback_test.go
@@ -308,9 +308,20 @@ type observingRecorder struct {
 	shape      Shape
 	err        error
 	noFirewall bool
+	// queue, when set, is read one Shape per Observe ahead of shape: how a
+	// test writes a machine that changes between two readings.
+	queue []Shape
+	// reads counts the Observe calls, which is how a test holds a bound.
+	reads int
 }
 
 func (o *observingRecorder) Observe(context.Context, string) (Shape, error) {
+	o.reads++
+	if len(o.queue) > 0 {
+		next := o.queue[0]
+		o.queue = o.queue[1:]
+		return next, o.err
+	}
 	return o.shape, o.err
 }
 

--- a/internal/core/machine/runtime.go
+++ b/internal/core/machine/runtime.go
@@ -62,6 +62,10 @@ import (
 // is what `--vm off` and CI get.
 type Runtime struct {
 	d driver
+	// tally counts what the reading half answered (#670), one per handle so
+	// that two emulators in one test binary count apart. Nil for the zero
+	// Runtime, which verifies nothing and counts nowhere.
+	tally *tally
 }
 
 // Use binds a driver into the handle. It is the one door in, and deliberately
@@ -72,7 +76,7 @@ type Runtime struct {
 // internal/cli passes the Incus driver, and how every fake runtime in the
 // packs' tests is still injected — but it cannot declare a variable of that
 // type, name it in a signature, or assert its way back to one.
-func Use(d driver) Runtime { return Runtime{d: d} }
+func Use(d driver) Runtime { return Runtime{d: d, tally: &tally{}} }
 
 // backing returns the driver, or the metadata-only one for a zero Runtime, so
 // every method below can be written without a nil branch.

--- a/internal/core/machine/verdicts.go
+++ b/internal/core/machine/verdicts.go
@@ -1,0 +1,205 @@
+package machine
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+
+	"github.com/stephrobert/feint/internal/core/resource"
+)
+
+// A verdict nobody reads is a confession nobody hears (#670). The reading half
+// (#668) answers every claim a plan makes; this file is where the answer goes:
+// a log line where a failure belongs, a key on the resource out of the
+// client's reach, four counters on /_feint/health, and one bounded retry for
+// the class of divergence a replay can mend.
+//
+// What the API state must NOT become. The rule this repository holds is that
+// the published state is the one the effect produced, not the one the
+// intention aimed at. A machine running with the wrong door is running and
+// unreachable; publishing it stopped would be the lie in the other direction,
+// the one incus.go already refuses twice. So the state stays true, and the
+// verdict goes everywhere else.
+
+// VerifiedKey is the Runtime key the last verification's summary is published
+// under. Runtime is never serialised into a client's view, and /_feint/state
+// shows it to whoever asks, which is how the runtime leg names a broken claim
+// rather than a counter.
+//
+// The value is one of "held", "broken: <claim> want <x>, got <y>; …" and
+// "unreadable: <claim>: <why>; …" — a prefix a reader can branch on, then the
+// verdicts themselves.
+const VerifiedKey = "verified"
+
+// Verification is the count of what the reading half answered, published on
+// /_feint/health. Held, Broken and Unreadable count claims; Repaired counts
+// verifications whose first reading was broken and whose second, after one
+// replay, held.
+//
+// Repaired is a counter for a reason: a repair that fires on every boot is a
+// defect hidden behind a retry, and the number is what makes it visible.
+type Verification struct {
+	Held       int64 `json:"held"`
+	Broken     int64 `json:"broken"`
+	Unreadable int64 `json:"unreadable"`
+	Repaired   int64 `json:"repaired"`
+}
+
+// tally is the process-wide count behind Verification. It lives on the
+// Runtime handle — one per Use, shared by every Binding that handle is bound
+// into — rather than in a package variable, so two emulators in one test
+// binary count apart and a test can read exactly what its own runtime saw.
+type tally struct {
+	held, broken, unreadable, repaired atomic.Int64
+}
+
+// count adds one verification's verdicts. Nil-safe: a Binding built without a
+// Runtime, which every bench in this package is, counts nowhere.
+func (t *tally) count(verdicts []Verdict, repaired bool) {
+	if t == nil {
+		return
+	}
+	for _, v := range verdicts {
+		switch v.Outcome {
+		case Held:
+			t.held.Add(1)
+		case Broken:
+			t.broken.Add(1)
+		case Unreadable:
+			t.unreadable.Add(1)
+		}
+	}
+	if repaired {
+		t.repaired.Add(1)
+	}
+}
+
+func (t *tally) snapshot() Verification {
+	if t == nil {
+		return Verification{}
+	}
+	return Verification{
+		Held:       t.held.Load(),
+		Broken:     t.broken.Load(),
+		Unreadable: t.unreadable.Load(),
+		Repaired:   t.repaired.Load(),
+	}
+}
+
+// Verification answers what this runtime's verifications counted so far.
+func (r Runtime) Verification() Verification { return r.tally.snapshot() }
+
+// summary renders one verification for VerifiedKey: the broken claims first,
+// because a reader branches on the prefix; the unreadable ones when nothing
+// is broken; "held" when every claim held.
+func summary(verdicts []Verdict) string {
+	var broken, unreadable []string
+	for _, v := range verdicts {
+		switch v.Outcome {
+		case Broken:
+			broken = append(broken, v.Claim+" want "+v.Want+", got "+v.Got)
+		case Unreadable:
+			unreadable = append(unreadable, v.Claim+": "+v.Got)
+		}
+	}
+	switch {
+	case len(broken) > 0:
+		return "broken: " + strings.Join(broken, "; ")
+	case len(unreadable) > 0:
+		return "unreadable: " + strings.Join(unreadable, "; ")
+	}
+	return "held"
+}
+
+func anyBroken(verdicts []Verdict) bool {
+	for _, v := range verdicts {
+		if v.Outcome == Broken {
+			return true
+		}
+	}
+	return false
+}
+
+// publish is where a verification's answer goes: the log, the resource, the
+// counters. It changes no state — see the file comment — and it is written
+// inside the change() closure of Transition, so the key lands through Commit
+// with everything else and merges per key with a concurrent writer to another
+// field (mergeRuntime). A resource deleted meanwhile makes Commit answer
+// false and the verdict falls with the rest, which is correct.
+//
+// ERROR for a broken claim and WARN for an unreadable one, in the words the
+// repository holds for the two levels: a failure, and a degradation. The
+// repair, when one happened, is a WARN naming what the first reading found:
+// it ended well, and the number of times it was needed is the point.
+//
+// TestABrokenVerdictReachesTheResourceAndNotItsState and
+// TestABrokenVerdictIsLoggedAsAFailure fail without this.
+func (r Reconciler) publish(res *resource.Resource, verdicts []Verdict, repairedFrom []Verdict) {
+	if len(verdicts) == 0 {
+		return
+	}
+	b := r.binding()
+	machine := res.Runtime[b.RuntimeKey]
+	var unreadable []Verdict
+	for _, v := range verdicts {
+		switch v.Outcome {
+		case Broken:
+			b.logger().Error("the machine does not carry what its plan claims",
+				"provider", b.Provider, "resource", res.ID, "machine", machine,
+				"claim", v.Claim, "want", v.Want, "got", v.Got)
+		case Unreadable:
+			unreadable = append(unreadable, v)
+		}
+	}
+	if len(unreadable) > 0 {
+		b.logger().Warn("part of the machine's shape could not be read, so those claims are neither held nor broken",
+			"provider", b.Provider, "resource", res.ID, "machine", machine,
+			"claims", len(unreadable), "first", unreadable[0].Claim, "why", unreadable[0].Got)
+	}
+	if len(repairedFrom) > 0 {
+		b.logger().Warn("the machine did not carry what its plan claims until the replay ran a second time",
+			"provider", b.Provider, "resource", res.ID, "machine", machine,
+			"first_reading", summary(repairedFrom))
+	}
+	if res.Runtime == nil {
+		res.Runtime = map[string]string{}
+	}
+	res.Runtime[VerifiedKey] = summary(verdicts)
+	b.tally.count(verdicts, len(repairedFrom) > 0)
+}
+
+// check verifies the machine behind a resource and publishes the answer,
+// with one bounded retry for the class a replay can mend.
+//
+// A broken first reading replays the post-boot order once — every step of it
+// is idempotent by construction — and reads again; what is published is the
+// second reading, with the first named beside it when the second held. Once,
+// and never for an unreadable reading: a virtual machine whose agent has not
+// answered is read again from the late-address door, and replaying onto it
+// would not make it readable. The contradiction class never reaches here, it
+// is refused at derivation (#667), and replaying it would replay the same
+// contradiction.
+//
+// TestARepairIsAttemptedOnceAndCounted fails without the bound.
+func (r Reconciler) check(ctx context.Context, res *resource.Resource) {
+	verdicts, asked := r.verify(ctx, res)
+	if !asked {
+		return
+	}
+	if !anyBroken(verdicts) {
+		r.publish(res, verdicts, nil)
+		return
+	}
+	plan, declared := r.plan(res)
+	if !declared {
+		r.publish(res, verdicts, nil)
+		return
+	}
+	r.replay(ctx, res, plan)
+	again, _ := r.verify(ctx, res)
+	if anyBroken(again) {
+		r.publish(res, again, nil)
+		return
+	}
+	r.publish(res, again, verdicts)
+}

--- a/internal/core/machine/verdicts_test.go
+++ b/internal/core/machine/verdicts_test.go
@@ -1,0 +1,341 @@
+package machine
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/netip"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/resource"
+	"github.com/stephrobert/feint/internal/core/store"
+)
+
+// Where a verdict goes (#670): the log, the resource, the counters — and
+// never the state.
+
+// pinnedPlan is the plan of a machine carrying one pinned address on fnt-x.
+var pinnedPlan = Plan{Boot: []Attachment{{Network: "fnt-x", Address: "10.30.1.10", PrefixLen: 24}}}
+
+// publicPlan is pinnedPlan with a promised public address, for the tests
+// that count the replay through the address it routes.
+var publicPlan = Plan{Boot: pinnedPlan.Boot, Publics: []string{"203.0.113.2"}}
+
+// withPublic is pinnedOn with the public /32 beside the pinned address, the
+// way the replay leaves a machine of publicPlan.
+func withPublic(shape Shape) Shape {
+	eth0 := shape.Interfaces["eth0"]
+	eth0.Addresses = append(eth0.Addresses, netip.MustParsePrefix("203.0.113.2/32"))
+	shape.Interfaces["eth0"] = eth0
+	return shape
+}
+
+// TestABrokenVerdictReachesTheResourceAndNotItsState: the state is the one
+// the boot produced, the verdict is the one the reading produced, and neither
+// stands in for the other.
+func TestABrokenVerdictReachesTheResourceAndNotItsState(t *testing.T) {
+	b := newGroupSyncBench()
+	o := &observingRecorder{Recorder: b.rec, shape: pinnedOn("fnt-x", "10.30.1.11/24")}
+	vm := b.machine("m", "")
+	r := observingReconciler(b, o, pinnedPlan)
+
+	if !r.PowerOn(context.Background(), vm, Boot{Image: "ubuntu:24.04"}) {
+		t.Fatalf("the boot did not start; sequence: %v", b.rec.Sequence())
+	}
+	if vm.State != "running" {
+		t.Fatalf("a broken reading moved the state to %q, and the machine IS running", vm.State)
+	}
+	want := "broken: carries(fnt-x, 10.30.1.10/24) want 10.30.1.10/24, got eth0: 10.30.1.11/24"
+	if got := vm.Runtime[VerifiedKey]; got != want {
+		t.Fatalf("Runtime[%s] = %q, want %q", VerifiedKey, got, want)
+	}
+
+	// And the accepting half, on the same runtime with the divergence gone.
+	o.shape = pinnedOn("fnt-x", "10.30.1.10/24")
+	vm.State = "stopped"
+	if !r.PowerOn(context.Background(), vm, Boot{Image: "ubuntu:24.04"}) {
+		t.Fatal("the second boot did not start")
+	}
+	if got := vm.Runtime[VerifiedKey]; got != "held" {
+		t.Fatalf("Runtime[%s] = %q after a boot that carries its plan, want held", VerifiedKey, got)
+	}
+}
+
+// The key lands through Commit and merges per key: a writer to another field
+// of the same resource, landing while the machine boots, keeps its field and
+// the verdict keeps its own (the mergeRuntime property, #295).
+func TestABrokenVerdictSurvivesAConcurrentWriteToAnotherKey(t *testing.T) {
+	st := store.New()
+	now := func() time.Time { return time.Unix(1700000000, 0).UTC() }
+	res := resource.New("m", "machine", resource.Tenant{Provider: "bench"}, "stopped", now())
+	res.Attrs = map[string]any{}
+	st.Put(res)
+
+	b := newGroupSyncBench()
+	o := &observingRecorder{Recorder: b.rec, shape: pinnedOn("fnt-x", "10.30.1.11/24")}
+	r := observingReconciler(b, o, pinnedPlan)
+
+	err := r.binding().Transition(st, now, "machine", "m", func(res *resource.Resource) {
+		// The other writer lands while this one works outside the lock.
+		if err := st.Update("bench", "machine", "m", func(stored *resource.Resource) error {
+			if stored.Runtime == nil {
+				stored.Runtime = map[string]string{}
+			}
+			stored.Runtime["tag"] = "kept"
+			return nil
+		}); err != nil {
+			t.Fatalf("the concurrent write failed: %v", err)
+		}
+		r.PowerOn(context.Background(), res, Boot{Image: "ubuntu:24.04"})
+	})
+	if err != nil {
+		t.Fatalf("transition: %v", err)
+	}
+	stored, found := st.Get("bench", "machine", "m")
+	if !found {
+		t.Fatal("the resource is gone")
+	}
+	if stored.Runtime["tag"] != "kept" {
+		t.Errorf("the concurrent writer's key was lost: %v", stored.Runtime)
+	}
+	if !strings.HasPrefix(stored.Runtime[VerifiedKey], "broken: carries(fnt-x, 10.30.1.10/24)") {
+		t.Errorf("the verdict did not reach the store: %v", stored.Runtime)
+	}
+	if stored.State != "running" {
+		t.Errorf("stored state %q, want running", stored.State)
+	}
+}
+
+// ERROR for a broken claim, WARN for an unreadable one: a failure and a
+// degradation, in the two words the repository holds for the two levels.
+func TestABrokenVerdictIsLoggedAsAFailure(t *testing.T) {
+	var log bytes.Buffer
+	b := newGroupSyncBench()
+	o := &observingRecorder{Recorder: b.rec, shape: pinnedOn("fnt-x", "10.30.1.11/24")}
+	vm := b.machine("m", "")
+	r := observingReconciler(b, o, pinnedPlan)
+	r.Groups.Binding.Log = slog.New(slog.NewTextHandler(&log, nil))
+
+	r.PowerOn(context.Background(), vm, Boot{Image: "ubuntu:24.04"})
+	lines := log.String()
+	if !strings.Contains(lines, "level=ERROR") ||
+		!strings.Contains(lines, "claim=\"carries(fnt-x, 10.30.1.10/24)\"") ||
+		!strings.Contains(lines, "got=\"eth0: 10.30.1.11/24\"") {
+		t.Fatalf("a broken claim was not logged as a failure naming the claim and both values:\n%s", lines)
+	}
+
+	log.Reset()
+	o.shape = Shape{}
+	o.err = errUnreadable
+	vm.State = "stopped"
+	r.PowerOn(context.Background(), vm, Boot{Image: "ubuntu:24.04"})
+	lines = log.String()
+	if strings.Contains(lines, "level=ERROR") || !strings.Contains(lines, "level=WARN") ||
+		!strings.Contains(lines, "why=\"the agent isn't currently running\"") {
+		t.Fatalf("an unreadable reading was not logged as a degradation:\n%s", lines)
+	}
+	if got := vm.Runtime[VerifiedKey]; !strings.HasPrefix(got, "unreadable: carries(fnt-x, 10.30.1.10/24): ") {
+		t.Errorf("Runtime[%s] = %q", VerifiedKey, got)
+	}
+}
+
+// The four counters follow the verdicts, on the handle the runtime was bound
+// through, so /_feint/health reads what every pack of one emulator counted.
+func TestTheCountersFollowTheVerdicts(t *testing.T) {
+	b := newGroupSyncBench()
+	o := &observingRecorder{Recorder: b.rec, shape: pinnedOn("fnt-x", "10.30.1.10/24")}
+	rt := Use(o)
+	vm := b.machine("m", "")
+	r := observingReconciler(b, o, pinnedPlan)
+	r.Groups.Binding = r.Groups.Binding.WithRuntime(rt)
+
+	if got := rt.Verification(); got != (Verification{}) {
+		t.Fatalf("a fresh runtime counts %+v", got)
+	}
+	r.PowerOn(context.Background(), vm, Boot{Image: "ubuntu:24.04"})
+	if got := rt.Verification(); got != (Verification{Held: 1}) {
+		t.Fatalf("after a held boot: %+v", got)
+	}
+	// Broken, and unrepaired: the machine stays wrong on the second reading.
+	o.shape = pinnedOn("fnt-x", "10.30.1.11/24")
+	vm.State = "stopped"
+	r.PowerOn(context.Background(), vm, Boot{Image: "ubuntu:24.04"})
+	if got := rt.Verification(); got != (Verification{Held: 1, Broken: 1}) {
+		t.Fatalf("after a broken boot: %+v", got)
+	}
+	o.err = errUnreadable
+	vm.State = "stopped"
+	r.PowerOn(context.Background(), vm, Boot{Image: "ubuntu:24.04"})
+	if got := rt.Verification(); got != (Verification{Held: 1, Broken: 1, Unreadable: 1}) {
+		t.Fatalf("after an unreadable boot: %+v", got)
+	}
+	// The zero Runtime, which every test without Use builds, counts nowhere
+	// and answers zero rather than panicking.
+	if got := (Runtime{}).Verification(); got != (Verification{}) {
+		t.Errorf("the zero runtime counts %+v", got)
+	}
+}
+
+// TestARepairIsAttemptedOnceAndCounted: a broken first reading replays the
+// post-boot order once and reads again; a machine that then carries its plan
+// is published held and counted repaired; one that does not is published
+// broken after exactly two readings, never three.
+func TestARepairIsAttemptedOnceAndCounted(t *testing.T) {
+	broken, held := withPublic(pinnedOn("fnt-x", "10.30.1.11/24")), withPublic(pinnedOn("fnt-x", "10.30.1.10/24"))
+
+	b := newGroupSyncBench()
+	o := &observingRecorder{Recorder: b.rec, queue: []Shape{broken, held}}
+	rt := Use(o)
+	vm := b.machine("m", "")
+	r := observingReconciler(b, o, publicPlan)
+	r.Groups.Binding = r.Groups.Binding.WithRuntime(rt)
+
+	var log bytes.Buffer
+	r.Groups.Binding.Log = slog.New(slog.NewTextHandler(&log, nil))
+	r.PowerOn(context.Background(), vm, Boot{Image: "ubuntu:24.04"})
+	if o.reads != 2 {
+		t.Fatalf("a broken reading was followed by %d reading(s), want exactly one more", o.reads-1)
+	}
+	if got := vm.Runtime[VerifiedKey]; got != "held" {
+		t.Fatalf("Runtime[%s] = %q after a repair, want held", VerifiedKey, got)
+	}
+	if got := rt.Verification(); got != (Verification{Held: 2, Repaired: 1}) {
+		t.Fatalf("after a repaired boot: %+v", got)
+	}
+	// The replay ran twice: the promised address was routed once by the boot
+	// and once by the repair, on one start.
+	routes, starts := 0, 0
+	for _, kind := range b.rec.Sequence() {
+		switch kind {
+		case "RouteAddress":
+			routes++
+		case "Start":
+			starts++
+		}
+	}
+	if routes != 2 || starts != 1 {
+		t.Errorf("the repair replayed %d route(s) on %d start(s), want 2 on 1: %v", routes, starts, b.rec.Sequence())
+	}
+	if !strings.Contains(log.String(), "level=WARN") || !strings.Contains(log.String(), "second time") {
+		t.Errorf("a repair was not logged as a degradation naming the first reading:\n%s", log.String())
+	}
+
+	// A machine that stays wrong: two readings and no more, however many
+	// broken shapes are queued behind them.
+	b = newGroupSyncBench()
+	o = &observingRecorder{Recorder: b.rec, queue: []Shape{broken, broken, held}}
+	rt = Use(o)
+	vm = b.machine("m", "")
+	r = observingReconciler(b, o, publicPlan)
+	r.Groups.Binding = r.Groups.Binding.WithRuntime(rt)
+	r.PowerOn(context.Background(), vm, Boot{Image: "ubuntu:24.04"})
+	if o.reads != 2 {
+		t.Fatalf("a machine that stays wrong was read %d times, want exactly two", o.reads)
+	}
+	if got := vm.Runtime[VerifiedKey]; !strings.HasPrefix(got, "broken: ") {
+		t.Fatalf("Runtime[%s] = %q after a failed repair", VerifiedKey, got)
+	}
+	if got := rt.Verification(); got != (Verification{Held: 1, Broken: 1}) {
+		t.Fatalf("after a failed repair: %+v", got)
+	}
+}
+
+// An unreadable reading is not retried: replaying onto a machine whose agent
+// has not answered would not make it readable, and the late-address door
+// reads it again when it can.
+func TestAnUnreadableReadingIsNotReplayedOnto(t *testing.T) {
+	b := newGroupSyncBench()
+	o := &observingRecorder{Recorder: b.rec, err: errUnreadable}
+	vm := b.machine("m", "")
+	r := observingReconciler(b, o, publicPlan)
+	r.PowerOn(context.Background(), vm, Boot{Image: "ubuntu:24.04"})
+	if o.reads != 1 {
+		t.Fatalf("an unreadable reading was followed by %d more", o.reads-1)
+	}
+	routes := 0
+	for _, kind := range b.rec.Sequence() {
+		if kind == "RouteAddress" {
+			routes++
+		}
+	}
+	if routes != 1 {
+		t.Errorf("the replay ran %d times onto an unreadable machine, want once", routes)
+	}
+}
+
+// TestTheLateAddressDoorVerifiesOnceItCanRead: the late-address door sits on
+// a read path, so it reads only while nothing readable has been published —
+// the virtual machine whose boot was unreadable — and never again after a
+// reading held or broke.
+func TestTheLateAddressDoorVerifiesOnceItCanRead(t *testing.T) {
+	b := newGroupSyncBench()
+	o := &observingRecorder{Recorder: b.rec, err: errUnreadable}
+	vm := b.machine("m", "")
+	r := observingReconciler(b, o, publicPlan)
+	r.PowerOn(context.Background(), vm, Boot{Image: "ubuntu:24.04"})
+	if o.reads != 1 || !strings.HasPrefix(vm.Runtime[VerifiedKey], "unreadable") {
+		t.Fatalf("the boot: reads=%d verified=%q", o.reads, vm.Runtime[VerifiedKey])
+	}
+
+	// The agent answers: the door reads, and the verdict replaces the
+	// unreadable one.
+	o.err = nil
+	o.shape = withPublic(pinnedOn("fnt-x", "10.30.1.10/24"))
+	r.ReplayAddresses(context.Background(), vm)
+	if o.reads != 2 || vm.Runtime[VerifiedKey] != "held" {
+		t.Fatalf("the late door: reads=%d verified=%q", o.reads, vm.Runtime[VerifiedKey])
+	}
+
+	// And not again: a GET is not a reason to exec into a machine.
+	r.ReplayAddresses(context.Background(), vm)
+	r.ReplayAddresses(context.Background(), vm)
+	if o.reads != 2 {
+		t.Fatalf("the late door read %d times in all, want 2: a verified machine is read again on every GET", o.reads)
+	}
+}
+
+// The hot doors — an address routed, a network joined — change what the
+// machine carries, and each is read back.
+func TestAHotJoinAndAHotRouteAreReadBack(t *testing.T) {
+	b := newGroupSyncBench()
+	o := &observingRecorder{Recorder: b.rec, shape: pinnedOn("fnt-x", "10.30.1.10/24")}
+	vm := b.machine("m", "")
+	r := observingReconciler(b, o, pinnedPlan)
+	r.PowerOn(context.Background(), vm, Boot{Image: "ubuntu:24.04"})
+	if o.reads != 1 {
+		t.Fatalf("the boot read %d times", o.reads)
+	}
+	_ = r.Join(context.Background(), vm, Attachment{Network: "fnt-y"})
+	if o.reads != 2 {
+		t.Fatalf("a hot join was not read back: reads=%d", o.reads)
+	}
+	r.Route(context.Background(), vm, "203.0.113.2")
+	if o.reads != 3 {
+		t.Fatalf("a hot route was not read back: reads=%d", o.reads)
+	}
+}
+
+// The summary a reader branches on: broken first, then unreadable, then held.
+func TestTheSummaryLeadsWithWhatIsBroken(t *testing.T) {
+	c := carries{Network: "fnt-x", Address: netip.MustParseAddr("10.30.1.10"), Bits: 24}
+	d := defaultRoute{Network: "fnt-x"}
+	if got := summary([]Verdict{held(c), broken(d, "via 10.30.1.1 dev eth0", "no default route"), unreadable(c, "x")}); got !=
+		"broken: default route want via 10.30.1.1 dev eth0, got no default route" {
+		t.Errorf("summary %q", got)
+	}
+	if got := summary([]Verdict{held(c), unreadable(d, "the gateway of fnt-x was not read")}); got !=
+		"unreadable: default route: the gateway of fnt-x was not read" {
+		t.Errorf("summary %q", got)
+	}
+	if got := summary([]Verdict{held(c), held(d)}); got != "held" {
+		t.Errorf("summary %q", got)
+	}
+}
+
+var errUnreadable = errorString("the agent isn't currently running")
+
+type errorString string
+
+func (e errorString) Error() string { return string(e) }

--- a/tools/conformance/guard.sh
+++ b/tools/conformance/guard.sh
@@ -334,6 +334,89 @@ EOF
   fi
 }
 
+# guard_verification refuses a pass whose emulator read back, on any machine,
+# something other than what that machine's plan claimed (#670).
+#
+# The runtime leg watched a machine come back from a restart and asked one
+# question — does the service answer at its published address — and when the
+# answer was no it named the far end, sixty seconds later. Since #668 the
+# emulator itself reads every machine back after every lifecycle action and
+# publishes what it found: four counters on /_feint/health, and the claim under
+# each resource's Runtime on /_feint/state. This is the gate that reads them,
+# asked before the emulator stops, because both payloads die with it.
+#
+# Two refusals, and they are not the same finding:
+#
+#   broken > 0        a machine does not carry what its plan claims; the claim
+#                     is named, with what was wanted and what was found
+#   unreadable > held more claims could not be read than were read: a pass
+#                     that measured its own blindness, which is a different
+#                     fact from success and must not read like it
+#
+# A pass with no machine runtime is not judged: nothing booted, so nothing was
+# read, and a gate that failed the client legs for it would teach `--no-verify`.
+# It says so instead of returning in silence.
+guard_verification() { # endpoint
+  local endpoint="${1:-}" health state
+  health="$(curl -sf "$endpoint/_feint/health" || true)"
+  if [ -z "$health" ]; then
+    echo "FAIL: $endpoint answered no health payload, so nothing here knows what its machines carried" >&2
+    exit 1
+  fi
+  state="$(curl -sf "$endpoint/_feint/state" || true)"
+  guard_verification_from "$health" "$state"
+}
+
+# guard_verification_from is the verdict itself, on payloads the caller
+# captured: a test plants a broken counter and a resource carrying the claim,
+# and requires the refusal — without which a gate that has never seen anything
+# is indistinguishable from a gate that looks nowhere.
+#
+# TestTheVerificationGateRefusesABrokenClaim and
+# TestTheVerificationGateRefusesAPassThatCouldNotRead fail without the two
+# refusals, and TestTheVerificationGateNamesTheClaim holds that the claim is
+# printed rather than the counter alone.
+guard_verification_from() { # health_json state_json
+  local health="$1" state="$2" machines held broken unreadable repaired claims
+  machines="$(printf '%s' "$health" | jq -r '.machines // "none"')"
+  case "$machines" in
+    ''|none|null)
+      echo "  verification: not judged, this emulator runs no machine runtime" >&2
+      return 0 ;;
+  esac
+  # The reader proves it can find before it judges: a payload with no
+  # counters is an emulator that never asked the question, and reading its
+  # absence as zero would pass every build that predates the gate.
+  held="$(printf '%s' "$health" | jq -r '.verification.held // "MISSING"')"
+  broken="$(printf '%s' "$health" | jq -r '.verification.broken // "MISSING"')"
+  unreadable="$(printf '%s' "$health" | jq -r '.verification.unreadable // "MISSING"')"
+  repaired="$(printf '%s' "$health" | jq -r '.verification.repaired // "MISSING"')"
+  for value in "$held" "$broken" "$unreadable" "$repaired"; do
+    case "$value" in
+      ''|*[!0-9]*)
+        echo "FAIL: the health payload carries no verification counters (held=$held broken=$broken unreadable=$unreadable repaired=$repaired): this emulator never read its machines back, and a gate that read that as zero would pass it" >&2
+        exit 1 ;;
+    esac
+  done
+  if [ "$broken" -gt 0 ]; then
+    claims="$(printf '%s' "$state" | jq -r '
+      [ .resources[]?
+        | select(.Runtime != null and (.Runtime.verified // "" | startswith("broken")))
+        | "  \(.Kind) \(.ID): \(.Runtime.verified)" ] | .[]' 2>/dev/null)"
+    [ -n "$claims" ] || claims="  (the resources carrying the claim are gone from the state, or the state could not be read)"
+    cat >&2 <<EOF
+FAIL: $broken claim(s) broken: a machine does not carry what its plan claims, and the emulator said so at the moment it happened (#670).
+$claims
+EOF
+    exit 1
+  fi
+  if [ "$unreadable" -gt "$held" ]; then
+    echo "FAIL: $unreadable claim(s) could not be read against $held held: this pass measured its own blindness, which is a different fact from success and must not read like it (#670)" >&2
+    exit 1
+  fi
+  echo "  verification: held=$held broken=$broken unreadable=$unreadable repaired=$repaired"
+}
+
 # Sourced by the suites above, and runnable for the one caller that has no suite
 # to source it into: `mise run conformance` asks this before `feint start`, so a
 # leg refuses at second zero instead of after every client suite has run.
@@ -344,9 +427,13 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     # is gone, so a leg that leaks fails the leg that leaked instead of the one
     # after it — and says so in those words.
     leftovers-after) guard_leftovers_for "${2:-off}" closing ;;
+    # What the emulator read back against every plan, asked while it still
+    # answers: the counters and the claims die with the process (#670).
+    verification) guard_verification "${2:-}" ;;
     *)
       echo "usage: tools/conformance/guard.sh leftovers <machine runtime>        (before a run starts)" >&2
       echo "       tools/conformance/guard.sh leftovers-after <machine runtime>  (after its emulator stopped)" >&2
+      echo "       tools/conformance/guard.sh verification <endpoint>            (before its emulator stops)" >&2
       echo "  (the other guards take an endpoint and are sourced, not run)" >&2
       exit 2 ;;
   esac

--- a/tools/conformance/leg.sh
+++ b/tools/conformance/leg.sh
@@ -167,6 +167,13 @@ else
   FEINT_FIELD_GATE=0 tools/conformance/score.sh "$endpoint"
 fi
 
+# What the emulator read back against every machine's plan, asked before it
+# stops because the counters and the claims die with it (#670). A leg with no
+# runtime is told so and not judged; the runtime leg fails here on a broken
+# claim, named, at the moment the emulator found it rather than sixty seconds
+# later at the far end of a fetch.
+tools/conformance/guard.sh verification "$endpoint"
+
 # The other half of the doorstep: asked again once the emulator is gone, so the
 # leg that left a machine or a network behind is the leg that fails. The trap
 # above stays the safety net for a leg that dies mid-flight.

--- a/tools/conformance/verification_gate_test.go
+++ b/tools/conformance/verification_gate_test.go
@@ -1,0 +1,88 @@
+package conformance
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The verification gate (#670), driven on planted payloads the way the
+// functional library is: a gate that has never seen anything is
+// indistinguishable from a gate that looks nowhere, so each refusal is
+// planted before it is trusted.
+
+func runVerificationGate(t *testing.T, script string) (int, string) {
+	t.Helper()
+	requireTool(t, "bash")
+	requireTool(t, "jq")
+	lib, err := filepath.Abs("guard.sh")
+	if err != nil {
+		t.Fatalf("locate guard.sh: %v", err)
+	}
+	return runShell(t, t.TempDir(), lib, script)
+}
+
+const healthyHealth = `{"machines":"incus-ovn","verification":{"held":12,"broken":0,"unreadable":1,"repaired":0}}`
+
+const oneBrokenHealth = `{"machines":"incus-ovn","verification":{"held":12,"broken":1,"unreadable":0,"repaired":0}}`
+
+// The planted state: one resource whose Runtime carries the claim, beside one
+// that held, so the gate has to pick the right one.
+const brokenState = `{"format":"feint-snapshot","version":3,"resources":[
+ {"ID":"web-0","Kind":"server","Runtime":{"machine":"feint-scw-web-0","verified":"held"}},
+ {"ID":"web-1","Kind":"server","Runtime":{"machine":"feint-scw-web-1","verified":"broken: door(203.0.113.2) want via 169.254.0.1 dev eth0, got via 10.77.0.1 dev eth0"}}
+]}`
+
+func TestTheVerificationGateRefusesABrokenClaim(t *testing.T) {
+	code, out := runVerificationGate(t, `guard_verification_from '`+oneBrokenHealth+`' '`+brokenState+`'`)
+	if code == 0 {
+		t.Fatalf("a broken claim passed the gate:\n%s", out)
+	}
+	if !strings.Contains(out, "FAIL: 1 claim(s) broken") {
+		t.Errorf("the refusal does not say what it refused:\n%s", out)
+	}
+}
+
+// TestTheVerificationGateNamesTheClaim: the counter says how many, the state
+// says which — and the refusal prints the claim, with what was wanted and
+// what was found, rather than the number alone.
+func TestTheVerificationGateNamesTheClaim(t *testing.T) {
+	_, out := runVerificationGate(t, `guard_verification_from '`+oneBrokenHealth+`' '`+brokenState+`'`)
+	if !strings.Contains(out, "server web-1: broken: door(203.0.113.2) want via 169.254.0.1 dev eth0, got via 10.77.0.1 dev eth0") {
+		t.Fatalf("the refusal does not name the claim:\n%s", out)
+	}
+	if strings.Contains(out, "web-0") {
+		t.Errorf("the refusal names a resource that held:\n%s", out)
+	}
+}
+
+// A pass that could read less than it read is a pass that measured its own
+// blindness, which is a different fact from success.
+func TestTheVerificationGateRefusesAPassThatCouldNotRead(t *testing.T) {
+	code, out := runVerificationGate(t, `guard_verification_from '{"machines":"incus-ovn","verification":{"held":2,"broken":0,"unreadable":9,"repaired":0}}' '{"resources":[]}'`)
+	if code == 0 || !strings.Contains(out, "9 claim(s) could not be read against 2 held") {
+		t.Fatalf("a pass that could not read passed the gate (exit %d):\n%s", code, out)
+	}
+}
+
+// The reader proves it can find before it judges: a payload with no counters
+// is an emulator that never asked, and zero would pass it.
+func TestTheVerificationGateRefusesAPayloadWithNoCounters(t *testing.T) {
+	code, out := runVerificationGate(t, `guard_verification_from '{"machines":"incus-ovn"}' '{"resources":[]}'`)
+	if code == 0 || !strings.Contains(out, "carries no verification counters") {
+		t.Fatalf("an emulator that never read its machines back passed the gate (exit %d):\n%s", code, out)
+	}
+}
+
+// The accepting halves: a healthy pass prints its counters and passes, and a
+// pass with no runtime is told so rather than judged.
+func TestTheVerificationGatePassesAHealthyPassAndSkipsARuntimelessOne(t *testing.T) {
+	code, out := runVerificationGate(t, `guard_verification_from '`+healthyHealth+`' '{"resources":[]}'`)
+	if code != 0 || !strings.Contains(out, "verification: held=12 broken=0 unreadable=1 repaired=0") {
+		t.Fatalf("a healthy pass did not pass (exit %d):\n%s", code, out)
+	}
+	code, out = runVerificationGate(t, `guard_verification_from '{"machines":"none"}' ''`)
+	if code != 0 || !strings.Contains(out, "not judged") {
+		t.Fatalf("a runtime-less pass was judged (exit %d):\n%s", code, out)
+	}
+}

--- a/tools/falsify/specs/a-verdict-somebody-reads.json
+++ b/tools/falsify/specs/a-verdict-somebody-reads.json
@@ -1,0 +1,100 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "the verdict never reaches the resource, so /_feint/state carries no claim to name (#670)",
+      "file": "internal/core/machine/verdicts.go",
+      "find": "\tres.Runtime[VerifiedKey] = summary(verdicts)\n",
+      "replace": "\tres.Runtime[VerifiedKey] = summary(verdicts)[:0]\n",
+      "test": "TestABrokenVerdictReachesTheResourceAndNotItsState"
+    },
+    {
+      "label": "a broken reading moves the state, which is the lie in the other direction (#670)",
+      "file": "internal/core/machine/verdicts.go",
+      "find": "\tres.Runtime[VerifiedKey] = summary(verdicts)\n\tb.tally.count(verdicts, len(repairedFrom) > 0)\n",
+      "replace": "\tres.Runtime[VerifiedKey] = summary(verdicts)\n\tif anyBroken(verdicts) {\n\t\tres.State = b.FailedState\n\t}\n\tb.tally.count(verdicts, len(repairedFrom) > 0)\n",
+      "test": "TestABrokenVerdictReachesTheResourceAndNotItsState"
+    },
+    {
+      "label": "a broken claim is logged as a degradation rather than a failure (#670)",
+      "file": "internal/core/machine/verdicts.go",
+      "find": "\t\t\tb.logger().Error(\"the machine does not carry what its plan claims\",",
+      "replace": "\t\t\tb.logger().Warn(\"the machine does not carry what its plan claims\",",
+      "test": "TestABrokenVerdictIsLoggedAsAFailure"
+    },
+    {
+      "label": "the counters stop following the verdicts, and health publishes zero over a broken fleet (#670)",
+      "file": "internal/core/machine/verdicts.go",
+      "find": "\tb.tally.count(verdicts, len(repairedFrom) > 0)\n",
+      "replace": "\tb.tally.count(verdicts[:0], len(repairedFrom) > 0)\n",
+      "test": "TestTheCountersFollowTheVerdicts"
+    },
+    {
+      "label": "the repair is unbounded: a machine that stays wrong is read a third time (#670)",
+      "file": "internal/core/machine/verdicts.go",
+      "find": "\tagain, _ := r.verify(ctx, res)\n\tif anyBroken(again) {\n\t\tr.publish(res, again, nil)\n\t\treturn\n\t}",
+      "replace": "\tagain, _ := r.verify(ctx, res)\n\tif anyBroken(again) {\n\t\tr.replay(ctx, res, plan)\n\t\tagain, _ = r.verify(ctx, res)\n\t\tr.publish(res, again, nil)\n\t\treturn\n\t}",
+      "test": "TestARepairIsAttemptedOnceAndCounted"
+    },
+    {
+      "label": "a repair is not counted, so one that fires on every boot stays a defect hidden behind a retry (#670)",
+      "file": "internal/core/machine/verdicts.go",
+      "find": "\tif repaired {\n\t\tt.repaired.Add(1)\n\t}",
+      "replace": "\tif repaired && false {\n\t\tt.repaired.Add(1)\n\t}",
+      "test": "TestARepairIsAttemptedOnceAndCounted"
+    },
+    {
+      "label": "an unreadable reading is replayed onto, which cannot make it readable (#670)",
+      "file": "internal/core/machine/verdicts.go",
+      "find": "\tif !anyBroken(verdicts) {\n\t\tr.publish(res, verdicts, nil)\n\t\treturn\n\t}",
+      "replace": "\tif !anyBroken(verdicts) && false {\n\t\tr.publish(res, verdicts, nil)\n\t\treturn\n\t}",
+      "test": "TestAnUnreadableReadingIsNotReplayedOnto"
+    },
+    {
+      "label": "the late-address door reads on every GET, and the emulator's latency becomes the runtime's (#670)",
+      "file": "internal/core/machine/plan.go",
+      "find": "\tif last := res.Runtime[VerifiedKey]; last == \"\" || strings.HasPrefix(last, \"unreadable\") {",
+      "replace": "\tif last := res.Runtime[VerifiedKey]; last == \"\" || strings.HasPrefix(last, \"unreadable\") || true {",
+      "test": "TestTheLateAddressDoorVerifiesOnceItCanRead"
+    },
+    {
+      "label": "a hot join is not read back (#670)",
+      "file": "internal/core/machine/plan.go",
+      "find": "\tr.ReplayAddresses(ctx, res)\n\tr.Groups.AfterBoot(ctx, res)\n\tr.check(ctx, res)\n\treturn err",
+      "replace": "\tr.ReplayAddresses(ctx, res)\n\tr.Groups.AfterBoot(ctx, res)\n\tif err != nil {\n\t\tr.check(ctx, res)\n\t}\n\treturn err",
+      "test": "TestAHotJoinAndAHotRouteAreReadBack"
+    },
+    {
+      "label": "the gate passes a pass with a broken claim, and names nothing (#670)",
+      "package": "./tools/conformance/",
+      "file": "tools/conformance/guard.sh",
+      "find": "  if [ \"$broken\" -gt 0 ]; then",
+      "replace": "  if [ \"$broken\" -gt 0 ] && false; then",
+      "test": "TestTheVerificationGateRefusesABrokenClaim"
+    },
+    {
+      "label": "the gate passes a pass that could not read, reading blindness as success (#670)",
+      "package": "./tools/conformance/",
+      "file": "tools/conformance/guard.sh",
+      "find": "  if [ \"$unreadable\" -gt \"$held\" ]; then",
+      "replace": "  if [ \"$unreadable\" -gt \"$held\" ] && false; then",
+      "test": "TestTheVerificationGateRefusesAPassThatCouldNotRead"
+    },
+    {
+      "label": "the gate stops refusing a payload with no counters, and passes every build that predates it (#670)",
+      "package": "./tools/conformance/",
+      "file": "tools/conformance/guard.sh",
+      "find": "      ''|*[!0-9]*)\n",
+      "replace": "      '\\x00never')\n",
+      "test": "TestTheVerificationGateRefusesAPayloadWithNoCounters"
+    },
+    {
+      "label": "the health payload drops the counters, and the frozen surface says so (#670)",
+      "package": "./internal/core/emulator/",
+      "file": "internal/core/emulator/emulator.go",
+      "find": "\t\t\"verification\": s.env.machines.Verification(),\n",
+      "replace": "\t\t\"verification_\": s.env.machines.Verification(),\n",
+      "test": "TestHealthCarriesTheVerificationCounters"
+    }
+  ]
+}

--- a/tools/falsify/specs/interface-plan.json
+++ b/tools/falsify/specs/interface-plan.json
@@ -11,8 +11,8 @@
     {
       "label": "a hot join resyncs the firewall before the interface it must cover exists (#510)",
       "file": "internal/core/machine/plan.go",
-      "find": "\terr := r.attach(ctx, res, att)\n\tr.ReplayAddresses(ctx, res)\n\tr.Groups.AfterBoot(ctx, res)\n\treturn err",
-      "replace": "\tr.Groups.AfterBoot(ctx, res)\n\terr := r.attach(ctx, res, att)\n\tr.ReplayAddresses(ctx, res)\n\treturn err",
+      "find": "\terr := r.attach(ctx, res, att)\n\tr.ReplayAddresses(ctx, res)\n\tr.Groups.AfterBoot(ctx, res)\n\tr.check(ctx, res)\n\treturn err",
+      "replace": "\tr.Groups.AfterBoot(ctx, res)\n\terr := r.attach(ctx, res, att)\n\tr.ReplayAddresses(ctx, res)\n\tr.check(ctx, res)\n\treturn err",
       "test": "TestJoinRunsTheFirewallAfterTheAttach"
     },
     {

--- a/tools/falsify/specs/pack-firewall-handoff.json
+++ b/tools/falsify/specs/pack-firewall-handoff.json
@@ -4,8 +4,8 @@
     {
       "label": "the Outscale boot stops handing the worn groups to the runtime, which is the whole of #475",
       "file": "internal/core/machine/plan.go",
-      "find": "\tr.Groups.AfterBoot(ctx, res)\n\treturn true",
-      "replace": "\tif false {\n\t\tr.Groups.AfterBoot(ctx, res)\n\t}\n\treturn true",
+      "find": "\t// is what holds it now.\n\tr.Groups.AfterBoot(ctx, res)\n}",
+      "replace": "\t// is what holds it now.\n\tif false {\n\t\tr.Groups.AfterBoot(ctx, res)\n\t}\n}",
       "test": "TestAnOutscaleGroupReachesTheHostWhenItsVmBoots"
     },
     {
@@ -19,8 +19,8 @@
       "label": "the Exoscale boot stops handing the worn groups to the runtime",
       "package": "./internal/providers/exoscale/",
       "file": "internal/core/machine/plan.go",
-      "find": "\tr.Groups.AfterBoot(ctx, res)\n\treturn true",
-      "replace": "\tif false {\n\t\tr.Groups.AfterBoot(ctx, res)\n\t}\n\treturn true",
+      "find": "\t// is what holds it now.\n\tr.Groups.AfterBoot(ctx, res)\n}",
+      "replace": "\t// is what holds it now.\n\tif false {\n\t\tr.Groups.AfterBoot(ctx, res)\n\t}\n}",
       "test": "TestAnExoscaleGroupReachesTheHostWhenAnInstanceBoots"
     },
     {
@@ -35,8 +35,8 @@
       "label": "a network attached after the boot leaves its interface without the instance's rule sets",
       "package": "./internal/providers/exoscale/",
       "file": "internal/core/machine/plan.go",
-      "find": "\terr := r.attach(ctx, res, att)\n\tr.ReplayAddresses(ctx, res)\n\tr.Groups.AfterBoot(ctx, res)\n\treturn err",
-      "replace": "\terr := r.attach(ctx, res, att)\n\tr.ReplayAddresses(ctx, res)\n\tif false {\n\t\tr.Groups.AfterBoot(ctx, res)\n\t}\n\treturn err",
+      "find": "\terr := r.attach(ctx, res, att)\n\tr.ReplayAddresses(ctx, res)\n\tr.Groups.AfterBoot(ctx, res)\n\tr.check(ctx, res)\n\treturn err",
+      "replace": "\terr := r.attach(ctx, res, att)\n\tr.ReplayAddresses(ctx, res)\n\tif false {\n\t\tr.Groups.AfterBoot(ctx, res)\n\t}\n\tr.check(ctx, res)\n\treturn err",
       "test": "TestALateNetworkAttachCarriesTheRuleSets"
     },
     {


### PR DESCRIPTION
A verdict nobody reads is a confession nobody hears. The reading half
(#668) answered every claim a plan makes and nothing published the
answer. Now, after every lifecycle door — a boot, a reboot, a hot join, a
hot route, the late-address door of a virtual machine — what the runtime
read back goes to the three places a human looks and a gate fails.

The log: one ERROR per broken claim, naming the claim, the wanted value
and the one found; a WARN for the claims that could not be read, and a
WARN for a repair, in the two words this repository holds for a failure
and a degradation. The resource: Runtime["verified"], never serialised
into a client's view, "held", "broken: <claim> want <x>, got <y>; …" or
"unreadable: …", a prefix a reader branches on. Written inside the
change() closure of Transition, so it lands through Commit and merges per
key with a concurrent writer to another field — measured here, the other
writer's key survives beside it. And /_feint/health: four counters,
verification.{held,broken,unreadable,repaired}, on the Runtime handle
rather than a package variable so two emulators in one binary count
apart; the health schema moves to 8 and the frozen fixture carries it.

What the state must not become: a machine running with the wrong door is
running and unreachable, and publishing it stopped would be the lie in
the other direction. The state stays the one the boot produced.

One bounded repair. A broken first reading replays the post-boot order
once — every step of it is idempotent by construction, which is why it is
now a function, replay — and reads again; the second reading is what is
published, with the first named in a WARN, and `repaired` counts it,
because a repair that fires on every boot is a defect hidden behind a
retry. Measured here: a machine that heals is read exactly twice and
counted held and repaired; one that stays wrong is read exactly twice,
never three times, and counted broken. An unreadable reading is never
replayed onto. The late-address door sits on a GET, so it reads only
while nothing readable was published for the machine, and a verified
machine is never exec'd into again by a read.

tools/conformance/guard.sh verification <endpoint>, called by every leg
before its emulator stops, because the counters and the claims die with
it: broken > 0 fails naming each claim from /_feint/state, more
unreadable than held fails as a pass that measured its own blindness,
absent counters fail rather than read as zero, and a pass with no runtime
is told so rather than judged. Driven on planted payloads by five tests,
one per verdict.

Not measured here: any real machine. The counters and the gate have seen
a planted divergence and a written shape; the runtime leg is where they
meet a kernel, and it was not run for this commit.

tools/falsify/specs/a-verdict-somebody-reads.json replays thirteen
mutations across three packages and all thirteen bite (2026-09-04).
Three specs whose fragments the refactor moved — pack-firewall-handoff,
interface-plan, ssh-suite-needs-its-images — are retargeted and replayed:
9, 5 and 5 of theirs still bite.

Assisted-by: Claude Code (claude-fable-5-1)


🤖 Generated with [Claude Code](https://claude.com/claude-code)
