### PR TITLE
feat(machine): the runtime reads back what a machine carries, and a reboot restores it (#668, #670, #669, #671)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -58,6 +58,25 @@ change ni l'un ni l'autre a sa place dans `git log`.
   lb certificate list` et `scw lb subscriber list` dans la suite de
   conformance.
 
+- **Un reboot compare la forme d'après à la forme d'avant, sans table de
+  valeurs attendues** (#669). Rien ne bouge dans le plan de contrôle entre
+  les deux, parce que le reboot tient le verrou par cible d'un bout à
+  l'autre ; ce que la machine portait quand elle était debout est donc ce
+  qu'elle doit porter une fois revenue, interface par interface (réseau,
+  nature, adresses, rule sets, en ensembles), la route par défaut par sa
+  porte, le reste de la table en ensemble. Les revendications empruntent la
+  même lecture que celles du plan, donc un reboot est lu une fois et réparé
+  une fois comme tout démarrage. Sur la régression du 2026-09-04, la réponse
+  tombe au moment du reboot : `restart(default route) want via 169.254.0.1
+  dev eth0, got via 10.77.0.1 dev eth1`, là où la suite runtime attendait
+  soixante secondes deux pas plus loin pour dire « rien ne répond ».
+
+  Un avant illisible est dit, par un `WARN`, et le reboot est jugé sur son
+  plan seul plutôt que sur une devinette ; une machine qui n'était pas debout
+  n'a pas d'avant. Un poweroff puis un poweron en deux actions API ne sont
+  pas un reboot : une NIC attachée à un serveur arrêté change légitimement la
+  forme, et là ce sont les revendications dérivées qui jugent.
+
 - **Un verdict que quelqu'un lit : la vérification est publiée, et la jambe
   runtime en fait un gate** (#670). Après chaque porte du cycle de vie (un
   démarrage, un reboot, une jonction à chaud, une route à chaud, la porte

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -58,6 +58,25 @@ change ni l'un ni l'autre a sa place dans `git log`.
   lb certificate list` et `scw lb subscriber list` dans la suite de
   conformance.
 
+- **La suite runtime regarde la table de la machine elle-même à travers un
+  redémarrage, et nomme la ligne** (#671). `tools/conformance/functional.sh`
+  capture, depuis l'intérieur de la machine et avant tout redémarrage, ses
+  adresses et chaque route à saut suivant, normalisées par deux lecteurs de
+  `functionallib.sh` (les routes connectées, le bloc link-local, les
+  métriques, `proto`, le loopback et les adresses de portée link n'y entrent
+  jamais) ; après le verbe reboot du provider, puis après un stop et un
+  start, elle capture à nouveau et compare. Une ligne qui a changé fait
+  échouer la stack avec ses deux graphies imprimées, avant et après : la cause
+  là où est l'effet, au lieu de « rien ne répond sur 203.0.113.4:443 »
+  soixante secondes plus tard à l'autre bout. Une capture qui a échoué est
+  « cannot look », jamais un côté vide qui compare égal à quelque chose.
+
+  `fnl_shape_reader_control` tourne avant tout verdict, comme les autres
+  contrôles de lecteur : il normalise deux tables plantées et exige que la
+  comparaison échoue sur une différence plantée, la régression à une ligne
+  près ; et un test remplace la comparaison par un oui systématique et exige
+  que le contrôle s'en aperçoive. Six execs sur une jambe de 590 s.
+
 - **Un reboot compare la forme d'après à la forme d'avant, sans table de
   valeurs attendues** (#669). Rien ne bouge dans le plan de contrôle entre
   les deux, parce que le reboot tient le verrou par cible d'un bout à

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -58,6 +58,35 @@ change ni l'un ni l'autre a sa place dans `git log`.
   lb certificate list` et `scw lb subscriber list` dans la suite de
   conformance.
 
+- **Un verdict que quelqu'un lit : la vérification est publiée, et la jambe
+  runtime en fait un gate** (#670). Après chaque porte du cycle de vie (un
+  démarrage, un reboot, une jonction à chaud, une route à chaud, la porte
+  tardive d'une machine virtuelle), ce que le runtime a relu est publié là où
+  un humain regarde et là où un gate échoue : une ligne `ERROR` par
+  revendication rompue, nommant la revendication, la valeur attendue et celle
+  trouvée ; `Runtime["verified"]` sur la ressource, hors de toute vue client
+  et sur `/_feint/state` pour qui le demande ; et quatre compteurs sur
+  `/_feint/health`, `verification.{held,broken,unreadable,repaired}`, ce qui
+  porte le schéma de health à la version 8.
+
+  L'état de l'API ne bouge pas. Une machine qui tourne avec la mauvaise porte
+  tourne et est injoignable, et la publier arrêtée serait le mensonge dans
+  l'autre sens. Une réparation bornée : une première lecture rompue rejoue
+  une fois l'ordre d'après-démarrage, dont chaque étape est idempotente, et
+  relit ; la seconde lecture est ce qui est publié, et `repaired` compte
+  combien de fois la première avait tort, parce qu'une réparation qui tire à
+  chaque démarrage est un défaut caché derrière une relance. Une lecture
+  illisible n'est jamais rejouée, et la porte tardive ne lit que tant que
+  rien de lisible n'a été publié : un GET n'exécute jamais rien dans une
+  machine déjà vérifiée.
+
+  `tools/conformance/guard.sh verification <endpoint>`, appelé par chaque
+  jambe avant l'arrêt de son émulateur : `broken > 0` fait échouer la jambe en
+  nommant chaque revendication depuis l'état, plus d'illisibles que de tenues
+  la fait échouer comme une passe qui a mesuré son propre aveuglement, des
+  compteurs absents la font échouer plutôt que d'être lus comme zéro, et une
+  passe sans runtime est prévenue plutôt que jugée.
+
 - **Le runtime relit ce qu'une machine porte réellement, et chaque
   revendication de son plan reçoit l'une de trois issues** (#668). Le pilote
   Incus implémente `Observer` : un `query` pour les devices propres de la

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -58,6 +58,35 @@ change ni l'un ni l'autre a sa place dans `git log`.
   lb certificate list` et `scw lb subscriber list` dans la suite de
   conformance.
 
+- **Le runtime relit ce qu'une machine porte réellement, et chaque
+  revendication de son plan reçoit l'une de trois issues** (#668). Le pilote
+  Incus implémente `Observer` : un `query` pour les devices propres de la
+  machine, un `network get` par réseau émulé où elle siège, et trois execs
+  dans l'invité pour les adresses, la table et, par porte qu'une revendication
+  demande, `ip route get <to> from <from>`. Le texte des deux implémentations
+  de `ip` est analysé (iproute2 sur Debian, Ubuntu et la famille RHEL, busybox
+  sur Alpine), et ce qui ne se compare pas n'entre jamais dans la `Shape` :
+  routes connectées, bloc link-local, métriques, `proto`, `src`, loopback, les
+  devices de profil de l'opérateur et les passerelles de leurs réseaux.
+
+  `held`, `broken`, `unreadable`, jamais deux : une lecture qui échoue répond
+  illisible sur chaque revendication, comptée, et un runtime sans moitié de
+  lecture est un quatrième état, non interrogé, pour que « personne n'a
+  regardé » ne passe jamais pour « rien n'était faux ». Les rule sets qu'une
+  machine porte sont revendiqués sur ses interfaces filtrées à partir des
+  champs mêmes que lit l'étape pare-feu, nus sur les réseaux qu'un pack a
+  déclarés hors de portée de ses groupes, et pas du tout sur un hôte qui a
+  retiré la capacité pare-feu.
+
+  Deux contrôles tiennent l'instrument, exigés par `measurement-integrity` :
+  une divergence plantée à un chiffre près est rapportée telle quelle, et une
+  lecture échouée n'est ni tenue ni rompue. Et la régression du 2026-09-04
+  est reproduite à travers le runtime factice : la réponse depuis l'adresse
+  publique sort par la passerelle privée, et une revendication de porte est
+  rompue en nommant les deux portes. Le comparateur de porte existe ; rien
+  n'en dérive encore (#672). Publier les verdicts est #670, comparer l'avant
+  et l'après d'un reboot est #669.
+
 - **Un plan qui revendique deux fois la route par défaut est refusé avant
   toute demande au runtime** (#667). `Reconciler.Expect` dérive, du plan
   déclaré, qui revendique quelle propriété : une adresse publique possède la

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,32 @@ what this project is judged on: **a response shape a client can observe**, and
   Driven by `scw lb backend list-statistics`, `scw lb lb get-stats`, `scw lb
   certificate list` and `scw lb subscriber list` in the conformance suite.
 
+- **A verdict somebody reads: the verification is published, and the runtime
+  leg gates on it** (#670). After every lifecycle door — a boot, a reboot, a
+  hot join, a hot route, the late-address door of a virtual machine — what the
+  runtime read back is published where a human looks and where a gate fails:
+  an `ERROR` line per broken claim naming the claim, the wanted value and the
+  one found; `Runtime["verified"]` on the resource, out of every client's view
+  and on `/_feint/state` for whoever asks; and four counters on
+  `/_feint/health`, `verification.{held,broken,unreadable,repaired}`, which
+  moves the health schema to version 8.
+
+  The API state does not move. A machine running with the wrong door is
+  running and unreachable, and publishing it stopped would be the lie in the
+  other direction. One bounded repair: a broken first reading replays the
+  post-boot order once, every step of it idempotent, and reads again; the
+  second reading is what is published, and `repaired` counts how often the
+  first was wrong, because a repair that fires on every boot is a defect
+  hidden behind a retry. An unreadable reading is never replayed onto, and the
+  late-address door reads only while nothing readable was published, so a GET
+  never execs into a verified machine.
+
+  `tools/conformance/guard.sh verification <endpoint>`, called by every leg
+  before its emulator stops: `broken > 0` fails the leg naming each claim from
+  the state, more unreadable than held fails it as a pass that measured its
+  own blindness, absent counters fail it rather than read as zero, and a pass
+  with no runtime is told so rather than judged.
+
 - **The runtime reads back what a machine actually carries, and every claim
   of its plan is answered with three outcomes** (#668). The Incus driver
   implements `Observer`: one `query` for the machine's own devices, one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,33 @@ what this project is judged on: **a response shape a client can observe**, and
   Driven by `scw lb backend list-statistics`, `scw lb lb get-stats`, `scw lb
   certificate list` and `scw lb subscriber list` in the conformance suite.
 
+- **The runtime reads back what a machine actually carries, and every claim
+  of its plan is answered with three outcomes** (#668). The Incus driver
+  implements `Observer`: one `query` for the machine's own devices, one
+  `network get` per emulated network it sits on, and three execs into the
+  guest for the addresses, the table and, per door a claim asks about, `ip
+  route get <to> from <from>`. The text of both `ip` implementations is parsed
+  (iproute2 on Debian, Ubuntu and the RHEL family, busybox on Alpine), and what
+  does not compare never enters the `Shape`: connected routes, the link-local
+  block, metrics, `proto`, `src`, loopback, the operator's profile devices and
+  their networks' gateways.
+
+  `held`, `broken`, `unreadable`, never two: a read that failed answers
+  unreadable on every claim, counted, and a runtime with no reading half is a
+  fourth state, not asked, so "nobody looked" cannot pass as "nothing was
+  wrong". The rule sets a machine wears are claimed on its filtered interfaces
+  from the same fields the firewall step reads, bare on the networks a pack
+  declared outside its groups' reach, and not at all on a host that withdrew
+  the firewall capability.
+
+  Two controls hold the instrument, both required by `measurement-integrity`:
+  a divergence planted one digit off is reported as itself, and a failed read
+  is neither held nor broken. And the regression of 2026-09-04 is reproduced
+  through the fake runtime: the reply from the public address leaves through
+  the private gateway, and a door claim is broken with both doors named. The
+  door comparator exists; nothing derives a door claim yet (#672). Publishing
+  the verdicts is #670, comparing a reboot's before and after is #669.
+
 - **A plan that claims the default route twice is refused before the runtime
   is asked for anything** (#667). `Reconciler.Expect` derives, from the
   declared plan, who claims which property: a public address owns the way out,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,25 @@ what this project is judged on: **a response shape a client can observe**, and
   Driven by `scw lb backend list-statistics`, `scw lb lb get-stats`, `scw lb
   certificate list` and `scw lb subscriber list` in the conformance suite.
 
+- **A reboot compares the shape after with the shape before, and needs no
+  table of expected values for it** (#669). Nothing moves in the control
+  plane between the two, because the reboot holds the per-target lock from
+  one end to the other; so what the machine carried while it was up is what
+  it must carry once it is back, interface by interface (network, kind,
+  addresses, rule sets, as sets), the default route by its door, the rest of
+  the table as a set. The claims ride the same reading as the plan's own, so
+  a reboot is read once and repaired once like any other boot. On the
+  regression of 2026-09-04 this answers, at the moment of the reboot,
+  `restart(default route) want via 169.254.0.1 dev eth0, got via 10.77.0.1
+  dev eth1`, where the runtime suite used to wait sixty seconds two steps
+  later to say "nothing answers".
+
+  A before that could not be read is said, in a `WARN`, and the reboot is
+  judged on its plan alone rather than on a guess; a machine that was not up
+  has no before. A poweroff then a poweron as two API actions is not a
+  reboot: a NIC attached to a stopped server legitimately changes the shape,
+  and there the derived claims judge.
+
 - **A verdict somebody reads: the verification is published, and the runtime
   leg gates on it** (#670). After every lifecycle door — a boot, a reboot, a
   hot join, a hot route, the late-address door of a virtual machine — what the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,24 @@ what this project is judged on: **a response shape a client can observe**, and
   Driven by `scw lb backend list-statistics`, `scw lb lb get-stats`, `scw lb
   certificate list` and `scw lb subscriber list` in the conformance suite.
 
+- **The runtime suite looks at the machine's own table across a restart, and
+  names the line** (#671). `tools/conformance/functional.sh` captures, from
+  inside the machine and before anything is restarted, its addresses and every
+  route with a next hop, normalised by two readers in `functionallib.sh`
+  (connected routes, the link-local block, metrics, `proto`, the loopback and
+  scope-link addresses never enter); after the provider's own reboot verb, and
+  again after a stop and a start, it captures again and diffs. A line that
+  changed fails the stack with both spellings printed, before and after: the
+  cause where the effect is, instead of "nothing answers at 203.0.113.4:443"
+  sixty seconds later at the far end. A capture that failed is "cannot look",
+  never a side that compares equal to something.
+
+  `fnl_shape_reader_control` runs before any verdict, like the other reader
+  controls: it normalises two planted tables and requires the comparison to
+  fail on a planted difference, the regression one line apart; and a test
+  stubs the comparison to pass everything and requires the control to notice.
+  Six execs on a leg of 590 s.
+
 - **A reboot compares the shape after with the shape before, and needs no
   table of expected values for it** (#669). Nothing moves in the control
   plane between the two, because the reboot holds the per-target lock from

--- a/internal/cli/testdata/frozen/health.json
+++ b/internal/cli/testdata/frozen/health.json
@@ -592,6 +592,129 @@
           }
         ]
       }
+    },
+    {
+      "schema_version": 8,
+      "content": {
+        "fields": [
+          {
+            "path": "capabilities",
+            "type": "object"
+          },
+          {
+            "path": "capabilities.addresses",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.balancing",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.firewall",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.firewall_public_only",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.firewall_public_when_joined",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.isolation",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.machines",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.own_kernel",
+            "type": "bool"
+          },
+          {
+            "path": "capabilities.private_from_host",
+            "type": "bool"
+          },
+          {
+            "path": "enforced",
+            "type": "object"
+          },
+          {
+            "path": "enforced.balancing",
+            "type": "array"
+          },
+          {
+            "path": "enforced.balancing[]",
+            "type": "string"
+          },
+          {
+            "path": "enforced.firewall",
+            "type": "array"
+          },
+          {
+            "path": "enforced.firewall[]",
+            "type": "string"
+          },
+          {
+            "path": "instance",
+            "type": "object"
+          },
+          {
+            "path": "instance.pid",
+            "type": "number"
+          },
+          {
+            "path": "instance.started_at",
+            "type": "string"
+          },
+          {
+            "path": "machines",
+            "type": "string"
+          },
+          {
+            "path": "providers",
+            "type": "array"
+          },
+          {
+            "path": "providers[]",
+            "type": "string"
+          },
+          {
+            "path": "resources",
+            "type": "number"
+          },
+          {
+            "path": "schema_version",
+            "type": "number"
+          },
+          {
+            "path": "status",
+            "type": "string"
+          },
+          {
+            "path": "verification",
+            "type": "object"
+          },
+          {
+            "path": "verification.broken",
+            "type": "number"
+          },
+          {
+            "path": "verification.held",
+            "type": "number"
+          },
+          {
+            "path": "verification.repaired",
+            "type": "number"
+          },
+          {
+            "path": "verification.unreadable",
+            "type": "number"
+          }
+        ]
+      }
     }
   ]
 }

--- a/internal/core/emulator/emulator.go
+++ b/internal/core/emulator/emulator.go
@@ -722,6 +722,12 @@ func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
 		"machines":       driver,
 		"capabilities":   capabilities,
 		"enforced":       enforcement(s.packs),
+		// What the reading half answered so far (#670): claims held, broken
+		// and unreadable, and verifications repaired by one replay. Counters
+		// rather than claims, because a claim names a resource and this
+		// payload names none; /_feint/state carries the claim under each
+		// resource's Runtime, and tools/conformance/guard.sh reads both.
+		"verification": s.env.machines.Verification(),
 		"instance": map[string]any{
 			"pid":        os.Getpid(),
 			"started_at": s.started.Format(time.RFC3339),

--- a/internal/core/emulator/schema.go
+++ b/internal/core/emulator/schema.go
@@ -76,7 +76,16 @@ const (
 	// modes on 2026-08-28. Two shapes, two words: this one is true, the older
 	// one is still false, and a build that cannot answer the second question
 	// is what the bump makes visible.
-	HealthSchemaVersion = 7
+	//
+	// 8 since #670: the payload gained `verification`, four counters —
+	// `held`, `broken`, `unreadable`, `repaired` — of what the runtime read
+	// back after every lifecycle action against what each machine's plan
+	// claimed. Additive, and a gate rather than a detail: the runtime leg
+	// fails on `broken > 0` and on more unreadable than held, and a consumer
+	// that branches on this version can tell a build that answers the
+	// question from one that never asked it. A verdict nobody reads is a
+	// confession nobody hears.
+	HealthSchemaVersion = 8
 	// RoutesSchemaVersion is the shape of GET /_feint/routes.
 	//
 	// This one is not on the wire: the endpoint answers a bare JSON array — the

--- a/internal/core/emulator/verification_test.go
+++ b/internal/core/emulator/verification_test.go
@@ -1,0 +1,58 @@
+package emulator_test
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+)
+
+// TestHealthCarriesTheVerificationCounters: /_feint/health publishes what the
+// runtime read back against every plan, as four counters (#670). The frozen
+// fixture holds the shape and the version; this holds that the four are
+// there and numeric on the ordinary runtime-less emulator, where they are
+// honestly zero — nothing booted, so nothing was read.
+func TestHealthCarriesTheVerificationCounters(t *testing.T) {
+	env := emulator.DefaultEnv()
+	srv, err := emulator.NewServer(env, stubPack{name: "stub"})
+	if err != nil {
+		t.Fatalf("build emulator: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	resp, err := ts.Client().Get(ts.URL + "/_feint/health")
+	if err != nil {
+		t.Fatalf("health: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var health struct {
+		Schema       int `json:"schema_version"`
+		Verification *struct {
+			Held       *int64 `json:"held"`
+			Broken     *int64 `json:"broken"`
+			Unreadable *int64 `json:"unreadable"`
+			Repaired   *int64 `json:"repaired"`
+		} `json:"verification"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&health); err != nil {
+		t.Fatalf("health: decode: %v", err)
+	}
+	if health.Verification == nil {
+		t.Fatal("health carries no verification: a verdict nobody reads is a confession nobody hears")
+	}
+	for name, value := range map[string]*int64{
+		"held": health.Verification.Held, "broken": health.Verification.Broken,
+		"unreadable": health.Verification.Unreadable, "repaired": health.Verification.Repaired,
+	} {
+		if value == nil {
+			t.Errorf("verification.%s is absent, and a gate reading its absence as zero would pass every build", name)
+		} else if *value != 0 {
+			t.Errorf("verification.%s = %d on an emulator that booted nothing", name, *value)
+		}
+	}
+	if health.Schema != emulator.HealthSchemaVersion || health.Schema < 8 {
+		t.Errorf("schema_version %d: the counters are a surface change, and the version is what lets a consumer notice", health.Schema)
+	}
+}

--- a/internal/core/machine/binding.go
+++ b/internal/core/machine/binding.go
@@ -45,6 +45,12 @@ type Binding struct {
 	// internal/cli's TestNoPackReachesPastTheDeclaredDriverSurface holds what
 	// typing cannot.
 	driver driver
+	// tally is where this binding's verifications are counted (#670): the
+	// Runtime handle's, handed over with the driver by WithRuntime, so every
+	// pack bound into one emulator counts into the same four numbers and
+	// /_feint/health reads them off the handle. Nil for a binding built
+	// without a runtime, which counts nowhere.
+	tally *tally
 	// Provider labels everything this binding creates, so a sweep can find its
 	// own work and an operator's machines are never touched.
 	Provider string
@@ -132,6 +138,7 @@ type Binding struct {
 // carry one and hand it over without ever naming what is inside it.
 func (b Binding) WithRuntime(r Runtime) Binding {
 	b.driver = r.d
+	b.tally = r.tally
 	return b
 }
 

--- a/internal/core/machine/claims.go
+++ b/internal/core/machine/claims.go
@@ -479,3 +479,72 @@ func prefixes(blocks []netip.Prefix) string {
 	}
 	return strings.Join(out, ", ")
 }
+
+// door claims which door a reply sent from an address leaves by, towards a
+// destination: the answer to `ip route get <To> from <From>`, compared on
+// `via` and `dev` alone. The comparator exists for the reading half (#668);
+// nothing derives a door claim yet, because the value is a measurement per
+// machine shape and one of the two shapes has none (#672).
+type door struct {
+	From, To netip.Addr
+	Via      netip.Addr
+	Dev      string
+}
+
+func (c door) String() string { return "door(" + c.From.String() + ")" }
+
+// door is what the reading half asks the runtime for on this claim's behalf.
+func (c door) door() (from, to netip.Addr) { return c.From, c.To }
+
+func (c door) Check(s Shape) Verdict {
+	got, read := s.Doors[c.From]
+	if !read {
+		return unreadable(c, "the door of "+c.From.String()+" was not read")
+	}
+	want := Route{Via: c.Via, Dev: c.Dev}
+	if got.Dev == "" {
+		return broken(c, want.String(), "no route")
+	}
+	if got.Via == c.Via && got.Dev == c.Dev {
+		return held(c)
+	}
+	return broken(c, want.String(), got.String())
+}
+
+// wears claims the rule sets the interface on a network carries: exactly Sets,
+// and none at all when Sets is empty — an interface on a network the pack
+// declared outside its security groups' reach (Attachment.Unfiltered, #574).
+// The contents of the sets are EnsureFirewall's and the network suites';
+// this compares the binding alone.
+type wears struct {
+	Network string
+	Sets    []string
+}
+
+func (c wears) String() string { return "wears(" + c.Network + ")" }
+
+func (c wears) want(dev string) string {
+	if len(c.Sets) == 0 {
+		return "no rule set on " + dev
+	}
+	return strings.Join(c.Sets, ", ") + " on " + dev
+}
+
+func (c wears) Check(s Shape) Verdict {
+	dev := s.interfaceOn(c.Network)
+	if dev == "" {
+		return broken(c, c.want("the interface of "+c.Network), "no interface on "+c.Network)
+	}
+	got := s.Interfaces[dev].RuleSets
+	if len(got) == 0 && len(c.Sets) == 0 {
+		return held(c)
+	}
+	if slices.Equal(got, c.Sets) {
+		return held(c)
+	}
+	rendered := "none"
+	if len(got) > 0 {
+		rendered = strings.Join(got, ", ")
+	}
+	return broken(c, c.want(dev), rendered+" on "+dev)
+}

--- a/internal/core/machine/incus_readback.go
+++ b/internal/core/machine/incus_readback.go
@@ -1,0 +1,278 @@
+package machine
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"slices"
+	"strings"
+)
+
+// How Incus reads back what a machine carries (#668). The contract is in
+// readback.go; what this file adds is the reading and the three parsers.
+//
+// Everything below is a read: one `query` for the devices, one `network get`
+// per emulated network the machine sits on, and three execs into the guest —
+// the addresses, the table, and one `route get` per door a claim asks about.
+// Nothing here changes the host.
+//
+// No `-j`, deliberately. iproute2 renders JSON on request and busybox's `ip`,
+// which is the one an Alpine image ships, does not — so the text is parsed,
+// the way guestAddresses already parses `ip -4 -o addr show`. The three
+// formats are stable across the two implementations because both print the
+// same keywords in the same order (`via`, `dev`, `scope`), and the parsers
+// scan for keywords rather than positions for exactly that reason.
+// TestTheParsersReadBothImplementationsOfIp holds the pairs.
+
+// linkLocal is the block the kernel lays its own routes in and a routed NIC
+// reaches the host through. Neither compares: a route or an address here is
+// the runtime's plumbing, never the plan's.
+var linkLocal = netip.MustParsePrefix("169.254.0.0/16")
+
+// Observe implements Observer.
+//
+// Own devices only, and that is a control rather than tidiness: a profile
+// device is the operator's — their default bridge, their address — and a
+// verifier that read it would judge what no plan ever claimed. The same rule
+// keeps `network get` off a network the emulator did not derive: the gateway
+// of an operator's bridge is theirs, and a claim needing it answers Unreadable
+// rather than reading it. TestObserveReadsOnlyTheMachinesOwnNICs and
+// TestObserveReadsNoForeignNetwork fail without the two halves.
+func (d *Incus) Observe(ctx context.Context, machine string) (Shape, error) {
+	if !safeName.MatchString(machine) {
+		return Shape{}, fmt.Errorf("invalid machine name %q", machine)
+	}
+	devices, err := d.instanceDevices(ctx, machine)
+	if err != nil {
+		return Shape{}, fmt.Errorf("inspect %s: %w", machine, err)
+	}
+	shape := Shape{Interfaces: map[string]Interface{}, Gateways: map[string]netip.Prefix{}}
+	names := make([]string, 0, len(devices.own))
+	for device, cfg := range devices.own {
+		if cfg["type"] == "nic" {
+			names = append(names, device)
+		}
+	}
+	slices.Sort(names)
+	for _, device := range names {
+		cfg := devices.own[device]
+		// The guest's name for it: the same as the device's on a container,
+		// the kernel's PCI name on a virtual machine (guestInterface).
+		iface, err := d.guestInterface(ctx, machine, device)
+		if err != nil {
+			return Shape{}, err
+		}
+		shape.Interfaces[iface] = Interface{
+			Network:  cfg["network"],
+			Routed:   cfg["nictype"] == "routed",
+			RuleSets: sortedList(cfg["security.acls"]),
+		}
+		network := cfg["network"]
+		if network == "" || !ownedNetwork(network) {
+			continue
+		}
+		if _, read := shape.Gateways[network]; read {
+			continue
+		}
+		gateway, err := d.networkGateway(ctx, network)
+		if err != nil {
+			return Shape{}, err
+		}
+		shape.Gateways[network] = gateway
+	}
+
+	out, err := d.run(ctx, "exec", machine, "--", "ip", "-4", "-o", "addr", "show")
+	if err != nil {
+		return Shape{}, fmt.Errorf("read the addresses of %s: %w", machine, err)
+	}
+	for iface, addresses := range parseAddresses(out) {
+		entry, ours := shape.Interfaces[iface]
+		if !ours {
+			// lo, or an interface behind a device this emulator does not own.
+			continue
+		}
+		entry.Addresses = addresses
+		shape.Interfaces[iface] = entry
+	}
+
+	out, err = d.run(ctx, "exec", machine, "--", "ip", "-4", "route", "show")
+	if err != nil {
+		return Shape{}, fmt.Errorf("read the routes of %s: %w", machine, err)
+	}
+	shape.Routes = parseRoutes(out)
+	return shape, nil
+}
+
+// Door implements Observer.
+func (d *Incus) Door(ctx context.Context, machine string, from, to netip.Addr) (Route, error) {
+	if !safeName.MatchString(machine) {
+		return Route{}, fmt.Errorf("invalid machine name %q", machine)
+	}
+	out, err := d.run(ctx, "exec", machine, "--",
+		"ip", "-4", "route", "get", to.String(), "from", from.String())
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "network is unreachable") {
+			// A fact about the machine — it has no route there — rather than
+			// a failure to read it. The zero Route says so.
+			return Route{}, nil
+		}
+		return Route{}, fmt.Errorf("read the door of %s from %s: %w", machine, from, err)
+	}
+	route, err := parseDoor(out)
+	if err != nil {
+		return Route{}, fmt.Errorf("read the door of %s from %s: %w", machine, from, err)
+	}
+	route.Dst = netip.PrefixFrom(to, to.BitLen())
+	return route, nil
+}
+
+// sortedList reads a comma-separated device value into a sorted list.
+func sortedList(value string) []string {
+	out := splitList(value)
+	slices.Sort(out)
+	return out
+}
+
+// parseAddresses reads `ip -4 -o addr show`: one address per line, the
+// interface second, the CIDR after `inet`, and the scope after `scope`. Only a
+// global address enters the Shape; link-local and host scopes are the
+// kernel's own.
+//
+//	iproute2  2: eth0    inet 10.30.1.10/24 brd 10.30.1.255 scope global eth0\       valid_lft forever preferred_lft forever
+//	busybox   2: eth0    inet 10.30.1.10/24 scope global eth0
+func parseAddresses(out []byte) map[string][]netip.Prefix {
+	found := map[string][]netip.Prefix{}
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			continue
+		}
+		iface := strings.TrimSuffix(fields[1], ":")
+		var cidr, scope string
+		for i, field := range fields {
+			if i+1 >= len(fields) {
+				break
+			}
+			switch field {
+			case "inet":
+				cidr = fields[i+1]
+			case "scope":
+				scope = fields[i+1]
+			}
+		}
+		if cidr == "" || scope != "global" {
+			continue
+		}
+		prefix, err := netip.ParsePrefix(cidr)
+		if err != nil || !prefix.Addr().Is4() || linkLocal.Contains(prefix.Addr()) {
+			continue
+		}
+		found[iface] = append(found[iface], prefix)
+	}
+	return found
+}
+
+// parseRoutes reads `ip -4 route show` down to what compares: a destination,
+// a next hop and a device. Everything else on the line — proto, src, metric,
+// onlink, linkdown — is dropped, and so is every line with no `via`: a
+// connected route is implied by the address that created it, and comparing
+// it would compare the address twice.
+//
+//	iproute2  default via 10.30.1.1 dev eth0 proto dhcp src 10.30.1.10 metric 100
+//	          10.30.1.0/24 dev eth0 proto kernel scope link src 10.30.1.10
+//	busybox   default via 10.30.1.1 dev eth0  metric 100
+//	          10.0.0.0/8 via 10.30.1.1 dev eth0
+func parseRoutes(out []byte) []Route {
+	var routes []Route
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		var dst netip.Prefix
+		switch first := fields[0]; first {
+		case "default":
+			dst = defaultDst
+		case "unreachable", "blackhole", "prohibit", "throw", "local", "broadcast", "multicast", "anycast", "nat":
+			continue
+		default:
+			parsed, err := parseDestination(first)
+			if err != nil {
+				continue
+			}
+			dst = parsed
+		}
+		via, dev := nextHop(fields)
+		if !via.IsValid() || dev == "" {
+			continue
+		}
+		if dst != defaultDst && linkLocal.Contains(dst.Addr()) {
+			continue
+		}
+		routes = append(routes, Route{Dst: dst.Masked(), Via: via, Dev: dev})
+	}
+	return routes
+}
+
+// parseDoor reads the first line of `ip -4 route get <to> from <from>`:
+//
+//	iproute2  10.209.83.1 from 203.0.113.2 via 169.254.0.1 dev eth0 uid 0
+//	busybox   10.209.83.1 from 203.0.113.2 via 169.254.0.1 dev eth0  src 203.0.113.2
+//
+// and a connected answer names the device alone. The device is required: an
+// answer with none is not a door.
+func parseDoor(out []byte) (Route, error) {
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		via, dev := nextHop(fields)
+		if dev == "" {
+			return Route{}, fmt.Errorf("no device in the answer %q", strings.TrimSpace(line))
+		}
+		return Route{Via: via, Dev: dev}, nil
+	}
+	return Route{}, fmt.Errorf("an empty answer")
+}
+
+// parseDestination reads a route's destination: a block, or a bare address
+// the kernel prints for a host route.
+func parseDestination(field string) (netip.Prefix, error) {
+	if strings.Contains(field, "/") {
+		prefix, err := netip.ParsePrefix(field)
+		if err != nil {
+			return netip.Prefix{}, err
+		}
+		if !prefix.Addr().Is4() {
+			return netip.Prefix{}, fmt.Errorf("%s is not IPv4", field)
+		}
+		return prefix, nil
+	}
+	addr, err := netip.ParseAddr(field)
+	if err != nil {
+		return netip.Prefix{}, err
+	}
+	if !addr.Is4() {
+		return netip.Prefix{}, fmt.Errorf("%s is not IPv4", field)
+	}
+	return netip.PrefixFrom(addr, addr.BitLen()), nil
+}
+
+// nextHop scans a route line for its `via` and `dev`, wherever they sit.
+func nextHop(fields []string) (via netip.Addr, dev string) {
+	for i, field := range fields {
+		if i+1 >= len(fields) {
+			break
+		}
+		switch field {
+		case "via":
+			if addr, err := netip.ParseAddr(fields[i+1]); err == nil {
+				via = addr
+			}
+		case "dev":
+			dev = fields[i+1]
+		}
+	}
+	return via, dev
+}

--- a/internal/core/machine/plan.go
+++ b/internal/core/machine/plan.go
@@ -3,6 +3,7 @@ package machine
 import (
 	"context"
 	"net/netip"
+	"strings"
 
 	"github.com/stephrobert/feint/internal/core/resource"
 )
@@ -197,12 +198,25 @@ func (r Reconciler) PowerOn(ctx context.Context, res *resource.Resource, boot Bo
 	if !r.binding().PowerOn(ctx, res, boot) {
 		return false
 	}
+	r.replay(ctx, res, plan)
+	// And what the replay produced is read back and published (#670): the
+	// state above is the one the boot produced, the verdict is the one the
+	// reading produced, and neither is allowed to stand in for the other.
+	r.check(ctx, res)
+	return true
+}
+
+// replay is the post-boot order, in the one order — the promised addresses,
+// the memberships, the way out, the record, the pack's bookkeeping, the
+// firewall last. It is PowerOn's second half, and check runs it a second time
+// on a broken reading, which is why it is a function: every step is
+// idempotent, and a machine that needs no repair is a machine this changes
+// nothing on.
+func (r Reconciler) replay(ctx context.Context, res *resource.Resource, plan Plan) {
 	// The launch installed the host half of every public route; this hands
 	// the guest its addresses, and repairs a machine that already existed.
 	// Idempotent, like everything in the replay.
-	for _, address := range plan.Publics {
-		r.route(ctx, res, plan, address)
-	}
+	r.replayAddresses(ctx, res, plan)
 	// The memberships come back as extra interfaces, after the boot rather
 	// than on it. Attach is idempotent by network, so a machine that kept its
 	// devices across a stop is repaired, not doubled. A refusal is already in
@@ -240,7 +254,6 @@ func (r Reconciler) PowerOn(ctx context.Context, res *resource.Resource, boot Bo
 	// packs kept in comments; TestTheReplayRoutesThenJoinsThenAppliesTheFirewall
 	// is what holds it now.
 	r.Groups.AfterBoot(ctx, res)
-	return true
 }
 
 // Reboot takes the machine down and brings it back up on its declared plan.
@@ -287,10 +300,24 @@ func (r Reconciler) ReplayAddresses(ctx context.Context, res *resource.Resource)
 	if !declared {
 		return
 	}
+	r.replayAddresses(ctx, res, plan)
+	r.ReplayEgress(ctx, res)
+	// This door sits on a read path, and an exec per GET would make the
+	// emulator's latency the runtime's. So the reading happens here only
+	// while nothing readable has been published for the machine: the boot of
+	// a virtual machine, whose shape was unreadable until its agent answered.
+	// Once a reading held or broke, this door reads no more (#670).
+	// TestTheLateAddressDoorVerifiesOnceItCanRead fails without the bound.
+	if last := res.Runtime[VerifiedKey]; last == "" || strings.HasPrefix(last, "unreadable") {
+		r.check(ctx, res)
+	}
+}
+
+// replayAddresses routes every promised address, the loop three doors share.
+func (r Reconciler) replayAddresses(ctx context.Context, res *resource.Resource, plan Plan) {
 	for _, address := range plan.Publics {
 		r.route(ctx, res, plan, address)
 	}
-	r.ReplayEgress(ctx, res)
 }
 
 // ReplayEgress gives the machine the way out its plan entitles it to, and takes
@@ -363,6 +390,7 @@ func (r Reconciler) Route(ctx context.Context, res *resource.Resource, address s
 		return
 	}
 	r.route(ctx, res, plan, address)
+	r.check(ctx, res)
 }
 
 func (r Reconciler) route(ctx context.Context, res *resource.Resource, plan Plan, address string) {
@@ -519,6 +547,7 @@ func (r Reconciler) Join(ctx context.Context, res *resource.Resource, att Attach
 	err := r.attach(ctx, res, att)
 	r.ReplayAddresses(ctx, res)
 	r.Groups.AfterBoot(ctx, res)
+	r.check(ctx, res)
 	return err
 }
 

--- a/internal/core/machine/plan.go
+++ b/internal/core/machine/plan.go
@@ -180,6 +180,12 @@ func (r Reconciler) consistent(res *resource.Resource, plan Plan) bool {
 // reports what PowerOn reported; a machine that did not start is not replayed
 // onto, and the state the pack publishes is the one the effect produced.
 func (r Reconciler) PowerOn(ctx context.Context, res *resource.Resource, boot Boot) bool {
+	return r.powerOn(ctx, res, boot, nil)
+}
+
+// powerOn is PowerOn with the claims the caller knew before the boot, which
+// a reboot has (#669) and a first boot does not.
+func (r Reconciler) powerOn(ctx context.Context, res *resource.Resource, boot Boot, extra []Claim) bool {
 	plan, declared := r.plan(res)
 	if !declared {
 		return false
@@ -202,7 +208,7 @@ func (r Reconciler) PowerOn(ctx context.Context, res *resource.Resource, boot Bo
 	// And what the replay produced is read back and published (#670): the
 	// state above is the one the boot produced, the verdict is the one the
 	// reading produced, and neither is allowed to stand in for the other.
-	r.check(ctx, res)
+	r.check(ctx, res, extra)
 	return true
 }
 
@@ -285,10 +291,27 @@ func (r Reconciler) Reboot(ctx context.Context, res *resource.Resource, boot Boo
 	// to stop a stopped instance logs a failure for an ordinary case. Which
 	// word means "up" is the pack's, held once here rather than compared to a
 	// literal in three places.
+	var extra []Claim
 	if res.State == r.binding().RunningState {
+		// The shape before, read while the machine is up (#669): what it
+		// carries now is what it must carry once it is back, and the reading
+		// after the boot answers that beside the plan's own claims. A before
+		// that could not be read is said, and the reboot is judged on its
+		// plan alone rather than on a guess.
+		// TestARebootComparesTheShapeAfterWithTheShapeBefore fails without
+		// this.
+		before, err := r.observe(ctx, res)
+		switch {
+		case err != nil:
+			r.binding().logger().Warn("the shape before the reboot could not be read, so the reboot is judged on its plan alone",
+				"provider", r.binding().Provider, "resource", res.ID,
+				"machine", res.Runtime[r.binding().RuntimeKey], "error", err)
+		case before != nil:
+			extra = restartClaims(*before)
+		}
 		r.binding().PowerOff(ctx, res)
 	}
-	return r.PowerOn(ctx, res, boot)
+	return r.powerOn(ctx, res, boot, extra)
 }
 
 // ReplayAddresses re-routes every promised address of a machine that just
@@ -309,7 +332,7 @@ func (r Reconciler) ReplayAddresses(ctx context.Context, res *resource.Resource)
 	// Once a reading held or broke, this door reads no more (#670).
 	// TestTheLateAddressDoorVerifiesOnceItCanRead fails without the bound.
 	if last := res.Runtime[VerifiedKey]; last == "" || strings.HasPrefix(last, "unreadable") {
-		r.check(ctx, res)
+		r.check(ctx, res, nil)
 	}
 }
 
@@ -390,7 +413,7 @@ func (r Reconciler) Route(ctx context.Context, res *resource.Resource, address s
 		return
 	}
 	r.route(ctx, res, plan, address)
-	r.check(ctx, res)
+	r.check(ctx, res, nil)
 }
 
 func (r Reconciler) route(ctx context.Context, res *resource.Resource, plan Plan, address string) {
@@ -547,7 +570,7 @@ func (r Reconciler) Join(ctx context.Context, res *resource.Resource, att Attach
 	err := r.attach(ctx, res, att)
 	r.ReplayAddresses(ctx, res)
 	r.Groups.AfterBoot(ctx, res)
-	r.check(ctx, res)
+	r.check(ctx, res, nil)
 	return err
 }
 

--- a/internal/core/machine/readback.go
+++ b/internal/core/machine/readback.go
@@ -59,10 +59,11 @@ func (r Reconciler) observer() Observer {
 	return obs
 }
 
-// verify derives what the plan claims, reads what the machine carries, and
-// answers every claim. asked is false when nobody could look: a runtime with
-// no Observer, a resource with no machine, or a plan that was refused before
-// the runtime was asked (its refusal is already in the log).
+// verify derives what the plan claims, adds what the caller claims on top —
+// the shape before a reboot — reads what the machine carries, and answers
+// every claim. asked is false when nobody could look: a runtime with no
+// Observer, a resource with no machine, or a plan that was refused before the
+// runtime was asked (its refusal is already in the log).
 //
 // A shape that could not be read answers Unreadable on every claim rather
 // than nothing, so the count of what was not verified is visible where the
@@ -71,7 +72,7 @@ func (r Reconciler) observer() Observer {
 //
 // TestAPlantedDivergenceIsReported and TestAnUnreadableShapeIsNeitherHeldNorBroken
 // are the instrument's two controls, and both fail without this.
-func (r Reconciler) verify(ctx context.Context, res *resource.Resource) (verdicts []Verdict, asked bool) {
+func (r Reconciler) verify(ctx context.Context, res *resource.Resource, extra []Claim) (verdicts []Verdict, asked bool) {
 	obs := r.observer()
 	name := res.Runtime[r.binding().RuntimeKey]
 	if obs == nil || name == "" {
@@ -86,6 +87,9 @@ func (r Reconciler) verify(ctx context.Context, res *resource.Resource) (verdict
 		return nil, false
 	}
 	claims = append(claims, r.wears(res, plan)...)
+	// And what the caller knew before the action: a reboot's shape before it
+	// (#669), answered by the same reading as the plan's claims.
+	claims = append(claims, extra...)
 	if len(claims) == 0 {
 		return nil, true
 	}

--- a/internal/core/machine/readback.go
+++ b/internal/core/machine/readback.go
@@ -1,0 +1,171 @@
+package machine
+
+import (
+	"context"
+	"net/netip"
+	"slices"
+
+	"github.com/stephrobert/feint/internal/core/resource"
+)
+
+// Nothing in this repository read back what a machine actually carried after
+// a lifecycle action (#668). Every step reported its own success, and the sum
+// of successful steps was not a working machine: on 2026-09-04 a route was
+// replaced, every exec returned 0, and the machine answered nothing at its
+// published address (#660). This file is the reading half of the guard whose
+// derivation half is claims.go: the driver reads a Shape, and every claim the
+// plan made is answered against it.
+//
+// Three outcomes, never two. A read that fails is Unreadable — neither held
+// nor broken, and counted — because folding it onto either is how a verifier
+// starts lying. And a runtime that cannot be asked at all is a fourth state,
+// held apart from the three: verify answers asked=false for it, so that
+// nothing downstream mistakes "nobody looked" for "nothing was wrong".
+//
+// When to read. The layer already knows when a container has finished
+// configuring itself, because it already waits: waitForGuestInterface blocks
+// until the interface carries an address, and settleFirstBoot and
+// restoreGuestNetwork run inside Start. When Binding.PowerOn returns, a
+// container is configured, and the aggregates arrive in DHCP option 121 with
+// the lease. A virtual machine is Unreadable until its agent answers, and the
+// verification replays from ReplayAddresses, the late-address door that
+// already exists for exactly that.
+
+// Observer is the optional half a driver implements, on the model of
+// EgressRouter and Capable: it reads back what a machine carries. A driver
+// that does not implement it is a driver nobody can ask, which is not a
+// failed read — see verify.
+type Observer interface {
+	// Observe reads the machine's interfaces, addresses, routes, rule-set
+	// bindings and the gateways of its emulated networks, normalised the way
+	// Shape documents.
+	Observe(ctx context.Context, machine string) (Shape, error)
+	// Door answers which door a reply from one address leaves by towards a
+	// destination: `ip route get <to> from <from>`. A machine with no route
+	// at all answers the zero Route and no error, because "no route" is a
+	// fact about the machine and not a failure to read it.
+	Door(ctx context.Context, machine string, from, to netip.Addr) (Route, error)
+}
+
+// doorAsker is the claim-side half of Door: a claim that needs one read says
+// which, and the reading half asks on its behalf before checking.
+type doorAsker interface {
+	door() (from, to netip.Addr)
+}
+
+// observer answers the runtime's reading half, nil when it has none.
+func (r Reconciler) observer() Observer {
+	obs, _ := r.binding().driver.(Observer)
+	return obs
+}
+
+// verify derives what the plan claims, reads what the machine carries, and
+// answers every claim. asked is false when nobody could look: a runtime with
+// no Observer, a resource with no machine, or a plan that was refused before
+// the runtime was asked (its refusal is already in the log).
+//
+// A shape that could not be read answers Unreadable on every claim rather
+// than nothing, so the count of what was not verified is visible where the
+// count of what was is. A door that could not be read answers Unreadable on
+// that claim alone.
+//
+// TestAPlantedDivergenceIsReported and TestAnUnreadableShapeIsNeitherHeldNorBroken
+// are the instrument's two controls, and both fail without this.
+func (r Reconciler) verify(ctx context.Context, res *resource.Resource) (verdicts []Verdict, asked bool) {
+	obs := r.observer()
+	name := res.Runtime[r.binding().RuntimeKey]
+	if obs == nil || name == "" {
+		return nil, false
+	}
+	plan, declared := r.plan(res)
+	if !declared {
+		return nil, false
+	}
+	claims, err := r.Expect(plan, r.dialect())
+	if err != nil {
+		return nil, false
+	}
+	claims = append(claims, r.wears(res, plan)...)
+	if len(claims) == 0 {
+		return nil, true
+	}
+	shape, err := obs.Observe(ctx, name)
+	if err != nil {
+		for _, c := range claims {
+			verdicts = append(verdicts, unreadable(c, err.Error()))
+		}
+		return verdicts, true
+	}
+	for _, c := range claims {
+		if asker, asks := c.(doorAsker); asks {
+			from, to := asker.door()
+			route, err := obs.Door(ctx, name, from, to)
+			if err != nil {
+				verdicts = append(verdicts, unreadable(c, err.Error()))
+				continue
+			}
+			if shape.Doors == nil {
+				shape.Doors = map[netip.Addr]Route{}
+			}
+			shape.Doors[from] = route
+		}
+		verdicts = append(verdicts, c.Check(shape))
+	}
+	return verdicts, true
+}
+
+// wears derives the rule-set claims from the same fields the firewall step
+// reads, so the claim cannot drift from what ApplyRuleSets asked for: the
+// machine's worn groups become names through the pack's own translation, and
+// the networks its groups do not reach come off the plan (#574).
+//
+// Claimed only when the machine wears at least one enforcing group. A machine
+// wearing none is left to the isolation pass, which binds either nothing or
+// the permissive posture set depending on whether the network is isolated —
+// a distinction that is the isolation pass's to make and would read as a
+// broken claim here. And not at all when the host withdrew the firewall
+// capability (#454): a claim about rule sets the host refused to bind would
+// be broken on every machine, for a fact /_feint/health already publishes.
+//
+// TestTheRuleSetsAMachineWearsAreClaimedOnItsFilteredInterfaces fails without
+// this.
+func (r Reconciler) wears(res *resource.Resource, plan Plan) []Claim {
+	s := r.Groups
+	if !s.wired() || s.enforcer() == nil {
+		return nil
+	}
+	if !CapabilitiesOf(r.binding().driver).Firewall {
+		return nil
+	}
+	var names []string
+	for _, id := range s.WornIDs(res) {
+		group, found := s.Group(id)
+		if !found {
+			continue
+		}
+		spec := s.spec(group, res)
+		if spec.EnforcesNothing() || slices.Contains(names, spec.Name) {
+			continue
+		}
+		names = append(names, spec.Name)
+	}
+	if len(names) == 0 {
+		return nil
+	}
+	slices.Sort(names)
+	unfiltered := s.unfiltered(res)
+	var claims []Claim
+	var seen []string
+	for _, att := range plan.attachments() {
+		if att.Network == "" || slices.Contains(seen, att.Network) {
+			continue
+		}
+		seen = append(seen, att.Network)
+		if slices.Contains(unfiltered, att.Network) {
+			claims = append(claims, wears{Network: att.Network})
+			continue
+		}
+		claims = append(claims, wears{Network: att.Network, Sets: names})
+	}
+	return claims
+}

--- a/internal/core/machine/readback_test.go
+++ b/internal/core/machine/readback_test.go
@@ -313,10 +313,17 @@ type observingRecorder struct {
 	queue []Shape
 	// reads counts the Observe calls, which is how a test holds a bound.
 	reads int
+	// failFirst makes that many leading reads fail before the shape answers:
+	// a machine unreadable before its reboot and readable after it.
+	failFirst int
 }
 
 func (o *observingRecorder) Observe(context.Context, string) (Shape, error) {
 	o.reads++
+	if o.failFirst > 0 {
+		o.failFirst--
+		return Shape{}, errUnreadable
+	}
 	if len(o.queue) > 0 {
 		next := o.queue[0]
 		o.queue = o.queue[1:]
@@ -383,7 +390,7 @@ func TestAPlantedDivergenceIsReported(t *testing.T) {
 	vm := b.machine("m", "10.30.1.10")
 	r := observingReconciler(b, o, plan)
 
-	verdicts, asked := r.verify(context.Background(), vm)
+	verdicts, asked := r.verify(context.Background(), vm, nil)
 	if !asked || len(verdicts) != 1 || verdicts[0].Outcome != Held {
 		t.Fatalf("a machine carrying what its plan claims answered asked=%v:\n%s", asked, outcomes(verdicts))
 	}
@@ -391,7 +398,7 @@ func TestAPlantedDivergenceIsReported(t *testing.T) {
 	// One digit off, planted: the address the runtime reports is not the
 	// one the plan pinned.
 	o.shape = pinnedOn("fnt-x", "10.30.1.11/24")
-	verdicts, asked = r.verify(context.Background(), vm)
+	verdicts, asked = r.verify(context.Background(), vm, nil)
 	if !asked || len(verdicts) != 1 {
 		t.Fatalf("asked=%v, verdicts:\n%s", asked, outcomes(verdicts))
 	}
@@ -410,7 +417,7 @@ func TestAnUnreadableShapeIsNeitherHeldNorBroken(t *testing.T) {
 	o := &observingRecorder{Recorder: b.rec, err: errors.New("the agent isn't currently running")}
 	vm := b.machine("m", "10.30.1.10")
 
-	verdicts, asked := observingReconciler(b, o, plan).verify(context.Background(), vm)
+	verdicts, asked := observingReconciler(b, o, plan).verify(context.Background(), vm, nil)
 	if !asked || len(verdicts) != 2 {
 		t.Fatalf("asked=%v, verdicts:\n%s", asked, outcomes(verdicts))
 	}
@@ -422,12 +429,12 @@ func TestAnUnreadableShapeIsNeitherHeldNorBroken(t *testing.T) {
 
 	// A runtime with no reading half is not asked, and says so.
 	plain := rebootReconciler(b, plan)
-	if verdicts, asked := plain.verify(context.Background(), vm); asked || len(verdicts) != 0 {
+	if verdicts, asked := plain.verify(context.Background(), vm, nil); asked || len(verdicts) != 0 {
 		t.Errorf("a runtime that cannot be asked answered asked=%v with %d verdicts", asked, len(verdicts))
 	}
 	// And so is a resource with no machine behind it.
 	bare := b.machine("bare", "")
-	if verdicts, asked := observingReconciler(b, o, plan).verify(context.Background(), bare); asked || len(verdicts) != 0 {
+	if verdicts, asked := observingReconciler(b, o, plan).verify(context.Background(), bare, nil); asked || len(verdicts) != 0 {
 		t.Errorf("a resource with no machine answered asked=%v with %d verdicts", asked, len(verdicts))
 	}
 }
@@ -450,7 +457,7 @@ func TestTheRuleSetsAMachineWearsAreClaimedOnItsFilteredInterfaces(t *testing.T)
 	vm := b.machine("m", "10.30.1.10", "g")
 	r := observingReconciler(b, o, plan)
 
-	verdicts, _ := r.verify(context.Background(), vm)
+	verdicts, _ := r.verify(context.Background(), vm, nil)
 	names := map[string]Verdict{}
 	for _, v := range verdicts {
 		names[v.Claim] = v
@@ -470,7 +477,7 @@ func TestTheRuleSetsAMachineWearsAreClaimedOnItsFilteredInterfaces(t *testing.T)
 	eth1 := shape.Interfaces["eth1"]
 	eth1.RuleSets = []string{set}
 	shape.Interfaces["eth1"] = eth1
-	verdicts, _ = r.verify(context.Background(), vm)
+	verdicts, _ = r.verify(context.Background(), vm, nil)
 	for _, v := range verdicts {
 		if v.Claim == "wears(fnt-y)" && (v.Outcome != Broken || v.Want != "no rule set on eth1") {
 			t.Errorf("an unfiltered interface wearing a set answered %s", v)
@@ -488,7 +495,7 @@ func TestAWithdrawnFirewallClaimsNoRuleSets(t *testing.T) {
 	o := &observingRecorder{Recorder: b.rec, shape: pinnedOn("fnt-x", "10.30.1.10/24"), noFirewall: true}
 	vm := b.machine("m", "10.30.1.10", "g")
 
-	verdicts, _ := observingReconciler(b, o, plan).verify(context.Background(), vm)
+	verdicts, _ := observingReconciler(b, o, plan).verify(context.Background(), vm, nil)
 	for _, v := range verdicts {
 		if strings.HasPrefix(v.Claim, "wears(") {
 			t.Fatalf("a withdrawn firewall still claims rule sets: %s", v)

--- a/internal/core/machine/readback_test.go
+++ b/internal/core/machine/readback_test.go
@@ -308,9 +308,20 @@ type observingRecorder struct {
 	shape      Shape
 	err        error
 	noFirewall bool
+	// queue, when set, is read one Shape per Observe ahead of shape: how a
+	// test writes a machine that changes between two readings.
+	queue []Shape
+	// reads counts the Observe calls, which is how a test holds a bound.
+	reads int
 }
 
 func (o *observingRecorder) Observe(context.Context, string) (Shape, error) {
+	o.reads++
+	if len(o.queue) > 0 {
+		next := o.queue[0]
+		o.queue = o.queue[1:]
+		return next, o.err
+	}
 	return o.shape, o.err
 }
 

--- a/internal/core/machine/readback_test.go
+++ b/internal/core/machine/readback_test.go
@@ -1,0 +1,509 @@
+package machine
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"strings"
+	"testing"
+)
+
+// The reading half of the guard (#668): what the driver reads back, how the
+// three outcomes are told apart, and the two controls without which the
+// instrument proves nothing — a divergence planted on purpose must be found,
+// and a read that failed must be neither held nor broken.
+
+// regressionMachine answers the fake runtime for the machine of 2026-09-04
+// (#660): one OVN interface on fnt-web carrying its private address and the
+// public /32, the default route through the private gateway, and the noise a
+// real table carries — connected routes, a link-local one, an unreachable
+// line, a metadata route, a profile device the operator owns.
+func regressionMachine(f *fakeRuntime) {
+	f.hook = func(_ int, args []string) ([]byte, error, bool) {
+		switch key := strings.Join(args, " "); {
+		case key == "query /1.0/instances/srv":
+			return []byte(`{
+  "devices": {
+    "eth0": {"type": "nic", "network": "fnt-web", "ipv4.address": "10.77.0.2", "ipv4.routes.external": "203.0.113.2/32", "security.acls": "fnt-sg1"},
+    "root": {"type": "disk", "path": "/"}
+  },
+  "expanded_devices": {
+    "eth0": {"type": "nic", "network": "fnt-web", "ipv4.address": "10.77.0.2", "ipv4.routes.external": "203.0.113.2/32", "security.acls": "fnt-sg1"},
+    "eth9": {"type": "nic", "network": "incusbr0"},
+    "root": {"type": "disk", "path": "/"}
+  }
+}`), nil, true
+		case key == "network get fnt-web ipv4.address":
+			return []byte("10.77.0.1/24\n"), nil, true
+		case key == "exec srv -- ip -4 -o addr show":
+			return []byte(`1: lo    inet 127.0.0.1/8 scope host lo\       valid_lft forever preferred_lft forever
+2: eth0    inet 10.77.0.2/24 brd 10.77.0.255 scope global eth0\       valid_lft forever preferred_lft forever
+2: eth0    inet 203.0.113.2/32 scope global eth0\       valid_lft forever preferred_lft forever
+2: eth0    inet 10.99.0.1/24 scope link eth0\       valid_lft forever preferred_lft forever
+9: eth9    inet 10.76.154.20/24 brd 10.76.154.255 scope global dynamic eth9\       valid_lft 3000sec preferred_lft 3000sec
+`), nil, true
+		case key == "exec srv -- ip -4 route show":
+			return []byte(`default via 10.77.0.1 dev eth0 proto dhcp src 10.77.0.2 metric 100
+10.0.0.0/8 via 10.77.0.1 dev eth0 proto dhcp src 10.77.0.2 metric 100
+10.77.0.0/24 dev eth0 proto kernel scope link src 10.77.0.2 metric 100
+10.77.0.1 dev eth0 proto dhcp scope link src 10.77.0.2 metric 100
+169.254.0.0/16 dev eth0 scope link metric 1000
+169.254.169.254 via 10.77.0.1 dev eth0 proto static
+172.16.0.0/12 via 10.77.0.1 dev eth0 proto dhcp src 10.77.0.2 metric 100
+192.168.0.0/16 via 10.77.0.1 dev eth0 proto dhcp src 10.77.0.2 metric 100
+unreachable 198.51.100.0/24 dev lo
+`), nil, true
+		case strings.HasPrefix(key, "exec srv -- ip -4 route get 10.209.83.1 from 203.0.113.2"):
+			return []byte("10.209.83.1 from 203.0.113.2 via 10.77.0.1 dev eth0 uid 0 \n    cache \n"), nil, true
+		}
+		return nil, nil, false
+	}
+}
+
+func mustObserve(t *testing.T, d *Incus) Shape {
+	t.Helper()
+	shape, err := d.Observe(context.Background(), "srv")
+	if err != nil {
+		t.Fatalf("observe: %v", err)
+	}
+	return shape
+}
+
+// TestObserveReadsBackWhatTheMachineCarries is the reading on the machine of
+// the regression, with everything a real table carries that must NOT enter
+// the Shape: the connected routes, the link-local block and the metadata
+// route inside it, the unreachable line, the scope-link address, the
+// loopback, and the profile device's address.
+func TestObserveReadsBackWhatTheMachineCarries(t *testing.T) {
+	f := &fakeRuntime{}
+	regressionMachine(f)
+	shape := mustObserve(t, ovnDriver(f))
+
+	if len(shape.Interfaces) != 1 {
+		t.Fatalf("interfaces %v, want eth0 alone", shape.interfaceNames())
+	}
+	eth0 := shape.Interfaces["eth0"]
+	if eth0.Network != "fnt-web" || eth0.Routed {
+		t.Errorf("eth0 read as %+v", eth0)
+	}
+	if got := prefixes(eth0.Addresses); got != "10.77.0.2/24, 203.0.113.2/32" {
+		t.Errorf("eth0 carries %s, want the private /24 and the public /32 and nothing of scope link", got)
+	}
+	if strings.Join(eth0.RuleSets, ",") != "fnt-sg1" {
+		t.Errorf("eth0 wears %v", eth0.RuleSets)
+	}
+	want := []string{
+		"0.0.0.0/0 via 10.77.0.1 dev eth0",
+		"10.0.0.0/8 via 10.77.0.1 dev eth0",
+		"172.16.0.0/12 via 10.77.0.1 dev eth0",
+		"192.168.0.0/16 via 10.77.0.1 dev eth0",
+	}
+	got := make([]string, 0, len(shape.Routes))
+	for _, r := range shape.Routes {
+		got = append(got, r.Dst.String()+" "+r.String())
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Errorf("routes:\n%s\nwant:\n%s", strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+	if gw := shape.Gateways["fnt-web"]; gw.String() != "10.77.0.1/24" {
+		t.Errorf("gateway of fnt-web read as %s", gw)
+	}
+	if len(shape.Gateways) != 1 {
+		t.Errorf("gateways %v, want fnt-web alone", shape.Gateways)
+	}
+}
+
+// A profile device is the operator's: their bridge, their address, and no
+// plan ever claimed it.
+func TestObserveReadsOnlyTheMachinesOwnNICs(t *testing.T) {
+	f := &fakeRuntime{}
+	regressionMachine(f)
+	shape := mustObserve(t, ovnDriver(f))
+	if _, read := shape.Interfaces["eth9"]; read {
+		t.Fatal("the profile's eth9 entered the Shape, and it carries an address no plan claims")
+	}
+}
+
+// A NIC the machine owns on a network the emulator did not derive is read as
+// an interface, and its network's gateway is not asked for: that gateway is
+// the operator's, and a claim needing it answers Unreadable instead.
+func TestObserveReadsNoForeignNetwork(t *testing.T) {
+	f := &fakeRuntime{}
+	f.hook = func(_ int, args []string) ([]byte, error, bool) {
+		switch key := strings.Join(args, " "); key {
+		case "query /1.0/instances/srv":
+			return []byte(`{"devices": {"eth1": {"type": "nic", "network": "incusbr0"}},
+ "expanded_devices": {"eth1": {"type": "nic", "network": "incusbr0"}}}`), nil, true
+		case "exec srv -- ip -4 -o addr show":
+			return []byte("3: eth1    inet 10.76.154.20/24 scope global eth1\n"), nil, true
+		case "exec srv -- ip -4 route show":
+			return []byte("default via 10.76.154.1 dev eth1 proto dhcp\n"), nil, true
+		}
+		return nil, nil, false
+	}
+	shape := mustObserve(t, newFakeDriver(f))
+	if shape.Interfaces["eth1"].Network != "incusbr0" {
+		t.Errorf("the foreign NIC was not read as an interface: %+v", shape.Interfaces)
+	}
+	if len(f.matching("network get incusbr0")) != 0 || len(shape.Gateways) != 0 {
+		t.Errorf("the operator's network was asked for its gateway: %v", f.matching("network get"))
+	}
+	v := leases{Network: "incusbr0"}.Check(shape)
+	if v.Outcome != Unreadable {
+		t.Errorf("a claim on the foreign network answered %s, want unreadable", v)
+	}
+}
+
+// A virtual machine names its interfaces by PCI slot, not by device: the
+// Shape is keyed by what the guest calls them, the way the routes are.
+func TestObserveNamesAVirtualMachinesInterfacesByMAC(t *testing.T) {
+	f := &fakeRuntime{}
+	f.hook = func(_ int, args []string) ([]byte, error, bool) {
+		switch key := strings.Join(args, " "); key {
+		case "query /1.0/instances/srv":
+			return []byte(`{"devices": {"eth0": {"type": "nic", "network": "fnt-web", "ipv4.address": "10.77.0.2"}},
+ "expanded_devices": {"eth0": {"type": "nic", "network": "fnt-web", "ipv4.address": "10.77.0.2"}}}`), nil, true
+		case "query /1.0/instances/srv/state":
+			return []byte(`{"network": {"enp5s0": {"hwaddr": "00:16:3e:11:22:33"}, "lo": {"hwaddr": ""}}}`), nil, true
+		case "config device get srv eth0 hwaddr":
+			return []byte("00:16:3e:11:22:33\n"), nil, true
+		case "network get fnt-web ipv4.address":
+			return []byte("10.77.0.1/24\n"), nil, true
+		case "exec srv -- ip -4 -o addr show":
+			return []byte("2: enp5s0    inet 10.77.0.2/24 brd 10.77.0.255 scope global enp5s0\n"), nil, true
+		case "exec srv -- ip -4 route show":
+			return []byte("default via 10.77.0.1 dev enp5s0 proto dhcp\n"), nil, true
+		}
+		return nil, nil, false
+	}
+	d := ovnDriver(f)
+	d.VM = true
+	shape := mustObserve(t, d)
+	iface, read := shape.Interfaces["enp5s0"]
+	if !read || prefixes(iface.Addresses) != "10.77.0.2/24" {
+		t.Fatalf("the VM's interface was not read under the guest's name: %+v", shape.Interfaces)
+	}
+	if v := (carries{Network: "fnt-web", Address: netip.MustParseAddr("10.77.0.2"), Bits: 24}).Check(shape); v.Outcome != Held {
+		t.Errorf("the pinned address on a VM answered %s", v)
+	}
+}
+
+// TestTheReplyDoorOfTheRegressionIsBroken reproduces #660 through the fake
+// runtime: the reply from the public address leaves through the private
+// gateway, and a door claim wanting the routed next hop is broken with both
+// doors named.
+//
+// The wanted door is the TEST's, written down as what docs/limits.md records
+// for the routed shape, and deliberately not derived: which door is right on
+// the shape this fixture models is the measurement #672 asks for, and this
+// test holds the comparator, not the table.
+func TestTheReplyDoorOfTheRegressionIsBroken(t *testing.T) {
+	f := &fakeRuntime{}
+	regressionMachine(f)
+	d := ovnDriver(f)
+	shape := mustObserve(t, d)
+
+	from, to := netip.MustParseAddr("203.0.113.2"), netip.MustParseAddr("10.209.83.1")
+	got, err := d.Door(context.Background(), "srv", from, to)
+	if err != nil {
+		t.Fatalf("door: %v", err)
+	}
+	shape.Doors = map[netip.Addr]Route{from: got}
+
+	claim := door{From: from, To: to, Via: netip.MustParseAddr("169.254.0.1"), Dev: "eth0"}
+	v := claim.Check(shape)
+	if v.Outcome != Broken {
+		t.Fatalf("the regression's door answered %s, want broken", v)
+	}
+	if v.Want != "via 169.254.0.1 dev eth0" || v.Got != "via 10.77.0.1 dev eth0" {
+		t.Errorf("the verdict does not name both doors: %s", v)
+	}
+	if v.String() != "door(203.0.113.2) broken: want via 169.254.0.1 dev eth0, got via 10.77.0.1 dev eth0" {
+		t.Errorf("rendered as %q", v.String())
+	}
+}
+
+// A machine with no route towards the destination has answered a fact about
+// itself, not refused a read: the door is broken, never unreadable. A read
+// the kernel refuses for another reason stays a failed read.
+func TestADoorWithNoRouteIsBrokenNotUnreadable(t *testing.T) {
+	f := &fakeRuntime{fail: map[string]error{
+		"route get": errors.New("RTNETLINK answers: Network is unreachable"),
+	}}
+	d := ovnDriver(f)
+	from, to := netip.MustParseAddr("203.0.113.2"), netip.MustParseAddr("10.209.83.1")
+	got, err := d.Door(context.Background(), "srv", from, to)
+	if err != nil || got.Dev != "" {
+		t.Fatalf("no route answered (%v, %v), want the zero route and no error", got, err)
+	}
+	v := (door{From: from, To: to, Via: netip.MustParseAddr("169.254.0.1"), Dev: "eth0"}).Check(
+		Shape{Doors: map[netip.Addr]Route{from: got}})
+	if v.Outcome != Broken || v.Got != "no route" {
+		t.Errorf("a machine with no route answered %s", v)
+	}
+
+	f.fail["route get"] = errors.New("RTNETLINK answers: Invalid argument")
+	if _, err := d.Door(context.Background(), "srv", from, to); err == nil {
+		t.Error("a read the kernel refused for another reason was not reported as a failed read")
+	}
+}
+
+// TestTheParsersReadBothImplementationsOfIp holds each parser to the two
+// formats in play: iproute2 on the Debian, Ubuntu and RHEL images, busybox on
+// Alpine. A parser that read one would report the other's machines bare.
+func TestTheParsersReadBothImplementationsOfIp(t *testing.T) {
+	for name, out := range map[string]string{
+		"iproute2": `2: eth0    inet 10.30.1.10/24 brd 10.30.1.255 scope global eth0\       valid_lft forever preferred_lft forever`,
+		"busybox":  `2: eth0    inet 10.30.1.10/24 scope global eth0`,
+	} {
+		got := parseAddresses([]byte(out))
+		if prefixes(got["eth0"]) != "10.30.1.10/24" {
+			t.Errorf("%s addresses: %v", name, got)
+		}
+	}
+	for name, out := range map[string]string{
+		"iproute2": "default via 10.30.1.1 dev eth0 proto dhcp src 10.30.1.10 metric 100\n10.30.1.0/24 dev eth0 proto kernel scope link src 10.30.1.10\n",
+		"busybox":  "default via 10.30.1.1 dev eth0  metric 100\n10.30.1.0/24 dev eth0 scope link  src 10.30.1.10\n",
+	} {
+		got := parseRoutes([]byte(out))
+		if len(got) != 1 || got[0].Dst != defaultDst || got[0].String() != "via 10.30.1.1 dev eth0" {
+			t.Errorf("%s routes: %v", name, got)
+		}
+	}
+	for name, out := range map[string]string{
+		"iproute2": "10.209.83.1 from 203.0.113.2 via 169.254.0.1 dev eth0 uid 0 \n    cache \n",
+		"busybox":  "10.209.83.1 from 203.0.113.2 via 169.254.0.1 dev eth0  src 203.0.113.2 \n",
+	} {
+		got, err := parseDoor([]byte(out))
+		if err != nil || got.String() != "via 169.254.0.1 dev eth0" {
+			t.Errorf("%s door: %v, %v", name, got, err)
+		}
+	}
+	// iproute2 ends every route line with a space, which the repository's
+	// whitespace hook strips from a fixture: held here as an escape, so the
+	// tolerance is measured rather than assumed.
+	if got := parseRoutes([]byte("default via 10.30.1.1 dev eth0 proto dhcp metric 100\x20\n")); len(got) != 1 {
+		t.Errorf("a trailing space on a route line: %v", got)
+	}
+	// A host route prints its address bare, and a connected door names the
+	// device alone.
+	if got := parseRoutes([]byte("203.0.113.9 via 10.0.0.1 dev eth1\n")); len(got) != 1 || got[0].Dst.String() != "203.0.113.9/32" {
+		t.Errorf("a bare host route: %v", got)
+	}
+	if got, err := parseDoor([]byte("10.30.1.11 from 10.30.1.10 dev eth0 uid 0\n")); err != nil || got.Via.IsValid() || got.Dev != "eth0" {
+		t.Errorf("a connected door: %v, %v", got, err)
+	}
+	if _, err := parseDoor([]byte("\n")); err == nil {
+		t.Error("an empty answer parsed as a door")
+	}
+}
+
+// ---- the layer: verify over an observing runtime ----------------------------
+
+// observingRecorder is the contract recorder with the reading half: the
+// Shape a test writes is what the runtime reports, which is the only way to
+// plant a divergence and know exactly what the verifier had to find.
+type observingRecorder struct {
+	*Recorder
+	shape      Shape
+	err        error
+	noFirewall bool
+}
+
+func (o *observingRecorder) Observe(context.Context, string) (Shape, error) {
+	return o.shape, o.err
+}
+
+func (o *observingRecorder) Door(_ context.Context, _ string, from, _ netip.Addr) (Route, error) {
+	if route, read := o.shape.Doors[from]; read {
+		return route, nil
+	}
+	return Route{}, errors.New("no door was planted")
+}
+
+func (o *observingRecorder) Capabilities() Capabilities {
+	caps := o.Recorder.Capabilities()
+	if o.noFirewall {
+		caps.Firewall = false
+	}
+	return caps
+}
+
+func observingReconciler(b *groupSyncBench, o *observingRecorder, plan Plan) Reconciler {
+	sync := b.sync()
+	sync.Binding.driver = o
+	sync.Binding.RunningState = "running"
+	sync.Binding.FailedState = "stopped"
+	sync.PlanOf = func(*testResource) Plan { return plan }
+	return Reconciler{
+		Groups:      sync,
+		PlanOf:      func(*testResource) Plan { return plan },
+		PublicBlock: netip.MustParsePrefix("203.0.113.0/24"),
+	}
+}
+
+// pinnedOn is the Shape of a machine carrying one pinned address on one
+// emulated network, its gateway read.
+func pinnedOn(network, cidr string, sets ...string) Shape {
+	return Shape{
+		Interfaces: map[string]Interface{
+			"eth0": {Network: network, Addresses: []netip.Prefix{netip.MustParsePrefix(cidr)}, RuleSets: sets},
+		},
+		Gateways: map[string]netip.Prefix{network: netip.MustParsePrefix("10.30.1.1/24")},
+	}
+}
+
+func outcomes(verdicts []Verdict) string {
+	out := make([]string, 0, len(verdicts))
+	for _, v := range verdicts {
+		out = append(out, v.String())
+	}
+	return strings.Join(out, "\n")
+}
+
+// TestAPlantedDivergenceIsReported is the positive control: a verifier that
+// has never found anything is indistinguishable from one that does not look.
+// The accepting half runs on the same plan and the same runtime, so the
+// finding cannot be a verifier that refuses everything.
+func TestAPlantedDivergenceIsReported(t *testing.T) {
+	plan := Plan{Boot: []Attachment{{Network: "fnt-x", Address: "10.30.1.10", PrefixLen: 24}}}
+	b := newGroupSyncBench()
+	o := &observingRecorder{Recorder: b.rec, shape: pinnedOn("fnt-x", "10.30.1.10/24")}
+	vm := b.machine("m", "10.30.1.10")
+	r := observingReconciler(b, o, plan)
+
+	verdicts, asked := r.verify(context.Background(), vm)
+	if !asked || len(verdicts) != 1 || verdicts[0].Outcome != Held {
+		t.Fatalf("a machine carrying what its plan claims answered asked=%v:\n%s", asked, outcomes(verdicts))
+	}
+
+	// One digit off, planted: the address the runtime reports is not the
+	// one the plan pinned.
+	o.shape = pinnedOn("fnt-x", "10.30.1.11/24")
+	verdicts, asked = r.verify(context.Background(), vm)
+	if !asked || len(verdicts) != 1 {
+		t.Fatalf("asked=%v, verdicts:\n%s", asked, outcomes(verdicts))
+	}
+	v := verdicts[0]
+	if v.Outcome != Broken || v.Claim != "carries(fnt-x, 10.30.1.10/24)" || v.Got != "eth0: 10.30.1.11/24" {
+		t.Fatalf("the planted divergence was not reported as itself: %s", v)
+	}
+}
+
+// TestAnUnreadableShapeIsNeitherHeldNorBroken is the second control: a read
+// that failed answers Unreadable on every claim, counted, and a runtime that
+// cannot be asked at all is not asked — a fourth state, told from the third.
+func TestAnUnreadableShapeIsNeitherHeldNorBroken(t *testing.T) {
+	plan := Plan{Boot: []Attachment{{Network: "fnt-x", Address: "10.30.1.10", PrefixLen: 24}}, Publics: []string{"203.0.113.2"}}
+	b := newGroupSyncBench()
+	o := &observingRecorder{Recorder: b.rec, err: errors.New("the agent isn't currently running")}
+	vm := b.machine("m", "10.30.1.10")
+
+	verdicts, asked := observingReconciler(b, o, plan).verify(context.Background(), vm)
+	if !asked || len(verdicts) != 2 {
+		t.Fatalf("asked=%v, verdicts:\n%s", asked, outcomes(verdicts))
+	}
+	for _, v := range verdicts {
+		if v.Outcome != Unreadable || !strings.Contains(v.Got, "agent") {
+			t.Errorf("a failed read answered %s, want unreadable naming the failure", v)
+		}
+	}
+
+	// A runtime with no reading half is not asked, and says so.
+	plain := rebootReconciler(b, plan)
+	if verdicts, asked := plain.verify(context.Background(), vm); asked || len(verdicts) != 0 {
+		t.Errorf("a runtime that cannot be asked answered asked=%v with %d verdicts", asked, len(verdicts))
+	}
+	// And so is a resource with no machine behind it.
+	bare := b.machine("bare", "")
+	if verdicts, asked := observingReconciler(b, o, plan).verify(context.Background(), bare); asked || len(verdicts) != 0 {
+		t.Errorf("a resource with no machine answered asked=%v with %d verdicts", asked, len(verdicts))
+	}
+}
+
+// The rule sets a machine wears are claimed on its filtered interfaces, from
+// the same fields the firewall step reads; an interface on a network the
+// pack declared outside its groups' reach is claimed bare.
+func TestTheRuleSetsAMachineWearsAreClaimedOnItsFilteredInterfaces(t *testing.T) {
+	plan := Plan{
+		Boot:        []Attachment{{Network: "fnt-x", Address: "10.30.1.10", PrefixLen: 24}},
+		Memberships: []Attachment{{Network: "fnt-y", Unfiltered: true}},
+	}
+	b := newGroupSyncBench()
+	b.group("g", "")
+	set := FirewallName("bench", "g")
+	shape := pinnedOn("fnt-x", "10.30.1.10/24", set)
+	shape.Interfaces["eth1"] = Interface{Network: "fnt-y", Addresses: []netip.Prefix{netip.MustParsePrefix("10.40.0.5/24")}}
+	shape.Gateways["fnt-y"] = netip.MustParsePrefix("10.40.0.1/24")
+	o := &observingRecorder{Recorder: b.rec, shape: shape}
+	vm := b.machine("m", "10.30.1.10", "g")
+	r := observingReconciler(b, o, plan)
+
+	verdicts, _ := r.verify(context.Background(), vm)
+	names := map[string]Verdict{}
+	for _, v := range verdicts {
+		names[v.Claim] = v
+	}
+	for _, claim := range []string{"wears(fnt-x)", "wears(fnt-y)"} {
+		v, claimed := names[claim]
+		if !claimed {
+			t.Fatalf("%s was not claimed:\n%s", claim, outcomes(verdicts))
+		}
+		if v.Outcome != Held {
+			t.Errorf("%s answered %s on a machine wearing exactly its group", claim, v)
+		}
+	}
+
+	// The unfiltered interface planted wearing the set: the pack said its
+	// groups do not reach it, and the runtime bound one anyway.
+	eth1 := shape.Interfaces["eth1"]
+	eth1.RuleSets = []string{set}
+	shape.Interfaces["eth1"] = eth1
+	verdicts, _ = r.verify(context.Background(), vm)
+	for _, v := range verdicts {
+		if v.Claim == "wears(fnt-y)" && (v.Outcome != Broken || v.Want != "no rule set on eth1") {
+			t.Errorf("an unfiltered interface wearing a set answered %s", v)
+		}
+	}
+}
+
+// A host that withdrew the firewall capability (#454) binds nothing, and a
+// claim about the bindings would be broken on every machine for a fact
+// /_feint/health already publishes.
+func TestAWithdrawnFirewallClaimsNoRuleSets(t *testing.T) {
+	plan := Plan{Boot: []Attachment{{Network: "fnt-x", Address: "10.30.1.10", PrefixLen: 24}}}
+	b := newGroupSyncBench()
+	b.group("g", "")
+	o := &observingRecorder{Recorder: b.rec, shape: pinnedOn("fnt-x", "10.30.1.10/24"), noFirewall: true}
+	vm := b.machine("m", "10.30.1.10", "g")
+
+	verdicts, _ := observingReconciler(b, o, plan).verify(context.Background(), vm)
+	for _, v := range verdicts {
+		if strings.HasPrefix(v.Claim, "wears(") {
+			t.Fatalf("a withdrawn firewall still claims rule sets: %s", v)
+		}
+	}
+}
+
+// The wears comparator on hand-built shapes: exact set equality, and "none"
+// when the claim is bare.
+func TestWearsComparesTheRuleSetsPerInterface(t *testing.T) {
+	shape := pinnedOn("fnt-x", "10.30.1.10/24", "fnt-a", "fnt-b")
+	requireOutcome(t, wears{Network: "fnt-x", Sets: []string{"fnt-a", "fnt-b"}}.Check(shape), Held)
+	v := wears{Network: "fnt-x", Sets: []string{"fnt-a"}}.Check(shape)
+	requireOutcome(t, v, Broken)
+	if v.Want != "fnt-a on eth0" || v.Got != "fnt-a, fnt-b on eth0" {
+		t.Errorf("the verdict does not name both bindings: %s", v)
+	}
+	v = wears{Network: "fnt-x"}.Check(shape)
+	requireOutcome(t, v, Broken)
+	if v.Want != "no rule set on eth0" {
+		t.Errorf("a bare claim wants %q", v.Want)
+	}
+	requireOutcome(t, wears{Network: "fnt-x"}.Check(pinnedOn("fnt-x", "10.30.1.10/24")), Held)
+	v = wears{Network: "fnt-z", Sets: []string{"fnt-a"}}.Check(shape)
+	requireOutcome(t, v, Broken)
+	if !strings.Contains(v.Got, "no interface on fnt-z") {
+		t.Errorf("a missing interface is not named: %s", v)
+	}
+}

--- a/internal/core/machine/restart.go
+++ b/internal/core/machine/restart.go
@@ -1,0 +1,191 @@
+package machine
+
+import (
+	"context"
+	"net/netip"
+	"slices"
+	"strings"
+
+	"github.com/stephrobert/feint/internal/core/resource"
+)
+
+// A reboot needs no table of expected values: the shape after is the shape
+// before (#669).
+//
+// Nothing moves in the control plane between the two, because Reconciler.
+// Reboot holds the per-target lock from one end to the other (Serialise). So
+// the reboot is the one case where the verification costs no measurement
+// campaign and no encoded expectation: what the machine carried while it was
+// up is what it must carry once it is back, property by property, and the
+// only tolerance is the one every reading already applies — nothing that does
+// not compare ever entered either Shape.
+//
+// On the regression of 2026-09-04 this answers, at the moment of the reboot:
+//
+//	restart(default route) want via 169.254.0.1 dev eth0, got via 10.77.0.1 dev eth0
+//
+// where the runtime suite used to wait sixty seconds two steps later to say
+// "nothing answers". The cause where the effect is, rather than the symptom
+// where it surfaces.
+//
+// Where the before does NOT apply. A poweroff then a poweron as two API
+// actions is not a reboot: a NIC attached to a stopped server legitimately
+// changes the shape, and that is the ordinary Terraform order. There, the
+// derived claims judge (#667, #668). The two are complementary: the reboot
+// needs no table, the first boot needs one.
+
+// observe reads the machine behind a resource. nil with no error is a runtime
+// that cannot be asked, or a resource with no machine: said, not guessed.
+func (r Reconciler) observe(ctx context.Context, res *resource.Resource) (*Shape, error) {
+	obs := r.observer()
+	name := res.Runtime[r.binding().RuntimeKey]
+	if obs == nil || name == "" {
+		return nil, nil
+	}
+	shape, err := obs.Observe(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	return &shape, nil
+}
+
+// restartClaims turns the shape before a reboot into the claims the shape
+// after must answer: one per interface, one for the default route, one for
+// the rest of the table. They ride the same reading as the plan's claims, so
+// a reboot is read once and repaired once like any other boot.
+func restartClaims(before Shape) []Claim {
+	claims := make([]Claim, 0, len(before.Interfaces)+2)
+	for _, name := range before.interfaceNames() {
+		claims = append(claims, sameInterface{Name: name, Was: before.Interfaces[name]})
+	}
+	route, had := before.defaultRoute()
+	claims = append(claims, sameDefaultRoute{Was: route, Had: had})
+	var others []Route
+	for _, route := range before.Routes {
+		if route.Dst != defaultDst {
+			others = append(others, route)
+		}
+	}
+	return append(claims, sameRoutes{Was: others})
+}
+
+// sameInterface claims that an interface carries, after the reboot, what it
+// carried before: the same network, the same kind, the same addresses, the
+// same rule sets. Sets, not lists: the order the kernel or the runtime lists
+// them in is not a property of the machine.
+type sameInterface struct {
+	Name string
+	Was  Interface
+}
+
+func (c sameInterface) String() string { return "restart(" + c.Name + ")" }
+
+func (c sameInterface) Check(s Shape) Verdict {
+	got, has := s.Interfaces[c.Name]
+	if !has {
+		return broken(c, describeInterface(c.Was), "no interface "+c.Name)
+	}
+	if got.Network == c.Was.Network && got.Routed == c.Was.Routed &&
+		slices.Equal(sortedPrefixes(got.Addresses), sortedPrefixes(c.Was.Addresses)) &&
+		slices.Equal(sortedStrings(got.RuleSets), sortedStrings(c.Was.RuleSets)) {
+		return held(c)
+	}
+	return broken(c, describeInterface(c.Was), describeInterface(got))
+}
+
+// sameDefaultRoute claims that the default route is, after the reboot, what
+// it was before — present with the same door, or absent.
+type sameDefaultRoute struct {
+	Was Route
+	Had bool
+}
+
+func (c sameDefaultRoute) String() string { return "restart(default route)" }
+
+func (c sameDefaultRoute) Check(s Shape) Verdict {
+	got, has := s.defaultRoute()
+	switch {
+	case !c.Had && !has:
+		return held(c)
+	case c.Had && !has:
+		return broken(c, c.Was.String(), "no default route")
+	case !c.Had && has:
+		return broken(c, "no default route", got.String())
+	}
+	if got.Via == c.Was.Via && got.Dev == c.Was.Dev {
+		return held(c)
+	}
+	return broken(c, c.Was.String(), got.String())
+}
+
+// sameRoutes claims that the rest of the table — every route with a next hop
+// but the default — is, after the reboot, the set it was before.
+type sameRoutes struct {
+	Was []Route
+}
+
+func (c sameRoutes) String() string { return "restart(routes)" }
+
+func (c sameRoutes) Check(s Shape) Verdict {
+	var got []Route
+	for _, route := range s.Routes {
+		if route.Dst != defaultDst {
+			got = append(got, route)
+		}
+	}
+	want, have := routeLines(c.Was), routeLines(got)
+	if slices.Equal(want, have) {
+		return held(c)
+	}
+	return broken(c, strings.Join(want, ", "), strings.Join(have, ", "))
+}
+
+// routeLines renders routes for a verdict, sorted so two readings of one
+// table compare equal whatever order the kernel printed them in.
+func routeLines(routes []Route) []string {
+	if len(routes) == 0 {
+		return []string{"none"}
+	}
+	out := make([]string, 0, len(routes))
+	for _, r := range routes {
+		out = append(out, r.Dst.String()+" "+r.String())
+	}
+	slices.Sort(out)
+	return out
+}
+
+func sortedPrefixes(prefixes []netip.Prefix) []string {
+	out := make([]string, 0, len(prefixes))
+	for _, p := range prefixes {
+		out = append(out, p.String())
+	}
+	slices.Sort(out)
+	return out
+}
+
+func sortedStrings(values []string) []string {
+	out := slices.Clone(values)
+	slices.Sort(out)
+	return out
+}
+
+// describeInterface renders an interface for a verdict: where it sits, what
+// it carries, what it wears.
+func describeInterface(i Interface) string {
+	where := i.Network
+	if i.Routed {
+		where = "routed"
+	}
+	if where == "" {
+		where = "no network"
+	}
+	addresses := "nothing"
+	if len(i.Addresses) > 0 {
+		addresses = strings.Join(sortedPrefixes(i.Addresses), ", ")
+	}
+	sets := "no rule set"
+	if len(i.RuleSets) > 0 {
+		sets = strings.Join(sortedStrings(i.RuleSets), ", ")
+	}
+	return where + ": " + addresses + "; " + sets
+}

--- a/internal/core/machine/restart_test.go
+++ b/internal/core/machine/restart_test.go
@@ -1,0 +1,186 @@
+package machine
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/netip"
+	"strings"
+	"testing"
+)
+
+// A reboot needs no table of expected values (#669): the shape after is the
+// shape before, and the observing recorder is the instrument — the test
+// writes both shapes, so what the comparison had to find is exact.
+
+// routedBeside is the routed shape beside a private NIC (shapeA) with the
+// default route as given: the shape of 2026-09-04 before and after.
+func routedBeside(defaultVia, defaultDev string) Shape {
+	s := shapeA()
+	s.Routes[0] = Route{Dst: defaultDst, Via: netip.MustParseAddr(defaultVia), Dev: defaultDev}
+	return s
+}
+
+// restartPlan is the plan both shapes satisfy: the pinned private address
+// and the public /32 the routed NIC carries.
+var restartPlan = Plan{
+	Boot:    []Attachment{{Network: "fnt-x", Address: "10.30.1.10", PrefixLen: 24}},
+	Publics: []string{"203.0.113.2"},
+}
+
+// TestARebootComparesTheShapeAfterWithTheShapeBefore is the regression, seen
+// at the moment of the reboot: the machine came back with its default route
+// through the private gateway where it had left through the routed next hop.
+// The accepting half runs first on the same runtime, so the finding cannot be
+// a comparison that refuses everything.
+func TestARebootComparesTheShapeAfterWithTheShapeBefore(t *testing.T) {
+	before := routedBeside("169.254.0.1", "eth0")
+	after := routedBeside("10.77.0.1", "eth1")
+
+	b := newGroupSyncBench()
+	o := &observingRecorder{Recorder: b.rec, queue: []Shape{before, before}}
+	vm := b.machine("m", "10.30.1.10")
+	vm.State = "running"
+	r := observingReconciler(b, o, restartPlan)
+	if !r.Reboot(context.Background(), vm, Boot{Image: "ubuntu:24.04"}) {
+		t.Fatalf("the reboot did not bring the machine back; sequence: %v", b.rec.Sequence())
+	}
+	if o.reads != 2 || vm.Runtime[VerifiedKey] != "held" {
+		t.Fatalf("a reboot that changed nothing: reads=%d verified=%q", o.reads, vm.Runtime[VerifiedKey])
+	}
+
+	// The same reboot, and the machine comes back by another door. Queued
+	// twice after the before, because a broken reading is read once more
+	// after one replay, and the machine stays wrong.
+	o.queue = []Shape{before, after, after}
+	o.reads = 0
+	r.Reboot(context.Background(), vm, Boot{Image: "ubuntu:24.04"})
+	if o.reads != 3 {
+		t.Fatalf("reads=%d, want the before, the after, and one more after the repair", o.reads)
+	}
+	want := "restart(default route) want via 169.254.0.1 dev eth0, got via 10.77.0.1 dev eth1"
+	got := vm.Runtime[VerifiedKey]
+	if !strings.HasPrefix(got, "broken: ") || !strings.Contains(got, want) {
+		t.Fatalf("Runtime[%s] = %q, want it broken on %q", VerifiedKey, got, want)
+	}
+	// And the plan's own claims still held: the address is carried, the
+	// public /32 is carried; only the restart claims moved.
+	if strings.Contains(got, "carries(") {
+		t.Errorf("a claim the machine still satisfies was reported broken: %s", got)
+	}
+	if vm.State != "running" {
+		t.Errorf("state %q after a reboot the runtime honoured, want running", vm.State)
+	}
+}
+
+// A before that could not be read is said, and the reboot is judged on its
+// plan alone: no restart claim is invented from a shape nobody saw.
+func TestARebootWhoseBeforeCouldNotBeReadIsJudgedOnItsPlanAlone(t *testing.T) {
+	var log bytes.Buffer
+	b := newGroupSyncBench()
+	o := &observingRecorder{Recorder: b.rec, shape: routedBeside("169.254.0.1", "eth0"), failFirst: 1}
+	vm := b.machine("m", "10.30.1.10")
+	vm.State = "running"
+	r := observingReconciler(b, o, restartPlan)
+	r.Groups.Binding.Log = slog.New(slog.NewTextHandler(&log, nil))
+	r.Reboot(context.Background(), vm, Boot{Image: "ubuntu:24.04"})
+	if got := vm.Runtime[VerifiedKey]; got != "held" {
+		t.Fatalf("Runtime[%s] = %q, want held on the plan alone", VerifiedKey, got)
+	}
+	if !strings.Contains(log.String(), "judged on its plan alone") || !strings.Contains(log.String(), "level=WARN") {
+		t.Errorf("an unreadable before was not said:\n%s", log.String())
+	}
+}
+
+// A machine that was not up has no before: nothing is read until the boot's
+// own reading, and nothing is claimed about a shape that did not exist.
+func TestARebootOfAStoppedMachineHasNoBefore(t *testing.T) {
+	b := newGroupSyncBench()
+	o := &observingRecorder{Recorder: b.rec, shape: routedBeside("169.254.0.1", "eth0")}
+	vm := b.machine("m", "10.30.1.10")
+	vm.State = "stopped"
+	r := observingReconciler(b, o, restartPlan)
+	r.Reboot(context.Background(), vm, Boot{Image: "ubuntu:24.04"})
+	if o.reads != 1 || vm.Runtime[VerifiedKey] != "held" {
+		t.Fatalf("a reboot of a stopped machine: reads=%d verified=%q", o.reads, vm.Runtime[VerifiedKey])
+	}
+}
+
+// TestTheRestartClaimsCompareWhatCompares: the three claims derived from a
+// before, each on hand-built shapes — sets rather than lists for addresses,
+// rule sets and routes; a lost interface, a lost route and a gained route
+// each named as themselves.
+func TestTheRestartClaimsCompareWhatCompares(t *testing.T) {
+	before := routedBeside("169.254.0.1", "eth0")
+	claims := restartClaims(before)
+	if got := claimNames(claims); strings.Join(got, ",") != "restart(eth0),restart(eth1),restart(default route),restart(routes)" {
+		t.Fatalf("claims %v", got)
+	}
+	for _, c := range claims {
+		requireOutcome(t, c.Check(before), Held)
+	}
+
+	// The same addresses in another order, and the same rule sets in another
+	// order, are the same interface.
+	shuffled := routedBeside("169.254.0.1", "eth0")
+	eth1 := shuffled.Interfaces["eth1"]
+	eth1.Addresses = []netip.Prefix{netip.MustParsePrefix("10.30.1.10/24")}
+	eth1.RuleSets = []string{"fnt-b", "fnt-a"}
+	shuffled.Interfaces["eth1"] = eth1
+	sets := before
+	sets.Interfaces["eth1"] = Interface{Network: "fnt-x", Addresses: eth1.Addresses, RuleSets: []string{"fnt-a", "fnt-b"}}
+	requireOutcome(t, restartClaims(sets)[1].Check(shuffled), Held)
+
+	// An address gone from eth1.
+	bare := routedBeside("169.254.0.1", "eth0")
+	bare.Interfaces["eth1"] = Interface{Network: "fnt-x"}
+	v := claims[1].Check(bare)
+	requireOutcome(t, v, Broken)
+	if v.Want != "fnt-x: 10.30.1.10/24; no rule set" || v.Got != "fnt-x: nothing; no rule set" {
+		t.Errorf("a lost address: %s", v)
+	}
+	// An interface gone altogether.
+	delete(bare.Interfaces, "eth0")
+	v = claims[0].Check(bare)
+	requireOutcome(t, v, Broken)
+	if v.Got != "no interface eth0" {
+		t.Errorf("a lost interface: %s", v)
+	}
+	// The default route by another door on the same device: the half the
+	// regression lived in, and the half a comparison on the device alone
+	// would miss.
+	viaOnly := routedBeside("10.77.0.1", "eth0")
+	v = claims[2].Check(viaOnly)
+	requireOutcome(t, v, Broken)
+	if v.Want != "via 169.254.0.1 dev eth0" || v.Got != "via 10.77.0.1 dev eth0" {
+		t.Errorf("a default route by another door: %s", v)
+	}
+	// A default route gone, and one gained.
+	none := routedBeside("169.254.0.1", "eth0")
+	none.Routes = none.Routes[1:]
+	v = claims[2].Check(none)
+	requireOutcome(t, v, Broken)
+	if v.Got != "no default route" {
+		t.Errorf("a lost default route: %s", v)
+	}
+	requireOutcome(t, restartClaims(none)[2].Check(before), Broken)
+	// A private route lost, and one gained.
+	fewer := routedBeside("169.254.0.1", "eth0")
+	fewer.Routes = fewer.Routes[:3]
+	v = claims[3].Check(fewer)
+	requireOutcome(t, v, Broken)
+	if !strings.Contains(v.Want, "192.168.0.0/16 via 10.30.1.1 dev eth1") || strings.Contains(v.Got, "192.168.0.0/16") {
+		t.Errorf("a lost route is not named: %s", v)
+	}
+	more := routedBeside("169.254.0.1", "eth0")
+	more.Routes = append(more.Routes, Route{Dst: netip.MustParsePrefix("100.64.0.0/10"), Via: netip.MustParseAddr("10.30.1.1"), Dev: "eth1"})
+	v = claims[3].Check(more)
+	requireOutcome(t, v, Broken)
+	if !strings.Contains(v.Got, "100.64.0.0/10 via 10.30.1.1 dev eth1") {
+		t.Errorf("a gained route is not named: %s", v)
+	}
+	// An empty table before and after compares equal, and says so.
+	empty := Shape{}
+	requireOutcome(t, restartClaims(empty)[0].Check(empty), Held)
+	requireOutcome(t, restartClaims(empty)[1].Check(empty), Held)
+}

--- a/internal/core/machine/runtime.go
+++ b/internal/core/machine/runtime.go
@@ -62,6 +62,10 @@ import (
 // is what `--vm off` and CI get.
 type Runtime struct {
 	d driver
+	// tally counts what the reading half answered (#670), one per handle so
+	// that two emulators in one test binary count apart. Nil for the zero
+	// Runtime, which verifies nothing and counts nowhere.
+	tally *tally
 }
 
 // Use binds a driver into the handle. It is the one door in, and deliberately
@@ -72,7 +76,7 @@ type Runtime struct {
 // internal/cli passes the Incus driver, and how every fake runtime in the
 // packs' tests is still injected — but it cannot declare a variable of that
 // type, name it in a signature, or assert its way back to one.
-func Use(d driver) Runtime { return Runtime{d: d} }
+func Use(d driver) Runtime { return Runtime{d: d, tally: &tally{}} }
 
 // backing returns the driver, or the metadata-only one for a zero Runtime, so
 // every method below can be written without a nil branch.

--- a/internal/core/machine/verdicts.go
+++ b/internal/core/machine/verdicts.go
@@ -1,0 +1,205 @@
+package machine
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+
+	"github.com/stephrobert/feint/internal/core/resource"
+)
+
+// A verdict nobody reads is a confession nobody hears (#670). The reading half
+// (#668) answers every claim a plan makes; this file is where the answer goes:
+// a log line where a failure belongs, a key on the resource out of the
+// client's reach, four counters on /_feint/health, and one bounded retry for
+// the class of divergence a replay can mend.
+//
+// What the API state must NOT become. The rule this repository holds is that
+// the published state is the one the effect produced, not the one the
+// intention aimed at. A machine running with the wrong door is running and
+// unreachable; publishing it stopped would be the lie in the other direction,
+// the one incus.go already refuses twice. So the state stays true, and the
+// verdict goes everywhere else.
+
+// VerifiedKey is the Runtime key the last verification's summary is published
+// under. Runtime is never serialised into a client's view, and /_feint/state
+// shows it to whoever asks, which is how the runtime leg names a broken claim
+// rather than a counter.
+//
+// The value is one of "held", "broken: <claim> want <x>, got <y>; …" and
+// "unreadable: <claim>: <why>; …" — a prefix a reader can branch on, then the
+// verdicts themselves.
+const VerifiedKey = "verified"
+
+// Verification is the count of what the reading half answered, published on
+// /_feint/health. Held, Broken and Unreadable count claims; Repaired counts
+// verifications whose first reading was broken and whose second, after one
+// replay, held.
+//
+// Repaired is a counter for a reason: a repair that fires on every boot is a
+// defect hidden behind a retry, and the number is what makes it visible.
+type Verification struct {
+	Held       int64 `json:"held"`
+	Broken     int64 `json:"broken"`
+	Unreadable int64 `json:"unreadable"`
+	Repaired   int64 `json:"repaired"`
+}
+
+// tally is the process-wide count behind Verification. It lives on the
+// Runtime handle — one per Use, shared by every Binding that handle is bound
+// into — rather than in a package variable, so two emulators in one test
+// binary count apart and a test can read exactly what its own runtime saw.
+type tally struct {
+	held, broken, unreadable, repaired atomic.Int64
+}
+
+// count adds one verification's verdicts. Nil-safe: a Binding built without a
+// Runtime, which every bench in this package is, counts nowhere.
+func (t *tally) count(verdicts []Verdict, repaired bool) {
+	if t == nil {
+		return
+	}
+	for _, v := range verdicts {
+		switch v.Outcome {
+		case Held:
+			t.held.Add(1)
+		case Broken:
+			t.broken.Add(1)
+		case Unreadable:
+			t.unreadable.Add(1)
+		}
+	}
+	if repaired {
+		t.repaired.Add(1)
+	}
+}
+
+func (t *tally) snapshot() Verification {
+	if t == nil {
+		return Verification{}
+	}
+	return Verification{
+		Held:       t.held.Load(),
+		Broken:     t.broken.Load(),
+		Unreadable: t.unreadable.Load(),
+		Repaired:   t.repaired.Load(),
+	}
+}
+
+// Verification answers what this runtime's verifications counted so far.
+func (r Runtime) Verification() Verification { return r.tally.snapshot() }
+
+// summary renders one verification for VerifiedKey: the broken claims first,
+// because a reader branches on the prefix; the unreadable ones when nothing
+// is broken; "held" when every claim held.
+func summary(verdicts []Verdict) string {
+	var broken, unreadable []string
+	for _, v := range verdicts {
+		switch v.Outcome {
+		case Broken:
+			broken = append(broken, v.Claim+" want "+v.Want+", got "+v.Got)
+		case Unreadable:
+			unreadable = append(unreadable, v.Claim+": "+v.Got)
+		}
+	}
+	switch {
+	case len(broken) > 0:
+		return "broken: " + strings.Join(broken, "; ")
+	case len(unreadable) > 0:
+		return "unreadable: " + strings.Join(unreadable, "; ")
+	}
+	return "held"
+}
+
+func anyBroken(verdicts []Verdict) bool {
+	for _, v := range verdicts {
+		if v.Outcome == Broken {
+			return true
+		}
+	}
+	return false
+}
+
+// publish is where a verification's answer goes: the log, the resource, the
+// counters. It changes no state — see the file comment — and it is written
+// inside the change() closure of Transition, so the key lands through Commit
+// with everything else and merges per key with a concurrent writer to another
+// field (mergeRuntime). A resource deleted meanwhile makes Commit answer
+// false and the verdict falls with the rest, which is correct.
+//
+// ERROR for a broken claim and WARN for an unreadable one, in the words the
+// repository holds for the two levels: a failure, and a degradation. The
+// repair, when one happened, is a WARN naming what the first reading found:
+// it ended well, and the number of times it was needed is the point.
+//
+// TestABrokenVerdictReachesTheResourceAndNotItsState and
+// TestABrokenVerdictIsLoggedAsAFailure fail without this.
+func (r Reconciler) publish(res *resource.Resource, verdicts []Verdict, repairedFrom []Verdict) {
+	if len(verdicts) == 0 {
+		return
+	}
+	b := r.binding()
+	machine := res.Runtime[b.RuntimeKey]
+	var unreadable []Verdict
+	for _, v := range verdicts {
+		switch v.Outcome {
+		case Broken:
+			b.logger().Error("the machine does not carry what its plan claims",
+				"provider", b.Provider, "resource", res.ID, "machine", machine,
+				"claim", v.Claim, "want", v.Want, "got", v.Got)
+		case Unreadable:
+			unreadable = append(unreadable, v)
+		}
+	}
+	if len(unreadable) > 0 {
+		b.logger().Warn("part of the machine's shape could not be read, so those claims are neither held nor broken",
+			"provider", b.Provider, "resource", res.ID, "machine", machine,
+			"claims", len(unreadable), "first", unreadable[0].Claim, "why", unreadable[0].Got)
+	}
+	if len(repairedFrom) > 0 {
+		b.logger().Warn("the machine did not carry what its plan claims until the replay ran a second time",
+			"provider", b.Provider, "resource", res.ID, "machine", machine,
+			"first_reading", summary(repairedFrom))
+	}
+	if res.Runtime == nil {
+		res.Runtime = map[string]string{}
+	}
+	res.Runtime[VerifiedKey] = summary(verdicts)
+	b.tally.count(verdicts, len(repairedFrom) > 0)
+}
+
+// check verifies the machine behind a resource and publishes the answer,
+// with one bounded retry for the class a replay can mend.
+//
+// A broken first reading replays the post-boot order once — every step of it
+// is idempotent by construction — and reads again; what is published is the
+// second reading, with the first named beside it when the second held. Once,
+// and never for an unreadable reading: a virtual machine whose agent has not
+// answered is read again from the late-address door, and replaying onto it
+// would not make it readable. The contradiction class never reaches here, it
+// is refused at derivation (#667), and replaying it would replay the same
+// contradiction.
+//
+// TestARepairIsAttemptedOnceAndCounted fails without the bound.
+func (r Reconciler) check(ctx context.Context, res *resource.Resource) {
+	verdicts, asked := r.verify(ctx, res)
+	if !asked {
+		return
+	}
+	if !anyBroken(verdicts) {
+		r.publish(res, verdicts, nil)
+		return
+	}
+	plan, declared := r.plan(res)
+	if !declared {
+		r.publish(res, verdicts, nil)
+		return
+	}
+	r.replay(ctx, res, plan)
+	again, _ := r.verify(ctx, res)
+	if anyBroken(again) {
+		r.publish(res, again, nil)
+		return
+	}
+	r.publish(res, again, verdicts)
+}

--- a/internal/core/machine/verdicts.go
+++ b/internal/core/machine/verdicts.go
@@ -181,8 +181,8 @@ func (r Reconciler) publish(res *resource.Resource, verdicts []Verdict, repaired
 // contradiction.
 //
 // TestARepairIsAttemptedOnceAndCounted fails without the bound.
-func (r Reconciler) check(ctx context.Context, res *resource.Resource) {
-	verdicts, asked := r.verify(ctx, res)
+func (r Reconciler) check(ctx context.Context, res *resource.Resource, extra []Claim) {
+	verdicts, asked := r.verify(ctx, res, extra)
 	if !asked {
 		return
 	}
@@ -196,7 +196,7 @@ func (r Reconciler) check(ctx context.Context, res *resource.Resource) {
 		return
 	}
 	r.replay(ctx, res, plan)
-	again, _ := r.verify(ctx, res)
+	again, _ := r.verify(ctx, res, extra)
 	if anyBroken(again) {
 		r.publish(res, again, nil)
 		return

--- a/internal/core/machine/verdicts_test.go
+++ b/internal/core/machine/verdicts_test.go
@@ -1,0 +1,341 @@
+package machine
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/netip"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/resource"
+	"github.com/stephrobert/feint/internal/core/store"
+)
+
+// Where a verdict goes (#670): the log, the resource, the counters — and
+// never the state.
+
+// pinnedPlan is the plan of a machine carrying one pinned address on fnt-x.
+var pinnedPlan = Plan{Boot: []Attachment{{Network: "fnt-x", Address: "10.30.1.10", PrefixLen: 24}}}
+
+// publicPlan is pinnedPlan with a promised public address, for the tests
+// that count the replay through the address it routes.
+var publicPlan = Plan{Boot: pinnedPlan.Boot, Publics: []string{"203.0.113.2"}}
+
+// withPublic is pinnedOn with the public /32 beside the pinned address, the
+// way the replay leaves a machine of publicPlan.
+func withPublic(shape Shape) Shape {
+	eth0 := shape.Interfaces["eth0"]
+	eth0.Addresses = append(eth0.Addresses, netip.MustParsePrefix("203.0.113.2/32"))
+	shape.Interfaces["eth0"] = eth0
+	return shape
+}
+
+// TestABrokenVerdictReachesTheResourceAndNotItsState: the state is the one
+// the boot produced, the verdict is the one the reading produced, and neither
+// stands in for the other.
+func TestABrokenVerdictReachesTheResourceAndNotItsState(t *testing.T) {
+	b := newGroupSyncBench()
+	o := &observingRecorder{Recorder: b.rec, shape: pinnedOn("fnt-x", "10.30.1.11/24")}
+	vm := b.machine("m", "")
+	r := observingReconciler(b, o, pinnedPlan)
+
+	if !r.PowerOn(context.Background(), vm, Boot{Image: "ubuntu:24.04"}) {
+		t.Fatalf("the boot did not start; sequence: %v", b.rec.Sequence())
+	}
+	if vm.State != "running" {
+		t.Fatalf("a broken reading moved the state to %q, and the machine IS running", vm.State)
+	}
+	want := "broken: carries(fnt-x, 10.30.1.10/24) want 10.30.1.10/24, got eth0: 10.30.1.11/24"
+	if got := vm.Runtime[VerifiedKey]; got != want {
+		t.Fatalf("Runtime[%s] = %q, want %q", VerifiedKey, got, want)
+	}
+
+	// And the accepting half, on the same runtime with the divergence gone.
+	o.shape = pinnedOn("fnt-x", "10.30.1.10/24")
+	vm.State = "stopped"
+	if !r.PowerOn(context.Background(), vm, Boot{Image: "ubuntu:24.04"}) {
+		t.Fatal("the second boot did not start")
+	}
+	if got := vm.Runtime[VerifiedKey]; got != "held" {
+		t.Fatalf("Runtime[%s] = %q after a boot that carries its plan, want held", VerifiedKey, got)
+	}
+}
+
+// The key lands through Commit and merges per key: a writer to another field
+// of the same resource, landing while the machine boots, keeps its field and
+// the verdict keeps its own (the mergeRuntime property, #295).
+func TestABrokenVerdictSurvivesAConcurrentWriteToAnotherKey(t *testing.T) {
+	st := store.New()
+	now := func() time.Time { return time.Unix(1700000000, 0).UTC() }
+	res := resource.New("m", "machine", resource.Tenant{Provider: "bench"}, "stopped", now())
+	res.Attrs = map[string]any{}
+	st.Put(res)
+
+	b := newGroupSyncBench()
+	o := &observingRecorder{Recorder: b.rec, shape: pinnedOn("fnt-x", "10.30.1.11/24")}
+	r := observingReconciler(b, o, pinnedPlan)
+
+	err := r.binding().Transition(st, now, "machine", "m", func(res *resource.Resource) {
+		// The other writer lands while this one works outside the lock.
+		if err := st.Update("bench", "machine", "m", func(stored *resource.Resource) error {
+			if stored.Runtime == nil {
+				stored.Runtime = map[string]string{}
+			}
+			stored.Runtime["tag"] = "kept"
+			return nil
+		}); err != nil {
+			t.Fatalf("the concurrent write failed: %v", err)
+		}
+		r.PowerOn(context.Background(), res, Boot{Image: "ubuntu:24.04"})
+	})
+	if err != nil {
+		t.Fatalf("transition: %v", err)
+	}
+	stored, found := st.Get("bench", "machine", "m")
+	if !found {
+		t.Fatal("the resource is gone")
+	}
+	if stored.Runtime["tag"] != "kept" {
+		t.Errorf("the concurrent writer's key was lost: %v", stored.Runtime)
+	}
+	if !strings.HasPrefix(stored.Runtime[VerifiedKey], "broken: carries(fnt-x, 10.30.1.10/24)") {
+		t.Errorf("the verdict did not reach the store: %v", stored.Runtime)
+	}
+	if stored.State != "running" {
+		t.Errorf("stored state %q, want running", stored.State)
+	}
+}
+
+// ERROR for a broken claim, WARN for an unreadable one: a failure and a
+// degradation, in the two words the repository holds for the two levels.
+func TestABrokenVerdictIsLoggedAsAFailure(t *testing.T) {
+	var log bytes.Buffer
+	b := newGroupSyncBench()
+	o := &observingRecorder{Recorder: b.rec, shape: pinnedOn("fnt-x", "10.30.1.11/24")}
+	vm := b.machine("m", "")
+	r := observingReconciler(b, o, pinnedPlan)
+	r.Groups.Binding.Log = slog.New(slog.NewTextHandler(&log, nil))
+
+	r.PowerOn(context.Background(), vm, Boot{Image: "ubuntu:24.04"})
+	lines := log.String()
+	if !strings.Contains(lines, "level=ERROR") ||
+		!strings.Contains(lines, "claim=\"carries(fnt-x, 10.30.1.10/24)\"") ||
+		!strings.Contains(lines, "got=\"eth0: 10.30.1.11/24\"") {
+		t.Fatalf("a broken claim was not logged as a failure naming the claim and both values:\n%s", lines)
+	}
+
+	log.Reset()
+	o.shape = Shape{}
+	o.err = errUnreadable
+	vm.State = "stopped"
+	r.PowerOn(context.Background(), vm, Boot{Image: "ubuntu:24.04"})
+	lines = log.String()
+	if strings.Contains(lines, "level=ERROR") || !strings.Contains(lines, "level=WARN") ||
+		!strings.Contains(lines, "why=\"the agent isn't currently running\"") {
+		t.Fatalf("an unreadable reading was not logged as a degradation:\n%s", lines)
+	}
+	if got := vm.Runtime[VerifiedKey]; !strings.HasPrefix(got, "unreadable: carries(fnt-x, 10.30.1.10/24): ") {
+		t.Errorf("Runtime[%s] = %q", VerifiedKey, got)
+	}
+}
+
+// The four counters follow the verdicts, on the handle the runtime was bound
+// through, so /_feint/health reads what every pack of one emulator counted.
+func TestTheCountersFollowTheVerdicts(t *testing.T) {
+	b := newGroupSyncBench()
+	o := &observingRecorder{Recorder: b.rec, shape: pinnedOn("fnt-x", "10.30.1.10/24")}
+	rt := Use(o)
+	vm := b.machine("m", "")
+	r := observingReconciler(b, o, pinnedPlan)
+	r.Groups.Binding = r.Groups.Binding.WithRuntime(rt)
+
+	if got := rt.Verification(); got != (Verification{}) {
+		t.Fatalf("a fresh runtime counts %+v", got)
+	}
+	r.PowerOn(context.Background(), vm, Boot{Image: "ubuntu:24.04"})
+	if got := rt.Verification(); got != (Verification{Held: 1}) {
+		t.Fatalf("after a held boot: %+v", got)
+	}
+	// Broken, and unrepaired: the machine stays wrong on the second reading.
+	o.shape = pinnedOn("fnt-x", "10.30.1.11/24")
+	vm.State = "stopped"
+	r.PowerOn(context.Background(), vm, Boot{Image: "ubuntu:24.04"})
+	if got := rt.Verification(); got != (Verification{Held: 1, Broken: 1}) {
+		t.Fatalf("after a broken boot: %+v", got)
+	}
+	o.err = errUnreadable
+	vm.State = "stopped"
+	r.PowerOn(context.Background(), vm, Boot{Image: "ubuntu:24.04"})
+	if got := rt.Verification(); got != (Verification{Held: 1, Broken: 1, Unreadable: 1}) {
+		t.Fatalf("after an unreadable boot: %+v", got)
+	}
+	// The zero Runtime, which every test without Use builds, counts nowhere
+	// and answers zero rather than panicking.
+	if got := (Runtime{}).Verification(); got != (Verification{}) {
+		t.Errorf("the zero runtime counts %+v", got)
+	}
+}
+
+// TestARepairIsAttemptedOnceAndCounted: a broken first reading replays the
+// post-boot order once and reads again; a machine that then carries its plan
+// is published held and counted repaired; one that does not is published
+// broken after exactly two readings, never three.
+func TestARepairIsAttemptedOnceAndCounted(t *testing.T) {
+	broken, held := withPublic(pinnedOn("fnt-x", "10.30.1.11/24")), withPublic(pinnedOn("fnt-x", "10.30.1.10/24"))
+
+	b := newGroupSyncBench()
+	o := &observingRecorder{Recorder: b.rec, queue: []Shape{broken, held}}
+	rt := Use(o)
+	vm := b.machine("m", "")
+	r := observingReconciler(b, o, publicPlan)
+	r.Groups.Binding = r.Groups.Binding.WithRuntime(rt)
+
+	var log bytes.Buffer
+	r.Groups.Binding.Log = slog.New(slog.NewTextHandler(&log, nil))
+	r.PowerOn(context.Background(), vm, Boot{Image: "ubuntu:24.04"})
+	if o.reads != 2 {
+		t.Fatalf("a broken reading was followed by %d reading(s), want exactly one more", o.reads-1)
+	}
+	if got := vm.Runtime[VerifiedKey]; got != "held" {
+		t.Fatalf("Runtime[%s] = %q after a repair, want held", VerifiedKey, got)
+	}
+	if got := rt.Verification(); got != (Verification{Held: 2, Repaired: 1}) {
+		t.Fatalf("after a repaired boot: %+v", got)
+	}
+	// The replay ran twice: the promised address was routed once by the boot
+	// and once by the repair, on one start.
+	routes, starts := 0, 0
+	for _, kind := range b.rec.Sequence() {
+		switch kind {
+		case "RouteAddress":
+			routes++
+		case "Start":
+			starts++
+		}
+	}
+	if routes != 2 || starts != 1 {
+		t.Errorf("the repair replayed %d route(s) on %d start(s), want 2 on 1: %v", routes, starts, b.rec.Sequence())
+	}
+	if !strings.Contains(log.String(), "level=WARN") || !strings.Contains(log.String(), "second time") {
+		t.Errorf("a repair was not logged as a degradation naming the first reading:\n%s", log.String())
+	}
+
+	// A machine that stays wrong: two readings and no more, however many
+	// broken shapes are queued behind them.
+	b = newGroupSyncBench()
+	o = &observingRecorder{Recorder: b.rec, queue: []Shape{broken, broken, held}}
+	rt = Use(o)
+	vm = b.machine("m", "")
+	r = observingReconciler(b, o, publicPlan)
+	r.Groups.Binding = r.Groups.Binding.WithRuntime(rt)
+	r.PowerOn(context.Background(), vm, Boot{Image: "ubuntu:24.04"})
+	if o.reads != 2 {
+		t.Fatalf("a machine that stays wrong was read %d times, want exactly two", o.reads)
+	}
+	if got := vm.Runtime[VerifiedKey]; !strings.HasPrefix(got, "broken: ") {
+		t.Fatalf("Runtime[%s] = %q after a failed repair", VerifiedKey, got)
+	}
+	if got := rt.Verification(); got != (Verification{Held: 1, Broken: 1}) {
+		t.Fatalf("after a failed repair: %+v", got)
+	}
+}
+
+// An unreadable reading is not retried: replaying onto a machine whose agent
+// has not answered would not make it readable, and the late-address door
+// reads it again when it can.
+func TestAnUnreadableReadingIsNotReplayedOnto(t *testing.T) {
+	b := newGroupSyncBench()
+	o := &observingRecorder{Recorder: b.rec, err: errUnreadable}
+	vm := b.machine("m", "")
+	r := observingReconciler(b, o, publicPlan)
+	r.PowerOn(context.Background(), vm, Boot{Image: "ubuntu:24.04"})
+	if o.reads != 1 {
+		t.Fatalf("an unreadable reading was followed by %d more", o.reads-1)
+	}
+	routes := 0
+	for _, kind := range b.rec.Sequence() {
+		if kind == "RouteAddress" {
+			routes++
+		}
+	}
+	if routes != 1 {
+		t.Errorf("the replay ran %d times onto an unreadable machine, want once", routes)
+	}
+}
+
+// TestTheLateAddressDoorVerifiesOnceItCanRead: the late-address door sits on
+// a read path, so it reads only while nothing readable has been published —
+// the virtual machine whose boot was unreadable — and never again after a
+// reading held or broke.
+func TestTheLateAddressDoorVerifiesOnceItCanRead(t *testing.T) {
+	b := newGroupSyncBench()
+	o := &observingRecorder{Recorder: b.rec, err: errUnreadable}
+	vm := b.machine("m", "")
+	r := observingReconciler(b, o, publicPlan)
+	r.PowerOn(context.Background(), vm, Boot{Image: "ubuntu:24.04"})
+	if o.reads != 1 || !strings.HasPrefix(vm.Runtime[VerifiedKey], "unreadable") {
+		t.Fatalf("the boot: reads=%d verified=%q", o.reads, vm.Runtime[VerifiedKey])
+	}
+
+	// The agent answers: the door reads, and the verdict replaces the
+	// unreadable one.
+	o.err = nil
+	o.shape = withPublic(pinnedOn("fnt-x", "10.30.1.10/24"))
+	r.ReplayAddresses(context.Background(), vm)
+	if o.reads != 2 || vm.Runtime[VerifiedKey] != "held" {
+		t.Fatalf("the late door: reads=%d verified=%q", o.reads, vm.Runtime[VerifiedKey])
+	}
+
+	// And not again: a GET is not a reason to exec into a machine.
+	r.ReplayAddresses(context.Background(), vm)
+	r.ReplayAddresses(context.Background(), vm)
+	if o.reads != 2 {
+		t.Fatalf("the late door read %d times in all, want 2: a verified machine is read again on every GET", o.reads)
+	}
+}
+
+// The hot doors — an address routed, a network joined — change what the
+// machine carries, and each is read back.
+func TestAHotJoinAndAHotRouteAreReadBack(t *testing.T) {
+	b := newGroupSyncBench()
+	o := &observingRecorder{Recorder: b.rec, shape: pinnedOn("fnt-x", "10.30.1.10/24")}
+	vm := b.machine("m", "")
+	r := observingReconciler(b, o, pinnedPlan)
+	r.PowerOn(context.Background(), vm, Boot{Image: "ubuntu:24.04"})
+	if o.reads != 1 {
+		t.Fatalf("the boot read %d times", o.reads)
+	}
+	_ = r.Join(context.Background(), vm, Attachment{Network: "fnt-y"})
+	if o.reads != 2 {
+		t.Fatalf("a hot join was not read back: reads=%d", o.reads)
+	}
+	r.Route(context.Background(), vm, "203.0.113.2")
+	if o.reads != 3 {
+		t.Fatalf("a hot route was not read back: reads=%d", o.reads)
+	}
+}
+
+// The summary a reader branches on: broken first, then unreadable, then held.
+func TestTheSummaryLeadsWithWhatIsBroken(t *testing.T) {
+	c := carries{Network: "fnt-x", Address: netip.MustParseAddr("10.30.1.10"), Bits: 24}
+	d := defaultRoute{Network: "fnt-x"}
+	if got := summary([]Verdict{held(c), broken(d, "via 10.30.1.1 dev eth0", "no default route"), unreadable(c, "x")}); got !=
+		"broken: default route want via 10.30.1.1 dev eth0, got no default route" {
+		t.Errorf("summary %q", got)
+	}
+	if got := summary([]Verdict{held(c), unreadable(d, "the gateway of fnt-x was not read")}); got !=
+		"unreadable: default route: the gateway of fnt-x was not read" {
+		t.Errorf("summary %q", got)
+	}
+	if got := summary([]Verdict{held(c), held(d)}); got != "held" {
+		t.Errorf("summary %q", got)
+	}
+}
+
+var errUnreadable = errorString("the agent isn't currently running")
+
+type errorString string
+
+func (e errorString) Error() string { return string(e) }

--- a/tools/conformance/functional.sh
+++ b/tools/conformance/functional.sh
@@ -216,6 +216,7 @@ fnl_listen_reader_control
 fnl_name_reader_control
 fnl_delivery_reader_control
 fnl_rule_set_reader_control
+fnl_shape_reader_control
 
 # ---- live transports --------------------------------------------------------
 #
@@ -322,6 +323,22 @@ station_fetch_within() { # seconds address port
 # target, which this gate only uses as the console that originates a probe.
 live_machine_pid() { # machine
 	incus query "/1.0/instances/$1/state" 2>/dev/null | jq -r '.pid // empty'
+}
+
+# live_shape writes what a machine carries — its addresses and every route with
+# a next hop, normalised by functionallib's two readers — into a file, non-zero
+# when the machine could not be read at all. Two execs, read from inside the
+# machine because the table IS the machine's: the host's view of a device is
+# what the driver asked for, and the difference between the two is exactly what
+# this gate exists to catch (#671).
+live_shape() { # machine out_file
+	local routes addresses
+	routes="$(incus exec "$1" -- ip -4 route show 2>/dev/null)" || return 1
+	addresses="$(incus exec "$1" -- ip -4 -o addr show 2>/dev/null)" || return 1
+	{
+		printf '%s\n' "$addresses" | fnl_shape_addresses
+		printf '%s\n' "$routes" | fnl_shape_routes
+	} >"$2"
 }
 
 # live_machine_acls answers the rule sets a machine's interfaces carry, comma
@@ -632,6 +649,12 @@ run_stack() { # name
 			fi
 		fi
 
+		# What the machine carries, read from inside it BEFORE anything is
+		# restarted (#671): the addresses and the routed table, normalised.
+		# The after-probe alone names the far end; this names the line.
+		live_shape "$rmachine" "$WORK/shape-before-$rmachine.txt" \
+			|| fail "cannot look: the shape of $restart ($rmachine) could not be read before the restart"
+
 		# ---- the provider's own reboot verb, which used to restart nothing ---
 		echo "- $name: the provider's own reboot verb restarts the machine"
 		local pid_before pid_after
@@ -651,6 +674,13 @@ run_stack() { # name
 			|| fail "$name: $restart came back '$state' ${waited}s after the API was asked to reboot it"
 		pid_after="$(live_machine_pid "$rmachine")"
 		fnl_restart_replaced_the_machine "$name" "$restart" "$rmachine" "$pid_before" "$pid_after"
+		# The machine's own table, back from the reboot verb: the layer compares
+		# it too (#669), and this is the same question asked from the station.
+		echo "- $name: the machine carries after the reboot what it carried before"
+		live_shape "$rmachine" "$WORK/shape-reboot-$rmachine.txt" \
+			|| fail "cannot look: the shape of $restart ($rmachine) could not be read after the reboot"
+		fnl_shape_survives_restart "$name" "$restart" "$rmachine" \
+			"$WORK/shape-before-$rmachine.txt" "$WORK/shape-reboot-$rmachine.txt" "after the reboot verb"
 
 		# ---- and the whole cycle through the other door ----------------------
 		power "$provider" "$id" off || fail "$name: $provider refused the stop of $restart"
@@ -687,6 +717,15 @@ run_stack() { # name
 		# and nowhere else, and the first boot is the one that needed it most.
 		fnl_service_came_up "$name" "$restart" "$unit" "$rmachine" "$port" \
 			"$WORK/listen-$rmachine.txt" "after a restart through the API"
+		# And after the other door, against the same before: a stop and a
+		# start through the API change nothing the machine carried, and the
+		# table says whether they did before the fetch below says what it
+		# cost.
+		echo "- $name: the machine carries after a stop and a start what it carried before"
+		live_shape "$rmachine" "$WORK/shape-after-$rmachine.txt" \
+			|| fail "cannot look: the shape of $restart ($rmachine) could not be read after the stop and the start"
+		fnl_shape_survives_restart "$name" "$restart" "$rmachine" \
+			"$WORK/shape-before-$rmachine.txt" "$WORK/shape-after-$rmachine.txt" "after a stop and a start"
 		address="$(published_address "$provider" "$restart")" \
 			|| fail "cannot look: $provider's API did not answer when asked for $restart's published address"
 		if [ -n "$address" ]; then

--- a/tools/conformance/functional_test.go
+++ b/tools/conformance/functional_test.go
@@ -723,6 +723,7 @@ func TestTheGateRunsItsReaderControlsBeforeAnyVerdict(t *testing.T) {
 		"fnl_name_reader_control",
 		"fnl_delivery_reader_control",
 		"fnl_rule_set_reader_control",
+		"fnl_shape_reader_control",
 	} {
 		called := false
 		for _, line := range strings.Split(gate, "\n") {
@@ -1015,4 +1016,124 @@ DIR="$1"
 		code = exit.ExitCode()
 	}
 	return code, string(out)
+}
+
+// ---- the machine's own table across a restart (#671) -----------------------
+//
+// The runtime suite asked one question of a restarted machine — does the
+// service answer at its published address — and when the answer was no it
+// named the far end, sixty seconds later. The service was alive, the address
+// was published, and the route was wrong (#660). These hold the readers that
+// look at the table, the comparison that names the line, and the control that
+// makes the comparison worth anything.
+
+const routeTable = `default via 10.77.0.1 dev eth0 proto dhcp src 10.77.0.2 metric 100
+10.77.0.0/24 dev eth0 proto kernel scope link src 10.77.0.2 metric 100
+10.77.0.1 dev eth0 proto dhcp scope link src 10.77.0.2 metric 100
+169.254.0.0/16 dev eth0 scope link metric 1000
+169.254.169.254 via 10.77.0.1 dev eth0 proto static
+10.0.0.0/8 via 10.77.0.1 dev eth0 proto dhcp src 10.77.0.2 metric 100
+203.0.113.9 via 10.0.0.1 dev eth1
+unreachable 198.51.100.0/24 dev lo
+`
+
+const addressList = `1: lo    inet 127.0.0.1/8 scope host lo\       valid_lft forever preferred_lft forever
+2: eth0    inet 10.77.0.2/24 brd 10.77.0.255 scope global eth0\       valid_lft forever preferred_lft forever
+2: eth0    inet 203.0.113.2/32 scope global eth0\       valid_lft forever preferred_lft forever
+2: eth0    inet 10.99.0.1/24 scope link eth0\       valid_lft forever preferred_lft forever
+9: eth9    inet 10.76.154.20/24 brd 10.76.154.255 scope global dynamic eth9\       valid_lft 3000sec preferred_lft 3000sec
+`
+
+// TestTheShapeReadersNormaliseWhatDoesNotCompare: connected routes, the
+// link-local block, an unreachable entry, metrics and proto leave the table;
+// the loopback and a scope-link address leave the list; default is spelled
+// as a block and a bare host gets its mask.
+func TestTheShapeReadersNormaliseWhatDoesNotCompare(t *testing.T) {
+	code, out := runFunctional(t, map[string]string{"routes": routeTable, "addrs": addressList},
+		`fnl_shape_routes <"$DIR/routes"; echo ---; fnl_shape_addresses <"$DIR/addrs"`)
+	want := "route 0.0.0.0/0 via 10.77.0.1 dev eth0\nroute 10.0.0.0/8 via 10.77.0.1 dev eth0\nroute 203.0.113.9/32 via 10.0.0.1 dev eth1\n---\naddr eth0 10.77.0.2/24\naddr eth0 203.0.113.2/32\naddr eth9 10.76.154.20/24\n"
+	if code != 0 || out != want {
+		t.Fatalf("exit %d, normalised:\n%s\nwant:\n%s", code, out, want)
+	}
+}
+
+// TestAShapeThatChangedAcrossARestartFailsNamingTheLine is the regression as
+// this gate sees it now: one line apart, both lines printed.
+func TestAShapeThatChangedAcrossARestartFailsNamingTheLine(t *testing.T) {
+	code, out := runFunctional(t, map[string]string{
+		"before": "addr eth0 203.0.113.2/32\nroute 0.0.0.0/0 via 169.254.0.1 dev eth0\n",
+		"after":  "addr eth0 203.0.113.2/32\nroute 0.0.0.0/0 via 10.77.0.1 dev eth0\n",
+	}, `fnl_shape_survives_restart scaleway platform-web-0 m-web-0 "$DIR/before" "$DIR/after" "after the reboot verb"`)
+	if code == 0 {
+		t.Fatalf("a changed shape passed:\n%s", out)
+	}
+	for _, line := range []string{
+		"FAIL: scaleway: platform-web-0 (m-web-0) does not carry after the reboot verb what it carried before the restart",
+		"before: route 0.0.0.0/0 via 169.254.0.1 dev eth0",
+		"after:  route 0.0.0.0/0 via 10.77.0.1 dev eth0",
+	} {
+		if !strings.Contains(out, line) {
+			t.Errorf("the verdict does not carry %q:\n%s", line, out)
+		}
+	}
+	if strings.Contains(out, "203.0.113.2/32") {
+		t.Errorf("a line that did not change is named:\n%s", out)
+	}
+}
+
+func TestAShapeThatSurvivedARestartPasses(t *testing.T) {
+	code, out := runFunctional(t, map[string]string{
+		"before": "addr eth0 203.0.113.2/32\nroute 0.0.0.0/0 via 169.254.0.1 dev eth0\n",
+		"after":  "addr eth0 203.0.113.2/32\nroute 0.0.0.0/0 via 169.254.0.1 dev eth0\n",
+	}, `fnl_shape_survives_restart scaleway platform-web-0 m-web-0 "$DIR/before" "$DIR/after" "after the reboot verb"`)
+	if code != 0 || !strings.Contains(out, "ok: scaleway: platform-web-0 carries after the reboot verb exactly what it carried before") {
+		t.Fatalf("an unchanged shape did not pass (exit %d):\n%s", code, out)
+	}
+}
+
+// A capture that failed is a side with nothing on it, and nothing compares
+// equal to something: the verdict is "cannot look", never a pass.
+func TestAShapeThatCouldNotBeReadIsNotAVerdict(t *testing.T) {
+	code, out := runFunctional(t, map[string]string{
+		"before": "addr eth0 203.0.113.2/32\n",
+		"after":  "",
+	}, `fnl_shape_survives_restart scaleway platform-web-0 m-web-0 "$DIR/before" "$DIR/after" "after the reboot verb"`)
+	if code == 0 || !strings.Contains(out, "cannot look") {
+		t.Fatalf("an unreadable after was judged (exit %d):\n%s", code, out)
+	}
+}
+
+// TestTheShapeReaderControlFindsABrokenComparator is the control of the
+// control: with the comparison stubbed to pass everything, the reader control
+// must fail, or the planted difference it claims to plant proves nothing.
+func TestTheShapeReaderControlFindsABrokenComparator(t *testing.T) {
+	code, out := runFunctional(t, nil, `fnl_shape_reader_control`)
+	if code != 0 {
+		t.Fatalf("the shape reader control fails on the real readers (exit %d):\n%s", code, out)
+	}
+	code, out = runFunctional(t, nil, `fnl_shape_survives_restart() { return 0; }
+fnl_shape_reader_control`)
+	if code == 0 || !strings.Contains(out, "passed a planted difference") {
+		t.Fatalf("the control did not notice a comparison that passes everything (exit %d):\n%s", code, out)
+	}
+}
+
+// TestTheRestartCapturesTheShapeBeforeAndAfter holds the gate to the order
+// that makes the comparison a measurement: the before is captured before the
+// reboot verb, and each door is compared against it.
+func TestTheRestartCapturesTheShapeBeforeAndAfter(t *testing.T) {
+	gate := readGate(t)
+	before := strings.Index(gate, `live_shape "$rmachine" "$WORK/shape-before-$rmachine.txt"`)
+	reboot := strings.Index(gate, `power "$provider" "$id" reboot`)
+	afterReboot := strings.Index(gate, `"$WORK/shape-before-$rmachine.txt" "$WORK/shape-reboot-$rmachine.txt"`)
+	stop := strings.Index(gate, `power "$provider" "$id" off`)
+	afterStart := strings.Index(gate, `"$WORK/shape-before-$rmachine.txt" "$WORK/shape-after-$rmachine.txt"`)
+	if before < 0 || reboot < 0 || afterReboot < 0 || stop < 0 || afterStart < 0 {
+		t.Fatalf("the restart does not capture and compare the shape at every door: before=%d reboot=%d afterReboot=%d stop=%d afterStart=%d",
+			before, reboot, afterReboot, stop, afterStart)
+	}
+	if before >= reboot || reboot >= afterReboot || afterReboot >= stop || stop >= afterStart {
+		t.Fatalf("the captures are not in the order that measures a restart: before=%d reboot=%d afterReboot=%d stop=%d afterStart=%d",
+			before, reboot, afterReboot, stop, afterStart)
+	}
 }

--- a/tools/conformance/functionallib.sh
+++ b/tools/conformance/functionallib.sh
@@ -147,6 +147,59 @@ fnl_delivery_addresses() { # record
 	}'
 }
 
+
+# fnl_shape_routes reads `ip -4 route show` on stdin and prints, one per line
+# and sorted, what compares of the guest's table: `route <dst> via <via> dev
+# <dev>`. Everything else on a line — proto, src, metric, onlink — is dropped,
+# and so is every line with no `via`: a connected route is implied by the
+# address that created it, and comparing it would compare the address twice.
+# The link-local block is the kernel's own plumbing and never enters; an
+# unreachable, blackhole or local entry is not a route to anywhere. `default`
+# is spelled 0.0.0.0/0 and a bare host address gets its /32, so iproute2 and
+# busybox read the same.
+#
+# This is the shell spelling of internal/core/machine's parseRoutes (#668), and
+# it is deliberately a second one: this file sees a machine from the station,
+# the driver sees it through the runtime API, and the two fail differently.
+fnl_shape_routes() {
+	awk '
+	$1 == "unreachable" || $1 == "blackhole" || $1 == "prohibit" || $1 == "throw" || $1 == "local" || $1 == "broadcast" || $1 == "multicast" || $1 == "anycast" || $1 == "nat" { next }
+	{
+		dst = $1
+		if (dst == "default") dst = "0.0.0.0/0"
+		else if (dst !~ /\//) dst = dst "/32"
+		if (dst ~ /^169\.254\./) next
+		via = ""; dev = ""
+		for (i = 2; i < NF; i++) {
+			if ($i == "via") via = $(i + 1)
+			if ($i == "dev") dev = $(i + 1)
+		}
+		if (via == "" || dev == "") next
+		print "route " dst " via " via " dev " dev
+	}' | sort
+}
+
+# fnl_shape_addresses reads `ip -4 -o addr show` on stdin and prints, one per
+# line and sorted, `addr <iface> <cidr>` for every global address: the
+# loopback, a link-local address and a scope-link one are not what a plan
+# claims.
+fnl_shape_addresses() {
+	awk '
+	NF < 4 { next }
+	{
+		iface = $2; sub(/:$/, "", iface)
+		if (iface == "lo") next
+		cidr = ""; scope = ""
+		for (i = 3; i < NF; i++) {
+			if ($i == "inet") cidr = $(i + 1)
+			if ($i == "scope") scope = $(i + 1)
+		}
+		if (cidr == "" || scope != "global") next
+		if (cidr ~ /^169\.254\./) next
+		print "addr " iface " " cidr
+	}' | sort
+}
+
 # ---- the controls: each reader finds a planted witness, and only it ---------
 #
 # Run before any verdict. A reader that cannot find its planted witness voids
@@ -198,6 +251,42 @@ fnl_name_reader_control() {
 	[ -z "$out" ] \
 		|| fail "the name reader matched 'platform-app' inside 'platform-app-2' (got '$out'); a neighbouring machine would answer for the one under test"
 	ok "the name reader resolves both naming shapes, and refuses a prefix match"
+}
+
+
+fnl_shape_reader_control() {
+	local out before after
+	out="$(printf '%s\n' \
+		'default via 10.77.0.1 dev eth0 proto dhcp src 10.77.0.2 metric 100 ' \
+		'10.77.0.0/24 dev eth0 proto kernel scope link src 10.77.0.2 ' \
+		'169.254.169.254 via 10.77.0.1 dev eth0 ' \
+		'10.0.0.0/8 via 10.77.0.1 dev eth0 proto dhcp metric 100 ' \
+		'203.0.113.9 via 10.0.0.1 dev eth1' \
+		'unreachable 198.51.100.0/24 dev lo' \
+		| fnl_shape_routes | tr '\n' '|')"
+	[ "$out" = "route 0.0.0.0/0 via 10.77.0.1 dev eth0|route 10.0.0.0/8 via 10.77.0.1 dev eth0|route 203.0.113.9/32 via 10.0.0.1 dev eth1|" ] \
+		|| fail "the route reader cannot normalise a table (got '$out'); every 'the shape survived' it reported would compare noise, and every 'it changed' would name a metric"
+	out="$(printf '%s\n' \
+		'1: lo    inet 127.0.0.1/8 scope host lo\       valid_lft forever preferred_lft forever' \
+		'2: eth0    inet 10.77.0.2/24 brd 10.77.0.255 scope global eth0\       valid_lft forever preferred_lft forever' \
+		'2: eth0    inet 203.0.113.2/32 scope global eth0\       valid_lft forever preferred_lft forever' \
+		'2: eth0    inet 10.99.0.1/24 scope link eth0\       valid_lft forever preferred_lft forever' \
+		| fnl_shape_addresses | tr '\n' '|')"
+	[ "$out" = "addr eth0 10.77.0.2/24|addr eth0 203.0.113.2/32|" ] \
+		|| fail "the address reader cannot normalise an address list (got '$out'); a scope-link address or the loopback would read as a change across a restart"
+	# And the comparison finds a planted difference: the regression of
+	# 2026-09-04, one line apart. A comparison that had never found anything
+	# is indistinguishable from one that looks nowhere.
+	before="$(mktemp)"
+	after="$(mktemp)"
+	printf '%s\n' 'addr eth0 203.0.113.2/32' 'route 0.0.0.0/0 via 169.254.0.1 dev eth0' >"$before"
+	printf '%s\n' 'addr eth0 203.0.113.2/32' 'route 0.0.0.0/0 via 10.77.0.1 dev eth0' >"$after"
+	if (fnl_shape_survives_restart control planted m "$before" "$after" "after a planted restart") >/dev/null 2>&1; then
+		rm -f "$before" "$after"
+		fail "the shape comparison passed a planted difference; every 'the shape survived' it reports would be an instrument that looks nowhere"
+	fi
+	rm -f "$before" "$after"
+	ok "the shape readers normalise both tables, and the comparison finds a planted difference"
 }
 
 # ---- the verdicts -----------------------------------------------------------
@@ -525,6 +614,37 @@ fnl_restart_replaced_the_machine() { # stack name machine before after
 	[ "$before" != "$after" ] \
 		|| fail "$stack: $name ($machine) came out of a reboot through the provider's own API on the same runtime process ($after) — the action was accepted and the machine never restarted (#547)"
 	ok "$stack: $name really restarts on the provider's own reboot verb (process $before then $after)"
+}
+
+
+# fnl_shape_survives_restart: a machine restarted through the provider's API
+# carries afterwards exactly what it carried before — its addresses, and every
+# route with a next hop — read from inside the machine and normalised by the
+# two readers above (#671).
+#
+# The runtime suite used to ask one question of a restarted machine, does the
+# service answer at its published address, and when the answer was no it said
+# so sixty seconds later and named the far end. On 2026-09-04 the service was
+# alive, the address was published, and the route was wrong: the reply left
+# through the private gateway where it had left through the routed next hop
+# (#660). The suite could not say that, because it never looked at the
+# machine's own table. This does, and names the line.
+#
+# Both files are the caller's captures, so a transport failure is its own
+# verdict — "cannot look" — and never an empty side that compares equal to
+# something. The lines that changed are printed as they read, before and
+# after, which is what an operator needs to see the cause where the effect is.
+fnl_shape_survives_restart() { # stack name machine before_file after_file moment
+	local stack="$1" name="$2" machine="$3" before="$4" after="$5" moment="$6" changed
+	[ -s "$before" ] \
+		|| fail "cannot look: the shape of $name ($machine) could not be read before the restart, and a comparison with nothing on one side is not a comparison"
+	[ -s "$after" ] \
+		|| fail "cannot look: the shape of $name ($machine) could not be read $moment, and a comparison with nothing on one side is not a comparison"
+	changed="$(diff "$before" "$after" | sed -n 's/^< /  before: /p; s/^> /  after:  /p')"
+	[ -z "$changed" ] \
+		|| fail "$stack: $name ($machine) does not carry $moment what it carried before the restart; the machine's own table changed, and this is the cause where the effect is (#671, #660):
+$changed"
+	ok "$stack: $name carries $moment exactly what it carried before the restart"
 }
 
 # fnl_restart_keeps_reaching: a machine restarted through the provider's API

--- a/tools/conformance/guard.sh
+++ b/tools/conformance/guard.sh
@@ -334,6 +334,89 @@ EOF
   fi
 }
 
+# guard_verification refuses a pass whose emulator read back, on any machine,
+# something other than what that machine's plan claimed (#670).
+#
+# The runtime leg watched a machine come back from a restart and asked one
+# question — does the service answer at its published address — and when the
+# answer was no it named the far end, sixty seconds later. Since #668 the
+# emulator itself reads every machine back after every lifecycle action and
+# publishes what it found: four counters on /_feint/health, and the claim under
+# each resource's Runtime on /_feint/state. This is the gate that reads them,
+# asked before the emulator stops, because both payloads die with it.
+#
+# Two refusals, and they are not the same finding:
+#
+#   broken > 0        a machine does not carry what its plan claims; the claim
+#                     is named, with what was wanted and what was found
+#   unreadable > held more claims could not be read than were read: a pass
+#                     that measured its own blindness, which is a different
+#                     fact from success and must not read like it
+#
+# A pass with no machine runtime is not judged: nothing booted, so nothing was
+# read, and a gate that failed the client legs for it would teach `--no-verify`.
+# It says so instead of returning in silence.
+guard_verification() { # endpoint
+  local endpoint="${1:-}" health state
+  health="$(curl -sf "$endpoint/_feint/health" || true)"
+  if [ -z "$health" ]; then
+    echo "FAIL: $endpoint answered no health payload, so nothing here knows what its machines carried" >&2
+    exit 1
+  fi
+  state="$(curl -sf "$endpoint/_feint/state" || true)"
+  guard_verification_from "$health" "$state"
+}
+
+# guard_verification_from is the verdict itself, on payloads the caller
+# captured: a test plants a broken counter and a resource carrying the claim,
+# and requires the refusal — without which a gate that has never seen anything
+# is indistinguishable from a gate that looks nowhere.
+#
+# TestTheVerificationGateRefusesABrokenClaim and
+# TestTheVerificationGateRefusesAPassThatCouldNotRead fail without the two
+# refusals, and TestTheVerificationGateNamesTheClaim holds that the claim is
+# printed rather than the counter alone.
+guard_verification_from() { # health_json state_json
+  local health="$1" state="$2" machines held broken unreadable repaired claims
+  machines="$(printf '%s' "$health" | jq -r '.machines // "none"')"
+  case "$machines" in
+    ''|none|null)
+      echo "  verification: not judged, this emulator runs no machine runtime" >&2
+      return 0 ;;
+  esac
+  # The reader proves it can find before it judges: a payload with no
+  # counters is an emulator that never asked the question, and reading its
+  # absence as zero would pass every build that predates the gate.
+  held="$(printf '%s' "$health" | jq -r '.verification.held // "MISSING"')"
+  broken="$(printf '%s' "$health" | jq -r '.verification.broken // "MISSING"')"
+  unreadable="$(printf '%s' "$health" | jq -r '.verification.unreadable // "MISSING"')"
+  repaired="$(printf '%s' "$health" | jq -r '.verification.repaired // "MISSING"')"
+  for value in "$held" "$broken" "$unreadable" "$repaired"; do
+    case "$value" in
+      ''|*[!0-9]*)
+        echo "FAIL: the health payload carries no verification counters (held=$held broken=$broken unreadable=$unreadable repaired=$repaired): this emulator never read its machines back, and a gate that read that as zero would pass it" >&2
+        exit 1 ;;
+    esac
+  done
+  if [ "$broken" -gt 0 ]; then
+    claims="$(printf '%s' "$state" | jq -r '
+      [ .resources[]?
+        | select(.Runtime != null and (.Runtime.verified // "" | startswith("broken")))
+        | "  \(.Kind) \(.ID): \(.Runtime.verified)" ] | .[]' 2>/dev/null)"
+    [ -n "$claims" ] || claims="  (the resources carrying the claim are gone from the state, or the state could not be read)"
+    cat >&2 <<EOF
+FAIL: $broken claim(s) broken: a machine does not carry what its plan claims, and the emulator said so at the moment it happened (#670).
+$claims
+EOF
+    exit 1
+  fi
+  if [ "$unreadable" -gt "$held" ]; then
+    echo "FAIL: $unreadable claim(s) could not be read against $held held: this pass measured its own blindness, which is a different fact from success and must not read like it (#670)" >&2
+    exit 1
+  fi
+  echo "  verification: held=$held broken=$broken unreadable=$unreadable repaired=$repaired"
+}
+
 # Sourced by the suites above, and runnable for the one caller that has no suite
 # to source it into: `mise run conformance` asks this before `feint start`, so a
 # leg refuses at second zero instead of after every client suite has run.
@@ -344,9 +427,13 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     # is gone, so a leg that leaks fails the leg that leaked instead of the one
     # after it — and says so in those words.
     leftovers-after) guard_leftovers_for "${2:-off}" closing ;;
+    # What the emulator read back against every plan, asked while it still
+    # answers: the counters and the claims die with the process (#670).
+    verification) guard_verification "${2:-}" ;;
     *)
       echo "usage: tools/conformance/guard.sh leftovers <machine runtime>        (before a run starts)" >&2
       echo "       tools/conformance/guard.sh leftovers-after <machine runtime>  (after its emulator stopped)" >&2
+      echo "       tools/conformance/guard.sh verification <endpoint>            (before its emulator stops)" >&2
       echo "  (the other guards take an endpoint and are sourced, not run)" >&2
       exit 2 ;;
   esac

--- a/tools/conformance/leg.sh
+++ b/tools/conformance/leg.sh
@@ -167,6 +167,13 @@ else
   FEINT_FIELD_GATE=0 tools/conformance/score.sh "$endpoint"
 fi
 
+# What the emulator read back against every machine's plan, asked before it
+# stops because the counters and the claims die with it (#670). A leg with no
+# runtime is told so and not judged; the runtime leg fails here on a broken
+# claim, named, at the moment the emulator found it rather than sixty seconds
+# later at the far end of a fetch.
+tools/conformance/guard.sh verification "$endpoint"
+
 # The other half of the doorstep: asked again once the emulator is gone, so the
 # leg that left a machine or a network behind is the leg that fails. The trap
 # above stays the safety net for a leg that dies mid-flight.

--- a/tools/conformance/verification_gate_test.go
+++ b/tools/conformance/verification_gate_test.go
@@ -1,0 +1,88 @@
+package conformance
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The verification gate (#670), driven on planted payloads the way the
+// functional library is: a gate that has never seen anything is
+// indistinguishable from a gate that looks nowhere, so each refusal is
+// planted before it is trusted.
+
+func runVerificationGate(t *testing.T, script string) (int, string) {
+	t.Helper()
+	requireTool(t, "bash")
+	requireTool(t, "jq")
+	lib, err := filepath.Abs("guard.sh")
+	if err != nil {
+		t.Fatalf("locate guard.sh: %v", err)
+	}
+	return runShell(t, t.TempDir(), lib, script)
+}
+
+const healthyHealth = `{"machines":"incus-ovn","verification":{"held":12,"broken":0,"unreadable":1,"repaired":0}}`
+
+const oneBrokenHealth = `{"machines":"incus-ovn","verification":{"held":12,"broken":1,"unreadable":0,"repaired":0}}`
+
+// The planted state: one resource whose Runtime carries the claim, beside one
+// that held, so the gate has to pick the right one.
+const brokenState = `{"format":"feint-snapshot","version":3,"resources":[
+ {"ID":"web-0","Kind":"server","Runtime":{"machine":"feint-scw-web-0","verified":"held"}},
+ {"ID":"web-1","Kind":"server","Runtime":{"machine":"feint-scw-web-1","verified":"broken: door(203.0.113.2) want via 169.254.0.1 dev eth0, got via 10.77.0.1 dev eth0"}}
+]}`
+
+func TestTheVerificationGateRefusesABrokenClaim(t *testing.T) {
+	code, out := runVerificationGate(t, `guard_verification_from '`+oneBrokenHealth+`' '`+brokenState+`'`)
+	if code == 0 {
+		t.Fatalf("a broken claim passed the gate:\n%s", out)
+	}
+	if !strings.Contains(out, "FAIL: 1 claim(s) broken") {
+		t.Errorf("the refusal does not say what it refused:\n%s", out)
+	}
+}
+
+// TestTheVerificationGateNamesTheClaim: the counter says how many, the state
+// says which — and the refusal prints the claim, with what was wanted and
+// what was found, rather than the number alone.
+func TestTheVerificationGateNamesTheClaim(t *testing.T) {
+	_, out := runVerificationGate(t, `guard_verification_from '`+oneBrokenHealth+`' '`+brokenState+`'`)
+	if !strings.Contains(out, "server web-1: broken: door(203.0.113.2) want via 169.254.0.1 dev eth0, got via 10.77.0.1 dev eth0") {
+		t.Fatalf("the refusal does not name the claim:\n%s", out)
+	}
+	if strings.Contains(out, "web-0") {
+		t.Errorf("the refusal names a resource that held:\n%s", out)
+	}
+}
+
+// A pass that could read less than it read is a pass that measured its own
+// blindness, which is a different fact from success.
+func TestTheVerificationGateRefusesAPassThatCouldNotRead(t *testing.T) {
+	code, out := runVerificationGate(t, `guard_verification_from '{"machines":"incus-ovn","verification":{"held":2,"broken":0,"unreadable":9,"repaired":0}}' '{"resources":[]}'`)
+	if code == 0 || !strings.Contains(out, "9 claim(s) could not be read against 2 held") {
+		t.Fatalf("a pass that could not read passed the gate (exit %d):\n%s", code, out)
+	}
+}
+
+// The reader proves it can find before it judges: a payload with no counters
+// is an emulator that never asked, and zero would pass it.
+func TestTheVerificationGateRefusesAPayloadWithNoCounters(t *testing.T) {
+	code, out := runVerificationGate(t, `guard_verification_from '{"machines":"incus-ovn"}' '{"resources":[]}'`)
+	if code == 0 || !strings.Contains(out, "carries no verification counters") {
+		t.Fatalf("an emulator that never read its machines back passed the gate (exit %d):\n%s", code, out)
+	}
+}
+
+// The accepting halves: a healthy pass prints its counters and passes, and a
+// pass with no runtime is told so rather than judged.
+func TestTheVerificationGatePassesAHealthyPassAndSkipsARuntimelessOne(t *testing.T) {
+	code, out := runVerificationGate(t, `guard_verification_from '`+healthyHealth+`' '{"resources":[]}'`)
+	if code != 0 || !strings.Contains(out, "verification: held=12 broken=0 unreadable=1 repaired=0") {
+		t.Fatalf("a healthy pass did not pass (exit %d):\n%s", code, out)
+	}
+	code, out = runVerificationGate(t, `guard_verification_from '{"machines":"none"}' ''`)
+	if code != 0 || !strings.Contains(out, "not judged") {
+		t.Fatalf("a runtime-less pass was judged (exit %d):\n%s", code, out)
+	}
+}

--- a/tools/falsify/specs/a-reboot-compares-before-and-after.json
+++ b/tools/falsify/specs/a-reboot-compares-before-and-after.json
@@ -1,0 +1,47 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "the reboot reads the shape before and claims nothing from it, so the machine is judged on its plan alone (#669)",
+      "file": "internal/core/machine/plan.go",
+      "find": "\t\tcase before != nil:\n\t\t\textra = restartClaims(*before)",
+      "replace": "\t\tcase before != nil && false:\n\t\t\textra = restartClaims(*before)",
+      "test": "TestARebootComparesTheShapeAfterWithTheShapeBefore"
+    },
+    {
+      "label": "the reading drops the claims the caller knew before the action (#669)",
+      "file": "internal/core/machine/readback.go",
+      "find": "\tclaims = append(claims, extra...)\n",
+      "replace": "\tclaims = append(claims, extra[:0]...)\n",
+      "test": "TestARebootComparesTheShapeAfterWithTheShapeBefore"
+    },
+    {
+      "label": "the default route after the reboot is compared on its device alone, and the regression's door reads as held (#669)",
+      "file": "internal/core/machine/restart.go",
+      "find": "\tif got.Via == c.Was.Via && got.Dev == c.Was.Dev {\n\t\treturn held(c)\n\t}",
+      "replace": "\tif (got.Via == c.Was.Via || true) && got.Dev == c.Was.Dev {\n\t\treturn held(c)\n\t}",
+      "test": "TestTheRestartClaimsCompareWhatCompares"
+    },
+    {
+      "label": "an interface after the reboot is compared on its network alone, and a lost address reads as held (#669)",
+      "file": "internal/core/machine/restart.go",
+      "find": "\t\tslices.Equal(sortedPrefixes(got.Addresses), sortedPrefixes(c.Was.Addresses)) &&",
+      "replace": "\t\t(slices.Equal(sortedPrefixes(got.Addresses), sortedPrefixes(c.Was.Addresses)) || true) &&",
+      "test": "TestTheRestartClaimsCompareWhatCompares"
+    },
+    {
+      "label": "the rest of the table is not compared, and a lost private route reads as held (#669)",
+      "file": "internal/core/machine/restart.go",
+      "find": "\twant, have := routeLines(c.Was), routeLines(got)\n\tif slices.Equal(want, have) {",
+      "replace": "\twant, have := routeLines(c.Was), routeLines(got)\n\tif slices.Equal(want, have) || true {",
+      "test": "TestTheRestartClaimsCompareWhatCompares"
+    },
+    {
+      "label": "a lost interface reads as held (#669)",
+      "file": "internal/core/machine/restart.go",
+      "find": "\tgot, has := s.Interfaces[c.Name]\n\tif !has {\n\t\treturn broken(c, describeInterface(c.Was), \"no interface \"+c.Name)\n\t}",
+      "replace": "\tgot, has := s.Interfaces[c.Name]\n\tif !has && false {\n\t\treturn broken(c, describeInterface(c.Was), \"no interface \"+c.Name)\n\t}",
+      "test": "TestTheRestartClaimsCompareWhatCompares"
+    }
+  ]
+}

--- a/tools/falsify/specs/a-restart-keeps-its-shape.json
+++ b/tools/falsify/specs/a-restart-keeps-its-shape.json
@@ -1,0 +1,47 @@
+{
+  "package": "./tools/conformance/",
+  "mutations": [
+    {
+      "label": "the shape comparison never fails, and the regression of 2026-09-04 reads as a table that survived (#671)",
+      "file": "tools/conformance/functionallib.sh",
+      "find": "\t[ -z \"$changed\" ] \\\n\t\t|| fail \"$stack: $name ($machine) does not carry $moment what it carried before the restart",
+      "replace": "\t[ -z \"$changed\" ] || true \\\n\t\t|| fail \"$stack: $name ($machine) does not carry $moment what it carried before the restart",
+      "test": "TestAShapeThatChangedAcrossARestartFailsNamingTheLine"
+    },
+    {
+      "label": "the route reader keeps the connected routes, and the comparison compares the address twice (#671)",
+      "file": "tools/conformance/functionallib.sh",
+      "find": "\t\tif (via == \"\" || dev == \"\") next\n\t\tprint \"route \" dst \" via \" via \" dev \" dev",
+      "replace": "\t\tif ((via == \"\" && 0) || dev == \"\") next\n\t\tprint \"route \" dst \" via \" via \" dev \" dev",
+      "test": "TestTheShapeReadersNormaliseWhatDoesNotCompare"
+    },
+    {
+      "label": "the route reader keeps the link-local block, the kernel's own plumbing (#671)",
+      "file": "tools/conformance/functionallib.sh",
+      "find": "\t\tif (dst ~ /^169\\.254\\./) next\n\t\tvia = \"\"; dev = \"\"",
+      "replace": "\t\tif (dst ~ /^169\\.254\\./ && 0) next\n\t\tvia = \"\"; dev = \"\"",
+      "test": "TestTheShapeReadersNormaliseWhatDoesNotCompare"
+    },
+    {
+      "label": "the address reader ignores the scope, and a scope-link address reads as a change across a restart (#671)",
+      "file": "tools/conformance/functionallib.sh",
+      "find": "\t\tif (cidr == \"\" || scope != \"global\") next",
+      "replace": "\t\tif (cidr == \"\" || (scope != \"global\" && 0)) next",
+      "test": "TestTheShapeReadersNormaliseWhatDoesNotCompare"
+    },
+    {
+      "label": "a capture that failed compares as an empty side, and reads as a table that changed or survived rather than as nobody looking (#671)",
+      "file": "tools/conformance/functionallib.sh",
+      "find": "\t[ -s \"$after\" ] \\\n\t\t|| fail \"cannot look: the shape of $name ($machine) could not be read $moment",
+      "replace": "\t[ -s \"$after\" ] || true \\\n\t\t|| fail \"cannot look: the shape of $name ($machine) could not be read $moment",
+      "test": "TestAShapeThatCouldNotBeReadIsNotAVerdict"
+    },
+    {
+      "label": "the reader control stops checking that the comparison finds a planted difference (#671)",
+      "file": "tools/conformance/functionallib.sh",
+      "find": "\tif (fnl_shape_survives_restart control planted m \"$before\" \"$after\" \"after a planted restart\") >/dev/null 2>&1; then",
+      "replace": "\tif (fnl_shape_survives_restart control planted m \"$before\" \"$after\" \"after a planted restart\") >/dev/null 2>&1 && false; then",
+      "test": "TestTheShapeReaderControlFindsABrokenComparator"
+    }
+  ]
+}

--- a/tools/falsify/specs/a-shape-read-back.json
+++ b/tools/falsify/specs/a-shape-read-back.json
@@ -1,0 +1,82 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "the door comparator ignores the next hop, and the regression of 2026-09-04 reads as held (#668)",
+      "file": "internal/core/machine/claims.go",
+      "find": "\tif got.Via == c.Via && got.Dev == c.Dev {\n\t\treturn held(c)\n\t}",
+      "replace": "\tif (got.Via == c.Via || true) && got.Dev == c.Dev {\n\t\treturn held(c)\n\t}",
+      "test": "TestTheReplyDoorOfTheRegressionIsBroken"
+    },
+    {
+      "label": "a read that failed is judged on an empty shape, folding the third outcome onto the second (#668)",
+      "file": "internal/core/machine/readback.go",
+      "find": "\tshape, err := obs.Observe(ctx, name)\n\tif err != nil {\n\t\tfor _, c := range claims {",
+      "replace": "\tshape, err := obs.Observe(ctx, name)\n\tif err != nil && false {\n\t\tfor _, c := range claims {",
+      "test": "TestAnUnreadableShapeIsNeitherHeldNorBroken"
+    },
+    {
+      "label": "the carries comparator accepts any address of the right mask, so a planted divergence reads as held (#668)",
+      "file": "internal/core/machine/claims.go",
+      "find": "\t\t\tif p.Addr() == c.Address && (c.Bits == 0 || p.Bits() == c.Bits) {",
+      "replace": "\t\t\tif (p.Addr() == c.Address || true) && (c.Bits == 0 || p.Bits() == c.Bits) {",
+      "test": "TestAPlantedDivergenceIsReported"
+    },
+    {
+      "label": "the table parser keeps the connected routes, which compare the address twice (#668)",
+      "file": "internal/core/machine/incus_readback.go",
+      "find": "\t\tif !via.IsValid() || dev == \"\" {\n\t\t\tcontinue\n\t\t}",
+      "replace": "\t\tif (!via.IsValid() && false) || dev == \"\" {\n\t\t\tcontinue\n\t\t}",
+      "test": "TestObserveReadsBackWhatTheMachineCarries"
+    },
+    {
+      "label": "the table parser keeps the link-local block, which is the kernel's plumbing (#668)",
+      "file": "internal/core/machine/incus_readback.go",
+      "find": "\t\tif dst != defaultDst && linkLocal.Contains(dst.Addr()) {",
+      "replace": "\t\tif dst != defaultDst && linkLocal.Contains(dst.Addr()) && false {",
+      "test": "TestObserveReadsBackWhatTheMachineCarries"
+    },
+    {
+      "label": "the address parser ignores the scope, and a link-scope address enters the shape (#668)",
+      "file": "internal/core/machine/incus_readback.go",
+      "find": "\t\tif cidr == \"\" || scope != \"global\" {",
+      "replace": "\t\tif cidr == \"\" || (scope != \"global\" && false) {",
+      "test": "TestObserveReadsBackWhatTheMachineCarries"
+    },
+    {
+      "label": "the reading walks the profile devices too, and the operator's bridge enters the shape (#668)",
+      "file": "internal/core/machine/incus_readback.go",
+      "find": "\tfor device, cfg := range devices.own {\n\t\tif cfg[\"type\"] == \"nic\" {",
+      "replace": "\tfor device, cfg := range devices.expanded {\n\t\tif cfg[\"type\"] == \"nic\" {",
+      "test": "TestObserveReadsOnlyTheMachinesOwnNICs"
+    },
+    {
+      "label": "the reading asks an operator's network for its gateway (#668)",
+      "file": "internal/core/machine/incus_readback.go",
+      "find": "\t\tif network == \"\" || !ownedNetwork(network) {\n\t\t\tcontinue\n\t\t}",
+      "replace": "\t\tif network == \"\" || (!ownedNetwork(network) && false) {\n\t\t\tcontinue\n\t\t}",
+      "test": "TestObserveReadsNoForeignNetwork"
+    },
+    {
+      "label": "a machine with no route towards the destination is reported as a failed read rather than as a fact about the machine (#668)",
+      "file": "internal/core/machine/incus_readback.go",
+      "find": "\t\tif strings.Contains(strings.ToLower(err.Error()), \"network is unreachable\") {",
+      "replace": "\t\tif strings.Contains(strings.ToLower(err.Error()), \"network is unreachable\") && false {",
+      "test": "TestADoorWithNoRouteIsBrokenNotUnreadable"
+    },
+    {
+      "label": "the rule sets are claimed on a host that withdrew the firewall capability, broken on every machine for a fact health already publishes (#454, #668)",
+      "file": "internal/core/machine/readback.go",
+      "find": "\tif !CapabilitiesOf(r.binding().driver).Firewall {\n\t\treturn nil\n\t}",
+      "replace": "\tif !CapabilitiesOf(r.binding().driver).Firewall && false {\n\t\treturn nil\n\t}",
+      "test": "TestAWithdrawnFirewallClaimsNoRuleSets"
+    },
+    {
+      "label": "an interface the pack declared outside its groups' reach is claimed wearing them (#574, #668)",
+      "file": "internal/core/machine/readback.go",
+      "find": "\t\tif slices.Contains(unfiltered, att.Network) {\n\t\t\tclaims = append(claims, wears{Network: att.Network})\n\t\t\tcontinue\n\t\t}",
+      "replace": "\t\tif slices.Contains(unfiltered, att.Network) && false {\n\t\t\tclaims = append(claims, wears{Network: att.Network})\n\t\t\tcontinue\n\t\t}",
+      "test": "TestTheRuleSetsAMachineWearsAreClaimedOnItsFilteredInterfaces"
+    }
+  ]
+}

--- a/tools/falsify/specs/a-verdict-somebody-reads.json
+++ b/tools/falsify/specs/a-verdict-somebody-reads.json
@@ -1,0 +1,100 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "the verdict never reaches the resource, so /_feint/state carries no claim to name (#670)",
+      "file": "internal/core/machine/verdicts.go",
+      "find": "\tres.Runtime[VerifiedKey] = summary(verdicts)\n",
+      "replace": "\tres.Runtime[VerifiedKey] = summary(verdicts)[:0]\n",
+      "test": "TestABrokenVerdictReachesTheResourceAndNotItsState"
+    },
+    {
+      "label": "a broken reading moves the state, which is the lie in the other direction (#670)",
+      "file": "internal/core/machine/verdicts.go",
+      "find": "\tres.Runtime[VerifiedKey] = summary(verdicts)\n\tb.tally.count(verdicts, len(repairedFrom) > 0)\n",
+      "replace": "\tres.Runtime[VerifiedKey] = summary(verdicts)\n\tif anyBroken(verdicts) {\n\t\tres.State = b.FailedState\n\t}\n\tb.tally.count(verdicts, len(repairedFrom) > 0)\n",
+      "test": "TestABrokenVerdictReachesTheResourceAndNotItsState"
+    },
+    {
+      "label": "a broken claim is logged as a degradation rather than a failure (#670)",
+      "file": "internal/core/machine/verdicts.go",
+      "find": "\t\t\tb.logger().Error(\"the machine does not carry what its plan claims\",",
+      "replace": "\t\t\tb.logger().Warn(\"the machine does not carry what its plan claims\",",
+      "test": "TestABrokenVerdictIsLoggedAsAFailure"
+    },
+    {
+      "label": "the counters stop following the verdicts, and health publishes zero over a broken fleet (#670)",
+      "file": "internal/core/machine/verdicts.go",
+      "find": "\tb.tally.count(verdicts, len(repairedFrom) > 0)\n",
+      "replace": "\tb.tally.count(verdicts[:0], len(repairedFrom) > 0)\n",
+      "test": "TestTheCountersFollowTheVerdicts"
+    },
+    {
+      "label": "the repair is unbounded: a machine that stays wrong is read a third time (#670)",
+      "file": "internal/core/machine/verdicts.go",
+      "find": "\tagain, _ := r.verify(ctx, res)\n\tif anyBroken(again) {\n\t\tr.publish(res, again, nil)\n\t\treturn\n\t}",
+      "replace": "\tagain, _ := r.verify(ctx, res)\n\tif anyBroken(again) {\n\t\tr.replay(ctx, res, plan)\n\t\tagain, _ = r.verify(ctx, res)\n\t\tr.publish(res, again, nil)\n\t\treturn\n\t}",
+      "test": "TestARepairIsAttemptedOnceAndCounted"
+    },
+    {
+      "label": "a repair is not counted, so one that fires on every boot stays a defect hidden behind a retry (#670)",
+      "file": "internal/core/machine/verdicts.go",
+      "find": "\tif repaired {\n\t\tt.repaired.Add(1)\n\t}",
+      "replace": "\tif repaired && false {\n\t\tt.repaired.Add(1)\n\t}",
+      "test": "TestARepairIsAttemptedOnceAndCounted"
+    },
+    {
+      "label": "an unreadable reading is replayed onto, which cannot make it readable (#670)",
+      "file": "internal/core/machine/verdicts.go",
+      "find": "\tif !anyBroken(verdicts) {\n\t\tr.publish(res, verdicts, nil)\n\t\treturn\n\t}",
+      "replace": "\tif !anyBroken(verdicts) && false {\n\t\tr.publish(res, verdicts, nil)\n\t\treturn\n\t}",
+      "test": "TestAnUnreadableReadingIsNotReplayedOnto"
+    },
+    {
+      "label": "the late-address door reads on every GET, and the emulator's latency becomes the runtime's (#670)",
+      "file": "internal/core/machine/plan.go",
+      "find": "\tif last := res.Runtime[VerifiedKey]; last == \"\" || strings.HasPrefix(last, \"unreadable\") {",
+      "replace": "\tif last := res.Runtime[VerifiedKey]; last == \"\" || strings.HasPrefix(last, \"unreadable\") || true {",
+      "test": "TestTheLateAddressDoorVerifiesOnceItCanRead"
+    },
+    {
+      "label": "a hot join is not read back (#670)",
+      "file": "internal/core/machine/plan.go",
+      "find": "\tr.ReplayAddresses(ctx, res)\n\tr.Groups.AfterBoot(ctx, res)\n\tr.check(ctx, res)\n\treturn err",
+      "replace": "\tr.ReplayAddresses(ctx, res)\n\tr.Groups.AfterBoot(ctx, res)\n\tif err != nil {\n\t\tr.check(ctx, res)\n\t}\n\treturn err",
+      "test": "TestAHotJoinAndAHotRouteAreReadBack"
+    },
+    {
+      "label": "the gate passes a pass with a broken claim, and names nothing (#670)",
+      "package": "./tools/conformance/",
+      "file": "tools/conformance/guard.sh",
+      "find": "  if [ \"$broken\" -gt 0 ]; then",
+      "replace": "  if [ \"$broken\" -gt 0 ] && false; then",
+      "test": "TestTheVerificationGateRefusesABrokenClaim"
+    },
+    {
+      "label": "the gate passes a pass that could not read, reading blindness as success (#670)",
+      "package": "./tools/conformance/",
+      "file": "tools/conformance/guard.sh",
+      "find": "  if [ \"$unreadable\" -gt \"$held\" ]; then",
+      "replace": "  if [ \"$unreadable\" -gt \"$held\" ] && false; then",
+      "test": "TestTheVerificationGateRefusesAPassThatCouldNotRead"
+    },
+    {
+      "label": "the gate stops refusing a payload with no counters, and passes every build that predates it (#670)",
+      "package": "./tools/conformance/",
+      "file": "tools/conformance/guard.sh",
+      "find": "      ''|*[!0-9]*)\n",
+      "replace": "      '\\x00never')\n",
+      "test": "TestTheVerificationGateRefusesAPayloadWithNoCounters"
+    },
+    {
+      "label": "the health payload drops the counters, and the frozen surface says so (#670)",
+      "package": "./internal/core/emulator/",
+      "file": "internal/core/emulator/emulator.go",
+      "find": "\t\t\"verification\": s.env.machines.Verification(),\n",
+      "replace": "\t\t\"verification_\": s.env.machines.Verification(),\n",
+      "test": "TestHealthCarriesTheVerificationCounters"
+    }
+  ]
+}

--- a/tools/falsify/specs/a-verdict-somebody-reads.json
+++ b/tools/falsify/specs/a-verdict-somebody-reads.json
@@ -32,8 +32,8 @@
     {
       "label": "the repair is unbounded: a machine that stays wrong is read a third time (#670)",
       "file": "internal/core/machine/verdicts.go",
-      "find": "\tagain, _ := r.verify(ctx, res)\n\tif anyBroken(again) {\n\t\tr.publish(res, again, nil)\n\t\treturn\n\t}",
-      "replace": "\tagain, _ := r.verify(ctx, res)\n\tif anyBroken(again) {\n\t\tr.replay(ctx, res, plan)\n\t\tagain, _ = r.verify(ctx, res)\n\t\tr.publish(res, again, nil)\n\t\treturn\n\t}",
+      "find": "\tagain, _ := r.verify(ctx, res, extra)\n\tif anyBroken(again) {\n\t\tr.publish(res, again, nil)\n\t\treturn\n\t}",
+      "replace": "\tagain, _ := r.verify(ctx, res, extra)\n\tif anyBroken(again) {\n\t\tr.replay(ctx, res, plan)\n\t\tagain, _ = r.verify(ctx, res, extra)\n\t\tr.publish(res, again, nil)\n\t\treturn\n\t}",
       "test": "TestARepairIsAttemptedOnceAndCounted"
     },
     {
@@ -60,8 +60,8 @@
     {
       "label": "a hot join is not read back (#670)",
       "file": "internal/core/machine/plan.go",
-      "find": "\tr.ReplayAddresses(ctx, res)\n\tr.Groups.AfterBoot(ctx, res)\n\tr.check(ctx, res)\n\treturn err",
-      "replace": "\tr.ReplayAddresses(ctx, res)\n\tr.Groups.AfterBoot(ctx, res)\n\tif err != nil {\n\t\tr.check(ctx, res)\n\t}\n\treturn err",
+      "find": "\tr.ReplayAddresses(ctx, res)\n\tr.Groups.AfterBoot(ctx, res)\n\tr.check(ctx, res, nil)\n\treturn err",
+      "replace": "\tr.ReplayAddresses(ctx, res)\n\tr.Groups.AfterBoot(ctx, res)\n\tif err != nil {\n\t\tr.check(ctx, res, nil)\n\t}\n\treturn err",
       "test": "TestAHotJoinAndAHotRouteAreReadBack"
     },
     {

--- a/tools/falsify/specs/interface-plan.json
+++ b/tools/falsify/specs/interface-plan.json
@@ -11,8 +11,8 @@
     {
       "label": "a hot join resyncs the firewall before the interface it must cover exists (#510)",
       "file": "internal/core/machine/plan.go",
-      "find": "\terr := r.attach(ctx, res, att)\n\tr.ReplayAddresses(ctx, res)\n\tr.Groups.AfterBoot(ctx, res)\n\tr.check(ctx, res)\n\treturn err",
-      "replace": "\tr.Groups.AfterBoot(ctx, res)\n\terr := r.attach(ctx, res, att)\n\tr.ReplayAddresses(ctx, res)\n\tr.check(ctx, res)\n\treturn err",
+      "find": "\terr := r.attach(ctx, res, att)\n\tr.ReplayAddresses(ctx, res)\n\tr.Groups.AfterBoot(ctx, res)\n\tr.check(ctx, res, nil)\n\treturn err",
+      "replace": "\tr.Groups.AfterBoot(ctx, res)\n\terr := r.attach(ctx, res, att)\n\tr.ReplayAddresses(ctx, res)\n\tr.check(ctx, res, nil)\n\treturn err",
       "test": "TestJoinRunsTheFirewallAfterTheAttach"
     },
     {

--- a/tools/falsify/specs/interface-plan.json
+++ b/tools/falsify/specs/interface-plan.json
@@ -11,8 +11,8 @@
     {
       "label": "a hot join resyncs the firewall before the interface it must cover exists (#510)",
       "file": "internal/core/machine/plan.go",
-      "find": "\terr := r.attach(ctx, res, att)\n\tr.ReplayAddresses(ctx, res)\n\tr.Groups.AfterBoot(ctx, res)\n\treturn err",
-      "replace": "\tr.Groups.AfterBoot(ctx, res)\n\terr := r.attach(ctx, res, att)\n\tr.ReplayAddresses(ctx, res)\n\treturn err",
+      "find": "\terr := r.attach(ctx, res, att)\n\tr.ReplayAddresses(ctx, res)\n\tr.Groups.AfterBoot(ctx, res)\n\tr.check(ctx, res)\n\treturn err",
+      "replace": "\tr.Groups.AfterBoot(ctx, res)\n\terr := r.attach(ctx, res, att)\n\tr.ReplayAddresses(ctx, res)\n\tr.check(ctx, res)\n\treturn err",
       "test": "TestJoinRunsTheFirewallAfterTheAttach"
     },
     {

--- a/tools/falsify/specs/lifecycle-tells-the-truth.json
+++ b/tools/falsify/specs/lifecycle-tells-the-truth.json
@@ -13,15 +13,15 @@
     {
       "label": "#547: a reboot stops taking the machine down, so the action answers success and the runtime — which refuses to relaunch a name it has already served — does nothing at all",
       "file": "internal/core/machine/plan.go",
-      "find": "\tif res.State == r.binding().RunningState {\n\t\tr.binding().PowerOff(ctx, res)\n\t}",
-      "replace": "\tif res.State == r.binding().RunningState && false {\n\t\tr.binding().PowerOff(ctx, res)\n\t}",
+      "find": "\tif res.State == r.binding().RunningState {\n\t\t// The shape before, read while the machine is up (#669)",
+      "replace": "\tif res.State == r.binding().RunningState && false {\n\t\t// The shape before, read while the machine is up (#669)",
       "test": "TestARebootStopsTheMachineBeforeStartingIt"
     },
     {
       "label": "#547, the accepting half: a reboot stops asking whether the machine was up, so a stopped one is stopped again and the runtime is told to stop what it already stopped",
       "file": "internal/core/machine/plan.go",
-      "find": "\tif res.State == r.binding().RunningState {\n\t\tr.binding().PowerOff(ctx, res)\n\t}",
-      "replace": "\tif res.State == r.binding().RunningState || true {\n\t\tr.binding().PowerOff(ctx, res)\n\t}",
+      "find": "\tif res.State == r.binding().RunningState {\n\t\t// The shape before, read while the machine is up (#669)",
+      "replace": "\tif res.State == r.binding().RunningState || true {\n\t\t// The shape before, read while the machine is up (#669)",
       "test": "TestARebootOfAStoppedMachineDoesNotStopItAgain"
     },
     {

--- a/tools/falsify/specs/pack-firewall-handoff.json
+++ b/tools/falsify/specs/pack-firewall-handoff.json
@@ -4,8 +4,8 @@
     {
       "label": "the Outscale boot stops handing the worn groups to the runtime, which is the whole of #475",
       "file": "internal/core/machine/plan.go",
-      "find": "\tr.Groups.AfterBoot(ctx, res)\n\treturn true",
-      "replace": "\tif false {\n\t\tr.Groups.AfterBoot(ctx, res)\n\t}\n\treturn true",
+      "find": "\t// is what holds it now.\n\tr.Groups.AfterBoot(ctx, res)\n}",
+      "replace": "\t// is what holds it now.\n\tif false {\n\t\tr.Groups.AfterBoot(ctx, res)\n\t}\n}",
       "test": "TestAnOutscaleGroupReachesTheHostWhenItsVmBoots"
     },
     {
@@ -19,8 +19,8 @@
       "label": "the Exoscale boot stops handing the worn groups to the runtime",
       "package": "./internal/providers/exoscale/",
       "file": "internal/core/machine/plan.go",
-      "find": "\tr.Groups.AfterBoot(ctx, res)\n\treturn true",
-      "replace": "\tif false {\n\t\tr.Groups.AfterBoot(ctx, res)\n\t}\n\treturn true",
+      "find": "\t// is what holds it now.\n\tr.Groups.AfterBoot(ctx, res)\n}",
+      "replace": "\t// is what holds it now.\n\tif false {\n\t\tr.Groups.AfterBoot(ctx, res)\n\t}\n}",
       "test": "TestAnExoscaleGroupReachesTheHostWhenAnInstanceBoots"
     },
     {
@@ -35,8 +35,8 @@
       "label": "a network attached after the boot leaves its interface without the instance's rule sets",
       "package": "./internal/providers/exoscale/",
       "file": "internal/core/machine/plan.go",
-      "find": "\terr := r.attach(ctx, res, att)\n\tr.ReplayAddresses(ctx, res)\n\tr.Groups.AfterBoot(ctx, res)\n\treturn err",
-      "replace": "\terr := r.attach(ctx, res, att)\n\tr.ReplayAddresses(ctx, res)\n\tif false {\n\t\tr.Groups.AfterBoot(ctx, res)\n\t}\n\treturn err",
+      "find": "\terr := r.attach(ctx, res, att)\n\tr.ReplayAddresses(ctx, res)\n\tr.Groups.AfterBoot(ctx, res)\n\tr.check(ctx, res)\n\treturn err",
+      "replace": "\terr := r.attach(ctx, res, att)\n\tr.ReplayAddresses(ctx, res)\n\tif false {\n\t\tr.Groups.AfterBoot(ctx, res)\n\t}\n\tr.check(ctx, res)\n\treturn err",
       "test": "TestALateNetworkAttachCarriesTheRuleSets"
     },
     {

--- a/tools/falsify/specs/pack-firewall-handoff.json
+++ b/tools/falsify/specs/pack-firewall-handoff.json
@@ -35,8 +35,8 @@
       "label": "a network attached after the boot leaves its interface without the instance's rule sets",
       "package": "./internal/providers/exoscale/",
       "file": "internal/core/machine/plan.go",
-      "find": "\terr := r.attach(ctx, res, att)\n\tr.ReplayAddresses(ctx, res)\n\tr.Groups.AfterBoot(ctx, res)\n\tr.check(ctx, res)\n\treturn err",
-      "replace": "\terr := r.attach(ctx, res, att)\n\tr.ReplayAddresses(ctx, res)\n\tif false {\n\t\tr.Groups.AfterBoot(ctx, res)\n\t}\n\tr.check(ctx, res)\n\treturn err",
+      "find": "\terr := r.attach(ctx, res, att)\n\tr.ReplayAddresses(ctx, res)\n\tr.Groups.AfterBoot(ctx, res)\n\tr.check(ctx, res, nil)\n\treturn err",
+      "replace": "\terr := r.attach(ctx, res, att)\n\tr.ReplayAddresses(ctx, res)\n\tif false {\n\t\tr.Groups.AfterBoot(ctx, res)\n\t}\n\tr.check(ctx, res, nil)\n\treturn err",
       "test": "TestALateNetworkAttachCarriesTheRuleSets"
     },
     {


### PR DESCRIPTION
Four issues of the verification stack, replayed onto `main` as four commits.

## Why this PR exists at all

#686 (#667) landed on `main`. The four PRs above it were stacked, each targeting
the branch below rather than `main`, and they were merged without deleting the
base branch — so GitHub never retargeted them, and each squash landed **in its
parent branch** instead of `main`. Nothing was lost: `feat/671-…` still carried
the whole stack cleanly. This is that content, cherry-picked onto `main`.

**Merge this one with rebase, not squash**, so each issue keeps its own commit.

## What it carries

| commit | issue |
|---|---|
| the runtime reads back what a machine carries, three outcomes | #668 |
| a verdict somebody reads, and the runtime leg gates on it | #670 |
| a reboot compares the shape after with the shape before | #669 |
| the runtime suite looks at the machine's own table | #671 |

Each was green on its own CI before this recomposition (#687, #688, #689, #690),
and `mise run prepush` is green on the replayed branch.

Closes #668
Closes #670
Closes #669
Closes #671

🤖 Generated with [Claude Code](https://claude.com/claude-code)
