### PR TITLE
feat(conformance): the runtime suite looks at the machine's own table across a restart, and names the line (#671)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -58,6 +58,25 @@ change ni l'un ni l'autre a sa place dans `git log`.
   lb certificate list` et `scw lb subscriber list` dans la suite de
   conformance.
 
+- **La suite runtime regarde la table de la machine elle-même à travers un
+  redémarrage, et nomme la ligne** (#671). `tools/conformance/functional.sh`
+  capture, depuis l'intérieur de la machine et avant tout redémarrage, ses
+  adresses et chaque route à saut suivant, normalisées par deux lecteurs de
+  `functionallib.sh` (les routes connectées, le bloc link-local, les
+  métriques, `proto`, le loopback et les adresses de portée link n'y entrent
+  jamais) ; après le verbe reboot du provider, puis après un stop et un
+  start, elle capture à nouveau et compare. Une ligne qui a changé fait
+  échouer la stack avec ses deux graphies imprimées, avant et après : la cause
+  là où est l'effet, au lieu de « rien ne répond sur 203.0.113.4:443 »
+  soixante secondes plus tard à l'autre bout. Une capture qui a échoué est
+  « cannot look », jamais un côté vide qui compare égal à quelque chose.
+
+  `fnl_shape_reader_control` tourne avant tout verdict, comme les autres
+  contrôles de lecteur : il normalise deux tables plantées et exige que la
+  comparaison échoue sur une différence plantée, la régression à une ligne
+  près ; et un test remplace la comparaison par un oui systématique et exige
+  que le contrôle s'en aperçoive. Six execs sur une jambe de 590 s.
+
 - **Un reboot compare la forme d'après à la forme d'avant, sans table de
   valeurs attendues** (#669). Rien ne bouge dans le plan de contrôle entre
   les deux, parce que le reboot tient le verrou par cible d'un bout à

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,24 @@ what this project is judged on: **a response shape a client can observe**, and
   Driven by `scw lb backend list-statistics`, `scw lb lb get-stats`, `scw lb
   certificate list` and `scw lb subscriber list` in the conformance suite.
 
+- **The runtime suite looks at the machine's own table across a restart, and
+  names the line** (#671). `tools/conformance/functional.sh` captures, from
+  inside the machine and before anything is restarted, its addresses and every
+  route with a next hop, normalised by two readers in `functionallib.sh`
+  (connected routes, the link-local block, metrics, `proto`, the loopback and
+  scope-link addresses never enter); after the provider's own reboot verb, and
+  again after a stop and a start, it captures again and diffs. A line that
+  changed fails the stack with both spellings printed, before and after: the
+  cause where the effect is, instead of "nothing answers at 203.0.113.4:443"
+  sixty seconds later at the far end. A capture that failed is "cannot look",
+  never a side that compares equal to something.
+
+  `fnl_shape_reader_control` runs before any verdict, like the other reader
+  controls: it normalises two planted tables and requires the comparison to
+  fail on a planted difference, the regression one line apart; and a test
+  stubs the comparison to pass everything and requires the control to notice.
+  Six execs on a leg of 590 s.
+
 - **A reboot compares the shape after with the shape before, and needs no
   table of expected values for it** (#669). Nothing moves in the control
   plane between the two, because the reboot holds the per-target lock from

--- a/tools/conformance/functional.sh
+++ b/tools/conformance/functional.sh
@@ -216,6 +216,7 @@ fnl_listen_reader_control
 fnl_name_reader_control
 fnl_delivery_reader_control
 fnl_rule_set_reader_control
+fnl_shape_reader_control
 
 # ---- live transports --------------------------------------------------------
 #
@@ -322,6 +323,22 @@ station_fetch_within() { # seconds address port
 # target, which this gate only uses as the console that originates a probe.
 live_machine_pid() { # machine
 	incus query "/1.0/instances/$1/state" 2>/dev/null | jq -r '.pid // empty'
+}
+
+# live_shape writes what a machine carries — its addresses and every route with
+# a next hop, normalised by functionallib's two readers — into a file, non-zero
+# when the machine could not be read at all. Two execs, read from inside the
+# machine because the table IS the machine's: the host's view of a device is
+# what the driver asked for, and the difference between the two is exactly what
+# this gate exists to catch (#671).
+live_shape() { # machine out_file
+	local routes addresses
+	routes="$(incus exec "$1" -- ip -4 route show 2>/dev/null)" || return 1
+	addresses="$(incus exec "$1" -- ip -4 -o addr show 2>/dev/null)" || return 1
+	{
+		printf '%s\n' "$addresses" | fnl_shape_addresses
+		printf '%s\n' "$routes" | fnl_shape_routes
+	} >"$2"
 }
 
 # live_machine_acls answers the rule sets a machine's interfaces carry, comma
@@ -632,6 +649,12 @@ run_stack() { # name
 			fi
 		fi
 
+		# What the machine carries, read from inside it BEFORE anything is
+		# restarted (#671): the addresses and the routed table, normalised.
+		# The after-probe alone names the far end; this names the line.
+		live_shape "$rmachine" "$WORK/shape-before-$rmachine.txt" \
+			|| fail "cannot look: the shape of $restart ($rmachine) could not be read before the restart"
+
 		# ---- the provider's own reboot verb, which used to restart nothing ---
 		echo "- $name: the provider's own reboot verb restarts the machine"
 		local pid_before pid_after
@@ -651,6 +674,13 @@ run_stack() { # name
 			|| fail "$name: $restart came back '$state' ${waited}s after the API was asked to reboot it"
 		pid_after="$(live_machine_pid "$rmachine")"
 		fnl_restart_replaced_the_machine "$name" "$restart" "$rmachine" "$pid_before" "$pid_after"
+		# The machine's own table, back from the reboot verb: the layer compares
+		# it too (#669), and this is the same question asked from the station.
+		echo "- $name: the machine carries after the reboot what it carried before"
+		live_shape "$rmachine" "$WORK/shape-reboot-$rmachine.txt" \
+			|| fail "cannot look: the shape of $restart ($rmachine) could not be read after the reboot"
+		fnl_shape_survives_restart "$name" "$restart" "$rmachine" \
+			"$WORK/shape-before-$rmachine.txt" "$WORK/shape-reboot-$rmachine.txt" "after the reboot verb"
 
 		# ---- and the whole cycle through the other door ----------------------
 		power "$provider" "$id" off || fail "$name: $provider refused the stop of $restart"
@@ -687,6 +717,15 @@ run_stack() { # name
 		# and nowhere else, and the first boot is the one that needed it most.
 		fnl_service_came_up "$name" "$restart" "$unit" "$rmachine" "$port" \
 			"$WORK/listen-$rmachine.txt" "after a restart through the API"
+		# And after the other door, against the same before: a stop and a
+		# start through the API change nothing the machine carried, and the
+		# table says whether they did before the fetch below says what it
+		# cost.
+		echo "- $name: the machine carries after a stop and a start what it carried before"
+		live_shape "$rmachine" "$WORK/shape-after-$rmachine.txt" \
+			|| fail "cannot look: the shape of $restart ($rmachine) could not be read after the stop and the start"
+		fnl_shape_survives_restart "$name" "$restart" "$rmachine" \
+			"$WORK/shape-before-$rmachine.txt" "$WORK/shape-after-$rmachine.txt" "after a stop and a start"
 		address="$(published_address "$provider" "$restart")" \
 			|| fail "cannot look: $provider's API did not answer when asked for $restart's published address"
 		if [ -n "$address" ]; then

--- a/tools/conformance/functional_test.go
+++ b/tools/conformance/functional_test.go
@@ -723,6 +723,7 @@ func TestTheGateRunsItsReaderControlsBeforeAnyVerdict(t *testing.T) {
 		"fnl_name_reader_control",
 		"fnl_delivery_reader_control",
 		"fnl_rule_set_reader_control",
+		"fnl_shape_reader_control",
 	} {
 		called := false
 		for _, line := range strings.Split(gate, "\n") {
@@ -1015,4 +1016,124 @@ DIR="$1"
 		code = exit.ExitCode()
 	}
 	return code, string(out)
+}
+
+// ---- the machine's own table across a restart (#671) -----------------------
+//
+// The runtime suite asked one question of a restarted machine — does the
+// service answer at its published address — and when the answer was no it
+// named the far end, sixty seconds later. The service was alive, the address
+// was published, and the route was wrong (#660). These hold the readers that
+// look at the table, the comparison that names the line, and the control that
+// makes the comparison worth anything.
+
+const routeTable = `default via 10.77.0.1 dev eth0 proto dhcp src 10.77.0.2 metric 100
+10.77.0.0/24 dev eth0 proto kernel scope link src 10.77.0.2 metric 100
+10.77.0.1 dev eth0 proto dhcp scope link src 10.77.0.2 metric 100
+169.254.0.0/16 dev eth0 scope link metric 1000
+169.254.169.254 via 10.77.0.1 dev eth0 proto static
+10.0.0.0/8 via 10.77.0.1 dev eth0 proto dhcp src 10.77.0.2 metric 100
+203.0.113.9 via 10.0.0.1 dev eth1
+unreachable 198.51.100.0/24 dev lo
+`
+
+const addressList = `1: lo    inet 127.0.0.1/8 scope host lo\       valid_lft forever preferred_lft forever
+2: eth0    inet 10.77.0.2/24 brd 10.77.0.255 scope global eth0\       valid_lft forever preferred_lft forever
+2: eth0    inet 203.0.113.2/32 scope global eth0\       valid_lft forever preferred_lft forever
+2: eth0    inet 10.99.0.1/24 scope link eth0\       valid_lft forever preferred_lft forever
+9: eth9    inet 10.76.154.20/24 brd 10.76.154.255 scope global dynamic eth9\       valid_lft 3000sec preferred_lft 3000sec
+`
+
+// TestTheShapeReadersNormaliseWhatDoesNotCompare: connected routes, the
+// link-local block, an unreachable entry, metrics and proto leave the table;
+// the loopback and a scope-link address leave the list; default is spelled
+// as a block and a bare host gets its mask.
+func TestTheShapeReadersNormaliseWhatDoesNotCompare(t *testing.T) {
+	code, out := runFunctional(t, map[string]string{"routes": routeTable, "addrs": addressList},
+		`fnl_shape_routes <"$DIR/routes"; echo ---; fnl_shape_addresses <"$DIR/addrs"`)
+	want := "route 0.0.0.0/0 via 10.77.0.1 dev eth0\nroute 10.0.0.0/8 via 10.77.0.1 dev eth0\nroute 203.0.113.9/32 via 10.0.0.1 dev eth1\n---\naddr eth0 10.77.0.2/24\naddr eth0 203.0.113.2/32\naddr eth9 10.76.154.20/24\n"
+	if code != 0 || out != want {
+		t.Fatalf("exit %d, normalised:\n%s\nwant:\n%s", code, out, want)
+	}
+}
+
+// TestAShapeThatChangedAcrossARestartFailsNamingTheLine is the regression as
+// this gate sees it now: one line apart, both lines printed.
+func TestAShapeThatChangedAcrossARestartFailsNamingTheLine(t *testing.T) {
+	code, out := runFunctional(t, map[string]string{
+		"before": "addr eth0 203.0.113.2/32\nroute 0.0.0.0/0 via 169.254.0.1 dev eth0\n",
+		"after":  "addr eth0 203.0.113.2/32\nroute 0.0.0.0/0 via 10.77.0.1 dev eth0\n",
+	}, `fnl_shape_survives_restart scaleway platform-web-0 m-web-0 "$DIR/before" "$DIR/after" "after the reboot verb"`)
+	if code == 0 {
+		t.Fatalf("a changed shape passed:\n%s", out)
+	}
+	for _, line := range []string{
+		"FAIL: scaleway: platform-web-0 (m-web-0) does not carry after the reboot verb what it carried before the restart",
+		"before: route 0.0.0.0/0 via 169.254.0.1 dev eth0",
+		"after:  route 0.0.0.0/0 via 10.77.0.1 dev eth0",
+	} {
+		if !strings.Contains(out, line) {
+			t.Errorf("the verdict does not carry %q:\n%s", line, out)
+		}
+	}
+	if strings.Contains(out, "203.0.113.2/32") {
+		t.Errorf("a line that did not change is named:\n%s", out)
+	}
+}
+
+func TestAShapeThatSurvivedARestartPasses(t *testing.T) {
+	code, out := runFunctional(t, map[string]string{
+		"before": "addr eth0 203.0.113.2/32\nroute 0.0.0.0/0 via 169.254.0.1 dev eth0\n",
+		"after":  "addr eth0 203.0.113.2/32\nroute 0.0.0.0/0 via 169.254.0.1 dev eth0\n",
+	}, `fnl_shape_survives_restart scaleway platform-web-0 m-web-0 "$DIR/before" "$DIR/after" "after the reboot verb"`)
+	if code != 0 || !strings.Contains(out, "ok: scaleway: platform-web-0 carries after the reboot verb exactly what it carried before") {
+		t.Fatalf("an unchanged shape did not pass (exit %d):\n%s", code, out)
+	}
+}
+
+// A capture that failed is a side with nothing on it, and nothing compares
+// equal to something: the verdict is "cannot look", never a pass.
+func TestAShapeThatCouldNotBeReadIsNotAVerdict(t *testing.T) {
+	code, out := runFunctional(t, map[string]string{
+		"before": "addr eth0 203.0.113.2/32\n",
+		"after":  "",
+	}, `fnl_shape_survives_restart scaleway platform-web-0 m-web-0 "$DIR/before" "$DIR/after" "after the reboot verb"`)
+	if code == 0 || !strings.Contains(out, "cannot look") {
+		t.Fatalf("an unreadable after was judged (exit %d):\n%s", code, out)
+	}
+}
+
+// TestTheShapeReaderControlFindsABrokenComparator is the control of the
+// control: with the comparison stubbed to pass everything, the reader control
+// must fail, or the planted difference it claims to plant proves nothing.
+func TestTheShapeReaderControlFindsABrokenComparator(t *testing.T) {
+	code, out := runFunctional(t, nil, `fnl_shape_reader_control`)
+	if code != 0 {
+		t.Fatalf("the shape reader control fails on the real readers (exit %d):\n%s", code, out)
+	}
+	code, out = runFunctional(t, nil, `fnl_shape_survives_restart() { return 0; }
+fnl_shape_reader_control`)
+	if code == 0 || !strings.Contains(out, "passed a planted difference") {
+		t.Fatalf("the control did not notice a comparison that passes everything (exit %d):\n%s", code, out)
+	}
+}
+
+// TestTheRestartCapturesTheShapeBeforeAndAfter holds the gate to the order
+// that makes the comparison a measurement: the before is captured before the
+// reboot verb, and each door is compared against it.
+func TestTheRestartCapturesTheShapeBeforeAndAfter(t *testing.T) {
+	gate := readGate(t)
+	before := strings.Index(gate, `live_shape "$rmachine" "$WORK/shape-before-$rmachine.txt"`)
+	reboot := strings.Index(gate, `power "$provider" "$id" reboot`)
+	afterReboot := strings.Index(gate, `"$WORK/shape-before-$rmachine.txt" "$WORK/shape-reboot-$rmachine.txt"`)
+	stop := strings.Index(gate, `power "$provider" "$id" off`)
+	afterStart := strings.Index(gate, `"$WORK/shape-before-$rmachine.txt" "$WORK/shape-after-$rmachine.txt"`)
+	if before < 0 || reboot < 0 || afterReboot < 0 || stop < 0 || afterStart < 0 {
+		t.Fatalf("the restart does not capture and compare the shape at every door: before=%d reboot=%d afterReboot=%d stop=%d afterStart=%d",
+			before, reboot, afterReboot, stop, afterStart)
+	}
+	if before >= reboot || reboot >= afterReboot || afterReboot >= stop || stop >= afterStart {
+		t.Fatalf("the captures are not in the order that measures a restart: before=%d reboot=%d afterReboot=%d stop=%d afterStart=%d",
+			before, reboot, afterReboot, stop, afterStart)
+	}
 }

--- a/tools/conformance/functionallib.sh
+++ b/tools/conformance/functionallib.sh
@@ -147,6 +147,59 @@ fnl_delivery_addresses() { # record
 	}'
 }
 
+
+# fnl_shape_routes reads `ip -4 route show` on stdin and prints, one per line
+# and sorted, what compares of the guest's table: `route <dst> via <via> dev
+# <dev>`. Everything else on a line — proto, src, metric, onlink — is dropped,
+# and so is every line with no `via`: a connected route is implied by the
+# address that created it, and comparing it would compare the address twice.
+# The link-local block is the kernel's own plumbing and never enters; an
+# unreachable, blackhole or local entry is not a route to anywhere. `default`
+# is spelled 0.0.0.0/0 and a bare host address gets its /32, so iproute2 and
+# busybox read the same.
+#
+# This is the shell spelling of internal/core/machine's parseRoutes (#668), and
+# it is deliberately a second one: this file sees a machine from the station,
+# the driver sees it through the runtime API, and the two fail differently.
+fnl_shape_routes() {
+	awk '
+	$1 == "unreachable" || $1 == "blackhole" || $1 == "prohibit" || $1 == "throw" || $1 == "local" || $1 == "broadcast" || $1 == "multicast" || $1 == "anycast" || $1 == "nat" { next }
+	{
+		dst = $1
+		if (dst == "default") dst = "0.0.0.0/0"
+		else if (dst !~ /\//) dst = dst "/32"
+		if (dst ~ /^169\.254\./) next
+		via = ""; dev = ""
+		for (i = 2; i < NF; i++) {
+			if ($i == "via") via = $(i + 1)
+			if ($i == "dev") dev = $(i + 1)
+		}
+		if (via == "" || dev == "") next
+		print "route " dst " via " via " dev " dev
+	}' | sort
+}
+
+# fnl_shape_addresses reads `ip -4 -o addr show` on stdin and prints, one per
+# line and sorted, `addr <iface> <cidr>` for every global address: the
+# loopback, a link-local address and a scope-link one are not what a plan
+# claims.
+fnl_shape_addresses() {
+	awk '
+	NF < 4 { next }
+	{
+		iface = $2; sub(/:$/, "", iface)
+		if (iface == "lo") next
+		cidr = ""; scope = ""
+		for (i = 3; i < NF; i++) {
+			if ($i == "inet") cidr = $(i + 1)
+			if ($i == "scope") scope = $(i + 1)
+		}
+		if (cidr == "" || scope != "global") next
+		if (cidr ~ /^169\.254\./) next
+		print "addr " iface " " cidr
+	}' | sort
+}
+
 # ---- the controls: each reader finds a planted witness, and only it ---------
 #
 # Run before any verdict. A reader that cannot find its planted witness voids
@@ -198,6 +251,42 @@ fnl_name_reader_control() {
 	[ -z "$out" ] \
 		|| fail "the name reader matched 'platform-app' inside 'platform-app-2' (got '$out'); a neighbouring machine would answer for the one under test"
 	ok "the name reader resolves both naming shapes, and refuses a prefix match"
+}
+
+
+fnl_shape_reader_control() {
+	local out before after
+	out="$(printf '%s\n' \
+		'default via 10.77.0.1 dev eth0 proto dhcp src 10.77.0.2 metric 100 ' \
+		'10.77.0.0/24 dev eth0 proto kernel scope link src 10.77.0.2 ' \
+		'169.254.169.254 via 10.77.0.1 dev eth0 ' \
+		'10.0.0.0/8 via 10.77.0.1 dev eth0 proto dhcp metric 100 ' \
+		'203.0.113.9 via 10.0.0.1 dev eth1' \
+		'unreachable 198.51.100.0/24 dev lo' \
+		| fnl_shape_routes | tr '\n' '|')"
+	[ "$out" = "route 0.0.0.0/0 via 10.77.0.1 dev eth0|route 10.0.0.0/8 via 10.77.0.1 dev eth0|route 203.0.113.9/32 via 10.0.0.1 dev eth1|" ] \
+		|| fail "the route reader cannot normalise a table (got '$out'); every 'the shape survived' it reported would compare noise, and every 'it changed' would name a metric"
+	out="$(printf '%s\n' \
+		'1: lo    inet 127.0.0.1/8 scope host lo\       valid_lft forever preferred_lft forever' \
+		'2: eth0    inet 10.77.0.2/24 brd 10.77.0.255 scope global eth0\       valid_lft forever preferred_lft forever' \
+		'2: eth0    inet 203.0.113.2/32 scope global eth0\       valid_lft forever preferred_lft forever' \
+		'2: eth0    inet 10.99.0.1/24 scope link eth0\       valid_lft forever preferred_lft forever' \
+		| fnl_shape_addresses | tr '\n' '|')"
+	[ "$out" = "addr eth0 10.77.0.2/24|addr eth0 203.0.113.2/32|" ] \
+		|| fail "the address reader cannot normalise an address list (got '$out'); a scope-link address or the loopback would read as a change across a restart"
+	# And the comparison finds a planted difference: the regression of
+	# 2026-09-04, one line apart. A comparison that had never found anything
+	# is indistinguishable from one that looks nowhere.
+	before="$(mktemp)"
+	after="$(mktemp)"
+	printf '%s\n' 'addr eth0 203.0.113.2/32' 'route 0.0.0.0/0 via 169.254.0.1 dev eth0' >"$before"
+	printf '%s\n' 'addr eth0 203.0.113.2/32' 'route 0.0.0.0/0 via 10.77.0.1 dev eth0' >"$after"
+	if (fnl_shape_survives_restart control planted m "$before" "$after" "after a planted restart") >/dev/null 2>&1; then
+		rm -f "$before" "$after"
+		fail "the shape comparison passed a planted difference; every 'the shape survived' it reports would be an instrument that looks nowhere"
+	fi
+	rm -f "$before" "$after"
+	ok "the shape readers normalise both tables, and the comparison finds a planted difference"
 }
 
 # ---- the verdicts -----------------------------------------------------------
@@ -525,6 +614,37 @@ fnl_restart_replaced_the_machine() { # stack name machine before after
 	[ "$before" != "$after" ] \
 		|| fail "$stack: $name ($machine) came out of a reboot through the provider's own API on the same runtime process ($after) — the action was accepted and the machine never restarted (#547)"
 	ok "$stack: $name really restarts on the provider's own reboot verb (process $before then $after)"
+}
+
+
+# fnl_shape_survives_restart: a machine restarted through the provider's API
+# carries afterwards exactly what it carried before — its addresses, and every
+# route with a next hop — read from inside the machine and normalised by the
+# two readers above (#671).
+#
+# The runtime suite used to ask one question of a restarted machine, does the
+# service answer at its published address, and when the answer was no it said
+# so sixty seconds later and named the far end. On 2026-09-04 the service was
+# alive, the address was published, and the route was wrong: the reply left
+# through the private gateway where it had left through the routed next hop
+# (#660). The suite could not say that, because it never looked at the
+# machine's own table. This does, and names the line.
+#
+# Both files are the caller's captures, so a transport failure is its own
+# verdict — "cannot look" — and never an empty side that compares equal to
+# something. The lines that changed are printed as they read, before and
+# after, which is what an operator needs to see the cause where the effect is.
+fnl_shape_survives_restart() { # stack name machine before_file after_file moment
+	local stack="$1" name="$2" machine="$3" before="$4" after="$5" moment="$6" changed
+	[ -s "$before" ] \
+		|| fail "cannot look: the shape of $name ($machine) could not be read before the restart, and a comparison with nothing on one side is not a comparison"
+	[ -s "$after" ] \
+		|| fail "cannot look: the shape of $name ($machine) could not be read $moment, and a comparison with nothing on one side is not a comparison"
+	changed="$(diff "$before" "$after" | sed -n 's/^< /  before: /p; s/^> /  after:  /p')"
+	[ -z "$changed" ] \
+		|| fail "$stack: $name ($machine) does not carry $moment what it carried before the restart; the machine's own table changed, and this is the cause where the effect is (#671, #660):
+$changed"
+	ok "$stack: $name carries $moment exactly what it carried before the restart"
 }
 
 # fnl_restart_keeps_reaching: a machine restarted through the provider's API

--- a/tools/falsify/specs/a-restart-keeps-its-shape.json
+++ b/tools/falsify/specs/a-restart-keeps-its-shape.json
@@ -1,0 +1,47 @@
+{
+  "package": "./tools/conformance/",
+  "mutations": [
+    {
+      "label": "the shape comparison never fails, and the regression of 2026-09-04 reads as a table that survived (#671)",
+      "file": "tools/conformance/functionallib.sh",
+      "find": "\t[ -z \"$changed\" ] \\\n\t\t|| fail \"$stack: $name ($machine) does not carry $moment what it carried before the restart",
+      "replace": "\t[ -z \"$changed\" ] || true \\\n\t\t|| fail \"$stack: $name ($machine) does not carry $moment what it carried before the restart",
+      "test": "TestAShapeThatChangedAcrossARestartFailsNamingTheLine"
+    },
+    {
+      "label": "the route reader keeps the connected routes, and the comparison compares the address twice (#671)",
+      "file": "tools/conformance/functionallib.sh",
+      "find": "\t\tif (via == \"\" || dev == \"\") next\n\t\tprint \"route \" dst \" via \" via \" dev \" dev",
+      "replace": "\t\tif ((via == \"\" && 0) || dev == \"\") next\n\t\tprint \"route \" dst \" via \" via \" dev \" dev",
+      "test": "TestTheShapeReadersNormaliseWhatDoesNotCompare"
+    },
+    {
+      "label": "the route reader keeps the link-local block, the kernel's own plumbing (#671)",
+      "file": "tools/conformance/functionallib.sh",
+      "find": "\t\tif (dst ~ /^169\\.254\\./) next\n\t\tvia = \"\"; dev = \"\"",
+      "replace": "\t\tif (dst ~ /^169\\.254\\./ && 0) next\n\t\tvia = \"\"; dev = \"\"",
+      "test": "TestTheShapeReadersNormaliseWhatDoesNotCompare"
+    },
+    {
+      "label": "the address reader ignores the scope, and a scope-link address reads as a change across a restart (#671)",
+      "file": "tools/conformance/functionallib.sh",
+      "find": "\t\tif (cidr == \"\" || scope != \"global\") next",
+      "replace": "\t\tif (cidr == \"\" || (scope != \"global\" && 0)) next",
+      "test": "TestTheShapeReadersNormaliseWhatDoesNotCompare"
+    },
+    {
+      "label": "a capture that failed compares as an empty side, and reads as a table that changed or survived rather than as nobody looking (#671)",
+      "file": "tools/conformance/functionallib.sh",
+      "find": "\t[ -s \"$after\" ] \\\n\t\t|| fail \"cannot look: the shape of $name ($machine) could not be read $moment",
+      "replace": "\t[ -s \"$after\" ] || true \\\n\t\t|| fail \"cannot look: the shape of $name ($machine) could not be read $moment",
+      "test": "TestAShapeThatCouldNotBeReadIsNotAVerdict"
+    },
+    {
+      "label": "the reader control stops checking that the comparison finds a planted difference (#671)",
+      "file": "tools/conformance/functionallib.sh",
+      "find": "\tif (fnl_shape_survives_restart control planted m \"$before\" \"$after\" \"after a planted restart\") >/dev/null 2>&1; then",
+      "replace": "\tif (fnl_shape_survives_restart control planted m \"$before\" \"$after\" \"after a planted restart\") >/dev/null 2>&1 && false; then",
+      "test": "TestTheShapeReaderControlFindsABrokenComparator"
+    }
+  ]
+}


### PR DESCRIPTION
The suite watched a machine come back from a restart and asked one
question — does the service answer at its published address — and when
the answer was no it said so sixty seconds later and named the far end.
On 2026-09-04 the service was alive, the address was published, and the
route was wrong (#660). The suite could not say that, because it never
looked at the machine's own table.

assert_restart now captures, from inside the machine and before anything
is restarted, its addresses and every route with a next hop, normalised
by two readers in functionallib.sh — connected routes, the link-local
block and the metadata route inside it, metrics, proto, an unreachable
entry, the loopback and a scope-link address never enter, default is
spelled 0.0.0.0/0 and a bare host gets its /32, so iproute2 and busybox
read the same. After the provider's own reboot verb, and again after a
stop and a start, it captures again and diffs against the same before.
A line that changed fails the stack with both spellings printed: the
cause where the effect is. A capture that failed is "cannot look", never
a side that compares equal to something. Six execs on a leg of 590 s.

The readers are a second spelling of internal/core/machine's parsers
(#668), deliberately: this file sees a machine from the station, the
driver sees it through the runtime API, and the two fail differently.
The layer says the route is not what the plan claims; the suite says and
here is what that costs.

fnl_shape_reader_control runs before any verdict, like the four reader
controls before it: it normalises two planted tables and requires the
comparison to fail on a planted difference — the regression, one line
apart — and TestTheShapeReaderControlFindsABrokenComparator stubs the
comparison to pass everything and requires the control to notice.

Measured here, with the fake transports of functional_test.go: the
readers' output on a real iproute2 table and address list; the verdict
on the regression names "before: route 0.0.0.0/0 via 169.254.0.1 dev
eth0" and "after: route 0.0.0.0/0 via 10.77.0.1 dev eth0" and nothing
that did not change; an unchanged table passes; an empty side is not a
verdict; and the gate captures and compares in the order that measures a
restart. Not measured here: a real restart on a real machine — the
runtime leg, under FEINT_VM=incus-ovn, is the only instrument for that
and it was not run for this commit.

tools/falsify/specs/a-restart-keeps-its-shape.json replays six mutations
and all six bite (2026-09-04).

Assisted-by: Claude Code (claude-fable-5-1)


🤖 Generated with [Claude Code](https://claude.com/claude-code)
