### PR TITLE
feat(machine): a reboot compares the shape after with the shape before (#669)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -58,6 +58,25 @@ change ni l'un ni l'autre a sa place dans `git log`.
   lb certificate list` et `scw lb subscriber list` dans la suite de
   conformance.
 
+- **Un reboot compare la forme d'après à la forme d'avant, sans table de
+  valeurs attendues** (#669). Rien ne bouge dans le plan de contrôle entre
+  les deux, parce que le reboot tient le verrou par cible d'un bout à
+  l'autre ; ce que la machine portait quand elle était debout est donc ce
+  qu'elle doit porter une fois revenue, interface par interface (réseau,
+  nature, adresses, rule sets, en ensembles), la route par défaut par sa
+  porte, le reste de la table en ensemble. Les revendications empruntent la
+  même lecture que celles du plan, donc un reboot est lu une fois et réparé
+  une fois comme tout démarrage. Sur la régression du 2026-09-04, la réponse
+  tombe au moment du reboot : `restart(default route) want via 169.254.0.1
+  dev eth0, got via 10.77.0.1 dev eth1`, là où la suite runtime attendait
+  soixante secondes deux pas plus loin pour dire « rien ne répond ».
+
+  Un avant illisible est dit, par un `WARN`, et le reboot est jugé sur son
+  plan seul plutôt que sur une devinette ; une machine qui n'était pas debout
+  n'a pas d'avant. Un poweroff puis un poweron en deux actions API ne sont
+  pas un reboot : une NIC attachée à un serveur arrêté change légitimement la
+  forme, et là ce sont les revendications dérivées qui jugent.
+
 - **Un verdict que quelqu'un lit : la vérification est publiée, et la jambe
   runtime en fait un gate** (#670). Après chaque porte du cycle de vie (un
   démarrage, un reboot, une jonction à chaud, une route à chaud, la porte

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,25 @@ what this project is judged on: **a response shape a client can observe**, and
   Driven by `scw lb backend list-statistics`, `scw lb lb get-stats`, `scw lb
   certificate list` and `scw lb subscriber list` in the conformance suite.
 
+- **A reboot compares the shape after with the shape before, and needs no
+  table of expected values for it** (#669). Nothing moves in the control
+  plane between the two, because the reboot holds the per-target lock from
+  one end to the other; so what the machine carried while it was up is what
+  it must carry once it is back, interface by interface (network, kind,
+  addresses, rule sets, as sets), the default route by its door, the rest of
+  the table as a set. The claims ride the same reading as the plan's own, so
+  a reboot is read once and repaired once like any other boot. On the
+  regression of 2026-09-04 this answers, at the moment of the reboot,
+  `restart(default route) want via 169.254.0.1 dev eth0, got via 10.77.0.1
+  dev eth1`, where the runtime suite used to wait sixty seconds two steps
+  later to say "nothing answers".
+
+  A before that could not be read is said, in a `WARN`, and the reboot is
+  judged on its plan alone rather than on a guess; a machine that was not up
+  has no before. A poweroff then a poweron as two API actions is not a
+  reboot: a NIC attached to a stopped server legitimately changes the shape,
+  and there the derived claims judge.
+
 - **A verdict somebody reads: the verification is published, and the runtime
   leg gates on it** (#670). After every lifecycle door — a boot, a reboot, a
   hot join, a hot route, the late-address door of a virtual machine — what the

--- a/internal/core/machine/plan.go
+++ b/internal/core/machine/plan.go
@@ -180,6 +180,12 @@ func (r Reconciler) consistent(res *resource.Resource, plan Plan) bool {
 // reports what PowerOn reported; a machine that did not start is not replayed
 // onto, and the state the pack publishes is the one the effect produced.
 func (r Reconciler) PowerOn(ctx context.Context, res *resource.Resource, boot Boot) bool {
+	return r.powerOn(ctx, res, boot, nil)
+}
+
+// powerOn is PowerOn with the claims the caller knew before the boot, which
+// a reboot has (#669) and a first boot does not.
+func (r Reconciler) powerOn(ctx context.Context, res *resource.Resource, boot Boot, extra []Claim) bool {
 	plan, declared := r.plan(res)
 	if !declared {
 		return false
@@ -202,7 +208,7 @@ func (r Reconciler) PowerOn(ctx context.Context, res *resource.Resource, boot Bo
 	// And what the replay produced is read back and published (#670): the
 	// state above is the one the boot produced, the verdict is the one the
 	// reading produced, and neither is allowed to stand in for the other.
-	r.check(ctx, res)
+	r.check(ctx, res, extra)
 	return true
 }
 
@@ -285,10 +291,27 @@ func (r Reconciler) Reboot(ctx context.Context, res *resource.Resource, boot Boo
 	// to stop a stopped instance logs a failure for an ordinary case. Which
 	// word means "up" is the pack's, held once here rather than compared to a
 	// literal in three places.
+	var extra []Claim
 	if res.State == r.binding().RunningState {
+		// The shape before, read while the machine is up (#669): what it
+		// carries now is what it must carry once it is back, and the reading
+		// after the boot answers that beside the plan's own claims. A before
+		// that could not be read is said, and the reboot is judged on its
+		// plan alone rather than on a guess.
+		// TestARebootComparesTheShapeAfterWithTheShapeBefore fails without
+		// this.
+		before, err := r.observe(ctx, res)
+		switch {
+		case err != nil:
+			r.binding().logger().Warn("the shape before the reboot could not be read, so the reboot is judged on its plan alone",
+				"provider", r.binding().Provider, "resource", res.ID,
+				"machine", res.Runtime[r.binding().RuntimeKey], "error", err)
+		case before != nil:
+			extra = restartClaims(*before)
+		}
 		r.binding().PowerOff(ctx, res)
 	}
-	return r.PowerOn(ctx, res, boot)
+	return r.powerOn(ctx, res, boot, extra)
 }
 
 // ReplayAddresses re-routes every promised address of a machine that just
@@ -309,7 +332,7 @@ func (r Reconciler) ReplayAddresses(ctx context.Context, res *resource.Resource)
 	// Once a reading held or broke, this door reads no more (#670).
 	// TestTheLateAddressDoorVerifiesOnceItCanRead fails without the bound.
 	if last := res.Runtime[VerifiedKey]; last == "" || strings.HasPrefix(last, "unreadable") {
-		r.check(ctx, res)
+		r.check(ctx, res, nil)
 	}
 }
 
@@ -390,7 +413,7 @@ func (r Reconciler) Route(ctx context.Context, res *resource.Resource, address s
 		return
 	}
 	r.route(ctx, res, plan, address)
-	r.check(ctx, res)
+	r.check(ctx, res, nil)
 }
 
 func (r Reconciler) route(ctx context.Context, res *resource.Resource, plan Plan, address string) {
@@ -547,7 +570,7 @@ func (r Reconciler) Join(ctx context.Context, res *resource.Resource, att Attach
 	err := r.attach(ctx, res, att)
 	r.ReplayAddresses(ctx, res)
 	r.Groups.AfterBoot(ctx, res)
-	r.check(ctx, res)
+	r.check(ctx, res, nil)
 	return err
 }
 

--- a/internal/core/machine/readback.go
+++ b/internal/core/machine/readback.go
@@ -59,10 +59,11 @@ func (r Reconciler) observer() Observer {
 	return obs
 }
 
-// verify derives what the plan claims, reads what the machine carries, and
-// answers every claim. asked is false when nobody could look: a runtime with
-// no Observer, a resource with no machine, or a plan that was refused before
-// the runtime was asked (its refusal is already in the log).
+// verify derives what the plan claims, adds what the caller claims on top —
+// the shape before a reboot — reads what the machine carries, and answers
+// every claim. asked is false when nobody could look: a runtime with no
+// Observer, a resource with no machine, or a plan that was refused before the
+// runtime was asked (its refusal is already in the log).
 //
 // A shape that could not be read answers Unreadable on every claim rather
 // than nothing, so the count of what was not verified is visible where the
@@ -71,7 +72,7 @@ func (r Reconciler) observer() Observer {
 //
 // TestAPlantedDivergenceIsReported and TestAnUnreadableShapeIsNeitherHeldNorBroken
 // are the instrument's two controls, and both fail without this.
-func (r Reconciler) verify(ctx context.Context, res *resource.Resource) (verdicts []Verdict, asked bool) {
+func (r Reconciler) verify(ctx context.Context, res *resource.Resource, extra []Claim) (verdicts []Verdict, asked bool) {
 	obs := r.observer()
 	name := res.Runtime[r.binding().RuntimeKey]
 	if obs == nil || name == "" {
@@ -86,6 +87,9 @@ func (r Reconciler) verify(ctx context.Context, res *resource.Resource) (verdict
 		return nil, false
 	}
 	claims = append(claims, r.wears(res, plan)...)
+	// And what the caller knew before the action: a reboot's shape before it
+	// (#669), answered by the same reading as the plan's claims.
+	claims = append(claims, extra...)
 	if len(claims) == 0 {
 		return nil, true
 	}

--- a/internal/core/machine/readback_test.go
+++ b/internal/core/machine/readback_test.go
@@ -313,10 +313,17 @@ type observingRecorder struct {
 	queue []Shape
 	// reads counts the Observe calls, which is how a test holds a bound.
 	reads int
+	// failFirst makes that many leading reads fail before the shape answers:
+	// a machine unreadable before its reboot and readable after it.
+	failFirst int
 }
 
 func (o *observingRecorder) Observe(context.Context, string) (Shape, error) {
 	o.reads++
+	if o.failFirst > 0 {
+		o.failFirst--
+		return Shape{}, errUnreadable
+	}
 	if len(o.queue) > 0 {
 		next := o.queue[0]
 		o.queue = o.queue[1:]
@@ -383,7 +390,7 @@ func TestAPlantedDivergenceIsReported(t *testing.T) {
 	vm := b.machine("m", "10.30.1.10")
 	r := observingReconciler(b, o, plan)
 
-	verdicts, asked := r.verify(context.Background(), vm)
+	verdicts, asked := r.verify(context.Background(), vm, nil)
 	if !asked || len(verdicts) != 1 || verdicts[0].Outcome != Held {
 		t.Fatalf("a machine carrying what its plan claims answered asked=%v:\n%s", asked, outcomes(verdicts))
 	}
@@ -391,7 +398,7 @@ func TestAPlantedDivergenceIsReported(t *testing.T) {
 	// One digit off, planted: the address the runtime reports is not the
 	// one the plan pinned.
 	o.shape = pinnedOn("fnt-x", "10.30.1.11/24")
-	verdicts, asked = r.verify(context.Background(), vm)
+	verdicts, asked = r.verify(context.Background(), vm, nil)
 	if !asked || len(verdicts) != 1 {
 		t.Fatalf("asked=%v, verdicts:\n%s", asked, outcomes(verdicts))
 	}
@@ -410,7 +417,7 @@ func TestAnUnreadableShapeIsNeitherHeldNorBroken(t *testing.T) {
 	o := &observingRecorder{Recorder: b.rec, err: errors.New("the agent isn't currently running")}
 	vm := b.machine("m", "10.30.1.10")
 
-	verdicts, asked := observingReconciler(b, o, plan).verify(context.Background(), vm)
+	verdicts, asked := observingReconciler(b, o, plan).verify(context.Background(), vm, nil)
 	if !asked || len(verdicts) != 2 {
 		t.Fatalf("asked=%v, verdicts:\n%s", asked, outcomes(verdicts))
 	}
@@ -422,12 +429,12 @@ func TestAnUnreadableShapeIsNeitherHeldNorBroken(t *testing.T) {
 
 	// A runtime with no reading half is not asked, and says so.
 	plain := rebootReconciler(b, plan)
-	if verdicts, asked := plain.verify(context.Background(), vm); asked || len(verdicts) != 0 {
+	if verdicts, asked := plain.verify(context.Background(), vm, nil); asked || len(verdicts) != 0 {
 		t.Errorf("a runtime that cannot be asked answered asked=%v with %d verdicts", asked, len(verdicts))
 	}
 	// And so is a resource with no machine behind it.
 	bare := b.machine("bare", "")
-	if verdicts, asked := observingReconciler(b, o, plan).verify(context.Background(), bare); asked || len(verdicts) != 0 {
+	if verdicts, asked := observingReconciler(b, o, plan).verify(context.Background(), bare, nil); asked || len(verdicts) != 0 {
 		t.Errorf("a resource with no machine answered asked=%v with %d verdicts", asked, len(verdicts))
 	}
 }
@@ -450,7 +457,7 @@ func TestTheRuleSetsAMachineWearsAreClaimedOnItsFilteredInterfaces(t *testing.T)
 	vm := b.machine("m", "10.30.1.10", "g")
 	r := observingReconciler(b, o, plan)
 
-	verdicts, _ := r.verify(context.Background(), vm)
+	verdicts, _ := r.verify(context.Background(), vm, nil)
 	names := map[string]Verdict{}
 	for _, v := range verdicts {
 		names[v.Claim] = v
@@ -470,7 +477,7 @@ func TestTheRuleSetsAMachineWearsAreClaimedOnItsFilteredInterfaces(t *testing.T)
 	eth1 := shape.Interfaces["eth1"]
 	eth1.RuleSets = []string{set}
 	shape.Interfaces["eth1"] = eth1
-	verdicts, _ = r.verify(context.Background(), vm)
+	verdicts, _ = r.verify(context.Background(), vm, nil)
 	for _, v := range verdicts {
 		if v.Claim == "wears(fnt-y)" && (v.Outcome != Broken || v.Want != "no rule set on eth1") {
 			t.Errorf("an unfiltered interface wearing a set answered %s", v)
@@ -488,7 +495,7 @@ func TestAWithdrawnFirewallClaimsNoRuleSets(t *testing.T) {
 	o := &observingRecorder{Recorder: b.rec, shape: pinnedOn("fnt-x", "10.30.1.10/24"), noFirewall: true}
 	vm := b.machine("m", "10.30.1.10", "g")
 
-	verdicts, _ := observingReconciler(b, o, plan).verify(context.Background(), vm)
+	verdicts, _ := observingReconciler(b, o, plan).verify(context.Background(), vm, nil)
 	for _, v := range verdicts {
 		if strings.HasPrefix(v.Claim, "wears(") {
 			t.Fatalf("a withdrawn firewall still claims rule sets: %s", v)

--- a/internal/core/machine/restart.go
+++ b/internal/core/machine/restart.go
@@ -1,0 +1,191 @@
+package machine
+
+import (
+	"context"
+	"net/netip"
+	"slices"
+	"strings"
+
+	"github.com/stephrobert/feint/internal/core/resource"
+)
+
+// A reboot needs no table of expected values: the shape after is the shape
+// before (#669).
+//
+// Nothing moves in the control plane between the two, because Reconciler.
+// Reboot holds the per-target lock from one end to the other (Serialise). So
+// the reboot is the one case where the verification costs no measurement
+// campaign and no encoded expectation: what the machine carried while it was
+// up is what it must carry once it is back, property by property, and the
+// only tolerance is the one every reading already applies — nothing that does
+// not compare ever entered either Shape.
+//
+// On the regression of 2026-09-04 this answers, at the moment of the reboot:
+//
+//	restart(default route) want via 169.254.0.1 dev eth0, got via 10.77.0.1 dev eth0
+//
+// where the runtime suite used to wait sixty seconds two steps later to say
+// "nothing answers". The cause where the effect is, rather than the symptom
+// where it surfaces.
+//
+// Where the before does NOT apply. A poweroff then a poweron as two API
+// actions is not a reboot: a NIC attached to a stopped server legitimately
+// changes the shape, and that is the ordinary Terraform order. There, the
+// derived claims judge (#667, #668). The two are complementary: the reboot
+// needs no table, the first boot needs one.
+
+// observe reads the machine behind a resource. nil with no error is a runtime
+// that cannot be asked, or a resource with no machine: said, not guessed.
+func (r Reconciler) observe(ctx context.Context, res *resource.Resource) (*Shape, error) {
+	obs := r.observer()
+	name := res.Runtime[r.binding().RuntimeKey]
+	if obs == nil || name == "" {
+		return nil, nil
+	}
+	shape, err := obs.Observe(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	return &shape, nil
+}
+
+// restartClaims turns the shape before a reboot into the claims the shape
+// after must answer: one per interface, one for the default route, one for
+// the rest of the table. They ride the same reading as the plan's claims, so
+// a reboot is read once and repaired once like any other boot.
+func restartClaims(before Shape) []Claim {
+	claims := make([]Claim, 0, len(before.Interfaces)+2)
+	for _, name := range before.interfaceNames() {
+		claims = append(claims, sameInterface{Name: name, Was: before.Interfaces[name]})
+	}
+	route, had := before.defaultRoute()
+	claims = append(claims, sameDefaultRoute{Was: route, Had: had})
+	var others []Route
+	for _, route := range before.Routes {
+		if route.Dst != defaultDst {
+			others = append(others, route)
+		}
+	}
+	return append(claims, sameRoutes{Was: others})
+}
+
+// sameInterface claims that an interface carries, after the reboot, what it
+// carried before: the same network, the same kind, the same addresses, the
+// same rule sets. Sets, not lists: the order the kernel or the runtime lists
+// them in is not a property of the machine.
+type sameInterface struct {
+	Name string
+	Was  Interface
+}
+
+func (c sameInterface) String() string { return "restart(" + c.Name + ")" }
+
+func (c sameInterface) Check(s Shape) Verdict {
+	got, has := s.Interfaces[c.Name]
+	if !has {
+		return broken(c, describeInterface(c.Was), "no interface "+c.Name)
+	}
+	if got.Network == c.Was.Network && got.Routed == c.Was.Routed &&
+		slices.Equal(sortedPrefixes(got.Addresses), sortedPrefixes(c.Was.Addresses)) &&
+		slices.Equal(sortedStrings(got.RuleSets), sortedStrings(c.Was.RuleSets)) {
+		return held(c)
+	}
+	return broken(c, describeInterface(c.Was), describeInterface(got))
+}
+
+// sameDefaultRoute claims that the default route is, after the reboot, what
+// it was before — present with the same door, or absent.
+type sameDefaultRoute struct {
+	Was Route
+	Had bool
+}
+
+func (c sameDefaultRoute) String() string { return "restart(default route)" }
+
+func (c sameDefaultRoute) Check(s Shape) Verdict {
+	got, has := s.defaultRoute()
+	switch {
+	case !c.Had && !has:
+		return held(c)
+	case c.Had && !has:
+		return broken(c, c.Was.String(), "no default route")
+	case !c.Had && has:
+		return broken(c, "no default route", got.String())
+	}
+	if got.Via == c.Was.Via && got.Dev == c.Was.Dev {
+		return held(c)
+	}
+	return broken(c, c.Was.String(), got.String())
+}
+
+// sameRoutes claims that the rest of the table — every route with a next hop
+// but the default — is, after the reboot, the set it was before.
+type sameRoutes struct {
+	Was []Route
+}
+
+func (c sameRoutes) String() string { return "restart(routes)" }
+
+func (c sameRoutes) Check(s Shape) Verdict {
+	var got []Route
+	for _, route := range s.Routes {
+		if route.Dst != defaultDst {
+			got = append(got, route)
+		}
+	}
+	want, have := routeLines(c.Was), routeLines(got)
+	if slices.Equal(want, have) {
+		return held(c)
+	}
+	return broken(c, strings.Join(want, ", "), strings.Join(have, ", "))
+}
+
+// routeLines renders routes for a verdict, sorted so two readings of one
+// table compare equal whatever order the kernel printed them in.
+func routeLines(routes []Route) []string {
+	if len(routes) == 0 {
+		return []string{"none"}
+	}
+	out := make([]string, 0, len(routes))
+	for _, r := range routes {
+		out = append(out, r.Dst.String()+" "+r.String())
+	}
+	slices.Sort(out)
+	return out
+}
+
+func sortedPrefixes(prefixes []netip.Prefix) []string {
+	out := make([]string, 0, len(prefixes))
+	for _, p := range prefixes {
+		out = append(out, p.String())
+	}
+	slices.Sort(out)
+	return out
+}
+
+func sortedStrings(values []string) []string {
+	out := slices.Clone(values)
+	slices.Sort(out)
+	return out
+}
+
+// describeInterface renders an interface for a verdict: where it sits, what
+// it carries, what it wears.
+func describeInterface(i Interface) string {
+	where := i.Network
+	if i.Routed {
+		where = "routed"
+	}
+	if where == "" {
+		where = "no network"
+	}
+	addresses := "nothing"
+	if len(i.Addresses) > 0 {
+		addresses = strings.Join(sortedPrefixes(i.Addresses), ", ")
+	}
+	sets := "no rule set"
+	if len(i.RuleSets) > 0 {
+		sets = strings.Join(sortedStrings(i.RuleSets), ", ")
+	}
+	return where + ": " + addresses + "; " + sets
+}

--- a/internal/core/machine/restart_test.go
+++ b/internal/core/machine/restart_test.go
@@ -1,0 +1,186 @@
+package machine
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/netip"
+	"strings"
+	"testing"
+)
+
+// A reboot needs no table of expected values (#669): the shape after is the
+// shape before, and the observing recorder is the instrument — the test
+// writes both shapes, so what the comparison had to find is exact.
+
+// routedBeside is the routed shape beside a private NIC (shapeA) with the
+// default route as given: the shape of 2026-09-04 before and after.
+func routedBeside(defaultVia, defaultDev string) Shape {
+	s := shapeA()
+	s.Routes[0] = Route{Dst: defaultDst, Via: netip.MustParseAddr(defaultVia), Dev: defaultDev}
+	return s
+}
+
+// restartPlan is the plan both shapes satisfy: the pinned private address
+// and the public /32 the routed NIC carries.
+var restartPlan = Plan{
+	Boot:    []Attachment{{Network: "fnt-x", Address: "10.30.1.10", PrefixLen: 24}},
+	Publics: []string{"203.0.113.2"},
+}
+
+// TestARebootComparesTheShapeAfterWithTheShapeBefore is the regression, seen
+// at the moment of the reboot: the machine came back with its default route
+// through the private gateway where it had left through the routed next hop.
+// The accepting half runs first on the same runtime, so the finding cannot be
+// a comparison that refuses everything.
+func TestARebootComparesTheShapeAfterWithTheShapeBefore(t *testing.T) {
+	before := routedBeside("169.254.0.1", "eth0")
+	after := routedBeside("10.77.0.1", "eth1")
+
+	b := newGroupSyncBench()
+	o := &observingRecorder{Recorder: b.rec, queue: []Shape{before, before}}
+	vm := b.machine("m", "10.30.1.10")
+	vm.State = "running"
+	r := observingReconciler(b, o, restartPlan)
+	if !r.Reboot(context.Background(), vm, Boot{Image: "ubuntu:24.04"}) {
+		t.Fatalf("the reboot did not bring the machine back; sequence: %v", b.rec.Sequence())
+	}
+	if o.reads != 2 || vm.Runtime[VerifiedKey] != "held" {
+		t.Fatalf("a reboot that changed nothing: reads=%d verified=%q", o.reads, vm.Runtime[VerifiedKey])
+	}
+
+	// The same reboot, and the machine comes back by another door. Queued
+	// twice after the before, because a broken reading is read once more
+	// after one replay, and the machine stays wrong.
+	o.queue = []Shape{before, after, after}
+	o.reads = 0
+	r.Reboot(context.Background(), vm, Boot{Image: "ubuntu:24.04"})
+	if o.reads != 3 {
+		t.Fatalf("reads=%d, want the before, the after, and one more after the repair", o.reads)
+	}
+	want := "restart(default route) want via 169.254.0.1 dev eth0, got via 10.77.0.1 dev eth1"
+	got := vm.Runtime[VerifiedKey]
+	if !strings.HasPrefix(got, "broken: ") || !strings.Contains(got, want) {
+		t.Fatalf("Runtime[%s] = %q, want it broken on %q", VerifiedKey, got, want)
+	}
+	// And the plan's own claims still held: the address is carried, the
+	// public /32 is carried; only the restart claims moved.
+	if strings.Contains(got, "carries(") {
+		t.Errorf("a claim the machine still satisfies was reported broken: %s", got)
+	}
+	if vm.State != "running" {
+		t.Errorf("state %q after a reboot the runtime honoured, want running", vm.State)
+	}
+}
+
+// A before that could not be read is said, and the reboot is judged on its
+// plan alone: no restart claim is invented from a shape nobody saw.
+func TestARebootWhoseBeforeCouldNotBeReadIsJudgedOnItsPlanAlone(t *testing.T) {
+	var log bytes.Buffer
+	b := newGroupSyncBench()
+	o := &observingRecorder{Recorder: b.rec, shape: routedBeside("169.254.0.1", "eth0"), failFirst: 1}
+	vm := b.machine("m", "10.30.1.10")
+	vm.State = "running"
+	r := observingReconciler(b, o, restartPlan)
+	r.Groups.Binding.Log = slog.New(slog.NewTextHandler(&log, nil))
+	r.Reboot(context.Background(), vm, Boot{Image: "ubuntu:24.04"})
+	if got := vm.Runtime[VerifiedKey]; got != "held" {
+		t.Fatalf("Runtime[%s] = %q, want held on the plan alone", VerifiedKey, got)
+	}
+	if !strings.Contains(log.String(), "judged on its plan alone") || !strings.Contains(log.String(), "level=WARN") {
+		t.Errorf("an unreadable before was not said:\n%s", log.String())
+	}
+}
+
+// A machine that was not up has no before: nothing is read until the boot's
+// own reading, and nothing is claimed about a shape that did not exist.
+func TestARebootOfAStoppedMachineHasNoBefore(t *testing.T) {
+	b := newGroupSyncBench()
+	o := &observingRecorder{Recorder: b.rec, shape: routedBeside("169.254.0.1", "eth0")}
+	vm := b.machine("m", "10.30.1.10")
+	vm.State = "stopped"
+	r := observingReconciler(b, o, restartPlan)
+	r.Reboot(context.Background(), vm, Boot{Image: "ubuntu:24.04"})
+	if o.reads != 1 || vm.Runtime[VerifiedKey] != "held" {
+		t.Fatalf("a reboot of a stopped machine: reads=%d verified=%q", o.reads, vm.Runtime[VerifiedKey])
+	}
+}
+
+// TestTheRestartClaimsCompareWhatCompares: the three claims derived from a
+// before, each on hand-built shapes — sets rather than lists for addresses,
+// rule sets and routes; a lost interface, a lost route and a gained route
+// each named as themselves.
+func TestTheRestartClaimsCompareWhatCompares(t *testing.T) {
+	before := routedBeside("169.254.0.1", "eth0")
+	claims := restartClaims(before)
+	if got := claimNames(claims); strings.Join(got, ",") != "restart(eth0),restart(eth1),restart(default route),restart(routes)" {
+		t.Fatalf("claims %v", got)
+	}
+	for _, c := range claims {
+		requireOutcome(t, c.Check(before), Held)
+	}
+
+	// The same addresses in another order, and the same rule sets in another
+	// order, are the same interface.
+	shuffled := routedBeside("169.254.0.1", "eth0")
+	eth1 := shuffled.Interfaces["eth1"]
+	eth1.Addresses = []netip.Prefix{netip.MustParsePrefix("10.30.1.10/24")}
+	eth1.RuleSets = []string{"fnt-b", "fnt-a"}
+	shuffled.Interfaces["eth1"] = eth1
+	sets := before
+	sets.Interfaces["eth1"] = Interface{Network: "fnt-x", Addresses: eth1.Addresses, RuleSets: []string{"fnt-a", "fnt-b"}}
+	requireOutcome(t, restartClaims(sets)[1].Check(shuffled), Held)
+
+	// An address gone from eth1.
+	bare := routedBeside("169.254.0.1", "eth0")
+	bare.Interfaces["eth1"] = Interface{Network: "fnt-x"}
+	v := claims[1].Check(bare)
+	requireOutcome(t, v, Broken)
+	if v.Want != "fnt-x: 10.30.1.10/24; no rule set" || v.Got != "fnt-x: nothing; no rule set" {
+		t.Errorf("a lost address: %s", v)
+	}
+	// An interface gone altogether.
+	delete(bare.Interfaces, "eth0")
+	v = claims[0].Check(bare)
+	requireOutcome(t, v, Broken)
+	if v.Got != "no interface eth0" {
+		t.Errorf("a lost interface: %s", v)
+	}
+	// The default route by another door on the same device: the half the
+	// regression lived in, and the half a comparison on the device alone
+	// would miss.
+	viaOnly := routedBeside("10.77.0.1", "eth0")
+	v = claims[2].Check(viaOnly)
+	requireOutcome(t, v, Broken)
+	if v.Want != "via 169.254.0.1 dev eth0" || v.Got != "via 10.77.0.1 dev eth0" {
+		t.Errorf("a default route by another door: %s", v)
+	}
+	// A default route gone, and one gained.
+	none := routedBeside("169.254.0.1", "eth0")
+	none.Routes = none.Routes[1:]
+	v = claims[2].Check(none)
+	requireOutcome(t, v, Broken)
+	if v.Got != "no default route" {
+		t.Errorf("a lost default route: %s", v)
+	}
+	requireOutcome(t, restartClaims(none)[2].Check(before), Broken)
+	// A private route lost, and one gained.
+	fewer := routedBeside("169.254.0.1", "eth0")
+	fewer.Routes = fewer.Routes[:3]
+	v = claims[3].Check(fewer)
+	requireOutcome(t, v, Broken)
+	if !strings.Contains(v.Want, "192.168.0.0/16 via 10.30.1.1 dev eth1") || strings.Contains(v.Got, "192.168.0.0/16") {
+		t.Errorf("a lost route is not named: %s", v)
+	}
+	more := routedBeside("169.254.0.1", "eth0")
+	more.Routes = append(more.Routes, Route{Dst: netip.MustParsePrefix("100.64.0.0/10"), Via: netip.MustParseAddr("10.30.1.1"), Dev: "eth1"})
+	v = claims[3].Check(more)
+	requireOutcome(t, v, Broken)
+	if !strings.Contains(v.Got, "100.64.0.0/10 via 10.30.1.1 dev eth1") {
+		t.Errorf("a gained route is not named: %s", v)
+	}
+	// An empty table before and after compares equal, and says so.
+	empty := Shape{}
+	requireOutcome(t, restartClaims(empty)[0].Check(empty), Held)
+	requireOutcome(t, restartClaims(empty)[1].Check(empty), Held)
+}

--- a/internal/core/machine/verdicts.go
+++ b/internal/core/machine/verdicts.go
@@ -181,8 +181,8 @@ func (r Reconciler) publish(res *resource.Resource, verdicts []Verdict, repaired
 // contradiction.
 //
 // TestARepairIsAttemptedOnceAndCounted fails without the bound.
-func (r Reconciler) check(ctx context.Context, res *resource.Resource) {
-	verdicts, asked := r.verify(ctx, res)
+func (r Reconciler) check(ctx context.Context, res *resource.Resource, extra []Claim) {
+	verdicts, asked := r.verify(ctx, res, extra)
 	if !asked {
 		return
 	}
@@ -196,7 +196,7 @@ func (r Reconciler) check(ctx context.Context, res *resource.Resource) {
 		return
 	}
 	r.replay(ctx, res, plan)
-	again, _ := r.verify(ctx, res)
+	again, _ := r.verify(ctx, res, extra)
 	if anyBroken(again) {
 		r.publish(res, again, nil)
 		return

--- a/tools/falsify/specs/a-reboot-compares-before-and-after.json
+++ b/tools/falsify/specs/a-reboot-compares-before-and-after.json
@@ -1,0 +1,47 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "the reboot reads the shape before and claims nothing from it, so the machine is judged on its plan alone (#669)",
+      "file": "internal/core/machine/plan.go",
+      "find": "\t\tcase before != nil:\n\t\t\textra = restartClaims(*before)",
+      "replace": "\t\tcase before != nil && false:\n\t\t\textra = restartClaims(*before)",
+      "test": "TestARebootComparesTheShapeAfterWithTheShapeBefore"
+    },
+    {
+      "label": "the reading drops the claims the caller knew before the action (#669)",
+      "file": "internal/core/machine/readback.go",
+      "find": "\tclaims = append(claims, extra...)\n",
+      "replace": "\tclaims = append(claims, extra[:0]...)\n",
+      "test": "TestARebootComparesTheShapeAfterWithTheShapeBefore"
+    },
+    {
+      "label": "the default route after the reboot is compared on its device alone, and the regression's door reads as held (#669)",
+      "file": "internal/core/machine/restart.go",
+      "find": "\tif got.Via == c.Was.Via && got.Dev == c.Was.Dev {\n\t\treturn held(c)\n\t}",
+      "replace": "\tif (got.Via == c.Was.Via || true) && got.Dev == c.Was.Dev {\n\t\treturn held(c)\n\t}",
+      "test": "TestTheRestartClaimsCompareWhatCompares"
+    },
+    {
+      "label": "an interface after the reboot is compared on its network alone, and a lost address reads as held (#669)",
+      "file": "internal/core/machine/restart.go",
+      "find": "\t\tslices.Equal(sortedPrefixes(got.Addresses), sortedPrefixes(c.Was.Addresses)) &&",
+      "replace": "\t\t(slices.Equal(sortedPrefixes(got.Addresses), sortedPrefixes(c.Was.Addresses)) || true) &&",
+      "test": "TestTheRestartClaimsCompareWhatCompares"
+    },
+    {
+      "label": "the rest of the table is not compared, and a lost private route reads as held (#669)",
+      "file": "internal/core/machine/restart.go",
+      "find": "\twant, have := routeLines(c.Was), routeLines(got)\n\tif slices.Equal(want, have) {",
+      "replace": "\twant, have := routeLines(c.Was), routeLines(got)\n\tif slices.Equal(want, have) || true {",
+      "test": "TestTheRestartClaimsCompareWhatCompares"
+    },
+    {
+      "label": "a lost interface reads as held (#669)",
+      "file": "internal/core/machine/restart.go",
+      "find": "\tgot, has := s.Interfaces[c.Name]\n\tif !has {\n\t\treturn broken(c, describeInterface(c.Was), \"no interface \"+c.Name)\n\t}",
+      "replace": "\tgot, has := s.Interfaces[c.Name]\n\tif !has && false {\n\t\treturn broken(c, describeInterface(c.Was), \"no interface \"+c.Name)\n\t}",
+      "test": "TestTheRestartClaimsCompareWhatCompares"
+    }
+  ]
+}

--- a/tools/falsify/specs/a-verdict-somebody-reads.json
+++ b/tools/falsify/specs/a-verdict-somebody-reads.json
@@ -32,8 +32,8 @@
     {
       "label": "the repair is unbounded: a machine that stays wrong is read a third time (#670)",
       "file": "internal/core/machine/verdicts.go",
-      "find": "\tagain, _ := r.verify(ctx, res)\n\tif anyBroken(again) {\n\t\tr.publish(res, again, nil)\n\t\treturn\n\t}",
-      "replace": "\tagain, _ := r.verify(ctx, res)\n\tif anyBroken(again) {\n\t\tr.replay(ctx, res, plan)\n\t\tagain, _ = r.verify(ctx, res)\n\t\tr.publish(res, again, nil)\n\t\treturn\n\t}",
+      "find": "\tagain, _ := r.verify(ctx, res, extra)\n\tif anyBroken(again) {\n\t\tr.publish(res, again, nil)\n\t\treturn\n\t}",
+      "replace": "\tagain, _ := r.verify(ctx, res, extra)\n\tif anyBroken(again) {\n\t\tr.replay(ctx, res, plan)\n\t\tagain, _ = r.verify(ctx, res, extra)\n\t\tr.publish(res, again, nil)\n\t\treturn\n\t}",
       "test": "TestARepairIsAttemptedOnceAndCounted"
     },
     {
@@ -60,8 +60,8 @@
     {
       "label": "a hot join is not read back (#670)",
       "file": "internal/core/machine/plan.go",
-      "find": "\tr.ReplayAddresses(ctx, res)\n\tr.Groups.AfterBoot(ctx, res)\n\tr.check(ctx, res)\n\treturn err",
-      "replace": "\tr.ReplayAddresses(ctx, res)\n\tr.Groups.AfterBoot(ctx, res)\n\tif err != nil {\n\t\tr.check(ctx, res)\n\t}\n\treturn err",
+      "find": "\tr.ReplayAddresses(ctx, res)\n\tr.Groups.AfterBoot(ctx, res)\n\tr.check(ctx, res, nil)\n\treturn err",
+      "replace": "\tr.ReplayAddresses(ctx, res)\n\tr.Groups.AfterBoot(ctx, res)\n\tif err != nil {\n\t\tr.check(ctx, res, nil)\n\t}\n\treturn err",
       "test": "TestAHotJoinAndAHotRouteAreReadBack"
     },
     {

--- a/tools/falsify/specs/interface-plan.json
+++ b/tools/falsify/specs/interface-plan.json
@@ -11,8 +11,8 @@
     {
       "label": "a hot join resyncs the firewall before the interface it must cover exists (#510)",
       "file": "internal/core/machine/plan.go",
-      "find": "\terr := r.attach(ctx, res, att)\n\tr.ReplayAddresses(ctx, res)\n\tr.Groups.AfterBoot(ctx, res)\n\tr.check(ctx, res)\n\treturn err",
-      "replace": "\tr.Groups.AfterBoot(ctx, res)\n\terr := r.attach(ctx, res, att)\n\tr.ReplayAddresses(ctx, res)\n\tr.check(ctx, res)\n\treturn err",
+      "find": "\terr := r.attach(ctx, res, att)\n\tr.ReplayAddresses(ctx, res)\n\tr.Groups.AfterBoot(ctx, res)\n\tr.check(ctx, res, nil)\n\treturn err",
+      "replace": "\tr.Groups.AfterBoot(ctx, res)\n\terr := r.attach(ctx, res, att)\n\tr.ReplayAddresses(ctx, res)\n\tr.check(ctx, res, nil)\n\treturn err",
       "test": "TestJoinRunsTheFirewallAfterTheAttach"
     },
     {

--- a/tools/falsify/specs/lifecycle-tells-the-truth.json
+++ b/tools/falsify/specs/lifecycle-tells-the-truth.json
@@ -13,15 +13,15 @@
     {
       "label": "#547: a reboot stops taking the machine down, so the action answers success and the runtime — which refuses to relaunch a name it has already served — does nothing at all",
       "file": "internal/core/machine/plan.go",
-      "find": "\tif res.State == r.binding().RunningState {\n\t\tr.binding().PowerOff(ctx, res)\n\t}",
-      "replace": "\tif res.State == r.binding().RunningState && false {\n\t\tr.binding().PowerOff(ctx, res)\n\t}",
+      "find": "\tif res.State == r.binding().RunningState {\n\t\t// The shape before, read while the machine is up (#669)",
+      "replace": "\tif res.State == r.binding().RunningState && false {\n\t\t// The shape before, read while the machine is up (#669)",
       "test": "TestARebootStopsTheMachineBeforeStartingIt"
     },
     {
       "label": "#547, the accepting half: a reboot stops asking whether the machine was up, so a stopped one is stopped again and the runtime is told to stop what it already stopped",
       "file": "internal/core/machine/plan.go",
-      "find": "\tif res.State == r.binding().RunningState {\n\t\tr.binding().PowerOff(ctx, res)\n\t}",
-      "replace": "\tif res.State == r.binding().RunningState || true {\n\t\tr.binding().PowerOff(ctx, res)\n\t}",
+      "find": "\tif res.State == r.binding().RunningState {\n\t\t// The shape before, read while the machine is up (#669)",
+      "replace": "\tif res.State == r.binding().RunningState || true {\n\t\t// The shape before, read while the machine is up (#669)",
       "test": "TestARebootOfAStoppedMachineDoesNotStopItAgain"
     },
     {

--- a/tools/falsify/specs/pack-firewall-handoff.json
+++ b/tools/falsify/specs/pack-firewall-handoff.json
@@ -35,8 +35,8 @@
       "label": "a network attached after the boot leaves its interface without the instance's rule sets",
       "package": "./internal/providers/exoscale/",
       "file": "internal/core/machine/plan.go",
-      "find": "\terr := r.attach(ctx, res, att)\n\tr.ReplayAddresses(ctx, res)\n\tr.Groups.AfterBoot(ctx, res)\n\tr.check(ctx, res)\n\treturn err",
-      "replace": "\terr := r.attach(ctx, res, att)\n\tr.ReplayAddresses(ctx, res)\n\tif false {\n\t\tr.Groups.AfterBoot(ctx, res)\n\t}\n\tr.check(ctx, res)\n\treturn err",
+      "find": "\terr := r.attach(ctx, res, att)\n\tr.ReplayAddresses(ctx, res)\n\tr.Groups.AfterBoot(ctx, res)\n\tr.check(ctx, res, nil)\n\treturn err",
+      "replace": "\terr := r.attach(ctx, res, att)\n\tr.ReplayAddresses(ctx, res)\n\tif false {\n\t\tr.Groups.AfterBoot(ctx, res)\n\t}\n\tr.check(ctx, res, nil)\n\treturn err",
       "test": "TestALateNetworkAttachCarriesTheRuleSets"
     },
     {


### PR DESCRIPTION
For a reboot, "identical" needs no table of expected values: the shape
after is the shape before. Nothing moves in the control plane between the
two, because Reconciler.Reboot holds the per-target lock from one end to
the other, so what the machine carried while it was up is what it must
carry once it is back — interface by interface (network, kind, addresses
and rule sets as sets), the default route by its door, the rest of the
table as a set. That makes the reboot the one case where the verification
costs no measurement campaign and no encoded expectation (#672 stays what
it is: the first boot's table).

The shape before becomes claims, and the claims ride the same reading as
the plan's own: verify and check take them as an extra list, so a reboot
is read once, repaired once and published once like any other boot, and
a broken restart claim sits in Runtime["verified"] beside the plan's.
On the regression of 2026-09-04 this answers, at the moment of the
reboot, `restart(default route) want via 169.254.0.1 dev eth0, got via
10.77.0.1 dev eth1`, where the runtime suite waited sixty seconds two
steps later to say "nothing answers".

A before that could not be read is said, in a WARN, and the reboot is
judged on its plan alone rather than on a guess; a machine that was not
up has no before and nothing is claimed about a shape that did not exist.
A poweroff then a poweron as two API actions is not a reboot — a NIC
attached to a stopped server legitimately changes the shape — and there
the derived claims judge; the code says so where it makes the difference.

Measured here, with the observing recorder and two written shapes: a
reboot that changed nothing is read twice and held; one that came back
by another door is read three times — the before, the after, and once
more after the one replay — and broken on the default route alone, the
plan's own claims still held and the state still running; the three
restart claims name a lost address, a lost interface, a lost default
route, a gained one, a lost private route and a gained one, each as
itself, and compare addresses, rule sets and routes as sets. Not
measured here: a real reboot on a real machine, which the runtime leg
and #671's shell half are for.

tools/falsify/specs/a-reboot-compares-before-and-after.json replays six
mutations and all six bite (2026-09-04), after one that did not: the
via-alone mutation stayed green until the comparison test varied the
door on the same device, which is the half the regression lived in.
Five fragments the extra-claims threading moved — in
a-verdict-somebody-reads, interface-plan, pack-firewall-handoff and
lifecycle-tells-the-truth — are retargeted; lifecycle's still bite.

Assisted-by: Claude Code (claude-fable-5-1)


🤖 Generated with [Claude Code](https://claude.com/claude-code)
