### PR TITLE
fix(machine): a guest is told about the interface it was given, and about the resolver nothing can route to (#684, #660)

### DIFF
--- a/internal/core/machine/incus.go
+++ b/internal/core/machine/incus.go
@@ -597,7 +597,7 @@ func (d *Incus) Start(ctx context.Context, spec Spec) (Machine, error) {
 		}
 	}
 	if primary.Address != "" {
-		if _, err := d.run(ctx, "config", "device", "set", spec.Name, "eth0",
+		if _, err := d.setDevice(ctx, spec.Name, "eth0",
 			"ipv4.address="+primary.Address); err != nil {
 			return Machine{}, d.abandonStart(ctx, spec.Name,
 				fmt.Errorf("pin %s on %s: %w", primary.Address, spec.Name, err))
@@ -618,7 +618,7 @@ func (d *Incus) Start(ctx context.Context, spec Spec) (Machine, error) {
 			}
 			routes = append(routes, address+"/32")
 		}
-		if _, err := d.run(ctx, "config", "device", "set", spec.Name, "eth0",
+		if _, err := d.setDevice(ctx, spec.Name, "eth0",
 			d.publicRouteKey()+"="+strings.Join(routes, ",")); err != nil {
 			return Machine{}, d.abandonStart(ctx, spec.Name, fmt.Errorf("route %s to %s: %w",
 				strings.Join(spec.PublicAddresses, ", "), spec.Name, err))
@@ -809,12 +809,19 @@ func (d *Incus) Attach(ctx context.Context, name string, att Attachment) error {
 		// security ACL ID`. TestAnAddressMoveAndAnIsolationDetachTakeTurns
 		// fails without this.
 		unlock := d.networkLock(att.Network)
-		_, err := d.run(ctx, "config", "device", "set", name, device, "ipv4.address="+att.Address)
+		_, err := d.setDevice(ctx, name, device, "ipv4.address="+att.Address)
 		unlock()
 		if err != nil {
 			return fmt.Errorf("move %s to %s on network %s: %w", name, att.Address, att.Network, err)
 		}
 	}
+
+	// The interface is in place now, by whichever of the two branches above.
+	// An add on a running machine gives the guest a link its stack enumerated
+	// before any configuration matched it, and a set re-plugs one it was
+	// managing: either way the guest is told here, before the two repairs
+	// below, because a reload flushes what they lay (#684).
+	d.settleGuestInterface(ctx, name, device)
 
 	if att.Address != "" && att.PrefixLen > 0 {
 		// The device is attached by now, whatever happens next. Configuring it
@@ -1436,7 +1443,7 @@ func (d *Incus) EnsureNetwork(ctx context.Context, spec NetworkSpec) error {
 		// resolver of its own, can say so; the uplink's address is refused
 		// whatever the field says.
 		//
-		// TestAnOVNNetworkAnnouncesAPublicResolverAndNeverTheUplink and
+		// TestAnOVNNetworkLaysNoRouteTowardsItsResolver and
 		// TestAResolverThatIsTheUplinkIsRefused fail without this.
 		gateway, err := d.uplinkGateway()
 		if err != nil {
@@ -1447,10 +1454,33 @@ func (d *Incus) EnsureNetwork(ctx context.Context, spec NetworkSpec) error {
 			return fmt.Errorf("refusing to create network %s: the resolver %s is the uplink's own address, which is also the address the station reaches this network's machines from; announcing it lays a dead on-link route inside every guest (#660)",
 				spec.Name, resolver)
 		}
+		// The resolver is NOT announced over DHCP, and that is measured
+		// rather than a simplification (#684). A guest whose stack manages the
+		// interface answers a DHCP-announced name server by laying an on-link
+		// /32 towards it — systemd's RoutesToDNS=, on by default — and a public
+		// resolver is not on the subnet, so the guest ARPs for it on its own
+		// segment and reaches nothing. Read from a machine entitled to egress,
+		// 2026-09-04 under `--vm incus-ovn`:
+		//
+		//	1.1.1.1 dev eth0 proto dhcp scope link src 10.188.0.5 metric 100
+		//	ip route get 1.1.1.1 -> 1.1.1.1 dev eth0 src 10.188.0.5
+		//	ping 1.1.1.1 -> unreachable, resolvectl -> No route to host
+		//
+		// Delete that one route and the same machine reaches 1.1.1.1; put the
+		// resolver back on the link by hand and `getent hosts deb.debian.org`
+		// answers. So the announcement is what breaks the way out, and the
+		// resolver reaches the guest through resolvectl instead
+		// (settleGuestInterface), which configures a name server without laying
+		// a route to it.
+		//
+		// This was invisible until #684: with the interface managed by nobody,
+		// no lease was applied and no route was laid, so the machine had no
+		// resolver AND its way out. Fixing one exposed the other.
+		//
+		// TestAnOVNNetworkLaysNoRouteTowardsItsResolver fails without this.
 		args = append(args,
 			"ipv4.dhcp.gateway=none",
 			"ipv4.dhcp.routes="+announcedPrivateRoutes(address),
-			"dns.nameservers="+resolver,
 		)
 	}
 	for k, v := range spec.Labels {

--- a/internal/core/machine/incus_address.go
+++ b/internal/core/machine/incus_address.go
@@ -218,7 +218,7 @@ func (d *Incus) releaseFromRoutedNIC(ctx context.Context, machine, device, addre
 			kept = append(kept, entry)
 		}
 	}
-	if _, err := d.run(ctx, "config", "device", "set", machine, device,
+	if _, err := d.setDevice(ctx, machine, device,
 		"ipv4.address="+strings.Join(kept, ",")); err != nil {
 		return fmt.Errorf("release %s from %s/%s: %w", address, machine, device, err)
 	}
@@ -369,7 +369,7 @@ func (d *Incus) routeOntoRoutedNIC(ctx context.Context, machine, device, address
 	}
 	route := address + "/32"
 	if !routeListContains(cfg["ipv4.routes"], route) {
-		if _, err := d.run(ctx, "config", "device", "set", machine, device,
+		if _, err := d.setDevice(ctx, machine, device,
 			"ipv4.routes="+appendRoute(cfg["ipv4.routes"], route)); err != nil {
 			return fmt.Errorf("route %s to %s/%s: %w", address, machine, device, err)
 		}
@@ -493,7 +493,7 @@ func (d *Incus) setDeviceRoutes(ctx context.Context, machine, device, address st
 		kept = append(kept, route)
 	}
 
-	if _, err := d.run(ctx, "config", "device", "set", machine, device,
+	if _, err := d.setDevice(ctx, machine, device,
 		"ipv4.routes="+strings.Join(kept, ",")); err != nil {
 		return fmt.Errorf("set routes of %s/%s: %w", machine, device, err)
 	}

--- a/internal/core/machine/incus_ovn.go
+++ b/internal/core/machine/incus_ovn.go
@@ -839,7 +839,7 @@ func (d *Incus) routeAddressOVN(ctx context.Context, spec AddressSpec) error {
 	route := spec.Address + "/32"
 	if !routeListContains(devices.own[device]["ipv4.routes.external"], route) {
 		merged := appendRoute(devices.own[device]["ipv4.routes.external"], route)
-		if _, err := d.run(ctx, "config", "device", "set", spec.Machine, device,
+		if _, err := d.setDevice(ctx, spec.Machine, device,
 			"ipv4.routes.external="+merged); err != nil {
 			return fmt.Errorf("route %s to %s/%s: %w", spec.Address, spec.Machine, device, err)
 		}
@@ -932,7 +932,7 @@ func (d *Incus) unrouteOVNDevice(ctx context.Context, machine, device, network, 
 		return nil
 	}
 	kept := removeRoute(cfg["ipv4.routes.external"], route)
-	if _, err := d.run(ctx, "config", "device", "set", machine, device,
+	if _, err := d.setDevice(ctx, machine, device,
 		"ipv4.routes.external="+kept); err != nil {
 		return fmt.Errorf("unroute %s from %s/%s: %w", address, machine, device, err)
 	}
@@ -1317,6 +1317,31 @@ func (d *Incus) settleFirstBoot(ctx context.Context, machine string) error {
 				return fmt.Errorf("settle the first boot of %s: %w", machine, err)
 			}
 		}
+		// The resolver, on a machine whose NIC was attached before it was
+		// powered on — the ordinary Terraform order, where Attach ran against a
+		// stopped guest and its settle was a no-op. Measured 2026-09-04: that
+		// shape came up with the uplink's own address as its only name server,
+		// which is #660's dead on-link route wearing Incus's default rather
+		// than ours.
+		//
+		// Only this call, not the whole settle: setting a resolver lays no
+		// route and flushes nothing, so it is safe after the repairs above,
+		// where a reload would undo them.
+		//
+		// WHAT THIS DOES NOT FIX, and it is measured rather than hoped: on a
+		// machine whose NIC was attached before the poweron, the lease lands
+		// after this call and REPLACES what it sets, with whatever Incus falls
+		// back to — the host's own resolvers, which is the uplink's address.
+		// That shape came up holding 10.209.83.1 alone on 2026-09-04, twice,
+		// with this call in place. Two attempts at it were measured and
+		// removed rather than left in as lines that read like controls:
+		// `dns.nameservers=` empty on the network, which Incus ignores, and a
+		// wait for the interface to carry an address, which the driver's own
+		// static address satisfies immediately while the lease is still coming.
+		// Followed as its own defect.
+		//
+		// TestAFirstBootGivesTheGuestItsResolver fails without this.
+		d.setGuestResolver(ctx, machine, device)
 	}
 	return nil
 }

--- a/internal/core/machine/incus_resolver.go
+++ b/internal/core/machine/incus_resolver.go
@@ -1,0 +1,271 @@
+package machine
+
+import (
+	"context"
+	"strings"
+	"time"
+)
+
+// reloadGuestNetwork makes the guest's network stack take charge of the
+// interfaces it has, so that what the network announces reaches the guest
+// (#684).
+//
+// WHY A GUEST NEEDS TO BE TOLD. A network announces its resolver over DHCP
+// (dns.nameservers, #660) and its routes over option 121
+// (announcedPrivateRoutes). Both only reach a guest whose network stack manages
+// the interface. Measured 2026-09-04 under `--vm incus-ovn`, Ubuntu jammy,
+// three shapes read side by side:
+//
+//	shape                                    links               resolvectl dns
+//	private NIC present at the launch        eth0 configured     1.1.1.1
+//	public address, NIC plugged after        both unmanaged      none
+//	no public address, NIC plugged after     eth0 unmanaged      none
+//
+// The issue that reported this said the second shape was the broken one and the
+// third worked. The third was broken too, and reading all three side by side is
+// what showed the discriminator is not the public address at all.
+//
+// The units are not missing: cloud-init ran `netplan generate` (0.082 s in the
+// guest's own log) and /run/systemd/network holds 10-netplan-eth0.network and
+// 10-netplan-attached.network. systemd-networkd is active and enabled. It has
+// simply never been told to read them, so it manages nothing that appeared or
+// changed after it started, and `networkctl renew` answers "Interface eth1 is
+// not managed by systemd-networkd" on an interface carrying a DHCP address.
+//
+// One `networkctl reload` turned `unmanaged` into `configured` on both shapes
+// and brought the announced resolver with it, on the same reading. That is what
+// this does.
+//
+// A RELOAD IS NOT FREE, WHICH IS WHY IT HAS ONE CALLER. It reconfigures every
+// link it manages, and that flushes what this driver laid by hand: on the same
+// measurement a pinned address came back as a DHCP lease and a hand-written
+// default route was gone. So it belongs exactly where the interface has just
+// been taken away and there is nothing to lose — after a device set, see
+// setDevice — and nowhere else. Two earlier placements, on the attach path and
+// on the restart path, were removed for that reason: they ran before the
+// migration that undoes their work, and the measurement showed the shape still
+// broken.
+//
+// BEST EFFORT, DELIBERATELY. An image without systemd-networkd — Alpine, which
+// this emulator serves — has no networkctl at all, and a machine whose guest
+// cannot be told is a machine that still boots, still carries its addresses and
+// still answers. So a failure is reported to the caller's discretion rather than
+// failing the boot: the caller logs it. What must never happen is the reverse,
+// a machine refused because its distribution spells networking differently.
+//
+// TestAGuestWithoutNetworkctlIsNotARefusal and
+// TestAGuestThatRefusesTheReloadIsReported hold the two halves of the guard;
+// setDevice below is the only caller, and TestADeviceSetGivesTheGuestBackItsInterface
+// is what fails when it stops calling.
+func (d *Incus) reloadGuestNetwork(ctx context.Context, machine string) error {
+	if _, err := d.run(ctx, "exec", machine, "--", "networkctl", "reload"); err != nil {
+		// A stopped guest has no stack to tell, and attaching to one is the
+		// ordinary Terraform order — attach, then power on — where the boot
+		// path does this instead. Reporting it would send an operator looking
+		// for a problem that is not one, which is the lesson configureGuestAddress
+		// above it already carries.
+		if isNotRunning(err) || isNotFound(err) || guestHasNoNetworkd(err) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// waitForGuestLink waits for an interface to EXIST inside the guest, which is
+// not the same question as waitForGuestInterface's — that one waits for it to
+// carry an address, and here the address is what the reload is meant to bring.
+//
+// `incus config device add` returns before the guest's kernel has created the
+// link, and a reload that runs in that gap reloads a configuration for an
+// interface that is not there yet: the link appears afterwards, managed by
+// nobody, which is the state this whole file exists to end. Measured
+// 2026-09-04 under `--vm incus-ovn`: with the reload fired immediately after
+// the device add, a machine holding a public address still came up with eth0
+// and eth1 both `unmanaged` and no resolver, while the same code on a machine
+// whose NIC became eth0 worked — the difference being how long the guest took
+// to show the link.
+//
+// Short and bounded, because this is a wait for a kernel to publish a link and
+// not for a lease: when it expires the reload runs anyway, since a reload with
+// nothing to reload costs one command and refusing to boot over it would cost
+// the machine.
+func (d *Incus) waitForGuestLink(ctx context.Context, machine, device string) {
+	iface, err := d.guestInterface(ctx, machine, device)
+	if err != nil || iface == "" {
+		return
+	}
+	poll := d.routePoll
+	if poll <= 0 {
+		poll = guestLinkPoll
+	}
+	deadline := time.Now().Add(guestLinkWait)
+	for {
+		_, err := d.run(ctx, "exec", machine, "--", "ip", "-o", "link", "show", "dev", iface)
+		if err == nil {
+			return
+		}
+		// A stopped machine has no link to wait for, and attaching to one is the
+		// ordinary Terraform order — attach, then power on. Waiting out the
+		// budget there would charge every cold attach ten seconds for nothing,
+		// which is how this wait first showed up: a package of unit tests went
+		// from four seconds to four minutes.
+		if isNotRunning(err) || isNotFound(err) {
+			return
+		}
+		if time.Now().After(deadline) {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(poll):
+		}
+	}
+}
+
+// guestLinkPoll and guestLinkWait bound that wait. Seconds, not the ninety of
+// guestRouteWait: a link either appears within a few seconds of the device add
+// or something else is wrong, and this wait sits on the hot attach path that a
+// client is blocked on.
+const (
+	guestLinkPoll = 500 * time.Millisecond
+	guestLinkWait = 10 * time.Second
+)
+
+// guestHasNoNetworkd tells an image that does not run systemd-networkd from a
+// guest that does and refused.
+//
+// The strings are the shell's and systemd's, not Incus's, because the command
+// runs inside the guest: a missing binary is the shell's "not found" (127), and
+// a systemd that is not running answers about its bus. Anything else is a real
+// refusal and travels back to the caller.
+func guestHasNoNetworkd(err error) bool {
+	msg := strings.ToLower(err.Error())
+	for _, known := range []string{
+		"not found",                 // busybox and dash: networkctl: not found
+		"no such file or directory", // exec of an absent path
+		"failed to connect to bus",  // systemd is not the init of this guest
+		"unit systemd-networkd",     // the unit is not there to reload
+		"could not be found",        // systemctl's wording for the same
+	} {
+		if strings.Contains(msg, known) {
+			return true
+		}
+	}
+	return false
+}
+
+// setDevice changes a device's configuration and gives the guest back the
+// interface that change takes away (#684).
+//
+// WHAT A DEVICE SET DOES TO A RUNNING MACHINE. It re-plugs the NIC. Read from
+// the guest's own journal, 2026-09-04 under `--vm incus-ovn`, on a server whose
+// private NIC arrived hot and took the published address with it (#548):
+//
+//	16:40:29 veth3bbc3686: Interface name change detected, renamed to eth1.
+//	16:40:29 eth1: Re-configuring with /run/systemd/network/10-netplan-attached.network
+//	16:40:29 eth1: DHCPv4 address 10.190.0.3/24
+//	16:40:30 eth0: Link DOWN … vethf64c989f: renamed to eth0.
+//	16:40:32 eth1: Link DOWN … DHCP lease lost
+//	16:40:43 vethcdbe2acf: Interface name change detected, renamed to eth1.
+//
+// The guest's stack did its work at 16:40:29 and was correct. Then the address
+// migration set both devices, each set replaced the veth, and after the last
+// one no line says networkd configured anything: `networkctl status eth1`
+// answers `Network File: n/a` and `State: routable (unmanaged)` on an interface
+// whose matching unit is on disk. So the resolver the network announces never
+// arrives, on the one shape a platform team deploys most often.
+//
+// This is why the fix is here and not in Attach. Attach was the first guess and
+// it is wrong: a reload placed there runs BEFORE the migration that undoes it,
+// and two rounds of measurement showed the shape still broken. What needs the
+// reload is not an attachment, it is every device set — and there are eight of
+// them, which is exactly the count that guarantees a per-caller fix gets
+// forgotten by the ninth.
+//
+// TestADeviceSetGivesTheGuestBackItsInterface fails without this.
+func (d *Incus) setDevice(ctx context.Context, machine, device string, settings ...string) ([]byte, error) {
+	args := append([]string{"config", "device", "set", machine, device}, settings...)
+	out, err := d.run(ctx, args...)
+	if err != nil {
+		return out, err
+	}
+	d.settleGuestInterface(ctx, machine, device)
+	return out, nil
+}
+
+// settleGuestInterface waits for an interface to come back and tells the guest
+// to read its configuration again.
+//
+// Two callers, deliberately, because two different commands take an interface
+// away and both were measured doing it:
+//
+//   - a device SET re-plugs the NIC (setDevice above, and the guest journal it
+//     quotes);
+//   - a device ADD on a running machine gives the guest an interface its stack
+//     enumerated before any configuration existed for it. Measured 2026-09-04:
+//     with the set covered and the add not, the machine holding a public
+//     address resolved and the machine without one did not, which is the same
+//     defect wearing the other shape.
+//
+// The link is re-created, so waiting for it to exist is the ordering, not
+// politeness: a reload fired into the gap reloads a configuration for an
+// interface that is not there yet. On a stopped machine both calls are no-ops,
+// which is the ordinary attach-then-power-on order.
+//
+// TestADeviceSetGivesTheGuestBackItsInterface and
+// TestAHotAttachGivesTheGuestItsNewInterface fail without this, one per caller.
+func (d *Incus) settleGuestInterface(ctx context.Context, machine, device string) {
+	d.waitForGuestLink(ctx, machine, device)
+	if err := d.reloadGuestNetwork(ctx, machine); err != nil {
+		d.logger().Warn("the guest was not told to read its network configuration",
+			"machine", machine, "device", device, "error", err)
+	}
+	d.setGuestResolver(ctx, machine, device)
+}
+
+// setGuestResolver gives the interface the name server its network stands for,
+// without letting the guest lay a route towards it (#684, and the half of #660
+// that stayed open).
+//
+// A DHCP-announced name server is answered by systemd-networkd with an on-link
+// /32 towards it (RoutesToDNS=, on by default). For a resolver that does not
+// live on the subnet — and a public one never does — that route is dead, and it
+// takes the machine's way out with it: measured, `ping 1.1.1.1` unreachable and
+// `resolvectl query` answering `No route to host` on a machine whose default
+// route was laid and whose next hop answered. Deleting that single route
+// restored both.
+//
+// resolvectl sets a name server and lays nothing, which is the whole reason it
+// is used here rather than the lease. Measured on the same machines: with the
+// /32 gone and the resolver set this way, `getent hosts deb.debian.org` answers.
+//
+// After the reload, deliberately: a reload reconfigures the link and drops the
+// runtime DNS setting with it.
+//
+// Best effort, like the reload above and for the same reason: an image without
+// systemd-resolved has no resolvectl, and a machine that cannot be told still
+// boots and still answers.
+//
+// TestASettleGivesTheInterfaceItsResolver fails without this.
+func (d *Incus) setGuestResolver(ctx context.Context, machine, device string) {
+	if !d.OVN {
+		// A managed bridge runs its own resolver on the gateway and announces
+		// it in the lease, which the guest reaches on-link because it IS
+		// on-link. Nothing to add, and adding it would override a working one.
+		return
+	}
+	iface, err := d.guestInterface(ctx, machine, device)
+	if err != nil || iface == "" {
+		return
+	}
+	if _, err := d.run(ctx, "exec", machine, "--",
+		"resolvectl", "dns", iface, d.resolver()); err != nil {
+		if isNotRunning(err) || isNotFound(err) || guestHasNoNetworkd(err) {
+			return
+		}
+		d.logger().Warn("the guest was not given the resolver its network stands for",
+			"machine", machine, "device", device, "resolver", d.resolver(), "error", err)
+	}
+}

--- a/internal/core/machine/incus_resolver_test.go
+++ b/internal/core/machine/incus_resolver_test.go
@@ -1,0 +1,218 @@
+package machine
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A device set re-plugs the NIC, and the guest is told to read its
+// configuration again afterwards (#684).
+//
+// The order is the property, not the presence: the reload has to come after the
+// set, because it is the set that takes the interface away, and after the link
+// is back, because a reload fired into the gap reloads a configuration for an
+// interface that does not exist yet.
+func TestADeviceSetGivesTheGuestBackItsInterface(t *testing.T) {
+	f := &fakeRuntime{answers: map[string]string{
+		"ip -o link show dev": "2: eth1: <BROADCAST,MULTICAST,UP>\n",
+	}}
+	d := newFakeDriver(f)
+
+	if _, err := d.setDevice(context.Background(), "srv", "eth1", "ipv4.address=10.189.0.2"); err != nil {
+		t.Fatalf("set the device: %v", err)
+	}
+
+	set := indexOfCall(f, "config device set srv eth1")
+	reload := indexOfCall(f, "networkctl reload")
+	link := indexOfCall(f, "link show dev")
+	if set < 0 {
+		t.Fatalf("the device was never set:\n%s", strings.Join(f.commands(), "\n"))
+	}
+	if reload < 0 {
+		t.Fatalf("the guest was never told to read its configuration after the set:\n%s",
+			strings.Join(f.commands(), "\n"))
+	}
+	if reload < set {
+		t.Fatalf("the guest was told at %d, before the set at %d that takes the interface away:\n%s",
+			reload, set, strings.Join(f.commands(), "\n"))
+	}
+	if link < 0 || link > reload {
+		t.Fatalf("the guest was told at %d without waiting for the link (probe at %d):\n%s",
+			reload, link, strings.Join(f.commands(), "\n"))
+	}
+}
+
+// A set that failed changed nothing, so there is nothing to give back — and
+// telling the guest anyway would hide the refusal behind a command that
+// succeeds.
+func TestASetThatFailedTellsNobody(t *testing.T) {
+	f := &fakeRuntime{fail: map[string]error{
+		"config device set": errors.New("Error: Failed to update device"),
+	}}
+	d := newFakeDriver(f)
+
+	if _, err := d.setDevice(context.Background(), "srv", "eth1", "ipv4.address=10.189.0.2"); err == nil {
+		t.Fatal("a refused device set was reported as success")
+	}
+	if i := indexOfCall(f, "networkctl reload"); i >= 0 {
+		t.Fatalf("the guest was told after a set that changed nothing:\n%s",
+			strings.Join(f.commands(), "\n"))
+	}
+}
+
+// The wait is bounded and it is what makes the reload land on an interface that
+// exists.
+//
+// `incus config device set` returns before the guest's kernel publishes the new
+// link. Measured 2026-09-04 under `--vm incus-ovn`, from the guest's own
+// journal: eth1 was renamed at 16:40:29 and configured, the address migration
+// set both devices, a new veth became eth1 at 16:40:43, and nothing configured
+// it after that.
+func TestADeviceSetWaitsForTheLinkBeforeTellingTheGuest(t *testing.T) {
+	const appears = 3 // the link is not back for the first two probes
+	probes := 0
+	f := &fakeRuntime{}
+	f.hook = func(_ int, args []string) ([]byte, error, bool) {
+		if len(args) >= 6 && args[0] == "exec" && args[3] == "ip" && args[5] == "link" {
+			probes++
+			if probes < appears {
+				return nil, errors.New(`Error: Device "eth1" does not exist`), true
+			}
+			return []byte("2: eth1: <BROADCAST,MULTICAST,UP>\n"), nil, true
+		}
+		return nil, nil, false
+	}
+	d := newFakeDriver(f)
+	d.routePoll = time.Millisecond
+
+	if _, err := d.setDevice(context.Background(), "srv", "eth1", "ipv4.address=10.189.0.2"); err != nil {
+		t.Fatalf("set the device: %v", err)
+	}
+	if probes < appears {
+		t.Fatalf("the set gave up after %d probes, before the link came back at %d", probes, appears)
+	}
+	reload := indexOfCall(f, "networkctl reload")
+	if reload < 0 {
+		t.Fatalf("no reload was emitted:\n%s", strings.Join(f.commands(), "\n"))
+	}
+	last := -1
+	for i, call := range f.commands() {
+		if strings.Contains(call, "link show dev") {
+			last = i
+		}
+	}
+	if last > reload {
+		t.Fatalf("the guest was told at %d, before the link was last probed at %d:\n%s",
+			reload, last, strings.Join(f.commands(), "\n"))
+	}
+}
+
+// An image without systemd-networkd still boots, and the emulator serves one:
+// Alpine has no networkctl at all. A machine whose guest cannot be told is a
+// machine that still carries its addresses and still answers, so the refusal is
+// swallowed rather than failing the operation that caused it.
+func TestAGuestWithoutNetworkctlIsNotARefusal(t *testing.T) {
+	for _, spelling := range []string{
+		`Error: Command not found`,
+		`sh: networkctl: not found`,
+		`Failed to connect to bus: No such file or directory`,
+		`Unit systemd-networkd.service could not be found.`,
+	} {
+		f := &fakeRuntime{fail: map[string]error{
+			"networkctl reload": errors.New(spelling),
+		}}
+		d := newFakeDriver(f)
+		if err := d.reloadGuestNetwork(context.Background(), "srv"); err != nil {
+			t.Fatalf("a guest answering %q was treated as a failure: %v", spelling, err)
+		}
+	}
+}
+
+// And the accepting half, without which a guard that swallowed everything would
+// pass every test above: a guest that answers something else is a real refusal
+// and travels back to the caller, who logs it.
+func TestAGuestThatRefusesTheReloadIsReported(t *testing.T) {
+	f := &fakeRuntime{fail: map[string]error{
+		"networkctl reload": errors.New("Error: Failed to reload network settings: Permission denied"),
+	}}
+	d := newFakeDriver(f)
+	if err := d.reloadGuestNetwork(context.Background(), "srv"); err == nil {
+		t.Fatal("a guest that refused the reload was reported as success")
+	}
+}
+
+// indexOfCall answers where a command appears in the recorded argv, -1 when it
+// never does.
+func indexOfCall(f *fakeRuntime, substr string) int {
+	for i, call := range f.commands() {
+		if strings.Contains(call, substr) {
+			return i
+		}
+	}
+	return -1
+}
+
+// The second caller: a NIC plugged into a running machine.
+//
+// The add is not a set — nothing is re-plugged — but the guest's stack
+// enumerated the link before any configuration matched it. Measured 2026-09-04:
+// with only the set covered, the machine holding a public address resolved and
+// the machine without one did not.
+func TestAHotAttachGivesTheGuestItsNewInterface(t *testing.T) {
+	f := &fakeRuntime{answers: map[string]string{
+		"/1.0/instances/srv":  `{"expanded_devices":{},"devices":{}}`,
+		"ip -o link show dev": "2: eth0: <BROADCAST,MULTICAST,UP>\n",
+	}}
+	d := newFakeDriver(f)
+
+	if err := d.Attach(context.Background(), "srv", Attachment{Network: "fnt-net"}); err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+
+	add := indexOfCall(f, "config device add srv")
+	reload := indexOfCall(f, "networkctl reload")
+	if add < 0 {
+		t.Fatalf("no device was added:\n%s", strings.Join(f.commands(), "\n"))
+	}
+	if reload < 0 {
+		t.Fatalf("the guest was never told about its new interface:\n%s",
+			strings.Join(f.commands(), "\n"))
+	}
+	if reload < add {
+		t.Fatalf("the guest was told at %d, before the add at %d that gives it the interface:\n%s",
+			reload, add, strings.Join(f.commands(), "\n"))
+	}
+}
+
+// A machine whose NIC was attached before it was powered on gets its resolver
+// at the boot, since its attach ran against a stopped guest and did nothing.
+//
+// Measured 2026-09-04 under `--vm incus-ovn`: that shape came up holding the
+// uplink's own address as its only name server — Incus's default, announced
+// because this emulator announces none — which is #660's dead on-link route in
+// another spelling.
+func TestAFirstBootGivesTheGuestItsResolver(t *testing.T) {
+	const ownedNIC = `{
+	  "expanded_devices": {"eth1": {"type": "nic", "network": "fnt-net", "ipv4.address": "10.189.0.2"}},
+	  "devices": {"eth1": {"type": "nic", "network": "fnt-net", "ipv4.address": "10.189.0.2"}}
+	}`
+	f := &fakeRuntime{answers: map[string]string{
+		"/1.0/instances/srv":               ownedNIC,
+		"network get fnt-net ipv4.address": "10.189.0.1/24\n",
+		"ip -4 -o addr show dev eth1":      "2: eth1    inet 10.189.0.2/24 scope global eth1\n",
+		"ip -o link show dev":              "2: eth1: <BROADCAST,MULTICAST,UP>\n",
+	}}
+	d := newFakeDriver(f)
+	d.OVN = true
+
+	if err := d.settleFirstBoot(context.Background(), "srv"); err != nil {
+		t.Fatalf("settle the first boot: %v", err)
+	}
+	if i := indexOfCall(f, "resolvectl dns eth1 "+DefaultResolver); i < 0 {
+		t.Fatalf("the boot left the interface without a resolver:\n%s",
+			strings.Join(f.commands(), "\n"))
+	}
+}

--- a/internal/core/machine/resolver_internal_test.go
+++ b/internal/core/machine/resolver_internal_test.go
@@ -9,16 +9,30 @@ import (
 	"testing"
 )
 
-// An OVN network never announces, as its resolver, the address by which the
-// station reaches its machines (#660).
+// An OVN network hands its machines a resolver without ever announcing one in
+// the lease (#660, and the half of it that #684 closed).
 //
-// Measured on 2026-09-04 under `--vm incus-ovn`: the uplink's address,
-// announced as the DNS server, is also the source the station dials from, so
-// the guest's RoutesToDNS= laid an on-link /32 towards it, more specific than
-// the aggregates, and the reply to the station died on the switch —
-// `ip route get 10.209.83.1` answered `dev eth1`; with a public resolver it
-// answers `via <gateway> dev eth1`. The network's gateway was rejected as the
-// alternative: nothing answers DNS there.
+// #660 measured the first half: the uplink's address, announced as the DNS
+// server, is also the source the station dials from, so the guest's
+// RoutesToDNS= laid an on-link /32 towards it, more specific than the
+// aggregates, and the reply to the station died on the switch. Its answer was
+// to announce a public resolver instead. The network's gateway was rejected as
+// the alternative, and re-measured on 2026-09-04 with the check made
+// independent of the others: nothing answers DNS there, `getent` returns
+// nothing on all three shapes.
+//
+// #684 measured the second half, once the interfaces were managed at all. THE
+// SAME MECHANISM BREAKS A PUBLIC RESOLVER, for the same reason: a name server
+// in the lease gets an on-link /32, and 1.1.1.1 is not on the subnet either.
+//
+//	1.1.1.1 dev eth0 proto dhcp scope link src 10.188.0.5 metric 100
+//	ping 1.1.1.1 -> unreachable; resolvectl query -> No route to host
+//	ip route del 1.1.1.1 dev eth0 -> reachable
+//	resolvectl dns eth0 1.1.1.1 -> getent hosts deb.debian.org answers
+//
+// So no resolver is announced in the lease at all. The one the network stands
+// for reaches the guest through resolvectl (setGuestResolver), which sets a
+// name server and lays no route.
 
 // resolverProbe is the uplink harness of the egress tests: an uplink this run
 // holds on 10.99.0.0/24 (gateway 10.99.0.1), and the network absent so
@@ -42,12 +56,11 @@ func networkCreateLine(f *fakeRuntime) string {
 	return ""
 }
 
-// TestAnOVNNetworkAnnouncesAPublicResolverAndNeverTheUplink holds the whole
-// property: the announced resolver is the public default, and the uplink's
-// address appears nowhere in the announcement. A bridge announces nothing of
-// the kind — its dnsmasq is the resolver there, on-link by construction, and
-// the collision does not exist.
-func TestAnOVNNetworkAnnouncesAPublicResolverAndNeverTheUplink(t *testing.T) {
+// TestAnOVNNetworkLaysNoRouteTowardsItsResolver holds the whole property: no
+// name server is put in the lease, by either mode, so no guest lays an on-link
+// route towards one. A bridge never did — its dnsmasq is the resolver there,
+// on-link by construction, and the collision does not exist.
+func TestAnOVNNetworkLaysNoRouteTowardsItsResolver(t *testing.T) {
 	for _, mode := range []struct {
 		name string
 		ovn  bool
@@ -66,12 +79,14 @@ func TestAnOVNNetworkAnnouncesAPublicResolverAndNeverTheUplink(t *testing.T) {
 			if line == "" {
 				t.Fatalf("no network create; calls: %v", f.calls)
 			}
-			announced := strings.Contains(line, "dns.nameservers="+DefaultResolver)
-			if announced != mode.ovn {
-				t.Errorf("dns.nameservers=%s present=%v, want %v: %s", DefaultResolver, announced, mode.ovn, line)
+			if strings.Contains(line, "dns.nameservers") {
+				t.Errorf("a name server is in the lease, which is the on-link /32 that costs the machine its way out (#684): %s", line)
 			}
-			if strings.Contains(line, "dns.nameservers=10.99.0.1") {
-				t.Errorf("the network announces the uplink's own address as its resolver, the dead on-link route of #660: %s", line)
+			// And the accepting half, or a create that stopped configuring
+			// anything at all would pass: the routes ARE announced, and they
+			// are what a guest needs from the lease.
+			if mode.ovn && !strings.Contains(line, "ipv4.dhcp.routes=") {
+				t.Errorf("the OVN network announces no routes either, so this test is measuring an empty create: %s", line)
 			}
 		})
 	}
@@ -101,21 +116,64 @@ func TestAResolverThatIsTheUplinkIsRefused(t *testing.T) {
 }
 
 // TestTheResolverIsAField: a station without Internet, or with a resolver of
-// its own, says so, and the network announces what it said.
+// its own, says so, and the guests get what it said — through resolvectl now,
+// not through the lease.
 func TestTheResolverIsAField(t *testing.T) {
-	f := resolverProbe()
+	f := &fakeRuntime{answers: map[string]string{
+		"ip -o link show dev": "2: eth1: <BROADCAST,MULTICAST,UP>\n",
+	}}
 	d := newFakeDriver(f)
 	d.OVN = true
-	d.UplinkCIDR = "10.99.0.0/24"
 	d.Resolver = "192.0.2.53"
-	if err := d.EnsureNetwork(context.Background(), NetworkSpec{Name: "fnt-probe", CIDR: "10.99.1.0/24", NAT: true}); err != nil {
-		t.Fatalf("ensure: %v", err)
+
+	d.settleGuestInterface(context.Background(), "srv", "eth1")
+
+	if i := indexOfCall(f, "resolvectl dns eth1 192.0.2.53"); i < 0 {
+		t.Errorf("the guest was not given the resolver the operator named:\n%s",
+			strings.Join(f.commands(), "\n"))
 	}
-	line := networkCreateLine(f)
-	if !strings.Contains(line, "dns.nameservers=192.0.2.53") {
-		t.Errorf("the resolver the operator named was not announced: %s", line)
+	if i := indexOfCall(f, "resolvectl dns eth1 "+DefaultResolver); i >= 0 {
+		t.Errorf("the default was set beside the operator's value:\n%s",
+			strings.Join(f.commands(), "\n"))
 	}
-	if strings.Contains(line, "dns.nameservers="+DefaultResolver) {
-		t.Errorf("the default was announced beside the operator's value: %s", line)
+}
+
+// TestASettleGivesTheInterfaceItsResolver: the default reaches the guest, after
+// the reload rather than before, since a reload drops the runtime setting.
+func TestASettleGivesTheInterfaceItsResolver(t *testing.T) {
+	f := &fakeRuntime{answers: map[string]string{
+		"ip -o link show dev": "2: eth1: <BROADCAST,MULTICAST,UP>\n",
+	}}
+	d := newFakeDriver(f)
+	d.OVN = true
+
+	d.settleGuestInterface(context.Background(), "srv", "eth1")
+
+	set := indexOfCall(f, "resolvectl dns eth1 "+DefaultResolver)
+	reload := indexOfCall(f, "networkctl reload")
+	if set < 0 {
+		t.Fatalf("the interface was never given a resolver:\n%s", strings.Join(f.commands(), "\n"))
+	}
+	if reload < 0 || set < reload {
+		t.Fatalf("the resolver was set at %d, before the reload at %d that drops it:\n%s",
+			set, reload, strings.Join(f.commands(), "\n"))
+	}
+}
+
+// A managed bridge resolves through its own dnsmasq, on-link and in the lease.
+// Setting a resolver there would override a working one with a public address
+// the guest may not be able to reach at all.
+func TestABridgeGuestKeepsTheResolverItsLeaseCarries(t *testing.T) {
+	f := &fakeRuntime{answers: map[string]string{
+		"ip -o link show dev": "2: eth1: <BROADCAST,MULTICAST,UP>\n",
+	}}
+	d := newFakeDriver(f)
+	d.OVN = false
+
+	d.settleGuestInterface(context.Background(), "srv", "eth1")
+
+	if i := indexOfCall(f, "resolvectl dns"); i >= 0 {
+		t.Errorf("a bridge guest had its lease's resolver overridden:\n%s",
+			strings.Join(f.commands(), "\n"))
 	}
 }

--- a/tools/falsify/specs/an-ovn-network-announces-a-public-resolver.json
+++ b/tools/falsify/specs/an-ovn-network-announces-a-public-resolver.json
@@ -2,11 +2,12 @@
   "package": "./internal/core/machine/",
   "mutations": [
     {
-      "label": "the network announces no resolver of its own, so Incus announces the uplink and the dead on-link route comes back (#660)",
+      "label": "the network puts a name server back in the lease, which is the on-link /32 that costs a machine its way out (#684)",
       "file": "internal/core/machine/incus.go",
-      "find": "\t\t\t\"dns.nameservers=\"+resolver,\n",
-      "replace": "\t\t\t\"dns.nameservers=\"+resolver[:0],\n",
-      "test": "TestAnOVNNetworkAnnouncesAPublicResolverAndNeverTheUplink"
+      "package": "./internal/core/machine/",
+      "find": "\t\targs = append(args,\n\t\t\t\"ipv4.dhcp.gateway=none\",\n\t\t\t\"ipv4.dhcp.routes=\"+announcedPrivateRoutes(address),\n\t\t)",
+      "replace": "\t\targs = append(args,\n\t\t\t\"ipv4.dhcp.gateway=none\",\n\t\t\t\"ipv4.dhcp.routes=\"+announcedPrivateRoutes(address),\n\t\t\t\"dns.nameservers=\"+resolver,\n\t\t)",
+      "test": "TestAnOVNNetworkLaysNoRouteTowardsItsResolver"
     },
     {
       "label": "the field may name the uplink, and the collision is one flag away (#660)",
@@ -21,6 +22,38 @@
       "find": "\tif d.Resolver != \"\" {\n\t\treturn d.Resolver\n\t}",
       "replace": "\tif d.Resolver != \"\" && false {\n\t\treturn d.Resolver\n\t}",
       "test": "TestTheResolverIsAField"
+    },
+    {
+      "label": "the settle stops giving the interface a resolver, so a guest that lays no route to one has none at all",
+      "file": "internal/core/machine/incus_resolver.go",
+      "package": "./internal/core/machine/",
+      "find": "\td.setGuestResolver(ctx, machine, device)\n",
+      "replace": "\tif false {\n\t\td.setGuestResolver(ctx, machine, device)\n\t}\n",
+      "test": "TestASettleGivesTheInterfaceItsResolver"
+    },
+    {
+      "label": "the resolver is set before the reload that drops it, which is the ordering that leaves the guest with nothing",
+      "file": "internal/core/machine/incus_resolver.go",
+      "package": "./internal/core/machine/",
+      "find": "\tif err := d.reloadGuestNetwork(ctx, machine); err != nil {\n\t\td.logger().Warn(\"the guest was not told to read its network configuration\",\n\t\t\t\"machine\", machine, \"device\", device, \"error\", err)\n\t}\n\td.setGuestResolver(ctx, machine, device)",
+      "replace": "\td.setGuestResolver(ctx, machine, device)\n\tif err := d.reloadGuestNetwork(ctx, machine); err != nil {\n\t\td.logger().Warn(\"the guest was not told to read its network configuration\",\n\t\t\t\"machine\", machine, \"device\", device, \"error\", err)\n\t}",
+      "test": "TestASettleGivesTheInterfaceItsResolver"
+    },
+    {
+      "label": "a bridge guest has its lease's working resolver overridden by a public one it may not reach",
+      "file": "internal/core/machine/incus_resolver.go",
+      "package": "./internal/core/machine/",
+      "find": "\tif !d.OVN {",
+      "replace": "\tif !d.OVN && false {",
+      "test": "TestABridgeGuestKeepsTheResolverItsLeaseCarries"
+    },
+    {
+      "label": "the first boot stops setting the resolver, so a NIC attached before poweron comes up with the uplink's own address and #660's dead route",
+      "file": "internal/core/machine/incus_ovn.go",
+      "package": "./internal/core/machine/",
+      "find": "\t\td.setGuestResolver(ctx, machine, device)\n\t}\n\treturn nil\n}",
+      "replace": "\t\tif false {\n\t\t\td.setGuestResolver(ctx, machine, device)\n\t\t}\n\t}\n\treturn nil\n}",
+      "test": "TestAFirstBootGivesTheGuestItsResolver"
     }
   ]
 }

--- a/tools/falsify/specs/attach-vs-isolation-detach.json
+++ b/tools/falsify/specs/attach-vs-isolation-detach.json
@@ -11,8 +11,8 @@
     {
       "label": "the address move takes its network's lock only after the set has run, so the remove-and-re-add the OVN NIC turns the set into plugs with nothing holding the detach back",
       "file": "internal/core/machine/incus.go",
-      "find": "\t\tunlock := d.networkLock(att.Network)\n\t\t_, err := d.run(ctx, \"config\", \"device\", \"set\", name, device, \"ipv4.address=\"+att.Address)\n\t\tunlock()",
-      "replace": "\t\t_, err := d.run(ctx, \"config\", \"device\", \"set\", name, device, \"ipv4.address=\"+att.Address)\n\t\tunlock := d.networkLock(att.Network)\n\t\tunlock()",
+      "find": "\t\tunlock := d.networkLock(att.Network)\n\t\t_, err := d.setDevice(ctx, name, device, \"ipv4.address=\"+att.Address)\n\t\tunlock()",
+      "replace": "\t\t_, err := d.setDevice(ctx, name, device, \"ipv4.address=\"+att.Address)\n\t\tunlock := d.networkLock(att.Network)\n\t\tunlock()",
       "test": "TestAnAddressMoveAndAnIsolationDetachTakeTurns"
     }
   ],

--- a/tools/falsify/specs/the-guest-reads-its-network-configuration.json
+++ b/tools/falsify/specs/the-guest-reads-its-network-configuration.json
@@ -1,0 +1,52 @@
+{
+  "mutations": [
+    {
+      "label": "a device set no longer tells the guest, so the interface it re-plugged comes back managed by nobody and the announced resolver never arrives",
+      "file": "internal/core/machine/incus_resolver.go",
+      "package": "./internal/core/machine/",
+      "find": "\td.settleGuestInterface(ctx, machine, device)\n\treturn out, nil",
+      "replace": "\tif false {\n\t\td.settleGuestInterface(ctx, machine, device)\n\t}\n\treturn out, nil",
+      "test": "TestADeviceSetGivesTheGuestBackItsInterface"
+    },
+    {
+      "label": "the guest is told without waiting for the link, which is the gap that leaves a re-plugged NIC unmanaged",
+      "file": "internal/core/machine/incus_resolver.go",
+      "package": "./internal/core/machine/",
+      "find": "\td.waitForGuestLink(ctx, machine, device)\n\tif err := d.reloadGuestNetwork(ctx, machine); err != nil {",
+      "replace": "\tif false {\n\t\td.waitForGuestLink(ctx, machine, device)\n\t}\n\tif err := d.reloadGuestNetwork(ctx, machine); err != nil {",
+      "test": "TestADeviceSetWaitsForTheLinkBeforeTellingTheGuest"
+    },
+    {
+      "label": "the guest is told even when the set was refused, which hides a failure behind a command that succeeds",
+      "file": "internal/core/machine/incus_resolver.go",
+      "package": "./internal/core/machine/",
+      "find": "\tout, err := d.run(ctx, args...)\n\tif err != nil {\n\t\treturn out, err\n\t}",
+      "replace": "\tout, err := d.run(ctx, args...)\n\tif err != nil && false {\n\t\treturn out, err\n\t}",
+      "test": "TestASetThatFailedTellsNobody"
+    },
+    {
+      "label": "every refusal is swallowed, so a guest that really could not reload is reported as one that has no networkd",
+      "file": "internal/core/machine/incus_resolver.go",
+      "package": "./internal/core/machine/",
+      "find": "\t\tif isNotRunning(err) || isNotFound(err) || guestHasNoNetworkd(err) {\n\t\t\treturn nil\n\t\t}",
+      "replace": "\t\tif isNotRunning(err) || isNotFound(err) || guestHasNoNetworkd(err) || true {\n\t\t\treturn nil\n\t\t}",
+      "test": "TestAGuestThatRefusesTheReloadIsReported"
+    },
+    {
+      "label": "no refusal is swallowed, so an Alpine guest that has no networkctl at all fails the operation that caused the set",
+      "file": "internal/core/machine/incus_resolver.go",
+      "package": "./internal/core/machine/",
+      "find": "\t\tif isNotRunning(err) || isNotFound(err) || guestHasNoNetworkd(err) {\n\t\t\treturn nil\n\t\t}",
+      "replace": "\t\tif isNotRunning(err) && isNotFound(err) && guestHasNoNetworkd(err) && false {\n\t\t\treturn nil\n\t\t}",
+      "test": "TestAGuestWithoutNetworkctlIsNotARefusal"
+    },
+    {
+      "label": "a hot attach no longer tells the guest, so the machine without a public address never applies the announced resolver",
+      "file": "internal/core/machine/incus.go",
+      "package": "./internal/core/machine/",
+      "find": "\td.settleGuestInterface(ctx, name, device)\n",
+      "replace": "\tif false {\n\t\td.settleGuestInterface(ctx, name, device)\n\t}\n",
+      "test": "TestAHotAttachGivesTheGuestItsNewInterface"
+    }
+  ]
+}


### PR DESCRIPTION
Two defects that hide each other, and neither can be fixed alone: fixing the
first exposes the second, and the second makes the first look like a regression.

THE FIRST: A DEVICE CHANGE TAKES THE INTERFACE AWAY.

A machine did not apply the resolver its network stands for. The reported cause
was cloud-init, and it is not — the guest's own journal shows systemd-networkd
doing its work correctly, and this driver undoing it.

    16:40:29 veth3bbc3686: Interface name change detected, renamed to eth1.
    16:40:29 eth1: Re-configuring with /run/systemd/network/10-netplan-attached.network
    16:40:29 eth1: DHCPv4 address 10.190.0.3/24
    16:40:30 eth0: Link DOWN … vethf64c989f: renamed to eth0.
    16:40:32 eth1: Link DOWN … DHCP lease lost
    16:40:43 vethcdbe2acf: Interface name change detected, renamed to eth1.

`incus config device set` RE-PLUGS the NIC. The address migration of #548 sets
both devices, each set replaces the veth, and after the last one nothing tells
the guest to look again: `networkctl status eth1` answers `Network File: n/a`
and `State: routable (unmanaged)` on an interface whose matching unit is on
disk. `netplan generate` had run — 0.082 s, in the guest's log.

So there is one choke point, `settleGuestInterface`: wait for the link to come
back, tell the guest to read its configuration, give the interface its resolver.
Two callers name the two commands that take an interface away — `setDevice`,
through which the eight device sets now pass, and the hot attach, whose add
hands the guest a link its stack enumerated before anything matched it.

THE SECOND: AN ANNOUNCED RESOLVER IS A DEAD ROUTE (#660's remaining half).

The moment the interfaces were managed, the machines stopped reaching anything.
Not a regression of the above — the defect was there all along, invisible
because no lease was ever applied:

    1.1.1.1 dev eth0 proto dhcp scope link src 10.188.0.5 metric 100
    ip route get 1.1.1.1 -> 1.1.1.1 dev eth0 src 10.188.0.5
    ping 1.1.1.1 -> unreachable; resolvectl query -> No route to host

systemd's RoutesToDNS= lays an on-link /32 towards every name server in the
lease. A public resolver is not on the subnet, so the guest ARPs for it on its
own segment. Delete that one route and the same machine reaches 1.1.1.1; put the
resolver back on the link by hand and `getent hosts deb.debian.org` answers.

#660 had already measured the same mechanism with the uplink's address and
answered it by announcing a public resolver instead. That moved the collision,
it did not remove it. So nothing is announced in the lease now, and the resolver
reaches the guest through `resolvectl`, which sets a name server and lays no
route.

MEASURED, ON THREE SHAPES, WITH A PUBLIC GATEWAY PUSHING THE DEFAULT ROUTE.

    shape                                  before                after
    private NIC at the launch              no resolver, no way out    unchanged
    public address, NIC plugged after      no resolver                1.1.1.1
    no public address, NIC plugged after   no resolver                1.1.1.1

and on the third — the shape a platform team's private machines have, and the
only one entitled to a way out — the whole chain, with nothing done by hand:

    resolvectl dns          1.1.1.1
    getent hosts            deb.debian.org -> debian.map.fastlydns.net
    ip route get 1.1.1.1    via 10.188.0.1 dev eth0      (no on-link /32)

WHAT IS NOT FIXED, NAMED RATHER THAN ROUNDED OFF.

A machine whose NIC was attached BEFORE the poweron still comes up holding the
uplink's address as its only name server: the lease lands after the boot sets
the resolver and replaces it, and Incus falls back to the host's resolvers
whether `dns.nameservers` is unset or explicitly empty. Two candidate fixes were
measured and REMOVED rather than left in as lines that read like controls — the
empty key, which Incus ignores, and a wait for the interface to carry an address,
which the driver's own static address satisfies while the lease is still coming.

And a machine holding a public address has no usable default route here at all.
That is the pack's declared policy (`egressNetworkOf` leaves its route alone,
#660) and predates this work, but a Scaleway server with a flexible IP does
reach the Internet, so it is a fidelity gap. Both are followed as their own
issues rather than folded in.

The reported issue said the shape with a public address was broken and the shape
without one worked. Read side by side, every shape whose NIC arrived hot was
broken, and the discriminator is not the public address — it is when the
interface appears.

Thirteen mutations bite across the two specs, one per property: the set that
stops telling, the reload that stops waiting, the refused set that tells anyway,
both halves of the networkd-absent guard, the hot attach that stops telling, the
name server put back in the lease, the resolver set before the reload that drops
it, the bridge guest whose working lease resolver is overridden, and the boot
that stops setting one. `attach-vs-isolation-detach.json` is retargeted at
`setDevice`; `falsify:lint` refused the commit until it was, and
`TestEveryCitedTestExists` refused it until a renamed test's citation followed.

Not run: `mise run conformance`. This lot is measured against the runtime it
changes, and the aggregate pass belongs on the assembled batch.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
