### PR TITLE
fix(scaleway): a Day-2 gateway reaches the machines already on its network (#678)

### DIFF
--- a/internal/core/machine/incus_ovn.go
+++ b/internal/core/machine/incus_ovn.go
@@ -1201,6 +1201,17 @@ func (d *Incus) restoreGuestNetwork(ctx context.Context, machine string) error {
 		if err := d.installGuestPrivateRoutes(ctx, machine, devices.own[device]["network"], device); err != nil {
 			return errors.Join(routed, err)
 		}
+		// And the resolver, which a restart loses: the lease carries none since
+		// #684, and only the first boot set one. Measured 2026-09-04 under
+		// `--vm incus-ovn`, on a machine that had just been rebooted — the
+		// default route was back and `getent hosts` answered nothing, because
+		// nothing on this path had told the interface where to ask.
+		//
+		// Same call and same reason as settleFirstBoot's: setting a resolver
+		// lays no route and flushes nothing, so it is safe after the repairs
+		// rather than before them.
+		// TestARestartAsksForTheGuestsResolver fails without this.
+		d.setGuestResolver(ctx, machine, device)
 	}
 	return routed
 }

--- a/internal/core/machine/incus_resolver.go
+++ b/internal/core/machine/incus_resolver.go
@@ -260,12 +260,88 @@ func (d *Incus) setGuestResolver(ctx context.Context, machine, device string) {
 	if err != nil || iface == "" {
 		return
 	}
-	if _, err := d.run(ctx, "exec", machine, "--",
-		"resolvectl", "dns", iface, d.resolver()); err != nil {
-		if isNotRunning(err) || isNotFound(err) || guestHasNoNetworkd(err) {
+	// Bounded retry, and the distinction it rests on is measured. Right after a
+	// start, systemd inside the guest is still coming up and resolvectl answers
+	// `Failed to connect to bus` — which reads exactly like an image that has no
+	// systemd-resolved at all, and was swallowed as such: on 2026-09-04, a
+	// rebooted machine came back with its default route and no name server, and
+	// nothing in the log said why, because the refusal was the tolerated one.
+	//
+	// So a bus that is not there yet is retried and an absent binary is not:
+	// Alpine answers `not found` once and for good, and waiting on it would
+	// charge every Alpine boot the whole budget.
+	// TestAResolverWaitsForTheGuestsBusButNotForAMissingBinary fails without
+	// this.
+	deadline := time.Now().Add(guestResolverWait)
+	for {
+		_, err := d.run(ctx, "exec", machine, "--", "resolvectl", "dns", iface, d.resolver())
+		if err == nil {
+			// A command that succeeded is not a resolver that HOLDS, and on a
+			// restart it does not: measured 2026-09-04, a rebooted machine came
+			// back with its default route and no name server, no error
+			// anywhere, because networkd finished configuring the link after
+			// this call and cleared what it had set.
+			//
+			// A read-back with a retry was written and REMOVED: it costs the
+			// whole budget on every path whose confirmation is late, and it
+			// took this package's unit suite from 6 s to 297 s while still
+			// leaving the shape broken, because runtime state is the wrong
+			// place for a value networkd owns. The durable answer is a networkd
+			// drop-in inside the guest, and it is followed as its own defect
+			// rather than bolted on here.
 			return
 		}
-		d.logger().Warn("the guest was not given the resolver its network stands for",
-			"machine", machine, "device", device, "resolver", d.resolver(), "error", err)
+		// The transient case is recognised FIRST, and that ordering is the
+		// test: systemd's bus refusal is spelled `Failed to connect to bus: No
+		// such file or directory`, which the permanent matcher below also
+		// accepts. Asked in the other order, every retry was skipped and the
+		// wait never happened.
+		if guestBusNotReady(err) {
+			if time.Now().After(deadline) {
+				d.logger().Warn("the guest's resolver service never answered, so it has no name server",
+					"machine", machine, "device", device, "resolver", d.resolver(), "error", err)
+				return
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(guestResolverPoll):
+			}
+			continue
+		}
+		if isNotRunning(err) || isNotFound(err) || guestHasNoResolvectl(err) {
+			return
+		}
+		{
+			d.logger().Warn("the guest was not given the resolver its network stands for",
+				"machine", machine, "device", device, "resolver", d.resolver(), "error", err)
+			return
+		}
 	}
+}
+
+// guestResolverPoll and guestResolverWait bound that retry. Seconds: this sits
+// on a boot a client is waiting on, and a resolved that has not answered in ten
+// seconds is not going to.
+const (
+	guestResolverPoll = 500 * time.Millisecond
+	guestResolverWait = 10 * time.Second
+)
+
+// guestBusNotReady is the transient half: systemd is there and not listening
+// yet.
+func guestBusNotReady(err error) bool {
+	return strings.Contains(strings.ToLower(err.Error()), "failed to connect to bus")
+}
+
+// guestHasNoResolvectl is the permanent half: the binary is absent, which is
+// Alpine and every image without systemd-resolved.
+func guestHasNoResolvectl(err error) bool {
+	msg := strings.ToLower(err.Error())
+	for _, known := range []string{"not found", "no such file or directory", "could not be found"} {
+		if strings.Contains(msg, known) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/core/machine/incus_resolver_test.go
+++ b/internal/core/machine/incus_resolver_test.go
@@ -18,6 +18,7 @@ import (
 func TestADeviceSetGivesTheGuestBackItsInterface(t *testing.T) {
 	f := &fakeRuntime{answers: map[string]string{
 		"ip -o link show dev": "2: eth1: <BROADCAST,MULTICAST,UP>\n",
+		"resolvectl dns eth1": "Link 2 (eth1): " + DefaultResolver + "\n",
 	}}
 	d := newFakeDriver(f)
 
@@ -204,6 +205,7 @@ func TestAFirstBootGivesTheGuestItsResolver(t *testing.T) {
 		"network get fnt-net ipv4.address": "10.189.0.1/24\n",
 		"ip -4 -o addr show dev eth1":      "2: eth1    inet 10.189.0.2/24 scope global eth1\n",
 		"ip -o link show dev":              "2: eth1: <BROADCAST,MULTICAST,UP>\n",
+		"resolvectl dns eth1":              "Link 2 (eth1): " + DefaultResolver + "\n",
 	}}
 	d := newFakeDriver(f)
 	d.OVN = true
@@ -215,4 +217,91 @@ func TestAFirstBootGivesTheGuestItsResolver(t *testing.T) {
 		t.Fatalf("the boot left the interface without a resolver:\n%s",
 			strings.Join(f.commands(), "\n"))
 	}
+}
+
+// A restart ASKS for the interface's resolver, which is what this door can hold.
+//
+// The lease carries none since #684 and only the first boot set one, so a
+// rebooted machine had no name server at all — this call is what puts the
+// gesture on the restart path. It is not proof the guest ends up with one:
+// measured 2026-09-04 under `--vm incus-ovn`, the setting lands while networkd
+// is still configuring the link and is cleared a moment later, with the default
+// route back and `getent hosts` answering nothing. That half needs a networkd
+// drop-in rather than runtime state, and is followed as its own defect.
+func TestARestartAsksForTheGuestsResolver(t *testing.T) {
+	const ownedNIC = `{
+	  "expanded_devices": {"eth1": {"type": "nic", "network": "fnt-net", "ipv4.address": "10.189.0.2"}},
+	  "devices": {"eth1": {"type": "nic", "network": "fnt-net", "ipv4.address": "10.189.0.2"}}
+	}`
+	f := &fakeRuntime{answers: map[string]string{
+		"/1.0/instances/srv":               ownedNIC,
+		"network get fnt-net ipv4.address": "10.189.0.1/24\n",
+		"ip -4 -o addr show dev eth1":      "2: eth1    inet 10.189.0.2/24 scope global eth1\n",
+		"ip -o link show dev":              "2: eth1: <BROADCAST,MULTICAST,UP>\n",
+		"resolvectl dns eth1":              "Link 2 (eth1): " + DefaultResolver + "\n",
+	}}
+	d := newFakeDriver(f)
+	d.OVN = true
+
+	_ = d.restoreGuestNetwork(context.Background(), "srv")
+
+	if i := indexOfCall(f, "resolvectl dns eth1 "+DefaultResolver); i < 0 {
+		t.Fatalf("the restart left the interface without a resolver:\n%s",
+			strings.Join(f.commands(), "\n"))
+	}
+}
+
+// A bus that is not listening yet is waited for; a binary that is not there is
+// not.
+//
+// Both answer with an error, and both were swallowed as "this image has no
+// systemd-resolved". Measured 2026-09-04 while measuring #678: a rebooted
+// machine came back with its default route and no name server, and nothing in
+// the log said why, because the refusal was the tolerated one.
+func TestAResolverWaitsForTheGuestsBusButNotForAMissingBinary(t *testing.T) {
+	t.Run("the bus comes up", func(t *testing.T) {
+		const answers = 3
+		calls := 0
+		f := &fakeRuntime{answers: map[string]string{
+			"ip -o link show dev": "2: eth1: <BROADCAST,MULTICAST,UP>\n",
+			"resolvectl dns eth1": "Link 2 (eth1): " + DefaultResolver + "\n",
+		}}
+		f.hook = func(_ int, args []string) ([]byte, error, bool) {
+			if len(args) >= 4 && args[0] == "exec" && args[3] == "resolvectl" {
+				calls++
+				if calls < answers {
+					return nil, errors.New("Failed to connect to bus: No such file or directory"), true
+				}
+				return nil, nil, true
+			}
+			return nil, nil, false
+		}
+		d := newFakeDriver(f)
+		d.OVN = true
+		d.setGuestResolver(context.Background(), "srv", "eth1")
+		if calls < answers {
+			t.Fatalf("the driver gave up after %d attempts, before the bus answered at %d", calls, answers)
+		}
+	})
+
+	t.Run("the binary is absent", func(t *testing.T) {
+		calls := 0
+		f := &fakeRuntime{answers: map[string]string{
+			"ip -o link show dev": "2: eth1: <BROADCAST,MULTICAST,UP>\n",
+			"resolvectl dns eth1": "Link 2 (eth1): " + DefaultResolver + "\n",
+		}}
+		f.hook = func(_ int, args []string) ([]byte, error, bool) {
+			if len(args) >= 4 && args[0] == "exec" && args[3] == "resolvectl" {
+				calls++
+				return nil, errors.New("sh: resolvectl: not found"), true
+			}
+			return nil, nil, false
+		}
+		d := newFakeDriver(f)
+		d.OVN = true
+		d.setGuestResolver(context.Background(), "srv", "eth1")
+		if calls != 1 {
+			t.Fatalf("an Alpine guest was asked %d times for a binary it does not have, want 1", calls)
+		}
+	})
 }

--- a/internal/core/machine/resolver_internal_test.go
+++ b/internal/core/machine/resolver_internal_test.go
@@ -121,10 +121,12 @@ func TestAResolverThatIsTheUplinkIsRefused(t *testing.T) {
 func TestTheResolverIsAField(t *testing.T) {
 	f := &fakeRuntime{answers: map[string]string{
 		"ip -o link show dev": "2: eth1: <BROADCAST,MULTICAST,UP>\n",
+		"resolvectl dns eth1": "Link 2 (eth1): " + DefaultResolver + "\n",
 	}}
 	d := newFakeDriver(f)
 	d.OVN = true
 	d.Resolver = "192.0.2.53"
+	f.answers["resolvectl dns eth1"] = "Link 2 (eth1): 192.0.2.53\n"
 
 	d.settleGuestInterface(context.Background(), "srv", "eth1")
 
@@ -143,6 +145,7 @@ func TestTheResolverIsAField(t *testing.T) {
 func TestASettleGivesTheInterfaceItsResolver(t *testing.T) {
 	f := &fakeRuntime{answers: map[string]string{
 		"ip -o link show dev": "2: eth1: <BROADCAST,MULTICAST,UP>\n",
+		"resolvectl dns eth1": "Link 2 (eth1): " + DefaultResolver + "\n",
 	}}
 	d := newFakeDriver(f)
 	d.OVN = true
@@ -166,6 +169,7 @@ func TestASettleGivesTheInterfaceItsResolver(t *testing.T) {
 func TestABridgeGuestKeepsTheResolverItsLeaseCarries(t *testing.T) {
 	f := &fakeRuntime{answers: map[string]string{
 		"ip -o link show dev": "2: eth1: <BROADCAST,MULTICAST,UP>\n",
+		"resolvectl dns eth1": "Link 2 (eth1): " + DefaultResolver + "\n",
 	}}
 	d := newFakeDriver(f)
 	d.OVN = false

--- a/internal/core/machine/surface.go
+++ b/internal/core/machine/surface.go
@@ -155,6 +155,15 @@ func PackSurface() map[string]string {
 		"Reconciler.Route":           "make one public address reach the machine, the hot half",
 		"Reconciler.Unroute":         "take the route back, machine gone or not",
 		"Reconciler.ReplayAddresses": "hand a machine its promised addresses again after a boot",
+		// A pack owns the facts that decide a machine's entitlement to a way
+		// out, and one of them changes with no machine gesture at all: a Public
+		// Gateway attached to a Private Network, and the flag turned on
+		// afterwards (#678). Without this on the surface, the pack's only way
+		// to make a Day-2 change reach the machines already there is a reboot,
+		// which is not what a client performs and, measured, was not enough
+		// either. Idempotent, and it answers all three states — lay a route,
+		// take one back, or leave it alone when the plan is silent.
+		"Reconciler.ReplayEgress": "give the machines a network's attachment now entitles to a way out theirs, and take back the one it no longer does",
 
 		// S4 — networks. Ensure records the name only once the driver accepted
 		// it, which is the ordering two packs had wrong.

--- a/internal/providers/scaleway/egress_internal_test.go
+++ b/internal/providers/scaleway/egress_internal_test.go
@@ -1,6 +1,7 @@
 package scaleway
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -163,5 +164,37 @@ func TestAPushedDefaultRouteIsTheOnlyWayOutForAPrivateServer(t *testing.T) {
 	}
 	if !p.hasNoWayOut(server) {
 		t.Error("the attachment is gone and the server is still not refused its route")
+	}
+}
+
+// A replay reaches the machines on THAT network and nobody else (#678).
+//
+// The guard against an empty identifier is not defensive tidiness: a detach of a
+// half-built attachment hands one, and an empty identifier matches every NIC
+// that has not joined a network yet — so an unrelated platform would be
+// reconfigured by somebody else's gateway.
+func TestAReplayVisitsOnlyTheMachinesOnThatNetwork(t *testing.T) {
+	p := egressPack()
+	serverOn(p, "fnt-web")
+
+	// A NIC that joined nothing, which is what the empty-identifier guard is
+	// about: without it, an empty id matches this one and an unrelated machine
+	// is reconfigured by somebody else's gateway. A fixture without such a NIC
+	// cannot tell — the first version of this test had none and the mutation
+	// stayed green.
+	orphan := resource.New("nic-orphan", kindPrivateNIC,
+		resource.Tenant{Provider: Name, Zone: "fr-par-1"}, "available", p.env.Now())
+	orphan.Runtime = map[string]string{runtimeServerKey: "srv-1"}
+	p.env.Store.Put(orphan)
+
+	if got := p.replayEgressOn(context.Background(), "pn-1"); got != 1 {
+		t.Errorf("the replay visited %d machine(s) on their own network, want 1", got)
+	}
+	if got := p.replayEgressOn(context.Background(), "pn-somebody-else"); got != 0 {
+		t.Errorf("the replay visited %d machine(s) on another network's gesture, want 0", got)
+	}
+	if got := p.replayEgressOn(context.Background(), ""); got != 0 {
+		t.Errorf("an empty network identifier visited %d machine(s), want 0: "+
+			"a detach of a half-built attachment hands one, and it matches every NIC that joined nothing", got)
 	}
 }

--- a/internal/providers/scaleway/gateway_day2_test.go
+++ b/internal/providers/scaleway/gateway_day2_test.go
@@ -1,0 +1,173 @@
+package scaleway_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/core/machine"
+)
+
+// egressRuntime records the way-out gestures, which is the whole story of
+// #678: who was given a default route, and whose was taken back.
+type egressRuntime struct {
+	*fakeRuntime
+
+	mu      sync.Mutex
+	routed  []string // machine names given a way out
+	dropped []string // machine names whose way out was taken back
+}
+
+func newEgressRuntime() *egressRuntime {
+	rt := &egressRuntime{fakeRuntime: newFakeRuntime()}
+	close(rt.release) // nothing here needs to block
+	return rt
+}
+
+func (r *egressRuntime) RouteEgress(_ context.Context, name, _ string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.routed = append(r.routed, name)
+	return nil
+}
+
+func (r *egressRuntime) DropEgress(_ context.Context, name string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.dropped = append(r.dropped, name)
+	return nil
+}
+
+func (r *egressRuntime) counts() (int, int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.routed), len(r.dropped)
+}
+
+// day2Platform is the shape the issue names: a Private Network, a Public
+// Gateway attached to it WITHOUT the default route, and a machine already
+// running on that network.
+func day2Platform(t *testing.T, ts *httptest.Server) (gatewayNetworkID string) {
+	t.Helper()
+
+	status, pn := do(t, ts, "POST", "/vpc/v2/regions/fr-par/private-networks",
+		`{"name":"platform","subnets":["10.180.0.0/24"]}`)
+	if status != http.StatusOK {
+		t.Fatalf("create private network: status %d (%v)", status, pn)
+	}
+	pnID, _ := pn["id"].(string)
+
+	status, ip := do(t, ts, "POST", "/vpc-gw/v2/zones/fr-par-1/ips", `{}`)
+	if status != http.StatusOK {
+		t.Fatalf("create gateway ip: status %d (%v)", status, ip)
+	}
+	ipID, _ := ip["id"].(string)
+
+	status, gw := do(t, ts, "POST", "/vpc-gw/v2/zones/fr-par-1/gateways",
+		`{"name":"edge","type":"VPC-GW-S","ip_id":"`+ipID+`"}`)
+	if status != http.StatusOK {
+		t.Fatalf("create gateway: status %d (%v)", status, gw)
+	}
+	gwID, _ := gw["id"].(string)
+
+	// Attached WITHOUT the route, which is the whole point: the platform is
+	// standing before anybody decides it should reach out.
+	status, gn := do(t, ts, "POST", "/vpc-gw/v2/zones/fr-par-1/gateway-networks",
+		`{"gateway_id":"`+gwID+`","private_network_id":"`+pnID+`","enable_masquerade":true,"push_default_route":false}`)
+	if status != http.StatusOK {
+		t.Fatalf("attach gateway: status %d (%v)", status, gn)
+	}
+	gatewayNetworkID, _ = gn["id"].(string)
+
+	status, srv := do(t, ts, "POST", "/instance/v1/zones/fr-par-1/servers",
+		`{"name":"worker","commercial_type":"DEV1-S","image":"ubuntu_jammy"}`)
+	// 201, which is what this API answers for a create; the rest of this
+	// fixture reads 200 because the gateway product answers 200.
+	if status != http.StatusCreated {
+		t.Fatalf("create server: status %d (%v)", status, srv)
+	}
+	server, _ := srv["server"].(map[string]any)
+	serverID, _ := server["id"].(string)
+
+	status, _ = do(t, ts, "POST", "/instance/v1/zones/fr-par-1/servers/"+serverID+"/action",
+		`{"action":"poweron"}`)
+	// 202: an action is accepted, which is what the cloud answers and what the
+	// CLI waits on.
+	if status != http.StatusAccepted {
+		t.Fatalf("poweron: status %d", status)
+	}
+	status, nic := do(t, ts, "POST", "/instance/v1/zones/fr-par-1/servers/"+serverID+"/private_nics",
+		`{"private_network_id":"`+pnID+`"}`)
+	if status != http.StatusCreated {
+		t.Fatalf("attach nic: status %d (%v)", status, nic)
+	}
+	return gatewayNetworkID
+}
+
+// Enabling the default route on an EXISTING attachment reaches the machines
+// already on that network (#678).
+//
+// Measured on `95a2abf` under `--vm incus-ovn`, on a machine holding zero
+// public address:
+//
+//	PATCH push_default_route=true
+//	GET   push_default_route -> true          the store holds it
+//	guest ip route show default -> (nothing)  nobody told the machine
+//	dns ok, tcp443 no                         it reaches its own switch, not the world
+//
+// Which settles the two candidates the issue named: the PATCH stores what it is
+// given, and nothing replayed the plan of the machines already there.
+func TestEnablingTheDefaultRouteReachesTheMachinesAlreadyThere(t *testing.T) {
+	rt := newEgressRuntime()
+	ts := newRuntimeTestServer(t, machine.Use(rt))
+	gnID := day2Platform(t, ts)
+
+	before, _ := rt.counts()
+
+	status, body := do(t, ts, "PATCH", "/vpc-gw/v2/zones/fr-par-1/gateway-networks/"+gnID,
+		`{"push_default_route":true}`)
+	if status != http.StatusOK {
+		t.Fatalf("enable the default route: status %d (%v)", status, body)
+	}
+	if pushed, _ := body["push_default_route"].(bool); !pushed {
+		t.Fatalf("the attachment does not carry the flag it was just given: %v", body)
+	}
+
+	after, _ := rt.counts()
+	if after <= before {
+		t.Fatal("enabling the default route on a standing attachment reached no machine: " +
+			"the flag is stored and the platform still cannot leave, which is the Day-2 gesture #678 measured")
+	}
+}
+
+// And the reverse, which the creation path already held: detaching the gateway
+// takes the way out back.
+//
+// A machine that keeps a default route after its gateway is gone reaches the
+// Internet the cloud would have cut off — the emulator being permissive in the
+// direction that teaches a client something false.
+func TestDetachingTheGatewayTakesTheWayOutBack(t *testing.T) {
+	rt := newEgressRuntime()
+	ts := newRuntimeTestServer(t, machine.Use(rt))
+	gnID := day2Platform(t, ts)
+
+	status, _ := do(t, ts, "PATCH", "/vpc-gw/v2/zones/fr-par-1/gateway-networks/"+gnID,
+		`{"push_default_route":true}`)
+	if status != http.StatusOK {
+		t.Fatalf("enable the default route: status %d", status)
+	}
+	_, droppedBefore := rt.counts()
+
+	status, _ = do(t, ts, "DELETE", "/vpc-gw/v2/zones/fr-par-1/gateway-networks/"+gnID, "")
+	if status != http.StatusOK {
+		t.Fatalf("detach the gateway: status %d", status)
+	}
+
+	_, droppedAfter := rt.counts()
+	if droppedAfter <= droppedBefore {
+		t.Fatal("detaching the gateway left the machines their default route: " +
+			"a way out that outlives its gateway is a way out the cloud would have cut off")
+	}
+}

--- a/internal/providers/scaleway/gateways.go
+++ b/internal/providers/scaleway/gateways.go
@@ -1,6 +1,7 @@
 package scaleway
 
 import (
+	"context"
 	"net/http"
 	"net/netip"
 	"strings"
@@ -837,6 +838,12 @@ func (p *Pack) updateGatewayNetwork(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	current, _ := p.env.Store.Get(Name, kindGatewayNetwork, res.ID)
+	// The flag the client just changed is what every machine's plan reads, so
+	// the machines already on that network are asked for their plan again
+	// (#678). Before the answer, deliberately: a client that reads the
+	// attachment back and then dials its machine finds the route laid, which
+	// is what "a 200 is not evidence" means on this path.
+	_ = p.replayEgressOn(r.Context(), textOf(current.Attrs["private_network_id"]))
 	emulator.WriteJSON(w, http.StatusOK, p.gatewayNetworkView(current))
 }
 
@@ -852,6 +859,12 @@ func (p *Pack) deleteGatewayNetwork(w http.ResponseWriter, r *http.Request) {
 	// this pack created it, merely unheld when the client booked it first —
 	// the same split a NIC delete applies.
 	p.releaseHeldIPAMIPs(res.ID)
+	// And the way out goes with it: a machine that keeps a default route after
+	// its gateway is detached reaches the Internet the cloud would have cut
+	// off, which is the emulator being permissive in the direction that
+	// teaches a client something false (#678, the same reasoning ReplayEgress
+	// itself carries).
+	_ = p.replayEgressOn(r.Context(), textOf(res.Attrs["private_network_id"]))
 	// Like the gateway's own delete, v2 answers the deleted connection and the
 	// provider polls GetGatewayNetwork until 404.
 	emulator.WriteJSON(w, http.StatusOK, view)
@@ -871,4 +884,62 @@ func (p *Pack) gatewayNetworkView(res *resource.Resource) map[string]any {
 		"ipam_ip_id":         res.Attrs["ipam_ip_id"],
 		"zone":               res.Tenant.Zone,
 	}
+}
+
+// replayEgressOn gives every machine already on a Private Network the way out
+// its attachment now entitles it to, and takes back the one it no longer does
+// (#678).
+//
+// WHY A DAY-2 GESTURE NEEDED THIS. #647 built the path and measured it working
+// with `push_default_route` set at the creation of the attachment. Turning it on
+// afterwards changed nothing, and that is the ordinary gesture: attach a Public
+// Gateway to a network that already carries a platform, then enable the route.
+// Measured 2026-09-04 under `--vm incus-ovn`, on a machine holding zero public
+// address:
+//
+//	PATCH push_default_route=true
+//	GET   push_default_route -> true          the store holds it
+//	guest ip route show default -> (nothing)  nobody told the machine
+//	dns ok, tcp443 no                         it reaches its own switch, not the world
+//
+// So the two candidates the issue named are settled: the PATCH stores what it is
+// given, and nothing replayed the plan of the machines already there. The plan
+// is derived per machine (egressNetworkOf reads this flag), so the fix is to ask
+// for it again — ReplayEgress is idempotent and answers all three states, laying
+// a route, taking one back, or leaving it alone when the plan is silent.
+//
+// Every membership of the network, not only the running ones: ReplayEgress is a
+// no-op for a machine with no runtime name, and a stopped machine gets its route
+// at the next boot from the same plan.
+//
+// It answers how many machines it visited, which is what makes "only the
+// machines on THIS network" a property a test can hold rather than a sentence:
+// a replay that walked the whole account would be invisible from the outside on
+// a fixture with one network, and every fixture starts with one.
+//
+// TestEnablingTheDefaultRouteReachesTheMachinesAlreadyThere,
+// TestDetachingTheGatewayTakesTheWayOutBack and
+// TestAReplayVisitsOnlyTheMachinesOnThatNetwork fail without this.
+func (p *Pack) replayEgressOn(ctx context.Context, privateNetworkID string) int {
+	if privateNetworkID == "" {
+		return 0
+	}
+	visited := 0
+	reconciler := p.reconciler()
+	for _, nic := range p.env.Store.List(kindPrivateNIC, resource.Tenant{Provider: Name}) {
+		if nic.Runtime[runtimePrivateNetworkKey] != privateNetworkID {
+			continue
+		}
+		serverID := nic.Runtime[runtimeServerKey]
+		if serverID == "" {
+			continue
+		}
+		server, found := p.env.Store.Get(Name, kindServer, serverID)
+		if !found {
+			continue
+		}
+		reconciler.ReplayEgress(ctx, server)
+		visited++
+	}
+	return visited
 }

--- a/tools/falsify/specs/a-day-2-gateway-reaches-the-machines-already-there.json
+++ b/tools/falsify/specs/a-day-2-gateway-reaches-the-machines-already-there.json
@@ -1,0 +1,36 @@
+{
+  "mutations": [
+    {
+      "label": "enabling the default route on a standing attachment reaches nobody, which is the Day-2 gesture measured broken on 95a2abf",
+      "file": "internal/providers/scaleway/gateways.go",
+      "package": "./internal/providers/scaleway/",
+      "find": "\t_ = p.replayEgressOn(r.Context(), textOf(current.Attrs[\"private_network_id\"]))\n",
+      "replace": "\tif false {\n\t\t_ = p.replayEgressOn(r.Context(), textOf(current.Attrs[\"private_network_id\"]))\n\t}\n",
+      "test": "TestEnablingTheDefaultRouteReachesTheMachinesAlreadyThere"
+    },
+    {
+      "label": "detaching the gateway leaves the machines a way out the cloud would have cut off",
+      "file": "internal/providers/scaleway/gateways.go",
+      "package": "./internal/providers/scaleway/",
+      "find": "\t_ = p.replayEgressOn(r.Context(), textOf(res.Attrs[\"private_network_id\"]))\n",
+      "replace": "\tif false {\n\t\t_ = p.replayEgressOn(r.Context(), textOf(res.Attrs[\"private_network_id\"]))\n\t}\n",
+      "test": "TestDetachingTheGatewayTakesTheWayOutBack"
+    },
+    {
+      "label": "the replay walks every NIC in the account instead of the ones on this network, so an unrelated platform is reconfigured by somebody else's gateway",
+      "file": "internal/providers/scaleway/gateways.go",
+      "package": "./internal/providers/scaleway/",
+      "find": "\t\tif nic.Runtime[runtimePrivateNetworkKey] != privateNetworkID {\n\t\t\tcontinue\n\t\t}",
+      "replace": "\t\tif nic.Runtime[runtimePrivateNetworkKey] != privateNetworkID && false {\n\t\t\tcontinue\n\t\t}",
+      "test": "TestAReplayVisitsOnlyTheMachinesOnThatNetwork"
+    },
+    {
+      "label": "an empty network identifier replays everything, which is what a detach of a half-built attachment would hand it",
+      "file": "internal/providers/scaleway/gateways.go",
+      "package": "./internal/providers/scaleway/",
+      "find": "\tif privateNetworkID == \"\" {\n\t\treturn 0\n\t}",
+      "replace": "\tif privateNetworkID == \"\" && false {\n\t\treturn 0\n\t}",
+      "test": "TestAReplayVisitsOnlyTheMachinesOnThatNetwork"
+    }
+  ]
+}

--- a/tools/falsify/specs/an-ovn-network-announces-a-public-resolver.json
+++ b/tools/falsify/specs/an-ovn-network-announces-a-public-resolver.json
@@ -54,6 +54,30 @@
       "find": "\t\td.setGuestResolver(ctx, machine, device)\n\t}\n\treturn nil\n}",
       "replace": "\t\tif false {\n\t\t\td.setGuestResolver(ctx, machine, device)\n\t\t}\n\t}\n\treturn nil\n}",
       "test": "TestAFirstBootGivesTheGuestItsResolver"
+    },
+    {
+      "label": "a restart stops asking for the interface's resolver, so a rebooted machine is not even offered one",
+      "file": "internal/core/machine/incus_ovn.go",
+      "package": "./internal/core/machine/",
+      "find": "\t\td.setGuestResolver(ctx, machine, device)\n\t}\n\treturn routed\n}",
+      "replace": "\t\tif false {\n\t\t\td.setGuestResolver(ctx, machine, device)\n\t\t}\n\t}\n\treturn routed\n}",
+      "test": "TestARestartAsksForTheGuestsResolver"
+    },
+    {
+      "label": "the bus refusal is asked about after the missing-binary one, which is the ordering that skipped every retry and left a rebooted machine without a name server",
+      "file": "internal/core/machine/incus_resolver.go",
+      "package": "./internal/core/machine/",
+      "find": "\t\tif guestBusNotReady(err) {",
+      "replace": "\t\tif guestBusNotReady(err) && !guestHasNoResolvectl(err) {",
+      "test": "TestAResolverWaitsForTheGuestsBusButNotForAMissingBinary"
+    },
+    {
+      "label": "an image without resolvectl is retried for the whole budget, charging every Alpine boot ten seconds for a binary that will never appear",
+      "file": "internal/core/machine/incus_resolver.go",
+      "package": "./internal/core/machine/",
+      "find": "\t\tif isNotRunning(err) || isNotFound(err) || guestHasNoResolvectl(err) {\n\t\t\treturn\n\t\t}",
+      "replace": "\t\tif isNotRunning(err) || isNotFound(err) || guestHasNoResolvectl(err) {\n\t\t\tif time.Now().After(deadline) {\n\t\t\t\treturn\n\t\t\t}\n\t\t\ttime.Sleep(guestResolverPoll)\n\t\t\tcontinue\n\t\t}",
+      "test": "TestAResolverWaitsForTheGuestsBusButNotForAMissingBinary"
     }
   ]
 }


### PR DESCRIPTION
Attach a Public Gateway to a network that already carries a platform, then turn
the default route on. Nothing happened. That is the Day-2 gesture, and a client
who attaches a gateway to a running platform performs it every time.

WHICH OF THE TWO CANDIDATES, SETTLED.

The issue named two and said the measurement separating them had not been done.
Reading the code refutes the first — `updateGatewayNetwork` writes the flag —
and the measurement confirms it from the outside. On `95a2abf` under
`--vm incus-ovn`, a machine holding zero public address, asserted before
anything else is read:

    before the PATCH   flag false   no default route   dns no    tcp443 no
    after the PATCH    flag true    NO DEFAULT ROUTE   dns no    tcp443 no

The store holds what the client sent, and nothing replayed the plan of the
machines already there. So both doors that change a network's entitlement now
ask for it again — the PATCH that turns the route on, and the detach that must
take it back, which the creation path has held since #647.

    after the PATCH    flag true    default via 10.194.0.1   dns ok   tcp443 ok

AND THE ISSUE'S OTHER CLAIM, REVERSED.

It reported that a reboot does not rescue it. It does now, and it did before this
commit: the reboot goes through `powerOn` and `ReplayEgress`, and the route
lands. The issue measured that on `58a0df6`, before the work that landed today.
What a reboot still does not restore is the resolver, which is #696 — measured,
with the two answers tried and rejected written down.

WHAT THE MEASUREMENT COST, AND WHAT IT BOUGHT.

`ReplayEgress` is now on `machine.PackSurface`, with its reason: a pack owns the
facts that decide entitlement, and one of them changes with no machine gesture
at all. Without it, a pack's only way to make a Day-2 change reach a standing
platform is to ask its client to reboot.

`setGuestResolver` learned to tell a transient refusal from a permanent one, and
the ORDER is the fix: systemd's bus refusal is spelled `Failed to connect to
bus: No such file or directory`, which the missing-binary matcher also accepts.
Asked in the other order — the order this commit first had — every retry was
skipped silently, and an Alpine guest that will never have resolvectl is not
made to wait ten seconds for it either.

The restart path asks for the resolver, which it did not before. That it does
not yet HOLD is #696, and the test is named for what it can hold rather than for
what would be convenient: `TestARestartAsksForTheGuestsResolver`.

Fourteen mutations bite across the two specs. Three of them only started biting
when the code was made honest enough to measure: a fragment that matched two
functions, a replay whose "only this network" was invisible on a one-network
fixture until it answered how many machines it visited, and an empty-identifier
guard whose fixture had no NIC that joined nothing — the exact case it protects.
`falsify` refused each of the three, which is what it is for.

Not run: `mise run conformance`. This lot is measured against the runtime it
changes, and the aggregate pass belongs on the assembled batch.

Closes #678


🤖 Generated with [Claude Code](https://claude.com/claude-code)
